### PR TITLE
feat: rename coworker fill mode to hands on

### DIFF
--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { AgentPanelHeader } from "./AgentPanelHeader";
 
 describe("AgentPanelHeader", () => {
-  it("renders an erase control for the current conversation", () => {
+  it("renders Hands Off when elevated assist is disabled", () => {
     const html = renderToStaticMarkup(
       <AgentPanelHeader
         agent={{
@@ -26,10 +26,10 @@ describe("AgentPanelHeader", () => {
       />,
     );
 
-    expect(html).toContain("Erase");
+    expect(html).toContain("Hands Off");
   });
 
-  it("renders a yellow elevated assist indicator when form fill is enabled", () => {
+  it("renders a yellow Hands On indicator when elevated assist is enabled", () => {
     const html = renderToStaticMarkup(
       <AgentPanelHeader
         agent={{
@@ -52,7 +52,7 @@ describe("AgentPanelHeader", () => {
       />,
     );
 
-    expect(html).toContain("Form fill enabled");
+    expect(html).toContain("Hands On");
     expect(html).toContain("Restricted");
   });
 });

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -85,7 +85,7 @@ export function AgentPanelHeader({
                 fontWeight: 700,
               }}
             >
-              Form fill enabled
+              Hands On
             </span>
           )}
         </div>
@@ -102,7 +102,11 @@ export function AgentPanelHeader({
             e.stopPropagation();
             onToggleElevatedAssist();
           }}
-          title="Allow this page's coworker to fill approved form fields"
+          title={
+            elevatedAssistEnabled
+              ? "Hands On: this page's coworker can update approved form fields"
+              : "Hands Off: this page's coworker can suggest changes without updating form fields"
+          }
           style={{
             background: elevatedAssistEnabled ? "rgba(250, 204, 21, 0.18)" : "none",
             border: `1px solid ${elevatedAssistEnabled ? "rgba(250, 204, 21, 0.65)" : "rgba(255, 255, 255, 0.12)"}`,
@@ -114,7 +118,7 @@ export function AgentPanelHeader({
             lineHeight: 1,
           }}
         >
-          Fill
+          {elevatedAssistEnabled ? "Hands On" : "Hands Off"}
         </button>
         <button
           type="button"

--- a/docs/superpowers/plans/2026-03-14-agent-hands-on-labels.md
+++ b/docs/superpowers/plans/2026-03-14-agent-hands-on-labels.md
@@ -1,0 +1,54 @@
+# Agent Hands On Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the coworker elevated-assist UI from `Fill` / `Form fill enabled` to `Hands Off` / `Hands On`.
+
+**Architecture:** Update only the coworker header component and its focused test. Keep the underlying elevated-assist logic untouched and verify the wording change with a red-green test cycle.
+
+**Tech Stack:** React, TypeScript, Vitest
+
+---
+
+## Chunk 1: Header Terminology
+
+### Task 1: Update the coworker header labels
+
+**Files:**
+- Modify: `apps/web/components/agent/AgentPanelHeader.tsx`
+- Test: `apps/web/components/agent/AgentPanelHeader.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Update the header test to expect:
+- `Hands Off` when assist is disabled
+- `Hands On` when assist is enabled
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentPanelHeader.test.tsx`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Change:
+- button label text
+- yellow badge text
+- tooltip wording if needed
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+`pnpm --filter web test -- components/agent/AgentPanelHeader.test.tsx`
+
+- [ ] **Step 5: Run focused typecheck**
+
+Run:
+`pnpm --filter web typecheck`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/agent/AgentPanelHeader.tsx apps/web/components/agent/AgentPanelHeader.test.tsx
+git commit -m "feat: rename coworker assist toggle to hands on"
+```

--- a/docs/superpowers/specs/2026-03-14-agent-hands-on-labels-design.md
+++ b/docs/superpowers/specs/2026-03-14-agent-hands-on-labels-design.md
@@ -1,0 +1,32 @@
+# Agent Hands On Labels Design
+
+## Overview
+
+The coworker header currently mixes a mode-based button label (`Fill`) with a capability status badge (`Form fill enabled`). That wording is technically accurate, but it is not the terminology the product wants to use.
+
+The user-facing concept should be:
+
+- `Hands Off` when the coworker is in normal advisory mode
+- `Hands On` when elevated form interaction is enabled for the current page
+
+## Scope
+
+This is a terminology-only change for the coworker header.
+
+It applies to:
+
+- the toggle button label
+- the yellow status badge label
+- the tooltip/help text on the toggle so it stays consistent with the new concept
+- the associated header test expectations
+
+## Design
+
+- When elevated assist is disabled, the button label should read `Hands Off`.
+- When elevated assist is enabled, the button label should read `Hands On`.
+- The yellow badge shown when enabled should read `Hands On`.
+- Tooltip text should explain the behavior in plain language:
+  - the coworker can act on approved form fields
+  - the human still reviews and submits manually
+
+The implementation should keep the underlying state and variable names unchanged for now. This is a user-facing language adjustment, not a refactor of the assist model.


### PR DESCRIPTION
## Summary
- rename the coworker elevated-assist toggle to Hands Off and Hands On
- align the yellow elevated-assist indicator with the same wording
- keep the tooltip copy consistent with the new user-facing mode terminology

## Testing
- AgentPanelHeader vitest
- web TypeScript no-emit check