### PR TITLE
feat: add discovery taxonomy attribution and software evidence

### DIFF
--- a/apps/web/app/(shell)/inventory/page.test.tsx
+++ b/apps/web/app/(shell)/inventory/page.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { DiscoveryRunSummary } from "@/components/inventory/DiscoveryRunSummary";
+import { InventoryEntityPanel } from "@/components/inventory/InventoryEntityPanel";
 
 describe("DiscoveryRunSummary", () => {
   it("renders latest discovery run counts", () => {
@@ -23,5 +24,51 @@ describe("DiscoveryRunSummary", () => {
     expect(html).toContain("DISC-001");
     expect(html).toContain("12");
     expect(html).toContain("Stale");
+  });
+});
+
+describe("InventoryEntityPanel", () => {
+  it("renders taxonomy attribution confidence and review state", () => {
+    const html = renderToStaticMarkup(
+      <InventoryEntityPanel
+        entities={[
+          {
+            id: "entity-1",
+            entityKey: "host:hostname:dpf-dev",
+            name: "dpf-dev",
+            entityType: "host",
+            status: "active",
+            attributionStatus: "attributed",
+            attributionMethod: "rule",
+            attributionConfidence: 0.98,
+            portfolio: { slug: "foundational", name: "Foundational" },
+            taxonomyNode: {
+              nodeId: "foundational/compute/servers",
+              name: "Servers",
+            },
+            digitalProduct: null,
+          },
+          {
+            id: "entity-2",
+            entityKey: "service:mystery-engine",
+            name: "Mystery Engine",
+            entityType: "service",
+            status: "active",
+            attributionStatus: "needs_review",
+            attributionMethod: "heuristic",
+            attributionConfidence: 0.32,
+            portfolio: null,
+            taxonomyNode: null,
+            digitalProduct: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("foundational / compute / servers");
+    expect(html).toContain("rule");
+    expect(html).toContain("98%");
+    expect(html).toContain("Review needed");
+    expect(html).toContain("32% confidence");
   });
 });

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -5,12 +5,17 @@ import { auth } from "@/lib/auth";
 import { resolveBrandingLogoUrl } from "@/lib/branding";
 import { redirect } from "next/navigation";
 import { Header } from "@/components/shell/Header";
+import { getOrCreateThread } from "@/lib/actions/agent-coworker";
+import { getRecentMessages } from "@/lib/agent-coworker-data";
+import { AgentCoworkerPanel } from "@/components/agent/AgentCoworkerPanel";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
   const session = await auth();
   if (!session?.user) redirect("/login");
 
-  const [latestDiscoveryRun, activeBranding] = await Promise.all([
+  const user = session.user;
+
+  const [latestDiscoveryRun, activeBranding, { threadId }] = await Promise.all([
     prisma.discoveryRun.findFirst({
       orderBy: { startedAt: "desc" },
       select: { id: true },
@@ -22,7 +27,10 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         logoUrl: true,
       },
     }),
+    getOrCreateThread(),
   ]);
+
+  const initialMessages = await getRecentMessages(threadId);
 
   if (!latestDiscoveryRun) {
     await executeBootstrapDiscovery(prisma as never, {
@@ -35,8 +43,8 @@ export default async function ShellLayout({ children }: { children: React.ReactN
   return (
     <div className="min-h-screen flex flex-col bg-[var(--dpf-bg)]">
       <Header
-        platformRole={session.user.platformRole}
-        isSuperuser={session.user.isSuperuser}
+        platformRole={user.platformRole}
+        isSuperuser={user.isSuperuser}
         brandName={activeBranding?.companyName ?? "Open Digital Product Factory"}
         brandLogoUrl={resolveBrandingLogoUrl(
           activeBranding?.logoUrl ?? null,
@@ -44,6 +52,11 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         )}
       />
       <main className="flex-1 p-6 max-w-7xl mx-auto w-full">{children}</main>
+      <AgentCoworkerPanel
+        threadId={threadId}
+        initialMessages={initialMessages}
+        userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
+      />
     </div>
   );
 }

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -15,7 +15,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
 
   const user = session.user;
 
-  const [latestDiscoveryRun, activeBranding, { threadId }] = await Promise.all([
+  const [latestDiscoveryRun, activeBranding, threadResult] = await Promise.all([
     prisma.discoveryRun.findFirst({
       orderBy: { startedAt: "desc" },
       select: { id: true },
@@ -30,7 +30,8 @@ export default async function ShellLayout({ children }: { children: React.ReactN
     getOrCreateThread(),
   ]);
 
-  const initialMessages = await getRecentMessages(threadId);
+  const threadId = threadResult?.threadId ?? null;
+  const initialMessages = threadId ? await getRecentMessages(threadId) : [];
 
   if (!latestDiscoveryRun) {
     await executeBootstrapDiscovery(prisma as never, {
@@ -52,11 +53,13 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         )}
       />
       <main className="flex-1 p-6 max-w-7xl mx-auto w-full">{children}</main>
-      <AgentCoworkerPanel
-        threadId={threadId}
-        initialMessages={initialMessages}
-        userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
-      />
+      {threadId && (
+        <AgentCoworkerPanel
+          threadId={threadId}
+          initialMessages={initialMessages}
+          userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { usePathname } from "next/navigation";
+import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
+import type { UserContext } from "@/lib/permissions";
+import { resolveAgentForRoute, AGENT_NAME_MAP } from "@/lib/agent-routing";
+import { sendMessage, recordAgentTransition } from "@/lib/actions/agent-coworker";
+import { AgentPanelHeader } from "./AgentPanelHeader";
+import { AgentMessageBubble } from "./AgentMessageBubble";
+import { AgentMessageInput } from "./AgentMessageInput";
+
+type Props = {
+  threadId: string;
+  initialMessages: AgentMessageRow[];
+  userContext: UserContext;
+};
+
+const PANEL_W = 380;
+const PANEL_H = 480;
+const EDGE_GAP = 16;
+const LS_KEY_OPEN = "agent-panel-open";
+const LS_KEY_POS = "agent-panel-position";
+
+function loadPosition(): { x: number; y: number } {
+  try {
+    const raw = localStorage.getItem(LS_KEY_POS);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { x: number; y: number };
+      if (typeof parsed.x === "number" && typeof parsed.y === "number") return parsed;
+    }
+  } catch { /* ignore */ }
+  return {
+    x: typeof window !== "undefined" ? window.innerWidth - PANEL_W - EDGE_GAP : EDGE_GAP,
+    y: typeof window !== "undefined" ? window.innerHeight - PANEL_H - EDGE_GAP : EDGE_GAP,
+  };
+}
+
+function loadOpen(): boolean {
+  try {
+    return localStorage.getItem(LS_KEY_OPEN) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: Props) {
+  const pathname = usePathname();
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [messages, setMessages] = useState<AgentMessageRow[]>(initialMessages);
+  const [isPending, startTransition] = useTransition();
+  const [lastAgentId, setLastAgentId] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
+
+  // Hydrate from localStorage after mount
+  useEffect(() => {
+    setIsOpen(loadOpen());
+    setPosition(loadPosition());
+  }, []);
+
+  // Listen for toggle event from Header Agent button
+  useEffect(() => {
+    function handleToggle() {
+      setIsOpen((prev) => {
+        const next = !prev;
+        localStorage.setItem(LS_KEY_OPEN, String(next));
+        return next;
+      });
+    }
+    document.addEventListener("toggle-agent-panel", handleToggle);
+    return () => document.removeEventListener("toggle-agent-panel", handleToggle);
+  }, []);
+
+  // Resolve agent for current route
+  const agent: AgentInfo = resolveAgentForRoute(pathname, userContext);
+
+  // Agent transition — persist system message when agent changes
+  useEffect(() => {
+    if (lastAgentId === null) {
+      setLastAgentId(agent.agentId);
+      return;
+    }
+    if (agent.agentId !== lastAgentId) {
+      setLastAgentId(agent.agentId);
+      // Optimistic: show immediately
+      const optimisticMsg: AgentMessageRow = {
+        id: `system-${Date.now()}`,
+        role: "system",
+        content: `${agent.agentName} has joined the conversation`,
+        agentId: agent.agentId,
+        routeContext: pathname,
+        createdAt: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, optimisticMsg]);
+      // Persist to DB (fire-and-forget — optimistic msg is already shown)
+      void recordAgentTransition({
+        threadId,
+        agentId: agent.agentId,
+        agentName: agent.agentName,
+        routeContext: pathname,
+      });
+    }
+  }, [agent.agentId, agent.agentName, pathname, lastAgentId, threadId]);
+
+  // Auto-scroll to bottom when new messages appear
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // ─── Drag handling ──────────────────────────────────────────────────────
+
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    dragRef.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      startPosX: position.x,
+      startPosY: position.y,
+    };
+
+    function onMouseMove(ev: MouseEvent) {
+      if (!dragRef.current) return;
+      const dx = ev.clientX - dragRef.current.startX;
+      const dy = ev.clientY - dragRef.current.startY;
+      const newPos = {
+        x: dragRef.current.startPosX + dx,
+        y: dragRef.current.startPosY + dy,
+      };
+      setPosition(newPos);
+      localStorage.setItem(LS_KEY_POS, JSON.stringify(newPos));
+    }
+
+    function onMouseUp() {
+      dragRef.current = null;
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, [position]);
+
+  // ─── Send message ───────────────────────────────────────────────────────
+
+  function handleSend(content: string) {
+    startTransition(async () => {
+      const result = await sendMessage({
+        threadId,
+        content,
+        routeContext: pathname,
+      });
+      if ("error" in result) {
+        console.warn("sendMessage error:", result.error);
+        return;
+      }
+      setMessages((prev) => [...prev, result.userMessage, result.agentMessage]);
+    });
+  }
+
+  function handleClose() {
+    setIsOpen(false);
+    localStorage.setItem(LS_KEY_OPEN, "false");
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: position.x,
+        top: position.y,
+        width: PANEL_W,
+        height: PANEL_H,
+        zIndex: 50,
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--dpf-surface-1)",
+        border: "1px solid var(--dpf-border)",
+        borderRadius: 12,
+        boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+        overflow: "hidden",
+      }}
+    >
+      <AgentPanelHeader
+        agent={agent}
+        onMouseDown={handleDragStart}
+        onClose={handleClose}
+      />
+
+      {/* Messages area */}
+      <div style={{
+        flex: 1,
+        overflowY: "auto",
+        padding: "12px",
+      }}>
+        {messages.length === 0 && (
+          <div style={{
+            textAlign: "center",
+            color: "var(--dpf-muted)",
+            fontSize: 12,
+            padding: "40px 20px",
+          }}>
+            Start a conversation with your AI co-worker
+          </div>
+        )}
+        {messages.map((msg, i) => {
+          const prevAgentId = i > 0 ? messages[i - 1]?.agentId : null;
+          const showAgentLabel = msg.role === "assistant" && msg.agentId !== prevAgentId;
+          return (
+            <AgentMessageBubble
+              key={msg.id}
+              message={msg}
+              showAgentLabel={showAgentLabel}
+              agentName={showAgentLabel && msg.agentId ? (AGENT_NAME_MAP[msg.agentId] ?? msg.agentId) : null}
+            />
+          );
+        })}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <AgentMessageInput onSend={handleSend} disabled={isPending} />
+    </div>
+  );
+}

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -53,11 +53,14 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: P
   const [lastAgentId, setLastAgentId] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
+  const positionRef = useRef(position);
 
   // Hydrate from localStorage after mount
   useEffect(() => {
     setIsOpen(loadOpen());
-    setPosition(loadPosition());
+    const pos = loadPosition();
+    positionRef.current = pos;
+    setPosition(pos);
   }, []);
 
   // Listen for toggle event from Header Agent button
@@ -102,7 +105,8 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: P
         routeContext: pathname,
       });
     }
-  }, [agent.agentId, agent.agentName, pathname, lastAgentId, threadId]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- agentName is derived from agentId
+  }, [agent.agentId, pathname, lastAgentId, threadId]);
 
   // Auto-scroll to bottom when new messages appear
   useEffect(() => {
@@ -115,8 +119,8 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: P
     dragRef.current = {
       startX: e.clientX,
       startY: e.clientY,
-      startPosX: position.x,
-      startPosY: position.y,
+      startPosX: positionRef.current.x,
+      startPosY: positionRef.current.y,
     };
 
     function onMouseMove(ev: MouseEvent) {
@@ -127,6 +131,7 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: P
         x: dragRef.current.startPosX + dx,
         y: dragRef.current.startPosY + dy,
       };
+      positionRef.current = newPos;
       setPosition(newPos);
       localStorage.setItem(LS_KEY_POS, JSON.stringify(newPos));
     }
@@ -139,7 +144,7 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: P
 
     document.addEventListener("mousemove", onMouseMove);
     document.addEventListener("mouseup", onMouseUp);
-  }, [position]);
+  }, []);
 
   // ─── Send message ───────────────────────────────────────────────────────
 

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+
+type Props = {
+  message: AgentMessageRow;
+  showAgentLabel: boolean; // true when agent changed from previous message
+  agentName: string | null;
+};
+
+function formatRelativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props) {
+  if (message.role === "system") {
+    return (
+      <div style={{
+        textAlign: "center",
+        padding: "8px 0",
+        fontSize: 11,
+        color: "var(--dpf-muted)",
+        fontStyle: "italic",
+      }}>
+        {message.content}
+      </div>
+    );
+  }
+
+  const isUser = message.role === "user";
+
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: "column",
+      alignItems: isUser ? "flex-end" : "flex-start",
+      gap: 2,
+      marginBottom: 8,
+    }}>
+      {showAgentLabel && agentName && !isUser && (
+        <span style={{ fontSize: 10, color: "var(--dpf-accent)", marginLeft: 4 }}>
+          {agentName}
+        </span>
+      )}
+      <div
+        title={formatRelativeTime(message.createdAt)}
+        style={{
+          maxWidth: "85%",
+          padding: "8px 12px",
+          borderRadius: isUser ? "12px 12px 2px 12px" : "12px 12px 12px 2px",
+          fontSize: 13,
+          lineHeight: 1.4,
+          background: isUser ? "var(--dpf-accent)" : "var(--dpf-surface-2)",
+          color: isUser ? "#ffffff" : "#e0e0ff",
+          wordBreak: "break-word",
+        }}
+      >
+        {message.content}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { MAX_MESSAGE_LENGTH } from "@/lib/agent-coworker-types";
+
+type Props = {
+  onSend: (content: string) => void;
+  disabled: boolean;
+};
+
+export function AgentMessageInput({ onSend, disabled }: Props) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleSubmit() {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    if (trimmed.length > MAX_MESSAGE_LENGTH) return;
+    onSend(trimmed);
+    setValue("");
+    inputRef.current?.focus();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  const overLimit = value.trim().length > MAX_MESSAGE_LENGTH;
+
+  return (
+    <div style={{
+      display: "flex",
+      gap: 6,
+      padding: "10px 12px",
+      borderTop: "1px solid var(--dpf-border)",
+    }}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        placeholder={disabled ? "Sending..." : "Ask your co-worker..."}
+        style={{
+          flex: 1,
+          background: "var(--dpf-bg)",
+          border: `1px solid ${overLimit ? "#ef4444" : "var(--dpf-border)"}`,
+          borderRadius: 6,
+          padding: "6px 10px",
+          fontSize: 12,
+          color: "#e0e0ff",
+          outline: "none",
+        }}
+      />
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={disabled || !value.trim() || overLimit}
+        style={{
+          background: "var(--dpf-accent)",
+          border: "none",
+          borderRadius: 6,
+          padding: "6px 12px",
+          fontSize: 12,
+          color: "#ffffff",
+          cursor: disabled || !value.trim() || overLimit ? "not-allowed" : "pointer",
+          opacity: disabled || !value.trim() || overLimit ? 0.5 : 1,
+        }}
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { AgentInfo } from "@/lib/agent-coworker-types";
+
+type Props = {
+  agent: AgentInfo;
+  onMouseDown: (e: React.MouseEvent) => void; // drag handle
+  onClose: () => void;
+};
+
+export function AgentPanelHeader({ agent, onMouseDown, onClose }: Props) {
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "10px 14px",
+        background: "var(--dpf-surface-2)",
+        borderBottom: "1px solid var(--dpf-border)",
+        borderRadius: "12px 12px 0 0",
+        cursor: "grab",
+        userSelect: "none",
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-400" />
+          <span style={{ fontSize: 12, fontWeight: 600, color: "#e0e0ff" }}>
+            {agent.agentName}
+          </span>
+        </div>
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: 12 }}>
+          {agent.agentDescription}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        title="Close"
+        style={{
+          background: "none",
+          border: "none",
+          color: "var(--dpf-muted)",
+          cursor: "pointer",
+          fontSize: 16,
+          padding: "2px 6px",
+          borderRadius: 4,
+          lineHeight: 1,
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/inventory/InventoryEntityPanel.tsx
+++ b/apps/web/components/inventory/InventoryEntityPanel.tsx
@@ -5,6 +5,8 @@ type InventoryEntity = {
   entityType: string;
   status: string;
   attributionStatus: string;
+  attributionMethod: string | null;
+  attributionConfidence: number | null;
   portfolio: { slug: string; name: string } | null;
   taxonomyNode: { nodeId: string; name: string } | null;
   digitalProduct: { productId: string; name: string } | null;
@@ -20,9 +22,9 @@ export function InventoryEntityPanel({
       <div className="flex items-center justify-between gap-2">
         <div>
           <p className="text-xs uppercase tracking-[0.2em] text-[var(--dpf-muted)]">
-            Foundational Inventory
+            Operational Inventory
           </p>
-          <h2 className="mt-1 text-lg font-semibold text-white">Discovered Infrastructure</h2>
+          <h2 className="mt-1 text-lg font-semibold text-white">Discovered Assets</h2>
         </div>
         <span className="text-sm text-[var(--dpf-muted)]">{entities.length} entities</span>
       </div>
@@ -41,7 +43,7 @@ export function InventoryEntityPanel({
                 </p>
               </div>
               <span className="rounded-full bg-white/5 px-2 py-1 text-[10px] text-[var(--dpf-muted)]">
-                {entity.attributionStatus}
+                {entity.attributionStatus === "needs_review" ? "Review needed" : entity.attributionStatus}
               </span>
             </div>
 
@@ -49,9 +51,15 @@ export function InventoryEntityPanel({
 
             <div className="mt-3 flex flex-wrap gap-2 text-[10px] text-[var(--dpf-muted)]">
               {entity.portfolio && <span>Portfolio: {entity.portfolio.name}</span>}
-              {entity.taxonomyNode && <span>Taxonomy: {entity.taxonomyNode.nodeId}</span>}
+              {entity.taxonomyNode && (
+                <span>Taxonomy: {entity.taxonomyNode.nodeId.replace(/\//g, " / ")}</span>
+              )}
               {entity.digitalProduct && <span>Product: {entity.digitalProduct.name}</span>}
               <span>Status: {entity.status}</span>
+              {entity.attributionMethod && <span>Method: {entity.attributionMethod}</span>}
+              {entity.attributionConfidence != null && (
+                <span>{Math.round(entity.attributionConfidence * 100)}% confidence</span>
+              )}
             </div>
           </article>
         ))}

--- a/apps/web/components/shell/Header.tsx
+++ b/apps/web/components/shell/Header.tsx
@@ -72,6 +72,7 @@ export function Header({ platformRole, isSuperuser, brandName, brandLogoUrl }: P
       <div className="flex items-center gap-3">
         <button
           type="button"
+          onClick={() => document.dispatchEvent(new CustomEvent("toggle-agent-panel"))}
           className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs border border-[var(--dpf-accent)] text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)] hover:text-white transition-colors"
         >
           <span>Agent</span>

--- a/apps/web/lib/actions/agent-coworker.test.ts
+++ b/apps/web/lib/actions/agent-coworker.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { validateMessageInput } from "../agent-coworker-types";
+
+describe("validateMessageInput", () => {
+  it("returns null for valid input", () => {
+    expect(validateMessageInput({ content: "Hello", routeContext: "/portfolio" })).toBeNull();
+  });
+
+  it("rejects empty content", () => {
+    expect(validateMessageInput({ content: "", routeContext: "/portfolio" })).toMatch(/empty/i);
+  });
+
+  it("rejects whitespace-only content", () => {
+    expect(validateMessageInput({ content: "   ", routeContext: "/portfolio" })).toMatch(/empty/i);
+  });
+
+  it("rejects content over 2000 chars", () => {
+    const long = "x".repeat(2001);
+    expect(validateMessageInput({ content: long, routeContext: "/portfolio" })).toMatch(/2000/);
+  });
+
+  it("accepts content at exactly 2000 chars", () => {
+    const exact = "x".repeat(2000);
+    expect(validateMessageInput({ content: exact, routeContext: "/portfolio" })).toBeNull();
+  });
+
+  it("rejects empty routeContext", () => {
+    expect(validateMessageInput({ content: "Hello", routeContext: "" })).toMatch(/route/i);
+  });
+});

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -18,8 +18,15 @@ async function requireAuthUser() {
 
 // ─── Server Actions ─────────────────────────────────────────────────────────
 
-export async function getOrCreateThread(): Promise<{ threadId: string }> {
+export async function getOrCreateThread(): Promise<{ threadId: string } | null> {
   const user = await requireAuthUser();
+
+  // Verify user exists in DB (JWT may reference a stale user after re-seed)
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { id: true },
+  });
+  if (!dbUser) return null;
 
   const thread = await prisma.agentThread.upsert({
     where: { userId_contextKey: { userId: user.id, contextKey: "coworker" } },

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1,0 +1,196 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { validateMessageInput } from "@/lib/agent-coworker-types";
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+import { resolveAgentForRoute, generateCannedResponse } from "@/lib/agent-routing";
+import { serializeMessage } from "@/lib/agent-coworker-data";
+
+// ─── Auth helper ────────────────────────────────────────────────────────────
+
+async function requireAuthUser() {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new Error("Unauthorized");
+  return user;
+}
+
+// ─── Server Actions ─────────────────────────────────────────────────────────
+
+export async function getOrCreateThread(): Promise<{ threadId: string }> {
+  const user = await requireAuthUser();
+
+  const existing = await prisma.agentThread.findUnique({
+    where: { userId_contextKey: { userId: user.id, contextKey: "coworker" } },
+    select: { id: true },
+  });
+
+  if (existing) return { threadId: existing.id };
+
+  const created = await prisma.agentThread.create({
+    data: { userId: user.id, contextKey: "coworker" },
+    select: { id: true },
+  });
+
+  return { threadId: created.id };
+}
+
+export async function sendMessage(input: {
+  threadId: string;
+  content: string;
+  routeContext: string;
+}): Promise<
+  | { userMessage: AgentMessageRow; agentMessage: AgentMessageRow }
+  | { error: string }
+> {
+  const user = await requireAuthUser();
+
+  // Verify thread ownership
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  // Validate input
+  const validationError = validateMessageInput(input);
+  if (validationError) return { error: validationError };
+
+  const trimmedContent = input.content.trim();
+
+  // Persist user message
+  const userMsg = await prisma.agentMessage.create({
+    data: {
+      threadId: input.threadId,
+      role: "user",
+      content: trimmedContent,
+      routeContext: input.routeContext,
+    },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  // Resolve agent and generate canned response
+  const agent = resolveAgentForRoute(input.routeContext, {
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  });
+
+  const responseContent = generateCannedResponse(
+    agent.agentId,
+    input.routeContext,
+    user.platformRole,
+  );
+
+  // Persist agent response
+  const agentMsg = await prisma.agentMessage.create({
+    data: {
+      threadId: input.threadId,
+      role: "assistant",
+      content: responseContent,
+      agentId: agent.agentId,
+      routeContext: input.routeContext,
+    },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    userMessage: serializeMessage(userMsg),
+    agentMessage: serializeMessage(agentMsg),
+  };
+}
+
+export async function loadEarlierMessages(input: {
+  threadId: string;
+  before: string;
+  limit?: number;
+}): Promise<{ messages: AgentMessageRow[]; hasMore: boolean } | { error: string }> {
+  const user = await requireAuthUser();
+
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  const limit = input.limit ?? 20;
+
+  const messages = await prisma.agentMessage.findMany({
+    where: { threadId: input.threadId },
+    orderBy: { createdAt: "desc" },
+    cursor: { id: input.before },
+    skip: 1, // skip the cursor itself
+    take: limit + 1, // fetch one extra to check hasMore
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  const hasMore = messages.length > limit;
+  const slice = hasMore ? messages.slice(0, limit) : messages;
+
+  return {
+    messages: slice.reverse().map(serializeMessage),
+    hasMore,
+  };
+}
+
+export async function recordAgentTransition(input: {
+  threadId: string;
+  agentId: string;
+  agentName: string;
+  routeContext: string;
+}): Promise<{ message: AgentMessageRow } | { error: string }> {
+  const user = await requireAuthUser();
+
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  const msg = await prisma.agentMessage.create({
+    data: {
+      threadId: input.threadId,
+      role: "system",
+      content: `${input.agentName} has joined the conversation`,
+      agentId: input.agentId,
+      routeContext: input.routeContext,
+    },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  return { message: serializeMessage(msg) };
+}

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -21,19 +21,14 @@ async function requireAuthUser() {
 export async function getOrCreateThread(): Promise<{ threadId: string }> {
   const user = await requireAuthUser();
 
-  const existing = await prisma.agentThread.findUnique({
+  const thread = await prisma.agentThread.upsert({
     where: { userId_contextKey: { userId: user.id, contextKey: "coworker" } },
+    update: {},
+    create: { userId: user.id, contextKey: "coworker" },
     select: { id: true },
   });
 
-  if (existing) return { threadId: existing.id };
-
-  const created = await prisma.agentThread.create({
-    data: { userId: user.id, contextKey: "coworker" },
-    select: { id: true },
-  });
-
-  return { threadId: created.id };
+  return { threadId: thread.id };
 }
 
 export async function sendMessage(input: {

--- a/apps/web/lib/actions/users.test.ts
+++ b/apps/web/lib/actions/users.test.ts
@@ -41,7 +41,7 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-import { summarizeGovernedLifecycleAttempt } from "./users";
+import { summarizeGovernedLifecycleAttempt } from "@/lib/user-governance";
 
 describe("summarizeGovernedLifecycleAttempt", () => {
   it("denies when a non-superuser tries to modify a superuser account", () => {

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -7,6 +7,7 @@ import { can } from "@/lib/permissions";
 import { getUserTeamIds, createAuthorizationDecisionLog } from "@/lib/governance-data";
 import { buildPrincipalContext } from "@/lib/principal-context";
 import { resolveGovernedAction } from "@/lib/governance-resolver";
+import { summarizeGovernedLifecycleAttempt } from "@/lib/user-governance";
 
 export type UserActionResult = {
   ok: boolean;
@@ -19,23 +20,6 @@ type SessionUserContext = {
   platformRole: string | null;
   isSuperuser: boolean;
 };
-
-export function summarizeGovernedLifecycleAttempt(input: {
-  actorIsSuperuser: boolean;
-  targetIsSuperuser: boolean;
-}): { decision: "allow" | "deny"; message: string } {
-  if (input.targetIsSuperuser && !input.actorIsSuperuser) {
-    return {
-      decision: "deny",
-      message: "Only a superuser can change another superuser account.",
-    };
-  }
-
-  return {
-    decision: "allow",
-    message: "Lifecycle update permitted.",
-  };
-}
 
 async function hashPassword(password: string): Promise<string> {
   const data = new TextEncoder().encode(password);

--- a/apps/web/lib/agent-coworker-data.ts
+++ b/apps/web/lib/agent-coworker-data.ts
@@ -12,7 +12,9 @@ function serializeMessage(m: {
 }): AgentMessageRow {
   return {
     id: m.id,
-    role: m.role as AgentMessageRow["role"],
+    role: (["user", "assistant", "system"] as const).includes(m.role as AgentMessageRow["role"])
+      ? (m.role as AgentMessageRow["role"])
+      : "system",
     content: m.content,
     agentId: m.agentId,
     routeContext: m.routeContext,

--- a/apps/web/lib/agent-coworker-data.ts
+++ b/apps/web/lib/agent-coworker-data.ts
@@ -1,0 +1,47 @@
+import { cache } from "react";
+import { prisma } from "@dpf/db";
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+
+function serializeMessage(m: {
+  id: string;
+  role: string;
+  content: string;
+  agentId: string | null;
+  routeContext: string | null;
+  createdAt: Date;
+}): AgentMessageRow {
+  return {
+    id: m.id,
+    role: m.role as AgentMessageRow["role"],
+    content: m.content,
+    agentId: m.agentId,
+    routeContext: m.routeContext,
+    createdAt: m.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Get recent messages for a thread. React-cache deduped within a single request.
+ * MUST only be called after session verification (shell layout).
+ */
+export const getRecentMessages = cache(
+  async (threadId: string, limit = 50): Promise<AgentMessageRow[]> => {
+    // Fetch newest N in desc order, then reverse to get chronological for display
+    const messages = await prisma.agentMessage.findMany({
+      where: { threadId },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      select: {
+        id: true,
+        role: true,
+        content: true,
+        agentId: true,
+        routeContext: true,
+        createdAt: true,
+      },
+    });
+    return messages.reverse().map(serializeMessage);
+  },
+);
+
+export { serializeMessage };

--- a/apps/web/lib/agent-coworker-types.ts
+++ b/apps/web/lib/agent-coworker-types.ts
@@ -1,0 +1,42 @@
+import type { CapabilityKey } from "@/lib/permissions";
+
+/** Serialized message for client/server boundary. */
+export type AgentMessageRow = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  agentId: string | null;
+  routeContext: string | null;
+  createdAt: string; // ISO string via .toISOString()
+};
+
+/** Resolved agent info returned by resolveAgentForRoute. */
+export type AgentInfo = {
+  agentId: string;
+  agentName: string;
+  agentDescription: string;
+  canAssist: boolean;
+};
+
+/** Entry in the route-to-agent map. */
+export type RouteAgentEntry = {
+  agentId: string;
+  agentName: string;
+  agentDescription: string;
+  capability: CapabilityKey | null;
+};
+
+/** Max message content length (chars). */
+export const MAX_MESSAGE_LENGTH = 2000;
+
+/** Validate message input (pure function, usable from tests and server actions). */
+export function validateMessageInput(input: {
+  content: string;
+  routeContext: string;
+}): string | null {
+  const trimmed = input.content.trim();
+  if (!trimmed) return "Message content cannot be empty";
+  if (trimmed.length > MAX_MESSAGE_LENGTH) return `Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`;
+  if (!input.routeContext) return "Route context is required";
+  return null;
+}

--- a/apps/web/lib/agent-routing.test.ts
+++ b/apps/web/lib/agent-routing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { resolveAgentForRoute, generateCannedResponse } from "./agent-routing";
+
+describe("resolveAgentForRoute", () => {
+  const superuser = { platformRole: "HR-000", isSuperuser: true };
+  const opsUser = { platformRole: "HR-500", isSuperuser: false };
+  const noRole = { platformRole: null, isSuperuser: false };
+
+  it("returns portfolio-advisor for /portfolio path", () => {
+    const result = resolveAgentForRoute("/portfolio", superuser);
+    expect(result.agentId).toBe("portfolio-advisor");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns ea-architect for /ea/views/123", () => {
+    const result = resolveAgentForRoute("/ea/views/123", superuser);
+    expect(result.agentId).toBe("ea-architect");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns workspace-guide for unknown routes", () => {
+    const result = resolveAgentForRoute("/unknown/path", superuser);
+    expect(result.agentId).toBe("workspace-guide");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns canAssist=false when user lacks capability", () => {
+    // HR-500 has view_operations but not view_ea_modeler
+    const result = resolveAgentForRoute("/ea", opsUser);
+    expect(result.agentId).toBe("ea-architect");
+    expect(result.canAssist).toBe(false);
+  });
+
+  it("returns canAssist=true for ungated routes (capability null)", () => {
+    const result = resolveAgentForRoute("/workspace", noRole);
+    expect(result.agentId).toBe("workspace-guide");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns canAssist=false when platformRole is null on gated route", () => {
+    const result = resolveAgentForRoute("/portfolio", noRole);
+    expect(result.agentId).toBe("portfolio-advisor");
+    expect(result.canAssist).toBe(false);
+  });
+
+  it("uses longest prefix match", () => {
+    const result = resolveAgentForRoute("/platform/ai/providers/openai", superuser);
+    expect(result.agentId).toBe("platform-engineer");
+  });
+
+  it("returns correct agent metadata", () => {
+    const result = resolveAgentForRoute("/ops", superuser);
+    expect(result.agentName).toBeTruthy();
+    expect(result.agentDescription).toBeTruthy();
+  });
+});
+
+describe("generateCannedResponse", () => {
+  it("returns a non-empty string", () => {
+    const response = generateCannedResponse("portfolio-advisor", "/portfolio", "HR-000");
+    expect(response).toBeTruthy();
+    expect(typeof response).toBe("string");
+  });
+
+  it("returns a response for unknown agent (fallback)", () => {
+    const response = generateCannedResponse("nonexistent-agent", "/somewhere", "HR-000");
+    expect(response).toBeTruthy();
+  });
+
+  it("returns different responses for different roles on same route", () => {
+    const adminResponse = generateCannedResponse("portfolio-advisor", "/portfolio", "HR-000");
+    const opsResponse = generateCannedResponse("portfolio-advisor", "/portfolio", "HR-500");
+    expect(adminResponse).toBeTruthy();
+    expect(opsResponse).toBeTruthy();
+    // HR-000 draws from default pool, HR-500 from restricted pool
+    expect(adminResponse).not.toBe(opsResponse);
+  });
+});

--- a/apps/web/lib/agent-routing.ts
+++ b/apps/web/lib/agent-routing.ts
@@ -1,0 +1,235 @@
+import { can } from "@/lib/permissions";
+import type { UserContext } from "@/lib/permissions";
+import type { AgentInfo, RouteAgentEntry } from "@/lib/agent-coworker-types";
+
+/** Route prefix → agent + capability mapping. */
+const ROUTE_AGENT_MAP: Record<string, RouteAgentEntry> = {
+  "/portfolio": {
+    agentId: "portfolio-advisor",
+    agentName: "Portfolio Advisor",
+    agentDescription: "Helps navigate portfolio structure, products, and health metrics",
+    capability: "view_portfolio",
+  },
+  "/inventory": {
+    agentId: "inventory-specialist",
+    agentName: "Inventory Specialist",
+    agentDescription: "Assists with digital product inventory and infrastructure CIs",
+    capability: "view_inventory",
+  },
+  "/ea": {
+    agentId: "ea-architect",
+    agentName: "EA Architect",
+    agentDescription: "Guides enterprise architecture modeling, views, and relationships",
+    capability: "view_ea_modeler",
+  },
+  "/employee": {
+    agentId: "hr-specialist",
+    agentName: "HR Specialist",
+    agentDescription: "Assists with role management, people, and organizational structure",
+    capability: "view_employee",
+  },
+  "/customer": {
+    agentId: "customer-advisor",
+    agentName: "Customer Advisor",
+    agentDescription: "Helps manage customer accounts and service relationships",
+    capability: "view_customer",
+  },
+  "/ops": {
+    agentId: "ops-coordinator",
+    agentName: "Ops Coordinator",
+    agentDescription: "Assists with backlog management, epics, and operational workflows",
+    capability: "view_operations",
+  },
+  "/platform": {
+    agentId: "platform-engineer",
+    agentName: "Platform Engineer",
+    agentDescription: "Helps configure AI providers, credentials, and platform services",
+    capability: "view_platform",
+  },
+  "/admin": {
+    agentId: "admin-assistant",
+    agentName: "Admin Assistant",
+    agentDescription: "Assists with platform administration and user management",
+    capability: "view_admin",
+  },
+  "/workspace": {
+    agentId: "workspace-guide",
+    agentName: "Workspace Guide",
+    agentDescription: "Helps navigate the portal and find the right tools for your task",
+    capability: null,
+  },
+};
+
+const FALLBACK_ENTRY = ROUTE_AGENT_MAP["/workspace"]!;
+
+/** Lookup agentId → agentName for rendering historical messages. */
+export const AGENT_NAME_MAP: Record<string, string> = Object.fromEntries(
+  Object.values(ROUTE_AGENT_MAP).map((e) => [e.agentId, e.agentName]),
+);
+
+/**
+ * Resolve which specialist agent should handle the current route.
+ * Uses longest prefix match, then checks user capabilities.
+ */
+export function resolveAgentForRoute(
+  pathname: string,
+  userContext: UserContext,
+): AgentInfo {
+  // Find longest matching prefix
+  let bestMatch: RouteAgentEntry = FALLBACK_ENTRY;
+  let bestLen = 0;
+
+  for (const [prefix, entry] of Object.entries(ROUTE_AGENT_MAP)) {
+    if (pathname === prefix || pathname.startsWith(prefix + "/")) {
+      if (prefix.length > bestLen) {
+        bestLen = prefix.length;
+        bestMatch = entry;
+      }
+    }
+  }
+
+  // Ungated routes (capability null) — always canAssist
+  if (bestMatch.capability === null) {
+    return {
+      agentId: bestMatch.agentId,
+      agentName: bestMatch.agentName,
+      agentDescription: bestMatch.agentDescription,
+      canAssist: true,
+    };
+  }
+
+  // Gated routes — check user permission
+  const canAssist = can(userContext, bestMatch.capability);
+
+  return {
+    agentId: bestMatch.agentId,
+    agentName: bestMatch.agentName,
+    agentDescription: bestMatch.agentDescription,
+    canAssist,
+  };
+}
+
+// ─── Canned Responses ───────────────────────────────────────────────────────
+
+type CannedResponseSet = Record<string, string[]>;
+
+const CANNED_RESPONSES: Record<string, CannedResponseSet> = {
+  "portfolio-advisor": {
+    default: [
+      "I can help you explore the portfolio structure, review product health metrics, and understand budget allocations across your portfolios.",
+      "Looking at the portfolio view — would you like me to explain the health scores or help you navigate to a specific product group?",
+      "I'm your Portfolio Advisor. I can guide you through portfolio nodes, agent assignments, and product ownership.",
+    ],
+    restricted: [
+      "I can see you're viewing the portfolio area. I can help explain what you see here, but some actions may require additional permissions.",
+    ],
+  },
+  "inventory-specialist": {
+    default: [
+      "I can help you explore the digital product inventory, review lifecycle stages, and understand infrastructure dependencies.",
+      "Looking at the inventory — would you like me to help filter products by status or explain the lifecycle stages?",
+    ],
+    restricted: [
+      "I can help you understand the inventory view, but modifying products may require elevated permissions.",
+    ],
+  },
+  "ea-architect": {
+    default: [
+      "I can help you with your architecture model — creating views, adding elements, and establishing relationships between components.",
+      "Welcome to the EA Modeler. I can guide you through viewpoint selection, element placement, and relationship mapping.",
+      "Need help with the canvas? I can explain how to drag elements from the palette, connect them, and organize your architecture view.",
+    ],
+    restricted: [
+      "I can explain the architecture model you're viewing, but editing requires EA management permissions.",
+    ],
+  },
+  "hr-specialist": {
+    default: [
+      "I can help you understand the role structure, review team assignments, and navigate the employee directory.",
+      "Looking at the employee view — I can explain role tiers, SLA commitments, and help you understand the organizational hierarchy.",
+    ],
+    restricted: [
+      "I can help you explore employee information visible to your role.",
+    ],
+  },
+  "customer-advisor": {
+    default: [
+      "I can help you manage customer accounts, review service relationships, and track engagement metrics.",
+    ],
+    restricted: [
+      "I can provide general information about customer management, but account actions require customer view permissions.",
+    ],
+  },
+  "ops-coordinator": {
+    default: [
+      "I can help you manage the backlog — creating items, organizing epics, and tracking progress across portfolio and product work.",
+      "Looking at operations — would you like help prioritizing backlog items or understanding the epic structure?",
+    ],
+    restricted: [
+      "I can help you understand the backlog view, but creating or editing items requires operations permissions.",
+    ],
+  },
+  "platform-engineer": {
+    default: [
+      "I can help you configure AI providers, manage credentials, monitor token spend, and set up scheduled sync jobs.",
+      "Looking at the platform services — would you like help connecting a new provider or reviewing the token usage dashboard?",
+    ],
+    restricted: [
+      "I can explain the platform configuration, but changes require platform management permissions.",
+    ],
+  },
+  "admin-assistant": {
+    default: [
+      "I can help with platform administration — user management, role assignments, and system configuration.",
+    ],
+    restricted: [
+      "Administration features require admin-level access. I can help you navigate to areas within your permissions.",
+    ],
+  },
+  "workspace-guide": {
+    default: [
+      "Welcome! I'm your Workspace Guide. I can help you find the right tools and navigate the portal. What are you looking to do?",
+      "I can help you get oriented — the workspace tiles show features available to your role. Would you like me to explain any of them?",
+      "Need help finding something? I can point you to portfolio management, the backlog, architecture modeling, and more.",
+    ],
+    restricted: [
+      "I'm here to help you navigate. Let me know what you're looking for and I'll point you in the right direction.",
+    ],
+  },
+};
+
+const GENERIC_FALLBACK = "I'm here to help. What would you like to know about this area of the portal?";
+
+/**
+ * Generate a canned response based on agent, route, and user role.
+ * Selects from role-appropriate templates. No LLM calls.
+ */
+export function generateCannedResponse(
+  agentId: string,
+  _routeContext: string,
+  platformRole: string | null,
+): string {
+  const agentResponses = CANNED_RESPONSES[agentId];
+  if (!agentResponses) return GENERIC_FALLBACK;
+
+  // HR-000 (superuser): full access responses
+  // Other roles (including null): use restricted if available
+  const isFullAccess = platformRole === "HR-000";
+  const pool = isFullAccess
+    ? agentResponses["default"] ?? [GENERIC_FALLBACK]
+    : agentResponses["restricted"] ?? agentResponses["default"] ?? [GENERIC_FALLBACK];
+
+  // Simple deterministic selection based on content hash to avoid randomness in tests
+  const index = Math.abs(hashCode(agentId + _routeContext + (platformRole ?? ""))) % pool.length;
+  return pool[index] ?? GENERIC_FALLBACK;
+}
+
+function hashCode(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0; // Convert to 32-bit integer
+  }
+  return hash;
+}

--- a/apps/web/lib/permissions.ts
+++ b/apps/web/lib/permissions.ts
@@ -47,7 +47,7 @@ const PERMISSIONS: Record<CapabilityKey, Permission> = {
   manage_ea_model:             { roles: ["HR-000", "HR-300"] },
 };
 
-type UserContext = {
+export type UserContext = {
   platformRole: string | null;
   isSuperuser: boolean;
 };

--- a/apps/web/lib/user-governance.ts
+++ b/apps/web/lib/user-governance.ts
@@ -1,0 +1,16 @@
+export function summarizeGovernedLifecycleAttempt(input: {
+  actorIsSuperuser: boolean;
+  targetIsSuperuser: boolean;
+}): { decision: "allow" | "deny"; message: string } {
+  if (input.targetIsSuperuser && !input.actorIsSuperuser) {
+    return {
+      decision: "deny",
+      message: "Only a superuser can change another superuser account.",
+    };
+  }
+
+  return {
+    decision: "allow",
+    message: "Lifecycle update permitted.",
+  };
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/superpowers/plans/2026-03-13-phase-7b-agent-coworker-ux.md
+++ b/docs/superpowers/plans/2026-03-13-phase-7b-agent-coworker-ux.md
@@ -1,0 +1,1628 @@
+# Phase 7B: AI Agent Co-worker UX — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a floating chat panel that provides route-aware, role-gated AI agent assistance on every screen, with canned responses and persistent conversation history.
+
+**Architecture:** Prisma migration adds `agentId`/`routeContext` fields and indexes to existing `AgentMessage` model. Pure `agent-routing.ts` handles route→agent resolution with capability checks. Server actions manage thread CRUD and message persistence. A draggable client-side `AgentCoworkerPanel` renders in the shell layout, toggled via the existing Header "Agent" button through a `CustomEvent`.
+
+**Tech Stack:** Next.js 14 App Router, Prisma 5, TypeScript (strict: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`), Vitest, React 18 (`useTransition`, `useEffect`, `useRef`), `@xyflow/react` CSS variables.
+
+**Spec:** `docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md`
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `packages/db/prisma/migrations/<timestamp>_agent_coworker_fields/migration.sql` | Add `agentId`, `routeContext`, indexes to `AgentMessage`; default on `AgentThread.contextKey` |
+| `apps/web/lib/agent-coworker-types.ts` | `AgentMessageRow`, `AgentInfo`, `RouteAgentEntry` types, `validateMessageInput` pure function |
+| `apps/web/lib/agent-routing.ts` | `ROUTE_AGENT_MAP`, `AGENT_NAME_MAP`, `resolveAgentForRoute`, `generateCannedResponse` |
+| `apps/web/lib/agent-routing.test.ts` | Unit tests for routing + canned responses |
+| `apps/web/lib/agent-coworker-data.ts` | React cache fetcher: `getRecentMessages` |
+| `apps/web/lib/actions/agent-coworker.ts` | Server actions: `getOrCreateThread`, `sendMessage`, `loadEarlierMessages`, `recordAgentTransition` |
+| `apps/web/lib/actions/agent-coworker.test.ts` | Tests for server action validation logic |
+| `apps/web/components/agent/AgentMessageBubble.tsx` | Single message renderer (user/assistant/system) |
+| `apps/web/components/agent/AgentPanelHeader.tsx` | Drag handle, agent name, minimize/close buttons |
+| `apps/web/components/agent/AgentMessageInput.tsx` | Text input with send, Enter-to-send, char limit |
+| `apps/web/components/agent/AgentCoworkerPanel.tsx` | Main panel: drag, toggle, routing, message list |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `packages/db/prisma/schema.prisma` | Add `agentId String?`, `routeContext String?`, `@@index` to `AgentMessage`; add `@default("coworker")` to `AgentThread.contextKey` |
+| `apps/web/lib/permissions.ts` | Export existing `UserContext` type (add `export` keyword) |
+| `apps/web/components/shell/Header.tsx` | Add `onClick` to Agent button dispatching `CustomEvent("toggle-agent-panel")` |
+| `apps/web/app/(shell)/layout.tsx` | Add `getOrCreateThread` + `getRecentMessages` calls; render `AgentCoworkerPanel` |
+
+---
+
+## Chunk 1: Schema Migration & Types
+
+### Task 1: Prisma Schema Migration
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma:607-627`
+
+- [ ] **Step 1: Update `AgentThread` model — add default to `contextKey`**
+
+In `packages/db/prisma/schema.prisma`, find the `AgentThread` model (line 611) and change:
+```prisma
+  contextKey String
+```
+to:
+```prisma
+  contextKey String         @default("coworker")
+```
+
+- [ ] **Step 2: Update `AgentMessage` model — add fields and indexes**
+
+In the same file, find the `AgentMessage` model (line 619). Add `agentId`, `routeContext`, and two indexes. The full model should become:
+```prisma
+model AgentMessage {
+  id           String      @id @default(cuid())
+  threadId     String
+  thread       AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  role         String      // user | assistant | system
+  content      String
+  tone         String?
+  agentId      String?     // specialist agent that authored this response
+  routeContext String?     // route pathname when message was sent
+  createdAt    DateTime    @default(now())
+
+  @@index([threadId])
+  @@index([createdAt])
+}
+```
+
+- [ ] **Step 3: Generate and apply migration**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm db:generate
+cd d:/OpenDigitalProductFactory && pnpm --filter @dpf/db exec npx prisma migrate dev --name agent_coworker_fields
+```
+Expected: Migration created successfully, Prisma client regenerated.
+
+- [ ] **Step 4: Verify migration applied**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter @dpf/db exec npx prisma migrate status
+```
+Expected: All migrations applied, no pending.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations/
+git commit -m "feat(db): add agentId, routeContext, indexes to AgentMessage schema"
+```
+
+---
+
+### Task 2: Export `UserContext` from `permissions.ts`
+
+**Files:**
+- Modify: `apps/web/lib/permissions.ts:50`
+
+- [ ] **Step 1: Add `export` to `UserContext` type**
+
+In `apps/web/lib/permissions.ts`, line 50, change:
+```typescript
+type UserContext = {
+```
+to:
+```typescript
+export type UserContext = {
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors (existing usages are internal, export is additive).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/permissions.ts
+git commit -m "feat(permissions): export UserContext type for agent routing"
+```
+
+---
+
+### Task 3: Shared Types — `agent-coworker-types.ts`
+
+**Files:**
+- Create: `apps/web/lib/agent-coworker-types.ts`
+
+- [ ] **Step 1: Create the types file**
+
+Create `apps/web/lib/agent-coworker-types.ts`:
+```typescript
+import type { CapabilityKey } from "@/lib/permissions";
+
+/** Serialized message for client/server boundary. */
+export type AgentMessageRow = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  agentId: string | null;
+  routeContext: string | null;
+  createdAt: string; // ISO string via .toISOString()
+};
+
+/** Resolved agent info returned by resolveAgentForRoute. */
+export type AgentInfo = {
+  agentId: string;
+  agentName: string;
+  agentDescription: string;
+  canAssist: boolean;
+};
+
+/** Entry in the route-to-agent map. */
+export type RouteAgentEntry = {
+  agentId: string;
+  agentName: string;
+  agentDescription: string;
+  capability: CapabilityKey | null;
+};
+
+/** Max message content length (chars). */
+export const MAX_MESSAGE_LENGTH = 2000;
+
+/** Validate message input (pure function, usable from tests and server actions). */
+export function validateMessageInput(input: {
+  content: string;
+  routeContext: string;
+}): string | null {
+  const trimmed = input.content.trim();
+  if (!trimmed) return "Message content cannot be empty";
+  if (trimmed.length > MAX_MESSAGE_LENGTH) return `Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`;
+  if (!input.routeContext) return "Route context is required";
+  return null;
+}
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/agent-coworker-types.ts
+git commit -m "feat: add agent coworker shared types"
+```
+
+---
+
+## Chunk 2: Agent Routing & Canned Responses (TDD)
+
+### Task 4: Write Failing Tests for Agent Routing
+
+**Files:**
+- Create: `apps/web/lib/agent-routing.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `apps/web/lib/agent-routing.test.ts`:
+```typescript
+import { describe, it, expect } from "vitest";
+import { resolveAgentForRoute, generateCannedResponse } from "./agent-routing";
+
+describe("resolveAgentForRoute", () => {
+  const superuser = { platformRole: "HR-000", isSuperuser: true };
+  const opsUser = { platformRole: "HR-500", isSuperuser: false };
+  const noRole = { platformRole: null, isSuperuser: false };
+
+  it("returns portfolio-advisor for /portfolio path", () => {
+    const result = resolveAgentForRoute("/portfolio", superuser);
+    expect(result.agentId).toBe("portfolio-advisor");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns ea-architect for /ea/views/123", () => {
+    const result = resolveAgentForRoute("/ea/views/123", superuser);
+    expect(result.agentId).toBe("ea-architect");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns workspace-guide for unknown routes", () => {
+    const result = resolveAgentForRoute("/unknown/path", superuser);
+    expect(result.agentId).toBe("workspace-guide");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns canAssist=false when user lacks capability", () => {
+    // HR-500 has view_operations but not view_ea_modeler
+    const result = resolveAgentForRoute("/ea", opsUser);
+    expect(result.agentId).toBe("ea-architect");
+    expect(result.canAssist).toBe(false);
+  });
+
+  it("returns canAssist=true for ungated routes (capability null)", () => {
+    const result = resolveAgentForRoute("/workspace", noRole);
+    expect(result.agentId).toBe("workspace-guide");
+    expect(result.canAssist).toBe(true);
+  });
+
+  it("returns canAssist=false when platformRole is null on gated route", () => {
+    const result = resolveAgentForRoute("/portfolio", noRole);
+    expect(result.agentId).toBe("portfolio-advisor");
+    expect(result.canAssist).toBe(false);
+  });
+
+  it("uses longest prefix match", () => {
+    const result = resolveAgentForRoute("/platform/ai/providers/openai", superuser);
+    expect(result.agentId).toBe("platform-engineer");
+  });
+
+  it("returns correct agent metadata", () => {
+    const result = resolveAgentForRoute("/ops", superuser);
+    expect(result.agentName).toBeTruthy();
+    expect(result.agentDescription).toBeTruthy();
+  });
+});
+
+describe("generateCannedResponse", () => {
+  it("returns a non-empty string", () => {
+    const response = generateCannedResponse("portfolio-advisor", "/portfolio", "HR-000");
+    expect(response).toBeTruthy();
+    expect(typeof response).toBe("string");
+  });
+
+  it("returns a response for unknown agent (fallback)", () => {
+    const response = generateCannedResponse("nonexistent-agent", "/somewhere", "HR-000");
+    expect(response).toBeTruthy();
+  });
+
+  it("returns different responses for different roles on same route", () => {
+    const adminResponse = generateCannedResponse("portfolio-advisor", "/portfolio", "HR-000");
+    const opsResponse = generateCannedResponse("portfolio-advisor", "/portfolio", "HR-500");
+    expect(adminResponse).toBeTruthy();
+    expect(opsResponse).toBeTruthy();
+    // HR-000 draws from default pool, HR-500 from restricted pool
+    expect(adminResponse).not.toBe(opsResponse);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec vitest run apps/web/lib/agent-routing.test.ts
+```
+Expected: FAIL — module `./agent-routing` not found.
+
+---
+
+### Task 5: Implement Agent Routing & Canned Responses
+
+**Files:**
+- Create: `apps/web/lib/agent-routing.ts`
+
+- [ ] **Step 1: Create the routing module**
+
+Create `apps/web/lib/agent-routing.ts`:
+```typescript
+import { can } from "@/lib/permissions";
+import type { UserContext } from "@/lib/permissions";
+import type { CapabilityKey } from "@/lib/permissions";
+import type { AgentInfo, RouteAgentEntry } from "@/lib/agent-coworker-types";
+
+/** Route prefix → agent + capability mapping. */
+const ROUTE_AGENT_MAP: Record<string, RouteAgentEntry> = {
+  "/portfolio": {
+    agentId: "portfolio-advisor",
+    agentName: "Portfolio Advisor",
+    agentDescription: "Helps navigate portfolio structure, products, and health metrics",
+    capability: "view_portfolio",
+  },
+  "/inventory": {
+    agentId: "inventory-specialist",
+    agentName: "Inventory Specialist",
+    agentDescription: "Assists with digital product inventory and infrastructure CIs",
+    capability: "view_inventory",
+  },
+  "/ea": {
+    agentId: "ea-architect",
+    agentName: "EA Architect",
+    agentDescription: "Guides enterprise architecture modeling, views, and relationships",
+    capability: "view_ea_modeler",
+  },
+  "/employee": {
+    agentId: "hr-specialist",
+    agentName: "HR Specialist",
+    agentDescription: "Assists with role management, people, and organizational structure",
+    capability: "view_employee",
+  },
+  "/customer": {
+    agentId: "customer-advisor",
+    agentName: "Customer Advisor",
+    agentDescription: "Helps manage customer accounts and service relationships",
+    capability: "view_customer",
+  },
+  "/ops": {
+    agentId: "ops-coordinator",
+    agentName: "Ops Coordinator",
+    agentDescription: "Assists with backlog management, epics, and operational workflows",
+    capability: "view_operations",
+  },
+  "/platform": {
+    agentId: "platform-engineer",
+    agentName: "Platform Engineer",
+    agentDescription: "Helps configure AI providers, credentials, and platform services",
+    capability: "view_platform",
+  },
+  "/admin": {
+    agentId: "admin-assistant",
+    agentName: "Admin Assistant",
+    agentDescription: "Assists with platform administration and user management",
+    capability: "view_admin",
+  },
+  "/workspace": {
+    agentId: "workspace-guide",
+    agentName: "Workspace Guide",
+    agentDescription: "Helps navigate the portal and find the right tools for your task",
+    capability: null,
+  },
+};
+
+const FALLBACK_ENTRY = ROUTE_AGENT_MAP["/workspace"]!;
+
+/** Lookup agentId → agentName for rendering historical messages. */
+export const AGENT_NAME_MAP: Record<string, string> = Object.fromEntries(
+  Object.values(ROUTE_AGENT_MAP).map((e) => [e.agentId, e.agentName]),
+);
+
+/**
+ * Resolve which specialist agent should handle the current route.
+ * Uses longest prefix match, then checks user capabilities.
+ */
+export function resolveAgentForRoute(
+  pathname: string,
+  userContext: UserContext,
+): AgentInfo {
+  // Find longest matching prefix
+  let bestMatch: RouteAgentEntry = FALLBACK_ENTRY;
+  let bestLen = 0;
+
+  for (const [prefix, entry] of Object.entries(ROUTE_AGENT_MAP)) {
+    if (pathname === prefix || pathname.startsWith(prefix + "/")) {
+      if (prefix.length > bestLen) {
+        bestLen = prefix.length;
+        bestMatch = entry;
+      }
+    }
+  }
+
+  // Ungated routes (capability null) — always canAssist
+  if (bestMatch.capability === null) {
+    return {
+      agentId: bestMatch.agentId,
+      agentName: bestMatch.agentName,
+      agentDescription: bestMatch.agentDescription,
+      canAssist: true,
+    };
+  }
+
+  // Gated routes — check user permission
+  const canAssist = can(userContext, bestMatch.capability);
+
+  return {
+    agentId: bestMatch.agentId,
+    agentName: bestMatch.agentName,
+    agentDescription: bestMatch.agentDescription,
+    canAssist,
+  };
+}
+
+// ─── Canned Responses ───────────────────────────────────────────────────────
+
+type CannedResponseSet = Record<string, string[]>;
+
+const CANNED_RESPONSES: Record<string, CannedResponseSet> = {
+  "portfolio-advisor": {
+    default: [
+      "I can help you explore the portfolio structure, review product health metrics, and understand budget allocations across your portfolios.",
+      "Looking at the portfolio view — would you like me to explain the health scores or help you navigate to a specific product group?",
+      "I'm your Portfolio Advisor. I can guide you through portfolio nodes, agent assignments, and product ownership.",
+    ],
+    restricted: [
+      "I can see you're viewing the portfolio area. I can help explain what you see here, but some actions may require additional permissions.",
+    ],
+  },
+  "inventory-specialist": {
+    default: [
+      "I can help you explore the digital product inventory, review lifecycle stages, and understand infrastructure dependencies.",
+      "Looking at the inventory — would you like me to help filter products by status or explain the lifecycle stages?",
+    ],
+    restricted: [
+      "I can help you understand the inventory view, but modifying products may require elevated permissions.",
+    ],
+  },
+  "ea-architect": {
+    default: [
+      "I can help you with your architecture model — creating views, adding elements, and establishing relationships between components.",
+      "Welcome to the EA Modeler. I can guide you through viewpoint selection, element placement, and relationship mapping.",
+      "Need help with the canvas? I can explain how to drag elements from the palette, connect them, and organize your architecture view.",
+    ],
+    restricted: [
+      "I can explain the architecture model you're viewing, but editing requires EA management permissions.",
+    ],
+  },
+  "hr-specialist": {
+    default: [
+      "I can help you understand the role structure, review team assignments, and navigate the employee directory.",
+      "Looking at the employee view — I can explain role tiers, SLA commitments, and help you understand the organizational hierarchy.",
+    ],
+    restricted: [
+      "I can help you explore employee information visible to your role.",
+    ],
+  },
+  "customer-advisor": {
+    default: [
+      "I can help you manage customer accounts, review service relationships, and track engagement metrics.",
+    ],
+    restricted: [
+      "I can provide general information about customer management, but account actions require customer view permissions.",
+    ],
+  },
+  "ops-coordinator": {
+    default: [
+      "I can help you manage the backlog — creating items, organizing epics, and tracking progress across portfolio and product work.",
+      "Looking at operations — would you like help prioritizing backlog items or understanding the epic structure?",
+    ],
+    restricted: [
+      "I can help you understand the backlog view, but creating or editing items requires operations permissions.",
+    ],
+  },
+  "platform-engineer": {
+    default: [
+      "I can help you configure AI providers, manage credentials, monitor token spend, and set up scheduled sync jobs.",
+      "Looking at the platform services — would you like help connecting a new provider or reviewing the token usage dashboard?",
+    ],
+    restricted: [
+      "I can explain the platform configuration, but changes require platform management permissions.",
+    ],
+  },
+  "admin-assistant": {
+    default: [
+      "I can help with platform administration — user management, role assignments, and system configuration.",
+    ],
+    restricted: [
+      "Administration features require admin-level access. I can help you navigate to areas within your permissions.",
+    ],
+  },
+  "workspace-guide": {
+    default: [
+      "Welcome! I'm your Workspace Guide. I can help you find the right tools and navigate the portal. What are you looking to do?",
+      "I can help you get oriented — the workspace tiles show features available to your role. Would you like me to explain any of them?",
+      "Need help finding something? I can point you to portfolio management, the backlog, architecture modeling, and more.",
+    ],
+    restricted: [
+      "I'm here to help you navigate. Let me know what you're looking for and I'll point you in the right direction.",
+    ],
+  },
+};
+
+const GENERIC_FALLBACK = "I'm here to help. What would you like to know about this area of the portal?";
+
+/**
+ * Generate a canned response based on agent, route, and user role.
+ * Selects from role-appropriate templates. No LLM calls.
+ */
+export function generateCannedResponse(
+  agentId: string,
+  _routeContext: string,
+  platformRole: string | null,
+): string {
+  const agentResponses = CANNED_RESPONSES[agentId];
+  if (!agentResponses) return GENERIC_FALLBACK;
+
+  // HR-000 (superuser): full access responses
+  // Other roles (including null): use restricted if available
+  const isFullAccess = platformRole === "HR-000";
+  const pool = isFullAccess
+    ? agentResponses["default"] ?? [GENERIC_FALLBACK]
+    : agentResponses["restricted"] ?? agentResponses["default"] ?? [GENERIC_FALLBACK];
+
+  // Simple deterministic selection based on content hash to avoid randomness in tests
+  const index = Math.abs(hashCode(agentId + _routeContext + (platformRole ?? ""))) % pool.length;
+  return pool[index] ?? GENERIC_FALLBACK;
+}
+
+function hashCode(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0; // Convert to 32-bit integer
+  }
+  return hash;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec vitest run apps/web/lib/agent-routing.test.ts
+```
+Expected: All 11 tests PASS.
+
+- [ ] **Step 3: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/agent-routing.ts apps/web/lib/agent-routing.test.ts
+git commit -m "feat: add agent routing with canned responses (TDD)"
+```
+
+---
+
+## Chunk 3: Server Actions & Data Layer
+
+### Task 6: Data Fetcher — `getRecentMessages`
+
+**Files:**
+- Create: `apps/web/lib/agent-coworker-data.ts`
+
+- [ ] **Step 1: Create the data fetcher**
+
+Create `apps/web/lib/agent-coworker-data.ts`:
+```typescript
+import { cache } from "react";
+import { prisma } from "@dpf/db";
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+
+function serializeMessage(m: {
+  id: string;
+  role: string;
+  content: string;
+  agentId: string | null;
+  routeContext: string | null;
+  createdAt: Date;
+}): AgentMessageRow {
+  return {
+    id: m.id,
+    role: m.role as AgentMessageRow["role"],
+    content: m.content,
+    agentId: m.agentId,
+    routeContext: m.routeContext,
+    createdAt: m.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Get recent messages for a thread. React-cache deduped within a single request.
+ * MUST only be called after session verification (shell layout).
+ */
+export const getRecentMessages = cache(
+  async (threadId: string, limit = 50): Promise<AgentMessageRow[]> => {
+    // Fetch newest N in desc order, then reverse to get chronological for display
+    const messages = await prisma.agentMessage.findMany({
+      where: { threadId },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      select: {
+        id: true,
+        role: true,
+        content: true,
+        agentId: true,
+        routeContext: true,
+        createdAt: true,
+      },
+    });
+    return messages.reverse().map(serializeMessage);
+  },
+);
+
+export { serializeMessage };
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/agent-coworker-data.ts
+git commit -m "feat: add getRecentMessages data fetcher for agent coworker"
+```
+
+---
+
+### Task 7: Write Failing Tests for Server Action Validation
+
+**Files:**
+- Create: `apps/web/lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `apps/web/lib/actions/agent-coworker.test.ts`:
+```typescript
+import { describe, it, expect } from "vitest";
+import { validateMessageInput } from "../agent-coworker-types";
+
+describe("validateMessageInput", () => {
+  it("returns null for valid input", () => {
+    expect(validateMessageInput({ content: "Hello", routeContext: "/portfolio" })).toBeNull();
+  });
+
+  it("rejects empty content", () => {
+    expect(validateMessageInput({ content: "", routeContext: "/portfolio" })).toMatch(/empty/i);
+  });
+
+  it("rejects whitespace-only content", () => {
+    expect(validateMessageInput({ content: "   ", routeContext: "/portfolio" })).toMatch(/empty/i);
+  });
+
+  it("rejects content over 2000 chars", () => {
+    const long = "x".repeat(2001);
+    expect(validateMessageInput({ content: long, routeContext: "/portfolio" })).toMatch(/2000/);
+  });
+
+  it("accepts content at exactly 2000 chars", () => {
+    const exact = "x".repeat(2000);
+    expect(validateMessageInput({ content: exact, routeContext: "/portfolio" })).toBeNull();
+  });
+
+  it("rejects empty routeContext", () => {
+    expect(validateMessageInput({ content: "Hello", routeContext: "" })).toMatch(/route/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts
+```
+Expected: FAIL — module not found or `validateMessageInput` not exported.
+
+---
+
+### Task 8: Implement Server Actions
+
+**Files:**
+- Create: `apps/web/lib/actions/agent-coworker.ts`
+
+- [ ] **Step 1: Create the server actions file**
+
+Create `apps/web/lib/actions/agent-coworker.ts`:
+```typescript
+"use server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { validateMessageInput } from "@/lib/agent-coworker-types";
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+import { resolveAgentForRoute, generateCannedResponse } from "@/lib/agent-routing";
+import { serializeMessage } from "@/lib/agent-coworker-data";
+
+// ─── Auth helper ────────────────────────────────────────────────────────────
+
+async function requireAuthUser() {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new Error("Unauthorized");
+  return user;
+}
+
+// ─── Server Actions ─────────────────────────────────────────────────────────
+
+export async function getOrCreateThread(): Promise<{ threadId: string }> {
+  const user = await requireAuthUser();
+
+  const existing = await prisma.agentThread.findUnique({
+    where: { userId_contextKey: { userId: user.id, contextKey: "coworker" } },
+    select: { id: true },
+  });
+
+  if (existing) return { threadId: existing.id };
+
+  const created = await prisma.agentThread.create({
+    data: { userId: user.id, contextKey: "coworker" },
+    select: { id: true },
+  });
+
+  return { threadId: created.id };
+}
+
+export async function sendMessage(input: {
+  threadId: string;
+  content: string;
+  routeContext: string;
+}): Promise<
+  | { userMessage: AgentMessageRow; agentMessage: AgentMessageRow }
+  | { error: string }
+> {
+  const user = await requireAuthUser();
+
+  // Verify thread ownership
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  // Validate input
+  const validationError = validateMessageInput(input);
+  if (validationError) return { error: validationError };
+
+  const trimmedContent = input.content.trim();
+
+  // Persist user message
+  const userMsg = await prisma.agentMessage.create({
+    data: {
+      threadId: input.threadId,
+      role: "user",
+      content: trimmedContent,
+      routeContext: input.routeContext,
+    },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  // Resolve agent and generate canned response
+  const agent = resolveAgentForRoute(input.routeContext, {
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  });
+
+  const responseContent = generateCannedResponse(
+    agent.agentId,
+    input.routeContext,
+    user.platformRole,
+  );
+
+  // Persist agent response
+  const agentMsg = await prisma.agentMessage.create({
+    data: {
+      threadId: input.threadId,
+      role: "assistant",
+      content: responseContent,
+      agentId: agent.agentId,
+      routeContext: input.routeContext,
+    },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    userMessage: serializeMessage(userMsg),
+    agentMessage: serializeMessage(agentMsg),
+  };
+}
+
+export async function loadEarlierMessages(input: {
+  threadId: string;
+  before: string;
+  limit?: number;
+}): Promise<{ messages: AgentMessageRow[]; hasMore: boolean } | { error: string }> {
+  const user = await requireAuthUser();
+
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  const limit = input.limit ?? 20;
+
+  const messages = await prisma.agentMessage.findMany({
+    where: { threadId: input.threadId },
+    orderBy: { createdAt: "desc" },
+    cursor: { id: input.before },
+    skip: 1, // skip the cursor itself
+    take: limit + 1, // fetch one extra to check hasMore
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  const hasMore = messages.length > limit;
+  const slice = hasMore ? messages.slice(0, limit) : messages;
+
+  return {
+    messages: slice.reverse().map(serializeMessage),
+    hasMore,
+  };
+}
+
+export async function recordAgentTransition(input: {
+  threadId: string;
+  agentId: string;
+  agentName: string;
+  routeContext: string;
+}): Promise<{ message: AgentMessageRow } | { error: string }> {
+  const user = await requireAuthUser();
+
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  const msg = await prisma.agentMessage.create({
+    data: {
+      threadId: input.threadId,
+      role: "system",
+      content: `${input.agentName} has joined the conversation`,
+      agentId: input.agentId,
+      routeContext: input.routeContext,
+    },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  return { message: serializeMessage(msg) };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts
+```
+Expected: All 6 tests PASS.
+
+- [ ] **Step 3: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/actions/agent-coworker.ts apps/web/lib/actions/agent-coworker.test.ts
+git commit -m "feat: add agent coworker server actions with validation (TDD)"
+```
+
+---
+
+## Chunk 4: UI Components
+
+### Task 9: `AgentMessageBubble` Component
+
+**Files:**
+- Create: `apps/web/components/agent/AgentMessageBubble.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `apps/web/components/agent/AgentMessageBubble.tsx`:
+```typescript
+"use client";
+
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+
+type Props = {
+  message: AgentMessageRow;
+  showAgentLabel: boolean; // true when agent changed from previous message
+  agentName: string | null;
+};
+
+function formatRelativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props) {
+  if (message.role === "system") {
+    return (
+      <div style={{
+        textAlign: "center",
+        padding: "8px 0",
+        fontSize: 11,
+        color: "var(--dpf-muted)",
+        fontStyle: "italic",
+      }}>
+        {message.content}
+      </div>
+    );
+  }
+
+  const isUser = message.role === "user";
+
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: "column",
+      alignItems: isUser ? "flex-end" : "flex-start",
+      gap: 2,
+      marginBottom: 8,
+    }}>
+      {showAgentLabel && agentName && !isUser && (
+        <span style={{ fontSize: 10, color: "var(--dpf-accent)", marginLeft: 4 }}>
+          {agentName}
+        </span>
+      )}
+      <div
+        title={formatRelativeTime(message.createdAt)}
+        style={{
+          maxWidth: "85%",
+          padding: "8px 12px",
+          borderRadius: isUser ? "12px 12px 2px 12px" : "12px 12px 12px 2px",
+          fontSize: 13,
+          lineHeight: 1.4,
+          background: isUser ? "var(--dpf-accent)" : "var(--dpf-surface-2)",
+          color: isUser ? "#ffffff" : "#e0e0ff",
+          wordBreak: "break-word",
+        }}
+      >
+        {message.content}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/agent/AgentMessageBubble.tsx
+git commit -m "feat: add AgentMessageBubble component"
+```
+
+---
+
+### Task 10: `AgentPanelHeader` Component
+
+**Files:**
+- Create: `apps/web/components/agent/AgentPanelHeader.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `apps/web/components/agent/AgentPanelHeader.tsx`:
+```typescript
+"use client";
+
+import type { AgentInfo } from "@/lib/agent-coworker-types";
+
+type Props = {
+  agent: AgentInfo;
+  onMouseDown: (e: React.MouseEvent) => void; // drag handle
+  onClose: () => void;
+};
+
+export function AgentPanelHeader({ agent, onMouseDown, onClose }: Props) {
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "10px 14px",
+        background: "var(--dpf-surface-2)",
+        borderBottom: "1px solid var(--dpf-border)",
+        borderRadius: "12px 12px 0 0",
+        cursor: "grab",
+        userSelect: "none",
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-400" />
+          <span style={{ fontSize: 12, fontWeight: 600, color: "#e0e0ff" }}>
+            {agent.agentName}
+          </span>
+        </div>
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: 12 }}>
+          {agent.agentDescription}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        title="Close"
+        style={{
+          background: "none",
+          border: "none",
+          color: "var(--dpf-muted)",
+          cursor: "pointer",
+          fontSize: 16,
+          padding: "2px 6px",
+          borderRadius: 4,
+          lineHeight: 1,
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/components/agent/AgentPanelHeader.tsx
+git commit -m "feat: add AgentPanelHeader component"
+```
+
+---
+
+### Task 11: `AgentMessageInput` Component
+
+**Files:**
+- Create: `apps/web/components/agent/AgentMessageInput.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `apps/web/components/agent/AgentMessageInput.tsx`:
+```typescript
+"use client";
+
+import { useState, useRef } from "react";
+import { MAX_MESSAGE_LENGTH } from "@/lib/agent-coworker-types";
+
+type Props = {
+  onSend: (content: string) => void;
+  disabled: boolean;
+};
+
+export function AgentMessageInput({ onSend, disabled }: Props) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleSubmit() {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    if (trimmed.length > MAX_MESSAGE_LENGTH) return;
+    onSend(trimmed);
+    setValue("");
+    inputRef.current?.focus();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  const overLimit = value.trim().length > MAX_MESSAGE_LENGTH;
+
+  return (
+    <div style={{
+      display: "flex",
+      gap: 6,
+      padding: "10px 12px",
+      borderTop: "1px solid var(--dpf-border)",
+    }}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        placeholder={disabled ? "Sending..." : "Ask your co-worker..."}
+        style={{
+          flex: 1,
+          background: "var(--dpf-bg)",
+          border: `1px solid ${overLimit ? "#ef4444" : "var(--dpf-border)"}`,
+          borderRadius: 6,
+          padding: "6px 10px",
+          fontSize: 12,
+          color: "#e0e0ff",
+          outline: "none",
+        }}
+      />
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={disabled || !value.trim() || overLimit}
+        style={{
+          background: "var(--dpf-accent)",
+          border: "none",
+          borderRadius: 6,
+          padding: "6px 12px",
+          fontSize: 12,
+          color: "#ffffff",
+          cursor: disabled || !value.trim() || overLimit ? "not-allowed" : "pointer",
+          opacity: disabled || !value.trim() || overLimit ? 0.5 : 1,
+        }}
+      >
+        Send
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/components/agent/AgentMessageInput.tsx
+git commit -m "feat: add AgentMessageInput component"
+```
+
+---
+
+## Chunk 5: Main Panel & Integration
+
+### Task 12: `AgentCoworkerPanel` — Main Client Component
+
+**Files:**
+- Create: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+
+- [ ] **Step 1: Create the panel component**
+
+Create `apps/web/components/agent/AgentCoworkerPanel.tsx`:
+```typescript
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { usePathname } from "next/navigation";
+import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
+import type { UserContext } from "@/lib/permissions";
+import { resolveAgentForRoute, AGENT_NAME_MAP } from "@/lib/agent-routing";
+import { sendMessage, recordAgentTransition } from "@/lib/actions/agent-coworker";
+import { AgentPanelHeader } from "./AgentPanelHeader";
+import { AgentMessageBubble } from "./AgentMessageBubble";
+import { AgentMessageInput } from "./AgentMessageInput";
+
+type Props = {
+  threadId: string;
+  initialMessages: AgentMessageRow[];
+  userContext: UserContext;
+};
+
+const PANEL_W = 380;
+const PANEL_H = 480;
+const EDGE_GAP = 16;
+const LS_KEY_OPEN = "agent-panel-open";
+const LS_KEY_POS = "agent-panel-position";
+
+function loadPosition(): { x: number; y: number } {
+  try {
+    const raw = localStorage.getItem(LS_KEY_POS);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { x: number; y: number };
+      if (typeof parsed.x === "number" && typeof parsed.y === "number") return parsed;
+    }
+  } catch { /* ignore */ }
+  return {
+    x: typeof window !== "undefined" ? window.innerWidth - PANEL_W - EDGE_GAP : EDGE_GAP,
+    y: typeof window !== "undefined" ? window.innerHeight - PANEL_H - EDGE_GAP : EDGE_GAP,
+  };
+}
+
+function loadOpen(): boolean {
+  try {
+    return localStorage.getItem(LS_KEY_OPEN) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function AgentCoworkerPanel({ threadId, initialMessages, userContext }: Props) {
+  const pathname = usePathname();
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [messages, setMessages] = useState<AgentMessageRow[]>(initialMessages);
+  const [isPending, startTransition] = useTransition();
+  const [lastAgentId, setLastAgentId] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
+
+  // Hydrate from localStorage after mount
+  useEffect(() => {
+    setIsOpen(loadOpen());
+    setPosition(loadPosition());
+  }, []);
+
+  // Listen for toggle event from Header Agent button
+  useEffect(() => {
+    function handleToggle() {
+      setIsOpen((prev) => {
+        const next = !prev;
+        localStorage.setItem(LS_KEY_OPEN, String(next));
+        return next;
+      });
+    }
+    document.addEventListener("toggle-agent-panel", handleToggle);
+    return () => document.removeEventListener("toggle-agent-panel", handleToggle);
+  }, []);
+
+  // Resolve agent for current route
+  const agent: AgentInfo = resolveAgentForRoute(pathname, userContext);
+
+  // Agent transition — persist system message when agent changes
+  useEffect(() => {
+    if (lastAgentId === null) {
+      setLastAgentId(agent.agentId);
+      return;
+    }
+    if (agent.agentId !== lastAgentId) {
+      setLastAgentId(agent.agentId);
+      // Optimistic: show immediately
+      const optimisticMsg: AgentMessageRow = {
+        id: `system-${Date.now()}`,
+        role: "system",
+        content: `${agent.agentName} has joined the conversation`,
+        agentId: agent.agentId,
+        routeContext: pathname,
+        createdAt: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, optimisticMsg]);
+      // Persist to DB (fire-and-forget — optimistic msg is already shown)
+      void recordAgentTransition({
+        threadId,
+        agentId: agent.agentId,
+        agentName: agent.agentName,
+        routeContext: pathname,
+      });
+    }
+  }, [agent.agentId, agent.agentName, pathname, lastAgentId, threadId]);
+
+  // Auto-scroll to bottom when new messages appear
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // ─── Drag handling ──────────────────────────────────────────────────────
+
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    dragRef.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      startPosX: position.x,
+      startPosY: position.y,
+    };
+
+    function onMouseMove(ev: MouseEvent) {
+      if (!dragRef.current) return;
+      const dx = ev.clientX - dragRef.current.startX;
+      const dy = ev.clientY - dragRef.current.startY;
+      const newPos = {
+        x: dragRef.current.startPosX + dx,
+        y: dragRef.current.startPosY + dy,
+      };
+      setPosition(newPos);
+      localStorage.setItem(LS_KEY_POS, JSON.stringify(newPos));
+    }
+
+    function onMouseUp() {
+      dragRef.current = null;
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, [position]);
+
+  // ─── Send message ───────────────────────────────────────────────────────
+
+  function handleSend(content: string) {
+    startTransition(async () => {
+      const result = await sendMessage({
+        threadId,
+        content,
+        routeContext: pathname,
+      });
+      if ("error" in result) {
+        console.warn("sendMessage error:", result.error);
+        return;
+      }
+      setMessages((prev) => [...prev, result.userMessage, result.agentMessage]);
+    });
+  }
+
+  function handleClose() {
+    setIsOpen(false);
+    localStorage.setItem(LS_KEY_OPEN, "false");
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: position.x,
+        top: position.y,
+        width: PANEL_W,
+        height: PANEL_H,
+        zIndex: 50,
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--dpf-surface-1)",
+        border: "1px solid var(--dpf-border)",
+        borderRadius: 12,
+        boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+        overflow: "hidden",
+      }}
+    >
+      <AgentPanelHeader
+        agent={agent}
+        onMouseDown={handleDragStart}
+        onClose={handleClose}
+      />
+
+      {/* Messages area */}
+      <div style={{
+        flex: 1,
+        overflowY: "auto",
+        padding: "12px",
+      }}>
+        {messages.length === 0 && (
+          <div style={{
+            textAlign: "center",
+            color: "var(--dpf-muted)",
+            fontSize: 12,
+            padding: "40px 20px",
+          }}>
+            Start a conversation with your AI co-worker
+          </div>
+        )}
+        {messages.map((msg, i) => {
+          const prevAgentId = i > 0 ? messages[i - 1]?.agentId : null;
+          const showAgentLabel = msg.role === "assistant" && msg.agentId !== prevAgentId;
+          return (
+            <AgentMessageBubble
+              key={msg.id}
+              message={msg}
+              showAgentLabel={showAgentLabel}
+              agentName={showAgentLabel && msg.agentId ? (AGENT_NAME_MAP[msg.agentId] ?? msg.agentId) : null}
+            />
+          );
+        })}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <AgentMessageInput onSend={handleSend} disabled={isPending} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/agent/AgentCoworkerPanel.tsx
+git commit -m "feat: add AgentCoworkerPanel main component"
+```
+
+---
+
+### Task 13: Wire Up Header Agent Button
+
+**Files:**
+- Modify: `apps/web/components/shell/Header.tsx:72-79`
+
+- [ ] **Step 1: Add onClick handler to the existing Agent button**
+
+In `apps/web/components/shell/Header.tsx`, find the Agent button (around line 72). Change from:
+```tsx
+        <button
+          type="button"
+          className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs border border-[var(--dpf-accent)] text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)] hover:text-white transition-colors"
+        >
+```
+to:
+```tsx
+        <button
+          type="button"
+          onClick={() => document.dispatchEvent(new CustomEvent("toggle-agent-panel"))}
+          className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs border border-[var(--dpf-accent)] text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)] hover:text-white transition-colors"
+        >
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/components/shell/Header.tsx
+git commit -m "feat: wire up Header Agent button to toggle co-worker panel"
+```
+
+---
+
+### Task 14: Integrate Panel into Shell Layout
+
+**Files:**
+- Modify: `apps/web/app/(shell)/layout.tsx`
+
+- [ ] **Step 1: Read the current layout file**
+
+Read `apps/web/app/(shell)/layout.tsx` to understand the current structure.
+
+- [ ] **Step 2: Add imports and panel rendering**
+
+Add these imports at the top of `apps/web/app/(shell)/layout.tsx`:
+```typescript
+import { getOrCreateThread } from "@/lib/actions/agent-coworker";
+import { getRecentMessages } from "@/lib/agent-coworker-data";
+import { AgentCoworkerPanel } from "@/components/agent/AgentCoworkerPanel";
+```
+
+In the component body, after the `if (!session?.user) redirect("/login");` guard (line 11), add a `user` variable and the thread/messages fetch. Place the thread fetch in the existing `Promise.all` block for parallelism:
+
+Change from:
+```typescript
+  const [latestDiscoveryRun, activeBranding] = await Promise.all([
+```
+to:
+```typescript
+  const user = session.user;
+  const [latestDiscoveryRun, activeBranding, { threadId }] = await Promise.all([
+```
+
+Add `getOrCreateThread()` as a third element in the `Promise.all` array:
+```typescript
+    getOrCreateThread(),
+  ]);
+```
+
+After the `Promise.all` block, fetch messages (depends on threadId):
+```typescript
+  const initialMessages = await getRecentMessages(threadId);
+```
+
+Update the Header props to use the `user` variable (replace `session.user.platformRole` → `user.platformRole`, etc.).
+
+Then add the `AgentCoworkerPanel` as a sibling to `<main>`, inside the outermost div (before the closing `</div>`):
+```tsx
+      <AgentCoworkerPanel
+        threadId={threadId}
+        initialMessages={initialMessages}
+        userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
+      />
+```
+
+- [ ] **Step 3: Verify no type errors**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm --filter web exec tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 4: Start dev server and verify visually**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm dev
+```
+
+Open `http://localhost:3000/workspace` in browser. Verify:
+1. Click the "Agent" button in the header → panel appears bottom-right
+2. Panel shows "Workspace Guide" as the active agent
+3. Type a message and send → user bubble appears, canned response appears
+4. Click ✕ to close → panel disappears
+5. Navigate to `/portfolio` → agent transition message appears, header updates to "Portfolio Advisor"
+6. Drag the panel header → panel repositions
+7. Refresh page → panel remembers open/closed state and position
+8. Refresh page → transition messages persist (visible from DB reload)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/\(shell\)/layout.tsx
+git commit -m "feat: integrate AgentCoworkerPanel into shell layout"
+```
+
+---
+
+## Chunk 6: Final Verification & Cleanup
+
+### Task 15: Run Full Test Suite
+
+- [ ] **Step 1: Run all tests**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm test
+```
+Expected: All tests pass (agent-routing tests + agent-coworker action tests + all existing tests).
+
+- [ ] **Step 2: Run type check**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm typecheck
+```
+Expected: No errors.
+
+- [ ] **Step 3: Run build**
+
+Run:
+```bash
+cd d:/OpenDigitalProductFactory && pnpm build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 4: Fix any issues found**
+
+If tests, types, or build fail: fix the issues and commit the fixes.
+
+- [ ] **Step 5: Final commit (if any fixes)**
+
+```bash
+git add -A
+git commit -m "fix: resolve Phase 7B build/test issues"
+```

--- a/docs/superpowers/plans/2026-03-14-discovery-taxonomy-attribution.md
+++ b/docs/superpowers/plans/2026-03-14-discovery-taxonomy-attribution.md
@@ -1,0 +1,518 @@
+# Discovery Taxonomy Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend bootstrap discovery so discovered entities are attributed to taxonomy descriptors with confidence and evidence, while also capturing host/container software evidence and normalized software identities for later license, vulnerability, and technical-debt analysis.
+
+**Architecture:** Keep the existing collector -> normalize -> persist pipeline, but insert two focused layers: taxonomy attribution and software normalization. Add persistence models for attribution metadata, software evidence, software identity, and deterministic normalization rules; then wire discovery sync to persist those results and surface quality issues for low-confidence cases.
+
+**Tech Stack:** Prisma 5, PostgreSQL, TypeScript, Vitest, Next.js App Router, React cache
+
+---
+
+## File Structure
+
+### Database and persistence layer
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_discovery_taxonomy_software_attribution/migration.sql`
+- Modify: `packages/db/src/index.ts`
+- Create: `packages/db/src/discovery-attribution-model.test.ts`
+
+### Discovery attribution and software normalization
+
+- Modify: `packages/db/src/discovery-types.ts`
+- Modify: `packages/db/src/discovery-normalize.ts`
+- Modify: `packages/db/src/discovery-runner.ts`
+- Create: `packages/db/src/discovery-attribution.ts`
+- Create: `packages/db/src/discovery-attribution.test.ts`
+- Create: `packages/db/src/software-normalization.ts`
+- Create: `packages/db/src/software-normalization.test.ts`
+- Modify: `packages/db/src/discovery-sync.ts`
+- Modify: `packages/db/src/discovery-sync.test.ts`
+
+### Web read layer
+
+- Modify: `apps/web/lib/discovery-data.ts`
+- Modify: `apps/web/app/(shell)/inventory/page.tsx`
+- Modify: `apps/web/components/inventory/InventoryEntityPanel.tsx`
+- Create or Modify: inventory tests if needed for attribution metadata rendering
+
+### Documentation
+
+- Modify: `docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md`
+
+---
+
+## Chunk 1: Schema And Model Foundation
+
+### Task 1: Add failing schema delegate expectations
+
+**Files:**
+- Create: `packages/db/src/discovery-attribution-model.test.ts`
+- Test: `packages/db/src/discovery-attribution-model.test.ts`
+
+- [ ] **Step 1: Write failing model smoke tests**
+
+Create `packages/db/src/discovery-attribution-model.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Prisma } from "../generated/client";
+
+describe("discovery attribution Prisma model names", () => {
+  it("exposes software normalization delegates", () => {
+    expect(Prisma.ModelName.DiscoveredSoftwareEvidence).toBe("DiscoveredSoftwareEvidence");
+    expect(Prisma.ModelName.SoftwareIdentity).toBe("SoftwareIdentity");
+    expect(Prisma.ModelName.SoftwareNormalizationRule).toBe("SoftwareNormalizationRule");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-attribution-model.test.ts
+```
+
+Expected: FAIL because the Prisma client does not yet expose those models.
+
+- [ ] **Step 3: Add schema fields and models**
+
+Update `packages/db/prisma/schema.prisma`:
+
+- extend `InventoryEntity` with:
+  - `attributionMethod String?`
+  - `attributionConfidence Float?`
+  - `attributionEvidence Json?`
+  - `candidateTaxonomy Json?`
+  - relation `softwareEvidence DiscoveredSoftwareEvidence[]`
+- add `DiscoveredSoftwareEvidence`
+- add `SoftwareIdentity`
+- add `SoftwareNormalizationRule`
+
+Model intent:
+
+```prisma
+model DiscoveredSoftwareEvidence {
+  id                    String   @id @default(cuid())
+  inventoryEntityId     String
+  inventoryEntity       InventoryEntity @relation(fields: [inventoryEntityId], references: [id], onDelete: Cascade)
+  evidenceKey           String   @unique
+  evidenceSource        String
+  packageManager        String?
+  rawVendor             String?
+  rawProductName        String?
+  rawPackageName        String?
+  rawVersion            String?
+  installLocation       String?
+  rawMetadata           Json?
+  normalizationStatus   String   @default("needs_review")
+  normalizationConfidence Float?
+  softwareIdentityId    String?
+  softwareIdentity      SoftwareIdentity? @relation(fields: [softwareIdentityId], references: [id], onDelete: SetNull)
+  firstSeenAt           DateTime @default(now())
+  lastSeenAt            DateTime @default(now())
+}
+
+model SoftwareIdentity {
+  id                    String   @id @default(cuid())
+  normalizedVendor      String?
+  normalizedProductName String
+  normalizedEdition     String?
+  canonicalVersion      String?
+  aliases               Json     @default("[]")
+  metadata              Json?
+  evidence              DiscoveredSoftwareEvidence[]
+  normalizationRules    SoftwareNormalizationRule[]
+
+  @@unique([normalizedProductName, normalizedEdition, canonicalVersion])
+}
+
+model SoftwareNormalizationRule {
+  id                    String   @id @default(cuid())
+  ruleKey               String   @unique
+  matchType             String
+  rawSignature          String
+  versionTransform      Json?
+  source                String
+  status                String   @default("active")
+  softwareIdentityId    String
+  softwareIdentity      SoftwareIdentity @relation(fields: [softwareIdentityId], references: [id], onDelete: Cascade)
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+}
+```
+
+- [ ] **Step 4: Create and apply the migration**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db exec prisma migrate dev --name discovery_taxonomy_software_attribution
+```
+
+Expected: migration created and Prisma client regenerated successfully.
+
+- [ ] **Step 5: Run the model smoke test to verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-attribution-model.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations packages/db/src/discovery-attribution-model.test.ts
+git commit -m "feat(db): add discovery attribution and software identity schema"
+```
+
+---
+
+## Chunk 2: Attribution And Software Normalization Logic
+
+### Task 2: Add failing attribution and software normalization tests
+
+**Files:**
+- Create: `packages/db/src/discovery-attribution.test.ts`
+- Create: `packages/db/src/software-normalization.test.ts`
+- Test: `packages/db/src/discovery-attribution.test.ts`
+- Test: `packages/db/src/software-normalization.test.ts`
+
+- [ ] **Step 1: Write failing taxonomy attribution tests**
+
+Create tests covering:
+
+- deterministic foundational host/runtime taxonomy attribution
+- heuristic fallback for non-obvious item types
+- low-confidence result becomes `needs_review`
+
+Example target shape:
+
+```ts
+expect(result.taxonomyNodeSlug).toBe("foundational");
+expect(result.attributionMethod).toBe("rule");
+expect(result.confidence).toBeGreaterThan(0.9);
+```
+
+and:
+
+```ts
+expect(result.attributionStatus).toBe("needs_review");
+expect(result.candidateTaxonomy?.length).toBeGreaterThan(0);
+```
+
+- [ ] **Step 2: Write failing software normalization tests**
+
+Cover:
+
+- deterministic normalization from known package aliases
+- heuristic normalization for noisy names
+- unresolved package stays reviewable
+- rule synthesis helper turns approved heuristic output into a deterministic rule candidate
+
+- [ ] **Step 3: Run targeted tests to verify RED**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-attribution.test.ts software-normalization.test.ts
+```
+
+Expected: FAIL because the modules and logic do not exist yet.
+
+- [ ] **Step 4: Implement taxonomy attribution module**
+
+Create `packages/db/src/discovery-attribution.ts` with focused pure functions:
+
+- `buildDiscoveryDescriptor(...)`
+- `scoreTaxonomyCandidates(...)`
+- `attributeInventoryEntity(...)`
+- `evaluateInventoryQuality(...)` extension for taxonomy confidence issues
+
+Rules for MVP:
+
+- obvious foundational infrastructure maps by rule
+- everything else gets candidate scoring from taxonomy labels
+- no freeform taxonomy invention
+
+- [ ] **Step 5: Implement software normalization module**
+
+Create `packages/db/src/software-normalization.ts` with:
+
+- `normalizeSoftwareEvidence(...)`
+- `matchSoftwareIdentityByRule(...)`
+- `scoreSoftwareIdentityCandidates(...)`
+- `buildNormalizationRuleCandidate(...)`
+
+Keep it deterministic-first. Heuristic scoring should be bounded and explainable.
+
+- [ ] **Step 6: Run targeted tests to verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-attribution.test.ts software-normalization.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/db/src/discovery-attribution.ts packages/db/src/discovery-attribution.test.ts packages/db/src/software-normalization.ts packages/db/src/software-normalization.test.ts
+git commit -m "feat(db): add taxonomy attribution and software normalization logic"
+```
+
+---
+
+## Chunk 3: Normalize Collector Output Into Attributed Entities And Software Evidence
+
+### Task 3: Extend discovery input/output types and normalization
+
+**Files:**
+- Modify: `packages/db/src/discovery-types.ts`
+- Modify: `packages/db/src/discovery-normalize.ts`
+- Modify: `packages/db/src/discovery-runner.ts`
+- Test: existing discovery normalization tests plus new targeted tests
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Add tests proving:
+
+- inventory entities receive attribution metadata
+- host and container items can emit software evidence records
+- normalized output includes software evidence entries
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-normalize.test.ts discovery-runner.test.ts
+```
+
+Expected: FAIL because normalization output does not yet include attribution/software structures.
+
+- [ ] **Step 3: Extend `discovery-types.ts`**
+
+Add optional software evidence arrays to collector output, for example:
+
+```ts
+export type DiscoveredSoftwareInput = {
+  hostExternalRef?: string;
+  containerExternalRef?: string;
+  evidenceSource: string;
+  packageManager?: string;
+  rawVendor?: string;
+  rawProductName?: string;
+  rawPackageName?: string;
+  rawVersion?: string;
+  installLocation?: string;
+  metadata?: Record<string, unknown>;
+};
+```
+
+Update `CollectorOutput` to include `software?: DiscoveredSoftwareInput[]`.
+
+- [ ] **Step 4: Extend `discovery-normalize.ts`**
+
+Update normalized output types to include:
+
+- attribution metadata on `NormalizedInventoryEntity`
+- `NormalizedSoftwareEvidence[]`
+
+Wire in:
+
+- taxonomy attribution for each entity
+- software normalization for host/container software evidence
+
+- [ ] **Step 5: Keep the existing runner contract stable**
+
+`executeBootstrapDiscovery(...)` should still return persistence summary, but pass the richer normalized output into persistence.
+
+- [ ] **Step 6: Run tests to verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-normalize.test.ts discovery-runner.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/db/src/discovery-types.ts packages/db/src/discovery-normalize.ts packages/db/src/discovery-runner.ts
+git commit -m "feat(db): normalize discovery attribution and software evidence"
+```
+
+---
+
+## Chunk 4: Persistence, Quality, And Graph Projection Inputs
+
+### Task 4: Persist attribution metadata and software evidence
+
+**Files:**
+- Modify: `packages/db/src/discovery-sync.ts`
+- Modify: `packages/db/src/discovery-sync.test.ts`
+- Modify: `packages/db/src/index.ts`
+
+- [ ] **Step 1: Write failing persistence tests**
+
+Extend `packages/db/src/discovery-sync.test.ts` to prove:
+
+- `taxonomyNodeId`, attribution metadata, and candidate JSON are persisted on inventory entities
+- software evidence rows are persisted and linked to inventory entities
+- low-confidence attribution creates the appropriate quality issue
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-sync.test.ts
+```
+
+Expected: FAIL because sync does not persist the new fields/models.
+
+- [ ] **Step 3: Update `discovery-sync.ts`**
+
+Add:
+
+- taxonomy node lookup/connect during inventory upsert
+- attribution metadata persistence
+- software evidence upsert/create behavior
+- quality issue creation for low-confidence taxonomy/software normalization
+
+Do not broaden graph projection yet beyond what the current sync adapters already support. Keep graph projection input enriched but still bounded.
+
+- [ ] **Step 4: Export new helpers from the db barrel**
+
+Update `packages/db/src/index.ts` to export the new attribution/normalization helpers needed by other layers.
+
+- [ ] **Step 5: Run test to verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/db/src/discovery-sync.ts packages/db/src/discovery-sync.test.ts packages/db/src/index.ts
+git commit -m "feat(db): persist taxonomy attribution and software evidence"
+```
+
+---
+
+## Chunk 5: Inventory Read Models And Minimal UI Surfacing
+
+### Task 5: Expose attribution metadata in inventory reads
+
+**Files:**
+- Modify: `apps/web/lib/discovery-data.ts`
+- Modify: `apps/web/components/inventory/InventoryEntityPanel.tsx`
+- Modify: `apps/web/app/(shell)/inventory/page.tsx`
+
+- [ ] **Step 1: Write failing UI/data tests**
+
+If test coverage exists, add assertions that inventory reads now expose:
+
+- taxonomy node label
+- attribution method/confidence
+- unresolved review signal
+
+If no dedicated UI test exists, add a focused data-layer test instead.
+
+- [ ] **Step 2: Run the targeted test to verify RED**
+
+Run the smallest relevant command, for example:
+
+```bash
+pnpm --filter web test -- app/(shell)/inventory/page.test.tsx lib/discovery-data.test.ts
+```
+
+Expected: FAIL because the read model or component does not expose the new fields yet.
+
+- [ ] **Step 3: Update discovery reads and panel rendering**
+
+Surface:
+
+- taxonomy node
+- attribution method/confidence
+- needs-review/unmapped signal
+
+Keep this additive. Do not redesign the inventory route.
+
+- [ ] **Step 4: Run the targeted test to verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter web test -- app/(shell)/inventory/page.test.tsx lib/discovery-data.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/discovery-data.ts apps/web/components/inventory/InventoryEntityPanel.tsx apps/web/app/(shell)/inventory/page.tsx
+git commit -m "feat(web): show discovery taxonomy attribution state"
+```
+
+---
+
+## Chunk 6: Final Verification And Spec Sync
+
+### Task 6: Verify the slice and sync documentation
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md`
+
+- [ ] **Step 1: Update the spec with implementation notes**
+
+Record what shipped in this slice and what remains deferred.
+
+- [ ] **Step 2: Run focused DB and web verification**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db test -- discovery-attribution-model.test.ts discovery-attribution.test.ts software-normalization.test.ts discovery-normalize.test.ts discovery-sync.test.ts
+pnpm --filter web test -- app/(shell)/inventory/page.test.tsx lib/discovery-data.test.ts
+pnpm --filter web build
+```
+
+Expected:
+
+- all targeted DB tests pass
+- targeted web tests pass
+- build succeeds
+
+- [ ] **Step 3: Commit doc sync**
+
+```bash
+git add docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md
+git commit -m "docs: sync discovery taxonomy attribution spec status"
+```
+
+---
+
+## Notes
+
+- Keep this slice additive. Do not attempt full digital-product reconstruction here.
+- Do not mutate `seed.ts` to represent runtime discovery outcomes.
+- Taxonomy attribution and software normalization must preserve uncertainty as managed quality work rather than dropping ambiguous evidence.

--- a/docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md
+++ b/docs/superpowers/specs/2026-03-13-phase-7b-agent-coworker-ux-design.md
@@ -52,18 +52,24 @@ The existing `AgentThread` already has `onDelete: Cascade` on the user relation 
 
 ### Route-to-Agent Mapping
 
-A static mapping defines which specialist agent handles each route prefix:
+A combined mapping defines which specialist agent handles each route prefix and which capability gates it. Routes with `capability: null` are accessible to all authenticated users.
 
 ```typescript
-const ROUTE_AGENT_MAP: Record<string, string> = {
-  "/portfolio":  "portfolio-advisor",
-  "/inventory":  "inventory-specialist",
-  "/ea":         "ea-architect",
-  "/employee":   "hr-specialist",
-  "/ops":        "ops-coordinator",
-  "/platform":   "platform-engineer",
-  "/admin":      "admin-assistant",   // forward-looking — activates when admin route is built
-  "/workspace":  "workspace-guide",
+type RouteAgentEntry = {
+  agentId: string;
+  capability: CapabilityKey | null;  // null = no gate, all authenticated users
+};
+
+const ROUTE_AGENT_MAP: Record<string, RouteAgentEntry> = {
+  "/portfolio":  { agentId: "portfolio-advisor",     capability: "view_portfolio" },
+  "/inventory":  { agentId: "inventory-specialist",  capability: "view_inventory" },
+  "/ea":         { agentId: "ea-architect",           capability: "view_ea_modeler" },
+  "/employee":   { agentId: "hr-specialist",          capability: "view_employee" },
+  "/customer":   { agentId: "customer-advisor",       capability: "view_customer" },
+  "/ops":        { agentId: "ops-coordinator",        capability: "view_operations" },
+  "/platform":   { agentId: "platform-engineer",      capability: "view_platform" },
+  "/admin":      { agentId: "admin-assistant",        capability: "view_admin" },      // forward-looking
+  "/workspace":  { agentId: "workspace-guide",        capability: null },               // all authenticated users
 };
 ```
 
@@ -111,7 +117,7 @@ This is persisted as a `role: "system"` message in the database and rendered cen
 
 ### `resolveAgentForRoute(pathname, userContext)`
 
-Pure function in `apps/web/lib/agent-routing.ts`. Imports and reuses the existing `UserContext` type from `permissions.ts` (which has `platformRole: string | null`):
+Pure function in `apps/web/lib/agent-routing.ts`. Reuses the existing `UserContext` type from `permissions.ts` (which has `platformRole: string | null`). **Prerequisite:** export the existing `UserContext` type in `permissions.ts` (add `export` keyword to the declaration at line 50).
 
 ```typescript
 import type { UserContext } from "@/lib/permissions";
@@ -129,10 +135,11 @@ function resolveAgentForRoute(pathname: string, userContext: UserContext): Agent
 ### Resolution Logic
 
 1. Match `pathname` against `ROUTE_AGENT_MAP` using longest prefix match
-2. If `userContext.platformRole` is `null`, return agent with `canAssist: false`
-3. Check if the user has the capability for that route's domain (reuse `can()` from permissions)
-4. If the user lacks permission: return the agent with `canAssist: false` — the agent will explain it cannot help with actions outside the user's authority
-5. If no route matches: fall back to `"workspace-guide"`
+2. If no route matches: fall back to `"workspace-guide"` (capability `null`)
+3. If the matched entry has `capability: null`: return agent with `canAssist: true` (ungated route)
+4. If `userContext.platformRole` is `null`: return agent with `canAssist: false`
+5. Check if the user has the entry's capability via `can()` from permissions
+6. If the user lacks permission: return the agent with `canAssist: false` — the agent will explain it cannot help with actions outside the user's authority
 
 ### Role-Aware Behavior
 

--- a/docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md
+++ b/docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md
@@ -473,3 +473,23 @@ Suggested implementation areas:
 - inventory quality/read surfaces as needed
 
 This slice should remain additive and should not attempt full product reconstruction or business-record restoration.
+
+---
+
+## Implemented Slice Status
+
+Implemented in this branch:
+
+- inventory entities now persist taxonomy attribution metadata including method, confidence, evidence, and review candidates
+- discovery includes deterministic-first taxonomy attribution with heuristic fallback and low-confidence quality issue generation
+- software evidence is captured for host installed software and Docker container images
+- software normalization supports deterministic rules, heuristic candidate scoring, and deterministic rule-candidate synthesis
+- bootstrap discovery now loads taxonomy nodes from the live database automatically when explicit taxonomy options are not provided
+- inventory UI surfaces taxonomy path, attribution method, confidence, and review-needed state
+
+Deferred:
+
+- automatic loading of software identities and normalization rules from runtime data stores
+- deeper package inspection inside containers beyond image-level evidence
+- AI-assisted attribution and normalization proposal execution
+- full digital-product reconstruction from discovered evidence

--- a/docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md
+++ b/docs/superpowers/specs/2026-03-14-discovery-taxonomy-attribution-design.md
@@ -1,0 +1,475 @@
+# Discovery Taxonomy Attribution Design
+
+**Date:** 2026-03-14  
+**Status:** Draft  
+**Scope:** Extend bootstrap discovery so discovered infrastructure, runtime, product-function evidence, and software/package evidence are matched to the appropriate taxonomy descriptor with confidence, attribution method, normalization evidence, and exception handling for low-confidence cases.
+
+---
+
+## Overview
+
+The platform already has:
+
+- a loaded taxonomy with 481 nodes
+- a bootstrap discovery foundation
+- normalized inventory entities and relationships
+- quality issue surfacing
+
+What is missing is taxonomy-aware attribution. Today, bootstrap discovery can place an entity into the `Foundational` portfolio, but it does not assign that entity to the correct taxonomy descriptor. That leaves the graph incomplete for later impact analysis, product responsibility mapping, and quality reporting.
+
+This slice adds a taxonomy attribution stage to discovery so each discovered entity attempts to find its best taxonomy fit. Strong matches are persisted directly. Weak or conflicting matches are preserved as proposed candidates and surfaced through a review queue rather than being silently dropped.
+
+This same slice also needs to begin software identification. Host-installed software, OS packages, and container package evidence should be captured in a way that supports later:
+
+- license analysis
+- vulnerability analysis
+- technical-debt reporting
+- product/version normalization
+
+The long-term direction is an in-platform agent that performs this attribution continuously. The MVP slice should establish the same pipeline shape now with deterministic and heuristic steps first, and a clean seam for later AI-assisted classification. For software normalization, heuristics are allowed to discover the mapping, but deterministic rules should become the durable operational path over time.
+
+---
+
+## Goals
+
+1. Attempt taxonomy attribution for every discovered entity.
+2. Persist both the selected taxonomy node and the evidence behind the match.
+3. Support deterministic, heuristic, and future AI-assisted attribution methods.
+4. Create exception issues only when confidence is low or candidates conflict.
+5. Keep discovered operational entities visible in the graph even when taxonomy attribution is uncertain.
+6. Make the result useful for later impact analysis, provider-side reporting, and digital product reconstruction.
+7. Capture raw software/package evidence and normalized software identity without turning every package immediately into a first-class graph node.
+8. Reduce future cognitive load by promoting approved heuristic results into deterministic rules.
+
+---
+
+## Non-Goals
+
+- Full remote network discovery
+- Freeform AI invention of new taxonomy nodes
+- Automatic creation of new taxonomy descriptors
+- Full digital-product reconstruction in this slice
+- Automatic restoration of epics or backlog from discovery output
+- Broad graph projection of every software package as an operational node in this slice
+
+---
+
+## Current-State Problem
+
+Current discovery normalization in `packages/db/src/discovery-normalize.ts` can:
+
+- derive stable discovered keys
+- create normalized inventory entities
+- assign foundational infrastructure to the `foundational` portfolio
+
+Current discovery persistence in `packages/db/src/discovery-sync.ts` can:
+
+- persist inventory entities and relationships
+- mark stale entities
+- create quality issues for attribution gaps
+
+But the pipeline does not yet:
+
+- assign `taxonomyNodeId`
+- record attribution method
+- record attribution confidence
+- store attribution evidence or candidate taxonomy matches
+- distinguish deterministic vs heuristic vs AI-proposed taxonomy fits
+- capture raw software/package evidence
+- normalize software product identity and version from noisy installation/package signals
+
+As a result, discovered entities are visible operationally but not semantically grounded in the taxonomy.
+
+---
+
+## Chosen Approach
+
+Three approaches were considered:
+
+1. Deterministic-only taxonomy rules
+2. AI-first taxonomy classification
+3. Hybrid attribution pipeline
+
+This design chooses **option 3**.
+
+Reasoning:
+
+- infrastructure and runtime entities often have obvious rule-based mappings
+- product-function evidence needs broader semantic comparison to the taxonomy
+- low-confidence items should become managed quality issues, not silent failures
+- the same staged pipeline can later be executed by an in-platform AI coworker
+- software normalization needs stable raw evidence plus a progressively improving deterministic catalog
+
+---
+
+## Architecture
+
+Add a new attribution stage between normalization and persistence:
+
+1. Collect runtime facts
+2. Normalize discovered facts into stable records
+3. Attribute each normalized entity to taxonomy candidates
+4. Normalize software/package evidence into stable software identities
+5. Persist:
+   - chosen taxonomy node when confidence is sufficient
+   - attribution method
+   - attribution confidence
+   - evidence and candidate set
+   - software evidence and normalized software identity
+6. Raise open quality issues for low-confidence or conflicting cases
+7. Project the discovered entity and taxonomy relationship into graph/inventory views
+
+This keeps the discovered entity as the operational source record while also attaching the provider-side semantic classification needed for analysis.
+
+Software identification should run in the same pipeline family:
+
+1. collect raw software/package evidence from host and container contexts
+2. normalize noisy software names and versions into a stable software identity
+3. attach the resulting software evidence to the discovered host/container/runtime entity
+4. create review issues when normalization confidence is low
+
+The key design rule is:
+
+**heuristics are allowed to discover the mapping, but deterministic rules should become the durable operational path over time.**
+
+---
+
+## Attribution Pipeline
+
+### 1. Deterministic Pass
+
+Use direct evidence where the mapping is obvious:
+
+- collector type
+- process name
+- container name
+- image name
+- known port
+- runtime technology
+- known platform component identifiers
+
+Examples:
+
+- local host, Docker runtime, Kubernetes runtime, Postgres, Neo4j
+- known DPF platform services if their process or container naming is explicit
+
+Deterministic matches should produce:
+
+- `attributionMethod = "rule"`
+- high confidence
+- explicit evidence entries listing the matched signals
+
+### 2. Heuristic Pass
+
+For entities not resolved deterministically:
+
+- create a normalized textual descriptor from the discovered evidence
+- compare that descriptor to taxonomy node labels and relevant descriptor text
+- produce ranked candidate matches
+- persist the top candidates with confidence scores
+
+Heuristics should be bounded and explainable. They should not fabricate taxonomy structure.
+
+Heuristic matches should produce:
+
+- `attributionMethod = "heuristic"`
+- ranked candidates
+- evidence such as token overlap, signature matches, and matched descriptors
+
+### 3. AI-Assisted Proposal Pass
+
+Only for unresolved or ambiguous entities:
+
+- send bounded candidate sets to a classifier
+- require:
+  - selected taxonomy node
+  - confidence
+  - rationale
+  - optional alternate candidates
+
+The classifier must not invent new taxonomy nodes. It only chooses among provided candidates.
+
+AI-assisted matches should produce:
+
+- `attributionMethod = "ai_proposed"`
+- persisted rationale/evidence
+- a review issue if confidence is below threshold
+
+### 4. Rule Synthesis And Operationalization
+
+The platform should not remain permanently dependent on expensive heuristic or AI analysis for the same signatures.
+
+Expected lifecycle:
+
+1. A new discovered signature has no deterministic match.
+2. Heuristic or AI-assisted analysis proposes the best taxonomy and software identity fit.
+3. A human or policy-approved process accepts the result.
+4. The accepted result becomes a new deterministic attribution/normalization rule.
+5. Future runs use the deterministic rule first.
+
+This progressively reduces cognitive load and operational cost over time.
+
+### 5. Persistence Decision
+
+- above threshold: persist selected `taxonomyNodeId`
+- below threshold: persist candidates and create a quality issue
+- conflicting strong candidates: create a review issue
+- no candidate: mark `unmapped`
+
+The entity itself is still persisted regardless of attribution certainty.
+
+For software normalization:
+
+- if normalized software identity confidence is high, persist directly
+- if confidence is low, persist raw evidence plus candidates and create a review issue
+- if no normalized match exists, preserve the raw discovered software evidence as unresolved
+
+---
+
+## Software Identification Design
+
+Software inventory is required for later licensing, vulnerability, and technical-debt analysis, but the first slice cannot model every installed package as a first-class graph node without creating unmanageable scale.
+
+The first slice should therefore use two layers:
+
+### 1. Software Evidence Layer
+
+Persist the raw software/package facts as discovered:
+
+- discovered host or container context
+- package manager or source type
+- raw package name
+- raw display name
+- raw vendor/publisher text
+- raw version string
+- architecture/edition when present
+- install path, image, or repository metadata
+- evidence source and discovery timestamp
+
+This layer must remain lossless and auditable.
+
+### 2. Normalized Software Identity Layer
+
+Resolve raw software evidence to a stable normalized identity:
+
+- normalized vendor
+- normalized product name
+- normalized version
+- normalized edition or package variant
+- confidence
+- alias/fingerprint basis
+
+One normalized software identity may map to many raw signatures.
+
+This structure supports:
+
+- later SBOM and vulnerability analysis
+- license normalization
+- version lifecycle and technical-debt reporting
+- repeated matching without reparsing the same noisy signatures each run
+
+### First-Slice Modeling Rule
+
+In the MVP slice:
+
+- software evidence should be first-class in persistence
+- normalized software identity should be first-class in persistence
+- software evidence should relate to discovered host/container/runtime entities
+- software identities should **not** yet be projected as broad first-class operational graph nodes by default
+
+This keeps the persistence model future-safe without creating graph explosion too early.
+
+---
+
+## Data Model Changes
+
+The first slice should preserve not only the taxonomy assignment, but how it was reached.
+
+### `InventoryEntity`
+
+Add or formalize:
+
+- `taxonomyNodeId`
+- `attributionMethod`
+  - `rule`
+  - `heuristic`
+  - `ai_proposed`
+  - `manual`
+- `attributionConfidence`
+- `attributionEvidenceJson`
+- `candidateTaxonomyJson`
+
+Software-related metadata may live on `InventoryEntity` only when it describes the entity itself, not package inventory. Software/package evidence should be stored separately.
+
+### `DiscoveredSoftwareEvidence`
+
+Add a new persistence model for raw installed software/package evidence:
+
+- discovered entity context
+- evidence source (`host_package`, `host_installed_software`, `container_package`, `container_image_layer`, etc.)
+- raw vendor
+- raw product name
+- raw package name
+- raw version
+- install location or package path
+- package manager type
+- raw metadata JSON
+- first/last seen timestamps
+
+### `SoftwareIdentity`
+
+Add a normalized software identity model:
+
+- normalized vendor
+- normalized product name
+- normalized edition/variant
+- canonical version string
+- alias/fingerprint data
+- confidence or source-of-normalization metadata
+
+### `SoftwareNormalizationRule`
+
+Add a rule model for the deterministic catalog that grows over time:
+
+- match type
+- raw alias/signature pattern
+- resolved software identity
+- version normalization transform
+- status
+- source (`seeded`, `approved_from_heuristic`, `approved_from_ai`, `manual`)
+
+This is the durable operational layer that reduces future heuristic load.
+
+`attributionStatus` remains the primary lifecycle signal:
+
+- `attributed`
+- `needs_review`
+- `unmapped`
+- `stale`
+
+### `PortfolioQualityIssue`
+
+Add or use issue types such as:
+
+- `taxonomy_attribution_low_confidence`
+- `taxonomy_attribution_conflict`
+- `discovered_function_unmapped`
+- `digital_product_match_missing`
+- `software_identity_low_confidence`
+- `software_version_unparsed`
+- `software_alias_conflict`
+
+These issues should remain open until resolved manually or by a later higher-confidence run.
+
+---
+
+## Graph Semantics
+
+Discovery output must support later impact analysis, so the graph should preserve both operational identity and semantic classification.
+
+For each discovered entity:
+
+- keep the operational entity as its own node
+- preserve its runtime or infrastructure relationships
+- attach its taxonomy classification as an explicit relationship
+- later attach digital-product mappings when those become available
+
+This allows later traversal such as:
+
+- runtime dependency -> discovered entity
+- discovered entity -> taxonomy node
+- taxonomy node -> portfolio responsibility
+- discovered entity -> digital product
+- discovered entity -> software evidence
+- software evidence -> normalized software identity
+
+That is the minimum needed for provider-side reporting and downstream analysis.
+
+---
+
+## Confidence And Review Handling
+
+Confidence handling should be explicit:
+
+- high confidence: persist direct attribution
+- medium confidence: persist attribution and flag for review if policy requires
+- low confidence: no final taxonomy assignment, create open quality issue
+
+Low confidence is still valuable. It should become a managed queue, not discarded output.
+
+This aligns with the broader portfolio-quality principle:
+
+- uncertain matches are quality work
+- missing future confirmations are quality work
+- discovered-but-unclassified entities are quality work
+- software signatures without durable normalization are quality work
+
+---
+
+## MVP Slice
+
+The MVP implementation slice should do all of the following:
+
+1. Add taxonomy attribution metadata fields to inventory entities.
+2. Add a dedicated attribution module in `packages/db/src`.
+3. Implement deterministic mappings for obvious platform/runtime entities.
+4. Implement heuristic candidate scoring against taxonomy nodes.
+5. Persist taxonomy candidates and confidence/evidence.
+6. Raise low-confidence review issues.
+7. Add raw software/package evidence capture for host and container contexts.
+8. Add normalized software identity matching with deterministic rules first.
+9. Add a path for heuristic or AI-derived matches to become approved deterministic rules.
+10. Keep AI-assisted attribution behind a clean interface, but do not require it to ship this slice.
+
+This is intentionally enough to improve discovery now without overbuilding the agent path.
+
+---
+
+## Expected Outcomes
+
+After this slice:
+
+- discovered infrastructure is not only in the `Foundational` portfolio, but tied to the right taxonomy descriptor
+- ambiguous product-function discoveries can be proposed against taxonomy with confidence
+- the graph becomes more useful for future impact analysis
+- low-confidence cases are surfaced as quality work instead of being lost
+- a future AI coworker can reuse the same attribution stages rather than replacing them
+- software inventory can begin supporting later license, vulnerability, and version lifecycle analysis
+- normalization effort decreases over time because approved heuristic results become deterministic rules
+
+---
+
+## Testing Strategy
+
+Add focused tests for:
+
+- deterministic rule attribution
+- heuristic candidate ranking
+- low-confidence review issue creation
+- persistence of taxonomy metadata on inventory entities
+- graph projection inputs including taxonomy assignment
+- regression case: foundational host/runtime discovery remains attributed even after taxonomy logic is added
+- host software evidence capture
+- container package evidence capture
+- software identity normalization from noisy names
+- deterministic rule synthesis path from approved heuristic results
+
+Do not rely on manual inspection alone. The attribution path needs repeatable tests because it will become part of bootstrap recovery and later agent automation.
+
+---
+
+## Implementation Notes
+
+Suggested implementation areas:
+
+- `packages/db/prisma/schema.prisma`
+- `packages/db/src/discovery-attribution.ts`
+- `packages/db/src/discovery-attribution.test.ts`
+- `packages/db/src/discovery-sync.ts`
+- `packages/db/src/discovery-sync.test.ts`
+- `packages/db/src/software-normalization.ts`
+- `packages/db/src/software-normalization.test.ts`
+- `apps/web/lib/discovery-data.ts`
+- inventory quality/read surfaces as needed
+
+This slice should remain additive and should not attempt full product reconstruction or business-record restoration.

--- a/docs/superpowers/specs/2026-03-14-mvp-epic-backlog-cleanup-design.md
+++ b/docs/superpowers/specs/2026-03-14-mvp-epic-backlog-cleanup-design.md
@@ -1,0 +1,248 @@
+# MVP Epic & Backlog Cleanup — Design Spec
+
+**Date:** 2026-03-14
+**Goal:** Clean up duplicate/stale backlog items, fix statuses, assign orphans, mark subsumed items, and create three new MVP-critical epics that define the path to a self-iterating platform.
+
+**MVP Definition:** A standalone platform deployment (no VS Code) that can iterate on itself and build new products within the context of the 4 portfolios. AI agents have real conversations, run in Docker with managed Ollama, and can take governed actions with human approval.
+
+---
+
+## Part 1: Backlog Cleanup
+
+### 1.1 Deduplicate (retire 4 thin BI-REST items)
+
+These restored items are covered by original items with richer detail:
+
+| Retire | Covered By | Reason |
+|--------|-----------|--------|
+| BI-REST-080 | BI-PROD-004/005/006/007/008 | Theme items with full acceptance criteria |
+| BI-REST-081 | BI-PROD-009/010/011/012/013 | A11y items with WCAG specs |
+| BI-REST-010 | BI-PROD-001 | Backlog CRUD (same work, less detail) |
+| BI-REST-012 | BI-PROD-002 | DPF self-registration (same work, less detail) |
+
+**Action:** Delete these 4 items from the database.
+
+### 1.2 Fix Statuses (3 items marked wrong)
+
+| Item | Current | Correct | Reason |
+|------|---------|---------|--------|
+| BI-PROD-001 | in-progress | done | Phase 5A Backlog CRUD shipped |
+| BI-PROD-002 | in-progress | done | DPF Portal product exists, seed works |
+| BI-PROD-003 | open | done | Phase 2B/2C agent counts and health metrics shipped |
+
+### 1.3 Assign Orphans to Existing Epics
+
+| Item | Assign To | Reason |
+|------|----------|--------|
+| BI-PORT-001 | EP-PORTAL-FOUND-001 | Portal foundation work |
+| BI-PORT-002 | EP-PORTAL-FOUND-001 | Taxonomy is portal foundation |
+| BI-PORT-003 | EP-PORTAL-FOUND-001 | Portfolio route is portal foundation |
+| BI-PORT-004 | EP-BACKLOG-FOUND-001 | Backlog system work |
+| BI-PROD-001 | EP-BACKLOG-FOUND-001 | Backlog CRUD |
+| BI-PROD-002 | EP-BACKLOG-FOUND-001 | DPF self-registration (backlog context) |
+| BI-PROD-003 | EP-BACKLOG-FOUND-001 | Agent counts are part of product management foundation |
+
+### 1.4 Mark Subsumed Items
+
+| Item | New Status | Reason |
+|------|-----------|--------|
+| BI-REST-042 | done | Subsumed by EP-DEPLOY-001 (new epic covers Docker/Ollama comprehensively) |
+| BI-REST-052 | done | Subsumed by EP-AGENT-EXEC-001 (new epic covers governed task execution) |
+
+### 1.5 Update Parent Epic Statuses
+
+| Epic | New Status | Reason |
+|------|-----------|--------|
+| EP-AI-PROVIDERS-001 | done | All 3 items done (BI-REST-040, 041 done; 042 subsumed) |
+| EP-AI-COWORKER-001 | done | All 3 items done (BI-REST-050, 051 done; 052 subsumed) |
+
+---
+
+## Part 2: New MVP Epics
+
+### 2.1 EP-LLM-LIVE-001 — Live LLM Conversations
+
+**Goal:** Replace canned responses in the co-worker panel with real AI inference via configured providers.
+
+**Architecture:** The existing `callProviderForProfiling` function in `actions/ai-providers.ts` already makes provider-specific API calls (Anthropic `/messages`, OpenAI `/chat/completions`, Ollama `/api/chat`, Gemini `/generateContent`). This epic generalizes that into a chat-capable inference function and wires it into `sendMessage`.
+
+**Prerequisite:** At least one provider must be configured and active (Ollama running locally, or a cloud API key entered).
+
+**Fallback:** When no provider is active, canned responses continue to work (graceful degradation).
+
+#### Backlog Items
+
+**BI-LLM-001: Build `callProvider` generalized inference function**
+- Type: product | Priority: 1 | Status: open
+- Generalize `callProviderForProfiling` into `callProvider(providerId, modelId, messages[], systemPrompt)` supporting multi-turn chat format.
+- Provider-specific request/response formats already handled in profiling code.
+- Return `{ content: string, inputTokens: number, outputTokens: number, inferenceMs: number }`.
+- Handle errors gracefully: provider down, rate limited, model not found.
+
+**BI-LLM-002: Define agent system prompts for all 9 route agents**
+- Type: product | Priority: 2 | Status: open
+- Each route agent (portfolio-advisor, ea-architect, ops-coordinator, etc.) gets a system prompt stored in `ROUTE_AGENT_MAP` alongside existing `agentName`/`agentDescription`.
+- System prompts describe the agent's role, what it can help with, and the user's current route context.
+- Prompts include the user's `platformRole` and capabilities so the agent knows what the user can access.
+
+**BI-LLM-003: Add platform default provider/model selection**
+- Type: product | Priority: 3 | Status: open
+- New fields or config: which provider+model is the default for agent conversations.
+- Selection UI in `/platform/ai` — dropdown of active providers, dropdown of discovered models for that provider.
+- `rankProvidersByCost` already exists for auto-selection fallback.
+- Stored as a platform-level setting (not per-agent — that's a future enhancement).
+
+**BI-LLM-004: Replace canned responses with live inference in `sendMessage`**
+- Type: product | Priority: 4 | Status: open
+- In `sendMessage` server action: after resolving the agent, check if a default provider is configured and active.
+- If yes: build messages array (system prompt + recent thread history + user message), call `callProvider`, persist the response with `agentId` and token counts.
+- If no: fall back to `generateCannedResponse` (existing behavior).
+- Thread history: include last N messages as context (configurable, default 20).
+
+**BI-LLM-005: Wire token usage logging into inference calls**
+- Type: product | Priority: 5 | Status: open
+- `logTokenUsage` already exists. Call it after every successful inference with agentId, providerId, contextKey="coworker", token counts, and computed cost.
+- Token spend is already visible in `/platform/ai` spend dashboard (By Provider / By Agent tabs).
+
+### 2.2 EP-DEPLOY-001 — Standalone Docker Deployment with Managed Ollama
+
+**Goal:** Single `docker compose up` brings the full platform online with portal, Postgres, and managed Ollama. The platform UI manages Docker/Ollama directly — users never touch Docker commands.
+
+**Architecture:** Three-service Docker Compose stack. The portal container mounts the Docker socket to manage the Ollama container. Auto-detection of host GPU/RAM selects an appropriate default model and pulls it automatically on first startup.
+
+#### Backlog Items
+
+**BI-DEPLOY-001: Create portal Dockerfile and Docker Compose stack**
+- Type: product | Priority: 1 | Status: open
+- Multi-stage Dockerfile: install deps → build Next.js standalone → production image.
+- Compose services: `portal` (Next.js, port 3000), `db` (Postgres 16, volume-mounted data), `ollama` (ollama/ollama image, GPU passthrough if available).
+- Environment variables for `DATABASE_URL`, `CREDENTIAL_ENCRYPTION_KEY`, `AUTH_SECRET`.
+- Prisma migrations run automatically on portal startup.
+
+**BI-DEPLOY-002: Build Docker API client for container management**
+- Type: product | Priority: 2 | Status: open
+- Server-side module that talks to Docker Engine API via mounted socket (`/var/run/docker.sock`).
+- Operations: inspect container status, start/stop/restart container, list images, pull image, exec command.
+- Scoped to the Ollama container only (not arbitrary Docker management).
+- Server actions with `manage_provider_connections` auth guard.
+
+**BI-DEPLOY-003: Add Ollama management UI in platform**
+- Type: product | Priority: 3 | Status: open
+- New section in `/platform/ai` or `/platform/ai/ollama`: Ollama container status (running/stopped/not found), start/stop/restart buttons.
+- Model management: list pulled models, pull new model by name, delete model.
+- Real-time pull progress indicator.
+
+**BI-DEPLOY-004: Implement host capability detection and auto-model selection**
+- Type: product | Priority: 4 | Status: open
+- On startup or from platform UI: detect GPU presence (NVIDIA runtime in Docker), available RAM.
+- Model selection matrix: CPU-only + <8GB → `phi3:mini` (~2GB), CPU + 16GB+ → `llama3:8b` (~5GB), GPU + 8GB VRAM → `llama3:8b`, GPU + 16GB+ VRAM → `llama3:70b-q4`.
+- Store detected capabilities and selected model as platform config.
+
+**BI-DEPLOY-005: Auto-pull default model and auto-configure provider on first startup**
+- Type: product | Priority: 5 | Status: open
+- Portal startup sequence: check if Ollama is reachable → check if any models are pulled → if not, trigger pull of auto-selected model → configure Ollama provider to `status: "active"` → set as default provider for agent conversations.
+- This makes the platform usable with zero manual configuration.
+
+**BI-DEPLOY-006: Add health check monitoring and status indicators**
+- Type: product | Priority: 6 | Status: open
+- Docker Compose health checks on all three services.
+- Portal status bar/banner when Ollama is unreachable or no models are available.
+- Health endpoint (`/api/health`) for external monitoring.
+
+### 2.3 EP-AGENT-EXEC-001 — Agent Task Execution with HITL Governance
+
+**Goal:** Agents can propose real actions (create backlog items, modify products, update EA models). Humans approve before execution. Every action is audit-logged for regulated industry compliance.
+
+**Architecture:** New `AgentActionProposal` model captures what the agent wants to do. Proposals render as structured cards in the chat. Approval triggers execution of existing server actions. The `AuthorizationDecisionLog` model (already in schema) records the audit trail.
+
+**Prerequisite:** EP-LLM-LIVE-001 must be complete (agents need real LLM conversations to understand user intent and formulate proposals).
+
+#### Backlog Items
+
+**BI-EXEC-001: Design AgentActionProposal schema**
+- Type: product | Priority: 1 | Status: open
+- New Prisma model: `AgentActionProposal` with fields: id, proposalId (unique), threadId FK, agentId, actionType (create_backlog_item | update_backlog_item | create_digital_product | update_digital_product | update_lifecycle | create_ea_element | create_ea_relationship), parameters (Json), status (proposed | approved | rejected | executed | failed), proposedAt, decidedAt, decidedBy (userId), executedAt, resultEntityId, resultError.
+- FK to AgentMessage (the message that proposed it) for traceability.
+
+**BI-EXEC-002: Build proposal creation from agent inference**
+- Type: product | Priority: 2 | Status: open
+- When the LLM response indicates an action (via tool-use / function-calling pattern), parse the proposed action into an `AgentActionProposal`.
+- Define the tool schemas the LLM can call: `create_backlog_item({ title, type, status, body, epicId? })`, `update_lifecycle({ productId, stage, status })`, `create_ea_element({ viewId, elementTypeSlug, name })`, etc.
+- Agent system prompts updated to include available tools based on user capabilities.
+
+**BI-EXEC-003: Create proposal card rendering in chat UX**
+- Type: product | Priority: 3 | Status: open
+- New message content type or `role: "proposal"` rendering in `AgentMessageBubble`.
+- Card shows: action type (human-readable label), key parameters, affected entity.
+- Approve / Reject buttons inline. Edit button opens parameter adjustment.
+- Approved/rejected state renders differently (green check / red X with timestamp and approver).
+
+**BI-EXEC-004: Implement proposal execution engine**
+- Type: product | Priority: 4 | Status: open
+- On approval: map `actionType` + `parameters` to existing server actions (`createBacklogItem`, `updateBacklogItem`, etc.).
+- Execute with the approving user's auth context (not the agent's).
+- Record result: `executedAt`, `resultEntityId` (the created/updated entity), or `resultError`.
+- Post confirmation message in agent thread.
+
+**BI-EXEC-005: Wire approval events into AuthorizationDecisionLog**
+- Type: product | Priority: 5 | Status: open
+- `AuthorizationDecisionLog` model already exists with `decision` (allow|deny|require_approval), `rationale` (Json), and related fields.
+- Every proposal approval/rejection writes a log entry: who, when, what action, what parameters, decision, rationale (user can optionally add a note).
+- This satisfies the regulated industry requirement: queryable, exportable audit evidence.
+
+**BI-EXEC-006: Add agent action history view in platform**
+- Type: product | Priority: 6 | Status: open
+- New page or section in `/platform` or `/admin`: table of all `AgentActionProposal` records.
+- Filterable by: status (proposed/approved/rejected/executed/failed), agent, action type, date range.
+- Detail view shows full proposal parameters, approval chain, execution result.
+- Export capability for compliance audits.
+
+---
+
+## Part 3: Complete Epic Landscape
+
+### MVP-Critical (build order: A → B → C)
+
+| Epic | Title | Status | Items |
+|------|-------|--------|-------|
+| EP-LLM-LIVE-001 | Live LLM Conversations | open | 5 (BI-LLM-001..005) |
+| EP-DEPLOY-001 | Standalone Docker Deployment with Managed Ollama | open | 6 (BI-DEPLOY-001..006) |
+| EP-AGENT-EXEC-001 | Agent Task Execution with HITL Governance | open | 6 (BI-EXEC-001..006) |
+
+### Active (in-progress, other agents)
+
+| Epic | Title | Status | Open Items |
+|------|-------|--------|------------|
+| EP-EA-MODEL-001 | EA Modeling Foundation and Canvas | in-progress | BI-REST-022 (structured notation) |
+| EP-EA-REF-001 | EA Reference Model Assessment | in-progress | BI-REST-032 (repeatable load) |
+| EP-GOV-FOUND-001 | Identity, Access, Agent Governance | in-progress | BI-REST-060/061/062 |
+| EP-DISCOVERY-001 | Bootstrap Discovery & Portfolio Quality | in-progress | BI-REST-070/071/072 |
+
+### Done
+
+| Epic | Title | Notes |
+|------|-------|-------|
+| EP-PORTAL-FOUND-001 | Portal Foundation | + 3 orphan items assigned |
+| EP-BACKLOG-FOUND-001 | Backlog Foundation | + 4 orphan items assigned, statuses fixed |
+| EP-AI-PROVIDERS-001 | AI Provider Registry | BI-REST-042 subsumed by EP-DEPLOY-001 |
+| EP-AI-COWORKER-001 | AI Agent Co-worker UX | BI-REST-052 subsumed by EP-AGENT-EXEC-001 |
+
+### Deferred (post-MVP)
+
+| Epic | Title | Notes |
+|------|-------|-------|
+| EP-UI-THEME-001 | Theme & Branding Modernization | 5 detailed items with acceptance criteria |
+| EP-UI-A11Y-001 | Dark Theme Usability & Accessibility | 2 open items remaining |
+
+---
+
+## Part 4: Cleanup Script Actions
+
+The following database mutations implement Parts 1.1–1.5:
+
+1. **Delete 4 duplicate items:** BI-REST-080, BI-REST-081, BI-REST-010, BI-REST-012
+2. **Fix 3 statuses:** BI-PROD-001→done, BI-PROD-002→done, BI-PROD-003→done
+3. **Assign 7 orphans:** BI-PORT-001/002/003→EP-PORTAL-FOUND-001, BI-PORT-004/BI-PROD-001/002/003→EP-BACKLOG-FOUND-001
+4. **Mark 2 subsumed:** BI-REST-042→done, BI-REST-052→done
+5. **Update 2 epic statuses:** EP-AI-PROVIDERS-001→done, EP-AI-COWORKER-001→done
+6. **Create 3 new epics** with 17 backlog items total

--- a/packages/db/prisma/migrations/20260314054720_agent_coworker_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260314054720_agent_coworker_fields/migration.sql
@@ -11,5 +11,14 @@ CREATE INDEX "AgentMessage_threadId_idx" ON "AgentMessage"("threadId");
 -- CreateIndex
 CREATE INDEX "AgentMessage_createdAt_idx" ON "AgentMessage"("createdAt");
 
--- RenameIndex
-ALTER INDEX "InventoryRelationship_fromEntityId_toEntityId_relationshipType_" RENAME TO "InventoryRelationship_fromEntityId_toEntityId_relationshipT_key";
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class
+        WHERE relkind = 'i'
+          AND relname = 'InventoryRelationship_fromEntityId_toEntityId_relationshipType_'
+    ) THEN
+        ALTER INDEX "InventoryRelationship_fromEntityId_toEntityId_relationshipType_" RENAME TO "InventoryRelationship_fromEntityId_toEntityId_relationshipT_key";
+    END IF;
+END $$;

--- a/packages/db/prisma/migrations/20260314054720_agent_coworker_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260314054720_agent_coworker_fields/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "AgentMessage" ADD COLUMN     "agentId" TEXT,
+ADD COLUMN     "routeContext" TEXT;
+
+-- AlterTable
+ALTER TABLE "AgentThread" ALTER COLUMN "contextKey" SET DEFAULT 'coworker';
+
+-- CreateIndex
+CREATE INDEX "AgentMessage_threadId_idx" ON "AgentMessage"("threadId");
+
+-- CreateIndex
+CREATE INDEX "AgentMessage_createdAt_idx" ON "AgentMessage"("createdAt");
+
+-- RenameIndex
+ALTER INDEX "InventoryRelationship_fromEntityId_toEntityId_relationshipType_" RENAME TO "InventoryRelationship_fromEntityId_toEntityId_relationshipT_key";

--- a/packages/db/prisma/migrations/20260314070000_discovery_taxonomy_software_attribution/migration.sql
+++ b/packages/db/prisma/migrations/20260314070000_discovery_taxonomy_software_attribution/migration.sql
@@ -1,0 +1,83 @@
+-- AlterTable
+ALTER TABLE "InventoryEntity"
+ADD COLUMN "attributionMethod" TEXT,
+ADD COLUMN "attributionConfidence" DOUBLE PRECISION,
+ADD COLUMN "attributionEvidence" JSONB,
+ADD COLUMN "candidateTaxonomy" JSONB;
+
+-- CreateTable
+CREATE TABLE "DiscoveredSoftwareEvidence" (
+    "id" TEXT NOT NULL,
+    "inventoryEntityId" TEXT NOT NULL,
+    "evidenceKey" TEXT NOT NULL,
+    "evidenceSource" TEXT NOT NULL,
+    "packageManager" TEXT,
+    "rawVendor" TEXT,
+    "rawProductName" TEXT,
+    "rawPackageName" TEXT,
+    "rawVersion" TEXT,
+    "installLocation" TEXT,
+    "rawMetadata" JSONB,
+    "normalizationStatus" TEXT NOT NULL DEFAULT 'needs_review',
+    "normalizationConfidence" DOUBLE PRECISION,
+    "softwareIdentityId" TEXT,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DiscoveredSoftwareEvidence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SoftwareIdentity" (
+    "id" TEXT NOT NULL,
+    "normalizedVendor" TEXT,
+    "normalizedProductName" TEXT NOT NULL,
+    "normalizedEdition" TEXT,
+    "canonicalVersion" TEXT,
+    "aliases" JSONB NOT NULL DEFAULT '[]',
+    "metadata" JSONB,
+
+    CONSTRAINT "SoftwareIdentity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SoftwareNormalizationRule" (
+    "id" TEXT NOT NULL,
+    "ruleKey" TEXT NOT NULL,
+    "matchType" TEXT NOT NULL,
+    "rawSignature" TEXT NOT NULL,
+    "versionTransform" JSONB,
+    "source" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "softwareIdentityId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SoftwareNormalizationRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DiscoveredSoftwareEvidence_evidenceKey_key" ON "DiscoveredSoftwareEvidence"("evidenceKey");
+CREATE INDEX "DiscoveredSoftwareEvidence_inventoryEntityId_idx" ON "DiscoveredSoftwareEvidence"("inventoryEntityId");
+CREATE INDEX "DiscoveredSoftwareEvidence_softwareIdentityId_idx" ON "DiscoveredSoftwareEvidence"("softwareIdentityId");
+CREATE INDEX "DiscoveredSoftwareEvidence_normalizationStatus_idx" ON "DiscoveredSoftwareEvidence"("normalizationStatus");
+
+CREATE UNIQUE INDEX "SoftwareIdentity_normalizedProductName_normalizedEdition_canonicalV_key"
+ON "SoftwareIdentity"("normalizedProductName", "normalizedEdition", "canonicalVersion");
+
+CREATE UNIQUE INDEX "SoftwareNormalizationRule_ruleKey_key" ON "SoftwareNormalizationRule"("ruleKey");
+CREATE INDEX "SoftwareNormalizationRule_softwareIdentityId_idx" ON "SoftwareNormalizationRule"("softwareIdentityId");
+CREATE INDEX "SoftwareNormalizationRule_status_idx" ON "SoftwareNormalizationRule"("status");
+
+-- AddForeignKey
+ALTER TABLE "DiscoveredSoftwareEvidence"
+ADD CONSTRAINT "DiscoveredSoftwareEvidence_inventoryEntityId_fkey"
+FOREIGN KEY ("inventoryEntityId") REFERENCES "InventoryEntity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "DiscoveredSoftwareEvidence"
+ADD CONSTRAINT "DiscoveredSoftwareEvidence_softwareIdentityId_fkey"
+FOREIGN KEY ("softwareIdentityId") REFERENCES "SoftwareIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "SoftwareNormalizationRule"
+ADD CONSTRAINT "SoftwareNormalizationRule_softwareIdentityId_fkey"
+FOREIGN KEY ("softwareIdentityId") REFERENCES "SoftwareIdentity"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -608,7 +608,7 @@ model AgentThread {
   id         String         @id @default(cuid())
   userId     String
   user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-  contextKey String
+  contextKey String @default("coworker")
   messages   AgentMessage[]
   createdAt  DateTime       @default(now())
   updatedAt  DateTime       @updatedAt
@@ -617,13 +617,18 @@ model AgentThread {
 }
 
 model AgentMessage {
-  id        String      @id @default(cuid())
-  threadId  String
-  thread    AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
-  role      String      // user | assistant | system
-  content   String
-  tone      String?
-  createdAt DateTime    @default(now())
+  id           String      @id @default(cuid())
+  threadId     String
+  thread       AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  role         String      // user | assistant | system
+  content      String
+  tone         String?
+  agentId      String?     // specialist agent that authored this response
+  routeContext String?     // route pathname when message was sent
+  createdAt    DateTime    @default(now())
+
+  @@index([threadId])
+  @@index([createdAt])
 }
 
 // ─── EA Modeling ─────────────────────────────────────────────────────────────

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -11,16 +11,16 @@ datasource db {
 // ─── Auth ───────────────────────────────────────────────────────────────────
 
 model User {
-  id           String        @id @default(cuid())
-  email        String        @unique
-  passwordHash String
-  isActive     Boolean       @default(true)
-  isSuperuser  Boolean       @default(false)
-  createdAt    DateTime      @default(now())
-  groups       UserGroup[]
-  agentThreads AgentThread[]
-  teamMemberships     TeamMembership[]
-  grantedDelegations  DelegationGrant[] @relation("DelegationGrantGrantor")
+  id                 String            @id @default(cuid())
+  email              String            @unique
+  passwordHash       String
+  isActive           Boolean           @default(true)
+  isSuperuser        Boolean           @default(false)
+  createdAt          DateTime          @default(now())
+  groups             UserGroup[]
+  agentThreads       AgentThread[]
+  teamMemberships    TeamMembership[]
+  grantedDelegations DelegationGrant[] @relation("DelegationGrantGrantor")
 }
 
 model UserGroup {
@@ -46,13 +46,13 @@ model CustomerContact {
 // ─── Roles ──────────────────────────────────────────────────────────────────
 
 model PlatformRole {
-  id            String      @id @default(cuid())
-  roleId        String      @unique // HR-000 … HR-500
-  name          String
-  description   String?
-  hitlTierMin   Int         @default(1)
-  slaDurationH  Int?
-  users         UserGroup[]
+  id           String      @id @default(cuid())
+  roleId       String      @unique // HR-000 … HR-500
+  name         String
+  description  String?
+  hitlTierMin  Int         @default(1)
+  slaDurationH Int?
+  users        UserGroup[]
 }
 
 // ─── Identity Governance ─────────────────────────────────────────────────────
@@ -75,12 +75,12 @@ model TeamMembership {
   id        String   @id @default(cuid())
   teamId    String
   userId    String
-  role      String   // member | manager | approver | operator
+  role      String // member | manager | approver | operator
   isPrimary Boolean  @default(false)
   createdAt DateTime @default(now())
 
-  team      Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  user      User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([teamId, userId])
   @@index([userId])
@@ -89,36 +89,36 @@ model TeamMembership {
 // ─── Portfolios & Products ───────────────────────────────────────────────────
 
 model Portfolio {
-  id          String           @id @default(cuid())
-  slug        String           @unique
-  name        String
-  description String?
-  rootNodeId  String?
-  budgetKUsd  Int?             // annual budget in $k — null means unset/unknown
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
-  products        DigitalProduct[]
-  agents          Agent[]
-  epicPortfolios  EpicPortfolio[]
-  eaElements      EaElement[]
+  id                     String                  @id @default(cuid())
+  slug                   String                  @unique
+  name                   String
+  description            String?
+  rootNodeId             String?
+  budgetKUsd             Int? // annual budget in $k — null means unset/unknown
+  createdAt              DateTime                @default(now())
+  updatedAt              DateTime                @updatedAt
+  products               DigitalProduct[]
+  agents                 Agent[]
+  epicPortfolios         EpicPortfolio[]
+  eaElements             EaElement[]
   inventoryEntities      InventoryEntity[]
   portfolioQualityIssues PortfolioQualityIssue[]
 }
 
 model DigitalProduct {
-  id              String        @id @default(cuid())
-  productId       String        @unique
-  name            String
-  lifecycleStage  String        @default("plan")   // plan | design | build | production | retirement
-  lifecycleStatus String        @default("draft")  // draft | active | inactive
-  portfolioId     String?
-  portfolio       Portfolio?    @relation(fields: [portfolioId], references: [id])
-  taxonomyNodeId  String?
-  taxonomyNode    TaxonomyNode? @relation(fields: [taxonomyNodeId], references: [id])
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
-  backlogItems    BacklogItem[]
-  eaElements      EaElement[]
+  id                     String                  @id @default(cuid())
+  productId              String                  @unique
+  name                   String
+  lifecycleStage         String                  @default("plan") // plan | design | build | production | retirement
+  lifecycleStatus        String                  @default("draft") // draft | active | inactive
+  portfolioId            String?
+  portfolio              Portfolio?              @relation(fields: [portfolioId], references: [id])
+  taxonomyNodeId         String?
+  taxonomyNode           TaxonomyNode?           @relation(fields: [taxonomyNodeId], references: [id])
+  createdAt              DateTime                @default(now())
+  updatedAt              DateTime                @updatedAt
+  backlogItems           BacklogItem[]
+  eaElements             EaElement[]
   inventoryEntities      InventoryEntity[]
   portfolioQualityIssues PortfolioQualityIssue[]
 }
@@ -126,20 +126,20 @@ model DigitalProduct {
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
 model TaxonomyNode {
-  id          String           @id @default(cuid())
-  nodeId      String           @unique
-  name        String
-  portfolioId String?
-  parentId    String?
-  parent      TaxonomyNode?    @relation("TaxonomyTree", fields: [parentId], references: [id])
-  children    TaxonomyNode[]   @relation("TaxonomyTree")
-  products    DigitalProduct[]
-  backlogItems BacklogItem[]
-  eaElements  EaElement[]
+  id                     String                  @id @default(cuid())
+  nodeId                 String                  @unique
+  name                   String
+  portfolioId            String?
+  parentId               String?
+  parent                 TaxonomyNode?           @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children               TaxonomyNode[]          @relation("TaxonomyTree")
+  products               DigitalProduct[]
+  backlogItems           BacklogItem[]
+  eaElements             EaElement[]
   inventoryEntities      InventoryEntity[]
   portfolioQualityIssues PortfolioQualityIssue[]
-  status      String           @default("active")
-  governance  Json?
+  status                 String                  @default("active")
+  governance             Json?
 }
 
 // ─── Backlog ─────────────────────────────────────────────────────────────────
@@ -148,8 +148,8 @@ model BacklogItem {
   id               String          @id @default(cuid())
   itemId           String          @unique
   title            String
-  status           String          // open | in-progress | done | deferred
-  type             String          // product | portfolio
+  status           String // open | in-progress | done | deferred
+  type             String // product | portfolio
   body             String?
   priority         Int?
   digitalProductId String?
@@ -165,24 +165,24 @@ model BacklogItem {
 // ─── Epics ───────────────────────────────────────────────────────────────────
 
 model Epic {
-  id          String          @id @default(cuid())
-  epicId      String          @unique
+  id          String   @id @default(cuid())
+  epicId      String   @unique
   title       String
   description String?
-  status      String          @default("open")
-  createdAt   DateTime        @default(now())
-  updatedAt   DateTime        @updatedAt
+  status      String   @default("open")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  portfolios  EpicPortfolio[]
-  items       BacklogItem[]
+  portfolios EpicPortfolio[]
+  items      BacklogItem[]
 }
 
 model EpicPortfolio {
   epicId      String
   portfolioId String
 
-  epic        Epic      @relation(fields: [epicId], references: [id], onDelete: Cascade)
-  portfolio   Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
+  epic      Epic      @relation(fields: [epicId], references: [id], onDelete: Cascade)
+  portfolio Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
 
   @@id([epicId, portfolioId])
 }
@@ -313,30 +313,30 @@ model ScheduledJob {
 // ─── Agents ──────────────────────────────────────────────────────────────────
 
 model Agent {
-  id          String   @id @default(cuid())
-  agentId     String   @unique
-  name        String
-  tier        Int
-  type        String   // orchestrator | specialist | cross-cutting
-  description String?
-  status      String   @default("active")
-  createdAt   DateTime @default(now())
-  portfolioId  String?
-  portfolio    Portfolio?  @relation(fields: [portfolioId], references: [id])
-  ownerships          AgentOwnership[]
-  governanceProfile   AgentGovernanceProfile?
-  delegationGrants    DelegationGrant[]
+  id                String                  @id @default(cuid())
+  agentId           String                  @unique
+  name              String
+  tier              Int
+  type              String // orchestrator | specialist | cross-cutting
+  description       String?
+  status            String                  @default("active")
+  createdAt         DateTime                @default(now())
+  portfolioId       String?
+  portfolio         Portfolio?              @relation(fields: [portfolioId], references: [id])
+  ownerships        AgentOwnership[]
+  governanceProfile AgentGovernanceProfile?
+  delegationGrants  DelegationGrant[]
 }
 
 model AgentOwnership {
   id             String   @id @default(cuid())
   agentId        String
   teamId         String
-  responsibility String   // owning_team | operating_team | approving_team
+  responsibility String // owning_team | operating_team | approving_team
   createdAt      DateTime @default(now())
 
-  agent          Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  team           Team  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  agent Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  team  Team  @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
   @@unique([agentId, teamId, responsibility])
   @@index([teamId])
@@ -347,7 +347,7 @@ model AgentCapabilityClass {
   capabilityClassId  String   @unique
   name               String
   description        String?
-  riskBand           String   // low | medium | high | critical
+  riskBand           String // low | medium | high | critical
   defaultActionScope Json
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
@@ -356,15 +356,15 @@ model AgentCapabilityClass {
 }
 
 model DirectivePolicyClass {
-  id                String   @id @default(cuid())
-  policyClassId     String   @unique
-  name              String
-  description       String?
-  configCategory    String   // persona | workflow | tool_access | compliance | domain_rules
-  approvalMode      String   // self_service | manager_approval | admin_approval
-  allowedRiskBand   String
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  id              String   @id @default(cuid())
+  policyClassId   String   @unique
+  name            String
+  description     String?
+  configCategory  String // persona | workflow | tool_access | compliance | domain_rules
+  approvalMode    String // self_service | manager_approval | admin_approval
+  allowedRiskBand String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   governanceProfiles AgentGovernanceProfile[]
 }
@@ -374,43 +374,43 @@ model AgentGovernanceProfile {
   agentId                String   @unique
   capabilityClassId      String
   directivePolicyClassId String
-  autonomyLevel          String   // advisory | constrained_execute | supervised_execute | elevated_execute
-  hitlPolicy             String   // always | risk_based | never_without_grant
+  autonomyLevel          String // advisory | constrained_execute | supervised_execute | elevated_execute
+  hitlPolicy             String // always | risk_based | never_without_grant
   allowDelegation        Boolean  @default(true)
-  maxDelegationRiskBand  String?  // low | medium | high | critical
+  maxDelegationRiskBand  String? // low | medium | high | critical
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 
-  agent                  Agent                @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  capabilityClass        AgentCapabilityClass @relation(fields: [capabilityClassId], references: [id])
-  directivePolicyClass   DirectivePolicyClass @relation(fields: [directivePolicyClassId], references: [id])
+  agent                Agent                @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  capabilityClass      AgentCapabilityClass @relation(fields: [capabilityClassId], references: [id])
+  directivePolicyClass DirectivePolicyClass @relation(fields: [directivePolicyClassId], references: [id])
 
   @@index([capabilityClassId])
   @@index([directivePolicyClassId])
 }
 
 model DelegationGrant {
-  id                 String   @id @default(cuid())
-  grantId            String   @unique
-  grantorUserId      String
-  granteeAgentId     String
-  targetUserId       String?
-  scopeJson          Json
-  reason             String?
-  riskBand           String
-  status             String   @default("active") // active | expired | revoked | consumed
-  validFrom          DateTime
-  expiresAt          DateTime
-  maxUses            Int?
-  useCount           Int      @default(0)
-  workflowKey        String?
-  objectRef          String?
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  id             String   @id @default(cuid())
+  grantId        String   @unique
+  grantorUserId  String
+  granteeAgentId String
+  targetUserId   String?
+  scopeJson      Json
+  reason         String?
+  riskBand       String
+  status         String   @default("active") // active | expired | revoked | consumed
+  validFrom      DateTime
+  expiresAt      DateTime
+  maxUses        Int?
+  useCount       Int      @default(0)
+  workflowKey    String?
+  objectRef      String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  grantorUser        User  @relation("DelegationGrantGrantor", fields: [grantorUserId], references: [id])
-  granteeAgent       Agent @relation(fields: [granteeAgentId], references: [id], onDelete: Cascade)
-  decisionLogs       AuthorizationDecisionLog[]
+  grantorUser  User                       @relation("DelegationGrantGrantor", fields: [grantorUserId], references: [id])
+  granteeAgent Agent                      @relation(fields: [granteeAgentId], references: [id], onDelete: Cascade)
+  decisionLogs AuthorizationDecisionLog[]
 
   @@index([grantorUserId])
   @@index([granteeAgentId])
@@ -420,18 +420,18 @@ model DelegationGrant {
 model AuthorizationDecisionLog {
   id                String   @id @default(cuid())
   decisionId        String   @unique
-  actorType         String   // user | customer_contact | agent
+  actorType         String // user | customer_contact | agent
   actorRef          String
   humanContextRef   String?
   agentContextRef   String?
   delegationGrantId String?
   actionKey         String
   objectRef         String?
-  decision          String   // allow | deny | require_approval
+  decision          String // allow | deny | require_approval
   rationale         Json
   createdAt         DateTime @default(now())
 
-  delegationGrant   DelegationGrant? @relation(fields: [delegationGrantId], references: [id], onDelete: SetNull)
+  delegationGrant DelegationGrant? @relation(fields: [delegationGrantId], references: [id], onDelete: SetNull)
 
   @@index([decision])
   @@index([createdAt])
@@ -461,39 +461,39 @@ model RuntimeAdvisory {
 // ─── Agent Threads ───────────────────────────────────────────────────────────
 
 model DiscoveryRun {
-  id                  String                  @id @default(cuid())
-  runKey              String                  @unique
+  id                  String                   @id @default(cuid())
+  runKey              String                   @unique
   sourceSlug          String
-  trigger             String                  @default("bootstrap")
-  status              String                  @default("running")
-  startedAt           DateTime                @default(now())
+  trigger             String                   @default("bootstrap")
+  status              String                   @default("running")
+  startedAt           DateTime                 @default(now())
   completedAt         DateTime?
-  itemCount           Int                     @default(0)
-  relationshipCount   Int                     @default(0)
+  itemCount           Int                      @default(0)
+  relationshipCount   Int                      @default(0)
   notes               Json?
   discoveredItems     DiscoveredItem[]
   discoveredRelations DiscoveredRelationship[]
-  confirmedEntities   InventoryEntity[]       @relation("InventoryEntityConfirmedRun")
-  confirmedRelations  InventoryRelationship[] @relation("InventoryRelationshipConfirmedRun")
+  confirmedEntities   InventoryEntity[]        @relation("InventoryEntityConfirmedRun")
+  confirmedRelations  InventoryRelationship[]  @relation("InventoryRelationshipConfirmedRun")
 }
 
 model DiscoveredItem {
-  id                 String                   @id @default(cuid())
-  discoveryRunId     String
-  discoveryRun       DiscoveryRun             @relation(fields: [discoveryRunId], references: [id], onDelete: Cascade)
-  observedKey        String
-  itemType           String
-  name               String
-  sourcePath         String?
-  confidence         Float?
-  attributionStatus  String                   @default("unmapped")
-  rawData            Json
-  firstSeenAt        DateTime                 @default(now())
-  lastSeenAt         DateTime                 @default(now())
-  inventoryEntityId  String?
-  inventoryEntity    InventoryEntity?         @relation(fields: [inventoryEntityId], references: [id], onDelete: SetNull)
-  fromRelationships  DiscoveredRelationship[] @relation("DiscoveredRelationshipFromItem")
-  toRelationships    DiscoveredRelationship[] @relation("DiscoveredRelationshipToItem")
+  id                String                   @id @default(cuid())
+  discoveryRunId    String
+  discoveryRun      DiscoveryRun             @relation(fields: [discoveryRunId], references: [id], onDelete: Cascade)
+  observedKey       String
+  itemType          String
+  name              String
+  sourcePath        String?
+  confidence        Float?
+  attributionStatus String                   @default("unmapped")
+  rawData           Json
+  firstSeenAt       DateTime                 @default(now())
+  lastSeenAt        DateTime                 @default(now())
+  inventoryEntityId String?
+  inventoryEntity   InventoryEntity?         @relation(fields: [inventoryEntityId], references: [id], onDelete: SetNull)
+  fromRelationships DiscoveredRelationship[] @relation("DiscoveredRelationshipFromItem")
+  toRelationships   DiscoveredRelationship[] @relation("DiscoveredRelationshipToItem")
 
   @@unique([discoveryRunId, observedKey])
   @@index([itemType])
@@ -520,35 +520,96 @@ model DiscoveredRelationship {
 }
 
 model InventoryEntity {
-  id                 String                  @id @default(cuid())
-  entityKey          String                  @unique
-  entityType         String
-  name               String
-  status             String                  @default("active")
-  attributionStatus  String                  @default("needs_review")
-  confidence         Float?
-  providerView       String                  @default("foundational")
-  properties         Json                    @default("{}")
-  firstSeenAt        DateTime                @default(now())
-  lastSeenAt         DateTime                @default(now())
-  lastConfirmedRunId String?
-  lastConfirmedRun   DiscoveryRun?           @relation("InventoryEntityConfirmedRun", fields: [lastConfirmedRunId], references: [id], onDelete: SetNull)
-  portfolioId        String?
-  portfolio          Portfolio?              @relation(fields: [portfolioId], references: [id], onDelete: SetNull)
-  taxonomyNodeId     String?
-  taxonomyNode       TaxonomyNode?           @relation(fields: [taxonomyNodeId], references: [id], onDelete: SetNull)
-  digitalProductId   String?
-  digitalProduct     DigitalProduct?         @relation(fields: [digitalProductId], references: [id], onDelete: SetNull)
-  discoveredItems    DiscoveredItem[]
-  fromRelationships  InventoryRelationship[] @relation("InventoryRelationshipFromEntity")
-  toRelationships    InventoryRelationship[] @relation("InventoryRelationshipToEntity")
-  qualityIssues      PortfolioQualityIssue[]
+  id                    String                       @id @default(cuid())
+  entityKey             String                       @unique
+  entityType            String
+  name                  String
+  status                String                       @default("active")
+  attributionStatus     String                       @default("needs_review")
+  confidence            Float?
+  attributionMethod     String?
+  attributionConfidence Float?
+  attributionEvidence   Json?
+  candidateTaxonomy     Json?
+  providerView          String                       @default("foundational")
+  properties            Json                         @default("{}")
+  firstSeenAt           DateTime                     @default(now())
+  lastSeenAt            DateTime                     @default(now())
+  lastConfirmedRunId    String?
+  lastConfirmedRun      DiscoveryRun?                @relation("InventoryEntityConfirmedRun", fields: [lastConfirmedRunId], references: [id], onDelete: SetNull)
+  portfolioId           String?
+  portfolio             Portfolio?                   @relation(fields: [portfolioId], references: [id], onDelete: SetNull)
+  taxonomyNodeId        String?
+  taxonomyNode          TaxonomyNode?                @relation(fields: [taxonomyNodeId], references: [id], onDelete: SetNull)
+  digitalProductId      String?
+  digitalProduct        DigitalProduct?              @relation(fields: [digitalProductId], references: [id], onDelete: SetNull)
+  discoveredItems       DiscoveredItem[]
+  softwareEvidence      DiscoveredSoftwareEvidence[]
+  fromRelationships     InventoryRelationship[]      @relation("InventoryRelationshipFromEntity")
+  toRelationships       InventoryRelationship[]      @relation("InventoryRelationshipToEntity")
+  qualityIssues         PortfolioQualityIssue[]
 
   @@index([entityType])
   @@index([attributionStatus])
   @@index([portfolioId])
   @@index([taxonomyNodeId])
   @@index([digitalProductId])
+}
+
+model DiscoveredSoftwareEvidence {
+  id                      String            @id @default(cuid())
+  inventoryEntityId       String
+  inventoryEntity         InventoryEntity   @relation(fields: [inventoryEntityId], references: [id], onDelete: Cascade)
+  evidenceKey             String            @unique
+  evidenceSource          String
+  packageManager          String?
+  rawVendor               String?
+  rawProductName          String?
+  rawPackageName          String?
+  rawVersion              String?
+  installLocation         String?
+  rawMetadata             Json?
+  normalizationStatus     String            @default("needs_review")
+  normalizationConfidence Float?
+  softwareIdentityId      String?
+  softwareIdentity        SoftwareIdentity? @relation(fields: [softwareIdentityId], references: [id], onDelete: SetNull)
+  firstSeenAt             DateTime          @default(now())
+  lastSeenAt              DateTime          @default(now())
+
+  @@index([inventoryEntityId])
+  @@index([softwareIdentityId])
+  @@index([normalizationStatus])
+}
+
+model SoftwareIdentity {
+  id                    String                       @id @default(cuid())
+  normalizedVendor      String?
+  normalizedProductName String
+  normalizedEdition     String?
+  canonicalVersion      String?
+  aliases               Json                         @default("[]")
+  metadata              Json?
+  evidence              DiscoveredSoftwareEvidence[]
+  normalizationRules    SoftwareNormalizationRule[]
+
+  @@unique([normalizedProductName, normalizedEdition, canonicalVersion])
+}
+
+model SoftwareNormalizationRule {
+  id                 String           @id @default(cuid())
+  ruleKey            String           @unique
+  matchType          String
+  rawSignature       String
+  versionTransform   Json?
+  source             String
+  status             String           @default("active")
+  softwareIdentityId String
+  softwareIdentity   SoftwareIdentity @relation(fields: [softwareIdentityId], references: [id], onDelete: Cascade)
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+
+  @@index([softwareIdentityId])
+  @@index([status])
 }
 
 model InventoryRelationship {
@@ -608,7 +669,7 @@ model AgentThread {
   id         String         @id @default(cuid())
   userId     String
   user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-  contextKey String @default("coworker")
+  contextKey String         @default("coworker")
   messages   AgentMessage[]
   createdAt  DateTime       @default(now())
   updatedAt  DateTime       @updatedAt
@@ -620,11 +681,11 @@ model AgentMessage {
   id           String      @id @default(cuid())
   threadId     String
   thread       AgentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
-  role         String      // user | assistant | system
+  role         String // user | assistant | system
   content      String
   tone         String?
-  agentId      String?     // specialist agent that authored this response
-  routeContext String?     // route pathname when message was sent
+  agentId      String? // specialist agent that authored this response
+  routeContext String? // route pathname when message was sent
   createdAt    DateTime    @default(now())
 
   @@index([threadId])
@@ -634,24 +695,24 @@ model AgentMessage {
 // ─── EA Modeling ─────────────────────────────────────────────────────────────
 
 model EaNotation {
-  id           String               @id @default(cuid())
-  slug         String               @unique  // "archimate4" | "uml2" | "bpmn2"
-  name         String               // "ArchiMate 4"
-  version      String               // "4.0"
-  elementTypes EaElementType[]
-  relTypes     EaRelationshipType[]
-  dqRules      EaDqRule[]
+  id             String               @id @default(cuid())
+  slug           String               @unique // "archimate4" | "uml2" | "bpmn2"
+  name           String // "ArchiMate 4"
+  version        String // "4.0"
+  elementTypes   EaElementType[]
+  relTypes       EaRelationshipType[]
+  dqRules        EaDqRule[]
   structureRules EaStructureRule[]
-  views        EaView[]
+  views          EaView[]
 }
 
 model EaReferenceModel {
-  id              String                    @id @default(cuid())
-  slug            String                    @unique
+  id              String                     @id @default(cuid())
+  slug            String                     @unique
   name            String
   version         String
   authorityType   String
-  status          String                    @default("draft")
+  status          String                     @default("draft")
   description     String?
   primaryIndustry String?
   sourceSummary   String?
@@ -659,8 +720,8 @@ model EaReferenceModel {
   elements        EaReferenceModelElement[]
   assessments     EaReferenceAssessment[]
   proposals       EaReferenceProposal[]
-  createdAt       DateTime                  @default(now())
-  updatedAt       DateTime                  @updatedAt
+  createdAt       DateTime                   @default(now())
+  updatedAt       DateTime                   @updatedAt
 }
 
 model EaReferenceModelElement {
@@ -686,16 +747,16 @@ model EaReferenceModelElement {
 }
 
 model EaReferenceModelArtifact {
-  id         String           @id @default(cuid())
-  modelId     String
-  model       EaReferenceModel @relation(fields: [modelId], references: [id], onDelete: Cascade)
-  kind        String
-  path        String
-  checksum    String?
-  authority   String
-  importedAt  DateTime?
-  proposals   EaReferenceProposal[]
-  createdAt   DateTime         @default(now())
+  id         String                @id @default(cuid())
+  modelId    String
+  model      EaReferenceModel      @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  kind       String
+  path       String
+  checksum   String?
+  authority  String
+  importedAt DateTime?
+  proposals  EaReferenceProposal[]
+  createdAt  DateTime              @default(now())
 
   @@unique([modelId, path])
   @@index([modelId, authority])
@@ -716,21 +777,21 @@ model EaAssessmentScope {
 }
 
 model EaReferenceAssessment {
-  id              String                 @id @default(cuid())
+  id              String                  @id @default(cuid())
   scopeId         String
-  scope           EaAssessmentScope      @relation(fields: [scopeId], references: [id], onDelete: Cascade)
+  scope           EaAssessmentScope       @relation(fields: [scopeId], references: [id], onDelete: Cascade)
   modelId         String
-  model           EaReferenceModel       @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  model           EaReferenceModel        @relation(fields: [modelId], references: [id], onDelete: Cascade)
   modelElementId  String
   modelElement    EaReferenceModelElement @relation(fields: [modelElementId], references: [id], onDelete: Cascade)
   coverageStatus  String
-  mvpIncluded     Boolean                @default(true)
+  mvpIncluded     Boolean                 @default(true)
   evidenceSummary String?
   rationale       String?
   confidence      String?
   assessedById    String?
-  updatedAt       DateTime               @updatedAt
-  createdAt       DateTime               @default(now())
+  updatedAt       DateTime                @updatedAt
+  createdAt       DateTime                @default(now())
 
   @@unique([scopeId, modelElementId])
   @@index([modelId, coverageStatus])
@@ -759,10 +820,10 @@ model EaElementType {
   id                     String               @id @default(cuid())
   notationId             String
   notation               EaNotation           @relation(fields: [notationId], references: [id])
-  slug                   String               // "business_capability"
-  name                   String               // "Business Capability"
-  neoLabel               String               // "ArchiMate__BusinessCapability" — set in seed
-  domain                 String               // "business"|"application"|"technology"|"strategy"|"motivation"|"common"|"impl_migration"
+  slug                   String // "business_capability"
+  name                   String // "Business Capability"
+  neoLabel               String // "ArchiMate__BusinessCapability" — set in seed
+  domain                 String // "business"|"application"|"technology"|"strategy"|"motivation"|"common"|"impl_migration"
   description            String?
   validLifecycleStages   String[]
   validLifecycleStatuses String[]
@@ -772,6 +833,7 @@ model EaElementType {
   toRules                EaRelationshipRule[] @relation("ToType")
   parentStructureRules   EaStructureRule[]    @relation("EaStructureRuleParent")
   childStructureRules    EaStructureRule[]    @relation("EaStructureRuleChild")
+
   @@unique([notationId, slug])
 }
 
@@ -779,12 +841,13 @@ model EaRelationshipType {
   id            String               @id @default(cuid())
   notationId    String
   notation      EaNotation           @relation(fields: [notationId], references: [id])
-  slug          String               // "realizes"
-  name          String               // "Realizes"
-  neoType       String               // "REALIZES"
+  slug          String // "realizes"
+  name          String // "Realizes"
+  neoType       String // "REALIZES"
   description   String?
   rules         EaRelationshipRule[]
   relationships EaRelationship[]
+
   @@unique([notationId, slug])
 }
 
@@ -796,46 +859,47 @@ model EaRelationshipRule {
   toElementType      EaElementType      @relation("ToType", fields: [toElementTypeId], references: [id])
   relationshipTypeId String
   relationshipType   EaRelationshipType @relation(fields: [relationshipTypeId], references: [id])
+
   @@unique([fromElementTypeId, toElementTypeId, relationshipTypeId])
 }
 
 model EaDqRule {
-  id              String         @id @default(cuid())
-  notationId      String
-  notation        EaNotation     @relation(fields: [notationId], references: [id])
-  elementTypeId   String?
-  elementType     EaElementType? @relation(fields: [elementTypeId], references: [id])
-  name            String
-  description     String?
-  lifecycleStage  String
-  severity        String         @default("error")  // "error" | "warn"
-  rule            Json
+  id             String         @id @default(cuid())
+  notationId     String
+  notation       EaNotation     @relation(fields: [notationId], references: [id])
+  elementTypeId  String?
+  elementType    EaElementType? @relation(fields: [elementTypeId], references: [id])
+  name           String
+  description    String?
+  lifecycleStage String
+  severity       String         @default("error") // "error" | "warn"
+  rule           Json
 }
 
 model EaElement {
-  id               String             @id @default(cuid())
-  elementTypeId    String
-  elementType      EaElementType      @relation(fields: [elementTypeId], references: [id])
-  name             String
-  description      String?
-  properties       Json               @default("{}")
-  lifecycleStage   String             @default("plan")
-  lifecycleStatus  String             @default("draft")
-  createdById      String?
-  digitalProductId String?
-  digitalProduct   DigitalProduct?    @relation(fields: [digitalProductId], references: [id])
-  infraCiKey       String?
-  portfolioId      String?
-  portfolio        Portfolio?         @relation(fields: [portfolioId], references: [id])
-  taxonomyNodeId   String?
-  taxonomyNode     TaxonomyNode?      @relation(fields: [taxonomyNodeId], references: [id])
-  fromRelationships EaRelationship[]  @relation("FromElement")
-  toRelationships   EaRelationship[]  @relation("ToElement")
+  id                String               @id @default(cuid())
+  elementTypeId     String
+  elementType       EaElementType        @relation(fields: [elementTypeId], references: [id])
+  name              String
+  description       String?
+  properties        Json                 @default("{}")
+  lifecycleStage    String               @default("plan")
+  lifecycleStatus   String               @default("draft")
+  createdById       String?
+  digitalProductId  String?
+  digitalProduct    DigitalProduct?      @relation(fields: [digitalProductId], references: [id])
+  infraCiKey        String?
+  portfolioId       String?
+  portfolio         Portfolio?           @relation(fields: [portfolioId], references: [id])
+  taxonomyNodeId    String?
+  taxonomyNode      TaxonomyNode?        @relation(fields: [taxonomyNodeId], references: [id])
+  fromRelationships EaRelationship[]     @relation("FromElement")
+  toRelationships   EaRelationship[]     @relation("ToElement")
   viewElements      EaViewElement[]
   conformanceIssues EaConformanceIssue[]
   syncedAt          DateTime?
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
 
   @@index([portfolioId])
   @@index([taxonomyNodeId])
@@ -864,42 +928,42 @@ model EaRelationship {
 }
 
 model EaView {
-  id          String          @id @default(cuid())
-  notationId  String
-  notation    EaNotation      @relation(fields: [notationId], references: [id])
-  name        String
-  description String?
-  layoutType  String          // "graph"|"swimlane"|"matrix"|"layered"
-  scopeType   String          // "portfolio"|"domain"|"custom"
-  scopeRef    String?
-  createdById String?
-  viewElements EaViewElement[]
-  status       String          @default("draft")
-  submittedAt  DateTime?
-  submittedById String?
-  approvedAt   DateTime?
-  approvedById String?
-  canvasState  Json?
-  viewpointId  String?
-  viewpoint    ViewpointDefinition? @relation(fields: [viewpointId], references: [id])
+  id                String               @id @default(cuid())
+  notationId        String
+  notation          EaNotation           @relation(fields: [notationId], references: [id])
+  name              String
+  description       String?
+  layoutType        String // "graph"|"swimlane"|"matrix"|"layered"
+  scopeType         String // "portfolio"|"domain"|"custom"
+  scopeRef          String?
+  createdById       String?
+  viewElements      EaViewElement[]
+  status            String               @default("draft")
+  submittedAt       DateTime?
+  submittedById     String?
+  approvedAt        DateTime?
+  approvedById      String?
+  canvasState       Json?
+  viewpointId       String?
+  viewpoint         ViewpointDefinition? @relation(fields: [viewpointId], references: [id])
   conformanceIssues EaConformanceIssue[]
-  snapshots    EaSnapshot[]
-  createdAt    DateTime        @default(now())
-  updatedAt    DateTime        @updatedAt
+  snapshots         EaSnapshot[]
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
 }
 
 model EaViewElement {
-  id                 String    @id @default(cuid())
-  viewId             String
-  view               EaView    @relation(fields: [viewId], references: [id], onDelete: Cascade)
-  elementId          String
-  element            EaElement @relation(fields: [elementId], references: [id])
+  id                  String          @id @default(cuid())
+  viewId              String
+  view                EaView          @relation(fields: [viewId], references: [id], onDelete: Cascade)
+  elementId           String
+  element             EaElement       @relation(fields: [elementId], references: [id])
   parentViewElementId String?
   parentViewElement   EaViewElement?  @relation("EaViewElementParent", fields: [parentViewElementId], references: [id], onDelete: SetNull)
   childViewElements   EaViewElement[] @relation("EaViewElementParent")
   orderIndex          Int?
-  mode               String    @default("new")
-  proposedProperties Json?
+  mode                String          @default("new")
+  proposedProperties  Json?
 
   @@unique([viewId, elementId])
   @@index([elementId])
@@ -907,40 +971,40 @@ model EaViewElement {
 }
 
 model EaStructureRule {
-  id                     String        @id @default(cuid())
-  notationId             String
-  notation               EaNotation    @relation(fields: [notationId], references: [id])
-  parentElementTypeId    String
-  parentElementType      EaElementType @relation("EaStructureRuleParent", fields: [parentElementTypeId], references: [id])
-  childElementTypeId     String
-  childElementType       EaElementType @relation("EaStructureRuleChild", fields: [childElementTypeId], references: [id])
-  patternSlug            String
-  minChildren            Int?
-  maxChildren            Int?
-  orderedChildren        Boolean       @default(false)
+  id                      String        @id @default(cuid())
+  notationId              String
+  notation                EaNotation    @relation(fields: [notationId], references: [id])
+  parentElementTypeId     String
+  parentElementType       EaElementType @relation("EaStructureRuleParent", fields: [parentElementTypeId], references: [id])
+  childElementTypeId      String
+  childElementType        EaElementType @relation("EaStructureRuleChild", fields: [childElementTypeId], references: [id])
+  patternSlug             String
+  minChildren             Int?
+  maxChildren             Int?
+  orderedChildren         Boolean       @default(false)
   impliedRelationshipSlug String?
-  defaultSeverity        String        @default("warn")
-  rendererHint           String?
-  createdAt              DateTime      @default(now())
-  updatedAt              DateTime      @updatedAt
+  defaultSeverity         String        @default("warn")
+  rendererHint            String?
+  createdAt               DateTime      @default(now())
+  updatedAt               DateTime      @updatedAt
 
   @@unique([notationId, parentElementTypeId, childElementTypeId, patternSlug])
   @@index([notationId, patternSlug])
 }
 
 model EaConformanceIssue {
-  id          String    @id @default(cuid())
-  viewId       String?
-  view         EaView?   @relation(fields: [viewId], references: [id], onDelete: Cascade)
-  elementId    String?
-  element      EaElement? @relation(fields: [elementId], references: [id], onDelete: Cascade)
-  issueType    String
-  severity     String    @default("warn")
-  message      String
-  status       String    @default("open")
-  detailsJson  Json?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  id          String     @id @default(cuid())
+  viewId      String?
+  view        EaView?    @relation(fields: [viewId], references: [id], onDelete: Cascade)
+  elementId   String?
+  element     EaElement? @relation(fields: [elementId], references: [id], onDelete: Cascade)
+  issueType   String
+  severity    String     @default("warn")
+  message     String
+  status      String     @default("open")
+  detailsJson Json?
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
 
   @@index([viewId, status])
   @@index([elementId, status])

--- a/packages/db/src/discovery-attribution-model.test.ts
+++ b/packages/db/src/discovery-attribution-model.test.ts
@@ -1,0 +1,16 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { PrismaClient } from "../generated/client";
+
+const prisma = new PrismaClient();
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("discovery attribution Prisma client", () => {
+  it("exposes software normalization delegates", () => {
+    expect(prisma.discoveredSoftwareEvidence).toBeDefined();
+    expect(prisma.softwareIdentity).toBeDefined();
+    expect(prisma.softwareNormalizationRule).toBeDefined();
+  });
+});

--- a/packages/db/src/discovery-attribution.test.ts
+++ b/packages/db/src/discovery-attribution.test.ts
@@ -1,20 +1,150 @@
 import { describe, expect, it } from "vitest";
 
-import { evaluateInventoryQuality } from "./discovery-attribution";
+import {
+  attributeInventoryEntity,
+  evaluateInventoryQuality,
+  scoreTaxonomyCandidates,
+  type TaxonomyNodeCandidate,
+} from "./discovery-attribution";
+
+const taxonomyNodes: TaxonomyNodeCandidate[] = [
+  {
+    nodeId: "foundational/compute/servers",
+    name: "Servers",
+    portfolioSlug: "foundational",
+  },
+  {
+    nodeId: "foundational/platform_services/container_platform",
+    name: "Container Platform",
+    portfolioSlug: "foundational",
+  },
+  {
+    nodeId: "products_and_services_sold/customer_relationship_management",
+    name: "Customer Relationship Management",
+    portfolioSlug: "products_and_services_sold",
+  },
+  {
+    nodeId: "for_employees/employee_services",
+    name: "Employee Services",
+    portfolioSlug: "for_employees",
+  },
+];
+
+describe("scoreTaxonomyCandidates", () => {
+  it("prefers close textual matches for heuristic attribution", () => {
+    const ranked = scoreTaxonomyCandidates(
+      "customer relationship management portal for accounts and leads",
+      taxonomyNodes,
+    );
+
+    expect(ranked[0]?.nodeId).toBe("products_and_services_sold/customer_relationship_management");
+    expect(ranked[0]?.score).toBeGreaterThan(ranked[1]?.score ?? 0);
+  });
+});
+
+describe("attributeInventoryEntity", () => {
+  it("maps a host to the foundational compute taxonomy by rule", () => {
+    const result = attributeInventoryEntity(
+      {
+        entityKey: "host:hostname:dpf-dev",
+        entityType: "host",
+        itemType: "host",
+        name: "dpf-dev",
+        properties: { platform: "linux" },
+      },
+      taxonomyNodes,
+    );
+
+    expect(result.taxonomyNodeId).toBe("foundational/compute/servers");
+    expect(result.portfolioSlug).toBe("foundational");
+    expect(result.attributionMethod).toBe("rule");
+    expect(result.attributionStatus).toBe("attributed");
+    expect(result.confidence).toBeGreaterThan(0.9);
+  });
+
+  it("maps a docker runtime to the container platform taxonomy by rule", () => {
+    const result = attributeInventoryEntity(
+      {
+        entityKey: "runtime:socket:/var/run/docker.sock",
+        entityType: "runtime",
+        itemType: "docker_runtime",
+        name: "Docker",
+        properties: { socketPath: "/var/run/docker.sock" },
+      },
+      taxonomyNodes,
+    );
+
+    expect(result.taxonomyNodeId).toBe("foundational/platform_services/container_platform");
+    expect(result.attributionMethod).toBe("rule");
+    expect(result.attributionStatus).toBe("attributed");
+  });
+
+  it("falls back to heuristic matching for non-obvious discovered functions", () => {
+    const result = attributeInventoryEntity(
+      {
+        entityKey: "service:crm-portal",
+        entityType: "service",
+        itemType: "application_service",
+        name: "CRM Portal",
+        properties: {
+          description: "Customer relationship management portal for accounts and leads",
+        },
+      },
+      taxonomyNodes,
+    );
+
+    expect(result.taxonomyNodeId).toBe("products_and_services_sold/customer_relationship_management");
+    expect(result.portfolioSlug).toBe("products_and_services_sold");
+    expect(result.attributionMethod).toBe("heuristic");
+    expect(result.attributionStatus).toBe("attributed");
+    expect(result.confidence).toBeGreaterThan(0.55);
+    expect(result.candidateTaxonomy?.[0]?.nodeId).toBe(
+      "products_and_services_sold/customer_relationship_management",
+    );
+  });
+
+  it("keeps low-confidence matches in needs-review with candidates", () => {
+    const result = attributeInventoryEntity(
+      {
+        entityKey: "service:mystery-engine",
+        entityType: "service",
+        itemType: "application_service",
+        name: "Mystery Engine",
+        properties: {
+          description: "Internal automation engine",
+        },
+      },
+      taxonomyNodes,
+    );
+
+    expect(result.attributionStatus).toBe("needs_review");
+    expect(result.attributionMethod).toBe("heuristic");
+    expect(result.taxonomyNodeId).toBeNull();
+    expect(result.candidateTaxonomy?.length).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThan(0.55);
+  });
+});
 
 describe("evaluateInventoryQuality", () => {
-  it("creates a needs-review issue for an unmapped runtime entity", () => {
+  it("creates a taxonomy low-confidence issue for reviewable entities", () => {
     const result = evaluateInventoryQuality([
       {
-        entityKey: "service:dpf-web",
+        entityKey: "service:mystery-engine",
         entityType: "service",
         attributionStatus: "needs_review",
+        attributionMethod: "heuristic",
+        attributionConfidence: 0.32,
+        candidateTaxonomy: [
+          { nodeId: "for_employees/employee_services", score: 0.32 },
+        ],
         taxonomyNodeId: null,
         digitalProductId: null,
         qualityStatus: "warning",
       },
     ]);
 
-    expect(result.issues[0]?.issueType).toBe("attribution_missing");
+    expect(result.issues.map((issue) => issue.issueType)).toContain(
+      "taxonomy_attribution_low_confidence",
+    );
   });
 });

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -1,7 +1,60 @@
+const LOW_CONFIDENCE_THRESHOLD = 0.55;
+const STOP_WORDS = new Set([
+  "and",
+  "app",
+  "application",
+  "engine",
+  "for",
+  "internal",
+  "management",
+  "platform",
+  "portal",
+  "service",
+  "services",
+  "system",
+  "the",
+]);
+
+export type TaxonomyNodeCandidate = {
+  nodeId: string;
+  name: string;
+  portfolioSlug?: string | null;
+};
+
+export type RankedTaxonomyCandidate = TaxonomyNodeCandidate & {
+  score: number;
+  evidence: string[];
+};
+
+export type InventoryAttributionInput = {
+  entityKey: string;
+  entityType: string;
+  itemType?: string;
+  name: string;
+  properties?: Record<string, unknown>;
+};
+
+export type InventoryAttributionResult = {
+  taxonomyNodeId: string | null;
+  portfolioSlug: string | null;
+  attributionMethod: "rule" | "heuristic";
+  attributionStatus: "attributed" | "needs_review";
+  confidence: number;
+  candidateTaxonomy: RankedTaxonomyCandidate[];
+  evidence: {
+    descriptor: string;
+    ruleId?: string;
+    matchedSignals: string[];
+  };
+};
+
 export type InventoryQualityEntityInput = {
   entityKey: string;
   entityType: string;
   attributionStatus: "attributed" | "needs_review" | "unmapped" | "stale";
+  attributionMethod?: "rule" | "heuristic" | "manual" | "ai_proposed" | null;
+  attributionConfidence?: number | null;
+  candidateTaxonomy?: Array<{ nodeId: string; score: number }> | null;
   taxonomyNodeId?: string | null;
   digitalProductId?: string | null;
   qualityStatus?: "warning" | "error";
@@ -27,6 +80,175 @@ export type InventoryQualityEvaluation = {
   issues: InventoryQualityIssue[];
 };
 
+function normalizeToken(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function tokenize(value: string): string[] {
+  return normalizeToken(value)
+    .split(/\s+/)
+    .map((token) => token.replace(/s$/, ""))
+    .filter((token) => token.length > 1 && !STOP_WORDS.has(token));
+}
+
+function toSentence(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => toSentence(entry)).join(" ");
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).map((entry) => toSentence(entry)).join(" ");
+  }
+
+  return "";
+}
+
+function resolvePortfolioSlug(node: TaxonomyNodeCandidate): string | null {
+  if (node.portfolioSlug) {
+    return node.portfolioSlug;
+  }
+
+  const [root] = node.nodeId.split("/");
+  return root || null;
+}
+
+function findRuleMatch(
+  input: InventoryAttributionInput,
+  taxonomyNodes: TaxonomyNodeCandidate[],
+): InventoryAttributionResult | null {
+  const itemType = (input.itemType ?? input.entityType).toLowerCase();
+  const matchByNodeId = (matcher: (nodeId: string) => boolean) =>
+    taxonomyNodes.find((node) => matcher(node.nodeId.toLowerCase()));
+
+  let node: TaxonomyNodeCandidate | undefined;
+  let ruleId: string | undefined;
+
+  if (input.entityType === "host" || itemType === "host") {
+    node = matchByNodeId((nodeId) => nodeId.endsWith("/servers"));
+    ruleId = node ? "foundational_host_servers" : undefined;
+  } else if (itemType.includes("docker") || itemType.includes("container")) {
+    node = matchByNodeId((nodeId) => nodeId.includes("container_platform"));
+    ruleId = node ? "container_platform_runtime" : undefined;
+  } else if (itemType.includes("database")) {
+    node = matchByNodeId((nodeId) => nodeId.endsWith("/database"));
+    ruleId = node ? "foundational_database" : undefined;
+  } else if (itemType.includes("network")) {
+    node = matchByNodeId((nodeId) => nodeId.includes("network_management"));
+    ruleId = node ? "foundational_network" : undefined;
+  } else if (itemType.includes("storage")) {
+    node = matchByNodeId((nodeId) => nodeId.endsWith("/online_storage"));
+    ruleId = node ? "foundational_storage" : undefined;
+  }
+
+  if (!node || !ruleId) {
+    return null;
+  }
+
+  return {
+    taxonomyNodeId: node.nodeId,
+    portfolioSlug: resolvePortfolioSlug(node),
+    attributionMethod: "rule",
+    attributionStatus: "attributed",
+    confidence: 0.98,
+    candidateTaxonomy: [
+      {
+        ...node,
+        score: 0.98,
+        evidence: [ruleId],
+      },
+    ],
+    evidence: {
+      descriptor: buildDiscoveryDescriptor(input),
+      ruleId,
+      matchedSignals: [input.entityType, itemType],
+    },
+  };
+}
+
+export function buildDiscoveryDescriptor(input: InventoryAttributionInput): string {
+  const propertiesText = toSentence(input.properties ?? {});
+  return [input.entityType, input.itemType, input.name, propertiesText]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ");
+}
+
+export function scoreTaxonomyCandidates(
+  descriptor: string,
+  taxonomyNodes: TaxonomyNodeCandidate[],
+): RankedTaxonomyCandidate[] {
+  const descriptorText = normalizeToken(descriptor);
+  const descriptorTokens = tokenize(descriptor);
+  const descriptorTokenSet = new Set(descriptorTokens);
+
+  return taxonomyNodes
+    .map((node) => {
+      const labelText = `${node.name} ${node.nodeId.split("/").join(" ")}`;
+      const nodeTokens = tokenize(labelText);
+      const overlap = nodeTokens.filter((token) => descriptorTokenSet.has(token));
+      const nodeCoverage = nodeTokens.length > 0 ? overlap.length / nodeTokens.length : 0;
+      const descriptorCoverage = descriptorTokens.length > 0 ? overlap.length / descriptorTokens.length : 0;
+      const phraseBonus = descriptorText.includes(normalizeToken(node.name)) ? 0.2 : 0;
+      const score = Math.min(0.95, Number((nodeCoverage * 0.7 + descriptorCoverage * 0.3 + phraseBonus).toFixed(3)));
+
+      return {
+        ...node,
+        score,
+        evidence: overlap.length > 0 ? overlap : ["fallback_candidate"],
+      };
+    })
+    .sort((left, right) => right.score - left.score)
+    .slice(0, 5);
+}
+
+export function attributeInventoryEntity(
+  input: InventoryAttributionInput,
+  taxonomyNodes: TaxonomyNodeCandidate[],
+): InventoryAttributionResult {
+  const ruleMatch = findRuleMatch(input, taxonomyNodes);
+  if (ruleMatch) {
+    return ruleMatch;
+  }
+
+  const descriptor = buildDiscoveryDescriptor(input);
+  const ranked = scoreTaxonomyCandidates(descriptor, taxonomyNodes);
+  const best = ranked[0] ?? null;
+
+  if (!best || best.score < LOW_CONFIDENCE_THRESHOLD) {
+    return {
+      taxonomyNodeId: null,
+      portfolioSlug: null,
+      attributionMethod: "heuristic",
+      attributionStatus: "needs_review",
+      confidence: best?.score ?? 0,
+      candidateTaxonomy: ranked,
+      evidence: {
+        descriptor,
+        matchedSignals: best?.evidence ?? [],
+      },
+    };
+  }
+
+  return {
+    taxonomyNodeId: best.nodeId,
+    portfolioSlug: resolvePortfolioSlug(best),
+    attributionMethod: "heuristic",
+    attributionStatus: "attributed",
+    confidence: best.score,
+    candidateTaxonomy: ranked,
+    evidence: {
+      descriptor,
+      matchedSignals: best.evidence,
+    },
+  };
+}
+
 export function evaluateInventoryQuality(
   entities: InventoryQualityEntityInput[],
   relationships: InventoryQualityRelationshipInput[] = [],
@@ -41,6 +263,21 @@ export function evaluateInventoryQuality(
         severity: entity.qualityStatus === "error" ? "error" : "warn",
         status: "open",
         summary: `${entity.entityType} ${entity.entityKey} requires taxonomy or product attribution review`,
+        inventoryEntityKey: entity.entityKey,
+      });
+    }
+
+    if (
+      (entity.attributionStatus === "needs_review" || entity.attributionStatus === "unmapped")
+      && (entity.attributionConfidence ?? 0) < LOW_CONFIDENCE_THRESHOLD
+      && (entity.candidateTaxonomy?.length ?? 0) > 0
+    ) {
+      issues.push({
+        issueKey: `inventory_entity:${entity.entityKey}:taxonomy_low_confidence`,
+        issueType: "taxonomy_attribution_low_confidence",
+        severity: "warn",
+        status: "open",
+        summary: `${entity.entityType} ${entity.entityKey} has low-confidence taxonomy attribution candidates`,
         inventoryEntityKey: entity.entityKey,
       });
     }
@@ -72,3 +309,4 @@ export function evaluateInventoryQuality(
 
   return { issues };
 }
+

--- a/packages/db/src/discovery-collectors/docker.ts
+++ b/packages/db/src/discovery-collectors/docker.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 
 import type { CollectorContext, CollectorOutput } from "../discovery-types";
@@ -10,11 +11,35 @@ const DOCKER_SOCKET_PATHS = [
 type DockerDeps = {
   socketPaths: string[];
   existsSync: (path: string) => boolean;
+  listContainers: () => Promise<Array<{ id: string; name: string; image: string }>>;
 };
+
+async function defaultListContainers(): Promise<Array<{ id: string; name: string; image: string }>> {
+  const result = spawnSync(
+    "docker",
+    ["ps", "--format", "{{json .}}"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0 || !result.stdout.trim()) {
+    return [];
+  }
+
+  return result.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { ID?: string; Names?: string; Image?: string })
+    .filter((entry) => entry.ID && entry.Image)
+    .map((entry) => ({
+      id: entry.ID!,
+      name: entry.Names ?? entry.ID!,
+      image: entry.Image!,
+    }));
+}
 
 const defaultDockerDeps: DockerDeps = {
   socketPaths: DOCKER_SOCKET_PATHS,
   existsSync: fs.existsSync,
+  listContainers: defaultListContainers,
 };
 
 export async function collectDockerDiscovery(
@@ -26,6 +51,8 @@ export async function collectDockerDiscovery(
   if (!socketPath) {
     return { items: [], relationships: [], warnings: ["docker_unavailable"] };
   }
+
+  const containers = await deps.listContainers();
 
   return {
     items: [
@@ -39,7 +66,35 @@ export async function collectDockerDiscovery(
         sourcePath: socketPath,
         attributes: { socketPath },
       },
+      ...containers.map((container) => ({
+        sourceKind: ctx?.sourceKind ?? "docker",
+        itemType: "container",
+        name: container.name,
+        externalRef: `container:${container.id}`,
+        naturalKey: `container:${container.id}`,
+        confidence: 0.9,
+        attributes: {
+          containerId: container.id,
+          image: container.image,
+        },
+      })),
     ],
-    relationships: [],
+    relationships: containers.map((container) => ({
+      sourceKind: ctx?.sourceKind ?? "docker",
+      relationshipType: "hosts",
+      fromExternalRef: `docker_runtime:${socketPath}`,
+      toExternalRef: `container:${container.id}`,
+      confidence: 0.9,
+      attributes: {
+        runtime: "docker",
+      },
+    })),
+    software: containers.map((container) => ({
+      sourceKind: ctx?.sourceKind ?? "docker",
+      entityExternalRef: `container:${container.id}`,
+      evidenceSource: "container_image",
+      rawProductName: container.image,
+      rawPackageName: container.image,
+    })),
   };
 }

--- a/packages/db/src/discovery-collectors/host.ts
+++ b/packages/db/src/discovery-collectors/host.ts
@@ -1,6 +1,11 @@
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 
-import type { CollectorContext, CollectorOutput } from "../discovery-types";
+import type {
+  CollectorContext,
+  CollectorOutput,
+  DiscoveredSoftwareInput,
+} from "../discovery-types";
 
 type HostOsAdapter = {
   hostname: typeof os.hostname;
@@ -10,7 +15,91 @@ type HostOsAdapter = {
   cpus: typeof os.cpus;
   totalmem: typeof os.totalmem;
   networkInterfaces: typeof os.networkInterfaces;
+  installedSoftware: () => Promise<DiscoveredSoftwareInput[]>;
 };
+
+function parseJsonArray<T>(value: string): T[] {
+  if (!value.trim()) {
+    return [];
+  }
+
+  const parsed = JSON.parse(value) as T | T[];
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+async function collectInstalledSoftware(): Promise<DiscoveredSoftwareInput[]> {
+  if (process.platform === "win32") {
+    const script = [
+      "$paths = @(",
+      "'HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',",
+      "'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'",
+      ")",
+      "Get-ItemProperty $paths |",
+      "Where-Object { $_.DisplayName } |",
+      "Select-Object DisplayName, DisplayVersion, Publisher, InstallLocation |",
+      "ConvertTo-Json -Compress",
+    ].join(" ");
+    const result = spawnSync("powershell", ["-NoProfile", "-Command", script], { encoding: "utf8" });
+    if (result.status !== 0 || !result.stdout.trim()) {
+      return [];
+    }
+
+    return parseJsonArray<{
+      DisplayName?: string;
+      DisplayVersion?: string;
+      Publisher?: string;
+      InstallLocation?: string;
+    }>(result.stdout).map((entry) => ({
+      evidenceSource: "installed_software",
+      ...(entry.DisplayName ? { rawProductName: entry.DisplayName } : {}),
+      ...(entry.DisplayVersion ? { rawVersion: entry.DisplayVersion } : {}),
+      ...(entry.Publisher ? { rawVendor: entry.Publisher } : {}),
+      ...(entry.InstallLocation ? { installLocation: entry.InstallLocation } : {}),
+    }));
+  }
+
+  const dpkg = spawnSync(
+    "dpkg-query",
+    ["-W", "-f=${Package}\\t${Version}\\n"],
+    { encoding: "utf8" },
+  );
+  if (dpkg.status === 0 && dpkg.stdout.trim()) {
+    return dpkg.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const [name, version] = line.split("\t");
+        return {
+          evidenceSource: "host_packages",
+          packageManager: "dpkg",
+          ...(name ? { rawPackageName: name } : {}),
+          ...(version ? { rawVersion: version } : {}),
+        };
+      });
+  }
+
+  const rpm = spawnSync(
+    "rpm",
+    ["-qa", "--queryformat", "%{NAME}\\t%{VERSION}-%{RELEASE}\\n"],
+    { encoding: "utf8" },
+  );
+  if (rpm.status === 0 && rpm.stdout.trim()) {
+    return rpm.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const [name, version] = line.split("\t");
+        return {
+          evidenceSource: "host_packages",
+          packageManager: "rpm",
+          ...(name ? { rawPackageName: name } : {}),
+          ...(version ? { rawVersion: version } : {}),
+        };
+      });
+  }
+
+  return [];
+}
 
 const defaultHostOsAdapter: HostOsAdapter = {
   hostname: os.hostname,
@@ -20,6 +109,7 @@ const defaultHostOsAdapter: HostOsAdapter = {
   cpus: os.cpus,
   totalmem: os.totalmem,
   networkInterfaces: os.networkInterfaces,
+  installedSoftware: collectInstalledSoftware,
 };
 
 export async function collectHostDiscovery(
@@ -27,6 +117,10 @@ export async function collectHostDiscovery(
   osAdapter: HostOsAdapter = defaultHostOsAdapter,
 ): Promise<CollectorOutput> {
   const hostname = osAdapter.hostname();
+  const software = (await osAdapter.installedSoftware()).map((entry) => ({
+    ...entry,
+    entityExternalRef: `host:${hostname}`,
+  }));
 
   return {
     items: [
@@ -48,5 +142,6 @@ export async function collectHostDiscovery(
       },
     ],
     relationships: [],
+    software,
   };
 }

--- a/packages/db/src/discovery-normalize.test.ts
+++ b/packages/db/src/discovery-normalize.test.ts
@@ -1,9 +1,43 @@
 import { describe, expect, it } from "vitest";
 
 import { normalizeDiscoveredFacts } from "./discovery-normalize";
+import type { SoftwareIdentityCandidate, SoftwareNormalizationRuleInput } from "./software-normalization";
+import type { TaxonomyNodeCandidate } from "./discovery-attribution";
+
+const taxonomyNodes: TaxonomyNodeCandidate[] = [
+  {
+    nodeId: "foundational/compute/servers",
+    name: "Servers",
+    portfolioSlug: "foundational",
+  },
+  {
+    nodeId: "foundational/platform_services/container_platform",
+    name: "Container Platform",
+    portfolioSlug: "foundational",
+  },
+];
+
+const softwareIdentities: SoftwareIdentityCandidate[] = [
+  {
+    id: "identity-postgres",
+    normalizedVendor: "PostgreSQL Global Development Group",
+    normalizedProductName: "PostgreSQL",
+    aliases: ["postgres", "postgresql"],
+  },
+];
+
+const softwareRules: SoftwareNormalizationRuleInput[] = [
+  {
+    ruleKey: "package:postgresql",
+    matchType: "package_name",
+    rawSignature: "postgresql",
+    source: "bootstrap_registry",
+    softwareIdentity: softwareIdentities[0]!,
+  },
+];
 
 describe("normalizeDiscoveredFacts", () => {
-  it("defaults discovered host infrastructure into the Foundational portfolio", () => {
+  it("defaults discovered host infrastructure into the Foundational portfolio taxonomy", () => {
     const result = normalizeDiscoveredFacts({
       items: [
         {
@@ -15,9 +49,51 @@ describe("normalizeDiscoveredFacts", () => {
         },
       ],
       relationships: [],
+    }, {
+      taxonomyNodes,
+      softwareIdentities,
+      softwareRules,
     });
 
     expect(result.inventoryEntities[0]?.portfolioSlug).toBe("foundational");
     expect(result.inventoryEntities[0]?.attributionStatus).toBe("attributed");
+    expect(result.inventoryEntities[0]?.taxonomyNodeId).toBe("foundational/compute/servers");
+    expect(result.inventoryEntities[0]?.attributionMethod).toBe("rule");
+  });
+
+  it("emits normalized software evidence linked to the discovered inventory entity", () => {
+    const result = normalizeDiscoveredFacts({
+      items: [
+        {
+          sourceKind: "dpf_bootstrap",
+          itemType: "host",
+          name: "dpf-dev",
+          externalRef: "host:dpf-dev",
+          naturalKey: "hostname:dpf-dev",
+          attributes: { hostname: "dpf-dev" },
+        },
+      ],
+      relationships: [],
+      software: [
+        {
+          entityExternalRef: "host:dpf-dev",
+          evidenceSource: "host_packages",
+          rawPackageName: "postgresql-16",
+          rawVersion: "16.3-1",
+        },
+      ],
+    }, {
+      taxonomyNodes,
+      softwareIdentities,
+      softwareRules,
+    });
+
+    expect(result.softwareEvidence).toHaveLength(1);
+    expect(result.softwareEvidence[0]).toMatchObject({
+      inventoryEntityKey: "host:hostname:dpf-dev",
+      evidenceSource: "host_packages",
+      normalizationStatus: "normalized",
+      normalizationMethod: "rule",
+    });
   });
 });

--- a/packages/db/src/discovery-normalize.ts
+++ b/packages/db/src/discovery-normalize.ts
@@ -1,11 +1,22 @@
 import {
+  attributeInventoryEntity,
+  type RankedTaxonomyCandidate,
+  type TaxonomyNodeCandidate,
+} from "./discovery-attribution";
+import {
   buildDiscoveredKey,
   buildInventoryEntityKey,
 } from "./discovery-identity";
+import {
+  normalizeSoftwareEvidence,
+  type SoftwareIdentityCandidate,
+  type SoftwareNormalizationRuleInput,
+} from "./software-normalization";
 import type {
   CollectorOutput,
   DiscoveredItemInput,
   DiscoveredRelationshipInput,
+  DiscoveredSoftwareInput,
 } from "./discovery-types";
 
 export type NormalizedDiscoveredItem = {
@@ -24,9 +35,14 @@ export type NormalizedInventoryEntity = {
   entityType: string;
   name: string;
   discoveredKey: string;
-  portfolioSlug?: string;
+  portfolioSlug?: string | null;
+  taxonomyNodeId?: string | null;
   attributionStatus: "attributed" | "needs_review" | "unmapped" | "stale";
-  providerView: "foundational";
+  attributionMethod?: "rule" | "heuristic";
+  attributionConfidence?: number;
+  attributionEvidence?: Record<string, unknown>;
+  candidateTaxonomy?: RankedTaxonomyCandidate[];
+  providerView: string;
   confidence?: number;
   properties: Record<string, unknown>;
 };
@@ -40,10 +56,49 @@ export type NormalizedInventoryRelationship = {
   properties: Record<string, unknown>;
 };
 
+export type NormalizedSoftwareEvidence = {
+  evidenceKey: string;
+  inventoryEntityKey: string;
+  evidenceSource: string;
+  packageManager?: string;
+  rawVendor?: string | null;
+  rawProductName?: string | null;
+  rawPackageName?: string | null;
+  rawVersion?: string | null;
+  installLocation?: string;
+  rawMetadata?: Record<string, unknown>;
+  normalizationStatus: "normalized" | "needs_review";
+  normalizationMethod: "rule" | "heuristic";
+  normalizationConfidence: number;
+  softwareIdentityId?: string | null;
+  normalizedVendor?: string | null;
+  normalizedProductName?: string | null;
+  normalizedEdition?: string | null;
+  canonicalVersion?: string | null;
+  candidateIdentities: Array<{ id: string; score: number; normalizedProductName: string }>;
+};
+
 export type NormalizedDiscoveryOutput = {
   discoveredItems: NormalizedDiscoveredItem[];
   inventoryEntities: NormalizedInventoryEntity[];
   inventoryRelationships: NormalizedInventoryRelationship[];
+  softwareEvidence: NormalizedSoftwareEvidence[];
+};
+
+export type NormalizeDiscoveryOptions = {
+  taxonomyNodes?: TaxonomyNodeCandidate[];
+  softwareIdentities?: SoftwareIdentityCandidate[];
+  softwareRules?: SoftwareNormalizationRuleInput[];
+};
+
+type DerivedAttribution = {
+  attributionStatus: "attributed" | "needs_review";
+  attributionMethod: "rule" | "heuristic";
+  confidence: number;
+  portfolioSlug: string | null;
+  taxonomyNodeId: string | null;
+  candidateTaxonomy: RankedTaxonomyCandidate[];
+  evidence: Record<string, unknown>;
 };
 
 function mapEntityType(itemType: string): string {
@@ -61,7 +116,27 @@ function isFoundationalInfrastructure(itemType: string): boolean {
     || itemType.includes("storage");
 }
 
-function normalizeItem(item: DiscoveredItemInput): {
+function buildFallbackAttribution(item: DiscoveredItemInput): DerivedAttribution {
+  const foundational = isFoundationalInfrastructure(item.itemType);
+
+  return {
+    attributionStatus: foundational ? "attributed" : "needs_review",
+    attributionMethod: foundational ? "rule" : "heuristic",
+    confidence: foundational ? 0.9 : 0.25,
+    portfolioSlug: foundational ? "foundational" : null,
+    taxonomyNodeId: null,
+    candidateTaxonomy: [],
+    evidence: {
+      descriptor: `${item.itemType} ${item.name}`,
+      matchedSignals: foundational ? [item.itemType] : [],
+    },
+  };
+}
+
+function normalizeItem(
+  item: DiscoveredItemInput,
+  options: NormalizeDiscoveryOptions,
+): {
   discoveredItem: NormalizedDiscoveredItem;
   inventoryEntity: NormalizedInventoryEntity;
 } {
@@ -77,8 +152,6 @@ function normalizeItem(item: DiscoveredItemInput): {
     entityType,
     naturalKey: item.naturalKey ?? externalRef,
   });
-  const foundational = isFoundationalInfrastructure(item.itemType);
-  const attributionStatus = foundational ? "attributed" : "needs_review";
   const discoveredItem: NormalizedDiscoveredItem = {
     discoveredKey,
     sourceKind,
@@ -96,19 +169,31 @@ function normalizeItem(item: DiscoveredItemInput): {
     discoveredItem.confidence = item.confidence;
   }
 
+  const attributed: DerivedAttribution = options.taxonomyNodes && options.taxonomyNodes.length > 0
+    ? attributeInventoryEntity({
+      entityKey,
+      entityType,
+      itemType: item.itemType,
+      name: item.name,
+      properties: item.attributes ?? {},
+    }, options.taxonomyNodes)
+    : buildFallbackAttribution(item);
+
   const inventoryEntity: NormalizedInventoryEntity = {
     entityKey,
     entityType,
     name: item.name,
     discoveredKey,
-    attributionStatus,
-    providerView: "foundational",
+    portfolioSlug: attributed.portfolioSlug,
+    taxonomyNodeId: attributed.taxonomyNodeId,
+    attributionStatus: attributed.attributionStatus,
+    attributionMethod: attributed.attributionMethod,
+    attributionConfidence: attributed.confidence,
+    attributionEvidence: attributed.evidence,
+    candidateTaxonomy: attributed.candidateTaxonomy,
+    providerView: attributed.portfolioSlug ?? "foundational",
     properties: item.attributes ?? {},
   };
-
-  if (foundational) {
-    inventoryEntity.portfolioSlug = "foundational";
-  }
 
   if (item.confidence != null) {
     inventoryEntity.confidence = item.confidence;
@@ -153,16 +238,94 @@ function normalizeRelationship(
   return normalizedRelationship;
 }
 
+function buildSoftwareEvidenceKey(
+  inventoryEntityKey: string,
+  software: DiscoveredSoftwareInput,
+): string {
+  const signature = software.rawPackageName
+    ?? software.rawProductName
+    ?? software.installLocation
+    ?? software.evidenceSource;
+  return `${inventoryEntityKey}:${software.evidenceSource}:${signature}`.toLowerCase();
+}
+
+function normalizeSoftware(
+  software: DiscoveredSoftwareInput,
+  inventoryEntityKeyByExternalRef: Map<string, string>,
+  options: NormalizeDiscoveryOptions,
+): NormalizedSoftwareEvidence | null {
+  const externalRef = software.entityExternalRef ?? software.hostExternalRef ?? software.containerExternalRef;
+  if (!externalRef) {
+    return null;
+  }
+
+  const inventoryEntityKey = inventoryEntityKeyByExternalRef.get(externalRef);
+  if (!inventoryEntityKey) {
+    return null;
+  }
+
+  const normalized = normalizeSoftwareEvidence(
+    {
+      evidenceKey: buildSoftwareEvidenceKey(inventoryEntityKey, software),
+      evidenceSource: software.evidenceSource,
+      ...(software.rawVendor ? { rawVendor: software.rawVendor } : {}),
+      ...(software.rawProductName ? { rawProductName: software.rawProductName } : {}),
+      ...(software.rawPackageName ? { rawPackageName: software.rawPackageName } : {}),
+      ...(software.rawVersion ? { rawVersion: software.rawVersion } : {}),
+    },
+    options.softwareIdentities ?? [],
+    options.softwareRules ?? [],
+  );
+
+  return {
+    evidenceKey: buildSoftwareEvidenceKey(inventoryEntityKey, software),
+    inventoryEntityKey,
+    evidenceSource: software.evidenceSource,
+    ...(software.packageManager ? { packageManager: software.packageManager } : {}),
+    ...(software.rawVendor ? { rawVendor: software.rawVendor } : {}),
+    ...(software.rawProductName ? { rawProductName: software.rawProductName } : {}),
+    ...(software.rawPackageName ? { rawPackageName: software.rawPackageName } : {}),
+    ...(software.rawVersion ? { rawVersion: software.rawVersion } : {}),
+    ...(software.installLocation ? { installLocation: software.installLocation } : {}),
+    ...(software.metadata ? { rawMetadata: software.metadata } : {}),
+    normalizationStatus: normalized.normalizationStatus,
+    normalizationMethod: normalized.method,
+    normalizationConfidence: normalized.confidence,
+    ...(normalized.identity?.id ? { softwareIdentityId: normalized.identity.id } : {}),
+    ...(normalized.identity?.normalizedVendor ? { normalizedVendor: normalized.identity.normalizedVendor } : {}),
+    ...(normalized.identity?.normalizedProductName
+      ? { normalizedProductName: normalized.identity.normalizedProductName }
+      : {}),
+    ...(normalized.identity?.normalizedEdition
+      ? { normalizedEdition: normalized.identity.normalizedEdition }
+      : {}),
+    ...(normalized.identity?.canonicalVersion
+      ? { canonicalVersion: normalized.identity.canonicalVersion }
+      : {}),
+    candidateIdentities: normalized.candidates.map((candidate) => ({
+      id: candidate.id,
+      score: candidate.score,
+      normalizedProductName: candidate.normalizedProductName,
+    })),
+  };
+}
+
 export function normalizeDiscoveredFacts(
   output: CollectorOutput,
+  options: NormalizeDiscoveryOptions = {},
 ): NormalizedDiscoveryOutput {
-  const normalizedItems = output.items.map(normalizeItem);
+  const normalizedItems = output.items.map((item) => normalizeItem(item, options));
   const discoveredKeyByExternalRef = new Map<string, string>();
+  const inventoryEntityKeyByExternalRef = new Map<string, string>();
 
   for (const entry of normalizedItems) {
     discoveredKeyByExternalRef.set(
       entry.discoveredItem.externalRef,
       entry.discoveredItem.discoveredKey,
+    );
+    inventoryEntityKeyByExternalRef.set(
+      entry.discoveredItem.externalRef,
+      entry.inventoryEntity.entityKey,
     );
   }
 
@@ -172,5 +335,8 @@ export function normalizeDiscoveredFacts(
     inventoryRelationships: output.relationships.map((relationship) =>
       normalizeRelationship(relationship, discoveredKeyByExternalRef),
     ),
+    softwareEvidence: (output.software ?? [])
+      .map((software) => normalizeSoftware(software, inventoryEntityKeyByExternalRef, options))
+      .filter((software): software is NormalizedSoftwareEvidence => software != null),
   };
 }

--- a/packages/db/src/discovery-runner.test.ts
+++ b/packages/db/src/discovery-runner.test.ts
@@ -12,12 +12,17 @@ import {
 describe("mergeCollectorOutputs", () => {
   it("combines collector outputs without dropping items or relationships", () => {
     const result = mergeCollectorOutputs([
-      { items: [{ itemType: "host", name: "dpf-dev" }], relationships: [] },
-      { items: [{ itemType: "docker_runtime", name: "docker" }], relationships: [{ relationshipType: "hosts" }] },
+      { items: [{ itemType: "host", name: "dpf-dev" }], relationships: [], software: [] },
+      {
+        items: [{ itemType: "docker_runtime", name: "docker" }],
+        relationships: [{ relationshipType: "hosts" }],
+        software: [{ evidenceSource: "container_packages", rawPackageName: "nginx" }],
+      },
     ]);
 
     expect(result.items).toHaveLength(2);
     expect(result.relationships).toHaveLength(1);
+    expect(result.software).toHaveLength(1);
   });
 });
 
@@ -35,11 +40,42 @@ describe("collectHostDiscovery", () => {
         networkInterfaces: () => ({
           eth0: [{ address: "127.0.0.1", netmask: "255.0.0.0", family: "IPv4", mac: "00:00:00:00:00:00", internal: false, cidr: "127.0.0.1/8" }],
         }),
+        installedSoftware: async () => [],
       },
     );
 
     expect(result.items[0]?.itemType).toBe("host");
     expect(result.items[0]?.name).toBe("dpf-dev");
+  });
+
+  it("captures installed host software as discovery evidence", async () => {
+    const result = await collectHostDiscovery(
+      { sourceKind: "dpf_bootstrap" },
+      {
+        hostname: () => "dpf-dev",
+        platform: () => "win32",
+        release: () => "11",
+        arch: () => "x64",
+        cpus: () => [{ model: "x", speed: 1, times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 } }],
+        totalmem: () => 1024,
+        networkInterfaces: () => ({}),
+        installedSoftware: async () => [
+          {
+            evidenceSource: "installed_software",
+            rawProductName: "Docker Desktop Community Edition",
+            rawVersion: "4.38.0",
+            rawVendor: "Docker",
+          },
+        ],
+      },
+    );
+
+    expect(result.software).toHaveLength(1);
+    expect(result.software?.[0]).toMatchObject({
+      entityExternalRef: "host:dpf-dev",
+      evidenceSource: "installed_software",
+      rawProductName: "Docker Desktop Community Edition",
+    });
   });
 });
 
@@ -47,11 +83,35 @@ describe("collectDockerDiscovery", () => {
   it("returns an empty output rather than throwing when Docker is unavailable", async () => {
     const result = await collectDockerDiscovery(
       { sourceKind: "dpf_bootstrap" },
-      { socketPaths: ["/missing.sock"], existsSync: () => false },
+      { socketPaths: ["/missing.sock"], existsSync: () => false, listContainers: async () => [] },
     );
 
     expect(result.items).toEqual([]);
     expect(result.warnings).toContain("docker_unavailable");
+  });
+
+  it("captures running containers and image evidence when Docker is available", async () => {
+    const result = await collectDockerDiscovery(
+      { sourceKind: "dpf_bootstrap" },
+      {
+        socketPaths: ["/var/run/docker.sock"],
+        existsSync: () => true,
+        listContainers: async () => [
+          {
+            id: "container-1",
+            name: "dpf-web",
+            image: "ghcr.io/acme/dpf-web:1.2.3",
+          },
+        ],
+      },
+    );
+
+    expect(result.items.map((item) => item.itemType)).toContain("container");
+    expect(result.software?.[0]).toMatchObject({
+      entityExternalRef: "container:container-1",
+      evidenceSource: "container_image",
+      rawProductName: "ghcr.io/acme/dpf-web:1.2.3",
+    });
   });
 });
 
@@ -102,12 +162,63 @@ describe("executeBootstrapDiscovery", () => {
       persist,
       runKey: "DISC-001",
       trigger: "bootstrap",
+      taxonomyNodes: [
+        {
+          nodeId: "foundational/compute/servers",
+          name: "Servers",
+          portfolioSlug: "foundational",
+        },
+      ],
     });
 
     expect(persist).toHaveBeenCalledOnce();
     expect(summary).toMatchObject({
       runId: "run-1",
       createdEntities: 1,
+    });
+    expect(persist.mock.calls[0]?.[1].inventoryEntities[0]).toMatchObject({
+      taxonomyNodeId: "foundational/compute/servers",
+      attributionMethod: "rule",
+    });
+  });
+
+  it("loads taxonomy nodes from the db client when options do not provide them", async () => {
+    const persist = vi.fn().mockResolvedValue({
+      runId: "run-2",
+      createdEntities: 1,
+      updatedEntities: 0,
+      staleEntities: 0,
+      createdRelationships: 0,
+      updatedRelationships: 0,
+      staleRelationships: 0,
+      createdIssues: 0,
+    });
+
+    await executeBootstrapDiscovery({
+      taxonomyNode: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            nodeId: "foundational/compute/servers",
+            name: "Servers",
+          },
+        ]),
+      },
+    } as never, {
+      collectors: [
+        async () => ({
+          items: [{ sourceKind: "dpf_bootstrap", itemType: "host", name: "dpf-dev", externalRef: "host:dpf-dev" }],
+          relationships: [],
+          software: [],
+        }),
+      ],
+      persist,
+      runKey: "DISC-002",
+      trigger: "bootstrap",
+    });
+
+    expect(persist.mock.calls[0]?.[1].inventoryEntities[0]).toMatchObject({
+      taxonomyNodeId: "foundational/compute/servers",
+      attributionMethod: "rule",
     });
   });
 });

--- a/packages/db/src/discovery-runner.ts
+++ b/packages/db/src/discovery-runner.ts
@@ -3,13 +3,16 @@ import {
   collectHostDiscovery,
   collectKubernetesDiscovery,
 } from "./discovery-collectors";
-import { normalizeDiscoveredFacts } from "./discovery-normalize";
+import {
+  normalizeDiscoveredFacts,
+  type NormalizeDiscoveryOptions,
+} from "./discovery-normalize";
 import { persistBootstrapDiscoveryRun } from "./discovery-sync";
 import type { CollectorOutput, DiscoveryCollector } from "./discovery-types";
 
 type BootstrapDiscoveryDb = Parameters<typeof persistBootstrapDiscoveryRun>[0];
 
-type BootstrapExecutionOptions = {
+type BootstrapExecutionOptions = NormalizeDiscoveryOptions & {
   collectors?: DiscoveryCollector[];
   normalize?: typeof normalizeDiscoveredFacts;
   persist?: typeof persistBootstrapDiscoveryRun;
@@ -23,10 +26,11 @@ export function mergeCollectorOutputs(outputs: CollectorOutput[]): CollectorOutp
     (merged, output) => {
       merged.items.push(...output.items);
       merged.relationships.push(...output.relationships);
+      merged.software?.push(...(output.software ?? []));
       merged.warnings?.push(...(output.warnings ?? []));
       return merged;
     },
-    { items: [], relationships: [], warnings: [] },
+    { items: [], relationships: [], software: [], warnings: [] },
   );
 }
 
@@ -54,7 +58,23 @@ export async function executeBootstrapDiscovery(
   options: BootstrapExecutionOptions = {},
 ) {
   const collected = await runBootstrapCollectors(options.collectors);
-  const normalized = (options.normalize ?? normalizeDiscoveredFacts)(collected);
+  const taxonomyNodes = options.taxonomyNodes
+    ?? (typeof (db as { taxonomyNode?: { findMany?: unknown } }).taxonomyNode?.findMany === "function"
+      ? await ((db as unknown) as {
+          taxonomyNode: {
+            findMany(args: {
+              select: { nodeId: true; name: true };
+            }): Promise<Array<{ nodeId: string; name: string }>>;
+          };
+        }).taxonomyNode.findMany({
+          select: { nodeId: true, name: true },
+        })
+      : undefined);
+  const normalized = (options.normalize ?? normalizeDiscoveredFacts)(collected, {
+    ...(taxonomyNodes ? { taxonomyNodes } : {}),
+    ...(options.softwareIdentities ? { softwareIdentities: options.softwareIdentities } : {}),
+    ...(options.softwareRules ? { softwareRules: options.softwareRules } : {}),
+  });
 
   return (options.persist ?? persistBootstrapDiscoveryRun)(db, normalized, {
     runKey: options.runKey ?? `DISC-${Date.now()}`,

--- a/packages/db/src/discovery-sync.test.ts
+++ b/packages/db/src/discovery-sync.test.ts
@@ -23,6 +23,9 @@ describe("persistBootstrapDiscoveryRun", () => {
   it("projects normalized inventory entities and relationships into Neo4j adapters", async () => {
     const projectInventoryEntity = vi.fn().mockResolvedValue(undefined);
     const projectInventoryRelationship = vi.fn().mockResolvedValue(undefined);
+    const upsertedEntityPayloads: Array<Record<string, unknown>> = [];
+    const createdSoftwareEvidence: Array<Record<string, unknown>> = [];
+    const qualityIssues: Array<Record<string, unknown>> = [];
 
     const db = {
       $transaction: async <T>(fn: (tx: any) => Promise<T>): Promise<T> => fn({
@@ -31,16 +34,25 @@ describe("persistBootstrapDiscoveryRun", () => {
         },
         inventoryEntity: {
           findMany: async () => [],
-          upsert: async ({ where }: { where: { entityKey: string } }) => ({
+          upsert: async ({ where, create, update }: { where: { entityKey: string }; create: Record<string, unknown>; update: Record<string, unknown> }) => {
+            upsertedEntityPayloads.push({ where, create, update });
+            return ({
             id: `entity:${where.entityKey}`,
             entityKey: where.entityKey,
-          }),
+            });
+          },
           updateMany: async () => ({ count: 0 }),
         },
         discoveredItem: {
           create: async ({ data }: { data: { observedKey: string } }) => ({
             id: `discovered:${data.observedKey}`,
           }),
+        },
+        discoveredSoftwareEvidence: {
+          upsert: async ({ create }: { create: Record<string, unknown> }) => {
+            createdSoftwareEvidence.push(create);
+            return {};
+          },
         },
         inventoryRelationship: {
           findMany: async () => [],
@@ -55,7 +67,10 @@ describe("persistBootstrapDiscoveryRun", () => {
         },
         portfolioQualityIssue: {
           findMany: async () => [],
-          upsert: async () => ({}),
+          upsert: async ({ create }: { create: Record<string, unknown> }) => {
+            qualityIssues.push(create);
+            return {};
+          },
         },
       }),
     };
@@ -88,7 +103,11 @@ describe("persistBootstrapDiscoveryRun", () => {
             name: "dpf-dev",
             discoveredKey: "dpf_bootstrap:host:host:dpf-dev",
             portfolioSlug: "foundational",
+            taxonomyNodeId: "foundational/compute/servers",
             attributionStatus: "attributed",
+            attributionMethod: "rule",
+            attributionConfidence: 0.98,
+            attributionEvidence: { ruleId: "foundational_host_servers" },
             providerView: "foundational",
             properties: {},
           },
@@ -98,7 +117,34 @@ describe("persistBootstrapDiscoveryRun", () => {
             name: "Docker",
             discoveredKey: "dpf_bootstrap:docker_runtime:docker_runtime:/var/run/docker.sock",
             portfolioSlug: "foundational",
+            taxonomyNodeId: "foundational/platform_services/container_platform",
             attributionStatus: "attributed",
+            attributionMethod: "rule",
+            attributionConfidence: 0.98,
+            attributionEvidence: { ruleId: "container_platform_runtime" },
+            providerView: "foundational",
+            properties: {},
+          },
+          {
+            entityKey: "service:mystery-engine",
+            entityType: "service",
+            name: "Mystery Engine",
+            discoveredKey: "dpf_bootstrap:application_service:service:mystery-engine",
+            portfolioSlug: null,
+            taxonomyNodeId: null,
+            attributionStatus: "needs_review",
+            attributionMethod: "heuristic",
+            attributionConfidence: 0.32,
+            attributionEvidence: { descriptor: "mystery engine" },
+            candidateTaxonomy: [
+              {
+                nodeId: "for_employees/employee_services",
+                name: "Employee Services",
+                portfolioSlug: "for_employees",
+                score: 0.32,
+                evidence: ["fallback_candidate"],
+              },
+            ],
             providerView: "foundational",
             properties: {},
           },
@@ -112,12 +158,47 @@ describe("persistBootstrapDiscoveryRun", () => {
             properties: {},
           },
         ],
+        softwareEvidence: [
+          {
+            evidenceKey: "host:hostname:dpf-dev:host_packages:postgresql-16",
+            inventoryEntityKey: "host:hostname:dpf-dev",
+            evidenceSource: "host_packages",
+            rawPackageName: "postgresql-16",
+            rawVersion: "16.3-1",
+            normalizationStatus: "normalized",
+            normalizationMethod: "rule",
+            normalizationConfidence: 0.99,
+            softwareIdentityId: "identity-postgres",
+            normalizedVendor: "PostgreSQL Global Development Group",
+            normalizedProductName: "PostgreSQL",
+            canonicalVersion: "16.3",
+            candidateIdentities: [
+              {
+                id: "identity-postgres",
+                score: 0.99,
+                normalizedProductName: "PostgreSQL",
+              },
+            ],
+          },
+        ],
       },
       { runKey: "run-1", sourceSlug: "dpf_bootstrap" },
       { projectInventoryEntity, projectInventoryRelationship },
     );
 
-    expect(projectInventoryEntity).toHaveBeenCalledTimes(2);
+    expect(projectInventoryEntity).toHaveBeenCalledTimes(3);
     expect(projectInventoryRelationship).toHaveBeenCalledTimes(1);
+    expect(upsertedEntityPayloads[0]?.create).toMatchObject({
+      taxonomyNode: { connect: { nodeId: "foundational/compute/servers" } },
+      attributionMethod: "rule",
+      attributionConfidence: 0.98,
+    });
+    expect(createdSoftwareEvidence[0]).toMatchObject({
+      evidenceKey: "host:hostname:dpf-dev:host_packages:postgresql-16",
+      softwareIdentity: { connect: { id: "identity-postgres" } },
+    });
+    expect(qualityIssues.map((issue) => issue.issueType)).toContain(
+      "taxonomy_attribution_low_confidence",
+    );
   });
 });

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -62,6 +62,13 @@ type DiscoverySyncTx = {
       select: { id: true };
     }): Promise<{ id: string }>;
   };
+  discoveredSoftwareEvidence: {
+    upsert(args: {
+      where: { evidenceKey: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }): Promise<unknown>;
+  };
   inventoryRelationship: {
     findMany(args: { select: { relationshipKey: true } }): Promise<Array<{ relationshipKey: string }>>;
     upsert(args: {
@@ -167,10 +174,17 @@ export async function persistBootstrapDiscoveryRun(
           name: entity.name,
           status: entity.attributionStatus === "stale" ? "stale" : "active",
           attributionStatus: entity.attributionStatus,
+          attributionMethod: entity.attributionMethod ?? null,
+          attributionConfidence: entity.attributionConfidence ?? null,
+          attributionEvidence: entity.attributionEvidence ?? null,
+          candidateTaxonomy: entity.candidateTaxonomy ?? undefined,
           providerView: entity.providerView,
           confidence: entity.confidence ?? null,
           portfolio: entity.portfolioSlug
             ? { connect: { slug: entity.portfolioSlug } }
+            : undefined,
+          taxonomyNode: entity.taxonomyNodeId
+            ? { connect: { nodeId: entity.taxonomyNodeId } }
             : undefined,
           properties: entity.properties,
           firstSeenAt: now,
@@ -182,10 +196,17 @@ export async function persistBootstrapDiscoveryRun(
           name: entity.name,
           status: entity.attributionStatus === "stale" ? "stale" : "active",
           attributionStatus: entity.attributionStatus,
+          attributionMethod: entity.attributionMethod ?? null,
+          attributionConfidence: entity.attributionConfidence ?? null,
+          attributionEvidence: entity.attributionEvidence ?? null,
+          candidateTaxonomy: entity.candidateTaxonomy ?? undefined,
           providerView: entity.providerView,
           confidence: entity.confidence ?? null,
           portfolio: entity.portfolioSlug
             ? { connect: { slug: entity.portfolioSlug } }
+            : undefined,
+          taxonomyNode: entity.taxonomyNodeId
+            ? { connect: { nodeId: entity.taxonomyNodeId } }
             : undefined,
           properties: entity.properties,
           lastSeenAt: now,
@@ -226,6 +247,53 @@ export async function persistBootstrapDiscoveryRun(
         select: { id: true },
       });
       discoveredItemIdsByKey.set(discoveredItem.discoveredKey, persistedDiscoveredItem.id);
+    }
+
+    for (const software of normalized.softwareEvidence) {
+      const inventoryEntityId = entityIdsByEntityKey.get(software.inventoryEntityKey);
+      if (!inventoryEntityId) {
+        continue;
+      }
+
+      await tx.discoveredSoftwareEvidence.upsert({
+        where: { evidenceKey: software.evidenceKey },
+        create: {
+          evidenceKey: software.evidenceKey,
+          inventoryEntity: { connect: { id: inventoryEntityId } },
+          evidenceSource: software.evidenceSource,
+          packageManager: software.packageManager ?? null,
+          rawVendor: software.rawVendor ?? null,
+          rawProductName: software.rawProductName ?? null,
+          rawPackageName: software.rawPackageName ?? null,
+          rawVersion: software.rawVersion ?? null,
+          installLocation: software.installLocation ?? null,
+          rawMetadata: software.rawMetadata ?? undefined,
+          normalizationStatus: software.normalizationStatus,
+          normalizationConfidence: software.normalizationConfidence,
+          softwareIdentity: software.softwareIdentityId
+            ? { connect: { id: software.softwareIdentityId } }
+            : undefined,
+          firstSeenAt: now,
+          lastSeenAt: now,
+        },
+        update: {
+          inventoryEntity: { connect: { id: inventoryEntityId } },
+          evidenceSource: software.evidenceSource,
+          packageManager: software.packageManager ?? null,
+          rawVendor: software.rawVendor ?? null,
+          rawProductName: software.rawProductName ?? null,
+          rawPackageName: software.rawPackageName ?? null,
+          rawVersion: software.rawVersion ?? null,
+          installLocation: software.installLocation ?? null,
+          rawMetadata: software.rawMetadata ?? undefined,
+          normalizationStatus: software.normalizationStatus,
+          normalizationConfidence: software.normalizationConfidence,
+          softwareIdentity: software.softwareIdentityId
+            ? { connect: { id: software.softwareIdentityId } }
+            : { disconnect: true },
+          lastSeenAt: now,
+        },
+      });
     }
 
     const currentEntityKeys = new Set(
@@ -330,6 +398,14 @@ export async function persistBootstrapDiscoveryRun(
             entityKey: entity.entityKey,
             entityType: entity.entityType,
             attributionStatus: entity.attributionStatus,
+            attributionMethod: entity.attributionMethod ?? null,
+            attributionConfidence: entity.attributionConfidence ?? null,
+            candidateTaxonomy: entity.candidateTaxonomy?.map((candidate) => ({
+              nodeId: candidate.nodeId,
+              score: candidate.score,
+            })) ?? null,
+            taxonomyNodeId: entity.taxonomyNodeId ?? null,
+            digitalProductId: null,
           };
 
           if (entity.attributionStatus === "needs_review") {
@@ -368,6 +444,16 @@ export async function persistBootstrapDiscoveryRun(
           status: issue.status,
           severity: issue.severity,
           summary: issue.summary,
+          taxonomyNode: issue.inventoryEntityKey
+            ? (() => {
+                const matchedEntity = normalized.inventoryEntities.find(
+                  (entity) => entity.entityKey === issue.inventoryEntityKey,
+                );
+                return matchedEntity?.taxonomyNodeId
+                  ? { connect: { nodeId: matchedEntity.taxonomyNodeId } }
+                  : undefined;
+              })()
+            : undefined,
           inventoryEntity: inventoryEntityId
             ? { connect: { id: inventoryEntityId } }
             : undefined,
@@ -377,6 +463,16 @@ export async function persistBootstrapDiscoveryRun(
           status: issue.status,
           severity: issue.severity,
           summary: issue.summary,
+          taxonomyNode: issue.inventoryEntityKey
+            ? (() => {
+                const matchedEntity = normalized.inventoryEntities.find(
+                  (entity) => entity.entityKey === issue.inventoryEntityKey,
+                );
+                return matchedEntity?.taxonomyNodeId
+                  ? { connect: { nodeId: matchedEntity.taxonomyNodeId } }
+                  : { disconnect: true };
+              })()
+            : undefined,
           inventoryEntity: inventoryEntityId
             ? { connect: { id: inventoryEntityId } }
             : undefined,

--- a/packages/db/src/discovery-types.ts
+++ b/packages/db/src/discovery-types.ts
@@ -24,9 +24,25 @@ export type DiscoveredRelationshipInput = {
   attributes?: Record<string, unknown>;
 };
 
+export type DiscoveredSoftwareInput = {
+  sourceKind?: DiscoverySourceKind;
+  entityExternalRef?: string;
+  hostExternalRef?: string;
+  containerExternalRef?: string;
+  evidenceSource: string;
+  packageManager?: string;
+  rawVendor?: string;
+  rawProductName?: string;
+  rawPackageName?: string;
+  rawVersion?: string;
+  installLocation?: string;
+  metadata?: Record<string, unknown>;
+};
+
 export type CollectorOutput = {
   items: DiscoveredItemInput[];
   relationships: DiscoveredRelationshipInput[];
+  software?: DiscoveredSoftwareInput[];
   warnings?: string[];
 };
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -25,7 +25,6 @@ export {
   syncInventoryEntityAsInfraCI,
   syncInventoryRelationship,
 } from "./neo4j-sync";
-export { seedEaReferenceModels } from "./seed-ea-reference-models";
 export {
   buildDiscoveredKey,
   buildInventoryEntityKey,
@@ -34,10 +33,39 @@ export {
 } from "./discovery-identity";
 export {
   normalizeDiscoveredFacts,
+  type NormalizeDiscoveryOptions,
   type NormalizedDiscoveryOutput,
   type NormalizedInventoryEntity,
   type NormalizedInventoryRelationship,
+  type NormalizedSoftwareEvidence,
 } from "./discovery-normalize";
+export {
+  attributeInventoryEntity,
+  buildDiscoveryDescriptor,
+  evaluateInventoryQuality,
+  scoreTaxonomyCandidates,
+  type InventoryAttributionInput,
+  type InventoryAttributionResult,
+  type InventoryQualityEntityInput,
+  type InventoryQualityEvaluation,
+  type InventoryQualityIssue,
+  type InventoryQualityRelationshipInput,
+  type RankedTaxonomyCandidate,
+  type TaxonomyNodeCandidate,
+} from "./discovery-attribution";
+export {
+  buildNormalizationRuleCandidate,
+  matchSoftwareIdentityByRule,
+  normalizeSoftwareEvidence,
+  scoreSoftwareIdentityCandidates,
+  type RankedSoftwareIdentityCandidate,
+  type RuleCandidateInput,
+  type SoftwareEvidenceInput,
+  type SoftwareIdentityCandidate,
+  type SoftwareNormalizationResult,
+  type SoftwareNormalizationRuleCandidate,
+  type SoftwareNormalizationRuleInput,
+} from "./software-normalization";
 export {
   executeBootstrapDiscovery,
   runBootstrapCollectors,
@@ -48,11 +76,6 @@ export {
   type StructuredChildRecord,
   type StructureConformanceWarning,
 } from "./ea-structure";
-export {
-  getDefaultEaStructureRules,
-  seedEaStructureRules,
-  type EaStructureRuleSeed,
-} from "./seed-ea-structure-rules";
 export {
   persistBootstrapDiscoveryRun,
   summarizeDiscoveryPersistence,

--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -24,7 +24,7 @@ describe("seed helpers", () => {
   });
 
   it("exports seedEaReferenceModels", async () => {
-    const mod = await import("./index.js");
+    const mod = await import("./seed-ea-reference-models.js");
     expect(typeof mod.seedEaReferenceModels).toBe("function");
   }, 15_000);
 

--- a/packages/db/src/software-normalization.test.ts
+++ b/packages/db/src/software-normalization.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNormalizationRuleCandidate,
+  normalizeSoftwareEvidence,
+  type SoftwareIdentityCandidate,
+  type SoftwareNormalizationRuleInput,
+} from "./software-normalization";
+
+const postgresIdentity: SoftwareIdentityCandidate = {
+  id: "identity-postgres",
+  normalizedVendor: "PostgreSQL Global Development Group",
+  normalizedProductName: "PostgreSQL",
+  aliases: ["postgres", "postgresql"],
+};
+
+const dockerDesktopIdentity: SoftwareIdentityCandidate = {
+  id: "identity-docker-desktop",
+  normalizedVendor: "Docker",
+  normalizedProductName: "Docker Desktop",
+  normalizedEdition: "Community",
+  aliases: ["docker desktop", "docker community"],
+};
+
+const identities: SoftwareIdentityCandidate[] = [
+  postgresIdentity,
+  {
+    ...dockerDesktopIdentity,
+  },
+];
+
+const rules: SoftwareNormalizationRuleInput[] = [
+  {
+    ruleKey: "package:postgresql",
+    matchType: "package_name",
+    rawSignature: "postgresql",
+    source: "bootstrap_registry",
+    softwareIdentity: postgresIdentity,
+  },
+];
+
+describe("normalizeSoftwareEvidence", () => {
+  it("uses deterministic rules when a package alias is known", () => {
+    const result = normalizeSoftwareEvidence(
+      {
+        evidenceKey: "host:pkg:postgresql-16",
+        evidenceSource: "host_packages",
+        rawPackageName: "postgresql-16",
+        rawVersion: "16.3-1",
+      },
+      identities,
+      rules,
+    );
+
+    expect(result.normalizationStatus).toBe("normalized");
+    expect(result.method).toBe("rule");
+    expect(result.identity?.normalizedProductName).toBe("PostgreSQL");
+    expect(result.identity?.canonicalVersion).toBe("16.3");
+    expect(result.confidence).toBeGreaterThan(0.95);
+  });
+
+  it("uses heuristic matching for noisy software names", () => {
+    const result = normalizeSoftwareEvidence(
+      {
+        evidenceKey: "host:app:docker-desktop",
+        evidenceSource: "installed_software",
+        rawProductName: "Docker Desktop Community Edition",
+        rawVersion: "4.38.0 (181591)",
+      },
+      identities,
+      rules,
+    );
+
+    expect(result.normalizationStatus).toBe("normalized");
+    expect(result.method).toBe("heuristic");
+    expect(result.identity?.normalizedProductName).toBe("Docker Desktop");
+    expect(result.confidence).toBeGreaterThan(0.7);
+  });
+
+  it("keeps unresolved software evidence reviewable", () => {
+    const result = normalizeSoftwareEvidence(
+      {
+        evidenceKey: "host:pkg:mystery-engine",
+        evidenceSource: "host_packages",
+        rawPackageName: "mystery-engine-build-123",
+        rawVersion: "2026.03",
+      },
+      identities,
+      rules,
+    );
+
+    expect(result.normalizationStatus).toBe("needs_review");
+    expect(result.identity).toBeNull();
+    expect(result.candidates.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildNormalizationRuleCandidate", () => {
+  it("synthesizes a deterministic rule candidate from an approved heuristic match", () => {
+    const result = normalizeSoftwareEvidence(
+      {
+        evidenceKey: "host:app:docker-desktop",
+        evidenceSource: "installed_software",
+        rawProductName: "Docker Desktop Community Edition",
+        rawVersion: "4.38.0 (181591)",
+      },
+      identities,
+      rules,
+    );
+
+    const ruleCandidate = buildNormalizationRuleCandidate(
+      {
+        rawProductName: "Docker Desktop Community Edition",
+        rawPackageName: null,
+      },
+      result,
+      "local_llm",
+    );
+
+    expect(ruleCandidate).toMatchObject({
+      matchType: "product_name",
+      rawSignature: "docker desktop community edition",
+      source: "local_llm",
+    });
+    expect(ruleCandidate.ruleKey).toContain("docker-desktop-community-edition");
+  });
+});

--- a/packages/db/src/software-normalization.ts
+++ b/packages/db/src/software-normalization.ts
@@ -1,0 +1,198 @@
+const NORMALIZATION_THRESHOLD = 0.7;
+
+export type SoftwareIdentityCandidate = {
+  id: string;
+  normalizedVendor?: string | null;
+  normalizedProductName: string;
+  normalizedEdition?: string | null;
+  canonicalVersion?: string | null;
+  aliases?: string[];
+};
+
+export type SoftwareNormalizationRuleInput = {
+  ruleKey: string;
+  matchType: "package_name" | "product_name";
+  rawSignature: string;
+  source: string;
+  softwareIdentity: SoftwareIdentityCandidate;
+};
+
+export type SoftwareEvidenceInput = {
+  evidenceKey: string;
+  evidenceSource: string;
+  rawVendor?: string | null;
+  rawProductName?: string | null;
+  rawPackageName?: string | null;
+  rawVersion?: string | null;
+};
+
+export type RankedSoftwareIdentityCandidate = SoftwareIdentityCandidate & {
+  score: number;
+};
+
+export type SoftwareNormalizationResult = {
+  normalizationStatus: "normalized" | "needs_review";
+  method: "rule" | "heuristic";
+  confidence: number;
+  identity: (SoftwareIdentityCandidate & { canonicalVersion?: string | null }) | null;
+  candidates: RankedSoftwareIdentityCandidate[];
+};
+
+export type RuleCandidateInput = {
+  rawProductName?: string | null;
+  rawPackageName?: string | null;
+};
+
+export type SoftwareNormalizationRuleCandidate = {
+  ruleKey: string;
+  matchType: "package_name" | "product_name";
+  rawSignature: string;
+  source: string;
+  softwareIdentityId: string;
+};
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function tokenize(value: string): string[] {
+  return normalizeText(value)
+    .split(/\s+/)
+    .map((token) => token.replace(/s$/, ""))
+    .filter((token) => token.length > 1);
+}
+
+function canonicalizeVersion(rawVersion?: string | null): string | null {
+  if (!rawVersion) {
+    return null;
+  }
+
+  const match = rawVersion.match(/\d+(?:\.\d+){0,2}/);
+  return match?.[0] ?? null;
+}
+
+export function matchSoftwareIdentityByRule(
+  evidence: SoftwareEvidenceInput,
+  rules: SoftwareNormalizationRuleInput[],
+): SoftwareNormalizationResult | null {
+  const packageName = normalizeText(evidence.rawPackageName ?? "");
+  const productName = normalizeText(evidence.rawProductName ?? "");
+
+  for (const rule of rules) {
+    const signature = normalizeText(rule.rawSignature);
+    const haystack = rule.matchType === "package_name" ? packageName : productName;
+    if (!haystack || !signature || !haystack.includes(signature)) {
+      continue;
+    }
+
+    return {
+      normalizationStatus: "normalized",
+      method: "rule",
+      confidence: 0.99,
+      identity: {
+        ...rule.softwareIdentity,
+        canonicalVersion: canonicalizeVersion(evidence.rawVersion),
+      },
+      candidates: [
+        {
+          ...rule.softwareIdentity,
+          canonicalVersion: canonicalizeVersion(evidence.rawVersion),
+          score: 0.99,
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
+export function scoreSoftwareIdentityCandidates(
+  evidence: SoftwareEvidenceInput,
+  identities: SoftwareIdentityCandidate[],
+): RankedSoftwareIdentityCandidate[] {
+  const evidenceText = normalizeText([
+    evidence.rawVendor,
+    evidence.rawProductName,
+    evidence.rawPackageName,
+  ].filter(Boolean).join(" "));
+  const evidenceTokens = new Set(tokenize(evidenceText));
+
+  return identities
+    .map((identity) => {
+      const aliasText = [identity.normalizedProductName, identity.normalizedVendor, ...(identity.aliases ?? [])]
+        .filter(Boolean)
+        .join(" ");
+      const identityTokens = tokenize(aliasText);
+      const overlap = identityTokens.filter((token) => evidenceTokens.has(token));
+      const coverage = identityTokens.length > 0 ? overlap.length / identityTokens.length : 0;
+      const evidenceCoverage = evidenceTokens.size > 0 ? overlap.length / evidenceTokens.size : 0;
+      const phraseBonus = evidenceText.includes(normalizeText(identity.normalizedProductName)) ? 0.25 : 0;
+      const score = Math.min(0.95, Number((coverage * 0.7 + evidenceCoverage * 0.3 + phraseBonus).toFixed(3)));
+
+      return {
+        ...identity,
+        score,
+      };
+    })
+    .sort((left, right) => right.score - left.score)
+    .slice(0, 5);
+}
+
+export function normalizeSoftwareEvidence(
+  evidence: SoftwareEvidenceInput,
+  identities: SoftwareIdentityCandidate[],
+  rules: SoftwareNormalizationRuleInput[],
+): SoftwareNormalizationResult {
+  const ruleMatch = matchSoftwareIdentityByRule(evidence, rules);
+  if (ruleMatch) {
+    return ruleMatch;
+  }
+
+  const candidates = scoreSoftwareIdentityCandidates(evidence, identities);
+  const best = candidates[0] ?? null;
+
+  if (!best || best.score < NORMALIZATION_THRESHOLD) {
+    return {
+      normalizationStatus: "needs_review",
+      method: "heuristic",
+      confidence: best?.score ?? 0,
+      identity: null,
+      candidates,
+    };
+  }
+
+  return {
+    normalizationStatus: "normalized",
+    method: "heuristic",
+    confidence: best.score,
+    identity: {
+      ...best,
+      canonicalVersion: canonicalizeVersion(evidence.rawVersion),
+    },
+    candidates,
+  };
+}
+
+export function buildNormalizationRuleCandidate(
+  input: RuleCandidateInput,
+  result: SoftwareNormalizationResult,
+  source: string,
+): SoftwareNormalizationRuleCandidate {
+  if (!result.identity) {
+    throw new Error("Cannot build a normalization rule candidate without a normalized identity");
+  }
+
+  const rawSignatureSource = input.rawPackageName ?? input.rawProductName ?? "";
+  const rawSignature = normalizeText(rawSignatureSource);
+  const matchType = input.rawPackageName ? "package_name" : "product_name";
+  const slug = rawSignature.replace(/\s+/g, "-");
+
+  return {
+    ruleKey: `${matchType}:${slug}`,
+    matchType,
+    rawSignature,
+    source,
+    softwareIdentityId: result.identity.id,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add taxonomy-aware discovery attribution with deterministic rules, heuristic fallback, confidence, and review issues
- capture host installed software and Docker container image evidence with normalization support and persistence
- surface attribution method, confidence, and review state in inventory UI while keeping web runtime safe from seed-module bundling

## Test Plan
- [x] pnpm --filter @dpf/db test -- discovery-attribution-model.test.ts discovery-attribution.test.ts software-normalization.test.ts discovery-normalize.test.ts discovery-runner.test.ts discovery-sync.test.ts seed.test.ts
- [x] pnpm --filter web test -- 'app/(shell)/inventory/page.test.tsx' 'lib/actions/users.test.ts'
- [x] pnpm --filter @dpf/db typecheck
- [x] pnpm --filter web typecheck
- [x] DATABASE_URL=postgresql://dpf:dpf_dev@localhost:5432/dpf pnpm --filter web build