### PR TITLE
feat: bundle Ollama as Docker Compose sidecar with zero-config AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,9 @@ BRANDING_LOGO_AWS_ACCESS_KEY_ID="<object storage access key id>"
 BRANDING_LOGO_AWS_SECRET_ACCESS_KEY="<object storage secret>"
 BRANDING_LOGO_PUBLIC_URL_PREFIX="https://cdn.example.com/branding"
 BRANDING_LOGO_ALLOW_DATA_URL_FALLBACK="0"
+
+# ── Ollama (Docker sidecar) ──────────────────────────────
+# Host port for Ollama (change if local Ollama already uses 11434)
+OLLAMA_HOST_PORT=11434
+# Internal Docker network URL for Ollama (server-side only; leave unset for local dev)
+# OLLAMA_INTERNAL_URL=http://ollama:11434

--- a/apps/web/app/(shell)/platform/ai/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/page.tsx
@@ -5,6 +5,7 @@ import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import { getProviders, getTokenSpendByProvider, getTokenSpendByAgent, getScheduledJobs } from "@/lib/ai-provider-data";
 import { syncProviderRegistry } from "@/lib/actions/ai-providers";
+import { checkBundledProviders } from "@/lib/ollama";
 import { TokenSpendPanel } from "@/components/platform/TokenSpendPanel";
 import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
 import { SyncProvidersButton } from "@/components/platform/SyncProvidersButton";
@@ -26,6 +27,9 @@ export default async function PlatformAiPage() {
   if (syncJob && syncJob.schedule !== "disabled" && syncJob.nextRunAt && syncJob.nextRunAt < new Date()) {
     await syncProviderRegistry();
   }
+
+  // Passive health check for bundled Ollama (may change provider status)
+  await checkBundledProviders();
 
   const now = new Date();
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };

--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -5,6 +5,8 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { getProviderById, getProviders, getDiscoveredModels, getModelProfiles } from "@/lib/ai-provider-data";
 import { ProviderDetailForm } from "@/components/platform/ProviderDetailForm";
+import { getInfraCIs } from "@dpf/db";
+import { OllamaHardwareInfo } from "@/components/platform/OllamaHardwareInfo";
 
 type Props = { params: Promise<{ providerId: string }> };
 
@@ -23,6 +25,20 @@ export default async function ProviderDetailPage({ params }: Props) {
   const session = await auth();
   const user = session?.user;
   const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
+
+  // Fetch hardware info for Ollama
+  let hardwareInfo: { gpu: string; vramGb: number | null; modelCount: number } | null = null;
+  if (providerId === "ollama") {
+    const infraCIs = await getInfraCIs("ai-inference");
+    const ollamaCI = infraCIs.find((ci) => ci.id === "CI-ollama-01");
+    if (ollamaCI?.properties.gpu) {
+      hardwareInfo = {
+        gpu: ollamaCI.properties.gpu as string,
+        vramGb: (ollamaCI.properties.vramGb as number) ?? null,
+        modelCount: (ollamaCI.properties.modelCount as number) ?? 0,
+      };
+    }
+  }
 
   return (
     <div>
@@ -43,6 +59,14 @@ export default async function ProviderDetailPage({ params }: Props) {
           )}
         </div>
       </div>
+
+      {hardwareInfo && (
+        <OllamaHardwareInfo
+          gpu={hardwareInfo.gpu}
+          vramGb={hardwareInfo.vramGb}
+          modelCount={hardwareInfo.modelCount}
+        />
+      )}
 
       <div style={{ background: "#1a1a2e", border: "1px solid #2a2a40", borderRadius: 8, padding: 20 }}>
         <ProviderDetailForm pw={pw} canWrite={canWrite} models={models} profiles={profiles} hasActiveProvider={hasActiveProvider} />

--- a/apps/web/components/platform/OllamaHardwareInfo.tsx
+++ b/apps/web/components/platform/OllamaHardwareInfo.tsx
@@ -1,0 +1,51 @@
+import { estimateMaxParameters } from "@/lib/ollama";
+
+interface OllamaHardwareInfoProps {
+  gpu: string;
+  vramGb: number | null;
+  modelCount: number;
+}
+
+export function OllamaHardwareInfo({ gpu, vramGb, modelCount }: OllamaHardwareInfoProps) {
+  const maxParams = estimateMaxParameters(vramGb);
+  const isGpu = gpu !== "CPU-only";
+
+  return (
+    <div style={{
+      background: "var(--dpf-surface-1, #1a1a2e)",
+      border: "1px solid var(--dpf-border, #2a2a40)",
+      borderRadius: 6,
+      padding: 12,
+      marginBottom: 16,
+    }}>
+      <div style={{
+        color: "var(--dpf-accent, #7c8cf8)",
+        fontSize: 10,
+        fontWeight: 600,
+        textTransform: "uppercase",
+        letterSpacing: "0.05em",
+        marginBottom: 8,
+      }}>
+        Hardware
+      </div>
+      <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ color: "var(--dpf-muted, #8888a0)", fontSize: 10 }}>Compute</div>
+          <div style={{ color: "#e0e0ff", fontSize: 12, fontWeight: 600 }}>
+            {isGpu ? `${gpu}${vramGb ? ` (${vramGb}GB VRAM)` : ""}` : "CPU-only"}
+          </div>
+        </div>
+        {maxParams && (
+          <div>
+            <div style={{ color: "var(--dpf-muted, #8888a0)", fontSize: 10 }}>Max Model Size (Q4)</div>
+            <div style={{ color: "#e0e0ff", fontSize: 12, fontWeight: 600 }}>{maxParams} parameters</div>
+          </div>
+        )}
+        <div>
+          <div style={{ color: "var(--dpf-muted, #8888a0)", fontSize: 10 }}>Available Models</div>
+          <div style={{ color: "#e0e0ff", fontSize: 12, fontWeight: 600 }}>{modelCount}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -2,24 +2,22 @@
 
 import { readFileSync } from "fs";
 import { join } from "path";
-import { prisma, type Prisma } from "@dpf/db";
+import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import {
-  computeTokenCost,
-  computeComputeCost,
   computeNextRunAt,
   getTestUrl,
-  parseModelsResponse,
   type RegistryProviderEntry,
 } from "@/lib/ai-provider-types";
+import { encryptSecret } from "@/lib/credential-crypto";
 import {
-  rankProvidersByCost,
-  buildProfilingPrompt,
-  parseProfilingResponse,
-  type ProfileResult,
-} from "@/lib/ai-profiling";
-import { encryptSecret, decryptSecret } from "@/lib/credential-crypto";
+  discoverModelsInternal,
+  profileModelsInternal,
+  getDecryptedCredential,
+  getProviderExtraHeaders,
+  getProviderBearerToken,
+} from "@/lib/ai-provider-internals";
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
@@ -138,23 +136,6 @@ export async function triggerProviderSync(): Promise<{ added: number; updated: n
   return syncProviderRegistry();
 }
 
-/** Decrypt the API key / client secret for a provider (server-only). */
-async function getDecryptedCredential(providerId: string) {
-  const cred = await prisma.credentialEntry.findUnique({ where: { providerId } });
-  if (!cred) return null;
-  return {
-    ...cred,
-    secretRef:    cred.secretRef    ? decryptSecret(cred.secretRef)    : null,
-    clientSecret: cred.clientSecret ? decryptSecret(cred.clientSecret) : null,
-  };
-}
-
-/** Provider-specific headers required beyond auth (e.g. Anthropic API versioning). */
-function getProviderExtraHeaders(providerId: string): Record<string, string> {
-  if (providerId === "anthropic") return { "anthropic-version": "2023-06-01" };
-  return {};
-}
-
 // ─── Configure provider ───────────────────────────────────────────────────────
 
 export async function configureProvider(input: {
@@ -225,54 +206,6 @@ export async function configureProvider(input: {
   return {};
 }
 
-// ─── OAuth token exchange ─────────────────────────────────────────────────────
-
-async function getProviderBearerToken(providerId: string): Promise<{ token: string } | { error: string }> {
-  const credential = await getDecryptedCredential(providerId);
-  if (!credential) return { error: "No credential configured" };
-  if (!credential.clientId || !credential.clientSecret || !credential.tokenEndpoint) {
-    return { error: "OAuth credentials incomplete — need client ID, secret, and token endpoint" };
-  }
-
-  // Return cached token if still valid (5-minute buffer)
-  if (credential.cachedToken && credential.tokenExpiresAt) {
-    const buffer = 5 * 60 * 1000;
-    if (credential.tokenExpiresAt.getTime() > Date.now() + buffer) {
-      return { token: credential.cachedToken };
-    }
-  }
-
-  // Exchange for new token
-  const params = new URLSearchParams({
-    grant_type: "client_credentials",
-    client_id: credential.clientId,
-    client_secret: credential.clientSecret,
-    ...(credential.scope ? { scope: credential.scope } : {}),
-  });
-
-  try {
-    const res = await fetch(credential.tokenEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: params.toString(),
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!res.ok) return { error: `Token exchange failed: HTTP ${res.status}` };
-
-    const body = await res.json() as { access_token: string; expires_in: number };
-    const expiresAt = new Date(Date.now() + body.expires_in * 1000);
-
-    await prisma.credentialEntry.update({
-      where: { providerId },
-      data: { cachedToken: body.access_token, tokenExpiresAt: expiresAt, status: "ok" },
-    });
-
-    return { token: body.access_token };
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : "Token exchange error" };
-  }
-}
-
 // ─── Test provider auth ───────────────────────────────────────────────────────
 
 export async function testProviderAuth(providerId: string): Promise<{ ok: boolean; message: string }> {
@@ -324,68 +257,11 @@ export async function testProviderAuth(providerId: string): Promise<{ ok: boolea
 
 // ─── Model discovery ─────────────────────────────────────────────────────────
 
-export async function discoverModels(providerId: string): Promise<{ discovered: number; newCount: number; error?: string }> {
+export async function discoverModels(
+  providerId: string,
+): Promise<{ discovered: number; newCount: number; error?: string }> {
   await requireManageProviders();
-
-  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
-  if (!provider) return { discovered: 0, newCount: 0, error: "Provider not found" };
-
-  const providerRow = {
-    ...provider,
-    families: provider.families as string[],
-    enabledFamilies: provider.enabledFamilies as string[],
-    supportedAuthMethods: provider.supportedAuthMethods as string[],
-  };
-
-  const testUrl = getTestUrl(providerRow);
-  if (!testUrl) return { discovered: 0, newCount: 0, error: "No base URL configured" };
-
-  // Build auth headers (same logic as testProviderAuth)
-  const headers: Record<string, string> = {
-    ...getProviderExtraHeaders(providerId),
-  };
-  if (provider.authMethod === "api_key") {
-    const cred = await getDecryptedCredential(providerId);
-    if (cred?.secretRef && provider.authHeader) {
-      headers[provider.authHeader] = provider.authHeader === "Authorization"
-        ? `Bearer ${cred.secretRef}` : cred.secretRef;
-    }
-  } else if (provider.authMethod === "oauth2_client_credentials") {
-    const tokenResult = await getProviderBearerToken(providerId);
-    if ("error" in tokenResult) return { discovered: 0, newCount: 0, error: tokenResult.error };
-    headers["Authorization"] = `Bearer ${tokenResult.token}`;
-  }
-
-  let json: unknown;
-  try {
-    const res = await fetch(testUrl, { headers, signal: AbortSignal.timeout(15_000) });
-    if (!res.ok) return { discovered: 0, newCount: 0, error: `HTTP ${res.status}` };
-    json = await res.json();
-  } catch (err) {
-    return { discovered: 0, newCount: 0, error: err instanceof Error ? err.message : "Fetch error" };
-  }
-
-  const models = parseModelsResponse(providerId, json);
-  let newCount = 0;
-
-  for (const m of models) {
-    const existing = await prisma.discoveredModel.findUnique({
-      where: { providerId_modelId: { providerId, modelId: m.modelId } },
-    });
-    if (existing) {
-      await prisma.discoveredModel.update({
-        where: { id: existing.id },
-        data: { rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
-      });
-    } else {
-      await prisma.discoveredModel.create({
-        data: { providerId, modelId: m.modelId, rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
-      });
-      newCount++;
-    }
-  }
-
-  return { discovered: models.length, newCount };
+  return discoverModelsInternal(providerId);
 }
 
 // ─── Scheduled jobs ───────────────────────────────────────────────────────────
@@ -410,319 +286,10 @@ export async function runScheduledJobNow(jobId: string): Promise<void> {
 
 // ─── Model profiling ──────────────────────────────────────────────────────────
 
-/** Known cheap models per provider for profiling tasks. */
-const PROFILING_MODELS: Record<string, string> = {
-  anthropic:      "claude-haiku-4-5-20251001",
-  openai:         "gpt-4o-mini",
-  "azure-openai": "gpt-4o-mini",
-  gemini:         "gemini-2.0-flash",
-  cohere:         "command-r",
-  mistral:        "mistral-small-latest",
-  deepseek:       "deepseek-chat",
-  groq:           "llama-3.1-8b-instant",
-  together:       "meta-llama/Llama-3-8b-chat-hf",
-  fireworks:      "accounts/fireworks/models/llama-v3p1-8b-instruct",
-  xai:            "grok-2-latest",
-  openrouter:     "meta-llama/llama-3.1-8b-instruct:free",
-};
-
-/** Pick a model for profiling: prefer discovered models (proven valid), then known defaults. */
-async function getProfilingModel(providerId: string): Promise<string> {
-  // Prefer a discovered model — we know the account has access to it
-  const discovered = await prisma.discoveredModel.findMany({
-    where: { providerId },
-    orderBy: { modelId: "asc" },
-    select: { modelId: true },
-  });
-
-  if (discovered.length > 0) {
-    // Try to match a known cheap model from the discovered list
-    const known = PROFILING_MODELS[providerId];
-    if (known && discovered.some((d) => d.modelId === known)) return known;
-
-    // Otherwise pick the first discovered model that looks like a chat model
-    // (skip embedding-only, whisper, tts, dall-e, etc.)
-    const skipPatterns = /embed|whisper|tts|dall-e|moderation|babbage|davinci-00/i;
-    const chatModel = discovered.find((d) => !skipPatterns.test(d.modelId));
-    if (chatModel) return chatModel.modelId;
-
-    // Last resort: first discovered model
-    return discovered[0]!.modelId;
-  }
-
-  // No discovered models — use the hardcoded default
-  const known = PROFILING_MODELS[providerId];
-  if (known) return known;
-
-  throw new Error(`No known or discovered model for profiling on ${providerId}`);
-}
-
-async function callProviderForProfiling(
-  profilingProviderId: string,
-  prompt: string,
-): Promise<{ text: string; inputTokens?: number; outputTokens?: number }> {
-  const prov = await prisma.modelProvider.findUnique({ where: { providerId: profilingProviderId } });
-  if (!prov) throw new Error("Provider not found");
-
-  const baseUrl = prov.baseUrl ?? prov.endpoint;
-  if (!baseUrl) throw new Error("No base URL");
-
-  const model = await getProfilingModel(profilingProviderId);
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...getProviderExtraHeaders(profilingProviderId),
-  };
-
-  if (prov.authMethod === "api_key") {
-    const cred = await getDecryptedCredential(profilingProviderId);
-    if (!cred?.secretRef || !prov.authHeader) throw new Error("No credential");
-    headers[prov.authHeader] = prov.authHeader === "Authorization"
-      ? `Bearer ${cred.secretRef}` : cred.secretRef;
-  } else if (prov.authMethod === "oauth2_client_credentials") {
-    const tokenResult = await getProviderBearerToken(profilingProviderId);
-    if ("error" in tokenResult) throw new Error(tokenResult.error);
-    headers["Authorization"] = `Bearer ${tokenResult.token}`;
-  }
-
-  // Each provider family has its own endpoint + request/response shape
-  let chatUrl: string;
-  let body: Record<string, unknown>;
-  let extractText: (data: Record<string, unknown>) => string;
-
-  if (profilingProviderId === "anthropic") {
-    chatUrl = `${baseUrl}/messages`;
-    body = { model, max_tokens: 4096, messages: [{ role: "user", content: prompt }] };
-    extractText = (d) => (d.content as Array<{ text?: string }>)?.[0]?.text ?? "";
-  } else if (profilingProviderId === "cohere") {
-    chatUrl = `${baseUrl}/chat`;
-    body = { model, message: prompt, max_tokens: 4096 };
-    extractText = (d) => (d.text as string) ?? "";
-  } else if (profilingProviderId === "gemini") {
-    // Gemini uses generateContent endpoint with different structure
-    chatUrl = `${baseUrl}/models/${model}:generateContent`;
-    body = { contents: [{ parts: [{ text: prompt }] }] };
-    extractText = (d) => {
-      const candidates = d.candidates as Array<{ content?: { parts?: Array<{ text?: string }> } }> | undefined;
-      return candidates?.[0]?.content?.parts?.[0]?.text ?? "";
-    };
-  } else {
-    // OpenAI-compatible (OpenAI, Azure, Mistral, Groq, Together, Fireworks, xAI, OpenRouter, LiteLLM, etc.)
-    chatUrl = `${baseUrl}/chat/completions`;
-    body = { model, messages: [{ role: "user", content: prompt }], max_tokens: 4096 };
-    extractText = (d) => (d.choices as Array<{ message?: { content?: string } }>)?.[0]?.message?.content ?? "";
-  }
-
-  const res = await fetch(chatUrl, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(30_000),
-  });
-
-  if (!res.ok) {
-    const errBody = await res.text().catch(() => "");
-    throw new Error(`HTTP ${res.status} from ${profilingProviderId}: ${errBody.slice(0, 200)}`);
-  }
-  const data = await res.json() as Record<string, unknown>;
-
-  const text = extractText(data);
-
-  return {
-    text,
-    inputTokens: data.usage?.input_tokens ?? data.usage?.prompt_tokens,
-    outputTokens: data.usage?.output_tokens ?? data.usage?.completion_tokens,
-  };
-}
-
 export async function profileModels(
   providerId: string,
   modelIds?: string[],
 ): Promise<{ profiled: number; failed: number; error?: string }> {
   await requireManageProviders();
-
-  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
-  if (!provider) return { profiled: 0, failed: 0, error: "Provider not found" };
-
-  // Get models to profile
-  const whereClause = modelIds
-    ? { providerId, modelId: { in: modelIds } }
-    : { providerId };
-  const models = await prisma.discoveredModel.findMany({ where: whereClause });
-  if (models.length === 0) return { profiled: 0, failed: 0, error: "No models to profile" };
-
-  // Find cheapest active provider to do the profiling
-  const allProviders = await prisma.modelProvider.findMany({
-    select: { providerId: true, status: true, outputPricePerMToken: true },
-  });
-  const ranked = rankProvidersByCost(allProviders);
-  if (ranked.length === 0) return { profiled: 0, failed: 0, error: "No active AI provider available for profiling" };
-
-  // Build prompt
-  const modelEntries = models.map((m) => ({
-    modelId: m.modelId,
-    providerName: provider.name,
-    rawMetadata: m.rawMetadata as Record<string, unknown>,
-  }));
-
-  // Batch in groups of 20
-  let totalProfiled = 0;
-  let totalFailed = 0;
-
-  for (let i = 0; i < modelEntries.length; i += 20) {
-    const batch = modelEntries.slice(i, i + 20);
-    const prompt = buildProfilingPrompt(batch);
-
-    let profiles: ProfileResult[] = [];
-    let usedProviderId: string | null = null;
-    let lastError: string | null = null;
-
-    // Try each provider in cost order
-    for (const candidateId of ranked) {
-      try {
-        const result = await callProviderForProfiling(candidateId, prompt);
-        profiles = parseProfilingResponse(result.text);
-
-        // If JSON parse failed, retry once with a stricter prompt
-        if (profiles.length === 0) {
-          const stricterPrompt =
-            "IMPORTANT: Respond ONLY with a valid JSON array. No markdown code fences, no explanation text.\n\n" +
-            prompt;
-          const retryResult = await callProviderForProfiling(candidateId, stricterPrompt);
-          profiles = parseProfilingResponse(retryResult.text);
-
-          if (profiles.length > 0) {
-            usedProviderId = candidateId;
-            await logTokenUsage({
-              agentId: "system:model-profiler",
-              providerId: candidateId,
-              contextKey: `profile-${providerId}-batch-${i}`,
-              inputTokens: (result.inputTokens ?? 0) + (retryResult.inputTokens ?? 0),
-              outputTokens: (result.outputTokens ?? 0) + (retryResult.outputTokens ?? 0),
-            });
-            break;
-          }
-
-          lastError = `${candidateId}: response was not valid JSON`;
-          await logTokenUsage({
-            agentId: "system:model-profiler",
-            providerId: candidateId,
-            contextKey: `profile-${providerId}-batch-${i}-failed`,
-            inputTokens: 0,
-            outputTokens: 0,
-          }).catch(() => {});
-          continue;
-        }
-
-        usedProviderId = candidateId;
-        await logTokenUsage({
-          agentId: "system:model-profiler",
-          providerId: candidateId,
-          contextKey: `profile-${providerId}-batch-${i}`,
-          inputTokens: result.inputTokens ?? 0,
-          outputTokens: result.outputTokens ?? 0,
-        });
-        break;
-      } catch (err) {
-        lastError = `${candidateId}: ${err instanceof Error ? err.message : "Unknown error"}`;
-        console.error(`[profiling] ${lastError}`);
-        await logTokenUsage({
-          agentId: "system:model-profiler",
-          providerId: candidateId,
-          contextKey: `profile-${providerId}-batch-${i}-failed`,
-          inputTokens: 0,
-          outputTokens: 0,
-        }).catch(() => {});
-        continue;
-      }
-    }
-
-    // If all providers failed for this batch, return the last error
-    if (profiles.length === 0 && lastError) {
-      return { profiled: totalProfiled, failed: batch.length, error: lastError };
-    }
-
-    // Save successful profiles
-    for (const profile of profiles) {
-      await prisma.modelProfile.upsert({
-        where: { providerId_modelId: { providerId, modelId: profile.modelId } },
-        create: {
-          providerId,
-          modelId: profile.modelId,
-          friendlyName: profile.friendlyName,
-          summary: profile.summary,
-          capabilityTier: profile.capabilityTier,
-          costTier: profile.costTier,
-          bestFor: profile.bestFor,
-          avoidFor: profile.avoidFor,
-          contextWindow: profile.contextWindow ?? null,
-          speedRating: profile.speedRating ?? null,
-          generatedBy: usedProviderId ?? "unknown",
-        },
-        update: {
-          friendlyName: profile.friendlyName,
-          summary: profile.summary,
-          capabilityTier: profile.capabilityTier,
-          costTier: profile.costTier,
-          bestFor: profile.bestFor,
-          avoidFor: profile.avoidFor,
-          contextWindow: profile.contextWindow ?? null,
-          speedRating: profile.speedRating ?? null,
-          generatedBy: usedProviderId ?? "unknown",
-          generatedAt: new Date(),
-        },
-      });
-      totalProfiled++;
-    }
-
-    const profiledIds = new Set(profiles.map((p) => p.modelId));
-    totalFailed += batch.filter((b) => !profiledIds.has(b.modelId)).length;
-  }
-
-  return { profiled: totalProfiled, failed: totalFailed };
-}
-
-// ─── Token usage logging ──────────────────────────────────────────────────────
-
-async function logTokenUsage(input: {
-  agentId: string;
-  providerId: string;
-  contextKey: string;
-  inputTokens: number;
-  outputTokens: number;
-  inferenceMs?: number;
-}): Promise<void> {
-  // Internal helper — callers (profileModels) already guard with requireManageProviders()
-
-  const provider = await prisma.modelProvider.findUnique({ where: { providerId: input.providerId } });
-
-  let costUsd = 0;
-  if (provider) {
-    if (provider.costModel === "compute" && input.inferenceMs !== undefined) {
-      costUsd = computeComputeCost(
-        input.inferenceMs,
-        provider.computeWatts ?? 150,
-        provider.electricityRateKwh ?? 0.12,
-      );
-    } else if (provider.costModel === "token") {
-      costUsd = computeTokenCost(
-        input.inputTokens,
-        input.outputTokens,
-        provider.inputPricePerMToken ?? 0,
-        provider.outputPricePerMToken ?? 0,
-      );
-    }
-  }
-
-  await prisma.tokenUsage.create({
-    data: {
-      agentId:      input.agentId,
-      providerId:   input.providerId,
-      contextKey:   input.contextKey,
-      inputTokens:  input.inputTokens,
-      outputTokens: input.outputTokens,
-      ...(input.inferenceMs !== undefined && { inferenceMs: input.inferenceMs }),
-      costUsd,
-    },
-  });
+  return profileModelsInternal(providerId, modelIds);
 }

--- a/apps/web/lib/ai-provider-internals.ts
+++ b/apps/web/lib/ai-provider-internals.ts
@@ -1,0 +1,467 @@
+// apps/web/lib/ai-provider-internals.ts
+// Internal discovery/profiling logic and shared private helpers.
+// NOT a server action file — must never have "use server" directive.
+// Called by checkBundledProviders() (page-load health check) and
+// by the server actions in ai-providers.ts (which add auth guards).
+
+import { prisma, type Prisma } from "@dpf/db";
+import { decryptSecret } from "@/lib/credential-crypto";
+import {
+  computeTokenCost,
+  computeComputeCost,
+  getTestUrl,
+  parseModelsResponse,
+} from "@/lib/ai-provider-types";
+import {
+  rankProvidersByCost,
+  buildProfilingPrompt,
+  parseProfilingResponse,
+  type ProfileResult,
+} from "@/lib/ai-profiling";
+
+// ─── Shared helpers (exported for use by ai-providers.ts server actions) ─────
+
+/** Decrypt the API key / client secret for a provider (server-only). */
+export async function getDecryptedCredential(providerId: string) {
+  const cred = await prisma.credentialEntry.findUnique({ where: { providerId } });
+  if (!cred) return null;
+  return {
+    ...cred,
+    secretRef:    cred.secretRef    ? decryptSecret(cred.secretRef)    : null,
+    clientSecret: cred.clientSecret ? decryptSecret(cred.clientSecret) : null,
+  };
+}
+
+/** Provider-specific headers required beyond auth (e.g. Anthropic API versioning). */
+export function getProviderExtraHeaders(providerId: string): Record<string, string> {
+  if (providerId === "anthropic") return { "anthropic-version": "2023-06-01" };
+  return {};
+}
+
+/** OAuth token exchange — obtain or refresh bearer token for a provider. */
+export async function getProviderBearerToken(providerId: string): Promise<{ token: string } | { error: string }> {
+  const credential = await getDecryptedCredential(providerId);
+  if (!credential) return { error: "No credential configured" };
+  if (!credential.clientId || !credential.clientSecret || !credential.tokenEndpoint) {
+    return { error: "OAuth credentials incomplete — need client ID, secret, and token endpoint" };
+  }
+
+  // Return cached token if still valid (5-minute buffer)
+  if (credential.cachedToken && credential.tokenExpiresAt) {
+    const buffer = 5 * 60 * 1000;
+    if (credential.tokenExpiresAt.getTime() > Date.now() + buffer) {
+      return { token: credential.cachedToken };
+    }
+  }
+
+  // Exchange for new token
+  const params = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: credential.clientId,
+    client_secret: credential.clientSecret,
+    ...(credential.scope ? { scope: credential.scope } : {}),
+  });
+
+  try {
+    const res = await fetch(credential.tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { error: `Token exchange failed: HTTP ${res.status}` };
+
+    const body = await res.json() as { access_token: string; expires_in: number };
+    const expiresAt = new Date(Date.now() + body.expires_in * 1000);
+
+    await prisma.credentialEntry.update({
+      where: { providerId },
+      data: { cachedToken: body.access_token, tokenExpiresAt: expiresAt, status: "ok" },
+    });
+
+    return { token: body.access_token };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Token exchange error" };
+  }
+}
+
+// ─── Internal helpers (not exported — only used within this module) ──────────
+
+/** Known cheap models per provider for profiling tasks. */
+const PROFILING_MODELS: Record<string, string> = {
+  anthropic:      "claude-haiku-4-5-20251001",
+  openai:         "gpt-4o-mini",
+  "azure-openai": "gpt-4o-mini",
+  gemini:         "gemini-2.0-flash",
+  cohere:         "command-r",
+  mistral:        "mistral-small-latest",
+  deepseek:       "deepseek-chat",
+  groq:           "llama-3.1-8b-instant",
+  together:       "meta-llama/Llama-3-8b-chat-hf",
+  fireworks:      "accounts/fireworks/models/llama-v3p1-8b-instruct",
+  xai:            "grok-2-latest",
+  openrouter:     "meta-llama/llama-3.1-8b-instruct:free",
+};
+
+/** Pick a model for profiling: prefer discovered models (proven valid), then known defaults. */
+async function getProfilingModel(providerId: string): Promise<string> {
+  // Prefer a discovered model — we know the account has access to it
+  const discovered = await prisma.discoveredModel.findMany({
+    where: { providerId },
+    orderBy: { modelId: "asc" },
+    select: { modelId: true },
+  });
+
+  if (discovered.length > 0) {
+    // Try to match a known cheap model from the discovered list
+    const known = PROFILING_MODELS[providerId];
+    if (known && discovered.some((d) => d.modelId === known)) return known;
+
+    // Otherwise pick the first discovered model that looks like a chat model
+    // (skip embedding-only, whisper, tts, dall-e, etc.)
+    const skipPatterns = /embed|whisper|tts|dall-e|moderation|babbage|davinci-00/i;
+    const chatModel = discovered.find((d) => !skipPatterns.test(d.modelId));
+    if (chatModel) return chatModel.modelId;
+
+    // Last resort: first discovered model
+    return discovered[0]!.modelId;
+  }
+
+  // No discovered models — use the hardcoded default
+  const known = PROFILING_MODELS[providerId];
+  if (known) return known;
+
+  throw new Error(`No known or discovered model for profiling on ${providerId}`);
+}
+
+async function callProviderForProfiling(
+  profilingProviderId: string,
+  prompt: string,
+): Promise<{ text: string; inputTokens?: number; outputTokens?: number }> {
+  const prov = await prisma.modelProvider.findUnique({ where: { providerId: profilingProviderId } });
+  if (!prov) throw new Error("Provider not found");
+
+  const baseUrl = prov.baseUrl ?? prov.endpoint;
+  if (!baseUrl) throw new Error("No base URL");
+
+  const model = await getProfilingModel(profilingProviderId);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...getProviderExtraHeaders(profilingProviderId),
+  };
+
+  if (prov.authMethod === "api_key") {
+    const cred = await getDecryptedCredential(profilingProviderId);
+    if (!cred?.secretRef || !prov.authHeader) throw new Error("No credential");
+    headers[prov.authHeader] = prov.authHeader === "Authorization"
+      ? `Bearer ${cred.secretRef}` : cred.secretRef;
+  } else if (prov.authMethod === "oauth2_client_credentials") {
+    const tokenResult = await getProviderBearerToken(profilingProviderId);
+    if ("error" in tokenResult) throw new Error(tokenResult.error);
+    headers["Authorization"] = `Bearer ${tokenResult.token}`;
+  }
+
+  // Each provider family has its own endpoint + request/response shape
+  let chatUrl: string;
+  let body: Record<string, unknown>;
+  let extractText: (data: Record<string, unknown>) => string;
+
+  if (profilingProviderId === "anthropic") {
+    chatUrl = `${baseUrl}/messages`;
+    body = { model, max_tokens: 4096, messages: [{ role: "user", content: prompt }] };
+    extractText = (d) => (d.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+  } else if (profilingProviderId === "cohere") {
+    chatUrl = `${baseUrl}/chat`;
+    body = { model, message: prompt, max_tokens: 4096 };
+    extractText = (d) => (d.text as string) ?? "";
+  } else if (profilingProviderId === "gemini") {
+    // Gemini uses generateContent endpoint with different structure
+    chatUrl = `${baseUrl}/models/${model}:generateContent`;
+    body = { contents: [{ parts: [{ text: prompt }] }] };
+    extractText = (d) => {
+      const candidates = d.candidates as Array<{ content?: { parts?: Array<{ text?: string }> } }> | undefined;
+      return candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+    };
+  } else {
+    // OpenAI-compatible (OpenAI, Azure, Mistral, Groq, Together, Fireworks, xAI, OpenRouter, LiteLLM, etc.)
+    chatUrl = `${baseUrl}/chat/completions`;
+    body = { model, messages: [{ role: "user", content: prompt }], max_tokens: 4096 };
+    extractText = (d) => (d.choices as Array<{ message?: { content?: string } }>)?.[0]?.message?.content ?? "";
+  }
+
+  const res = await fetch(chatUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status} from ${profilingProviderId}: ${errBody.slice(0, 200)}`);
+  }
+  const data = await res.json() as Record<string, unknown>;
+
+  const text = extractText(data);
+
+  return {
+    text,
+    inputTokens: data.usage?.input_tokens ?? data.usage?.prompt_tokens,
+    outputTokens: data.usage?.output_tokens ?? data.usage?.completion_tokens,
+  };
+}
+
+async function logTokenUsage(input: {
+  agentId: string;
+  providerId: string;
+  contextKey: string;
+  inputTokens: number;
+  outputTokens: number;
+  inferenceMs?: number;
+}): Promise<void> {
+  // Internal helper — callers (profileModelsInternal) already guard at the action layer
+
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId: input.providerId } });
+
+  let costUsd = 0;
+  if (provider) {
+    if (provider.costModel === "compute" && input.inferenceMs !== undefined) {
+      costUsd = computeComputeCost(
+        input.inferenceMs,
+        provider.computeWatts ?? 150,
+        provider.electricityRateKwh ?? 0.12,
+      );
+    } else if (provider.costModel === "token") {
+      costUsd = computeTokenCost(
+        input.inputTokens,
+        input.outputTokens,
+        provider.inputPricePerMToken ?? 0,
+        provider.outputPricePerMToken ?? 0,
+      );
+    }
+  }
+
+  await prisma.tokenUsage.create({
+    data: {
+      agentId:      input.agentId,
+      providerId:   input.providerId,
+      contextKey:   input.contextKey,
+      inputTokens:  input.inputTokens,
+      outputTokens: input.outputTokens,
+      ...(input.inferenceMs !== undefined && { inferenceMs: input.inferenceMs }),
+      costUsd,
+    },
+  });
+}
+
+// ─── Exported internal functions (no auth guard) ─────────────────────────────
+
+export async function discoverModelsInternal(
+  providerId: string,
+): Promise<{ discovered: number; newCount: number; error?: string }> {
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
+  if (!provider) return { discovered: 0, newCount: 0, error: "Provider not found" };
+
+  const providerRow = {
+    ...provider,
+    families: provider.families as string[],
+    enabledFamilies: provider.enabledFamilies as string[],
+    supportedAuthMethods: provider.supportedAuthMethods as string[],
+  };
+
+  const testUrl = getTestUrl(providerRow);
+  if (!testUrl) return { discovered: 0, newCount: 0, error: "No base URL configured" };
+
+  // Build auth headers (same logic as testProviderAuth)
+  const headers: Record<string, string> = {
+    ...getProviderExtraHeaders(providerId),
+  };
+  if (provider.authMethod === "api_key") {
+    const cred = await getDecryptedCredential(providerId);
+    if (cred?.secretRef && provider.authHeader) {
+      headers[provider.authHeader] = provider.authHeader === "Authorization"
+        ? `Bearer ${cred.secretRef}` : cred.secretRef;
+    }
+  } else if (provider.authMethod === "oauth2_client_credentials") {
+    const tokenResult = await getProviderBearerToken(providerId);
+    if ("error" in tokenResult) return { discovered: 0, newCount: 0, error: tokenResult.error };
+    headers["Authorization"] = `Bearer ${tokenResult.token}`;
+  }
+
+  let json: unknown;
+  try {
+    const res = await fetch(testUrl, { headers, signal: AbortSignal.timeout(15_000) });
+    if (!res.ok) return { discovered: 0, newCount: 0, error: `HTTP ${res.status}` };
+    json = await res.json();
+  } catch (err) {
+    return { discovered: 0, newCount: 0, error: err instanceof Error ? err.message : "Fetch error" };
+  }
+
+  const models = parseModelsResponse(providerId, json);
+  let newCount = 0;
+
+  for (const m of models) {
+    const existing = await prisma.discoveredModel.findUnique({
+      where: { providerId_modelId: { providerId, modelId: m.modelId } },
+    });
+    if (existing) {
+      await prisma.discoveredModel.update({
+        where: { id: existing.id },
+        data: { rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
+      });
+    } else {
+      await prisma.discoveredModel.create({
+        data: { providerId, modelId: m.modelId, rawMetadata: m.rawMetadata as unknown as Prisma.InputJsonValue },
+      });
+      newCount++;
+    }
+  }
+
+  return { discovered: models.length, newCount };
+}
+
+export async function profileModelsInternal(
+  providerId: string,
+  modelIds?: string[],
+): Promise<{ profiled: number; failed: number; error?: string }> {
+  const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
+  if (!provider) return { profiled: 0, failed: 0, error: "Provider not found" };
+
+  // Get models to profile
+  const whereClause = modelIds
+    ? { providerId, modelId: { in: modelIds } }
+    : { providerId };
+  const models = await prisma.discoveredModel.findMany({ where: whereClause });
+  if (models.length === 0) return { profiled: 0, failed: 0, error: "No models to profile" };
+
+  // Find cheapest active provider to do the profiling
+  const allProviders = await prisma.modelProvider.findMany({
+    select: { providerId: true, status: true, outputPricePerMToken: true },
+  });
+  const ranked = rankProvidersByCost(allProviders);
+  if (ranked.length === 0) return { profiled: 0, failed: 0, error: "No active AI provider available for profiling" };
+
+  // Build prompt
+  const modelEntries = models.map((m) => ({
+    modelId: m.modelId,
+    providerName: provider.name,
+    rawMetadata: m.rawMetadata as Record<string, unknown>,
+  }));
+
+  // Batch in groups of 20
+  let totalProfiled = 0;
+  let totalFailed = 0;
+
+  for (let i = 0; i < modelEntries.length; i += 20) {
+    const batch = modelEntries.slice(i, i + 20);
+    const prompt = buildProfilingPrompt(batch);
+
+    let profiles: ProfileResult[] = [];
+    let usedProviderId: string | null = null;
+    let lastError: string | null = null;
+
+    // Try each provider in cost order
+    for (const candidateId of ranked) {
+      try {
+        const result = await callProviderForProfiling(candidateId, prompt);
+        profiles = parseProfilingResponse(result.text);
+
+        // If JSON parse failed, retry once with a stricter prompt
+        if (profiles.length === 0) {
+          const stricterPrompt =
+            "IMPORTANT: Respond ONLY with a valid JSON array. No markdown code fences, no explanation text.\n\n" +
+            prompt;
+          const retryResult = await callProviderForProfiling(candidateId, stricterPrompt);
+          profiles = parseProfilingResponse(retryResult.text);
+
+          if (profiles.length > 0) {
+            usedProviderId = candidateId;
+            await logTokenUsage({
+              agentId: "system:model-profiler",
+              providerId: candidateId,
+              contextKey: `profile-${providerId}-batch-${i}`,
+              inputTokens: (result.inputTokens ?? 0) + (retryResult.inputTokens ?? 0),
+              outputTokens: (result.outputTokens ?? 0) + (retryResult.outputTokens ?? 0),
+            });
+            break;
+          }
+
+          lastError = `${candidateId}: response was not valid JSON`;
+          await logTokenUsage({
+            agentId: "system:model-profiler",
+            providerId: candidateId,
+            contextKey: `profile-${providerId}-batch-${i}-failed`,
+            inputTokens: 0,
+            outputTokens: 0,
+          }).catch(() => {});
+          continue;
+        }
+
+        usedProviderId = candidateId;
+        await logTokenUsage({
+          agentId: "system:model-profiler",
+          providerId: candidateId,
+          contextKey: `profile-${providerId}-batch-${i}`,
+          inputTokens: result.inputTokens ?? 0,
+          outputTokens: result.outputTokens ?? 0,
+        });
+        break;
+      } catch (err) {
+        lastError = `${candidateId}: ${err instanceof Error ? err.message : "Unknown error"}`;
+        console.error(`[profiling] ${lastError}`);
+        await logTokenUsage({
+          agentId: "system:model-profiler",
+          providerId: candidateId,
+          contextKey: `profile-${providerId}-batch-${i}-failed`,
+          inputTokens: 0,
+          outputTokens: 0,
+        }).catch(() => {});
+        continue;
+      }
+    }
+
+    // If all providers failed for this batch, return the last error
+    if (profiles.length === 0 && lastError) {
+      return { profiled: totalProfiled, failed: batch.length, error: lastError };
+    }
+
+    // Save successful profiles
+    for (const profile of profiles) {
+      await prisma.modelProfile.upsert({
+        where: { providerId_modelId: { providerId, modelId: profile.modelId } },
+        create: {
+          providerId,
+          modelId: profile.modelId,
+          friendlyName: profile.friendlyName,
+          summary: profile.summary,
+          capabilityTier: profile.capabilityTier,
+          costTier: profile.costTier,
+          bestFor: profile.bestFor,
+          avoidFor: profile.avoidFor,
+          contextWindow: profile.contextWindow ?? null,
+          speedRating: profile.speedRating ?? null,
+          generatedBy: usedProviderId ?? "unknown",
+        },
+        update: {
+          friendlyName: profile.friendlyName,
+          summary: profile.summary,
+          capabilityTier: profile.capabilityTier,
+          costTier: profile.costTier,
+          bestFor: profile.bestFor,
+          avoidFor: profile.avoidFor,
+          contextWindow: profile.contextWindow ?? null,
+          speedRating: profile.speedRating ?? null,
+          generatedBy: usedProviderId ?? "unknown",
+          generatedAt: new Date(),
+        },
+      });
+      totalProfiled++;
+    }
+
+    const profiledIds = new Set(profiles.map((p) => p.modelId));
+    totalFailed += batch.filter((b) => !profiledIds.has(b.modelId)).length;
+  }
+
+  return { profiled: totalProfiled, failed: totalFailed };
+}

--- a/apps/web/lib/ollama-estimate.test.ts
+++ b/apps/web/lib/ollama-estimate.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { estimateMaxParameters } from "./ollama";
+
+describe("estimateMaxParameters", () => {
+  it("returns null for null VRAM", () => {
+    expect(estimateMaxParameters(null)).toBeNull();
+  });
+
+  it("returns ~1B for very low VRAM", () => {
+    expect(estimateMaxParameters(0.5)).toBe("~1B");
+  });
+
+  it("estimates ~6B for 8GB VRAM", () => {
+    const result = estimateMaxParameters(8);
+    expect(result).toBe("~6B");
+  });
+
+  it("estimates ~20B for 24GB VRAM", () => {
+    const result = estimateMaxParameters(24);
+    expect(result).toBe("~20B");
+  });
+
+  it("estimates ~40B for 48GB VRAM", () => {
+    const result = estimateMaxParameters(48);
+    expect(result).toBe("~40B");
+  });
+});

--- a/apps/web/lib/ollama-health.test.ts
+++ b/apps/web/lib/ollama-health.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock prisma
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProvider: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  syncInfraCI: vi.fn(),
+}));
+
+// Mock internal functions
+vi.mock("./ai-provider-internals", () => ({
+  discoverModelsInternal: vi.fn().mockResolvedValue({ discovered: 2, newCount: 2 }),
+  profileModelsInternal: vi.fn().mockResolvedValue({ profiled: 2, failed: 0 }),
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { prisma, syncInfraCI } from "@dpf/db";
+import { discoverModelsInternal, profileModelsInternal } from "./ai-provider-internals";
+import { checkBundledProviders } from "./ollama";
+
+const mockFindFirst = vi.mocked(prisma.modelProvider.findFirst);
+const mockUpdate = vi.mocked(prisma.modelProvider.update);
+const mockDiscover = vi.mocked(discoverModelsInternal);
+const mockProfile = vi.mocked(profileModelsInternal);
+const mockSyncInfraCI = vi.mocked(syncInfraCI);
+
+describe("checkBundledProviders", () => {
+  beforeEach(() => {
+    mockFindFirst.mockReset();
+    mockUpdate.mockReset();
+    mockFetch.mockReset();
+    mockDiscover.mockReset().mockResolvedValue({ discovered: 2, newCount: 2 });
+    mockProfile.mockReset().mockResolvedValue({ profiled: 2, failed: 0 });
+    mockSyncInfraCI.mockReset();
+  });
+
+  it("activates Ollama and triggers discovery when reachable and unconfigured", async () => {
+    mockFindFirst.mockResolvedValue({
+      providerId: "ollama",
+      status: "unconfigured",
+      baseUrl: "http://localhost:11434/v1",
+      endpoint: null,
+    } as any);
+    // /api/tags response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [{ name: "llama3:8b" }, { name: "phi3:mini" }] }),
+    });
+    // /api/ps response (for hardware enrichment)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [] }),
+    });
+    // /api/tags again (for model count in hardware info)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [{ name: "llama3:8b" }, { name: "phi3:mini" }] }),
+    });
+
+    await checkBundledProviders();
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { providerId: "ollama" },
+      data: { status: "active" },
+    });
+    expect(mockDiscover).toHaveBeenCalledWith("ollama");
+    expect(mockProfile).toHaveBeenCalledWith("ollama");
+  });
+
+  it("deactivates Ollama when unreachable and currently active", async () => {
+    mockFindFirst.mockResolvedValue({
+      providerId: "ollama",
+      status: "active",
+      baseUrl: "http://localhost:11434/v1",
+      endpoint: null,
+    } as any);
+    mockFetch.mockRejectedValue(new Error("Connection refused"));
+
+    await checkBundledProviders();
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { providerId: "ollama" },
+      data: { status: "inactive" },
+    });
+    expect(mockDiscover).not.toHaveBeenCalled();
+    expect(mockSyncInfraCI).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "offline" }),
+    );
+  });
+
+  it("leaves unconfigured status when unreachable and unconfigured", async () => {
+    mockFindFirst.mockResolvedValue({
+      providerId: "ollama",
+      status: "unconfigured",
+      baseUrl: "http://localhost:11434/v1",
+      endpoint: null,
+    } as any);
+    mockFetch.mockRejectedValue(new Error("Connection refused"));
+
+    await checkBundledProviders();
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDiscover).not.toHaveBeenCalled();
+  });
+
+  it("skips auto-profiling when model count >= 20", async () => {
+    mockFindFirst.mockResolvedValue({
+      providerId: "ollama",
+      status: "unconfigured",
+      baseUrl: "http://localhost:11434/v1",
+      endpoint: null,
+    } as any);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: Array.from({ length: 25 }, (_, i) => ({ name: `model-${i}` })) }),
+    });
+    mockDiscover.mockResolvedValue({ discovered: 25, newCount: 25 });
+
+    await checkBundledProviders();
+
+    expect(mockDiscover).toHaveBeenCalled();
+    expect(mockProfile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when Ollama provider not in database", async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await checkBundledProviders();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refreshes hardware info when already active and reachable (steady state)", async () => {
+    mockFindFirst.mockResolvedValue({
+      providerId: "ollama",
+      status: "active",
+      baseUrl: "http://localhost:11434/v1",
+      endpoint: null,
+    } as any);
+    // /api/tags (health check)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [{ name: "llama3:8b" }] }),
+    });
+    // /api/ps (hardware enrichment)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [{ name: "llama3:8b", size_vram: 5_000_000_000 }] }),
+    });
+    // /api/tags (model count)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [{ name: "llama3:8b" }] }),
+    });
+
+    await checkBundledProviders();
+
+    // Should NOT re-discover or re-profile
+    expect(mockDiscover).not.toHaveBeenCalled();
+    expect(mockProfile).not.toHaveBeenCalled();
+    // Should update hardware info
+    expect(mockSyncInfraCI).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "operational" }),
+      expect.objectContaining({ modelCount: 1 }),
+    );
+  });
+});

--- a/apps/web/lib/ollama-health.test.ts
+++ b/apps/web/lib/ollama-health.test.ts
@@ -92,6 +92,7 @@ describe("checkBundledProviders", () => {
     expect(mockDiscover).not.toHaveBeenCalled();
     expect(mockSyncInfraCI).toHaveBeenCalledWith(
       expect.objectContaining({ status: "offline" }),
+      undefined,
     );
   });
 

--- a/apps/web/lib/ollama-url.test.ts
+++ b/apps/web/lib/ollama-url.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("getOllamaBaseUrl", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.OLLAMA_INTERNAL_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns OLLAMA_INTERNAL_URL when set", async () => {
+    process.env.OLLAMA_INTERNAL_URL = "http://ollama:11434";
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(getOllamaBaseUrl()).toBe("http://ollama:11434");
+  });
+
+  it("strips /v1 suffix from baseUrl", async () => {
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(
+      getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("strips /v1/ suffix with trailing slash", async () => {
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(
+      getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1/", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("returns baseUrl unchanged if no /v1 suffix", async () => {
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(
+      getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434", endpoint: null }),
+    ).toBe("http://localhost:11434");
+  });
+
+  it("prefers endpoint over baseUrl", async () => {
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(
+      getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1", endpoint: "http://custom:9999/v1" }),
+    ).toBe("http://custom:9999");
+  });
+
+  it("falls back to localhost when no provider given", async () => {
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(getOllamaBaseUrl()).toBe("http://localhost:11434");
+  });
+
+  it("OLLAMA_INTERNAL_URL takes precedence over provider", async () => {
+    process.env.OLLAMA_INTERNAL_URL = "http://ollama:11434";
+    const { getOllamaBaseUrl } = await import("./ollama");
+    expect(
+      getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1", endpoint: null }),
+    ).toBe("http://ollama:11434");
+  });
+});

--- a/apps/web/lib/ollama-url.test.ts
+++ b/apps/web/lib/ollama-url.test.ts
@@ -15,46 +15,46 @@ describe("getOllamaBaseUrl", () => {
 
   it("returns OLLAMA_INTERNAL_URL when set", async () => {
     process.env.OLLAMA_INTERNAL_URL = "http://ollama:11434";
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(getOllamaBaseUrl()).toBe("http://ollama:11434");
   });
 
   it("strips /v1 suffix from baseUrl", async () => {
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(
       getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1", endpoint: null }),
     ).toBe("http://localhost:11434");
   });
 
   it("strips /v1/ suffix with trailing slash", async () => {
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(
       getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1/", endpoint: null }),
     ).toBe("http://localhost:11434");
   });
 
   it("returns baseUrl unchanged if no /v1 suffix", async () => {
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(
       getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434", endpoint: null }),
     ).toBe("http://localhost:11434");
   });
 
   it("prefers endpoint over baseUrl", async () => {
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(
       getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1", endpoint: "http://custom:9999/v1" }),
     ).toBe("http://custom:9999");
   });
 
   it("falls back to localhost when no provider given", async () => {
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(getOllamaBaseUrl()).toBe("http://localhost:11434");
   });
 
   it("OLLAMA_INTERNAL_URL takes precedence over provider", async () => {
     process.env.OLLAMA_INTERNAL_URL = "http://ollama:11434";
-    const { getOllamaBaseUrl } = await import("./ollama");
+    const { getOllamaBaseUrl } = await import("./ollama-url");
     expect(
       getOllamaBaseUrl({ providerId: "ollama", baseUrl: "http://localhost:11434/v1", endpoint: null }),
     ).toBe("http://ollama:11434");

--- a/apps/web/lib/ollama-url.ts
+++ b/apps/web/lib/ollama-url.ts
@@ -1,0 +1,21 @@
+// apps/web/lib/ollama-url.ts
+// Pure helper — no DB or server-side imports so it can be used in tests without mocking.
+
+type ProviderUrlFields = {
+  providerId: string;
+  baseUrl: string | null;
+  endpoint: string | null;
+};
+
+/**
+ * Returns the root Ollama URL for native API calls (/api/tags, /api/ps).
+ * The registry baseUrl is "http://localhost:11434/v1" (OpenAI-compatible),
+ * but native health/management endpoints live at the root without /v1.
+ */
+export function getOllamaBaseUrl(provider?: ProviderUrlFields | null): string {
+  if (process.env.OLLAMA_INTERNAL_URL) {
+    return process.env.OLLAMA_INTERNAL_URL;
+  }
+  const raw = provider?.endpoint ?? provider?.baseUrl ?? "http://localhost:11434";
+  return raw.replace(/\/v1\/?$/, "");
+}

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -1,0 +1,20 @@
+// apps/web/lib/ollama.ts
+
+type ProviderUrlFields = {
+  providerId: string;
+  baseUrl: string | null;
+  endpoint: string | null;
+};
+
+/**
+ * Returns the root Ollama URL for native API calls (/api/tags, /api/ps).
+ * The registry baseUrl is "http://localhost:11434/v1" (OpenAI-compatible),
+ * but native health/management endpoints live at the root without /v1.
+ */
+export function getOllamaBaseUrl(provider?: ProviderUrlFields | null): string {
+  if (process.env.OLLAMA_INTERNAL_URL) {
+    return process.env.OLLAMA_INTERNAL_URL;
+  }
+  const raw = provider?.endpoint ?? provider?.baseUrl ?? "http://localhost:11434";
+  return raw.replace(/\/v1\/?$/, "");
+}

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -2,25 +2,8 @@
 
 import { prisma, syncInfraCI } from "@dpf/db";
 import { discoverModelsInternal, profileModelsInternal } from "./ai-provider-internals";
-
-type ProviderUrlFields = {
-  providerId: string;
-  baseUrl: string | null;
-  endpoint: string | null;
-};
-
-/**
- * Returns the root Ollama URL for native API calls (/api/tags, /api/ps).
- * The registry baseUrl is "http://localhost:11434/v1" (OpenAI-compatible),
- * but native health/management endpoints live at the root without /v1.
- */
-export function getOllamaBaseUrl(provider?: ProviderUrlFields | null): string {
-  if (process.env.OLLAMA_INTERNAL_URL) {
-    return process.env.OLLAMA_INTERNAL_URL;
-  }
-  const raw = provider?.endpoint ?? provider?.baseUrl ?? "http://localhost:11434";
-  return raw.replace(/\/v1\/?$/, "");
-}
+import { getOllamaBaseUrl } from "./ollama-url";
+export { getOllamaBaseUrl } from "./ollama-url";
 
 // ─── Hardware info ────────────────────────────────────────────────────────────
 

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -74,6 +74,22 @@ export function estimateMaxParameters(vramGb: number | null): string | null {
   return `~${maxB}B`;
 }
 
+/**
+ * Enrich the Ollama InfraCI node with hardware info.
+ * Failures are silently swallowed — Neo4j being down should not crash the page.
+ */
+async function enrichOllamaInfraCI(baseUrl: string, status: string): Promise<void> {
+  try {
+    const hwInfo = status === "offline" ? null : await getOllamaHardwareInfo(baseUrl);
+    await syncInfraCI(
+      { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status },
+      hwInfo ? { baseUrl, gpu: hwInfo.gpu, vramGb: hwInfo.vramGb, modelCount: hwInfo.modelCount } : undefined,
+    );
+  } catch {
+    // Neo4j unavailable — don't crash the page
+  }
+}
+
 // ─── Bundled provider health check ───────────────────────────────────────────
 
 /**
@@ -116,32 +132,17 @@ export async function checkBundledProviders(): Promise<void> {
       await profileModelsInternal("ollama");
     }
 
-    // Enrich InfraCI node with hardware info
-    const hwInfo = await getOllamaHardwareInfo(baseUrl);
-    if (hwInfo) {
-      await syncInfraCI(
-        { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status: "operational" },
-        { baseUrl, gpu: hwInfo.gpu, vramGb: hwInfo.vramGb, modelCount: hwInfo.modelCount },
-      );
-    }
+    await enrichOllamaInfraCI(baseUrl, "operational");
   } else if (reachable && provider.status === "active") {
     // Already active — refresh hardware info only (no re-discovery)
-    const hwInfo = await getOllamaHardwareInfo(baseUrl);
-    if (hwInfo) {
-      await syncInfraCI(
-        { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status: "operational" },
-        { baseUrl, gpu: hwInfo.gpu, vramGb: hwInfo.vramGb, modelCount: hwInfo.modelCount },
-      );
-    }
+    await enrichOllamaInfraCI(baseUrl, "operational");
   } else if (!reachable && provider.status === "active") {
     // Deactivate
     await prisma.modelProvider.update({
       where: { providerId: "ollama" },
       data: { status: "inactive" },
     });
-    await syncInfraCI(
-      { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status: "offline" },
-    );
+    await enrichOllamaInfraCI(baseUrl, "offline");
   }
   // If unreachable + unconfigured → leave as-is
 }

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -1,5 +1,8 @@
 // apps/web/lib/ollama.ts
 
+import { prisma, syncInfraCI } from "@dpf/db";
+import { discoverModelsInternal, profileModelsInternal } from "./ai-provider-internals";
+
 type ProviderUrlFields = {
   providerId: string;
   baseUrl: string | null;
@@ -17,4 +20,128 @@ export function getOllamaBaseUrl(provider?: ProviderUrlFields | null): string {
   }
   const raw = provider?.endpoint ?? provider?.baseUrl ?? "http://localhost:11434";
   return raw.replace(/\/v1\/?$/, "");
+}
+
+// ─── Hardware info ────────────────────────────────────────────────────────────
+
+export interface OllamaHardwareInfo {
+  gpu: string;
+  vramGb: number | null;
+  modelCount: number;
+}
+
+/**
+ * Query Ollama's native /api/ps and /api/tags to extract hardware info.
+ * Returns null if Ollama is unreachable.
+ */
+async function getOllamaHardwareInfo(baseUrl: string): Promise<OllamaHardwareInfo | null> {
+  try {
+    const psRes = await fetch(`${baseUrl}/api/ps`, { signal: AbortSignal.timeout(3000) });
+    if (!psRes.ok) return null;
+    const psData = await psRes.json();
+
+    const tagsRes = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
+    if (!tagsRes.ok) return null;
+    const tagsData = await tagsRes.json();
+
+    const loadedModels = psData.models ?? [];
+    let totalVramBytes = 0;
+    for (const m of loadedModels) {
+      totalVramBytes += m.size_vram ?? 0;
+    }
+
+    const hasGpu = totalVramBytes > 0;
+    const vramGb = hasGpu ? Math.round((totalVramBytes / 1_073_741_824) * 10) / 10 : null;
+
+    // Ollama /api/ps doesn't directly report GPU name;
+    // use a generic label — the InfraCI node will show "GPU (XGB VRAM)"
+    const gpuName = hasGpu ? "GPU" : "CPU-only";
+
+    return { gpu: gpuName, vramGb, modelCount: (tagsData.models ?? []).length };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rough estimate of max model parameters (Q4 quantization) for given VRAM.
+ * Returns a human-friendly string like "~7B" or null for CPU-only.
+ */
+export function estimateMaxParameters(vramGb: number | null): string | null {
+  if (vramGb == null) return null;
+  const maxB = Math.floor(vramGb * 0.85);
+  if (maxB < 1) return "~1B";
+  return `~${maxB}B`;
+}
+
+// ─── Bundled provider health check ───────────────────────────────────────────
+
+/**
+ * Page-load health check for the bundled Ollama provider.
+ * - Unreachable + unconfigured → leave as-is
+ * - Unreachable + active → deactivate, mark InfraCI offline
+ * - Reachable + not active → activate, discover, profile, enrich hardware
+ * - Reachable + already active → refresh hardware info only (no re-discovery)
+ * No auth guard — this is internal server-side logic.
+ */
+export async function checkBundledProviders(): Promise<void> {
+  const provider = await prisma.modelProvider.findFirst({
+    where: { providerId: "ollama" },
+    select: { providerId: true, status: true, baseUrl: true, endpoint: true },
+  });
+
+  if (!provider) return;
+
+  const baseUrl = getOllamaBaseUrl(provider);
+  let reachable = false;
+
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
+    reachable = res.ok;
+  } catch {
+    // Timeout or connection error
+  }
+
+  if (reachable && provider.status !== "active") {
+    // Activate and discover
+    await prisma.modelProvider.update({
+      where: { providerId: "ollama" },
+      data: { status: "active" },
+    });
+
+    const result = await discoverModelsInternal("ollama");
+
+    // Auto-profile if reasonable model count
+    if (result.discovered < 20) {
+      await profileModelsInternal("ollama");
+    }
+
+    // Enrich InfraCI node with hardware info
+    const hwInfo = await getOllamaHardwareInfo(baseUrl);
+    if (hwInfo) {
+      await syncInfraCI(
+        { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status: "operational" },
+        { baseUrl, gpu: hwInfo.gpu, vramGb: hwInfo.vramGb, modelCount: hwInfo.modelCount },
+      );
+    }
+  } else if (reachable && provider.status === "active") {
+    // Already active — refresh hardware info only (no re-discovery)
+    const hwInfo = await getOllamaHardwareInfo(baseUrl);
+    if (hwInfo) {
+      await syncInfraCI(
+        { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status: "operational" },
+        { baseUrl, gpu: hwInfo.gpu, vramGb: hwInfo.vramGb, modelCount: hwInfo.modelCount },
+      );
+    }
+  } else if (!reachable && provider.status === "active") {
+    // Deactivate
+    await prisma.modelProvider.update({
+      where: { providerId: "ollama" },
+      data: { status: "inactive" },
+    });
+    await syncInfraCI(
+      { ciId: "CI-ollama-01", name: "Ollama", ciType: "ai-inference", status: "offline" },
+    );
+  }
+  // If unreachable + unconfigured → leave as-is
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,32 @@ services:
       retries: 5
       start_period: 30s
 
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "${OLLAMA_HOST_PORT:-11434}:11434"
+    volumes:
+      - ollama_models:/root/.ollama
+      - ./scripts/ollama-entrypoint.sh:/ollama-entrypoint.sh:ro
+    entrypoint: ["/bin/bash", "/ollama-entrypoint.sh"]
+    # GPU passthrough: requires NVIDIA Container Toolkit.
+    # If this block causes errors on CPU-only hosts, remove or comment out
+    # the entire 'deploy' section — Ollama will still work in CPU-only mode.
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:11434/api/tags"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
 volumes:
   pgdata:
   neo4jdata:
+  ollama_models:

--- a/packages/db/scripts/init-neo4j.ts
+++ b/packages/db/scripts/init-neo4j.ts
@@ -77,6 +77,7 @@ async function main() {
     { ciId: "CI-neo4j-01",      name: "DPF Neo4j",          ciType: "database",  status: "operational", portfolioSlug: "foundational" },
     { ciId: "CI-docker-host-01",name: "Docker Host",         ciType: "server",    status: "operational", portfolioSlug: "foundational" },
     { ciId: "CI-nextjs-01",     name: "DPF Web (Next.js)",  ciType: "service",   status: "operational", portfolioSlug: "foundational" },
+    { ciId: "CI-ollama-01",     name: "Ollama",             ciType: "ai-inference", status: "offline",      portfolioSlug: "foundational" },
   ];
   for (const ci of infraNodes) {
     await syncInfraCI(ci);
@@ -90,7 +91,8 @@ async function main() {
   await syncDependsOn({ fromLabel: "InfraCI", fromId: "CI-nextjs-01",  toLabel: "InfraCI", toId: "CI-neo4j-01",       role: "graph-db" });
   await syncDependsOn({ fromLabel: "InfraCI", fromId: "CI-postgres-01",toLabel: "InfraCI", toId: "CI-docker-host-01", role: "runtime"  });
   await syncDependsOn({ fromLabel: "InfraCI", fromId: "CI-neo4j-01",   toLabel: "InfraCI", toId: "CI-docker-host-01", role: "runtime"  });
-  console.log("  4 edges done");
+  await syncDependsOn({ fromLabel: "InfraCI", fromId: "CI-ollama-01", toLabel: "InfraCI", toId: "CI-docker-host-01", role: "runtime" });
+  console.log("  5 edges done");
 
   console.log("\n✓ Neo4j initialised. Open http://localhost:7474 to browse the graph.");
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22,4 +22,5 @@ export {
   syncPortfolio,
   syncInfraCI,
   syncDependsOn,
+  type InfraCIExtendedProps,
 } from "./neo4j-sync";

--- a/packages/db/src/neo4j-sync.test.ts
+++ b/packages/db/src/neo4j-sync.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock neo4j module before import
+vi.mock("./neo4j", () => ({
+  runCypher: vi.fn().mockResolvedValue([]),
+}));
+
+import { runCypher } from "./neo4j";
+import { syncInfraCI } from "./neo4j-sync";
+
+const mockRunCypher = vi.mocked(runCypher);
+
+describe("syncInfraCI", () => {
+  beforeEach(() => {
+    mockRunCypher.mockClear();
+  });
+
+  it("merges basic InfraCI node without extended props", async () => {
+    await syncInfraCI({
+      ciId: "CI-test-01",
+      name: "Test Node",
+      ciType: "service",
+      status: "operational",
+    });
+
+    expect(mockRunCypher).toHaveBeenCalledTimes(1);
+    const cypher = mockRunCypher.mock.calls[0]![0] as string;
+    expect(cypher).toContain("MERGE (ci:InfraCI {ciId: $ciId})");
+    expect(cypher).toContain("ci.name = $name");
+    expect(cypher).toContain("ci.status = $status");
+  });
+
+  it("sets extended properties when provided", async () => {
+    await syncInfraCI(
+      {
+        ciId: "CI-ollama-01",
+        name: "Ollama",
+        ciType: "ai-inference",
+        status: "operational",
+      },
+      {
+        baseUrl: "http://ollama:11434",
+        gpu: "NVIDIA RTX 4090",
+        vramGb: 24,
+        modelCount: 3,
+      },
+    );
+
+    expect(mockRunCypher).toHaveBeenCalledTimes(1);
+    const params = mockRunCypher.mock.calls[0]![1] as Record<string, unknown>;
+    expect(params).toMatchObject({
+      ciId: "CI-ollama-01",
+      baseUrl: "http://ollama:11434",
+      gpu: "NVIDIA RTX 4090",
+      vramGb: 24,
+      modelCount: 3,
+    });
+    const cypher = mockRunCypher.mock.calls[0]![0] as string;
+    expect(cypher).toContain("ci.baseUrl = $baseUrl");
+    expect(cypher).toContain("ci.gpu = $gpu");
+    expect(cypher).toContain("ci.vramGb = $vramGb");
+    expect(cypher).toContain("ci.modelCount = $modelCount");
+  });
+
+  it("omits all extended properties when not provided", async () => {
+    await syncInfraCI({
+      ciId: "CI-test-02",
+      name: "Test",
+      ciType: "database",
+      status: "operational",
+    });
+
+    const cypher = mockRunCypher.mock.calls[0]![0] as string;
+    expect(cypher).not.toContain("ci.baseUrl");
+    expect(cypher).not.toContain("ci.gpu");
+    expect(cypher).not.toContain("ci.vramGb");
+    expect(cypher).not.toContain("ci.modelCount");
+  });
+
+  it("creates BELONGS_TO edge when portfolioSlug provided", async () => {
+    await syncInfraCI({
+      ciId: "CI-test-03",
+      name: "Test",
+      ciType: "service",
+      status: "operational",
+      portfolioSlug: "foundational",
+    });
+
+    expect(mockRunCypher).toHaveBeenCalledTimes(2);
+    const edgeCypher = mockRunCypher.mock.calls[1]![0] as string;
+    expect(edgeCypher).toContain("BELONGS_TO");
+  });
+});

--- a/packages/db/src/neo4j-sync.ts
+++ b/packages/db/src/neo4j-sync.ts
@@ -83,21 +83,60 @@ export async function syncPortfolio(p: {
   );
 }
 
+export interface InfraCIExtendedProps {
+  baseUrl?: string;
+  gpu?: string;
+  vramGb?: number | null;
+  modelCount?: number;
+}
+
 /** Upsert an InfraCI node. */
-export async function syncInfraCI(ci: {
-  ciId: string;
-  name: string;
-  ciType: string;   // server | container | database | service | network
-  status: string;   // operational | degraded | offline
-  portfolioSlug?: string | null;
-}): Promise<void> {
+export async function syncInfraCI(
+  ci: {
+    ciId: string;
+    name: string;
+    ciType: string;   // server | container | database | service | network
+    status: string;   // operational | degraded | offline
+    portfolioSlug?: string | null;
+  },
+  extendedProps?: InfraCIExtendedProps,
+): Promise<void> {
+  const setClauses = [
+    "ci.name = $name",
+    "ci.ciType = $ciType",
+    "ci.status = $status",
+    "ci.syncedAt = datetime()",
+  ];
+  const params: Record<string, unknown> = {
+    ciId: ci.ciId,
+    name: ci.name,
+    ciType: ci.ciType,
+    status: ci.status,
+  };
+
+  if (extendedProps) {
+    if (extendedProps.baseUrl !== undefined) {
+      setClauses.push("ci.baseUrl = $baseUrl");
+      params.baseUrl = extendedProps.baseUrl;
+    }
+    if (extendedProps.gpu !== undefined) {
+      setClauses.push("ci.gpu = $gpu");
+      params.gpu = extendedProps.gpu;
+    }
+    if (extendedProps.vramGb !== undefined) {
+      setClauses.push("ci.vramGb = $vramGb");
+      params.vramGb = extendedProps.vramGb;
+    }
+    if (extendedProps.modelCount !== undefined) {
+      setClauses.push("ci.modelCount = $modelCount");
+      params.modelCount = extendedProps.modelCount;
+    }
+  }
+
   await runCypher(
     `MERGE (ci:InfraCI {ciId: $ciId})
-     SET ci.name        = $name,
-         ci.ciType      = $ciType,
-         ci.status      = $status,
-         ci.syncedAt    = datetime()`,
-    ci,
+     SET ${setClauses.join(", ")}`,
+    params,
   );
 
   if (ci.portfolioSlug) {

--- a/scripts/ollama-entrypoint.sh
+++ b/scripts/ollama-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# 1. Start Ollama server in background
+ollama serve &
+OLLAMA_PID=$!
+
+# Forward signals for graceful shutdown
+trap "kill $OLLAMA_PID; wait $OLLAMA_PID" SIGTERM SIGINT
+
+# 2. Wait for Ollama to be ready (max 60s)
+echo "Waiting for Ollama to start..."
+READY=false
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then
+    echo "Ollama is ready."
+    READY=true
+    break
+  fi
+  sleep 2
+done
+
+if [ "$READY" = false ]; then
+  echo "ERROR: Ollama failed to start within 60 seconds."
+  exit 1
+fi
+
+# 3. Check if models already loaded (persisted volume)
+MODEL_COUNT=$(ollama list 2>/dev/null | tail -n +2 | wc -l)
+
+if [ "$MODEL_COUNT" = "0" ]; then
+  echo "No models found. Detecting hardware..."
+
+  # 4. Runtime GPU detection
+  GPU_DETECTED=false
+  if command -v nvidia-smi &> /dev/null && nvidia-smi &> /dev/null; then
+    GPU_DETECTED=true
+    echo "GPU detected: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
+  fi
+
+  # 5. Pull appropriate default model
+  if [ "$GPU_DETECTED" = true ]; then
+    echo "Pulling llama3:8b (GPU-optimized default)..."
+    ollama pull llama3:8b
+  else
+    echo "Pulling phi3:mini (CPU-optimized default)..."
+    ollama pull phi3:mini
+  fi
+
+  echo "Default model ready."
+else
+  echo "$MODEL_COUNT model(s) already available."
+fi
+
+# 6. Foreground the Ollama process
+wait $OLLAMA_PID

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -64,6 +64,8 @@ if (-not (Test-Path "apps\web\.env.local")) {
     } else {
         Write-Warn "Created apps\web\.env.local — please set AUTH_SECRET manually"
     }
+    # Enable Docker internal URL for Ollama
+    Add-Content -Path "apps\web\.env.local" -Value "OLLAMA_INTERNAL_URL=http://ollama:11434"
 } else {
     Write-Ok "apps\web\.env.local already exists — skipping"
 }
@@ -75,7 +77,7 @@ if (-not (Test-Path "packages\db\.env")) {
 
 # -- Databases -------------------------------------------------------------------
 
-Write-Step "Starting databases (PostgreSQL + Neo4j)"
+Write-Step "Starting services (PostgreSQL + Neo4j + Ollama)"
 docker compose up -d
 
 Write-Host "  Waiting for PostgreSQL to be ready..."
@@ -88,6 +90,20 @@ do {
     Start-Sleep -Seconds 2
 } while ($true)
 Write-Ok "PostgreSQL is ready"
+
+Write-Host "  Waiting for Ollama... (first run may take a few minutes to download default model)" -ForegroundColor Yellow
+$retries = 90
+do {
+    $null = docker compose exec -T ollama curl -sf http://localhost:11434/api/tags 2>$null
+    if ($LASTEXITCODE -eq 0) { break }
+    $retries--
+    if ($retries -eq 0) {
+        Write-Host "  [FAIL] Ollama did not start in time. Check: docker compose logs ollama" -ForegroundColor Red
+        exit 1
+    }
+    Start-Sleep -Seconds 2
+} while ($true)
+Write-Host "  [OK] Ollama is ready" -ForegroundColor Green
 
 # -- Database Setup --------------------------------------------------------------
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -55,6 +55,8 @@ if [ ! -f apps/web/.env.local ]; then
   # Generate a secure AUTH_SECRET
   SECRET=$(openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))" 2>/dev/null || echo "change-me-$(date +%s)")
   sed -i "s|<generate with: openssl rand -base64 32>|$SECRET|" apps/web/.env.local
+  # Enable Docker internal URL for Ollama
+  echo "OLLAMA_INTERNAL_URL=http://ollama:11434" >> apps/web/.env.local
   ok "Created apps/web/.env.local with generated AUTH_SECRET"
 else
   ok "apps/web/.env.local already exists — skipping"
@@ -67,7 +69,7 @@ fi
 
 # ── Databases ─────────────────────────────────────────────────────────────────
 
-step "Starting databases (PostgreSQL + Neo4j)"
+step "Starting services (PostgreSQL + Neo4j + Ollama)"
 docker compose up -d
 
 echo "  Waiting for PostgreSQL to be ready..."
@@ -80,6 +82,17 @@ until docker compose exec -T postgres pg_isready -U dpf -q 2>/dev/null; do
   sleep 2
 done
 ok "PostgreSQL is ready"
+
+echo "  Waiting for Ollama... (first run may take a few minutes to download default model)"
+RETRIES=90
+until docker compose exec -T ollama curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; do
+  RETRIES=$((RETRIES - 1))
+  if [ $RETRIES -eq 0 ]; then
+    fail "Ollama did not start in time. Check: docker compose logs ollama"
+  fi
+  sleep 2
+done
+ok "Ollama is ready"
 
 # ── Database Setup ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add Ollama as a third Docker Compose service with GPU passthrough, custom entrypoint (auto-detects GPU, pulls default model), and health checks
- Extend Neo4j `syncInfraCI()` with optional hardware properties (GPU, VRAM, model count) and seed Ollama InfraCI node
- Extract discovery/profiling internals from `"use server"` file to prevent unguarded server action exposure (security refactor)
- Implement passive page-load health check (`checkBundledProviders`) with 4-state machine: auto-activate/deactivate, discover, profile, enrich hardware
- Add `OllamaHardwareInfo` component on provider detail page showing GPU, VRAM, max model size, and available models

## Test Plan
- [ ] 22 new tests across 4 files (syncInfraCI, URL resolution, health check state transitions, estimateMaxParameters)
- [ ] `pnpm test` — 117 pass, 3 pre-existing failures (unrelated permissions tests)
- [ ] `docker compose config --quiet` validates compose file
- [ ] Verify `ai-provider-internals.ts` has NO `"use server"` directive
- [ ] Manual: `docker compose up` starts Ollama, first page load auto-discovers models

🤖 Generated with [Claude Code](https://claude.com/claude-code)