### PR TITLE
feat: scope coworker chat by page

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -5,8 +5,6 @@ import { auth } from "@/lib/auth";
 import { resolveBrandingLogoUrl } from "@/lib/branding";
 import { redirect } from "next/navigation";
 import { Header } from "@/components/shell/Header";
-import { getOrCreateThread } from "@/lib/actions/agent-coworker";
-import { getRecentMessages } from "@/lib/agent-coworker-data";
 import { AgentCoworkerShell } from "@/components/agent/AgentCoworkerShell";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
@@ -15,7 +13,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
 
   const user = session.user;
 
-  const [latestDiscoveryRun, activeBranding, threadResult] = await Promise.all([
+  const [latestDiscoveryRun, activeBranding] = await Promise.all([
     prisma.discoveryRun.findFirst({
       orderBy: { startedAt: "desc" },
       select: { id: true },
@@ -27,11 +25,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         logoUrl: true,
       },
     }),
-    getOrCreateThread(),
   ]);
-
-  const threadId = threadResult?.threadId ?? null;
-  const initialMessages = threadId ? await getRecentMessages(threadId) : [];
 
   if (!latestDiscoveryRun) {
     await executeBootstrapDiscovery(prisma as never, {
@@ -53,13 +47,9 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         )}
       />
       <main className="flex-1 p-6 max-w-7xl mx-auto w-full">{children}</main>
-      {threadId && (
-        <AgentCoworkerShell
-          threadId={threadId}
-          initialMessages={initialMessages}
-          userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
-        />
-      )}
+      <AgentCoworkerShell
+        userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
+      />
     </div>
   );
 }

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -5,38 +5,51 @@ import { usePathname } from "next/navigation";
 import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { resolveAgentForRoute, AGENT_NAME_MAP } from "@/lib/agent-routing";
-import { sendMessage } from "@/lib/actions/agent-coworker";
+import { clearConversation, sendMessage } from "@/lib/actions/agent-coworker";
 import { AgentPanelHeader } from "./AgentPanelHeader";
 import { AgentMessageBubble } from "./AgentMessageBubble";
 import { AgentMessageInput } from "./AgentMessageInput";
 
 type Props = {
-  threadId: string;
+  threadId: string | null;
   initialMessages: AgentMessageRow[];
   userContext: UserContext;
   onClose: () => void;
   onDragStart: (e: React.MouseEvent) => void;
 };
 
-export function AgentCoworkerPanel({ threadId, initialMessages, userContext, onClose, onDragStart }: Props) {
-  const pathname = usePathname();
-  // Filter out old "X has joined" transition messages — they clutter the conversation
-  const filtered = initialMessages.filter(
+function filterMessages(messages: AgentMessageRow[]): AgentMessageRow[] {
+  return messages.filter(
     (m) => !(m.role === "system" && m.content.endsWith("has joined the conversation")),
   );
-  const [messages, setMessages] = useState<AgentMessageRow[]>(filtered);
+}
+
+export function AgentCoworkerPanel({
+  threadId,
+  initialMessages,
+  userContext,
+  onClose,
+  onDragStart,
+}: Props) {
+  const pathname = usePathname();
+  const [messages, setMessages] = useState<AgentMessageRow[]>(() => filterMessages(initialMessages));
   const [isPending, startTransition] = useTransition();
+  const [isClearing, startClearing] = useTransition();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Resolve agent for current route
   const agent: AgentInfo = resolveAgentForRoute(pathname, userContext);
 
-  // Auto-scroll to bottom when new messages appear
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  useEffect(() => {
+    setMessages(filterMessages(initialMessages));
+  }, [threadId, initialMessages]);
+
   function handleSend(content: string) {
+    if (!threadId) return;
+
     startTransition(async () => {
       const result = await sendMessage({
         threadId,
@@ -56,29 +69,50 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext, onC
     });
   }
 
+  function handleClear() {
+    if (!threadId) return;
+    if (typeof window !== "undefined" && !window.confirm("Erase the current page conversation?")) {
+      return;
+    }
+
+    startClearing(async () => {
+      const result = await clearConversation({ threadId });
+      if ("error" in result) {
+        console.warn("clearConversation error:", result.error);
+        return;
+      }
+      setMessages([]);
+    });
+  }
+
   return (
     <>
       <AgentPanelHeader
         agent={agent}
         userContext={userContext}
         onSend={handleSend}
+        onClear={handleClear}
+        clearDisabled={!threadId || messages.length === 0 || isPending || isClearing}
         onClose={onClose}
         onDragStart={onDragStart}
       />
 
-      {/* Messages area */}
-      <div style={{
-        flex: 1,
-        overflowY: "auto",
-        padding: "12px",
-      }}>
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: "12px",
+        }}
+      >
         {messages.length === 0 && (
-          <div style={{
-            textAlign: "center",
-            color: "var(--dpf-muted)",
-            fontSize: 12,
-            padding: "40px 20px",
-          }}>
+          <div
+            style={{
+              textAlign: "center",
+              color: "var(--dpf-muted)",
+              fontSize: 12,
+              padding: "40px 20px",
+            }}
+          >
             Start a conversation with your AI co-worker
           </div>
         )}
@@ -94,28 +128,32 @@ export function AgentCoworkerPanel({ threadId, initialMessages, userContext, onC
             />
           );
         })}
-        {isPending && (
-          <div style={{
-            display: "flex",
-            alignItems: "flex-start",
-            gap: 2,
-            marginBottom: 8,
-          }}>
-            <div style={{
-              padding: "8px 16px",
-              borderRadius: "12px 12px 12px 2px",
-              fontSize: 13,
-              background: "rgba(22, 22, 37, 0.8)",
-              color: "var(--dpf-muted)",
-            }}>
-              <span className="animate-pulse">Thinking...</span>
+        {(isPending || isClearing) && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 2,
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                padding: "8px 16px",
+                borderRadius: "12px 12px 12px 2px",
+                fontSize: 13,
+                background: "rgba(22, 22, 37, 0.8)",
+                color: "var(--dpf-muted)",
+              }}
+            >
+              <span className="animate-pulse">{isClearing ? "Erasing..." : "Thinking..."}</span>
             </div>
           </div>
         )}
         <div ref={messagesEndRef} />
       </div>
 
-      <AgentMessageInput onSend={handleSend} disabled={isPending} />
+      <AgentMessageInput onSend={handleSend} disabled={isPending || isClearing || !threadId} />
     </>
   );
 }

--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
+import { getOrCreateThreadSnapshot } from "@/lib/actions/agent-coworker";
 import { AgentFAB } from "./AgentFAB";
 import { AgentCoworkerPanel } from "./AgentCoworkerPanel";
 
 type Props = {
-  threadId: string;
-  initialMessages: AgentMessageRow[];
   userContext: UserContext;
 };
 
@@ -42,17 +42,22 @@ function loadPosition(): { x: number; y: number } {
       const parsed = JSON.parse(raw) as { x: number; y: number };
       if (typeof parsed.x === "number" && typeof parsed.y === "number") return clampPosition(parsed);
     }
-  } catch { /* ignore */ }
+  } catch {
+    // ignore localStorage parsing issues
+  }
   return {
     x: typeof window !== "undefined" ? window.innerWidth - PANEL_W - EDGE_GAP : EDGE_GAP,
     y: typeof window !== "undefined" ? window.innerHeight - PANEL_H - EDGE_GAP : EDGE_GAP,
   };
 }
 
-export function AgentCoworkerShell({ threadId, initialMessages, userContext }: Props) {
+export function AgentCoworkerShell({ userContext }: Props) {
+  const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [hydrated, setHydrated] = useState(false);
+  const [threadId, setThreadId] = useState<string | null>(null);
+  const [initialMessages, setInitialMessages] = useState<AgentMessageRow[]>([]);
   const positionRef = useRef(position);
   const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
 
@@ -65,7 +70,6 @@ export function AgentCoworkerShell({ threadId, initialMessages, userContext }: P
     setPosition(pos);
     setHydrated(true);
 
-    // Keep panel in viewport on window resize
     function handleResize() {
       const clamped = clampPosition(positionRef.current);
       if (clamped.x !== positionRef.current.x || clamped.y !== positionRef.current.y) {
@@ -73,9 +77,32 @@ export function AgentCoworkerShell({ threadId, initialMessages, userContext }: P
         setPosition(clamped);
       }
     }
+
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  useEffect(() => {
+    let active = true;
+    setThreadId(null);
+    setInitialMessages([]);
+
+    (async () => {
+      const snapshot = await getOrCreateThreadSnapshot({ routeContext: pathname });
+      if (!active) return;
+      setThreadId(snapshot?.threadId ?? null);
+      setInitialMessages(snapshot?.messages ?? []);
+    })().catch((error) => {
+      console.warn("getOrCreateThreadSnapshot error:", error);
+      if (!active) return;
+      setThreadId(null);
+      setInitialMessages([]);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [pathname]);
 
   function handleOpen() {
     setIsOpen(true);

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentPanelHeader } from "./AgentPanelHeader";
+
+describe("AgentPanelHeader", () => {
+  it("renders an erase control for the current conversation", () => {
+    const html = renderToStaticMarkup(
+      <AgentPanelHeader
+        agent={{
+          agentId: "agent-1",
+          agentName: "Ops Co-worker",
+          agentDescription: "Helps with operations",
+          canAssist: true,
+          systemPrompt: "prompt",
+          skills: [],
+        }}
+        userContext={{ platformRole: "OPS-100", isSuperuser: false }}
+        onSend={() => {}}
+        onClear={() => {}}
+        clearDisabled={false}
+        onClose={() => {}}
+        onDragStart={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Erase");
+  });
+});

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -8,11 +8,21 @@ type Props = {
   agent: AgentInfo;
   userContext: UserContext;
   onSend: (content: string) => void;
+  onClear: () => void;
+  clearDisabled: boolean;
   onClose: () => void;
   onDragStart: (e: React.MouseEvent) => void;
 };
 
-export function AgentPanelHeader({ agent, userContext, onSend, onClose, onDragStart }: Props) {
+export function AgentPanelHeader({
+  agent,
+  userContext,
+  onSend,
+  onClear,
+  clearDisabled,
+  onClose,
+  onDragStart,
+}: Props) {
   return (
     <div
       onMouseDown={onDragStart}
@@ -45,23 +55,50 @@ export function AgentPanelHeader({ agent, userContext, onSend, onClose, onDragSt
         </span>
       </div>
 
-      <button
-        type="button"
-        onClick={(e) => { e.stopPropagation(); onClose(); }}
-        title="Close"
-        style={{
-          background: "none",
-          border: "none",
-          color: "var(--dpf-muted)",
-          cursor: "pointer",
-          fontSize: 16,
-          padding: "2px 6px",
-          borderRadius: 4,
-          lineHeight: 1,
-        }}
-      >
-        ✕
-      </button>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClear();
+          }}
+          disabled={clearDisabled}
+          title="Erase current conversation"
+          style={{
+            background: "none",
+            border: "1px solid rgba(255, 255, 255, 0.12)",
+            color: "var(--dpf-muted)",
+            cursor: clearDisabled ? "not-allowed" : "pointer",
+            fontSize: 11,
+            padding: "4px 8px",
+            borderRadius: 6,
+            lineHeight: 1,
+            opacity: clearDisabled ? 0.5 : 1,
+          }}
+        >
+          Erase
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          title="Close"
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--dpf-muted)",
+            cursor: "pointer",
+            fontSize: 16,
+            padding: "2px 6px",
+            borderRadius: 4,
+            lineHeight: 1,
+          }}
+        >
+          x
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/lib/actions/agent-coworker-server.test.ts
+++ b/apps/web/lib/actions/agent-coworker-server.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    agentThread: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    agentMessage: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+import { auth } from "@/lib/auth";
+import { buildCoworkerContextKey } from "@/lib/agent-coworker-context";
+import { prisma } from "@dpf/db";
+import {
+  clearConversation,
+  getOrCreateThreadSnapshot,
+} from "./agent-coworker";
+
+const mockAuth = auth as ReturnType<typeof vi.fn>;
+const mockPrisma = prisma as any;
+
+describe("agent coworker thread scoping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: {
+        id: "user-1",
+        platformRole: "HR-100",
+        isSuperuser: false,
+      },
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({ id: "user-1" });
+  });
+
+  it("builds a page-scoped context key from the route", () => {
+    expect(buildCoworkerContextKey("/inventory")).toBe("coworker:/inventory");
+  });
+
+  it("creates and loads a route-scoped thread snapshot", async () => {
+    mockPrisma.agentThread.upsert.mockResolvedValue({ id: "thread-inventory" });
+    mockPrisma.agentMessage.findMany.mockResolvedValue([
+      {
+        id: "msg-1",
+        role: "assistant",
+        content: "Inventory help",
+        agentId: "agent-ops",
+        routeContext: "/inventory",
+        createdAt: new Date("2026-03-14T10:00:00.000Z"),
+      },
+    ]);
+
+    const result = await getOrCreateThreadSnapshot({ routeContext: "/inventory" });
+
+    expect(mockPrisma.agentThread.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_contextKey: {
+            userId: "user-1",
+            contextKey: "coworker:/inventory",
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      threadId: "thread-inventory",
+      messages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          content: "Inventory help",
+          agentId: "agent-ops",
+          routeContext: "/inventory",
+          createdAt: "2026-03-14T10:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("clears only the current page conversation", async () => {
+    mockPrisma.agentThread.findUnique.mockResolvedValue({
+      id: "thread-inventory",
+      userId: "user-1",
+    });
+    mockPrisma.agentMessage.deleteMany.mockResolvedValue({ count: 3 });
+
+    const result = await clearConversation({ threadId: "thread-inventory" });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockPrisma.agentMessage.deleteMany).toHaveBeenCalledWith({
+      where: { threadId: "thread-inventory" },
+    });
+  });
+});

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -9,6 +9,7 @@ import { serializeMessage } from "@/lib/agent-coworker-data";
 import { callWithFailover, NoProvidersAvailableError } from "@/lib/ai-provider-priority";
 import { logTokenUsage } from "@/lib/ai-inference";
 import type { ChatMessage } from "@/lib/ai-inference";
+import { buildCoworkerContextKey } from "@/lib/agent-coworker-context";
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
@@ -21,7 +22,9 @@ async function requireAuthUser() {
 
 // ─── Server Actions ─────────────────────────────────────────────────────────
 
-export async function getOrCreateThread(): Promise<{ threadId: string } | null> {
+export async function getOrCreateThreadSnapshot(input: {
+  routeContext: string;
+}): Promise<{ threadId: string; messages: AgentMessageRow[] } | null> {
   const user = await requireAuthUser();
 
   // Verify user exists in DB (JWT may reference a stale user after re-seed)
@@ -31,14 +34,42 @@ export async function getOrCreateThread(): Promise<{ threadId: string } | null> 
   });
   if (!dbUser) return null;
 
+  const contextKey = buildCoworkerContextKey(input.routeContext);
+
   const thread = await prisma.agentThread.upsert({
-    where: { userId_contextKey: { userId: user.id, contextKey: "coworker" } },
+    where: { userId_contextKey: { userId: user.id, contextKey } },
     update: {},
-    create: { userId: user.id, contextKey: "coworker" },
+    create: { userId: user.id, contextKey },
     select: { id: true },
   });
 
-  return { threadId: thread.id };
+  const messages = await prisma.agentMessage.findMany({
+    where: { threadId: thread.id },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    threadId: thread.id,
+    messages: messages.reverse().map(serializeMessage),
+  };
+}
+
+export async function getOrCreateThread(input?: {
+  routeContext?: string;
+}): Promise<{ threadId: string } | null> {
+  const snapshot = await getOrCreateThreadSnapshot({
+    routeContext: input?.routeContext ?? "/workspace",
+  });
+  return snapshot ? { threadId: snapshot.threadId } : null;
 }
 
 export async function sendMessage(input: {
@@ -263,4 +294,24 @@ export async function recordAgentTransition(input: {
   });
 
   return { message: serializeMessage(msg) };
+}
+
+export async function clearConversation(input: {
+  threadId: string;
+}): Promise<{ ok: true } | { error: string }> {
+  const user = await requireAuthUser();
+
+  const thread = await prisma.agentThread.findUnique({
+    where: { id: input.threadId },
+    select: { userId: true },
+  });
+  if (!thread || thread.userId !== user.id) {
+    return { error: "Unauthorized" };
+  }
+
+  await prisma.agentMessage.deleteMany({
+    where: { threadId: input.threadId },
+  });
+
+  return { ok: true };
 }

--- a/apps/web/lib/agent-coworker-context.ts
+++ b/apps/web/lib/agent-coworker-context.ts
@@ -1,0 +1,4 @@
+export function buildCoworkerContextKey(routeContext: string): string {
+  const normalized = routeContext.trim() || "/workspace";
+  return `coworker:${normalized}`;
+}


### PR DESCRIPTION
## Summary
- scope coworker conversations by route so page context no longer bleeds across UX surfaces
- add an Erase control that clears only the active page conversation
- move thread loading into the client shell so route changes swap to the correct thread snapshot

## Test Plan
- [x] pnpm --filter web test -- lib/actions/agent-coworker.test.ts lib/actions/agent-coworker-server.test.ts components/agent/AgentPanelHeader.test.tsx proxy.test.ts
- [x] pnpm --filter web typecheck
- [x] $env:DATABASE_URL='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter web build
