### PR TITLE
Add structured EA value stream notation

### DIFF
--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -24,6 +24,11 @@ import {
 const NODE_TYPES = { eaElement: EaElementNode };
 const EDGE_TYPES = { eaRelationship: EaRelationshipEdge };
 
+const DEFAULT_CANVAS_STATE: CanvasState = {
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: {},
+};
+
 type EdgeVariant = "straight" | "bezier" | "step";
 
 type ElementTypeOption = { id: string; slug: string; name: string; neoLabel: string };
@@ -47,13 +52,95 @@ type Props = {
   isReadOnly: boolean;
 };
 
-function buildNodes(elements: SerializedViewElement[], canvasState: CanvasState | null): Node[] {
-  return elements.map((ve) => ({
-    id: ve.viewElementId,
-    type: "eaElement",
-    position: canvasState?.nodes[ve.viewElementId] ?? { x: 0, y: 0 },
-    data: ve,
-  }));
+function buildNodeLayout(
+  elements: SerializedViewElement[],
+  canvasState: CanvasState | null,
+): {
+  nodes: Record<string, { x: number; y: number }>;
+  shouldPersist: boolean;
+} {
+  const savedNodes = canvasState?.nodes ?? {};
+  const elementCount = elements.length;
+
+  if (elementCount <= 1) {
+    const single = elements[0];
+    if (!single) return { nodes: {}, shouldPersist: false };
+    return {
+      nodes: { [single.viewElementId]: savedNodes[single.viewElementId] ?? { x: 0, y: 0 } },
+      shouldPersist: false,
+    };
+  }
+
+  const allSavedPresent = elements.every((ve) => Boolean(savedNodes[ve.viewElementId]));
+  const allSavedAtOrigin = allSavedPresent
+    ? elements.every((ve) => {
+        const pos = savedNodes[ve.viewElementId];
+        return pos != null && pos.x === 0 && pos.y === 0;
+      })
+    : false;
+
+  const shouldLayoutAll = !allSavedPresent || allSavedAtOrigin;
+
+  if (shouldLayoutAll) {
+    const cols = Math.ceil(Math.sqrt(elementCount));
+    const xStep = 240;
+    const yStep = 150;
+    const nodes: Record<string, { x: number; y: number }> = {};
+
+    for (let i = 0; i < elementCount; i += 1) {
+      const ve = elements[i];
+      if (!ve) continue;
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      nodes[ve.viewElementId] = { x: col * xStep, y: row * yStep };
+    }
+
+    return { nodes, shouldPersist: true };
+  }
+
+  // Keep existing saved coordinates, but backfill any missing node positions.
+  const used = new Set<string>();
+  const nodes = { ...savedNodes } as Record<string, { x: number; y: number }>;
+  for (const pos of Object.values(savedNodes)) {
+    used.add(`${pos.x},${pos.y}`);
+  }
+
+  const cols = Math.ceil(Math.sqrt(elementCount));
+  const xStep = 240;
+  const yStep = 150;
+  let fillIndex = 0;
+
+  for (const ve of elements) {
+    if (nodes[ve.viewElementId]) continue;
+    while (true) {
+      const candidate = { x: (fillIndex % cols) * xStep, y: Math.floor(fillIndex / cols) * yStep };
+      const key = `${candidate.x},${candidate.y}`;
+      fillIndex += 1;
+      if (used.has(key)) continue;
+      nodes[ve.viewElementId] = candidate;
+      used.add(key);
+      break;
+    }
+  }
+
+  return { nodes, shouldPersist: false };
+}
+
+function buildNodes(elements: SerializedViewElement[], canvasState: CanvasState | null): {
+  nodes: Node[];
+  shouldPersist: boolean;
+} {
+  const layout = buildNodeLayout(elements, canvasState);
+
+  return {
+    shouldPersist: layout.shouldPersist,
+    nodes: elements.map((ve) => ({
+      id: ve.viewElementId,
+      type: "eaElement",
+      position: layout.nodes[ve.viewElementId] ?? { x: 0, y: 0 },
+      data: ve,
+    })),
+  };
 }
 
 function buildEdges(edges: SerializedEdge[], onDelete: (id: string) => void, edgeVariant: EdgeVariant): Edge[] {
@@ -98,7 +185,8 @@ export function EaCanvas({
     window.location.reload();
   }, [isReadOnly]);
 
-  const [nodes, setNodes, onNodesChange] = useNodesState(buildNodes(initialElements, initialCanvasState));
+  const initialNodeLayout = buildNodes(initialElements, initialCanvasState);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodeLayout.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(buildEdges(initialEdges, handleDeleteEdge, edgeVariant));
   const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(null);
   const [pendingDrop, setPendingDrop] = useState<{
@@ -117,11 +205,17 @@ export function EaCanvas({
 
   const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestCanvasStateRef = useRef<CanvasState>(
-    initialCanvasState ?? { viewport: { x: 0, y: 0, zoom: 1 }, nodes: {} }
+    initialCanvasState ?? DEFAULT_CANVAS_STATE
   );
   // Track live viewport (pan + zoom) so handleDrop can convert screen → flow coordinates.
   // Updated by onInit (after fitView) and onMove (during pan/zoom).
   const viewportRef = useRef(initialCanvasState?.viewport ?? { x: 0, y: 0, zoom: 1 });
+
+  useEffect(() => {
+    if (!initialNodeLayout.shouldPersist) return;
+    const nodesRecord = Object.fromEntries(nodes.map((node) => [node.id, node.position]));
+    scheduleAutoSave({ ...latestCanvasStateRef.current, nodes: nodesRecord });
+  }, [nodes, initialNodeLayout.shouldPersist]);
 
   function scheduleAutoSave(state: CanvasState) {
     latestCanvasStateRef.current = state;
@@ -270,6 +364,12 @@ export function EaCanvas({
             connectionMode={ConnectionMode.Loose}
             colorMode="dark"
             fitView
+            minZoom={0.05}
+            maxZoom={4}
+            panOnDrag
+            zoomOnScroll
+            zoomOnPinch
+            translateExtent={[[-Infinity, -Infinity], [Infinity, Infinity]]}
             onInit={(rf) => { viewportRef.current = rf.getViewport(); }}
             onMove={(_evt, vp) => { viewportRef.current = vp; }}
           >

--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -8,6 +8,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { SerializedViewElement, SerializedEdge, CanvasState } from "@/lib/ea-types";
+import { buildStructuredViewElements, filterStructuredEdges } from "@/lib/ea-structure";
 import { EaElementNode } from "./EaElementNode";
 import { EaRelationshipEdge } from "./EaRelationshipEdge";
 import { ElementPalette } from "./ElementPalette";
@@ -17,6 +18,7 @@ import {
   addElementToView,
   createEaRelationship,
   deleteEaRelationship,
+  moveStructuredViewElement,
   saveCanvasState,
   getDefaultRelTypeIdForView,
 } from "@/lib/actions/ea";
@@ -143,6 +145,45 @@ function buildNodes(elements: SerializedViewElement[], canvasState: CanvasState 
   };
 }
 
+function buildStructuredProjection(elements: SerializedViewElement[]): {
+  visibleElements: SerializedViewElement[];
+  structuredRoots: ReturnType<typeof buildStructuredViewElements>;
+} {
+  const structuredRoots = buildStructuredViewElements(
+    elements.map((element) => ({
+      viewElementId: element.viewElementId,
+      elementId: element.elementId,
+      elementTypeSlug: element.elementType.slug,
+      parentViewElementId: element.parentViewElementId,
+      orderIndex: element.orderIndex,
+      rendererHint: element.rendererHint,
+    })),
+  );
+  const elementsByViewElementId = new Map(elements.map((element) => [element.viewElementId, element]));
+
+  const hydrateStructuredElement = (
+    structuredElement: (typeof structuredRoots)[number],
+  ): SerializedViewElement => {
+    const baseElement = elementsByViewElementId.get(structuredElement.viewElementId);
+    if (!baseElement) {
+      throw new Error(`Structured element ${structuredElement.viewElementId} was not found in the view payload`);
+    }
+
+    return {
+      ...baseElement,
+      parentViewElementId: structuredElement.parentViewElementId,
+      orderIndex: structuredElement.orderIndex,
+      rendererHint: structuredElement.rendererHint,
+      childViewElements: structuredElement.childViewElements.map(hydrateStructuredElement),
+    };
+  };
+
+  return {
+    visibleElements: structuredRoots.map(hydrateStructuredElement),
+    structuredRoots,
+  };
+}
+
 function buildEdges(edges: SerializedEdge[], onDelete: (id: string) => void, edgeVariant: EdgeVariant): Edge[] {
   return edges.map((e) => ({
     id: e.id,
@@ -185,9 +226,40 @@ export function EaCanvas({
     window.location.reload();
   }, [isReadOnly]);
 
-  const initialNodeLayout = buildNodes(initialElements, initialCanvasState);
+  const projection = buildStructuredProjection(initialElements);
+  const visibleElements = projection.visibleElements.map((element) => ({
+    ...element,
+    isReadOnly,
+    onMoveStructuredChild: async (input: { childViewElementId: string; targetOrderIndex: number }) => {
+      if (isReadOnly) return;
+      await moveStructuredViewElement({
+        viewElementId: input.childViewElementId,
+        targetParentViewElementId: element.viewElementId,
+        targetOrderIndex: input.targetOrderIndex,
+      });
+      window.location.reload();
+    },
+    childViewElements: (element.childViewElements ?? []).map((child) => ({
+      ...child,
+      isReadOnly,
+    })),
+  }));
+  const visibleEdgeIds = new Set(
+    filterStructuredEdges(
+      initialEdges.map((edge) => ({
+        id: edge.id,
+        fromViewElementId: edge.fromViewElementId,
+        toViewElementId: edge.toViewElementId,
+        relationshipTypeSlug: edge.relationshipType.slug,
+      })),
+      projection.structuredRoots,
+    ).map((edge) => edge.id),
+  );
+  const visibleEdges = initialEdges.filter((edge) => visibleEdgeIds.has(edge.id));
+
+  const initialNodeLayout = buildNodes(visibleElements, initialCanvasState);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodeLayout.nodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(buildEdges(initialEdges, handleDeleteEdge, edgeVariant));
+  const [edges, setEdges, onEdgesChange] = useEdgesState(buildEdges(visibleEdges, handleDeleteEdge, edgeVariant));
   const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(null);
   const [pendingDrop, setPendingDrop] = useState<{
     elementId: string; name: string; typeName: string;

--- a/apps/web/components/ea/EaElementNode.tsx
+++ b/apps/web/components/ea/EaElementNode.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import { Handle, Position, useConnection, type NodeProps } from "@xyflow/react";
 import { layerFromNeoLabel, LAYER_COLOURS, type SerializedViewElement } from "@/lib/ea-types";
+import { StructuredValueStreamNode } from "./StructuredValueStreamNode";
 
 // One source handle per side. ConnectionMode.Loose allows source→source connections,
 // so target handles are unnecessary. Floating edge routing uses node intersection, not handle IDs.
@@ -52,6 +53,23 @@ export const EaElementNode = memo(function EaElementNode({ id, data, selected }:
     transition: "opacity 0.12s ease",
     zIndex: 10,
   };
+
+  if (nodeData.rendererHint === "nested_chevron_sequence") {
+    return (
+      <div style={{ position: "relative" }}>
+        {SIDES.map(({ position, id: handleId }) => (
+          <Handle
+            key={handleId}
+            type="source"
+            id={handleId}
+            position={position}
+            style={handleStyle}
+          />
+        ))}
+        <StructuredValueStreamNode data={nodeData} selected={selected} />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/components/ea/StructuredValueStreamNode.test.tsx
+++ b/apps/web/components/ea/StructuredValueStreamNode.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StructuredValueStreamNode } from "./StructuredValueStreamNode";
+import type { SerializedViewElement } from "@/lib/ea-types";
+
+function buildStage(
+  viewElementId: string,
+  name: string,
+  orderIndex: number,
+  structureIssueCount = 0,
+): SerializedViewElement {
+  return {
+    viewElementId,
+    elementId: `element-${viewElementId}`,
+    mode: "reference",
+    parentViewElementId: "stream-1",
+    orderIndex,
+    rendererHint: null,
+    structureIssueCount,
+    proposedProperties: null,
+    elementType: {
+      slug: "value_stream_stage",
+      name: "Value Stream Stage",
+      neoLabel: "ArchiMate__ValueStreamStage",
+    },
+    element: {
+      name,
+      description: null,
+      lifecycleStage: "plan",
+      lifecycleStatus: "draft",
+      properties: null,
+    },
+    childViewElements: [],
+  };
+}
+
+describe("StructuredValueStreamNode", () => {
+  it("renders a value stream with ordered nested stage chevrons", () => {
+    const html = renderToStaticMarkup(
+      <StructuredValueStreamNode
+        selected={false}
+        data={{
+          viewElementId: "stream-1",
+          elementId: "element-stream-1",
+          mode: "reference",
+          parentViewElementId: null,
+          orderIndex: null,
+          rendererHint: "nested_chevron_sequence",
+          structureIssueCount: 0,
+          proposedProperties: null,
+          elementType: {
+            slug: "value_stream",
+            name: "Value Stream",
+            neoLabel: "ArchiMate__ValueStream",
+          },
+          element: {
+            name: "Deliver Workforce Services",
+            description: null,
+            lifecycleStage: "plan",
+            lifecycleStatus: "draft",
+            properties: null,
+          },
+          childViewElements: [
+            buildStage("stage-2", "Support", 1),
+            buildStage("stage-1", "Request", 0),
+          ],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Deliver Workforce Services");
+    expect(html).toContain("Request");
+    expect(html).toContain("Support");
+    expect(html.indexOf("Request")).toBeLessThan(html.indexOf("Support"));
+    expect(html).toContain("value-stream-stage");
+  });
+
+  it("renders a warning state when the structure is non-conformant", () => {
+    const html = renderToStaticMarkup(
+      <StructuredValueStreamNode
+        selected
+        data={{
+          viewElementId: "stream-1",
+          elementId: "element-stream-1",
+          mode: "reference",
+          parentViewElementId: null,
+          orderIndex: null,
+          rendererHint: "nested_chevron_sequence",
+          structureIssueCount: 1,
+          proposedProperties: null,
+          elementType: {
+            slug: "value_stream",
+            name: "Value Stream",
+            neoLabel: "ArchiMate__ValueStream",
+          },
+          element: {
+            name: "Deliver Workforce Services",
+            description: null,
+            lifecycleStage: "plan",
+            lifecycleStatus: "draft",
+            properties: null,
+          },
+          childViewElements: [buildStage("stage-1", "Request", 0, 1)],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Structural warning");
+    expect(html).toContain("1 issue");
+  });
+
+  it("renders stage move controls when the view is editable", () => {
+    const html = renderToStaticMarkup(
+      <StructuredValueStreamNode
+        selected={false}
+        data={{
+          viewElementId: "stream-1",
+          elementId: "element-stream-1",
+          mode: "reference",
+          parentViewElementId: null,
+          orderIndex: null,
+          rendererHint: "nested_chevron_sequence",
+          structureIssueCount: 0,
+          proposedProperties: null,
+          elementType: {
+            slug: "value_stream",
+            name: "Value Stream",
+            neoLabel: "ArchiMate__ValueStream",
+          },
+          element: {
+            name: "Deliver Workforce Services",
+            description: null,
+            lifecycleStage: "plan",
+            lifecycleStatus: "draft",
+            properties: null,
+          },
+          isReadOnly: false,
+          onMoveStructuredChild: () => undefined,
+          childViewElements: [
+            buildStage("stage-1", "Request", 0),
+            buildStage("stage-2", "Support", 1),
+          ],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Move stage right");
+    expect(html).toContain("Move stage left");
+  });
+});

--- a/apps/web/components/ea/StructuredValueStreamNode.tsx
+++ b/apps/web/components/ea/StructuredValueStreamNode.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import type { SerializedViewElement } from "@/lib/ea-types";
+
+type Props = {
+  data: SerializedViewElement;
+  selected?: boolean;
+};
+
+function sortStages(stages: SerializedViewElement[]): SerializedViewElement[] {
+  return [...stages].sort((left, right) => {
+    const leftOrder = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return left.viewElementId.localeCompare(right.viewElementId);
+  });
+}
+
+function chevronClipPath(inset = 14): string {
+  return `polygon(0 0, calc(100% - ${inset}px) 0, 100% 50%, calc(100% - ${inset}px) 100%, 0 100%, ${inset}px 50%)`;
+}
+
+export function StructuredValueStreamNode({ data, selected = false }: Props) {
+  const stages = sortStages(data.childViewElements ?? []);
+  const childIssueCount = stages.reduce((sum, stage) => sum + stage.structureIssueCount, 0);
+  const issueCount = data.structureIssueCount > 0 ? data.structureIssueCount : childIssueCount;
+  const canReorderStages = !data.isReadOnly && typeof data.onMoveStructuredChild === "function" && stages.length > 1;
+
+  return (
+    <div
+      style={{
+        width: 440,
+        padding: 12,
+        border: selected ? "2px solid #f59e0b" : "2px solid #c8b400",
+        borderRadius: 10,
+        background: "linear-gradient(135deg, #fff8bf 0%, #f3ea9e 100%)",
+        boxShadow: selected ? "0 0 0 3px rgba(245, 158, 11, 0.18)" : undefined,
+      }}
+    >
+      <div
+        style={{
+          clipPath: chevronClipPath(18),
+          background: "linear-gradient(90deg, #ffe58f 0%, #facc15 100%)",
+          padding: "14px 48px 14px 22px",
+          border: "1px solid #c8b400",
+        }}
+      >
+        <div style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "#6a5400" }}>
+          Value Stream
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 700, color: "#3b2f00", marginTop: 2 }}>
+          {data.element.name}
+        </div>
+        <div style={{ fontSize: 11, color: "#5f4b00", marginTop: 4 }}>
+          {data.element.lifecycleStage} / {data.element.lifecycleStatus}
+        </div>
+      </div>
+
+      {issueCount > 0 ? (
+        <div
+          style={{
+            marginTop: 10,
+            padding: "6px 10px",
+            borderRadius: 8,
+            background: "#fff1d6",
+            border: "1px solid #f59e0b",
+            color: "#92400e",
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          Structural warning: {issueCount} issue{issueCount === 1 ? "" : "s"}
+        </div>
+      ) : null}
+
+      <div style={{ display: "grid", gridTemplateColumns: `repeat(${Math.max(stages.length, 1)}, minmax(0, 1fr))`, gap: 8, marginTop: 12 }}>
+        {stages.map((stage, index) => (
+          <div
+            key={stage.viewElementId}
+            className="value-stream-stage"
+            style={{
+              clipPath: chevronClipPath(12),
+              background: stage.structureIssueCount > 0
+                ? "linear-gradient(90deg, #ffd9bf 0%, #fdba74 100%)"
+                : "linear-gradient(90deg, #fff7d6 0%, #fde68a 100%)",
+              border: `1px solid ${stage.structureIssueCount > 0 ? "#f97316" : "#d4b106"}`,
+              padding: "12px 24px 12px 18px",
+              minHeight: 84,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "space-between",
+            }}
+          >
+            <div style={{ fontSize: 10, fontWeight: 700, color: "#7c5f00", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+              Stage {index + 1}
+            </div>
+            <div style={{ fontSize: 12, fontWeight: 700, color: "#3b2f00", marginTop: 4 }}>
+              {stage.element.name}
+            </div>
+            <div style={{ fontSize: 10, color: "#6a5400", marginTop: 8 }}>
+              {stage.element.lifecycleStage} / {stage.element.lifecycleStatus}
+            </div>
+            {canReorderStages ? (
+              <div style={{ display: "flex", gap: 6, marginTop: 10 }}>
+                {index > 0 ? (
+                  <button
+                    type="button"
+                    title="Move stage left"
+                    onClick={() => {
+                      void Promise.resolve(
+                        data.onMoveStructuredChild?.({
+                          childViewElementId: stage.viewElementId,
+                          targetOrderIndex: index - 1,
+                        }),
+                      );
+                    }}
+                    style={{
+                      border: "1px solid #c8b400",
+                      background: "#fff8bf",
+                      borderRadius: 999,
+                      color: "#6a5400",
+                      fontSize: 10,
+                      fontWeight: 700,
+                      padding: "4px 8px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Left
+                  </button>
+                ) : null}
+                {index < stages.length - 1 ? (
+                  <button
+                    type="button"
+                    title="Move stage right"
+                    onClick={() => {
+                      void Promise.resolve(
+                        data.onMoveStructuredChild?.({
+                          childViewElementId: stage.viewElementId,
+                          targetOrderIndex: index + 1,
+                        }),
+                      );
+                    }}
+                    style={{
+                      border: "1px solid #c8b400",
+                      background: "#fff8bf",
+                      borderRadius: 999,
+                      color: "#6a5400",
+                      fontSize: 10,
+                      fontWeight: 700,
+                      padding: "4px 8px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Right
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/ea.test.ts
+++ b/apps/web/lib/actions/ea.test.ts
@@ -36,7 +36,13 @@ vi.mock("@dpf/db", () => ({
       create:     vi.fn(),
       delete:     vi.fn(),
       findUnique: vi.fn(),
+      findMany:   vi.fn(),
       update:     vi.fn(),
+      updateMany: vi.fn(),
+    },
+    eaConformanceIssue: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
     },
     viewpointDefinition: { findUnique: vi.fn() },
     $transaction: vi.fn(),
@@ -68,6 +74,7 @@ import {
   advanceEaLifecycle,
   deleteEaElement,
   addElementToView,
+  moveStructuredViewElement,
   removeElementFromView,
   updateProposedProperties,
   saveCanvasState,
@@ -491,5 +498,64 @@ describe("createEaRelationship — viewpoint check", () => {
       viewId: "v1",
     });
     expect(result).toEqual({ error: "RelationshipTypeNotAllowedByViewpoint" });
+  });
+});
+describe("moveStructuredViewElement", () => {
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({ user: { platformRole: "HR-000", isSuperuser: false, id: "u1" } });
+    mockCan.mockReturnValue(true);
+  });
+
+  it("resequences sibling stages under a value stream parent", async () => {
+    (prisma.eaViewElement.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "stage-ve-2",
+      viewId: "view-1",
+      elementId: "stage-el-2",
+      parentViewElementId: "stream-ve-1",
+      orderIndex: 1,
+      element: { id: "stage-el-2" },
+    });
+    (prisma.eaViewElement.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "stage-ve-1", elementId: "stage-el-1", parentViewElementId: "stream-ve-1", orderIndex: 0 },
+      { id: "stage-ve-2", elementId: "stage-el-2", parentViewElementId: "stream-ve-1", orderIndex: 1 },
+    ]);
+
+    await moveStructuredViewElement({
+      viewElementId: "stage-ve-2",
+      targetParentViewElementId: "stream-ve-1",
+      targetOrderIndex: 0,
+    });
+
+    expect(prisma.eaViewElement.updateMany).toHaveBeenCalled();
+    expect(prisma.eaConformanceIssue.deleteMany).toHaveBeenCalled();
+  });
+
+  it("creates a conformance warning when a stage is detached", async () => {
+    (prisma.eaViewElement.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "stage-ve-1",
+      viewId: "view-1",
+      elementId: "stage-el-1",
+      parentViewElementId: "stream-ve-1",
+      orderIndex: 0,
+      element: { id: "stage-el-1" },
+    });
+    (prisma.eaViewElement.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await moveStructuredViewElement({
+      viewElementId: "stage-ve-1",
+      targetParentViewElementId: null,
+      targetOrderIndex: null,
+    });
+
+    expect(prisma.eaConformanceIssue.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            issueType: "detached_child",
+            severity: "warn",
+          }),
+        ]),
+      })
+    );
   });
 });

--- a/apps/web/lib/actions/ea.ts
+++ b/apps/web/lib/actions/ea.ts
@@ -547,6 +547,300 @@ export async function addElementToView(input: {
   }
 }
 
+type StructuredMutationRecord = {
+  id: string;
+  elementId: string;
+  parentViewElementId: string | null;
+  orderIndex: number | null;
+};
+
+type StructuredConformanceWarning = {
+  issueType: "missing_required_children" | "detached_child" | "duplicate_order_index";
+  severity: "warn" | "error";
+  message: string;
+  viewElementIds: string[];
+  details?: Record<string, unknown>;
+};
+
+function sortStructuredMutationRecords(records: StructuredMutationRecord[]): StructuredMutationRecord[] {
+  return [...records].sort((left, right) => {
+    const leftOrder = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function resequenceStructuredChildren(
+  records: StructuredMutationRecord[],
+  parentViewElementId: string,
+): StructuredMutationRecord[] {
+  return sortStructuredMutationRecords(records).map((record, index) => ({
+    ...record,
+    parentViewElementId,
+    orderIndex: index,
+  }));
+}
+
+function insertStructuredChild(
+  records: StructuredMutationRecord[],
+  movingRecord: StructuredMutationRecord,
+  parentViewElementId: string,
+  targetOrderIndex: number | null,
+): StructuredMutationRecord[] {
+  const ordered = sortStructuredMutationRecords(records.filter((record) => record.id !== movingRecord.id));
+  const insertionIndex = targetOrderIndex == null
+    ? ordered.length
+    : Math.max(0, Math.min(targetOrderIndex, ordered.length));
+
+  ordered.splice(insertionIndex, 0, {
+    ...movingRecord,
+    parentViewElementId,
+  });
+
+  return ordered.map((record, index) => ({
+    ...record,
+    parentViewElementId,
+    orderIndex: index,
+  }));
+}
+
+function deriveStructuredWarnings(input: {
+  parentViewElementId: string;
+  minChildren: number;
+  children: StructuredMutationRecord[];
+}): StructuredConformanceWarning[] {
+  const warnings: StructuredConformanceWarning[] = [];
+  const attachedChildren = input.children.filter(
+    (child) => child.parentViewElementId === input.parentViewElementId,
+  );
+  const detachedChildren = input.children.filter(
+    (child) => child.parentViewElementId !== input.parentViewElementId,
+  );
+
+  if (attachedChildren.length < input.minChildren) {
+    warnings.push({
+      issueType: "missing_required_children",
+      severity: "warn",
+      message: `Expected at least ${input.minChildren} structured child elements`,
+      viewElementIds: [input.parentViewElementId],
+      details: {
+        minChildren: input.minChildren,
+        attachedChildCount: attachedChildren.length,
+      },
+    });
+  }
+
+  for (const child of detachedChildren) {
+    warnings.push({
+      issueType: "detached_child",
+      severity: "warn",
+      message: "Structured child is detached from its expected parent",
+      viewElementIds: [child.id],
+      details: {
+        expectedParentViewElementId: input.parentViewElementId,
+        actualParentViewElementId: child.parentViewElementId,
+      },
+    });
+  }
+
+  const siblingsByOrderIndex = new Map<number, string[]>();
+  for (const child of attachedChildren) {
+    if (child.orderIndex == null) continue;
+    const siblings = siblingsByOrderIndex.get(child.orderIndex) ?? [];
+    siblings.push(child.id);
+    siblingsByOrderIndex.set(child.orderIndex, siblings);
+  }
+
+  for (const [orderIndex, siblings] of siblingsByOrderIndex) {
+    if (siblings.length < 2) continue;
+    warnings.push({
+      issueType: "duplicate_order_index",
+      severity: "warn",
+      message: `Multiple structured children share order index ${orderIndex}`,
+      viewElementIds: siblings,
+      details: { orderIndex },
+    });
+  }
+
+  return warnings;
+}
+
+export async function moveStructuredViewElement(input: {
+  viewElementId: string;
+  targetParentViewElementId: string | null;
+  targetOrderIndex: number | null;
+}): Promise<{ error?: string }> {
+  await requireManageEaModel();
+
+  const existing = await prisma.eaViewElement.findUnique({
+    where: { id: input.viewElementId },
+    select: {
+      id: true,
+      viewId: true,
+      elementId: true,
+      parentViewElementId: true,
+      orderIndex: true,
+      element: { select: { id: true } },
+    },
+  });
+
+  if (!existing) return { error: "ViewElementNotFound" };
+
+  const oldParentViewElementId = existing.parentViewElementId;
+  const targetParentViewElementId = input.targetParentViewElementId;
+
+  await prisma.$transaction(async (tx) => {
+    const affectedParentViewElementIds = Array.from(
+      new Set([oldParentViewElementId, targetParentViewElementId].filter((value): value is string => value != null)),
+    );
+
+    const siblingCandidates = affectedParentViewElementIds.length > 0
+      ? await tx.eaViewElement.findMany({
+          where: {
+            viewId: existing.viewId,
+            OR: affectedParentViewElementIds.map((parentViewElementId) => ({ parentViewElementId })),
+          },
+          select: {
+            id: true,
+            elementId: true,
+            parentViewElementId: true,
+            orderIndex: true,
+          },
+        })
+      : [];
+
+    const recordsById = new Map<string, StructuredMutationRecord>();
+    for (const record of siblingCandidates) {
+      recordsById.set(record.id, record);
+    }
+    recordsById.set(existing.id, {
+      id: existing.id,
+      elementId: existing.elementId,
+      parentViewElementId: existing.parentViewElementId,
+      orderIndex: existing.orderIndex,
+    });
+
+    const movingRecord = recordsById.get(existing.id)!;
+    const oldSiblings = oldParentViewElementId == null
+      ? []
+      : sortStructuredMutationRecords(
+          Array.from(recordsById.values()).filter((record) => record.parentViewElementId === oldParentViewElementId),
+        );
+    const targetSiblings = targetParentViewElementId == null
+      ? []
+      : oldParentViewElementId === targetParentViewElementId
+        ? oldSiblings
+        : sortStructuredMutationRecords(
+            Array.from(recordsById.values()).filter((record) => record.parentViewElementId === targetParentViewElementId),
+          );
+
+    const finalRecordsById = new Map<string, StructuredMutationRecord>();
+    const warningInputs = new Map<string, StructuredMutationRecord[]>();
+
+    if (oldParentViewElementId && oldParentViewElementId === targetParentViewElementId) {
+      const resequenced = insertStructuredChild(
+        oldSiblings,
+        movingRecord,
+        oldParentViewElementId,
+        input.targetOrderIndex,
+      );
+      warningInputs.set(oldParentViewElementId, resequenced);
+      for (const record of resequenced) {
+        finalRecordsById.set(record.id, record);
+      }
+    } else {
+      const movingFinalRecord: StructuredMutationRecord = {
+        ...movingRecord,
+        parentViewElementId: targetParentViewElementId,
+        orderIndex: targetParentViewElementId == null ? null : movingRecord.orderIndex,
+      };
+
+      if (oldParentViewElementId) {
+        const resequencedOldSiblings = resequenceStructuredChildren(
+          oldSiblings.filter((record) => record.id !== movingRecord.id),
+          oldParentViewElementId,
+        );
+        warningInputs.set(oldParentViewElementId, [...resequencedOldSiblings, movingFinalRecord]);
+        for (const record of resequencedOldSiblings) {
+          finalRecordsById.set(record.id, record);
+        }
+      }
+
+      if (targetParentViewElementId) {
+        const resequencedTargetSiblings = insertStructuredChild(
+          targetSiblings,
+          movingRecord,
+          targetParentViewElementId,
+          input.targetOrderIndex,
+        );
+        warningInputs.set(targetParentViewElementId, resequencedTargetSiblings);
+        for (const record of resequencedTargetSiblings) {
+          finalRecordsById.set(record.id, record);
+        }
+      } else {
+        finalRecordsById.set(movingRecord.id, movingFinalRecord);
+      }
+    }
+
+    if (affectedParentViewElementIds.length > 0) {
+      await tx.eaViewElement.updateMany({
+        where: {
+          viewId: existing.viewId,
+          OR: affectedParentViewElementIds.map((parentViewElementId) => ({ parentViewElementId })),
+        },
+        data: { orderIndex: null },
+      });
+    }
+
+    for (const record of finalRecordsById.values()) {
+      await tx.eaViewElement.update({
+        where: { id: record.id },
+        data: {
+          parentViewElementId: record.parentViewElementId,
+          orderIndex: record.orderIndex,
+        },
+      });
+    }
+
+    await tx.eaConformanceIssue.deleteMany({
+      where: {
+        viewId: existing.viewId,
+        issueType: {
+          in: ["missing_required_children", "detached_child", "duplicate_order_index"],
+        },
+      },
+    });
+
+    const warnings = Array.from(warningInputs.entries()).flatMap(([parentViewElementId, children]) =>
+      deriveStructuredWarnings({
+        parentViewElementId,
+        minChildren: 1,
+        children,
+      }),
+    );
+
+    if (warnings.length > 0) {
+      await tx.eaConformanceIssue.createMany({
+        data: warnings.map((warning) => {
+          const issueViewElementId = warning.viewElementIds[0] ?? null;
+          return {
+            viewId: existing.viewId,
+            elementId: issueViewElementId ? recordsById.get(issueViewElementId)?.elementId ?? null : null,
+            issueType: warning.issueType,
+            severity: warning.severity,
+            message: warning.message,
+            status: "open",
+            detailsJson: (warning.details ?? {}) as Prisma.InputJsonValue,
+          };
+        }),
+      });
+    }
+  });
+
+  return {};
+}
+
 export async function removeElementFromView(input: {
   viewElementId: string;
 }): Promise<{ error?: string }> {

--- a/apps/web/lib/ea-data.ts
+++ b/apps/web/lib/ea-data.ts
@@ -35,6 +35,8 @@ export const getEaView = cache(async (id: string) => {
           id: true,
           elementId: true,
           mode: true,
+          parentViewElementId: true,
+          orderIndex: true,
           proposedProperties: true,
           element: {
             select: {
@@ -42,6 +44,7 @@ export const getEaView = cache(async (id: string) => {
               description: true,
               lifecycleStage: true,
               lifecycleStatus: true,
+              properties: true,
               elementType: {
                 select: { slug: true, name: true, neoLabel: true },
               },
@@ -55,11 +58,46 @@ export const getEaView = cache(async (id: string) => {
   if (!view) return null;
 
   const elementIds = view.viewElements.map((ve) => ve.elementId);
+  const elementTypeSlugs = Array.from(new Set(view.viewElements.map((ve) => ve.element.elementType.slug)));
   // Map elementId → viewElementId for edge source/target resolution.
   // React Flow node IDs are EaViewElement.id, not EaElement.id.
   const elementIdToViewElementId = new Map(
     view.viewElements.map((ve) => [ve.elementId, ve.id])
   );
+
+  const [structureRules, conformanceIssues] = await Promise.all([
+    elementTypeSlugs.length > 0
+      ? prisma.eaStructureRule.findMany({
+          where: {
+            notationId: view.notationId,
+            parentElementType: { slug: { in: elementTypeSlugs } },
+          },
+          select: {
+            rendererHint: true,
+            parentElementType: { select: { slug: true } },
+          },
+        })
+      : Promise.resolve([]),
+    elementIds.length > 0
+      ? prisma.eaConformanceIssue.findMany({
+          where: {
+            viewId: view.id,
+            status: "open",
+            elementId: { in: elementIds },
+          },
+          select: { elementId: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const rendererHintByElementTypeSlug = new Map<string, string | null>(
+    structureRules.map((rule) => [rule.parentElementType.slug, rule.rendererHint]),
+  );
+  const issueCountByElementId = new Map<string, number>();
+  for (const issue of conformanceIssues) {
+    if (!issue.elementId) continue;
+    issueCountByElementId.set(issue.elementId, (issueCountByElementId.get(issue.elementId) ?? 0) + 1);
+  }
 
   // Load edges where both endpoints are on this view
   const relationships = elementIds.length > 1
@@ -81,6 +119,10 @@ export const getEaView = cache(async (id: string) => {
     viewElementId: ve.id,
     elementId: ve.elementId,
     mode: ve.mode as SerializedViewElement["mode"],
+    parentViewElementId: ve.parentViewElementId,
+    orderIndex: ve.orderIndex,
+    rendererHint: rendererHintByElementTypeSlug.get(ve.element.elementType.slug) ?? null,
+    structureIssueCount: issueCountByElementId.get(ve.elementId) ?? 0,
     proposedProperties: ve.proposedProperties as Record<string, unknown> | null,
     elementType: ve.element.elementType,
     element: {
@@ -88,6 +130,7 @@ export const getEaView = cache(async (id: string) => {
       description: ve.element.description,
       lifecycleStage: ve.element.lifecycleStage,
       lifecycleStatus: ve.element.lifecycleStatus,
+      properties: (ve.element.properties as Record<string, unknown> | null) ?? null,
     },
   }));
 

--- a/apps/web/lib/ea-structure.test.ts
+++ b/apps/web/lib/ea-structure.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildStructuredViewElements,
+  filterStructuredEdges,
+  type StructuredEdgeCandidate,
+  type StructuredViewElementCandidate,
+} from "./ea-structure";
+
+describe("app ea structure helpers", () => {
+  it("groups and orders child stages under a value stream", () => {
+    const elements: StructuredViewElementCandidate[] = [
+      {
+        viewElementId: "stream-1",
+        elementId: "el-stream-1",
+        elementTypeSlug: "value_stream",
+        parentViewElementId: null,
+        orderIndex: null,
+        rendererHint: "nested_chevron_sequence",
+      },
+      {
+        viewElementId: "stage-2",
+        elementId: "el-stage-2",
+        elementTypeSlug: "value_stream_stage",
+        parentViewElementId: "stream-1",
+        orderIndex: 2,
+        rendererHint: null,
+      },
+      {
+        viewElementId: "stage-1",
+        elementId: "el-stage-1",
+        elementTypeSlug: "value_stream_stage",
+        parentViewElementId: "stream-1",
+        orderIndex: 1,
+        rendererHint: null,
+      },
+    ];
+
+    const structured = buildStructuredViewElements(elements);
+    expect(structured[0]?.childViewElements.map((child) => child.viewElementId)).toEqual([
+      "stage-1",
+      "stage-2",
+    ]);
+  });
+
+  it("hides implied stage-to-stage edges inside a structured value stream", () => {
+    const elements: StructuredViewElementCandidate[] = [
+      {
+        viewElementId: "stream-1",
+        elementId: "el-stream-1",
+        elementTypeSlug: "value_stream",
+        parentViewElementId: null,
+        orderIndex: null,
+        rendererHint: "nested_chevron_sequence",
+      },
+      {
+        viewElementId: "stage-1",
+        elementId: "el-stage-1",
+        elementTypeSlug: "value_stream_stage",
+        parentViewElementId: "stream-1",
+        orderIndex: 0,
+        rendererHint: null,
+      },
+      {
+        viewElementId: "stage-2",
+        elementId: "el-stage-2",
+        elementTypeSlug: "value_stream_stage",
+        parentViewElementId: "stream-1",
+        orderIndex: 1,
+        rendererHint: null,
+      },
+    ];
+
+    const edges: StructuredEdgeCandidate[] = [
+      { id: "edge-1", fromViewElementId: "stage-1", toViewElementId: "stage-2", relationshipTypeSlug: "flows_to" },
+      { id: "edge-2", fromViewElementId: "stream-1", toViewElementId: "stage-1", relationshipTypeSlug: "composed_of" },
+    ];
+
+    expect(filterStructuredEdges(edges, buildStructuredViewElements(elements)).map((edge) => edge.id)).toEqual([
+      "edge-2",
+    ]);
+  });
+});

--- a/apps/web/lib/ea-structure.ts
+++ b/apps/web/lib/ea-structure.ts
@@ -1,0 +1,92 @@
+export type StructuredViewElementCandidate = {
+  viewElementId: string;
+  elementId: string;
+  elementTypeSlug: string;
+  parentViewElementId: string | null;
+  orderIndex: number | null;
+  rendererHint: string | null;
+};
+
+export type StructuredViewElement = StructuredViewElementCandidate & {
+  childViewElements: StructuredViewElement[];
+};
+
+export type StructuredEdgeCandidate = {
+  id: string;
+  fromViewElementId: string;
+  toViewElementId: string;
+  relationshipTypeSlug: string;
+};
+
+function sortStructuredElements<T extends { orderIndex: number | null; viewElementId: string }>(elements: T[]): T[] {
+  return [...elements].sort((left, right) => {
+    const leftOrder = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return left.viewElementId.localeCompare(right.viewElementId);
+  });
+}
+
+export function buildStructuredViewElements(
+  elements: StructuredViewElementCandidate[],
+): StructuredViewElement[] {
+  const structuredById = new Map<string, StructuredViewElement>(
+    elements.map((element) => [
+      element.viewElementId,
+      {
+        ...element,
+        childViewElements: [],
+      },
+    ]),
+  );
+
+  const roots: StructuredViewElement[] = [];
+  for (const element of elements) {
+    const structured = structuredById.get(element.viewElementId);
+    if (!structured) continue;
+
+    const parent =
+      element.parentViewElementId == null
+        ? null
+        : structuredById.get(element.parentViewElementId) ?? null;
+
+    if (!parent) {
+      roots.push(structured);
+      continue;
+    }
+
+    parent.childViewElements.push(structured);
+  }
+
+  const sortTree = (node: StructuredViewElement) => {
+    node.childViewElements = sortStructuredElements(node.childViewElements);
+    node.childViewElements.forEach(sortTree);
+  };
+
+  roots.forEach(sortTree);
+  return roots;
+}
+
+export function filterStructuredEdges(
+  edges: StructuredEdgeCandidate[],
+  structuredElements: StructuredViewElement[],
+): StructuredEdgeCandidate[] {
+  const childViewElementToStructuredParent = new Map<string, string>();
+
+  for (const element of structuredElements) {
+    if (element.rendererHint !== "nested_chevron_sequence") continue;
+    for (const child of element.childViewElements) {
+      childViewElementToStructuredParent.set(child.viewElementId, element.viewElementId);
+    }
+  }
+
+  return edges.filter((edge) => {
+    if (edge.relationshipTypeSlug !== "flows_to") return true;
+
+    const fromParent = childViewElementToStructuredParent.get(edge.fromViewElementId);
+    const toParent = childViewElementToStructuredParent.get(edge.toViewElementId);
+    if (!fromParent || !toParent) return true;
+
+    return fromParent !== toParent;
+  });
+}

--- a/apps/web/lib/ea-types.ts
+++ b/apps/web/lib/ea-types.ts
@@ -12,6 +12,10 @@ export type SerializedViewElement = {
   viewElementId: string;     // EaViewElement.id — used as React Flow node id
   elementId: string;
   mode: EaViewMode;
+  parentViewElementId: string | null;
+  orderIndex: number | null;
+  rendererHint: string | null;
+  structureIssueCount: number;
   proposedProperties: Record<string, unknown> | null;
   elementType: {
     slug: string;
@@ -23,6 +27,7 @@ export type SerializedViewElement = {
     description: string | null;
     lifecycleStage: string;
     lifecycleStatus: string;
+    properties: Record<string, unknown> | null;
   };
 };
 

--- a/apps/web/lib/ea-types.ts
+++ b/apps/web/lib/ea-types.ts
@@ -29,6 +29,12 @@ export type SerializedViewElement = {
     lifecycleStatus: string;
     properties: Record<string, unknown> | null;
   };
+  childViewElements?: SerializedViewElement[];
+  isReadOnly?: boolean;
+  onMoveStructuredChild?: (input: {
+    childViewElementId: string;
+    targetOrderIndex: number;
+  }) => void | Promise<void>;
 };
 
 // Serialised relationship edge passed from server → EaCanvas

--- a/docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md
+++ b/docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md
@@ -14,39 +14,41 @@ A floating chat panel that provides context-aware AI agent assistance on every s
 
 Each user gets a single `AgentThread` with `contextKey: "coworker"`. The conversation persists across all routes and sessions, giving the user a continuous history with their AI co-worker.
 
-### Schema Additions
+### Schema Migration
 
+The `AgentThread` and `AgentMessage` models already exist in the schema. This phase adds fields to them via a Prisma migration:
+
+**`AgentThread`** — add default to `contextKey`:
 ```prisma
-model AgentThread {
-  id         String         @id @default(cuid())
-  userId     String
-  contextKey String         @default("coworker")
-  createdAt  DateTime       @default(now())
-  updatedAt  DateTime       @updatedAt
-  messages   AgentMessage[]
+contextKey String @default("coworker")   // existing field, adding default
+```
 
-  user User @relation(fields: [userId], references: [id])
-  @@unique([userId, contextKey])
-}
-
+**`AgentMessage`** — add two new columns and indexes:
+```prisma
 model AgentMessage {
   id           String      @id @default(cuid())
   threadId     String
-  role         String      // "user" | "assistant"
+  thread       AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  role         String      // "user" | "assistant" | "system"
   content      String
-  agentId      String?     // which specialist agent authored this (null for user messages)
-  routeContext String?     // route pathname when message was sent
+  tone         String?     // existing field, retained
+  agentId      String?     // NEW: which specialist agent authored this (null for user messages)
+  routeContext String?     // NEW: route pathname when message was sent
   createdAt    DateTime    @default(now())
 
-  thread AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  @@index([threadId])      // NEW: needed for pagination queries
+  @@index([createdAt])     // NEW: needed for cursor-based ordering
 }
 ```
+
+The existing `AgentThread` already has `onDelete: Cascade` on the user relation — no change needed there.
 
 ### Key Decisions
 
 - **`agentId` on messages**: Tracks which specialist authored each response. Enables future multi-agent deliberation (Phase 7D) where messages from different specialists appear in the same thread.
 - **`routeContext`**: Records the route pathname when the message was sent. Useful for understanding conversation flow and for agents to reference what the user was looking at.
-- **No separate threads per route**: The user sees one continuous conversation. Agent identity changes are shown inline via avatar/label transitions.
+- **`role: "system"`**: The existing schema already supports `"system"` role. Agent transition messages ("EA Architect has joined the conversation") use `role: "system"`.
+- **No separate threads per route**: The user sees one continuous conversation. Agent identity changes are shown inline via system messages and avatar/label transitions.
 
 ### Route-to-Agent Mapping
 
@@ -60,7 +62,7 @@ const ROUTE_AGENT_MAP: Record<string, string> = {
   "/employee":   "hr-specialist",
   "/ops":        "ops-coordinator",
   "/platform":   "platform-engineer",
-  "/admin":      "admin-assistant",
+  "/admin":      "admin-assistant",   // forward-looking — activates when admin route is built
   "/workspace":  "workspace-guide",
 };
 ```
@@ -78,7 +80,7 @@ const ROUTE_AGENT_MAP: Record<string, string> = {
 - **Z-index**: 50 (above page content, below modals)
 - **Draggable**: Click-and-drag on the header bar to reposition
 - **Position persistence**: Saved to `localStorage` key `"agent-panel-position"` as `{x, y}`
-- **Toggle**: Button in the Header component (agent icon), toggles open/closed state stored in `localStorage` key `"agent-panel-open"`
+- **Toggle**: Existing "Agent" button in the Header component (pill with green dot, currently no onClick handler) is wired up to dispatch a `CustomEvent("toggle-agent-panel")`. The `AgentCoworkerPanel` listens for this event and syncs open/closed state with `localStorage` key `"agent-panel-open"`.
 
 ### Visual Design
 
@@ -93,6 +95,7 @@ const ROUTE_AGENT_MAP: Record<string, string> = {
 
 - **User messages**: Right-aligned, accent background (`var(--dpf-accent)` #7c8cf8), white text
 - **Agent messages**: Left-aligned, `var(--dpf-surface-2)` (#161625) background, light text
+- **System messages**: Centered, muted text (`var(--dpf-muted)` #8888a0), used for agent transition indicators
 - **Agent identity**: Small label above agent messages showing agent name when the specialist changes (e.g., "EA Architect" when navigating to /ea)
 - **Timestamps**: Relative time (e.g., "2m ago"), shown on hover
 
@@ -102,36 +105,34 @@ When the user navigates to a different route, the panel shows a subtle transitio
 
 > *EA Architect has joined the conversation*
 
-This appears as a system message (centered, muted text) in the message stream. The new agent has access to the full conversation history for continuity.
+This is persisted as a `role: "system"` message in the database and rendered centered with muted text. The new agent has access to the full conversation history for continuity.
 
 ## 3. Agent Routing & Role Awareness
 
 ### `resolveAgentForRoute(pathname, userContext)`
 
-Pure function in `apps/web/lib/agent-routing.ts`:
+Pure function in `apps/web/lib/agent-routing.ts`. Imports and reuses the existing `UserContext` type from `permissions.ts` (which has `platformRole: string | null`):
 
 ```typescript
-type UserContext = {
-  platformRole: string;
-  isSuperuser: boolean;
-};
+import type { UserContext } from "@/lib/permissions";
 
-type ResolvedAgent = {
+type AgentInfo = {
   agentId: string;
   agentName: string;
   agentDescription: string;
   canAssist: boolean;  // false if user lacks permission for this route's domain
 };
 
-function resolveAgentForRoute(pathname: string, userContext: UserContext): ResolvedAgent;
+function resolveAgentForRoute(pathname: string, userContext: UserContext): AgentInfo;
 ```
 
 ### Resolution Logic
 
 1. Match `pathname` against `ROUTE_AGENT_MAP` using longest prefix match
-2. Check if the user has the capability for that route's domain (reuse `can()` from permissions)
-3. If the user lacks permission: return the agent with `canAssist: false` — the agent will explain it cannot help with actions outside the user's authority
-4. If no route matches: fall back to `"workspace-guide"`
+2. If `userContext.platformRole` is `null`, return agent with `canAssist: false`
+3. Check if the user has the capability for that route's domain (reuse `can()` from permissions)
+4. If the user lacks permission: return the agent with `canAssist: false` — the agent will explain it cannot help with actions outside the user's authority
+5. If no route matches: fall back to `"workspace-guide"`
 
 ### Role-Aware Behavior
 
@@ -148,7 +149,7 @@ This is enforced in `generateCannedResponse` by selecting from role-appropriate 
 When the active agent changes (route navigation), the panel:
 
 1. Calls `resolveAgentForRoute` with the new pathname
-2. If the agent ID differs from the current one, inserts a system message ("X has joined the conversation")
+2. If the agent ID differs from the current one, persists a `role: "system"` message ("X has joined the conversation") via `sendMessage`
 3. Updates the header to show the new agent's name and description
 4. Does NOT clear the conversation — full history is preserved
 
@@ -163,41 +164,60 @@ When the active agent changes (route navigation), the panel:
 async function getOrCreateThread(): Promise<{ threadId: string }>;
 
 // Send a message and get a canned response
+// Returns { error: string } on validation failure or auth error
 async function sendMessage(input: {
   threadId: string;
-  content: string;
+  content: string;       // max 2000 chars, must be non-empty after trimming
   routeContext: string;
-}): Promise<{ userMessage: AgentMessageRow; agentMessage: AgentMessageRow }>;
+}): Promise<{ userMessage: AgentMessageRow; agentMessage: AgentMessageRow } | { error: string }>;
 
 // Load earlier messages (pagination)
 async function loadEarlierMessages(input: {
   threadId: string;
   before: string;  // cursor (message ID)
   limit?: number;  // default 20
-}): Promise<{ messages: AgentMessageRow[]; hasMore: boolean }>;
+}): Promise<{ messages: AgentMessageRow[]; hasMore: boolean } | { error: string }>;
 ```
+
+### Error Handling
+
+All server actions follow the existing codebase pattern (e.g., `actions/backlog.ts`):
+- Return `{ error: string }` union on failure
+- Auth: call `auth()`, verify user owns the thread — return `{ error: "Unauthorized" }` if not
+- Validation: reject empty content (after trim), reject content longer than 2000 characters
+- Thread ownership: verify `thread.userId === session.user.id`
 
 ### Data Fetcher (`apps/web/lib/agent-coworker-data.ts`)
 
 ```typescript
 // React cache — get recent messages for initial render
+// MUST only be called from the shell layout after session is verified.
+// The threadId is obtained via the authenticated getOrCreateThread() call,
+// which guarantees the user owns the thread.
 async function getRecentMessages(threadId: string, limit?: number): Promise<AgentMessageRow[]>;
+```
+
+### Serialization
+
+Server actions and data fetchers map Prisma `DateTime` to ISO strings when constructing `AgentMessageRow`:
+```typescript
+createdAt: message.createdAt.toISOString()
 ```
 
 ### Auth Guards
 
-All server actions call `auth()` and verify the user owns the thread. No new capability needed — any authenticated user can use the co-worker panel.
+All server actions call `auth()` and verify the user owns the thread. No new capability needed — any authenticated user can use the co-worker panel. The `getRecentMessages` data fetcher does not re-check auth; it relies on the caller (shell layout) having verified the session and obtained the `threadId` via `getOrCreateThread`.
 
 ### Types (`apps/web/lib/agent-coworker-types.ts`)
 
 ```typescript
 type AgentMessageRow = {
   id: string;
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "system";
   content: string;
   agentId: string | null;
   routeContext: string | null;
-  createdAt: string;  // ISO string for serialization
+  createdAt: string;  // ISO string — serialized from Prisma DateTime via .toISOString()
 };
 
 type AgentInfo = {
@@ -217,14 +237,14 @@ ShellLayout
   └── AgentCoworkerPanel (client component, rendered at layout level)
         ├── AgentPanelHeader (drag handle, agent name, minimize/close)
         ├── AgentMessageList (scrollable message area)
-        │     └── AgentMessageBubble (per message)
+        │     └── AgentMessageBubble (per message, handles user/assistant/system roles)
         └── AgentMessageInput (text input + send)
 ```
 
 ### `AgentCoworkerPanel` (`apps/web/components/agent/AgentCoworkerPanel.tsx`)
 
 Client component. Manages:
-- Open/closed state (localStorage + Header button)
+- Open/closed state (listens for `CustomEvent("toggle-agent-panel")`, syncs with `localStorage`)
 - Drag position (localStorage)
 - Current agent (derived from `usePathname()` + `resolveAgentForRoute`)
 - Message state (initial SSR data + optimistic updates)
@@ -237,13 +257,13 @@ Displays current agent name and description. Provides drag handle, minimize butt
 ### `AgentMessageBubble` (`apps/web/components/agent/AgentMessageBubble.tsx`)
 
 Renders a single message. Handles:
-- User vs. agent alignment and styling
+- User vs. agent vs. system alignment and styling
 - Agent identity label (shown when agent changes)
 - Relative timestamp on hover
 
 ### `AgentMessageInput` (`apps/web/components/agent/AgentMessageInput.tsx`)
 
-Text input with send button. Handles Enter-to-send, disabled state during processing.
+Text input with send button. Handles Enter-to-send, disabled state during processing, max 2000 char client-side validation.
 
 ### Integration with Shell Layout
 
@@ -253,31 +273,32 @@ Text input with send button. Handles Enter-to-send, disabled state during proces
 - `initialMessages` (from `getRecentMessages`)
 - `userContext` ({ platformRole, isSuperuser })
 
-The Header component gets a new "Agent" button that toggles the panel via a shared state mechanism (custom event or URL search param).
+The existing "Agent" button in the Header component (pill-shaped with green dot) is wired up with `onClick={() => document.dispatchEvent(new CustomEvent("toggle-agent-panel"))}`. No new button is created.
 
 ### Testing Strategy
 
 Unit tests for pure functions:
-- `resolveAgentForRoute` — route matching, permission gating, fallback behavior
+- `resolveAgentForRoute` — route matching, permission gating, fallback behavior, null platformRole handling
 - `generateCannedResponse` — correct response selection by agent, route, and role
 - Agent transition detection — when agent ID changes between messages
 
 Integration tests for server actions:
 - `getOrCreateThread` — creates on first call, returns existing on second
 - `sendMessage` — persists both user and agent messages, returns correct structure
+- `sendMessage` validation — rejects empty content, over-length content, unauthorized thread access
 - `loadEarlierMessages` — pagination cursor behavior, hasMore flag
 - Auth guards — rejects unauthenticated requests
 
 ## Scope Boundaries
 
 ### In Scope (Phase 7B)
-- Prisma schema migration (AgentThread, AgentMessage)
+- Prisma migration: add `agentId`, `routeContext` to `AgentMessage`; add `@default("coworker")` to `AgentThread.contextKey`; add indexes
 - Floating panel UI with drag, minimize, close
 - Route-based agent routing with permission awareness
 - Canned responses (no LLM)
-- Message persistence and pagination
-- Agent transition indicators
-- Header toggle button
+- Message persistence and pagination with error handling
+- Agent transition indicators (system messages)
+- Wire up existing Header "Agent" button via CustomEvent
 
 ### Out of Scope (Future Phases)
 - **Phase 7C**: Agent job configuration — assigning agents to UX interfaces, configuring per-screen behavior

--- a/docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md
+++ b/docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md
@@ -1,0 +1,293 @@
+# Phase 7B: AI Agent Co-worker UX
+
+**Date:** 2026-03-13
+**Status:** Approved
+**Depends on:** Phase 7A (AI Provider Registry & Token Spend)
+
+## Overview
+
+A floating chat panel that provides context-aware AI agent assistance on every screen. The panel follows the user across routes with a single persistent conversation thread, while specialist agents rotate in based on the current route and user permissions. No real AI wiring in this phase — agents produce canned responses that demonstrate the routing and UX patterns.
+
+## 1. Thread & Message Model
+
+### One Thread Per User
+
+Each user gets a single `AgentThread` with `contextKey: "coworker"`. The conversation persists across all routes and sessions, giving the user a continuous history with their AI co-worker.
+
+### Schema Additions
+
+```prisma
+model AgentThread {
+  id         String         @id @default(cuid())
+  userId     String
+  contextKey String         @default("coworker")
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+  messages   AgentMessage[]
+
+  user User @relation(fields: [userId], references: [id])
+  @@unique([userId, contextKey])
+}
+
+model AgentMessage {
+  id           String      @id @default(cuid())
+  threadId     String
+  role         String      // "user" | "assistant"
+  content      String
+  agentId      String?     // which specialist agent authored this (null for user messages)
+  routeContext String?     // route pathname when message was sent
+  createdAt    DateTime    @default(now())
+
+  thread AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+}
+```
+
+### Key Decisions
+
+- **`agentId` on messages**: Tracks which specialist authored each response. Enables future multi-agent deliberation (Phase 7D) where messages from different specialists appear in the same thread.
+- **`routeContext`**: Records the route pathname when the message was sent. Useful for understanding conversation flow and for agents to reference what the user was looking at.
+- **No separate threads per route**: The user sees one continuous conversation. Agent identity changes are shown inline via avatar/label transitions.
+
+### Route-to-Agent Mapping
+
+A static mapping defines which specialist agent handles each route prefix:
+
+```typescript
+const ROUTE_AGENT_MAP: Record<string, string> = {
+  "/portfolio":  "portfolio-advisor",
+  "/inventory":  "inventory-specialist",
+  "/ea":         "ea-architect",
+  "/employee":   "hr-specialist",
+  "/ops":        "ops-coordinator",
+  "/platform":   "platform-engineer",
+  "/admin":      "admin-assistant",
+  "/workspace":  "workspace-guide",
+};
+```
+
+### Canned Responses
+
+`generateCannedResponse(agentId, routeContext, platformRole)` returns a contextually appropriate static response. Each agent has 3-5 canned responses per route that demonstrate awareness of the current screen and user role. No LLM calls in Phase 7B.
+
+## 2. Floating Panel UX
+
+### Panel Specifications
+
+- **Dimensions**: 380px wide x 480px tall (resizable in future phase)
+- **Default position**: Bottom-right corner, 16px from edges
+- **Z-index**: 50 (above page content, below modals)
+- **Draggable**: Click-and-drag on the header bar to reposition
+- **Position persistence**: Saved to `localStorage` key `"agent-panel-position"` as `{x, y}`
+- **Toggle**: Button in the Header component (agent icon), toggles open/closed state stored in `localStorage` key `"agent-panel-open"`
+
+### Visual Design
+
+- **Background**: `var(--dpf-surface-1)` (#1a1a2e)
+- **Border**: 1px solid `var(--dpf-border)` (#2a2a40), with `border-radius: 12px`
+- **Shadow**: Subtle dark shadow for floating effect
+- **Header bar**: Agent name + role label, minimize/close buttons, drag handle
+- **Message area**: Scrollable, newest at bottom, auto-scroll on new messages
+- **Input area**: Text input with send button, disabled when panel is processing
+
+### Message Bubbles
+
+- **User messages**: Right-aligned, accent background (`var(--dpf-accent)` #7c8cf8), white text
+- **Agent messages**: Left-aligned, `var(--dpf-surface-2)` (#161625) background, light text
+- **Agent identity**: Small label above agent messages showing agent name when the specialist changes (e.g., "EA Architect" when navigating to /ea)
+- **Timestamps**: Relative time (e.g., "2m ago"), shown on hover
+
+### Agent Transition
+
+When the user navigates to a different route, the panel shows a subtle transition indicator:
+
+> *EA Architect has joined the conversation*
+
+This appears as a system message (centered, muted text) in the message stream. The new agent has access to the full conversation history for continuity.
+
+## 3. Agent Routing & Role Awareness
+
+### `resolveAgentForRoute(pathname, userContext)`
+
+Pure function in `apps/web/lib/agent-routing.ts`:
+
+```typescript
+type UserContext = {
+  platformRole: string;
+  isSuperuser: boolean;
+};
+
+type ResolvedAgent = {
+  agentId: string;
+  agentName: string;
+  agentDescription: string;
+  canAssist: boolean;  // false if user lacks permission for this route's domain
+};
+
+function resolveAgentForRoute(pathname: string, userContext: UserContext): ResolvedAgent;
+```
+
+### Resolution Logic
+
+1. Match `pathname` against `ROUTE_AGENT_MAP` using longest prefix match
+2. Check if the user has the capability for that route's domain (reuse `can()` from permissions)
+3. If the user lacks permission: return the agent with `canAssist: false` — the agent will explain it cannot help with actions outside the user's authority
+4. If no route matches: fall back to `"workspace-guide"`
+
+### Role-Aware Behavior
+
+Agents scope their responses to the user's authority level:
+
+- **HR-000 (superuser)**: Full access — agent can suggest any action
+- **HR-100/200/300/400/500**: Domain-scoped — agent won't suggest actions outside the user's portfolio or capability set
+- **Read-only users**: Agent provides information and navigation help but never suggests write operations
+
+This is enforced in `generateCannedResponse` by selecting from role-appropriate response templates.
+
+### Agent Switch
+
+When the active agent changes (route navigation), the panel:
+
+1. Calls `resolveAgentForRoute` with the new pathname
+2. If the agent ID differs from the current one, inserts a system message ("X has joined the conversation")
+3. Updates the header to show the new agent's name and description
+4. Does NOT clear the conversation — full history is preserved
+
+## 4. Server Actions & Data Layer
+
+### Server Actions (`apps/web/lib/actions/agent-coworker.ts`)
+
+```typescript
+"use server";
+
+// Get or create the user's coworker thread
+async function getOrCreateThread(): Promise<{ threadId: string }>;
+
+// Send a message and get a canned response
+async function sendMessage(input: {
+  threadId: string;
+  content: string;
+  routeContext: string;
+}): Promise<{ userMessage: AgentMessageRow; agentMessage: AgentMessageRow }>;
+
+// Load earlier messages (pagination)
+async function loadEarlierMessages(input: {
+  threadId: string;
+  before: string;  // cursor (message ID)
+  limit?: number;  // default 20
+}): Promise<{ messages: AgentMessageRow[]; hasMore: boolean }>;
+```
+
+### Data Fetcher (`apps/web/lib/agent-coworker-data.ts`)
+
+```typescript
+// React cache — get recent messages for initial render
+async function getRecentMessages(threadId: string, limit?: number): Promise<AgentMessageRow[]>;
+```
+
+### Auth Guards
+
+All server actions call `auth()` and verify the user owns the thread. No new capability needed — any authenticated user can use the co-worker panel.
+
+### Types (`apps/web/lib/agent-coworker-types.ts`)
+
+```typescript
+type AgentMessageRow = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  agentId: string | null;
+  routeContext: string | null;
+  createdAt: string;  // ISO string for serialization
+};
+
+type AgentInfo = {
+  agentId: string;
+  agentName: string;
+  agentDescription: string;
+  canAssist: boolean;
+};
+```
+
+## 5. Component Architecture
+
+### Component Tree
+
+```
+ShellLayout
+  └── AgentCoworkerPanel (client component, rendered at layout level)
+        ├── AgentPanelHeader (drag handle, agent name, minimize/close)
+        ├── AgentMessageList (scrollable message area)
+        │     └── AgentMessageBubble (per message)
+        └── AgentMessageInput (text input + send)
+```
+
+### `AgentCoworkerPanel` (`apps/web/components/agent/AgentCoworkerPanel.tsx`)
+
+Client component. Manages:
+- Open/closed state (localStorage + Header button)
+- Drag position (localStorage)
+- Current agent (derived from `usePathname()` + `resolveAgentForRoute`)
+- Message state (initial SSR data + optimistic updates)
+- Auto-scroll behavior
+
+### `AgentPanelHeader` (`apps/web/components/agent/AgentPanelHeader.tsx`)
+
+Displays current agent name and description. Provides drag handle, minimize button, and close button.
+
+### `AgentMessageBubble` (`apps/web/components/agent/AgentMessageBubble.tsx`)
+
+Renders a single message. Handles:
+- User vs. agent alignment and styling
+- Agent identity label (shown when agent changes)
+- Relative timestamp on hover
+
+### `AgentMessageInput` (`apps/web/components/agent/AgentMessageInput.tsx`)
+
+Text input with send button. Handles Enter-to-send, disabled state during processing.
+
+### Integration with Shell Layout
+
+`AgentCoworkerPanel` is rendered in `apps/web/app/(shell)/layout.tsx` as a sibling to the main content area. It receives:
+- `userId` (from session)
+- `threadId` (from `getOrCreateThread`)
+- `initialMessages` (from `getRecentMessages`)
+- `userContext` ({ platformRole, isSuperuser })
+
+The Header component gets a new "Agent" button that toggles the panel via a shared state mechanism (custom event or URL search param).
+
+### Testing Strategy
+
+Unit tests for pure functions:
+- `resolveAgentForRoute` — route matching, permission gating, fallback behavior
+- `generateCannedResponse` — correct response selection by agent, route, and role
+- Agent transition detection — when agent ID changes between messages
+
+Integration tests for server actions:
+- `getOrCreateThread` — creates on first call, returns existing on second
+- `sendMessage` — persists both user and agent messages, returns correct structure
+- `loadEarlierMessages` — pagination cursor behavior, hasMore flag
+- Auth guards — rejects unauthenticated requests
+
+## Scope Boundaries
+
+### In Scope (Phase 7B)
+- Prisma schema migration (AgentThread, AgentMessage)
+- Floating panel UI with drag, minimize, close
+- Route-based agent routing with permission awareness
+- Canned responses (no LLM)
+- Message persistence and pagination
+- Agent transition indicators
+- Header toggle button
+
+### Out of Scope (Future Phases)
+- **Phase 7C**: Agent job configuration — assigning agents to UX interfaces, configuring per-screen behavior
+- **Phase 7D**: Multi-agent deliberation — multiple specialists collaborating on a single task, diversity of thought
+- **Phase 7E**: Real AI wiring — replacing canned responses with actual LLM calls via the provider registry
+- Panel resize
+- Rich message content (markdown, code blocks, action buttons)
+- Voice input
+- Agent-initiated messages (proactive suggestions)
+
+## Multi-Agent Vision (Phase 7D Preview)
+
+The `agentId` field on messages is designed to support future multi-agent scenarios where different specialists with different perspectives deliberate together on complex tasks. This aligns with the project's diversity-of-thought philosophy: some decisions benefit from multiple viewpoints rather than a single agent's opinion. The data model is ready for this — no schema changes will be needed when Phase 7D arrives.

--- a/packages/db/prisma/migrations/20260314045455_add_ea_structure_rules/migration.sql
+++ b/packages/db/prisma/migrations/20260314045455_add_ea_structure_rules/migration.sql
@@ -1,0 +1,77 @@
+-- AlterTable
+ALTER TABLE "EaViewElement" ADD COLUMN     "orderIndex" INTEGER,
+ADD COLUMN     "parentViewElementId" TEXT;
+
+-- CreateTable
+CREATE TABLE "EaStructureRule" (
+    "id" TEXT NOT NULL,
+    "notationId" TEXT NOT NULL,
+    "parentElementTypeId" TEXT NOT NULL,
+    "childElementTypeId" TEXT NOT NULL,
+    "patternSlug" TEXT NOT NULL,
+    "minChildren" INTEGER,
+    "maxChildren" INTEGER,
+    "orderedChildren" BOOLEAN NOT NULL DEFAULT false,
+    "impliedRelationshipSlug" TEXT,
+    "defaultSeverity" TEXT NOT NULL DEFAULT 'warn',
+    "rendererHint" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EaStructureRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EaConformanceIssue" (
+    "id" TEXT NOT NULL,
+    "viewId" TEXT,
+    "elementId" TEXT,
+    "issueType" TEXT NOT NULL,
+    "severity" TEXT NOT NULL DEFAULT 'warn',
+    "message" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "detailsJson" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EaConformanceIssue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EaStructureRule_notationId_patternSlug_idx" ON "EaStructureRule"("notationId", "patternSlug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EaStructureRule_notationId_parentElementTypeId_childElement_key" ON "EaStructureRule"("notationId", "parentElementTypeId", "childElementTypeId", "patternSlug");
+
+-- CreateIndex
+CREATE INDEX "EaConformanceIssue_viewId_status_idx" ON "EaConformanceIssue"("viewId", "status");
+
+-- CreateIndex
+CREATE INDEX "EaConformanceIssue_elementId_status_idx" ON "EaConformanceIssue"("elementId", "status");
+
+-- CreateIndex
+CREATE INDEX "EaConformanceIssue_issueType_severity_idx" ON "EaConformanceIssue"("issueType", "severity");
+
+-- CreateIndex
+CREATE INDEX "EaViewElement_viewId_parentViewElementId_orderIndex_idx" ON "EaViewElement"("viewId", "parentViewElementId", "orderIndex");
+
+-- AddForeignKey
+ALTER TABLE "EaViewElement" ADD CONSTRAINT "EaViewElement_parentViewElementId_fkey" FOREIGN KEY ("parentViewElementId") REFERENCES "EaViewElement"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EaStructureRule" ADD CONSTRAINT "EaStructureRule_notationId_fkey" FOREIGN KEY ("notationId") REFERENCES "EaNotation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EaStructureRule" ADD CONSTRAINT "EaStructureRule_parentElementTypeId_fkey" FOREIGN KEY ("parentElementTypeId") REFERENCES "EaElementType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EaStructureRule" ADD CONSTRAINT "EaStructureRule_childElementTypeId_fkey" FOREIGN KEY ("childElementTypeId") REFERENCES "EaElementType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EaConformanceIssue" ADD CONSTRAINT "EaConformanceIssue_viewId_fkey" FOREIGN KEY ("viewId") REFERENCES "EaView"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EaConformanceIssue" ADD CONSTRAINT "EaConformanceIssue_elementId_fkey" FOREIGN KEY ("elementId") REFERENCES "EaElement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "InventoryRelationship_fromEntityId_toEntityId_relationshipType_" RENAME TO "InventoryRelationship_fromEntityId_toEntityId_relationshipT_key";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -636,6 +636,7 @@ model EaNotation {
   elementTypes EaElementType[]
   relTypes     EaRelationshipType[]
   dqRules      EaDqRule[]
+  structureRules EaStructureRule[]
   views        EaView[]
 }
 
@@ -764,6 +765,8 @@ model EaElementType {
   dqRules                EaDqRule[]
   fromRules              EaRelationshipRule[] @relation("FromType")
   toRules                EaRelationshipRule[] @relation("ToType")
+  parentStructureRules   EaStructureRule[]    @relation("EaStructureRuleParent")
+  childStructureRules    EaStructureRule[]    @relation("EaStructureRuleChild")
   @@unique([notationId, slug])
 }
 
@@ -824,6 +827,7 @@ model EaElement {
   fromRelationships EaRelationship[]  @relation("FromElement")
   toRelationships   EaRelationship[]  @relation("ToElement")
   viewElements      EaViewElement[]
+  conformanceIssues EaConformanceIssue[]
   syncedAt          DateTime?
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
@@ -873,6 +877,7 @@ model EaView {
   canvasState  Json?
   viewpointId  String?
   viewpoint    ViewpointDefinition? @relation(fields: [viewpointId], references: [id])
+  conformanceIssues EaConformanceIssue[]
   snapshots    EaSnapshot[]
   createdAt    DateTime        @default(now())
   updatedAt    DateTime        @updatedAt
@@ -884,11 +889,57 @@ model EaViewElement {
   view               EaView    @relation(fields: [viewId], references: [id], onDelete: Cascade)
   elementId          String
   element            EaElement @relation(fields: [elementId], references: [id])
+  parentViewElementId String?
+  parentViewElement   EaViewElement?  @relation("EaViewElementParent", fields: [parentViewElementId], references: [id], onDelete: SetNull)
+  childViewElements   EaViewElement[] @relation("EaViewElementParent")
+  orderIndex          Int?
   mode               String    @default("new")
   proposedProperties Json?
 
   @@unique([viewId, elementId])
   @@index([elementId])
+  @@index([viewId, parentViewElementId, orderIndex])
+}
+
+model EaStructureRule {
+  id                     String        @id @default(cuid())
+  notationId             String
+  notation               EaNotation    @relation(fields: [notationId], references: [id])
+  parentElementTypeId    String
+  parentElementType      EaElementType @relation("EaStructureRuleParent", fields: [parentElementTypeId], references: [id])
+  childElementTypeId     String
+  childElementType       EaElementType @relation("EaStructureRuleChild", fields: [childElementTypeId], references: [id])
+  patternSlug            String
+  minChildren            Int?
+  maxChildren            Int?
+  orderedChildren        Boolean       @default(false)
+  impliedRelationshipSlug String?
+  defaultSeverity        String        @default("warn")
+  rendererHint           String?
+  createdAt              DateTime      @default(now())
+  updatedAt              DateTime      @updatedAt
+
+  @@unique([notationId, parentElementTypeId, childElementTypeId, patternSlug])
+  @@index([notationId, patternSlug])
+}
+
+model EaConformanceIssue {
+  id          String    @id @default(cuid())
+  viewId       String?
+  view         EaView?   @relation(fields: [viewId], references: [id], onDelete: Cascade)
+  elementId    String?
+  element      EaElement? @relation(fields: [elementId], references: [id], onDelete: Cascade)
+  issueType    String
+  severity     String    @default("warn")
+  message      String
+  status       String    @default("open")
+  detailsJson  Json?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([viewId, status])
+  @@index([elementId, status])
+  @@index([issueType, severity])
 }
 
 model ViewpointDefinition {

--- a/packages/db/src/ea-structure.test.ts
+++ b/packages/db/src/ea-structure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveNestedChevronSequenceWarnings,
+  sortStructuredChildren,
+  type StructuredChildRecord,
+} from "./ea-structure";
+
+describe("ea structure helpers", () => {
+  it("sorts ordered children by order index", () => {
+    const children: StructuredChildRecord[] = [
+      { viewElementId: "stage-2", elementId: "el-2", elementTypeSlug: "value_stream_stage", parentViewElementId: "stream-1", orderIndex: 2 },
+      { viewElementId: "stage-0", elementId: "el-0", elementTypeSlug: "value_stream_stage", parentViewElementId: "stream-1", orderIndex: 0 },
+      { viewElementId: "stage-1", elementId: "el-1", elementTypeSlug: "value_stream_stage", parentViewElementId: "stream-1", orderIndex: 1 },
+    ];
+
+    expect(sortStructuredChildren(children).map((child) => child.viewElementId)).toEqual([
+      "stage-0",
+      "stage-1",
+      "stage-2",
+    ]);
+  });
+
+  it("warns when a stage is detached from its value stream", () => {
+    const warnings = deriveNestedChevronSequenceWarnings({
+      parentViewElementId: "stream-1",
+      minChildren: 1,
+      children: [
+        { viewElementId: "stage-1", elementId: "el-1", elementTypeSlug: "value_stream_stage", parentViewElementId: null, orderIndex: 0 },
+      ],
+    });
+
+    expect(warnings.map((warning) => warning.issueType)).toContain("detached_child");
+  });
+
+  it("warns when sibling stages reuse the same order index", () => {
+    const warnings = deriveNestedChevronSequenceWarnings({
+      parentViewElementId: "stream-1",
+      minChildren: 1,
+      children: [
+        { viewElementId: "stage-1", elementId: "el-1", elementTypeSlug: "value_stream_stage", parentViewElementId: "stream-1", orderIndex: 0 },
+        { viewElementId: "stage-2", elementId: "el-2", elementTypeSlug: "value_stream_stage", parentViewElementId: "stream-1", orderIndex: 0 },
+      ],
+    });
+
+    expect(warnings.map((warning) => warning.issueType)).toContain("duplicate_order_index");
+  });
+});

--- a/packages/db/src/ea-structure.ts
+++ b/packages/db/src/ea-structure.ts
@@ -1,0 +1,78 @@
+export type StructuredChildRecord = {
+  viewElementId: string;
+  elementId: string;
+  elementTypeSlug: string;
+  parentViewElementId: string | null;
+  orderIndex: number | null;
+};
+
+export type StructureConformanceWarning = {
+  issueType: "missing_required_children" | "detached_child" | "duplicate_order_index";
+  severity: "warn" | "error";
+  message: string;
+  viewElementIds: string[];
+  details?: Record<string, unknown>;
+};
+
+export function sortStructuredChildren(children: StructuredChildRecord[]): StructuredChildRecord[] {
+  return [...children].sort((left, right) => {
+    const leftOrder = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return left.viewElementId.localeCompare(right.viewElementId);
+  });
+}
+
+export function deriveNestedChevronSequenceWarnings(input: {
+  parentViewElementId: string;
+  minChildren: number;
+  children: StructuredChildRecord[];
+}): StructureConformanceWarning[] {
+  const warnings: StructureConformanceWarning[] = [];
+  const attachedChildren = input.children.filter((child) => child.parentViewElementId === input.parentViewElementId);
+  const detachedChildren = input.children.filter((child) => child.parentViewElementId !== input.parentViewElementId);
+
+  if (attachedChildren.length < input.minChildren) {
+    warnings.push({
+      issueType: "missing_required_children",
+      severity: "warn",
+      message: `Expected at least ${input.minChildren} structured child elements`,
+      viewElementIds: [input.parentViewElementId],
+      details: { minChildren: input.minChildren, attachedChildCount: attachedChildren.length },
+    });
+  }
+
+  for (const child of detachedChildren) {
+    warnings.push({
+      issueType: "detached_child",
+      severity: "warn",
+      message: "Structured child is detached from its expected parent",
+      viewElementIds: [child.viewElementId],
+      details: {
+        expectedParentViewElementId: input.parentViewElementId,
+        actualParentViewElementId: child.parentViewElementId,
+      },
+    });
+  }
+
+  const seenOrderIndexes = new Map<number, string[]>();
+  for (const child of attachedChildren) {
+    if (child.orderIndex == null) continue;
+    const siblings = seenOrderIndexes.get(child.orderIndex) ?? [];
+    siblings.push(child.viewElementId);
+    seenOrderIndexes.set(child.orderIndex, siblings);
+  }
+
+  for (const [orderIndex, siblings] of seenOrderIndexes) {
+    if (siblings.length < 2) continue;
+    warnings.push({
+      issueType: "duplicate_order_index",
+      severity: "warn",
+      message: `Multiple structured children share order index ${orderIndex}`,
+      viewElementIds: siblings,
+      details: { orderIndex },
+    });
+  }
+
+  return warnings;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43,6 +43,17 @@ export {
   runBootstrapCollectors,
 } from "./discovery-runner";
 export {
+  deriveNestedChevronSequenceWarnings,
+  sortStructuredChildren,
+  type StructuredChildRecord,
+  type StructureConformanceWarning,
+} from "./ea-structure";
+export {
+  getDefaultEaStructureRules,
+  seedEaStructureRules,
+  type EaStructureRuleSeed,
+} from "./seed-ea-structure-rules";
+export {
   persistBootstrapDiscoveryRun,
   summarizeDiscoveryPersistence,
   type DiscoveryPersistenceSummary,

--- a/packages/db/src/seed-ea-archimate4.ts
+++ b/packages/db/src/seed-ea-archimate4.ts
@@ -34,6 +34,7 @@ type ElementTypeDef = {
 const ELEMENT_TYPES: ElementTypeDef[] = [
   // Strategy
   { slug: "value_stream",        name: "Value Stream",        neoLabel: "ArchiMate__ValueStream",      domain: "strategy",        description: "A sequence of activities creating overall value for a customer or stakeholder",  stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES },
+  { slug: "value_stream_stage",  name: "Value Stream Stage",  neoLabel: "ArchiMate__ValueStreamStage", domain: "strategy",        description: "An ordered stage within a value stream",                                            stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES },
   { slug: "capability",          name: "Capability",          neoLabel: "ArchiMate__Capability",       domain: "strategy",        description: "An ability of an active structure element",                                      stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES },
   { slug: "course_of_action",    name: "Course of Action",    neoLabel: "ArchiMate__CourseOfAction",   domain: "strategy",        description: "An approach or plan for configuring capabilities",                               stages: LOGICAL_STAGES, statuses: LOGICAL_STATUSES },
   // Business
@@ -120,6 +121,7 @@ const RULES: RuleDef[] = [
   ["business_actor",        "business_role",         "assigned_to"],
   ["business_capability",   "business_capability",   "associated_with"],
   ["business_capability",   "business_capability",   "composed_of"],
+  ["value_stream",          "value_stream_stage",    "composed_of"],
   ["value_stream",          "business_capability",   "associated_with"],
   // Motivation → Strategy / Business
   ["goal",                  "business_capability",   "influences"],

--- a/packages/db/src/seed-ea-structure-rules.ts
+++ b/packages/db/src/seed-ea-structure-rules.ts
@@ -1,0 +1,93 @@
+import { prisma } from "./client.js";
+import type { PrismaClient } from "../generated/client";
+
+export type EaStructureRuleSeed = {
+  notationSlug: string;
+  parentElementTypeSlug: string;
+  childElementTypeSlug: string;
+  patternSlug: string;
+  minChildren: number | null;
+  maxChildren: number | null;
+  orderedChildren: boolean;
+  impliedRelationshipSlug: string | null;
+  defaultSeverity: string;
+  rendererHint: string | null;
+};
+
+export function getDefaultEaStructureRules(): EaStructureRuleSeed[] {
+  return [
+    {
+      notationSlug: "archimate4",
+      parentElementTypeSlug: "value_stream",
+      childElementTypeSlug: "value_stream_stage",
+      patternSlug: "nested_chevron_sequence",
+      minChildren: 1,
+      maxChildren: null,
+      orderedChildren: true,
+      impliedRelationshipSlug: "flows_to",
+      defaultSeverity: "warn",
+      rendererHint: "nested_chevron_sequence",
+    },
+  ];
+}
+
+export async function seedEaStructureRules(prismaClient: PrismaClient = prisma): Promise<void> {
+  for (const rule of getDefaultEaStructureRules()) {
+    const notation = await prismaClient.eaNotation.findUniqueOrThrow({
+      where: { slug: rule.notationSlug },
+      select: { id: true },
+    });
+
+    const [parentElementType, childElementType] = await Promise.all([
+      prismaClient.eaElementType.findUniqueOrThrow({
+        where: {
+          notationId_slug: {
+            notationId: notation.id,
+            slug: rule.parentElementTypeSlug,
+          },
+        },
+        select: { id: true },
+      }),
+      prismaClient.eaElementType.findUniqueOrThrow({
+        where: {
+          notationId_slug: {
+            notationId: notation.id,
+            slug: rule.childElementTypeSlug,
+          },
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    await prismaClient.eaStructureRule.upsert({
+      where: {
+        notationId_parentElementTypeId_childElementTypeId_patternSlug: {
+          notationId: notation.id,
+          parentElementTypeId: parentElementType.id,
+          childElementTypeId: childElementType.id,
+          patternSlug: rule.patternSlug,
+        },
+      },
+      update: {
+        minChildren: rule.minChildren,
+        maxChildren: rule.maxChildren,
+        orderedChildren: rule.orderedChildren,
+        impliedRelationshipSlug: rule.impliedRelationshipSlug,
+        defaultSeverity: rule.defaultSeverity,
+        rendererHint: rule.rendererHint,
+      },
+      create: {
+        notationId: notation.id,
+        parentElementTypeId: parentElementType.id,
+        childElementTypeId: childElementType.id,
+        patternSlug: rule.patternSlug,
+        minChildren: rule.minChildren,
+        maxChildren: rule.maxChildren,
+        orderedChildren: rule.orderedChildren,
+        impliedRelationshipSlug: rule.impliedRelationshipSlug,
+        defaultSeverity: rule.defaultSeverity,
+        rendererHint: rule.rendererHint,
+      },
+    });
+  }
+}

--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -27,4 +27,9 @@ describe("seed helpers", () => {
     const mod = await import("./index.js");
     expect(typeof mod.seedEaReferenceModels).toBe("function");
   }, 15_000);
+
+  it("exports seedEaStructureRules", async () => {
+    const mod = await import("./seed-ea-structure-rules.js");
+    expect(typeof mod.seedEaStructureRules).toBe("function");
+  }, 15_000);
 });

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -5,6 +5,7 @@ import { prisma } from "./client.js";
 import { parseRoleId, parseAgentTier, parseAgentType, parseAgentPortfolioSlug } from "./seed-helpers.js";
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
 import { seedEaReferenceModels } from "./seed-ea-reference-models.js";
+import { seedEaStructureRules } from "./seed-ea-structure-rules.js";
 import { seedGovernanceReferenceData } from "./governance-seed.js";
 import * as crypto from "crypto";
 
@@ -619,7 +620,7 @@ async function seedEaViewpoints(): Promise<void> {
     {
       name: "Business Architecture",
       description: "Business capabilities, roles, actors, and value streams.",
-      elementSlugs: ["business_capability", "business_role", "business_actor", "business_object", "value_stream"],
+      elementSlugs: ["business_capability", "business_role", "business_actor", "business_object", "value_stream", "value_stream_stage"],
       relSlugs: ["realizes", "assigned_to", "influences", "composed_of", "associated_with"],
     },
     {
@@ -726,6 +727,7 @@ async function main(): Promise<void> {
   await seedEaReferenceModels();
   await seedDigitalProducts();
   await seedEaArchimate4();
+  await seedEaStructureRules();
   await seedEaViewpoints();
   await seedEaViews();
   await seedDpfSelfRegistration();


### PR DESCRIPTION
## Summary
- add EA structure rule persistence and seeding for the ArchiMate value stream to value stream stage pattern
- add structure-aware EA view serialization and actions, including reparent/resequence support with conformance warnings
- render value streams as nested chevron bands in the EA canvas, hide implied intra-stage flow edges, and expose stage reorder controls

## Test Plan
- [x] pnpm --filter @dpf/db test
- [x] pnpm --filter web test
- [x] pnpm --filter web typecheck