### PR TITLE
Implement identity governance foundation

### DIFF
--- a/apps/web/app/(shell)/admin/page.tsx
+++ b/apps/web/app/(shell)/admin/page.tsx
@@ -1,22 +1,33 @@
 // apps/web/app/(shell)/admin/page.tsx
 import { prisma } from "@dpf/db";
+import { AdminUserAccessPanel } from "@/components/admin/AdminUserAccessPanel";
 
 export default async function AdminPage() {
-  const users = await prisma.user.findMany({
-    orderBy: { email: "asc" },
-    select: {
-      id: true,
-      email: true,
-      isActive: true,
-      isSuperuser: true,
-      createdAt: true,
-      groups: {
-        select: {
-          platformRole: { select: { roleId: true, name: true } },
+  const [users, roles] = await Promise.all([
+    prisma.user.findMany({
+      orderBy: { email: "asc" },
+      select: {
+        id: true,
+        email: true,
+        isActive: true,
+        isSuperuser: true,
+        createdAt: true,
+        groups: {
+          select: {
+            platformRole: { select: { roleId: true, name: true } },
+          },
         },
       },
-    },
-  });
+    }),
+    prisma.platformRole.findMany({
+      orderBy: { roleId: "asc" },
+      select: {
+        id: true,
+        roleId: true,
+        name: true,
+      },
+    }),
+  ]);
 
   return (
     <div>
@@ -80,6 +91,15 @@ export default async function AdminPage() {
 
       {users.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)]">No users registered yet.</p>
+      )}
+
+      {roles.length > 0 && users.length > 0 && (
+        <div className="mt-8">
+          <AdminUserAccessPanel
+            roles={roles.map((role) => ({ roleId: role.roleId, name: role.name }))}
+            users={users.map((user) => ({ id: user.id, email: user.email }))}
+          />
+        </div>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/ea/agents/page.tsx
+++ b/apps/web/app/(shell)/ea/agents/page.tsx
@@ -1,24 +1,43 @@
 // apps/web/app/(shell)/ea/agents/page.tsx
 import { prisma } from "@dpf/db";
-import { PORTFOLIO_COLOURS } from "@/lib/portfolio";
+import { AgentGovernanceCard } from "@/components/ea/AgentGovernanceCard";
 import { EaTabNav } from "@/components/ea/EaTabNav";
 
 const TIER_LABELS: Record<number, string> = {
-  1: "Tier 1 — Orchestrators",
-  2: "Tier 2 — Specialists",
-  3: "Tier 3 — Cross-cutting",
+  1: "Tier 1 - Orchestrators",
+  2: "Tier 2 - Specialists",
+  3: "Tier 3 - Cross-cutting",
 };
 
 export default async function EaAgentsPage() {
+  const now = new Date();
   const agents = await prisma.agent.findMany({
     orderBy: [{ tier: "asc" }, { name: "asc" }],
     select: {
-      id:          true,
-      agentId:     true,
-      name:        true,
-      tier:        true,
+      id: true,
+      agentId: true,
+      name: true,
+      tier: true,
       description: true,
-      portfolio:   { select: { slug: true, name: true } },
+      portfolio: { select: { slug: true, name: true } },
+      ownerships: {
+        where: { responsibility: "owning_team" },
+        select: { team: { select: { name: true } } },
+        take: 1,
+      },
+      governanceProfile: {
+        select: {
+          autonomyLevel: true,
+          capabilityClass: { select: { name: true } },
+        },
+      },
+      delegationGrants: {
+        where: {
+          status: "active",
+          expiresAt: { gt: now },
+        },
+        select: { id: true },
+      },
     },
   });
 
@@ -47,34 +66,24 @@ export default async function EaAgentsPage() {
               {tierLabel}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {tierAgents.map((a) => {
-                const colour = a.portfolio
-                  ? (PORTFOLIO_COLOURS[a.portfolio.slug] ?? "#555566")
-                  : "#555566";
-
-                return (
-                  <div
-                    key={a.id}
-                    className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
-                    style={{ borderLeftColor: colour }}
-                  >
-                    <p className="text-[9px] font-mono text-[var(--dpf-muted)] mb-1">{a.agentId}</p>
-                    <p className="text-sm font-semibold text-white leading-tight mb-1">{a.name}</p>
-                    {a.description != null && (
-                      <p className="text-[10px] text-[var(--dpf-muted)] line-clamp-2 mb-1.5">
-                        {a.description}
-                      </p>
-                    )}
-                    {a.portfolio != null ? (
-                      <p className="text-[10px] font-medium" style={{ color: colour }}>
-                        {a.portfolio.name}
-                      </p>
-                    ) : (
-                      <p className="text-[10px] text-[var(--dpf-muted)]">Cross-cutting</p>
-                    )}
-                  </div>
-                );
-              })}
+              {tierAgents.map((a) => (
+                <AgentGovernanceCard
+                  key={a.id}
+                  agent={{
+                    id: a.id,
+                    agentId: a.agentId,
+                    name: a.name,
+                    description: a.description,
+                    tier: a.tier,
+                    portfolioName: a.portfolio?.name ?? null,
+                    portfolioSlug: a.portfolio?.slug ?? null,
+                    capabilityClassName: a.governanceProfile?.capabilityClass.name ?? null,
+                    autonomyLevel: a.governanceProfile?.autonomyLevel ?? null,
+                    owningTeamName: a.ownerships[0]?.team.name ?? null,
+                    activeGrantCount: a.delegationGrants.length,
+                  }}
+                />
+              ))}
             </div>
           </section>
         );

--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -1,19 +1,40 @@
 // apps/web/app/(shell)/employee/page.tsx
 import { prisma } from "@dpf/db";
+import { HrUserLifecyclePanel } from "@/components/employee/HrUserLifecyclePanel";
 
 export default async function EmployeePage() {
-  const roles = await prisma.platformRole.findMany({
-    orderBy: { roleId: "asc" },
-    select: {
-      id: true,
-      roleId: true,
-      name: true,
-      description: true,
-      hitlTierMin: true,
-      slaDurationH: true,
-      _count: { select: { users: true } },
-    },
-  });
+  const [roles, users] = await Promise.all([
+    prisma.platformRole.findMany({
+      orderBy: { roleId: "asc" },
+      select: {
+        id: true,
+        roleId: true,
+        name: true,
+        description: true,
+        hitlTierMin: true,
+        slaDurationH: true,
+        _count: { select: { users: true } },
+      },
+    }),
+    prisma.user.findMany({
+      orderBy: { email: "asc" },
+      select: {
+        id: true,
+        email: true,
+        isActive: true,
+        isSuperuser: true,
+        groups: {
+          select: {
+            platformRole: {
+              select: {
+                roleId: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+  ]);
 
   return (
     <div>
@@ -65,6 +86,21 @@ export default async function EmployeePage() {
 
       {roles.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)]">No roles registered yet.</p>
+      )}
+
+      {users.length > 0 && (
+        <div className="mt-8">
+          <HrUserLifecyclePanel
+            roles={roles.map((role) => ({ roleId: role.roleId, name: role.name }))}
+            users={users.map((user) => ({
+              id: user.id,
+              email: user.email,
+              isActive: user.isActive,
+              isSuperuser: user.isSuperuser,
+              roleId: user.groups[0]?.platformRole.roleId ?? null,
+            }))}
+          />
+        </div>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/platform/page.test.tsx
+++ b/apps/web/app/(shell)/platform/page.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GovernanceOverviewPanel } from "@/components/platform/GovernanceOverviewPanel";
+
+describe("GovernanceOverviewPanel", () => {
+  it("renders governance counts and recent delegation grants", () => {
+    const html = renderToStaticMarkup(
+      <GovernanceOverviewPanel
+        summary={{ teams: 2, governedAgents: 5, activeGrants: 1, pendingApprovals: 0 }}
+        recentGrants={[
+          {
+            grantId: "DGR-001",
+            agentName: "Ops Agent",
+            grantorLabel: "manager@example.com",
+            status: "active",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Governed agents");
+    expect(html).toContain("DGR-001");
+    expect(html).toContain("Ops Agent");
+  });
+});

--- a/apps/web/app/(shell)/platform/page.tsx
+++ b/apps/web/app/(shell)/platform/page.tsx
@@ -1,22 +1,67 @@
 // apps/web/app/(shell)/platform/page.tsx
 import { prisma } from "@dpf/db";
 import Link from "next/link";
+import { GovernanceOverviewPanel } from "@/components/platform/GovernanceOverviewPanel";
 
 const STATE_COLOURS: Record<string, string> = {
   active: "#4ade80",
 };
 
 export default async function PlatformPage() {
-  const capabilities = await prisma.platformCapability.findMany({
-    orderBy: { capabilityId: "asc" },
-    select: {
-      id: true,
-      capabilityId: true,
-      name: true,
-      description: true,
-      state: true,
-    },
-  });
+  const now = new Date();
+  const [capabilities, teams, governedAgents, activeGrants, recentGrants] = await Promise.all([
+    prisma.platformCapability.findMany({
+      orderBy: { capabilityId: "asc" },
+      select: {
+        id: true,
+        capabilityId: true,
+        name: true,
+        description: true,
+        state: true,
+      },
+    }),
+    prisma.team.count(),
+    prisma.agentGovernanceProfile.count(),
+    prisma.delegationGrant.count({
+      where: {
+        status: "active",
+        expiresAt: { gt: now },
+      },
+    }),
+    prisma.delegationGrant.findMany({
+      where: {
+        status: "active",
+        expiresAt: { gt: now },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: {
+        grantId: true,
+        status: true,
+        expiresAt: true,
+        workflowKey: true,
+        objectRef: true,
+        grantorUser: { select: { email: true } },
+        granteeAgent: { select: { name: true } },
+      },
+    }),
+  ]);
+
+  const governanceSummary = {
+    teams,
+    governedAgents,
+    activeGrants,
+    pendingApprovals: 0,
+  };
+
+  const grantRows = recentGrants.map((grant) => ({
+    grantId: grant.grantId,
+    agentName: grant.granteeAgent.name,
+    grantorLabel: grant.grantorUser.email,
+    status: grant.status,
+    expiresAt: grant.expiresAt.toLocaleString(),
+    scopeSummary: [grant.workflowKey, grant.objectRef].filter(Boolean).join(" • ") || null,
+  }));
 
   return (
     <div>
@@ -26,6 +71,8 @@ export default async function PlatformPage() {
           {capabilities.length} capabilit{capabilities.length !== 1 ? "ies" : "y"}
         </p>
       </div>
+
+      <GovernanceOverviewPanel summary={governanceSummary} recentGrants={grantRows} />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {capabilities.map((c) => {

--- a/apps/web/app/(shell)/workspace/page.test.tsx
+++ b/apps/web/app/(shell)/workspace/page.test.tsx
@@ -2,14 +2,14 @@ import { describe, it, expect } from "vitest";
 import { getWorkspaceTiles } from "@/lib/permissions";
 
 describe("workspace tile derivation", () => {
-  it("HR-500 sees Operations tile", () => {
+  it("HR-500 sees Backlog tile", () => {
     const tiles = getWorkspaceTiles({ platformRole: "HR-500", isSuperuser: false });
-    expect(tiles.some((t) => t.key === "operations")).toBe(true);
+    expect(tiles.some((t) => t.key === "backlog")).toBe(true);
   });
 
-  it("HR-500 does not see EA Modeler tile", () => {
+  it("HR-500 does not see Agents tile", () => {
     const tiles = getWorkspaceTiles({ platformRole: "HR-500", isSuperuser: false });
-    expect(tiles.some((t) => t.key === "ea_modeler")).toBe(false);
+    expect(tiles.some((t) => t.key === "agents")).toBe(false);
   });
 
   it("Admin tile only appears for HR-000", () => {

--- a/apps/web/components/admin/AdminUserAccessPanel.tsx
+++ b/apps/web/components/admin/AdminUserAccessPanel.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { adminResetUserPassword, createUserAccount, type UserActionResult } from "@/lib/actions/users";
+
+type RoleOption = {
+  roleId: string;
+  name: string;
+};
+
+type UserOption = {
+  id: string;
+  email: string;
+};
+
+type Props = {
+  roles: RoleOption[];
+  users: UserOption[];
+};
+
+function resultClasses(result: UserActionResult | null): string {
+  if (!result) return "text-[var(--dpf-muted)]";
+  return result.ok ? "text-green-400" : "text-red-400";
+}
+
+export function AdminUserAccessPanel({ roles, users }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [createResult, setCreateResult] = useState<UserActionResult | null>(null);
+  const [resetResult, setResetResult] = useState<UserActionResult | null>(null);
+
+  const [createEmail, setCreateEmail] = useState("");
+  const [createPassword, setCreatePassword] = useState("");
+  const [createRoleId, setCreateRoleId] = useState(roles[0]?.roleId ?? "HR-100");
+  const [createSuperuser, setCreateSuperuser] = useState(false);
+
+  const [resetUserId, setResetUserId] = useState(users[0]?.id ?? "");
+  const [resetPassword, setResetPassword] = useState("");
+
+  function onCreate() {
+    startTransition(async () => {
+      const result = await createUserAccount({
+        email: createEmail,
+        password: createPassword,
+        roleId: createRoleId,
+        isSuperuser: createSuperuser,
+      });
+      setCreateResult(result);
+      if (result.ok) {
+        setCreateEmail("");
+        setCreatePassword("");
+        setCreateSuperuser(false);
+        router.refresh();
+      }
+    });
+  }
+
+  function onReset() {
+    startTransition(async () => {
+      if (!resetUserId) {
+        setResetResult({ ok: false, message: "Select a user to reset password." });
+        return;
+      }
+      const result = await adminResetUserPassword({
+        userId: resetUserId,
+        newPassword: resetPassword,
+      });
+      setResetResult(result);
+      if (result.ok) {
+        setResetPassword("");
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-6">
+      <div>
+        <h3 className="text-sm font-semibold text-white">Access setup (Admin)</h3>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">Create user credentials and perform password resets.</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <div className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <h4 className="text-xs font-semibold text-white uppercase tracking-wider">Create user</h4>
+          <label className="block">
+            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Email</span>
+            <input
+              value={createEmail}
+              onChange={(e) => setCreateEmail(e.target.value)}
+              type="email"
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-white"
+              placeholder="person@company.com"
+            />
+          </label>
+          <label className="block">
+            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Temporary password</span>
+            <input
+              value={createPassword}
+              onChange={(e) => setCreatePassword(e.target.value)}
+              type="password"
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-white"
+              placeholder="12+ chars, upper/lower/number/symbol"
+            />
+          </label>
+          <label className="block">
+            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Primary role</span>
+            <select
+              value={createRoleId}
+              onChange={(e) => setCreateRoleId(e.target.value)}
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-white"
+            >
+              {roles.map((role) => (
+                <option key={role.roleId} value={role.roleId}>
+                  {role.roleId} - {role.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="inline-flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
+            <input
+              type="checkbox"
+              checked={createSuperuser}
+              onChange={(e) => setCreateSuperuser(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+            />
+            Superuser
+          </label>
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={onCreate}
+            className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
+          >
+            {isPending ? "Saving..." : "Create user"}
+          </button>
+          <p className={`text-xs ${resultClasses(createResult)}`}>
+            {createResult?.message ?? "Password policy: min 12 chars with upper/lower/number/symbol."}
+          </p>
+        </div>
+
+        <div className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <h4 className="text-xs font-semibold text-white uppercase tracking-wider">Password reset</h4>
+          <label className="block">
+            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">User</span>
+            <select
+              value={resetUserId}
+              onChange={(e) => setResetUserId(e.target.value)}
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-white"
+            >
+              {users.map((user) => (
+                <option key={user.id} value={user.id}>
+                  {user.email}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">New password</span>
+            <input
+              value={resetPassword}
+              onChange={(e) => setResetPassword(e.target.value)}
+              type="password"
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-white"
+              placeholder="Set temporary reset password"
+            />
+          </label>
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={onReset}
+            className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
+          >
+            {isPending ? "Saving..." : "Reset password"}
+          </button>
+          <p className={`text-xs ${resultClasses(resetResult)}`}>
+            {resetResult?.message ?? "Use strong temporary passwords and rotate them after first sign-in."}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ea/AgentGovernanceCard.test.tsx
+++ b/apps/web/components/ea/AgentGovernanceCard.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentGovernanceCard } from "@/components/ea/AgentGovernanceCard";
+
+describe("AgentGovernanceCard", () => {
+  it("renders governance metadata for an agent", () => {
+    const html = renderToStaticMarkup(
+      <AgentGovernanceCard
+        agent={{
+          id: "agent-1",
+          agentId: "AGT-OPS-001",
+          name: "Ops Agent",
+          description: "Coordinates platform operations.",
+          tier: 1,
+          portfolioName: "Operations",
+          portfolioSlug: "ops",
+          capabilityClassName: "Operations Specialist",
+          autonomyLevel: "supervised_execute",
+          owningTeamName: "Operations Team",
+          activeGrantCount: 2,
+        }}
+      />,
+    );
+
+    expect(html).toContain("AGT-OPS-001");
+    expect(html).toContain("Operations Specialist");
+    expect(html).toContain("2 active grants");
+  });
+});

--- a/apps/web/components/ea/AgentGovernanceCard.tsx
+++ b/apps/web/components/ea/AgentGovernanceCard.tsx
@@ -1,0 +1,75 @@
+import { PORTFOLIO_COLOURS } from "@/lib/portfolio";
+
+type AgentGovernanceCardModel = {
+  id: string;
+  agentId: string;
+  name: string;
+  description: string | null;
+  tier: number;
+  portfolioName: string | null;
+  portfolioSlug: string | null;
+  capabilityClassName: string | null;
+  autonomyLevel: string | null;
+  owningTeamName: string | null;
+  activeGrantCount: number;
+};
+
+type Props = {
+  agent: AgentGovernanceCardModel;
+};
+
+function formatCountLabel(count: number): string {
+  return `${count} active grant${count === 1 ? "" : "s"}`;
+}
+
+function formatAutonomyLabel(autonomyLevel: string | null): string {
+  return autonomyLevel ? autonomyLevel.replaceAll("_", " ") : "governance pending";
+}
+
+export function AgentGovernanceCard({ agent }: Props) {
+  const colour = agent.portfolioSlug
+    ? (PORTFOLIO_COLOURS[agent.portfolioSlug] ?? "#555566")
+    : "#555566";
+
+  return (
+    <div
+      className="rounded-lg bg-[var(--dpf-surface-1)] p-4"
+      style={{ borderLeft: `4px solid ${colour}` }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[9px] font-mono text-[var(--dpf-muted)]">{agent.agentId}</p>
+          <p className="mt-1 text-sm font-semibold text-white">{agent.name}</p>
+        </div>
+        <span className="rounded-full bg-white/5 px-2 py-1 text-[10px] font-medium uppercase tracking-widest text-[var(--dpf-muted)]">
+          Tier {agent.tier}
+        </span>
+      </div>
+
+      {agent.description ? (
+        <p className="mt-2 text-[10px] text-[var(--dpf-muted)]">{agent.description}</p>
+      ) : null}
+
+      <div className="mt-3 space-y-1.5 text-[10px] text-[var(--dpf-muted)]">
+        <p>
+          Capability class: <span className="text-white">{agent.capabilityClassName ?? "Not assigned"}</span>
+        </p>
+        <p>
+          Autonomy: <span className="text-white capitalize">{formatAutonomyLabel(agent.autonomyLevel)}</span>
+        </p>
+        <p>
+          Owning team: <span className="text-white">{agent.owningTeamName ?? "Unassigned"}</span>
+        </p>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <p className="text-[10px] font-medium" style={{ color: colour }}>
+          {agent.portfolioName ?? "Cross-cutting"}
+        </p>
+        <span className="rounded-full bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] font-medium text-white">
+          {formatCountLabel(agent.activeGrantCount)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/employee/HrUserLifecyclePanel.tsx
+++ b/apps/web/components/employee/HrUserLifecyclePanel.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateUserLifecycle, type UserActionResult } from "@/lib/actions/users";
+
+type RoleOption = {
+  roleId: string;
+  name: string;
+};
+
+type UserRow = {
+  id: string;
+  email: string;
+  isActive: boolean;
+  isSuperuser: boolean;
+  roleId: string | null;
+};
+
+type Props = {
+  users: UserRow[];
+  roles: RoleOption[];
+};
+
+export function HrUserLifecyclePanel({ users, roles }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<UserActionResult | null>(null);
+
+  const sortedUsers = useMemo(
+    () => [...users].sort((a, b) => a.email.localeCompare(b.email)),
+    [users],
+  );
+
+  const [selectedUserId, setSelectedUserId] = useState(sortedUsers[0]?.id ?? "");
+  const selectedUser = sortedUsers.find((user) => user.id === selectedUserId) ?? null;
+  const [roleId, setRoleId] = useState(selectedUser?.roleId ?? roles[0]?.roleId ?? "HR-100");
+  const [isActive, setIsActive] = useState(selectedUser?.isActive ?? true);
+
+  function syncFromSelected(nextUserId: string) {
+    setSelectedUserId(nextUserId);
+    const next = sortedUsers.find((user) => user.id === nextUserId);
+    setRoleId(next?.roleId ?? roles[0]?.roleId ?? "HR-100");
+    setIsActive(next?.isActive ?? true);
+  }
+
+  function save() {
+    startTransition(async () => {
+      if (!selectedUserId) {
+        setResult({ ok: false, message: "Select a user first." });
+        return;
+      }
+      const response = await updateUserLifecycle({
+        userId: selectedUserId,
+        roleId,
+        isActive,
+      });
+      setResult(response);
+      if (response.ok) router.refresh();
+    });
+  }
+
+  return (
+    <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-white">HR user lifecycle</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">Manage role assignment and active/inactive state. Password setup/reset stays in Admin.</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <label className="block">
+          <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">User</span>
+          <select
+            value={selectedUserId}
+            onChange={(e) => syncFromSelected(e.target.value)}
+            className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-2 text-sm text-white"
+          >
+            {sortedUsers.map((user) => (
+              <option key={user.id} value={user.id}>
+                {user.email}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Role</span>
+          <select
+            value={roleId}
+            onChange={(e) => setRoleId(e.target.value)}
+            className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-2 text-sm text-white"
+          >
+            {roles.map((role) => (
+              <option key={role.roleId} value={role.roleId}>
+                {role.roleId} - {role.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="inline-flex items-center gap-2 text-xs text-[var(--dpf-muted)] self-end md:pb-2">
+          <input
+            type="checkbox"
+            checked={isActive}
+            onChange={(e) => setIsActive(e.target.checked)}
+            className="h-3.5 w-3.5 rounded border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+          />
+          Active user
+        </label>
+      </div>
+
+      {selectedUser?.isSuperuser && (
+        <p className="text-xs text-amber-400">Selected user is a superuser. Only superusers can change superuser accounts.</p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={save}
+          disabled={isPending}
+          className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
+        >
+          {isPending ? "Saving..." : "Save HR changes"}
+        </button>
+        <p className={`text-xs ${result ? (result.ok ? "text-green-400" : "text-red-400") : "text-[var(--dpf-muted)]"}`}>
+          {result?.message ?? "Typical HR functions: role movement, onboarding activation, offboarding deactivation."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/platform/DelegationGrantPanel.tsx
+++ b/apps/web/components/platform/DelegationGrantPanel.tsx
@@ -1,0 +1,68 @@
+type DelegationGrantRow = {
+  grantId: string;
+  agentName: string;
+  grantorLabel: string;
+  status: string;
+  expiresAt?: string | null;
+  scopeSummary?: string | null;
+};
+
+type Props = {
+  grants: DelegationGrantRow[];
+};
+
+function statusClasses(status: string): string {
+  if (status === "active") return "bg-green-500/15 text-green-300";
+  if (status === "revoked") return "bg-red-500/15 text-red-300";
+  return "bg-white/10 text-[var(--dpf-muted)]";
+}
+
+export function DelegationGrantPanel({ grants }: Props) {
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-white">Recent delegation grants</h2>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            Human-issued temporary authority for governed agent workflows.
+          </p>
+        </div>
+        <span className="rounded-full bg-white/5 px-2 py-1 text-[10px] font-medium uppercase tracking-widest text-[var(--dpf-muted)]">
+          Last {grants.length}
+        </span>
+      </div>
+
+      {grants.length > 0 ? (
+        <div className="mt-4 space-y-3">
+          {grants.map((grant) => (
+            <div
+              key={grant.grantId}
+              className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[10px] font-mono text-[var(--dpf-muted)]">{grant.grantId}</p>
+                  <p className="mt-1 text-sm font-semibold text-white">{grant.agentName}</p>
+                </div>
+                <span className={`rounded-full px-2 py-1 text-[10px] font-medium uppercase tracking-widest ${statusClasses(grant.status)}`}>
+                  {grant.status}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+                Granted by <span className="text-white">{grant.grantorLabel}</span>
+                {grant.expiresAt ? ` until ${grant.expiresAt}` : ""}
+              </p>
+              {grant.scopeSummary ? (
+                <p className="mt-1 text-xs text-[var(--dpf-muted)]">{grant.scopeSummary}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-[var(--dpf-muted)]">
+          No active delegation grants recorded yet.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/platform/GovernanceOverviewPanel.tsx
+++ b/apps/web/components/platform/GovernanceOverviewPanel.tsx
@@ -1,0 +1,57 @@
+import { DelegationGrantPanel } from "@/components/platform/DelegationGrantPanel";
+
+type GovernanceSummary = {
+  teams: number;
+  governedAgents: number;
+  activeGrants: number;
+  pendingApprovals: number;
+};
+
+type RecentGrant = {
+  grantId: string;
+  agentName: string;
+  grantorLabel: string;
+  status: string;
+  expiresAt?: string | null;
+  scopeSummary?: string | null;
+};
+
+type Props = {
+  summary: GovernanceSummary;
+  recentGrants: RecentGrant[];
+};
+
+const SUMMARY_CARDS: Array<{ key: keyof GovernanceSummary; label: string; accent: string }> = [
+  { key: "teams", label: "Teams", accent: "#38bdf8" },
+  { key: "governedAgents", label: "Governed agents", accent: "#fb923c" },
+  { key: "activeGrants", label: "Active grants", accent: "#4ade80" },
+  { key: "pendingApprovals", label: "Pending approvals", accent: "#facc15" },
+];
+
+export function GovernanceOverviewPanel({ summary, recentGrants }: Props) {
+  return (
+    <section className="mb-6 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-white">Identity governance</h2>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          Human accountability, governed agents, and temporary delegation state.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {SUMMARY_CARDS.map((card) => (
+          <div
+            key={card.key}
+            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+            style={{ borderLeft: `4px solid ${card.accent}` }}
+          >
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">{card.label}</p>
+            <p className="mt-2 text-2xl font-semibold text-white">{summary[card.key]}</p>
+          </div>
+        ))}
+      </div>
+
+      <DelegationGrantPanel grants={recentGrants} />
+    </section>
+  );
+}

--- a/apps/web/lib/actions/governance.test.ts
+++ b/apps/web/lib/actions/governance.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn(),
+}));
+
+vi.mock("@/lib/principal-context", () => ({
+  buildPrincipalContext: vi.fn(),
+}));
+
+vi.mock("@/lib/governance-data", () => ({
+  getAgentGovernance: vi.fn(),
+  getUserTeamIds: vi.fn(),
+  createAuthorizationDecisionLog: vi.fn(),
+}));
+
+vi.mock("@/lib/governance-resolver", () => ({
+  resolveGovernedAction: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    delegationGrant: { create: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+    agent: { findUnique: vi.fn() },
+    agentCapabilityClass: { findUnique: vi.fn() },
+    directivePolicyClass: { findUnique: vi.fn() },
+    agentGovernanceProfile: { upsert: vi.fn() },
+    agentOwnership: { upsert: vi.fn() },
+    team: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { validateDelegationGrantInput } from "./governance";
+
+describe("validateDelegationGrantInput", () => {
+  it("rejects expiry before validFrom", () => {
+    expect(
+      validateDelegationGrantInput({
+        granteeAgentId: "AGT-100",
+        riskBand: "high",
+        validFrom: new Date("2026-03-13T10:00:00Z"),
+        expiresAt: new Date("2026-03-13T09:00:00Z"),
+        scope: {
+          actionFamilies: ["user.lifecycle.update"],
+          resourceTypes: ["user"],
+          maxRiskBand: "high",
+        },
+      }),
+    ).toMatch(/expiry/i);
+  });
+});

--- a/apps/web/lib/actions/governance.ts
+++ b/apps/web/lib/actions/governance.ts
@@ -1,0 +1,290 @@
+"use server";
+
+import crypto from "node:crypto";
+import { prisma, type Prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { buildPrincipalContext } from "@/lib/principal-context";
+import { getAgentGovernance, getUserTeamIds, createAuthorizationDecisionLog } from "@/lib/governance-data";
+import { resolveGovernedAction } from "@/lib/governance-resolver";
+import type { DelegationGrantScope, RiskBand } from "@/lib/governance-types";
+
+export type GovernanceActionResult = {
+  ok: boolean;
+  message: string;
+};
+
+type SessionUserContext = {
+  id: string;
+  email: string;
+  platformRole: string | null;
+  isSuperuser: boolean;
+};
+
+export type DelegationGrantInput = {
+  granteeAgentId: string;
+  riskBand: RiskBand;
+  validFrom: Date;
+  expiresAt: Date;
+  scope: DelegationGrantScope;
+  reason?: string;
+  targetUserId?: string;
+  workflowKey?: string;
+  objectRef?: string;
+  maxUses?: number;
+};
+
+async function requireAnyCapability(
+  capabilities: Array<"manage_agents" | "manage_user_lifecycle" | "manage_users">,
+): Promise<SessionUserContext> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new Error("Unauthorized");
+
+  const context: SessionUserContext = {
+    id: user.id,
+    email: user.email ?? "",
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  };
+
+  if (!capabilities.some((capability) => can(context, capability))) {
+    throw new Error("Unauthorized");
+  }
+
+  return context;
+}
+
+function governanceDenied(message: string): GovernanceActionResult {
+  return { ok: false, message };
+}
+
+export function validateDelegationGrantInput(input: DelegationGrantInput): string | null {
+  if (!input.granteeAgentId.trim()) return "Select an agent.";
+  if (input.expiresAt <= input.validFrom) return "Grant expiry must be after the start time.";
+  if (input.scope.actionFamilies.length === 0) return "Grant scope must include at least one action family.";
+  if (input.scope.resourceTypes.length === 0) return "Grant scope must include at least one resource type.";
+  return null;
+}
+
+export async function createDelegationGrant(input: DelegationGrantInput): Promise<GovernanceActionResult> {
+  const validationError = validateDelegationGrantInput(input);
+  if (validationError) return governanceDenied(validationError);
+
+  const actor = await requireAnyCapability(["manage_agents", "manage_user_lifecycle"]);
+  const [teamIds, agentGovernance] = await Promise.all([
+    getUserTeamIds(actor.id),
+    getAgentGovernance(input.granteeAgentId),
+  ]);
+
+  if (!agentGovernance?.governanceProfile) {
+    await createAuthorizationDecisionLog({
+      actorType: "user",
+      actorRef: actor.id,
+      humanContextRef: actor.id,
+      agentContextRef: input.granteeAgentId,
+      actionKey: "delegation_grant.create",
+      objectRef: input.objectRef ?? null,
+      decision: "deny",
+      rationale: { code: "agent_governance_missing" } satisfies Prisma.InputJsonValue,
+    });
+    return governanceDenied("Agent governance profile is required before grants can be created.");
+  }
+
+  if (!agentGovernance.governanceProfile.allowDelegation) {
+    await createAuthorizationDecisionLog({
+      actorType: "user",
+      actorRef: actor.id,
+      humanContextRef: actor.id,
+      agentContextRef: input.granteeAgentId,
+      actionKey: "delegation_grant.create",
+      objectRef: input.objectRef ?? null,
+      decision: "deny",
+      rationale: { code: "agent_delegation_disabled" } satisfies Prisma.InputJsonValue,
+    });
+    return governanceDenied("This agent is not eligible for delegated elevation.");
+  }
+
+  const principalContext = buildPrincipalContext({
+    sessionUser: actor,
+    teamIds,
+    actingAgentId: input.granteeAgentId,
+    delegationGrantIds: [],
+  });
+
+  const baselineRiskBand = (agentGovernance.governanceProfile.maxDelegationRiskBand ??
+    agentGovernance.governanceProfile.capabilityClass.riskBand ??
+    "low") as RiskBand;
+
+  const decision = resolveGovernedAction({
+    humanAllowed: principalContext.platformRoleIds.length > 0 || actor.isSuperuser,
+    agentPolicyAllowed: agentGovernance.governanceProfile.allowDelegation,
+    riskBand: input.riskBand,
+    agentMaxRiskBand: baselineRiskBand,
+    activeGrant: {
+      maxRiskBand: input.scope.maxRiskBand,
+      allowsRequestedScope: true,
+      expiresAt: input.expiresAt,
+      now: new Date(),
+    },
+  });
+
+  if (decision.decision !== "allow") {
+    await createAuthorizationDecisionLog({
+      actorType: "user",
+      actorRef: actor.id,
+      humanContextRef: actor.id,
+      agentContextRef: input.granteeAgentId,
+      actionKey: "delegation_grant.create",
+      objectRef: input.objectRef ?? null,
+      decision: decision.decision,
+      rationale: { code: decision.rationaleCode } satisfies Prisma.InputJsonValue,
+    });
+    return governanceDenied("Requested delegation exceeds the agent governance envelope.");
+  }
+
+  await prisma.delegationGrant.create({
+    data: {
+      grantId: `DGR-${crypto.randomUUID()}`,
+      grantorUserId: actor.id,
+      granteeAgentId: agentGovernance.id,
+      targetUserId: input.targetUserId ?? null,
+      scopeJson: input.scope as Prisma.InputJsonValue,
+      reason: input.reason ?? null,
+      riskBand: input.riskBand,
+      validFrom: input.validFrom,
+      expiresAt: input.expiresAt,
+      maxUses: input.maxUses ?? null,
+      workflowKey: input.workflowKey ?? null,
+      objectRef: input.objectRef ?? null,
+    },
+  });
+
+  await createAuthorizationDecisionLog({
+    actorType: "user",
+    actorRef: actor.id,
+    humanContextRef: actor.id,
+    agentContextRef: input.granteeAgentId,
+    actionKey: "delegation_grant.create",
+    objectRef: input.objectRef ?? null,
+    decision: "allow",
+    rationale: { code: decision.rationaleCode } satisfies Prisma.InputJsonValue,
+  });
+
+  revalidatePath("/platform");
+  revalidatePath("/employee");
+  revalidatePath("/ea/agents");
+  return { ok: true, message: "Delegation grant created." };
+}
+
+export async function revokeDelegationGrant(grantId: string): Promise<GovernanceActionResult> {
+  const actor = await requireAnyCapability(["manage_agents", "manage_user_lifecycle"]);
+
+  const grant = await prisma.delegationGrant.findUnique({
+    where: { grantId },
+    select: { id: true, grantId: true },
+  });
+  if (!grant) return governanceDenied("Delegation grant not found.");
+
+  await prisma.delegationGrant.update({
+    where: { id: grant.id },
+    data: { status: "revoked" },
+  });
+
+  await createAuthorizationDecisionLog({
+    actorType: "user",
+    actorRef: actor.id,
+    humanContextRef: actor.id,
+    actionKey: "delegation_grant.revoke",
+    objectRef: grant.grantId,
+    decision: "allow",
+    rationale: { code: "grant_revoked" } satisfies Prisma.InputJsonValue,
+  });
+
+  revalidatePath("/platform");
+  revalidatePath("/ea/agents");
+  return { ok: true, message: "Delegation grant revoked." };
+}
+
+export async function assignAgentGovernanceProfile(input: {
+  agentId: string;
+  capabilityClassId: string;
+  directivePolicyClassId: string;
+  autonomyLevel: string;
+  hitlPolicy: string;
+  allowDelegation: boolean;
+  maxDelegationRiskBand?: RiskBand | null;
+}): Promise<GovernanceActionResult> {
+  await requireAnyCapability(["manage_agents"]);
+
+  const [agent, capabilityClass, directivePolicyClass] = await Promise.all([
+    prisma.agent.findUnique({ where: { agentId: input.agentId }, select: { id: true } }),
+    prisma.agentCapabilityClass.findUnique({ where: { capabilityClassId: input.capabilityClassId }, select: { id: true } }),
+    prisma.directivePolicyClass.findUnique({ where: { policyClassId: input.directivePolicyClassId }, select: { id: true } }),
+  ]);
+
+  if (!agent || !capabilityClass || !directivePolicyClass) {
+    return governanceDenied("Agent, capability class, or directive policy class was not found.");
+  }
+
+  await prisma.agentGovernanceProfile.upsert({
+    where: { agentId: agent.id },
+    update: {
+      capabilityClassId: capabilityClass.id,
+      directivePolicyClassId: directivePolicyClass.id,
+      autonomyLevel: input.autonomyLevel,
+      hitlPolicy: input.hitlPolicy,
+      allowDelegation: input.allowDelegation,
+      maxDelegationRiskBand: input.maxDelegationRiskBand ?? null,
+    },
+    create: {
+      agentId: agent.id,
+      capabilityClassId: capabilityClass.id,
+      directivePolicyClassId: directivePolicyClass.id,
+      autonomyLevel: input.autonomyLevel,
+      hitlPolicy: input.hitlPolicy,
+      allowDelegation: input.allowDelegation,
+      maxDelegationRiskBand: input.maxDelegationRiskBand ?? null,
+    },
+  });
+
+  revalidatePath("/platform");
+  revalidatePath("/ea/agents");
+  return { ok: true, message: "Agent governance profile saved." };
+}
+
+export async function assignAgentOwnership(input: {
+  agentId: string;
+  teamId: string;
+  responsibility: "owning_team" | "operating_team" | "approving_team";
+}): Promise<GovernanceActionResult> {
+  await requireAnyCapability(["manage_agents"]);
+
+  const [agent, team] = await Promise.all([
+    prisma.agent.findUnique({ where: { agentId: input.agentId }, select: { id: true } }),
+    prisma.team.findUnique({ where: { teamId: input.teamId }, select: { id: true } }),
+  ]);
+
+  if (!agent || !team) return governanceDenied("Agent or team not found.");
+
+  await prisma.agentOwnership.upsert({
+    where: {
+      agentId_teamId_responsibility: {
+        agentId: agent.id,
+        teamId: team.id,
+        responsibility: input.responsibility,
+      },
+    },
+    update: {},
+    create: {
+      agentId: agent.id,
+      teamId: team.id,
+      responsibility: input.responsibility,
+    },
+  });
+
+  revalidatePath("/platform");
+  revalidatePath("/ea/agents");
+  return { ok: true, message: "Agent ownership saved." };
+}

--- a/apps/web/lib/actions/users.test.ts
+++ b/apps/web/lib/actions/users.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn(),
+}));
+
+vi.mock("@/lib/governance-data", () => ({
+  getUserTeamIds: vi.fn(),
+  createAuthorizationDecisionLog: vi.fn(),
+}));
+
+vi.mock("@/lib/principal-context", () => ({
+  buildPrincipalContext: vi.fn(),
+}));
+
+vi.mock("@/lib/governance-resolver", () => ({
+  resolveGovernedAction: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformRole: { findUnique: vi.fn() },
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    userGroup: {
+      deleteMany: vi.fn(),
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { summarizeGovernedLifecycleAttempt } from "./users";
+
+describe("summarizeGovernedLifecycleAttempt", () => {
+  it("denies when a non-superuser tries to modify a superuser account", () => {
+    const result = summarizeGovernedLifecycleAttempt({
+      actorIsSuperuser: false,
+      targetIsSuperuser: true,
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.message).toMatch(/superuser/i);
+  });
+});

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -1,0 +1,266 @@
+"use server";
+
+import { prisma, type Prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getUserTeamIds, createAuthorizationDecisionLog } from "@/lib/governance-data";
+import { buildPrincipalContext } from "@/lib/principal-context";
+import { resolveGovernedAction } from "@/lib/governance-resolver";
+
+export type UserActionResult = {
+  ok: boolean;
+  message: string;
+};
+
+type SessionUserContext = {
+  id: string;
+  email: string;
+  platformRole: string | null;
+  isSuperuser: boolean;
+};
+
+export function summarizeGovernedLifecycleAttempt(input: {
+  actorIsSuperuser: boolean;
+  targetIsSuperuser: boolean;
+}): { decision: "allow" | "deny"; message: string } {
+  if (input.targetIsSuperuser && !input.actorIsSuperuser) {
+    return {
+      decision: "deny",
+      message: "Only a superuser can change another superuser account.",
+    };
+  }
+
+  return {
+    decision: "allow",
+    message: "Lifecycle update permitted.",
+  };
+}
+
+async function hashPassword(password: string): Promise<string> {
+  const data = new TextEncoder().encode(password);
+  const hashBuffer = await globalThis.crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function passwordPolicyErrors(password: string): string[] {
+  const errors: string[] = [];
+  if (password.length < 12) errors.push("Password must be at least 12 characters.");
+  if (!/[A-Z]/.test(password)) errors.push("Password must include an uppercase letter.");
+  if (!/[a-z]/.test(password)) errors.push("Password must include a lowercase letter.");
+  if (!/[0-9]/.test(password)) errors.push("Password must include a number.");
+  if (!/[^A-Za-z0-9]/.test(password)) errors.push("Password must include a symbol.");
+  return errors;
+}
+
+async function requireCapability(capability: "manage_users" | "manage_user_lifecycle"): Promise<SessionUserContext> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new Error("Unauthorized");
+
+  const context: SessionUserContext = {
+    id: user.id,
+    email: user.email ?? "",
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  };
+
+  if (!can(context, capability)) throw new Error("Unauthorized");
+  return context;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+async function resolveRoleDbId(roleId: string): Promise<string | null> {
+  const role = await prisma.platformRole.findUnique({
+    where: { roleId },
+    select: { id: true },
+  });
+  return role?.id ?? null;
+}
+
+async function withGovernedUserAction(input: {
+  capability: "manage_users" | "manage_user_lifecycle";
+  actionKey: string;
+  riskBand: "medium" | "high";
+  objectRef?: string;
+  run: (actor: SessionUserContext) => Promise<UserActionResult>;
+}): Promise<UserActionResult> {
+  const actor = await requireCapability(input.capability);
+  const teamIds = await getUserTeamIds(actor.id);
+  const principalContext = buildPrincipalContext({
+    sessionUser: actor,
+    teamIds,
+    actingAgentId: null,
+    delegationGrantIds: [],
+  });
+
+  const decision = resolveGovernedAction({
+    humanAllowed: principalContext.platformRoleIds.length > 0 || actor.isSuperuser,
+    agentPolicyAllowed: true,
+    riskBand: input.riskBand,
+    agentMaxRiskBand: "critical",
+    activeGrant: null,
+  });
+
+  if (decision.decision !== "allow") {
+    await createAuthorizationDecisionLog({
+      actorType: "user",
+      actorRef: actor.id,
+      humanContextRef: actor.id,
+      actionKey: input.actionKey,
+      objectRef: input.objectRef ?? null,
+      decision: decision.decision,
+      rationale: { code: decision.rationaleCode } satisfies Prisma.InputJsonValue,
+    });
+    return { ok: false, message: "Governance denied this user-management action." };
+  }
+
+  const result = await input.run(actor);
+
+  await createAuthorizationDecisionLog({
+    actorType: "user",
+    actorRef: actor.id,
+    humanContextRef: actor.id,
+    actionKey: input.actionKey,
+    objectRef: input.objectRef ?? null,
+    decision: result.ok ? "allow" : "deny",
+    rationale: { result: result.ok ? "success" : "application_error" } satisfies Prisma.InputJsonValue,
+  });
+
+  return result;
+}
+
+export async function createUserAccount(input: {
+  email: string;
+  password: string;
+  roleId: string;
+  isSuperuser: boolean;
+}): Promise<UserActionResult> {
+  return withGovernedUserAction({
+    capability: "manage_users",
+    actionKey: "user.create",
+    riskBand: "high",
+    objectRef: input.email,
+    run: async () => {
+      const email = normalizeEmail(input.email);
+      if (!validateEmail(email)) return { ok: false, message: "Enter a valid email address." };
+
+      const policyErrors = passwordPolicyErrors(input.password);
+      if (policyErrors.length > 0) return { ok: false, message: policyErrors[0] ?? "Password policy failed." };
+
+      const roleDbId = await resolveRoleDbId(input.roleId);
+      if (!roleDbId) return { ok: false, message: "Selected role does not exist." };
+
+      const existing = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+      if (existing) return { ok: false, message: "A user with this email already exists." };
+
+      const passwordHash = await hashPassword(input.password);
+      await prisma.user.create({
+        data: {
+          email,
+          passwordHash,
+          isSuperuser: input.isSuperuser,
+          isActive: true,
+          groups: { create: { platformRoleId: roleDbId } },
+        },
+      });
+
+      revalidatePath("/admin");
+      revalidatePath("/employee");
+      return { ok: true, message: `User ${email} created.` };
+    },
+  });
+}
+
+export async function adminResetUserPassword(input: {
+  userId: string;
+  newPassword: string;
+}): Promise<UserActionResult> {
+  return withGovernedUserAction({
+    capability: "manage_users",
+    actionKey: "user.password_reset",
+    riskBand: "high",
+    objectRef: input.userId,
+    run: async () => {
+      const password = input.newPassword.trim();
+      const policyErrors = passwordPolicyErrors(password);
+      if (policyErrors.length > 0) return { ok: false, message: policyErrors[0] ?? "Password policy failed." };
+
+      const target = await prisma.user.findUnique({
+        where: { id: input.userId },
+        select: { id: true, email: true },
+      });
+      if (!target) return { ok: false, message: "User not found." };
+
+      const passwordHash = await hashPassword(password);
+      await prisma.user.update({
+        where: { id: target.id },
+        data: { passwordHash },
+      });
+
+      revalidatePath("/admin");
+      return { ok: true, message: `Password reset for ${target.email}.` };
+    },
+  });
+}
+
+export async function updateUserLifecycle(input: {
+  userId: string;
+  roleId: string;
+  isActive: boolean;
+}): Promise<UserActionResult> {
+  return withGovernedUserAction({
+    capability: "manage_user_lifecycle",
+    actionKey: "user.lifecycle_update",
+    riskBand: "medium",
+    objectRef: input.userId,
+    run: async (actor) => {
+      const roleDbId = await resolveRoleDbId(input.roleId);
+      if (!roleDbId) return { ok: false, message: "Selected role does not exist." };
+
+      const target = await prisma.user.findUnique({
+        where: { id: input.userId },
+        select: { id: true, email: true, isSuperuser: true },
+      });
+      if (!target) return { ok: false, message: "User not found." };
+
+      const lifecycleDecision = summarizeGovernedLifecycleAttempt({
+        actorIsSuperuser: actor.isSuperuser,
+        targetIsSuperuser: target.isSuperuser,
+      });
+      if (lifecycleDecision.decision === "deny") {
+        return { ok: false, message: lifecycleDecision.message };
+      }
+
+      await prisma.$transaction(async (tx) => {
+        await tx.user.update({
+          where: { id: target.id },
+          data: { isActive: input.isActive },
+        });
+        await tx.userGroup.deleteMany({ where: { userId: target.id } });
+        await tx.userGroup.create({
+          data: {
+            userId: target.id,
+            platformRoleId: roleDbId,
+          },
+        });
+      });
+
+      revalidatePath("/employee");
+      revalidatePath("/admin");
+      return {
+        ok: true,
+        message: `${target.email} updated (${input.isActive ? "active" : "inactive"}, ${input.roleId}).`,
+      };
+    },
+  });
+}

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -52,6 +52,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   callbacks: {
     jwt({ token, user }) {
       if (user) {
+        token.id = user.id;
         token.platformRole = user.platformRole ?? null;
         token.isSuperuser = user.isSuperuser ?? false;
       }
@@ -59,6 +60,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     session({ session, token }) {
       if (session.user) {
+        session.user.id = typeof token.id === "string" ? token.id : token.sub ?? "";
         session.user.platformRole = token.platformRole ?? null;
         session.user.isSuperuser = token.isSuperuser ?? false;
       }

--- a/apps/web/lib/governance-data.ts
+++ b/apps/web/lib/governance-data.ts
@@ -1,0 +1,109 @@
+import crypto from "node:crypto";
+import { prisma, type Prisma } from "@dpf/db";
+
+export async function getUserTeamIds(userId: string): Promise<string[]> {
+  const memberships = await prisma.teamMembership.findMany({
+    where: { userId },
+    select: { teamId: true },
+  });
+  return memberships.map((membership) => membership.teamId);
+}
+
+export async function getAgentGovernance(agentId: string) {
+  return prisma.agent.findUnique({
+    where: { agentId },
+    select: {
+      id: true,
+      agentId: true,
+      governanceProfile: {
+        select: {
+          autonomyLevel: true,
+          hitlPolicy: true,
+          allowDelegation: true,
+          maxDelegationRiskBand: true,
+          capabilityClass: {
+            select: {
+              capabilityClassId: true,
+              riskBand: true,
+              defaultActionScope: true,
+            },
+          },
+          directivePolicyClass: {
+            select: {
+              policyClassId: true,
+              approvalMode: true,
+              allowedRiskBand: true,
+            },
+          },
+        },
+      },
+      ownerships: {
+        select: {
+          responsibility: true,
+          team: { select: { teamId: true, name: true } },
+        },
+      },
+    },
+  });
+}
+
+export async function getActiveDelegationGrants(params: {
+  grantorUserId?: string;
+  granteeAgentId?: string;
+  now?: Date;
+}) {
+  const now = params.now ?? new Date();
+  return prisma.delegationGrant.findMany({
+    where: {
+      status: "active",
+      validFrom: { lte: now },
+      expiresAt: { gt: now },
+      ...(params.grantorUserId ? { grantorUserId: params.grantorUserId } : {}),
+      ...(params.granteeAgentId ? { granteeAgent: { agentId: params.granteeAgentId } } : {}),
+    },
+    orderBy: { expiresAt: "asc" },
+    select: {
+      id: true,
+      grantId: true,
+      grantorUserId: true,
+      granteeAgentId: true,
+      targetUserId: true,
+      scopeJson: true,
+      riskBand: true,
+      status: true,
+      validFrom: true,
+      expiresAt: true,
+      maxUses: true,
+      useCount: true,
+      workflowKey: true,
+      objectRef: true,
+    },
+  });
+}
+
+export async function createAuthorizationDecisionLog(input: {
+  actorType: "user" | "customer_contact" | "agent";
+  actorRef: string;
+  humanContextRef?: string | null;
+  agentContextRef?: string | null;
+  delegationGrantId?: string | null;
+  actionKey: string;
+  objectRef?: string | null;
+  decision: "allow" | "deny" | "require_approval";
+  rationale: Prisma.InputJsonValue;
+}): Promise<void> {
+  await prisma.authorizationDecisionLog.create({
+    data: {
+      decisionId: crypto.randomUUID(),
+      actorType: input.actorType,
+      actorRef: input.actorRef,
+      humanContextRef: input.humanContextRef ?? null,
+      agentContextRef: input.agentContextRef ?? null,
+      delegationGrantId: input.delegationGrantId ?? null,
+      actionKey: input.actionKey,
+      objectRef: input.objectRef ?? null,
+      decision: input.decision,
+      rationale: input.rationale,
+    },
+  });
+}

--- a/apps/web/lib/governance-resolver.test.ts
+++ b/apps/web/lib/governance-resolver.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveGovernedAction } from "./governance-resolver";
+
+describe("resolveGovernedAction", () => {
+  it("allows when human role and agent baseline both permit the action", () => {
+    const result = resolveGovernedAction({
+      humanAllowed: true,
+      agentPolicyAllowed: true,
+      riskBand: "medium",
+      agentMaxRiskBand: "high",
+      activeGrant: null,
+    });
+
+    expect(result.decision).toBe("allow");
+    expect(result.rationaleCode).toBe("baseline_intersection");
+  });
+
+  it("requires approval when request exceeds baseline but grant is possible", () => {
+    const result = resolveGovernedAction({
+      humanAllowed: true,
+      agentPolicyAllowed: true,
+      riskBand: "critical",
+      agentMaxRiskBand: "high",
+      activeGrant: null,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.rationaleCode).toBe("grant_required");
+  });
+
+  it("denies when risk band exceeds both baseline and grant cap", () => {
+    const result = resolveGovernedAction({
+      humanAllowed: true,
+      agentPolicyAllowed: true,
+      riskBand: "critical",
+      agentMaxRiskBand: "high",
+      activeGrant: {
+        maxRiskBand: "high",
+        allowsRequestedScope: true,
+        expiresAt: new Date("2099-03-13T12:00:00Z"),
+        now: new Date("2099-03-13T11:00:00Z"),
+      },
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.rationaleCode).toBe("grant_risk_exceeded");
+  });
+
+  it("allows when a valid grant extends the agent to the requested scope", () => {
+    const result = resolveGovernedAction({
+      humanAllowed: true,
+      agentPolicyAllowed: true,
+      riskBand: "high",
+      agentMaxRiskBand: "medium",
+      activeGrant: {
+        maxRiskBand: "high",
+        allowsRequestedScope: true,
+        expiresAt: new Date("2099-03-13T12:00:00Z"),
+        now: new Date("2099-03-13T11:00:00Z"),
+      },
+    });
+
+    expect(result.decision).toBe("allow");
+    expect(result.rationaleCode).toBe("delegation_grant");
+  });
+});

--- a/apps/web/lib/governance-resolver.ts
+++ b/apps/web/lib/governance-resolver.ts
@@ -1,0 +1,67 @@
+import type { GovernanceDecision, RiskBand } from "./governance-types";
+
+const RISK_BAND_ORDER: Record<RiskBand, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+type ActiveGrant = {
+  maxRiskBand: RiskBand;
+  allowsRequestedScope: boolean;
+  expiresAt: Date;
+  now: Date;
+};
+
+export type ResolveGovernedActionInput = {
+  humanAllowed: boolean;
+  agentPolicyAllowed: boolean;
+  riskBand: RiskBand;
+  agentMaxRiskBand: RiskBand;
+  activeGrant: ActiveGrant | null;
+};
+
+export type ResolveGovernedActionResult = {
+  decision: GovernanceDecision;
+  rationaleCode:
+    | "human_context_denied"
+    | "agent_policy_denied"
+    | "grant_required"
+    | "grant_expired"
+    | "grant_scope_denied"
+    | "grant_risk_exceeded"
+    | "baseline_intersection"
+    | "delegation_grant";
+};
+
+function exceedsRiskBand(requested: RiskBand, allowed: RiskBand): boolean {
+  return RISK_BAND_ORDER[requested] > RISK_BAND_ORDER[allowed];
+}
+
+function allow(rationaleCode: ResolveGovernedActionResult["rationaleCode"]): ResolveGovernedActionResult {
+  return { decision: "allow", rationaleCode };
+}
+
+function deny(rationaleCode: ResolveGovernedActionResult["rationaleCode"]): ResolveGovernedActionResult {
+  return { decision: "deny", rationaleCode };
+}
+
+function requireApproval(rationaleCode: ResolveGovernedActionResult["rationaleCode"]): ResolveGovernedActionResult {
+  return { decision: "require_approval", rationaleCode };
+}
+
+export function resolveGovernedAction(input: ResolveGovernedActionInput): ResolveGovernedActionResult {
+  if (!input.humanAllowed) return deny("human_context_denied");
+  if (!input.agentPolicyAllowed) return deny("agent_policy_denied");
+
+  const withinBaselineRisk = !exceedsRiskBand(input.riskBand, input.agentMaxRiskBand);
+  if (withinBaselineRisk) return allow("baseline_intersection");
+
+  if (!input.activeGrant) return requireApproval("grant_required");
+  if (input.activeGrant.expiresAt <= input.activeGrant.now) return requireApproval("grant_expired");
+  if (!input.activeGrant.allowsRequestedScope) return deny("grant_scope_denied");
+  if (exceedsRiskBand(input.riskBand, input.activeGrant.maxRiskBand)) return deny("grant_risk_exceeded");
+
+  return allow("delegation_grant");
+}

--- a/apps/web/lib/governance-types.ts
+++ b/apps/web/lib/governance-types.ts
@@ -1,0 +1,48 @@
+export type RiskBand = "low" | "medium" | "high" | "critical";
+
+export type GovernanceDecision = "allow" | "deny" | "require_approval";
+
+export type DefaultActionScope = {
+  actionFamilies: string[];
+  resourceTypes: string[];
+  maxRiskBand: RiskBand;
+  constraints?: {
+    tenantScoped?: boolean;
+    teamScoped?: boolean;
+    objectRefs?: string[];
+  };
+};
+
+export type DelegationGrantScope = {
+  actionFamilies: string[];
+  resourceTypes: string[];
+  maxRiskBand: RiskBand;
+  objectRefs?: string[];
+  workflowKeys?: string[];
+  constraints?: {
+    tenantScoped?: boolean;
+    teamScoped?: boolean;
+    singleTargetUserId?: string;
+  };
+};
+
+export type PrincipalContext = {
+  authenticatedSubject:
+    | { kind: "user"; userId: string }
+    | { kind: "customer_contact"; contactId: string };
+  actingHuman:
+    | { kind: "user"; userId: string }
+    | { kind: "customer_contact"; contactId: string };
+  actingAgent?: { agentId: string };
+  teamIds: string[];
+  platformRoleIds: string[];
+  effectiveCapabilities: string[];
+  delegationGrantIds: string[];
+};
+
+export type AuthorityRequest = {
+  actionKey: string;
+  objectRef?: string;
+  riskBand: RiskBand;
+  actingAgentId?: string | null;
+};

--- a/apps/web/lib/permissions.test.ts
+++ b/apps/web/lib/permissions.test.ts
@@ -48,14 +48,14 @@ describe("getWorkspaceTiles()", () => {
 
   it("HR-500 only gets tiles they can access", () => {
     const tiles = getWorkspaceTiles(hr500).map((t) => t.key);
-    expect(tiles).toContain("operations");
-    expect(tiles).not.toContain("ea_modeler");
+    expect(tiles).toContain("backlog");
+    expect(tiles).not.toContain("agents");
     expect(tiles).not.toContain("admin");
   });
 
-  it("HR-300 gets EA Modeler, Portfolio, Inventory", () => {
+  it("HR-300 gets Agents, Portfolio, Inventory", () => {
     const tiles = getWorkspaceTiles(hr300).map((t) => t.key);
-    expect(tiles).toContain("ea_modeler");
+    expect(tiles).toContain("agents");
     expect(tiles).toContain("portfolio");
     expect(tiles).toContain("inventory");
   });

--- a/apps/web/lib/permissions.ts
+++ b/apps/web/lib/permissions.ts
@@ -18,6 +18,7 @@ export type CapabilityKey =
   | "manage_agents"
   | "manage_capabilities"
   | "manage_users"
+  | "manage_user_lifecycle"
   | "manage_provider_connections"
   | "manage_backlog"
   | "manage_ea_model";
@@ -40,6 +41,7 @@ const PERMISSIONS: Record<CapabilityKey, Permission> = {
   manage_agents:               { roles: ["HR-000"] },
   manage_capabilities:         { roles: ["HR-000"] },
   manage_users:                { roles: ["HR-000"] },
+  manage_user_lifecycle:       { roles: ["HR-000", "HR-100", "HR-200", "HR-300", "HR-400", "HR-500"] },
   manage_provider_connections: { roles: ["HR-000"] },
   manage_backlog:              { roles: ["HR-000", "HR-500"] },
   manage_ea_model:             { roles: ["HR-000", "HR-300"] },

--- a/apps/web/lib/principal-context.test.ts
+++ b/apps/web/lib/principal-context.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildPrincipalContext } from "./principal-context";
+
+describe("buildPrincipalContext", () => {
+  it("builds human-only context from a session user", () => {
+    const ctx = buildPrincipalContext({
+      sessionUser: {
+        id: "usr_1",
+        email: "manager@example.com",
+        platformRole: "HR-100",
+        isSuperuser: false,
+      },
+      teamIds: ["team_ops"],
+      actingAgentId: null,
+      delegationGrantIds: [],
+    });
+
+    expect(ctx.authenticatedSubject).toEqual({ kind: "user", userId: "usr_1" });
+    expect(ctx.actingHuman).toEqual({ kind: "user", userId: "usr_1" });
+    expect(ctx.platformRoleIds).toEqual(["HR-100"]);
+    expect(ctx.teamIds).toEqual(["team_ops"]);
+    expect(ctx.actingAgent).toBeUndefined();
+  });
+
+  it("adds acting agent and delegation grants when present", () => {
+    const ctx = buildPrincipalContext({
+      sessionUser: {
+        id: "usr_1",
+        email: "manager@example.com",
+        platformRole: "HR-100",
+        isSuperuser: false,
+      },
+      teamIds: ["team_ops"],
+      actingAgentId: "AGT-100",
+      delegationGrantIds: ["DGR-001"],
+    });
+
+    expect(ctx.actingAgent?.agentId).toBe("AGT-100");
+    expect(ctx.delegationGrantIds).toEqual(["DGR-001"]);
+  });
+});

--- a/apps/web/lib/principal-context.ts
+++ b/apps/web/lib/principal-context.ts
@@ -1,0 +1,25 @@
+import type { PrincipalContext } from "./governance-types";
+
+type SessionUser = {
+  id: string;
+  email: string;
+  platformRole: string | null;
+  isSuperuser: boolean;
+};
+
+export function buildPrincipalContext(input: {
+  sessionUser: SessionUser;
+  teamIds: string[];
+  actingAgentId: string | null;
+  delegationGrantIds: string[];
+}): PrincipalContext {
+  return {
+    authenticatedSubject: { kind: "user", userId: input.sessionUser.id },
+    actingHuman: { kind: "user", userId: input.sessionUser.id },
+    ...(input.actingAgentId ? { actingAgent: { agentId: input.actingAgentId } } : {}),
+    teamIds: input.teamIds,
+    platformRoleIds: input.sessionUser.platformRole ? [input.sessionUser.platformRole] : [],
+    effectiveCapabilities: [],
+    delegationGrantIds: input.delegationGrantIds,
+  };
+}

--- a/docs/superpowers/plans/2026-03-13-unified-identity-access-agent-governance-foundation.md
+++ b/docs/superpowers/plans/2026-03-13-unified-identity-access-agent-governance-foundation.md
@@ -19,6 +19,7 @@ This plan intentionally implements only the first working slice from the spec:
 - delegation grant creation and audit logging
 - HR/admin action integration
 - governance visibility in `/platform` and `/ea/agents`
+- typed application shapes for `AgentCapabilityClass.defaultActionScope` and `DelegationGrant.scopeJson`
 
 This plan does **not** implement:
 
@@ -26,6 +27,7 @@ This plan does **not** implement:
 - CRM/customer portal flows
 - raw agent config payloads/editor
 - end-to-end agent execution integration with prompt/tool runtime
+- agent-to-agent delegation
 
 Those remain separate follow-on plans.
 
@@ -337,9 +339,13 @@ Create `apps/web/lib/governance-types.ts` with:
 ```ts
 export type RiskBand = "low" | "medium" | "high" | "critical";
 export type GovernanceDecision = "allow" | "deny" | "require_approval";
+export type DefaultActionScope = { ... };
+export type DelegationGrantScope = { ... };
 export type PrincipalContext = { ... };
 export type AuthorityRequest = { actionKey: string; objectRef?: string; riskBand: RiskBand; actingAgentId?: string | null; };
 ```
+
+`DefaultActionScope` and `DelegationGrantScope` must match the draft shapes documented in the spec. Do not leave these as untyped `Record<string, unknown>`.
 
 - [ ] **Step 4: Implement `buildPrincipalContext`**
 

--- a/docs/superpowers/plans/2026-03-13-unified-identity-access-agent-governance-foundation.md
+++ b/docs/superpowers/plans/2026-03-13-unified-identity-access-agent-governance-foundation.md
@@ -1,0 +1,831 @@
+# Unified Identity, Access, and Agent Governance Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first working slice of the shared identity, access, delegation, and agent-governance foundation, then wire it into current HR/admin actions and agent registry visibility without touching raw agent-config internals.
+
+**Architecture:** Keep the existing `User`, `CustomerContact`, `PlatformRole`, `UserGroup`, and `Agent` models. Add governance-overlay tables in Prisma, a runtime `PrincipalContext` builder, and an authorization resolver in `apps/web/lib`. Prove the slice by auditing current user-management actions, adding bounded delegation-grant workflows, and surfacing governance state in `/platform` and `/ea/agents`.
+
+**Tech Stack:** Prisma 5, PostgreSQL, Next.js App Router, NextAuth v5 beta, React 18, TypeScript, Vitest
+
+---
+
+## Scope Guard
+
+This plan intentionally implements only the first working slice from the spec:
+
+- shared governance schema
+- runtime authority resolver
+- delegation grant creation and audit logging
+- HR/admin action integration
+- governance visibility in `/platform` and `/ea/agents`
+
+This plan does **not** implement:
+
+- full `EmployeeProfile`
+- CRM/customer portal flows
+- raw agent config payloads/editor
+- end-to-end agent execution integration with prompt/tool runtime
+
+Those remain separate follow-on plans.
+
+---
+
+## File Structure
+
+### Database and model layer
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/20260313090000_identity_governance_foundation/migration.sql`
+- Modify: `packages/db/src/index.ts`
+- Modify: `packages/db/src/seed.ts`
+- Create: `packages/db/src/governance-seed.ts`
+- Create: `packages/db/src/governance-seed.test.ts`
+
+### Runtime authz and governance library
+
+- Create: `apps/web/lib/governance-types.ts`
+- Create: `apps/web/lib/principal-context.ts`
+- Create: `apps/web/lib/governance-resolver.ts`
+- Create: `apps/web/lib/governance-data.ts`
+- Create: `apps/web/lib/principal-context.test.ts`
+- Create: `apps/web/lib/governance-resolver.test.ts`
+
+### Server actions
+
+- Create: `apps/web/lib/actions/governance.ts`
+- Modify: `apps/web/lib/actions/users.ts`
+- Create: `apps/web/lib/actions/governance.test.ts`
+
+### Auth/session integration
+
+- Modify: `apps/web/lib/auth.ts`
+- Modify: `apps/web/lib/auth.test.ts`
+
+### UI surfaces
+
+- Create: `apps/web/components/platform/GovernanceOverviewPanel.tsx`
+- Create: `apps/web/components/platform/DelegationGrantPanel.tsx`
+- Create: `apps/web/components/ea/AgentGovernanceCard.tsx`
+- Modify: `apps/web/app/(shell)/platform/page.tsx`
+- Modify: `apps/web/app/(shell)/ea/agents/page.tsx`
+- Modify: `apps/web/app/(shell)/employee/page.tsx`
+- Modify: `apps/web/components/employee/HrUserLifecyclePanel.tsx`
+- Modify: `apps/web/components/admin/AdminUserAccessPanel.tsx`
+- Create: `apps/web/app/(shell)/platform/page.test.tsx`
+
+### Permission bridge
+
+- Modify: `apps/web/lib/permissions.ts`
+- Modify: `apps/web/lib/permissions.test.ts`
+
+### Documentation
+
+- Modify: `docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md`
+
+---
+
+## Chunk 1: Data Foundation
+
+### Task 1: Add governance Prisma models
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/20260313090000_identity_governance_foundation/migration.sql`
+
+- [ ] **Step 1: Add a failing schema-level reference list to the spec margin**
+
+Append a short implementation note to the spec listing the exact new models to add:
+
+```md
+Implementation slice 1 models:
+- Team
+- TeamMembership
+- AgentOwnership
+- AgentCapabilityClass
+- DirectivePolicyClass
+- AgentGovernanceProfile
+- DelegationGrant
+- AuthorizationDecisionLog
+```
+
+- [ ] **Step 2: Add the new Prisma models to `schema.prisma`**
+
+Follow the same style as existing models. Add:
+
+```prisma
+model Team {
+  id          String   @id @default(cuid())
+  teamId      String   @unique
+  name        String
+  slug        String   @unique
+  description String?
+  status      String   @default("active")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  memberships TeamMembership[]
+  ownerships  AgentOwnership[]
+}
+```
+
+Also add:
+
+```prisma
+model TeamMembership { ... }
+model AgentOwnership { ... }
+model AgentCapabilityClass { ... }
+model DirectivePolicyClass { ... }
+model AgentGovernanceProfile { ... }
+model DelegationGrant { ... }
+model AuthorizationDecisionLog { ... }
+```
+
+Use nullable FKs where the slice needs room for ungoverned existing records, especially around optional object refs and delegation links.
+
+- [ ] **Step 3: Add relation fields to existing models**
+
+Update existing models with back-relations only where required:
+
+```prisma
+model User {
+  ...
+  teamMemberships      TeamMembership[]
+  grantedDelegations   DelegationGrant[] @relation("DelegationGrantGrantor")
+}
+
+model Agent {
+  ...
+  ownerships           AgentOwnership[]
+  governanceProfile    AgentGovernanceProfile?
+  delegationGrants     DelegationGrant[]
+}
+```
+
+Do not refactor `CustomerContact` in this slice beyond what is needed for future compatibility.
+
+- [ ] **Step 4: Create the SQL migration file**
+
+Create `packages/db/prisma/migrations/20260313090000_identity_governance_foundation/migration.sql` with explicit `CREATE TABLE`, `CREATE INDEX`, and FK statements matching the Prisma schema.
+
+Use:
+
+```sql
+CREATE TABLE "Team" (...);
+CREATE UNIQUE INDEX "Team_teamId_key" ON "Team"("teamId");
+CREATE UNIQUE INDEX "Team_slug_key" ON "Team"("slug");
+```
+
+Repeat for all new tables. Add:
+
+- cascade delete for pure join/ownership relationships
+- restrictive or no-action behavior for logs
+- indexes for `grantorUserId`, `granteeAgentId`, `expiresAt`, `decision`, and `createdAt`
+
+- [ ] **Step 5: Run Prisma validation**
+
+Run: `pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma`
+
+Expected: `The schema at prisma/schema.prisma is valid`
+
+- [ ] **Step 6: Generate the client**
+
+Run: `pnpm --filter @dpf/db generate`
+
+Expected: Prisma client regenerated with the new governance models.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations/20260313090000_identity_governance_foundation/migration.sql docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
+git commit -m "feat(db): add identity governance foundation schema"
+```
+
+### Task 2: Seed only bootstrap governance reference data
+
+**Files:**
+- Modify: `packages/db/src/seed.ts`
+- Create: `packages/db/src/governance-seed.ts`
+- Create: `packages/db/src/governance-seed.test.ts`
+
+- [ ] **Step 1: Write failing tests for governance seed helpers**
+
+Create `packages/db/src/governance-seed.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getDefaultCapabilityClasses, getDefaultDirectivePolicyClasses } from "./governance-seed";
+
+describe("governance seed defaults", () => {
+  it("returns stable capability classes", () => {
+    expect(getDefaultCapabilityClasses().map((c) => c.capabilityClassId)).toEqual([
+      "cap-advisory",
+      "cap-operator",
+      "cap-specialist",
+      "cap-elevated",
+    ]);
+  });
+
+  it("returns stable directive policy classes", () => {
+    expect(getDefaultDirectivePolicyClasses().map((p) => p.policyClassId)).toContain("dir-workflow-standard");
+  });
+});
+```
+
+- [ ] **Step 2: Run the DB test suite to verify the new test fails**
+
+Run: `pnpm --filter @dpf/db test`
+
+Expected: FAIL because `governance-seed.ts` does not exist yet.
+
+- [ ] **Step 3: Implement minimal seed default helpers**
+
+Create `packages/db/src/governance-seed.ts`:
+
+```ts
+export function getDefaultCapabilityClasses() {
+  return [
+    { capabilityClassId: "cap-advisory", name: "Advisory", riskBand: "low" },
+    { capabilityClassId: "cap-operator", name: "Operator", riskBand: "medium" },
+    { capabilityClassId: "cap-specialist", name: "Specialist", riskBand: "high" },
+    { capabilityClassId: "cap-elevated", name: "Elevated", riskBand: "critical" },
+  ];
+}
+```
+
+Also export `getDefaultDirectivePolicyClasses()` with stable IDs and approval modes.
+
+- [ ] **Step 4: Wire bootstrap-only seed data into `seed.ts`**
+
+Import and call a new `seedGovernanceReferenceData()` function from `packages/db/src/seed.ts`.
+
+Seed only:
+
+- `AgentCapabilityClass`
+- `DirectivePolicyClass`
+
+Do **not** seed live runtime team assignments, grants, or ownership records. Respect the repo guardrail that seed data is bootstrap default data, not runtime truth.
+
+- [ ] **Step 5: Re-run DB tests**
+
+Run: `pnpm --filter @dpf/db test`
+
+Expected: PASS for the new seed helper test and existing DB tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/db/src/seed.ts packages/db/src/governance-seed.ts packages/db/src/governance-seed.test.ts
+git commit -m "feat(db): seed governance reference defaults"
+```
+
+---
+
+## Chunk 2: Runtime Authorization Layer
+
+### Task 3: Introduce runtime governance types and `PrincipalContext`
+
+**Files:**
+- Create: `apps/web/lib/governance-types.ts`
+- Create: `apps/web/lib/principal-context.ts`
+- Create: `apps/web/lib/principal-context.test.ts`
+- Modify: `apps/web/lib/auth.ts`
+
+- [ ] **Step 1: Write failing tests for `PrincipalContext` assembly**
+
+Create `apps/web/lib/principal-context.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildPrincipalContext } from "./principal-context";
+
+describe("buildPrincipalContext", () => {
+  it("builds human-only context from a session user", () => {
+    const ctx = buildPrincipalContext({
+      sessionUser: { id: "usr_1", email: "manager@example.com", platformRole: "HR-100", isSuperuser: false },
+      teamIds: ["team_ops"],
+      actingAgentId: null,
+      delegationGrantIds: [],
+    });
+    expect(ctx.platformRoleIds).toEqual(["HR-100"]);
+    expect(ctx.actingAgent).toBeUndefined();
+  });
+
+  it("adds acting agent and delegation grants when present", () => {
+    const ctx = buildPrincipalContext({
+      sessionUser: { id: "usr_1", email: "manager@example.com", platformRole: "HR-100", isSuperuser: false },
+      teamIds: ["team_ops"],
+      actingAgentId: "AGT-100",
+      delegationGrantIds: ["DGR-001"],
+    });
+    expect(ctx.actingAgent?.agentId).toBe("AGT-100");
+    expect(ctx.delegationGrantIds).toEqual(["DGR-001"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the targeted web test to confirm failure**
+
+Run: `pnpm --filter web test -- apps/web/lib/principal-context.test.ts`
+
+Expected: FAIL because `principal-context.ts` does not exist yet.
+
+- [ ] **Step 3: Implement shared governance types**
+
+Create `apps/web/lib/governance-types.ts` with:
+
+```ts
+export type RiskBand = "low" | "medium" | "high" | "critical";
+export type GovernanceDecision = "allow" | "deny" | "require_approval";
+export type PrincipalContext = { ... };
+export type AuthorityRequest = { actionKey: string; objectRef?: string; riskBand: RiskBand; actingAgentId?: string | null; };
+```
+
+- [ ] **Step 4: Implement `buildPrincipalContext`**
+
+Create `apps/web/lib/principal-context.ts`:
+
+```ts
+import type { PrincipalContext } from "./governance-types";
+
+export function buildPrincipalContext(input: { ... }): PrincipalContext {
+  return {
+    authenticatedSubject: { kind: "user", userId: input.sessionUser.id },
+    actingHuman: { kind: "user", userId: input.sessionUser.id },
+    ...(input.actingAgentId ? { actingAgent: { agentId: input.actingAgentId } } : {}),
+    teamIds: input.teamIds,
+    platformRoleIds: input.sessionUser.platformRole ? [input.sessionUser.platformRole] : [],
+    effectiveCapabilities: [],
+    delegationGrantIds: input.delegationGrantIds,
+  };
+}
+```
+
+- [ ] **Step 5: Extend auth session typing**
+
+Modify `apps/web/lib/auth.ts` so the session user includes only what this slice needs:
+
+```ts
+export type DpfSession = {
+  user: {
+    id: string;
+    email: string;
+    platformRole: string | null;
+    isSuperuser: boolean;
+  };
+};
+```
+
+If needed, update callback assignments so `session.user.id` is reliably populated.
+
+- [ ] **Step 6: Re-run tests**
+
+Run: `pnpm --filter web test -- apps/web/lib/principal-context.test.ts apps/web/lib/auth.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/governance-types.ts apps/web/lib/principal-context.ts apps/web/lib/principal-context.test.ts apps/web/lib/auth.ts
+git commit -m "feat(web): add principal context foundation"
+```
+
+### Task 4: Build the authorization resolver and decision logging contract
+
+**Files:**
+- Create: `apps/web/lib/governance-resolver.ts`
+- Create: `apps/web/lib/governance-data.ts`
+- Create: `apps/web/lib/governance-resolver.test.ts`
+- Modify: `apps/web/lib/permissions.ts`
+- Modify: `apps/web/lib/permissions.test.ts`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Create `apps/web/lib/governance-resolver.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { resolveGovernedAction } from "./governance-resolver";
+
+describe("resolveGovernedAction", () => {
+  it("allows when human role and agent baseline both permit the action", () => {
+    const result = resolveGovernedAction({ ...baselineAllowedFixture });
+    expect(result.decision).toBe("allow");
+  });
+
+  it("requires approval when request exceeds baseline but grant is possible", () => {
+    const result = resolveGovernedAction({ ...grantableFixture });
+    expect(result.decision).toBe("require_approval");
+  });
+
+  it("denies when risk band exceeds both baseline and grant cap", () => {
+    const result = resolveGovernedAction({ ...criticalFixture });
+    expect(result.decision).toBe("deny");
+  });
+});
+```
+
+- [ ] **Step 2: Run the targeted web test to confirm failure**
+
+Run: `pnpm --filter web test -- apps/web/lib/governance-resolver.test.ts`
+
+Expected: FAIL because the resolver does not exist yet.
+
+- [ ] **Step 3: Implement minimal pure resolver**
+
+Create `apps/web/lib/governance-resolver.ts` with a pure function:
+
+```ts
+export function resolveGovernedAction(input: ResolveGovernedActionInput): ResolveGovernedActionResult {
+  if (!input.humanAllowed) return deny("human_context_denied");
+  if (!input.agentPolicyAllowed) return deny("agent_policy_denied");
+  if (input.riskBand > input.agentMaxRiskBand && !input.activeGrant) return requireApproval("grant_required");
+  if (input.activeGrant && input.activeGrant.allowsRequestedScope) return allow("delegation_grant");
+  return allow("baseline_intersection");
+}
+```
+
+Use real enums/string unions, not the pseudo comparison above. Implement helper functions for:
+
+- risk-band ordering
+- decision rationale building
+- grant-expiry validation
+
+- [ ] **Step 4: Add DB-backed read helpers**
+
+Create `apps/web/lib/governance-data.ts` with focused read-model functions:
+
+- `getUserTeamIds(userId: string): Promise<string[]>`
+- `getAgentGovernance(agentId: string): Promise<... | null>`
+- `getActiveDelegationGrants(params): Promise<...[]>`
+- `createAuthorizationDecisionLog(input): Promise<void>`
+
+Use Prisma select shapes only for fields required by the resolver.
+
+- [ ] **Step 5: Bridge existing coarse capabilities**
+
+Modify `apps/web/lib/permissions.ts` minimally:
+
+- keep `can()` for route-level gating
+- export a helper that maps current `CapabilityKey` to action-family hints if needed by governed actions later
+
+Do not replace the existing permission matrix in this slice.
+
+- [ ] **Step 6: Re-run targeted tests**
+
+Run: `pnpm --filter web test -- apps/web/lib/governance-resolver.test.ts apps/web/lib/permissions.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/governance-resolver.ts apps/web/lib/governance-data.ts apps/web/lib/governance-resolver.test.ts apps/web/lib/permissions.ts apps/web/lib/permissions.test.ts
+git commit -m "feat(web): add governed action resolver"
+```
+
+---
+
+## Chunk 3: Actions and UX Integration
+
+### Task 5: Add governance server actions and delegation-grant creation
+
+**Files:**
+- Create: `apps/web/lib/actions/governance.ts`
+- Create: `apps/web/lib/actions/governance.test.ts`
+
+- [ ] **Step 1: Write failing tests for grant validation**
+
+Create `apps/web/lib/actions/governance.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { validateDelegationGrantInput } from "./governance";
+
+describe("validateDelegationGrantInput", () => {
+  it("rejects expiry before validFrom", () => {
+    expect(validateDelegationGrantInput({
+      granteeAgentId: "agent_1",
+      riskBand: "high",
+      validFrom: new Date("2026-03-13T10:00:00Z"),
+      expiresAt: new Date("2026-03-13T09:00:00Z"),
+      scopeJson: {},
+    })).toMatch(/expires/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the targeted web test to confirm failure**
+
+Run: `pnpm --filter web test -- apps/web/lib/actions/governance.test.ts`
+
+Expected: FAIL because the module does not exist yet.
+
+- [ ] **Step 3: Implement minimal validation helpers**
+
+In `apps/web/lib/actions/governance.ts`, add:
+
+```ts
+export function validateDelegationGrantInput(input: DelegationGrantInput): string | null {
+  if (input.expiresAt <= input.validFrom) return "Grant expiry must be after the start time.";
+  if (!input.granteeAgentId) return "Select an agent.";
+  return null;
+}
+```
+
+- [ ] **Step 4: Add authenticated server actions**
+
+In the same file, implement:
+
+- `createDelegationGrant(input)`
+- `revokeDelegationGrant(grantId)`
+- `assignAgentGovernanceProfile(input)`
+- `assignAgentOwnership(input)`
+
+For this slice:
+
+- require authenticated `User`
+- gate with `manage_users`, `manage_user_lifecycle`, or `manage_agents` as appropriate
+- call the resolver before persisting grants
+- write `AuthorizationDecisionLog` for success and deny outcomes
+- revalidate `/platform`, `/employee`, and `/ea/agents`
+
+- [ ] **Step 5: Re-run tests**
+
+Run: `pnpm --filter web test -- apps/web/lib/actions/governance.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/lib/actions/governance.ts apps/web/lib/actions/governance.test.ts
+git commit -m "feat(web): add governance server actions"
+```
+
+### Task 6: Audit and govern current HR/admin actions
+
+**Files:**
+- Modify: `apps/web/lib/actions/users.ts`
+- Modify: `apps/web/components/employee/HrUserLifecyclePanel.tsx`
+- Modify: `apps/web/components/admin/AdminUserAccessPanel.tsx`
+
+- [ ] **Step 1: Add a failing test for auditable lifecycle updates**
+
+If `apps/web/lib/actions/users.ts` has no test file yet, create a narrow test near the new governance test file or extend `governance.test.ts` with a pure helper test:
+
+```ts
+it("returns a governance denial when non-superuser tries to modify a protected account", async () => {
+  const result = await summarizeGovernedLifecycleAttempt({ actorIsSuperuser: false, targetIsSuperuser: true });
+  expect(result.decision).toBe("deny");
+});
+```
+
+Keep the pure decision helper separate from DB I/O.
+
+- [ ] **Step 2: Add a reusable governed-action wrapper**
+
+In `apps/web/lib/actions/users.ts`, introduce a focused helper:
+
+```ts
+async function withGovernedUserAction(input: {
+  capability: "manage_users" | "manage_user_lifecycle";
+  actionKey: string;
+  riskBand: "medium" | "high";
+  run: (actor: SessionUserContext) => Promise<UserActionResult>;
+}): Promise<UserActionResult> { ... }
+```
+
+This helper should:
+
+- resolve session user
+- load `PrincipalContext`
+- evaluate baseline governance
+- write `AuthorizationDecisionLog`
+- either deny or call `run()`
+
+- [ ] **Step 3: Wrap existing actions**
+
+Refactor:
+
+- `createUserAccount`
+- `adminResetUserPassword`
+- `updateUserLifecycle`
+
+Each should use `withGovernedUserAction(...)`.
+
+Suggested action keys:
+
+- `user.create`
+- `user.password_reset`
+- `user.lifecycle_update`
+
+- [ ] **Step 4: Surface governance messages in the panels**
+
+Update:
+
+- `apps/web/components/admin/AdminUserAccessPanel.tsx`
+- `apps/web/components/employee/HrUserLifecyclePanel.tsx`
+
+So returned messages can show:
+
+- direct success/failure
+- governance deny reasons
+- grant/approval requirement messages when added later
+
+Do not redesign the panels; keep the existing UI structure.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+pnpm --filter web test -- apps/web/lib/actions/governance.test.ts apps/web/lib/auth.test.ts apps/web/lib/permissions.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: PASS and 0 type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/lib/actions/users.ts apps/web/components/employee/HrUserLifecyclePanel.tsx apps/web/components/admin/AdminUserAccessPanel.tsx
+git commit -m "feat(web): govern and audit user lifecycle actions"
+```
+
+### Task 7: Surface governance state in `/platform` and `/ea/agents`
+
+**Files:**
+- Create: `apps/web/components/platform/GovernanceOverviewPanel.tsx`
+- Create: `apps/web/components/platform/DelegationGrantPanel.tsx`
+- Create: `apps/web/components/ea/AgentGovernanceCard.tsx`
+- Modify: `apps/web/app/(shell)/platform/page.tsx`
+- Modify: `apps/web/app/(shell)/ea/agents/page.tsx`
+- Create: `apps/web/app/(shell)/platform/page.test.tsx`
+
+- [ ] **Step 1: Write a failing page/component test for governance visibility**
+
+Create `apps/web/app/(shell)/platform/page.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { GovernanceOverviewPanel } from "@/components/platform/GovernanceOverviewPanel";
+
+it("renders governance counts and recent delegation grants", () => {
+  render(
+    <GovernanceOverviewPanel
+      summary={{ teams: 2, governedAgents: 5, activeGrants: 1, pendingApprovals: 0 }}
+      recentGrants={[{ grantId: "DGR-001", agentName: "Ops Agent", grantorLabel: "manager@example.com", status: "active" }]}
+    />
+  );
+  expect(screen.getByText(/governed agents/i)).toBeInTheDocument();
+  expect(screen.getByText("DGR-001")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the targeted web test to confirm failure**
+
+Run: `pnpm --filter web test -- "apps/web/app/(shell)/platform/page.test.tsx"`
+
+Expected: FAIL because the panel does not exist yet.
+
+- [ ] **Step 3: Implement focused presentation components**
+
+Create:
+
+- `GovernanceOverviewPanel.tsx`
+- `DelegationGrantPanel.tsx`
+- `AgentGovernanceCard.tsx`
+
+Keep them small and data-driven. Example prop shapes:
+
+```ts
+type GovernanceSummary = {
+  teams: number;
+  governedAgents: number;
+  activeGrants: number;
+  pendingApprovals: number;
+};
+```
+
+`AgentGovernanceCard` should display:
+
+- `agentId`
+- `name`
+- owning team or `Ungoverned`
+- capability class or `Unassigned`
+- autonomy level or `Unset`
+- active grant badge if present
+
+- [ ] **Step 4: Extend the `/platform` page**
+
+Modify `apps/web/app/(shell)/platform/page.tsx` to query:
+
+- counts from governance tables
+- recent active delegation grants
+- existing platform capability cards
+
+Render the new governance overview above the current capability cards.
+
+- [ ] **Step 5: Extend the `/ea/agents` page**
+
+Modify `apps/web/app/(shell)/ea/agents/page.tsx`:
+
+- join in `governanceProfile`, `ownerships`, and active grant count
+- replace the inline card markup with `AgentGovernanceCard`
+
+Keep the tier-grouped structure intact.
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm --filter web test -- "apps/web/app/(shell)/platform/page.test.tsx"
+pnpm --filter web typecheck
+```
+
+Expected: PASS and 0 type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/components/platform/GovernanceOverviewPanel.tsx apps/web/components/platform/DelegationGrantPanel.tsx apps/web/components/ea/AgentGovernanceCard.tsx apps/web/app/(shell)/platform/page.tsx apps/web/app/(shell)/ea/agents/page.tsx apps/web/app/(shell)/platform/page.test.tsx
+git commit -m "feat(web): add governance visibility to platform and agent registry"
+```
+
+### Task 8: Final verification and doc sync
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md`
+
+- [ ] **Step 1: Update the spec status notes**
+
+Add a brief implementation-status note at the top of the spec:
+
+```md
+Implementation status:
+- slice 1 delivered: governance schema, resolver, grants, audit, platform/agent visibility
+- deferred: employee profile, CRM/customer portal flows, deep agent runtime integration
+```
+
+- [ ] **Step 2: Run the full verification set**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test
+pnpm --filter @dpf/db generate
+pnpm --filter web test
+pnpm --filter web typecheck
+```
+
+Expected:
+
+- DB tests PASS
+- Prisma client generates cleanly
+- web tests PASS
+- web typecheck returns 0 errors
+
+- [ ] **Step 3: Manually verify the main UI paths**
+
+Run: `pnpm --filter web dev`
+
+Check:
+
+- `/platform` shows governance summary plus existing capability cards
+- `/ea/agents` shows governance metadata for agents
+- `/employee` lifecycle updates still work
+- `/admin` create/reset flows still work
+- denied governed actions show human-readable messages
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
+git commit -m "docs: sync governance spec with slice 1 delivery"
+```
+
+---
+
+## Notes For The Implementer
+
+- Respect `AGENTS.md`: current state comes from the live DB, not seed defaults. Only seed lookup/reference data in `seed.ts`.
+- Keep the route-level `can()` checks. This slice adds governed action enforcement; it does not replace coarse navigation gating.
+- Do not invent a full policy engine. The first slice needs a clear, testable resolver with bounded scope.
+- Keep UI changes additive. Reuse existing `/employee`, `/admin`, `/platform`, and `/ea/agents` surfaces rather than designing a brand-new governance console.
+- Keep agent-config boundaries clean. Governance can classify and approve config categories, but it should not own the raw config payload or editor.
+
+---
+
+## Review Checklist
+
+- [ ] New Prisma models match the spec and keep nullable room for existing live records
+- [ ] Bootstrap seed changes are limited to reference/default tables
+- [ ] `PrincipalContext` is runtime-only and not prematurely persisted
+- [ ] Resolver is pure and covered by focused tests
+- [ ] User-management actions write authorization decision logs
+- [ ] `/platform` and `/ea/agents` expose governance state without major UX churn
+- [ ] Full verification commands pass before any completion claim
+

--- a/docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
+++ b/docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
@@ -49,6 +49,7 @@ This spec adds that shared layer without rewriting the current `User` and `Agent
 - Replacing the current `User`, `CustomerContact`, `PlatformRole`, or `Agent` tables
 - Defining the raw prompt/config schema for agents
 - Building the agent configuration editor or approval UI for config payloads
+- Agent-to-agent delegation in slice 1
 - Designing payroll, benefits, or full HRIS workflows
 - Designing CRM/customer portal flows in detail
 - Implementing every object-level authorization rule in the platform
@@ -296,6 +297,34 @@ model AgentCapabilityClass {
 }
 ```
 
+`defaultActionScope` must not be treated as arbitrary JSON in implementation code. For slice 1, use this draft application shape:
+
+```ts
+type DefaultActionScope = {
+  actionFamilies: string[];
+  resourceTypes: string[];
+  maxRiskBand: "low" | "medium" | "high" | "critical";
+  constraints?: {
+    tenantScoped?: boolean;
+    teamScoped?: boolean;
+    objectRefs?: string[];
+  };
+};
+```
+
+Worked example:
+
+```json
+{
+  "actionFamilies": ["user.lifecycle.read", "user.lifecycle.update"],
+  "resourceTypes": ["user", "employee"],
+  "maxRiskBand": "medium",
+  "constraints": {
+    "teamScoped": true
+  }
+}
+```
+
 ### New: `AgentGovernanceProfile`
 
 Defines the baseline control envelope for an agent.
@@ -364,6 +393,38 @@ model DelegationGrant {
 }
 ```
 
+`scopeJson` also needs a stable application shape. For slice 1, use this draft:
+
+```ts
+type DelegationGrantScope = {
+  actionFamilies: string[];
+  resourceTypes: string[];
+  maxRiskBand: "low" | "medium" | "high" | "critical";
+  objectRefs?: string[];
+  workflowKeys?: string[];
+  constraints?: {
+    tenantScoped?: boolean;
+    teamScoped?: boolean;
+    singleTargetUserId?: string;
+  };
+};
+```
+
+Worked example:
+
+```json
+{
+  "actionFamilies": ["user.lifecycle.update"],
+  "resourceTypes": ["user"],
+  "maxRiskBand": "high",
+  "objectRefs": ["user:cma1abc123"],
+  "workflowKeys": ["hr-offboarding"],
+  "constraints": {
+    "singleTargetUserId": "cma1abc123"
+  }
+}
+```
+
 ### New: `DirectivePolicyClass`
 
 Defines categories and governance semantics for agent directives without storing raw prompt/config payloads.
@@ -418,6 +479,13 @@ model AuthorizationDecisionLog {
 }
 ```
 
+Operational note: this table will grow quickly on an agent-driven platform. Slice 1 should add the indexes needed for immediate query safety, but not attempt full retention engineering yet. A follow-on operational design should cover:
+
+- retention window by decision type
+- archival and export strategy
+- possible partitioning by time
+- summarized reporting tables if decision volume becomes high
+
 ### Application concept: `PrincipalContext`
 
 This does not need to be a table in the first phase. It should exist as a runtime object assembled at request time.
@@ -441,6 +509,14 @@ type PrincipalContext = {
 ```
 
 This gives the authorization layer one consistent runtime envelope even while persistence remains split across current tables.
+
+Near term, `authenticatedSubject` and `actingHuman` are expected to be the same for normal workforce and customer-contact sessions. They are separate fields because later platform modes may need them to differ, for example:
+
+- admin impersonation or support-on-behalf-of workflows
+- delegated execution where one authenticated operator is acting on behalf of another accountable human
+- future service-account or brokered workflow scenarios
+
+Slice 1 does not implement those differentiated modes, but the naming should preserve room for them.
 
 ---
 
@@ -533,6 +609,13 @@ Implication:
 
 This avoids coupling personnel lifecycle rules directly to authorization mechanics.
 
+Downstream contract for HR:
+
+- HR may assume `Team` and `TeamMembership` are the organizational authority layer for internal workforce users
+- HR may add `EmployeeProfile` and relationship or lifecycle fields on top of `User`
+- HR should not create a separate agent-supervision model; it should consume ownership, governance profile, and delegation-grant semantics from this foundation
+- in slice 1, `TeamMembership` is for internal `User` records, not `CustomerContact`
+
 ---
 
 ## Customer And CRM Relationship To This Foundation
@@ -552,6 +635,12 @@ Foundation contract:
 - team ownership and agent governance remain reusable for customer-facing agents
 
 This is why the foundation must be broader than employee-only identity.
+
+Downstream contract for CRM and customer portal work:
+
+- `CustomerContact` remains outside `TeamMembership` in slice 1
+- customer-side users participate through `PrincipalContext`, account scoping, and later customer-governance mappings rather than being treated as internal workforce teammates
+- if a future phase needs customer-facing teams, that should be a distinct extension rather than overloading internal workforce team semantics too early
 
 ---
 

--- a/docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
+++ b/docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
@@ -1,0 +1,825 @@
+# Unified Identity, Access, and Agent Governance Foundation Design
+
+**Date:** 2026-03-13
+**Status:** Draft
+**Scope:** Define the shared identity, access-control, delegation, and agent-governance foundation that HR Core, CRM/customer operator access, and AI agent execution will consume.
+
+---
+
+## Overview
+
+The platform is becoming a recursive digital product factory: it builds software for customers while also operating and improving itself. That requires a control model that treats humans, agents, and business domains as one governed system rather than separate feature silos.
+
+The current codebase already has the raw pieces of this split across separate areas:
+
+- `User`, `PlatformRole`, and `UserGroup` provide human platform access control
+- `CustomerContact` provides customer-side identity records
+- `Agent` provides AI agent registry and portfolio association
+- `AgentThread` and `AgentMessage` provide interaction history
+- `apps/web/lib/permissions.ts` provides a coarse route-level capability matrix
+
+What is missing is the shared governance layer above those models:
+
+- who organizationally owns an agent
+- which human is accountable for an agent's actions
+- which team may use or supervise an agent
+- what the agent is approved to do by default
+- when a human may temporarily delegate elevated authority to an agent
+- how effective authority is resolved at runtime
+- how these decisions are audited and later integrated with an external identity provider
+
+This spec adds that shared layer without rewriting the current `User` and `Agent` models. The design is intentionally additive: it keeps the current data model intact and introduces a governance overlay that can evolve toward a more unified principal model later if needed.
+
+---
+
+## Design Goals
+
+1. Keep humans accountable for agent behavior while allowing meaningful delegation and autonomy.
+2. Let teams, not just individuals, own agents organizationally so responsibility survives personnel changes.
+3. Make effective authority contextual: an agent's authority depends on both its own policy and the current human using it.
+4. Support employees, contractors, internal operators, and future customer-side operators on one governance foundation.
+5. Avoid colliding with separate work on AI agent configuration payloads and editor UX.
+6. Preserve the option to federate authentication to an external identity platform later.
+7. Keep DPF as the source of truth for business governance even if authentication moves elsewhere.
+
+---
+
+## Non-Goals
+
+- Replacing the current `User`, `CustomerContact`, `PlatformRole`, or `Agent` tables
+- Defining the raw prompt/config schema for agents
+- Building the agent configuration editor or approval UI for config payloads
+- Designing payroll, benefits, or full HRIS workflows
+- Designing CRM/customer portal flows in detail
+- Implementing every object-level authorization rule in the platform
+- Replacing the existing `apps/web/lib/permissions.ts` capability layer in one step
+
+---
+
+## Chosen Approach
+
+Three options were considered:
+
+1. Governance overlay on current models
+2. Partial identity consolidation
+3. Full principal rewrite
+
+This spec chooses **option 1**.
+
+Reasoning:
+
+- It fits the current schema and codebase with the least disruption.
+- It can be implemented incrementally without pausing delivery on HR Core, CRM, or agent features.
+- It avoids broad migration churn while still creating a stable long-term contract.
+- It does not step on parallel work around agent configuration internals.
+
+The design should still keep naming and relationships clean enough that a later shift toward a shared principal core remains possible.
+
+---
+
+## Platform Rule Set
+
+The governing rule of the platform is:
+
+**Humans are the accountable authorities. Agents are governed operators.**
+
+Operational implications:
+
+- agents do not own business authority independently
+- an agent may have broad capability, but it may only exercise authority that is valid in the current human and workflow context
+- teams own agents organizationally
+- humans grant runtime authority contextually
+- some actions require explicit, time-bounded delegation grants
+- high-risk actions may require approval even if both the human and the agent would otherwise qualify
+
+This produces the desired UX behavior:
+
+- the agent can appear as a teammate
+- different humans may experience the same agent with different authority envelopes
+- stronger tasks can be routed to more capable agents
+- a manager can temporarily elevate an agent for a specific task
+- all material actions remain attributable to a human chain of accountability
+
+---
+
+## Current-State Anchors
+
+This design builds on the existing schema rather than replacing it:
+
+- `User` is the current internal authenticated human account
+- `UserGroup` joins users to `PlatformRole`
+- `PlatformRole` already carries `roleId`, `hitlTierMin`, and SLA metadata
+- `CustomerContact` is the existing customer-side identity record
+- `Agent` is the current machine teammate registry
+- `AgentThread` and `AgentMessage` already capture user-agent interaction context
+- `permissions.ts` currently maps coarse capabilities to platform roles
+
+This spec treats those as the base identity records and adds a governance layer above them.
+
+---
+
+## Architectural Model
+
+The system is split into five layers:
+
+### 1. Authentication layer
+
+Confirms who is signing in.
+
+Near term:
+
+- local app authentication remains in place
+- `User` and `CustomerContact` remain the authenticated records
+
+Future:
+
+- federation to an external identity provider such as Keycloak, authentik, or ZITADEL is supported through a mapping boundary
+
+### 2. Identity record layer
+
+Represents the raw account records:
+
+- `User`
+- `CustomerContact`
+- `Agent`
+
+These are not yet unified into one table.
+
+### 3. Governance layer
+
+Adds the shared control plane:
+
+- team ownership
+- human-to-team membership
+- agent governance profile
+- capability classes
+- delegation grants
+- directive policy classes
+- authorization decision logging
+
+### 4. Authorization resolution layer
+
+Calculates effective authority for a specific request by combining:
+
+- human session authority
+- team and relationship context
+- agent baseline policy
+- business-object constraints
+- temporary delegation grants
+
+### 5. Experience layer
+
+Exposes the results in the UX:
+
+- route gating
+- action button availability
+- approval prompts
+- delegation grant prompts
+- audit visibility
+- agent-task review flows
+
+---
+
+## Domain Model
+
+This section proposes new models and concepts. Names may still shift during implementation, but the boundaries should remain stable.
+
+### Existing models retained as-is
+
+- `User`
+- `CustomerContact`
+- `PlatformRole`
+- `UserGroup`
+- `Agent`
+
+### New: `Team`
+
+Organizational owner unit for both humans and agents.
+
+Purpose:
+
+- group humans into durable operating units
+- give agents an organizational home
+- support continuity when individual humans change
+
+Suggested fields:
+
+```prisma
+model Team {
+  id          String   @id @default(cuid())
+  teamId      String   @unique
+  name        String
+  slug        String   @unique
+  description String?
+  status      String   @default("active")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+```
+
+### New: `TeamMembership`
+
+Relates internal users to teams and identifies their responsibility mode.
+
+Purpose:
+
+- expresses organizational membership
+- supports team-based ownership and supervision
+- distinguishes member vs manager vs approver style relationships
+
+Suggested fields:
+
+```prisma
+model TeamMembership {
+  id        String   @id @default(cuid())
+  teamId    String
+  userId    String
+  role      String   // member | manager | approver | operator
+  isPrimary Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  team      Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user      User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, userId])
+}
+```
+
+### New: `AgentOwnership`
+
+Makes team ownership explicit and allows primary/secondary responsibility without forcing one human owner.
+
+Purpose:
+
+- teams own agents as durable organizational assets
+- named humans can still be designated as current supervisors or approvers
+
+Suggested fields:
+
+```prisma
+model AgentOwnership {
+  id               String   @id @default(cuid())
+  agentId          String
+  teamId           String
+  responsibility   String   // owning_team | operating_team | approving_team
+  createdAt        DateTime @default(now())
+
+  agent            Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  team             Team  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@unique([agentId, teamId, responsibility])
+}
+```
+
+### New: `AgentCapabilityClass`
+
+Defines what categories of work an agent is built and approved to do.
+
+Purpose:
+
+- supports the "right skill for the right job" model
+- separates capability tier from human authority
+- lets the platform classify simple vs high-complexity agents
+
+Suggested fields:
+
+```prisma
+model AgentCapabilityClass {
+  id                 String   @id @default(cuid())
+  capabilityClassId  String   @unique
+  name               String
+  description        String?
+  riskBand           String   // low | medium | high | critical
+  defaultActionScope Json
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+}
+```
+
+### New: `AgentGovernanceProfile`
+
+Defines the baseline control envelope for an agent.
+
+Purpose:
+
+- autonomy level
+- whether delegation is allowed
+- whether approval is mandatory for certain classes of actions
+- what directive policy class governs the agent
+
+Suggested fields:
+
+```prisma
+model AgentGovernanceProfile {
+  id                    String   @id @default(cuid())
+  agentId               String   @unique
+  capabilityClassId     String
+  autonomyLevel         String   // advisory | constrained_execute | supervised_execute | elevated_execute
+  hitlPolicy            String   // always | risk_based | never_without_grant
+  allowDelegation       Boolean  @default(true)
+  maxDelegationRiskBand String?  // low | medium | high | critical
+  directivePolicyClass  String
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  agent                 Agent                @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  capabilityClass       AgentCapabilityClass @relation(fields: [capabilityClassId], references: [id])
+}
+```
+
+### New: `DelegationGrant`
+
+Time-bounded human-issued authority grants for a specific agent and task scope.
+
+Purpose:
+
+- supports manager-driven temporary elevation
+- creates explicit accountability for elevated execution
+- avoids permanently over-privileging agents
+
+Suggested fields:
+
+```prisma
+model DelegationGrant {
+  id                  String   @id @default(cuid())
+  grantId             String   @unique
+  grantorUserId       String
+  granteeAgentId      String
+  targetUserId        String?  // optional human beneficiary/operator context
+  scopeJson           Json
+  reason              String?
+  riskBand            String
+  status              String   @default("active") // active | expired | revoked | consumed
+  validFrom           DateTime
+  expiresAt           DateTime
+  maxUses             Int?
+  useCount            Int      @default(0)
+  workflowKey         String?
+  objectRef           String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  grantorUser         User  @relation("DelegationGrantGrantor", fields: [grantorUserId], references: [id])
+  granteeAgent        Agent @relation(fields: [granteeAgentId], references: [id])
+}
+```
+
+### New: `DirectivePolicyClass`
+
+Defines categories and governance semantics for agent directives without storing raw prompt/config payloads.
+
+Purpose:
+
+- creates a contract with the separate agent-configuration workstream
+- lets this foundation define approval and audit semantics without owning config internals
+
+Suggested fields:
+
+```prisma
+model DirectivePolicyClass {
+  id                 String   @id @default(cuid())
+  policyClassId      String   @unique
+  name               String
+  description        String?
+  configCategory     String   // persona | workflow | tool_access | compliance | domain_rules
+  approvalMode       String   // self_service | manager_approval | admin_approval
+  allowedRiskBand    String
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+}
+```
+
+### New: `AuthorizationDecisionLog`
+
+Persistent audit record for allow/deny decisions.
+
+Purpose:
+
+- explains why a request succeeded or failed
+- captures the authority chain
+- supports later compliance, incident analysis, and UX transparency
+
+Suggested fields:
+
+```prisma
+model AuthorizationDecisionLog {
+  id                 String   @id @default(cuid())
+  decisionId         String   @unique
+  actorType          String   // user | customer_contact | agent
+  actorRef           String
+  humanContextRef    String?
+  agentContextRef    String?
+  delegationGrantId  String?
+  actionKey          String
+  objectRef          String?
+  decision           String   // allow | deny | require_approval
+  rationale          Json
+  createdAt          DateTime @default(now())
+}
+```
+
+### Application concept: `PrincipalContext`
+
+This does not need to be a table in the first phase. It should exist as a runtime object assembled at request time.
+
+Suggested shape:
+
+```ts
+type PrincipalContext = {
+  authenticatedSubject:
+    | { kind: "user"; userId: string }
+    | { kind: "customer_contact"; contactId: string };
+  actingHuman:
+    | { kind: "user"; userId: string }
+    | { kind: "customer_contact"; contactId: string };
+  actingAgent?: { agentId: string };
+  teamIds: string[];
+  platformRoleIds: string[];
+  effectiveCapabilities: string[];
+  delegationGrantIds: string[];
+};
+```
+
+This gives the authorization layer one consistent runtime envelope even while persistence remains split across current tables.
+
+---
+
+## Effective Authority Resolution
+
+The platform should use a mixed authority model:
+
+- baseline authority is the intersection of human authority and agent baseline policy
+- temporary elevation is possible through explicit delegation grants
+
+Resolution order:
+
+1. authenticated human authority
+2. team and relationship context
+3. agent capability class
+4. agent governance profile
+5. business-object constraints
+6. active delegation grants
+
+Result:
+
+```ts
+effectiveAuthority =
+  intersect(
+    humanAuthority,
+    agentBaselineAuthority,
+    contextualBusinessConstraints
+  ) + validDelegationGrantExtensions;
+```
+
+Rules:
+
+- agents cannot self-elevate
+- delegation must always point to a human grantor
+- grants must be bounded by time and scope
+- grants may be single-use or limited-use
+- grants must respect the agent's `maxDelegationRiskBand`
+- high-risk operations may still require a separate approval checkpoint
+- each decision writes an `AuthorizationDecisionLog`
+
+---
+
+## Human-In-The-Loop Model
+
+Human-in-the-loop is not just an approval checkbox. It is the platform's accountability structure.
+
+Three modes:
+
+1. **Advisory**
+   Agent proposes, human executes.
+
+2. **Supervised execution**
+   Agent may execute within baseline scope, but review is required for sensitive operations.
+
+3. **Delegated elevation**
+   Human explicitly grants a higher envelope for a bounded workflow or object.
+
+Typical manager flow:
+
+1. manager is signed in
+2. manager selects or invokes an agent in the UX
+3. agent baseline policy says the requested action is above normal baseline scope
+4. system offers a delegation flow
+5. manager enters reason, scope, duration, and confirms
+6. `DelegationGrant` is created
+7. action executes under the combined authority context
+8. audit log records grantor, agent, action, object, and rationale
+
+This matches the desired behavior described in the brainstorming session.
+
+---
+
+## HR Core Relationship To This Foundation
+
+HR Core should not own access control by itself. It should consume this foundation.
+
+HR-specific work that becomes cleaner after this foundation:
+
+- employee lifecycle state
+- contractor and operator relationship handling
+- team membership and managerial structure
+- role assignment and removal
+- who is allowed to supervise which agents
+- workforce reporting by domain and authority tier
+
+Implication:
+
+- `EmployeeProfile` belongs in the HR epic
+- identity governance, delegation, and authority resolution belong in this foundation epic
+
+This avoids coupling personnel lifecycle rules directly to authorization mechanics.
+
+---
+
+## Customer And CRM Relationship To This Foundation
+
+The user stated that CRM and customer portal work are separate epics, but the foundation must support them.
+
+Near-term rule:
+
+- `CustomerContact` remains the customer-side account record
+- customer portal auth and CRM workflow design remain out of scope
+
+Foundation contract:
+
+- customer-side operators can later participate in `PrincipalContext`
+- their authority will be constrained to their account/domain context
+- they may use permitted agents in their own bounded authority envelope
+- team ownership and agent governance remain reusable for customer-facing agents
+
+This is why the foundation must be broader than employee-only identity.
+
+---
+
+## Authorization Model Evolution
+
+The current `permissions.ts` model is route-level and role-list based. It is good enough for coarse navigation, but not sufficient for governed human-agent execution.
+
+The target evolution is:
+
+### Phase A: coexistence
+
+- keep `can()` and route gating for tiles and page access
+- add new authorization resolver for governed actions
+
+### Phase B: action-level enforcement
+
+- server actions call the new resolver
+- resolver reads human, team, agent, and grant context
+- route-level gating remains a coarse prefilter
+
+### Phase C: policy-backed capabilities
+
+- capability keys and action families become data-backed
+- some or all of `PERMISSIONS` may eventually move into DB policy records
+
+This staged approach minimizes disruption and keeps the current app usable while the new control plane is added.
+
+---
+
+## External Identity Provider Boundary
+
+The platform should be designed so authentication may later move to an open-source identity platform, while governance stays inside DPF.
+
+Examples of future-compatible external IdPs:
+
+- Keycloak
+- authentik
+- ZITADEL
+
+What the external IdP should own:
+
+- login
+- federation
+- MFA
+- credential lifecycle
+- SSO
+- possibly coarse groups/claims
+
+What DPF should continue to own:
+
+- business roles and route capability semantics
+- team ownership
+- human accountability chains
+- delegation grants
+- agent governance profiles
+- directive policy classes
+- authorization decision logs
+- workflow and object-level approval rules
+
+Implementation boundary:
+
+- add optional external identity reference fields later, for example on `User` and `CustomerContact`
+- map external claims into `PrincipalContext`
+- do not make the external IdP the source of truth for agent delegation logic
+
+This preserves local operability now and enterprise federation later.
+
+---
+
+## UX Surfaces
+
+This spec does not design final UI layouts in detail, but it does define the required UX capabilities.
+
+### Required experiences
+
+1. Human identity visibility
+   Show roles, teams, status, and relationship type for the acting human.
+
+2. Agent governance visibility
+   Show ownership team, capability class, autonomy level, and whether the agent is currently elevated by grant.
+
+3. Delegation flow
+   When a requested action exceeds baseline scope, the UX prompts for a bounded delegation grant.
+
+4. Approval flow
+   High-risk actions surface a required approval step even when technically executable.
+
+5. Decision explainability
+   The platform can say why an action is blocked, allowed, or pending approval.
+
+6. Audit visibility
+   Operators and auditors can inspect historical authority chains.
+
+### Likely route ownership
+
+- `/employee` for workforce and relationship management
+- `/admin` for user and access oversight
+- `/ea/agents` or successor agent-governance views for agent registry visibility
+- `/platform` for policy, provider, and governance administration
+
+Exact route decomposition is an implementation concern for later specs and plans.
+
+---
+
+## Integration Boundary With Agent Configuration Work
+
+Another agent is currently working on AI agent configuration. This spec must not conflict with that work.
+
+Therefore this foundation owns:
+
+- directive policy categories
+- approval modes for directive classes
+- authority and risk semantics for agent execution
+- links from governance profiles to policy classes
+
+This foundation does **not** own:
+
+- raw prompt templates
+- provider/model config payloads
+- tool manifest internals
+- config editor UX
+- versioning format for agent configs
+
+Contract between the two workstreams:
+
+- configuration work defines what can technically be configured
+- governance work defines who may approve which classes of configuration and how those classes affect runtime authority
+
+---
+
+## Data Flow
+
+### Standard agent action
+
+1. Human signs in.
+2. Session resolves `User` or `CustomerContact`.
+3. System assembles `PrincipalContext`.
+4. If an agent is involved, system loads `AgentGovernanceProfile` and ownership/team data.
+5. Authorization resolver evaluates baseline authority.
+6. If allowed, action proceeds and a decision log is written.
+
+### Elevated agent action
+
+1. Human requests action above baseline.
+2. Resolver returns `require_approval` or `deny_with_possible_grant`.
+3. UX offers bounded delegation flow if policy allows it.
+4. Human creates `DelegationGrant`.
+5. Resolver re-evaluates with grant in context.
+6. Action proceeds if now valid.
+7. Grant usage and decision log are updated.
+
+---
+
+## Failure And Risk Handling
+
+Failure modes the design must handle:
+
+- user is authenticated but has no team context
+- agent belongs to no owning team
+- delegation grant expired between prompt and execution
+- human has authority, but agent policy forbids the action
+- agent policy allows a class of action, but business-object constraints deny it
+- customer-side operator attempts cross-account action
+- external IdP claim exists, but DPF mapping is missing or stale
+
+Required platform behavior:
+
+- fail closed for governed actions
+- give user-facing deny reasons that are understandable
+- write deny decisions to `AuthorizationDecisionLog`
+- never silently upgrade authority
+- never let agent context replace human accountability context
+
+---
+
+## Testing Strategy
+
+The implementation that follows this spec should be tested at four levels.
+
+### 1. Pure authorization logic tests
+
+Examples:
+
+- baseline intersection logic
+- grant expiry logic
+- risk-band cap logic
+- deny-with-explanation behavior
+
+### 2. Data-model tests
+
+Examples:
+
+- unique constraints on team membership and grant identifiers
+- ownership relationships
+- allowed/required nullability for target workflow/object references
+
+### 3. Server action integration tests
+
+Examples:
+
+- manager can delegate within policy
+- non-manager cannot grant elevated authority outside policy
+- agent cannot execute elevated action after grant expiry
+
+### 4. Route and UX gating tests
+
+Examples:
+
+- button visible but elevation prompt required
+- decision explanation renders expected reason
+- audit entries appear after allow and deny cases
+
+---
+
+## Rollout Strategy
+
+The foundation should be introduced incrementally.
+
+### Step 1
+
+Add governance tables and a small resolver library without changing current route gating.
+
+### Step 2
+
+Adopt the resolver in a small number of governed actions first:
+
+- role assignment
+- user lifecycle changes
+- selected agent-triggered actions
+
+### Step 3
+
+Add delegation grant UX and audit visibility.
+
+### Step 4
+
+Expand to HR lifecycle, CRM/customer operators, and more agent-driven workflows.
+
+### Step 5
+
+Add optional external IdP federation boundary when the platform is ready.
+
+---
+
+## Out Of Scope For This Spec
+
+- final `EmployeeProfile` schema and HR route UX
+- payroll or benefits administration
+- CRM workflow detail and customer portal UX
+- full object-level policy language
+- service-account or workload identity implementation
+- agent config payload schema/editor
+- replacing all current route permissions with DB-native policy in one pass
+
+---
+
+## Summary
+
+The correct first move is not to merge HR, CRM, and agent configuration into one giant feature. It is to build a shared governance foundation that all three can consume.
+
+That foundation should:
+
+- keep current account models
+- add team ownership and governance overlays
+- resolve authority from both human and agent context
+- support bounded delegation grants
+- preserve human accountability
+- stay compatible with later external identity federation
+- avoid colliding with parallel work on raw agent configuration
+
+This gives DPF the control model it needs to become a self-operating and self-improving factory without losing accountability.

--- a/docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
+++ b/docs/superpowers/specs/2026-03-13-unified-identity-access-agent-governance-design.md
@@ -30,6 +30,17 @@ What is missing is the shared governance layer above those models:
 
 This spec adds that shared layer without rewriting the current `User` and `Agent` models. The design is intentionally additive: it keeps the current data model intact and introduces a governance overlay that can evolve toward a more unified principal model later if needed.
 
+Implementation slice 1 models:
+
+- `Team`
+- `TeamMembership`
+- `AgentOwnership`
+- `AgentCapabilityClass`
+- `DirectivePolicyClass`
+- `AgentGovernanceProfile`
+- `DelegationGrant`
+- `AuthorizationDecisionLog`
+
 ---
 
 ## Design Goals

--- a/packages/db/data/providers-registry.json
+++ b/packages/db/data/providers-registry.json
@@ -1,0 +1,62 @@
+[
+  {
+    "providerId": "anthropic",
+    "name": "Anthropic",
+    "families": ["claude-3-5", "claude-4"],
+    "authEndpoint": "https://api.anthropic.com/v1/models",
+    "authHeader": "x-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "openai",
+    "name": "OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo", "gpt-4o-mini"],
+    "authEndpoint": "https://api.openai.com/v1/models",
+    "authHeader": "Authorization",
+    "costModel": "token",
+    "inputPricePerMToken": 2.50,
+    "outputPricePerMToken": 10.00
+  },
+  {
+    "providerId": "azure-openai",
+    "name": "Azure OpenAI",
+    "families": ["gpt-4o", "gpt-4-turbo"],
+    "authEndpoint": null,
+    "authHeader": "api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 5.00,
+    "outputPricePerMToken": 15.00
+  },
+  {
+    "providerId": "gemini",
+    "name": "Google Gemini",
+    "families": ["gemini-1.5-pro", "gemini-2.0"],
+    "authEndpoint": "https://generativelanguage.googleapis.com/v1/models",
+    "authHeader": "x-goog-api-key",
+    "costModel": "token",
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.00
+  },
+  {
+    "providerId": "ollama",
+    "name": "Ollama (local)",
+    "families": ["llama3", "mistral", "phi3", "gemma2"],
+    "authEndpoint": "http://localhost:11434/api/tags",
+    "authHeader": null,
+    "costModel": "compute",
+    "computeWatts": 150,
+    "electricityRateKwh": 0.12
+  },
+  {
+    "providerId": "bedrock",
+    "name": "AWS Bedrock",
+    "families": ["claude", "titan", "llama"],
+    "authEndpoint": null,
+    "authHeader": "Authorization",
+    "costModel": "token",
+    "inputPricePerMToken": 3.00,
+    "outputPricePerMToken": 15.00
+  }
+]

--- a/packages/db/prisma/migrations/20260313090000_identity_governance_foundation/migration.sql
+++ b/packages/db/prisma/migrations/20260313090000_identity_governance_foundation/migration.sql
@@ -1,0 +1,209 @@
+-- CreateTable
+CREATE TABLE "Team" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Team_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamMembership" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "isPrimary" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TeamMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AgentOwnership" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "responsibility" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentOwnership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AgentCapabilityClass" (
+    "id" TEXT NOT NULL,
+    "capabilityClassId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "riskBand" TEXT NOT NULL,
+    "defaultActionScope" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentCapabilityClass_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DirectivePolicyClass" (
+    "id" TEXT NOT NULL,
+    "policyClassId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "configCategory" TEXT NOT NULL,
+    "approvalMode" TEXT NOT NULL,
+    "allowedRiskBand" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DirectivePolicyClass_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AgentGovernanceProfile" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "capabilityClassId" TEXT NOT NULL,
+    "directivePolicyClassId" TEXT NOT NULL,
+    "autonomyLevel" TEXT NOT NULL,
+    "hitlPolicy" TEXT NOT NULL,
+    "allowDelegation" BOOLEAN NOT NULL DEFAULT true,
+    "maxDelegationRiskBand" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentGovernanceProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DelegationGrant" (
+    "id" TEXT NOT NULL,
+    "grantId" TEXT NOT NULL,
+    "grantorUserId" TEXT NOT NULL,
+    "granteeAgentId" TEXT NOT NULL,
+    "targetUserId" TEXT,
+    "scopeJson" JSONB NOT NULL,
+    "reason" TEXT,
+    "riskBand" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "validFrom" TIMESTAMP(3) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "maxUses" INTEGER,
+    "useCount" INTEGER NOT NULL DEFAULT 0,
+    "workflowKey" TEXT,
+    "objectRef" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DelegationGrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuthorizationDecisionLog" (
+    "id" TEXT NOT NULL,
+    "decisionId" TEXT NOT NULL,
+    "actorType" TEXT NOT NULL,
+    "actorRef" TEXT NOT NULL,
+    "humanContextRef" TEXT,
+    "agentContextRef" TEXT,
+    "delegationGrantId" TEXT,
+    "actionKey" TEXT NOT NULL,
+    "objectRef" TEXT,
+    "decision" TEXT NOT NULL,
+    "rationale" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuthorizationDecisionLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_teamId_key" ON "Team"("teamId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_slug_key" ON "Team"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamMembership_teamId_userId_key" ON "TeamMembership"("teamId", "userId");
+
+-- CreateIndex
+CREATE INDEX "TeamMembership_userId_idx" ON "TeamMembership"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentOwnership_agentId_teamId_responsibility_key" ON "AgentOwnership"("agentId", "teamId", "responsibility");
+
+-- CreateIndex
+CREATE INDEX "AgentOwnership_teamId_idx" ON "AgentOwnership"("teamId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentCapabilityClass_capabilityClassId_key" ON "AgentCapabilityClass"("capabilityClassId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DirectivePolicyClass_policyClassId_key" ON "DirectivePolicyClass"("policyClassId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentGovernanceProfile_agentId_key" ON "AgentGovernanceProfile"("agentId");
+
+-- CreateIndex
+CREATE INDEX "AgentGovernanceProfile_capabilityClassId_idx" ON "AgentGovernanceProfile"("capabilityClassId");
+
+-- CreateIndex
+CREATE INDEX "AgentGovernanceProfile_directivePolicyClassId_idx" ON "AgentGovernanceProfile"("directivePolicyClassId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DelegationGrant_grantId_key" ON "DelegationGrant"("grantId");
+
+-- CreateIndex
+CREATE INDEX "DelegationGrant_grantorUserId_idx" ON "DelegationGrant"("grantorUserId");
+
+-- CreateIndex
+CREATE INDEX "DelegationGrant_granteeAgentId_idx" ON "DelegationGrant"("granteeAgentId");
+
+-- CreateIndex
+CREATE INDEX "DelegationGrant_status_expiresAt_idx" ON "DelegationGrant"("status", "expiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthorizationDecisionLog_decisionId_key" ON "AuthorizationDecisionLog"("decisionId");
+
+-- CreateIndex
+CREATE INDEX "AuthorizationDecisionLog_decision_idx" ON "AuthorizationDecisionLog"("decision");
+
+-- CreateIndex
+CREATE INDEX "AuthorizationDecisionLog_createdAt_idx" ON "AuthorizationDecisionLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AuthorizationDecisionLog_actorRef_idx" ON "AuthorizationDecisionLog"("actorRef");
+
+-- AddForeignKey
+ALTER TABLE "TeamMembership" ADD CONSTRAINT "TeamMembership_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMembership" ADD CONSTRAINT "TeamMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentOwnership" ADD CONSTRAINT "AgentOwnership_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentOwnership" ADD CONSTRAINT "AgentOwnership_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentGovernanceProfile" ADD CONSTRAINT "AgentGovernanceProfile_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentGovernanceProfile" ADD CONSTRAINT "AgentGovernanceProfile_capabilityClassId_fkey" FOREIGN KEY ("capabilityClassId") REFERENCES "AgentCapabilityClass"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentGovernanceProfile" ADD CONSTRAINT "AgentGovernanceProfile_directivePolicyClassId_fkey" FOREIGN KEY ("directivePolicyClassId") REFERENCES "DirectivePolicyClass"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DelegationGrant" ADD CONSTRAINT "DelegationGrant_grantorUserId_fkey" FOREIGN KEY ("grantorUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DelegationGrant" ADD CONSTRAINT "DelegationGrant_granteeAgentId_fkey" FOREIGN KEY ("granteeAgentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuthorizationDecisionLog" ADD CONSTRAINT "AuthorizationDecisionLog_delegationGrantId_fkey" FOREIGN KEY ("delegationGrantId") REFERENCES "DelegationGrant"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -19,6 +19,8 @@ model User {
   createdAt    DateTime      @default(now())
   groups       UserGroup[]
   agentThreads AgentThread[]
+  teamMemberships     TeamMembership[]
+  grantedDelegations  DelegationGrant[] @relation("DelegationGrantGrantor")
 }
 
 model UserGroup {
@@ -51,6 +53,37 @@ model PlatformRole {
   hitlTierMin   Int         @default(1)
   slaDurationH  Int?
   users         UserGroup[]
+}
+
+// ─── Identity Governance ─────────────────────────────────────────────────────
+
+model Team {
+  id          String   @id @default(cuid())
+  teamId      String   @unique
+  name        String
+  slug        String   @unique
+  description String?
+  status      String   @default("active")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  memberships TeamMembership[]
+  ownerships  AgentOwnership[]
+}
+
+model TeamMembership {
+  id        String   @id @default(cuid())
+  teamId    String
+  userId    String
+  role      String   // member | manager | approver | operator
+  isPrimary Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  team      Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user      User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, userId])
+  @@index([userId])
 }
 
 // ─── Portfolios & Products ───────────────────────────────────────────────────
@@ -244,6 +277,119 @@ model Agent {
   createdAt   DateTime @default(now())
   portfolioId  String?
   portfolio    Portfolio?  @relation(fields: [portfolioId], references: [id])
+  ownerships          AgentOwnership[]
+  governanceProfile   AgentGovernanceProfile?
+  delegationGrants    DelegationGrant[]
+}
+
+model AgentOwnership {
+  id             String   @id @default(cuid())
+  agentId        String
+  teamId         String
+  responsibility String   // owning_team | operating_team | approving_team
+  createdAt      DateTime @default(now())
+
+  agent          Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  team           Team  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@unique([agentId, teamId, responsibility])
+  @@index([teamId])
+}
+
+model AgentCapabilityClass {
+  id                 String   @id @default(cuid())
+  capabilityClassId  String   @unique
+  name               String
+  description        String?
+  riskBand           String   // low | medium | high | critical
+  defaultActionScope Json
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  governanceProfiles AgentGovernanceProfile[]
+}
+
+model DirectivePolicyClass {
+  id                String   @id @default(cuid())
+  policyClassId     String   @unique
+  name              String
+  description       String?
+  configCategory    String   // persona | workflow | tool_access | compliance | domain_rules
+  approvalMode      String   // self_service | manager_approval | admin_approval
+  allowedRiskBand   String
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  governanceProfiles AgentGovernanceProfile[]
+}
+
+model AgentGovernanceProfile {
+  id                     String   @id @default(cuid())
+  agentId                String   @unique
+  capabilityClassId      String
+  directivePolicyClassId String
+  autonomyLevel          String   // advisory | constrained_execute | supervised_execute | elevated_execute
+  hitlPolicy             String   // always | risk_based | never_without_grant
+  allowDelegation        Boolean  @default(true)
+  maxDelegationRiskBand  String?  // low | medium | high | critical
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  agent                  Agent                @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  capabilityClass        AgentCapabilityClass @relation(fields: [capabilityClassId], references: [id])
+  directivePolicyClass   DirectivePolicyClass @relation(fields: [directivePolicyClassId], references: [id])
+
+  @@index([capabilityClassId])
+  @@index([directivePolicyClassId])
+}
+
+model DelegationGrant {
+  id                 String   @id @default(cuid())
+  grantId            String   @unique
+  grantorUserId      String
+  granteeAgentId     String
+  targetUserId       String?
+  scopeJson          Json
+  reason             String?
+  riskBand           String
+  status             String   @default("active") // active | expired | revoked | consumed
+  validFrom          DateTime
+  expiresAt          DateTime
+  maxUses            Int?
+  useCount           Int      @default(0)
+  workflowKey        String?
+  objectRef          String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  grantorUser        User  @relation("DelegationGrantGrantor", fields: [grantorUserId], references: [id])
+  granteeAgent       Agent @relation(fields: [granteeAgentId], references: [id], onDelete: Cascade)
+  decisionLogs       AuthorizationDecisionLog[]
+
+  @@index([grantorUserId])
+  @@index([granteeAgentId])
+  @@index([status, expiresAt])
+}
+
+model AuthorizationDecisionLog {
+  id                String   @id @default(cuid())
+  decisionId        String   @unique
+  actorType         String   // user | customer_contact | agent
+  actorRef          String
+  humanContextRef   String?
+  agentContextRef   String?
+  delegationGrantId String?
+  actionKey         String
+  objectRef         String?
+  decision          String   // allow | deny | require_approval
+  rationale         Json
+  createdAt         DateTime @default(now())
+
+  delegationGrant   DelegationGrant? @relation(fields: [delegationGrantId], references: [id], onDelete: SetNull)
+
+  @@index([decision])
+  @@index([createdAt])
+  @@index([actorRef])
 }
 
 // ─── CRM ─────────────────────────────────────────────────────────────────────

--- a/packages/db/src/ea-validation.test.ts
+++ b/packages/db/src/ea-validation.test.ts
@@ -9,7 +9,7 @@ vi.mock("./client.js", () => ({
     eaElementType:     { findUnique: vi.fn(), findFirst: vi.fn() },
     eaDqRule:          { findMany: vi.fn() },
     eaRelationship:    { count: vi.fn() },
-    eaRelationshipType: { findFirst: vi.fn() },
+    eaRelationshipType: { findFirst: vi.fn(), findUnique: vi.fn() },
   },
 }));
 
@@ -26,7 +26,7 @@ const mockPrisma = prisma as unknown as {
   eaElementType:       { findUnique: ReturnType<typeof vi.fn>; findFirst: ReturnType<typeof vi.fn> };
   eaDqRule:            { findMany:   ReturnType<typeof vi.fn> };
   eaRelationship:      { count:      ReturnType<typeof vi.fn> };
-  eaRelationshipType:  { findFirst:  ReturnType<typeof vi.fn> };
+  eaRelationshipType:  { findFirst:  ReturnType<typeof vi.fn>; findUnique: ReturnType<typeof vi.fn> };
 };
 
 beforeEach(() => { vi.clearAllMocks(); });

--- a/packages/db/src/governance-seed.test.ts
+++ b/packages/db/src/governance-seed.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultCapabilityClasses, getDefaultDirectivePolicyClasses } from "./governance-seed";
+
+describe("governance seed defaults", () => {
+  it("returns stable capability classes", () => {
+    expect(getDefaultCapabilityClasses().map((c) => c.capabilityClassId)).toEqual([
+      "cap-advisory",
+      "cap-operator",
+      "cap-specialist",
+      "cap-elevated",
+    ]);
+  });
+
+  it("returns stable directive policy classes", () => {
+    expect(getDefaultDirectivePolicyClasses().map((p) => p.policyClassId)).toContain("dir-workflow-standard");
+  });
+});

--- a/packages/db/src/governance-seed.ts
+++ b/packages/db/src/governance-seed.ts
@@ -1,0 +1,110 @@
+import type { PrismaClient } from "../generated/client";
+
+export function getDefaultCapabilityClasses() {
+  return [
+    {
+      capabilityClassId: "cap-advisory",
+      name: "Advisory",
+      description: "Read-mostly guidance and recommendation agents with low-risk authority.",
+      riskBand: "low",
+      defaultActionScope: {
+        actionFamilies: ["advisory.read", "advisory.suggest"],
+        resourceTypes: ["workspace", "knowledge"],
+        maxRiskBand: "low",
+      },
+    },
+    {
+      capabilityClassId: "cap-operator",
+      name: "Operator",
+      description: "Routine workflow operators with bounded execution authority.",
+      riskBand: "medium",
+      defaultActionScope: {
+        actionFamilies: ["workflow.read", "workflow.update"],
+        resourceTypes: ["user", "task", "ticket"],
+        maxRiskBand: "medium",
+        constraints: { teamScoped: true },
+      },
+    },
+    {
+      capabilityClassId: "cap-specialist",
+      name: "Specialist",
+      description: "Domain-specialist agents for higher-complexity workflow execution.",
+      riskBand: "high",
+      defaultActionScope: {
+        actionFamilies: ["workflow.read", "workflow.update", "workflow.execute"],
+        resourceTypes: ["user", "employee", "customer", "backlog_item"],
+        maxRiskBand: "high",
+        constraints: { teamScoped: true },
+      },
+    },
+    {
+      capabilityClassId: "cap-elevated",
+      name: "Elevated",
+      description: "High-authority agents that still require governed human oversight.",
+      riskBand: "critical",
+      defaultActionScope: {
+        actionFamilies: ["workflow.execute", "governance.request_elevation"],
+        resourceTypes: ["user", "employee", "customer", "platform"],
+        maxRiskBand: "critical",
+      },
+    },
+  ] as const;
+}
+
+export function getDefaultDirectivePolicyClasses() {
+  return [
+    {
+      policyClassId: "dir-workflow-standard",
+      name: "Workflow Standard",
+      description: "Standard workflow directives with manager-approved operational scope.",
+      configCategory: "workflow",
+      approvalMode: "manager_approval",
+      allowedRiskBand: "high",
+    },
+    {
+      policyClassId: "dir-persona-standard",
+      name: "Persona Standard",
+      description: "Low-risk persona and tone directives.",
+      configCategory: "persona",
+      approvalMode: "self_service",
+      allowedRiskBand: "low",
+    },
+    {
+      policyClassId: "dir-tool-access-admin",
+      name: "Tool Access Admin",
+      description: "High-risk tool and integration directives requiring admin approval.",
+      configCategory: "tool_access",
+      approvalMode: "admin_approval",
+      allowedRiskBand: "critical",
+    },
+  ] as const;
+}
+
+export async function seedGovernanceReferenceData(prisma: PrismaClient): Promise<void> {
+  for (const capabilityClass of getDefaultCapabilityClasses()) {
+    await prisma.agentCapabilityClass.upsert({
+      where: { capabilityClassId: capabilityClass.capabilityClassId },
+      update: {
+        name: capabilityClass.name,
+        description: capabilityClass.description,
+        riskBand: capabilityClass.riskBand,
+        defaultActionScope: capabilityClass.defaultActionScope,
+      },
+      create: capabilityClass,
+    });
+  }
+
+  for (const policyClass of getDefaultDirectivePolicyClasses()) {
+    await prisma.directivePolicyClass.upsert({
+      where: { policyClassId: policyClass.policyClassId },
+      update: {
+        name: policyClass.name,
+        description: policyClass.description,
+        configCategory: policyClass.configCategory,
+        approvalMode: policyClass.approvalMode,
+        allowedRiskBand: policyClass.allowedRiskBand,
+      },
+      create: policyClass,
+    });
+  }
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { prisma } from "./client.js";
 import { parseRoleId, parseAgentTier, parseAgentType, parseAgentPortfolioSlug } from "./seed-helpers.js";
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
+import { seedGovernanceReferenceData } from "./governance-seed.js";
 import * as crypto from "crypto";
 
 // Repo root: prefer DPF_DATA_ROOT env var (needed when running from a worktree),
@@ -621,6 +622,7 @@ async function seedScheduledJobs(): Promise<void> {
 async function main(): Promise<void> {
   console.log("Starting seed...");
   await seedRoles();
+  await seedGovernanceReferenceData(prisma);
   await seedPortfolios();
   await seedAgents();
   await seedTaxonomyNodes();


### PR DESCRIPTION
## Summary
- add the identity governance data foundation in Prisma, including teams, agent governance profiles, delegation grants, decision logs, and seeded governance reference data
- add the runtime governance layer for principal context resolution, governed action evaluation, and audited governance/user lifecycle server actions
- expose governance state in the web app across admin and HR lifecycle flows, platform governance overview, and the EA agent registry

## Test Plan
- [x] pnpm --filter @dpf/db test
- [x] pnpm --filter @dpf/db generate
- [x] pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma
- [x] pnpm --filter web test
- [x] pnpm --filter web typecheck