### PR TITLE
feat: Phase 6A — Epic Grouping for Backlog

### DIFF
--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -1,12 +1,14 @@
 // apps/web/app/(shell)/ops/page.tsx
-import { getBacklogItems, getDigitalProductsForSelect, getTaxonomyNodesFlat } from "@/lib/backlog-data";
+import { getBacklogItems, getDigitalProductsForSelect, getTaxonomyNodesFlat, getEpics, getPortfoliosForSelect } from "@/lib/backlog-data";
 import { OpsClient } from "@/components/ops/OpsClient";
 
 export default async function OpsPage() {
-  const [items, digitalProducts, taxonomyNodes] = await Promise.all([
+  const [items, digitalProducts, taxonomyNodes, epics, portfolios] = await Promise.all([
     getBacklogItems(),
     getDigitalProductsForSelect(),
     getTaxonomyNodesFlat(),
+    getEpics(),
+    getPortfoliosForSelect(),
   ]);
 
   return (
@@ -14,7 +16,7 @@ export default async function OpsPage() {
       <div className="mb-6">
         <h1 className="text-xl font-bold text-white">Operations</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          {items.length} item{items.length !== 1 ? "s" : ""}
+          {epics.length} epic{epics.length !== 1 ? "s" : ""} · {items.length} item{items.length !== 1 ? "s" : ""}
         </p>
       </div>
 
@@ -22,6 +24,8 @@ export default async function OpsPage() {
         items={items}
         digitalProducts={digitalProducts}
         taxonomyNodes={taxonomyNodes}
+        epics={epics}
+        portfolios={portfolios}
       />
     </div>
   );

--- a/apps/web/components/ops/BacklogPanel.tsx
+++ b/apps/web/components/ops/BacklogPanel.tsx
@@ -1,30 +1,48 @@
+// apps/web/components/ops/BacklogPanel.tsx
 "use client";
 
 import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { createBacklogItem, updateBacklogItem } from "@/lib/actions/backlog";
-import { validateBacklogInput, type BacklogItemInput, type BacklogItemWithRelations, type DigitalProductSelect, type TaxonomyNodeSelect } from "@/lib/backlog";
+import {
+  validateBacklogInput,
+  type BacklogItemInput,
+  type BacklogItemWithRelations,
+  type DigitalProductSelect,
+  type TaxonomyNodeSelect,
+  type EpicForSelect,
+} from "@/lib/backlog";
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
   item?: BacklogItemWithRelations;
   defaultType?: "portfolio" | "product";
+  defaultEpicId?: string;
   digitalProducts: DigitalProductSelect[];
   taxonomyNodes: TaxonomyNodeSelect[];
+  epics: EpicForSelect[];
 };
 
-function emptyForm(type: "portfolio" | "product" = "portfolio"): BacklogItemInput {
-  return { title: "", type, status: "open", body: "" };
+function emptyForm(type: "portfolio" | "product" = "portfolio", epicId?: string): BacklogItemInput {
+  return { title: "", type, status: "open", body: "", ...(epicId ? { epicId } : {}) };
 }
 
-export function BacklogPanel({ isOpen, onClose, item, defaultType, digitalProducts, taxonomyNodes }: Props) {
+export function BacklogPanel({
+  isOpen,
+  onClose,
+  item,
+  defaultType,
+  defaultEpicId,
+  digitalProducts,
+  taxonomyNodes,
+  epics,
+}: Props) {
   const router = useRouter();
-  const [form, setForm] = useState<BacklogItemInput>(() => emptyForm(defaultType));
+  const [form, setForm] = useState<BacklogItemInput>(() => emptyForm(defaultType, defaultEpicId));
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  // Populate form when switching between create/edit
   useEffect(() => {
     if (item) {
       const next: BacklogItemInput = {
@@ -36,12 +54,13 @@ export function BacklogPanel({ isOpen, onClose, item, defaultType, digitalProduc
       if (item.priority !== null && item.priority !== undefined) next.priority = item.priority;
       if (item.taxonomyNode?.id) next.taxonomyNodeId = item.taxonomyNode.id;
       if (item.digitalProduct?.id) next.digitalProductId = item.digitalProduct.id;
+      if (item.epicId) next.epicId = item.epicId;
       setForm(next);
     } else {
-      setForm(emptyForm(defaultType));
+      setForm(emptyForm(defaultType, defaultEpicId));
     }
     setError(null);
-  }, [item, isOpen, defaultType]);
+  }, [item, isOpen, defaultType, defaultEpicId]);
 
   function set<K extends keyof BacklogItemInput>(key: K, value: BacklogItemInput[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -154,6 +173,21 @@ export function BacklogPanel({ isOpen, onClose, item, defaultType, digitalProduc
               className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-[var(--dpf-accent)]"
               placeholder="Optional"
             />
+          </label>
+
+          {/* Epic */}
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Epic</span>
+            <select
+              value={form.epicId ?? ""}
+              onChange={(e) => set("epicId", e.target.value || undefined)}
+              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-[var(--dpf-accent)]"
+            >
+              <option value="">— no epic —</option>
+              {epics.map((ep) => (
+                <option key={ep.id} value={ep.id}>{ep.title}</option>
+              ))}
+            </select>
           </label>
 
           {/* Taxonomy Node */}

--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -1,0 +1,143 @@
+// apps/web/components/ops/EpicCard.tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { deleteEpic } from "@/lib/actions/backlog";
+import {
+  EPIC_STATUS_COLOURS,
+  type EpicWithRelations,
+} from "@/lib/backlog";
+import { BacklogItemRow } from "./BacklogItemRow";
+import type { BacklogItemWithRelations } from "@/lib/backlog";
+
+type Props = {
+  epic: EpicWithRelations;
+  onEdit: (epic: EpicWithRelations) => void;
+};
+
+export function EpicCard({ epic, onEdit }: Props) {
+  const router = useRouter();
+  const [expanded, setExpanded] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const doneCount = epic.items.filter((i) => i.status === "done").length;
+  const totalCount = epic.items.length;
+  const progressPct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
+
+  const statusColour = EPIC_STATUS_COLOURS[epic.status] ?? "#555566";
+  const portfolioLabels = epic.portfolios.map((p) => p.portfolio.name).join(" · ");
+
+  function handleDelete() {
+    startTransition(async () => {
+      await deleteEpic(epic.id);
+      router.refresh();
+    });
+  }
+
+  function handleItemEdit(_item: BacklogItemWithRelations) {
+    // editing items from within epic card is handled by OpsClient
+  }
+
+  return (
+    <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] mb-3">
+      {/* Card header */}
+      <div className="flex items-start gap-3 px-4 py-3">
+        {/* Expand toggle */}
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="shrink-0 mt-0.5 text-[var(--dpf-muted)] hover:text-white text-xs w-4"
+          aria-label={expanded ? "Collapse" : "Expand"}
+        >
+          {expanded ? "▼" : "▶"}
+        </button>
+
+        {/* Main info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="text-[9px] font-mono text-[var(--dpf-muted)]">{epic.epicId}</span>
+            <span
+              className="text-[9px] px-1.5 py-0.5 rounded-full font-semibold"
+              style={{ background: `${statusColour}20`, color: statusColour }}
+            >
+              {epic.status}
+            </span>
+          </div>
+          <p className="text-sm font-semibold text-white leading-tight truncate">{epic.title}</p>
+          {portfolioLabels && (
+            <p className="text-[10px] text-[var(--dpf-muted)] mt-0.5">{portfolioLabels}</p>
+          )}
+
+          {/* Progress bar */}
+          <div className="mt-2 flex items-center gap-2">
+            <div className="flex-1 h-1 rounded-full bg-[var(--dpf-surface-2)]">
+              <div
+                className="h-1 rounded-full bg-[var(--dpf-accent)]"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <span className="text-[9px] text-[var(--dpf-muted)] shrink-0 tabular-nums">
+              {doneCount} / {totalCount}
+            </span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="shrink-0 flex items-center gap-1 mt-0.5">
+          {confirmDelete ? (
+            <>
+              <button
+                onClick={handleDelete}
+                disabled={isPending}
+                className="text-[10px] text-red-400 hover:text-red-300 px-1"
+              >
+                {isPending ? "…" : "confirm"}
+              </button>
+              <button
+                onClick={() => setConfirmDelete(false)}
+                className="text-[10px] text-[var(--dpf-muted)] hover:text-white px-1"
+              >
+                cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => onEdit(epic)}
+                className="text-[10px] text-[var(--dpf-muted)] hover:text-white px-1"
+              >
+                edit
+              </button>
+              <button
+                onClick={() => setConfirmDelete(true)}
+                className="text-[10px] text-[var(--dpf-muted)] hover:text-red-400 px-1"
+              >
+                del
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded: item list */}
+      {expanded && (
+        <div className="border-t border-[var(--dpf-border)] px-4 py-3">
+          {epic.items.length === 0 ? (
+            <p className="text-xs text-[var(--dpf-muted)]">No items in this epic yet.</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {epic.items.map((item) => (
+                <BacklogItemRow
+                  key={item.id}
+                  item={item}
+                  onEdit={handleItemEdit}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -7,16 +7,17 @@ import { deleteEpic } from "@/lib/actions/backlog";
 import {
   EPIC_STATUS_COLOURS,
   type EpicWithRelations,
+  type BacklogItemWithRelations,
 } from "@/lib/backlog";
 import { BacklogItemRow } from "./BacklogItemRow";
-import type { BacklogItemWithRelations } from "@/lib/backlog";
 
 type Props = {
   epic: EpicWithRelations;
   onEdit: (epic: EpicWithRelations) => void;
+  onItemEdit: (item: BacklogItemWithRelations) => void;
 };
 
-export function EpicCard({ epic, onEdit }: Props) {
+export function EpicCard({ epic, onEdit, onItemEdit }: Props) {
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -36,9 +37,6 @@ export function EpicCard({ epic, onEdit }: Props) {
     });
   }
 
-  function handleItemEdit(_item: BacklogItemWithRelations) {
-    // editing items from within epic card is handled by OpsClient
-  }
 
   return (
     <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] mb-3">
@@ -131,7 +129,7 @@ export function EpicCard({ epic, onEdit }: Props) {
                 <BacklogItemRow
                   key={item.id}
                   item={item}
-                  onEdit={handleItemEdit}
+                  onEdit={onItemEdit}
                 />
               ))}
             </div>

--- a/apps/web/components/ops/EpicPanel.tsx
+++ b/apps/web/components/ops/EpicPanel.tsx
@@ -1,0 +1,189 @@
+// apps/web/components/ops/EpicPanel.tsx
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createEpic, updateEpic } from "@/lib/actions/backlog";
+import {
+  validateEpicInput,
+  EPIC_STATUSES,
+  type EpicInput,
+  type EpicWithRelations,
+  type PortfolioForSelect,
+} from "@/lib/backlog";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  epic?: EpicWithRelations;
+  portfolios: PortfolioForSelect[];
+};
+
+function emptyForm(): EpicInput {
+  return { title: "", status: "open", portfolioIds: [] };
+}
+
+export function EpicPanel({ isOpen, onClose, epic, portfolios }: Props) {
+  const router = useRouter();
+  const [form, setForm] = useState<EpicInput>(emptyForm);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (epic) {
+      setForm({
+        title:        epic.title,
+        description:  epic.description ?? "",
+        status:       epic.status as EpicInput["status"],
+        portfolioIds: epic.portfolios.map((p) => p.portfolioId),
+      });
+    } else {
+      setForm(emptyForm());
+    }
+    setError(null);
+  }, [epic, isOpen]);
+
+  function togglePortfolio(portfolioId: string) {
+    setForm((prev) => {
+      const already = prev.portfolioIds.includes(portfolioId);
+      return {
+        ...prev,
+        portfolioIds: already
+          ? prev.portfolioIds.filter((id) => id !== portfolioId)
+          : [...prev.portfolioIds, portfolioId],
+      };
+    });
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const validationError = validateEpicInput(form);
+    if (validationError) { setError(validationError); return; }
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        if (epic) {
+          await updateEpic(epic.id, form);
+        } else {
+          await createEpic(form);
+        }
+        router.refresh();
+        onClose();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Something went wrong");
+      }
+    });
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="fixed right-0 top-0 h-full w-96 bg-[var(--dpf-surface-1)] border-l border-[var(--dpf-border)] z-50 flex flex-col shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--dpf-border)]">
+          <h2 className="text-sm font-semibold text-white">
+            {epic ? "Edit Epic" : "New Epic"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-[var(--dpf-muted)] hover:text-white text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-4">
+          {/* Title */}
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Title *</span>
+            <input
+              type="text"
+              value={form.title}
+              onChange={(e) => setForm((prev) => ({ ...prev, title: e.target.value }))}
+              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-white placeholder:text-[var(--dpf-muted)] focus:outline-none focus:border-[var(--dpf-accent)]"
+              placeholder="What is this initiative?"
+              required
+            />
+          </label>
+
+          {/* Description */}
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Description</span>
+            <textarea
+              value={form.description ?? ""}
+              onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+              rows={3}
+              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-white placeholder:text-[var(--dpf-muted)] focus:outline-none focus:border-[var(--dpf-accent)] resize-none"
+              placeholder="Optional context…"
+            />
+          </label>
+
+          {/* Status */}
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Status</span>
+            <select
+              value={form.status}
+              onChange={(e) => setForm((prev) => ({ ...prev, status: e.target.value as EpicInput["status"] }))}
+              className="bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-[var(--dpf-accent)]"
+            >
+              {EPIC_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {/* Portfolios */}
+          <div className="flex flex-col gap-2">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Portfolios</span>
+            {portfolios.map((p) => (
+              <label key={p.id} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={form.portfolioIds.includes(p.id)}
+                  onChange={() => togglePortfolio(p.id)}
+                  className="accent-[var(--dpf-accent)]"
+                />
+                <span className="text-sm text-white">{p.name}</span>
+              </label>
+            ))}
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-400">{error}</p>
+          )}
+        </form>
+
+        {/* Footer */}
+        <div className="px-5 py-4 border-t border-[var(--dpf-border)] flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 py-2 rounded border border-[var(--dpf-border)] text-xs text-[var(--dpf-muted)] hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isPending}
+            className="flex-1 py-2 rounded bg-[var(--dpf-accent)] text-xs text-white font-semibold hover:opacity-90 disabled:opacity-50"
+          >
+            {isPending ? "Saving…" : epic ? "Save Changes" : "Create Epic"}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -1,20 +1,38 @@
+// apps/web/components/ops/OpsClient.tsx
 "use client";
 
 import { useState } from "react";
 import { BacklogPanel } from "./BacklogPanel";
 import { BacklogItemRow } from "./BacklogItemRow";
-import type { BacklogItemWithRelations, DigitalProductSelect, TaxonomyNodeSelect } from "@/lib/backlog";
+import { EpicCard } from "./EpicCard";
+import { EpicPanel } from "./EpicPanel";
+import type {
+  BacklogItemWithRelations,
+  DigitalProductSelect,
+  TaxonomyNodeSelect,
+  EpicWithRelations,
+  EpicForSelect,
+  PortfolioForSelect,
+} from "@/lib/backlog";
 
-type PanelState = {
+type ItemPanelState = {
   open: boolean;
   item?: BacklogItemWithRelations | undefined;
   defaultType?: "portfolio" | "product" | undefined;
+  defaultEpicId?: string | undefined;
 };
+
+type EpicPanelState =
+  | { mode: "create" }
+  | { mode: "edit"; epic: EpicWithRelations }
+  | null;
 
 type Props = {
   items: BacklogItemWithRelations[];
   digitalProducts: DigitalProductSelect[];
   taxonomyNodes: TaxonomyNodeSelect[];
+  epics: EpicWithRelations[];
+  portfolios: PortfolioForSelect[];
 };
 
 const TYPE_LABELS: Record<string, string> = {
@@ -22,64 +40,122 @@ const TYPE_LABELS: Record<string, string> = {
   product:   "Product Backlog",
 };
 
-export function OpsClient({ items, digitalProducts, taxonomyNodes }: Props) {
-  const [panel, setPanel] = useState<PanelState>({ open: false });
+export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfolios }: Props) {
+  const [panel, setPanel] = useState<ItemPanelState>({ open: false });
+  const [epicPanel, setEpicPanel] = useState<EpicPanelState>(null);
 
+  // Unassigned items only (not belonging to any epic)
+  const unassigned = items.filter((i) => i.epicId === null);
   const types = ["portfolio", "product"] as const;
-  const byType = new Map(types.map((t) => [t, items.filter((i) => i.type === t)]));
+  const byType = new Map(types.map((t) => [t, unassigned.filter((i) => i.type === t)]));
 
-  function openCreate(defaultType: "portfolio" | "product") {
-    setPanel({ open: true, item: undefined, defaultType });
+  // EpicForSelect list for BacklogPanel epic dropdown (open + in-progress only)
+  const epicsForSelect: EpicForSelect[] = epics
+    .filter((e) => e.status !== "done")
+    .map((e) => ({ id: e.id, epicId: e.epicId, title: e.title }));
+
+  function openCreate(defaultType: "portfolio" | "product", defaultEpicId?: string) {
+    setEpicPanel(null);
+    setPanel({ open: true, item: undefined, defaultType, ...(defaultEpicId ? { defaultEpicId } : {}) });
   }
-  function openEdit(item: BacklogItemWithRelations) { setPanel({ open: true, item }); }
+  function openEdit(item: BacklogItemWithRelations) {
+    setEpicPanel(null);
+    setPanel({ open: true, item });
+  }
   function closePanel() { setPanel({ open: false }); }
+
+  function openCreateEpic() {
+    setPanel({ open: false });
+    setEpicPanel({ mode: "create" });
+  }
+  function openEditEpic(epic: EpicWithRelations) {
+    setPanel({ open: false });
+    setEpicPanel({ mode: "edit", epic });
+  }
+  function closeEpicPanel() { setEpicPanel(null); }
 
   return (
     <>
-      {types.map((t) => {
-        const typeItems = byType.get(t) ?? [];
-        const label = TYPE_LABELS[t] ?? t;
+      {/* ── Epics section ──────────────────────────────────── */}
+      <div className="mb-8">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest">
+            Epics
+            <span className="ml-2 normal-case font-normal">{epics.length}</span>
+          </h2>
+          <button
+            onClick={openCreateEpic}
+            className="text-[10px] font-semibold text-[var(--dpf-accent)] hover:opacity-80"
+          >
+            + Add epic
+          </button>
+        </div>
 
-        return (
-          <section key={t} className="mb-8">
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest">
-                {label}
-                <span className="ml-2 text-[var(--dpf-muted)] normal-case font-normal">
-                  {typeItems.length}
-                </span>
-              </h2>
-              <button
-                onClick={() => openCreate(t)}
-                className="text-[10px] font-semibold text-[var(--dpf-accent)] hover:opacity-80"
-              >
-                + Add item
-              </button>
-            </div>
-            {typeItems.length === 0 ? (
-              <p className="text-xs text-[var(--dpf-muted)]">No {label.toLowerCase()} items.</p>
-            ) : (
-              <div className="flex flex-col gap-2">
-                {typeItems.map((item) => (
-                  <BacklogItemRow key={item.id} item={item} onEdit={openEdit} />
-                ))}
+        {epics.length === 0 ? (
+          <p className="text-xs text-[var(--dpf-muted)]">No epics yet. Add one to start organising your backlog.</p>
+        ) : (
+          epics.map((epic) => (
+            <EpicCard key={epic.id} epic={epic} onEdit={openEditEpic} />
+          ))
+        )}
+      </div>
+
+      {/* ── Unassigned items ───────────────────────────────── */}
+      <div>
+        <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest mb-4">
+          Unassigned
+          <span className="ml-2 normal-case font-normal">{unassigned.length}</span>
+        </h2>
+
+        {types.map((t) => {
+          const typeItems = byType.get(t) ?? [];
+          const label = TYPE_LABELS[t] ?? t;
+
+          return (
+            <section key={t} className="mb-8">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest">
+                  {label}
+                  <span className="ml-2 normal-case font-normal">{typeItems.length}</span>
+                </h3>
+                <button
+                  onClick={() => openCreate(t)}
+                  className="text-[10px] font-semibold text-[var(--dpf-accent)] hover:opacity-80"
+                >
+                  + Add item
+                </button>
               </div>
-            )}
-          </section>
-        );
-      })}
+              {typeItems.length === 0 ? (
+                <p className="text-xs text-[var(--dpf-muted)]">No unassigned {label.toLowerCase()} items.</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {typeItems.map((item) => (
+                    <BacklogItemRow key={item.id} item={item} onEdit={openEdit} />
+                  ))}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
 
-      {items.length === 0 && (
-        <p className="text-sm text-[var(--dpf-muted)]">No backlog items yet.</p>
-      )}
-
+      {/* ── Panels ─────────────────────────────────────────── */}
       <BacklogPanel
         isOpen={panel.open}
         onClose={closePanel}
         {...(panel.item !== undefined ? { item: panel.item } : {})}
         {...(panel.defaultType !== undefined ? { defaultType: panel.defaultType } : {})}
+        {...(panel.defaultEpicId !== undefined ? { defaultEpicId: panel.defaultEpicId } : {})}
         digitalProducts={digitalProducts}
         taxonomyNodes={taxonomyNodes}
+        epics={epicsForSelect}
+      />
+
+      <EpicPanel
+        isOpen={epicPanel !== null}
+        onClose={closeEpicPanel}
+        {...(epicPanel?.mode === "edit" ? { epic: epicPanel.epic } : {})}
+        portfolios={portfolios}
       />
     </>
   );

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -95,7 +95,7 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
           <p className="text-xs text-[var(--dpf-muted)]">No epics yet. Add one to start organising your backlog.</p>
         ) : (
           epics.map((epic) => (
-            <EpicCard key={epic.id} epic={epic} onEdit={openEditEpic} />
+            <EpicCard key={epic.id} epic={epic} onEdit={openEditEpic} onItemEdit={openEdit} />
           ))
         )}
       </div>

--- a/apps/web/lib/actions/backlog.ts
+++ b/apps/web/lib/actions/backlog.ts
@@ -4,7 +4,12 @@ import * as crypto from "crypto";
 import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { validateBacklogInput, type BacklogItemInput } from "@/lib/backlog";
+import {
+  validateBacklogInput,
+  validateEpicInput,
+  type BacklogItemInput,
+  type EpicInput,
+} from "@/lib/backlog";
 
 async function requireManageBacklog(): Promise<void> {
   const session = await auth();
@@ -20,19 +25,22 @@ async function requireManageBacklog(): Promise<void> {
   }
 }
 
+// ─── BacklogItem actions ──────────────────────────────────────────────────────
+
 export async function createBacklogItem(input: BacklogItemInput): Promise<void> {
   await requireManageBacklog();
   const error = validateBacklogInput(input);
   if (error) throw new Error(error);
 
   const createData = {
-    itemId:          `BI-${crypto.randomUUID()}`,
-    title:           input.title.trim(),
-    type:            input.type,
-    status:          input.status,
-    priority:        input.priority ?? null,
-    taxonomyNodeId:  input.taxonomyNodeId ?? null,
+    itemId:           `BI-${crypto.randomUUID()}`,
+    title:            input.title.trim(),
+    type:             input.type,
+    status:           input.status,
+    priority:         input.priority ?? null,
+    taxonomyNodeId:   input.taxonomyNodeId ?? null,
     digitalProductId: input.digitalProductId ?? null,
+    epicId:           input.epicId ?? null,
     ...(input.body !== undefined && { body: input.body.trim() || null }),
   };
   await prisma.backlogItem.create({ data: createData });
@@ -44,12 +52,13 @@ export async function updateBacklogItem(id: string, input: BacklogItemInput): Pr
   if (error) throw new Error(error);
 
   const updateData = {
-    title:           input.title.trim(),
-    type:            input.type,
-    status:          input.status,
-    priority:        input.priority ?? null,
-    taxonomyNodeId:  input.taxonomyNodeId ?? null,
+    title:            input.title.trim(),
+    type:             input.type,
+    status:           input.status,
+    priority:         input.priority ?? null,
+    taxonomyNodeId:   input.taxonomyNodeId ?? null,
     digitalProductId: input.digitalProductId ?? null,
+    epicId:           input.epicId ?? null,
     ...(input.body !== undefined && { body: input.body.trim() || null }),
   };
   await prisma.backlogItem.update({ where: { id }, data: updateData });
@@ -58,4 +67,65 @@ export async function updateBacklogItem(id: string, input: BacklogItemInput): Pr
 export async function deleteBacklogItem(id: string): Promise<void> {
   await requireManageBacklog();
   await prisma.backlogItem.delete({ where: { id } });
+}
+
+// ─── Epic actions ─────────────────────────────────────────────────────────────
+
+export async function createEpic(input: EpicInput): Promise<void> {
+  await requireManageBacklog();
+  const error = validateEpicInput(input);
+  if (error) throw new Error(error);
+
+  await prisma.$transaction(async (tx) => {
+    const epic = await tx.epic.create({
+      data: {
+        epicId:      `EP-${crypto.randomUUID()}`,
+        title:       input.title.trim(),
+        status:      input.status,
+        ...(input.description !== undefined && {
+          description: input.description.trim() || null,
+        }),
+      },
+    });
+    if (input.portfolioIds.length > 0) {
+      await tx.epicPortfolio.createMany({
+        data: input.portfolioIds.map((portfolioId) => ({
+          epicId:      epic.id,
+          portfolioId,
+        })),
+      });
+    }
+  });
+}
+
+export async function updateEpic(id: string, input: EpicInput): Promise<void> {
+  await requireManageBacklog();
+  const error = validateEpicInput(input);
+  if (error) throw new Error(error);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.epic.update({
+      where: { id },
+      data: {
+        title:  input.title.trim(),
+        status: input.status,
+        ...(input.description !== undefined && {
+          description: input.description.trim() || null,
+        }),
+      },
+    });
+    // Replace portfolio links atomically
+    await tx.epicPortfolio.deleteMany({ where: { epicId: id } });
+    if (input.portfolioIds.length > 0) {
+      await tx.epicPortfolio.createMany({
+        data: input.portfolioIds.map((portfolioId) => ({ epicId: id, portfolioId })),
+      });
+    }
+  });
+}
+
+export async function deleteEpic(id: string): Promise<void> {
+  await requireManageBacklog();
+  await prisma.epic.delete({ where: { id } });
+  // onDelete: SetNull in schema handles nullifying BacklogItem.epicId automatically
 }

--- a/apps/web/lib/backlog-data.ts
+++ b/apps/web/lib/backlog-data.ts
@@ -2,7 +2,13 @@
 // Server-only: uses React cache() to deduplicate Prisma calls within one request.
 import { cache } from "react";
 import { prisma } from "@dpf/db";
-import type { BacklogItemWithRelations, DigitalProductSelect, TaxonomyNodeSelect } from "./backlog";
+import type {
+  BacklogItemWithRelations,
+  DigitalProductSelect,
+  TaxonomyNodeSelect,
+  PortfolioForSelect,
+  EpicWithRelations,
+} from "./backlog";
 
 export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[]> => {
   return prisma.backlogItem.findMany({
@@ -15,12 +21,52 @@ export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[
       type: true,
       body: true,
       priority: true,
+      epicId: true,
       createdAt: true,
       updatedAt: true,
       digitalProduct: { select: { id: true, productId: true, name: true } },
       taxonomyNode: { select: { id: true, nodeId: true, name: true } },
     },
   });
+});
+
+export const getEpics = cache(async (): Promise<EpicWithRelations[]> => {
+  return prisma.epic.findMany({
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      epicId: true,
+      title: true,
+      description: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+      portfolios: {
+        select: {
+          epicId: true,
+          portfolioId: true,
+          portfolio: { select: { id: true, slug: true, name: true } },
+        },
+      },
+      items: {
+        orderBy: [{ priority: "asc" }, { createdAt: "asc" }],
+        select: {
+          id: true,
+          itemId: true,
+          title: true,
+          status: true,
+          type: true,
+          body: true,
+          priority: true,
+          epicId: true,
+          createdAt: true,
+          updatedAt: true,
+          digitalProduct: { select: { id: true, productId: true, name: true } },
+          taxonomyNode: { select: { id: true, nodeId: true, name: true } },
+        },
+      },
+    },
+  }) as Promise<EpicWithRelations[]>;
 });
 
 export const getDigitalProductsForSelect = cache(async (): Promise<DigitalProductSelect[]> => {
@@ -30,14 +76,17 @@ export const getDigitalProductsForSelect = cache(async (): Promise<DigitalProduc
   });
 });
 
-// Note: The spec originally proposed reusing getPortfolioTree() and flattening at call site.
-// A direct query is used here instead: getPortfolioTree() returns nodes with product-count
-// metadata that is irrelevant for the form selector, and coupling the form to the portfolio
-// tree shape creates an unnecessary dependency. A dedicated active-node query is cleaner.
 export const getTaxonomyNodesFlat = cache(async (): Promise<TaxonomyNodeSelect[]> => {
   return prisma.taxonomyNode.findMany({
     where: { status: "active" },
     select: { id: true, nodeId: true, name: true },
     orderBy: { nodeId: "asc" },
+  });
+});
+
+export const getPortfoliosForSelect = cache(async (): Promise<PortfolioForSelect[]> => {
+  return prisma.portfolio.findMany({
+    select: { id: true, slug: true, name: true },
+    orderBy: { name: "asc" },
   });
 });

--- a/apps/web/lib/backlog.test.ts
+++ b/apps/web/lib/backlog.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   validateBacklogInput,
+  validateEpicInput,
   BACKLOG_STATUS_COLOURS,
+  EPIC_STATUS_COLOURS,
+  EPIC_STATUSES,
   LIFECYCLE_STAGE_LABELS,
   type BacklogItemInput,
+  type EpicInput,
 } from "./backlog";
 
 describe("validateBacklogInput()", () => {
@@ -46,6 +50,44 @@ describe("LIFECYCLE_STAGE_LABELS", () => {
   it("has a label for every stage", () => {
     for (const stage of ["plan", "design", "build", "production", "retirement"]) {
       expect(LIFECYCLE_STAGE_LABELS[stage]).toBeDefined();
+    }
+  });
+});
+
+describe("EPIC_STATUSES", () => {
+  it("contains exactly open, in-progress, done", () => {
+    expect(EPIC_STATUSES).toContain("open");
+    expect(EPIC_STATUSES).toContain("in-progress");
+    expect(EPIC_STATUSES).toContain("done");
+    expect(EPIC_STATUSES).toHaveLength(3);
+  });
+});
+
+describe("validateEpicInput()", () => {
+  it("returns null for a valid epic", () => {
+    const input: EpicInput = {
+      title: "My epic",
+      status: "open",
+      portfolioIds: [],
+    };
+    expect(validateEpicInput(input)).toBeNull();
+  });
+
+  it("returns an error for blank title", () => {
+    const input: EpicInput = { title: "   ", status: "open", portfolioIds: [] };
+    expect(validateEpicInput(input)).toMatch(/title/i);
+  });
+
+  it("returns an error for invalid status", () => {
+    const input = { title: "My epic", status: "invalid", portfolioIds: [] } as unknown as EpicInput;
+    expect(validateEpicInput(input)).toMatch(/status/i);
+  });
+});
+
+describe("EPIC_STATUS_COLOURS", () => {
+  it("has a colour for every EPIC_STATUS", () => {
+    for (const s of EPIC_STATUSES) {
+      expect(EPIC_STATUS_COLOURS[s]).toBeDefined();
     }
   });
 });

--- a/apps/web/lib/backlog.ts
+++ b/apps/web/lib/backlog.ts
@@ -8,6 +8,7 @@ export type BacklogItemInput = {
   body?: string;
   taxonomyNodeId?: string;
   digitalProductId?: string;
+  epicId?: string;
 };
 
 export type BacklogItemWithRelations = {
@@ -18,6 +19,7 @@ export type BacklogItemWithRelations = {
   type: string;
   body: string | null;
   priority: number | null;
+  epicId: string | null;
   digitalProduct: { id: string; productId: string; name: string } | null;
   taxonomyNode: { id: string; nodeId: string; name: string } | null;
   createdAt: Date;
@@ -37,6 +39,43 @@ export type TaxonomyNodeSelect = {
   name: string;
 };
 
+export type PortfolioForSelect = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
+export type EpicInput = {
+  title: string;
+  description?: string;
+  status: "open" | "in-progress" | "done";
+  portfolioIds: string[];
+};
+
+export type EpicForSelect = {
+  id: string;
+  epicId: string;
+  title: string;
+};
+
+export type EpicPortfolioLink = {
+  epicId: string;
+  portfolioId: string;
+  portfolio: { id: string; slug: string; name: string };
+};
+
+export type EpicWithRelations = {
+  id: string;
+  epicId: string;
+  title: string;
+  description: string | null;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  portfolios: EpicPortfolioLink[];
+  items: BacklogItemWithRelations[];
+};
+
 /** Returns null if valid, or an error message if invalid. */
 export function validateBacklogInput(input: BacklogItemInput): string | null {
   if (!input.title.trim()) return "Title is required";
@@ -46,12 +85,29 @@ export function validateBacklogInput(input: BacklogItemInput): string | null {
   return null;
 }
 
-/** Status badge colours (Tailwind inline styles). */
+export const EPIC_STATUSES = ["open", "in-progress", "done"] as const;
+export type EpicStatus = typeof EPIC_STATUSES[number];
+
+/** Returns null if valid, or an error message if invalid. */
+export function validateEpicInput(input: EpicInput): string | null {
+  if (!input.title.trim()) return "Title is required";
+  if (!(EPIC_STATUSES as readonly string[]).includes(input.status)) return "Invalid status";
+  return null;
+}
+
+/** Status badge colours (inline styles). */
 export const BACKLOG_STATUS_COLOURS: Record<string, string> = {
   "open":        "#38bdf8",
   "in-progress": "#fb923c",
   "done":        "#4ade80",
   "deferred":    "#555566",
+};
+
+/** Epic status badge colours (inline styles). */
+export const EPIC_STATUS_COLOURS: Record<string, string> = {
+  "open":        "#38bdf8",
+  "in-progress": "#fb923c",
+  "done":        "#4ade80",
 };
 
 /** Human-readable labels for CSDM lifecycle stages. */

--- a/docs/superpowers/specs/2026-03-11-phase-6a-epic-grouping-design.md
+++ b/docs/superpowers/specs/2026-03-11-phase-6a-epic-grouping-design.md
@@ -1,0 +1,297 @@
+# Phase 6A — Epic Grouping for Backlog Design
+
+**Date:** 2026-03-11
+**Status:** Approved
+**Scope:** Add epics as a first-class planning construct above backlog items in the existing backlog system.
+
+---
+
+## Context and Motivation
+
+The backlog system (Phase 5A+B) tracks individual portfolio and product backlog items. As the platform grows — with large initiatives like the Digital Product Backbone, EA Modeler, and infrastructure registry all in flight simultaneously — flat item lists become unmanageable. Epics provide the grouping layer that makes the programme of work legible.
+
+The platform's delivery team is AI agents. Epics are the primary contract between a human's intent and agent execution: a user or human role expresses what they want, an agent structures it into an epic with stories, the human reviews and approves the scope via the `/ops` interface, and agents execute against it. The design must serve both sides — agents write to it programmatically, humans read and manage it directly.
+
+Epics are **cross-portfolio capable**. A single initiative (e.g. the Digital Product Backbone) spans the `foundational` portfolio (Neo4j, Docker infrastructure) and the `manufacturing_and_delivery` portfolio (factory modeling capability). Epics are not locked to a single taxonomy node.
+
+---
+
+## Operating Model
+
+The `/ops` route is the shared workspace for humans and AI agents:
+
+- **Agents** create epics and backlog items via server actions, scoped by their role and the user's expressed intent
+- **Humans** review, edit, approve, and reprioritise via the UI
+- The `manage_backlog` capability controls write access for both paths — same permission, same enforcement
+
+This model scales: as more agent roles are introduced, they interact with the same backlog surface. The human remains in control through the review and management UI.
+
+---
+
+## Data Model
+
+### New: `Epic`
+
+```prisma
+model Epic {
+  id          String   @id @default(cuid())
+  epicId      String   @unique           // e.g. "EP-<uuid>" — stable human-readable ID
+  title       String
+  description String?
+  status      String   @default("open") // open | in-progress | done
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  portfolios  EpicPortfolio[]
+  items       BacklogItem[]
+}
+```
+
+Status values use hyphens (`in-progress`) to match the existing `BacklogItem.status` convention established in `backlog.ts`.
+
+### New: `EpicPortfolio` (join table)
+
+```prisma
+model EpicPortfolio {
+  epicId      String
+  portfolioId String
+
+  epic        Epic      @relation(fields: [epicId], references: [id], onDelete: Cascade)
+  portfolio   Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
+
+  @@id([epicId, portfolioId])
+}
+```
+
+The existing `Portfolio` model gains a back-relation field:
+
+```prisma
+// Added to the Portfolio model in schema.prisma:
+epicPortfolios  EpicPortfolio[]
+```
+
+### Modified: `BacklogItem`
+
+Add optional FK to `Epic` and `epicId` to the select shape:
+
+```prisma
+epicId  String?
+epic    Epic?   @relation(fields: [epicId], references: [id], onDelete: SetNull)
+```
+
+`onDelete: SetNull` means deleting an epic orphans its items back to the unassigned pool rather than deleting them.
+
+`BacklogItemWithRelations` type in `backlog.ts` gains `epicId: string | null`. The `getBacklogItems` query in `backlog-data.ts` adds `epicId: true` to its select — required for `OpsClient` to filter unassigned items (`epicId === null`).
+
+### `epicId` generation
+
+Format: `EP-${crypto.randomUUID()}` — full UUID, matching the established `BI-${crypto.randomUUID()}` pattern used for `BacklogItem.itemId`. The unique constraint on the column is the collision safety net.
+
+---
+
+## Status Values
+
+Epic status uses the same hyphenated convention as `BacklogItem.status`:
+
+| Status | Meaning |
+|---|---|
+| `open` | Defined, work not yet started or partially started |
+| `in-progress` | Actively being worked on |
+| `done` | All intended items complete |
+
+No approval gate at this stage — epics are planning containers, not governance artefacts. Governance workflow is a future concern.
+
+---
+
+## UI — `/ops` Page Restructured
+
+### Epic cards (top section)
+
+Each epic renders as a collapsible card:
+
+```
+[▶] EP-<uuid>  Digital Product Backbone          [open]
+    foundational · manufacturing_and_delivery
+    ████████░░  3 / 8 items done
+```
+
+Expanded, the card shows the backlog items belonging to that epic, grouped by type (portfolio items first, then product items). Each item renders using the existing `BacklogItemRow` component (see Data section for the full select shape required).
+
+An **"Add epic"** button sits in the page header area.
+
+Clicking the epic title or an edit icon opens the `EpicPanel` for editing.
+
+### Unassigned items (bottom section)
+
+Items with no epic continue to appear below the epic cards, grouped by type as today. Filtered client-side to `items.filter(i => i.epicId === null)`. This ensures no item is lost during the transition period while epics are being organised.
+
+### Progress bar
+
+Computed client-side:
+- **Denominator**: all items in the epic (including `deferred` — they remain part of the epic's scope)
+- **Numerator**: items with `status === "done"`
+- Label: `X / N items done`
+- A `deferred` item counts in N but not in X, reflecting that the work is deferred, not complete
+
+---
+
+## New Components
+
+### `components/ops/EpicCard.tsx`
+
+Client component. Props: `epic` (with portfolios and full items), callbacks for edit/delete.
+
+- Collapsible via `useState`
+- Progress bar computed from items: `done = items.filter(i => i.status === "done").length`
+- Renders `BacklogItemRow` for each item (requires full `BacklogItemWithRelations` shape — see Data section)
+- Edit button → calls `onEdit(epic)` → parent opens `EpicPanel`
+
+### `components/ops/EpicPanel.tsx`
+
+Client slide-in panel (same pattern as `BacklogPanel`). Fields:
+
+| Field | Control |
+|---|---|
+| Title | Text input, required |
+| Description | Textarea, optional |
+| Status | Select: open / in-progress / done |
+| Portfolios | Multi-checkbox: all 4 portfolio roots |
+
+Calls `createEpic` or `updateEpic` server action on submit. Calls `router.refresh()` on success. A close button calls `onClose()`.
+
+---
+
+## Modified Components
+
+### `BacklogPanel.tsx`
+
+Add an optional **Epic** select field — lists all `open` and `in-progress` epics by title. Selecting one assigns the item's `epicId`. The field is optional; items can remain unassigned.
+
+### `OpsClient.tsx`
+
+Receives `epics` prop (array of epics with portfolios and full items) and `items` prop as today.
+
+State uses **two independent panel state variables** to keep concerns separate and avoid mutual exclusion complexity:
+
+```ts
+// Existing — unchanged:
+const [panelState, setPanelState] = useState<PanelState | null>(null);
+
+// New — for epics:
+const [epicPanelState, setEpicPanelState] = useState<
+  { mode: "create" } | { mode: "edit"; epic: EpicWithRelations } | null
+>(null);
+```
+
+Two independent `null` checks mean the panels are implicitly mutually exclusive in practice (opening one doesn't close the other, but the UI never presents both open simultaneously — "Add epic" always sets `epicPanelState` and clears `panelState`, and vice versa).
+
+Renders:
+1. Page header with "Add epic" button (`setEpicPanelState({ mode: "create" })`)
+2. Epic cards list (one `EpicCard` per epic, passing `onEdit` and `onDelete` handlers)
+3. Unassigned items section (filtered to `items.filter(i => i.epicId === null)`, grouped by type as today)
+4. `<EpicPanel>` conditionally rendered when `epicPanelState !== null`
+5. `<BacklogPanel>` conditionally rendered when `panelState !== null` (unchanged)
+
+### `ops/page.tsx`
+
+Adds `getEpics()` to the `Promise.all` fetch. Passes epics to `OpsClient`.
+
+---
+
+## Server-Side Data
+
+### `lib/backlog-data.ts` (extended)
+
+`getBacklogItems` gains `epicId: true` in its select to support client-side unassigned filtering.
+
+New function:
+
+```ts
+export const getEpics = cache(async () => {
+  return prisma.epic.findMany({
+    orderBy: { createdAt: "asc" },
+    include: {
+      portfolios: { include: { portfolio: true } },
+      items: {
+        orderBy: { createdAt: "asc" },
+        include: {
+          digitalProduct: { select: { id: true, productId: true, name: true } },
+          taxonomyNode:   { select: { id: true, nodeId: true, name: true } },
+        },
+      },
+    },
+  });
+});
+```
+
+The `items` include uses `include` (not `select`) to match the full `BacklogItemWithRelations` shape required by `BacklogItemRow`. This ensures type compatibility without a separate component variant.
+
+### `lib/actions/backlog.ts` (extended)
+
+Three new server actions, all gated behind `requireManageBacklog()`:
+
+**`createEpic(input)`**
+- Validates title (non-empty)
+- Generates `epicId: "EP-" + crypto.randomUUID()`
+- Creates Epic + EpicPortfolio join rows in a `prisma.$transaction`
+
+**`updateEpic(id, input)`**
+- Updates title, description, status
+- Replaces portfolio links in a `prisma.$transaction`: delete existing `EpicPortfolio` rows for this epic, insert new ones
+
+**`deleteEpic(id)`**
+- Deletes epic; `onDelete: SetNull` cascades to `BacklogItem.epicId` automatically
+
+### `lib/backlog.ts` (extended)
+
+- `EPIC_STATUSES` constant: `["open", "in-progress", "done"] as const`
+- `validateEpicInput(input)` — validates title non-empty, status is a valid `EPIC_STATUSES` value
+- `EpicInput` type
+
+---
+
+## Migration
+
+One new Prisma migration:
+
+```sql
+CREATE TABLE "Epic" (
+  "id"          TEXT NOT NULL PRIMARY KEY,
+  "epicId"      TEXT NOT NULL UNIQUE,
+  "title"       TEXT NOT NULL,
+  "description" TEXT,
+  "status"      TEXT NOT NULL DEFAULT 'open',
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL
+);
+
+CREATE TABLE "EpicPortfolio" (
+  "epicId"      TEXT NOT NULL,
+  "portfolioId" TEXT NOT NULL,
+  PRIMARY KEY ("epicId", "portfolioId"),
+  FOREIGN KEY ("epicId") REFERENCES "Epic"("id") ON DELETE CASCADE,
+  FOREIGN KEY ("portfolioId") REFERENCES "Portfolio"("id") ON DELETE CASCADE
+);
+
+ALTER TABLE "BacklogItem"
+  ADD COLUMN "epicId" TEXT REFERENCES "Epic"("id") ON DELETE SET NULL;
+```
+
+---
+
+## Testing
+
+**Unit tests** (`lib/backlog.test.ts` extended):
+- `validateEpicInput` — title required; status must be one of `EPIC_STATUSES`
+- `epicId` format: matches `EP-[0-9a-f-]{36}` (full UUID pattern, consistent with `BI-` items)
+
+---
+
+## What This Does Not Include
+
+- Epic approval workflow (proposed → approved gate) — future governance concern
+- Epic owner assignment — future
+- Epic target date / roadmap timeline view — future
+- Nested epics or themes above epics — future
+- Agent-created epics via API — server actions are callable programmatically today; a dedicated agent API surface is a future concern
+- Epic-level comments or activity log — future

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,10 +16,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@prisma/client": "^5.14.0"
+    "@prisma/client": "5.22.0"
   },
   "devDependencies": {
-    "prisma": "^5.14.0",
+    "prisma": "5.22.0",
     "tsx": "^4.15.0",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"

--- a/packages/db/prisma/migrations/20260312000311_epic_grouping/migration.sql
+++ b/packages/db/prisma/migrations/20260312000311_epic_grouping/migration.sql
@@ -1,0 +1,35 @@
+-- AlterTable
+ALTER TABLE "BacklogItem" ADD COLUMN     "epicId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Epic" (
+    "id" TEXT NOT NULL,
+    "epicId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Epic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EpicPortfolio" (
+    "epicId" TEXT NOT NULL,
+    "portfolioId" TEXT NOT NULL,
+
+    CONSTRAINT "EpicPortfolio_pkey" PRIMARY KEY ("epicId","portfolioId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Epic_epicId_key" ON "Epic"("epicId");
+
+-- AddForeignKey
+ALTER TABLE "BacklogItem" ADD CONSTRAINT "BacklogItem_epicId_fkey" FOREIGN KEY ("epicId") REFERENCES "Epic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EpicPortfolio" ADD CONSTRAINT "EpicPortfolio_epicId_fkey" FOREIGN KEY ("epicId") REFERENCES "Epic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EpicPortfolio" ADD CONSTRAINT "EpicPortfolio_portfolioId_fkey" FOREIGN KEY ("portfolioId") REFERENCES "Portfolio"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -63,8 +63,9 @@ model Portfolio {
   budgetKUsd  Int?             // annual budget in $k — null means unset/unknown
   createdAt   DateTime         @default(now())
   updatedAt   DateTime         @updatedAt
-  products    DigitalProduct[]
-  agents       Agent[]
+  products        DigitalProduct[]
+  agents          Agent[]
+  epicPortfolios  EpicPortfolio[]
 }
 
 model DigitalProduct {
@@ -114,6 +115,33 @@ model BacklogItem {
   taxonomyNode     TaxonomyNode?   @relation(fields: [taxonomyNodeId], references: [id])
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt
+  epicId           String?
+  epic             Epic?           @relation(fields: [epicId], references: [id], onDelete: SetNull)
+}
+
+// ─── Epics ───────────────────────────────────────────────────────────────────
+
+model Epic {
+  id          String          @id @default(cuid())
+  epicId      String          @unique
+  title       String
+  description String?
+  status      String          @default("open")
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+
+  portfolios  EpicPortfolio[]
+  items       BacklogItem[]
+}
+
+model EpicPortfolio {
+  epicId      String
+  portfolioId String
+
+  epic        Epic      @relation(fields: [epicId], references: [id], onDelete: Cascade)
+  portfolio   Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
+
+  @@id([epicId, portfolioId])
 }
 
 // ─── Branding ────────────────────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,11 +63,11 @@ importers:
   packages/db:
     dependencies:
       '@prisma/client':
-        specifier: ^5.14.0
+        specifier: 5.22.0
         version: 5.22.0(prisma@5.22.0)
     devDependencies:
       prisma:
-        specifier: ^5.14.0
+        specifier: 5.22.0
         version: 5.22.0
       tsx:
         specifier: ^4.15.0


### PR DESCRIPTION
## Summary

- Adds `Epic` and `EpicPortfolio` Prisma models with a Postgres migration; `BacklogItem` gains an optional `epicId` FK (SetNull on delete)
- Implements full epic CRUD (`createEpic`, `updateEpic`, `deleteEpic`) as gated server actions; item actions updated to carry `epicId`
- New `EpicCard` (collapsible with progress bar) and `EpicPanel` (slide-in create/edit form with multi-portfolio checkboxes) components wired into `/ops`
- `/ops` page now shows an Epics section above Unassigned items; BacklogPanel gains an epic selector dropdown

## Test Plan

- [ ] All 66 tests pass (`pnpm test`)
- [ ] TypeScript clean (`pnpm --filter @dpf/web exec tsc --noEmit`)
- [ ] Open `/ops` — Epics section is visible with "+ Add epic" button
- [ ] Create an epic, assign it to one or more portfolios — epic card appears with progress bar
- [ ] Expand the epic card — item list renders; edit button opens the item panel
- [ ] Create a backlog item and assign it to the epic — it disappears from Unassigned and appears in the epic card
- [ ] Edit and delete epic work correctly; deleting an epic nullifies `epicId` on its items (they return to Unassigned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)