### PR TITLE
feat: Phase 7A — AI Provider Registry & Token Spend

### DIFF
--- a/apps/web/app/(shell)/ea/agents/page.tsx
+++ b/apps/web/app/(shell)/ea/agents/page.tsx
@@ -1,0 +1,88 @@
+// apps/web/app/(shell)/ea/agents/page.tsx
+import { prisma } from "@dpf/db";
+import { PORTFOLIO_COLOURS } from "@/lib/portfolio";
+import { EaTabNav } from "@/components/ea/EaTabNav";
+
+const TIER_LABELS: Record<number, string> = {
+  1: "Tier 1 — Orchestrators",
+  2: "Tier 2 — Specialists",
+  3: "Tier 3 — Cross-cutting",
+};
+
+export default async function EaAgentsPage() {
+  const agents = await prisma.agent.findMany({
+    orderBy: [{ tier: "asc" }, { name: "asc" }],
+    select: {
+      id:          true,
+      agentId:     true,
+      name:        true,
+      tier:        true,
+      description: true,
+      portfolio:   { select: { slug: true, name: true } },
+    },
+  });
+
+  const tiers = [1, 2, 3] as const;
+  const byTier = new Map(tiers.map((t) => [t, agents.filter((a) => a.tier === t)]));
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-white">Enterprise Architecture</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          {agents.length} agent{agents.length !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      <EaTabNav />
+
+      {tiers.map((t) => {
+        const tierAgents = byTier.get(t) ?? [];
+        if (tierAgents.length === 0) return null;
+        const tierLabel = TIER_LABELS[t] ?? `Tier ${t}`;
+
+        return (
+          <section key={t} className="mb-8">
+            <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest mb-3">
+              {tierLabel}
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {tierAgents.map((a) => {
+                const colour = a.portfolio
+                  ? (PORTFOLIO_COLOURS[a.portfolio.slug] ?? "#555566")
+                  : "#555566";
+
+                return (
+                  <div
+                    key={a.id}
+                    className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
+                    style={{ borderLeftColor: colour }}
+                  >
+                    <p className="text-[9px] font-mono text-[var(--dpf-muted)] mb-1">{a.agentId}</p>
+                    <p className="text-sm font-semibold text-white leading-tight mb-1">{a.name}</p>
+                    {a.description != null && (
+                      <p className="text-[10px] text-[var(--dpf-muted)] line-clamp-2 mb-1.5">
+                        {a.description}
+                      </p>
+                    )}
+                    {a.portfolio != null ? (
+                      <p className="text-[10px] font-medium" style={{ color: colour }}>
+                        {a.portfolio.name}
+                      </p>
+                    ) : (
+                      <p className="text-[10px] text-[var(--dpf-muted)]">Cross-cutting</p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+
+      {agents.length === 0 && (
+        <p className="text-sm text-[var(--dpf-muted)]">No agents registered yet.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/ea/page.tsx
+++ b/apps/web/app/(shell)/ea/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/app/(shell)/ea/page.tsx
 import Link from "next/link";
 import { prisma } from "@dpf/db";
+import { EaTabNav } from "@/components/ea/EaTabNav";
 
 const LAYOUT_LABELS: Record<string, string> = {
   graph:    "Graph",
@@ -38,6 +39,8 @@ export default async function EaPage() {
           {views.length} view{views.length !== 1 ? "s" : ""}
         </p>
       </div>
+
+      <EaTabNav />
 
       {views.length > 0 ? (
         <>

--- a/apps/web/app/(shell)/ea/views/[id]/page.tsx
+++ b/apps/web/app/(shell)/ea/views/[id]/page.tsx
@@ -6,7 +6,8 @@ import { getEaView } from "@/lib/ea-data";
 import { prisma } from "@dpf/db";
 import { EaCanvas } from "@/components/ea/EaCanvas";
 
-export default async function EaViewPage({ params }: { params: { id: string } }) {
+export default async function EaViewPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   const session = await auth();
   const user = session?.user;
 
@@ -15,7 +16,7 @@ export default async function EaViewPage({ params }: { params: { id: string } })
     notFound();
   }
 
-  const view = await getEaView(params.id);
+  const view = await getEaView(id);
   if (!view) notFound();
 
   const isReadOnly = !can(

--- a/apps/web/app/(shell)/platform/ai/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
 import { getProviders, getTokenSpendByProvider, getTokenSpendByAgent, getScheduledJobs } from "@/lib/ai-provider-data";
 import { syncProviderRegistry, triggerProviderSync } from "@/lib/actions/ai-providers";
 import { TokenSpendPanel } from "@/components/platform/TokenSpendPanel";
@@ -33,14 +34,12 @@ export default async function PlatformAiPage() {
   const now = new Date();
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
 
-  // Second getScheduledJobs() call — not deduplicated by React cache because
-  // syncProviderRegistry() may have mutated the DB between the two calls.
-  // freshJobs reflects the updated lastRunAt/nextRunAt after any auto-sync.
+  // Bypass React cache for jobs — syncProviderRegistry() may have mutated the DB above.
   const [providers, byProvider, byAgent, freshJobs] = await Promise.all([
     getProviders(),
     getTokenSpendByProvider(currentMonth),
     getTokenSpendByAgent(currentMonth),
-    getScheduledJobs(),
+    prisma.scheduledJob.findMany({ orderBy: { jobId: "asc" } }),
   ]);
 
   const lastSync = freshJobs.find((j) => j.jobId === "provider-registry-sync")?.lastRunAt;

--- a/apps/web/app/(shell)/platform/ai/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/page.tsx
@@ -1,0 +1,121 @@
+// apps/web/app/(shell)/platform/ai/page.tsx
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getProviders, getTokenSpendByProvider, getTokenSpendByAgent, getScheduledJobs } from "@/lib/ai-provider-data";
+import { syncProviderRegistry, triggerProviderSync } from "@/lib/actions/ai-providers";
+import { TokenSpendPanel } from "@/components/platform/TokenSpendPanel";
+import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
+
+async function syncAction(_formData: FormData): Promise<void> {
+  "use server";
+  await triggerProviderSync();
+}
+
+const STATUS_COLOURS: Record<string, string> = {
+  active:        "#4ade80",
+  unconfigured:  "#fbbf24",
+  inactive:      "#555566",
+};
+
+export default async function PlatformAiPage() {
+  const session = await auth();
+  const user = session?.user;
+  const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
+
+  // Auto-sync if due
+  const jobs = await getScheduledJobs();
+  const syncJob = jobs.find((j) => j.jobId === "provider-registry-sync");
+  if (syncJob && syncJob.schedule !== "disabled" && syncJob.nextRunAt && syncJob.nextRunAt < new Date()) {
+    await syncProviderRegistry();
+  }
+
+  const now = new Date();
+  const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+
+  // Second getScheduledJobs() call — not deduplicated by React cache because
+  // syncProviderRegistry() may have mutated the DB between the two calls.
+  // freshJobs reflects the updated lastRunAt/nextRunAt after any auto-sync.
+  const [providers, byProvider, byAgent, freshJobs] = await Promise.all([
+    getProviders(),
+    getTokenSpendByProvider(currentMonth),
+    getTokenSpendByAgent(currentMonth),
+    getScheduledJobs(),
+  ]);
+
+  const lastSync = freshJobs.find((j) => j.jobId === "provider-registry-sync")?.lastRunAt;
+
+  return (
+    <div>
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "#fff", margin: 0 }}>AI Providers</h1>
+        <p style={{ fontSize: 11, color: "#555566", marginTop: 2 }}>
+          {providers.length} provider{providers.length !== 1 ? "s" : ""} registered
+          {lastSync ? ` · last synced ${new Date(lastSync).toLocaleDateString()}` : ""}
+        </p>
+      </div>
+
+      {/* Section 1: Provider Registry */}
+      <div style={{ marginBottom: 32 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+          <div style={{ color: "#7c8cf8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>Providers</div>
+          {canWrite && (
+            <form action={syncAction}>
+              <button
+                type="submit"
+                style={{ fontSize: 10, padding: "3px 10px", background: "transparent", border: "1px solid #2a2a40", color: "#555566", borderRadius: 3, cursor: "pointer" }}
+              >
+                ↻ Sync from registry
+              </button>
+            </form>
+          )}
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+          {providers.map(({ provider }) => {
+            const colour = STATUS_COLOURS[provider.status] ?? "#555566";
+            return (
+              <div
+                key={provider.providerId}
+                style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderLeft: `3px solid ${colour}`, borderRadius: 6, padding: 10 }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 4 }}>
+                  <span style={{ color: "#e0e0ff", fontWeight: 600, fontSize: 12 }}>{provider.name}</span>
+                  <span style={{ background: `${colour}20`, color: colour, fontSize: 8, padding: "1px 5px", borderRadius: 3 }}>
+                    {provider.status}
+                  </span>
+                </div>
+                <div style={{ color: "#555566", fontSize: 9, marginBottom: 6 }}>
+                  {provider.families.slice(0, 3).join(" · ")}
+                  {provider.families.length > 3 ? " +more" : ""}
+                </div>
+                <Link
+                  href={`/platform/ai/providers/${provider.providerId}`}
+                  style={{ color: "#7c8cf8", fontSize: 9 }}
+                >
+                  Configure →
+                </Link>
+              </div>
+            );
+          })}
+          {providers.length === 0 && (
+            <p style={{ color: "#555566", fontSize: 11 }}>No providers registered. Click &quot;Sync from registry&quot; to import.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Section 2: Token Spend */}
+      <div style={{ marginBottom: 32 }}>
+        <TokenSpendPanel initialMonth={currentMonth} byProvider={byProvider} byAgent={byAgent} />
+      </div>
+
+      {/* Section 3: Scheduled Jobs */}
+      <div>
+        <div style={{ color: "#7c8cf8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 12 }}>
+          Scheduled Jobs
+        </div>
+        <ScheduledJobsTable jobs={freshJobs} canWrite={canWrite} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -1,0 +1,33 @@
+// apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getProviderById } from "@/lib/ai-provider-data";
+import { ProviderDetailForm } from "@/components/platform/ProviderDetailForm";
+
+type Props = { params: Promise<{ providerId: string }> };
+
+export default async function ProviderDetailPage({ params }: Props) {
+  const { providerId } = await params;
+  const pw = await getProviderById(providerId);
+  if (!pw) notFound();
+
+  const session = await auth();
+  const user = session?.user;
+  const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
+
+  return (
+    <div>
+      <div style={{ marginBottom: 20 }}>
+        <Link href="/platform/ai" style={{ color: "#555566", fontSize: 10 }}>← AI Providers</Link>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "#fff", margin: "6px 0 2px" }}>{pw.provider.name}</h1>
+        <p style={{ fontSize: 10, color: "#555566", margin: 0, fontFamily: "monospace" }}>{pw.provider.providerId}</p>
+      </div>
+
+      <div style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderRadius: 8, padding: 20 }}>
+        <ProviderDetailForm pw={pw} canWrite={canWrite} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/platform/page.tsx
+++ b/apps/web/app/(shell)/platform/page.tsx
@@ -1,5 +1,6 @@
 // apps/web/app/(shell)/platform/page.tsx
 import { prisma } from "@dpf/db";
+import Link from "next/link";
 
 const STATE_COLOURS: Record<string, string> = {
   active: "#4ade80",
@@ -63,6 +64,29 @@ export default async function PlatformPage() {
       {capabilities.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)]">No capabilities registered yet.</p>
       )}
+
+      <div style={{ marginTop: 32 }}>
+        <h2 style={{ fontSize: 14, fontWeight: 600, color: "#e0e0ff", marginBottom: 12 }}>Platform Services</h2>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+          <Link
+            href="/platform/ai"
+            style={{
+              display: "block",
+              padding: 16,
+              background: "var(--dpf-surface-1)",
+              border: "1px solid var(--dpf-border)",
+              borderLeft: "4px solid #7c8cf8",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            <p style={{ fontSize: 11, fontWeight: 600, color: "#e0e0ff", margin: "0 0 4px" }}>AI Providers</p>
+            <p style={{ fontSize: 10, color: "#555566", margin: 0 }}>
+              Provider registry, credentials, token spend
+            </p>
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
@@ -7,11 +7,12 @@ import { PortfolioOverview } from "@/components/portfolio/PortfolioOverview";
 import { PortfolioNodeDetail } from "@/components/portfolio/PortfolioNodeDetail";
 
 type Props = {
-  params: { slug?: string[] };
+  params: Promise<{ slug?: string[] }>;
 };
 
 export default async function PortfolioPage({ params }: Props) {
-  const slugs = params.slug ?? [];
+  const { slug } = await params;
+  const slugs = slug ?? [];
   const [roots, agentCounts, budgets, ownerRoles] = await Promise.all([
     getPortfolioTree(),
     getAgentCounts(),

--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import {
-  ReactFlow, Background, Controls,
+  ReactFlow, Background, Controls, ConnectionMode,
   useNodesState, useEdgesState, addEdge,
   type Node, type Edge, type Connection, type OnNodesChange,
 } from "@xyflow/react";
@@ -216,6 +216,7 @@ export function EaCanvas({
             onNodeClick={handleNodeClick}
             nodeTypes={NODE_TYPES}
             edgeTypes={EDGE_TYPES}
+            connectionMode={ConnectionMode.Loose}
             colorMode="dark"
             fitView
           >

--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -118,8 +118,9 @@ export function EaCanvas({
     const fromElementId = (sourceNode.data as SerializedViewElement).elementId;
     const toElementId = (targetNode.data as SerializedViewElement).elementId;
 
-    // Resolve the default relationship type ID for this viewpoint (first allowed slug → DB ID).
-    const relTypeId = await getDefaultRelTypeIdForView(viewId);
+    // Resolve a relationship type that has a rule for this specific element pair.
+    // Falls back to associated_with (or first allowed) if no specific rule matches.
+    const relTypeId = await getDefaultRelTypeIdForView(viewId, fromElementId, toElementId);
     if (!relTypeId) {
       console.warn("No allowed relationship types for this viewpoint");
       return;
@@ -215,10 +216,11 @@ export function EaCanvas({
             onNodeClick={handleNodeClick}
             nodeTypes={NODE_TYPES}
             edgeTypes={EDGE_TYPES}
+            colorMode="dark"
             fitView
           >
             <Background color="#2a2a40" gap={20} />
-            <Controls />
+            <Controls style={{ background: "#1a1a2e", border: "1px solid #2a2a40" }} />
           </ReactFlow>
         </div>
       </div>

--- a/apps/web/components/ea/EaElementNode.tsx
+++ b/apps/web/components/ea/EaElementNode.tsx
@@ -4,6 +4,15 @@ import { memo } from "react";
 import { Handle, Position, useConnection, type NodeProps } from "@xyflow/react";
 import { layerFromNeoLabel, LAYER_COLOURS, type SerializedViewElement } from "@/lib/ea-types";
 
+// Each side has a source and target handle so React Flow can route edges in any direction.
+// IDs are unique per handle to avoid React Flow warnings.
+const SIDES = [
+  { position: Position.Top,    sourceId: "t-s", targetId: "t-t" },
+  { position: Position.Right,  sourceId: "r-s", targetId: "r-t" },
+  { position: Position.Bottom, sourceId: "b-s", targetId: "b-t" },
+  { position: Position.Left,   sourceId: "l-s", targetId: "l-t" },
+];
+
 export const EaElementNode = memo(function EaElementNode({ id, data, selected }: NodeProps) {
   const nodeData = data as SerializedViewElement;
   const layer = layerFromNeoLabel(nodeData.elementType.neoLabel);
@@ -11,7 +20,6 @@ export const EaElementNode = memo(function EaElementNode({ id, data, selected }:
 
   const connection = useConnection();
   const isConnecting = connection.inProgress;
-  // This node is the source of the drag — don't highlight it as a target
   const isThisSource = isConnecting && connection.fromNode?.id === id;
 
   const isReference = nodeData.mode === "reference";
@@ -23,7 +31,6 @@ export const EaElementNode = memo(function EaElementNode({ id, data, selected }:
     ? `2px solid #7c8cf8`
     : `2px solid ${colours.border}`;
 
-  // Glow potential targets while a connection is being drawn
   const targetGlow = isConnecting && !isThisSource
     ? `0 0 0 2px ${colours.border}, 0 0 10px 3px ${colours.border}55`
     : undefined;
@@ -33,14 +40,17 @@ export const EaElementNode = memo(function EaElementNode({ id, data, selected }:
     ? String(nodeData.proposedProperties["name"])
     : nodeData.element.name;
 
-  // All handles are typed "source" — ReactFlow connectionMode="loose" lets them act as targets too.
-  // This enables connections from/to any side.
+  // Handles visible on hover or while connecting
+  const handleVisible = isConnecting && !isThisSource;
   const handleStyle = {
-    width: 10, height: 10, borderRadius: "50%",
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
     background: colours.border,
     border: `1px solid ${colours.bg}`,
-    opacity: isConnecting ? 1 : 0,
-    transition: "opacity 0.15s ease",
+    opacity: handleVisible ? 1 : 0,
+    transition: "opacity 0.12s ease",
+    zIndex: 10,
   };
 
   return (
@@ -59,7 +69,6 @@ export const EaElementNode = memo(function EaElementNode({ id, data, selected }:
         transition: "box-shadow 0.15s ease",
       }}
       onMouseEnter={(e) => {
-        // Show handles on hover even when not connecting
         e.currentTarget.querySelectorAll<HTMLElement>(".react-flow__handle").forEach((h) => {
           h.style.opacity = "1";
         });
@@ -72,10 +81,24 @@ export const EaElementNode = memo(function EaElementNode({ id, data, selected }:
         }
       }}
     >
-      <Handle type="source" position={Position.Top}    style={handleStyle} />
-      <Handle type="source" position={Position.Right}  style={handleStyle} />
-      <Handle type="source" position={Position.Bottom} style={handleStyle} />
-      <Handle type="source" position={Position.Left}   style={handleStyle} />
+      {SIDES.map(({ position, sourceId, targetId }) => (
+        <>
+          <Handle
+            key={sourceId}
+            type="source"
+            id={sourceId}
+            position={position}
+            style={handleStyle}
+          />
+          <Handle
+            key={targetId}
+            type="target"
+            id={targetId}
+            position={position}
+            style={{ ...handleStyle, opacity: 0, pointerEvents: "none" }}
+          />
+        </>
+      ))}
 
       <div style={{ fontSize: 7, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em", color: "#336", marginBottom: 2 }}>
         {nodeData.elementType.name} · {nodeData.mode}

--- a/apps/web/components/ea/EaElementNode.tsx
+++ b/apps/web/components/ea/EaElementNode.tsx
@@ -1,48 +1,82 @@
 "use client";
 
 import { memo } from "react";
-import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Handle, Position, useConnection, type NodeProps } from "@xyflow/react";
 import { layerFromNeoLabel, LAYER_COLOURS, type SerializedViewElement } from "@/lib/ea-types";
 
-type EaElementNodeData = SerializedViewElement & { selected?: boolean };
-
-export const EaElementNode = memo(function EaElementNode({ data, selected }: NodeProps) {
-  const nodeData = data as EaElementNodeData;
+export const EaElementNode = memo(function EaElementNode({ id, data, selected }: NodeProps) {
+  const nodeData = data as SerializedViewElement;
   const layer = layerFromNeoLabel(nodeData.elementType.neoLabel);
-  const fallback = { bg: "#CCE5FF", border: "#4a90d9" } as const;
-  const colours = LAYER_COLOURS[layer] ?? fallback;
+  const colours = LAYER_COLOURS[layer] ?? { bg: "#CCE5FF", border: "#4a90d9" };
+
+  const connection = useConnection();
+  const isConnecting = connection.inProgress;
+  // This node is the source of the drag — don't highlight it as a target
+  const isThisSource = isConnecting && connection.fromNode?.id === id;
+
   const isReference = nodeData.mode === "reference";
   const isPropose = nodeData.mode === "propose";
 
-  const borderStyle = isReference
+  const baseBorder = isReference
     ? `2px dashed ${colours.border}`
     : isPropose
     ? `2px solid #7c8cf8`
     : `2px solid ${colours.border}`;
 
-  const boxShadow = isPropose && selected ? "0 0 0 2px #7c8cf833" : undefined;
-  const opacity = isReference ? 0.85 : 1;
+  // Glow potential targets while a connection is being drawn
+  const targetGlow = isConnecting && !isThisSource
+    ? `0 0 0 2px ${colours.border}, 0 0 10px 3px ${colours.border}55`
+    : undefined;
+  const selectionGlow = isPropose && selected ? "0 0 0 2px #7c8cf833" : undefined;
 
   const displayName = isPropose && nodeData.proposedProperties?.["name"]
     ? String(nodeData.proposedProperties["name"])
     : nodeData.element.name;
+
+  // All handles are typed "source" — ReactFlow connectionMode="loose" lets them act as targets too.
+  // This enables connections from/to any side.
+  const handleStyle = {
+    width: 10, height: 10, borderRadius: "50%",
+    background: colours.border,
+    border: `1px solid ${colours.bg}`,
+    opacity: isConnecting ? 1 : 0,
+    transition: "opacity 0.15s ease",
+  };
 
   return (
     <div
       style={{
         padding: "8px 10px",
         background: colours.bg,
-        border: borderStyle,
+        border: baseBorder,
         borderRadius: 5,
-        boxShadow,
-        opacity,
+        boxShadow: targetGlow ?? selectionGlow,
+        opacity: isReference ? 0.85 : 1,
         minWidth: 120,
         maxWidth: 160,
         position: "relative",
         userSelect: "none",
+        transition: "box-shadow 0.15s ease",
+      }}
+      onMouseEnter={(e) => {
+        // Show handles on hover even when not connecting
+        e.currentTarget.querySelectorAll<HTMLElement>(".react-flow__handle").forEach((h) => {
+          h.style.opacity = "1";
+        });
+      }}
+      onMouseLeave={(e) => {
+        if (!connection.inProgress) {
+          e.currentTarget.querySelectorAll<HTMLElement>(".react-flow__handle").forEach((h) => {
+            h.style.opacity = "0";
+          });
+        }
       }}
     >
-      <Handle type="target" position={Position.Top} style={{ background: colours.border }} />
+      <Handle type="source" position={Position.Top}    style={handleStyle} />
+      <Handle type="source" position={Position.Right}  style={handleStyle} />
+      <Handle type="source" position={Position.Bottom} style={handleStyle} />
+      <Handle type="source" position={Position.Left}   style={handleStyle} />
+
       <div style={{ fontSize: 7, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em", color: "#336", marginBottom: 2 }}>
         {nodeData.elementType.name} · {nodeData.mode}
       </div>
@@ -56,7 +90,6 @@ export const EaElementNode = memo(function EaElementNode({ data, selected }: Nod
       {isPropose && (
         <div style={{ position: "absolute", top: 4, right: 6, fontSize: 9, color: "#7c8cf8" }}>✏️</div>
       )}
-      <Handle type="source" position={Position.Bottom} style={{ background: colours.border }} />
     </div>
   );
 });

--- a/apps/web/components/ea/EaTabNav.tsx
+++ b/apps/web/components/ea/EaTabNav.tsx
@@ -1,0 +1,35 @@
+// apps/web/components/ea/EaTabNav.tsx
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { label: "Views",  href: "/ea" },
+  { label: "Agents", href: "/ea/agents" },
+];
+
+export function EaTabNav() {
+  const pathname = usePathname();
+  const active = (href: string) =>
+    href === "/ea" ? pathname === "/ea" : pathname.startsWith(href);
+
+  return (
+    <div className="flex gap-1 mb-6 border-b border-[var(--dpf-border)]">
+      {TABS.map((t) => (
+        <Link
+          key={t.href}
+          href={t.href}
+          className={[
+            "px-3 py-1.5 text-xs font-medium rounded-t transition-colors",
+            active(t.href)
+              ? "text-white border-b-2 border-[var(--dpf-accent)]"
+              : "text-[var(--dpf-muted)] hover:text-white",
+          ].join(" ")}
+        >
+          {t.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/platform/ProviderDetailForm.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { configureProvider, testProviderAuth } from "@/lib/actions/ai-providers";
+import type { ProviderWithCredential } from "@/lib/ai-provider-types";
+
+type Props = { pw: ProviderWithCredential; canWrite: boolean };
+
+export function ProviderDetailForm({ pw, canWrite }: Props) {
+  const { provider, credential } = pw;
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const [secretRef, setSecretRef]                 = useState(credential?.secretRef ?? "");
+  const [endpoint, setEndpoint]                   = useState(provider.endpoint ?? "");
+  const [computeWatts, setComputeWatts]           = useState(String(provider.computeWatts ?? 150));
+  const [electricityRate, setElectricityRate]     = useState(String(provider.electricityRateKwh ?? 0.12));
+  const [enabledFamilies, setEnabledFamilies]     = useState<string[]>(provider.enabledFamilies);
+  const [testResult, setTestResult]               = useState<{ ok: boolean; message: string } | null>(null);
+  const [saveMessage, setSaveMessage]             = useState<string | null>(null);
+
+  const isKeyed      = provider.authHeader !== null;
+  const needsEndpoint = provider.authEndpoint === null;
+  const isCompute    = provider.costModel === "compute";
+
+  function toggleFamily(family: string) {
+    setEnabledFamilies((prev) =>
+      prev.includes(family) ? prev.filter((f) => f !== family) : [...prev, family]
+    );
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await configureProvider({
+        providerId: provider.providerId,
+        enabledFamilies,
+        ...(isKeyed && secretRef ? { secretRef } : {}),
+        ...(needsEndpoint && endpoint ? { endpoint } : {}),
+        ...(isCompute ? { computeWatts: Number(computeWatts), electricityRateKwh: Number(electricityRate) } : {}),
+      });
+      setSaveMessage(result.error ? `Error: ${result.error}` : "Saved");
+      router.refresh();
+    });
+  }
+
+  function handleTest() {
+    startTransition(async () => {
+      const result = await testProviderAuth(provider.providerId);
+      setTestResult(result);
+      router.refresh();
+    });
+  }
+
+  const statusColour = provider.status === "active" ? "#4ade80" : provider.status === "inactive" ? "#555566" : "#fbbf24";
+
+  return (
+    <div style={{ maxWidth: 560 }}>
+      {/* Status */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 20 }}>
+        <span style={{ background: `${statusColour}20`, color: statusColour, fontSize: 9, padding: "2px 6px", borderRadius: 3 }}>
+          {provider.status}
+        </span>
+        <span style={{ color: "#555566", fontSize: 10 }}>{provider.costModel === "compute" ? "compute-priced" : "token-priced"}</span>
+      </div>
+
+      {/* Enabled families */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ color: "#555566", fontSize: 10, marginBottom: 6 }}>Enabled model families</div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {provider.families.map((f) => (
+            <label key={f} style={{ display: "flex", alignItems: "center", gap: 4, cursor: canWrite ? "pointer" : "default" }}>
+              <input
+                type="checkbox"
+                checked={enabledFamilies.includes(f)}
+                disabled={!canWrite || isPending}
+                onChange={() => toggleFamily(f)}
+              />
+              <span style={{ fontSize: 10, color: "#e0e0ff" }}>{f}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Custom endpoint (Azure OpenAI etc.) */}
+      {needsEndpoint && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>
+            Custom endpoint URL
+          </label>
+          <input
+            value={endpoint}
+            onChange={(e) => setEndpoint(e.target.value)}
+            disabled={!canWrite || isPending}
+            placeholder="https://my-resource.openai.azure.com"
+            style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4 }}
+          />
+        </div>
+      )}
+
+      {/* API key env var name */}
+      {isKeyed && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>
+            Environment variable name
+          </label>
+          <input
+            value={secretRef}
+            onChange={(e) => setSecretRef(e.target.value)}
+            disabled={!canWrite || isPending}
+            placeholder="ANTHROPIC_API_KEY"
+            style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4, fontFamily: "monospace" }}
+          />
+          <p style={{ color: "#555566", fontSize: 9, marginTop: 3 }}>
+            Enter the name of the env var that holds the API key — not the key itself.
+          </p>
+        </div>
+      )}
+
+      {/* Compute settings */}
+      {isCompute && (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 16 }}>
+          <div>
+            <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>GPU/CPU wattage</label>
+            <input
+              type="number"
+              value={computeWatts}
+              onChange={(e) => setComputeWatts(e.target.value)}
+              disabled={!canWrite || isPending}
+              style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4 }}
+            />
+          </div>
+          <div>
+            <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>Electricity rate ($/kWh)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={electricityRate}
+              onChange={(e) => setElectricityRate(e.target.value)}
+              disabled={!canWrite || isPending}
+              style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4 }}
+            />
+          </div>
+        </div>
+      )}
+
+      {canWrite && (
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <button
+            onClick={handleSave}
+            disabled={isPending}
+            style={{ padding: "6px 14px", background: "#2a2a50", border: "1px solid #7c8cf8", color: "#7c8cf8", borderRadius: 4, fontSize: 11, cursor: "pointer" }}
+          >
+            Save
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={isPending}
+            style={{ padding: "6px 14px", background: "transparent", border: "1px solid #2a2a40", color: "#e0e0ff", borderRadius: 4, fontSize: 11, cursor: "pointer" }}
+          >
+            Test connection
+          </button>
+          {saveMessage && <span style={{ fontSize: 10, color: saveMessage.startsWith("Error") ? "#f87171" : "#4ade80" }}>{saveMessage}</span>}
+          {testResult && (
+            <span style={{ fontSize: 10, color: testResult.ok ? "#4ade80" : "#f87171" }}>
+              {testResult.ok ? "✓" : "✗"} {testResult.message}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/platform/ScheduledJobsTable.tsx
+++ b/apps/web/components/platform/ScheduledJobsTable.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateScheduledJob, runScheduledJobNow } from "@/lib/actions/ai-providers";
+import type { ScheduledJobRow } from "@/lib/ai-provider-types";
+
+type Props = { jobs: ScheduledJobRow[]; canWrite: boolean };
+
+const SCHEDULES = ["daily", "weekly", "monthly", "disabled"] as const;
+
+function formatDate(d: Date | null): string {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function ScheduledJobsTable({ jobs, canWrite }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleScheduleChange(jobId: string, schedule: string) {
+    startTransition(async () => {
+      await updateScheduledJob({ jobId, schedule });
+      router.refresh();
+    });
+  }
+
+  function handleRunNow(jobId: string) {
+    startTransition(async () => {
+      await runScheduledJobNow(jobId);
+      router.refresh();
+    });
+  }
+
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 10 }}>
+      <thead>
+        <tr style={{ color: "#555566", textAlign: "left" }}>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Job</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Schedule</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Last run</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Next run</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Status</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }} />
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map((job) => (
+          <tr key={job.jobId} style={{ borderTop: "1px solid #2a2a40", color: "#e0e0ff" }}>
+            <td style={{ padding: "6px 8px" }}>{job.name}</td>
+            <td style={{ padding: "6px 8px" }}>
+              {canWrite ? (
+                <select
+                  value={job.schedule}
+                  disabled={isPending}
+                  onChange={(e) => handleScheduleChange(job.jobId, e.target.value)}
+                  style={{ background: "#1a1a2e", border: "1px solid #2a2a40", color: "#7c8cf8", fontSize: 9, padding: "1px 4px", borderRadius: 3 }}
+                >
+                  {SCHEDULES.map((s) => <option key={s} value={s}>{s}</option>)}
+                </select>
+              ) : (
+                <span style={{ color: "#7c8cf8" }}>{job.schedule}</span>
+              )}
+            </td>
+            <td style={{ padding: "6px 8px", color: "#555566" }}>{formatDate(job.lastRunAt)}</td>
+            <td style={{ padding: "6px 8px", color: "#555566" }}>{formatDate(job.nextRunAt)}</td>
+            <td style={{ padding: "6px 8px" }}>
+              {job.lastStatus === "ok"    && <span style={{ color: "#4ade80" }}>✓ ok</span>}
+              {job.lastStatus === "error" && <span style={{ color: "#f87171" }}>✗ error</span>}
+              {!job.lastStatus            && <span style={{ color: "#555566" }}>—</span>}
+            </td>
+            <td style={{ padding: "6px 8px", textAlign: "right" }}>
+              {canWrite && (
+                <button
+                  onClick={() => handleRunNow(job.jobId)}
+                  disabled={isPending}
+                  style={{ color: "#7c8cf8", background: "none", border: "none", fontSize: 9, cursor: "pointer" }}
+                >
+                  Run now
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/components/platform/TokenSpendPanel.tsx
+++ b/apps/web/components/platform/TokenSpendPanel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import type { SpendByProvider, SpendByAgent } from "@/lib/ai-provider-types";
+
+// Month selector (switching between months) is deferred to a later phase —
+// TokenUsage will be empty in Phase 7A. Current month is fixed server-side.
+
+type Props = {
+  initialMonth: { year: number; month: number };
+  byProvider: SpendByProvider[];
+  byAgent: SpendByAgent[];
+};
+
+const MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
+function formatCost(usd: number): string {
+  if (usd === 0) return "$0.00";
+  return `$${usd.toFixed(2)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
+}
+
+export function TokenSpendPanel({ initialMonth, byProvider, byAgent }: Props) {
+  const [tab, setTab] = useState<"provider" | "agent">("provider");
+  const totalCost = byProvider.reduce((s, r) => s + r.totalCostUsd, 0);
+  const monthLabel = `${MONTH_NAMES[(initialMonth.month - 1) % 12]} ${initialMonth.year}`;
+
+  const isEmpty = byProvider.length === 0 && byAgent.length === 0;
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+        <div>
+          <div style={{ color: "#7c8cf8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            Token Spend — {monthLabel}
+          </div>
+          {!isEmpty && (
+            <div style={{ color: "#e0e0ff", fontSize: 18, fontWeight: 700, marginTop: 2 }}>
+              {formatCost(totalCost)} total
+            </div>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 4 }}>
+          {(["provider", "agent"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              style={{
+                fontSize: 9, padding: "2px 8px", borderRadius: 3, cursor: "pointer",
+                background: tab === t ? "#2a2a50" : "transparent",
+                border: `1px solid ${tab === t ? "#7c8cf8" : "#2a2a40"}`,
+                color: tab === t ? "#7c8cf8" : "#555566",
+              }}
+            >
+              {t === "provider" ? "By Provider" : "By Agent"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isEmpty && (
+        <p style={{ color: "#555566", fontSize: 11 }}>No spend data yet — token usage will appear here once agents are active.</p>
+      )}
+
+      {!isEmpty && tab === "provider" && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+          {byProvider.map((r) => {
+            const pct = totalCost > 0 ? Math.round((r.totalCostUsd / totalCost) * 100) : 0;
+            return (
+              <div key={r.providerId} style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderRadius: 6, padding: 10 }}>
+                <div style={{ color: "#555566", fontSize: 9, marginBottom: 2 }}>{r.providerId}</div>
+                <div style={{ color: "#e0e0ff", fontSize: 16, fontWeight: 700 }}>{formatCost(r.totalCostUsd)}</div>
+                <div style={{ color: "#555566", fontSize: 9, marginTop: 2 }}>
+                  {formatTokens(r.totalInputTokens)} in · {formatTokens(r.totalOutputTokens)} out
+                </div>
+                <div style={{ height: 4, background: "#2a2a40", borderRadius: 2, marginTop: 6 }}>
+                  <div style={{ height: 4, background: "#4ade80", borderRadius: 2, width: `${pct}%` }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!isEmpty && tab === "agent" && (
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 10 }}>
+          <thead>
+            <tr style={{ color: "#555566", textAlign: "left" }}>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Agent</th>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Input</th>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Output</th>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {byAgent.map((r) => (
+              <tr key={r.agentId} style={{ borderTop: "1px solid #2a2a40", color: "#e0e0ff" }}>
+                <td style={{ padding: "6px 8px" }}>{r.agentName}</td>
+                <td style={{ padding: "6px 8px", color: "#555566" }}>{formatTokens(r.totalInputTokens)}</td>
+                <td style={{ padding: "6px 8px", color: "#555566" }}>{formatTokens(r.totalOutputTokens)}</td>
+                <td style={{ padding: "6px 8px", fontWeight: 600 }}>{formatCost(r.totalCostUsd)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -1,0 +1,283 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  computeTokenCost,
+  computeComputeCost,
+  computeNextRunAt,
+  type RegistryProviderEntry,
+} from "@/lib/ai-provider-types";
+
+// ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+async function requireManageProviders(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections")) {
+    throw new Error("Unauthorized");
+  }
+}
+
+async function requireSession(): Promise<void> {
+  const session = await auth();
+  if (!session?.user) throw new Error("Unauthorized");
+}
+
+// ─── Registry sync ────────────────────────────────────────────────────────────
+
+const REGISTRY_URL =
+  "https://raw.githubusercontent.com/markdbodman/opendigitalproductfactory/main/packages/db/data/providers-registry.json";
+
+/**
+ * Sync provider registry from GitHub. No auth guard — called from server component
+ * on page load for any view_platform holder. Use triggerProviderSync() for the
+ * admin button (which adds the manage_provider_connections check).
+ */
+export async function syncProviderRegistry(): Promise<{ added: number; updated: number; error?: string }> {
+  const job = await prisma.scheduledJob.findUnique({ where: { jobId: "provider-registry-sync" } });
+  let entries: RegistryProviderEntry[];
+
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    entries = (await res.json()) as RegistryProviderEntry[];
+  } catch (err) {
+    const error = err instanceof Error ? err.message : "Unknown error";
+    if (job) {
+      await prisma.scheduledJob.update({
+        where: { jobId: "provider-registry-sync" },
+        data: { lastRunAt: new Date(), lastStatus: "error", lastError: error },
+      });
+    }
+    return { added: 0, updated: 0, error };
+  }
+
+  let added = 0;
+  let updated = 0;
+
+  for (const entry of entries) {
+    const existing = await prisma.modelProvider.findUnique({ where: { providerId: entry.providerId } });
+    if (existing) {
+      await prisma.modelProvider.update({
+        where: { providerId: entry.providerId },
+        data: {
+          name:                 entry.name,
+          families:             entry.families,
+          authEndpoint:         entry.authEndpoint ?? null,
+          authHeader:           entry.authHeader ?? null,
+          costModel:            entry.costModel,
+          ...(entry.inputPricePerMToken !== undefined  && { inputPricePerMToken:  entry.inputPricePerMToken }),
+          ...(entry.outputPricePerMToken !== undefined && { outputPricePerMToken: entry.outputPricePerMToken }),
+          ...(entry.computeWatts !== undefined         && { computeWatts:         entry.computeWatts }),
+          ...(entry.electricityRateKwh !== undefined   && { electricityRateKwh:   entry.electricityRateKwh }),
+          // status and enabledFamilies deliberately NOT updated — preserve admin config
+        },
+      });
+      updated++;
+    } else {
+      await prisma.modelProvider.create({
+        data: {
+          providerId:           entry.providerId,
+          name:                 entry.name,
+          families:             entry.families,
+          enabledFamilies:      [],
+          status:               "unconfigured",
+          authEndpoint:         entry.authEndpoint ?? null,
+          authHeader:           entry.authHeader ?? null,
+          costModel:            entry.costModel,
+          inputPricePerMToken:  entry.inputPricePerMToken ?? null,
+          outputPricePerMToken: entry.outputPricePerMToken ?? null,
+          computeWatts:         entry.computeWatts ?? null,
+          electricityRateKwh:   entry.electricityRateKwh ?? null,
+        },
+      });
+      added++;
+    }
+  }
+
+  const now = new Date();
+  if (job) {
+    await prisma.scheduledJob.update({
+      where: { jobId: "provider-registry-sync" },
+      data: {
+        lastRunAt:  now,
+        lastStatus: "ok",
+        lastError:  null,
+        nextRunAt:  computeNextRunAt(job.schedule, now),
+      },
+    });
+  }
+
+  return { added, updated };
+}
+
+/** Admin button wrapper — requires manage_provider_connections. */
+export async function triggerProviderSync(): Promise<{ added: number; updated: number; error?: string }> {
+  await requireManageProviders();
+  return syncProviderRegistry();
+}
+
+// ─── Configure provider ───────────────────────────────────────────────────────
+
+export async function configureProvider(input: {
+  providerId: string;
+  enabledFamilies: string[];
+  secretRef?: string;
+  endpoint?: string;
+  computeWatts?: number;
+  electricityRateKwh?: number;
+}): Promise<{ error?: string }> {
+  await requireManageProviders();
+
+  if (input.secretRef !== undefined) {
+    await prisma.credentialEntry.upsert({
+      where:  { providerId: input.providerId },
+      create: { providerId: input.providerId, secretRef: input.secretRef, status: "pending" },
+      update: { secretRef: input.secretRef, status: "pending" },
+    });
+  }
+
+  await prisma.modelProvider.update({
+    where: { providerId: input.providerId },
+    data: {
+      enabledFamilies: input.enabledFamilies,
+      ...(input.endpoint !== undefined           && { endpoint:           input.endpoint }),
+      ...(input.computeWatts !== undefined       && { computeWatts:       input.computeWatts }),
+      ...(input.electricityRateKwh !== undefined && { electricityRateKwh: input.electricityRateKwh }),
+    },
+  });
+
+  return {};
+}
+
+// ─── Test provider auth ───────────────────────────────────────────────────────
+
+export async function testProviderAuth(providerId: string): Promise<{ ok: boolean; message: string }> {
+  await requireManageProviders();
+
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
+  if (!provider) return { ok: false, message: "Provider not found" };
+
+  const credential = await prisma.credentialEntry.findUnique({ where: { providerId } });
+
+  // Guard: keyed providers need a credential with a secretRef
+  if (provider.authHeader !== null) {
+    if (!credential || credential.secretRef === null) {
+      return { ok: false, message: "No credential configured" };
+    }
+    if (process.env[credential.secretRef] === undefined) {
+      return { ok: false, message: `Environment variable not set: ${credential.secretRef}` };
+    }
+  }
+
+  // Guard: Azure OpenAI-style providers need a custom endpoint
+  if (provider.authEndpoint === null && provider.endpoint === null) {
+    return { ok: false, message: "Custom endpoint required" };
+  }
+
+  const authUrl = provider.endpoint
+    ? `${provider.endpoint}/openai/models?api-version=2024-02-01`
+    : (provider.authEndpoint as string);
+
+  const headers: Record<string, string> = {};
+  if (provider.authHeader !== null && credential?.secretRef) {
+    const apiKey = process.env[credential.secretRef];
+    if (apiKey !== undefined) {
+      headers[provider.authHeader] = provider.authHeader === "Authorization"
+        ? `Bearer ${apiKey}`
+        : apiKey;
+    }
+  }
+
+  try {
+    const res = await fetch(authUrl, {
+      headers,
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (res.ok) {
+      await prisma.modelProvider.update({ where: { providerId }, data: { status: "active" } });
+      if (credential) {
+        await prisma.credentialEntry.update({ where: { providerId }, data: { status: "ok" } });
+      }
+      return { ok: true, message: `Connected — HTTP ${res.status}` };
+    } else {
+      if (credential) {
+        await prisma.credentialEntry.update({ where: { providerId }, data: { status: "error" } });
+      }
+      return { ok: false, message: `HTTP ${res.status} — ${res.statusText}` };
+    }
+  } catch (err) {
+    if (credential) {
+      await prisma.credentialEntry.update({ where: { providerId }, data: { status: "error" } });
+    }
+    return { ok: false, message: err instanceof Error ? err.message : "Network error" };
+  }
+}
+
+// ─── Scheduled jobs ───────────────────────────────────────────────────────────
+
+export async function updateScheduledJob(input: { jobId: string; schedule: string }): Promise<void> {
+  await requireManageProviders();
+  const nextRunAt = computeNextRunAt(input.schedule, new Date());
+  await prisma.scheduledJob.update({
+    where: { jobId: input.jobId },
+    data: { schedule: input.schedule, nextRunAt },
+  });
+}
+
+export async function runScheduledJobNow(jobId: string): Promise<void> {
+  await requireManageProviders();
+  if (jobId === "provider-registry-sync") {
+    await syncProviderRegistry();
+    return;
+  }
+  console.warn(`runScheduledJobNow: unknown jobId "${jobId}"`);
+}
+
+// ─── Token usage logging ──────────────────────────────────────────────────────
+
+export async function logTokenUsage(input: {
+  agentId: string;
+  providerId: string;
+  contextKey: string;
+  inputTokens: number;
+  outputTokens: number;
+  inferenceMs?: number;
+}): Promise<void> {
+  await requireSession();
+
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId: input.providerId } });
+
+  let costUsd = 0;
+  if (provider) {
+    if (provider.costModel === "compute" && input.inferenceMs !== undefined) {
+      costUsd = computeComputeCost(
+        input.inferenceMs,
+        provider.computeWatts ?? 150,
+        provider.electricityRateKwh ?? 0.12,
+      );
+    } else if (provider.costModel === "token") {
+      costUsd = computeTokenCost(
+        input.inputTokens,
+        input.outputTokens,
+        provider.inputPricePerMToken ?? 0,
+        provider.outputPricePerMToken ?? 0,
+      );
+    }
+  }
+
+  await prisma.tokenUsage.create({
+    data: {
+      agentId:      input.agentId,
+      providerId:   input.providerId,
+      contextKey:   input.contextKey,
+      inputTokens:  input.inputTokens,
+      outputTokens: input.outputTokens,
+      ...(input.inferenceMs !== undefined && { inferenceMs: input.inferenceMs }),
+      costUsd,
+    },
+  });
+}

--- a/apps/web/lib/actions/ea.ts
+++ b/apps/web/lib/actions/ea.ts
@@ -505,7 +505,11 @@ export async function saveCanvasState(input: {
   });
 }
 
-export async function getDefaultRelTypeIdForView(viewId: string): Promise<string | null> {
+export async function getDefaultRelTypeIdForView(
+  viewId: string,
+  fromElementId?: string,
+  toElementId?: string,
+): Promise<string | null> {
   await requireManageEaModel();
   const view = await prisma.eaView.findUnique({
     where: { id: viewId },
@@ -515,10 +519,48 @@ export async function getDefaultRelTypeIdForView(viewId: string): Promise<string
     },
   });
   if (!view?.viewpoint?.allowedRelTypeSlugs.length) return null;
-  const slug = view.viewpoint.allowedRelTypeSlugs[0];
+  const allowedSlugs = view.viewpoint.allowedRelTypeSlugs;
+  const notationId = view.notation.id;
+
+  // If element IDs are supplied, find the first allowed rel type that has a rule for this pair.
+  if (fromElementId && toElementId) {
+    const [fromEl, toEl] = await Promise.all([
+      prisma.eaElement.findUnique({ where: { id: fromElementId }, select: { elementTypeId: true } }),
+      prisma.eaElement.findUnique({ where: { id: toElementId },   select: { elementTypeId: true } }),
+    ]);
+    if (fromEl && toEl) {
+      for (const slug of allowedSlugs) {
+        const rt = await prisma.eaRelationshipType.findUnique({
+          where: { notationId_slug: { notationId, slug } },
+          select: { id: true },
+        });
+        if (!rt) continue;
+        const rule = await prisma.eaRelationshipRule.findFirst({
+          where: {
+            fromElementTypeId:  fromEl.elementTypeId,
+            toElementTypeId:    toEl.elementTypeId,
+            relationshipTypeId: rt.id,
+          },
+          select: { id: true },
+        });
+        if (rule) return rt.id;
+      }
+      // No specific rule found — fall back to associated_with if it's allowed
+      const fallbackSlug = allowedSlugs.includes("associated_with") ? "associated_with" : allowedSlugs[0];
+      if (!fallbackSlug) return null;
+      const fallback = await prisma.eaRelationshipType.findUnique({
+        where: { notationId_slug: { notationId, slug: fallbackSlug } },
+        select: { id: true },
+      });
+      return fallback?.id ?? null;
+    }
+  }
+
+  // No element context — return first allowed rel type.
+  const slug = allowedSlugs[0];
   if (!slug) return null;
   const rt = await prisma.eaRelationshipType.findUnique({
-    where: { notationId_slug: { notationId: view.notation.id, slug } },
+    where: { notationId_slug: { notationId, slug } },
     select: { id: true },
   });
   return rt?.id ?? null;

--- a/apps/web/lib/ai-provider-data.ts
+++ b/apps/web/lib/ai-provider-data.ts
@@ -1,0 +1,90 @@
+// apps/web/lib/ai-provider-data.ts
+// Server-only: uses React cache() to deduplicate Prisma calls within one request.
+import { cache } from "react";
+import { prisma } from "@dpf/db";
+import type {
+  ProviderWithCredential,
+  ProviderRow,
+  SpendByProvider,
+  SpendByAgent,
+  ScheduledJobRow,
+} from "./ai-provider-types";
+
+export const getProviders = cache(async (): Promise<ProviderWithCredential[]> => {
+  const providers = await prisma.modelProvider.findMany({ orderBy: { name: "asc" } });
+  const credentials = await prisma.credentialEntry.findMany({
+    where: { providerId: { in: providers.map((p) => p.providerId) } },
+  });
+  const credMap = new Map(credentials.map((c) => [c.providerId, c]));
+  return providers.map((p) => ({
+    provider: {
+      ...p,
+      families:        p.families as string[],
+      enabledFamilies: p.enabledFamilies as string[],
+    } satisfies ProviderRow,
+    credential: credMap.get(p.providerId) ?? null,
+  }));
+});
+
+export const getProviderById = cache(async (providerId: string): Promise<ProviderWithCredential | null> => {
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
+  if (!provider) return null;
+  const credential = await prisma.credentialEntry.findUnique({ where: { providerId } });
+  return {
+    provider: {
+      ...provider,
+      families:        provider.families as string[],
+      enabledFamilies: provider.enabledFamilies as string[],
+    } satisfies ProviderRow,
+    credential: credential ?? null,
+  };
+});
+
+function monthRange(month: { year: number; month: number }): { gte: Date; lt: Date } {
+  const gte = new Date(Date.UTC(month.year, month.month - 1, 1));
+  const lt  = new Date(Date.UTC(month.year, month.month, 1));
+  return { gte, lt };
+}
+
+export const getTokenSpendByProvider = cache(
+  async (month: { year: number; month: number }): Promise<SpendByProvider[]> => {
+    const range = monthRange(month);
+    const rows = await prisma.tokenUsage.groupBy({
+      by: ["providerId"],
+      where: { createdAt: range },
+      _sum: { inputTokens: true, outputTokens: true, costUsd: true },
+    });
+    return rows.map((r) => ({
+      providerId:        r.providerId,
+      totalInputTokens:  r._sum.inputTokens  ?? 0,
+      totalOutputTokens: r._sum.outputTokens ?? 0,
+      totalCostUsd:      r._sum.costUsd      ?? 0,
+    }));
+  }
+);
+
+export const getTokenSpendByAgent = cache(
+  async (month: { year: number; month: number }): Promise<SpendByAgent[]> => {
+    const range = monthRange(month);
+    const rows = await prisma.tokenUsage.groupBy({
+      by: ["agentId"],
+      where: { createdAt: range },
+      _sum: { inputTokens: true, outputTokens: true, costUsd: true },
+      orderBy: { _sum: { costUsd: "desc" } },
+    });
+    const agentIds = rows.map((r) => r.agentId);
+    const agents = await prisma.agent.findMany({ where: { agentId: { in: agentIds } } });
+    const agentMap = new Map(agents.map((a) => [a.agentId, a.name]));
+    return rows.map((r) => ({
+      agentId:           r.agentId,
+      agentName:         agentMap.get(r.agentId) ?? r.agentId,
+      totalInputTokens:  r._sum.inputTokens  ?? 0,
+      totalOutputTokens: r._sum.outputTokens ?? 0,
+      totalCostUsd:      r._sum.costUsd      ?? 0,
+    }));
+  }
+);
+
+export const getScheduledJobs = cache(async (): Promise<ScheduledJobRow[]> => {
+  return prisma.scheduledJob.findMany({ orderBy: { jobId: "asc" } });
+});

--- a/apps/web/lib/ai-provider-types.ts
+++ b/apps/web/lib/ai-provider-types.ts
@@ -1,0 +1,111 @@
+// apps/web/lib/ai-provider-types.ts
+
+// ─── Schedule helpers ─────────────────────────────────────────────────────────
+
+export const SCHEDULE_INTERVALS_MS = {
+  daily:   1 * 24 * 60 * 60 * 1000,
+  weekly:  7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000,
+} as const;
+
+export type ScheduleValue = "daily" | "weekly" | "monthly" | "disabled";
+
+export function computeNextRunAt(schedule: string, from: Date): Date | null {
+  if (schedule === "disabled") return null;
+  const ms = SCHEDULE_INTERVALS_MS[schedule as keyof typeof SCHEDULE_INTERVALS_MS];
+  if (ms === undefined) return null;
+  return new Date(from.getTime() + ms);
+}
+
+// ─── Cost calculation ─────────────────────────────────────────────────────────
+
+/** Token-priced provider cost (cloud APIs). */
+export function computeTokenCost(
+  inputTokens: number,
+  outputTokens: number,
+  inputPricePerMToken: number,
+  outputPricePerMToken: number,
+): number {
+  return (inputTokens / 1_000_000) * inputPricePerMToken
+       + (outputTokens / 1_000_000) * outputPricePerMToken;
+}
+
+/** Compute-priced provider cost (local inference, e.g. Ollama). */
+export function computeComputeCost(
+  inferenceMs: number,
+  computeWatts: number,
+  electricityRateKwh: number,
+): number {
+  return (inferenceMs / 3_600_000) * (computeWatts / 1_000) * electricityRateKwh;
+}
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export type ProviderRow = {
+  id: string;
+  providerId: string;
+  name: string;
+  families: string[];
+  enabledFamilies: string[];
+  status: string;
+  costModel: string;
+  authEndpoint: string | null;
+  authHeader: string | null;
+  endpoint: string | null;
+  inputPricePerMToken: number | null;
+  outputPricePerMToken: number | null;
+  computeWatts: number | null;
+  electricityRateKwh: number | null;
+};
+
+export type CredentialRow = {
+  providerId: string;
+  secretRef: string | null;
+  status: string;
+};
+
+export type ProviderWithCredential = {
+  provider: ProviderRow;
+  credential: CredentialRow | null;
+};
+
+export type SpendByProvider = {
+  providerId: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+};
+
+export type SpendByAgent = {
+  agentId: string;
+  agentName: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+};
+
+export type ScheduledJobRow = {
+  id: string;
+  jobId: string;
+  name: string;
+  schedule: string;
+  lastRunAt: Date | null;
+  nextRunAt: Date | null;
+  lastStatus: string | null;
+  lastError: string | null;
+};
+
+// ─── Registry JSON shape ──────────────────────────────────────────────────────
+
+export type RegistryProviderEntry = {
+  providerId: string;
+  name: string;
+  families: string[];
+  authEndpoint: string | null;
+  authHeader: string | null;
+  costModel: string;
+  inputPricePerMToken?: number;
+  outputPricePerMToken?: number;
+  computeWatts?: number;
+  electricityRateKwh?: number;
+};

--- a/apps/web/lib/ai-providers.test.ts
+++ b/apps/web/lib/ai-providers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeTokenCost,
+  computeComputeCost,
+  computeNextRunAt,
+  SCHEDULE_INTERVALS_MS,
+} from "./ai-provider-types";
+
+describe("computeTokenCost", () => {
+  it("returns 0 for zero tokens", () => {
+    expect(computeTokenCost(0, 0, 3.0, 15.0)).toBe(0);
+  });
+
+  it("computes cost for input tokens only", () => {
+    // 1M input tokens at $3/M = $3.00
+    expect(computeTokenCost(1_000_000, 0, 3.0, 15.0)).toBeCloseTo(3.0);
+  });
+
+  it("computes cost for output tokens only", () => {
+    // 1M output tokens at $15/M = $15.00
+    expect(computeTokenCost(0, 1_000_000, 3.0, 15.0)).toBeCloseTo(15.0);
+  });
+
+  it("computes combined cost", () => {
+    // 500K in + 100K out = $1.50 + $1.50 = $3.00
+    expect(computeTokenCost(500_000, 100_000, 3.0, 15.0)).toBeCloseTo(3.0);
+  });
+});
+
+describe("computeComputeCost", () => {
+  it("returns 0 for zero inference time", () => {
+    expect(computeComputeCost(0, 150, 0.12)).toBe(0);
+  });
+
+  it("computes cost for 1 hour at 150W and $0.12/kWh", () => {
+    // 1h = 3_600_000ms, 150W = 0.15kW, 0.15kWh * $0.12 = $0.018
+    expect(computeComputeCost(3_600_000, 150, 0.12)).toBeCloseTo(0.018);
+  });
+
+  it("computes cost for 10 minutes at 300W", () => {
+    // 600_000ms = 1/6 hour, 300W = 0.3kW, (1/6)*0.3*0.12 = 0.006
+    expect(computeComputeCost(600_000, 300, 0.12)).toBeCloseTo(0.006);
+  });
+});
+
+describe("computeNextRunAt", () => {
+  it("returns null for disabled schedule", () => {
+    expect(computeNextRunAt("disabled", new Date())).toBeNull();
+  });
+
+  it("adds 1 day for daily", () => {
+    const now = new Date("2026-03-12T00:00:00Z");
+    const next = computeNextRunAt("daily", now);
+    expect(next?.getTime()).toBe(now.getTime() + SCHEDULE_INTERVALS_MS.daily);
+  });
+
+  it("adds 7 days for weekly", () => {
+    const now = new Date("2026-03-12T00:00:00Z");
+    const next = computeNextRunAt("weekly", now);
+    expect(next?.getTime()).toBe(now.getTime() + SCHEDULE_INTERVALS_MS.weekly);
+  });
+
+  it("adds 30 days for monthly", () => {
+    const now = new Date("2026-03-12T00:00:00Z");
+    const next = computeNextRunAt("monthly", now);
+    expect(next?.getTime()).toBe(now.getTime() + SCHEDULE_INTERVALS_MS.monthly);
+  });
+});

--- a/apps/web/lib/ea-types.ts
+++ b/apps/web/lib/ea-types.ts
@@ -47,10 +47,12 @@ export const LAYER_COLOURS: Record<string, { bg: string; border: string }> = {
   technology:  { bg: "#CCFFCC", border: "#4a9460" },
 };
 
-// Infer layer from elementType.neoLabel prefix
+// Infer ArchiMate layer from neoLabel.
+// Labels follow the pattern "ArchiMate__<Domain><Concept>", e.g. "ArchiMate__BusinessCapability".
+// Strip the vendor prefix before the __ then match on the domain name.
 export function layerFromNeoLabel(neoLabel: string): keyof typeof LAYER_COLOURS {
-  const lower = neoLabel.toLowerCase();
-  if (lower.startsWith("business")) return "business";
-  if (lower.startsWith("app") || lower.startsWith("data") || lower.startsWith("interface")) return "application";
+  const part = neoLabel.replace(/^[^_]+__/, "").toLowerCase();
+  if (part.startsWith("business") || part.startsWith("value")) return "business";
+  if (part.startsWith("application") || part.startsWith("data") || part.startsWith("interface")) return "application";
   return "technology";
 }

--- a/docs/superpowers/plans/2026-03-12-phase-7a-ai-provider-registry.md
+++ b/docs/superpowers/plans/2026-03-12-phase-7a-ai-provider-registry.md
@@ -1,0 +1,1646 @@
+# Phase 7A — AI Provider Registry & Token Spend Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `/platform/ai` — a dynamic AI provider registry with credential management, auth validation, token spend tracking, and a central platform scheduler.
+
+**Architecture:** Prisma schema migration adds `TokenUsage`, `ScheduledJob`, and new columns on `ModelProvider`. Server actions in `ai-providers.ts` handle sync, configure, test, and log operations. A new `/platform/ai` route (three sections: provider grid, spend dashboard, scheduler) and a `/platform/ai/providers/[providerId]` detail page complete the UI.
+
+**Tech Stack:** Next.js 14 App Router, Prisma 5, PostgreSQL, React cache, Auth.js v5, Vitest (node environment)
+
+**Spec:** `docs/superpowers/specs/2026-03-12-phase-7a-ai-provider-registry-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Purpose |
+|---|---|---|
+| `packages/db/prisma/schema.prisma` | Modify | Add `TokenUsage`, `ScheduledJob`; extend `ModelProvider` |
+| `packages/db/data/providers-registry.json` | Create | Initial 6-provider registry |
+| `packages/db/src/seed.ts` | Modify | Add `seedScheduledJobs()` call |
+| `apps/web/lib/ai-provider-types.ts` | Create | Shared TypeScript types + cost calculation helpers |
+| `apps/web/lib/ai-providers.test.ts` | Create | Unit tests for cost helpers |
+| `apps/web/lib/ai-provider-data.ts` | Create | React-cached server fetchers |
+| `apps/web/lib/actions/ai-providers.ts` | Create | Server actions (sync, configure, test, log, schedule) |
+| `apps/web/app/(shell)/platform/ai/page.tsx` | Create | Main page (provider grid + spend + scheduler) |
+| `apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx` | Create | Provider detail + configure form |
+| `apps/web/components/platform/TokenSpendPanel.tsx` | Create | Client component: tabbed spend dashboard |
+| `apps/web/components/platform/ScheduledJobsTable.tsx` | Create | Client component: jobs table with inline schedule editor |
+| `apps/web/components/platform/ProviderDetailForm.tsx` | Create | Client component: configure + test connection form |
+| `apps/web/app/(shell)/platform/page.tsx` | Modify | Add "AI Providers" link card |
+
+---
+
+## Chunk 1: Schema, Types, and Seed Data
+
+### Task 1: Prisma schema migration
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+
+- [ ] **Step 1: Add new models and extend ModelProvider**
+
+Open `packages/db/prisma/schema.prisma`. Find the `ModelProvider` model (currently around line 191) and replace it, then add `TokenUsage` and `ScheduledJob` after it:
+
+```prisma
+model ModelProvider {
+  id                   String   @id @default(cuid())
+  providerId           String   @unique
+  name                 String
+  families             Json
+  enabledFamilies      Json     @default("[]")
+  status               String   @default("unconfigured")
+  authEndpoint         String?
+  authHeader           String?
+  endpoint             String?
+  costModel            String   @default("token")
+  inputPricePerMToken  Float?
+  outputPricePerMToken Float?
+  computeWatts         Float?
+  electricityRateKwh   Float?
+  updatedAt            DateTime @updatedAt
+}
+
+model TokenUsage {
+  id           String   @id @default(cuid())
+  agentId      String
+  providerId   String
+  contextKey   String
+  inputTokens  Int      @default(0)
+  outputTokens Int      @default(0)
+  inferenceMs  Int?
+  costUsd      Float    @default(0)
+  createdAt    DateTime @default(now())
+}
+
+model ScheduledJob {
+  id         String    @id @default(cuid())
+  jobId      String    @unique
+  name       String
+  schedule   String    @default("weekly")
+  lastRunAt  DateTime?
+  nextRunAt  DateTime?
+  lastStatus String?
+  lastError  String?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+}
+```
+
+- [ ] **Step 2: Run migration**
+
+```bash
+cd packages/db && npx prisma migrate dev --name add_ai_provider_registry
+```
+
+Expected: migration file created in `prisma/migrations/`, `✔ Generated Prisma Client`
+
+- [ ] **Step 3: Verify no TypeScript errors**
+
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit 2>&1 | grep -v "branding\|Header"
+```
+
+Expected: no errors related to new models
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations/
+git commit -m "feat(db): add TokenUsage, ScheduledJob, extend ModelProvider for Phase 7A"
+```
+
+---
+
+### Task 2: TypeScript types and cost calculation helpers
+
+**Files:**
+- Create: `apps/web/lib/ai-provider-types.ts`
+- Create: `apps/web/lib/ai-providers.test.ts`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `apps/web/lib/ai-providers.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  computeTokenCost,
+  computeComputeCost,
+  computeNextRunAt,
+  SCHEDULE_INTERVALS_MS,
+} from "./ai-provider-types";
+
+describe("computeTokenCost", () => {
+  it("returns 0 for zero tokens", () => {
+    expect(computeTokenCost(0, 0, 3.0, 15.0)).toBe(0);
+  });
+
+  it("computes cost for input tokens only", () => {
+    // 1M input tokens at $3/M = $3.00
+    expect(computeTokenCost(1_000_000, 0, 3.0, 15.0)).toBeCloseTo(3.0);
+  });
+
+  it("computes cost for output tokens only", () => {
+    // 1M output tokens at $15/M = $15.00
+    expect(computeTokenCost(0, 1_000_000, 3.0, 15.0)).toBeCloseTo(15.0);
+  });
+
+  it("computes combined cost", () => {
+    // 500K in + 100K out = $1.50 + $1.50 = $3.00
+    expect(computeTokenCost(500_000, 100_000, 3.0, 15.0)).toBeCloseTo(3.0);
+  });
+});
+
+describe("computeComputeCost", () => {
+  it("returns 0 for zero inference time", () => {
+    expect(computeComputeCost(0, 150, 0.12)).toBe(0);
+  });
+
+  it("computes cost for 1 hour at 150W and $0.12/kWh", () => {
+    // 1h = 3_600_000ms, 150W = 0.15kW, 0.15kWh * $0.12 = $0.018
+    expect(computeComputeCost(3_600_000, 150, 0.12)).toBeCloseTo(0.018);
+  });
+
+  it("computes cost for 10 minutes at 300W", () => {
+    // 600_000ms = 1/6 hour, 300W = 0.3kW, (1/6)*0.3*0.12 = 0.006
+    expect(computeComputeCost(600_000, 300, 0.12)).toBeCloseTo(0.006);
+  });
+});
+
+describe("computeNextRunAt", () => {
+  it("returns null for disabled schedule", () => {
+    expect(computeNextRunAt("disabled", new Date())).toBeNull();
+  });
+
+  it("adds 1 day for daily", () => {
+    const now = new Date("2026-03-12T00:00:00Z");
+    const next = computeNextRunAt("daily", now);
+    expect(next?.getTime()).toBe(now.getTime() + SCHEDULE_INTERVALS_MS.daily);
+  });
+
+  it("adds 7 days for weekly", () => {
+    const now = new Date("2026-03-12T00:00:00Z");
+    const next = computeNextRunAt("weekly", now);
+    expect(next?.getTime()).toBe(now.getTime() + SCHEDULE_INTERVALS_MS.weekly);
+  });
+
+  it("adds 30 days for monthly", () => {
+    const now = new Date("2026-03-12T00:00:00Z");
+    const next = computeNextRunAt("monthly", now);
+    expect(next?.getTime()).toBe(now.getTime() + SCHEDULE_INTERVALS_MS.monthly);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+pnpm test 2>&1 | grep -E "FAIL|cannot find|ai-providers"
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create the types and helper file**
+
+Create `apps/web/lib/ai-provider-types.ts`:
+
+```ts
+// apps/web/lib/ai-provider-types.ts
+
+// ─── Schedule helpers ─────────────────────────────────────────────────────────
+
+export const SCHEDULE_INTERVALS_MS = {
+  daily:   1 * 24 * 60 * 60 * 1000,
+  weekly:  7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000,
+} as const;
+
+export type ScheduleValue = "daily" | "weekly" | "monthly" | "disabled";
+
+export function computeNextRunAt(schedule: string, from: Date): Date | null {
+  if (schedule === "disabled") return null;
+  const ms = SCHEDULE_INTERVALS_MS[schedule as keyof typeof SCHEDULE_INTERVALS_MS];
+  if (ms === undefined) return null;
+  return new Date(from.getTime() + ms);
+}
+
+// ─── Cost calculation ─────────────────────────────────────────────────────────
+
+/** Token-priced provider cost (cloud APIs). */
+export function computeTokenCost(
+  inputTokens: number,
+  outputTokens: number,
+  inputPricePerMToken: number,
+  outputPricePerMToken: number,
+): number {
+  return (inputTokens / 1_000_000) * inputPricePerMToken
+       + (outputTokens / 1_000_000) * outputPricePerMToken;
+}
+
+/** Compute-priced provider cost (local inference, e.g. Ollama). */
+export function computeComputeCost(
+  inferenceMs: number,
+  computeWatts: number,
+  electricityRateKwh: number,
+): number {
+  return (inferenceMs / 3_600_000) * (computeWatts / 1_000) * electricityRateKwh;
+}
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export type ProviderRow = {
+  id: string;
+  providerId: string;
+  name: string;
+  families: string[];
+  enabledFamilies: string[];
+  status: string;
+  costModel: string;
+  authEndpoint: string | null;
+  authHeader: string | null;
+  endpoint: string | null;
+  inputPricePerMToken: number | null;
+  outputPricePerMToken: number | null;
+  computeWatts: number | null;
+  electricityRateKwh: number | null;
+};
+
+export type CredentialRow = {
+  providerId: string;
+  secretRef: string | null;
+  status: string;
+};
+
+export type ProviderWithCredential = {
+  provider: ProviderRow;
+  credential: CredentialRow | null;
+};
+
+export type SpendByProvider = {
+  providerId: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+};
+
+export type SpendByAgent = {
+  agentId: string;
+  agentName: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+};
+
+export type ScheduledJobRow = {
+  id: string;
+  jobId: string;
+  name: string;
+  schedule: string;
+  lastRunAt: Date | null;
+  nextRunAt: Date | null;
+  lastStatus: string | null;
+  lastError: string | null;
+};
+
+// ─── Registry JSON shape ──────────────────────────────────────────────────────
+
+export type RegistryProviderEntry = {
+  providerId: string;
+  name: string;
+  families: string[];
+  authEndpoint: string | null;
+  authHeader: string | null;
+  costModel: string;
+  inputPricePerMToken?: number;
+  outputPricePerMToken?: number;
+  computeWatts?: number;
+  electricityRateKwh?: number;
+};
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+pnpm test 2>&1 | grep -E "PASS|FAIL|ai-providers"
+```
+
+Expected: `PASS apps/web/lib/ai-providers.test.ts` — all 11 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/ai-provider-types.ts apps/web/lib/ai-providers.test.ts
+git commit -m "feat(web): add AI provider types and cost calculation helpers with tests"
+```
+
+---
+
+### Task 3: Provider registry JSON
+
+**Files:**
+- Create: `packages/db/data/providers-registry.json`
+
+- [ ] **Step 1: Create the registry file**
+
+Create `packages/db/data/providers-registry.json`:
+
+```json
+[
+  {
+    "providerId": "anthropic",
+    "name": "Anthropic",
+    "families": ["claude-3-5", "claude-4"],
+    "authEndpoint": "https://api.anthropic.com/v1/models",
+    "authHeader": "x-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "openai",
+    "name": "OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo", "gpt-4o-mini"],
+    "authEndpoint": "https://api.openai.com/v1/models",
+    "authHeader": "Authorization",
+    "costModel": "token",
+    "inputPricePerMToken": 2.50,
+    "outputPricePerMToken": 10.00
+  },
+  {
+    "providerId": "azure-openai",
+    "name": "Azure OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo"],
+    "authEndpoint": null,
+    "authHeader": "api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 5.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "gemini",
+    "name": "Google Gemini",
+    "families": ["gemini-1.5-pro", "gemini-2.0"],
+    "authEndpoint": "https://generativelanguage.googleapis.com/v1/models",
+    "authHeader": "x-goog-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.00
+  },
+  {
+    "providerId": "ollama",
+    "name": "Ollama (local)",
+    "families": ["llama3", "mistral", "phi3", "gemma2"],
+    "authEndpoint": "http://localhost:11434/api/tags",
+    "authHeader": null,
+    "costModel": "compute",
+    "computeWatts": 150,
+    "electricityRateKwh": 0.12
+  },
+  {
+    "providerId": "bedrock",
+    "name": "AWS Bedrock",
+    "families": ["claude", "titan", "llama"],
+    "authEndpoint": null,
+    "authHeader": "Authorization",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  }
+]
+```
+
+- [ ] **Step 2: Verify JSON is valid**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('packages/db/data/providers-registry.json','utf8')); console.log('OK')"
+```
+
+Expected: `OK`
+
+> **Note:** OpenAI uses `authHeader: "Authorization"` — the `testProviderAuth` action sends this value with the `Bearer ` prefix automatically for providers whose header is `Authorization`. AWS Bedrock uses SigV4 signing and cannot be tested via a simple header auth check; `testProviderAuth` will skip the check and return a configuration-only confirmation for Bedrock (`authEndpoint: null`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/db/data/providers-registry.json
+git commit -m "feat(db): add initial provider registry JSON with 6 providers"
+```
+
+---
+
+### Task 4: Seed scheduled jobs
+
+**Files:**
+- Modify: `packages/db/src/seed.ts`
+
+- [ ] **Step 1: Add seedScheduledJobs function**
+
+In `packages/db/src/seed.ts`, add this function before the `main()` function:
+
+```ts
+async function seedScheduledJobs(): Promise<void> {
+  await prisma.scheduledJob.upsert({
+    where:  { jobId: "provider-registry-sync" },
+    create: {
+      jobId:     "provider-registry-sync",
+      name:      "Provider registry sync",
+      schedule:  "weekly",
+      nextRunAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+    update: {
+      // Only reset schedule — preserve operational state on re-seed
+      schedule: "weekly",
+    },
+  });
+  console.log("Seeded scheduled jobs");
+}
+```
+
+- [ ] **Step 2: Call it from main()**
+
+In the `main()` function, add `await seedScheduledJobs();` after `await seedDefaultAdminUser();`:
+
+```ts
+async function main(): Promise<void> {
+  console.log("Starting seed...");
+  await seedRoles();
+  await seedPortfolios();
+  await seedAgents();
+  await seedTaxonomyNodes();
+  await seedDigitalProducts();
+  await seedEaArchimate4();
+  await seedEaViewpoints();
+  await seedEaViews();
+  await seedDpfSelfRegistration();
+  await seedThemeBrandingEpic();
+  await seedDefaultAdminUser();
+  await seedScheduledJobs();     // ← add this
+  console.log("Seed complete.");
+}
+```
+
+- [ ] **Step 3: Run seed to verify**
+
+```bash
+cd packages/db && npx prisma db seed
+```
+
+Expected: `Seeded scheduled jobs` in output, no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/db/src/seed.ts
+git commit -m "feat(db): seed provider-registry-sync scheduled job"
+```
+
+---
+
+## Chunk 2: Data Layer and Server Actions
+
+### Task 5: Data fetchers
+
+**Files:**
+- Create: `apps/web/lib/ai-provider-data.ts`
+
+- [ ] **Step 1: Create the fetchers file**
+
+Create `apps/web/lib/ai-provider-data.ts`:
+
+```ts
+// apps/web/lib/ai-provider-data.ts
+// Server-only: uses React cache() to deduplicate Prisma calls within one request.
+import { cache } from "react";
+import { prisma } from "@dpf/db";
+import type {
+  ProviderWithCredential,
+  ProviderRow,
+  SpendByProvider,
+  SpendByAgent,
+  ScheduledJobRow,
+} from "./ai-provider-types";
+
+export const getProviders = cache(async (): Promise<ProviderWithCredential[]> => {
+  const providers = await prisma.modelProvider.findMany({ orderBy: { name: "asc" } });
+  const credentials = await prisma.credentialEntry.findMany({
+    where: { providerId: { in: providers.map((p) => p.providerId) } },
+  });
+  const credMap = new Map(credentials.map((c) => [c.providerId, c]));
+  return providers.map((p) => ({
+    provider: {
+      ...p,
+      families:        p.families as string[],
+      enabledFamilies: p.enabledFamilies as string[],
+    } satisfies ProviderRow,
+    credential: credMap.get(p.providerId) ?? null,
+  }));
+});
+
+export const getProviderById = cache(async (providerId: string): Promise<ProviderWithCredential | null> => {
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
+  if (!provider) return null;
+  const credential = await prisma.credentialEntry.findUnique({ where: { providerId } });
+  return {
+    provider: {
+      ...provider,
+      families:        provider.families as string[],
+      enabledFamilies: provider.enabledFamilies as string[],
+    } satisfies ProviderRow,
+    credential: credential ?? null,
+  };
+});
+
+function monthRange(month: { year: number; month: number }): { gte: Date; lt: Date } {
+  const gte = new Date(Date.UTC(month.year, month.month - 1, 1));
+  const lt  = new Date(Date.UTC(month.year, month.month, 1));
+  return { gte, lt };
+}
+
+export const getTokenSpendByProvider = cache(
+  async (month: { year: number; month: number }): Promise<SpendByProvider[]> => {
+    const range = monthRange(month);
+    const rows = await prisma.tokenUsage.groupBy({
+      by: ["providerId"],
+      where: { createdAt: range },
+      _sum: { inputTokens: true, outputTokens: true, costUsd: true },
+    });
+    return rows.map((r) => ({
+      providerId:        r.providerId,
+      totalInputTokens:  r._sum.inputTokens  ?? 0,
+      totalOutputTokens: r._sum.outputTokens ?? 0,
+      totalCostUsd:      r._sum.costUsd      ?? 0,
+    }));
+  }
+);
+
+export const getTokenSpendByAgent = cache(
+  async (month: { year: number; month: number }): Promise<SpendByAgent[]> => {
+    const range = monthRange(month);
+    const rows = await prisma.tokenUsage.groupBy({
+      by: ["agentId"],
+      where: { createdAt: range },
+      _sum: { inputTokens: true, outputTokens: true, costUsd: true },
+      orderBy: { _sum: { costUsd: "desc" } },
+    });
+    const agentIds = rows.map((r) => r.agentId);
+    const agents = await prisma.agent.findMany({ where: { agentId: { in: agentIds } } });
+    const agentMap = new Map(agents.map((a) => [a.agentId, a.name]));
+    return rows.map((r) => ({
+      agentId:           r.agentId,
+      agentName:         agentMap.get(r.agentId) ?? r.agentId,
+      totalInputTokens:  r._sum.inputTokens  ?? 0,
+      totalOutputTokens: r._sum.outputTokens ?? 0,
+      totalCostUsd:      r._sum.costUsd      ?? 0,
+    }));
+  }
+);
+
+export const getScheduledJobs = cache(async (): Promise<ScheduledJobRow[]> => {
+  return prisma.scheduledJob.findMany({ orderBy: { jobId: "asc" } });
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep "ai-provider"
+```
+
+Expected: no output (no errors in these files)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/ai-provider-data.ts
+git commit -m "feat(web): add AI provider data fetchers"
+```
+
+---
+
+### Task 6: Server actions
+
+**Files:**
+- Create: `apps/web/lib/actions/ai-providers.ts`
+
+- [ ] **Step 1: Create the actions file**
+
+Create `apps/web/lib/actions/ai-providers.ts`:
+
+```ts
+"use server";
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  computeTokenCost,
+  computeComputeCost,
+  computeNextRunAt,
+  type RegistryProviderEntry,
+} from "@/lib/ai-provider-types";
+
+// ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+async function requireManageProviders(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections")) {
+    throw new Error("Unauthorized");
+  }
+}
+
+async function requireSession(): Promise<void> {
+  const session = await auth();
+  if (!session?.user) throw new Error("Unauthorized");
+}
+
+// ─── Registry sync ────────────────────────────────────────────────────────────
+
+const REGISTRY_URL =
+  "https://raw.githubusercontent.com/markdbodman/opendigitalproductfactory/main/packages/db/data/providers-registry.json";
+
+/**
+ * Sync provider registry from GitHub. No auth guard — called from server component
+ * on page load for any view_platform holder. Use triggerProviderSync() for the
+ * admin button (which adds the manage_provider_connections check).
+ */
+export async function syncProviderRegistry(): Promise<{ added: number; updated: number; error?: string }> {
+  const job = await prisma.scheduledJob.findUnique({ where: { jobId: "provider-registry-sync" } });
+  let entries: RegistryProviderEntry[];
+
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    entries = (await res.json()) as RegistryProviderEntry[];
+  } catch (err) {
+    const error = err instanceof Error ? err.message : "Unknown error";
+    if (job) {
+      await prisma.scheduledJob.update({
+        where: { jobId: "provider-registry-sync" },
+        data: { lastRunAt: new Date(), lastStatus: "error", lastError: error },
+      });
+    }
+    return { added: 0, updated: 0, error };
+  }
+
+  let added = 0;
+  let updated = 0;
+
+  for (const entry of entries) {
+    const existing = await prisma.modelProvider.findUnique({ where: { providerId: entry.providerId } });
+    if (existing) {
+      await prisma.modelProvider.update({
+        where: { providerId: entry.providerId },
+        data: {
+          name:                 entry.name,
+          families:             entry.families,
+          authEndpoint:         entry.authEndpoint ?? null,
+          authHeader:           entry.authHeader ?? null,
+          costModel:            entry.costModel,
+          ...(entry.inputPricePerMToken !== undefined  && { inputPricePerMToken:  entry.inputPricePerMToken }),
+          ...(entry.outputPricePerMToken !== undefined && { outputPricePerMToken: entry.outputPricePerMToken }),
+          ...(entry.computeWatts !== undefined         && { computeWatts:         entry.computeWatts }),
+          ...(entry.electricityRateKwh !== undefined   && { electricityRateKwh:   entry.electricityRateKwh }),
+          // status and enabledFamilies deliberately NOT updated — preserve admin config
+        },
+      });
+      updated++;
+    } else {
+      await prisma.modelProvider.create({
+        data: {
+          providerId:          entry.providerId,
+          name:                entry.name,
+          families:            entry.families,
+          enabledFamilies:     [],
+          status:              "unconfigured",
+          authEndpoint:        entry.authEndpoint ?? null,
+          authHeader:          entry.authHeader ?? null,
+          costModel:           entry.costModel,
+          inputPricePerMToken:  entry.inputPricePerMToken ?? null,
+          outputPricePerMToken: entry.outputPricePerMToken ?? null,
+          computeWatts:        entry.computeWatts ?? null,
+          electricityRateKwh:  entry.electricityRateKwh ?? null,
+        },
+      });
+      added++;
+    }
+  }
+
+  const now = new Date();
+  if (job) {
+    await prisma.scheduledJob.update({
+      where: { jobId: "provider-registry-sync" },
+      data: {
+        lastRunAt:  now,
+        lastStatus: "ok",
+        lastError:  null,
+        nextRunAt:  computeNextRunAt(job.schedule, now),
+      },
+    });
+  }
+
+  return { added, updated };
+}
+
+/** Admin button wrapper — requires manage_provider_connections. */
+export async function triggerProviderSync(): Promise<{ added: number; updated: number; error?: string }> {
+  await requireManageProviders();
+  return syncProviderRegistry();
+}
+
+// ─── Configure provider ───────────────────────────────────────────────────────
+
+export async function configureProvider(input: {
+  providerId: string;
+  enabledFamilies: string[];
+  secretRef?: string;
+  endpoint?: string;
+  computeWatts?: number;
+  electricityRateKwh?: number;
+}): Promise<{ error?: string }> {
+  await requireManageProviders();
+
+  if (input.secretRef !== undefined) {
+    await prisma.credentialEntry.upsert({
+      where:  { providerId: input.providerId },
+      create: { providerId: input.providerId, secretRef: input.secretRef, status: "pending" },
+      update: { secretRef: input.secretRef, status: "pending" },
+    });
+  }
+
+  await prisma.modelProvider.update({
+    where: { providerId: input.providerId },
+    data: {
+      enabledFamilies: input.enabledFamilies,
+      ...(input.endpoint !== undefined         && { endpoint:           input.endpoint }),
+      ...(input.computeWatts !== undefined     && { computeWatts:       input.computeWatts }),
+      ...(input.electricityRateKwh !== undefined && { electricityRateKwh: input.electricityRateKwh }),
+    },
+  });
+
+  return {};
+}
+
+// ─── Test provider auth ───────────────────────────────────────────────────────
+
+export async function testProviderAuth(providerId: string): Promise<{ ok: boolean; message: string }> {
+  await requireManageProviders();
+
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
+  if (!provider) return { ok: false, message: "Provider not found" };
+
+  const credential = await prisma.credentialEntry.findUnique({ where: { providerId } });
+
+  // Guard: keyed providers need a credential with a secretRef
+  if (provider.authHeader !== null) {
+    if (!credential || credential.secretRef === null) {
+      return { ok: false, message: "No credential configured" };
+    }
+    if (process.env[credential.secretRef] === undefined) {
+      return { ok: false, message: `Environment variable not set: ${credential.secretRef}` };
+    }
+  }
+
+  // Guard: Azure OpenAI-style providers need a custom endpoint
+  if (provider.authEndpoint === null && provider.endpoint === null) {
+    return { ok: false, message: "Custom endpoint required" };
+  }
+
+  const authUrl = provider.endpoint
+    ? `${provider.endpoint}/openai/models?api-version=2024-02-01`
+    : (provider.authEndpoint as string);
+
+  const headers: Record<string, string> = {};
+  if (provider.authHeader !== null && credential?.secretRef) {
+    const apiKey = process.env[credential.secretRef];
+    if (apiKey !== undefined) {
+      headers[provider.authHeader] = provider.authHeader === "Authorization"
+        ? `Bearer ${apiKey}`
+        : apiKey;
+    }
+  }
+
+  try {
+    const res = await fetch(authUrl, {
+      headers,
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (res.ok) {
+      await prisma.modelProvider.update({ where: { providerId }, data: { status: "active" } });
+      if (credential) {
+        await prisma.credentialEntry.update({ where: { providerId }, data: { status: "ok" } });
+      }
+      return { ok: true, message: `Connected — HTTP ${res.status}` };
+    } else {
+      if (credential) {
+        await prisma.credentialEntry.update({ where: { providerId }, data: { status: "error" } });
+      }
+      return { ok: false, message: `HTTP ${res.status} — ${res.statusText}` };
+    }
+  } catch (err) {
+    if (credential) {
+      await prisma.credentialEntry.update({ where: { providerId }, data: { status: "error" } });
+    }
+    return { ok: false, message: err instanceof Error ? err.message : "Network error" };
+  }
+}
+
+// ─── Scheduled jobs ───────────────────────────────────────────────────────────
+
+export async function updateScheduledJob(input: { jobId: string; schedule: string }): Promise<void> {
+  await requireManageProviders();
+  const nextRunAt = computeNextRunAt(input.schedule, new Date());
+  await prisma.scheduledJob.update({
+    where: { jobId: input.jobId },
+    data: { schedule: input.schedule, nextRunAt },
+  });
+}
+
+export async function runScheduledJobNow(jobId: string): Promise<void> {
+  await requireManageProviders();
+  if (jobId === "provider-registry-sync") {
+    await syncProviderRegistry();
+    return;
+  }
+  console.warn(`runScheduledJobNow: unknown jobId "${jobId}"`);
+}
+
+// ─── Token usage logging ──────────────────────────────────────────────────────
+
+export async function logTokenUsage(input: {
+  agentId: string;
+  providerId: string;
+  contextKey: string;
+  inputTokens: number;
+  outputTokens: number;
+  inferenceMs?: number;
+}): Promise<void> {
+  await requireSession();
+
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId: input.providerId } });
+
+  let costUsd = 0;
+  if (provider) {
+    if (provider.costModel === "compute" && input.inferenceMs !== undefined) {
+      costUsd = computeComputeCost(
+        input.inferenceMs,
+        provider.computeWatts ?? 150,
+        provider.electricityRateKwh ?? 0.12,
+      );
+    } else if (provider.costModel === "token") {
+      costUsd = computeTokenCost(
+        input.inputTokens,
+        input.outputTokens,
+        provider.inputPricePerMToken ?? 0,
+        provider.outputPricePerMToken ?? 0,
+      );
+    }
+  }
+
+  await prisma.tokenUsage.create({
+    data: {
+      agentId:     input.agentId,
+      providerId:  input.providerId,
+      contextKey:  input.contextKey,
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      ...(input.inferenceMs !== undefined && { inferenceMs: input.inferenceMs }),
+      costUsd,
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep "ai-providers"
+```
+
+Expected: no output
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/actions/ai-providers.ts
+git commit -m "feat(web): add AI provider server actions (sync, configure, test, log)"
+```
+
+---
+
+## Chunk 3: UI Pages and Components
+
+### Task 7: Client components
+
+**Files:**
+- Create: `apps/web/components/platform/TokenSpendPanel.tsx`
+- Create: `apps/web/components/platform/ScheduledJobsTable.tsx`
+
+- [ ] **Step 1: Create TokenSpendPanel**
+
+Create `apps/web/components/platform/TokenSpendPanel.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import type { SpendByProvider, SpendByAgent } from "@/lib/ai-provider-types";
+
+// Month selector (switching between months) is deferred to a later phase —
+// TokenUsage will be empty in Phase 7A. Current month is fixed server-side.
+
+type Props = {
+  initialMonth: { year: number; month: number };
+  byProvider: SpendByProvider[];
+  byAgent: SpendByAgent[];
+};
+
+const MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
+function formatCost(usd: number): string {
+  if (usd === 0) return "$0.00";
+  return `$${usd.toFixed(2)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
+}
+
+export function TokenSpendPanel({ initialMonth, byProvider, byAgent }: Props) {
+  const [tab, setTab] = useState<"provider" | "agent">("provider");
+  const totalCost = byProvider.reduce((s, r) => s + r.totalCostUsd, 0);
+  const monthLabel = `${MONTH_NAMES[(initialMonth.month - 1) % 12]} ${initialMonth.year}`;
+
+  const isEmpty = byProvider.length === 0 && byAgent.length === 0;
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+        <div>
+          <div style={{ color: "#7c8cf8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            Token Spend — {monthLabel}
+          </div>
+          {!isEmpty && (
+            <div style={{ color: "#e0e0ff", fontSize: 18, fontWeight: 700, marginTop: 2 }}>
+              {formatCost(totalCost)} total
+            </div>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 4 }}>
+          {(["provider", "agent"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              style={{
+                fontSize: 9, padding: "2px 8px", borderRadius: 3, cursor: "pointer",
+                background: tab === t ? "#2a2a50" : "transparent",
+                border: `1px solid ${tab === t ? "#7c8cf8" : "#2a2a40"}`,
+                color: tab === t ? "#7c8cf8" : "#555566",
+              }}
+            >
+              {t === "provider" ? "By Provider" : "By Agent"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isEmpty && (
+        <p style={{ color: "#555566", fontSize: 11 }}>No spend data yet — token usage will appear here once agents are active.</p>
+      )}
+
+      {!isEmpty && tab === "provider" && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+          {byProvider.map((r) => {
+            const pct = totalCost > 0 ? Math.round((r.totalCostUsd / totalCost) * 100) : 0;
+            return (
+              <div key={r.providerId} style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderRadius: 6, padding: 10 }}>
+                <div style={{ color: "#555566", fontSize: 9, marginBottom: 2 }}>{r.providerId}</div>
+                <div style={{ color: "#e0e0ff", fontSize: 16, fontWeight: 700 }}>{formatCost(r.totalCostUsd)}</div>
+                <div style={{ color: "#555566", fontSize: 9, marginTop: 2 }}>
+                  {formatTokens(r.totalInputTokens)} in · {formatTokens(r.totalOutputTokens)} out
+                </div>
+                <div style={{ height: 4, background: "#2a2a40", borderRadius: 2, marginTop: 6 }}>
+                  <div style={{ height: 4, background: "#4ade80", borderRadius: 2, width: `${pct}%` }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!isEmpty && tab === "agent" && (
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 10 }}>
+          <thead>
+            <tr style={{ color: "#555566", textAlign: "left" }}>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Agent</th>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Input</th>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Output</th>
+              <th style={{ padding: "4px 8px", fontWeight: 500 }}>Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {byAgent.map((r) => (
+              <tr key={r.agentId} style={{ borderTop: "1px solid #2a2a40", color: "#e0e0ff" }}>
+                <td style={{ padding: "6px 8px" }}>{r.agentName}</td>
+                <td style={{ padding: "6px 8px", color: "#555566" }}>{formatTokens(r.totalInputTokens)}</td>
+                <td style={{ padding: "6px 8px", color: "#555566" }}>{formatTokens(r.totalOutputTokens)}</td>
+                <td style={{ padding: "6px 8px", fontWeight: 600 }}>{formatCost(r.totalCostUsd)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create ScheduledJobsTable**
+
+Create `apps/web/components/platform/ScheduledJobsTable.tsx`:
+
+```tsx
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateScheduledJob, runScheduledJobNow } from "@/lib/actions/ai-providers";
+import type { ScheduledJobRow } from "@/lib/ai-provider-types";
+
+type Props = { jobs: ScheduledJobRow[]; canWrite: boolean };
+
+const SCHEDULES = ["daily", "weekly", "monthly", "disabled"] as const;
+
+function formatDate(d: Date | null): string {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function ScheduledJobsTable({ jobs, canWrite }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleScheduleChange(jobId: string, schedule: string) {
+    startTransition(async () => {
+      await updateScheduledJob({ jobId, schedule });
+      router.refresh();
+    });
+  }
+
+  function handleRunNow(jobId: string) {
+    startTransition(async () => {
+      await runScheduledJobNow(jobId);
+      router.refresh();
+    });
+  }
+
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 10 }}>
+      <thead>
+        <tr style={{ color: "#555566", textAlign: "left" }}>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Job</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Schedule</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Last run</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Next run</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }}>Status</th>
+          <th style={{ padding: "4px 8px", fontWeight: 500 }} />
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map((job) => (
+          <tr key={job.jobId} style={{ borderTop: "1px solid #2a2a40", color: "#e0e0ff" }}>
+            <td style={{ padding: "6px 8px" }}>{job.name}</td>
+            <td style={{ padding: "6px 8px" }}>
+              {canWrite ? (
+                <select
+                  value={job.schedule}
+                  disabled={isPending}
+                  onChange={(e) => handleScheduleChange(job.jobId, e.target.value)}
+                  style={{ background: "#1a1a2e", border: "1px solid #2a2a40", color: "#7c8cf8", fontSize: 9, padding: "1px 4px", borderRadius: 3 }}
+                >
+                  {SCHEDULES.map((s) => <option key={s} value={s}>{s}</option>)}
+                </select>
+              ) : (
+                <span style={{ color: "#7c8cf8" }}>{job.schedule}</span>
+              )}
+            </td>
+            <td style={{ padding: "6px 8px", color: "#555566" }}>{formatDate(job.lastRunAt)}</td>
+            <td style={{ padding: "6px 8px", color: "#555566" }}>{formatDate(job.nextRunAt)}</td>
+            <td style={{ padding: "6px 8px" }}>
+              {job.lastStatus === "ok"    && <span style={{ color: "#4ade80" }}>✓ ok</span>}
+              {job.lastStatus === "error" && <span style={{ color: "#f87171" }}>✗ error</span>}
+              {!job.lastStatus            && <span style={{ color: "#555566" }}>—</span>}
+            </td>
+            <td style={{ padding: "6px 8px", textAlign: "right" }}>
+              {canWrite && (
+                <button
+                  onClick={() => handleRunNow(job.jobId)}
+                  disabled={isPending}
+                  style={{ color: "#7c8cf8", background: "none", border: "none", fontSize: 9, cursor: "pointer" }}
+                >
+                  Run now
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+```
+
+- [ ] **Step 3: Verify TypeScript**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep "platform/"
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/components/platform/
+git commit -m "feat(web): add TokenSpendPanel and ScheduledJobsTable client components"
+```
+
+---
+
+### Task 8: Provider detail form component
+
+**Files:**
+- Create: `apps/web/components/platform/ProviderDetailForm.tsx`
+
+- [ ] **Step 1: Create the form component**
+
+Create `apps/web/components/platform/ProviderDetailForm.tsx`:
+
+```tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { configureProvider, testProviderAuth } from "@/lib/actions/ai-providers";
+import type { ProviderWithCredential } from "@/lib/ai-provider-types";
+
+type Props = { pw: ProviderWithCredential; canWrite: boolean };
+
+export function ProviderDetailForm({ pw, canWrite }: Props) {
+  const { provider, credential } = pw;
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const [secretRef, setSecretRef]                 = useState(credential?.secretRef ?? "");
+  const [endpoint, setEndpoint]                   = useState(provider.endpoint ?? "");
+  const [computeWatts, setComputeWatts]           = useState(String(provider.computeWatts ?? 150));
+  const [electricityRate, setElectricityRate]     = useState(String(provider.electricityRateKwh ?? 0.12));
+  const [enabledFamilies, setEnabledFamilies]     = useState<string[]>(provider.enabledFamilies);
+  const [testResult, setTestResult]               = useState<{ ok: boolean; message: string } | null>(null);
+  const [saveMessage, setSaveMessage]             = useState<string | null>(null);
+
+  const isKeyed      = provider.authHeader !== null;
+  const needsEndpoint = provider.authEndpoint === null;
+  const isCompute    = provider.costModel === "compute";
+
+  function toggleFamily(family: string) {
+    setEnabledFamilies((prev) =>
+      prev.includes(family) ? prev.filter((f) => f !== family) : [...prev, family]
+    );
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await configureProvider({
+        providerId: provider.providerId,
+        enabledFamilies,
+        ...(isKeyed && secretRef ? { secretRef } : {}),
+        ...(needsEndpoint && endpoint ? { endpoint } : {}),
+        ...(isCompute ? { computeWatts: Number(computeWatts), electricityRateKwh: Number(electricityRate) } : {}),
+      });
+      setSaveMessage(result.error ? `Error: ${result.error}` : "Saved");
+      router.refresh();
+    });
+  }
+
+  function handleTest() {
+    startTransition(async () => {
+      const result = await testProviderAuth(provider.providerId);
+      setTestResult(result);
+      router.refresh();
+    });
+  }
+
+  const statusColour = provider.status === "active" ? "#4ade80" : provider.status === "inactive" ? "#555566" : "#fbbf24";
+
+  return (
+    <div style={{ maxWidth: 560 }}>
+      {/* Status */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 20 }}>
+        <span style={{ background: `${statusColour}20`, color: statusColour, fontSize: 9, padding: "2px 6px", borderRadius: 3 }}>
+          {provider.status}
+        </span>
+        <span style={{ color: "#555566", fontSize: 10 }}>{provider.costModel === "compute" ? "compute-priced" : "token-priced"}</span>
+      </div>
+
+      {/* Enabled families */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ color: "#555566", fontSize: 10, marginBottom: 6 }}>Enabled model families</div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {provider.families.map((f) => (
+            <label key={f} style={{ display: "flex", alignItems: "center", gap: 4, cursor: canWrite ? "pointer" : "default" }}>
+              <input
+                type="checkbox"
+                checked={enabledFamilies.includes(f)}
+                disabled={!canWrite || isPending}
+                onChange={() => toggleFamily(f)}
+              />
+              <span style={{ fontSize: 10, color: "#e0e0ff" }}>{f}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Custom endpoint (Azure OpenAI etc.) */}
+      {needsEndpoint && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>
+            Custom endpoint URL
+          </label>
+          <input
+            value={endpoint}
+            onChange={(e) => setEndpoint(e.target.value)}
+            disabled={!canWrite || isPending}
+            placeholder="https://my-resource.openai.azure.com"
+            style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4 }}
+          />
+        </div>
+      )}
+
+      {/* API key env var name */}
+      {isKeyed && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>
+            Environment variable name
+          </label>
+          <input
+            value={secretRef}
+            onChange={(e) => setSecretRef(e.target.value)}
+            disabled={!canWrite || isPending}
+            placeholder="ANTHROPIC_API_KEY"
+            style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4, fontFamily: "monospace" }}
+          />
+          <p style={{ color: "#555566", fontSize: 9, marginTop: 3 }}>
+            Enter the name of the env var that holds the API key — not the key itself.
+          </p>
+        </div>
+      )}
+
+      {/* Compute settings */}
+      {isCompute && (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 16 }}>
+          <div>
+            <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>GPU/CPU wattage</label>
+            <input
+              type="number"
+              value={computeWatts}
+              onChange={(e) => setComputeWatts(e.target.value)}
+              disabled={!canWrite || isPending}
+              style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4 }}
+            />
+          </div>
+          <div>
+            <label style={{ display: "block", color: "#555566", fontSize: 10, marginBottom: 4 }}>Electricity rate ($/kWh)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={electricityRate}
+              onChange={(e) => setElectricityRate(e.target.value)}
+              disabled={!canWrite || isPending}
+              style={{ width: "100%", background: "#1a1a2e", border: "1px solid #2a2a40", color: "#e0e0ff", fontSize: 11, padding: "6px 8px", borderRadius: 4 }}
+            />
+          </div>
+        </div>
+      )}
+
+      {canWrite && (
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <button
+            onClick={handleSave}
+            disabled={isPending}
+            style={{ padding: "6px 14px", background: "#2a2a50", border: "1px solid #7c8cf8", color: "#7c8cf8", borderRadius: 4, fontSize: 11, cursor: "pointer" }}
+          >
+            Save
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={isPending}
+            style={{ padding: "6px 14px", background: "transparent", border: "1px solid #2a2a40", color: "#e0e0ff", borderRadius: 4, fontSize: 11, cursor: "pointer" }}
+          >
+            Test connection
+          </button>
+          {saveMessage && <span style={{ fontSize: 10, color: saveMessage.startsWith("Error") ? "#f87171" : "#4ade80" }}>{saveMessage}</span>}
+          {testResult && (
+            <span style={{ fontSize: 10, color: testResult.ok ? "#4ade80" : "#f87171" }}>
+              {testResult.ok ? "✓" : "✗"} {testResult.message}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep "ProviderDetailForm"
+```
+
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/platform/ProviderDetailForm.tsx
+git commit -m "feat(web): add ProviderDetailForm client component"
+```
+
+---
+
+### Task 9: /platform/ai main page
+
+**Files:**
+- Create: `apps/web/app/(shell)/platform/ai/page.tsx`
+
+- [ ] **Step 1: Create the page**
+
+Create `apps/web/app/(shell)/platform/ai/page.tsx`:
+
+```tsx
+// apps/web/app/(shell)/platform/ai/page.tsx
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getProviders, getTokenSpendByProvider, getTokenSpendByAgent, getScheduledJobs } from "@/lib/ai-provider-data";
+import { syncProviderRegistry, triggerProviderSync } from "@/lib/actions/ai-providers";
+import { TokenSpendPanel } from "@/components/platform/TokenSpendPanel";
+import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
+
+const STATUS_COLOURS: Record<string, string> = {
+  active:        "#4ade80",
+  unconfigured:  "#fbbf24",
+  inactive:      "#555566",
+};
+
+export default async function PlatformAiPage() {
+  const session = await auth();
+  const user = session?.user;
+  const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
+
+  // Auto-sync if due
+  const jobs = await getScheduledJobs();
+  const syncJob = jobs.find((j) => j.jobId === "provider-registry-sync");
+  if (syncJob && syncJob.schedule !== "disabled" && syncJob.nextRunAt && syncJob.nextRunAt < new Date()) {
+    await syncProviderRegistry();
+  }
+
+  const now = new Date();
+  const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+
+  // Second getScheduledJobs() call — not deduplicated by React cache because
+  // syncProviderRegistry() may have mutated the DB between the two calls.
+  // freshJobs reflects the updated lastRunAt/nextRunAt after any auto-sync.
+  const [providers, byProvider, byAgent, freshJobs] = await Promise.all([
+    getProviders(),
+    getTokenSpendByProvider(currentMonth),
+    getTokenSpendByAgent(currentMonth),
+    getScheduledJobs(),
+  ]);
+
+  const lastSync = freshJobs.find((j) => j.jobId === "provider-registry-sync")?.lastRunAt;
+
+  return (
+    <div>
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "#fff", margin: 0 }}>AI Providers</h1>
+        <p style={{ fontSize: 11, color: "#555566", marginTop: 2 }}>
+          {providers.length} provider{providers.length !== 1 ? "s" : ""} registered
+          {lastSync ? ` · last synced ${new Date(lastSync).toLocaleDateString()}` : ""}
+        </p>
+      </div>
+
+      {/* Section 1: Provider Registry */}
+      <div style={{ marginBottom: 32 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+          <div style={{ color: "#7c8cf8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>Providers</div>
+          {canWrite && (
+            <form action={triggerProviderSync}>
+              <button
+                type="submit"
+                style={{ fontSize: 10, padding: "3px 10px", background: "transparent", border: "1px solid #2a2a40", color: "#555566", borderRadius: 3, cursor: "pointer" }}
+              >
+                ↻ Sync from registry
+              </button>
+            </form>
+          )}
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+          {providers.map(({ provider }) => {
+            const colour = STATUS_COLOURS[provider.status] ?? "#555566";
+            return (
+              <div
+                key={provider.providerId}
+                style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderLeft: `3px solid ${colour}`, borderRadius: 6, padding: 10 }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 4 }}>
+                  <span style={{ color: "#e0e0ff", fontWeight: 600, fontSize: 12 }}>{provider.name}</span>
+                  <span style={{ background: `${colour}20`, color: colour, fontSize: 8, padding: "1px 5px", borderRadius: 3 }}>
+                    {provider.status}
+                  </span>
+                </div>
+                <div style={{ color: "#555566", fontSize: 9, marginBottom: 6 }}>
+                  {provider.families.slice(0, 3).join(" · ")}
+                  {provider.families.length > 3 ? " +more" : ""}
+                </div>
+                <Link
+                  href={`/platform/ai/providers/${provider.providerId}`}
+                  style={{ color: "#7c8cf8", fontSize: 9 }}
+                >
+                  Configure →
+                </Link>
+              </div>
+            );
+          })}
+          {providers.length === 0 && (
+            <p style={{ color: "#555566", fontSize: 11 }}>No providers registered. Click "Sync from registry" to import.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Section 2: Token Spend */}
+      <div style={{ marginBottom: 32 }}>
+        <TokenSpendPanel initialMonth={currentMonth} byProvider={byProvider} byAgent={byAgent} />
+      </div>
+
+      {/* Section 3: Scheduled Jobs */}
+      <div>
+        <div style={{ color: "#7c8cf8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 12 }}>
+          Scheduled Jobs
+        </div>
+        <ScheduledJobsTable jobs={freshJobs} canWrite={canWrite} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep "platform/ai"
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/\(shell\)/platform/ai/
+git commit -m "feat(web): add /platform/ai page (provider grid, spend dashboard, scheduler)"
+```
+
+---
+
+### Task 10: /platform/ai/providers/[providerId] detail page
+
+**Files:**
+- Create: `apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx`
+
+- [ ] **Step 1: Create the detail page**
+
+Create `apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx`:
+
+```tsx
+// apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getProviderById } from "@/lib/ai-provider-data";
+import { ProviderDetailForm } from "@/components/platform/ProviderDetailForm";
+
+type Props = { params: Promise<{ providerId: string }> };
+
+export default async function ProviderDetailPage({ params }: Props) {
+  const { providerId } = await params;
+  const pw = await getProviderById(providerId);
+  if (!pw) notFound();
+
+  const session = await auth();
+  const user = session?.user;
+  const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
+
+  return (
+    <div>
+      <div style={{ marginBottom: 20 }}>
+        <Link href="/platform/ai" style={{ color: "#555566", fontSize: 10 }}>← AI Providers</Link>
+        <h1 style={{ fontSize: 18, fontWeight: 700, color: "#fff", margin: "6px 0 2px" }}>{pw.provider.name}</h1>
+        <p style={{ fontSize: 10, color: "#555566", margin: 0, fontFamily: "monospace" }}>{pw.provider.providerId}</p>
+      </div>
+
+      <div style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderRadius: 8, padding: 20 }}>
+        <ProviderDetailForm pw={pw} canWrite={canWrite} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep "platform/ai/providers"
+```
+
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/web/app/(shell)/platform/ai/providers/"
+git commit -m "feat(web): add /platform/ai/providers/[providerId] detail page"
+```
+
+---
+
+### Task 11: Update /platform page with AI Providers card
+
+**Files:**
+- Modify: `apps/web/app/(shell)/platform/page.tsx`
+
+- [ ] **Step 1: Add AI Providers card**
+
+In `apps/web/app/(shell)/platform/page.tsx`, read the file first to find the correct insertion point, then add a `Link` import if not already present, and add this block after the closing `</div>` of the capabilities grid (after the `{capabilities.length === 0 && ...}` line):
+
+```tsx
+      <div style={{ marginTop: 32 }}>
+        <h2 style={{ fontSize: 14, fontWeight: 600, color: "#e0e0ff", marginBottom: 12 }}>Platform Services</h2>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+          <Link
+            href="/platform/ai"
+            style={{
+              display: "block",
+              padding: 16,
+              background: "var(--dpf-surface-1)",
+              border: "1px solid var(--dpf-border)",
+              borderLeft: "4px solid #7c8cf8",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            <p style={{ fontSize: 11, fontWeight: 600, color: "#e0e0ff", margin: "0 0 4px" }}>AI Providers</p>
+            <p style={{ fontSize: 10, color: "#555566", margin: 0 }}>
+              Provider registry, credentials, token spend
+            </p>
+          </Link>
+        </div>
+      </div>
+```
+
+- [ ] **Step 2: Verify TypeScript and run tests**
+
+```bash
+pnpm --filter web exec tsc --noEmit 2>&1 | grep -E "Error|error" | grep -v "branding\|Header"
+pnpm test 2>&1 | tail -10
+```
+
+Expected: no new TypeScript errors; all tests passing (including the 11 new ai-providers tests)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/web/app/(shell)/platform/page.tsx"
+git commit -m "feat(web): add AI Providers link card to /platform page"
+```
+
+---
+
+## Done
+
+All tasks complete. Run full test suite one final time:
+
+```bash
+pnpm test
+```
+
+Expected: all tests passing, no TypeScript errors.

--- a/docs/superpowers/specs/2026-03-12-phase-7a-ai-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-03-12-phase-7a-ai-provider-registry-design.md
@@ -1,0 +1,382 @@
+# Phase 7A — AI Provider Registry & Token Spend Design
+
+**Date:** 2026-03-12
+**Status:** Draft
+**Scope:** Dynamic AI provider registry, credential management, auth validation, token spend tracking, and a central platform scheduler. Lives at `/platform/ai`.
+
+---
+
+## Context and Motivation
+
+The platform's AI agents call LLM APIs. Today, provider credentials and model choices are implicit (env vars, hard-coded assumptions). As the agent roster grows — and as local models like Ollama become viable — the platform needs a first-class way to register providers, manage API keys, and understand what AI costs. The analogy to HR is intentional: just as human employees have salaries tracked per role, AI agents have token spend tracked per context. Phase 7A builds the infrastructure layer that Phases 7B (agent job assignment) and 7C (AI co-worker sidebar) depend on.
+
+---
+
+## Architecture
+
+A new `/platform/ai` route surfaces three concerns in a single admin page: the provider registry, the token spend dashboard, and the platform scheduler. Provider definitions are sourced from a JSON file in the ODPF GitHub repo and synced on a configurable schedule. Two cost models are supported: token-priced (cloud APIs) and compute-priced (local inference). A new `ScheduledJob` table coordinates all recurring platform tasks — provider sync is the first entry.
+
+**Tech stack:** Next.js 14 App Router, Prisma 5, PostgreSQL. No new runtime dependencies.
+
+---
+
+## Capability
+
+The existing `manage_provider_connections` capability (already in `permissions.ts`, assigned to `HR-000`) is repurposed for this feature. No new capability is added. All write actions on `/platform/ai` check `manage_provider_connections`. The capability name is kept as-is to avoid churn in downstream call sites.
+
+---
+
+## Data Model
+
+### New: `TokenUsage`
+
+```prisma
+model TokenUsage {
+  id           String   @id @default(cuid())
+  agentId      String                          // Agent.agentId business key (e.g. "HR-100")
+  providerId   String                          // ModelProvider.providerId business key
+  contextKey   String                          // route path, e.g. "/ea/views/abc"
+  inputTokens  Int      @default(0)
+  outputTokens Int      @default(0)
+  inferenceMs  Int?                            // compute-priced providers only
+  costUsd      Float    @default(0)            // computed at log time
+  createdAt    DateTime @default(now())
+}
+```
+
+`agentId` and `providerId` are bare string business keys with no FK relations. `getTokenSpendByAgent` uses a two-step fetch: aggregate `TokenUsage` by `agentId`, then `prisma.agent.findMany({ where: { agentId: { in: ids }}})` to join agent names. This avoids requiring every agent to have a DB row before spend can be logged.
+
+### New: `ScheduledJob`
+
+```prisma
+model ScheduledJob {
+  id         String    @id @default(cuid())
+  jobId      String    @unique
+  name       String
+  schedule   String    @default("weekly")   // "daily" | "weekly" | "monthly" | "disabled"
+  lastRunAt  DateTime?
+  nextRunAt  DateTime?
+  lastStatus String?                        // "ok" | "error" — application-enforced
+  lastError  String?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+}
+```
+
+`nextRunAt` computation: on each run or schedule change, `nextRunAt = now + interval` where `daily → 1 day`, `weekly → 7 days`, `monthly → 30 days`. If `schedule = "disabled"`, `nextRunAt = null`. The on-load check is the only trigger mechanism in Phase 7A — "weekly" means the sync fires at most once per week and only when an admin visits `/platform/ai`. A background runner is out of scope.
+
+### Extended: `ModelProvider` (migration required)
+
+The migration adds these columns and changes the status default:
+
+```prisma
+// Changes to existing ModelProvider model:
+status              String    @default("unconfigured")  // was @default("inactive")
+// New columns:
+authEndpoint        String?   // URL for auth check; null for custom-endpoint providers
+authHeader          String?   // header name for API key; null = keyless provider
+endpoint            String?   // custom base URL (Azure OpenAI and similar)
+costModel           String    @default("token")         // "token" | "compute"
+inputPricePerMToken  Float?
+outputPricePerMToken Float?
+computeWatts        Float?
+electricityRateKwh  Float?
+enabledFamilies     Json      @default("[]")
+```
+
+`status` valid values (enforced by application logic only, not a DB constraint):
+- `"unconfigured"` — default for new rows (registry-synced but not yet configured)
+- `"active"` — configured and auth check passed
+- `"inactive"` — manually disabled
+
+The migration changes `@default("inactive")` to `@default("unconfigured")`. Existing rows with `status = "inactive"` are unchanged by the migration — the application treats both as "not active" for routing purposes.
+
+### `CredentialEntry` (existing, unchanged schema)
+
+`providerId` (business key, `@unique`) → `secretRef String?` (env var name, e.g. `"ANTHROPIC_API_KEY"`) + `status String`.
+
+One credential entry per provider. `secretRef` is nullable — keyless providers (Ollama, `authHeader: null`) have no entry or have `secretRef = null`.
+
+---
+
+## TypeScript Types
+
+```ts
+// apps/web/lib/ai-provider-types.ts
+
+export type ProviderRow = {
+  id: string;
+  providerId: string;
+  name: string;
+  families: string[];
+  enabledFamilies: string[];
+  status: string;
+  costModel: string;
+  authEndpoint: string | null;
+  authHeader: string | null;
+  endpoint: string | null;
+  inputPricePerMToken: number | null;
+  outputPricePerMToken: number | null;
+  computeWatts: number | null;
+  electricityRateKwh: number | null;
+};
+
+export type CredentialRow = {
+  providerId: string;
+  secretRef: string | null;
+  status: string;
+};
+
+export type ProviderWithCredential = {
+  provider: ProviderRow;
+  credential: CredentialRow | null;
+};
+
+export type SpendByProvider = {
+  providerId: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+};
+
+export type SpendByAgent = {
+  agentId: string;
+  agentName: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+};
+```
+
+---
+
+## Provider Registry JSON
+
+Hosted at:
+`https://raw.githubusercontent.com/markdbodman/opendigitalproductfactory/main/packages/db/data/providers-registry.json`
+
+Schema per entry:
+
+```json
+[
+  {
+    "providerId": "anthropic",
+    "name": "Anthropic",
+    "families": ["claude-3-5", "claude-4"],
+    "authEndpoint": "https://api.anthropic.com/v1/models",
+    "authHeader": "x-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "azure-openai",
+    "name": "Azure OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo"],
+    "authEndpoint": null,
+    "authHeader": "api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 5.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "ollama",
+    "name": "Ollama (local)",
+    "families": ["llama3", "mistral", "phi3"],
+    "authEndpoint": "http://localhost:11434/api/tags",
+    "authHeader": null,
+    "costModel": "compute",
+    "computeWatts": 150,
+    "electricityRateKwh": 0.12
+  }
+]
+```
+
+**Azure OpenAI special case:** `authEndpoint: null` because the auth URL depends on the admin's resource name. The auth check constructs `${ModelProvider.endpoint}/openai/models?api-version=2024-02-01` using the `endpoint` field the admin enters on the detail page.
+
+**Keyless providers** (`authHeader: null`): auth check is `GET authEndpoint` with no credentials. HTTP 2xx = ok. No `CredentialEntry` is created for these providers (or `secretRef` is null if one exists).
+
+**`syncProviderRegistry()` upsert behaviour:**
+- `create` branch: all registry fields written, `status = "unconfigured"`, `enabledFamilies = []`
+- `update` branch: all registry fields written including `name`, `families`, `authEndpoint`, `authHeader`, `costModel`, all pricing fields. **`status` and `enabledFamilies` are never overwritten on update.** This preserves admin configuration across syncs.
+
+---
+
+## Cost Calculation
+
+**Token-priced:**
+```
+costUsd = (inputTokens / 1_000_000 × inputPricePerMToken)
+        + (outputTokens / 1_000_000 × outputPricePerMToken)
+```
+
+**Compute-priced:**
+```
+costUsd = (inferenceMs / 3_600_000) × (computeWatts / 1_000) × electricityRateKwh
+```
+
+Both store `costUsd` in `TokenUsage` at log time.
+
+---
+
+## Routes & Pages
+
+### `/platform/ai` (new)
+
+**Auth:** Inherited from the parent `/platform/layout.tsx` which already gates on `view_platform`. No additional `layout.tsx` is needed for `/platform/ai` or `/platform/ai/providers/[providerId]` — the parent layout covers both. Write actions are independently enforced inside each server action via `manage_provider_connections`.
+
+**On-load auto-sync:** The server component queries `ScheduledJob` for `jobId = "provider-registry-sync"`. If `nextRunAt` is not null, is in the past, and `schedule ≠ "disabled"`, it `await`s `syncProviderRegistry()` before rendering. This keeps data fresh without a background runner. The await adds latency only when a sync is due.
+
+The auto-sync call **does not check `manage_provider_connections`** — it is triggered by the server render, not by user intent, and the page is already gated by `view_platform`. Any authorized viewer's page load can trigger a due sync. The `manage_provider_connections` check applies only to the explicit "↻ Sync from registry" button action and to all other write actions.
+
+Three sections:
+
+**1 — Provider Registry**
+Card grid of all `ModelProvider` rows. Each card: name, status badge (`"unconfigured"` / `"active"` / `"inactive"`), model families, "Configure →" link. Header: last sync timestamp (from `ScheduledJob.lastRunAt`) + "↻ Sync from registry" button (server action `syncProviderRegistry`, requires `manage_provider_connections`).
+
+**2 — Token Spend**
+Client component with two tabs: *By Provider* | *By Agent*. Month selector (client state `{ year: number; month: number }`, defaults to current month) triggers a re-render via `useTransition` + `router.refresh()`, or a direct server action call with the selected month. If `TokenUsage` is empty (expected in Phase 7A), both tabs show a "No spend data yet" empty state.
+
+- *By Provider*: stat cards — `totalCostUsd`, `totalInputTokens`, `totalOutputTokens`, proportional progress bar.
+- *By Agent*: table sorted by `totalCostUsd` descending — agent name, token counts, cost. No `contextKey` column (one agent can have many context keys; the table aggregates all of them).
+
+**3 — Scheduled Jobs**
+Table of all `ScheduledJob` rows ordered by `jobId`. Columns: name, schedule (editable `<select>` for `manage_provider_connections` holders, calls `updateScheduledJob` on change), last run, next run, last status. "Run now" button calls `runScheduledJobNow`.
+
+### `/platform/ai/providers/[providerId]` (new)
+
+Detail page (server component + client form). Fields shown conditionally:
+
+| Field | Shown when |
+|---|---|
+| Enabled families (multi-checkbox) | always |
+| API key env var name | `authHeader !== null` (token-priced / keyed providers) |
+| Custom endpoint | `authEndpoint === null` (Azure OpenAI etc.) |
+| Compute wattage + electricity rate | `costModel === "compute"` |
+
+**"API key env var name" input:** Admin types the env var name (e.g. `ANTHROPIC_API_KEY`), not the key value. Label reads "Environment variable name". Saves to `CredentialEntry.secretRef`.
+
+**"Test connection" button:** Calls `testProviderAuth`. Shows inline ✓ or ✗ with message. On success also sets `ModelProvider.status = "active"`.
+
+---
+
+## Server Actions
+
+**`apps/web/lib/actions/ai-providers.ts`** — write actions gated by `manage_provider_connections` unless noted.
+
+`syncProviderRegistry` carries **no auth guard internally** so the server component can call it on page load for any `view_platform` holder. A thin wrapper action `triggerProviderSync` adds the `manage_provider_connections` guard and is what the "↻ Sync from registry" button wires to. This matches the `requireManageBacklog` wrapper pattern used in `backlog.ts`.
+
+### `syncProviderRegistry(): Promise<{ added: number; updated: number; error?: string }>` *(no auth guard)*
+- Fetches registry JSON (5s timeout). Returns `{ error }` on network failure.
+- Upserts each entry into `ModelProvider` per the create/update rules above.
+- Updates `ScheduledJob` (`lastRunAt = now`, `nextRunAt = now + interval`, `lastStatus = "ok"` or `"error"`).
+
+### `configureProvider(input: { providerId: string; secretRef?: string; enabledFamilies: string[]; endpoint?: string; computeWatts?: number; electricityRateKwh?: number }): Promise<{ error?: string }>`
+- `secretRef`, `endpoint`, `computeWatts`, and `electricityRateKwh` are optional. Under `exactOptionalPropertyTypes: true`, callers must **omit** these properties entirely rather than pass `undefined` — e.g. `{ providerId, enabledFamilies }` for keyless providers. Passing `secretRef: undefined` is a compile error.
+- For keyless providers (where `secretRef` is omitted): skips `CredentialEntry` upsert.
+- For keyed providers: upserts `CredentialEntry { providerId, secretRef, status: "pending" }`.
+- Updates `ModelProvider`: `enabledFamilies`, and conditionally `endpoint`, `computeWatts`, `electricityRateKwh`.
+- Does **not** set `ModelProvider.status = "active"` — that only happens after `testProviderAuth` succeeds.
+
+### `testProviderAuth(providerId: string): Promise<{ ok: boolean; message: string }>`
+
+Guard conditions (checked in order, return early with `{ ok: false, message }` if any fail):
+1. `ModelProvider` not found → `"Provider not found"`
+2. `authHeader !== null` and no `CredentialEntry` row or `secretRef` is null → `"No credential configured"`
+3. `authHeader !== null` and `process.env[secretRef]` is `undefined` → `"Environment variable not set"`
+4. `authEndpoint === null` and `endpoint` is null → `"Custom endpoint required"`
+
+Auth URL: `ModelProvider.endpoint ? "${endpoint}/openai/models?api-version=2024-02-01" : authEndpoint`.
+
+Request: GET to auth URL, 8s timeout, with header `{ [authHeader]: process.env[secretRef] }` (omitted entirely for keyless providers).
+
+- HTTP 2xx → `{ ok: true, message: "Connected — HTTP 200" }`. Sets `ModelProvider.status = "active"`, `CredentialEntry.status = "ok"`.
+- Non-2xx or network error → `{ ok: false, message: "HTTP 401 — Unauthorized" }` (includes status code). Sets `CredentialEntry.status = "error"`. Leaves `ModelProvider.status` unchanged.
+
+### `triggerProviderSync(): Promise<{ added: number; updated: number; error?: string }>` *(requires `manage_provider_connections`)*
+Thin wrapper: checks capability, then calls `syncProviderRegistry()`. This is what the "↻ Sync from registry" button binds to as a form action.
+
+### `updateScheduledJob(input: { jobId: string; schedule: string }): Promise<void>`
+Updates `schedule`. Sets `nextRunAt = now + interval` (or `null` if `"disabled"`).
+
+### `runScheduledJobNow(jobId: string): Promise<void>`
+Dispatches job by `jobId`. For `"provider-registry-sync"`: calls `syncProviderRegistry()`. Unknown `jobId`: no-op.
+
+### `logTokenUsage(input: { agentId: string; providerId: string; contextKey: string; inputTokens: number; outputTokens: number; inferenceMs?: number }): Promise<void>`
+**Auth:** Requires a valid platform session (`auth()` check, `session.user` must exist). No capability restriction — any authenticated HR role may log spend on behalf of an agent. No `manage_provider_connections` guard needed since this is written by agent infrastructure, not the admin UI.
+
+Fetches `ModelProvider` pricing fields, computes `costUsd`, writes `TokenUsage` row. Called by agent infrastructure in Phase 7B+. **The table will be empty during Phase 7A** — this action is implemented now so the schema and hook are ready.
+
+---
+
+## Data Fetchers
+
+**`apps/web/lib/ai-provider-data.ts`**
+
+### `getProviders(): Promise<ProviderWithCredential[]>`
+```ts
+const providers = await prisma.modelProvider.findMany({ orderBy: { name: "asc" } });
+const credentials = await prisma.credentialEntry.findMany({
+  where: { providerId: { in: providers.map((p) => p.providerId) } },
+});
+const credMap = new Map(credentials.map((c) => [c.providerId, c]));
+return providers.map((p) => ({ provider: p as ProviderRow, credential: credMap.get(p.providerId) ?? null }));
+```
+
+### `getTokenSpendByProvider(month: { year: number; month: number }): Promise<SpendByProvider[]>`
+Date range: `gte: first day of month, lt: first day of next month` (UTC). Prisma `groupBy: ["providerId"]`, `_sum: { inputTokens, outputTokens, costUsd }`. Prisma `_sum` fields return `number | null` — coalesce with `?? 0` when mapping to `SpendByProvider`.
+
+### `getTokenSpendByAgent(month: { year: number; month: number }): Promise<SpendByAgent[]>`
+Same date filter. `groupBy: ["agentId"]`, `_sum: { inputTokens, outputTokens, costUsd }`. Coalesce all `_sum` fields with `?? 0`. Then `prisma.agent.findMany({ where: { agentId: { in: agentIds }}})` to build a name map. Name resolution pattern:
+```ts
+const agentMap = new Map(agents.map((a) => [a.agentId, a.name]));
+// per row:
+agentName: agentMap.get(row.agentId) ?? row.agentId,
+```
+Agents with no matching `Agent` row fall back to displaying `agentId`.
+
+### `getScheduledJobs(): Promise<ScheduledJob[]>`
+`prisma.scheduledJob.findMany({ orderBy: { jobId: "asc" } })`.
+
+---
+
+## Navigation
+
+`/platform/ai` is accessed via an "AI Providers" card added to the `/platform` capabilities grid (always visible to `view_platform` holders). No new top-level nav item.
+
+---
+
+## Seed Data
+
+**`packages/db/data/providers-registry.json`** (initial entries, committed to repo):
+`anthropic`, `openai`, `azure-openai`, `gemini`, `ollama`, `bedrock`.
+
+**`seed.ts`** adds `seedScheduledJobs()`:
+```ts
+await prisma.scheduledJob.upsert({
+  where: { jobId: "provider-registry-sync" },
+  create: {
+    jobId: "provider-registry-sync",
+    name: "Provider registry sync",
+    schedule: "weekly",
+    nextRunAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  },
+  update: {
+    // Only reset schedule; preserve operational state (lastRunAt, lastStatus, nextRunAt)
+    schedule: "weekly",
+  },
+});
+```
+
+The `update` branch only resets `schedule` — it does not overwrite `lastRunAt`, `lastStatus`, or `nextRunAt` on re-seed, preserving recorded sync history on production databases.
+
+---
+
+## Out of Scope for Phase 7A
+
+- Actual LLM call integration — agents still use env vars directly; `logTokenUsage` is the hook for Phase 7B+
+- Budget alerts or spend limits
+- Per-user spend breakdown
+- Secrets manager integration (Phase 7A uses env var name references only)
+- Background job runner (sync fires on page visit only)
+- Route handler for sync — the server component calls `syncProviderRegistry()` directly

--- a/packages/db/data/providers-registry.json
+++ b/packages/db/data/providers-registry.json
@@ -1,0 +1,62 @@
+[
+  {
+    "providerId": "anthropic",
+    "name": "Anthropic",
+    "families": ["claude-3-5", "claude-4"],
+    "authEndpoint": "https://api.anthropic.com/v1/models",
+    "authHeader": "x-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "openai",
+    "name": "OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo", "gpt-4o-mini"],
+    "authEndpoint": "https://api.openai.com/v1/models",
+    "authHeader": "Authorization",
+    "costModel": "token",
+    "inputPricePerMToken": 2.50,
+    "outputPricePerMToken": 10.00
+  },
+  {
+    "providerId": "azure-openai",
+    "name": "Azure OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo"],
+    "authEndpoint": null,
+    "authHeader": "api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 5.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "gemini",
+    "name": "Google Gemini",
+    "families": ["gemini-1.5-pro", "gemini-2.0"],
+    "authEndpoint": "https://generativelanguage.googleapis.com/v1/models",
+    "authHeader": "x-goog-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.00
+  },
+  {
+    "providerId": "ollama",
+    "name": "Ollama (local)",
+    "families": ["llama3", "mistral", "phi3", "gemma2"],
+    "authEndpoint": "http://localhost:11434/api/tags",
+    "authHeader": null,
+    "costModel": "compute",
+    "computeWatts": 150,
+    "electricityRateKwh": 0.12
+  },
+  {
+    "providerId": "bedrock",
+    "name": "AWS Bedrock",
+    "families": ["claude", "titan", "llama"],
+    "authEndpoint": null,
+    "authHeader": "Authorization",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  }
+]

--- a/packages/db/prisma/migrations/20260313042631_add_ai_provider_registry/migration.sql
+++ b/packages/db/prisma/migrations/20260313042631_add_ai_provider_registry/migration.sql
@@ -1,0 +1,45 @@
+-- AlterTable
+ALTER TABLE "ModelProvider" ADD COLUMN     "authEndpoint" TEXT,
+ADD COLUMN     "authHeader" TEXT,
+ADD COLUMN     "computeWatts" DOUBLE PRECISION,
+ADD COLUMN     "costModel" TEXT NOT NULL DEFAULT 'token',
+ADD COLUMN     "electricityRateKwh" DOUBLE PRECISION,
+ADD COLUMN     "enabledFamilies" JSONB NOT NULL DEFAULT '[]',
+ADD COLUMN     "endpoint" TEXT,
+ADD COLUMN     "inputPricePerMToken" DOUBLE PRECISION,
+ADD COLUMN     "outputPricePerMToken" DOUBLE PRECISION,
+ALTER COLUMN "status" SET DEFAULT 'unconfigured';
+
+-- CreateTable
+CREATE TABLE "TokenUsage" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "contextKey" TEXT NOT NULL,
+    "inputTokens" INTEGER NOT NULL DEFAULT 0,
+    "outputTokens" INTEGER NOT NULL DEFAULT 0,
+    "inferenceMs" INTEGER,
+    "costUsd" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TokenUsage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ScheduledJob" (
+    "id" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "schedule" TEXT NOT NULL DEFAULT 'weekly',
+    "lastRunAt" TIMESTAMP(3),
+    "nextRunAt" TIMESTAMP(3),
+    "lastStatus" TEXT,
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ScheduledJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScheduledJob_jobId_key" ON "ScheduledJob"("jobId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -189,12 +189,46 @@ model CredentialEntry {
 }
 
 model ModelProvider {
-  id         String   @id @default(cuid())
-  providerId String   @unique
+  id                   String   @id @default(cuid())
+  providerId           String   @unique
+  name                 String
+  families             Json
+  enabledFamilies      Json     @default("[]")
+  status               String   @default("unconfigured")
+  authEndpoint         String?
+  authHeader           String?
+  endpoint             String?
+  costModel            String   @default("token")
+  inputPricePerMToken  Float?
+  outputPricePerMToken Float?
+  computeWatts         Float?
+  electricityRateKwh   Float?
+  updatedAt            DateTime @updatedAt
+}
+
+model TokenUsage {
+  id           String   @id @default(cuid())
+  agentId      String
+  providerId   String
+  contextKey   String
+  inputTokens  Int      @default(0)
+  outputTokens Int      @default(0)
+  inferenceMs  Int?
+  costUsd      Float    @default(0)
+  createdAt    DateTime @default(now())
+}
+
+model ScheduledJob {
+  id         String    @id @default(cuid())
+  jobId      String    @unique
   name       String
-  families   Json
-  status     String   @default("inactive")
-  updatedAt  DateTime @updatedAt
+  schedule   String    @default("weekly")
+  lastRunAt  DateTime?
+  nextRunAt  DateTime?
+  lastStatus String?
+  lastError  String?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
 }
 
 // ─── Agents ──────────────────────────────────────────────────────────────────

--- a/packages/db/src/ea-validation.ts
+++ b/packages/db/src/ea-validation.ts
@@ -21,18 +21,25 @@ export type DqViolation = {
 
 /** Check that (fromElementType, toElementType, relationshipType) is a permitted combination
  *  per EaRelationshipRule. Called before createEaRelationship. */
+// Relationship type slugs that ArchiMate defines as universal (no element-type constraints).
+const UNIVERSAL_REL_TYPE_SLUGS = new Set(["associated_with", "influences"]);
+
 export async function validateEaRelationship(
   fromElementId: string,
   toElementId: string,
   relationshipTypeId: string,
 ): Promise<ValidationResult> {
-  const [from, to] = await Promise.all([
+  const [from, to, relType] = await Promise.all([
     prisma.eaElement.findUnique({ where: { id: fromElementId }, select: { elementTypeId: true } }),
     prisma.eaElement.findUnique({ where: { id: toElementId },   select: { elementTypeId: true } }),
+    prisma.eaRelationshipType.findUnique({ where: { id: relationshipTypeId }, select: { slug: true } }),
   ]);
 
   if (!from) return { valid: false, reason: `Source element "${fromElementId}" not found` };
   if (!to)   return { valid: false, reason: `Target element "${toElementId}" not found` };
+
+  // Universal relationship types (ArchiMate Association, Influence) may connect any two elements.
+  if (relType && UNIVERSAL_REL_TYPE_SLUGS.has(relType.slug)) return { valid: true };
 
   const rule = await prisma.eaRelationshipRule.findFirst({
     where: {

--- a/packages/db/src/ea-validation.ts
+++ b/packages/db/src/ea-validation.ts
@@ -2,7 +2,7 @@
 // Validation functions for EA model writes.
 // All functions read from Postgres meta-model; never write.
 
-import { prisma } from "./client.js";
+import { prisma } from "./client";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -601,6 +601,23 @@ async function seedEaViews(): Promise<void> {
   console.log(`Seeded ${views.length} EA views`);
 }
 
+async function seedScheduledJobs(): Promise<void> {
+  await prisma.scheduledJob.upsert({
+    where:  { jobId: "provider-registry-sync" },
+    create: {
+      jobId:     "provider-registry-sync",
+      name:      "Provider registry sync",
+      schedule:  "weekly",
+      nextRunAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+    update: {
+      // Only reset schedule — preserve operational state on re-seed
+      schedule: "weekly",
+    },
+  });
+  console.log("Seeded scheduled jobs");
+}
+
 async function main(): Promise<void> {
   console.log("Starting seed...");
   await seedRoles();
@@ -614,6 +631,7 @@ async function main(): Promise<void> {
   await seedDpfSelfRegistration();
   await seedThemeBrandingEpic();
   await seedDefaultAdminUser();
+  await seedScheduledJobs();
   console.log("Seed complete.");
 }
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -286,17 +286,176 @@ async function seedDpfSelfRegistration(): Promise<void> {
     { itemId: "BI-PROD-001", title: "Phase 5A — Backlog CRUD in /ops",                                    status: "in-progress", priority: 1 },
     { itemId: "BI-PROD-002", title: "Phase 5B — DPF self-registration as managed digital product",        status: "in-progress", priority: 2 },
     { itemId: "BI-PROD-003", title: "Phase 2B — Live Agent counts and Health metrics in portfolio panels", status: "open",        priority: 3 },
+    {
+      itemId: "BI-PROD-004",
+      title: "Add a resilient theme option library with branding presets from 10+ companies",
+      status: "open",
+      priority: 4,
+      body: [
+        "Branding source references:",
+        "- ServiceNow",
+        "- TeamLogicIT",
+        "- The Open Group",
+        "- state of TX",
+        "- Rudys",
+        "- Buccees",
+        "- Great Clips",
+        "- Dunkin' Donuts",
+        "- Floyds Glass Co.",
+        "- Atlassian",
+        "- Adobe",
+        "",
+        "Acceptance criteria:",
+        "- Theme presets are stored as structured JSON with palette, typography, spacing, and radius variables.",
+        "- Users can switch themes at runtime and see immediate, consistent UI updates.",
+        "- The application has graceful fallback defaults if a preset is missing one or more tokens.",
+        "- Presets render correctly in dark and light modes where supported.",
+        "- Preset selection is persisted per user and applied on next login.",
+        "- New preset files can be added without code changes to core theme logic.",
+      ].join("\n"),
+    },
+    {
+      itemId: "BI-PROD-005",
+      title: "Define theme token schema and preset packaging contract",
+      status: "open",
+      priority: 5,
+      body: [
+        "Scope:",
+        "- Define a versioned JSON contract for theme presets (palette, typography, spacing, radius, shadows, surfaces, states).",
+        "- Add validation to ensure required tokens exist before publish.",
+        "- Store presets in a repo/config path and load through shared runtime service.",
+        "- Provide migration path for old presets.",
+        "",
+        "Acceptance criteria:",
+        "- Contract is documented and versioned (v1+).",
+        "- CI validation rejects malformed preset objects.",
+        "- No hard-coded theme constants remain outside preset source.",
+      ].join("\n"),
+    },
+    {
+      itemId: "BI-PROD-006",
+      title: "Implement theme provider and runtime theme switching",
+      status: "open",
+      priority: 6,
+      body: [
+        "Scope:",
+        "- Add a centralized ThemeProvider for app-wide CSS variable injection.",
+        "- Render immediate switch between presets without full-page refresh.",
+        "- Support both light and dark mode variants for every preset where available.",
+        "",
+        "Acceptance criteria:",
+        "- Changing preset updates key surfaces within <300ms in normal conditions.",
+        "- Preset fallbacks apply automatically on missing tokens.",
+        "- No visual regression on default app pages.",
+      ].join("\n"),
+    },
+    {
+      itemId: "BI-PROD-007",
+      title: "Persist theme preference per user and add admin preset management",
+      status: "open",
+      priority: 7,
+      body: [
+        "Scope:",
+        "- Persist selected preset to user profile and restore on login.",
+        "- Add admin UI/API to preview and enable/disable preset availability.",
+        "- Add governance metadata (owner, approval, enabled, deprecation date).",
+        "",
+        "Acceptance criteria:",
+        "- User selection is recovered after refresh and across sessions.",
+        "- Admin can toggle preset visibility without redeploy.",
+        "- Deactivated preset is never selectable by regular users.",
+      ].join("\n"),
+    },
+    {
+      itemId: "BI-PROD-008",
+      title: "AI co-worker branding setup from admin prompt or website URL",
+      status: "open",
+      priority: 8,
+      body: [
+        "Scope:",
+        "- Add an admin action where a user can provide either plain-language branding instructions or a public website URL.",
+        "- Route that request through the co-worker layer to generate a draft branding configuration.",
+        "- Populate theme tokens, logo candidates, and metadata with confidence indicators.",
+        "- Keep a human-in-the-loop approval step before publishing any generated branding profile.",
+        "",
+        "Acceptance criteria:",
+        "- Admin can submit either free-text instructions or URL input from the admin page.",
+        "- Generated branding draft includes primary/secondary colors, accent, and logo recommendation.",
+        "- Admin can review, edit, and approve the generated draft before it becomes active.",
+        "- Rejected drafts remain saved with traceability for later revision.",
+      ].join("\n"),
+    },
   ];
 
   for (const item of productItems) {
+    const backlogBody = item.body ?? null;
     await prisma.backlogItem.upsert({
       where:  { itemId: item.itemId },
-      update: { title: item.title, status: item.status, priority: item.priority, type: "product", digitalProductId: dpfPortal.id, taxonomyNodeId: taxonomyNode.id },
-      create: { itemId: item.itemId, title: item.title, status: item.status, priority: item.priority, type: "product", digitalProductId: dpfPortal.id, taxonomyNodeId: taxonomyNode.id },
+      update: {
+        title: item.title,
+        status: item.status,
+        priority: item.priority,
+        body: backlogBody,
+        type: "product",
+        digitalProductId: dpfPortal.id,
+        taxonomyNodeId: taxonomyNode.id,
+      },
+      create: {
+        itemId: item.itemId,
+        title: item.title,
+        status: item.status,
+        priority: item.priority,
+        body: backlogBody,
+        type: "product",
+        digitalProductId: dpfPortal.id,
+        taxonomyNodeId: taxonomyNode.id,
+      },
     });
   }
 
-  console.log("Seeded DPF Portal digital product and 7 backlog items");
+  console.log(`Seeded DPF Portal digital product and ${portfolioItems.length + productItems.length} backlog items`);
+}
+
+async function seedThemeBrandingEpic(): Promise<void> {
+  const portfolio = await prisma.portfolio.findUnique({ where: { slug: "manufacturing_and_delivery" } });
+  if (!portfolio) throw new Error("manufacturing_and_delivery portfolio not seeded");
+
+  const epic = await prisma.epic.upsert({
+    where: { epicId: "EP-UI-THEME-001" },
+    update: {
+      title: "Theme & Branding Modernization",
+      description:
+        "Create a resilient theme-system foundation with configurable color/branding presets from a curated set of company styles.",
+      status: "open",
+    },
+    create: {
+      epicId: "EP-UI-THEME-001",
+      title: "Theme & Branding Modernization",
+      description:
+        "Create a resilient theme-system foundation with configurable color/branding presets from a curated set of company styles.",
+      status: "open",
+    },
+  });
+
+  await prisma.epicPortfolio.upsert({
+    where: { epicId_portfolioId: { epicId: epic.id, portfolioId: portfolio.id } },
+    update: {},
+    create: { epicId: epic.id, portfolioId: portfolio.id },
+  });
+
+  await prisma.backlogItem.update({
+    where: { itemId: "BI-PROD-004" },
+    data: { epicId: epic.id },
+  });
+
+  await Promise.all([
+    prisma.backlogItem.update({ where: { itemId: "BI-PROD-005" }, data: { epicId: epic.id } }),
+    prisma.backlogItem.update({ where: { itemId: "BI-PROD-006" }, data: { epicId: epic.id } }),
+    prisma.backlogItem.update({ where: { itemId: "BI-PROD-007" }, data: { epicId: epic.id } }),
+    prisma.backlogItem.update({ where: { itemId: "BI-PROD-008" }, data: { epicId: epic.id } }),
+  ]);
+
+  console.log(`Seeded theme epic ${epic.epicId} and linked BI-PROD-004/005/006/007/008`);
 }
 
 async function seedDefaultAdminUser(): Promise<void> {
@@ -391,6 +550,57 @@ async function seedEaViewpoints(): Promise<void> {
   console.log("Seeded 4 viewpoint definitions");
 }
 
+async function seedEaViews(): Promise<void> {
+  const notation = await prisma.eaNotation.findUniqueOrThrow({
+    where: { slug: "archimate4" },
+    select: { id: true },
+  });
+  const appVp = await prisma.viewpointDefinition.findUnique({
+    where: { name: "Application Architecture" },
+    select: { id: true },
+  });
+  const bizVp = await prisma.viewpointDefinition.findUnique({
+    where: { name: "Business Architecture" },
+    select: { id: true },
+  });
+  const views = [
+    {
+      name: "DPF Platform — Application Architecture",
+      description: "Application components and services that make up the Digital Product Factory platform.",
+      layoutType: "graph",
+      scopeType: "portfolio",
+      scopeRef: "foundational",
+      viewpointId: appVp?.id ?? null,
+    },
+    {
+      name: "Business Capability Map",
+      description: "Top-level business capabilities across the organisation.",
+      layoutType: "graph",
+      scopeType: "custom",
+      scopeRef: null,
+      viewpointId: bizVp?.id ?? null,
+    },
+  ];
+  for (const v of views) {
+    const existing = await prisma.eaView.findFirst({ where: { name: v.name }, select: { id: true } });
+    if (!existing) {
+      await prisma.eaView.create({
+        data: {
+          notationId: notation.id,
+          name: v.name,
+          description: v.description,
+          layoutType: v.layoutType,
+          scopeType: v.scopeType,
+          ...(v.scopeRef != null && { scopeRef: v.scopeRef }),
+          ...(v.viewpointId != null && { viewpointId: v.viewpointId }),
+          status: "draft",
+        },
+      });
+    }
+  }
+  console.log(`Seeded ${views.length} EA views`);
+}
+
 async function main(): Promise<void> {
   console.log("Starting seed...");
   await seedRoles();
@@ -400,7 +610,9 @@ async function main(): Promise<void> {
   await seedDigitalProducts();
   await seedEaArchimate4();
   await seedEaViewpoints();
+  await seedEaViews();
   await seedDpfSelfRegistration();
+  await seedThemeBrandingEpic();
   await seedDefaultAdminUser();
   console.log("Seed complete.");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.777.0
+        version: 3.1008.0
       '@dpf/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -107,6 +110,165 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1008.0':
+    resolution: {integrity: sha512-w/SIRD25v2zVMbkn8CYIxUsac8yf5Jghkhw5j7EsNWdJhl56m/nWpUX7t1etFUW1cnzpFjZV0lXt0dNFSnbXwA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.19':
+    resolution: {integrity: sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.4':
+    resolution: {integrity: sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.17':
+    resolution: {integrity: sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.19':
+    resolution: {integrity: sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.19':
+    resolution: {integrity: sha512-pVJVjWqVrPqjpFq7o0mCmeZu1Y0c94OCHSYgivdCD2wfmYVtBbwQErakruhgOD8pcMcx9SCqRw1pzHKR7OGBcA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.19':
+    resolution: {integrity: sha512-jOXdZ1o+CywQKr6gyxgxuUmnGwTTnY2Kxs1PM7fI6AYtDWDnmW/yKXayNqkF8KjP1unflqMWKVbVt5VgmE3L0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.20':
+    resolution: {integrity: sha512-0xHca2BnPY0kzjDYPH7vk8YbfdBPpWVS67rtqQMalYDQUCBYS37cZ55K6TuFxCoIyNZgSCFrVKr9PXC5BVvQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.17':
+    resolution: {integrity: sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.19':
+    resolution: {integrity: sha512-kVjQsEU3b///q7EZGrUzol9wzwJFKbEzqJKSq82A9ShrUTEO7FNylTtby3sPV19ndADZh1H3FB3+5ZrvKtEEeg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.19':
+    resolution: {integrity: sha512-BV1BlTFdG4w4tAihxN7iXDBoNcNewXD4q8uZlNQiUrnqxwGWUhKHODIQVSPlQGxXClEj+63m+cqZskw+ESmeZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.7':
+    resolution: {integrity: sha512-goX+axlJ6PQlRnzE2bQisZ8wVrlm6dXJfBzMJhd8LhAIBan/w1Kl73fJnalM/S+18VnpzIHumyV6DtgmvqG5IA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.7':
+    resolution: {integrity: sha512-mvWqvm61bmZUKmmrtl2uWbokqpenY3Mc3Jf4nXB/Hse6gWxLPaCQThmhPBDzsPSV8/Odn8V6ovWt3pZ7vy4BFQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.973.5':
+    resolution: {integrity: sha512-Dp3hqE5W6hG8HQ3Uh+AINx9wjjqYmFHbxede54sGj3akx/haIQrkp85lNdTdC+ouNUcSYNiuGkzmyDREfHX1Gg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.7':
+    resolution: {integrity: sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.7':
+    resolution: {integrity: sha512-vdK1LJfffBp87Lj0Bw3WdK1rJk9OLDYdQpqoKgmpIZPe+4+HawZ6THTbvjhJt4C4MNnRrHTKHQjkwBiIpDBoig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.7':
+    resolution: {integrity: sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.7':
+    resolution: {integrity: sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.19':
+    resolution: {integrity: sha512-/CtOHHVFg4ZuN6CnLnYkrqWgVEnbOBC4kNiKa+4fldJ9cioDt3dD/f5vpq0cWLOXwmGL2zgVrVxNhjxWpxNMkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.7':
+    resolution: {integrity: sha512-G9clGVuAml7d8DYzY6DnRi7TIIDRvZ3YpqJPz/8wnWS5fYx/FNWNmkO6iJVlVkQg9BfeMzd+bVPtPJOvC4B+nQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.20':
+    resolution: {integrity: sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.9':
+    resolution: {integrity: sha512-+RpVtpmQbbtzFOKhMlsRcXM/3f1Z49qTOHaA8gEpHOYruERmog6f2AUtf/oTRLCWjR9H2b3roqryV/hI7QMW8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.7':
+    resolution: {integrity: sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.7':
+    resolution: {integrity: sha512-mYhh7FY+7OOqjkYkd6+6GgJOsXK1xBWmuR+c5mxJPj2kr5TBNeZq+nUvE9kANWAux5UxDVrNOSiEM/wlHzC3Lg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1008.0':
+    resolution: {integrity: sha512-TulwlHQBWcJs668kNUDMZHN51DeLrDsYT59Ux4a/nbvr025gM6HjKJJ3LvnZccam7OS/ZKUVkWomCneRQKJbBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.5':
+    resolution: {integrity: sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.4':
+    resolution: {integrity: sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.7':
+    resolution: {integrity: sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==}
+
+  '@aws-sdk/util-user-agent-node@3.973.6':
+    resolution: {integrity: sha512-iF7G0prk7AvmOK64FcLvc/fW+Ty1H+vttajL7PvJFReU8urMxfYmynTTuFKDTA76Wgpq3FzTPKwabMQIXQHiXQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.10':
+    resolution: {integrity: sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -920,6 +1082,222 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@smithy/abort-controller@4.2.12':
+    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.11':
+    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.11':
+    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.12':
+    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.12':
+    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.12':
+    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.12':
+    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.12':
+    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.15':
+    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.13':
+    resolution: {integrity: sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.12':
+    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.12':
+    resolution: {integrity: sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.12':
+    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.12':
+    resolution: {integrity: sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.12':
+    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.25':
+    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.42':
+    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.14':
+    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.12':
+    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.12':
+    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.16':
+    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.12':
+    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.12':
+    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.12':
+    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.12':
+    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.12':
+    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.7':
+    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.12':
+    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.5':
+    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.13.1':
+    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.12':
+    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.41':
+    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.44':
+    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.3.3':
+    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.12':
+    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.12':
+    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.19':
+    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.13':
+    resolution: {integrity: sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1050,6 +1428,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1205,6 +1586,13 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-xml-builder@1.1.2:
+    resolution: {integrity: sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==}
+
+  fast-xml-parser@5.4.1:
+    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1445,6 +1833,10 @@ packages:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
 
+  path-expression-matcher@1.1.3:
+    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1658,6 +2050,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  strnum@2.2.0:
+    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -1858,6 +2253,450 @@ snapshots:
       oauth4webapi: 3.8.5
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.5
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.5
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.5
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1008.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/credential-provider-node': 3.972.20
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.7
+      '@aws-sdk/middleware-expect-continue': 3.972.7
+      '@aws-sdk/middleware-flexible-checksums': 3.973.5
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-location-constraint': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-sdk-s3': 3.972.19
+      '@aws-sdk/middleware-ssec': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/signature-v4-multi-region': 3.996.7
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-endpoints': 3.996.4
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.6
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/core': 3.23.11
+      '@smithy/eventstream-serde-browser': 4.2.12
+      '@smithy/eventstream-serde-config-resolver': 4.3.12
+      '@smithy/eventstream-serde-node': 4.2.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-blob-browser': 4.2.13
+      '@smithy/hash-node': 4.2.12
+      '@smithy/hash-stream-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/md5-js': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-retry': 4.4.42
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.41
+      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-stream': 4.5.19
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.13
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.19':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/xml-builder': 3.972.10
+      '@smithy/core': 3.23.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.4':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.17':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/types': 3.973.5
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.19':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/types': 3.973.5
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.19
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.19':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/credential-provider-env': 3.972.17
+      '@aws-sdk/credential-provider-http': 3.972.19
+      '@aws-sdk/credential-provider-login': 3.972.19
+      '@aws-sdk/credential-provider-process': 3.972.17
+      '@aws-sdk/credential-provider-sso': 3.972.19
+      '@aws-sdk/credential-provider-web-identity': 3.972.19
+      '@aws-sdk/nested-clients': 3.996.9
+      '@aws-sdk/types': 3.973.5
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.19':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/nested-clients': 3.996.9
+      '@aws-sdk/types': 3.973.5
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.20':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.17
+      '@aws-sdk/credential-provider-http': 3.972.19
+      '@aws-sdk/credential-provider-ini': 3.972.19
+      '@aws-sdk/credential-provider-process': 3.972.17
+      '@aws-sdk/credential-provider-sso': 3.972.19
+      '@aws-sdk/credential-provider-web-identity': 3.972.19
+      '@aws-sdk/types': 3.973.5
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.17':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/types': 3.973.5
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.19':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/nested-clients': 3.996.9
+      '@aws-sdk/token-providers': 3.1008.0
+      '@aws-sdk/types': 3.973.5
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.19':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/nested-clients': 3.996.9
+      '@aws-sdk/types': 3.973.5
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.973.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/crc64-nvme': 3.972.4
+      '@aws-sdk/types': 3.973.5
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.19
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.19':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.19
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.20':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-endpoints': 3.996.4
+      '@smithy/core': 3.23.11
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-retry': 4.2.12
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.996.9':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/util-endpoints': 3.996.4
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.6
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/core': 3.23.11
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-retry': 4.4.42
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.41
+      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.7':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.19
+      '@aws-sdk/types': 3.973.5
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1008.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/nested-clients': 3.996.9
+      '@aws-sdk/types': 3.973.5
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.5':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.4':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-endpoints': 3.3.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.5
+      '@smithy/types': 4.13.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.6':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/types': 3.973.5
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.10':
+    dependencies:
+      '@smithy/types': 4.13.1
+      fast-xml-parser: 5.4.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2412,6 +3251,345 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@smithy/abort-controller@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.11':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.11':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.19
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.12':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.12':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.13.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.12':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.12':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.12':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.15':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.13':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.12':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.25':
+    dependencies:
+      '@smithy/core': 3.23.11
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.42':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.14':
+    dependencies:
+      '@smithy/core': 3.23.11
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.12':
+    dependencies:
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.16':
+    dependencies:
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+
+  '@smithy/shared-ini-file-loader@4.4.7':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.12':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.5':
+    dependencies:
+      '@smithy/core': 3.23.11
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.19
+      tslib: 2.8.1
+
+  '@smithy/types@4.13.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.12':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.41':
+    dependencies:
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.44':
+    dependencies:
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.3.3':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.12':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.19':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.13':
+    dependencies:
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2576,6 +3754,8 @@ snapshots:
   bcryptjs@2.4.3: {}
 
   binary-extensions@2.3.0: {}
+
+  bowser@2.14.1: {}
 
   braces@3.0.3:
     dependencies:
@@ -2782,6 +3962,15 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-xml-builder@1.1.2:
+    dependencies:
+      path-expression-matcher: 1.1.3
+
+  fast-xml-parser@5.4.1:
+    dependencies:
+      fast-xml-builder: 1.1.2
+      strnum: 2.2.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -2977,6 +4166,8 @@ snapshots:
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.2.2
+
+  path-expression-matcher@1.1.3: {}
 
   path-key@3.1.1: {}
 
@@ -3209,6 +4400,8 @@ snapshots:
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.2.0: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- **Schema**: Added `TokenUsage`, `ScheduledJob` models; extended `ModelProvider` with cost model fields, auth config, and enabled families
- **Provider Registry**: 6 providers (Anthropic, OpenAI, Azure OpenAI, Gemini, Ollama, Bedrock) synced from GitHub-hosted JSON; auto-sync on page load when scheduled, manual sync via admin button
- **Token Spend Dashboard**: Tabbed view (By Provider / By Agent) with cost formatting and progress bars; supports both token-priced (cloud) and compute-priced (local/Ollama) cost models
- **Credential Management**: Per-provider env var reference configuration, auth endpoint validation, connection testing
- **Scheduled Jobs**: Central `ScheduledJob` table with inline schedule editor (daily/weekly/monthly/disabled) and "Run now" button
- **Routes**: `/platform/ai` (main page with 3 sections) + `/platform/ai/providers/[providerId]` (detail/config form) + "AI Providers" link card on `/platform`

## Test plan
- [ ] 11 new Vitest tests for cost calculation helpers (computeTokenCost, computeComputeCost, computeNextRunAt) — all passing
- [ ] TypeScript: 0 errors under strict config (noUncheckedIndexedAccess + exactOptionalPropertyTypes)
- [ ] Navigate to /platform → verify "AI Providers" card appears in Platform Services section
- [ ] Navigate to /platform/ai → verify provider grid renders (empty until first sync)
- [ ] Click "Sync from registry" → verify 6 providers appear with status "unconfigured"
- [ ] Click "Configure →" on a provider → verify detail form loads with correct fields (API key for keyed providers, endpoint for Azure, compute settings for Ollama)
- [ ] Verify non-HR-000 users see read-only views (no Save/Test/Sync buttons)
- [ ] Verify scheduled jobs table shows provider-registry-sync job with "weekly" schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)