### PR TITLE
feat: add HR workforce core

### DIFF
--- a/apps/web/app/(shell)/employee/page.test.tsx
+++ b/apps/web/app/(shell)/employee/page.test.tsx
@@ -1,8 +1,142 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformRole: {
+      findMany: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/workforce-data", () => ({
+  getEmployeeDirectoryRows: vi.fn(),
+  getWorkforceReferenceData: vi.fn(),
+  getEmployeeProfileByUserId: vi.fn(),
+  getEmployeeLifecycleEvents: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/users", () => ({
+  updateUserLifecycle: vi.fn(),
+}));
+
+import { prisma } from "@dpf/db";
+import {
+  getEmployeeDirectoryRows,
+  getEmployeeLifecycleEvents,
+  getEmployeeProfileByUserId,
+  getWorkforceReferenceData,
+} from "@/lib/workforce-data";
 import { EmployeeDirectoryPanel } from "@/components/employee/EmployeeDirectoryPanel";
 import { EmployeeProfilePanel } from "@/components/employee/EmployeeProfilePanel";
 import { LifecycleEventPanel } from "@/components/employee/LifecycleEventPanel";
+import EmployeePage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(prisma.platformRole.findMany).mockResolvedValue(
+    [
+      {
+        id: "role-db-1",
+        roleId: "HR-100",
+        name: "HR Lead",
+        description: "Handles workforce management",
+        hitlTierMin: 1,
+        slaDurationH: 24,
+        _count: { users: 1 },
+      },
+    ] as never,
+  );
+
+  vi.mocked(prisma.user.findMany).mockResolvedValue(
+    [
+      {
+        id: "user-1",
+        email: "ada@example.com",
+        isActive: true,
+        isSuperuser: false,
+        groups: [
+          {
+            platformRole: {
+              roleId: "HR-100",
+            },
+          },
+        ],
+      },
+    ] as never,
+  );
+
+  vi.mocked(getEmployeeDirectoryRows).mockResolvedValue([
+    {
+      id: "emp-db-1",
+      employeeId: "EMP-001",
+      userId: "user-1",
+      displayName: "Ada Lovelace",
+      workEmail: "ada@example.com",
+      status: "active",
+      departmentId: "dept-people",
+      departmentName: "People Operations",
+      positionId: "pos-hr-manager",
+      positionTitle: "HR Manager",
+      managerEmployeeId: "emp-db-2",
+      managerName: "Grace Hopper",
+      workLocationId: "loc-remote",
+      workLocationName: "Remote",
+    },
+  ]);
+
+  vi.mocked(getWorkforceReferenceData).mockResolvedValue({
+    employmentTypes: [],
+    positions: [{ id: "pos-hr-manager", positionId: "POS-001", title: "HR Manager" }],
+    workLocations: [{ id: "loc-remote", locationId: "LOC-001", name: "Remote", timezone: "America/Chicago" }],
+    departments: [{ id: "dept-people", departmentId: "DEPT-001", name: "People Operations", parentDepartmentId: null }],
+  });
+
+  vi.mocked(getEmployeeProfileByUserId).mockResolvedValue({
+    id: "emp-db-1",
+    employeeId: "EMP-001",
+    userId: "user-1",
+    firstName: "Ada",
+    middleName: null,
+    lastName: "Lovelace",
+    displayName: "Ada Lovelace",
+    workEmail: "ada@example.com",
+    personalEmail: null,
+    phoneNumber: null,
+    status: "active",
+    departmentId: "dept-people",
+    departmentName: "People Operations",
+    positionId: "pos-hr-manager",
+    positionTitle: "HR Manager",
+    managerEmployeeId: "emp-db-2",
+    managerName: "Grace Hopper",
+    workLocationId: "loc-remote",
+    workLocationName: "Remote",
+    timezone: "America/Chicago",
+    startDate: new Date("2026-03-13"),
+    confirmationDate: new Date("2026-03-20"),
+    endDate: null,
+  });
+
+  vi.mocked(getEmployeeLifecycleEvents).mockResolvedValue([
+    {
+      id: "evt-db-1",
+      eventId: "EEVT-001",
+      eventType: "activated",
+      effectiveAt: new Date("2026-03-13"),
+      reason: "Initial activation",
+      createdAt: new Date("2026-03-13"),
+    },
+  ]);
+});
 
 describe("EmployeeDirectoryPanel", () => {
   it("renders employee profile and org details", () => {
@@ -93,5 +227,14 @@ describe("LifecycleEventPanel", () => {
     expect(html).toContain("Recent lifecycle events");
     expect(html).toContain("activated");
     expect(html).toContain("Initial activation");
+  });
+});
+
+describe("EmployeePage", () => {
+  it("renders both workforce context and HR user lifecycle controls", async () => {
+    const html = renderToStaticMarkup(await EmployeePage());
+
+    expect(html).toContain("Employee directory");
+    expect(html).toContain("HR user lifecycle");
   });
 });

--- a/apps/web/app/(shell)/employee/page.test.tsx
+++ b/apps/web/app/(shell)/employee/page.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EmployeeDirectoryPanel } from "@/components/employee/EmployeeDirectoryPanel";
+import { EmployeeProfilePanel } from "@/components/employee/EmployeeProfilePanel";
+import { LifecycleEventPanel } from "@/components/employee/LifecycleEventPanel";
+
+describe("EmployeeDirectoryPanel", () => {
+  it("renders employee profile and org details", () => {
+    const html = renderToStaticMarkup(
+      <EmployeeDirectoryPanel
+        employees={[
+          {
+            id: "emp-db-1",
+            employeeId: "EMP-001",
+            userId: "user-1",
+            displayName: "Ada Lovelace",
+            workEmail: "ada@example.com",
+            status: "active",
+            departmentId: "dept-people",
+            departmentName: "People Operations",
+            positionId: "pos-hr-manager",
+            positionTitle: "HR Manager",
+            managerEmployeeId: "emp-db-2",
+            managerName: "Grace Hopper",
+            workLocationId: "loc-remote",
+            workLocationName: "Remote",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("EMP-001");
+    expect(html).toContain("People Operations");
+    expect(html).toContain("Grace Hopper");
+  });
+});
+
+describe("EmployeeProfilePanel", () => {
+  it("renders lifecycle dates for the selected employee", () => {
+    const html = renderToStaticMarkup(
+      <EmployeeProfilePanel
+        employee={{
+          id: "emp-db-1",
+          employeeId: "EMP-001",
+          userId: "user-1",
+          firstName: "Ada",
+          middleName: null,
+          lastName: "Lovelace",
+          displayName: "Ada Lovelace",
+          workEmail: "ada@example.com",
+          personalEmail: null,
+          phoneNumber: null,
+          status: "active",
+          departmentId: "dept-people",
+          departmentName: "People Operations",
+          positionId: "pos-hr-manager",
+          positionTitle: "HR Manager",
+          managerEmployeeId: "emp-db-2",
+          managerName: "Grace Hopper",
+          workLocationId: "loc-remote",
+          workLocationName: "Remote",
+          timezone: "America/Chicago",
+          startDate: new Date("2026-03-13"),
+          confirmationDate: new Date("2026-03-20"),
+          endDate: null,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Employee profile");
+    expect(html).toContain("2026");
+    expect(html).toContain("Remote");
+  });
+});
+
+describe("LifecycleEventPanel", () => {
+  it("renders recent employment events", () => {
+    const html = renderToStaticMarkup(
+      <LifecycleEventPanel
+        events={[
+          {
+            id: "evt-db-1",
+            eventId: "EEVT-001",
+            eventType: "activated",
+            effectiveAt: new Date("2026-03-13"),
+            reason: "Initial activation",
+            createdAt: new Date("2026-03-13"),
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Recent lifecycle events");
+    expect(html).toContain("activated");
+    expect(html).toContain("Initial activation");
+  });
+});

--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -1,9 +1,19 @@
 // apps/web/app/(shell)/employee/page.tsx
 import { prisma } from "@dpf/db";
+import { EmployeeDirectoryPanel } from "@/components/employee/EmployeeDirectoryPanel";
+import { EmployeeProfilePanel } from "@/components/employee/EmployeeProfilePanel";
 import { HrUserLifecyclePanel } from "@/components/employee/HrUserLifecyclePanel";
+import { LifecycleEventPanel } from "@/components/employee/LifecycleEventPanel";
+import { OrgAssignmentPanel } from "@/components/employee/OrgAssignmentPanel";
+import {
+  getEmployeeDirectoryRows,
+  getEmployeeLifecycleEvents,
+  getEmployeeProfileByUserId,
+  getWorkforceReferenceData,
+} from "@/lib/workforce-data";
 
 export default async function EmployeePage() {
-  const [roles, users] = await Promise.all([
+  const [roles, users, employees, workforceReferenceData] = await Promise.all([
     prisma.platformRole.findMany({
       orderBy: { roleId: "asc" },
       select: {
@@ -34,7 +44,17 @@ export default async function EmployeePage() {
         },
       },
     }),
+    getEmployeeDirectoryRows(),
+    getWorkforceReferenceData(),
   ]);
+
+  const primaryEmployeeUserId = employees.find((employee) => employee.userId)?.userId ?? null;
+  const selectedEmployee = primaryEmployeeUserId
+    ? await getEmployeeProfileByUserId(primaryEmployeeUserId)
+    : null;
+  const lifecycleEvents = selectedEmployee
+    ? await getEmployeeLifecycleEvents(selectedEmployee.id)
+    : [];
 
   return (
     <div>
@@ -87,6 +107,21 @@ export default async function EmployeePage() {
       {roles.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)]">No roles registered yet.</p>
       )}
+
+      <div className="mt-8 grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <EmployeeDirectoryPanel employees={employees} />
+        <EmployeeProfilePanel employee={selectedEmployee} />
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <OrgAssignmentPanel
+          employee={selectedEmployee}
+          departments={workforceReferenceData.departments}
+          positions={workforceReferenceData.positions}
+          workLocations={workforceReferenceData.workLocations}
+        />
+        <LifecycleEventPanel events={lifecycleEvents} />
+      </div>
 
       {users.length > 0 && (
         <div className="mt-8">

--- a/apps/web/components/employee/EmployeeDirectoryPanel.tsx
+++ b/apps/web/components/employee/EmployeeDirectoryPanel.tsx
@@ -1,0 +1,65 @@
+import type { EmployeeDirectoryRow } from "@/lib/workforce-types";
+
+type Props = {
+  employees: EmployeeDirectoryRow[];
+};
+
+function formatStatus(status: EmployeeDirectoryRow["status"]): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export function EmployeeDirectoryPanel({ employees }: Props) {
+  return (
+    <section className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-white">Employee directory</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          Workforce identity, organization placement, and reporting lines.
+        </p>
+      </div>
+
+      {employees.length === 0 ? (
+        <p className="text-sm text-[var(--dpf-muted)]">No employee profiles registered yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+          {employees.map((employee) => (
+            <article
+              key={employee.id}
+              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 space-y-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[10px] font-mono text-[var(--dpf-muted)]">{employee.employeeId}</p>
+                  <p className="text-sm font-semibold text-white">{employee.displayName}</p>
+                  <p className="text-xs text-[var(--dpf-muted)]">{employee.workEmail ?? "No work email set"}</p>
+                </div>
+                <span className="rounded-full border border-[var(--dpf-border)] px-2 py-1 text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                  {formatStatus(employee.status)}
+                </span>
+              </div>
+
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+                <div>
+                  <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Department</dt>
+                  <dd className="text-white">{employee.departmentName ?? "Unassigned"}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Position</dt>
+                  <dd className="text-white">{employee.positionTitle ?? "Unassigned"}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Manager</dt>
+                  <dd className="text-white">{employee.managerName ?? "None"}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Location</dt>
+                  <dd className="text-white">{employee.workLocationName ?? "Unset"}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/employee/EmployeeProfilePanel.tsx
+++ b/apps/web/components/employee/EmployeeProfilePanel.tsx
@@ -1,0 +1,80 @@
+import type { EmployeeProfileRecord } from "@/lib/workforce-types";
+
+type Props = {
+  employee: EmployeeProfileRecord | null;
+};
+
+function formatDate(value: Date | null): string {
+  if (!value) return "Not set";
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(value);
+}
+
+export function EmployeeProfilePanel({ employee }: Props) {
+  return (
+    <section className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-white">Employee profile</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          Current portal-facing workforce record and lifecycle dates.
+        </p>
+      </div>
+
+      {!employee ? (
+        <p className="text-sm text-[var(--dpf-muted)]">Select or link an employee profile to view detailed workforce data.</p>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 space-y-2">
+            <p className="text-[10px] font-mono text-[var(--dpf-muted)]">{employee.employeeId}</p>
+            <p className="text-base font-semibold text-white">{employee.displayName}</p>
+            <p className="text-xs text-[var(--dpf-muted)]">
+              {employee.positionTitle ?? "Role pending"} in {employee.departmentName ?? "unassigned department"}
+            </p>
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Work email</dt>
+                <dd className="text-white">{employee.workEmail ?? "Not set"}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Location</dt>
+                <dd className="text-white">{employee.workLocationName ?? "Not set"}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Manager</dt>
+                <dd className="text-white">{employee.managerName ?? "None"}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Timezone</dt>
+                <dd className="text-white">{employee.timezone ?? "Not set"}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Status</dt>
+                <dd className="text-white">{employee.status}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Start date</dt>
+                <dd className="text-white">{formatDate(employee.startDate)}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Confirmation date</dt>
+                <dd className="text-white">{formatDate(employee.confirmationDate)}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">End date</dt>
+                <dd className="text-white">{formatDate(employee.endDate)}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/employee/LifecycleEventPanel.tsx
+++ b/apps/web/components/employee/LifecycleEventPanel.tsx
@@ -1,0 +1,55 @@
+type LifecycleEvent = {
+  id: string;
+  eventId: string;
+  eventType: string;
+  effectiveAt: Date;
+  reason: string | null;
+  createdAt: Date;
+};
+
+type Props = {
+  events: LifecycleEvent[];
+};
+
+function formatDate(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(value);
+}
+
+export function LifecycleEventPanel({ events }: Props) {
+  return (
+    <section className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-white">Recent lifecycle events</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          Append-only workforce timeline for onboarding, role movement, and exits.
+        </p>
+      </div>
+
+      {events.length === 0 ? (
+        <p className="text-sm text-[var(--dpf-muted)]">No lifecycle events recorded yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {events.map((event) => (
+            <article
+              key={event.id}
+              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold text-white">{event.eventType}</p>
+                  <p className="text-[10px] font-mono text-[var(--dpf-muted)]">{event.eventId}</p>
+                </div>
+                <p className="text-[10px] text-[var(--dpf-muted)]">{formatDate(event.effectiveAt)}</p>
+              </div>
+              {event.reason && <p className="mt-2 text-xs text-[var(--dpf-muted)]">{event.reason}</p>}
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/employee/OrgAssignmentPanel.tsx
+++ b/apps/web/components/employee/OrgAssignmentPanel.tsx
@@ -1,0 +1,94 @@
+import type { EmployeeProfileRecord } from "@/lib/workforce-types";
+
+type DepartmentRef = {
+  id: string;
+  departmentId: string;
+  name: string;
+  parentDepartmentId: string | null;
+};
+
+type PositionRef = {
+  id: string;
+  positionId: string;
+  title: string;
+};
+
+type WorkLocationRef = {
+  id: string;
+  locationId: string;
+  name: string;
+  timezone: string | null;
+};
+
+type Props = {
+  employee: EmployeeProfileRecord | null;
+  departments: DepartmentRef[];
+  positions: PositionRef[];
+  workLocations: WorkLocationRef[];
+};
+
+export function OrgAssignmentPanel({ employee, departments, positions, workLocations }: Props) {
+  return (
+    <section className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-white">Organization assignment</h2>
+        <p className="text-xs text-[var(--dpf-muted)] mt-1">
+          Current placement plus reference sets for department, position, and location.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 space-y-2">
+          <p className="text-xs font-semibold text-white">Current assignment</p>
+          {!employee ? (
+            <p className="text-xs text-[var(--dpf-muted)]">No employee profile selected yet.</p>
+          ) : (
+            <dl className="grid grid-cols-1 gap-2 text-xs">
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Department</dt>
+                <dd className="text-white">{employee.departmentName ?? "Unassigned"}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Position</dt>
+                <dd className="text-white">{employee.positionTitle ?? "Unassigned"}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Manager</dt>
+                <dd className="text-white">{employee.managerName ?? "None"}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Work location</dt>
+                <dd className="text-white">{employee.workLocationName ?? "Not set"}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-3">
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <p className="text-xs font-semibold text-white">Reference coverage</p>
+            <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--dpf-muted)]">
+              <span>{departments.length} departments</span>
+              <span>{positions.length} positions</span>
+              <span>{workLocations.length} locations</span>
+            </div>
+          </div>
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <p className="text-xs font-semibold text-white">Available departments</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {departments.slice(0, 6).map((department) => (
+                <span
+                  key={department.id}
+                  className="rounded-full border border-[var(--dpf-border)] px-2 py-1 text-[10px] text-[var(--dpf-muted)]"
+                >
+                  {department.name}
+                </span>
+              ))}
+              {departments.length === 0 && <span className="text-[10px] text-[var(--dpf-muted)]">No department references yet.</span>}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/actions/workforce.test.ts
+++ b/apps/web/lib/actions/workforce.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn(),
+}));
+
+vi.mock("@/lib/governance-data", () => ({
+  getUserTeamIds: vi.fn(),
+  createAuthorizationDecisionLog: vi.fn(),
+}));
+
+vi.mock("@/lib/principal-context", () => ({
+  buildPrincipalContext: vi.fn(),
+}));
+
+vi.mock("@/lib/governance-resolver", () => ({
+  resolveGovernedAction: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    employeeProfile: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    employmentEvent: {
+      create: vi.fn(),
+    },
+    terminationRecord: {
+      upsert: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { buildPrincipalContext } from "@/lib/principal-context";
+import { getUserTeamIds, createAuthorizationDecisionLog } from "@/lib/governance-data";
+import { resolveGovernedAction } from "@/lib/governance-resolver";
+import {
+  createEmployeeProfile,
+  recordEmploymentLifecycleEvent,
+  validateEmployeeProfileInput,
+  validateLifecycleTransition,
+} from "./workforce";
+
+const authMock = auth as unknown as { mockResolvedValue: (value: unknown) => void };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  authMock.mockResolvedValue({
+    user: {
+      id: "user-1",
+      email: "hr@example.com",
+      platformRole: "HR-100",
+      isSuperuser: false,
+    },
+  });
+  vi.mocked(can).mockReturnValue(true);
+  vi.mocked(getUserTeamIds).mockResolvedValue(["team-1"]);
+  vi.mocked(buildPrincipalContext).mockReturnValue({
+    authenticatedSubject: { kind: "user", userId: "user-1" },
+    actingHuman: { kind: "user", userId: "user-1" },
+    teamIds: ["team-1"],
+    platformRoleIds: ["HR-100"],
+    effectiveCapabilities: [],
+    delegationGrantIds: [],
+  });
+  vi.mocked(resolveGovernedAction).mockReturnValue({
+    decision: "allow",
+    rationaleCode: "baseline_intersection",
+  });
+  vi.mocked(createAuthorizationDecisionLog).mockResolvedValue();
+});
+
+describe("validateEmployeeProfileInput", () => {
+  it("rejects an end date before the start date", () => {
+    expect(
+      validateEmployeeProfileInput({
+        employeeId: "EMP-001",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        status: "active",
+        startDate: new Date("2026-03-13"),
+        endDate: new Date("2026-03-12"),
+      }),
+    ).toMatch(/start date/i);
+  });
+
+  it("rejects a confirmation date before the start date", () => {
+    expect(
+      validateEmployeeProfileInput({
+        employeeId: "EMP-001",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        status: "active",
+        startDate: new Date("2026-03-13"),
+        confirmationDate: new Date("2026-03-12"),
+      }),
+    ).toMatch(/confirmation date/i);
+  });
+
+  it("rejects a self-manager relationship", () => {
+    expect(
+      validateEmployeeProfileInput({
+        employeeId: "EMP-001",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        status: "active",
+        managerEmployeeId: "EMP-001",
+      }),
+    ).toMatch(/manager/i);
+  });
+});
+
+describe("validateLifecycleTransition", () => {
+  it("requires a termination date when setting inactive through termination", () => {
+    expect(
+      validateLifecycleTransition({
+        currentStatus: "active",
+        nextStatus: "inactive",
+        eventType: "terminated",
+        terminationDate: null,
+      }),
+    ).toMatch(/termination date/i);
+  });
+});
+
+describe("createEmployeeProfile", () => {
+  it("returns a validation error before writing invalid profile data", async () => {
+    const result = await createEmployeeProfile({
+      employeeId: "EMP-001",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      status: "active",
+      startDate: new Date("2026-03-13"),
+      endDate: new Date("2026-03-12"),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/start date/i);
+    expect(vi.mocked(prisma.employeeProfile.create)).not.toHaveBeenCalled();
+  });
+});
+
+describe("recordEmploymentLifecycleEvent", () => {
+  it("returns a validation error before recording a termination without a date", async () => {
+    const result = await recordEmploymentLifecycleEvent({
+      employeeProfileId: "emp-db-1",
+      currentStatus: "active",
+      nextStatus: "inactive",
+      eventType: "terminated",
+      effectiveAt: new Date("2026-03-13"),
+      terminationDate: null,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/termination date/i);
+    expect(vi.mocked(prisma.employmentEvent.create)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/workforce.ts
+++ b/apps/web/lib/actions/workforce.ts
@@ -1,0 +1,504 @@
+"use server";
+
+import crypto from "node:crypto";
+import { prisma, type Prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getUserTeamIds, createAuthorizationDecisionLog } from "@/lib/governance-data";
+import { buildPrincipalContext } from "@/lib/principal-context";
+import { resolveGovernedAction } from "@/lib/governance-resolver";
+import type { EmploymentEventType, WorkforceStatus } from "@/lib/workforce-types";
+
+export type WorkforceActionResult = {
+  ok: boolean;
+  message: string;
+};
+
+type SessionUserContext = {
+  id: string;
+  email: string;
+  platformRole: string | null;
+  isSuperuser: boolean;
+};
+
+export type EmployeeProfileInput = {
+  employeeProfileId?: string;
+  employeeId: string;
+  userId?: string | null;
+  firstName: string;
+  middleName?: string | null;
+  lastName: string;
+  displayName?: string | null;
+  workEmail?: string | null;
+  personalEmail?: string | null;
+  phoneNumber?: string | null;
+  status: WorkforceStatus;
+  employmentTypeId?: string | null;
+  departmentId?: string | null;
+  positionId?: string | null;
+  managerEmployeeId?: string | null;
+  dottedLineManagerId?: string | null;
+  workLocationId?: string | null;
+  timezone?: string | null;
+  startDate?: Date | null;
+  confirmationDate?: Date | null;
+  endDate?: Date | null;
+};
+
+export type AssignEmployeeOrgInput = {
+  employeeProfileId: string;
+  departmentId?: string | null;
+  positionId?: string | null;
+  managerEmployeeId?: string | null;
+  dottedLineManagerId?: string | null;
+  workLocationId?: string | null;
+  timezone?: string | null;
+  effectiveAt?: Date;
+};
+
+export type RecordEmploymentLifecycleEventInput = {
+  employeeProfileId: string;
+  currentStatus: WorkforceStatus;
+  nextStatus: WorkforceStatus;
+  eventType: EmploymentEventType;
+  effectiveAt: Date;
+  reason?: string | null;
+  terminationDate?: Date | null;
+  terminationReason?: string | null;
+  terminationNotes?: string | null;
+  exitInterviewDone?: boolean;
+  metadata?: Prisma.InputJsonValue;
+};
+
+function workforceDenied(message: string): WorkforceActionResult {
+  return { ok: false, message };
+}
+
+function trimRequired(value: string): string {
+  return value.trim();
+}
+
+function trimOptional(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function buildDisplayName(input: {
+  firstName: string;
+  middleName?: string | null;
+  lastName: string;
+  displayName?: string | null;
+}): string {
+  const displayName = trimOptional(input.displayName);
+  if (displayName) return displayName;
+  return [trimRequired(input.firstName), trimOptional(input.middleName), trimRequired(input.lastName)]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
+}
+
+async function requireAnyCapability(
+  capabilities: Array<"manage_users" | "manage_user_lifecycle">,
+): Promise<SessionUserContext> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new Error("Unauthorized");
+
+  const context: SessionUserContext = {
+    id: user.id,
+    email: user.email ?? "",
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  };
+
+  if (!capabilities.some((capability) => can(context, capability))) {
+    throw new Error("Unauthorized");
+  }
+
+  return context;
+}
+
+async function withGovernedWorkforceAction(input: {
+  actionKey: string;
+  riskBand: "medium" | "high";
+  objectRef?: string;
+  run: (actor: SessionUserContext) => Promise<WorkforceActionResult>;
+}): Promise<WorkforceActionResult> {
+  const actor = await requireAnyCapability(["manage_user_lifecycle", "manage_users"]);
+  const teamIds = await getUserTeamIds(actor.id);
+  const principalContext = buildPrincipalContext({
+    sessionUser: actor,
+    teamIds,
+    actingAgentId: null,
+    delegationGrantIds: [],
+  });
+
+  const decision = resolveGovernedAction({
+    humanAllowed: principalContext.platformRoleIds.length > 0 || actor.isSuperuser,
+    agentPolicyAllowed: true,
+    riskBand: input.riskBand,
+    agentMaxRiskBand: "critical",
+    activeGrant: null,
+  });
+
+  if (decision.decision !== "allow") {
+    await createAuthorizationDecisionLog({
+      actorType: "user",
+      actorRef: actor.id,
+      humanContextRef: actor.id,
+      actionKey: input.actionKey,
+      objectRef: input.objectRef ?? null,
+      decision: decision.decision,
+      rationale: { code: decision.rationaleCode } satisfies Prisma.InputJsonValue,
+    });
+    return workforceDenied("Governance denied this workforce action.");
+  }
+
+  const result = await input.run(actor);
+
+  await createAuthorizationDecisionLog({
+    actorType: "user",
+    actorRef: actor.id,
+    humanContextRef: actor.id,
+    actionKey: input.actionKey,
+    objectRef: input.objectRef ?? null,
+    decision: result.ok ? "allow" : "deny",
+    rationale: { result: result.ok ? "success" : "application_error" } satisfies Prisma.InputJsonValue,
+  });
+
+  return result;
+}
+
+export function validateEmployeeProfileInput(input: EmployeeProfileInput): string | null {
+  if (!trimRequired(input.firstName)) return "Enter a first name.";
+  if (!trimRequired(input.lastName)) return "Enter a last name.";
+
+  const selfRefs = [input.employeeProfileId, input.employeeId].filter((value): value is string => Boolean(value?.trim()));
+  if (input.managerEmployeeId && selfRefs.includes(input.managerEmployeeId)) {
+    return "Employee cannot be their own manager.";
+  }
+  if (input.dottedLineManagerId && selfRefs.includes(input.dottedLineManagerId)) {
+    return "Employee cannot be their own manager.";
+  }
+
+  if (input.startDate && input.endDate && input.startDate > input.endDate) {
+    return "Start date must be on or before the end date.";
+  }
+  if (input.startDate && input.confirmationDate && input.confirmationDate < input.startDate) {
+    return "Confirmation date cannot be before the start date.";
+  }
+
+  return null;
+}
+
+export function validateLifecycleTransition(input: {
+  currentStatus: WorkforceStatus;
+  nextStatus: WorkforceStatus;
+  eventType: EmploymentEventType;
+  terminationDate?: Date | null;
+}): string | null {
+  if (input.eventType === "terminated" && !input.terminationDate) {
+    return "Termination date is required for termination events.";
+  }
+
+  if (input.currentStatus === "inactive" && input.nextStatus === "onboarding") {
+    return "Inactive employees cannot return to onboarding.";
+  }
+
+  return null;
+}
+
+async function ensureUserLinkIsAvailable(userId: string | null, employeeProfileId?: string): Promise<string | null> {
+  if (!userId) return null;
+
+  const existing = await prisma.employeeProfile.findUnique({
+    where: { userId },
+    select: { id: true },
+  });
+  if (existing && existing.id !== employeeProfileId) {
+    return "Selected user is already linked to another employee profile.";
+  }
+
+  return null;
+}
+
+function buildLifecycleCreateEvent(status: WorkforceStatus): EmploymentEventType {
+  switch (status) {
+    case "active":
+      return "activated";
+    case "leave":
+      return "leave_started";
+    case "offboarding":
+    case "inactive":
+      return "offboarding_started";
+    default:
+      return "onboarding_started";
+  }
+}
+
+export async function createEmployeeProfile(input: EmployeeProfileInput): Promise<WorkforceActionResult> {
+  const validationError = validateEmployeeProfileInput(input);
+  if (validationError) return workforceDenied(validationError);
+
+  return withGovernedWorkforceAction({
+    actionKey: "employee_profile.create",
+    riskBand: "medium",
+    objectRef: input.employeeId,
+    run: async (actor) => {
+      const employeeId = trimRequired(input.employeeId);
+      const userId = trimOptional(input.userId);
+      const linkageError = await ensureUserLinkIsAvailable(userId);
+      if (linkageError) return workforceDenied(linkageError);
+
+      const existing = await prisma.employeeProfile.findUnique({
+        where: { employeeId },
+        select: { id: true },
+      });
+      if (existing) return workforceDenied("Employee ID already exists.");
+
+      const displayName = buildDisplayName(input);
+      const employee = await prisma.employeeProfile.create({
+        data: {
+          employeeId,
+          userId,
+          firstName: trimRequired(input.firstName),
+          middleName: trimOptional(input.middleName),
+          lastName: trimRequired(input.lastName),
+          displayName,
+          workEmail: trimOptional(input.workEmail),
+          personalEmail: trimOptional(input.personalEmail),
+          phoneNumber: trimOptional(input.phoneNumber),
+          status: input.status,
+          employmentTypeId: trimOptional(input.employmentTypeId),
+          departmentId: trimOptional(input.departmentId),
+          positionId: trimOptional(input.positionId),
+          managerEmployeeId: trimOptional(input.managerEmployeeId),
+          dottedLineManagerId: trimOptional(input.dottedLineManagerId),
+          workLocationId: trimOptional(input.workLocationId),
+          timezone: trimOptional(input.timezone),
+          startDate: input.startDate ?? null,
+          confirmationDate: input.confirmationDate ?? null,
+          endDate: input.endDate ?? null,
+        },
+        select: { id: true, displayName: true },
+      });
+
+      await prisma.employmentEvent.create({
+        data: {
+          eventId: `EEVT-${crypto.randomUUID()}`,
+          employeeProfileId: employee.id,
+          eventType: buildLifecycleCreateEvent(input.status),
+          effectiveAt: input.startDate ?? new Date(),
+          reason: "employee_profile_created",
+          actorUserId: actor.id,
+          metadata: {
+            source: "employee_profile.create",
+            initialStatus: input.status,
+          } satisfies Prisma.InputJsonValue,
+        },
+      });
+
+      revalidatePath("/employee");
+      revalidatePath("/admin");
+      return { ok: true, message: `Employee ${employee.displayName} created.` };
+    },
+  });
+}
+
+export async function updateEmployeeProfile(input: EmployeeProfileInput): Promise<WorkforceActionResult> {
+  if (!trimOptional(input.employeeProfileId)) return workforceDenied("Employee profile is required.");
+
+  const validationError = validateEmployeeProfileInput(input);
+  if (validationError) return workforceDenied(validationError);
+
+  return withGovernedWorkforceAction({
+    actionKey: "employee_profile.update",
+    riskBand: "medium",
+    ...(input.employeeProfileId ? { objectRef: input.employeeProfileId } : {}),
+    run: async () => {
+      const employeeProfileId = trimRequired(input.employeeProfileId ?? "");
+      const userId = trimOptional(input.userId);
+      const linkageError = await ensureUserLinkIsAvailable(userId, employeeProfileId);
+      if (linkageError) return workforceDenied(linkageError);
+
+      const existing = await prisma.employeeProfile.findUnique({
+        where: { id: employeeProfileId },
+        select: { id: true },
+      });
+      if (!existing) return workforceDenied("Employee profile not found.");
+
+      const displayName = buildDisplayName(input);
+      await prisma.employeeProfile.update({
+        where: { id: employeeProfileId },
+        data: {
+          employeeId: trimRequired(input.employeeId),
+          userId,
+          firstName: trimRequired(input.firstName),
+          middleName: trimOptional(input.middleName),
+          lastName: trimRequired(input.lastName),
+          displayName,
+          workEmail: trimOptional(input.workEmail),
+          personalEmail: trimOptional(input.personalEmail),
+          phoneNumber: trimOptional(input.phoneNumber),
+          status: input.status,
+          employmentTypeId: trimOptional(input.employmentTypeId),
+          departmentId: trimOptional(input.departmentId),
+          positionId: trimOptional(input.positionId),
+          managerEmployeeId: trimOptional(input.managerEmployeeId),
+          dottedLineManagerId: trimOptional(input.dottedLineManagerId),
+          workLocationId: trimOptional(input.workLocationId),
+          timezone: trimOptional(input.timezone),
+          startDate: input.startDate ?? null,
+          confirmationDate: input.confirmationDate ?? null,
+          endDate: input.endDate ?? null,
+        },
+      });
+
+      revalidatePath("/employee");
+      revalidatePath("/admin");
+      return { ok: true, message: `Employee ${displayName} updated.` };
+    },
+  });
+}
+
+export async function assignEmployeeOrg(input: AssignEmployeeOrgInput): Promise<WorkforceActionResult> {
+  const employeeProfileId = trimRequired(input.employeeProfileId);
+  if (!employeeProfileId) return workforceDenied("Employee profile is required.");
+  if (input.managerEmployeeId && input.managerEmployeeId === employeeProfileId) {
+    return workforceDenied("Employee cannot be their own manager.");
+  }
+
+  return withGovernedWorkforceAction({
+    actionKey: "employee_profile.assign_org",
+    riskBand: "medium",
+    objectRef: employeeProfileId,
+    run: async (actor) => {
+      const existing = await prisma.employeeProfile.findUnique({
+        where: { id: employeeProfileId },
+        select: {
+          id: true,
+          displayName: true,
+          departmentId: true,
+          positionId: true,
+          managerEmployeeId: true,
+          dottedLineManagerId: true,
+          workLocationId: true,
+          timezone: true,
+        },
+      });
+      if (!existing) return workforceDenied("Employee profile not found.");
+
+      const nextDepartmentId = trimOptional(input.departmentId);
+      const nextPositionId = trimOptional(input.positionId);
+      const nextManagerEmployeeId = trimOptional(input.managerEmployeeId);
+      const nextDottedLineManagerId = trimOptional(input.dottedLineManagerId);
+      const nextWorkLocationId = trimOptional(input.workLocationId);
+      const nextTimezone = trimOptional(input.timezone);
+      const effectiveAt = input.effectiveAt ?? new Date();
+
+      await prisma.$transaction(async (tx) => {
+        await tx.employeeProfile.update({
+          where: { id: employeeProfileId },
+          data: {
+            departmentId: nextDepartmentId,
+            positionId: nextPositionId,
+            managerEmployeeId: nextManagerEmployeeId,
+            dottedLineManagerId: nextDottedLineManagerId,
+            workLocationId: nextWorkLocationId,
+            timezone: nextTimezone,
+          },
+        });
+
+        const eventTypes: EmploymentEventType[] = [];
+        if (existing.departmentId !== nextDepartmentId) eventTypes.push("department_changed");
+        if (existing.positionId !== nextPositionId) eventTypes.push("position_changed");
+        if (existing.managerEmployeeId !== nextManagerEmployeeId) eventTypes.push("manager_changed");
+
+        await Promise.all(
+          eventTypes.map((eventType) =>
+            tx.employmentEvent.create({
+              data: {
+                eventId: `EEVT-${crypto.randomUUID()}`,
+                employeeProfileId,
+                eventType,
+                effectiveAt,
+                reason: "org_assignment_updated",
+                actorUserId: actor.id,
+              },
+            }),
+          ),
+        );
+      });
+
+      revalidatePath("/employee");
+      revalidatePath("/admin");
+      return { ok: true, message: `Organization assignment updated for ${existing.displayName}.` };
+    },
+  });
+}
+
+export async function recordEmploymentLifecycleEvent(
+  input: RecordEmploymentLifecycleEventInput,
+): Promise<WorkforceActionResult> {
+  const validationError = validateLifecycleTransition(input);
+  if (validationError) return workforceDenied(validationError);
+
+  return withGovernedWorkforceAction({
+    actionKey: "employee_profile.lifecycle_event",
+    riskBand: input.eventType === "terminated" ? "high" : "medium",
+    objectRef: input.employeeProfileId,
+    run: async (actor) => {
+      const employee = await prisma.employeeProfile.findUnique({
+        where: { id: input.employeeProfileId },
+        select: { id: true, displayName: true, status: true },
+      });
+      if (!employee) return workforceDenied("Employee profile not found.");
+
+      await prisma.$transaction(async (tx) => {
+        await tx.employeeProfile.update({
+          where: { id: employee.id },
+          data: {
+            status: input.nextStatus,
+            ...(input.eventType === "terminated" ? { endDate: input.terminationDate ?? null } : {}),
+          },
+        });
+
+        await tx.employmentEvent.create({
+          data: {
+            eventId: `EEVT-${crypto.randomUUID()}`,
+            employeeProfileId: employee.id,
+            eventType: input.eventType,
+            effectiveAt: input.effectiveAt,
+            reason: trimOptional(input.reason),
+            actorUserId: actor.id,
+            ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+          },
+        });
+
+        if (input.eventType === "terminated" && input.terminationDate) {
+          await tx.terminationRecord.upsert({
+            where: { employeeProfileId: employee.id },
+            update: {
+              terminationDate: input.terminationDate,
+              terminationReason: trimOptional(input.terminationReason),
+              notes: trimOptional(input.terminationNotes),
+              exitInterviewDone: input.exitInterviewDone ?? false,
+            },
+            create: {
+              terminationId: `TERM-${crypto.randomUUID()}`,
+              employeeProfileId: employee.id,
+              terminationDate: input.terminationDate,
+              terminationReason: trimOptional(input.terminationReason),
+              notes: trimOptional(input.terminationNotes),
+              exitInterviewDone: input.exitInterviewDone ?? false,
+            },
+          });
+        }
+      });
+
+      revalidatePath("/employee");
+      revalidatePath("/admin");
+      return { ok: true, message: `Lifecycle event recorded for ${employee.displayName}.` };
+    },
+  });
+}

--- a/apps/web/lib/workforce-context.test.ts
+++ b/apps/web/lib/workforce-context.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildWorkforceContext } from "./workforce-context";
+
+describe("buildWorkforceContext", () => {
+  it("maps an employee profile into a stable runtime shape", () => {
+    const ctx = buildWorkforceContext({
+      employeeId: "EMP-001",
+      departmentId: "dept-people",
+      managerEmployeeId: "EMP-002",
+      status: "active",
+      workLocationId: "loc-remote",
+      timezone: "America/Chicago",
+    });
+
+    expect(ctx.employeeId).toBe("EMP-001");
+    expect(ctx.departmentId).toBe("dept-people");
+    expect(ctx.employmentStatus).toBe("active");
+  });
+});

--- a/apps/web/lib/workforce-context.ts
+++ b/apps/web/lib/workforce-context.ts
@@ -1,0 +1,19 @@
+import type { WorkforceContext, WorkforceStatus } from "./workforce-types";
+
+export function buildWorkforceContext(input: {
+  employeeId: string;
+  departmentId?: string | null;
+  managerEmployeeId?: string | null;
+  status: WorkforceStatus;
+  workLocationId?: string | null;
+  timezone?: string | null;
+}): WorkforceContext {
+  return {
+    employeeId: input.employeeId,
+    employmentStatus: input.status,
+    ...(input.departmentId ? { departmentId: input.departmentId } : {}),
+    ...(input.managerEmployeeId ? { managerEmployeeId: input.managerEmployeeId } : {}),
+    ...(input.workLocationId ? { workLocationId: input.workLocationId } : {}),
+    ...(input.timezone ? { timezone: input.timezone } : {}),
+  };
+}

--- a/apps/web/lib/workforce-data.test.ts
+++ b/apps/web/lib/workforce-data.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { summarizeEmployeeDisplayName } from "./workforce-data";
+
+describe("summarizeEmployeeDisplayName", () => {
+  it("prefers displayName when present", () => {
+    expect(summarizeEmployeeDisplayName({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      displayName: "Ada Lovelace",
+    })).toBe("Ada Lovelace");
+  });
+});

--- a/apps/web/lib/workforce-data.ts
+++ b/apps/web/lib/workforce-data.ts
@@ -1,0 +1,156 @@
+import { prisma } from "@dpf/db";
+import type { EmployeeDirectoryRow, EmployeeProfileRecord } from "./workforce-types";
+
+export function summarizeEmployeeDisplayName(input: {
+  firstName: string;
+  middleName?: string | null;
+  lastName: string;
+  displayName?: string | null;
+}): string {
+  const displayName = input.displayName?.trim();
+  if (displayName) return displayName;
+  return [input.firstName, input.middleName ?? null, input.lastName]
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join(" ");
+}
+
+export async function getEmployeeDirectoryRows(): Promise<EmployeeDirectoryRow[]> {
+  const employees = await prisma.employeeProfile.findMany({
+    orderBy: { displayName: "asc" },
+    select: {
+      id: true,
+      employeeId: true,
+      userId: true,
+      displayName: true,
+      workEmail: true,
+      status: true,
+      departmentId: true,
+      positionId: true,
+      managerEmployeeId: true,
+      workLocationId: true,
+      department: { select: { name: true } },
+      position: { select: { title: true } },
+      manager: { select: { displayName: true } },
+      workLocation: { select: { name: true } },
+    },
+  });
+
+  return employees.map((employee) => ({
+    id: employee.id,
+    employeeId: employee.employeeId,
+    userId: employee.userId,
+    displayName: employee.displayName,
+    workEmail: employee.workEmail,
+    status: employee.status as EmployeeDirectoryRow["status"],
+    departmentId: employee.departmentId,
+    departmentName: employee.department?.name ?? null,
+    positionId: employee.positionId,
+    positionTitle: employee.position?.title ?? null,
+    managerEmployeeId: employee.managerEmployeeId,
+    managerName: employee.manager?.displayName ?? null,
+    workLocationId: employee.workLocationId,
+    workLocationName: employee.workLocation?.name ?? null,
+  }));
+}
+
+export async function getEmployeeProfileByUserId(userId: string): Promise<EmployeeProfileRecord | null> {
+  const employee = await prisma.employeeProfile.findUnique({
+    where: { userId },
+    select: {
+      id: true,
+      employeeId: true,
+      userId: true,
+      firstName: true,
+      middleName: true,
+      lastName: true,
+      displayName: true,
+      workEmail: true,
+      personalEmail: true,
+      phoneNumber: true,
+      status: true,
+      departmentId: true,
+      positionId: true,
+      managerEmployeeId: true,
+      workLocationId: true,
+      timezone: true,
+      startDate: true,
+      confirmationDate: true,
+      endDate: true,
+      department: { select: { name: true } },
+      position: { select: { title: true } },
+      manager: { select: { displayName: true } },
+      workLocation: { select: { name: true } },
+    },
+  });
+
+  if (!employee) return null;
+
+  return {
+    id: employee.id,
+    employeeId: employee.employeeId,
+    userId: employee.userId,
+    firstName: employee.firstName,
+    middleName: employee.middleName,
+    lastName: employee.lastName,
+    displayName: employee.displayName,
+    workEmail: employee.workEmail,
+    personalEmail: employee.personalEmail,
+    phoneNumber: employee.phoneNumber,
+    status: employee.status as EmployeeProfileRecord["status"],
+    departmentId: employee.departmentId,
+    departmentName: employee.department?.name ?? null,
+    positionId: employee.positionId,
+    positionTitle: employee.position?.title ?? null,
+    managerEmployeeId: employee.managerEmployeeId,
+    managerName: employee.manager?.displayName ?? null,
+    workLocationId: employee.workLocationId,
+    workLocationName: employee.workLocation?.name ?? null,
+    timezone: employee.timezone,
+    startDate: employee.startDate,
+    confirmationDate: employee.confirmationDate,
+    endDate: employee.endDate,
+  };
+}
+
+export async function getWorkforceReferenceData() {
+  const [employmentTypes, positions, workLocations, departments] = await Promise.all([
+    prisma.employmentType.findMany({
+      where: { status: "active" },
+      orderBy: { name: "asc" },
+      select: { id: true, employmentTypeId: true, name: true },
+    }),
+    prisma.position.findMany({
+      where: { status: "active" },
+      orderBy: { title: "asc" },
+      select: { id: true, positionId: true, title: true },
+    }),
+    prisma.workLocation.findMany({
+      where: { status: "active" },
+      orderBy: { name: "asc" },
+      select: { id: true, locationId: true, name: true, timezone: true },
+    }),
+    prisma.department.findMany({
+      where: { status: "active" },
+      orderBy: { name: "asc" },
+      select: { id: true, departmentId: true, name: true, parentDepartmentId: true },
+    }),
+  ]);
+
+  return { employmentTypes, positions, workLocations, departments };
+}
+
+export async function getEmployeeLifecycleEvents(employeeProfileId: string) {
+  return prisma.employmentEvent.findMany({
+    where: { employeeProfileId },
+    orderBy: [{ effectiveAt: "desc" }, { createdAt: "desc" }],
+    take: 20,
+    select: {
+      id: true,
+      eventId: true,
+      eventType: true,
+      effectiveAt: true,
+      reason: true,
+      createdAt: true,
+    },
+  });
+}

--- a/apps/web/lib/workforce-types.ts
+++ b/apps/web/lib/workforce-types.ts
@@ -1,0 +1,72 @@
+export type WorkforceStatus =
+  | "onboarding"
+  | "active"
+  | "leave"
+  | "suspended"
+  | "offboarding"
+  | "inactive";
+
+export type EmploymentEventType =
+  | "hired"
+  | "onboarding_started"
+  | "activated"
+  | "manager_changed"
+  | "department_changed"
+  | "position_changed"
+  | "leave_started"
+  | "leave_ended"
+  | "offboarding_started"
+  | "terminated"
+  | "reactivated";
+
+export type WorkforceContext = {
+  employeeId: string;
+  departmentId?: string;
+  managerEmployeeId?: string;
+  employmentStatus: WorkforceStatus;
+  workLocationId?: string;
+  timezone?: string;
+};
+
+export type EmployeeDirectoryRow = {
+  id: string;
+  employeeId: string;
+  userId: string | null;
+  displayName: string;
+  workEmail: string | null;
+  status: WorkforceStatus;
+  departmentId: string | null;
+  departmentName: string | null;
+  positionId: string | null;
+  positionTitle: string | null;
+  managerEmployeeId: string | null;
+  managerName: string | null;
+  workLocationId: string | null;
+  workLocationName: string | null;
+};
+
+export type EmployeeProfileRecord = {
+  id: string;
+  employeeId: string;
+  userId: string | null;
+  firstName: string;
+  middleName: string | null;
+  lastName: string;
+  displayName: string;
+  workEmail: string | null;
+  personalEmail: string | null;
+  phoneNumber: string | null;
+  status: WorkforceStatus;
+  departmentId: string | null;
+  departmentName: string | null;
+  positionId: string | null;
+  positionTitle: string | null;
+  managerEmployeeId: string | null;
+  managerName: string | null;
+  workLocationId: string | null;
+  workLocationName: string | null;
+  timezone: string | null;
+  startDate: Date | null;
+  confirmationDate: Date | null;
+  endDate: Date | null;
+};

--- a/docs/superpowers/plans/2026-03-13-hr-workforce-core.md
+++ b/docs/superpowers/plans/2026-03-13-hr-workforce-core.md
@@ -1,0 +1,775 @@
+# HR Workforce Core Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first working slice of the HR workforce domain by adding employee profiles, org structure, and lifecycle scaffolding on top of the identity-governance foundation, then surface it in the existing employee portal.
+
+**Architecture:** Keep `User`, `PlatformRole`, `Team`, and `TeamMembership` as the auth/governance layer. Add a separate workforce overlay in Prisma for `EmployeeProfile`, `Department`, `Position`, `EmploymentType`, `WorkLocation`, `EmploymentEvent`, and `TerminationRecord`. Prove the slice by extending `/employee` to manage employee records and organization assignment without introducing payroll or a full external HRMS.
+
+**Tech Stack:** Prisma 5, PostgreSQL, Next.js App Router, NextAuth v5 beta, React 18, TypeScript, Vitest
+
+---
+
+## Scope Guard
+
+This plan intentionally implements only the first workforce slice from the spec:
+
+- employee master/profile records
+- normalized org reference data
+- manager and department relationships
+- lifecycle status and event scaffolding
+- governed HR server actions
+- additive `/employee` UI for directory and profile operations
+
+This plan does **not** implement:
+
+- payroll
+- benefits
+- attendance
+- leave workflow execution
+- recruiting ATS
+- performance reviews
+- customer-contact workforce semantics
+- full AI coworker runtime integration
+
+Those remain follow-on plans.
+
+---
+
+## File Structure
+
+### Database and model layer
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/20260313170000_hr_workforce_core/migration.sql`
+- Modify: `packages/db/src/index.ts`
+- Modify: `packages/db/src/seed.ts`
+- Create: `packages/db/src/workforce-seed.ts`
+- Create: `packages/db/src/workforce-seed.test.ts`
+
+### Workforce data/runtime library
+
+- Create: `apps/web/lib/workforce-types.ts`
+- Create: `apps/web/lib/workforce-data.ts`
+- Create: `apps/web/lib/workforce-context.ts`
+- Create: `apps/web/lib/workforce-data.test.ts`
+- Create: `apps/web/lib/workforce-context.test.ts`
+
+### Workforce server actions
+
+- Create: `apps/web/lib/actions/workforce.ts`
+- Create: `apps/web/lib/actions/workforce.test.ts`
+- Modify: `apps/web/lib/actions/users.ts`
+
+### Employee route UI
+
+- Modify: `apps/web/app/(shell)/employee/page.tsx`
+- Create: `apps/web/app/(shell)/employee/page.test.tsx`
+- Create: `apps/web/components/employee/EmployeeDirectoryPanel.tsx`
+- Create: `apps/web/components/employee/EmployeeProfilePanel.tsx`
+- Create: `apps/web/components/employee/OrgAssignmentPanel.tsx`
+- Create: `apps/web/components/employee/LifecycleEventPanel.tsx`
+- Modify: `apps/web/components/employee/HrUserLifecyclePanel.tsx`
+
+### Documentation
+
+- Modify: `docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md`
+
+---
+
+## Chunk 1: Workforce Data Foundation
+
+### Task 1: Add workforce Prisma models
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/20260313170000_hr_workforce_core/migration.sql`
+- Modify: `docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md`
+
+- [ ] **Step 1: Add an implementation note to the spec**
+
+Append this note near the top of the spec:
+
+```md
+Implementation slice 1 models:
+- EmployeeProfile
+- Department
+- Position
+- EmploymentType
+- WorkLocation
+- EmploymentEvent
+- TerminationRecord
+```
+
+- [ ] **Step 2: Add the workforce models to `schema.prisma`**
+
+Add these models following the style used by the existing governance models:
+
+```prisma
+model EmployeeProfile { ... }
+model Department { ... }
+model Position { ... }
+model EmploymentType { ... }
+model WorkLocation { ... }
+model EmploymentEvent { ... }
+model TerminationRecord { ... }
+```
+
+Use the spec's field shapes. Keep nullable room where the slice needs it, especially for:
+
+- `userId`
+- `managerEmployeeId`
+- `dottedLineManagerId`
+- `departmentId`
+- `positionId`
+- `workLocationId`
+- `terminationRecordId`
+- optional dates
+
+- [ ] **Step 3: Add relations to existing models**
+
+Update existing models only where needed:
+
+```prisma
+model User {
+  ...
+  employeeProfile EmployeeProfile?
+}
+```
+
+Add back-relations on workforce tables for manager/report structures, department heads, lifecycle events, and termination records. Do not refactor `TeamMembership` or the governance models in this slice.
+
+- [ ] **Step 4: Add validation-focused indexes and constraints**
+
+Ensure the Prisma schema includes:
+
+- unique `employeeId`
+- unique optional `userId`
+- indexes on `status`, `departmentId`, `managerEmployeeId`, `effectiveAt`
+- foreign keys that use `SetNull` for manager/head links where deletion should not cascade the workforce tree
+
+- [ ] **Step 5: Create the SQL migration**
+
+Create `packages/db/prisma/migrations/20260313170000_hr_workforce_core/migration.sql` with explicit `CREATE TABLE`, `CREATE INDEX`, and FK statements matching the schema.
+
+Add indexes for:
+
+- `EmployeeProfile.status`
+- `EmployeeProfile.departmentId`
+- `EmployeeProfile.managerEmployeeId`
+- `EmploymentEvent.employeeProfileId`
+- `EmploymentEvent.effectiveAt`
+- `Department.parentDepartmentId`
+
+- [ ] **Step 6: Run Prisma validation**
+
+Run:
+
+```bash
+$env:DATABASE_URL='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma
+```
+
+Expected: `The schema at prisma/schema.prisma is valid`
+
+- [ ] **Step 7: Generate the Prisma client**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db generate
+```
+
+Expected: Prisma client regenerates successfully.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations/20260313170000_hr_workforce_core/migration.sql docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
+git commit -m "feat(db): add workforce core schema"
+```
+
+### Task 2: Seed only workforce reference defaults
+
+**Files:**
+- Modify: `packages/db/src/seed.ts`
+- Modify: `packages/db/src/index.ts`
+- Create: `packages/db/src/workforce-seed.ts`
+- Create: `packages/db/src/workforce-seed.test.ts`
+
+- [ ] **Step 1: Write failing tests for workforce seed helpers**
+
+Create `packages/db/src/workforce-seed.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getDefaultEmploymentTypes, getDefaultWorkLocations } from "./workforce-seed";
+
+describe("workforce seed defaults", () => {
+  it("returns stable employment types", () => {
+    expect(getDefaultEmploymentTypes().map((item) => item.employmentTypeId)).toEqual([
+      "emp-full-time",
+      "emp-part-time",
+      "emp-contractor",
+      "emp-intern",
+      "emp-advisor",
+    ]);
+  });
+
+  it("returns a default remote work location", () => {
+    expect(getDefaultWorkLocations().map((item) => item.locationId)).toContain("loc-remote");
+  });
+});
+```
+
+- [ ] **Step 2: Run the DB tests to confirm failure**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test
+```
+
+Expected: FAIL because `workforce-seed.ts` does not exist yet.
+
+- [ ] **Step 3: Implement minimal workforce seed helpers**
+
+Create `packages/db/src/workforce-seed.ts` with:
+
+```ts
+export function getDefaultEmploymentTypes() {
+  return [
+    { employmentTypeId: "emp-full-time", name: "Full-time" },
+    { employmentTypeId: "emp-part-time", name: "Part-time" },
+    { employmentTypeId: "emp-contractor", name: "Contractor" },
+    { employmentTypeId: "emp-intern", name: "Intern" },
+    { employmentTypeId: "emp-advisor", name: "Advisor" },
+  ];
+}
+```
+
+Also export:
+
+- `getDefaultWorkLocations()`
+- `seedWorkforceReferenceData(prisma)`
+
+Do not seed live employees, managers, or departments.
+
+- [ ] **Step 4: Wire workforce reference seeding into `seed.ts`**
+
+Call `seedWorkforceReferenceData(prisma)` from `packages/db/src/seed.ts` after governance reference data seeding.
+
+Seed only:
+
+- `EmploymentType`
+- `WorkLocation`
+
+Do not seed `EmployeeProfile`, `Department`, `EmploymentEvent`, or `TerminationRecord`.
+
+- [ ] **Step 5: Export helper types or functions only if needed**
+
+If plan execution needs seed helpers reachable from other packages, update `packages/db/src/index.ts` minimally. Otherwise leave exports unchanged.
+
+- [ ] **Step 6: Re-run DB tests**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test
+```
+
+Expected: PASS for the new seed-helper tests and existing DB tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/db/src/seed.ts packages/db/src/index.ts packages/db/src/workforce-seed.ts packages/db/src/workforce-seed.test.ts
+git commit -m "feat(db): seed workforce reference defaults"
+```
+
+---
+
+## Chunk 2: Workforce Runtime and Actions
+
+### Task 3: Add workforce runtime types and read models
+
+**Files:**
+- Create: `apps/web/lib/workforce-types.ts`
+- Create: `apps/web/lib/workforce-data.ts`
+- Create: `apps/web/lib/workforce-context.ts`
+- Create: `apps/web/lib/workforce-data.test.ts`
+- Create: `apps/web/lib/workforce-context.test.ts`
+
+- [ ] **Step 1: Write failing tests for workforce summary mapping**
+
+Create `apps/web/lib/workforce-context.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildWorkforceContext } from "./workforce-context";
+
+describe("buildWorkforceContext", () => {
+  it("maps an employee profile into a stable runtime shape", () => {
+    const ctx = buildWorkforceContext({
+      employeeId: "EMP-001",
+      departmentId: "dept-people",
+      managerEmployeeId: "EMP-002",
+      status: "active",
+      workLocationId: "loc-remote",
+      timezone: "America/Chicago",
+    });
+
+    expect(ctx.employeeId).toBe("EMP-001");
+    expect(ctx.departmentId).toBe("dept-people");
+    expect(ctx.employmentStatus).toBe("active");
+  });
+});
+```
+
+Create `apps/web/lib/workforce-data.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { summarizeEmployeeDisplayName } from "./workforce-data";
+
+describe("summarizeEmployeeDisplayName", () => {
+  it("prefers displayName when present", () => {
+    expect(summarizeEmployeeDisplayName({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      displayName: "Ada Lovelace",
+    })).toBe("Ada Lovelace");
+  });
+});
+```
+
+- [ ] **Step 2: Run the targeted web tests to confirm failure**
+
+Run:
+
+```bash
+pnpm --filter web test -- apps/web/lib/workforce-context.test.ts apps/web/lib/workforce-data.test.ts
+```
+
+Expected: FAIL because the modules do not exist yet.
+
+- [ ] **Step 3: Implement shared workforce types**
+
+Create `apps/web/lib/workforce-types.ts` with:
+
+```ts
+export type WorkforceStatus =
+  | "onboarding"
+  | "active"
+  | "leave"
+  | "suspended"
+  | "offboarding"
+  | "inactive";
+
+export type EmploymentEventType =
+  | "hired"
+  | "onboarding_started"
+  | "activated"
+  | "manager_changed"
+  | "department_changed"
+  | "position_changed"
+  | "leave_started"
+  | "leave_ended"
+  | "offboarding_started"
+  | "terminated"
+  | "reactivated";
+
+export type WorkforceContext = { ... };
+export type EmployeeDirectoryRow = { ... };
+export type EmployeeProfileRecord = { ... };
+```
+
+Keep these typed and aligned with the spec. Do not use loose `Record<string, unknown>` for domain objects.
+
+- [ ] **Step 4: Implement pure runtime helpers**
+
+Create:
+
+- `summarizeEmployeeDisplayName()` in `apps/web/lib/workforce-data.ts`
+- `buildWorkforceContext()` in `apps/web/lib/workforce-context.ts`
+
+Keep them pure and small.
+
+- [ ] **Step 5: Add DB-backed read helpers**
+
+In `apps/web/lib/workforce-data.ts`, add focused Prisma readers:
+
+- `getEmployeeDirectoryRows()`
+- `getEmployeeProfileByUserId(userId: string)`
+- `getWorkforceReferenceData()`
+- `getEmployeeLifecycleEvents(employeeProfileId: string)`
+
+Use narrow `select` projections only for fields needed by `/employee`.
+
+- [ ] **Step 6: Re-run targeted tests**
+
+Run:
+
+```bash
+pnpm --filter web test -- apps/web/lib/workforce-context.test.ts apps/web/lib/workforce-data.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: PASS and 0 type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/workforce-types.ts apps/web/lib/workforce-data.ts apps/web/lib/workforce-context.ts apps/web/lib/workforce-data.test.ts apps/web/lib/workforce-context.test.ts
+git commit -m "feat(web): add workforce data and context helpers"
+```
+
+### Task 4: Add governed workforce server actions
+
+**Files:**
+- Create: `apps/web/lib/actions/workforce.ts`
+- Create: `apps/web/lib/actions/workforce.test.ts`
+- Modify: `apps/web/lib/actions/users.ts`
+
+- [ ] **Step 1: Write failing tests for workforce action validation**
+
+Create `apps/web/lib/actions/workforce.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { validateEmployeeProfileInput, validateLifecycleTransition } from "./workforce";
+
+describe("validateEmployeeProfileInput", () => {
+  it("rejects an end date before the start date", () => {
+    expect(validateEmployeeProfileInput({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      status: "active",
+      startDate: new Date("2026-03-13"),
+      endDate: new Date("2026-03-12"),
+    })).toMatch(/start date/i);
+  });
+});
+
+describe("validateLifecycleTransition", () => {
+  it("requires a termination date when setting inactive through termination", () => {
+    expect(validateLifecycleTransition({
+      currentStatus: "active",
+      nextStatus: "inactive",
+      eventType: "terminated",
+      terminationDate: null,
+    })).toMatch(/termination date/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the targeted test to confirm failure**
+
+Run:
+
+```bash
+pnpm --filter web test -- apps/web/lib/actions/workforce.test.ts
+```
+
+Expected: FAIL because `workforce.ts` does not exist yet.
+
+- [ ] **Step 3: Implement pure validation helpers**
+
+Create `apps/web/lib/actions/workforce.ts` with:
+
+- `validateEmployeeProfileInput(input)`
+- `validateLifecycleTransition(input)`
+
+Cover at minimum:
+
+- required first/last name
+- start/end date order
+- confirmation date not before start date
+- no self-manager relationship
+- termination requires date
+
+- [ ] **Step 4: Add governed server actions**
+
+In the same file, implement:
+
+- `createEmployeeProfile(input)`
+- `updateEmployeeProfile(input)`
+- `assignEmployeeOrg(input)`
+- `recordEmploymentLifecycleEvent(input)`
+
+Each action should:
+
+- require authenticated user
+- gate via existing HR/admin capabilities using `can()`
+- use the governance/audit helpers already present on the branch
+- write `EmploymentEvent` entries where appropriate
+- revalidate `/employee` and `/admin`
+
+- [ ] **Step 5: Keep `users.ts` focused on account management**
+
+Modify `apps/web/lib/actions/users.ts` only if needed to:
+
+- expose a stable helper for account-to-employee linkage
+- avoid duplicating workforce validation in the user-account actions
+
+Do not merge employee-domain logic into `users.ts`.
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm --filter web test -- apps/web/lib/actions/workforce.test.ts apps/web/lib/actions/users.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: PASS and 0 type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/actions/workforce.ts apps/web/lib/actions/workforce.test.ts apps/web/lib/actions/users.ts
+git commit -m "feat(web): add governed workforce actions"
+```
+
+---
+
+## Chunk 3: Employee Portal UX
+
+### Task 5: Add workforce panels for `/employee`
+
+**Files:**
+- Create: `apps/web/components/employee/EmployeeDirectoryPanel.tsx`
+- Create: `apps/web/components/employee/EmployeeProfilePanel.tsx`
+- Create: `apps/web/components/employee/OrgAssignmentPanel.tsx`
+- Create: `apps/web/components/employee/LifecycleEventPanel.tsx`
+- Modify: `apps/web/components/employee/HrUserLifecyclePanel.tsx`
+
+- [ ] **Step 1: Write a failing component test for workforce visibility**
+
+Create `apps/web/app/(shell)/employee/page.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EmployeeDirectoryPanel } from "@/components/employee/EmployeeDirectoryPanel";
+
+describe("EmployeeDirectoryPanel", () => {
+  it("renders employee profile and org details", () => {
+    const html = renderToStaticMarkup(
+      <EmployeeDirectoryPanel
+        employees={[
+          {
+            employeeId: "EMP-001",
+            displayName: "Ada Lovelace",
+            status: "active",
+            departmentName: "People Operations",
+            positionTitle: "HR Manager",
+            managerName: "Grace Hopper",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("EMP-001");
+    expect(html).toContain("People Operations");
+    expect(html).toContain("Grace Hopper");
+  });
+});
+```
+
+- [ ] **Step 2: Run the targeted test to confirm failure**
+
+Run:
+
+```bash
+pnpm --filter web test -- "app/(shell)/employee/page.test.tsx"
+```
+
+Expected: FAIL because the new panel does not exist yet.
+
+- [ ] **Step 3: Implement focused presentation components**
+
+Create:
+
+- `EmployeeDirectoryPanel.tsx`
+- `EmployeeProfilePanel.tsx`
+- `OrgAssignmentPanel.tsx`
+- `LifecycleEventPanel.tsx`
+
+Keep the components small and data-driven.
+
+Display at minimum:
+
+- employee identifier and name
+- employment status
+- department
+- position
+- manager
+- important lifecycle dates or recent events
+
+- [ ] **Step 4: Keep `HrUserLifecyclePanel` additive**
+
+Update `apps/web/components/employee/HrUserLifecyclePanel.tsx` only so it coexists with the new workforce panels. Do not remove the existing role/account lifecycle controls; they still matter.
+
+- [ ] **Step 5: Re-run the targeted test**
+
+Run:
+
+```bash
+pnpm --filter web test -- "app/(shell)/employee/page.test.tsx"
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/employee/EmployeeDirectoryPanel.tsx apps/web/components/employee/EmployeeProfilePanel.tsx apps/web/components/employee/OrgAssignmentPanel.tsx apps/web/components/employee/LifecycleEventPanel.tsx apps/web/components/employee/HrUserLifecyclePanel.tsx apps/web/app/(shell)/employee/page.test.tsx
+git commit -m "feat(web): add workforce employee panels"
+```
+
+### Task 6: Extend the `/employee` page with workforce data
+
+**Files:**
+- Modify: `apps/web/app/(shell)/employee/page.tsx`
+- Modify: `apps/web/app/(shell)/admin/page.tsx`
+
+- [ ] **Step 1: Add a failing route-level expectation**
+
+Extend `apps/web/app/(shell)/employee/page.test.tsx` with an additional expectation that the employee page renders both role/admin context and workforce context by checking for labels like `Employee directory` and `HR user lifecycle`.
+
+- [ ] **Step 2: Run the targeted test to confirm failure**
+
+Run:
+
+```bash
+pnpm --filter web test -- "app/(shell)/employee/page.test.tsx"
+```
+
+Expected: FAIL because the route has not been updated yet.
+
+- [ ] **Step 3: Update `/employee/page.tsx`**
+
+Modify the page to load, in parallel:
+
+- platform roles
+- user accounts
+- employee directory rows
+- workforce reference data
+
+Render:
+
+- existing role summary cards
+- `EmployeeDirectoryPanel`
+- `EmployeeProfilePanel`
+- `OrgAssignmentPanel`
+- `LifecycleEventPanel`
+- existing `HrUserLifecyclePanel`
+
+Keep the route additive and do not redesign the whole page.
+
+- [ ] **Step 4: Update `/admin/page.tsx` only if needed**
+
+If account-to-employee linkage needs visibility for admins, add a minimal employee linkage hint to the existing user cards. If not needed for slice 1, leave `admin/page.tsx` unchanged.
+
+- [ ] **Step 5: Re-run tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter web test -- "app/(shell)/employee/page.test.tsx" apps/web/lib/actions/workforce.test.ts apps/web/lib/workforce-data.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: PASS and 0 type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/(shell)/employee/page.tsx apps/web/app/(shell)/admin/page.tsx apps/web/app/(shell)/employee/page.test.tsx
+git commit -m "feat(web): extend employee route with workforce core"
+```
+
+---
+
+## Chunk 4: Lifecycle Verification and Docs Sync
+
+### Task 7: Sync the spec and verify the slice
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md`
+
+- [ ] **Step 1: Update the spec status note**
+
+Add a brief note near the top of the spec:
+
+```md
+Implementation status:
+- slice 1 delivered: employee profile core, org references, manager links, lifecycle events, employee route visibility
+- deferred: payroll, benefits, attendance, leave execution, performance workflows
+```
+
+- [ ] **Step 2: Run the full verification set**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test
+pnpm --filter @dpf/db generate
+$env:DATABASE_URL='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma
+pnpm --filter web test
+pnpm --filter web typecheck
+```
+
+Expected:
+
+- DB tests PASS
+- Prisma client generates cleanly
+- Prisma validate succeeds
+- web tests PASS
+- web typecheck returns 0 errors
+
+- [ ] **Step 3: Manually verify the main employee paths**
+
+Run:
+
+```bash
+pnpm --filter web dev
+```
+
+Check:
+
+- `/employee` shows employee directory and workforce information
+- manager and department fields render correctly
+- lifecycle actions produce human-readable messages
+- existing account lifecycle controls still work
+- no regression on `/admin`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
+git commit -m "docs: sync HR workforce spec with slice 1 delivery"
+```
+
+---
+
+## Notes For The Implementer
+
+- Respect `AGENTS.md`: current state comes from the live DB, not seed defaults. Only seed lookup/reference data in `seed.ts`.
+- Keep workforce data separate from `User`. Do not stuff HR profile fields into the auth table.
+- Do not collapse `Department` into governance `Team`. They have different meanings.
+- Reuse the existing `/employee` route rather than inventing a new HR console.
+- Keep lifecycle history append-only via `EmploymentEvent` where possible.
+- Follow TDD strictly. Every new helper, action, and component should start with a failing test.
+
+---
+
+## Review Checklist
+
+- [ ] `EmployeeProfile` stays separate from `User`
+- [ ] Department/org structure remains separate from governance teams
+- [ ] Reference seeding is limited to lookup data only
+- [ ] Manager relationships and lifecycle validations are covered by tests
+- [ ] `/employee` gains workforce functionality without losing current account lifecycle controls
+- [ ] Full verification commands pass before any completion claim

--- a/docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
+++ b/docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
@@ -19,6 +19,16 @@ This spec treats HR workforce data as a domain overlay on top of:
 
 The workforce layer is not just "HR admin". It becomes the human operating model that AI coworkers will attach to. Employee identity and reporting structure are therefore product-critical, not back-office decoration.
 
+Implementation slice 1 models:
+
+- `EmployeeProfile`
+- `Department`
+- `Position`
+- `EmploymentType`
+- `WorkLocation`
+- `EmploymentEvent`
+- `TerminationRecord`
+
 ---
 
 ## Approved Working Assumptions

--- a/docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
+++ b/docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
@@ -19,6 +19,11 @@ This spec treats HR workforce data as a domain overlay on top of:
 
 The workforce layer is not just "HR admin". It becomes the human operating model that AI coworkers will attach to. Employee identity and reporting structure are therefore product-critical, not back-office decoration.
 
+Implementation status:
+
+- slice 1 delivered: employee profile core, org references, manager links, lifecycle events, employee route visibility
+- deferred: payroll, benefits, attendance, leave execution, performance workflows
+
 Implementation slice 1 models:
 
 - `EmployeeProfile`

--- a/docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
+++ b/docs/superpowers/specs/2026-03-13-hr-workforce-core-design.md
@@ -1,0 +1,679 @@
+# HR Workforce Core Design
+
+**Date:** 2026-03-13  
+**Status:** Draft  
+**Scope:** Define the first workforce-domain layer that sits on top of the unified identity, access, and agent-governance foundation.
+
+---
+
+## Overview
+
+The identity-governance foundation now gives DPF a control plane for humans, teams, roles, delegation, and agent accountability. The next layer is the workforce domain itself: the platform needs a durable employee record, org structure, and employment lifecycle model so the employee portal can represent real people rather than just login accounts.
+
+This spec treats HR workforce data as a domain overlay on top of:
+
+- `User` as the authenticated internal account
+- `Team` and `TeamMembership` as governance and operating-unit constructs
+- `PlatformRole` and `UserGroup` as coarse application access
+- agent governance as the downstream consumer of workforce reporting structure and accountable-human context
+
+The workforce layer is not just "HR admin". It becomes the human operating model that AI coworkers will attach to. Employee identity and reporting structure are therefore product-critical, not back-office decoration.
+
+---
+
+## Approved Working Assumptions
+
+From the current conversation:
+
+- employee profile is the first priority because it anchors the portal experience
+- org structure is the second priority because it anchors the AI coworker authority model
+- lifecycle must be designed now, but can be phased after profile and structure
+- open-source HR systems should be used as references where helpful
+- if a reference product's UX does not fit DPF, its data-model patterns may still be borrowed
+
+---
+
+## Design Goals
+
+1. Add a durable workforce identity layer without overloading `User` with HR-specific fields.
+2. Separate governance teams from HR org structure so operating authority and reporting structure can evolve independently.
+3. Represent primary reporting lines clearly enough for AI coworker accountability.
+4. Make employee profile data useful both to human portal UX and agent runtime context.
+5. Support employment lifecycle transitions without forcing payroll or full HRIS scope immediately.
+6. Remain compatible with future external HR imports or sync from another system.
+7. Keep the first slice focused on small-to-mid-sized business needs.
+
+---
+
+## Non-Goals
+
+- payroll and tax calculation
+- benefits administration
+- recruiting ATS implementation
+- deep leave/attendance scheduling workflows
+- learning management
+- performance-review systems
+- replacing the identity-governance foundation
+- customer-contact HR semantics
+
+These may come later, but they should not distort the first workforce slice.
+
+---
+
+## OSS Reference Research
+
+### Reference systems reviewed
+
+- **Frappe HR / ERPNext HR**
+  - Strongest reference for employee master data plus lifecycle fields.
+  - Official docs show broad HR coverage including onboarding, transfers, promotions, exits, payroll, expense, attendance, and performance.
+  - Repo structure shows an employee master that includes `user_id`, `department`, `designation`, `reports_to`, `date_of_joining`, `contract_end_date`, `holiday_list`, and `relieving_date`, with explicit validation around reporting and status transitions.
+
+- **OrangeHRM Starter**
+  - Best reference for SMB-oriented HR decomposition and employee-detail APIs.
+  - Source structure shows a clean split between personal details, job details, supervisors/subordinates, termination, attachments, qualifications, and work shifts.
+  - The API model split is especially useful for DPF because it separates the employee core record from job detail, reporting relationships, and termination records.
+
+- **IceHrm**
+  - Useful as a process reference for employee management, hierarchy, documents, and audit logs.
+  - Better as a secondary reference than as the primary design model for DPF.
+
+- **Odoo / OCA HR**
+  - Strong modular reference for departments, equipment, certifications, contracts, and offboarding extensions.
+  - Best used as an ecosystem reference, not as the direct product model for DPF.
+
+### What to borrow
+
+From those systems, the strongest recurring patterns are:
+
+- employee identity is separate from the login account
+- job and org placement are modeled explicitly, not inferred from app roles
+- reporting hierarchy is first-class data
+- employment status and termination records are separate from authentication flags
+- dates are validated as a coherent lifecycle timeline
+- employee portal needs both self-service data and manager-facing org context
+
+### What not to borrow wholesale
+
+- giant monolithic HR suites
+- payroll-first schema design
+- broad country-specific compliance tables
+- UX assumptions built around legacy HR admin software instead of an operator platform
+
+The right move for DPF is to **build a targeted workforce core in DPF using these systems as references**, not to import an entire external HR product model.
+
+---
+
+## Approaches Considered
+
+### 1. Full external HRMS adoption
+
+Run something like Frappe HR or OrangeHRM as the primary workforce system and integrate DPF against it.
+
+Pros:
+
+- fastest path to broad HR feature coverage
+- mature workflows already exist
+- lower greenfield modeling risk
+
+Cons:
+
+- creates UX and data-ownership fragmentation
+- weak fit for DPF-specific governance and AI coworker requirements
+- likely pushes the product toward integration work instead of platform-native capability
+
+### 2. External-schema mimic
+
+Use a reference system's schema as the direct template for DPF's workforce design.
+
+Pros:
+
+- reduces domain-model guesswork
+- benefits from mature concepts
+
+Cons:
+
+- imports baggage that DPF does not need yet
+- makes the model feel like someone else's product
+- can still miss DPF-specific agent-accountability concepts
+
+### 3. Targeted DPF-native workforce core
+
+Build a small, platform-native workforce model that explicitly borrows proven concepts from Frappe HR and OrangeHRM but is shaped around DPF's portal, governance, and AI coworker requirements.
+
+Pros:
+
+- best fit for the portal and agent model
+- keeps schema lean
+- supports future integration rather than depending on it
+
+Cons:
+
+- more greenfield design work now
+- some advanced HR features remain deferred
+
+**Recommendation: option 3.**
+
+---
+
+## Chosen Scope
+
+This workforce spec covers three layers, intentionally phased:
+
+### Layer 1: Employee profile core
+
+The portal-facing workforce identity record.
+
+### Layer 2: Org structure and reporting
+
+The operating hierarchy needed for manager views and AI coworker accountability.
+
+### Layer 3: Employment lifecycle
+
+The status model and lifecycle dates needed for onboarding, active employment, leave, and offboarding.
+
+The implementation order should still be:
+
+1. profile
+2. org structure
+3. lifecycle workflows
+
+But the data model should be designed together so the pieces do not conflict later.
+
+---
+
+## Domain Boundaries
+
+### `User` remains the auth account
+
+`User` should continue to represent:
+
+- authentication
+- password and login state
+- coarse platform access
+- system-level active/inactive account semantics
+
+It should not become the full HR profile.
+
+### New workforce layer owns:
+
+- employee identity and personnel record
+- job placement
+- reporting line
+- department assignment
+- employment relationship and lifecycle dates
+- manager and directory context for the portal
+
+### Governance layer still owns:
+
+- team ownership
+- governed access
+- delegation and agent accountability
+- platform authority resolution
+
+### Key design rule
+
+**Department and manager hierarchy are not the same as governance teams.**
+
+Examples:
+
+- a person may belong to the `People Operations` department but still be in a governance team that owns `HR Agent` workflows
+- a manager may supervise employees in the org chart but not own the same agent operating team
+
+This distinction is required for the AI coworker model to stay clear.
+
+---
+
+## Proposed Data Model
+
+### New: `EmployeeProfile`
+
+Primary workforce record, linked one-to-one with `User` when the employee has a platform account.
+
+Suggested shape:
+
+```prisma
+model EmployeeProfile {
+  id                    String   @id @default(cuid())
+  employeeId            String   @unique
+  userId                String?  @unique
+  firstName             String
+  middleName            String?
+  lastName              String
+  displayName           String
+  workEmail             String?
+  personalEmail         String?
+  phoneNumber           String?
+  status                String   // onboarding | active | leave | suspended | offboarding | inactive
+  employmentTypeId      String?
+  departmentId          String?
+  positionId            String?
+  managerEmployeeId     String?
+  dottedLineManagerId   String?
+  workLocationId        String?
+  timezone              String?
+  startDate             DateTime?
+  confirmationDate      DateTime?
+  endDate               DateTime?
+  terminationRecordId   String?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+}
+```
+
+Purpose:
+
+- keeps workforce data separate from auth
+- gives the portal a first-class person record
+- gives agent flows a durable accountable-human record even if access changes later
+
+### New: `Department`
+
+Org structure node for business hierarchy.
+
+Suggested shape:
+
+```prisma
+model Department {
+  id                 String   @id @default(cuid())
+  departmentId       String   @unique
+  name               String
+  slug               String   @unique
+  parentDepartmentId String?
+  headEmployeeId     String?
+  status             String   @default("active")
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+}
+```
+
+Purpose:
+
+- gives the portal and directory a business org tree
+- supports department heads separate from line managers
+- keeps org semantics out of governance `Team`
+
+### New: `Position`
+
+Normalized job placement record.
+
+Suggested shape:
+
+```prisma
+model Position {
+  id              String   @id @default(cuid())
+  positionId      String   @unique
+  title           String
+  jobFamily       String?
+  jobLevel        String?
+  status          String   @default("active")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}
+```
+
+Purpose:
+
+- allows job title reuse across employees
+- gives lifecycle and approval flows a consistent role anchor
+- avoids storing job metadata only in free text
+
+### New: `EmploymentType`
+
+Lookup for relationship type.
+
+Suggested shape:
+
+```prisma
+model EmploymentType {
+  id               String   @id @default(cuid())
+  employmentTypeId String   @unique
+  name             String   // full_time | part_time | contractor | intern | advisor
+  status           String   @default("active")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+}
+```
+
+Purpose:
+
+- supports workforce segmentation without building payroll
+- useful for authority policies and future lifecycle flows
+
+### New: `WorkLocation`
+
+Optional normalized location model.
+
+Suggested shape:
+
+```prisma
+model WorkLocation {
+  id             String   @id @default(cuid())
+  locationId     String   @unique
+  name           String
+  locationType   String   // office | remote | hybrid | customer_site
+  timezone       String?
+  status         String   @default("active")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}
+```
+
+Purpose:
+
+- supports timezone-aware workflow routing
+- helps AI coworkers know operational context
+- avoids hard-coding location strings into profiles
+
+### New: `EmploymentEvent`
+
+Append-only lifecycle log.
+
+Suggested shape:
+
+```prisma
+model EmploymentEvent {
+  id                 String   @id @default(cuid())
+  eventId            String   @unique
+  employeeProfileId  String
+  eventType          String   // hired | onboarded | transferred | promoted | leave_started | leave_ended | offboarding_started | terminated | reactivated
+  effectiveAt        DateTime
+  reason             String?
+  actorUserId        String?
+  metadata           Json?
+  createdAt          DateTime @default(now())
+}
+```
+
+Purpose:
+
+- separates current state from lifecycle history
+- gives the portal and audits a timeline
+- avoids encoding every status change only in mutable columns
+
+### New: `TerminationRecord`
+
+Separate termination/offboarding detail.
+
+Suggested shape:
+
+```prisma
+model TerminationRecord {
+  id                 String   @id @default(cuid())
+  terminationId      String   @unique
+  employeeProfileId  String   @unique
+  terminationDate    DateTime
+  terminationReason  String?
+  notes              String?
+  exitInterviewDone  Boolean  @default(false)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+}
+```
+
+Purpose:
+
+- follows OrangeHRM's useful pattern of a separate termination concept
+- keeps offboarding detail out of the base employee row
+- supports future offboarding workflow without overloading `status`
+
+---
+
+## Runtime Relationships
+
+### `User` to `EmployeeProfile`
+
+- one `User` may map to zero or one `EmployeeProfile`
+- one `EmployeeProfile` may exist before a `User` account exists
+
+This is important for:
+
+- pre-start onboarding
+- inactive employees with retained history
+- future imports from another HR source
+
+### `EmployeeProfile` to manager
+
+- `managerEmployeeId` should point to another `EmployeeProfile`
+- `dottedLineManagerId` is optional and should not replace the primary manager
+
+For slice 1, only the primary manager relationship must drive approval and visibility behavior.
+
+### `EmployeeProfile` to `Department`
+
+- department is business placement
+- not a substitute for governance `Team`
+
+### `EmployeeProfile` to agent governance
+
+The workforce layer should later feed:
+
+- accountable human selection
+- manager approval routing
+- department-aware AI coworker behavior
+- worker directory context for agent selection
+
+---
+
+## Portal Experience Requirements
+
+The workforce portal should eventually provide three views:
+
+### 1. Self profile
+
+For the employee:
+
+- identity details
+- job placement
+- manager
+- department
+- employment status
+- start/confirmation/end dates
+
+### 2. Manager view
+
+For a manager:
+
+- direct reports
+- org placement
+- lifecycle actions on reports
+- future agent delegation context
+
+### 3. HR operations view
+
+For HR/admin users:
+
+- workforce directory
+- employment changes
+- organizational assignment changes
+- lifecycle timeline visibility
+
+The first slice should prioritize self profile plus HR operations. Manager views can start simple if the data model supports them.
+
+---
+
+## AI Coworker Implications
+
+The org structure is not just for chart rendering. It should support agent context such as:
+
+- who the accountable human is
+- who the manager approver is
+- which department the user belongs to
+- whether a manager is authorized to request elevated AI work for a report
+- which AI coworkers should appear by default in a person's workspace
+
+This means the workforce model should later expose stable runtime context like:
+
+```ts
+type WorkforceContext = {
+  employeeId: string;
+  departmentId?: string;
+  managerEmployeeId?: string;
+  employmentStatus: string;
+  workLocationId?: string;
+  timezone?: string;
+};
+```
+
+That runtime context should be assembled alongside `PrincipalContext`, not inside it.
+
+---
+
+## Lifecycle Model
+
+The first slice should define the lifecycle states now even if not all workflows are implemented immediately.
+
+Recommended current-state field:
+
+- `onboarding`
+- `active`
+- `leave`
+- `suspended`
+- `offboarding`
+- `inactive`
+
+Recommended event types:
+
+- `hired`
+- `onboarding_started`
+- `activated`
+- `manager_changed`
+- `department_changed`
+- `position_changed`
+- `leave_started`
+- `leave_ended`
+- `offboarding_started`
+- `terminated`
+- `reactivated`
+
+Validation rules to borrow from Frappe-style lifecycle modeling:
+
+- start date cannot be after end date
+- confirmation date cannot be before start date
+- termination requires a termination date
+- inactive or terminated managers should not retain active reports
+
+---
+
+## Suggested Slice Order
+
+### Slice A: Workforce identity core
+
+- `EmployeeProfile`
+- `EmploymentType`
+- `Position`
+- `WorkLocation`
+- lightweight employee directory and profile panel
+- `User` linkage
+
+### Slice B: Org structure
+
+- `Department`
+- `managerEmployeeId`
+- department heads
+- basic org tree and manager relationships
+- downstream AI coworker context hooks
+
+### Slice C: Lifecycle
+
+- `EmploymentEvent`
+- `TerminationRecord`
+- lifecycle transitions and validations
+- HR/admin workflow surfaces
+
+This keeps the initial portal useful quickly while preserving room for the rest of the domain.
+
+---
+
+## Recommended Borrowing Strategy
+
+### Borrow from Frappe HR / ERPNext
+
+- employee master data breadth
+- user-to-employee mapping
+- manager hierarchy via `reports_to`
+- lifecycle date validation
+- status rules around leaving/offboarding
+
+### Borrow from OrangeHRM
+
+- separation between personal detail, job detail, supervisors, and termination
+- employee API/view decomposition
+- subunit and employment-status normalization
+
+### Borrow selectively from Odoo / OCA
+
+- department and contract modularization
+- extension strategy for later certifications, equipment, and offboarding
+
+### Do not copy from references
+
+- payroll-heavy schema
+- product-specific naming that clashes with DPF
+- legacy HR admin navigation patterns
+
+---
+
+## Recommended Architecture
+
+For DPF, the cleanest architecture is:
+
+1. keep the governance layer as the control plane
+2. add workforce records as a separate business domain
+3. map workforce context into governed actions and AI coworker routing
+4. keep optional future import/sync boundaries open
+
+That means the first implementation should **not** attempt to make HR the master for authentication or for governance teams. It should remain a domain consumer of those systems.
+
+---
+
+## Testing Expectations For The Future Plan
+
+The eventual implementation plan should cover:
+
+- employee profile creation and update validation
+- manager self-reference and cycle checks
+- lifecycle date validation
+- status transition validation
+- user-to-employee uniqueness
+- employee directory and profile rendering
+- governed HR actions tied to lifecycle changes
+
+---
+
+## Summary
+
+The next correct slice is a DPF-native workforce core.
+
+It should:
+
+- create a first-class `EmployeeProfile`
+- normalize departments, positions, employment types, and work locations
+- model manager hierarchy explicitly
+- separate lifecycle events and termination details from the base employee row
+- feed future AI coworker accountability and routing
+
+The best reference pattern is a blend:
+
+- **Frappe HR** for employee master and lifecycle semantics
+- **OrangeHRM** for profile/job/supervisor/termination decomposition
+- **Odoo/OCA** for long-term modular extension ideas
+
+This gives DPF a workforce model that fits the portal and the AI coworker architecture without becoming a monolithic HR suite.
+
+---
+
+## Reference URLs
+
+- Frappe HR docs: https://docs.frappe.io/hr/introduction
+- Frappe employee lifecycle overview: https://frappe.io/hr/employee-lifecycle
+- Frappe HR GitHub: https://github.com/frappe/hrms
+- OrangeHRM open-source overview: https://www.orangehrm.com/open-source
+- OrangeHRM starter overview: https://www.orangehrm.com/assets/Documents/pdf/Starter-Overview.pdf
+- OrangeHRM GitHub: https://github.com/orangehrm/orangehrm
+- IceHrm site: https://icehrm.org/
+- IceHrm employee management docs: https://icehrm.github.io/docs/employees/
+- IceHrm audit log docs: https://icehrm.github.io/docs/auditlog/
+- Odoo Employees docs: https://www.odoo.com/documentation/19.0/applications/hr/employees.html
+- Odoo Departments docs: https://www.odoo.com/documentation/18.0/applications/hr/employees/departments.html
+- OCA HR repository: https://github.com/OCA/hr

--- a/packages/db/prisma/migrations/20260313170000_hr_workforce_core/migration.sql
+++ b/packages/db/prisma/migrations/20260313170000_hr_workforce_core/migration.sql
@@ -1,0 +1,187 @@
+CREATE TABLE "EmploymentType" (
+    "id" TEXT NOT NULL,
+    "employmentTypeId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmploymentType_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Position" (
+    "id" TEXT NOT NULL,
+    "positionId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "jobFamily" TEXT,
+    "jobLevel" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Position_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "WorkLocation" (
+    "id" TEXT NOT NULL,
+    "locationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "locationType" TEXT NOT NULL,
+    "timezone" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkLocation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Department" (
+    "id" TEXT NOT NULL,
+    "departmentId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "parentDepartmentId" TEXT,
+    "headEmployeeId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Department_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "EmployeeProfile" (
+    "id" TEXT NOT NULL,
+    "employeeId" TEXT NOT NULL,
+    "userId" TEXT,
+    "firstName" TEXT NOT NULL,
+    "middleName" TEXT,
+    "lastName" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "workEmail" TEXT,
+    "personalEmail" TEXT,
+    "phoneNumber" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'onboarding',
+    "employmentTypeId" TEXT,
+    "departmentId" TEXT,
+    "positionId" TEXT,
+    "managerEmployeeId" TEXT,
+    "dottedLineManagerId" TEXT,
+    "workLocationId" TEXT,
+    "timezone" TEXT,
+    "startDate" TIMESTAMP(3),
+    "confirmationDate" TIMESTAMP(3),
+    "endDate" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmployeeProfile_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "EmploymentEvent" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "effectiveAt" TIMESTAMP(3) NOT NULL,
+    "reason" TEXT,
+    "actorUserId" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EmploymentEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "TerminationRecord" (
+    "id" TEXT NOT NULL,
+    "terminationId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "terminationDate" TIMESTAMP(3) NOT NULL,
+    "terminationReason" TEXT,
+    "notes" TEXT,
+    "exitInterviewDone" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TerminationRecord_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EmploymentType_employmentTypeId_key" ON "EmploymentType"("employmentTypeId");
+CREATE INDEX "EmploymentType_status_idx" ON "EmploymentType"("status");
+
+CREATE UNIQUE INDEX "Position_positionId_key" ON "Position"("positionId");
+CREATE INDEX "Position_status_idx" ON "Position"("status");
+
+CREATE UNIQUE INDEX "WorkLocation_locationId_key" ON "WorkLocation"("locationId");
+CREATE INDEX "WorkLocation_status_idx" ON "WorkLocation"("status");
+
+CREATE UNIQUE INDEX "Department_departmentId_key" ON "Department"("departmentId");
+CREATE UNIQUE INDEX "Department_slug_key" ON "Department"("slug");
+CREATE INDEX "Department_parentDepartmentId_idx" ON "Department"("parentDepartmentId");
+CREATE INDEX "Department_headEmployeeId_idx" ON "Department"("headEmployeeId");
+CREATE INDEX "Department_status_idx" ON "Department"("status");
+
+CREATE UNIQUE INDEX "EmployeeProfile_employeeId_key" ON "EmployeeProfile"("employeeId");
+CREATE UNIQUE INDEX "EmployeeProfile_userId_key" ON "EmployeeProfile"("userId");
+CREATE INDEX "EmployeeProfile_status_idx" ON "EmployeeProfile"("status");
+CREATE INDEX "EmployeeProfile_departmentId_idx" ON "EmployeeProfile"("departmentId");
+CREATE INDEX "EmployeeProfile_managerEmployeeId_idx" ON "EmployeeProfile"("managerEmployeeId");
+CREATE INDEX "EmployeeProfile_employmentTypeId_idx" ON "EmployeeProfile"("employmentTypeId");
+CREATE INDEX "EmployeeProfile_positionId_idx" ON "EmployeeProfile"("positionId");
+CREATE INDEX "EmployeeProfile_workLocationId_idx" ON "EmployeeProfile"("workLocationId");
+
+CREATE UNIQUE INDEX "EmploymentEvent_eventId_key" ON "EmploymentEvent"("eventId");
+CREATE INDEX "EmploymentEvent_employeeProfileId_idx" ON "EmploymentEvent"("employeeProfileId");
+CREATE INDEX "EmploymentEvent_effectiveAt_idx" ON "EmploymentEvent"("effectiveAt");
+CREATE INDEX "EmploymentEvent_eventType_idx" ON "EmploymentEvent"("eventType");
+
+CREATE UNIQUE INDEX "TerminationRecord_terminationId_key" ON "TerminationRecord"("terminationId");
+CREATE UNIQUE INDEX "TerminationRecord_employeeProfileId_key" ON "TerminationRecord"("employeeProfileId");
+CREATE INDEX "TerminationRecord_terminationDate_idx" ON "TerminationRecord"("terminationDate");
+
+ALTER TABLE "Department"
+    ADD CONSTRAINT "Department_parentDepartmentId_fkey"
+    FOREIGN KEY ("parentDepartmentId") REFERENCES "Department"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "Department"
+    ADD CONSTRAINT "Department_headEmployeeId_fkey"
+    FOREIGN KEY ("headEmployeeId") REFERENCES "EmployeeProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_employmentTypeId_fkey"
+    FOREIGN KEY ("employmentTypeId") REFERENCES "EmploymentType"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_departmentId_fkey"
+    FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_positionId_fkey"
+    FOREIGN KEY ("positionId") REFERENCES "Position"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_managerEmployeeId_fkey"
+    FOREIGN KEY ("managerEmployeeId") REFERENCES "EmployeeProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_dottedLineManagerId_fkey"
+    FOREIGN KEY ("dottedLineManagerId") REFERENCES "EmployeeProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmployeeProfile"
+    ADD CONSTRAINT "EmployeeProfile_workLocationId_fkey"
+    FOREIGN KEY ("workLocationId") REFERENCES "WorkLocation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EmploymentEvent"
+    ADD CONSTRAINT "EmploymentEvent_employeeProfileId_fkey"
+    FOREIGN KEY ("employeeProfileId") REFERENCES "EmployeeProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "EmploymentEvent"
+    ADD CONSTRAINT "EmploymentEvent_actorUserId_fkey"
+    FOREIGN KEY ("actorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "TerminationRecord"
+    ADD CONSTRAINT "TerminationRecord_employeeProfileId_fkey"
+    FOREIGN KEY ("employeeProfileId") REFERENCES "EmployeeProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -19,6 +19,8 @@ model User {
   createdAt    DateTime      @default(now())
   groups       UserGroup[]
   agentThreads AgentThread[]
+  employeeProfile      EmployeeProfile?
+  authoredEmploymentEvents EmploymentEvent[]
   teamMemberships     TeamMembership[]
   grantedDelegations  DelegationGrant[] @relation("DelegationGrantGrantor")
 }
@@ -84,6 +86,153 @@ model TeamMembership {
 
   @@unique([teamId, userId])
   @@index([userId])
+}
+
+// Workforce Core
+
+model EmployeeProfile {
+  id                  String   @id @default(cuid())
+  employeeId          String   @unique
+  userId              String?  @unique
+  firstName           String
+  middleName          String?
+  lastName            String
+  displayName         String
+  workEmail           String?
+  personalEmail       String?
+  phoneNumber         String?
+  status              String   @default("onboarding") // onboarding | active | leave | suspended | offboarding | inactive
+  employmentTypeId    String?
+  departmentId        String?
+  positionId          String?
+  managerEmployeeId   String?
+  dottedLineManagerId String?
+  workLocationId      String?
+  timezone            String?
+  startDate           DateTime?
+  confirmationDate    DateTime?
+  endDate             DateTime?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  user                User?             @relation(fields: [userId], references: [id], onDelete: SetNull)
+  employmentType      EmploymentType?   @relation(fields: [employmentTypeId], references: [id], onDelete: SetNull)
+  department          Department?       @relation("DepartmentEmployees", fields: [departmentId], references: [id], onDelete: SetNull)
+  position            Position?         @relation(fields: [positionId], references: [id], onDelete: SetNull)
+  manager             EmployeeProfile?  @relation("EmployeeManager", fields: [managerEmployeeId], references: [id], onDelete: SetNull)
+  directReports       EmployeeProfile[] @relation("EmployeeManager")
+  dottedLineManager   EmployeeProfile?  @relation("EmployeeDottedManager", fields: [dottedLineManagerId], references: [id], onDelete: SetNull)
+  dottedLineReports   EmployeeProfile[] @relation("EmployeeDottedManager")
+  workLocation        WorkLocation?     @relation(fields: [workLocationId], references: [id], onDelete: SetNull)
+  employmentEvents    EmploymentEvent[]
+  terminationRecord   TerminationRecord?
+  headedDepartments   Department[]      @relation("DepartmentHead")
+
+  @@index([status])
+  @@index([departmentId])
+  @@index([managerEmployeeId])
+  @@index([employmentTypeId])
+  @@index([positionId])
+  @@index([workLocationId])
+}
+
+model Department {
+  id                 String          @id @default(cuid())
+  departmentId       String          @unique
+  name               String
+  slug               String          @unique
+  parentDepartmentId String?
+  headEmployeeId     String?
+  status             String          @default("active")
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+
+  parentDepartment   Department?     @relation("DepartmentTree", fields: [parentDepartmentId], references: [id], onDelete: SetNull)
+  childDepartments   Department[]    @relation("DepartmentTree")
+  headEmployee       EmployeeProfile? @relation("DepartmentHead", fields: [headEmployeeId], references: [id], onDelete: SetNull)
+  employees          EmployeeProfile[] @relation("DepartmentEmployees")
+
+  @@index([parentDepartmentId])
+  @@index([headEmployeeId])
+  @@index([status])
+}
+
+model Position {
+  id          String   @id @default(cuid())
+  positionId  String   @unique
+  title       String
+  jobFamily   String?
+  jobLevel    String?
+  status      String   @default("active")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  employees   EmployeeProfile[]
+
+  @@index([status])
+}
+
+model EmploymentType {
+  id               String   @id @default(cuid())
+  employmentTypeId String   @unique
+  name             String
+  status           String   @default("active")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  employees        EmployeeProfile[]
+
+  @@index([status])
+}
+
+model WorkLocation {
+  id           String   @id @default(cuid())
+  locationId    String   @unique
+  name          String
+  locationType  String   // office | remote | hybrid | customer_site
+  timezone      String?
+  status        String   @default("active")
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  employees     EmployeeProfile[]
+
+  @@index([status])
+}
+
+model EmploymentEvent {
+  id                String          @id @default(cuid())
+  eventId           String          @unique
+  employeeProfileId String
+  eventType         String          // hired | onboarding_started | activated | manager_changed | department_changed | position_changed | leave_started | leave_ended | offboarding_started | terminated | reactivated
+  effectiveAt       DateTime
+  reason            String?
+  actorUserId       String?
+  metadata          Json?
+  createdAt         DateTime        @default(now())
+
+  employeeProfile   EmployeeProfile @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
+  actorUser         User?           @relation(fields: [actorUserId], references: [id], onDelete: SetNull)
+
+  @@index([employeeProfileId])
+  @@index([effectiveAt])
+  @@index([eventType])
+}
+
+model TerminationRecord {
+  id                String          @id @default(cuid())
+  terminationId     String          @unique
+  employeeProfileId String          @unique
+  terminationDate   DateTime
+  terminationReason String?
+  notes             String?
+  exitInterviewDone Boolean         @default(false)
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+
+  employeeProfile   EmployeeProfile @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
+
+  @@index([terminationDate])
 }
 
 // ─── Portfolios & Products ───────────────────────────────────────────────────

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -5,6 +5,7 @@ import { prisma } from "./client.js";
 import { parseRoleId, parseAgentTier, parseAgentType, parseAgentPortfolioSlug } from "./seed-helpers.js";
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
 import { seedGovernanceReferenceData } from "./governance-seed.js";
+import { seedWorkforceReferenceData } from "./workforce-seed.js";
 import * as crypto from "crypto";
 
 // Repo root: prefer DPF_DATA_ROOT env var (needed when running from a worktree),
@@ -623,6 +624,7 @@ async function main(): Promise<void> {
   console.log("Starting seed...");
   await seedRoles();
   await seedGovernanceReferenceData(prisma);
+  await seedWorkforceReferenceData(prisma);
   await seedPortfolios();
   await seedAgents();
   await seedTaxonomyNodes();

--- a/packages/db/src/workforce-seed.test.ts
+++ b/packages/db/src/workforce-seed.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultEmploymentTypes, getDefaultWorkLocations } from "./workforce-seed";
+
+describe("workforce seed defaults", () => {
+  it("returns stable employment types", () => {
+    expect(getDefaultEmploymentTypes().map((item) => item.employmentTypeId)).toEqual([
+      "emp-full-time",
+      "emp-part-time",
+      "emp-contractor",
+      "emp-intern",
+      "emp-advisor",
+    ]);
+  });
+
+  it("returns a default remote work location", () => {
+    expect(getDefaultWorkLocations().map((item) => item.locationId)).toContain("loc-remote");
+  });
+});

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -1,0 +1,66 @@
+import type { PrismaClient } from "../generated/client";
+
+export function getDefaultEmploymentTypes() {
+  return [
+    { employmentTypeId: "emp-full-time", name: "Full-time" },
+    { employmentTypeId: "emp-part-time", name: "Part-time" },
+    { employmentTypeId: "emp-contractor", name: "Contractor" },
+    { employmentTypeId: "emp-intern", name: "Intern" },
+    { employmentTypeId: "emp-advisor", name: "Advisor" },
+  ] as const;
+}
+
+export function getDefaultWorkLocations() {
+  return [
+    {
+      locationId: "loc-hq",
+      name: "Headquarters",
+      locationType: "office",
+      timezone: "America/Chicago",
+    },
+    {
+      locationId: "loc-remote",
+      name: "Remote",
+      locationType: "remote",
+      timezone: null,
+    },
+    {
+      locationId: "loc-hybrid",
+      name: "Hybrid",
+      locationType: "hybrid",
+      timezone: null,
+    },
+  ] as const;
+}
+
+export async function seedWorkforceReferenceData(prisma: PrismaClient): Promise<void> {
+  for (const employmentType of getDefaultEmploymentTypes()) {
+    await prisma.employmentType.upsert({
+      where: { employmentTypeId: employmentType.employmentTypeId },
+      update: {
+        name: employmentType.name,
+        status: "active",
+      },
+      create: {
+        ...employmentType,
+        status: "active",
+      },
+    });
+  }
+
+  for (const workLocation of getDefaultWorkLocations()) {
+    await prisma.workLocation.upsert({
+      where: { locationId: workLocation.locationId },
+      update: {
+        name: workLocation.name,
+        locationType: workLocation.locationType,
+        timezone: workLocation.timezone,
+        status: "active",
+      },
+      create: {
+        ...workLocation,
+        status: "active",
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add the workforce core schema, migration, and reference seed data for employee profiles, org references, and lifecycle records
- add governed workforce read models and server actions for profile updates, org assignment, and lifecycle events
- extend the employee route with workforce directory, profile, org assignment, and lifecycle visibility panels

## Test Plan
- [x] pnpm --filter @dpf/db test
- [x] pnpm --filter @dpf/db generate
- [x] \='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma
- [x] pnpm --filter web test
- [x] pnpm --filter web typecheck