### PR TITLE
chore: track vscode run and debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: dev server",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "pnpm --filter web dev",
+      "cwd": "${workspaceFolder}",
+      "skipFiles": [
+        "${workspaceFolder}/packages/db/generated/**"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run DPF Web",
+      "type": "shell",
+      "command": "cmd",
+      "args": [
+        "/c",
+        "pnpm --filter web dev"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add tracked VS Code launch and task definitions for running the web app from the repo root
- restore the Next.js dev server debug entry so Run and Debug works in the shared workspace

## Test Plan
- verified `.vscode/launch.json` and `.vscode/tasks.json` are the intended tracked files on a clean branch
- `pnpm --filter web dev` from the fresh worktree is blocked there until dependencies are installed in that worktree
