### PR TITLE
feat: implement /portfolio route (Phase 2A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .env.local
 .env*.local
 .superpowers/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .env
 .env.local
 .env*.local
+.superpowers/

--- a/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
@@ -1,0 +1,47 @@
+// apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { getPortfolioTree } from "@/lib/portfolio-data";
+import { resolveNodeFromSlug, getSubtreeIds, buildBreadcrumbs } from "@/lib/portfolio";
+import { PortfolioOverview } from "@/components/portfolio/PortfolioOverview";
+import { PortfolioNodeDetail } from "@/components/portfolio/PortfolioNodeDetail";
+
+type Props = {
+  params: { slug?: string[] };
+};
+
+export default async function PortfolioPage({ params }: Props) {
+  const slugs = params.slug ?? [];
+  const roots = await getPortfolioTree(); // deduplicated by React cache()
+
+  // Overview: /portfolio
+  if (slugs.length === 0) {
+    return <PortfolioOverview roots={roots} />;
+  }
+
+  // Node detail: /portfolio/[...slug]
+  const node = resolveNodeFromSlug(roots, slugs);
+  if (!node) return notFound();
+
+  // Fetch products in this node's subtree
+  const subtreeIds = getSubtreeIds([node]);
+  const products = await prisma.digitalProduct.findMany({
+    where: {
+      taxonomyNodeId: { in: subtreeIds },
+      status: "active",
+    },
+    select: { id: true, productId: true, name: true, status: true },
+    orderBy: { name: "asc" },
+  });
+
+  const breadcrumbs = buildBreadcrumbs(roots, slugs);
+
+  return (
+    <PortfolioNodeDetail
+      node={node}
+      subNodes={node.children}
+      products={products}
+      breadcrumbs={breadcrumbs}
+    />
+  );
+}

--- a/apps/web/app/(shell)/portfolio/layout.tsx
+++ b/apps/web/app/(shell)/portfolio/layout.tsx
@@ -1,0 +1,38 @@
+// apps/web/app/(shell)/portfolio/layout.tsx
+import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getPortfolioTree } from "@/lib/portfolio-data";
+import { PortfolioTree } from "@/components/portfolio/PortfolioTree";
+
+export default async function PortfolioLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_portfolio"
+    )
+  ) {
+    notFound();
+  }
+
+  const roots = await getPortfolioTree();
+
+  // Layout cannot access searchParams — PortfolioTree reads ?open= from window.location
+  // client-side on mount (brief collapse flash is acceptable).
+  return (
+    <div className="flex gap-0 -m-6 h-[calc(100vh-57px)] overflow-hidden">
+      {/* Sidebar */}
+      <div className="w-56 flex-shrink-0 border-r border-[var(--dpf-border)] overflow-y-auto bg-[var(--dpf-bg)]">
+        <PortfolioTree roots={roots} />
+      </div>
+      {/* Content panel */}
+      <div className="flex-1 overflow-y-auto p-6">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioNodeDetail.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeDetail.tsx
@@ -1,0 +1,159 @@
+// apps/web/components/portfolio/PortfolioNodeDetail.tsx
+import Link from "next/link";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PORTFOLIO_COLOURS, PORTFOLIO_OWNER_ROLES } from "@/lib/portfolio";
+import { ProductList } from "./ProductList";
+
+type Product = { id: string; productId: string; name: string; status: string };
+
+type Props = {
+  node: PortfolioTreeNode;
+  subNodes: PortfolioTreeNode[];
+  products: Product[];
+  breadcrumbs: Array<{ nodeId: string; name: string }>;
+};
+
+function getRootSlug(nodeId: string): string {
+  return nodeId.split("/")[0] ?? nodeId;
+}
+
+export function PortfolioNodeDetail({
+  node,
+  subNodes,
+  products,
+  breadcrumbs,
+}: Props) {
+  const rootSlug = getRootSlug(node.nodeId);
+  const colour = PORTFOLIO_COLOURS[rootSlug] ?? "#7c8cf8";
+  const ownerRole = PORTFOLIO_OWNER_ROLES[rootSlug] ?? "—";
+  const subLabel = node.parentId === null ? "Capability Domains" : "Functional Groups";
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <nav className="flex flex-wrap items-center gap-1 text-xs text-[var(--dpf-muted)] mb-4">
+        <Link href="/portfolio" className="hover:text-white transition-colors">
+          Portfolio
+        </Link>
+        {breadcrumbs.map((bc) => (
+          <span key={bc.nodeId} className="flex items-center gap-1">
+            <span>›</span>
+            <Link
+              href={`/portfolio/${bc.nodeId}`}
+              className="hover:text-white transition-colors"
+            >
+              {bc.name}
+            </Link>
+          </span>
+        ))}
+      </nav>
+
+      {/* Title */}
+      <div className="flex items-baseline gap-3 mb-5">
+        <h1 className="text-xl font-bold text-white">{node.name}</h1>
+        <span className="text-sm" style={{ color: colour }}>
+          {node.totalCount} products
+        </span>
+      </div>
+
+      {/* Stats strip */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <StatBox label="Products" value={String(node.totalCount)} colour="#e2e2f0" />
+        <StatBox label="Owner" value={ownerRole} colour={colour} />
+        <StatBox label="Agents" value="—" colour="#555566" dashed />
+        <StatBox label="Health" value="—" colour="#555566" dashed />
+        <StatBox label="Investment" value="—" colour="#555566" dashed />
+      </div>
+
+      {/* Sub-nodes */}
+      {subNodes.length > 0 && (
+        <div className="mb-6">
+          <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest mb-2">
+            {subLabel}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {subNodes.map((child) => (
+              <Link
+                key={child.nodeId}
+                href={`/portfolio/${child.nodeId}`}
+                className="flex items-center justify-between p-3 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg hover:bg-[var(--dpf-surface-2)] transition-colors"
+              >
+                <span className="text-sm text-[#e2e2f0]">{child.name}</span>
+                {child.totalCount > 0 && (
+                  <span
+                    className="text-[9px] px-2 py-0.5 rounded-full"
+                    style={{ background: `${colour}20`, color: colour }}
+                  >
+                    {child.totalCount}
+                  </span>
+                )}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Products */}
+      {products.length > 0 && (
+        <ProductList products={products} colour={colour} />
+      )}
+
+      {/* Empty state */}
+      {subNodes.length === 0 && products.length === 0 && (
+        <p className="text-sm text-[var(--dpf-muted)]">
+          No products classified here yet.
+        </p>
+      )}
+
+      {/* People + Agents placeholders */}
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <PlaceholderPanel label="People" description="Human role assignments — coming soon" />
+        <PlaceholderPanel label="Agents" description="AI agent assignments — coming soon" />
+      </div>
+    </div>
+  );
+}
+
+function StatBox({
+  label,
+  value,
+  colour,
+  dashed = false,
+}: {
+  label: string;
+  value: string;
+  colour: string;
+  dashed?: boolean;
+}) {
+  return (
+    <div
+      className={`bg-[var(--dpf-surface-1)] rounded-lg px-4 py-2.5 text-center ${
+        dashed ? "border border-dashed border-[var(--dpf-border)] opacity-40" : "border border-[var(--dpf-border)]"
+      }`}
+    >
+      <p className="text-sm font-bold" style={{ color: colour }}>
+        {value}
+      </p>
+      <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function PlaceholderPanel({
+  label,
+  description,
+}: {
+  label: string;
+  description: string;
+}) {
+  return (
+    <div className="bg-[var(--dpf-surface-1)] border border-dashed border-[var(--dpf-border)] rounded-lg p-4 opacity-50">
+      <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest mb-1">
+        {label}
+      </p>
+      <p className="text-xs text-[var(--dpf-muted)]">{description}</p>
+    </div>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioOverview.tsx
+++ b/apps/web/components/portfolio/PortfolioOverview.tsx
@@ -1,0 +1,61 @@
+// apps/web/components/portfolio/PortfolioOverview.tsx
+import Link from "next/link";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PORTFOLIO_COLOURS, PORTFOLIO_OWNER_ROLES } from "@/lib/portfolio";
+
+type Props = { roots: PortfolioTreeNode[] };
+
+export function PortfolioOverview({ roots }: Props) {
+  const totalProducts = roots.reduce((sum, r) => sum + r.totalCount, 0);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-white">Portfolio</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          {roots.length} portfolios · {totalProducts} products
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {roots.map((root) => {
+          const colour = PORTFOLIO_COLOURS[root.nodeId] ?? "#7c8cf8";
+          const ownerRole = PORTFOLIO_OWNER_ROLES[root.nodeId] ?? "—";
+          return (
+            <Link
+              key={root.nodeId}
+              href={`/portfolio/${root.nodeId}`}
+              className="block p-5 rounded-lg bg-[var(--dpf-surface-1)] border-l-4 hover:bg-[var(--dpf-surface-2)] transition-colors"
+              style={{ borderLeftColor: colour }}
+            >
+              <h2 className="text-base font-semibold text-white mb-3">
+                {root.name}
+              </h2>
+              <div className="flex items-center gap-4">
+                <div>
+                  <p className="text-xl font-bold text-white">
+                    {root.totalCount}
+                  </p>
+                  <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-wider">
+                    Products
+                  </p>
+                </div>
+                <div>
+                  <p
+                    className="text-sm font-bold"
+                    style={{ color: colour }}
+                  >
+                    {ownerRole}
+                  </p>
+                  <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-wider">
+                    Owner
+                  </p>
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioTree.tsx
+++ b/apps/web/components/portfolio/PortfolioTree.tsx
@@ -1,0 +1,67 @@
+// apps/web/components/portfolio/PortfolioTree.tsx
+"use client";
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PortfolioTreeNodeItem } from "./PortfolioTreeNode";
+
+type Props = {
+  roots: PortfolioTreeNode[];
+};
+
+export function PortfolioTree({ roots }: Props) {
+  // Start collapsed; read ?open= from URL on mount to restore state
+  const [openIds, setOpenIds] = useState<Set<string>>(new Set<string>());
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const open = new URLSearchParams(window.location.search).get("open");
+    if (open) {
+      setOpenIds(new Set(open.split(",")));
+    }
+  }, []);
+
+  // Derive active nodeId from pathname: /portfolio/foundational/compute → "foundational/compute"
+  const activeNodeId = pathname.startsWith("/portfolio/")
+    ? pathname.slice("/portfolio/".length)
+    : null;
+
+  function toggle(nodeId: string) {
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      // Sync to URL without triggering a server re-render
+      const url = new URL(window.location.href);
+      if (next.size > 0) {
+        url.searchParams.set("open", [...next].join(","));
+      } else {
+        url.searchParams.delete("open");
+      }
+      window.history.replaceState(null, "", url.toString());
+      return next;
+    });
+  }
+
+  return (
+    <nav className="py-2" aria-label="Portfolio navigation">
+      {roots.map((root, i) => (
+        <div key={root.nodeId}>
+          {i > 0 && (
+            <div className="border-t border-[var(--dpf-border)] my-1.5 mx-3" />
+          )}
+          <PortfolioTreeNodeItem
+            node={root}
+            depth={0}
+            openIds={openIds}
+            activeNodeId={activeNodeId}
+            onToggle={toggle}
+          />
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioTreeNode.tsx
+++ b/apps/web/components/portfolio/PortfolioTreeNode.tsx
@@ -1,0 +1,98 @@
+// apps/web/components/portfolio/PortfolioTreeNode.tsx
+"use client";
+import Link from "next/link";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PORTFOLIO_COLOURS } from "@/lib/portfolio";
+
+// Left-padding per depth level (px)
+const DEPTH_PADDING = [12, 24, 36, 48] as const;
+
+type Props = {
+  node: PortfolioTreeNode;
+  depth: number;
+  openIds: Set<string>;
+  activeNodeId: string | null;
+  onToggle: (nodeId: string) => void;
+};
+
+export function PortfolioTreeNodeItem({
+  node,
+  depth,
+  openIds,
+  activeNodeId,
+  onToggle,
+}: Props) {
+  const isOpen = openIds.has(node.nodeId);
+  const isActive = activeNodeId === node.nodeId;
+  const hasChildren = node.children.length > 0;
+  const href = `/portfolio/${node.nodeId}`;
+
+  // Portfolio roots use their accent colour; deeper nodes inherit muted styling
+  const colour =
+    depth === 0 ? (PORTFOLIO_COLOURS[node.nodeId] ?? "#7c8cf8") : undefined;
+
+  const pl = `${DEPTH_PADDING[Math.min(depth, 3)] ?? 48}px`;
+
+  return (
+    <>
+      <div
+        className={`flex items-center pr-3 py-1 border-l-2 transition-colors ${
+          isActive
+            ? "bg-[var(--dpf-surface-1)]"
+            : "border-l-transparent hover:bg-[var(--dpf-surface-2)]"
+        }`}
+        style={{
+          paddingLeft: pl,
+          borderLeftColor: isActive ? (colour ?? "var(--dpf-accent)") : "transparent",
+        }}
+      >
+        {/* Expand/collapse chevron */}
+        <button
+          className="w-4 flex-shrink-0 text-[9px] text-[var(--dpf-muted)] hover:text-white mr-1"
+          onClick={() => hasChildren && onToggle(node.nodeId)}
+          aria-label={isOpen ? "Collapse" : "Expand"}
+          tabIndex={hasChildren ? 0 : -1}
+        >
+          {hasChildren ? (isOpen ? "▼" : "▶") : ""}
+        </button>
+
+        {/* Node name — navigates */}
+        <Link
+          href={href}
+          className="flex-1 min-w-0 flex items-center justify-between gap-1"
+        >
+          <span
+            className={`truncate ${depth === 0 ? "text-sm font-semibold" : "text-xs"}`}
+            style={{ color: isActive ? (colour ?? "#e2e2f0") : (colour ?? "#e2e2f0") }}
+          >
+            {node.name}
+          </span>
+          {node.totalCount > 0 && (
+            <span
+              className="text-[8px] px-1.5 py-0.5 rounded-full flex-shrink-0"
+              style={{
+                background: `${colour ?? "#7c8cf8"}20`,
+                color: colour ?? "#7c8cf8",
+              }}
+            >
+              {node.totalCount}
+            </span>
+          )}
+        </Link>
+      </div>
+
+      {/* Children (rendered when open) */}
+      {isOpen &&
+        node.children.map((child) => (
+          <PortfolioTreeNodeItem
+            key={child.nodeId}
+            node={child}
+            depth={depth + 1}
+            openIds={openIds}
+            activeNodeId={activeNodeId}
+            onToggle={onToggle}
+          />
+        ))}
+    </>
+  );
+}

--- a/apps/web/components/portfolio/ProductList.tsx
+++ b/apps/web/components/portfolio/ProductList.tsx
@@ -1,0 +1,52 @@
+// apps/web/components/portfolio/ProductList.tsx
+type Product = {
+  id: string;
+  productId: string;
+  name: string;
+  status: string;
+};
+
+type Props = {
+  products: Product[];
+  colour: string;
+  className?: string;
+};
+
+const STATUS_COLOURS: Record<string, string> = {
+  active:  "#4ade80",
+  review:  "#fb923c",
+  retired: "#555566",
+  idea:    "#a78bfa",
+};
+
+export function ProductList({ products, colour, className = "" }: Props) {
+  return (
+    <div className={className}>
+      <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest mb-2">
+        Digital Products &amp; Services
+      </p>
+      <div className="flex flex-col gap-2">
+        {products.map((product) => {
+          const statusColour = STATUS_COLOURS[product.status] ?? "#555566";
+          return (
+            <div
+              key={product.id}
+              className="bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg px-3 py-2.5"
+            >
+              <div className="flex items-center justify-between mb-0.5">
+                <span className="text-sm font-medium text-white">{product.name}</span>
+                <span
+                  className="text-[9px] px-1.5 py-0.5 rounded-full"
+                  style={{ background: `${statusColour}20`, color: statusColour }}
+                >
+                  {product.status}
+                </span>
+              </div>
+              <p className="text-[10px] text-[var(--dpf-muted)]">{product.productId}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/portfolio-data.ts
+++ b/apps/web/lib/portfolio-data.ts
@@ -1,0 +1,21 @@
+// apps/web/lib/portfolio-data.ts
+// Server-only: uses React cache() to deduplicate Prisma calls within one request.
+// Both layout.tsx and page.tsx call getPortfolioTree() — React deduplicates automatically.
+import { cache } from "react";
+import { prisma } from "@dpf/db";
+import { buildPortfolioTree } from "./portfolio";
+
+export const getPortfolioTree = cache(async () => {
+  const [nodes, counts] = await Promise.all([
+    prisma.taxonomyNode.findMany({
+      where: { status: "active" },
+      select: { id: true, nodeId: true, name: true, parentId: true, portfolioId: true },
+    }),
+    prisma.digitalProduct.groupBy({
+      by: ["taxonomyNodeId"],
+      _count: { id: true },
+      where: { status: "active" },
+    }),
+  ]);
+  return buildPortfolioTree(nodes, counts);
+});

--- a/apps/web/lib/portfolio.test.ts
+++ b/apps/web/lib/portfolio.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { buildPortfolioTree, resolveNodeFromSlug } from "./portfolio";
+import type { PortfolioTreeNode } from "./portfolio";
+
+// Minimal fixture: 2 portfolio roots, one with a 2-level subtree
+const NODES = [
+  { id: "root1", nodeId: "foundational",          name: "Foundational",      parentId: null,    portfolioId: "port1" },
+  { id: "l1a",   nodeId: "foundational/compute",   name: "Compute",           parentId: "root1", portfolioId: null },
+  { id: "l2a",   nodeId: "foundational/compute/physical-compute", name: "Physical Compute", parentId: "l1a", portfolioId: null },
+  { id: "l1b",   nodeId: "foundational/platform-services", name: "Platform Services", parentId: "root1", portfolioId: null },
+  { id: "root2", nodeId: "for_employees",          name: "For Employees",     parentId: null,    portfolioId: "port2" },
+];
+
+const COUNTS = [
+  { taxonomyNodeId: "root1", _count: { id: 2 } },
+  { taxonomyNodeId: "l1a",   _count: { id: 1 } },
+  { taxonomyNodeId: "l2a",   _count: { id: 1 } },
+];
+
+describe("buildPortfolioTree()", () => {
+  it("returns one root per portfolio root node", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    expect(roots).toHaveLength(2);
+  });
+
+  it("nests children under their parent", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const foundational = roots.find((r) => r.nodeId === "foundational")!;
+    expect(foundational.children).toHaveLength(2);
+    expect(foundational.children.map((c) => c.nodeId)).toContain("foundational/compute");
+    expect(foundational.children.map((c) => c.nodeId)).toContain("foundational/platform-services");
+  });
+
+  it("builds a 3-level subtree correctly", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const foundational = roots.find((r) => r.nodeId === "foundational")!;
+    const compute = foundational.children.find((c) => c.nodeId === "foundational/compute")!;
+    expect(compute.children).toHaveLength(1);
+    expect(compute.children[0]?.nodeId).toBe("foundational/compute/physical-compute");
+  });
+
+  it("sets directCount from counts array (matching on .id, not .nodeId)", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const foundational = roots.find((r) => r.nodeId === "foundational")!;
+    // root1 has 2 direct products
+    expect(foundational.directCount).toBe(2);
+  });
+
+  it("sets totalCount as sum of subtree directCounts", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const foundational = roots.find((r) => r.nodeId === "foundational")!;
+    // root1: 2 direct + l1a: 1 direct + l2a: 1 direct = 4 total
+    expect(foundational.totalCount).toBe(4);
+  });
+
+  it("nodes with no counts get directCount=0 and totalCount=0", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const forEmployees = roots.find((r) => r.nodeId === "for_employees")!;
+    expect(forEmployees.directCount).toBe(0);
+    expect(forEmployees.totalCount).toBe(0);
+  });
+});
+
+describe("resolveNodeFromSlug()", () => {
+  it("returns null for an empty slug array", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const result = resolveNodeFromSlug(roots, []);
+    expect(result).toBeNull();
+  });
+
+  it("finds a portfolio root by single slug segment", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const node = resolveNodeFromSlug(roots, ["foundational"]);
+    expect(node?.nodeId).toBe("foundational");
+  });
+
+  it("finds an L1 node by two slug segments", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const node = resolveNodeFromSlug(roots, ["foundational", "compute"]);
+    expect(node?.nodeId).toBe("foundational/compute");
+  });
+
+  it("finds an L2 node by three slug segments", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const node = resolveNodeFromSlug(roots, ["foundational", "compute", "physical-compute"]);
+    expect(node?.nodeId).toBe("foundational/compute/physical-compute");
+  });
+
+  it("returns null for a slug that doesn't exist", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS);
+    const result = resolveNodeFromSlug(roots, ["foundational", "nonexistent"]);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/lib/portfolio.test.ts
+++ b/apps/web/lib/portfolio.test.ts
@@ -6,8 +6,8 @@ import type { PortfolioTreeNode } from "./portfolio";
 const NODES = [
   { id: "root1", nodeId: "foundational",          name: "Foundational",      parentId: null,    portfolioId: "port1" },
   { id: "l1a",   nodeId: "foundational/compute",   name: "Compute",           parentId: "root1", portfolioId: null },
-  { id: "l2a",   nodeId: "foundational/compute/physical-compute", name: "Physical Compute", parentId: "l1a", portfolioId: null },
-  { id: "l1b",   nodeId: "foundational/platform-services", name: "Platform Services", parentId: "root1", portfolioId: null },
+  { id: "l2a",   nodeId: "foundational/compute/physical_compute", name: "Physical Compute", parentId: "l1a", portfolioId: null },
+  { id: "l1b",   nodeId: "foundational/platform_services", name: "Platform Services", parentId: "root1", portfolioId: null },
   { id: "root2", nodeId: "for_employees",          name: "For Employees",     parentId: null,    portfolioId: "port2" },
 ];
 
@@ -28,7 +28,7 @@ describe("buildPortfolioTree()", () => {
     const foundational = roots.find((r) => r.nodeId === "foundational")!;
     expect(foundational.children).toHaveLength(2);
     expect(foundational.children.map((c) => c.nodeId)).toContain("foundational/compute");
-    expect(foundational.children.map((c) => c.nodeId)).toContain("foundational/platform-services");
+    expect(foundational.children.map((c) => c.nodeId)).toContain("foundational/platform_services");
   });
 
   it("builds a 3-level subtree correctly", () => {
@@ -36,7 +36,7 @@ describe("buildPortfolioTree()", () => {
     const foundational = roots.find((r) => r.nodeId === "foundational")!;
     const compute = foundational.children.find((c) => c.nodeId === "foundational/compute")!;
     expect(compute.children).toHaveLength(1);
-    expect(compute.children[0]?.nodeId).toBe("foundational/compute/physical-compute");
+    expect(compute.children[0]?.nodeId).toBe("foundational/compute/physical_compute");
   });
 
   it("sets directCount from counts array (matching on .id, not .nodeId)", () => {
@@ -82,8 +82,8 @@ describe("resolveNodeFromSlug()", () => {
 
   it("finds an L2 node by three slug segments", () => {
     const roots = buildPortfolioTree(NODES, COUNTS);
-    const node = resolveNodeFromSlug(roots, ["foundational", "compute", "physical-compute"]);
-    expect(node?.nodeId).toBe("foundational/compute/physical-compute");
+    const node = resolveNodeFromSlug(roots, ["foundational", "compute", "physical_compute"]);
+    expect(node?.nodeId).toBe("foundational/compute/physical_compute");
   });
 
   it("returns null for a slug that doesn't exist", () => {

--- a/apps/web/lib/portfolio.ts
+++ b/apps/web/lib/portfolio.ts
@@ -1,0 +1,136 @@
+// apps/web/lib/portfolio.ts
+// Pure utility library — no server imports, safe to import in tests and client components.
+
+export type PortfolioTreeNode = {
+  id: string;
+  nodeId: string;
+  name: string;
+  parentId: string | null;
+  portfolioId: string | null;
+  directCount: number;
+  totalCount: number;
+  children: PortfolioTreeNode[];
+};
+
+/** Portfolio root accent colours (keyed by nodeId). */
+export const PORTFOLIO_COLOURS: Record<string, string> = {
+  foundational: "#7c8cf8",
+  manufacturing_and_delivery: "#fb923c",
+  for_employees: "#a78bfa",
+  products_and_services_sold: "#f472b6",
+};
+
+/** Portfolio owner HR role codes (keyed by nodeId). */
+export const PORTFOLIO_OWNER_ROLES: Record<string, string> = {
+  foundational: "HR-300",
+  manufacturing_and_delivery: "HR-500",
+  for_employees: "HR-200",
+  products_and_services_sold: "HR-100",
+};
+
+type RawNode = {
+  id: string;
+  nodeId: string;
+  name: string;
+  parentId: string | null;
+  portfolioId: string | null | undefined;
+};
+
+type CountRow = {
+  taxonomyNodeId: string | null;
+  _count: { id: number };
+};
+
+/** Build a tree from flat node rows + product count rows. */
+export function buildPortfolioTree(
+  nodes: RawNode[],
+  counts: CountRow[]
+): PortfolioTreeNode[] {
+  // Build count lookup keyed by node.id (cuid PK)
+  const countById = new Map<string, number>();
+  for (const c of counts) {
+    if (c.taxonomyNodeId) countById.set(c.taxonomyNodeId, c._count.id);
+  }
+
+  // Build a map of id → node (with empty children array)
+  const nodeMap = new Map<string, PortfolioTreeNode>();
+  for (const n of nodes) {
+    nodeMap.set(n.id, {
+      id: n.id,
+      nodeId: n.nodeId,
+      name: n.name,
+      parentId: n.parentId,
+      portfolioId: n.portfolioId ?? null,
+      directCount: countById.get(n.id) ?? 0,
+      totalCount: 0,
+      children: [],
+    });
+  }
+
+  // Wire up parent → children
+  const roots: PortfolioTreeNode[] = [];
+  for (const node of nodeMap.values()) {
+    if (node.parentId === null) {
+      roots.push(node);
+    } else {
+      const parent = nodeMap.get(node.parentId);
+      if (parent) parent.children.push(node);
+    }
+  }
+
+  // Compute totalCount bottom-up via DFS
+  function sumSubtree(node: PortfolioTreeNode): number {
+    const childSum = node.children.reduce((acc, c) => acc + sumSubtree(c), 0);
+    node.totalCount = node.directCount + childSum;
+    return node.totalCount;
+  }
+  for (const root of roots) sumSubtree(root);
+
+  return roots;
+}
+
+/** Walk the tree to find the node matching a slug path. */
+export function resolveNodeFromSlug(
+  roots: PortfolioTreeNode[],
+  slugs: string[]
+): PortfolioTreeNode | null {
+  if (slugs.length === 0) return null;
+
+  let current: PortfolioTreeNode | undefined = roots.find(
+    (r) => r.nodeId === slugs[0]
+  );
+  if (!current) return null;
+
+  for (let i = 1; i < slugs.length; i++) {
+    const targetNodeId = slugs.slice(0, i + 1).join("/");
+    current = current.children.find((c) => c.nodeId === targetNodeId);
+    if (!current) return null;
+  }
+
+  return current;
+}
+
+/** Return all node .id (cuid PK) values in a subtree, including roots. */
+export function getSubtreeIds(nodes: PortfolioTreeNode[]): string[] {
+  return nodes.flatMap((n) => [n.id, ...getSubtreeIds(n.children)]);
+}
+
+/** Build breadcrumb array of ancestors (excludes the current/selected node). */
+export function buildBreadcrumbs(
+  roots: PortfolioTreeNode[],
+  slugs: string[]
+): Array<{ nodeId: string; name: string }> {
+  const breadcrumbs: Array<{ nodeId: string; name: string }> = [];
+  let current: PortfolioTreeNode | undefined;
+  // Stop before the last slug — the current node is rendered as the <h1>, not in the trail
+  for (let i = 0; i < slugs.length - 1; i++) {
+    const targetNodeId = slugs.slice(0, i + 1).join("/");
+    if (i === 0) {
+      current = roots.find((r) => r.nodeId === slugs[0]);
+    } else {
+      current = current?.children.find((c) => c.nodeId === targetNodeId);
+    }
+    if (current) breadcrumbs.push({ nodeId: current.nodeId, name: current.name });
+  }
+  return breadcrumbs;
+}

--- a/docs/superpowers/plans/2026-03-10-portfolio-route.md
+++ b/docs/superpowers/plans/2026-03-10-portfolio-route.md
@@ -1,0 +1,1363 @@
+# Portfolio Route Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `/portfolio` route — a master/detail portfolio browser with a full 4-level taxonomy tree sidebar and server-rendered right panel, backed by PostgreSQL via Prisma.
+
+**Architecture:** Catch-all optional route `[[...slug]]` under `app/(shell)/portfolio/`. A server-component layout loads the full taxonomy tree once per request (deduplicated via React `cache()`). A thin client component manages expand/collapse state, syncing to `?open=` via `window.history.replaceState`. The right panel is a server component that queries product detail for the selected node.
+
+**Tech Stack:** Next.js 14 App Router, Prisma 5, TypeScript strict mode (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`), Tailwind CSS, Auth.js v5, Vitest.
+
+---
+
+## Chunk 1: Data Layer
+
+### Task 1: Schema Migration
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: migration via `pnpm db:migrate`
+
+- [ ] **Step 1.1: Add `taxonomyNodeId` to `DigitalProduct` and the back-relation to `TaxonomyNode`**
+
+Open `packages/db/prisma/schema.prisma`. Find the `DigitalProduct` model (around line 68) and add two lines. Find `TaxonomyNode` (around line 81) and add one line:
+
+```prisma
+model DigitalProduct {
+  id             String        @id @default(cuid())
+  productId      String        @unique
+  name           String
+  status         String        @default("active")
+  portfolioId    String?
+  portfolio      Portfolio?    @relation(fields: [portfolioId], references: [id])
+  taxonomyNodeId String?                                                        // ADD
+  taxonomyNode   TaxonomyNode? @relation(fields: [taxonomyNodeId], references: [id])  // ADD
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+}
+
+model TaxonomyNode {
+  id          String         @id @default(cuid())
+  nodeId      String         @unique
+  name        String
+  portfolioId String?
+  parentId    String?
+  parent      TaxonomyNode?  @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children    TaxonomyNode[] @relation("TaxonomyTree")
+  products    DigitalProduct[]                                                  // ADD
+  status      String         @default("active")
+  governance  Json?
+}
+```
+
+- [ ] **Step 1.2: Generate and run the migration**
+
+```bash
+pnpm db:migrate
+```
+
+When prompted for a migration name, enter: `add_taxonomy_node_to_digital_product`
+
+Expected output:
+```
+Your database is now in sync with your schema.
+```
+
+- [ ] **Step 1.3: Regenerate the Prisma client**
+
+```bash
+pnpm db:generate
+```
+
+Expected: no errors, updated client in `node_modules/.prisma/client/`.
+
+- [ ] **Step 1.4: Verify typecheck passes**
+
+```bash
+pnpm typecheck
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations/
+git commit -m "feat: add taxonomyNodeId to DigitalProduct for taxonomy tree placement"
+```
+
+---
+
+### Task 2: Portfolio Utility Library (TDD)
+
+**Files:**
+- Create: `apps/web/lib/portfolio.ts`
+- Create: `apps/web/lib/portfolio.test.ts`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `apps/web/lib/portfolio.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildPortfolioTree, resolveNodeFromSlug } from "./portfolio";
+import type { PortfolioTreeNode } from "./portfolio";
+
+// Minimal fixture: 2 portfolio roots, one with a 2-level subtree
+const NODES = [
+  { id: "root1", nodeId: "foundational",          name: "Foundational",      parentId: null,    portfolioId: "port1" },
+  { id: "l1a",   nodeId: "foundational/compute",   name: "Compute",           parentId: "root1", portfolioId: null },
+  { id: "l2a",   nodeId: "foundational/compute/physical-compute", name: "Physical Compute", parentId: "l1a", portfolioId: null },
+  { id: "l1b",   nodeId: "foundational/platform-services", name: "Platform Services", parentId: "root1", portfolioId: null },
+  { id: "root2", nodeId: "for_employees",          name: "For Employees",     parentId: null,    portfolioId: "port2" },
+];
+
+const COUNTS = [
+  { taxonomyNodeId: "l2a",  _count: { id: 3 } },
+  { taxonomyNodeId: "l1b",  _count: { id: 2 } },
+  { taxonomyNodeId: null,   _count: { id: 1 } }, // unclassified — must be ignored
+];
+
+describe("buildPortfolioTree()", () => {
+  it("returns one root node per portfolio", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    expect(tree).toHaveLength(2);
+  });
+
+  it("wires parent-child relationships correctly", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    const foundational = tree.find((n) => n.nodeId === "foundational")!;
+    expect(foundational.children).toHaveLength(2);
+    const compute = foundational.children.find((n) => n.nodeId === "foundational/compute")!;
+    expect(compute.children).toHaveLength(1);
+    expect(compute.children[0]!.nodeId).toBe("foundational/compute/physical-compute");
+  });
+
+  it("assigns direct product counts to leaf nodes", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    const foundational = tree.find((n) => n.nodeId === "foundational")!;
+    const l1b = foundational.children.find((n) => n.nodeId === "foundational/platform-services")!;
+    expect(l1b.directCount).toBe(2);
+  });
+
+  it("rolls product counts up to parent nodes", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    const foundational = tree.find((n) => n.nodeId === "foundational")!;
+    const compute = foundational.children.find((n) => n.nodeId === "foundational/compute")!;
+    expect(compute.directCount).toBe(0);
+    expect(compute.totalCount).toBe(3); // 0 direct + 3 from l2a
+    expect(foundational.totalCount).toBe(5); // 3 (compute subtree) + 2 (l1b)
+  });
+
+  it("nodes with no products get totalCount 0", () => {
+    const tree = buildPortfolioTree(NODES, []);
+    const foundational = tree.find((n) => n.nodeId === "foundational")!;
+    expect(foundational.totalCount).toBe(0);
+    expect(tree.find((n) => n.nodeId === "for_employees")!.totalCount).toBe(0);
+  });
+
+  it("ignores count rows with null taxonomyNodeId", () => {
+    // The fixture COUNTS includes a null-key row; total should still be 5
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    const foundational = tree.find((n) => n.nodeId === "foundational")!;
+    expect(foundational.totalCount).toBe(5);
+  });
+});
+
+describe("resolveNodeFromSlug()", () => {
+  it("resolves a portfolio root from a single-element slug array", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    const node = resolveNodeFromSlug(tree, ["foundational"]);
+    expect(node?.nodeId).toBe("foundational");
+  });
+
+  it("resolves a deep path across multiple slug segments", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    const node = resolveNodeFromSlug(tree, ["foundational", "compute", "physical-compute"]);
+    expect(node?.nodeId).toBe("foundational/compute/physical-compute");
+  });
+
+  it("returns null for an unknown portfolio slug", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    expect(resolveNodeFromSlug(tree, ["unknown"])).toBeNull();
+  });
+
+  it("returns null for a valid root but unknown child slug", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    expect(resolveNodeFromSlug(tree, ["foundational", "unknown-domain"])).toBeNull();
+  });
+
+  it("returns null for an empty slug array", () => {
+    const tree = buildPortfolioTree(NODES, COUNTS);
+    expect(resolveNodeFromSlug(tree, [])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the tests to confirm they fail**
+
+```bash
+cd apps/web && pnpm test -- lib/portfolio.test.ts
+```
+
+Expected: FAIL — `Cannot find module './portfolio'`
+
+- [ ] **Step 2.3: Implement `apps/web/lib/portfolio.ts`**
+
+```ts
+// apps/web/lib/portfolio.ts
+
+export type PortfolioTreeNode = {
+  id: string;
+  nodeId: string;        // globally unique path slug: "foundational" | "foundational/compute" | …
+  name: string;
+  parentId: string | null;
+  portfolioId: string | null;
+  directCount: number;   // products directly placed at this node
+  totalCount: number;    // products in this node + all descendants
+  children: PortfolioTreeNode[];
+};
+
+// Static maps — avoid DB queries for stable metadata
+export const PORTFOLIO_COLOURS: Record<string, string> = {
+  foundational:              "#7c8cf8",
+  manufacturing_and_delivery: "#fb923c",
+  for_employees:             "#a78bfa",
+  products_and_services_sold: "#f472b6",
+};
+
+export const PORTFOLIO_OWNER_ROLES: Record<string, string> = {
+  foundational:              "HR-300",
+  manufacturing_and_delivery: "HR-500",
+  for_employees:             "HR-200",
+  products_and_services_sold: "HR-100",
+};
+
+type RawNode = {
+  id: string;
+  nodeId: string;
+  name: string;
+  parentId: string | null;
+  portfolioId: string | null;
+};
+
+type CountRow = {
+  taxonomyNodeId: string | null;
+  _count: { id: number };
+};
+
+export function buildPortfolioTree(
+  nodes: RawNode[],
+  counts: CountRow[]
+): PortfolioTreeNode[] {
+  // Build direct-count lookup: TaxonomyNode.id (cuid) → product count
+  const countMap = new Map<string, number>();
+  for (const c of counts) {
+    if (c.taxonomyNodeId !== null) {
+      countMap.set(c.taxonomyNodeId, c._count.id);
+    }
+  }
+
+  // Initialise tree nodes
+  const nodeMap = new Map<string, PortfolioTreeNode>();
+  for (const n of nodes) {
+    nodeMap.set(n.id, {
+      id: n.id,
+      nodeId: n.nodeId,
+      name: n.name,
+      parentId: n.parentId,
+      portfolioId: n.portfolioId,
+      directCount: countMap.get(n.id) ?? 0,
+      totalCount: 0,
+      children: [],
+    });
+  }
+
+  // Wire parent → child and collect roots
+  const roots: PortfolioTreeNode[] = [];
+  for (const node of nodeMap.values()) {
+    if (node.parentId === null) {
+      roots.push(node);
+    } else {
+      const parent = nodeMap.get(node.parentId);
+      if (parent) parent.children.push(node);
+    }
+  }
+
+  // Roll counts upward (post-order DFS)
+  function rollUp(node: PortfolioTreeNode): number {
+    let total = node.directCount;
+    for (const child of node.children) {
+      total += rollUp(child);
+    }
+    node.totalCount = total;
+    return total;
+  }
+  for (const root of roots) rollUp(root);
+
+  return roots;
+}
+
+/**
+ * Resolve a URL slug array to the matching tree node.
+ * Slugs are URL segments: ["foundational", "compute", "physical-compute"]
+ * nodeId is the slash-joined path: "foundational/compute/physical-compute"
+ */
+export function resolveNodeFromSlug(
+  roots: PortfolioTreeNode[],
+  slugs: string[]
+): PortfolioTreeNode | null {
+  if (slugs.length === 0) return null;
+
+  let current: PortfolioTreeNode | undefined = roots.find(
+    (r) => r.nodeId === slugs[0]
+  );
+  if (!current) return null;
+
+  for (let i = 1; i < slugs.length; i++) {
+    const targetNodeId = slugs.slice(0, i + 1).join("/");
+    current = current.children.find((c) => c.nodeId === targetNodeId);
+    if (!current) return null;
+  }
+
+  return current;
+}
+
+/** Collect the cuid IDs of a node and all its descendants (for product queries). */
+export function getSubtreeIds(nodes: PortfolioTreeNode[]): string[] {
+  return nodes.flatMap((n) => [n.id, ...getSubtreeIds(n.children)]);
+}
+
+/** Build breadcrumb array of ancestors (excludes the current/selected node). */
+export function buildBreadcrumbs(
+  roots: PortfolioTreeNode[],
+  slugs: string[]
+): Array<{ nodeId: string; name: string }> {
+  const breadcrumbs: Array<{ nodeId: string; name: string }> = [];
+  let current: PortfolioTreeNode | undefined;
+  // Stop before the last slug — the current node is rendered as the <h1>, not in the trail
+  for (let i = 0; i < slugs.length - 1; i++) {
+    const targetNodeId = slugs.slice(0, i + 1).join("/");
+    if (i === 0) {
+      current = roots.find((r) => r.nodeId === slugs[0]);
+    } else {
+      current = current?.children.find((c) => c.nodeId === targetNodeId);
+    }
+    if (current) breadcrumbs.push({ nodeId: current.nodeId, name: current.name });
+  }
+  return breadcrumbs;
+}
+```
+
+- [ ] **Step 2.4: Run the tests — all must pass**
+
+```bash
+cd apps/web && pnpm test -- lib/portfolio.test.ts
+```
+
+Expected:
+```
+✓ lib/portfolio.test.ts (11)
+  ✓ buildPortfolioTree() (6)
+  ✓ resolveNodeFromSlug() (5)
+11 tests passed
+```
+
+- [ ] **Step 2.5: Run full typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add apps/web/lib/portfolio.ts apps/web/lib/portfolio.test.ts
+git commit -m "feat: add portfolio tree builder and slug resolver utilities"
+```
+
+---
+
+### Task 3: Taxonomy Data and Seeding
+
+**Files:**
+- Create: `packages/db/data/taxonomy_v2.json` (generated from old project CSV)
+- Create: `packages/db/scripts/generate-taxonomy-json.ts` (one-time generator)
+- Modify: `packages/db/src/seed.ts`
+
+- [ ] **Step 3.1: Create the taxonomy data directory**
+
+```bash
+mkdir -p packages/db/data
+mkdir -p packages/db/scripts
+```
+
+- [ ] **Step 3.2: Create the JSON generator script**
+
+Create `packages/db/scripts/generate-taxonomy-json.ts`:
+
+```ts
+// One-time script: reads taxonomy_v2.csv from the old project and writes
+// packages/db/data/taxonomy_v2.json for use by seed.ts.
+// Run: npx tsx packages/db/scripts/generate-taxonomy-json.ts
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const CSV_PATH = "D:/digital-product-factory/PORTFOLIOS/taxonomy_v2.csv";
+
+function parseQuotedCsv(content: string): Array<Record<string, string>> {
+  const lines = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const nonEmpty = lines.filter((l) => l.trim().length > 0);
+  if (nonEmpty.length === 0) return [];
+  const [headerLine, ...dataLines] = nonEmpty as [string, ...string[]];
+  const headers = parseCsvLine(headerLine);
+
+  return dataLines.map((line) => {
+    const values = parseCsvLine(line);
+    return Object.fromEntries(
+      headers.map((h, i) => [h.trim(), (values[i] ?? "").trim()])
+    ) as Record<string, string>;
+  });
+}
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]!;
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+const content = readFileSync(CSV_PATH, "utf-8");
+const rows = parseQuotedCsv(content);
+
+const out = rows.map((r) => ({
+  portfolio_id: r["portfolio_id"] ?? "",
+  level_1: r["level_1"] ?? "",
+  level_2: r["level_2"] ?? "",
+  level_3: r["level_3"] ?? "",
+}));
+
+const outPath = join(__dirname, "..", "data", "taxonomy_v2.json");
+writeFileSync(outPath, JSON.stringify(out, null, 2), "utf-8");
+console.log(`Wrote ${out.length} rows to ${outPath}`);
+```
+
+- [ ] **Step 3.3: Run the generator to produce the JSON**
+
+```bash
+npx tsx packages/db/scripts/generate-taxonomy-json.ts
+```
+
+Expected:
+```
+Wrote 378 rows to …/packages/db/data/taxonomy_v2.json
+```
+
+If the old project is not available at `D:/digital-product-factory/`, create an empty file instead and the seed will skip taxonomy seeding gracefully:
+
+```bash
+echo "[]" > packages/db/data/taxonomy_v2.json
+```
+
+- [ ] **Step 3.4: Add `seedTaxonomyNodes()` to `packages/db/src/seed.ts`**
+
+Add the helper function `toSlug` and `seedTaxonomyNodes` before the `main()` function. Also add `seedTaxonomyNodes()` call inside `main()`.
+
+Add `import { join } from "path"` if not already present (it is already in scope via existing `REPO_ROOT`).
+
+Insert after line 135 (after `seedDigitalProducts`), before `seedDefaultAdminUser`:
+
+```ts
+function toSlug(s: string): string {
+  return s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+async function seedTaxonomyNodes(): Promise<void> {
+  const dataPath = join(__dirname, "..", "data", "taxonomy_v2.json");
+  type TaxRow = { portfolio_id: string; level_1: string; level_2: string; level_3: string };
+  let rows: TaxRow[];
+  try {
+    rows = JSON.parse(readFileSync(dataPath, "utf-8")) as TaxRow[];
+  } catch {
+    console.log("taxonomy_v2.json not found — skipping taxonomy seeding");
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log("taxonomy_v2.json is empty — skipping taxonomy seeding");
+    return;
+  }
+
+  // Get all portfolios (must be seeded first)
+  const portfolios = await prisma.portfolio.findMany({ select: { id: true, slug: true, name: true } });
+  const portfolioMap = new Map(portfolios.map((p) => [p.slug, p]));
+
+  // nodeId (slug path) → TaxonomyNode.id (cuid)
+  const nodeIdMap = new Map<string, string>();
+
+  // 1. Portfolio root nodes
+  for (const p of portfolios) {
+    const node = await prisma.taxonomyNode.upsert({
+      where: { nodeId: p.slug },
+      update: { name: p.name, portfolioId: p.id, parentId: null },
+      create: { nodeId: p.slug, name: p.name, portfolioId: p.id, parentId: null, status: "active" },
+    });
+    nodeIdMap.set(p.slug, node.id);
+  }
+
+  // 2. L1 capability domains
+  const l1Seen = new Set<string>();
+  for (const row of rows) {
+    if (!row.level_1) continue;
+    const l1NodeId = `${row.portfolio_id}/${toSlug(row.level_1)}`;
+    if (l1Seen.has(l1NodeId)) continue;
+    l1Seen.add(l1NodeId);
+    const parentId = nodeIdMap.get(row.portfolio_id);
+    if (!parentId) continue;
+    const node = await prisma.taxonomyNode.upsert({
+      where: { nodeId: l1NodeId },
+      update: { name: row.level_1, parentId },
+      create: { nodeId: l1NodeId, name: row.level_1, parentId, portfolioId: null, status: "active" },
+    });
+    nodeIdMap.set(l1NodeId, node.id);
+  }
+
+  // 3. L2 functional groups
+  const l2Seen = new Set<string>();
+  for (const row of rows) {
+    if (!row.level_1 || !row.level_2) continue;
+    const l1NodeId = `${row.portfolio_id}/${toSlug(row.level_1)}`;
+    const l2NodeId = `${l1NodeId}/${toSlug(row.level_2)}`;
+    if (l2Seen.has(l2NodeId)) continue;
+    l2Seen.add(l2NodeId);
+    const parentId = nodeIdMap.get(l1NodeId);
+    if (!parentId) continue;
+    const node = await prisma.taxonomyNode.upsert({
+      where: { nodeId: l2NodeId },
+      update: { name: row.level_2, parentId },
+      create: { nodeId: l2NodeId, name: row.level_2, parentId, portfolioId: null, status: "active" },
+    });
+    nodeIdMap.set(l2NodeId, node.id);
+  }
+
+  // 4. L3 specialisations (sparse)
+  const l3Seen = new Set<string>();
+  for (const row of rows) {
+    if (!row.level_1 || !row.level_2 || !row.level_3) continue;
+    const l2NodeId = `${row.portfolio_id}/${toSlug(row.level_1)}/${toSlug(row.level_2)}`;
+    const l3NodeId = `${l2NodeId}/${toSlug(row.level_3)}`;
+    if (l3Seen.has(l3NodeId)) continue;
+    l3Seen.add(l3NodeId);
+    const parentId = nodeIdMap.get(l2NodeId);
+    if (!parentId) continue;
+    await prisma.taxonomyNode.upsert({
+      where: { nodeId: l3NodeId },
+      update: { name: row.level_3, parentId },
+      create: { nodeId: l3NodeId, name: row.level_3, parentId, portfolioId: null, status: "active" },
+    });
+  }
+
+  console.log(`Seeded ${nodeIdMap.size} taxonomy nodes`);
+}
+```
+
+Update `main()` to call `seedTaxonomyNodes()` after `seedPortfolios()` (portfolios must exist before taxonomy roots):
+
+```ts
+async function main(): Promise<void> {
+  console.log("Starting seed...");
+  await seedRoles();
+  await seedAgents();
+  await seedPortfolios();
+  await seedTaxonomyNodes();   // ADD — must come after seedPortfolios
+  await seedDigitalProducts();
+  await seedDefaultAdminUser();
+  console.log("Seed complete.");
+}
+```
+
+- [ ] **Step 3.5: Run the seed**
+
+```bash
+pnpm db:seed
+```
+
+Expected (with taxonomy data):
+```
+Starting seed...
+Seeded 6 platform roles
+Seeded 40 agents
+Seeded 4 portfolios
+Seeded 383 taxonomy nodes
+Seeded N digital products
+...
+Seed complete.
+```
+
+- [ ] **Step 3.6: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add packages/db/src/seed.ts packages/db/data/ packages/db/scripts/
+git commit -m "feat: seed 4-level portfolio taxonomy tree from taxonomy_v2.json"
+```
+
+---
+
+## Chunk 2: UI Layer
+
+### Task 4: Cached Tree Data Helper
+
+**Files:**
+- Create: `apps/web/lib/portfolio-data.ts`
+
+- [ ] **Step 4.1: Create the server-side cached tree loader**
+
+Create `apps/web/lib/portfolio-data.ts`:
+
+```ts
+// apps/web/lib/portfolio-data.ts
+// Server-only: uses React cache() to deduplicate Prisma calls within one request.
+// Both layout.tsx and page.tsx call getPortfolioTree() — React deduplicates automatically.
+import { cache } from "react";
+import { prisma } from "@dpf/db";
+import { buildPortfolioTree } from "./portfolio";
+
+export const getPortfolioTree = cache(async () => {
+  const [nodes, counts] = await Promise.all([
+    prisma.taxonomyNode.findMany({
+      where: { status: "active" },
+      select: { id: true, nodeId: true, name: true, parentId: true, portfolioId: true },
+    }),
+    prisma.digitalProduct.groupBy({
+      by: ["taxonomyNodeId"],
+      _count: { id: true },
+      where: { status: "active" },
+    }),
+  ]);
+  return buildPortfolioTree(nodes, counts);
+});
+```
+
+- [ ] **Step 4.2: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: `0 errors`.
+
+---
+
+### Task 5: Portfolio Layout
+
+**Files:**
+- Create: `apps/web/app/(shell)/portfolio/layout.tsx`
+
+- [ ] **Step 5.1: Create the portfolio layout**
+
+Create `apps/web/app/(shell)/portfolio/layout.tsx`:
+
+```tsx
+// apps/web/app/(shell)/portfolio/layout.tsx
+import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getPortfolioTree } from "@/lib/portfolio-data";
+import { PortfolioTree } from "@/components/portfolio/PortfolioTree";
+
+export default async function PortfolioLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_portfolio"
+    )
+  ) {
+    notFound();
+  }
+
+  const roots = await getPortfolioTree();
+
+  // Layout cannot access searchParams — PortfolioTree reads ?open= from window.location
+  // client-side on mount (brief collapse flash is acceptable).
+  return (
+    <div className="flex gap-0 -m-6 h-[calc(100vh-57px)] overflow-hidden">
+      {/* Sidebar */}
+      <div className="w-56 flex-shrink-0 border-r border-[var(--dpf-border)] overflow-y-auto bg-[var(--dpf-bg)]">
+        <PortfolioTree roots={roots} />
+      </div>
+      {/* Content panel */}
+      <div className="flex-1 overflow-y-auto p-6">{children}</div>
+    </div>
+  );
+}
+```
+
+Note: `57px` is the header height (matches the `<Header>` component in the shell layout). Adjust if the header height differs.
+
+- [ ] **Step 5.2: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: compile errors for missing `PortfolioTree` component — that's expected. Proceed to Task 6.
+
+---
+
+### Task 6: PortfolioTree and PortfolioTreeNode Components
+
+**Files:**
+- Create: `apps/web/components/portfolio/PortfolioTree.tsx`
+- Create: `apps/web/components/portfolio/PortfolioTreeNode.tsx`
+
+- [ ] **Step 6.1: Create `PortfolioTreeNode.tsx`**
+
+Create `apps/web/components/portfolio/PortfolioTreeNode.tsx`:
+
+```tsx
+// apps/web/components/portfolio/PortfolioTreeNode.tsx
+"use client";
+import Link from "next/link";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PORTFOLIO_COLOURS } from "@/lib/portfolio";
+
+// Left-padding per depth level (px)
+const DEPTH_PADDING = [12, 24, 36, 48] as const;
+
+type Props = {
+  node: PortfolioTreeNode;
+  depth: number;
+  openIds: Set<string>;
+  activeNodeId: string | null;
+  onToggle: (nodeId: string) => void;
+};
+
+export function PortfolioTreeNodeItem({
+  node,
+  depth,
+  openIds,
+  activeNodeId,
+  onToggle,
+}: Props) {
+  const isOpen = openIds.has(node.nodeId);
+  const isActive = activeNodeId === node.nodeId;
+  const hasChildren = node.children.length > 0;
+  const href = `/portfolio/${node.nodeId}`;
+
+  // Portfolio roots use their accent colour; deeper nodes inherit muted styling
+  const colour =
+    depth === 0 ? (PORTFOLIO_COLOURS[node.nodeId] ?? "#7c8cf8") : undefined;
+
+  const pl = `${DEPTH_PADDING[Math.min(depth, 3)] ?? 48}px`;
+
+  return (
+    <>
+      <div
+        className={`flex items-center pr-3 py-1 border-l-2 transition-colors ${
+          isActive
+            ? "bg-[var(--dpf-surface-1)]"
+            : "border-l-transparent hover:bg-[var(--dpf-surface-2)]"
+        }`}
+        style={{
+          paddingLeft: pl,
+          borderLeftColor: isActive ? (colour ?? "var(--dpf-accent)") : "transparent",
+        }}
+      >
+        {/* Expand/collapse chevron */}
+        <button
+          className="w-4 flex-shrink-0 text-[9px] text-[var(--dpf-muted)] hover:text-white mr-1"
+          onClick={() => hasChildren && onToggle(node.nodeId)}
+          aria-label={isOpen ? "Collapse" : "Expand"}
+          tabIndex={hasChildren ? 0 : -1}
+        >
+          {hasChildren ? (isOpen ? "▼" : "▶") : ""}
+        </button>
+
+        {/* Node name — navigates */}
+        <Link
+          href={href}
+          className="flex-1 min-w-0 flex items-center justify-between gap-1"
+        >
+          <span
+            className={`truncate ${depth === 0 ? "text-sm font-semibold" : "text-xs"}`}
+            style={{ color: isActive ? (colour ?? "#e2e2f0") : (colour ?? "#e2e2f0") }}
+          >
+            {node.name}
+          </span>
+          {node.totalCount > 0 && (
+            <span
+              className="text-[8px] px-1.5 py-0.5 rounded-full flex-shrink-0"
+              style={{
+                background: `${colour ?? "#7c8cf8"}20`,
+                color: colour ?? "#7c8cf8",
+              }}
+            >
+              {node.totalCount}
+            </span>
+          )}
+        </Link>
+      </div>
+
+      {/* Children (rendered when open) */}
+      {isOpen &&
+        node.children.map((child) => (
+          <PortfolioTreeNodeItem
+            key={child.nodeId}
+            node={child}
+            depth={depth + 1}
+            openIds={openIds}
+            activeNodeId={activeNodeId}
+            onToggle={onToggle}
+          />
+        ))}
+    </>
+  );
+}
+```
+
+- [ ] **Step 6.2: Create `PortfolioTree.tsx`**
+
+Create `apps/web/components/portfolio/PortfolioTree.tsx`:
+
+```tsx
+// apps/web/components/portfolio/PortfolioTree.tsx
+"use client";
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PortfolioTreeNodeItem } from "./PortfolioTreeNode";
+
+type Props = {
+  roots: PortfolioTreeNode[];
+};
+
+export function PortfolioTree({ roots }: Props) {
+  // Start collapsed; read ?open= from URL on mount to restore state
+  const [openIds, setOpenIds] = useState<Set<string>>(new Set<string>());
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const open = new URLSearchParams(window.location.search).get("open");
+    if (open) {
+      setOpenIds(new Set(open.split(",")));
+    }
+  }, []);
+
+  // Derive active nodeId from pathname: /portfolio/foundational/compute → "foundational/compute"
+  const activeNodeId = pathname.startsWith("/portfolio/")
+    ? pathname.slice("/portfolio/".length)
+    : null;
+
+  function toggle(nodeId: string) {
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      // Sync to URL without triggering a server re-render
+      const url = new URL(window.location.href);
+      if (next.size > 0) {
+        url.searchParams.set("open", [...next].join(","));
+      } else {
+        url.searchParams.delete("open");
+      }
+      window.history.replaceState(null, "", url.toString());
+      return next;
+    });
+  }
+
+  return (
+    <nav className="py-2" aria-label="Portfolio navigation">
+      {roots.map((root, i) => (
+        <div key={root.nodeId}>
+          {i > 0 && (
+            <div className="border-t border-[var(--dpf-border)] my-1.5 mx-3" />
+          )}
+          <PortfolioTreeNodeItem
+            node={root}
+            depth={0}
+            openIds={openIds}
+            activeNodeId={activeNodeId}
+            onToggle={toggle}
+          />
+        </div>
+      ))}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 6.3: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: errors for missing right-panel components — proceed.
+
+---
+
+### Task 7: Right Panel Components
+
+**Files:**
+- Create: `apps/web/components/portfolio/ProductList.tsx`
+- Create: `apps/web/components/portfolio/PortfolioNodeDetail.tsx`
+- Create: `apps/web/components/portfolio/PortfolioOverview.tsx`
+
+- [ ] **Step 7.1: Create `ProductList.tsx`**
+
+Create `apps/web/components/portfolio/ProductList.tsx`:
+
+```tsx
+// apps/web/components/portfolio/ProductList.tsx
+type Product = {
+  id: string;
+  productId: string;
+  name: string;
+  status: string;
+};
+
+type Props = {
+  products: Product[];
+  colour: string;
+  className?: string;
+};
+
+const STATUS_COLOURS: Record<string, string> = {
+  active:  "#4ade80",
+  review:  "#fb923c",
+  retired: "#555566",
+  idea:    "#a78bfa",
+};
+
+export function ProductList({ products, colour, className = "" }: Props) {
+  return (
+    <div className={className}>
+      <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest mb-2">
+        Digital Products &amp; Services
+      </p>
+      <div className="flex flex-col gap-2">
+        {products.map((product) => {
+          const statusColour = STATUS_COLOURS[product.status] ?? "#555566";
+          return (
+            <div
+              key={product.id}
+              className="bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg px-3 py-2.5"
+            >
+              <div className="flex items-center justify-between mb-0.5">
+                <span className="text-sm font-medium text-white">{product.name}</span>
+                <span
+                  className="text-[9px] px-1.5 py-0.5 rounded-full"
+                  style={{ background: `${statusColour}20`, color: statusColour }}
+                >
+                  {product.status}
+                </span>
+              </div>
+              <p className="text-[10px] text-[var(--dpf-muted)]">{product.productId}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7.2: Create `PortfolioNodeDetail.tsx`**
+
+Create `apps/web/components/portfolio/PortfolioNodeDetail.tsx`:
+
+```tsx
+// apps/web/components/portfolio/PortfolioNodeDetail.tsx
+import Link from "next/link";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PORTFOLIO_COLOURS, PORTFOLIO_OWNER_ROLES } from "@/lib/portfolio";
+import { ProductList } from "./ProductList";
+
+type Product = { id: string; productId: string; name: string; status: string };
+
+type Props = {
+  node: PortfolioTreeNode;
+  subNodes: PortfolioTreeNode[];
+  products: Product[];
+  breadcrumbs: Array<{ nodeId: string; name: string }>;
+};
+
+function getRootSlug(nodeId: string): string {
+  return nodeId.split("/")[0] ?? nodeId;
+}
+
+export function PortfolioNodeDetail({
+  node,
+  subNodes,
+  products,
+  breadcrumbs,
+}: Props) {
+  const rootSlug = getRootSlug(node.nodeId);
+  const colour = PORTFOLIO_COLOURS[rootSlug] ?? "#7c8cf8";
+  const ownerRole = PORTFOLIO_OWNER_ROLES[rootSlug] ?? "—";
+  const subLabel = node.parentId === null ? "Capability Domains" : "Functional Groups";
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <nav className="flex flex-wrap items-center gap-1 text-xs text-[var(--dpf-muted)] mb-4">
+        <Link href="/portfolio" className="hover:text-white transition-colors">
+          Portfolio
+        </Link>
+        {breadcrumbs.map((bc) => (
+          <span key={bc.nodeId} className="flex items-center gap-1">
+            <span>›</span>
+            <Link
+              href={`/portfolio/${bc.nodeId}`}
+              className="hover:text-white transition-colors"
+            >
+              {bc.name}
+            </Link>
+          </span>
+        ))}
+      </nav>
+
+      {/* Title */}
+      <div className="flex items-baseline gap-3 mb-5">
+        <h1 className="text-xl font-bold text-white">{node.name}</h1>
+        <span className="text-sm" style={{ color: colour }}>
+          {node.totalCount} products
+        </span>
+      </div>
+
+      {/* Stats strip */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <StatBox label="Products" value={String(node.totalCount)} colour="#e2e2f0" />
+        <StatBox label="Owner" value={ownerRole} colour={colour} />
+        <StatBox label="Agents" value="—" colour="#555566" dashed />
+        <StatBox label="Health" value="—" colour="#555566" dashed />
+        <StatBox label="Investment" value="—" colour="#555566" dashed />
+      </div>
+
+      {/* Sub-nodes */}
+      {subNodes.length > 0 && (
+        <div className="mb-6">
+          <p className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest mb-2">
+            {subLabel}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {subNodes.map((child) => (
+              <Link
+                key={child.nodeId}
+                href={`/portfolio/${child.nodeId}`}
+                className="flex items-center justify-between p-3 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg hover:bg-[var(--dpf-surface-2)] transition-colors"
+              >
+                <span className="text-sm text-[#e2e2f0]">{child.name}</span>
+                {child.totalCount > 0 && (
+                  <span
+                    className="text-[9px] px-2 py-0.5 rounded-full"
+                    style={{ background: `${colour}20`, color: colour }}
+                  >
+                    {child.totalCount}
+                  </span>
+                )}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Products */}
+      {products.length > 0 && (
+        <ProductList products={products} colour={colour} />
+      )}
+
+      {/* Empty state */}
+      {subNodes.length === 0 && products.length === 0 && (
+        <p className="text-sm text-[var(--dpf-muted)]">
+          No products classified here yet.
+        </p>
+      )}
+
+      {/* People + Agents placeholders */}
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <PlaceholderPanel label="People" description="Human role assignments — coming soon" />
+        <PlaceholderPanel label="Agents" description="AI agent assignments — coming soon" />
+      </div>
+    </div>
+  );
+}
+
+function StatBox({
+  label,
+  value,
+  colour,
+  dashed = false,
+}: {
+  label: string;
+  value: string;
+  colour: string;
+  dashed?: boolean;
+}) {
+  return (
+    <div
+      className={`bg-[var(--dpf-surface-1)] rounded-lg px-4 py-2.5 text-center ${
+        dashed ? "border border-dashed border-[var(--dpf-border)] opacity-40" : "border border-[var(--dpf-border)]"
+      }`}
+    >
+      <p className="text-sm font-bold" style={{ color }}>
+        {value}
+      </p>
+      <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function PlaceholderPanel({
+  label,
+  description,
+}: {
+  label: string;
+  description: string;
+}) {
+  return (
+    <div className="bg-[var(--dpf-surface-1)] border border-dashed border-[var(--dpf-border)] rounded-lg p-4 opacity-50">
+      <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest mb-1">
+        {label}
+      </p>
+      <p className="text-xs text-[var(--dpf-muted)]">{description}</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7.3: Create `PortfolioOverview.tsx`**
+
+Create `apps/web/components/portfolio/PortfolioOverview.tsx`:
+
+```tsx
+// apps/web/components/portfolio/PortfolioOverview.tsx
+import Link from "next/link";
+import type { PortfolioTreeNode } from "@/lib/portfolio";
+import { PORTFOLIO_COLOURS, PORTFOLIO_OWNER_ROLES } from "@/lib/portfolio";
+
+type Props = { roots: PortfolioTreeNode[] };
+
+export function PortfolioOverview({ roots }: Props) {
+  const totalProducts = roots.reduce((sum, r) => sum + r.totalCount, 0);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-white">Portfolio</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          {roots.length} portfolios · {totalProducts} products
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {roots.map((root) => {
+          const colour = PORTFOLIO_COLOURS[root.nodeId] ?? "#7c8cf8";
+          const ownerRole = PORTFOLIO_OWNER_ROLES[root.nodeId] ?? "—";
+          return (
+            <Link
+              key={root.nodeId}
+              href={`/portfolio/${root.nodeId}`}
+              className="block p-5 rounded-lg bg-[var(--dpf-surface-1)] border-l-4 hover:bg-[var(--dpf-surface-2)] transition-colors"
+              style={{ borderLeftColor: colour }}
+            >
+              <h2 className="text-base font-semibold text-white mb-3">
+                {root.name}
+              </h2>
+              <div className="flex items-center gap-4">
+                <div>
+                  <p className="text-xl font-bold text-white">
+                    {root.totalCount}
+                  </p>
+                  <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-wider">
+                    Products
+                  </p>
+                </div>
+                <div>
+                  <p
+                    className="text-sm font-bold"
+                    style={{ color: colour }}
+                  >
+                    {ownerRole}
+                  </p>
+                  <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-wider">
+                    Owner
+                  </p>
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7.4: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: `0 errors` (or errors for missing page.tsx — proceed).
+
+---
+
+### Task 8: Catch-All Page
+
+**Files:**
+- Create: `apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx`
+
+- [ ] **Step 8.1: Create the portfolio page**
+
+Create `apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx`:
+
+```tsx
+// apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { getPortfolioTree } from "@/lib/portfolio-data";
+import { resolveNodeFromSlug, getSubtreeIds, buildBreadcrumbs } from "@/lib/portfolio";
+import { PortfolioOverview } from "@/components/portfolio/PortfolioOverview";
+import { PortfolioNodeDetail } from "@/components/portfolio/PortfolioNodeDetail";
+
+type Props = {
+  params: { slug?: string[] };
+};
+
+export default async function PortfolioPage({ params }: Props) {
+  const slugs = params.slug ?? [];
+  const roots = await getPortfolioTree(); // deduplicated by React cache()
+
+  // Overview: /portfolio
+  if (slugs.length === 0) {
+    return <PortfolioOverview roots={roots} />;
+  }
+
+  // Node detail: /portfolio/[...slug]
+  const node = resolveNodeFromSlug(roots, slugs);
+  if (!node) notFound();
+
+  // Fetch products in this node's subtree
+  const subtreeIds = getSubtreeIds([node]);
+  const products = await prisma.digitalProduct.findMany({
+    where: {
+      taxonomyNodeId: { in: subtreeIds },
+      status: "active",
+    },
+    select: { id: true, productId: true, name: true, status: true },
+    orderBy: { name: "asc" },
+  });
+
+  const breadcrumbs = buildBreadcrumbs(roots, slugs);
+
+  return (
+    <PortfolioNodeDetail
+      node={node}
+      subNodes={node.children}
+      products={products}
+      breadcrumbs={breadcrumbs}
+    />
+  );
+}
+```
+
+- [ ] **Step 8.2: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 8.3: Run all tests**
+
+```bash
+cd apps/web && pnpm test
+```
+
+Expected:
+```
+✓ lib/portfolio.test.ts (11)
+✓ lib/permissions.test.ts (9)
+✓ lib/auth.test.ts (...)
+✓ app/(shell)/workspace/page.test.tsx (3)
+All tests passed
+```
+
+- [ ] **Step 8.4: Start dev server and verify manually**
+
+Ensure Docker databases are running (`docker compose up -d`), then:
+
+```bash
+pnpm dev
+```
+
+Navigate to `http://localhost:3000` and log in as `admin@dpf.local` / `changeme123`.
+
+Verify:
+1. Workspace tile "Portfolio" appears and is clickable
+2. `/portfolio` shows 4 portfolio root cards with product counts
+3. Clicking "Foundational" → `/portfolio/foundational` shows the node detail + capability domain grid
+4. Clicking a capability domain → L2 groups appear in grid
+5. Tree sidebar updates active highlight as you navigate
+6. Click a chevron → branch expands, `?open=` updates in URL bar
+7. HR-500 role cannot access `/portfolio` (direct URL returns 404)
+
+- [ ] **Step 8.5: Final commit**
+
+```bash
+git add apps/web/app/(shell)/portfolio/ apps/web/components/portfolio/ apps/web/lib/portfolio-data.ts
+git commit -m "feat: implement /portfolio route with 4-level taxonomy tree and master/detail layout"
+```
+
+---
+
+## Summary
+
+| Chunk | Tasks | What it produces |
+|---|---|---|
+| 1 — Data Layer | 1–3 | Schema migration, `portfolio.ts` utility (tested), taxonomy seeding |
+| 2 — UI Layer | 4–8 | Cached data helper, layout + permission gate, tree sidebar, right panel, catch-all page |
+
+**Run order for a fresh environment:**
+1. `pnpm db:migrate` (task 1)
+2. `pnpm db:generate` (task 1)
+3. `npx tsx packages/db/scripts/generate-taxonomy-json.ts` (task 3 — requires old project)
+4. `pnpm db:seed` (task 3)
+5. `pnpm typecheck` (should be clean after task 8)
+6. `pnpm test` (11+ tests passing after task 2)

--- a/docs/superpowers/specs/2026-03-10-portfolio-route-design.md
+++ b/docs/superpowers/specs/2026-03-10-portfolio-route-design.md
@@ -1,0 +1,239 @@
+# Portfolio Route Design
+
+**Date:** 2026-03-10
+**Status:** Approved
+**Scope:** `/portfolio` route — Phase 2A of the Open Digital Product Factory monorepo
+
+---
+
+## Overview
+
+The `/portfolio` route gives Portfolio Managers (HR-100), Enterprise Architects (HR-300), ITFM Directors (HR-400), and the CDIO (HR-000) a read-only structural view of the company's digital product landscape.
+
+The page expresses three perspectives simultaneously:
+- **Digital Products** — what products exist and where they sit in the taxonomy
+- **People** — which human roles own and manage each capability domain
+- **AI Agents** — which agents are operating in each domain
+
+The conceptual foundation is the Open Group DPPM guide (G252, 2025): four portfolio types aligned to Conway's Law, investment rolling down from portfolio to product, metrics rolling up from product to portfolio.
+
+---
+
+## The Four Portfolios
+
+| Slug | Name | Colour | Primary Owner |
+|---|---|---|---|
+| `foundational` | Foundational | `#7c8cf8` | HR-300 (EA) |
+| `manufacturing_and_delivery` | Mfr & Delivery | `#fb923c` | HR-500 (Ops) |
+| `for_employees` | For Employees | `#a78bfa` | HR-200 (DPM) |
+| `products_and_services_sold` | Products Sold | `#f472b6` | HR-100 (Portfolio) |
+
+**Foundational** = technology management services underpinning the platform (infrastructure, platform services, security, data, networking). Not customer-facing. Aligns to the IT4IT Foundational portfolio type.
+
+---
+
+## Route Structure
+
+```
+app/(shell)/portfolio/
+  layout.tsx                  — server component; loads full taxonomy tree + product counts once
+  [[...slug]]/
+    page.tsx                  — server component; renders right panel for the selected node
+```
+
+**URL → selection mapping:**
+
+| URL | What is selected |
+|---|---|
+| `/portfolio` | Overview — all 4 portfolio roots |
+| `/portfolio/foundational` | Foundational portfolio root |
+| `/portfolio/foundational/platform-services` | L1 capability domain |
+| `/portfolio/foundational/platform-services/container-platform` | L2 functional group (leaf) |
+
+Up to 4 URL segments deep (portfolio root → L1 → L2 → L3). The `[[...slug]]` catch-all handles all depths with one page file.
+
+---
+
+## Data Model Changes
+
+### Schema migration
+
+Add `taxonomyNodeId` to `DigitalProduct`:
+
+```prisma
+model DigitalProduct {
+  // existing fields …
+  taxonomyNodeId  String?
+  taxonomyNode    TaxonomyNode? @relation(fields: [taxonomyNodeId], references: [id])
+}
+```
+
+Products without a `taxonomyNodeId` remain valid — they appear as "unclassified" at the portfolio root level.
+
+### TaxonomyNode seeding
+
+Seed `TaxonomyNode` from `PORTFOLIOS/taxonomy_v2.csv` in the old project (~379 rows). Tree structure:
+
+```
+Portfolio root  (portfolioId set, parentId null, nodeId = portfolio slug)
+  └─ L1 capability domain   (parentId → root nodeId)
+       └─ L2 functional group  (parentId → L1 nodeId)
+            └─ L3 specialisation  (parentId → L2 nodeId, sparse)
+```
+
+Node `nodeId` values are URL-safe slugs (e.g. `compute`, `platform-services`, `container-platform`) — stable across seeds.
+
+---
+
+## Component Architecture
+
+### New files
+
+```
+apps/web/
+  app/(shell)/portfolio/
+    layout.tsx                     server component — tree data loader
+    [[...slug]]/
+      page.tsx                     server component — right panel renderer
+
+  components/portfolio/
+    PortfolioTree.tsx               'use client' — manages expand/collapse state only
+    PortfolioTreeNode.tsx           recursive — renders one tree node + children
+    PortfolioOverview.tsx           right panel: /portfolio (all 4 roots)
+    PortfolioNodeDetail.tsx         right panel: single node at any depth
+    ProductList.tsx                 product/service list for leaf nodes
+```
+
+### PortfolioTree (client component)
+
+Responsibilities:
+- Receive the full annotated tree from layout as a prop (serialised, no Prisma calls)
+- Manage expand/collapse state in `useState` — initialised from `?open=` search param
+- Sync open state back to URL via `router.replace` (shallow, no navigation)
+- Highlight the active node derived from `usePathname()`
+- Render `PortfolioTreeNode` recursively
+
+The client component holds **no data-fetching logic** — it only manages interaction state.
+
+### Layout (server component)
+
+Two parallel Prisma queries on every request into `/portfolio/*`:
+
+```ts
+const [nodes, counts] = await Promise.all([
+  prisma.taxonomyNode.findMany({
+    where: { status: 'active' },
+    select: { id: true, nodeId: true, name: true, parentId: true, portfolioId: true }
+  }),
+  prisma.digitalProduct.groupBy({
+    by: ['taxonomyNodeId'],
+    _count: { id: true },
+    where: { status: 'active' }
+  })
+])
+// Build tree in memory, roll product counts up to parents bottom-up
+// Pass annotated tree to PortfolioTree
+```
+
+~379 nodes, in-memory tree build — negligible overhead.
+
+### Right panel (server component, page.tsx)
+
+Renders differently by depth:
+
+| Depth | Content |
+|---|---|
+| 0 — `/portfolio` | 4 portfolio root cards with product count, agent count, owner role |
+| 1 — portfolio root | Portfolio name + description, stats strip, grid of L1 capability domains |
+| 2 — L1 domain | Breadcrumb, stats strip, grid of L2 functional groups |
+| 3/4 — L2/L3 leaf | Breadcrumb, stats strip, product/service list |
+
+**Stats strip** (all non-overview levels):
+- Products count (filled)
+- Agents count — matched to portfolio slug via `Agent.description` or portfolio association (filled)
+- Owner role — mapped from `Portfolio.slug` → static role map (filled)
+- Health slot — dashed placeholder, wired up in a future phase
+- Investment slot — dashed placeholder, wired up in a future phase
+
+**People and Agents panels** — dashed placeholders rendered at all levels. Represent the three-perspective model (Products / People / Agents) from day one. Wired up in a later phase.
+
+---
+
+## Tree Sidebar Design
+
+- 4 portfolio roots always visible, colour-coded by portfolio accent colour
+- Each root is expandable — click to reveal L1 nodes
+- L1 nodes expandable to L2, L2 to L3 (full 4-level depth)
+- Product count badge on every node (direct + subtree cumulative)
+- Active node: accent-coloured left border + background highlight
+- Collapsed portfolios show root name + total count only
+- Dividers between the 4 portfolio roots
+
+---
+
+## State & URL Design
+
+| State | Source of truth |
+|---|---|
+| Selected node | URL path (`params.slug`) |
+| Expanded nodes | `?open=node1,node2` search param |
+| Active portfolio colour | Derived from selected node's root portfolio |
+
+Deep links work by default. Sharing `/portfolio/foundational/platform-services?open=foundational` opens the tree at the right position.
+
+---
+
+## Error & Empty States
+
+| Condition | Handling |
+|---|---|
+| Slug not found in taxonomy | `notFound()` → Next.js 404 |
+| No taxonomy seeded | Sidebar shows 4 portfolio root names only (graceful degradation) |
+| Node has no products | "No products classified here yet" message in right panel |
+| No agents matched | Agent count shows 0, no error |
+
+---
+
+## Testing
+
+Following existing project patterns (Vitest, synchronous, no asyncio):
+
+| Test | Type | File |
+|---|---|---|
+| `buildPortfolioTree(nodes, counts)` — correct parent-child wiring | Unit | `lib/portfolio.test.ts` |
+| `buildPortfolioTree()` — count roll-up to parents | Unit | `lib/portfolio.test.ts` |
+| `can(user, 'view_portfolio')` for all 6 roles | Already in `permissions.test.ts` | — |
+| `/portfolio` route renders sidebar + overview | Integration | `app/(shell)/portfolio/portfolio.test.tsx` |
+| `/portfolio/foundational` renders portfolio detail | Integration | same |
+| `/portfolio/invalid-slug` returns 404 | Integration | same |
+
+---
+
+## What This Does Not Include (Phase 2A scope boundary)
+
+- Editing or creating portfolios/taxonomy nodes — admin task, later phase
+- Wiring People and Agents panels with live data — placeholders only
+- Health or Investment metrics — placeholder slots only
+- `/inventory` and `/ea` routes — separate specs
+- Neo4j graph traversal — PostgreSQL only for Phase 2A
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|---|---|
+| `packages/db/prisma/schema.prisma` | Add `taxonomyNodeId` + relation to `DigitalProduct` |
+| `packages/db/prisma/migrations/…` | New migration |
+| `packages/db/src/seed.ts` | Add taxonomy node seeding from CSV data |
+| `apps/web/app/(shell)/portfolio/layout.tsx` | New — tree data loader |
+| `apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx` | New — right panel server component |
+| `apps/web/lib/portfolio.ts` | New — `buildPortfolioTree()` utility |
+| `apps/web/components/portfolio/PortfolioTree.tsx` | New — client tree component |
+| `apps/web/components/portfolio/PortfolioTreeNode.tsx` | New — recursive tree node |
+| `apps/web/components/portfolio/PortfolioOverview.tsx` | New — all-portfolios overview panel |
+| `apps/web/components/portfolio/PortfolioNodeDetail.tsx` | New — single-node detail panel |
+| `apps/web/components/portfolio/ProductList.tsx` | New — product/service list |
+| `apps/web/lib/portfolio.test.ts` | New — unit tests for tree builder |
+| `apps/web/app/(shell)/portfolio/portfolio.test.tsx` | New — integration tests |
+| `.gitignore` | Add `.superpowers/` if not present |

--- a/docs/superpowers/specs/2026-03-10-portfolio-route-design.md
+++ b/docs/superpowers/specs/2026-03-10-portfolio-route-design.md
@@ -83,6 +83,8 @@ Portfolio root  (portfolioId set, parentId null, nodeId = portfolio slug)
 
 Node `nodeId` values are URL-safe slugs (e.g. `compute`, `platform-services`, `container-platform`) — stable across seeds.
 
+`TaxonomyNode.id` is the cuid primary key used for all FK references (including `DigitalProduct.taxonomyNodeId` and `TaxonomyNode.parentId`). `TaxonomyNode.nodeId` is the human-readable URL slug — a separate unique field used only for routing. Do not use `nodeId` as a FK target.
+
 ---
 
 ## Component Architecture
@@ -109,7 +111,7 @@ apps/web/
 Responsibilities:
 - Receive the full annotated tree from layout as a prop (serialised, no Prisma calls)
 - Manage expand/collapse state in `useState` — initialised from `?open=` search param
-- Sync open state back to URL via `router.replace` (shallow, no navigation)
+- Sync open state back to URL via `window.history.replaceState` (not `router.replace` — App Router's replace triggers a server re-render; `replaceState` updates the URL client-side only, preserving deep-link behaviour without unnecessary Prisma round-trips)
 - Highlight the active node derived from `usePathname()`
 - Render `PortfolioTreeNode` recursively
 
@@ -131,9 +133,13 @@ const [nodes, counts] = await Promise.all([
     where: { status: 'active' }
   })
 ])
-// Build tree in memory, roll product counts up to parents bottom-up
+// counts[n].taxonomyNodeId is a cuid matching TaxonomyNode.id
+// In-memory join: directCount = counts.find(c => c.taxonomyNodeId === node.id)?._count.id ?? 0
+// Roll cumulative counts up to parents bottom-up after building the tree
 // Pass annotated tree to PortfolioTree
 ```
+
+The layout also checks `can(user, 'view_portfolio')` and calls `notFound()` if false, preventing direct URL access by roles without this capability (e.g. HR-500).
 
 ~379 nodes, in-memory tree build — negligible overhead.
 
@@ -149,9 +155,9 @@ Renders differently by depth:
 | 3/4 — L2/L3 leaf | Breadcrumb, stats strip, product/service list |
 
 **Stats strip** (all non-overview levels):
-- Products count (filled)
-- Agents count — matched to portfolio slug via `Agent.description` or portfolio association (filled)
-- Owner role — mapped from `Portfolio.slug` → static role map (filled)
+- Products count — filled (Prisma count)
+- Agents count — **placeholder (dashed)** in Phase 2A; the `Agent` model has no portfolio association yet; wired up when `Agent.portfolioId` is added in a future phase
+- Owner role — mapped from `Portfolio.slug` → static role map (filled; no DB query needed)
 - Health slot — dashed placeholder, wired up in a future phase
 - Investment slot — dashed placeholder, wired up in a future phase
 
@@ -187,10 +193,10 @@ Deep links work by default. Sharing `/portfolio/foundational/platform-services?o
 
 | Condition | Handling |
 |---|---|
-| Slug not found in taxonomy | `notFound()` → Next.js 404 |
+| User lacks `view_portfolio` capability | `notFound()` in `portfolio/layout.tsx` — checked via `can(user, 'view_portfolio')` |
+| Slug not found in taxonomy | `notFound()` in page.tsx via `resolveNodeFromSlug` returning null |
 | No taxonomy seeded | Sidebar shows 4 portfolio root names only (graceful degradation) |
 | Node has no products | "No products classified here yet" message in right panel |
-| No agents matched | Agent count shows 0, no error |
 
 ---
 
@@ -200,12 +206,13 @@ Following existing project patterns (Vitest, synchronous, no asyncio):
 
 | Test | Type | File |
 |---|---|---|
-| `buildPortfolioTree(nodes, counts)` — correct parent-child wiring | Unit | `lib/portfolio.test.ts` |
-| `buildPortfolioTree()` — count roll-up to parents | Unit | `lib/portfolio.test.ts` |
-| `can(user, 'view_portfolio')` for all 6 roles | Already in `permissions.test.ts` | — |
-| `/portfolio` route renders sidebar + overview | Integration | `app/(shell)/portfolio/portfolio.test.tsx` |
-| `/portfolio/foundational` renders portfolio detail | Integration | same |
-| `/portfolio/invalid-slug` returns 404 | Integration | same |
+| `buildPortfolioTree(nodes, counts)` — correct parent-child wiring | Unit | `apps/web/lib/portfolio.test.ts` |
+| `buildPortfolioTree()` — count roll-up to parents | Unit | `apps/web/lib/portfolio.test.ts` |
+| `can(user, 'view_portfolio')` for all 6 roles | Already covered | `apps/web/lib/permissions.test.ts` |
+| `resolveNodeFromSlug(tree, slug)` — valid slug returns node | Unit | `apps/web/lib/portfolio.test.ts` |
+| `resolveNodeFromSlug(tree, unknownSlug)` — returns null | Unit | `apps/web/lib/portfolio.test.ts` |
+
+**Note on integration tests:** The existing vitest config (`apps/web/vitest.config.ts`) uses `environment: "node"` with no jsdom/happy-dom setup — React component rendering tests are not supported without additional config. Integration-style coverage for the portfolio route is therefore provided via unit tests of the pure functions (`buildPortfolioTree`, `resolveNodeFromSlug`) that contain all routing and data-shaping logic. Full component render tests are deferred until the project adds a DOM test environment.
 
 ---
 
@@ -234,6 +241,5 @@ Following existing project patterns (Vitest, synchronous, no asyncio):
 | `apps/web/components/portfolio/PortfolioOverview.tsx` | New — all-portfolios overview panel |
 | `apps/web/components/portfolio/PortfolioNodeDetail.tsx` | New — single-node detail panel |
 | `apps/web/components/portfolio/ProductList.tsx` | New — product/service list |
-| `apps/web/lib/portfolio.test.ts` | New — unit tests for tree builder |
-| `apps/web/app/(shell)/portfolio/portfolio.test.tsx` | New — integration tests |
-| `.gitignore` | Add `.superpowers/` if not present |
+| `apps/web/lib/portfolio.test.ts` | New — unit tests for `buildPortfolioTree` and `resolveNodeFromSlug` |
+| `.gitignore` | Add `.superpowers/` if not present (done) |

--- a/packages/db/data/taxonomy_v2.json
+++ b/packages/db/data/taxonomy_v2.json
@@ -1,0 +1,3404 @@
+[
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Corporate Communication",
+    "level_2": "Community Outreach",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable community relations and connections with the people constituting the environment the organization operates within the and community. The objective is to foster mutual understanding, trust, and support from all parties external to the organization.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Corporate Communication",
+    "level_2": "External Communications",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable developing and managing relations with media, analysts and other outlets by fostering critical, third-party endorsements of the company to include products, services, and organizational reputation.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Corporate Communication",
+    "level_2": "Government and Standards Relations",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable creating and maintaining relationships with international and local governments and standards organizations, with the objective of understanding and persuading mutually favorable laws, standards, and regulations.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Corporate Communication",
+    "level_2": "Manage Relations with Board of Directors",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to maintaining relations with stockholder and market representative. Establish corporate management-related policies and to make decisions on major company issues. Implement practices designed to engender communication, trust, and cooperation.",
+    "notes": "From APQC, merge with"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Corporate Communication",
+    "level_2": "Stakeholder Relations",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable fostering external relationships to include investors, government and industry, the board of directors, and the general public. This is not related to customer management.",
+    "notes": "From TBM, A catch-all for the segments not captured in the other segments."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Business Capabilities",
+    "level_2": "Manage Business Processes",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to document, analyze, improve and govern processes across the foundational, employee, customer and manufactur and delibery activities.",
+    "notes": "From APQC, there is no context with this activity; improvement or to automate etc. Need to determine how to carry this forward in an outcome specific approach."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Business Capabilities",
+    "level_2": "Manage Enterprise Quality",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to measure and improve the quality across all portfolio outputs. Helps to determine quality requirements, evaluate quality performance and specify improvement requirements. Manage non-conformance activities. Ensure implementation and maintenance of the enterprise quality management system.",
+    "notes": "From APQC, re-worded to be specific to the portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Business Capabilities",
+    "level_2": "Manage Portfolio, Program, and Project",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used in managing organizational investments, holdings, products, businesses, and brands, along with the related projects that together constitute a program.",
+    "notes": "From APQC, reworded but consider mentioning  4 portfolio as focal areas"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Business Capabilities",
+    "level_2": "Manage Sustainability",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to managing sustainability practices and measures for the organization. Provides common understanding and communication of ESG standards, requirements, capabilities, and future trends. Promote awareness, alignment, and continuity.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Business Capabilities",
+    "level_2": "Measure and Benchmark",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used in defining, measurement, and benchmarking performance each of the 4 portfolios, digital products, process, costs and other related metrics for the organization as a whole.",
+    "notes": "From APQC, tweaked for the portfolio approach"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Generate and Refine Product / Service Portfolios",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to identify, refine and prioritize ideas, requirements and between the portfolios to align with organizational objectives, mission, and goals.",
+    "notes": "From APQC, addressed this as the cross-portfolio planning exercise."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Govern and Manage Product / Service Investment and Planning",
+    "level_3": "Manage Employee Facing Products and Services Portfolio",
+    "definition": "Digital products and services used by employees to process ideas and supervise investment through outcomes of the products and services used by employees and partners of the organization, ensuring they meet the consumer demands and expectations.",
+    "notes": "From APQC, consider moving to the respective portfolio"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Govern and Manage Product / Service Investment and Planning",
+    "level_3": "Manage External Facing Products and Services Portfolio",
+    "definition": "Digital products and services used by employees used to process ideas and supervise investment through outcomes of the products and services used external to the organization, ensuring they meet the consumer demands and expectations.",
+    "notes": "From APQC, consider moving to the respective portfolio"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Govern and Manage Product / Service Investment and Planning",
+    "level_3": "Manage Foundational Facing Products and Services Portfolio",
+    "definition": "Digital products and services used by employees used to process ideas and supervise investment through outcomes of the products and services used as foundational technologies or building blocks, ensuring they meet the consumer demands and expectations across all other portfolios.",
+    "notes": "From APQC, consider moving to the respective portfolio"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Govern and Manage Product / Service Investment and Planning",
+    "level_3": "Manage Manufacturing and Delivery Products and Services Portfolio",
+    "definition": "Digital products and services used by employees used to process ideas and supervise investment through outcomes of the products and services used to manufacture and deliver Digital Products, Services, and goods, ensuring they meet the consumer demands and expectations.",
+    "notes": "From APQC, consider moving to the respective portfolio"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Innovation and Ideation",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to allocate investment, development and incubation of new technologies to create new or better solutions which meet unarticulated or existing market needs. Includes new technology solutions and new product incubation services.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Program, Product and Project Management",
+    "level_3": "Product Development",
+    "definition": "Digital products and services used by employees enabling product design and development activity to include innovation, CAD, simulations, consumer feedback and crowdsourcing activities.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Program, Product and Project Management",
+    "level_3": "Product Management",
+    "definition": "Digital products and services used by employees used for continuous planning, prioritization and delivery process to provide releases in an iterative approach, associatd with backlogs and team allocation where an outcome is unknown, and variable outcomes. Fixed resources for a time period are allocated in short itterations, often sprints with releases often commucated with a roadmap of continues change.",
+    "notes": "From TBM, seperated from Project with a focus on Product"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Program, Product and Project Management",
+    "level_3": "Product Planning",
+    "definition": "Digital products and services used by employees that enable product life-cycle management from ideation, requirements management, through specifications management and implementation. Interfaces with Manufacturing and delivery to execute on product plans.",
+    "notes": "From TBM, Interfaces with Manufacture and Delivery portfolio, focused on the 4 portfolios as potential use of the products being planned"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Program, Product and Project Management",
+    "level_3": "Project Management",
+    "definition": "Digital products and services used by employees used for managing resources and activities for time-bound projects, often with the intention of improving an organization's performance. Discreet outcomes with fixed timeframe and resources that enable budgeting and execution of projects to an outcome. Often this includes planning, execution, controls, reporting, time tracking of assigned teams who are focused on specific outcome and success criteria.",
+    "notes": "From TBM, seperated from agile"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Technology Business Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to The disciplines and value conversations for improving the business outcomes enabled by the technology portfolio. Enables technology leaders and their business partners to collaborate on business-aligned decisions. Includes IT management, IT finance and costing, IT billing, business value, metrics, benchmarking, service portfolio management, service catalog management, service level management and availability management.",
+    "notes": "From TBM, NEED to incorproate into the 4 portfolio approach"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop and Manage Products and Services",
+    "level_2": "Vendor Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to The management of technology suppliers who provide, deliver and support technology products and services. Includes services across the life cycle of a vendor including selection, negotiation, contracting, procurement, maintenance and subscription renewals, and performance management.",
+    "notes": "From TBM, need to duplicate per per portfolio or expand to include  vendors for any other portfolio"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Business Entity Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to create, structure, and govern the legal body or bodies that comprises or comprise a single organization, and subsidiaries.",
+    "notes": "From BA Guild, merge with strategy implementation models"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Campaign Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to identify the need for, plan, design, execute, and measure the effectiveness of an outreach activity that targets a specific population; customers, human resources, partners, and patients, to achieve a certain goal, marketing awareness, hiring activities, and health awareness.",
+    "notes": "From BA Guild, Should move this under the sales and marketing taxonomy area, merge with other elements if similar"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Develop and Maintain Business Models",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that review and refine how the organization creates, delivers and captures value or makes profit. Identify the products or services that a business will sell, its target market, anticipated expenses, and other core aspects of its modus operandi. Revise the plan as required to reflect changing circumstances.",
+    "notes": "From APQC, should be combined with EA?"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Develop and Measure Strategic Initiatives",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that define and set strategic initiatives, from development through selection, execution, and evaluation. Conduct and oversee strategic projects supporting long-term objectives. Administer programs of strategic significance by developing such initiatives, select the most appropriate projects, and formulate measures to assess their impact.",
+    "notes": ""
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Develop Business Strategy",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to create and socialize the organization's strategic vision, goals and objectives. Identifies themes, markets, organizational structure and determines the yearly business activities required to meet long-term goals to reach desired markets, products and business ecosystem.",
+    "notes": "From APQC; Merged Level 3 items: Long Term Strategy Formulation; Organizational Strategic Planning"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Market Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that define, identify, quantify, qualify, analyze, segment, address, and create demand for existing or future products by individuals, populations of individuals, or organizations.",
+    "notes": "From BA Guild, central employee-facing to manage what's sold, but potentially in the other portfolios too."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Message Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that define, craft, frame, vet, disseminate, and track a verbal, written, recorded, or digitally-represented communication, including missives, notifications, alerts, and other internally or externally targeted communication about the organization's mission, products, plans, activities, and other focal points.",
+    "notes": "From BA Guild, merge with APQC 1.0 above"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Plan Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to define, develop, validate, maintain, and coordinate a set of related activities to achieve a result.",
+    "notes": "From BA Guild, potentially merge with 2.0 from APQC above."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Develop Vision and Strategy",
+    "level_2": "Strategic Portfolio Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to control, organize, and allocate a set of resources expected to increase in value or provide income, in order to achieve a targeted balance of risk, return, and volatility.",
+    "notes": "From BA Guild, merge with financial management. Also need to consider the top-down funding of each of the 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Digital Product Strategy and Planning",
+    "level_3": "",
+    "definition": "Digital products and services used by employees COE to help the enterprise improve their performance, primarily through the analysis of existing business problems and development of plans for improvement. This includes business relationship management, demand management, business process analysis as well as technology selection.",
+    "notes": "From TBM, re-articulated in Digital Product context, seems like a 6-sigma continuous improvement approach.  Should be applied to each of the 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Enterprise Architecture",
+    "level_3": "",
+    "definition": "Digital products and services used by employees for Enterprise architecture to use that captures on business, information, application and technical architecture to be applied across each of the 4 portfolios to include customer facing, employee facing, manufacture and delivery, and foundational technologies.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Investment Allocation and Optimization",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to identify how to best allocate investment in new and existing resources to achieve the desired outcomes of the organizational goals and strategy in support of the overall organizational mission, objectives, and goals.",
+    "notes": "New, added to incorporate balancing budgets and human resources once identified"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Review and Balance 4 Portfolios",
+    "level_3": "Refine Employee Facing Portfolio Taxonomy",
+    "definition": "Digital products and services used by employees to refine taxonomy of digital products and services required for employees and partners require for their jobs.",
+    "notes": "New, central function to bring together full investment plans across all 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Review and Balance 4 Portfolios",
+    "level_3": "Refine External Facing Portfolio Taxonomy",
+    "definition": "Digital products and services used by employees to refine taxonomy of digital products and services the overall organization provides externally to customers or citizens for non-commercial.",
+    "notes": "New, central function to bring together full investment plans across all 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Review and Balance 4 Portfolios",
+    "level_3": "Refine Foundational Portfolio Taxonomy",
+    "definition": "Digital products and services used by employees that refine the taxonomy of digital products and services underpinning all other portfolios to be crated and delivered.",
+    "notes": "New, central function to bring together full investment plans across all 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Review and Balance 4 Portfolios",
+    "level_3": "Refine Manufacturing and Deliver Portfolio Taxonomy",
+    "definition": "Digital products and services used by employees that refine the taxonomy of digital products and services used to build, integrate, and deliver Digital products and services in the other portfolios.",
+    "notes": "New, central function to bring together full investment plans across all 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Evaluate and Plan Portfolio Investments",
+    "level_2": "Technology Management and Planning",
+    "level_3": "",
+    "definition": "Digital products and services used by employees offering the management and administration of technology resource often involving CIO, Manufacturing, CTO and other technology leaders involved with technology strategy and planning activities and decisions.",
+    "notes": "From TBM, should we separate this out into the 4 different areas?  CIO's used to be focused on back office, but now CIO concerns are spread into the 4 areas…"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Manage Internal Controls",
+    "level_3": "",
+    "definition": "Capabilities to design, document, test, and monitor internal controls (e.g., SOX) across financial processes, ensuring compliance, evidence collection, and remediation tracking.",
+    "notes": "Often used jointly by finance, internal audit, and compliance teams; overlaps with GRC but focused on financial controls and auditability."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Manage International Funds / Consolidation",
+    "level_3": "",
+    "definition": "Capabilities to consolidate financial results across legal entities, currencies, and geographies, producing group financial statements and supporting multi-GAAP/management views where needed.",
+    "notes": "Often paired with close management/reconciliations and statutory reporting; scope is distinct from FP&A planning (but shares dimensions and master data)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Manage Project Accounting",
+    "level_3": "",
+    "definition": "Financial management of projects and programs, including budgeting, cost capture, capitalization (where applicable), billing, and profitability tracking across the project lifecycle.",
+    "notes": "In some organizations this is run as professional services automation (PSA) or capital projects accounting; ensure scope aligns to your project types (IT, engineering, client delivery)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Manage Taxes",
+    "level_3": "",
+    "definition": "Capabilities to calculate, file, and report taxes across jurisdictions, including indirect tax determination, direct tax provision support, and tax compliance reporting.",
+    "notes": "Indirect tax determination is often embedded into transaction systems; compliance and reporting may require specialized tax engines and content updates."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Manage Treasury Operations",
+    "level_3": "",
+    "definition": "Capabilities to manage enterprise cash, liquidity, banking, and financial risk, including cash positioning, forecasting, payments, and hedge/accounting support where required.",
+    "notes": "Treasury may be centralized or regional; integrations to banks and ERP are critical. Payments may also be split into a separate payments/treasury function depending on operating model."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Perform General Accounting and Reporting",
+    "level_3": "",
+    "definition": "Core financial accounting capabilities to record, classify, and report financial transactions, including the general ledger, statutory reporting, and period close activities.",
+    "notes": "The market is dominated by ERP finance suites; close acceleration tools are commonly layered on top."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Perform Global Trade Services",
+    "level_3": "",
+    "definition": "Capabilities that support global trade compliance and finance-related trade processes, including customs documentation, tariff/classification, and trade controls impacting order-to-cash and procure-to-pay.",
+    "notes": "Sometimes owned by supply chain/compliance rather than finance; included here when the organization treats trade compliance and landed cost as finance-adjacent services."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Perform Planning and Management Accounting",
+    "level_3": "",
+    "definition": "Capabilities to plan, budget, forecast, and analyze performance (FP&A), including driver-based planning, management reporting, and scenario modeling for decision support.",
+    "notes": "Often delivered through EPM/FP&A platforms and analytics layers, integrated with ERP actuals and HR/headcount drivers."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Perform Revenue Accounting",
+    "level_3": "",
+    "definition": "Capabilities to support revenue accounting, including revenue recognition policy execution, contract performance obligations tracking, and accurate revenue reporting (where required).",
+    "notes": "Scope varies by business model (subscription, usage-based, services). For some orgs, this is handled in ERP; for subscription/usage models it often requires specialized revenue automation."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Process Accounts Payable and Expense Reimbursements",
+    "level_3": "",
+    "definition": "Capabilities and supporting applications to validate, approve, and pay supplier invoices and employee expense claims, ensuring accurate coding, compliance, and timely disbursement.",
+    "notes": "Often split into AP (supplier invoices) and T&E (employee expenses) but frequently delivered together through ERP + specialized AP/expense tools."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Process Accounts Receivable",
+    "level_3": "",
+    "definition": "Capabilities and supporting applications to invoice customers, collect payments, manage disputes/deductions, and maintain accurate customer receivables balances and cash application.",
+    "notes": "Often closely tied to order-to-cash, billing, and revenue recognition; AR may live in ERP, while collections/disputes are frequently best-of-breed."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Financial Management",
+    "level_2": "Process Payroll",
+    "level_3": "",
+    "definition": "Capabilities and supporting applications to calculate and pay employee compensation accurately and on time, including payroll processing, statutory deductions, and payroll reporting; may include time capture integration where required.",
+    "notes": "Time reporting is often owned by HR/workforce management; include it here only where payroll service explicitly includes time capture or approvals."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Health, Safety, Security and Environmental Services",
+    "level_2": "Healthcare Services",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable the definition and structuring of health services provided to/by the workforce, to promote preventative health and basic treatment, including the provision of on-site health services.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Health, Safety, Security and Environmental Services",
+    "level_2": "Occupational Safety",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable the programmatic evaluation and management of risks and opportunities that may affect industry-specific or role-related personal health and safety of employees, contractors or other 3rd parties. Provide required compliance and reporting as required by local and national governing bodies.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Health, Safety, Security and Environmental Services",
+    "level_2": "Oversight and Enforcement",
+    "level_3": "",
+    "definition": "Digital products and services used by employees for creating, implememtig and enforcing HSSE activities (including investigations) related to environmental, health and safety activities.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Health, Safety, Security and Environmental Services",
+    "level_2": "Policy and Governance",
+    "level_3": "",
+    "definition": "Digital products and services used by employees determining the desired outcomes, obligations, conduct and impacts related to personal and environmental health and safety imn accordin gto local, state and federal government and corporate HSSE program policy. Train and educate employees of the on the HSSE program. Oversee and manage the HSSE program.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Legal",
+    "level_2": "Case Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used for managing the lifecycle of legal cases and litigation matters. May include matter management, time and billing, documentation creation and submittal, monitoring case status, hearings and meeting scheduling, time and billing, orchestration of litigation support, collaboration and communications, e-discovery record search and storage, coordinating legal holds as necessary.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Legal",
+    "level_2": "Contract Review",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enables review and negotiation of terms to reach a final legally binding contracts acceptable to all interested stakeholders.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Legal",
+    "level_2": "Intellectual Property Rights Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that define, establish, validate, valuate, register, obtain, and dispose of, legal protections patents, trademarks, and copyrights.",
+    "notes": "From BA Guild, merge with Legal Services, Risk and Audit possibly"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Legal",
+    "level_2": "Legal Counsel",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that provide guidance and legal practices to abide by laws involving the practical application of legal theories, local and international laws, regulations and knowledge to govern the organization’s messaging, products, and business operations. May include establishing, litigation, and defense of intellectual property, brand, confidential information, exposure to liabilities and other related forms and applications of law.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Legal",
+    "level_2": "Legal Proceeding Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that provide administration, oversight, response of tribunal law enforcement.",
+    "notes": "From BA Guild, merge with others in legal section"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Auditing",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that offer ongoing planning, preparation, execution and review of controls, policies and procedures used to mitigate risks. Includes observation, reviews, interviews, fact-finding and the generation of management action plans to make the identified changes as identified. Can also include the implementation and maintenance of technologies and engage external services to enable internal controls-related activities.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Breach Management and Remediation",
+    "level_3": "",
+    "definition": "Digital products and services used by employees for administering efforts and activities when breaches occur. Includes assessment / estimation of impact, causalities, containment and approved remediation activities. May include coordinating plans for corrective action internally, with partners, customers or government agencies specialized in the legal, public impact and business situation of the organization.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Investigations",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that offer breach root cause and follow-up activities on changing standard procedures to prevent repeat occurrences and identify full impact of a breach. Investigations often include research, interviews, evidence collection, data preservation and various methods of investigation, legal / law enforcement, as well as the gathering and documentation of findings and observations, and reporting of them.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Manage Business Continuity and Resiliency",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that identify and implement processes required to rapidly adapt and respond to internal or external disruptions or threat of disruptions to the operations of the organization. Establishes dynamic, strategic, and integrated approach to managing all compliance obligations to maintain the integrity of daily business operations.",
+    "notes": "From APQC, combined with TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Manage Enterprise Portfolio Risks",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that create and administers frameworks used across all 4 portfolios and functions. Manages enterprise risks by outlining the risk policies and procedures for each portfolio area. Monitor and communicate all risk management activities. Encourage correspondence among the business units. Manage the risk of all business units and functions.",
+    "notes": "From APQC, Modified to provide oversight over all 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that ensuring organizational risks from an industry regulations perspective are understood and met, and aligned with the overall posture of the organization. Process groups are aligned with traditional risk management activities, and engage the 4 portfolios of Digital products and services to make sure the organizational governance and risk posture is understood and met.",
+    "notes": "From APQC, modified to be aligned with the 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Manage External Regulatory Compliance and Reporting",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to understand and confirm ongoing compliance to industry regulations and government legislation bodies the organization is subject to.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Manage Remediation Efforts",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to manage plans for corrective action in collaboration with government, regulatory, and professional agencies requiring specializes remediation efforts relevant to the organization. Additionally, the organization needs to consult.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Records Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to manage digital records and media within the organization throughout its life cycle and state/form from creation, life, and final physical disposal. This includes identifying, classifying, storing, securing, retrieving, tracking and destroying, or permanently preserving records within structured and non-structured data stores.",
+    "notes": "From TBM, APQC; Merged Level 3 items: Digial Records; Physical Records and Media"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Risk Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Applications and services that enable establishing umbrella frameworks, management activities, policy and related procedures and requirements for the entire organization, to defend against risks that may negatively impact the viability, growth, performance, health, stability, competitiveness, preparedness, or reputation of an ongoing concern, state, product or service. Ensures the identification, detection, assessment, monitoring and communication of risk and the execution of risk management activities across all levels of the organization, including all risk facets, including but not limited to sector, organization, operations, compliance, data, personal privacy, cyber, espionage, geo-political, etc.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+    "level_2": "Technology Compliance",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that address IT Compliance use cases setting technology use policy, coding standards and policies, opensource use and licensing policies, and establishing controls and measuring compliance to relevant legal and compliance requirements. May also include: Data Privacy, obfuscation, encryption and data sovereignty requirements for how data is stored and moved across country boundaries.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage External Relationships",
+    "level_2": "Build Investor Relationships",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Creating a strategic management responsibility for integrating finance, communication, marketing, and securities law compliance. Allow the most effective two-way communication among the organization, the financial community, and other constituencies. Enlist the investor relations function to provide market intelligence to corporate management.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage External Relationships",
+    "level_2": "Manage External Relationships",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Fostering external relationships with stakeholders of the entity, including investors, government and industry, the board of directors, and the general public. This is not related to customer management.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage External Relationships",
+    "level_2": "Manage Government and Industry Relationships",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Creating and maintaining relationships with government and industry representatives.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage External Relationships",
+    "level_2": "Manage Legal and Ethical Issues",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Managing legal practices to abide by the law, as well as ethical practices.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Manage External Relationships",
+    "level_2": "Manage Public Relations Program",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Managing a public relations programs through business and communications skills.",
+    "notes": "From APQC, need to decomposed into proper 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Organizational Direction Setting",
+    "level_2": "Business Continuity and Disaster Recovery Strategy",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to IT Disaster Recovery resources setting DR policy, establishing process and means, dedicated failover facilities, performing DR testing. NOTE: DR designated equipment is included directly in its own sub-tower. The implementation actions defined by Disaster Recovery policy are not included in the Disaster and Recovery sub-tower and are part of the respective towers where the actions take place.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Organizational Direction Setting",
+    "level_2": "Enterprise Policy Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to establish, maintain, comply with, and administer a course or principle of action adopted or proposed by an organization.",
+    "notes": "From BA Guild, merge with Risk and compliance section above"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Organizational Direction Setting",
+    "level_2": "Research Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to conduct systematic investigation into materials and sources in order to establish facts and reach conclusions that comprise a result.",
+    "notes": "From BA Guild, merge with APQC 2.0 above"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Organizational Direction Setting",
+    "level_2": "Strategy Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to define and disseminate an integrated pattern and perspective that aligns an organization’s goals, objectives, and action sequences into a cohesive whole.",
+    "notes": "From BA Guild, merge with APQC 1.0 above"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Analytics and Insights Enablement",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to create and use existing analytics capabilities for employees.",
+    "notes": "From APQC, perhaps combine with data management"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Collaboration and Communications",
+    "level_3": "Communication",
+    "definition": "Digital products and services used by employees used to communicate with other users, partners or customers.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Collaboration and Communications",
+    "level_3": "Printing",
+    "definition": "Digital products and services used by employees providing peripheral devices that enable the print and distribution of information within the organization or externally that is delivered as physical documents, presentations, spreadsheets, posterboards, banners etc. May also include converting physical documents and media into a digital formats.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Collaboration and Communications",
+    "level_3": "Productivity Software",
+    "definition": "Digital products and services used by employees providing employee productivity software including document creation, presentation, spreadsheet, diagramming, desktop publishing, video editing, web design, graphics and image editing, audio and video editing, media recording.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Collaboration and Communications",
+    "level_3": "Work and Collaboration Management",
+    "definition": "Digital products and services used by employees offering selection of collaborative capabilities that enable people to work together as teams or workgroups to achieve common goals across locations and time zones. Enables meetings and sharing of documents, notes and other deliverables across distributed internal and external users.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Conferencing and AV",
+    "level_3": "",
+    "definition": "Digital products and services used by employees offering audio and video conferencing facilities and equipment typically used in conference rooms or dedicated telepresence rooms to enable internal and external workforce communications / collaboration.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Content and Knowledge Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to plan, develop, create, capture, modify, evaluate, catalog, archive, and publish a creative work or other authored item, is manifested in audio/visual, still image, textual, experiential, mixed-media, or other forms.",
+    "notes": "From BA Guild, consider foundational for a broad-use by all other portfolios and automated for the most part and contextualized from each portfolio perspective (employee content vs. product and customer content etc.)"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Develop and Manage Enterprise-Wide Knowledge Management (KM) Capability",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that offer an organizational knowledge management capability that employees use to manage knowledge for use by other employees, and external consumers.",
+    "notes": "From APQC, BA Guild"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "End-User Computing",
+    "level_3": "Bring Your Own Device",
+    "definition": "Digital products and services used by employees used to manage employees personal computing devices use within the workplace, to include laptops, tablets and smartphone. Often software and services that enable connection, authentication, authorization and data management and security services are included.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "End-User Computing",
+    "level_3": "Mobile",
+    "definition": "Digital products and services used by employees offering selection of standard connected smartphones and tablets with network connectivity. Usually these include support packages including lifecycle replacement, security, encryption, back-up, updates and patches, remote access and service desks support.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "End-User Computing",
+    "level_3": "Mobile Devices",
+    "definition": "Digital products and services used by employees to Client compute tablets, smart phones (iOS, Android, Windows Mobile) and apps used by individuals to perform work.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "End-User Computing",
+    "level_3": "Virtual Client",
+    "definition": "Digital products and services used by employees offering virtualization of desktop and application software allowing virtual access separate from the physical devices hosting those functions in both fixed or mobile situations.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Information Management",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to the ability to define, organize, structure, secure, protect, and disseminate facts, statistics, attributes, and other types of data about an organization’s set of business objects.",
+    "notes": "From BA Guild, placed in Foundational as the need for cross-portfolio impact and visibility and reporting should be implemented here."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Language Management",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to the ability to define, express, recognize, interpret, and translate a method of communication or dialect variant consisting of units of representation or meaning numbers, words, symbols, sounds, or other physical manifestations and gestures, presented in a structured way.",
+    "notes": "From BA Guild, placed in Foundational as a more automated plug-in, automated aspect of the other portfolios.  Consider for the employee portfolio too"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Network Access",
+    "level_3": "",
+    "definition": "Digital products and services used by employees offering connection for users to access a private or public networks from their client computing device. Once connected, as part of the network they can access business applications and information; and can communicate and collaborate with other users on the network. Often times, this may be bundled with a Client Computing service.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Printing and Document Services",
+    "level_3": "",
+    "definition": "Digital products and services used by employees providing on-demand print services, often for high-volume and advanced printing activities invoices, product literature or other complex documents for mass distribution. Additional post-print services may include folding, envelope stuffing, postage and bundling to expedite distribution.",
+    "notes": "From TBM; Merged Level 3 items: As a Service; In-Office"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Productivity Applications",
+    "level_3": "",
+    "definition": "Digital products and services used by employees providing client software used to author, create, collaborate and share documents and other content to include email, communications, messaging, word processing, spreadsheets, presentations, desktop publishing, graphics and others. Optional Level 3 categories include Productivity; Communications; Collaboration.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Service Desk and Support",
+    "level_3": "Application Support",
+    "definition": "Digital products and services used by employees to Application Support services provide the ongoing operational activities required to keep the application or service up and running, provide Tier 2 and Tier 3 technical support to more complex or difficulty user questions and requests. Application Support may also include minor development and validation of smaller application enhancements.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Service Desk and Support",
+    "level_3": "Deskside Support",
+    "definition": "Digital products and services used by employees to Local support resources that provide on-site support for moves, adds, changes and hands on issue resolution.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Service Desk and Support",
+    "level_3": "IT Help Desk",
+    "definition": "Digital products and services used by employees to Centralized Tier 1 help desk resources that handle user requests, answer questions and resolve issues.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Service Desk and Support",
+    "level_3": "Service Desk",
+    "definition": "Digital products and services used by employees to Service Desk provides a single point of contact to meet the support needs of users and the IT organization. Service Desk services provide end users with information and support related to IT products and services, usually to troubleshoot problems or provide guidance about products computers, electronic equipment, or software. Help desk support may be delivered through various channels phone, website, instant messaging, or email. . Additional service delivery offerings include IT knowledge management, request fulfillment, desk-side and “tech bar” service offerings.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Training and Adoption",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to IT Training provides educational services to the organization's users on how the access and effectively use the organization's business application services, as well as common productivity software and tools.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Work and Collaboration Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to help employees define, route, and assign tasks queues across teams and other connected workers.",
+    "notes": "From BA Guild, rather generic but highly contextual to other portfolios too.  Assuming this is for employees primarily?"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Productivity Services",
+    "level_2": "Workplace and Remote Work Enablement",
+    "level_3": "",
+    "definition": "Digital products and services used by employees providing workspace delivered via public cloud, 3rd party providers for use in daily workplace and event management.",
+    "notes": "From TBM, changed to be focused on remote use workspace offerings; Merged Level 3 items: Facilities; Network Access; Workspace"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Enterprise Asset Management",
+    "level_3": "",
+    "definition": "Digital products and services managing enterprise assets.",
+    "notes": ""
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Enterprise Data Center",
+    "level_3": "",
+    "definition": "Digital products and services offering facilities to securely host computer equipment providing physical security, power, networking, and fire suppression capabilities. Includes data centers owned and operated by the enterprise, co-location, point-of-presence.",
+    "notes": "From TBM, consider as part of facilities"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Hardware Asset Management",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to manage foundational assets and context of location, lifecycle, vendor and overall lifecycle from initial acquisition to disposal.",
+    "notes": "From APQC, Asset perhaps better in the employee facing and contextualized within the 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Other Data Center",
+    "level_3": "",
+    "definition": "Digital products and services offering data center services that may be delivered through dedicated secure rooms, SCIFs, or remote closets within stores, warehouses, towers, or other facilitates.",
+    "notes": "From TBM, consider as part of facilities"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Physical Security Operations",
+    "level_3": "",
+    "definition": "Digital products and services used by employees offering management of physical property, facilities, equipment and people through physical security, gates and controls workforce authentication and authorization, badge readers and other identification means.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Physical Security Operations' (prior L2 now L3).; Collapsed single Level 3: Physical Security"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Resilience and Disaster Recovery Services",
+    "level_3": "",
+    "definition": "Digital products and services to manage storage resources used for archive, backup and recovery to support data loss, data corruption, disaster recovery and compliance requirements of the mainframe storage needs.",
+    "notes": "From TBM; Merged Level 3 items: Mainframe Offline Storage; Offline Storage; Public Cloud; Goldilocks restructure: moved Disaster Recovery to Enterprise Enablement Foundations for clearer accountability.; Collapsed single Level 3: Disaster Recovery"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Site and Data Center Facilities Operations",
+    "level_3": "Data Center Management",
+    "definition": "Digital products and services used by employees that serve IT equipment including the space, power, environment controls, racks, cabling and smart hand support.",
+    "notes": "From TBM combine with datacenter on foundational; Merged Level 3 items: Enterprise; Remote / Edge; Goldilocks restructure: moved under 'Site and Data Center Facilities Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Site and Data Center Facilities Operations",
+    "level_3": "Operations, Maintenance, Repair and Improvements",
+    "definition": "Digital products and services used by employees used to preserve operational use and improvement of physical assets through the planning, managing, and performance of preventative, routine, and critical maintenance work, and re-occurring improvements to facilities and equipment.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Site and Data Center Facilities Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Site and Data Center Facilities Operations",
+    "level_3": "Workspace Services",
+    "definition": "Digital products and services used by employees to Applications and services that enable provisioning workspaces and related assets, and management of that provisioning effort. The orchestration and/or installation of office, shared community or light industrial spaces according to requirements. Not intended for large scale industrial/plant construction. Excludes Physical Security.",
+    "notes": "From TBM, consider sub-section for human vs. compute, manufacturing, retail and other types of facilities to be managed; Goldilocks restructure: moved under 'Site and Data Center Facilities Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Software Asset Management",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to software asset management, including license tracking, allocation, and utilization measurement.",
+    "notes": "Part of the enterprise asset management on Provided to Employees to account for all assets."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Workplace and Real Estate Operations",
+    "level_3": "Asset Management",
+    "definition": "Digital products and services used by employees used to create, track, report on, and dispose of tangible or intangible property.",
+    "notes": "From BA guild, merge with asset above; Goldilocks restructure: moved under 'Site and Data Center Facilities Operations' (prior L2 now L3).; Manual override: Asset Management treated as workplace/real estate domain in Business Services."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Workplace and Real Estate Operations",
+    "level_3": "Facility Management and Space Planning",
+    "definition": "Digital products and services used by employees used to plan the use, maintenance, acquisition and construction or build out, of non-performing or performing real property for the organization. Planning, approvals, acquisition, lease of sites, for the build and use of property or assets for use of human resources, equipment, or inventory management or manufacturing requirements.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Workplace and Real Estate Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Workplace and Real Estate Operations",
+    "level_3": "Fleet Management (non-Logistics)",
+    "definition": "Digital products and services used by employees used to managing vehicles used to conduct business workforce transportation, delivering goods, resources and materials. May include financing, maintenance, telematics, and usage scheduling.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Workplace and Real Estate Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Workplace and Real Estate Operations",
+    "level_3": "Food and Beverage",
+    "definition": "Digital products and services used by employees supporting on-site food and beverage services for consumption by the organization’s workforce in any location.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Workplace and Real Estate Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Property and Facility Services",
+    "level_2": "Workplace and Real Estate Operations",
+    "level_3": "Location Management",
+    "definition": "Digital products and services used by employees that provide the ability to define, plan and determine locations used for the organization to operate and interact with external suppliers and customers.",
+    "notes": "From BA Guild, moves to the main provided to employees area; Goldilocks restructure: moved under 'Workplace and Real Estate Operations' (prior L2 now L3)."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Agreement Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to establish, organize, analyze, administer, and report on all aspects of a set of legally binding rights and obligations between two or more legal entities.",
+    "notes": "From BA Guild, potentially part of asset or building new products, but this is also needed in the customer facing and supply chain for provided externally in the context of physical goods or distribution partners too."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Customer Analytics",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Applications and services that enable customer and product analytics and voice of the customer input.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Customer Sales",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Applications and services that enable B2C commerce platforms, B2B commerce platforms, product configurations, POS platforms and payments.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Event Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to identify, define, and predict an occurrence that has happened or may happen, especially one of importance, concern, or interest.",
+    "notes": "From BA Guild, an operational aspect for all 4 portfolios, maybe foundational? Events here are not specific to IT, so there is potentially a broader context that is better for foundational."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Inquiry Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to manage questions, requests, feedback, or comment that may exist inside or outside of the organization which can be received, identified, harvested, disseminated, classified, and tracked.",
+    "notes": "From BA Guild, a bit too generic, integrate into specific areas where it makes more sense"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Marketing and Advertising",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Applications and services that enable marketing automation, online marketing, mobile marketing, and ad technologies.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Partner Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to identify, engage, collaborate with, control, predict, process, organize, present, and analyze all information, documents, preferences, experiences, and history related to a legal entity that has, plans to have, or has had some degree of involvement with the organization.",
+    "notes": "From BA Guild, consider for segmenting into the 4 portfolios as each a need potentially, and section 12 from APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Product Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to conceptualize, design, develop, bundle, source, maintain, and retire a named combination of goods and services that can be offered to customers, in whole or in part.",
+    "notes": "Part of 2.0 above, consider the products in all 4 portfolios as an evolution for employees to use"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Sales and Marketing",
+    "level_2": "Sales Force and Channel Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Applications and services that enable sales force automation, sales enablement and training, partner relationship management and pricing management.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Cybersecurity Operations",
+    "level_3": "Cyber Security and Incident Response",
+    "definition": "Digital products and services used by employees offering cybersecurity assurances to include maintaining policies, procedures and technologies to recognize current and emerging threats, determining associated risks and impacts. Manages processes to continuously improve defense and response activity, to included Monitoring and Incident Response for security related threats.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Identity and Access Management' (prior L2 now L3).; Manual override based on prior L2 classification."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Cybersecurity Operations",
+    "level_3": "Cybersecurity Operations",
+    "definition": "Digital products and services used by employees to IT Security resources setting policy, establishing process and means, measuring compliance and responding to security breaches. and providing real-time operational security vulnerability scanning, managing firewalls, intrusion prevention systems, and security information and event management (SIEM). Optional Level 3 categories include: Cyber Security. The implementation actions defined by security policies are not included in the Security sub-tower and are part of the respective towers where the actions take place.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Privacy and Data Protection' (prior L2 now L3).; Manual override based on prior L2 classification."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Cybersecurity Operations",
+    "level_3": "Threat and Vulnerability Management",
+    "definition": "Digital products and services used by employees offering threat and vulnerability services to applications and infrastructure vulnerabilities are proactively identified, classified and corrected to ensure they are not exploited by unauthorized individuals or parties. Specific areas included: Application Vulnerability Management, Infrastructure Vulnerability Management, and Network / Endpoint Security.",
+    "notes": "From TBM Similar to cybersecurity above, should combine?; Merged Level 3 items: On-Premise; Public Cloud; Goldilocks restructure: moved under 'Identity and Access Management' (prior L2 now L3).; Manual override based on prior L2 classification."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Governance, Risk and Compliance",
+    "level_3": "Business Continuity and Disaster Recovery Operations",
+    "definition": "Digital products and services used by employees that ensures that the operational continuity of the organization is planned to include business impacts, resiliency plans, disaster recovery, and exercising plans periodically. May include testing, training and awareness for people, process analysis, and technology redundancy and recovery processes in preparation for emergencies or incidents.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Governance, Risk and Compliance' (prior L2 now L3).; Manual override based on prior L2 classification."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Governance, Risk and Compliance",
+    "level_3": "Governance, Risk and Compliance",
+    "definition": "Digital products and services used by employees addressing technology compliance and policy to include establishing controls, measuring compliance to ensure risks are understood, identified, and met in alignment to regulatory requirements DORA, SSAE16, HIPAA, PCI DSS, SOX, TRICARE etc.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Governance, Risk and Compliance' (prior L2 now L3).; Manual override based on prior L2 classification."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Governance, Risk and Compliance",
+    "level_3": "Security Awareness",
+    "definition": "Digital products and services used by employees offering security awareness policy, procedures for all individuals regarding the protection of an organizations physical and digital assets. Specific areas included: Security Training, Security Advisory, and Security Policies and procedures.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Identity and Access Management' (prior L2 now L3).; Manual override based on prior L2 classification."
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Identity and Access Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that provide identity and access management (IAM) services per policy for all business processes and technology implementation. Controls and technologies required to facilitate the management of physical and digital identities by ensuring people have the appropriate access to appropriate facilities, digital assets and systems.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Identity and Access Management' (prior L2 now L3).; Manual override based on prior L2 classification.; Collapsed single Level 3: Identity and Access Management"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Security and Compliance",
+    "level_2": "Privacy and Data Protection",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to establish and maintain data privacy and security procedures that mitigate corporate and user data risks unauthorized access, authorization, authentication practices, lifecycle management practices, data classified procedures and controls for data loss prevention.",
+    "notes": "From TBM; Goldilocks restructure: moved under 'Identity and Access Management' (prior L2 now L3).; Manual override based on prior L2 classification.; Collapsed single Level 3: Data Privacy and Security"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Vendor and Procurement Services",
+    "level_2": "Contract Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Applications and services that enable the intake and management of vendor contracts. Keeping contracts current with routine evaluation. Ensure proactive dissemination of knowledge to key stakeholders regarding renewals, expirations, price changes, volume thresholds or other contract aspects, to provide adequate lead times and avoid lapses in service, or surprise / unplanned expenditures.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Vendor and Procurement Services",
+    "level_2": "Sourcing and Procurement",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to create strategies, standards, processes and policies in procuring goods and services from approved sources. Addresses evaluation and sourcing of suppliers, create sourcing relationships, continuously improve price performance, asses historical purchasing activities, standards, pricing to value respective chains.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Vendor and Procurement Services",
+    "level_2": "Supplier Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used in evaluating supplier options and selection criteria for the most effective, efficient and low risk suppliers. Periodically validate existing suppliers. Rank and manage strategic and non-strategic suppliers, optimize vendor spend, output, risks and performance.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Vendor and Procurement Services",
+    "level_2": "Technology Vendor Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees involved in the selection, contract management, oversight, performance management and general delivery of technology services by external vendors to include software, hardware and services.",
+    "notes": "From TBM, should we combine with other areas for vendor management?  Put this under each pillar, as part of the enterprise version?"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Compensation, Benefits, and Rewards",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to manage and administer employee benefits, benefit plans, enrollment, claims, funding and entitlements. Perform the analysis and planning of provider selection, employee communications, education, and regulatory compliance and reporting.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Employee Relations and Communications",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to craft and execute employee communications plans, customer messaging. Partner and distribution channel communication and go to market updates to include analysts and PR activities. Awareness campaigns for new policy, practices, or other internal / external events or actions to the relevant parties. Execute feedback processes for employees and customers.",
+    "notes": "From TBM, should duplicate / separate for customer-facing portfolios vs. employees and Foundational Technology feedback.; Merged Level 3 items: Employee Communications and Relations; Manage Employee Communication; Manage Employee Relations"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "HR Operations and Administration",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to assess, mentor, compensate, terminate, and otherwise coordinate individuals who have, plan to have, or have had a legal agreement with the organization, which includes compensation and other benefits on a temporary or permanent basis.",
+    "notes": "From BA Guild, merge with workforce management / APQC 7.0"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Learning, Development, and Onboarding",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to help employees and partners rate and improve skills, knowledge, and/or capability development, and education.. New hire and existing employee continuous education for technical and business skills; safety, security, ethics and compliance training. Includes OCM, course creation, delivery, management, reporting and penalty actions.",
+    "notes": "From TBM, combined with BA Guild; Merged Level 3 items: Employee Development - Developing Competencies; Manage Employee Onboarding, Training, and Development"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Offboarding and Transitions",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that enable managing full-time and contingent employees, partner transitions to include promotion, demotion, geographic moves. Management and administration of programs for: ex-pat foreign assignment, job reassignments, promotion/demotion, separation, outplacement, leave of absence, repatriation, anniversary rewards, and retirement.",
+    "notes": "From TBM; Merged Level 3 items: Employee Transitions and Separation; Redeploy and Retire Employees"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Performance and Rewards",
+    "level_3": "",
+    "definition": "Digital products and services used by employees used to perform management and administration of employee rewards and recognition to include short-term and long term retainment incentives and distribution.",
+    "notes": "From TBM; Merged Level 3 items: Performance, Retention and Rewards Management; Reward and Retain Employees"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Talent Acquisition",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Determining and handling employee requirements. Recruit or source the candidates as per the requirements. Screen and select the most appropriate candidates. Take care of the newly hired and re-hired employees. Maintain records of information for all applicants.",
+    "notes": "From APQC; Merged Level 3 items: Recruit, Source, and Select Employees; Recruitment"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Workforce Analytics and Insights",
+    "level_3": "",
+    "definition": "Digital products and services used by employees offering reporting capabilities about employees and contractors to include inquiry, information and data requests, and privileged access to HR information systems. Create and administer the employee metrics. Develop and handle the time and attendance systems.",
+    "notes": "From APQC"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Workforce Health and Safety",
+    "level_3": "",
+    "definition": "Digital products and services used by employees that help determine impacts of environmental health and safety to the organization. Create and implement the EHS program. Train and educate employees of the EHS function. Oversee and manage the EHS program.",
+    "notes": "From APQC, added to workforce management"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Workforce Planning and Management",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to identify, define, assign, and manage named category of accountabilities, whether remunerative or non-remunerative, associated with an assigned, specific, and accountable organization duty, role, or function that can be executed by a human or non-human resource.",
+    "notes": "From BA Guild, merge with workforce / APQC 7.0; Merged Level 3 items: Job Management - Managing Jobs; Workforce Management"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Workforce Planning and Strategy",
+    "level_3": "",
+    "definition": "Digital products and services used by employees to Creating strategies for the organization. Create and implement strategies for managing the work force. Supervise and enhance the strategies, plans, and policies supporting the HR function. Developing models for managing competency levels of the HR of the organization.",
+    "notes": "From APQC, need to decomposed into proper 4 portfolios"
+  },
+  {
+    "portfolio": "For Employees",
+    "portfolio_id": "for_employees",
+    "level_1": "Workforce Services",
+    "level_2": "Workforce Policy and Compliance",
+    "level_3": "",
+    "definition": "Digital products and services used by employees establish standards of conduct, corporate and legal HR compliance, skills and competencies, and resource Performance, Rewards and Transitions. Includes planning, supervising and implementation of workforce policy inclusive of modeling, analysis and reporting.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Embedded",
+    "level_3": "",
+    "definition": "Digital products and services offering embedded compute used in edge, small-scale, manufacturing, industrial and other remote applications.",
+    "notes": "Created for OT / Manufacturing"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "High Performance",
+    "level_3": "",
+    "definition": "Digital products and services offering High-Performance Computing (HPC), large-scale concurrent use computing resources and parallel processing often used in scientific and industrial research, product engineering and development, complex business modeling, simulation and analysis.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Mainframe Compute",
+    "level_3": "",
+    "definition": "Digital products and services that offer transactional and batch oriented compute services supported by a mainframe infrastructure, and monitoring.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "On Demand Compute",
+    "level_3": "",
+    "definition": "Digital products and services that offer virtual and often short-lived (ephemeral) compute services that are allocated automatically, either on a schedule or triggered on demand.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Physical Compute",
+    "level_3": "",
+    "definition": "Digital products and services that offer physical servers with lifecycle management services. These include compute services based on the Windows, Linux or UNIX operating systems with pre-defined offerings of memory, CPU and storage. Includes standard and optional operational support to include security, backup, updates, patches, and centralized monitoring, and usually in tiers of service.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Servers",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to Digital Products and Servies offering offer Public Cloud Compute as direct pass-though, arbitrage, central account and provisioning services, or federated cloud account allocation, management, and tags governance processes.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Unix",
+    "level_3": "",
+    "definition": "Digital products and services that offer vendor specific specialized compute services embedded compute, embedded systems, edge compute devices etc.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Compute",
+    "level_2": "Virtual Compute and Containers",
+    "level_3": "",
+    "definition": "Digital products and services offering compute delivered through virtualized compute resources to include on-demand provisioning and de-provisioning based on user self-service or scale-up / down performance based allocation. Configurations may provision memory, CPU and storage. Lifecycle management and operational support to include security, back-up, updates, patching and monitoring.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Data Analytics and Visualizations",
+    "level_3": "",
+    "definition": "Digital products and services that offer analytic, Business Intelligence, and visualization for use in analysis, reporting, and communications. May include real-time streaming analysis of complex events and screamed data processing.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Data Protection and Backup",
+    "level_3": "",
+    "definition": "Digital products and services offering Secure, lower-cost storage for data backup and archiving and restoring structured or non-structured data.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Data Warehouse",
+    "level_3": "",
+    "definition": "Digital products and services supporting a central repositories of integrated data from multiple disparate sources, containing current and historical data used in analytical reports for knowledge workers within the organization.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Database",
+    "level_3": "",
+    "definition": "Digital products and services offering the integration, management, analysis and storage of high volumes of structured and unstructured data, often ingested at high velocities.",
+    "notes": "From TBM; Merged Level 3 items: Big Data; On-Premise"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Distributed Cache",
+    "level_3": "",
+    "definition": "Digital products and services offering in-memory cache data services that for high-volume data retrieval.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Mainframe Database",
+    "level_3": "",
+    "definition": "Digital products and services offering Mainframe databases physical database and storage including administration, management tools and operational support.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Mainframe Online Storage",
+    "level_3": "",
+    "definition": "Digital products and services offering mainframe attached storage capacity.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Offline Storage",
+    "level_3": "",
+    "definition": "Digital products and services offering longer-term archival storage delivered via public cloud or 3rd party providers in facilities outside the main corporate datacenters and operational locations.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Online Storage",
+    "level_3": "",
+    "definition": "Digital products and services offering transactional, real-time storage capacity, delivered via public cloud and 3rd party providers.",
+    "notes": "From TBM; Merged Level 3 items: Public Cloud Storage; File and Object Storage; Networked Storage"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Data and Storage Management",
+    "level_2": "Transformation",
+    "level_3": "",
+    "definition": "Digital products and services offering data analytic that automate ETL (Extract, Transform, and Load) processes, data quality management and master data management.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Content Delivery Network (CDN)",
+    "level_3": "",
+    "definition": "Digital products and services offering content delivery networks and services for storing high-bandwidth content at the edge, used in reducing latency to edge consuming customers or applications.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Dedicated Data Networks",
+    "level_3": "",
+    "definition": "Digital products and services offering network communications across the organization including data centers, office buildings, remote locations, partners and service providers (including public cloud service providers) without traversing the public internet. Typically provides a greater level of performance, security and control. The available service offerings may include terrestrial and non-terrestrial technologies as well as field networks or special-use networks.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Domain Services",
+    "level_3": "",
+    "definition": "Digital products and services for managing Domain services and lookup for convert domain names into the associated IP address to enable communication between hosts internal and external to the company.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Internet Connectivity",
+    "level_3": "",
+    "definition": "Digital products and services offering telecommunication services using private intranet and public internet communications across the organization to including data centers, offices, remote locations and employees, partners, and service providers. Virtual Private Networks may be created to limit access and provide security.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Load Balancing",
+    "level_3": "",
+    "definition": "Digital products and services Offering network allocation, load balancing and management to deliver high availability connectivity for other critical digital products and services.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Network Connectivity",
+    "level_3": "",
+    "definition": "Digital products and services offering Physical and wireless local and wide area network capabilities allowing connecting devices within the core data centers, end users within facilities, and remotely. Wide area network equipment, labor and support services directly connecting data centers, offices and third parties (excludes telecom and communication services). Optional Level 3 categories include: LAN, WAN.",
+    "notes": "From TBM; Merged Level 3 items: LAN; WAN; Public Cloud"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Transport",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to Data network circuits and associated access facilities and services; includes dedicated and virtual data networks and internet access. Also includes usage associated with mobility and other data transit based on usage billing. Voice network circuits and associated access facilities and services. Also includes usage associated with standard telephone calls and 800 number service. Both voice and data transport may include terrestrial and non-terrestrial technologies. Optional Level 3 categories include: Data, Voice.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Virtual Private Network",
+    "level_3": "",
+    "definition": "Digital products and services offering VPN for secure authentication and connectivity access to corporate systems and information. VPN can also isolate and secure environments in the data center across physical and virtual machines and applications.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Voice",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to Voice resources which enable or distribute voice services through on-premise equipment including PBX, VoIP, voicemail and handsets (excludes telecom and communication services).",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Network Management",
+    "level_2": "Voice Network",
+    "level_3": "",
+    "definition": "Digital products and services offering telecommunication capabilities for voice circuits to deliver voice and intervoice communication and automation services. May include 800-services, call distribution, IVR, and call center services etc.",
+    "notes": "From TBM"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "AI and Agent Platform",
+    "level_3": "",
+    "definition": "Digital products and services providing agent orchestration, tool/function integration, evaluation, governance, and lifecycle management to build, deploy, and operate AI agents used by other digital products.",
+    "notes": "Goldilocks add: emerging platform family for agentic AI."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "API Management Platform",
+    "level_3": "",
+    "definition": "Digital products and services providing API gateway, developer onboarding, policy enforcement, and API lifecycle management to enable digital product integration.",
+    "notes": "Goldilocks add: common foundational platform family."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Application Hosting Platform",
+    "level_3": "",
+    "definition": "Digital products and services offering application and web hosting management services including the general computing server, database server, web and application server services. Includes standalone Web Service and App Service platform services.",
+    "notes": "From TBM  Need to sort out what to do with this one, not sure…; Merged Level 3 items: Application Hosting; Content Management; Goldilocks restructure: renamed 'Application' to 'Application Hosting Platform'.; Collapsed single Level 3: Application and Web Hosting"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Container Platform",
+    "level_3": "",
+    "definition": "Digital products and services used by product and IT teams to Digital Products for managing the resources and lifecycles of containers, includes the control and automation of tasks provisioning and deployment of containers, maintaining availability, scaling up or removing containers to manage application loads, relocating containers, allocating resources for containers, and monitoring container and host health.",
+    "notes": "From TBM; Goldilocks restructure: renamed 'Container Orchestration' to 'Container Platform'."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Decision Intelligence and Automation Platform",
+    "level_3": "",
+    "definition": "Digital products and services offering decision Intelligence and automation services focused on large datasets for accurate prediction, often low-code and self-service. Natural language processing, facial recognition, object recognition, intelligent personal assistants and robotic process automation are offerings that utilize these technologies to augment the human thought process.",
+    "notes": "From TBM; Goldilocks restructure: former L2 'Application Components' split to 'Decision Intelligence and Automation Platform'."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Enterprise SaaS Platform Enablement",
+    "level_3": "",
+    "definition": "Digital products and services offering platforms to include foundation capabilities ERP, low-code, workforce management, hospital management, collaboration and other types of platforms as a service. These platforms often applications purchased or written on the platform, often consisting lifecycle management capabilities for the applications created on the platform.",
+    "notes": "From TBM; Goldilocks restructure: clarified scope to SaaS platform enablement (tenant/admin/integration).; Collapsed single Level 3: ERP and Enterprise SaaS Platforms"
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Event Streaming Platform",
+    "level_3": "",
+    "definition": "Digital products and services that deliver real-time and on-demand media streams including audio, video, maps, weather, and other streaming data services.",
+    "notes": "From TBM; Goldilocks restructure: former L2 'Application Components' split to 'Event Streaming Platform'."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Identity and Access Platform",
+    "level_3": "",
+    "definition": "Digital products and services providing identity lifecycle, authentication, authorization, and privileged access capabilities consumed by digital products and services across the enterprise.",
+    "notes": "Goldilocks add: common foundational platform family."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Integration and Messaging Platform",
+    "level_3": "",
+    "definition": "Digital products and services offering messaging, integration, and gateway capabilities that allow different systems to communicate with one another, often through a canonical messaging and normalized data and interfaces. This includes specialized integration capabilities KAFKA bus, MQ Series, KONG, Apigee, WebMethods and other type of pub-sub or guaranteed messaging middleware.",
+    "notes": "From TBM Investigate the messaging and alerting to move somewhere else.; Goldilocks restructure: former L2 'Application Components' split to 'Integration and Messaging Platform'."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Middleware Platform",
+    "level_3": "",
+    "definition": "Digital products and services offering Mainframe integration capabilities and resources for cross application development, communications and information sharing.",
+    "notes": "From TBM; Merged Level 3 items: Mainframe Middleware; Public Cloud; Goldilocks restructure: clarified 'Middleware' as a platform family."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Observability Platform",
+    "level_3": "",
+    "definition": "Digital products and services providing centralized logging, metrics, tracing, alerting, and service health visibility for digital products and foundational services.",
+    "notes": "Goldilocks add: common foundational platform family."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Search Platform",
+    "level_3": "",
+    "definition": "Digital products and services offering keyword search service for web and mobile applications, or other internal, centralized search capabilities.",
+    "notes": "From TBM; Goldilocks restructure: former L2 'Application Components' split to 'Search Platform'."
+  },
+  {
+    "portfolio": "Foundational",
+    "portfolio_id": "foundational",
+    "level_1": "Platform Services",
+    "level_2": "Service Management Platform",
+    "level_3": "",
+    "definition": "Digital products and services providing IT/service workflow management, CMDB/service mapping enablement, request/incident/problem/change workflows, and automation for operating services.",
+    "notes": "Goldilocks add: common foundational platform family."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Monitoring & Event Detection",
+    "level_3": "Event — Hybrid delivery",
+    "definition": "Digital products and services that manage operational events (alerts, notifications, state changes), correlation, and routing to support rapid detection, triage, and response.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Monitoring & Event Detection",
+    "level_3": "Event — OT/Industrial delivery",
+    "definition": "Digital products and services that manage operational events (alerts, notifications, state changes), correlation, and routing to support rapid detection, triage, and response.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Monitoring & Event Detection",
+    "level_3": "Monitoring — Hybrid delivery",
+    "definition": "Digital products and services that collect and analyze metrics and signals to provide health, performance, and availability visibility for Digital Products and their components.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Monitoring & Event Detection",
+    "level_3": "Monitoring — OT/Industrial delivery",
+    "definition": "Digital products and services that collect and analyze metrics and signals to provide health, performance, and availability visibility for Digital Products and their components.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Monitoring & Event Detection",
+    "level_3": "Operational Monitoring and Control — OT/Industrial delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Operational Monitoring and Control. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Operational dashboards, Alert intake and triage, Control room workflows, Performance KPIs, Operational incident coordination, and SCADA/telemetry integration.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Change — OT/Industrial delivery",
+    "definition": "Digital products and services that manage change records and approvals for deployments/releases, providing governance, risk controls, and auditability integrated with delivery pipelines.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Configuration — OT/Industrial delivery",
+    "definition": "Digital products and services that provide the system of record for configuration of product instances, environments, and dependencies, linking desired state to actual state for controlled operations and compliance.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Customer Service Operations — Digital delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Customer Service Operations. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Case intake and routing, Claims management, Service request tracking, Customer communication templates, and Contact center knowledge.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Diagnostics & Remediation — Hybrid delivery",
+    "definition": "Digital products and services that support diagnostics, troubleshooting, and automated remediation (runbooks/automation) to reduce mean time to restore and improve operational resilience.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Diagnostics & Remediation — OT/Industrial delivery",
+    "definition": "Digital products and services that support diagnostics, troubleshooting, and automated remediation (runbooks/automation) to reduce mean time to restore and improve operational resilience.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Field Service Management — Digital delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Field Service Management. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Service request to work order, Dispatch optimization, Technician mobile, Parts logistics, and First-time-fix analytics.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Health, Safety, and Environmental Operations — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Health, Safety, and Environmental Operations. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Safety incident reporting, Permit-to-work, EHS inspections, Hazard identification, and Regulatory reporting support.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Incident — OT/Industrial delivery",
+    "definition": "Digital products and services that manage incident records and workflows to restore service quickly, including communication, escalation, and linkage to impacted product instances and changes.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Knowledge — OT/Industrial delivery",
+    "definition": "Digital products and services that manage operational knowledge (articles, runbooks, known errors, FAQs) to support support teams and enable consistent resolution and self-service.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Operational Risk Management — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Operational Risk Management. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Risk registers, Operational controls testing, BCM/DR for operations, Incident trend analysis, and Risk reporting.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Outage and Service Restoration — Digital delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Outage and Service Restoration. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Outage detection intake, Restoration coordination, Crew dispatch integration, Customer notifications, Post-incident reporting, and Incident to restoration workflows.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Pipeline and Midstream Operations — Digital delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Asset Operations (Pipeline and Midstream Operations). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Throughput monitoring, Integrity inspections, Leak detection workflows, Maintenance planning, and Regulatory reporting support.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Problem — OT/Industrial delivery",
+    "definition": "Digital products and services that manage root-cause analysis and known error records, linking recurring incidents to defects and remediation work to prevent recurrence.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Retail Store Operations — Digital delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Retail Store Operations. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Store task management, Planogram execution, In-store picking, Workforce scheduling, and Store performance analytics.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Service Level — OT/Industrial delivery",
+    "definition": "Digital products and services that define, measure, and report service levels (SLA/SLO/SLI) for Digital Products, including objectives, thresholds, and compliance reporting.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Telecom Network Operations — Digital delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Asset Operations (Telecom Network Operations). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Network assurance workflows, Trouble ticketing integration, Capacity alarms, Service assurance dashboards, and Change windows management.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Incident, Outage & Restoration",
+    "level_3": "Utilities Grid Operations — OT/Industrial delivery",
+    "definition": "Digital products and services that enable organizations to run production/service operations, restore service, and sustain asset performance through Asset Operations (Utilities Grid Operations). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities SCADA integration workflows, Switching orders, Asset health monitoring, Outage management integration, and Grid performance analytics.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Problem, RCA & Prevent",
+    "level_3": "Problem — Hybrid delivery",
+    "definition": "Digital products and services that manage root-cause analysis and known error records, linking recurring incidents to defects and remediation work to prevent recurrence.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Detect to Correct",
+    "level_2": "Change, Remediation & Knowledge",
+    "level_3": "Platform and Infrastructure CI/CD (IaC) — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (Platform and Infrastructure CI/CD (IaC)). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities IaC pipelines, Environment provisioning, Drift detection, Baseline enforcement, Platform upgrade orchestration, and IaC plan/apply pipelines.",
+    "notes": "Supports foundational compute/network/storage/platform services."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Usage, Subscription & Billing",
+    "level_3": "Customer Provisioning and Activation — Digital delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Customer Provisioning and Activation. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Service activation orders, Provisioning orchestration, Number/identifier assignment, Meter/service start, Activation status tracking, and Account and entitlement provisioning.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Consumption Experience — Hybrid delivery",
+    "definition": "Digital products and services that provide end-user experiences for discovering, requesting, and using digital product offerings (portals, APIs, developer experience).",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Continuous and Refining Operations — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Production Execution (Continuous and Refining Operations). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Run management, Throughput optimization, Unit operations monitoring, Alarm management integration, Production balance reporting, and Manufacturing execution workflows.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Cost Modeling — OT/Industrial delivery",
+    "definition": "Digital products and services that model unit costs and financial drivers for Digital Products across build, run, and consumption dimensions to inform planning and pricing.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Exploration and Extraction — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Exploration and Extraction. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Well planning, Drilling operations tracking, Production accounting, Mine planning integration, and Field production monitoring.",
+    "notes": "Collapsed single Level 3 into Level 2 (former Level 2: Resource Operations)"
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Identity — Hybrid delivery",
+    "definition": "Digital products and services that manage identities, access, and entitlements for digital product consumption, including authentication, authorization, and policy enforcement.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Knowledge — OT/Industrial delivery",
+    "definition": "Digital products and services that manage operational knowledge (articles, runbooks, known errors, FAQs) to support support teams and enable consistent resolution and self-service.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Maintenance and Reliability — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Maintenance and Reliability. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Preventive maintenance scheduling, Work order management, Condition monitoring intake, Reliability analytics, Spare parts planning, and Condition-based maintenance triggers.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Offer — OT/Industrial delivery",
+    "definition": "Digital products and services that define and publish offers (digital product packages, editions, entitlements) including terms and release associations for consumption.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Order — OT/Industrial delivery",
+    "definition": "Digital products and services that manage ordering workflows for offers, capturing customer requests, approvals, and fulfillment triggers across channels.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Packaging, Labeling, and Serialization — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Packaging, Labeling, and Serialization. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Packaging line execution, Label generation, Serialization management, Aggregation reporting, and Recall support workflows.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Process and Batch Manufacturing — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Production Execution (Process and Batch Manufacturing). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Recipe/Formula management, Batch execution, Batch genealogy, In-process quality checks, Electronic batch records, and Manufacturing execution workflows.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Procurement and Purchasing — Digital delivery",
+    "definition": "Digital products and services that enable organizations to select suppliers, procure materials/services, and control inbound quality and risk through Procurement and Purchasing. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Requisition and approval, Purchase order creation, Catalog management, Contracted pricing enforcement, and Procurement analytics.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Production Reporting and Traceability — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Production Reporting and Traceability. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Genealogy tracking, Lot/batch trace, Yield reporting, Scrap tracking, and Traceability reporting.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Receiving, Inspection, and Put-away — Digital delivery",
+    "definition": "Digital products and services that enable organizations to select suppliers, procure materials/services, and control inbound quality and risk through Receiving, Inspection, and Put-away. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities ASN processing, Receiving workflows, Quality inspection records, Put-away tasks, and Exceptions and holds management.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Release Composition — Hybrid delivery",
+    "definition": "Digital products and services that define and manage Product Release structure and content (blueprints, bill-of-materials, versions, dependencies) to enable repeatable, auditable, and compliant releases.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Offer, Request & Order Management",
+    "level_3": "Service Level — OT/Industrial delivery",
+    "definition": "Digital products and services that define, measure, and report service levels (SLA/SLO/SLI) for Digital Products, including objectives, thresholds, and compliance reporting.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Fulfillment Orchestration & Provisioning",
+    "level_3": "Configuration — Hybrid delivery",
+    "definition": "Digital products and services that provide the system of record for configuration of product instances, environments, and dependencies, linking desired state to actual state for controlled operations and compliance.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Fulfillment Orchestration & Provisioning",
+    "level_3": "Fulfillment — Hybrid delivery",
+    "definition": "Digital products and services that execute provisioning and deployment actions (e.g., create/update environments, deploy releases) based on orchestration instructions and desired-state definitions.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Fulfillment Orchestration & Provisioning",
+    "level_3": "Fulfillment Orchestration — Hybrid delivery",
+    "definition": "Digital products and services that orchestrate provisioning and deployment workflows across environments and platforms (pipeline-driven and consumer-driven), coordinating approvals, sequencing, and automation end-to-end.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Fulfillment Orchestration & Provisioning",
+    "level_3": "Knowledge — Hybrid delivery",
+    "definition": "Digital products and services that manage operational knowledge (articles, runbooks, known errors, FAQs) to support support teams and enable consistent resolution and self-service.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Fulfillment Orchestration & Provisioning",
+    "level_3": "Resource — Hybrid delivery",
+    "definition": "Digital products and services that manage the inventory and lifecycle of deployable resources (compute, storage, network, clusters, namespaces) used to host and run Digital Products across environments.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Fulfillment Orchestration & Provisioning",
+    "level_3": "Service Level — Hybrid delivery",
+    "definition": "Digital products and services that define, measure, and report service levels (SLA/SLO/SLI) for Digital Products, including objectives, thresholds, and compliance reporting.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "AI/ML and Agent CI/CD (ModelOps/AgentOps) — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (AI/ML and Agent CI/CD (ModelOps/AgentOps)). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Model registry integration, Evaluation gates, Prompt/version packaging, Agent deployment automation, Safety/guardrail test suites, and Rollback to prior version.",
+    "notes": "Supports AI Agent Platform and AI-enabled products."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "API and Microservices CI/CD — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (API and Microservices CI/CD). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Contract testing, API versioning automation, Container build pipelines, Progressive delivery, Rollback automation, and Container image build and scan.",
+    "notes": "Supports platform and integration services."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Application CI/CD (Web and Enterprise Apps) — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (Application CI/CD (Web and Enterprise Apps)). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Build and test pipelines, SAST/DAST integration, Progressive delivery (canary/blue-green), Feature flag integration, Release scheduling, and Build and unit test automation.",
+    "notes": "Supports employee-facing digital products and internal business applications."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Change — Hybrid delivery",
+    "definition": "Digital products and services that manage change records and approvals for deployments/releases, providing governance, risk controls, and auditability integrated with delivery pipelines.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Data and Analytics CI/CD — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (Data and Analytics CI/CD). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities ETL/ELT automation, Data quality gates, Schema migration automation, Lineage publishing, Release promotion across environments, and ETL/ELT pipeline promotion.",
+    "notes": "Supports data products used by employee and platform portfolios."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Discrete Manufacturing — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Production Execution (Discrete Manufacturing). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Work order execution, Work instruction delivery, Station/line monitoring, Andon alerts, OEE reporting, and Manufacturing execution workflows.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Last-mile and Field Delivery — Physical delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Distribution and Last-Mile Delivery (Last-mile and Field Delivery). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Delivery route dispatch, Driver mobile app, Proof of delivery capture, Delivery exception workflows, Customer delivery notifications, and Route optimization.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Materials and Warehouse Master Data — Physical delivery",
+    "definition": "Digital products and services that enable organizations to select suppliers, procure materials/services, and control inbound quality and risk through Materials and Warehouse Master Data. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Item master creation, UoM management, Location/bin master, Material classification, and Master data change control workflow.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Mobile CI/CD — Hybrid delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (Mobile CI/CD). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Mobile build pipelines, Signing key management, App store release automation, Device/test matrix automation, Crash reporting integration, and Mobile build farm/runners.",
+    "notes": "Supports mobile employee apps and customer apps where applicable."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Operational Data and Digital Twin — OT/Industrial delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Operational Data and Digital Twin. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Asset hierarchy modeling, Digital twin model management, Time-series ingestion, Simulation runs, Twin-based performance analytics, and SCADA/telemetry integration.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Operational Partner and Ecosystem Integration — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Operational Partner and Ecosystem Integration. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Partner onboarding, EDI/API integrations, Contractor work management, Partner performance reporting, and Joint exception management.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Order and Fulfillment Management — Physical delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Order and Fulfillment Management. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Order capture, ATP/CTP promise, Allocation rules, Fulfillment orchestration, Order status and exceptions management, and Order capture and validation.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Progressive Delivery and Release Orchestration — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Deployment and Operations Enablement (Progressive Delivery and Release Orchestration). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Canary orchestration, Feature flag integration, Deployment windows, Automated rollback, Release calendars, and Feature flag service integration.",
+    "notes": "Supports safe delivery across business and foundational products."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Regulatory and Trade Compliance — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Regulatory and Trade Compliance. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Regulatory filings support, Trade compliance checks, Certifications tracking, Audit evidence collection, and Compliance dashboards.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Release Governance and Evidence Automation — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through DevSecOps Controls and Compliance (Release Governance and Evidence Automation). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Release evidence packs, Automated control attestations, Change record integration, Audit trail export, Segregation-of-duties checks, and Automated evidence packs.",
+    "notes": "Reduces manual compliance overhead."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Reverse Logistics and Returns — Physical delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Distribution and Last-Mile Delivery (Reverse Logistics and Returns). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Returns authorization, Return routing, Refurbish workflows, Disposal management, Returns analytics, and Reverse logistics routing.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Software Supply Chain Security — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through DevSecOps Controls and Compliance (Software Supply Chain Security). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities SBOM generation, Artifact signing, Dependency scanning, Provenance attestation, Policy enforcement, and Provenance attestations.",
+    "notes": "Standardizes controls across all product teams."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Standard Pipeline Templates and Golden Paths — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through CI/CD and Release Engineering (Standard Pipeline Templates and Golden Paths). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Pipeline template catalog, Approved build steps library, Standard deployment stages, Policy-as-code checks, Reference implementations, and Reusable build/test stages library.",
+    "notes": "Added to support standardized digital product manufacturing and delivery across portfolios."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Test Automation Platforms — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Environment and Test Enablement (Test Automation Platforms). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Test framework libraries, Performance test harness, Test reporting dashboards, Flaky test management, Coverage analytics, and Standard test frameworks.",
+    "notes": "Improves quality and consistency across portfolios."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Test Environments and Ephemeral Environments — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Environment and Test Enablement (Test Environments and Ephemeral Environments). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Ephemeral environment provisioning, Test data refresh, Environment catalog, Sandbox management, Access controls, and Test data refresh/sanitization.",
+    "notes": "Supports standardized delivery across diverse products."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Training, Certification, and Competency — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Training, Certification, and Competency. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Training assignments, Certification tracking, Competency assessments, Role-based learning paths, and Audit-ready training records.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Transportation Management — Physical delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Transportation Management. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Load planning, Carrier selection, Freight tendering, Track and trace, Freight audit support, and Shipment planning.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Delivery, Distribution & Activation",
+    "level_3": "Warehouse Operations — Physical delivery",
+    "definition": "Digital products and services that enable organizations to activate, fulfill, ship, and complete delivery to customers and channels through Warehouse Operations. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Pick/pack tasks, Wave management, Cycle counts, Yard and dock management, Inventory movement workflows, and Inbound receiving workflows.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Usage, Subscription & Billing",
+    "level_3": "Chargeback — OT/Industrial delivery",
+    "definition": "Digital products and services that support cost allocation and chargeback/showback for digital product consumption using usage, rate models, and financial reporting.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Usage, Subscription & Billing",
+    "level_3": "Subscription — OT/Industrial delivery",
+    "definition": "Digital products and services that manage subscriptions (start/stop/change), renewal, and lifecycle events for digital offers and entitlements.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Usage, Subscription & Billing",
+    "level_3": "Toolchain Standardization and Managed CI/CD Service — Digital delivery",
+    "definition": "Digital products and services that enable organizations to standardize operational enablement, automation, data, and controls across delivery teams through Pipeline Standardization and Adoption (Toolchain Standardization and Managed CI/CD Service). These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Managed runners, Toolchain lifecycle management, Pipeline onboarding service, Usage metering, Platform support tiers, and Managed runners/agents.",
+    "notes": "Addresses redundancy and Conway’s Law concerns by standardizing pipelines."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Request to Fulfill",
+    "level_2": "Usage, Subscription & Billing",
+    "level_3": "Usage — OT/Industrial delivery",
+    "definition": "Digital products and services that capture usage telemetry for digital products to support metering, analytics, entitlement enforcement, and value realization reporting.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Test & Validate",
+    "level_3": "Build Package — Hybrid delivery",
+    "definition": "Digital products and services that manage packaged build artifacts (binaries, containers, packages) created by pipelines, including integrity, signing, provenance, and retrieval for deployment and release.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Test & Validate",
+    "level_3": "Defect — Hybrid delivery",
+    "definition": "Digital products and services that provide the system of record for defects (including vulnerabilities and technical debt) with lifecycle management and linkage to requirements, source, builds, and releases.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Test & Validate",
+    "level_3": "Pipeline — OT/Industrial delivery",
+    "definition": "Digital products and services that orchestrate automated build, verification, test, and deployment workflows to produce a tested, validated, and compliant Product Release.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Test & Validate",
+    "level_3": "Release Composition — Hybrid delivery",
+    "definition": "Digital products and services that define and manage Product Release structure and content (blueprints, bill-of-materials, versions, dependencies) to enable repeatable, auditable, and compliant releases.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Test & Validate",
+    "level_3": "Source Control — Hybrid delivery",
+    "definition": "Digital products and services that provide the system of record for product source (code, configuration, policy-as-code) with versioning, traceability, and controlled collaboration for Digital Products.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Test & Validate",
+    "level_3": "Test — OT/Industrial delivery",
+    "definition": "Digital products and services that plan, orchestrate, and execute automated and manual testing to ensure a Product Release meets quality, security, compliance, and expected service levels, producing test evidence and defects.",
+    "notes": "IT4IT v3.0.1 (Digital Product Factory)."
+  },
+  {
+    "portfolio": "Manufacturing and and Delivery",
+    "portfolio_id": "manufacturing_and_delivery",
+    "level_1": "Requirement to Deploy",
+    "level_2": "Release & Deploy",
+    "level_3": "Quality Management — Digital delivery",
+    "definition": "Digital products and services that enable organizations to execute production safely, consistently, and with traceability through Quality Management. These capabilities coordinate workflows, operational data, integrations, and controls so that work can be executed reliably across sites, partners, and channels. It typically includes capabilities Inspection plans, Nonconformance management, CAPA workflows, Lot release approvals, Quality analytics, and Quality inspections.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Automotive and Mobility",
+    "level_2": "Mobility Services",
+    "level_3": "Connected Vehicle Services",
+    "definition": "Products and services sold to external customers that provide connected vehicle services. Digital services tied to vehicles (telematics, subscriptions).",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Automotive and Mobility",
+    "level_2": "Mobility Services",
+    "level_3": "Mobility-as-a-Service",
+    "definition": "Products and services sold to external customers that provide mobility-as-a-service. Subscription/usage-based mobility services (car share, ride services).",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Automotive and Mobility",
+    "level_2": "Vehicle Sales",
+    "level_3": "Commercial Vehicles",
+    "definition": "Products and services sold to external customers that provide commercial vehicles. Sales of commercial vehicles and fleets.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Automotive and Mobility",
+    "level_2": "Vehicle Sales",
+    "level_3": "Passenger Vehicles",
+    "definition": "Products and services sold to external customers that provide passenger vehicles. Sales of passenger vehicles.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Chemicals",
+    "level_2": "Commodity Chemicals",
+    "level_3": "Bulk Chemicals",
+    "definition": "Products and services sold to external customers that provide bulk chemicals. Bulk/commodity chemical products.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Chemicals",
+    "level_2": "Specialty Chemicals",
+    "level_3": "Specialty Formulations",
+    "definition": "Products and services sold to external customers that provide specialty formulations. Specialty chemical products and formulations.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "AI Platforms",
+    "level_3": "AI/Agent Platform as a Service",
+    "definition": "Products and services sold to external customers that provide ai/agent platform as a service. Managed AI and agent platforms sold externally enabling customers to build, deploy, and operate AI agents with governance, safety, and observability.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Application Platforms",
+    "level_3": "Application Hosting Platform (PaaS)",
+    "definition": "Products and services sold to external customers that provide application hosting platform (paas). Managed application hosting platforms (runtime, container hosting, app services) sold to external customers to build and run applications without managing underlying infrastructure.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Cloud Infrastructure",
+    "level_3": "Compute, Storage, and Network (IaaS)",
+    "definition": "Products and services sold to external customers that provide compute, storage, and network (iaas). Infrastructure services sold to external customers enabling them to provision compute, storage, and network resources on-demand and build their own digital products.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Data Platforms",
+    "level_3": "Managed Data Services",
+    "definition": "Products and services sold to external customers that provide managed data services. Managed database, analytics, and data integration services sold externally, including provisioning, scaling, backup, and governance features.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Developer Platforms",
+    "level_3": "CI/CD and Dev Toolchain as a Service",
+    "definition": "Products and services sold to external customers that provide ci/cd and dev toolchain as a service. Managed CI/CD, repositories, runners, and developer toolchains sold as a platform service to standardize software delivery for customer-built solutions.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Identity and Security",
+    "level_3": "Identity and Access as a Service",
+    "definition": "Products and services sold to external customers that provide identity and access as a service. External identity, access, and customer authentication services sold to enable secure customer sign-in, authorization, and entitlement across apps.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Network and Edge",
+    "level_3": "Content Delivery and Edge Platforms",
+    "definition": "Products and services sold to external customers that provide content delivery and edge platforms. CDN/edge delivery services sold externally to deliver low-latency content, APIs, and streaming workloads close to end users.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Digital Platform Services",
+    "level_2": "Payments",
+    "level_3": "Payments Platform Services",
+    "definition": "Products and services sold to external customers that provide payments platform services. Payments acceptance, processing, and payout services sold as APIs/platform products to support digital commerce and embedded finance.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Energy (Oil and Gas)",
+    "level_2": "Downstream",
+    "level_3": "Refined Fuels and Products",
+    "definition": "Products and services sold to external customers that provide refined fuels and products. Refined fuels and petroleum-derived products.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Energy (Oil and Gas)",
+    "level_2": "Midstream",
+    "level_3": "Transportation and Storage Services",
+    "definition": "Products and services sold to external customers that provide transportation and storage services. Pipeline/terminal transportation and storage services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Energy (Oil and Gas)",
+    "level_2": "Upstream",
+    "level_3": "Crude and Natural Gas Production",
+    "definition": "Products and services sold to external customers that provide crude and natural gas production. Produced crude oil and natural gas sold as commodities.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Commercial Banking",
+    "level_3": "Treasury & Cash Management (Bank Platforms)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Target buyers: corporate treasurers/CFO orgs. Typical offerings: payment initiation, collections/lockbox, liquidity dashboards, forecasting, FX, trade finance. Often bundled with relationship banking."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Commercial Banking",
+    "level_3": "Treasury Management Systems (TMS) Software",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Often bought by larger corporates to work across multiple banks; complements bank portals. Revenue via subscription + implementation services."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Payments",
+    "level_3": "Buy Now, Pay Later (BNPL) & Installments",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Offered via merchants and sometimes cards. Revenue via merchant discount + interest on longer plans."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Payments",
+    "level_3": "Card Issuing & Card Program Management",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Often used by fintechs/neobanks to launch cards. Commercial models: per-transaction + platform fees."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Payments",
+    "level_3": "Card Networks & Schemes",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Provides payment network services used by issuing banks, acquirers and merchants. Monetization via network fees/assessment fees."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Payments",
+    "level_3": "Digital Wallets & Consumer Payment Apps",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Wallets can be closed-loop or network-tokenized. Revenue via merchant fees, interchange, subscriptions, and value-added services."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Payments",
+    "level_3": "Merchant Acquiring & Payment Processing",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Serves merchants/marketplaces; monetization via take-rate and value-added services (fraud, invoicing, payouts)."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Payments",
+    "level_3": "P2P & Account-to-Account Transfers",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Zelle is offered through participating banks/credit unions; infrastructure partners (e.g., Fiserv) help institutions implement it."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Retail Banking",
+    "level_3": "Consumer Lending (Mortgages & Home Equity)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "High-touch processes still common; digital origination is a differentiator."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Retail Banking",
+    "level_3": "Consumer Lending (Personal/Installment Loans)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Distribution via direct-to-consumer digital channels and partner marketplaces. Revenue via interest + origination fees."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Retail Banking",
+    "level_3": "Consumer Lending (Student Loans & Refinancing)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Often digital-first; sensitivity to regulation and macro rate environment."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Retail Banking",
+    "level_3": "Deposit Accounts (Digital Banks/Neobanks)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Differentiation: UX, pricing, financial wellness tooling, and ecosystem partnerships."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Retail Banking",
+    "level_3": "Deposit Accounts (Traditional Banks)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Often cross-sold with cards/loans. Hybrid channels (branch + digital)."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Wealth and Investment",
+    "level_3": "Asset & Fund Management (ETFs/Mutual Funds/Model Portfolios)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Product-centric offerings; revenue via management fees/expense ratios."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Wealth and Investment",
+    "level_3": "Full-Service Wealth Management & Advisory",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Targets HNW/mass affluent; revenue via AUM fees, commissions (where applicable), and banking cross-sell."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Financial Services",
+    "level_2": "Wealth and Investment",
+    "level_3": "Hybrid / Robo-Advisors (Managed Portfolios)",
+    "definition": "Products and services sold to external customers.",
+    "notes": "Differentiation via fees, minimums, tax-loss harvesting, and advisor access."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Healthcare Services",
+    "level_2": "Clinical Care",
+    "level_3": "Ambulatory and Specialty Care",
+    "definition": "Products and services sold to external customers that provide ambulatory and specialty care. Clinics, ambulatory care, imaging, and specialty services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Healthcare Services",
+    "level_2": "Clinical Care",
+    "level_3": "Hospital Services",
+    "definition": "Products and services sold to external customers that provide hospital services. Inpatient and outpatient hospital care services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Healthcare Services",
+    "level_2": "Payer Services",
+    "level_3": "Health Plan and Claims Services",
+    "definition": "Products and services sold to external customers that provide health plan and claims services. Health insurance administration, claims, and member services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Insurance",
+    "level_2": "Commercial Insurance",
+    "level_3": "Commercial Lines",
+    "definition": "Products and services sold to external customers that provide commercial lines. Business insurance (liability, property, workers comp, etc.).",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Insurance",
+    "level_2": "Life and Benefits",
+    "level_3": "Life Insurance and Annuities",
+    "definition": "Products and services sold to external customers that provide life insurance and annuities. Life insurance, annuities, and related benefits products.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Insurance",
+    "level_2": "Personal Insurance",
+    "level_3": "Auto Insurance",
+    "definition": "Products and services sold to external customers that provide auto insurance. Personal auto insurance policies and related services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Insurance",
+    "level_2": "Personal Insurance",
+    "level_3": "Homeowners and Property",
+    "definition": "Products and services sold to external customers that provide homeowners and property. Homeowners/renters and personal property insurance products.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Life Sciences and Pharma",
+    "level_2": "Biotech and Biologics",
+    "level_3": "Vaccines and Biologics",
+    "definition": "Products and services sold to external customers that provide vaccines and biologics. Biological products including vaccines and therapeutics.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Life Sciences and Pharma",
+    "level_2": "Medical Devices",
+    "level_3": "Devices and Diagnostics",
+    "definition": "Products and services sold to external customers that provide devices and diagnostics. Medical devices, diagnostics, and related consumables.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Life Sciences and Pharma",
+    "level_2": "Pharmaceuticals",
+    "level_3": "Branded and Generic Drugs",
+    "definition": "Products and services sold to external customers that provide branded and generic drugs. Manufactured drug products including generics and branded medicines.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Manufacturing and Industrial",
+    "level_2": "Aftermarket Services",
+    "level_3": "Maintenance and Repair Services",
+    "definition": "Products and services sold to external customers that provide maintenance and repair services. Service contracts, maintenance, repair, and parts services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Manufacturing and Industrial",
+    "level_2": "Industrial Products",
+    "level_3": "Components and Materials",
+    "definition": "Products and services sold to external customers that provide components and materials. Manufactured components, subassemblies, and industrial materials.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Manufacturing and Industrial",
+    "level_2": "Industrial Products",
+    "level_3": "Industrial Equipment",
+    "definition": "Products and services sold to external customers that provide industrial equipment. Manufactured industrial equipment and machinery.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Media and Entertainment",
+    "level_2": "Advertising",
+    "level_3": "Advertising Products",
+    "definition": "Products and services sold to external customers that provide advertising products. Advertising inventory/products (digital, broadcast, programmatic).",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Media and Entertainment",
+    "level_2": "Streaming Services",
+    "level_3": "Music and Audio Streaming",
+    "definition": "Products and services sold to external customers that provide music and audio streaming. streaming services delivered through apps on customer devices and web experiences, backed by customer identity/account management, entitlements, content catalog, DRM/session control, and content delivery networks.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Media and Entertainment",
+    "level_2": "Streaming Services",
+    "level_3": "Video Streaming",
+    "definition": "Products and services sold to external customers that provide video streaming. streaming services delivered through apps on customer devices and web experiences, backed by customer identity/account management, entitlements, content catalog, DRM/session control, and content delivery networks.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Retail and Consumer",
+    "level_2": "Digital Commerce",
+    "level_3": "Marketplace and Subscriptions",
+    "definition": "Products and services sold to external customers that provide marketplace and subscriptions. Marketplace services, membership programs, and digital subscriptions.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Retail and Consumer",
+    "level_2": "Merchandise",
+    "level_3": "Consumer Goods Sales",
+    "definition": "Products and services sold to external customers that provide consumer goods sales. Retail sale of physical goods through stores and digital channels.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Retail and Consumer",
+    "level_2": "Private Label and Brands",
+    "level_3": "Private Label Products",
+    "definition": "Products and services sold to external customers that provide private label products. Company-branded goods and private label product lines.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Telecommunications",
+    "level_2": "Connectivity",
+    "level_3": "Fixed Broadband",
+    "definition": "Products and services sold to external customers that provide fixed broadband. Connectivity services (mobile, broadband, voice) delivered through network access and customer self-service channels, supported by customer accounts, service activation/provisioning, usage metering, billing, and device/SIM onboarding.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Telecommunications",
+    "level_2": "Connectivity",
+    "level_3": "Mobile Services",
+    "definition": "Products and services sold to external customers that provide mobile services. Connectivity services (mobile, broadband, voice) delivered through network access and customer self-service channels, supported by customer accounts, service activation/provisioning, usage metering, billing, and device/SIM onboarding.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Telecommunications",
+    "level_2": "Enterprise Services",
+    "level_3": "Managed Network and UCaaS",
+    "definition": "Products and services sold to external customers that provide managed network and ucaas. Connectivity services (mobile, broadband, voice) delivered through network access and customer self-service channels, supported by customer accounts, service activation/provisioning, usage metering, billing, and device/SIM onboarding.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Transportation and Logistics",
+    "level_2": "Logistics Services",
+    "level_3": "Parcel and Freight Delivery",
+    "definition": "Products and services sold to external customers that provide parcel and freight delivery. Parcel delivery, freight, forwarding, and logistics services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Transportation and Logistics",
+    "level_2": "Logistics Services",
+    "level_3": "Warehousing and Fulfillment",
+    "definition": "Products and services sold to external customers that provide warehousing and fulfillment. Warehousing, fulfillment, and distribution services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Transportation and Logistics",
+    "level_2": "Passenger Transport",
+    "level_3": "Air/Rail/Transit Services",
+    "definition": "Products and services sold to external customers that provide air/rail/transit services. Passenger transportation services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Utilities",
+    "level_2": "Energy Supply",
+    "level_3": "Electricity Supply Services",
+    "definition": "Products and services sold to external customers that provide electricity supply services. Electricity generation and retail supply services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Utilities",
+    "level_2": "Energy Supply",
+    "level_3": "Natural Gas Distribution",
+    "definition": "Products and services sold to external customers that provide natural gas distribution. Gas distribution and retail supply services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Utilities",
+    "level_2": "Water Services",
+    "level_3": "Water and Wastewater Services",
+    "definition": "Products and services sold to external customers that provide water and wastewater services. Water delivery and wastewater treatment services.",
+    "notes": ""
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Marketing and Demand Generation",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that identify and shape market demand, generate qualified leads, and drive awareness of products and services offered. Encompasses market intelligence, segmentation, campaign execution, and inbound lead generation across channels.",
+    "notes": "APQC PCF 3.1, 3.2, 3.4, 3.9 / eTOM Market Strategy and Policy L2. Synergy: For Employees > Sales and Marketing > Marketing and Advertising (employee tool layer); For Employees > Develop Vision and Strategy > Campaign Management (strategy); For Employees > Develop Vision and Strategy > Market Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Marketing and Demand Generation",
+    "level_3": "Market Intelligence and Segmentation",
+    "definition": "Capabilities to research and analyse market conditions, competitive landscape, customer segments, and buying behaviour to inform product positioning and targeting strategies. Sources data from internal and external signals including voice-of-customer, competitive intelligence, and market sizing.",
+    "notes": "APQC PCF 3.1 (Understand markets, customers, and capabilities). Synergy: For Employees > Sales and Marketing > Customer Analytics."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Marketing and Demand Generation",
+    "level_3": "Campaign Planning and Execution",
+    "definition": "Capabilities to design, execute, and measure multi-channel marketing campaigns targeting customer segments with the objective of generating demand and driving pipeline. Includes content, digital advertising, events, email, and partner co-marketing.",
+    "notes": "APQC PCF 3.9 (Manage and execute marketing programs) / eTOM Marketing Fulfillment Response L2. Synergy: For Employees > Develop Vision and Strategy > Campaign Management; For Employees > Sales and Marketing > Marketing and Advertising; For Employees > Sales and Marketing > Event Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Marketing and Demand Generation",
+    "level_3": "Lead Generation and Capture",
+    "definition": "Capabilities to generate, capture, score, and route qualified leads from marketing programmes into the sales pipeline. Includes web forms, inbound enquiry handling, third-party lead sources, intent data, and lead qualification workflows.",
+    "notes": "APQC PCF 3.8.1 / eTOM Selling L3 / CDM entity: Lead. Synergy: For Employees > Sales and Marketing > Inquiry Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Marketing and Demand Generation",
+    "level_3": "Demand Management",
+    "definition": "Capabilities to forecast, shape, and balance market demand against organisational capacity to supply products and services. Includes demand sensing, capacity signalling, and demand-supply matching across commercial and operational planning cycles.",
+    "notes": "APQC PCF 3.4 (Develop and manage marketing plans) / eTOM Demand Management process group L2."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Sales and Opportunity Management",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that manage the progression of qualified leads through the sales cycle to a closed commitment. Encompasses opportunity management, sales forecasting, and partner/channel sales coordination.",
+    "notes": "APQC PCF 3.3, 3.5, 3.8 / eTOM Selling process group L2. Synergy: For Employees > Sales and Marketing > Customer Sales; For Employees > Sales and Marketing > Sales Force and Channel Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Sales and Opportunity Management",
+    "level_3": "Opportunity Management",
+    "definition": "Capabilities to qualify, track, and advance sales opportunities through defined pipeline stages from initial engagement to a committed order. Includes opportunity scoring, competitive analysis, stakeholder mapping, and win/loss analysis.",
+    "notes": "APQC PCF 3.8.2 / eTOM Selling L3 / CDM entity: Opportunity."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Sales and Opportunity Management",
+    "level_3": "Sales Pipeline and Forecasting",
+    "definition": "Capabilities to maintain an accurate view of the sales pipeline, generate revenue forecasts, and manage resource allocation to sales activities. Includes stage-weighted forecasting, commit vs best-case analysis, and pipeline health reporting.",
+    "notes": "APQC PCF 3.5 (Develop and manage sales plans) / eTOM Selling L3."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Sales and Opportunity Management",
+    "level_3": "Partner and Channel Sales Management",
+    "definition": "Capabilities to manage relationships and transaction flows with resellers, distributors, system integrators, and other commercial partners who sell products and services on behalf of or alongside the organisation. Includes deal registration, partner portal, channel incentives, and co-selling workflows.",
+    "notes": "APQC PCF 3.7 (Develop and manage sales partners and alliances) / eTOM Channel Management L2. Synergy: For Employees > Sales and Marketing > Partner Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Configure-Price-Quote",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that enable the specification, pricing, and formal quotation of product and service offerings tailored to customer requirements. Bridges product catalog, pricing rules, and commercial terms into a deliverable proposal or quote.",
+    "notes": "APQC PCF 3.6, 3.11 / eTOM Proposal and Quotation Management L2 / TM Forum TMF620 Product Catalog Management API. Synergy: For Employees > Sales and Marketing > Agreement Management; Manufacturing and Delivery > Request to Fulfill > Offer, Request & Order Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Configure-Price-Quote",
+    "level_3": "Product Configuration and Eligibility",
+    "definition": "Capabilities to configure complex product and service combinations according to customer requirements, business rules, and compatibility constraints. Includes rules-based configuration engines, eligibility checks, and guided selling workflows that enforce valid product combinations.",
+    "notes": "TM Forum TMF620 Product Catalog Management API / eTOM Product Capability Assessment L3. Synergy: Manufacturing and Delivery > Request to Fulfill > Offer, Request & Order Management > Offer."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Configure-Price-Quote",
+    "level_3": "Pricing and Discount Management",
+    "definition": "Capabilities to apply and govern list prices, negotiated discounts, bundling incentives, and promotional pricing to configured product combinations. Includes price book management, approval workflows for non-standard discounts, and deal economics modelling.",
+    "notes": "APQC PCF 3.6, 3.11 / TM Forum TMF620 / Zuora entities: ProductRatePlan, ProductRatePlanCharge. Synergy: TM Forum TMF671 Promotion Management API."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Configure-Price-Quote",
+    "level_3": "Proposal and Quotation Management",
+    "definition": "Capabilities to generate, version, deliver, and track formal proposals and quotations presented to prospective customers. Includes document generation, e-signature, expiry management, and proposal analytics to optimise win rates.",
+    "notes": "APQC PCF 3.8.3 / eTOM Proposal and Quotation Management L3 / CDM entity: Quote."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Configure-Price-Quote",
+    "level_3": "Contract Authoring and Negotiation",
+    "definition": "Capabilities to draft, negotiate, and execute commercial contracts governing the supply of products and services. Includes template management, clause libraries, redline and negotiation workflows, and electronic execution integrated with downstream order and subscription systems.",
+    "notes": "APQC PCF 3.8.4 / TM Forum TMF651 Agreement Management API / CDM entity: Contract / IT4IT v3.0.1 §4.2.3 Contract Definition (MUST-0017). Synergy: For Employees > Sales and Marketing > Agreement Management; For Employees > Legal > Contract Review; For Employees > Vendor and Procurement Services > Contract Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Order Management",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that receive, validate, orchestrate, and track customer product orders from point of commitment through to fulfillment trigger. Manages the order lifecycle across channels and ensures order integrity, completeness, and traceability.",
+    "notes": "eTOM Order Handling process group L2 / TM Forum TMF622 Product Order Management API / APQC PCF 4.x. Synergy: Manufacturing and Delivery > Request to Fulfill > Offer, Request & Order Management > Order."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Order Management",
+    "level_3": "Order Entry and Validation",
+    "definition": "Capabilities to receive customer orders across channels (web, portal, EDI, sales-assisted), validate completeness and commercial correctness against configured rules, and confirm acceptance to the customer. Includes order schema validation, credit checking, and conflict detection.",
+    "notes": "eTOM Order Entry and Validation L3 / TM Forum TMF622 / CDM entity: Order."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Order Management",
+    "level_3": "Order Orchestration and Fulfillment Trigger",
+    "definition": "Capabilities to decompose customer orders into downstream fulfillment tasks, coordinate execution across manufacturing, provisioning, logistics, and third-party systems, and trigger the appropriate fulfillment path based on product type.",
+    "notes": "eTOM Order Orchestration L3 / TM Forum TMF622 / IT4IT v3.0.1 Request to Fulfill value stream. Synergy: Manufacturing and Delivery > Request to Fulfill > Fulfillment Orchestration & Provisioning."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Order Management",
+    "level_3": "Order Tracking and Amendment",
+    "definition": "Capabilities to provide real-time order status visibility to customers and internal stakeholders, manage order modifications, cancellations, and partial fulfillments, and maintain a complete audit trail of order lifecycle events.",
+    "notes": "eTOM Order Tracking L3 / TM Forum TMF622 / CDM entity: Order."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Onboarding and Provisioning",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that establish a new customer's account, identity, and entitlements following a committed order, ensuring the customer is ready to consume the product or service. Covers account creation through to activation and first-use readiness.",
+    "notes": "eTOM CRM process group / TM Forum TMF629 Customer Management API / TMF632 Party Management API. Synergy: Manufacturing and Delivery > Request to Fulfill > Customer Provisioning and Activation."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Onboarding and Provisioning",
+    "level_3": "Account and Identity Setup",
+    "definition": "Capabilities to create and configure customer account records, link party relationships (organisation, contacts, sites), assign roles and permissions, and establish the customer identity used across all product and service interactions.",
+    "notes": "TM Forum TMF629 Customer Management API / TMF632 Party Management API / CDM entities: Account, Contact. Synergy: Foundational > Platform Services > Identity and Access Platform."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Onboarding and Provisioning",
+    "level_3": "Service Activation and Provisioning",
+    "definition": "Capabilities to activate purchased products and services in the delivery environment upon order completion, including configuration of service parameters, assignment of identifiers, and confirmation of service readiness to the customer.",
+    "notes": "TM Forum TMF641 Service Order Management API / eTOM Service Fulfillment process group L2. Synergy: Manufacturing and Delivery > Request to Fulfill > Customer Provisioning and Activation."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Onboarding and Provisioning",
+    "level_3": "Entitlement Assignment and Access Control",
+    "definition": "Capabilities to assign, enforce, and revoke customer entitlements governing which products, features, editions, and usage levels a customer is authorised to consume, aligned to their contractual commitments.",
+    "notes": "TM Forum TMF637 Product Inventory Management API / IT4IT v3.0.1 §4.2.2 Service Offer Definition / Zuora: Entitlement entity. Synergy: Manufacturing and Delivery > Request to Fulfill > Offer, Request & Order Management > Identity."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Subscription and Contract Lifecycle",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that manage the ongoing lifecycle of subscription-based products and commercial agreements, from initial activation through amendments, renewals, and termination. Supports recurring revenue models including usage-based, seat-based, and hybrid pricing.",
+    "notes": "eTOM Billing process group L1 / TM Forum TMF637 Product Inventory Management API / TMF651 Agreement Management API / IT4IT v3.0.1 §4.2.3 Contract Definition (MUST-0017) / Zuora subscription lifecycle: Active/Suspended/Cancelled/Expired. Synergy: Manufacturing and Delivery > Request to Fulfill > Usage, Subscription & Billing."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Subscription and Contract Lifecycle",
+    "level_3": "Subscription Activation and Amendment",
+    "definition": "Capabilities to activate new subscriptions, process mid-term changes (upgrades, downgrades, add-ons, seat changes), and maintain an accurate subscription record reflecting the current contractual state. Includes proration calculation and downstream billing notification.",
+    "notes": "Zuora entities: Subscription, Amendment, RatePlan / TM Forum TMF637 / eTOM Product and Customer Information Management L2."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Subscription and Contract Lifecycle",
+    "level_3": "Renewal and Retention Management",
+    "definition": "Capabilities to manage the subscription renewal cycle including early renewal outreach, auto-renewal configuration, renewal quoting, and churn prevention interventions. Integrates with customer health signals to prioritise at-risk renewal accounts.",
+    "notes": "eTOM Retention and Loyalty process group L2 / Zuora: Renewal workflow / APQC PCF 3.10 (Manage customer/client relationships)."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Subscription and Contract Lifecycle",
+    "level_3": "Contract and Agreement Management",
+    "definition": "Capabilities to maintain the full repository of executed commercial contracts and service agreements, track key dates (expiry, review, auto-renewal), manage amendments and addenda, and provide compliance monitoring against contracted terms.",
+    "notes": "TM Forum TMF651 Agreement Management API / CDM entity: Contract / APQC PCF 3.8.4. Synergy: For Employees > Sales and Marketing > Agreement Management; For Employees > Vendor and Procurement Services > Contract Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Billing and Revenue Collection",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that rate usage, generate invoices, collect payments, and ensure the accuracy and completeness of revenue recognised from customer transactions. Supports one-time, recurring, usage-based, and hybrid billing models.",
+    "notes": "eTOM Billing process group L1 / TM Forum TMF666 Account Management API / APQC PCF 8.x. Synergy: For Employees > Financial Management > Process Accounts Receivable; For Employees > Financial Management > Perform Revenue Accounting."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Billing and Revenue Collection",
+    "level_3": "Usage Rating and Invoice Generation",
+    "definition": "Capabilities to collect consumption data, apply rate plans and pricing rules to calculate charges, and generate accurate invoices for delivery to customers. Supports complex rating scenarios including tiered pricing, volume discounts, usage aggregation, and multi-currency billing.",
+    "notes": "eTOM Billing Rating process group L3 / TM Forum TMF666 / Zuora entity: RatePlanCharge."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Billing and Revenue Collection",
+    "level_3": "Payment Processing and Collections",
+    "definition": "Capabilities to process customer payments across methods (card, bank transfer, digital wallet, invoice terms), manage failed payment retries, and execute collections processes for overdue balances including dunning, disputes, and write-off workflows.",
+    "notes": "eTOM Bill Collections process group L3 / TM Forum TMF666 / APQC PCF 8.x. Synergy: For Employees > Financial Management > Process Accounts Receivable."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Billing and Revenue Collection",
+    "level_3": "Revenue Assurance and Leakage Prevention",
+    "definition": "Capabilities to detect and resolve discrepancies between ordered, provisioned, rated, and billed quantities, preventing revenue leakage and ensuring billing accuracy. Includes automated reconciliation across order, provisioning, and billing systems and anomaly detection for billing errors.",
+    "notes": "eTOM Revenue Assurance process group L2 / APQC PCF 8.x. Synergy: For Employees > Financial Management > Perform Revenue Accounting."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Service and Support",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that handle post-sale customer requests, incidents, complaints, and self-service needs across the full product and service lifecycle. Encompasses reactive support, proactive service quality management, and knowledge-enabled self-service.",
+    "notes": "APQC PCF 6.0 (Manage Customer Service) / eTOM Assurance process group L1 / TM Forum TMF621 Trouble Ticket Management API. Synergy: For Employees > Productivity Services > Service Desk and Support (employee-facing equivalent); Manufacturing and Delivery > Detect to Correct > Incident, Outage & Restoration."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Service and Support",
+    "level_3": "Customer Request and Inquiry Handling",
+    "definition": "Capabilities to receive, classify, route, and resolve customer service requests and inquiries across channels (phone, email, chat, portal, social). Includes request intake, SLA-governed tracking, agent assignment, and resolution confirmation workflows.",
+    "notes": "APQC PCF 6.3 (Manage customer service requests/inquiries) / eTOM Customer Problem Handling L2 / TM Forum TMF621. Synergy: For Employees > Sales and Marketing > Inquiry Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Service and Support",
+    "level_3": "Incident and Problem Resolution",
+    "definition": "Capabilities to detect, diagnose, and resolve customer-impacting incidents and recurring problems in product and service delivery, minimising customer impact and time to resolution. Includes customer communication management during incidents and post-incident review.",
+    "notes": "eTOM Assurance / Customer Problem Management L2 / TM Forum TMF621 / IT4IT v3.0.1 Detect to Correct value stream. Synergy: Manufacturing and Delivery > Detect to Correct > Incident, Outage & Restoration."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Service and Support",
+    "level_3": "Complaint and Escalation Management",
+    "definition": "Capabilities to manage formal customer complaints and escalations through a structured resolution process, ensuring appropriate ownership, regulatory compliance where applicable, and customer-outcome focus. Includes root-cause tracking, compensatory action management, and trend analysis.",
+    "notes": "APQC PCF 6.4 (Manage customer complaints and feedback) / eTOM Customer Quality Management L2 / TM Forum TMF621."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Service and Support",
+    "level_3": "Self-Service and Knowledge Access",
+    "definition": "Capabilities that enable customers to independently resolve issues, manage their accounts, and access product knowledge through digital self-service channels. Includes customer portals, knowledge bases, guided troubleshooting, community forums, and AI-assisted support.",
+    "notes": "APQC PCF 6.2 / eTOM Assurance process group. Synergy: Manufacturing and Delivery > Request to Fulfill > Offer, Request & Order Management > Consumption Experience; Manufacturing and Delivery > Request to Fulfill > Offer, Request & Order Management > Knowledge."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Lifecycle and Retention",
+    "level_3": "",
+    "definition": "Customer-facing capabilities that manage the long-term relationship with customers across the full post-sale lifecycle, from onboarding success through growth, renewal, and potential offboarding. Focuses on maximising customer lifetime value and minimising churn.",
+    "notes": "eTOM Retention and Loyalty process group L2 / APQC PCF 3.10 (Manage customer/client relationships). Synergy: For Employees > Sales and Marketing > Customer Analytics."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Lifecycle and Retention",
+    "level_3": "Customer Health Monitoring and Churn Prevention",
+    "definition": "Capabilities to aggregate product usage, support, commercial, and engagement signals into customer health scores that identify at-risk accounts and trigger proactive intervention before churn occurs.",
+    "notes": "eTOM Retention and Loyalty L3 / APQC PCF 3.10."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Lifecycle and Retention",
+    "level_3": "Upsell and Cross-sell Management",
+    "definition": "Capabilities to identify and execute revenue expansion opportunities within the existing customer base through structured upsell (higher tier, more seats, usage growth) and cross-sell (adjacent products) motions, integrated with CPQ and order management.",
+    "notes": "APQC PCF 3.8.x / eTOM Selling L2 / Zuora: Subscription upgrade/amendment workflow."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Customer Lifecycle and Retention",
+    "level_3": "Customer Loyalty and Advocacy",
+    "definition": "Capabilities to build structured loyalty programmes, manage customer references and case studies, and cultivate customer advocates who amplify brand credibility. Includes NPS/CSAT measurement, community building, and formal customer advisory board management.",
+    "notes": "eTOM Retention and Loyalty L3 / APQC PCF 3.10. Synergy: For Employees > Develop Vision and Strategy > Market Management."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Party and Customer Data Management",
+    "level_3": "",
+    "definition": "Foundational customer-facing capabilities that maintain a consistent, authoritative, and consented view of all party (individual and organisation) and account records across the commercial lifecycle. Provides the master data layer enabling consistent customer experience across all engagement and operational systems.",
+    "notes": "TM Forum SID Customer Data Domain / TMF629 Customer Management API / TMF632 Party Management API / Microsoft CDM: Account, Contact, Individual entities. Synergy: For Employees > Security and Compliance > Identity and Access Management (employee vs customer identity distinction); Foundational > Platform Services > Identity and Access Platform."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Party and Customer Data Management",
+    "level_3": "Party and Account Management",
+    "definition": "Capabilities to create, maintain, and govern master records for all parties (individuals, organisations, groups) and their commercial account relationships, including account hierarchies, contact roles, and site relationships. Implements the universal party model to support both B2C and B2B customer structures.",
+    "notes": "TM Forum TMF632 Party Management API / TMF629 Customer Management API / TM Forum SID Party and Customer domains / CDM entities: Account, Contact. Conceptual predecessor: Oracle Trading Community Architecture (TCA) party model (HZ_PARTIES)."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Party and Customer Data Management",
+    "level_3": "Customer Identity and Consent Management",
+    "definition": "Capabilities to manage customer digital identities, authentication credentials, privacy consents, and data processing preferences across all channels and touchpoints. Ensures compliance with privacy regulations (GDPR, CCPA) and maintains an auditable consent record.",
+    "notes": "TM Forum TMF632 Party Management API / GDPR and CCPA compliance alignment. Synergy: Foundational > Platform Services > Identity and Access Platform; For Employees > Security and Compliance > Privacy and Data Protection."
+  },
+  {
+    "portfolio": "Products and Services Sold",
+    "portfolio_id": "products_and_services_sold",
+    "level_1": "Customer Engagement and Lifecycle",
+    "level_2": "Party and Customer Data Management",
+    "level_3": "Customer Analytics and Insights",
+    "definition": "Capabilities to aggregate, analyse, and interpret customer behavioural, transactional, and engagement data to generate actionable insights for commercial decision-making. Supports segmentation, propensity modelling, customer lifetime value analysis, and personalisation.",
+    "notes": "APQC PCF 3.1 (Understand markets, customers, and capabilities) / eTOM CRM analytics / TM Forum TMF629 / CDM Analytics DMOs. Synergy: For Employees > Sales and Marketing > Customer Analytics (employee tool for accessing these insights)."
+  }
+]

--- a/packages/db/prisma/migrations/20260311041420_add_taxonomy_node_to_digital_product/migration.sql
+++ b/packages/db/prisma/migrations/20260311041420_add_taxonomy_node_to_digital_product/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "DigitalProduct" ADD COLUMN     "taxonomyNodeId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "DigitalProduct" ADD CONSTRAINT "DigitalProduct_taxonomyNodeId_fkey" FOREIGN KEY ("taxonomyNodeId") REFERENCES "TaxonomyNode"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -66,27 +66,30 @@ model Portfolio {
 }
 
 model DigitalProduct {
-  id          String     @id @default(cuid())
-  productId   String     @unique
-  name        String
-  status      String     @default("active")
-  portfolioId String?
-  portfolio   Portfolio? @relation(fields: [portfolioId], references: [id])
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
+  id             String        @id @default(cuid())
+  productId      String        @unique
+  name           String
+  status         String        @default("active")
+  portfolioId    String?
+  portfolio      Portfolio?    @relation(fields: [portfolioId], references: [id])
+  taxonomyNodeId String?
+  taxonomyNode   TaxonomyNode? @relation(fields: [taxonomyNodeId], references: [id])
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 }
 
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
 model TaxonomyNode {
-  id          String         @id @default(cuid())
-  nodeId      String         @unique
+  id          String           @id @default(cuid())
+  nodeId      String           @unique
   name        String
   portfolioId String?
   parentId    String?
-  parent      TaxonomyNode?  @relation("TaxonomyTree", fields: [parentId], references: [id])
-  children    TaxonomyNode[] @relation("TaxonomyTree")
-  status      String         @default("active")
+  parent      TaxonomyNode?    @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children    TaxonomyNode[]   @relation("TaxonomyTree")
+  products    DigitalProduct[]
+  status      String           @default("active")
   governance  Json?
 }
 

--- a/packages/db/scripts/generate-taxonomy-json.ts
+++ b/packages/db/scripts/generate-taxonomy-json.ts
@@ -1,0 +1,74 @@
+// packages/db/scripts/generate-taxonomy-json.ts
+// Run once: npx tsx packages/db/scripts/generate-taxonomy-json.ts
+// Reads taxonomy_v2.csv from the old project, outputs taxonomy_v2.json for seed.ts
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+// Adjust this path to wherever the old project lives
+const CSV_PATH = "D:/digital-product-factory/PORTFOLIOS/taxonomy_v2.csv";
+const OUT_DIR  = join(__dirname, "..", "data");
+const OUT_PATH = join(OUT_DIR, "taxonomy_v2.json");
+
+type TaxonomyRow = {
+  portfolio:    string;
+  portfolio_id: string;
+  level_1:      string;
+  level_2:      string;
+  level_3:      string;
+  definition:   string;
+  notes:        string;
+};
+
+function parseCSV(content: string): TaxonomyRow[] {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines = normalized.split("\n").filter((l) => l.trim().length > 0);
+  const rows: TaxonomyRow[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    const fields = splitCSVLine(line);
+    rows.push({
+      portfolio:    strip(fields[0] ?? ""),
+      portfolio_id: strip(fields[1] ?? ""),
+      level_1:      strip(fields[2] ?? ""),
+      level_2:      strip(fields[3] ?? ""),
+      level_3:      strip(fields[4] ?? ""),
+      definition:   strip(fields[5] ?? ""),
+      notes:        strip(fields[6] ?? ""),
+    });
+  }
+  return rows;
+}
+
+/** Splits a CSV line respecting quoted fields containing commas. */
+function splitCSVLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === "," && !inQuotes) {
+      fields.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+function strip(s: string): string {
+  return s.trim().replace(/^"|"$/g, "");
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+const content = readFileSync(CSV_PATH, "utf-8");
+const rows    = parseCSV(content);
+writeFileSync(OUT_PATH, JSON.stringify(rows, null, 2), "utf-8");
+console.log(`Written ${rows.length} rows to ${OUT_PATH}`);

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -5,8 +5,9 @@ import { prisma } from "./client.js";
 import { parseRoleId, parseAgentTier, parseAgentType } from "./seed-helpers.js";
 import * as crypto from "crypto";
 
-// Repo root is 4 levels up from packages/db/src → packages/db → packages → dpf → repo root
-const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+// Repo root: prefer DPF_DATA_ROOT env var (needed when running from a worktree),
+// otherwise fall back to 4 levels up (packages/db/src → packages/db → packages → repo root → data root)
+const REPO_ROOT = process.env.DPF_DATA_ROOT ?? join(__dirname, "..", "..", "..", "..");
 
 function readJson<T>(relPath: string): T {
   return JSON.parse(readFileSync(join(REPO_ROOT, relPath), "utf-8")) as T;
@@ -101,6 +102,82 @@ async function seedPortfolios(): Promise<void> {
   console.log(`Seeded ${registry.portfolios.length} portfolios`);
 }
 
+async function seedTaxonomyNodes(): Promise<void> {
+  const DATA_PATH = join(__dirname, "..", "data", "taxonomy_v2.json");
+  type Row = { portfolio: string; portfolio_id: string; level_1: string; level_2: string; level_3: string };
+  const rows: Row[] = JSON.parse(readFileSync(DATA_PATH, "utf-8"));
+
+  function slugify(s: string): string {
+    return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+  }
+
+  // Collect all unique nodes in insertion order (root → L1 → L2 → L3)
+  const seen = new Set<string>();
+  type NodeEntry = { nodeId: string; name: string; parentNodeId: string | null; portfolioId: string };
+
+  const entries: NodeEntry[] = [];
+
+  for (const row of rows) {
+    const pid = row.portfolio_id;
+    if (!seen.has(pid)) {
+      seen.add(pid);
+      entries.push({ nodeId: pid, name: row.portfolio, parentNodeId: null, portfolioId: pid });
+    }
+    if (!row.level_1) continue;
+    const l1id = `${pid}/${slugify(row.level_1)}`;
+    if (!seen.has(l1id)) {
+      seen.add(l1id);
+      entries.push({ nodeId: l1id, name: row.level_1, parentNodeId: pid, portfolioId: pid });
+    }
+    if (!row.level_2) continue;
+    const l2id = `${l1id}/${slugify(row.level_2)}`;
+    if (!seen.has(l2id)) {
+      seen.add(l2id);
+      entries.push({ nodeId: l2id, name: row.level_2, parentNodeId: l1id, portfolioId: pid });
+    }
+    if (!row.level_3) continue;
+    const l3id = `${l2id}/${slugify(row.level_3)}`;
+    if (!seen.has(l3id)) {
+      seen.add(l3id);
+      entries.push({ nodeId: l3id, name: row.level_3, parentNodeId: l2id, portfolioId: pid });
+    }
+  }
+
+  // Look up Portfolio.id values by portfolioId slug
+  const portfolios = await prisma.portfolio.findMany({ select: { id: true, slug: true } });
+  const portfolioIdMap = new Map<string, string>(); // portfolio slug → Portfolio.id
+  for (const p of portfolios) {
+    portfolioIdMap.set(p.slug, p.id);
+  }
+
+  // Insert in order so parent always exists before child
+  const nodeIdToCuid = new Map<string, string>();
+  for (const entry of entries) {
+    const parentCuid = entry.parentNodeId ? (nodeIdToCuid.get(entry.parentNodeId) ?? null) : null;
+    const portfolioCuid = portfolioIdMap.get(entry.portfolioId) ?? null;
+    const node = await prisma.taxonomyNode.upsert({
+      where: { nodeId: entry.nodeId },
+      create: {
+        nodeId:      entry.nodeId,
+        name:        entry.name,
+        parentId:    parentCuid,
+        portfolioId: portfolioCuid,
+        status:      "active",
+      },
+      update: {
+        name:        entry.name,
+        parentId:    parentCuid,
+        portfolioId: portfolioCuid,
+        status:      "active",
+      },
+      select: { id: true },
+    });
+    nodeIdToCuid.set(entry.nodeId, node.id);
+  }
+
+  console.log(`Seeded ${entries.length} taxonomy nodes`);
+}
+
 async function seedDigitalProducts(): Promise<void> {
   const registry = readJson<{
     digital_products: Array<{
@@ -162,6 +239,7 @@ async function main(): Promise<void> {
   await seedRoles();
   await seedAgents();
   await seedPortfolios();
+  await seedTaxonomyNodes();
   await seedDigitalProducts();
   await seedDefaultAdminUser();
   console.log("Seed complete.");


### PR DESCRIPTION
## Summary

- Adds the `/portfolio` route: a master/detail browser with a 4-level taxonomy tree sidebar and server-rendered right panel
- Seeds 481 taxonomy nodes from the DPPM taxonomy CSV (4 portfolio types, full `foundational / L1 / L2 / L3` hierarchy) into PostgreSQL
- Implements the full data flow: CSV → JSON → Prisma seed → `getPortfolioTree()` (React `cache()` deduplication) → layout sidebar + catch-all page

## What's in this PR

**Data layer**
- `packages/db/prisma/schema.prisma` — adds `taxonomyNodeId` FK on `DigitalProduct`, `products` back-relation on `TaxonomyNode`
- `packages/db/scripts/generate-taxonomy-json.ts` — one-shot CSV → JSON converter (handles quoted commas)
- `packages/db/data/taxonomy_v2.json` — 378-row taxonomy source data (committed)
- `packages/db/src/seed.ts` — `seedTaxonomyNodes()` seeding 481 unique nodes in root→L1→L2→L3 order

**Web layer**
- `apps/web/lib/portfolio.ts` — pure utility library: `buildPortfolioTree`, `resolveNodeFromSlug`, `getSubtreeIds`, `buildBreadcrumbs`, colour/role constants
- `apps/web/lib/portfolio.test.ts` — 11 unit tests (TDD)
- `apps/web/lib/portfolio-data.ts` — server-only `getPortfolioTree()` using `React.cache()`
- `apps/web/app/(shell)/portfolio/layout.tsx` — auth gate (`can(user, "view_portfolio")` → `notFound()`), sidebar
- `apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx` — catch-all: overview at `/portfolio`, node detail at `/portfolio/[...slug]`
- `apps/web/components/portfolio/` — `PortfolioTree`, `PortfolioTreeNode` (client), `PortfolioOverview`, `PortfolioNodeDetail`, `ProductList` (server)

## Test plan

- [ ] `pnpm test` — 26 tests passing (4 test files)
- [ ] `pnpm typecheck` — 0 TypeScript errors
- [ ] `pnpm db:migrate && pnpm db:generate && pnpm db:seed` — database seeded with 481 taxonomy nodes
- [ ] Navigate to `/portfolio` — 4 portfolio root cards visible with product counts and owner roles
- [ ] Click a portfolio card → node detail with capability domain grid
- [ ] Click a capability domain → functional groups grid
- [ ] Tree sidebar highlights active node; chevron expand/collapse syncs to `?open=` URL param
- [ ] Log in as HR-500 user — `/portfolio` returns 404 (access denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)