### PR TITLE
feat: add sensitivity-aware coworker form assist

### DIFF
--- a/apps/web/app/(shell)/error.tsx
+++ b/apps/web/app/(shell)/error.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ShellError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const [description, setDescription] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [reportId, setReportId] = useState<string | null>(null);
+
+  // Auto-report on mount (fire-and-forget)
+  useEffect(() => {
+    const body = {
+      type: "runtime_error",
+      severity: "critical",
+      title: error.message?.slice(0, 200) || "Page crash",
+      description: error.message,
+      routeContext: typeof window !== "undefined" ? window.location.pathname : null,
+      errorStack: error.stack?.slice(0, 20000),
+      userAgent: typeof navigator !== "undefined" ? navigator.userAgent : null,
+      source: "crash_boundary",
+    };
+    fetch("/api/quality/report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).catch(() => {
+      // Queue to localStorage if fetch fails
+      try {
+        const key = "dpf-quality-queue";
+        const raw = localStorage.getItem(key);
+        const queue = raw ? JSON.parse(raw) : [];
+        if (Array.isArray(queue)) {
+          queue.push({ ...body, queuedAt: new Date().toISOString() });
+          localStorage.setItem(key, JSON.stringify(queue));
+        }
+      } catch { /* silent */ }
+    });
+  }, [error]);
+
+  async function handleSubmit() {
+    try {
+      const res = await fetch("/api/quality/report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "user_report",
+          severity: "high",
+          title: description.slice(0, 100) || "User report from error page",
+          description,
+          routeContext: typeof window !== "undefined" ? window.location.pathname : null,
+          errorStack: error.stack?.slice(0, 20000),
+          source: "crash_boundary",
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setReportId(data.reportId);
+      }
+    } catch { /* silent */ }
+    setSubmitted(true);
+  }
+
+  return (
+    <div style={{
+      minHeight: "60vh",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 40,
+    }}>
+      <div style={{
+        maxWidth: 480,
+        width: "100%",
+        background: "rgba(26, 26, 46, 0.9)",
+        border: "1px solid rgba(42, 42, 64, 0.6)",
+        borderRadius: 16,
+        padding: "32px 28px",
+        textAlign: "center",
+      }}>
+        <div style={{ fontSize: 36, marginBottom: 12 }}>!</div>
+        <h2 style={{ fontSize: 18, fontWeight: 600, color: "#e0e0ff", marginBottom: 8 }}>
+          Something went wrong
+        </h2>
+        <p style={{ fontSize: 13, color: "var(--dpf-muted)", marginBottom: 20 }}>
+          The platform team has been automatically notified.
+          You can also describe what happened below.
+        </p>
+
+        {!submitted ? (
+          <>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What were you doing when this happened? (optional)"
+              rows={3}
+              style={{
+                width: "100%",
+                background: "rgba(15,15,26,0.8)",
+                border: "1px solid rgba(42,42,64,0.6)",
+                borderRadius: 8,
+                padding: "8px 10px",
+                color: "#e0e0ff",
+                fontSize: 12,
+                resize: "vertical",
+                marginBottom: 12,
+              }}
+            />
+            <div style={{ display: "flex", gap: 8, justifyContent: "center" }}>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                style={{
+                  background: "var(--dpf-accent)",
+                  border: "none",
+                  borderRadius: 8,
+                  padding: "8px 20px",
+                  fontSize: 13,
+                  color: "#fff",
+                  cursor: "pointer",
+                }}
+              >
+                Send feedback
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                style={{
+                  background: "none",
+                  border: "1px solid rgba(42,42,64,0.6)",
+                  borderRadius: 8,
+                  padding: "8px 20px",
+                  fontSize: 13,
+                  color: "#e0e0ff",
+                  cursor: "pointer",
+                }}
+              >
+                Try again
+              </button>
+            </div>
+          </>
+        ) : (
+          <div style={{ fontSize: 13, color: "var(--dpf-muted)" }}>
+            {reportId
+              ? `Thanks! Report ${reportId} filed.`
+              : "Thanks for the feedback."}
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                display: "block",
+                margin: "16px auto 0",
+                background: "var(--dpf-accent)",
+                border: "none",
+                borderRadius: 8,
+                padding: "8px 20px",
+                fontSize: 13,
+                color: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -6,6 +6,8 @@ import { resolveBrandingLogoUrl } from "@/lib/branding";
 import { redirect } from "next/navigation";
 import { Header } from "@/components/shell/Header";
 import { AgentCoworkerShell } from "@/components/agent/AgentCoworkerShell";
+import { FeedbackButton } from "@/components/feedback/FeedbackButton";
+import { QueueFlusher } from "@/components/feedback/QueueFlusher";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
   const session = await auth();
@@ -50,6 +52,8 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       <AgentCoworkerShell
         userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
       />
+      <FeedbackButton userId={user.id} />
+      <QueueFlusher />
     </div>
   );
 }

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -50,7 +50,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       />
       <main className="flex-1 p-6 max-w-7xl mx-auto w-full">{children}</main>
       <AgentCoworkerShell
-        userContext={{ platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
+        userContext={{ userId: user.id, platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
       />
       <FeedbackButton userId={user.id} />
       <QueueFlusher />

--- a/apps/web/app/api/quality/report/route.ts
+++ b/apps/web/app/api/quality/report/route.ts
@@ -1,0 +1,33 @@
+import { prisma } from "@dpf/db";
+
+export async function POST(request: Request) {
+  try {
+    const contentLength = parseInt(request.headers.get("content-length") ?? "0", 10);
+    if (contentLength > 65536) {
+      return Response.json({ ok: false, error: "Too large" }, { status: 413 });
+    }
+
+    const body = (await request.json()) as Record<string, unknown>;
+    const reportId = "PIR-" + Math.random().toString(36).substring(2, 7).toUpperCase();
+
+    await prisma.platformIssueReport.create({
+      data: {
+        reportId,
+        type: String(body.type ?? "user_report").slice(0, 50),
+        severity: String(body.severity ?? "medium").slice(0, 20),
+        title: String(body.title ?? "Untitled report").slice(0, 500),
+        description: body.description ? String(body.description).slice(0, 10000) : null,
+        routeContext: body.routeContext ? String(body.routeContext).slice(0, 500) : null,
+        errorStack: body.errorStack ? String(body.errorStack).slice(0, 20000) : null,
+        userAgent: body.userAgent ? String(body.userAgent).slice(0, 500) : null,
+        reportedById: typeof body.userId === "string" ? body.userId : null,
+        source: String(body.source ?? "manual").slice(0, 30),
+        portfolioId: typeof body.portfolioId === "string" ? body.portfolioId : null,
+        digitalProductId: typeof body.digitalProductId === "string" ? body.digitalProductId : null,
+      },
+    });
+    return Response.json({ ok: true, reportId });
+  } catch {
+    return Response.json({ ok: false }, { status: 500 });
+  }
+}

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -9,6 +9,14 @@ import { clearConversation, sendMessage } from "@/lib/actions/agent-coworker";
 import { AgentPanelHeader } from "./AgentPanelHeader";
 import { AgentMessageBubble } from "./AgentMessageBubble";
 import { AgentMessageInput } from "./AgentMessageInput";
+import {
+  loadElevatedAssistPreference,
+  saveElevatedAssistPreference,
+} from "./agent-form-assist-prefs";
+import {
+  buildAgentFormAssistContext,
+  getActiveFormAssist,
+} from "@/lib/agent-form-assist";
 
 type Props = {
   threadId: string | null;
@@ -35,9 +43,11 @@ export function AgentCoworkerPanel({
   const [messages, setMessages] = useState<AgentMessageRow[]>(() => filterMessages(initialMessages));
   const [isPending, startTransition] = useTransition();
   const [isClearing, startClearing] = useTransition();
+  const [elevatedAssistEnabled, setElevatedAssistEnabled] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const agent: AgentInfo = resolveAgentForRoute(pathname, userContext);
+  const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -47,14 +57,30 @@ export function AgentCoworkerPanel({
     setMessages(filterMessages(initialMessages));
   }, [threadId, initialMessages]);
 
+  useEffect(() => {
+    setElevatedAssistEnabled(loadElevatedAssistPreference(preferenceUserKey, pathname));
+  }, [pathname, preferenceUserKey]);
+
+  function handleToggleElevatedAssist() {
+    setElevatedAssistEnabled((prev) => {
+      const next = !prev;
+      saveElevatedAssistPreference(preferenceUserKey, pathname, next);
+      return next;
+    });
+  }
+
   function handleSend(content: string) {
     if (!threadId) return;
+    const activeFormAssist = elevatedAssistEnabled ? getActiveFormAssist(pathname) : null;
+    const formAssistContext = activeFormAssist ? buildAgentFormAssistContext(activeFormAssist) : undefined;
 
     startTransition(async () => {
       const result = await sendMessage({
         threadId,
         content,
         routeContext: pathname,
+        elevatedFormFillEnabled: elevatedAssistEnabled,
+        ...(formAssistContext ? { formAssistContext } : {}),
       });
       if ("error" in result) {
         console.warn("sendMessage error:", result.error);
@@ -65,6 +91,17 @@ export function AgentCoworkerPanel({
         newMessages.push(result.systemMessage);
       }
       newMessages.push(result.agentMessage);
+      if ("formAssistUpdate" in result && result.formAssistUpdate && activeFormAssist) {
+        activeFormAssist.applyFieldUpdates(result.formAssistUpdate);
+        newMessages.push({
+          id: `local-form-assist-${Date.now()}`,
+          role: "system",
+          content: "Applied the agent's suggested field updates to the active form for your review.",
+          agentId: agent.agentId,
+          routeContext: pathname,
+          createdAt: new Date().toISOString(),
+        });
+      }
       setMessages((prev) => [...prev, ...newMessages]);
     });
   }
@@ -93,6 +130,8 @@ export function AgentCoworkerPanel({
         onSend={handleSend}
         onClear={handleClear}
         clearDisabled={!threadId || messages.length === 0 || isPending || isClearing}
+        elevatedAssistEnabled={elevatedAssistEnabled}
+        onToggleElevatedAssist={handleToggleElevatedAssist}
         onClose={onClose}
         onDragStart={onDragStart}
       />

--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -7,80 +7,82 @@ import type { UserContext } from "@/lib/permissions";
 import { getOrCreateThreadSnapshot } from "@/lib/actions/agent-coworker";
 import { AgentFAB } from "./AgentFAB";
 import { AgentCoworkerPanel } from "./AgentCoworkerPanel";
+import {
+  clampPanelPosition,
+  clampPanelSize,
+  type PanelPosition,
+  type PanelSize,
+} from "./agent-panel-layout";
+import {
+  loadPanelOpen,
+  loadPanelPosition,
+  loadPanelSize,
+  savePanelOpen,
+  savePanelPosition,
+  savePanelSize,
+} from "./agent-panel-prefs";
 
 type Props = {
   userContext: UserContext;
 };
 
-const LS_KEY_OPEN = "agent-panel-open";
-const LS_KEY_POS = "agent-panel-position";
-
-const PANEL_W = 380;
-const PANEL_H = 480;
-const EDGE_GAP = 16;
-
-function loadOpen(): boolean {
-  try {
-    return localStorage.getItem(LS_KEY_OPEN) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function clampPosition(pos: { x: number; y: number }): { x: number; y: number } {
-  if (typeof window === "undefined") return pos;
+function getViewport() {
   return {
-    x: Math.max(0, Math.min(pos.x, window.innerWidth - PANEL_W)),
-    y: Math.max(0, Math.min(pos.y, window.innerHeight - PANEL_H)),
-  };
-}
-
-function loadPosition(): { x: number; y: number } {
-  try {
-    const raw = localStorage.getItem(LS_KEY_POS);
-    if (raw) {
-      const parsed = JSON.parse(raw) as { x: number; y: number };
-      if (typeof parsed.x === "number" && typeof parsed.y === "number") return clampPosition(parsed);
-    }
-  } catch {
-    // ignore localStorage parsing issues
-  }
-  return {
-    x: typeof window !== "undefined" ? window.innerWidth - PANEL_W - EDGE_GAP : EDGE_GAP,
-    y: typeof window !== "undefined" ? window.innerHeight - PANEL_H - EDGE_GAP : EDGE_GAP,
+    width: window.innerWidth,
+    height: window.innerHeight,
   };
 }
 
 export function AgentCoworkerShell({ userContext }: Props) {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
-  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [position, setPosition] = useState<PanelPosition>({ x: 0, y: 0 });
+  const [size, setSize] = useState<PanelSize>({ width: 380, height: 480 });
   const [hydrated, setHydrated] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);
   const [initialMessages, setInitialMessages] = useState<AgentMessageRow[]>([]);
   const positionRef = useRef(position);
+  const sizeRef = useRef(size);
   const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
+  const resizeRef = useRef<{ startX: number; startY: number; startWidth: number; startHeight: number } | null>(null);
+  const userKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
 
   useEffect(() => {
-    if (loadOpen()) {
+    const viewport = getViewport();
+    const initialSize = loadPanelSize(userKey, viewport);
+    const initialPosition = loadPanelPosition(userKey, viewport, initialSize);
+
+    sizeRef.current = initialSize;
+    positionRef.current = initialPosition;
+    setSize(initialSize);
+    setPosition(initialPosition);
+
+    if (loadPanelOpen(userKey)) {
       setIsOpen(true);
     }
-    const pos = loadPosition();
-    positionRef.current = pos;
-    setPosition(pos);
     setHydrated(true);
 
     function handleResize() {
-      const clamped = clampPosition(positionRef.current);
-      if (clamped.x !== positionRef.current.x || clamped.y !== positionRef.current.y) {
-        positionRef.current = clamped;
-        setPosition(clamped);
+      const viewport = getViewport();
+      const clampedSize = clampPanelSize(sizeRef.current, viewport);
+      const clampedPosition = clampPanelPosition(positionRef.current, clampedSize, viewport);
+
+      if (clampedSize.width !== sizeRef.current.width || clampedSize.height !== sizeRef.current.height) {
+        sizeRef.current = clampedSize;
+        setSize(clampedSize);
+        savePanelSize(userKey, clampedSize);
+      }
+
+      if (clampedPosition.x !== positionRef.current.x || clampedPosition.y !== positionRef.current.y) {
+        positionRef.current = clampedPosition;
+        setPosition(clampedPosition);
+        savePanelPosition(userKey, clampedPosition);
       }
     }
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  }, [userKey]);
 
   useEffect(() => {
     let active = true;
@@ -106,23 +108,23 @@ export function AgentCoworkerShell({ userContext }: Props) {
 
   function handleOpen() {
     setIsOpen(true);
-    localStorage.setItem(LS_KEY_OPEN, "true");
+    savePanelOpen(userKey, true);
   }
 
   function handleClose() {
     setIsOpen(false);
-    localStorage.setItem(LS_KEY_OPEN, "false");
+    savePanelOpen(userKey, false);
   }
 
   // Listen for feedback button
   useEffect(() => {
     function handleFeedback() {
       setIsOpen(true);
-      localStorage.setItem(LS_KEY_OPEN, "true");
+      savePanelOpen(userKey, true);
     }
     document.addEventListener("open-agent-feedback", handleFeedback);
     return () => document.removeEventListener("open-agent-feedback", handleFeedback);
-  }, []);
+  }, [userKey]);
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     dragRef.current = {
@@ -136,13 +138,13 @@ export function AgentCoworkerShell({ userContext }: Props) {
       if (!dragRef.current) return;
       const dx = ev.clientX - dragRef.current.startX;
       const dy = ev.clientY - dragRef.current.startY;
-      const newPos = {
+      const newPos = clampPanelPosition({
         x: dragRef.current.startPosX + dx,
         y: dragRef.current.startPosY + dy,
-      };
+      }, sizeRef.current, getViewport());
       positionRef.current = newPos;
       setPosition(newPos);
-      localStorage.setItem(LS_KEY_POS, JSON.stringify(newPos));
+      savePanelPosition(userKey, newPos);
     }
 
     function onMouseUp() {
@@ -153,7 +155,42 @@ export function AgentCoworkerShell({ userContext }: Props) {
 
     document.addEventListener("mousemove", onMouseMove);
     document.addEventListener("mouseup", onMouseUp);
-  }, []);
+  }, [userKey]);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    resizeRef.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      startWidth: sizeRef.current.width,
+      startHeight: sizeRef.current.height,
+    };
+
+    function onMouseMove(ev: MouseEvent) {
+      if (!resizeRef.current) return;
+      const nextSize = clampPanelSize({
+        width: resizeRef.current.startWidth + (ev.clientX - resizeRef.current.startX),
+        height: resizeRef.current.startHeight + (ev.clientY - resizeRef.current.startY),
+      }, getViewport());
+
+      const nextPosition = clampPanelPosition(positionRef.current, nextSize, getViewport());
+      sizeRef.current = nextSize;
+      positionRef.current = nextPosition;
+      setSize(nextSize);
+      setPosition(nextPosition);
+      savePanelSize(userKey, nextSize);
+      savePanelPosition(userKey, nextPosition);
+    }
+
+    function onMouseUp() {
+      resizeRef.current = null;
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, [userKey]);
 
   if (!hydrated) return null;
 
@@ -169,8 +206,8 @@ export function AgentCoworkerShell({ userContext }: Props) {
             zIndex: 50,
             left: position.x,
             top: position.y,
-            width: PANEL_W,
-            height: PANEL_H,
+            width: size.width,
+            height: size.height,
             borderRadius: 12,
             background: "rgba(26, 26, 46, 0.7)",
             backdropFilter: "blur(12px)",
@@ -188,6 +225,20 @@ export function AgentCoworkerShell({ userContext }: Props) {
             userContext={userContext}
             onClose={handleClose}
             onDragStart={handleDragStart}
+          />
+          <div
+            onMouseDown={handleResizeStart}
+            title="Resize coworker panel"
+            style={{
+              position: "absolute",
+              right: 0,
+              bottom: 0,
+              width: 18,
+              height: 18,
+              cursor: "nwse-resize",
+              background:
+                "linear-gradient(135deg, transparent 0 40%, rgba(124, 140, 248, 0.2) 40% 60%, rgba(124, 140, 248, 0.55) 60% 100%)",
+            }}
           />
         </div>
       )}

--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -114,6 +114,16 @@ export function AgentCoworkerShell({ userContext }: Props) {
     localStorage.setItem(LS_KEY_OPEN, "false");
   }
 
+  // Listen for feedback button
+  useEffect(() => {
+    function handleFeedback() {
+      setIsOpen(true);
+      localStorage.setItem(LS_KEY_OPEN, "true");
+    }
+    document.addEventListener("open-agent-feedback", handleFeedback);
+    return () => document.removeEventListener("open-agent-feedback", handleFeedback);
+  }, []);
+
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     dragRef.current = {
       startX: e.clientX,
@@ -153,6 +163,7 @@ export function AgentCoworkerShell({ userContext }: Props) {
 
       {isOpen && (
         <div
+          data-agent-panel="true"
           style={{
             position: "fixed",
             zIndex: 50,

--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentMessageBubble } from "./AgentMessageBubble";
+
+describe("AgentMessageBubble", () => {
+  it("renders assistant markdown as structured HTML", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-1",
+          role: "assistant",
+          content: "**Agents** help with:\n\n- automation\n- workflow management",
+          agentId: "ops-coordinator",
+          routeContext: "/ops",
+          createdAt: "2026-03-14T12:00:00.000Z",
+        }}
+        showAgentLabel={true}
+        agentName="Ops Coordinator"
+      />,
+    );
+
+    expect(html).toContain("<strong");
+    expect(html).toContain("Agents</strong>");
+    expect(html).toContain("<ul");
+    expect(html).toContain("automation</li>");
+    expect(html).not.toContain("**Agents**");
+  });
+
+  it("keeps user messages as plain text bubbles", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-2",
+          role: "user",
+          content: "**raw** user text",
+          agentId: null,
+          routeContext: "/ops",
+          createdAt: "2026-03-14T12:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName={null}
+      />,
+    );
+
+    expect(html).toContain("**raw** user text");
+    expect(html).not.toContain("<strong>raw</strong>");
+  });
+});

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -1,11 +1,67 @@
 "use client";
 
+import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
+import type { ExtraProps } from "react-markdown";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 
 type Props = {
   message: AgentMessageRow;
-  showAgentLabel: boolean; // true when agent changed from previous message
+  showAgentLabel: boolean;
   agentName: string | null;
+};
+
+const MARKDOWN_COMPONENTS: Components = {
+  p: ({ children }) => <p style={{ margin: "0 0 8px 0" }}>{children}</p>,
+  ul: ({ children }) => <ul style={{ margin: "0 0 8px 18px", padding: 0 }}>{children}</ul>,
+  ol: ({ children }) => <ol style={{ margin: "0 0 8px 18px", padding: 0 }}>{children}</ol>,
+  li: ({ children }) => <li style={{ marginBottom: 4 }}>{children}</li>,
+  strong: ({ children }) => <strong style={{ fontWeight: 700, color: "#ffffff" }}>{children}</strong>,
+  em: ({ children }) => <em style={{ fontStyle: "italic" }}>{children}</em>,
+  h1: ({ children }) => (
+    <h1 style={{ margin: "0 0 8px 0", fontSize: 16, fontWeight: 700, lineHeight: 1.3 }}>{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 style={{ margin: "0 0 8px 0", fontSize: 15, fontWeight: 700, lineHeight: 1.3 }}>{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 style={{ margin: "0 0 6px 0", fontSize: 14, fontWeight: 700, lineHeight: 1.3 }}>{children}</h3>
+  ),
+  code: ({ children, className, ...props }) => {
+    const inline = !className;
+    return inline ? (
+      <code
+        {...props}
+        style={{
+          background: "rgba(255,255,255,0.08)",
+          borderRadius: 4,
+          padding: "1px 4px",
+          fontSize: 12,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        }}
+      >
+        {children}
+      </code>
+    ) : (
+      <code className={className} {...props}>{children}</code>
+    );
+  },
+  pre: ({ children }) => (
+    <pre
+      style={{
+        margin: "0 0 8px 0",
+        padding: "8px 10px",
+        background: "rgba(0,0,0,0.22)",
+        borderRadius: 8,
+        overflowX: "auto",
+        fontSize: 12,
+        lineHeight: 1.45,
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+      }}
+    >
+      {children}
+    </pre>
+  ),
 };
 
 function formatRelativeTime(isoString: string): string {
@@ -22,13 +78,15 @@ function formatRelativeTime(isoString: string): string {
 export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props) {
   if (message.role === "system") {
     return (
-      <div style={{
-        textAlign: "center",
-        padding: "8px 0",
-        fontSize: 11,
-        color: "var(--dpf-muted)",
-        fontStyle: "italic",
-      }}>
+      <div
+        style={{
+          textAlign: "center",
+          padding: "8px 0",
+          fontSize: 11,
+          color: "var(--dpf-muted)",
+          fontStyle: "italic",
+        }}
+      >
         {message.content}
       </div>
     );
@@ -37,13 +95,15 @@ export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props
   const isUser = message.role === "user";
 
   return (
-    <div style={{
-      display: "flex",
-      flexDirection: "column",
-      alignItems: isUser ? "flex-end" : "flex-start",
-      gap: 2,
-      marginBottom: 8,
-    }}>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: isUser ? "flex-end" : "flex-start",
+        gap: 2,
+        marginBottom: 8,
+      }}
+    >
       {showAgentLabel && agentName && !isUser && (
         <span style={{ fontSize: 10, color: "var(--dpf-accent)", marginLeft: 4 }}>
           {agentName}
@@ -56,13 +116,19 @@ export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props
           padding: "8px 12px",
           borderRadius: isUser ? "12px 12px 2px 12px" : "12px 12px 12px 2px",
           fontSize: 13,
-          lineHeight: 1.4,
+          lineHeight: 1.5,
           background: isUser ? "var(--dpf-accent)" : "rgba(22, 22, 37, 0.8)",
           color: isUser ? "#ffffff" : "#e0e0ff",
           wordBreak: "break-word",
         }}
       >
-        {message.content}
+        {isUser ? (
+          message.content
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+            <ReactMarkdown components={MARKDOWN_COMPONENTS}>{message.content}</ReactMarkdown>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -11,18 +11,48 @@ describe("AgentPanelHeader", () => {
           agentName: "Ops Co-worker",
           agentDescription: "Helps with operations",
           canAssist: true,
+          sensitivity: "internal",
           systemPrompt: "prompt",
           skills: [],
         }}
-        userContext={{ platformRole: "OPS-100", isSuperuser: false }}
+        userContext={{ userId: "user-1", platformRole: "OPS-100", isSuperuser: false }}
         onSend={() => {}}
         onClear={() => {}}
         clearDisabled={false}
+        elevatedAssistEnabled={false}
+        onToggleElevatedAssist={() => {}}
         onClose={() => {}}
         onDragStart={() => {}}
       />,
     );
 
     expect(html).toContain("Erase");
+  });
+
+  it("renders a yellow elevated assist indicator when form fill is enabled", () => {
+    const html = renderToStaticMarkup(
+      <AgentPanelHeader
+        agent={{
+          agentId: "agent-1",
+          agentName: "Ops Co-worker",
+          agentDescription: "Helps with operations",
+          canAssist: true,
+          sensitivity: "restricted",
+          systemPrompt: "prompt",
+          skills: [],
+        }}
+        userContext={{ userId: "user-1", platformRole: "OPS-100", isSuperuser: false }}
+        onSend={() => {}}
+        onClear={() => {}}
+        clearDisabled={false}
+        elevatedAssistEnabled
+        onToggleElevatedAssist={() => {}}
+        onClose={() => {}}
+        onDragStart={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Form fill enabled");
+    expect(html).toContain("Restricted");
   });
 });

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -4,12 +4,18 @@ import type { AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { AgentSkillsDropdown } from "./AgentSkillsDropdown";
 
+function formatSensitivityLabel(value: AgentInfo["sensitivity"]): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 type Props = {
   agent: AgentInfo;
   userContext: UserContext;
   onSend: (content: string) => void;
   onClear: () => void;
   clearDisabled: boolean;
+  elevatedAssistEnabled: boolean;
+  onToggleElevatedAssist: () => void;
   onClose: () => void;
   onDragStart: (e: React.MouseEvent) => void;
 };
@@ -20,6 +26,8 @@ export function AgentPanelHeader({
   onSend,
   onClear,
   clearDisabled,
+  elevatedAssistEnabled,
+  onToggleElevatedAssist,
   onClose,
   onDragStart,
 }: Props) {
@@ -50,6 +58,37 @@ export function AgentPanelHeader({
             onSend={onSend}
           />
         </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", marginLeft: 12 }}>
+          <span
+            style={{
+              fontSize: 9,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "rgba(224, 224, 255, 0.78)",
+              border: "1px solid rgba(255, 255, 255, 0.12)",
+              borderRadius: 999,
+              padding: "2px 6px",
+            }}
+          >
+            {formatSensitivityLabel(agent.sensitivity)}
+          </span>
+          {elevatedAssistEnabled && (
+            <span
+              style={{
+                fontSize: 9,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "#241700",
+                background: "#facc15",
+                borderRadius: 999,
+                padding: "2px 6px",
+                fontWeight: 700,
+              }}
+            >
+              Form fill enabled
+            </span>
+          )}
+        </div>
         <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: 12 }}>
           {agent.agentDescription}
         </span>
@@ -58,6 +97,28 @@ export function AgentPanelHeader({
       <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
         <button
           type="button"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleElevatedAssist();
+          }}
+          title="Allow this page's coworker to fill approved form fields"
+          style={{
+            background: elevatedAssistEnabled ? "rgba(250, 204, 21, 0.18)" : "none",
+            border: `1px solid ${elevatedAssistEnabled ? "rgba(250, 204, 21, 0.65)" : "rgba(255, 255, 255, 0.12)"}`,
+            color: elevatedAssistEnabled ? "#facc15" : "var(--dpf-muted)",
+            cursor: "pointer",
+            fontSize: 11,
+            padding: "4px 8px",
+            borderRadius: 6,
+            lineHeight: 1,
+          }}
+        >
+          Fill
+        </button>
+        <button
+          type="button"
+          onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
             onClear();
@@ -80,6 +141,7 @@ export function AgentPanelHeader({
         </button>
         <button
           type="button"
+          onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
             onClose();

--- a/apps/web/components/agent/agent-form-assist-prefs.ts
+++ b/apps/web/components/agent/agent-form-assist-prefs.ts
@@ -1,0 +1,15 @@
+export function getElevatedAssistKey(userId: string, routeContext: string): string {
+  return `agent-elevated-form-assist:${userId}:${routeContext}`;
+}
+
+export function loadElevatedAssistPreference(userId: string, routeContext: string): boolean {
+  try {
+    return localStorage.getItem(getElevatedAssistKey(userId, routeContext)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function saveElevatedAssistPreference(userId: string, routeContext: string, enabled: boolean): void {
+  localStorage.setItem(getElevatedAssistKey(userId, routeContext), String(enabled));
+}

--- a/apps/web/components/agent/agent-panel-layout.test.ts
+++ b/apps/web/components/agent/agent-panel-layout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PANEL_HEIGHT,
+  DEFAULT_PANEL_WIDTH,
+  MIN_PANEL_HEIGHT,
+  MIN_PANEL_WIDTH,
+  clampPanelPosition,
+  clampPanelSize,
+  getDefaultPanelPosition,
+} from "./agent-panel-layout";
+
+describe("agent panel layout helpers", () => {
+  it("clamps panel size to configured minimums", () => {
+    expect(clampPanelSize({ width: 100, height: 120 }, { width: 1440, height: 900 })).toEqual({
+      width: MIN_PANEL_WIDTH,
+      height: MIN_PANEL_HEIGHT,
+    });
+  });
+
+  it("clamps panel size to the viewport minus edge gap", () => {
+    expect(clampPanelSize({ width: 2000, height: 2000 }, { width: 900, height: 700 })).toEqual({
+      width: 900 - 32,
+      height: 700 - 32,
+    });
+  });
+
+  it("clamps panel position using the active panel size", () => {
+    expect(
+      clampPanelPosition(
+        { x: 2000, y: 2000 },
+        { width: DEFAULT_PANEL_WIDTH, height: DEFAULT_PANEL_HEIGHT },
+        { width: 1200, height: 900 },
+      ),
+    ).toEqual({
+      x: 1200 - DEFAULT_PANEL_WIDTH,
+      y: 900 - DEFAULT_PANEL_HEIGHT,
+    });
+  });
+
+  it("returns a bottom-right default position that respects the current size", () => {
+    expect(
+      getDefaultPanelPosition(
+        { width: DEFAULT_PANEL_WIDTH, height: DEFAULT_PANEL_HEIGHT },
+        { width: 1600, height: 1000 },
+      ),
+    ).toEqual({
+      x: 1600 - DEFAULT_PANEL_WIDTH - 16,
+      y: 1000 - DEFAULT_PANEL_HEIGHT - 16,
+    });
+  });
+});

--- a/apps/web/components/agent/agent-panel-layout.ts
+++ b/apps/web/components/agent/agent-panel-layout.ts
@@ -1,0 +1,42 @@
+export const EDGE_GAP = 16;
+export const DEFAULT_PANEL_WIDTH = 380;
+export const DEFAULT_PANEL_HEIGHT = 480;
+export const MIN_PANEL_WIDTH = 320;
+export const MIN_PANEL_HEIGHT = 320;
+
+export type ViewportSize = { width: number; height: number };
+export type PanelSize = { width: number; height: number };
+export type PanelPosition = { x: number; y: number };
+
+function maxPanelWidth(viewport: ViewportSize): number {
+  return Math.max(MIN_PANEL_WIDTH, viewport.width - (EDGE_GAP * 2));
+}
+
+function maxPanelHeight(viewport: ViewportSize): number {
+  return Math.max(MIN_PANEL_HEIGHT, viewport.height - (EDGE_GAP * 2));
+}
+
+export function clampPanelSize(size: PanelSize, viewport: ViewportSize): PanelSize {
+  return {
+    width: Math.max(MIN_PANEL_WIDTH, Math.min(size.width, maxPanelWidth(viewport))),
+    height: Math.max(MIN_PANEL_HEIGHT, Math.min(size.height, maxPanelHeight(viewport))),
+  };
+}
+
+export function clampPanelPosition(
+  position: PanelPosition,
+  size: PanelSize,
+  viewport: ViewportSize,
+): PanelPosition {
+  return {
+    x: Math.max(0, Math.min(position.x, viewport.width - size.width)),
+    y: Math.max(0, Math.min(position.y, viewport.height - size.height)),
+  };
+}
+
+export function getDefaultPanelPosition(size: PanelSize, viewport: ViewportSize): PanelPosition {
+  return {
+    x: Math.max(EDGE_GAP, viewport.width - size.width - EDGE_GAP),
+    y: Math.max(EDGE_GAP, viewport.height - size.height - EDGE_GAP),
+  };
+}

--- a/apps/web/components/agent/agent-panel-prefs.ts
+++ b/apps/web/components/agent/agent-panel-prefs.ts
@@ -1,0 +1,74 @@
+import {
+  clampPanelPosition,
+  clampPanelSize,
+  DEFAULT_PANEL_HEIGHT,
+  DEFAULT_PANEL_WIDTH,
+  getDefaultPanelPosition,
+  type PanelPosition,
+  type PanelSize,
+  type ViewportSize,
+} from "./agent-panel-layout";
+
+export function getAgentPanelOpenKey(userId: string): string {
+  return `agent-panel-open:${userId}`;
+}
+
+export function getAgentPanelPositionKey(userId: string): string {
+  return `agent-panel-position:${userId}`;
+}
+
+export function getAgentPanelSizeKey(userId: string): string {
+  return `agent-panel-size:${userId}`;
+}
+
+export function loadPanelOpen(userId: string): boolean {
+  try {
+    return localStorage.getItem(getAgentPanelOpenKey(userId)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function savePanelOpen(userId: string, open: boolean): void {
+  localStorage.setItem(getAgentPanelOpenKey(userId), String(open));
+}
+
+export function loadPanelSize(userId: string, viewport: ViewportSize): PanelSize {
+  try {
+    const raw = localStorage.getItem(getAgentPanelSizeKey(userId));
+    if (raw) {
+      const parsed = JSON.parse(raw) as PanelSize;
+      if (typeof parsed.width === "number" && typeof parsed.height === "number") {
+        return clampPanelSize(parsed, viewport);
+      }
+    }
+  } catch {
+    // ignore localStorage parsing issues
+  }
+
+  return clampPanelSize({ width: DEFAULT_PANEL_WIDTH, height: DEFAULT_PANEL_HEIGHT }, viewport);
+}
+
+export function savePanelSize(userId: string, size: PanelSize): void {
+  localStorage.setItem(getAgentPanelSizeKey(userId), JSON.stringify(size));
+}
+
+export function loadPanelPosition(userId: string, viewport: ViewportSize, size: PanelSize): PanelPosition {
+  try {
+    const raw = localStorage.getItem(getAgentPanelPositionKey(userId));
+    if (raw) {
+      const parsed = JSON.parse(raw) as PanelPosition;
+      if (typeof parsed.x === "number" && typeof parsed.y === "number") {
+        return clampPanelPosition(parsed, size, viewport);
+      }
+    }
+  } catch {
+    // ignore localStorage parsing issues
+  }
+
+  return getDefaultPanelPosition(size, viewport);
+}
+
+export function savePanelPosition(userId: string, position: PanelPosition): void {
+  localStorage.setItem(getAgentPanelPositionKey(userId), JSON.stringify(position));
+}

--- a/apps/web/components/feedback/FeedbackButton.tsx
+++ b/apps/web/components/feedback/FeedbackButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { FeedbackForm } from "./FeedbackForm";
+
+type Props = {
+  userId?: string | null;
+};
+
+export function FeedbackButton({ userId }: Props) {
+  const pathname = usePathname();
+  const [showForm, setShowForm] = useState(false);
+
+  function handleClick() {
+    // Try to open AI co-worker with feedback prompt
+    const event = new CustomEvent("open-agent-feedback");
+    document.dispatchEvent(event);
+
+    // Fallback: if panel doesn't open (no listener, not hydrated, no provider),
+    // show the simple form after a short delay
+    setTimeout(() => {
+      // Check if co-worker panel opened by looking for it in the DOM
+      const panel = document.querySelector("[data-agent-panel]");
+      if (!panel) {
+        setShowForm(true);
+      }
+    }, 500);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        title="Send feedback"
+        style={{
+          position: "fixed",
+          left: 16,
+          bottom: 16,
+          padding: "6px 14px",
+          borderRadius: 16,
+          background: "rgba(136, 136, 160, 0.4)",
+          backdropFilter: "blur(4px)",
+          WebkitBackdropFilter: "blur(4px)",
+          border: "1px solid rgba(136, 136, 160, 0.25)",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          gap: 5,
+          boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+          zIndex: 49,
+          color: "rgba(224, 224, 255, 0.8)",
+          fontSize: 11,
+          fontWeight: 400,
+        }}
+      >
+        Feedback
+      </button>
+
+      {showForm && (
+        <div style={{
+          position: "fixed",
+          left: 16,
+          bottom: 50,
+          width: 300,
+          background: "rgba(26, 26, 46, 0.9)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+          border: "1px solid rgba(42, 42, 64, 0.6)",
+          borderRadius: 12,
+          boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
+          zIndex: 50,
+          overflow: "hidden",
+        }}>
+          <div style={{ padding: "10px 12px 0", fontSize: 12, fontWeight: 600, color: "#e0e0ff" }}>
+            Send Feedback
+          </div>
+          <FeedbackForm
+            routeContext={pathname}
+            userId={userId}
+            source="manual"
+            onClose={() => setShowForm(false)}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/feedback/FeedbackButton.tsx
+++ b/apps/web/components/feedback/FeedbackButton.tsx
@@ -37,7 +37,7 @@ export function FeedbackButton({ userId }: Props) {
         style={{
           position: "fixed",
           left: 16,
-          bottom: 16,
+          bottom: 60,
           padding: "6px 14px",
           borderRadius: 16,
           background: "rgba(136, 136, 160, 0.4)",
@@ -62,7 +62,7 @@ export function FeedbackButton({ userId }: Props) {
         <div style={{
           position: "fixed",
           left: 16,
-          bottom: 50,
+          bottom: 100,
           width: 300,
           background: "rgba(26, 26, 46, 0.9)",
           backdropFilter: "blur(12px)",

--- a/apps/web/components/feedback/FeedbackButton.tsx
+++ b/apps/web/components/feedback/FeedbackButton.tsx
@@ -78,7 +78,7 @@ export function FeedbackButton({ userId }: Props) {
           </div>
           <FeedbackForm
             routeContext={pathname}
-            userId={userId}
+            {...(userId != null && { userId })}
             source="manual"
             onClose={() => setShowForm(false)}
           />

--- a/apps/web/components/feedback/FeedbackForm.tsx
+++ b/apps/web/components/feedback/FeedbackForm.tsx
@@ -26,9 +26,9 @@ export function FeedbackForm({ routeContext, userId, errorMessage, errorStack, s
       description,
       severity: type === "runtime_error" ? "high" : "medium",
       routeContext,
-      errorStack: errorStack ?? undefined,
+      ...(errorStack !== undefined && { errorStack }),
       source: source ?? "manual",
-      userId: userId ?? undefined,
+      ...(userId != null && { userId }),
     });
     if (result.ok && result.reportId) {
       setReportId(result.reportId);

--- a/apps/web/components/feedback/FeedbackForm.tsx
+++ b/apps/web/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { submitReport } from "@/lib/quality-queue";
+
+type Props = {
+  routeContext: string;
+  userId?: string | null;
+  errorMessage?: string;
+  errorStack?: string;
+  source?: string;
+  onClose?: () => void;
+};
+
+export function FeedbackForm({ routeContext, userId, errorMessage, errorStack, source, onClose }: Props) {
+  const [type, setType] = useState<string>(errorMessage ? "runtime_error" : "user_report");
+  const [description, setDescription] = useState(errorMessage ?? "");
+  const [submitted, setSubmitted] = useState(false);
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [queued, setQueued] = useState(false);
+
+  async function handleSubmit() {
+    const result = await submitReport({
+      type,
+      title: description.slice(0, 100) || "User report",
+      description,
+      severity: type === "runtime_error" ? "high" : "medium",
+      routeContext,
+      errorStack: errorStack ?? undefined,
+      source: source ?? "manual",
+      userId: userId ?? undefined,
+    });
+    if (result.ok && result.reportId) {
+      setReportId(result.reportId);
+    } else {
+      setQueued(true);
+    }
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div style={{ padding: 16, textAlign: "center", color: "#e0e0ff", fontSize: 13 }}>
+        {reportId
+          ? `Thanks! Report ${reportId} filed. The platform team has been notified.`
+          : "Saved — will be sent when connectivity is restored."}
+        {onClose && (
+          <button type="button" onClick={onClose} style={{ display: "block", margin: "12px auto 0", background: "none", border: "1px solid rgba(42,42,64,0.6)", borderRadius: 6, padding: "4px 12px", color: "#e0e0ff", fontSize: 12, cursor: "pointer" }}>
+            Close
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 12, fontSize: 13, color: "#e0e0ff" }}>
+      <div style={{ marginBottom: 8 }}>
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          style={{ width: "100%", background: "rgba(15,15,26,0.8)", border: "1px solid rgba(42,42,64,0.6)", borderRadius: 6, padding: "6px 8px", color: "#e0e0ff", fontSize: 12 }}
+        >
+          <option value="runtime_error">Bug Report</option>
+          <option value="feedback">Suggestion</option>
+          <option value="user_report">Question</option>
+        </select>
+      </div>
+      <div style={{ marginBottom: 8 }}>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe what happened or what you'd like to see..."
+          rows={4}
+          style={{ width: "100%", background: "rgba(15,15,26,0.8)", border: "1px solid rgba(42,42,64,0.6)", borderRadius: 6, padding: "6px 8px", color: "#e0e0ff", fontSize: 12, resize: "vertical" }}
+        />
+      </div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!description.trim()}
+          style={{ flex: 1, background: "var(--dpf-accent)", border: "none", borderRadius: 6, padding: "6px 12px", fontSize: 12, color: "#fff", cursor: description.trim() ? "pointer" : "not-allowed", opacity: description.trim() ? 1 : 0.5 }}
+        >
+          Submit
+        </button>
+        {onClose && (
+          <button type="button" onClick={onClose} style={{ background: "none", border: "1px solid rgba(42,42,64,0.6)", borderRadius: 6, padding: "6px 12px", fontSize: 12, color: "#e0e0ff", cursor: "pointer" }}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/feedback/QueueFlusher.tsx
+++ b/apps/web/components/feedback/QueueFlusher.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+import { flushQueue } from "@/lib/quality-queue";
+
+export function QueueFlusher() {
+  useEffect(() => {
+    flushQueue().catch(() => {});
+  }, []);
+  return null;
+}

--- a/apps/web/components/ops/BacklogPanel.tsx
+++ b/apps/web/components/ops/BacklogPanel.tsx
@@ -4,6 +4,7 @@
 import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { createBacklogItem, updateBacklogItem } from "@/lib/actions/backlog";
+import { registerActiveFormAssist } from "@/lib/agent-form-assist";
 import {
   validateBacklogInput,
   type BacklogItemInput,
@@ -12,6 +13,7 @@ import {
   type TaxonomyNodeSelect,
   type EpicForSelect,
 } from "@/lib/backlog";
+import { applyBacklogFormAssistUpdates } from "./backlog-form-assist";
 
 type Props = {
   isOpen: boolean;
@@ -61,6 +63,31 @@ export function BacklogPanel({
     }
     setError(null);
   }, [item, isOpen, defaultType, defaultEpicId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    return registerActiveFormAssist({
+      routeContext: "/ops",
+      formId: "backlog-panel",
+      formName: item ? "Backlog item editor" : "New backlog item form",
+      fields: [
+        { key: "title", label: "Title", type: "text" },
+        { key: "type", label: "Type", type: "select", allowedValues: ["portfolio", "product"] },
+        { key: "status", label: "Status", type: "select", allowedValues: ["open", "in-progress", "done", "deferred"] },
+        { key: "priority", label: "Priority", type: "number", helperText: "Lower numbers mean higher priority." },
+        { key: "body", label: "Notes", type: "textarea" },
+      ],
+      getValues: () => ({
+        title: form.title,
+        type: form.type,
+        status: form.status,
+        priority: form.priority ?? null,
+        body: form.body ?? "",
+      }),
+      applyFieldUpdates: (updates) => setForm((prev) => applyBacklogFormAssistUpdates(prev, updates)),
+    });
+  }, [form, isOpen, item]);
 
   function set<K extends keyof BacklogItemInput>(key: K, value: BacklogItemInput[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));

--- a/apps/web/components/ops/backlog-form-assist.test.ts
+++ b/apps/web/components/ops/backlog-form-assist.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { BacklogItemInput } from "@/lib/backlog";
+import { applyBacklogFormAssistUpdates } from "./backlog-form-assist";
+
+describe("applyBacklogFormAssistUpdates", () => {
+  it("applies supported scalar fields", () => {
+    const next = applyBacklogFormAssistUpdates(
+      { title: "", type: "portfolio", status: "open", body: "" },
+      {
+        title: "Investigate provider filtering",
+        priority: 2,
+        body: "Use local providers for restricted routes.",
+      },
+    );
+
+    expect(next).toEqual<BacklogItemInput>({
+      title: "Investigate provider filtering",
+      type: "portfolio",
+      status: "open",
+      priority: 2,
+      body: "Use local providers for restricted routes.",
+    });
+  });
+
+  it("drops unsupported values and clears product selection when switching to portfolio", () => {
+    const next = applyBacklogFormAssistUpdates(
+      {
+        title: "Existing",
+        type: "product",
+        status: "open",
+        digitalProductId: "prod-1",
+      },
+      {
+        type: "portfolio",
+        status: "invalid",
+        priority: "abc",
+      },
+    );
+
+    expect(next).toEqual<BacklogItemInput>({
+      title: "Existing",
+      type: "portfolio",
+      status: "open",
+    });
+  });
+});

--- a/apps/web/components/ops/backlog-form-assist.ts
+++ b/apps/web/components/ops/backlog-form-assist.ts
@@ -1,0 +1,51 @@
+import type { BacklogItemInput } from "@/lib/backlog";
+
+const VALID_TYPES = new Set<BacklogItemInput["type"]>(["portfolio", "product"]);
+const VALID_STATUSES = new Set<BacklogItemInput["status"]>(["open", "in-progress", "done", "deferred"]);
+
+export function applyBacklogFormAssistUpdates(
+  current: BacklogItemInput,
+  updates: Record<string, unknown>,
+): BacklogItemInput {
+  const next: BacklogItemInput = { ...current };
+
+  if (typeof updates.title === "string") {
+    next.title = updates.title;
+  }
+
+  if (typeof updates.type === "string" && VALID_TYPES.has(updates.type as BacklogItemInput["type"])) {
+    next.type = updates.type as BacklogItemInput["type"];
+    if (next.type === "portfolio") {
+      delete next.digitalProductId;
+    }
+  }
+
+  if (typeof updates.status === "string" && VALID_STATUSES.has(updates.status as BacklogItemInput["status"])) {
+    next.status = updates.status as BacklogItemInput["status"];
+  }
+
+  if (typeof updates.priority === "number" && Number.isFinite(updates.priority)) {
+    next.priority = updates.priority;
+  }
+
+  if (typeof updates.body === "string") {
+    next.body = updates.body;
+  }
+
+  if (typeof updates.taxonomyNodeId === "string" || updates.taxonomyNodeId === null) {
+    if (updates.taxonomyNodeId === null) delete next.taxonomyNodeId;
+    else next.taxonomyNodeId = updates.taxonomyNodeId;
+  }
+
+  if (typeof updates.digitalProductId === "string" || updates.digitalProductId === null) {
+    if (updates.digitalProductId === null) delete next.digitalProductId;
+    else next.digitalProductId = updates.digitalProductId;
+  }
+
+  if (typeof updates.epicId === "string" || updates.epicId === null) {
+    if (updates.epicId === null) delete next.epicId;
+    else next.epicId = updates.epicId;
+  }
+
+  return next;
+}

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -6,10 +6,19 @@ import { validateMessageInput } from "@/lib/agent-coworker-types";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 import { resolveAgentForRoute, generateCannedResponse } from "@/lib/agent-routing";
 import { serializeMessage } from "@/lib/agent-coworker-data";
-import { callWithFailover, NoProvidersAvailableError } from "@/lib/ai-provider-priority";
+import {
+  callWithFailover,
+  NoAllowedProvidersForSensitivityError,
+  NoProvidersAvailableError,
+} from "@/lib/ai-provider-priority";
 import { logTokenUsage } from "@/lib/ai-inference";
 import type { ChatMessage } from "@/lib/ai-inference";
 import { buildCoworkerContextKey } from "@/lib/agent-coworker-context";
+import {
+  buildFormAssistInstruction,
+  extractFormAssistResult,
+  type AgentFormAssistContext,
+} from "@/lib/agent-form-assist";
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
@@ -76,8 +85,10 @@ export async function sendMessage(input: {
   threadId: string;
   content: string;
   routeContext: string;
+  elevatedFormFillEnabled?: boolean;
+  formAssistContext?: AgentFormAssistContext;
 }): Promise<
-  | { userMessage: AgentMessageRow; agentMessage: AgentMessageRow; systemMessage?: AgentMessageRow }
+  | { userMessage: AgentMessageRow; agentMessage: AgentMessageRow; systemMessage?: AgentMessageRow; formAssistUpdate?: Record<string, unknown> }
   | { error: string }
 > {
   const user = await requireAuthUser();
@@ -134,10 +145,24 @@ export async function sendMessage(input: {
   }));
 
   // Inject route context and user role into system prompt
-  const populatedPrompt = `${agent.systemPrompt}\n\nCurrent context:\n- Route: ${input.routeContext}\n- User role: ${user.platformRole ?? "none"}`;
+  const promptSections = [
+    agent.systemPrompt,
+    "",
+    "Current context:",
+    `- Route: ${input.routeContext}`,
+    `- User role: ${user.platformRole ?? "none"}`,
+    `- Page sensitivity: ${agent.sensitivity}`,
+  ];
+
+  if (input.elevatedFormFillEnabled && input.formAssistContext) {
+    promptSections.push("", buildFormAssistInstruction(input.formAssistContext));
+  }
+
+  const populatedPrompt = promptSections.join("\n");
 
   let responseContent: string;
   let responseProviderId: string | null = null;
+  let formAssistUpdate: Record<string, unknown> | undefined;
   let systemMessage: AgentMessageRow | undefined;
 
   try {
@@ -170,7 +195,21 @@ export async function sendMessage(input: {
       systemMessage = serializeMessage(sysMsg);
     }
   } catch (e) {
-    if (e instanceof NoProvidersAvailableError) {
+    if (e instanceof NoAllowedProvidersForSensitivityError) {
+      responseContent = generateCannedResponse(agent.agentId, input.routeContext, user.platformRole);
+
+      const sysMsg = await prisma.agentMessage.create({
+        data: {
+          threadId: input.threadId,
+          role: "system",
+          content: `The current page is marked ${agent.sensitivity}. No allowed AI provider is configured for that sensitivity, so the coworker switched to a local fallback response.`,
+          agentId: agent.agentId,
+          routeContext: input.routeContext,
+        },
+        select: { id: true, role: true, content: true, agentId: true, routeContext: true, createdAt: true },
+      });
+      systemMessage = serializeMessage(sysMsg);
+    } else if (e instanceof NoProvidersAvailableError) {
       // Fall back to canned response
       responseContent = generateCannedResponse(agent.agentId, input.routeContext, user.platformRole);
 
@@ -188,6 +227,12 @@ export async function sendMessage(input: {
     } else {
       throw e;
     }
+  }
+
+  if (input.elevatedFormFillEnabled && input.formAssistContext) {
+    const extracted = extractFormAssistResult(responseContent, input.formAssistContext);
+    responseContent = extracted.displayContent;
+    formAssistUpdate = extracted.fieldUpdates ?? undefined;
   }
 
   // Persist agent response
@@ -213,6 +258,7 @@ export async function sendMessage(input: {
   return {
     userMessage: serializeMessage(userMsg),
     agentMessage: serializeMessage(agentMsg),
+    ...(formAssistUpdate !== undefined && { formAssistUpdate }),
     ...(systemMessage !== undefined && { systemMessage }),
   };
 }

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -141,7 +141,7 @@ export async function sendMessage(input: {
   let systemMessage: AgentMessageRow | undefined;
 
   try {
-    const result = await callWithFailover(chatHistory, populatedPrompt);
+    const result = await callWithFailover(chatHistory, populatedPrompt, agent.sensitivity);
     responseContent = result.content;
     responseProviderId = result.providerId;
 

--- a/apps/web/lib/actions/quality.ts
+++ b/apps/web/lib/actions/quality.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+
+const ROUTE_PORTFOLIO_MAP: Record<string, string> = {
+  "/portfolio": "foundational",
+  "/ea": "foundational",
+  "/inventory": "foundational",
+  "/platform": "foundational",
+  "/admin": "foundational",
+  "/ops": "manufacturing_and_delivery",
+  "/employee": "for_employees",
+  "/customer": "products_and_services_sold",
+};
+
+function resolvePortfolioSlug(routeContext: string): string | null {
+  for (const [prefix, slug] of Object.entries(ROUTE_PORTFOLIO_MAP)) {
+    if (routeContext === prefix || routeContext.startsWith(prefix + "/")) {
+      return slug;
+    }
+  }
+  return null;
+}
+
+export async function reportQualityIssue(input: {
+  type: "runtime_error" | "user_report" | "feedback";
+  title: string;
+  description?: string;
+  severity?: string;
+  routeContext: string;
+  errorStack?: string;
+  source?: string;
+}): Promise<{ reportId: string } | { error: string }> {
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+  const reportId = "PIR-" + Math.random().toString(36).substring(2, 7).toUpperCase();
+
+  // Best-effort route-to-owner resolution
+  let portfolioId: string | null = null;
+  const slug = resolvePortfolioSlug(input.routeContext);
+  if (slug) {
+    const portfolio = await prisma.portfolio.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+    portfolioId = portfolio?.id ?? null;
+  }
+
+  try {
+    await prisma.platformIssueReport.create({
+      data: {
+        reportId,
+        type: input.type,
+        severity: input.severity ?? "medium",
+        title: input.title.slice(0, 500),
+        description: input.description?.slice(0, 10000) ?? null,
+        routeContext: input.routeContext,
+        errorStack: input.errorStack?.slice(0, 20000) ?? null,
+        reportedById: userId,
+        source: input.source ?? "ai_assisted",
+        portfolioId,
+      },
+    });
+    return { reportId };
+  } catch {
+    return { error: "Failed to create report" };
+  }
+}

--- a/apps/web/lib/agent-coworker-types.ts
+++ b/apps/web/lib/agent-coworker-types.ts
@@ -16,6 +16,7 @@ export type AgentInfo = {
   agentName: string;
   agentDescription: string;
   canAssist: boolean;
+  sensitivity: "public" | "internal" | "confidential" | "restricted";
   systemPrompt: string;
   skills: AgentSkill[];
 };
@@ -34,6 +35,7 @@ export type RouteAgentEntry = {
   agentName: string;
   agentDescription: string;
   capability: CapabilityKey | null;
+  sensitivity: "public" | "internal" | "confidential" | "restricted";
   systemPrompt: string;
   skills: AgentSkill[];
 };

--- a/apps/web/lib/agent-form-assist.test.ts
+++ b/apps/web/lib/agent-form-assist.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractFormAssistResult,
+  registerActiveFormAssist,
+  getActiveFormAssist,
+  type AgentFormAssistContext,
+} from "./agent-form-assist";
+
+describe("extractFormAssistResult", () => {
+  const context: AgentFormAssistContext = {
+    formId: "backlog-panel",
+    formName: "Backlog item",
+    fields: [
+      { key: "title", label: "Title", type: "text" },
+      { key: "priority", label: "Priority", type: "number" },
+    ],
+  };
+
+  it("returns plain content when no assist block is present", () => {
+    expect(extractFormAssistResult("Hello there", context)).toEqual({
+      displayContent: "Hello there",
+      fieldUpdates: null,
+    });
+  });
+
+  it("extracts allowed field updates from a fenced assist block", () => {
+    const result = extractFormAssistResult(
+      "I drafted the form updates for you.\n```agent-form\n{\"fieldUpdates\":{\"title\":\"Document the route help flow\",\"priority\":2,\"status\":\"open\"}}\n```",
+      context,
+    );
+
+    expect(result.displayContent).toBe("I drafted the form updates for you.");
+    expect(result.fieldUpdates).toEqual({
+      title: "Document the route help flow",
+      priority: 2,
+    });
+  });
+});
+
+describe("active form assist registry", () => {
+  it("registers and clears the active adapter", () => {
+    const dispose = registerActiveFormAssist({
+      routeContext: "/ops",
+      formId: "backlog-panel",
+      formName: "Backlog item",
+      fields: [{ key: "title", label: "Title", type: "text" }],
+      getValues: () => ({ title: "Existing" }),
+      applyFieldUpdates: () => {},
+    });
+
+    expect(getActiveFormAssist("/ops")?.formId).toBe("backlog-panel");
+    dispose();
+    expect(getActiveFormAssist("/ops")).toBeNull();
+  });
+});

--- a/apps/web/lib/agent-form-assist.ts
+++ b/apps/web/lib/agent-form-assist.ts
@@ -1,0 +1,131 @@
+export type AgentFormAssistField = {
+  key: string;
+  label: string;
+  type: "text" | "textarea" | "number" | "select";
+  helperText?: string;
+  allowedValues?: string[];
+  shareCurrentValue?: boolean;
+};
+
+export type AgentFormAssistContext = {
+  formId: string;
+  formName: string;
+  fields: AgentFormAssistField[];
+  values?: Record<string, unknown>;
+};
+
+export type AgentFormAssistClientAdapter = AgentFormAssistContext & {
+  routeContext: string;
+  getValues: () => Record<string, unknown>;
+  applyFieldUpdates: (updates: Record<string, unknown>) => void;
+};
+
+type ExtractedAssist = {
+  displayContent: string;
+  fieldUpdates: Record<string, unknown> | null;
+};
+
+const activeAssistByRoute = new Map<string, AgentFormAssistClientAdapter>();
+
+function sanitizeFieldUpdates(
+  raw: unknown,
+  fields: AgentFormAssistField[],
+): Record<string, unknown> | null {
+  if (!raw || typeof raw !== "object") return null;
+  const allowed = new Set(fields.map((field) => field.key));
+  const next: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (allowed.has(key)) {
+      next[key] = value;
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : null;
+}
+
+export function buildAgentFormAssistContext(
+  adapter: AgentFormAssistClientAdapter,
+): AgentFormAssistContext {
+  const values = adapter.getValues();
+  const safeValues: Record<string, unknown> = {};
+
+  for (const field of adapter.fields) {
+    if (field.shareCurrentValue !== false && field.key in values) {
+      safeValues[field.key] = values[field.key];
+    }
+  }
+
+  return {
+    formId: adapter.formId,
+    formName: adapter.formName,
+    fields: adapter.fields,
+    values: safeValues,
+  };
+}
+
+export function buildFormAssistInstruction(context: AgentFormAssistContext): string {
+  const fieldLines = context.fields.map((field) => {
+    const currentValue = context.values && field.key in context.values
+      ? ` Current value: ${String(context.values[field.key] ?? "")}.`
+      : "";
+    const allowedValues = field.allowedValues && field.allowedValues.length > 0
+      ? ` Allowed values: ${field.allowedValues.join(", ")}.`
+      : "";
+    const helperText = field.helperText ? ` ${field.helperText}` : "";
+
+    return `- ${field.key} (${field.type}) — ${field.label}.${allowedValues}${currentValue}${helperText}`.trim();
+  });
+
+  return [
+    `A page form is available for optional assistance: ${context.formName}.`,
+    "If the user asks you to help fill the form, provide your normal explanation and then append a fenced ```agent-form block.",
+    "Inside that block, emit JSON shaped like {\"fieldUpdates\": {\"fieldKey\": value}}.",
+    "Only include fields listed below. Never include submit actions or hidden fields.",
+    ...fieldLines,
+  ].join("\n");
+}
+
+export function extractFormAssistResult(
+  content: string,
+  context: AgentFormAssistContext,
+): ExtractedAssist {
+  const blockMatch = content.match(/```agent-form\s*([\s\S]*?)```/i);
+  if (!blockMatch) {
+    return {
+      displayContent: content.trim(),
+      fieldUpdates: null,
+    };
+  }
+
+  const displayContent = content.replace(blockMatch[0], "").trim();
+  try {
+    const parsed = JSON.parse(blockMatch[1] ?? "{}") as { fieldUpdates?: unknown };
+    return {
+      displayContent,
+      fieldUpdates: sanitizeFieldUpdates(parsed.fieldUpdates, context.fields),
+    };
+  } catch {
+    return {
+      displayContent,
+      fieldUpdates: null,
+    };
+  }
+}
+
+export function registerActiveFormAssist(
+  adapter: AgentFormAssistClientAdapter,
+): () => void {
+  activeAssistByRoute.set(adapter.routeContext, adapter);
+
+  return () => {
+    const current = activeAssistByRoute.get(adapter.routeContext);
+    if (current?.formId === adapter.formId) {
+      activeAssistByRoute.delete(adapter.routeContext);
+    }
+  };
+}
+
+export function getActiveFormAssist(routeContext: string): AgentFormAssistClientAdapter | null {
+  return activeAssistByRoute.get(routeContext) ?? null;
+}

--- a/apps/web/lib/agent-routing.ts
+++ b/apps/web/lib/agent-routing.ts
@@ -1,6 +1,7 @@
 import { can } from "@/lib/permissions";
 import type { UserContext } from "@/lib/permissions";
 import type { AgentInfo, RouteAgentEntry, AgentSkill } from "@/lib/agent-coworker-types";
+import { getRouteSensitivity } from "@/lib/agent-sensitivity";
 
 /** Route prefix → agent + capability mapping. */
 const ROUTE_AGENT_MAP: Record<string, RouteAgentEntry> = {
@@ -9,6 +10,7 @@ const ROUTE_AGENT_MAP: Record<string, RouteAgentEntry> = {
     agentName: "Portfolio Advisor",
     agentDescription: "Helps navigate portfolio structure, products, and health metrics",
     capability: "view_portfolio",
+    sensitivity: "internal",
     systemPrompt: `You are Portfolio Advisor, an AI assistant in the Digital Product Factory portal.
 
 Role: You help navigate the portfolio structure, review product health metrics, and understand budget allocations.
@@ -33,6 +35,7 @@ Guidelines:
     agentName: "Inventory Specialist",
     agentDescription: "Assists with digital product inventory and infrastructure CIs",
     capability: "view_inventory",
+    sensitivity: "internal",
     systemPrompt: `You are Inventory Specialist, an AI assistant in the Digital Product Factory portal.
 
 Role: You help explore the digital product inventory, review lifecycle stages, and understand infrastructure dependencies.
@@ -56,6 +59,7 @@ Guidelines:
     agentName: "EA Architect",
     agentDescription: "Guides enterprise architecture modeling, views, and relationships",
     capability: "view_ea_modeler",
+    sensitivity: "internal",
     systemPrompt: `You are EA Architect, an AI assistant in the Digital Product Factory portal.
 
 Role: You guide enterprise architecture modeling using ArchiMate 4 notation.
@@ -82,6 +86,7 @@ Guidelines:
     agentName: "HR Specialist",
     agentDescription: "Assists with role management, people, and organizational structure",
     capability: "view_employee",
+    sensitivity: "confidential",
     systemPrompt: `You are HR Specialist, an AI assistant in the Digital Product Factory portal.
 
 Role: You help understand the role structure, review team assignments, and navigate the organizational hierarchy.
@@ -105,6 +110,7 @@ Guidelines:
     agentName: "Customer Advisor",
     agentDescription: "Helps manage customer accounts and service relationships",
     capability: "view_customer",
+    sensitivity: "confidential",
     systemPrompt: `You are Customer Advisor, an AI assistant in the Digital Product Factory portal.
 
 Role: You help manage customer accounts, review service relationships, and track engagement.
@@ -127,6 +133,7 @@ Guidelines:
     agentName: "Ops Coordinator",
     agentDescription: "Assists with backlog management, epics, and operational workflows",
     capability: "view_operations",
+    sensitivity: "internal",
     systemPrompt: `You are Ops Coordinator, an AI assistant in the Digital Product Factory portal.
 
 Role: You help manage the backlog system with portfolio-type and product-type items, epic grouping, and lifecycle tracking.
@@ -151,6 +158,7 @@ Guidelines:
     agentName: "Platform Engineer",
     agentDescription: "Helps configure AI providers, credentials, and platform services",
     capability: "view_platform",
+    sensitivity: "confidential",
     systemPrompt: `You are Platform Engineer, an AI assistant in the Digital Product Factory portal.
 
 Role: You help configure AI providers, manage credentials, monitor token spend, and manage platform services.
@@ -175,6 +183,7 @@ Guidelines:
     agentName: "Admin Assistant",
     agentDescription: "Assists with platform administration and user management",
     capability: "view_admin",
+    sensitivity: "restricted",
     systemPrompt: `You are Admin Assistant, an AI assistant in the Digital Product Factory portal.
 
 Role: You help with platform administration — user management, role assignments, and system configuration.
@@ -197,6 +206,7 @@ Guidelines:
     agentName: "Workspace Guide",
     agentDescription: "Helps navigate the portal and find the right tools for your task",
     capability: null,
+    sensitivity: "internal",
     systemPrompt: `You are Workspace Guide, an AI assistant in the Digital Product Factory portal.
 
 Role: You help users navigate the portal and find the right tools for their tasks.
@@ -253,6 +263,7 @@ export function resolveAgentForRoute(
       agentName: bestMatch.agentName,
       agentDescription: bestMatch.agentDescription,
       canAssist: true,
+      sensitivity: bestMatch.sensitivity,
       systemPrompt: bestMatch.systemPrompt,
       skills: bestMatch.skills,
     };
@@ -266,6 +277,7 @@ export function resolveAgentForRoute(
     agentName: bestMatch.agentName,
     agentDescription: bestMatch.agentDescription,
     canAssist,
+    sensitivity: bestMatch.sensitivity ?? getRouteSensitivity(pathname),
     systemPrompt: bestMatch.systemPrompt,
     skills: bestMatch.skills,
   };

--- a/apps/web/lib/agent-routing.ts
+++ b/apps/web/lib/agent-routing.ts
@@ -17,6 +17,7 @@ You have expertise in the portfolio hierarchy with 4 root portfolios (foundation
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Reference specific portfolio nodes, health scores, or budget figures when relevant
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
@@ -39,6 +40,7 @@ You understand digital products with lifecycle stages (plan, design, build, prod
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Reference lifecycle stages and product statuses when relevant
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
@@ -60,6 +62,7 @@ You understand viewpoints that restrict which element and relationship types app
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Reference viewpoints, element types, and relationship rules when relevant
 - Explain why constraints exist (they enforce modeling discipline)
 - If you cannot help with something, suggest which area of the portal might
@@ -84,6 +87,7 @@ You understand platform roles (HR-000 through HR-500), HITL tier assignments, SL
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Reference role tiers, SLA commitments, and team structures when relevant
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
@@ -105,6 +109,7 @@ You understand customer account management, service delivery relationships, and 
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
     skills: [
@@ -125,6 +130,7 @@ You understand backlog items (open, in-progress, done, deferred), epics that gro
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Reference backlog items, epics, and lifecycle stages when relevant
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
@@ -147,6 +153,7 @@ You understand the AI provider registry with cloud and local providers, credenti
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Reference provider configuration, token spend, and model capabilities when relevant
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
@@ -169,6 +176,7 @@ You understand user account lifecycle, platform role assignments (HR-000 through
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
     skills: [
@@ -189,6 +197,7 @@ You understand the workspace tile layout showing features available to each role
 
 Guidelines:
 - Be concise and helpful
+- Prefer short paragraphs and flat bullet lists over walls of text
 - Help users understand what each area of the portal does
 - If the user needs something specific, point them to the right route
 - Do not make up data — if you don't know, say so`,

--- a/apps/web/lib/agent-routing.ts
+++ b/apps/web/lib/agent-routing.ts
@@ -24,6 +24,7 @@ Guidelines:
       { label: "Show health summary", description: "Summarize health metrics for this portfolio", capability: "view_portfolio", prompt: "Summarize the health metrics for this portfolio" },
       { label: "Explain budget", description: "Explain budget allocation across the portfolio", capability: "view_portfolio", prompt: "Explain how the budget is allocated across this portfolio" },
       { label: "Find a product", description: "Search for a digital product in the portfolio", capability: "view_portfolio", prompt: "Help me find a specific digital product in the portfolio" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/inventory": {
@@ -45,6 +46,7 @@ Guidelines:
     skills: [
       { label: "Filter by status", description: "Filter inventory by lifecycle status", capability: "view_inventory", prompt: "Help me filter the inventory by lifecycle status" },
       { label: "Explain lifecycle", description: "Explain the lifecycle stages and statuses", capability: "view_inventory", prompt: "Explain the lifecycle stages and what each status means" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/ea": {
@@ -69,6 +71,7 @@ Guidelines:
       { label: "Add an element", description: "Add an element to the current view", capability: "manage_ea_model", prompt: "Guide me through adding a new element to this view" },
       { label: "Map a relationship", description: "Connect two elements with a relationship", capability: "manage_ea_model", prompt: "Help me create a relationship between two elements" },
       { label: "Explain viewpoint", description: "What this viewpoint allows and restricts", capability: "view_ea_modeler", prompt: "Explain what this viewpoint allows and restricts" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/employee": {
@@ -90,6 +93,7 @@ Guidelines:
     skills: [
       { label: "Explain role tiers", description: "Understand HITL tiers and SLA commitments", capability: "view_employee", prompt: "Explain the role tiers and their SLA commitments" },
       { label: "Show team structure", description: "View team memberships and assignments", capability: "view_employee", prompt: "Show me the team structure and assignments" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/customer": {
@@ -110,6 +114,7 @@ Guidelines:
     skills: [
       { label: "Account overview", description: "Summarize a customer account", capability: "view_customer", prompt: "Give me an overview of this customer account" },
       { label: "Service relationships", description: "Show service delivery relationships", capability: "view_customer", prompt: "Show the service relationships for this customer" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/ops": {
@@ -132,6 +137,7 @@ Guidelines:
       { label: "Create backlog item", description: "Add a new item to the backlog", capability: "manage_backlog", prompt: "Help me create a new backlog item" },
       { label: "Epic progress", description: "Summarize progress across epics", capability: "view_operations", prompt: "Give me a summary of the current epic progress" },
       { label: "Prioritize items", description: "Help order backlog items by priority", capability: "manage_backlog", prompt: "Help me prioritize the open backlog items" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/platform": {
@@ -154,6 +160,7 @@ Guidelines:
       { label: "Configure provider", description: "Set up an AI provider connection", capability: "manage_provider_connections", prompt: "Help me configure an AI provider" },
       { label: "Token spend", description: "Review token usage and costs", capability: "view_platform", prompt: "Show me a summary of token usage and costs" },
       { label: "Run optimization", description: "Optimize provider priority rankings", capability: "manage_provider_connections", prompt: "Run the provider priority optimization now" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/admin": {
@@ -174,6 +181,7 @@ Guidelines:
     skills: [
       { label: "Manage users", description: "User account lifecycle and roles", capability: "manage_users", prompt: "Help me manage user accounts" },
       { label: "System config", description: "Platform configuration and settings", capability: "view_admin", prompt: "Show me the current system configuration" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
   "/workspace": {
@@ -196,6 +204,7 @@ Guidelines:
       { label: "What can I do?", description: "Features available to your role", capability: null, prompt: "What features and actions are available to me?" },
       { label: "Navigate to...", description: "Find the right portal section", capability: null, prompt: "Help me find the right section of the portal for what I need" },
       { label: "Explain my role", description: "What your role gives you access to", capability: null, prompt: "Explain what my current role gives me access to" },
+      { label: "Report an issue", description: "Report a bug, suggest an improvement, or ask a question", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
 };

--- a/apps/web/lib/agent-sensitivity.test.ts
+++ b/apps/web/lib/agent-sensitivity.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRouteSensitivity,
+  isProviderAllowedForSensitivity,
+  filterProviderPriorityBySensitivity,
+  type RouteSensitivity,
+} from "./agent-sensitivity";
+
+describe("getRouteSensitivity", () => {
+  it("returns restricted for admin routes", () => {
+    expect(getRouteSensitivity("/admin")).toBe("restricted");
+  });
+
+  it("returns confidential for employee routes", () => {
+    expect(getRouteSensitivity("/employee")).toBe("confidential");
+  });
+
+  it("returns internal for operations routes", () => {
+    expect(getRouteSensitivity("/ops")).toBe("internal");
+  });
+
+  it("falls back to internal for unknown routes", () => {
+    expect(getRouteSensitivity("/unknown")).toBe("internal");
+  });
+});
+
+describe("isProviderAllowedForSensitivity", () => {
+  it("allows any provider for public routes", () => {
+    expect(
+      isProviderAllowedForSensitivity("public", { providerId: "openai", costModel: "token", category: "direct" }),
+    ).toBe(true);
+  });
+
+  it("prefers but does not block cloud providers for internal routes", () => {
+    expect(
+      isProviderAllowedForSensitivity("internal", { providerId: "openai", costModel: "token", category: "direct" }),
+    ).toBe(true);
+  });
+
+  it("blocks cloud providers for restricted routes", () => {
+    expect(
+      isProviderAllowedForSensitivity("restricted", { providerId: "openai", costModel: "token", category: "direct" }),
+    ).toBe(false);
+  });
+
+  it("allows local compute providers for restricted routes", () => {
+    expect(
+      isProviderAllowedForSensitivity("restricted", { providerId: "ollama", costModel: "compute", category: "direct" }),
+    ).toBe(true);
+  });
+});
+
+describe("filterProviderPriorityBySensitivity", () => {
+  const priority = [
+    { providerId: "openai", modelId: "gpt-4.1", rank: 1, capabilityTier: "deep-thinker" },
+    { providerId: "ollama", modelId: "llama3.1", rank: 2, capabilityTier: "fast-worker" },
+  ];
+
+  const providers = [
+    { providerId: "openai", costModel: "token", category: "direct" },
+    { providerId: "ollama", costModel: "compute", category: "direct" },
+  ];
+
+  it("keeps both providers for internal routes", () => {
+    expect(filterProviderPriorityBySensitivity(priority, providers, "internal").map((p) => p.providerId)).toEqual([
+      "openai",
+      "ollama",
+    ]);
+  });
+
+  it("keeps only local providers for restricted routes", () => {
+    expect(filterProviderPriorityBySensitivity(priority, providers, "restricted").map((p) => p.providerId)).toEqual([
+      "ollama",
+    ]);
+  });
+
+  it("returns an empty list when no provider qualifies", () => {
+    expect(
+      filterProviderPriorityBySensitivity(priority, [{ providerId: "openai", costModel: "token", category: "direct" }], "restricted"),
+    ).toEqual([]);
+  });
+});
+
+describe("route sensitivity coverage", () => {
+  it("uses only supported sensitivity levels", () => {
+    const levels: RouteSensitivity[] = ["public", "internal", "confidential", "restricted"];
+    expect(levels).toHaveLength(4);
+  });
+});

--- a/apps/web/lib/agent-sensitivity.ts
+++ b/apps/web/lib/agent-sensitivity.ts
@@ -1,0 +1,66 @@
+import type { ProviderPriorityEntry } from "@/lib/ai-provider-priority";
+
+export type RouteSensitivity = "public" | "internal" | "confidential" | "restricted";
+
+export type ProviderPolicyInfo = {
+  providerId: string;
+  costModel: string;
+  category: string;
+};
+
+const ROUTE_SENSITIVITY: Array<{ prefix: string; sensitivity: RouteSensitivity }> = [
+  { prefix: "/admin", sensitivity: "restricted" },
+  { prefix: "/employee", sensitivity: "confidential" },
+  { prefix: "/customer", sensitivity: "confidential" },
+  { prefix: "/platform", sensitivity: "confidential" },
+  { prefix: "/ea", sensitivity: "internal" },
+  { prefix: "/ops", sensitivity: "internal" },
+  { prefix: "/inventory", sensitivity: "internal" },
+  { prefix: "/portfolio", sensitivity: "internal" },
+  { prefix: "/workspace", sensitivity: "internal" },
+];
+
+function isLocalProvider(provider: ProviderPolicyInfo): boolean {
+  return provider.providerId === "ollama" || provider.costModel === "compute";
+}
+
+export function getRouteSensitivity(pathname: string): RouteSensitivity {
+  let best: RouteSensitivity = "internal";
+  let bestLen = 0;
+
+  for (const entry of ROUTE_SENSITIVITY) {
+    if (pathname === entry.prefix || pathname.startsWith(`${entry.prefix}/`)) {
+      if (entry.prefix.length > bestLen) {
+        best = entry.sensitivity;
+        bestLen = entry.prefix.length;
+      }
+    }
+  }
+
+  return best;
+}
+
+export function isProviderAllowedForSensitivity(
+  sensitivity: RouteSensitivity,
+  provider: ProviderPolicyInfo,
+): boolean {
+  if (sensitivity === "public") return true;
+  if (sensitivity === "internal") return true;
+  if (sensitivity === "confidential") return true;
+  if (sensitivity === "restricted") return isLocalProvider(provider);
+  return true;
+}
+
+export function filterProviderPriorityBySensitivity(
+  priority: ProviderPriorityEntry[],
+  providers: ProviderPolicyInfo[],
+  sensitivity: RouteSensitivity,
+): ProviderPriorityEntry[] {
+  const providerMap = new Map(providers.map((provider) => [provider.providerId, provider]));
+
+  return priority.filter((entry) => {
+    const provider = providerMap.get(entry.providerId);
+    if (!provider) return false;
+    return isProviderAllowedForSensitivity(sensitivity, provider);
+  });
+}

--- a/apps/web/lib/ai-provider-priority.test.ts
+++ b/apps/web/lib/ai-provider-priority.test.ts
@@ -4,6 +4,12 @@ import { describe, it, expect } from "vitest";
 // buildBootstrapPriority and callWithFailover require DB mocking (tested via integration).
 
 describe("provider priority types", () => {
+  it("NoAllowedProvidersForSensitivityError carries the blocked sensitivity", async () => {
+    const err = new (await import("./ai-provider-priority")).NoAllowedProvidersForSensitivityError("restricted");
+    expect(err.sensitivity).toBe("restricted");
+    expect(err.name).toBe("NoAllowedProvidersForSensitivityError");
+  });
+
   it("ProviderPriorityEntry has required fields", async () => {
     // Type-level test: if this compiles, the type is correct
     const entry: import("./ai-provider-priority").ProviderPriorityEntry = {

--- a/apps/web/lib/ai-provider-priority.ts
+++ b/apps/web/lib/ai-provider-priority.ts
@@ -4,6 +4,11 @@
 import { prisma, type Prisma } from "@dpf/db";
 import { callProvider, logTokenUsage, InferenceError } from "@/lib/ai-inference";
 import type { ChatMessage, InferenceResult } from "@/lib/ai-inference";
+import {
+  filterProviderPriorityBySensitivity,
+  type ProviderPolicyInfo,
+  type RouteSensitivity,
+} from "@/lib/agent-sensitivity";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -104,6 +109,19 @@ export async function getProviderPriority(): Promise<ProviderPriorityEntry[]> {
   return buildBootstrapPriority();
 }
 
+async function getActiveProviderPolicyInfo(): Promise<ProviderPolicyInfo[]> {
+  const providers = await prisma.modelProvider.findMany({
+    where: { status: "active" },
+    select: { providerId: true, costModel: true, category: true },
+  });
+
+  return providers.map((provider) => ({
+    providerId: provider.providerId,
+    costModel: provider.costModel,
+    category: provider.category,
+  }));
+}
+
 // ─── Failover Engine ─────────────────────────────────────────────────────────
 
 const MAX_CASCADE_DEPTH = 5;
@@ -111,18 +129,21 @@ const MAX_CASCADE_DEPTH = 5;
 export async function callWithFailover(
   messages: ChatMessage[],
   systemPrompt: string,
+  sensitivity: RouteSensitivity = "internal",
 ): Promise<FailoverResult> {
   const priority = await getProviderPriority();
-  if (priority.length === 0) {
+  const providerPolicy = await getActiveProviderPolicyInfo();
+  const filteredPriority = filterProviderPriorityBySensitivity(priority, providerPolicy, sensitivity);
+  if (filteredPriority.length === 0) {
     throw new NoProvidersAvailableError([]);
   }
 
-  const baselineTier = priority[0]!.capabilityTier;
+  const baselineTier = filteredPriority[0]!.capabilityTier;
   const attempts: Array<{ providerId: string; error: string }> = [];
-  const limit = Math.min(priority.length, MAX_CASCADE_DEPTH);
+  const limit = Math.min(filteredPriority.length, MAX_CASCADE_DEPTH);
 
   for (let i = 0; i < limit; i++) {
-    const entry = priority[i]!;
+    const entry = filteredPriority[i]!;
     try {
       const result = await callProvider(entry.providerId, entry.modelId, messages, systemPrompt);
 
@@ -131,7 +152,7 @@ export async function callWithFailover(
       // Look up provider name for the message
       let downgradeMessage: string | null = null;
       if (downgraded) {
-        const failedName = priority[0]!.providerId;
+        const failedName = filteredPriority[0]!.providerId;
         const usedProvider = await prisma.modelProvider.findUnique({
           where: { providerId: entry.providerId },
           select: { name: true },

--- a/apps/web/lib/ai-provider-priority.ts
+++ b/apps/web/lib/ai-provider-priority.ts
@@ -33,6 +33,13 @@ export class NoProvidersAvailableError extends Error {
   }
 }
 
+export class NoAllowedProvidersForSensitivityError extends Error {
+  constructor(public readonly sensitivity: RouteSensitivity) {
+    super(`No providers allowed for sensitivity ${sensitivity}`);
+    this.name = "NoAllowedProvidersForSensitivityError";
+  }
+}
+
 // ─── Skip patterns for non-chat models ───────────────────────────────────────
 
 const NON_CHAT_PATTERN = /embed|whisper|tts|dall-e|moderation|babbage|davinci-00|text-search|text-similarity|audio|image/i;
@@ -135,7 +142,7 @@ export async function callWithFailover(
   const providerPolicy = await getActiveProviderPolicyInfo();
   const filteredPriority = filterProviderPriorityBySensitivity(priority, providerPolicy, sensitivity);
   if (filteredPriority.length === 0) {
-    throw new NoProvidersAvailableError([]);
+    throw new NoAllowedProvidersForSensitivityError(sensitivity);
   }
 
   const baselineTier = filteredPriority[0]!.capabilityTier;

--- a/apps/web/lib/permissions.ts
+++ b/apps/web/lib/permissions.ts
@@ -48,6 +48,7 @@ const PERMISSIONS: Record<CapabilityKey, Permission> = {
 };
 
 export type UserContext = {
+  userId?: string;
   platformRole: string | null;
   isSuperuser: boolean;
 };

--- a/apps/web/lib/quality-queue.ts
+++ b/apps/web/lib/quality-queue.ts
@@ -1,0 +1,104 @@
+const QUEUE_KEY = "dpf-quality-queue";
+
+type QueuedReport = {
+  type: string;
+  title: string;
+  description?: string;
+  severity?: string;
+  routeContext?: string;
+  errorStack?: string;
+  source?: string;
+  userAgent?: string;
+  userId?: string;
+  queuedAt: string;
+};
+
+export function queueReport(report: Omit<QueuedReport, "queuedAt">): void {
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY);
+    let queue: QueuedReport[] = [];
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) queue = parsed;
+      } catch {
+        // Corrupt data — discard
+      }
+    }
+    queue.push({ ...report, queuedAt: new Date().toISOString() });
+    // Keep max 50 queued reports
+    if (queue.length > 50) queue = queue.slice(-50);
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  } catch {
+    // localStorage full or unavailable — silent fail
+  }
+}
+
+export async function flushQueue(): Promise<number> {
+  let flushed = 0;
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY);
+    if (!raw) return 0;
+    let queue: QueuedReport[];
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        localStorage.removeItem(QUEUE_KEY);
+        return 0;
+      }
+      queue = parsed;
+    } catch {
+      localStorage.removeItem(QUEUE_KEY);
+      return 0;
+    }
+
+    const remaining: QueuedReport[] = [];
+    for (const report of queue) {
+      try {
+        const res = await fetch("/api/quality/report", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(report),
+        });
+        if (res.ok) {
+          flushed++;
+        } else {
+          remaining.push(report);
+        }
+      } catch {
+        remaining.push(report);
+      }
+    }
+
+    if (remaining.length > 0) {
+      localStorage.setItem(QUEUE_KEY, JSON.stringify(remaining));
+    } else {
+      localStorage.removeItem(QUEUE_KEY);
+    }
+  } catch {
+    // Silent fail
+  }
+  return flushed;
+}
+
+export async function submitReport(report: Omit<QueuedReport, "queuedAt">): Promise<{ ok: boolean; reportId?: string }> {
+  try {
+    const res = await fetch("/api/quality/report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...report,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      }),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { ok: boolean; reportId?: string };
+      return data;
+    }
+    queueReport(report);
+    return { ok: false };
+  } catch {
+    queueReport(report);
+    return { ok: false };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
     "next": "^16",
     "next-auth": "5.0.0-beta.30",
     "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+    "react-dom": "^18.3.0",
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/docs/superpowers/plans/2026-03-14-agent-resize-sensitivity-form-assist.md
+++ b/docs/superpowers/plans/2026-03-14-agent-resize-sensitivity-form-assist.md
@@ -1,0 +1,241 @@
+# Agent Resize, Sensitivity, and Form Assist Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the coworker panel resizable, add route sensitivity policy for provider selection, and support human-approved agent form filling without form submission.
+
+**Architecture:** Extend the current route-aware coworker stack with route metadata for sensitivity, persisted panel sizing and elevated assist preferences, and a structured form-assist adapter that pages opt into. Keep the human-in-the-loop boundary by allowing field updates only, not submit.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Prisma, Vitest
+
+---
+
+## File Map
+
+- Modify: `apps/web/components/agent/AgentCoworkerShell.tsx`
+  - add resize state, persistence, and viewport clamping
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+  - surface elevated assist controls and policy cues
+- Modify: `apps/web/components/agent/AgentPanelHeader.tsx`
+  - add yellow elevated-assist indicator and toggle affordance
+- Modify: `apps/web/lib/agent-routing.ts`
+  - add route sensitivity metadata and provider policy resolution
+- Modify: `apps/web/lib/actions/agent-coworker.ts`
+  - include sensitivity and form-assist context in the server action path
+- Create: `apps/web/lib/agent-sensitivity.ts`
+  - route sensitivity resolution and provider allowance logic
+- Create: `apps/web/lib/agent-form-assist.ts`
+  - types and helper functions for structured form assist adapters
+- Create or modify: preference persistence files as needed based on current repo patterns
+- Add tests in:
+  - `apps/web/components/agent/AgentCoworkerShell.test.tsx`
+  - `apps/web/components/agent/AgentPanelHeader.test.tsx`
+  - `apps/web/lib/agent-sensitivity.test.ts`
+  - `apps/web/lib/actions/agent-coworker.test.ts`
+  - form-specific tests for the first integrated form
+
+## Chunk 1: Sensitivity and Provider Policy
+
+### Task 1: Add route sensitivity metadata
+
+**Files:**
+- Create: `apps/web/lib/agent-sensitivity.ts`
+- Modify: `apps/web/lib/agent-routing.ts`
+- Test: `apps/web/lib/agent-sensitivity.test.ts`
+
+- [ ] **Step 1: Write failing tests for sensitivity resolution**
+
+Cover:
+- route-to-sensitivity mapping
+- allowed provider sets for each sensitivity level
+- fallback behavior when no provider is allowed
+
+- [ ] **Step 2: Run the targeted test command and confirm failure**
+
+Run:
+`pnpm --filter web test -- lib/agent-sensitivity.test.ts`
+
+- [ ] **Step 3: Implement `agent-sensitivity.ts`**
+
+Add:
+- sensitivity type
+- route lookup helper
+- provider policy helper
+
+- [ ] **Step 4: Wire route agent resolution to include sensitivity metadata**
+
+Keep current route specialist behavior intact while exposing sensitivity.
+
+- [ ] **Step 5: Re-run the targeted tests**
+
+Run:
+`pnpm --filter web test -- lib/agent-sensitivity.test.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/lib/agent-sensitivity.ts apps/web/lib/agent-routing.ts apps/web/lib/agent-sensitivity.test.ts
+git commit -m "feat: add route sensitivity policy for coworker agents"
+```
+
+## Chunk 2: Resizable Coworker Panel
+
+### Task 2: Add panel resize behavior and persistence
+
+**Files:**
+- Modify: `apps/web/components/agent/AgentCoworkerShell.tsx`
+- Test: `apps/web/components/agent/AgentCoworkerShell.test.tsx`
+
+- [ ] **Step 1: Write failing tests for resize persistence and viewport clamping**
+
+Cover:
+- restoring stored size
+- clamping oversize dimensions
+- preserving drag behavior
+
+- [ ] **Step 2: Run the targeted test command and confirm failure**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentCoworkerShell.test.tsx`
+
+- [ ] **Step 3: Implement resizable shell behavior**
+
+Add:
+- width and height state
+- resize handle
+- persisted dimensions
+- window-resize clamping
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentCoworkerShell.test.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/AgentCoworkerShell.tsx apps/web/components/agent/AgentCoworkerShell.test.tsx
+git commit -m "feat: make coworker panel resizable"
+```
+
+## Chunk 3: Elevated Assist Preference and Header Cues
+
+### Task 3: Add per-user per-route elevated assist state
+
+**Files:**
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+- Modify: `apps/web/components/agent/AgentPanelHeader.tsx`
+- Modify: preference persistence files as required by current repo patterns
+- Test: `apps/web/components/agent/AgentPanelHeader.test.tsx`
+- Test: `apps/web/lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 1: Write failing tests for elevated assist indicator and toggle behavior**
+
+Cover:
+- yellow indicator rendering
+- enabled state persistence
+- route-scoped behavior
+
+- [ ] **Step 2: Run the targeted test commands and confirm failure**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentPanelHeader.test.tsx lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 3: Implement elevated assist persistence**
+
+Prefer a user-aware persisted preference keyed by route.
+
+- [ ] **Step 4: Implement the header indicator and toggle**
+
+The indicator should be visibly yellow and present only when elevated assist is active.
+
+- [ ] **Step 5: Re-run the targeted tests**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentPanelHeader.test.tsx lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/agent/AgentCoworkerPanel.tsx apps/web/components/agent/AgentPanelHeader.tsx apps/web/lib/actions/agent-coworker.ts
+git commit -m "feat: add elevated form assist preference for coworker"
+```
+
+## Chunk 4: Structured Form Assist Adapter
+
+### Task 4: Add the form assist interface and wire one form
+
+**Files:**
+- Create: `apps/web/lib/agent-form-assist.ts`
+- Modify: one representative form component in the portal
+- Modify: `apps/web/lib/actions/agent-coworker.ts`
+- Test: form-specific test file
+- Test: `apps/web/lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 1: Write failing tests for structured field updates**
+
+Cover:
+- registered field metadata
+- safe field update application
+- no submit path
+
+- [ ] **Step 2: Run the targeted tests and confirm failure**
+
+Run:
+`pnpm --filter web test -- <form test file> lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 3: Implement `agent-form-assist.ts`**
+
+Add:
+- field metadata types
+- adapter contract
+- structured update payload helpers
+
+- [ ] **Step 4: Wire one real form to opt in**
+
+Choose a representative portal form with manageable scope.
+
+- [ ] **Step 5: Pass structured form context into the coworker action path**
+
+Only when elevated assist is enabled and the page has opted in.
+
+- [ ] **Step 6: Re-run the targeted tests**
+
+Run:
+`pnpm --filter web test -- <form test file> lib/actions/agent-coworker.test.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/agent-form-assist.ts apps/web/lib/actions/agent-coworker.ts <form files>
+git commit -m "feat: add structured agent form assist"
+```
+
+## Chunk 5: Full Verification
+
+### Task 5: Run branch-level verification
+
+**Files:**
+- No code changes unless verification exposes defects
+
+- [ ] **Step 1: Run focused web tests**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentCoworkerShell.test.tsx components/agent/AgentPanelHeader.test.tsx lib/agent-sensitivity.test.ts lib/actions/agent-coworker.test.ts <form test file>`
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+`pnpm --filter web typecheck`
+
+- [ ] **Step 3: Run production build**
+
+Run:
+`$env:DATABASE_URL='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter web build`
+
+- [ ] **Step 4: Commit any verification-driven fixes**
+
+```bash
+git add <changed files>
+git commit -m "fix: address verification issues for coworker assist controls"
+```

--- a/docs/superpowers/specs/2026-03-14-agent-resize-sensitivity-form-assist-design.md
+++ b/docs/superpowers/specs/2026-03-14-agent-resize-sensitivity-form-assist-design.md
@@ -1,0 +1,220 @@
+# Agent Resize, Sensitivity, and Form Assist Design
+
+## Overview
+
+The portal coworker needs to become a safer and more useful human-in-the-loop assistant. Today it is draggable and route-aware, but it is fixed-size, it cannot interact with forms in a structured way, and provider choice does not respect the sensitivity of the current page.
+
+This design adds three linked capabilities:
+
+- a resizable coworker panel with persisted size
+- route-level data sensitivity metadata that constrains provider selection
+- a per-user, per-page elevated assist mode that lets the agent fill approved form fields, but never submit them
+
+The goal is to establish a reusable platform pattern rather than a one-off UX tweak.
+
+## Current State
+
+The relevant current code paths are:
+
+- `apps/web/components/agent/AgentCoworkerShell.tsx`
+  - fixed panel width and height
+  - persisted open state and position only
+- `apps/web/components/agent/AgentCoworkerPanel.tsx`
+  - renders the header, messages, and input
+  - no resize controls or elevated assist controls
+- `apps/web/lib/agent-routing.ts`
+  - picks the specialist agent for the route
+  - does not consider page sensitivity or provider restrictions
+- `apps/web/lib/actions/agent-coworker.ts`
+  - sends route context into the agent action
+  - does not include sensitivity or form-assist state
+
+The portal already has route help and page-aware agent selection, so the new policy metadata should align with those route-driven mechanisms instead of introducing an unrelated config source.
+
+## Goals
+
+- Let users resize the coworker panel and remember the size per user.
+- Classify each portal route by sensitivity using a simple platform-wide scheme:
+  - `public`
+  - `internal`
+  - `confidential`
+  - `restricted`
+- Use the route sensitivity to constrain provider selection.
+- Let users enable elevated form-fill assistance per user and per page.
+- Show a visible yellow indicator in the agent header when elevated form-fill assist is active.
+- Allow approved forms to expose structured field metadata so the agent can propose or apply values safely.
+- Keep the human as the final approver by forbidding agent-driven submit in the first slice.
+
+## Non-Goals
+
+- No fully autonomous form submission.
+- No arbitrary DOM scraping or browser automation by the agent.
+- No full governance engine for provider policy in this slice.
+- No role-based help variations in this feature.
+- No cross-page standing permission model beyond per-user, per-route preferences.
+
+## Sensitivity Model
+
+Each page route gets one sensitivity level:
+
+- `public`
+- `internal`
+- `confidential`
+- `restricted`
+
+For the first slice, this can live in route metadata alongside route help or route agent definitions.
+
+Recommended provider policy:
+
+- `public`
+  - any enabled provider
+- `internal`
+  - local preferred, cloud allowed if not otherwise blocked
+- `confidential`
+  - local strongly preferred, cloud allowed only if policy permits
+- `restricted`
+  - local-only by default
+
+This is intentionally simple. The point is to establish a platform-level policy seam that future governance logic can strengthen.
+
+## Provider Selection Behavior
+
+Agent routing should stop being purely route-to-specialist. It should become:
+
+1. resolve route specialist agent
+2. resolve route sensitivity
+3. evaluate allowed provider set for that sensitivity
+4. select the best available provider from the allowed set
+5. if no provider is allowed:
+   - fall back to read-only canned/help behavior
+   - explain the restriction in the UI
+
+This keeps public LLMs out of routes that should remain local-only.
+
+## Resizable Panel Behavior
+
+The coworker shell should support both drag and resize.
+
+Requirements:
+
+- panel remains draggable
+- panel gains resize affordances, ideally bottom-right first
+- size is persisted per user
+- size is restored on reopen
+- size is clamped to the viewport
+- size is adjusted on window resize if the stored dimensions would overflow
+
+For MVP, one resize handle is sufficient. The implementation should still keep the panel layout flexible enough that future multi-edge resizing is possible.
+
+## Elevated Form-Fill Assist
+
+Elevated form-fill assist is disabled by default and can be enabled per user per route.
+
+Behavior:
+
+- user enables elevated assist for a page
+- the setting is remembered for that user on that route
+- the agent header shows a yellow indicator while active
+- the agent may fill structured form fields on approved forms
+- the agent may not submit the form
+
+The yellow indicator is not decorative. It is a privacy and authority cue that the page is currently allowing higher-impact agent interaction.
+
+## Structured Form Assist Adapter
+
+Forms should not expose raw DOM access to the agent. Instead, pages opt in with a structured adapter.
+
+The adapter should define:
+
+- route key
+- form id
+- allowed fields
+- for each field:
+  - field key
+  - label
+  - type
+  - optional helper text
+  - whether current value can be shared with the provider under the page sensitivity policy
+
+The form assist workflow:
+
+1. page registers a form assist adapter
+2. user enables elevated assist
+3. user asks the agent for help
+4. the agent receives the structured form context
+5. the agent returns structured field updates
+6. the page applies those updates into the form state
+7. the human reviews and submits manually
+
+This keeps page code in control and avoids brittle automation.
+
+## Persistence Model
+
+The system needs lightweight persistence for:
+
+- panel size per user
+- elevated assist enabled per user per route
+
+For the first slice:
+
+- panel size can remain local client persistence if needed for speed
+- elevated assist should be persisted in a user-aware way that survives device/browser changes if practical
+
+If there is no existing user preference model yet, a small server-side preference store or a constrained route-keyed user preference table is preferable for elevated assist. That permission is more meaningful than a purely local UI preference.
+
+## UI Changes
+
+### Agent Header
+
+Add:
+
+- elevated assist toggle or control
+- yellow elevated-assist indicator when active
+- optional provider restriction explanation when the current page sensitivity limits provider choice
+
+### Agent Shell
+
+Add:
+
+- resize handle
+- persisted width and height
+- clamped layout behavior
+
+### Forms
+
+Opted-in forms can expose:
+
+- available field list
+- field-fill action path
+- optional “agent assisted” messaging near the form if helpful
+
+## Error Handling
+
+- If no allowed provider exists for the page sensitivity, the user should get a clear explanation and the agent should fall back to safe assistance.
+- If elevated assist is enabled but the page has no registered form adapter, the agent should stay informational.
+- If applying agent-suggested field updates fails validation, the page should preserve user edits and surface normal form validation messaging.
+- If a provider is downgraded because of sensitivity restrictions, the system should say so clearly.
+
+## Testing Strategy
+
+Tests should cover:
+
+- panel resize persistence and viewport clamping
+- sensitivity metadata resolution by route
+- provider filtering based on sensitivity
+- elevated assist toggle persistence
+- yellow header indicator rendering
+- structured form adapter field application behavior
+- guarantee that agent assist cannot submit forms in this slice
+
+## Recommended First Slice
+
+The first implementation slice should be:
+
+1. add route sensitivity metadata
+2. add provider filtering by sensitivity
+3. add resizable panel with persisted dimensions
+4. add per-user per-route elevated assist preference and header indicator
+5. integrate one or two representative forms with the structured form-assist adapter
+
+This order gives immediate user value while building the correct long-term platform controls.

--- a/packages/db/prisma/migrations/20260314160000_platform_issue_report/migration.sql
+++ b/packages/db/prisma/migrations/20260314160000_platform_issue_report/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "PlatformIssueReport" (
+    "id" TEXT NOT NULL,
+    "reportId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "severity" TEXT NOT NULL DEFAULT 'medium',
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "routeContext" TEXT,
+    "errorStack" TEXT,
+    "userAgent" TEXT,
+    "reportedById" TEXT,
+    "digitalProductId" TEXT,
+    "portfolioId" TEXT,
+    "agentId" TEXT,
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PlatformIssueReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlatformIssueReport_reportId_key" ON "PlatformIssueReport"("reportId");
+
+-- AddForeignKey
+ALTER TABLE "PlatformIssueReport" ADD CONSTRAINT "PlatformIssueReport_reportedById_fkey" FOREIGN KEY ("reportedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   grantedDelegations  DelegationGrant[] @relation("DelegationGrantGrantor")
   passwordResetTokens  PasswordResetToken[] @relation("PasswordResetForUser")
   requestedPasswordResetTokens PasswordResetToken[] @relation("PasswordResetRequestedBy")
+  issueReports    PlatformIssueReport[]
 }
 
 model UserGroup {
@@ -649,6 +650,29 @@ model AgentMessage {
 
   @@index([threadId])
   @@index([createdAt])
+}
+
+// ─── Platform Issue Reporting ────────────────────────────────────────────────
+
+model PlatformIssueReport {
+  id               String   @id @default(cuid())
+  reportId         String   @unique
+  type             String   // "runtime_error" | "user_report" | "feedback"
+  severity         String   @default("medium")
+  status           String   @default("open")
+  title            String
+  description      String?  @db.Text
+  routeContext     String?
+  errorStack       String?  @db.Text
+  userAgent        String?
+  reportedById     String?
+  reportedBy       User?    @relation(fields: [reportedById], references: [id])
+  digitalProductId String?
+  portfolioId      String?
+  agentId          String?
+  source           String   @default("manual")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 }
 
 // ─── Platform Configuration ──────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       react-dom:
         specifier: ^18.3.0
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
     devDependencies:
       '@types/bcryptjs':
         specifier: ^2.4.6
@@ -959,8 +962,23 @@ packages:
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
@@ -975,6 +993,15 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1043,6 +1070,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1081,6 +1111,9 @@ packages:
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   cfb@1.2.2:
     resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
     engines: {node: '>=0.8'}
@@ -1088,6 +1121,18 @@ packages:
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
@@ -1105,6 +1150,9 @@ packages:
   codepage@1.15.0:
     resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
     engines: {node: '>=0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1180,13 +1228,23 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1215,12 +1273,18 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1283,12 +1347,30 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1298,6 +1380,9 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1306,9 +1391,16 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -1351,6 +1443,9 @@ packages:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1364,12 +1459,99 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1468,6 +1650,9 @@ packages:
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1579,6 +1764,9 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1589,6 +1777,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1604,6 +1798,12 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1666,6 +1866,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   ssf@0.11.2:
     resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
     engines: {node: '>=0.8'}
@@ -1679,12 +1882,21 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1742,6 +1954,12 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -1768,6 +1986,24 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1781,6 +2017,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -1887,6 +2129,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2501,7 +2746,25 @@ snapshots:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.37':
     dependencies:
@@ -2517,6 +2780,12 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@20.19.37))':
     dependencies:
@@ -2612,6 +2881,8 @@ snapshots:
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
+  bail@2.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -2643,6 +2914,8 @@ snapshots:
 
   caniuse-lite@1.0.30001777: {}
 
+  ccount@2.0.1: {}
+
   cfb@1.2.2:
     dependencies:
       adler-32: 1.3.1
@@ -2657,6 +2930,14 @@ snapshots:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.1.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   check-error@1.0.3:
     dependencies:
@@ -2679,6 +2960,8 @@ snapshots:
   client-only@0.0.1: {}
 
   codepage@1.15.0: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
 
@@ -2738,12 +3021,22 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2:
     optional: true
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -2810,6 +3103,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2825,6 +3120,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  extend@3.0.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -2877,9 +3174,44 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-url-attributes@3.0.1: {}
+
   human-signals@5.0.0: {}
 
   ieee754@1.2.1: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-binary-path@2.1.0:
     dependencies:
@@ -2889,13 +3221,19 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-stream@3.0.0: {}
 
@@ -2922,6 +3260,8 @@ snapshots:
       mlly: 1.8.1
       pkg-types: 1.3.1
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -2938,9 +3278,231 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3032,6 +3594,16 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -3122,6 +3694,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  property-information@7.1.0: {}
+
   queue-microtask@1.2.3: {}
 
   react-dom@18.3.1(react@18.3.1):
@@ -3131,6 +3705,24 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@18.3.1: {}
+
+  react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.28
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -3145,6 +3737,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3250,6 +3859,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   ssf@0.11.2:
     dependencies:
       frac: 1.1.2
@@ -3262,11 +3873,24 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-final-newline@3.0.0: {}
 
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
@@ -3340,6 +3964,10 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1: {}
@@ -3359,6 +3987,39 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -3370,6 +4031,16 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@1.6.1(@types/node@20.19.37):
     dependencies:
@@ -3465,3 +4136,5 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       react: 18.3.1
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- make the coworker panel resizable with persisted size and viewport clamping
- add route sensitivity policy and provider filtering for coworker inference
- add per-page elevated form-fill assist with a first structured integration for the backlog panel

## Test Plan
- pnpm --filter web test -- components/agent/agent-panel-layout.test.ts components/agent/AgentPanelHeader.test.tsx lib/agent-sensitivity.test.ts lib/agent-routing.test.ts lib/agent-form-assist.test.ts lib/ai-provider-priority.test.ts components/ops/backlog-form-assist.test.ts
- pnpm --filter web typecheck
- DATABASE_URL=postgresql://dpf:dpf_dev@localhost:5432/dpf pnpm --filter web build