### PR TITLE
feat: polish coworker send and erase ux

### DIFF
--- a/apps/web/app/api/mcp/call/route.ts
+++ b/apps/web/app/api/mcp/call/route.ts
@@ -1,0 +1,33 @@
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { PLATFORM_TOOLS, executeTool } from "@/lib/mcp-tools";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json()) as { name?: string; arguments?: Record<string, unknown> };
+  if (!body.name) {
+    return Response.json({ error: "Missing tool name" }, { status: 400 });
+  }
+
+  const tool = PLATFORM_TOOLS.find((t) => t.name === body.name);
+  if (!tool) {
+    return Response.json({ error: `Unknown tool: ${body.name}` }, { status: 404 });
+  }
+
+  if (
+    tool.requiredCapability &&
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      tool.requiredCapability,
+    )
+  ) {
+    return Response.json({ error: "Insufficient permissions" }, { status: 403 });
+  }
+
+  const result = await executeTool(body.name, body.arguments ?? {}, session.user.id);
+  return Response.json(result);
+}

--- a/apps/web/app/api/mcp/tools/route.ts
+++ b/apps/web/app/api/mcp/tools/route.ts
@@ -1,0 +1,22 @@
+import { auth } from "@/lib/auth";
+import { getAvailableTools } from "@/lib/mcp-tools";
+
+export async function POST() {
+  const session = await auth();
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const tools = getAvailableTools({
+    platformRole: session.user.platformRole,
+    isSuperuser: session.user.isSuperuser,
+  });
+
+  return Response.json({
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  });
+}

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -6,6 +6,7 @@ import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { resolveAgentForRoute, AGENT_NAME_MAP } from "@/lib/agent-routing";
 import { clearConversation, sendMessage } from "@/lib/actions/agent-coworker";
+import { approveProposal, rejectProposal } from "@/lib/actions/proposals";
 import { AgentPanelHeader } from "./AgentPanelHeader";
 import { AgentMessageBubble } from "./AgentMessageBubble";
 import { AgentMessageInput } from "./AgentMessageInput";
@@ -106,6 +107,39 @@ export function AgentCoworkerPanel({
     });
   }
 
+  async function handleApprove(proposalId: string) {
+    const result = await approveProposal(proposalId);
+    if (result.success) {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.proposal?.proposalId === proposalId
+            ? {
+                ...m,
+                proposal: {
+                  ...m.proposal,
+                  status: "executed",
+                  ...(result.resultEntityId !== undefined ? { resultEntityId: result.resultEntityId } : {}),
+                },
+              }
+            : m,
+        ),
+      );
+    }
+  }
+
+  async function handleReject(proposalId: string) {
+    const result = await rejectProposal(proposalId);
+    if (result.success) {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.proposal?.proposalId === proposalId
+            ? { ...m, proposal: { ...m.proposal, status: "rejected" } }
+            : m,
+        ),
+      );
+    }
+  }
+
   function handleClear() {
     if (!threadId) return;
     if (typeof window !== "undefined" && !window.confirm("Erase the current page conversation?")) {
@@ -164,6 +198,8 @@ export function AgentCoworkerPanel({
               message={msg}
               showAgentLabel={showAgentLabel}
               agentName={showAgentLabel && msg.agentId ? (AGENT_NAME_MAP[msg.agentId] ?? msg.agentId) : null}
+              onApprove={handleApprove}
+              onReject={handleReject}
             />
           );
         })}

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -18,6 +18,13 @@ import {
   buildAgentFormAssistContext,
   getActiveFormAssist,
 } from "@/lib/agent-form-assist";
+import {
+  createOptimisticUserMessage,
+  failOptimisticMessage,
+  reconcileOptimisticMessage,
+  retryOptimisticMessage,
+  type AgentRenderableMessage,
+} from "./agent-message-state";
 
 type Props = {
   threadId: string | null;
@@ -33,6 +40,15 @@ function filterMessages(messages: AgentMessageRow[]): AgentMessageRow[] {
   );
 }
 
+function isClearDisabled(
+  messages: AgentRenderableMessage[],
+  isPending: boolean,
+  isClearing: boolean,
+  threadId?: string | null,
+) {
+  return !threadId || messages.length === 0 || isPending || isClearing;
+}
+
 export function AgentCoworkerPanel({
   threadId,
   initialMessages,
@@ -41,10 +57,11 @@ export function AgentCoworkerPanel({
   onDragStart,
 }: Props) {
   const pathname = usePathname();
-  const [messages, setMessages] = useState<AgentMessageRow[]>(() => filterMessages(initialMessages));
+  const [messages, setMessages] = useState<AgentRenderableMessage[]>(() => filterMessages(initialMessages));
   const [isPending, startTransition] = useTransition();
   const [isClearing, startClearing] = useTransition();
   const [elevatedAssistEnabled, setElevatedAssistEnabled] = useState(false);
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const agent: AgentInfo = resolveAgentForRoute(pathname, userContext);
@@ -56,6 +73,7 @@ export function AgentCoworkerPanel({
 
   useEffect(() => {
     setMessages(filterMessages(initialMessages));
+    setClearConfirmOpen(false);
   }, [threadId, initialMessages]);
 
   useEffect(() => {
@@ -70,10 +88,17 @@ export function AgentCoworkerPanel({
     });
   }
 
-  function handleSend(content: string) {
+  function submitMessage(
+    content: string,
+    optimisticMessage = createOptimisticUserMessage(content, pathname),
+    appendOptimistic = true,
+  ) {
     if (!threadId) return;
     const activeFormAssist = elevatedAssistEnabled ? getActiveFormAssist(pathname) : null;
     const formAssistContext = activeFormAssist ? buildAgentFormAssistContext(activeFormAssist) : undefined;
+    if (appendOptimistic) {
+      setMessages((prev) => [...prev, optimisticMessage]);
+    }
 
     startTransition(async () => {
       const result = await sendMessage({
@@ -85,9 +110,14 @@ export function AgentCoworkerPanel({
       });
       if ("error" in result) {
         console.warn("sendMessage error:", result.error);
+        setMessages((prev) =>
+          prev.map((message) =>
+            message.id === optimisticMessage.id ? failOptimisticMessage(message) : message,
+          ),
+        );
         return;
       }
-      const newMessages = [result.userMessage];
+      const newMessages: AgentRenderableMessage[] = [];
       if ("systemMessage" in result && result.systemMessage) {
         newMessages.push(result.systemMessage);
       }
@@ -103,8 +133,33 @@ export function AgentCoworkerPanel({
           createdAt: new Date().toISOString(),
         });
       }
-      setMessages((prev) => [...prev, ...newMessages]);
+      setMessages((prev) => {
+        const reconciled = prev.flatMap((message) =>
+          message.id === optimisticMessage.id
+            ? [reconcileOptimisticMessage(message, result.userMessage)]
+            : [message],
+        );
+        return [...reconciled, ...newMessages];
+      });
     });
+  }
+
+  function handleSend(content: string) {
+    submitMessage(content);
+  }
+
+  function handleRetry(messageId: string) {
+    const failedMessage = messages.find(
+      (message) => message.id === messageId && message.role === "user" && message.deliveryState === "failed",
+    );
+    if (!failedMessage) return;
+    const retryContent = failedMessage.retryContent ?? failedMessage.content;
+
+    const retriedMessage = retryOptimisticMessage(failedMessage);
+    setMessages((prev) =>
+      prev.map((message) => (message.id === messageId ? retriedMessage : message)),
+    );
+    submitMessage(retryContent, retriedMessage, false);
   }
 
   async function handleApprove(proposalId: string) {
@@ -140,11 +195,18 @@ export function AgentCoworkerPanel({
     }
   }
 
-  function handleClear() {
+  function handleOpenClearConfirm() {
+    if (isClearDisabled(messages, isPending, isClearing, threadId)) return;
+    setClearConfirmOpen(true);
+  }
+
+  function handleCancelClearConfirm() {
+    setClearConfirmOpen(false);
+  }
+
+  function handleConfirmClear() {
     if (!threadId) return;
-    if (typeof window !== "undefined" && !window.confirm("Erase the current page conversation?")) {
-      return;
-    }
+    setClearConfirmOpen(false);
 
     startClearing(async () => {
       const result = await clearConversation({ threadId });
@@ -162,8 +224,11 @@ export function AgentCoworkerPanel({
         agent={agent}
         userContext={userContext}
         onSend={handleSend}
-        onClear={handleClear}
-        clearDisabled={!threadId || messages.length === 0 || isPending || isClearing}
+        onOpenClearConfirm={handleOpenClearConfirm}
+        onCancelClearConfirm={handleCancelClearConfirm}
+        onConfirmClear={handleConfirmClear}
+        clearDisabled={isClearDisabled(messages, isPending, isClearing, threadId)}
+        clearConfirmOpen={clearConfirmOpen}
         elevatedAssistEnabled={elevatedAssistEnabled}
         onToggleElevatedAssist={handleToggleElevatedAssist}
         onClose={onClose}
@@ -200,6 +265,8 @@ export function AgentCoworkerPanel({
               agentName={showAgentLabel && msg.agentId ? (AGENT_NAME_MAP[msg.agentId] ?? msg.agentId) : null}
               onApprove={handleApprove}
               onReject={handleReject}
+              {...(msg.deliveryState ? { deliveryState: msg.deliveryState } : {})}
+              {...(msg.deliveryState === "failed" ? { onRetry: () => handleRetry(msg.id) } : {})}
             />
           );
         })}

--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -45,4 +45,46 @@ describe("AgentMessageBubble", () => {
     expect(html).toContain("**raw** user text");
     expect(html).not.toContain("<strong>raw</strong>");
   });
+
+  it("renders a sending status for optimistic user messages", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-3",
+          role: "user",
+          content: "Drafting a change request",
+          agentId: null,
+          routeContext: "/ops",
+          createdAt: "2026-03-14T12:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName={null}
+        deliveryState="sending"
+      />,
+    );
+
+    expect(html).toContain("Sending...");
+  });
+
+  it("renders a failed status and retry action for unsent user messages", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-4",
+          role: "user",
+          content: "Please update the backlog item",
+          agentId: null,
+          routeContext: "/ops",
+          createdAt: "2026-03-14T12:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName={null}
+        deliveryState="failed"
+        onRetry={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Not sent");
+    expect(html).toContain("Retry");
+  });
 });

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -2,13 +2,14 @@
 
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
-import type { ExtraProps } from "react-markdown";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 
 type Props = {
   message: AgentMessageRow;
   showAgentLabel: boolean;
   agentName: string | null;
+  onApprove?: (proposalId: string) => void;
+  onReject?: (proposalId: string) => void;
 };
 
 const MARKDOWN_COMPONENTS: Components = {
@@ -75,7 +76,7 @@ function formatRelativeTime(isoString: string): string {
   return `${days}d ago`;
 }
 
-export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props) {
+export function AgentMessageBubble({ message, showAgentLabel, agentName, onApprove, onReject }: Props) {
   if (message.role === "system") {
     return (
       <div
@@ -93,6 +94,134 @@ export function AgentMessageBubble({ message, showAgentLabel, agentName }: Props
   }
 
   const isUser = message.role === "user";
+
+  // Proposal card rendering for assistant messages with a proposal
+  if (!isUser && message.proposal) {
+    const p = message.proposal;
+    const isPending = p.status === "proposed";
+    const isExecuted = p.status === "executed";
+    const isRejected = p.status === "rejected";
+    const isFailed = p.status === "failed";
+
+    const borderColor = isExecuted
+      ? "rgba(74,222,128,0.4)"
+      : isRejected || isFailed
+        ? "rgba(239,68,68,0.4)"
+        : "rgba(124,140,248,0.4)";
+
+    const actionLabel = p.actionType
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          gap: 2,
+          marginBottom: 8,
+        }}
+      >
+        {showAgentLabel && agentName && (
+          <span style={{ fontSize: 10, color: "var(--dpf-accent)", marginLeft: 4 }}>
+            {agentName}
+          </span>
+        )}
+        <div style={{ maxWidth: "85%" }}>
+          {/* Show the text content first if any */}
+          {message.content && (
+            <div
+              title={formatRelativeTime(message.createdAt)}
+              style={{
+                padding: "8px 12px",
+                borderRadius: "12px 12px 12px 2px",
+                fontSize: 13,
+                lineHeight: 1.4,
+                background: "rgba(22, 22, 37, 0.8)",
+                color: "#e0e0ff",
+                marginBottom: 6,
+                wordBreak: "break-word",
+              }}
+            >
+              {message.content}
+            </div>
+          )}
+          {/* Proposal card */}
+          <div
+            style={{
+              background: "rgba(26, 26, 46, 0.9)",
+              border: `1px solid ${borderColor}`,
+              borderRadius: 10,
+              padding: "10px 14px",
+              fontSize: 12,
+            }}
+          >
+            <div style={{ fontWeight: 600, color: "#e0e0ff", marginBottom: 6 }}>
+              {actionLabel}
+            </div>
+            <div style={{ color: "var(--dpf-muted)", fontSize: 11, marginBottom: 8 }}>
+              {Object.entries(p.parameters).map(([k, v]) => (
+                <div key={k}>
+                  <span style={{ color: "#8888a0" }}>{k}:</span>{" "}
+                  {String(v)}
+                </div>
+              ))}
+            </div>
+            {isPending && (
+              <div style={{ display: "flex", gap: 6 }}>
+                <button
+                  type="button"
+                  onClick={() => onApprove?.(p.proposalId)}
+                  style={{
+                    flex: 1,
+                    background: "rgba(74,222,128,0.2)",
+                    border: "1px solid rgba(74,222,128,0.4)",
+                    borderRadius: 6,
+                    padding: "5px 10px",
+                    fontSize: 11,
+                    color: "#4ade80",
+                    cursor: "pointer",
+                  }}
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onReject?.(p.proposalId)}
+                  style={{
+                    flex: 1,
+                    background: "rgba(239,68,68,0.15)",
+                    border: "1px solid rgba(239,68,68,0.3)",
+                    borderRadius: 6,
+                    padding: "5px 10px",
+                    fontSize: 11,
+                    color: "#ef4444",
+                    cursor: "pointer",
+                  }}
+                >
+                  Reject
+                </button>
+              </div>
+            )}
+            {isExecuted && (
+              <div style={{ color: "#4ade80", fontSize: 11 }}>
+                ✓ Approved{p.resultEntityId ? ` — Created ${p.resultEntityId}` : ""}
+              </div>
+            )}
+            {isRejected && (
+              <div style={{ color: "#ef4444", fontSize: 11 }}>✕ Rejected</div>
+            )}
+            {isFailed && (
+              <div style={{ color: "#ef4444", fontSize: 11 }}>
+                ⚠ Failed: {p.resultError}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -10,6 +10,8 @@ type Props = {
   agentName: string | null;
   onApprove?: (proposalId: string) => void;
   onReject?: (proposalId: string) => void;
+  deliveryState?: "sending" | "sent" | "failed";
+  onRetry?: () => void;
 };
 
 const MARKDOWN_COMPONENTS: Components = {
@@ -76,7 +78,15 @@ function formatRelativeTime(isoString: string): string {
   return `${days}d ago`;
 }
 
-export function AgentMessageBubble({ message, showAgentLabel, agentName, onApprove, onReject }: Props) {
+export function AgentMessageBubble({
+  message,
+  showAgentLabel,
+  agentName,
+  onApprove,
+  onReject,
+  deliveryState,
+  onRetry,
+}: Props) {
   if (message.role === "system") {
     return (
       <div
@@ -249,6 +259,7 @@ export function AgentMessageBubble({ message, showAgentLabel, agentName, onAppro
           background: isUser ? "var(--dpf-accent)" : "rgba(22, 22, 37, 0.8)",
           color: isUser ? "#ffffff" : "#e0e0ff",
           wordBreak: "break-word",
+          opacity: isUser && deliveryState === "sending" ? 0.74 : 1,
         }}
       >
         {isUser ? (
@@ -259,6 +270,38 @@ export function AgentMessageBubble({ message, showAgentLabel, agentName, onAppro
           </div>
         )}
       </div>
+      {isUser && deliveryState && deliveryState !== "sent" && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: 11,
+            color: "var(--dpf-muted)",
+            marginRight: 4,
+          }}
+        >
+          <span>{deliveryState === "sending" ? "Sending..." : "Not sent"}</span>
+          {deliveryState === "failed" && onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              style={{
+                background: "none",
+                border: "1px solid rgba(255, 255, 255, 0.12)",
+                borderRadius: 999,
+                color: "#e0e0ff",
+                cursor: "pointer",
+                fontSize: 11,
+                lineHeight: 1,
+                padding: "3px 8px",
+              }}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -2,28 +2,33 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { AgentPanelHeader } from "./AgentPanelHeader";
 
+const baseProps = {
+  agent: {
+    agentId: "agent-1",
+    agentName: "Ops Co-worker",
+    agentDescription: "Helps with operations",
+    canAssist: true,
+    sensitivity: "internal" as const,
+    systemPrompt: "prompt",
+    skills: [],
+  },
+  userContext: { userId: "user-1", platformRole: "OPS-100", isSuperuser: false },
+  onSend: () => {},
+  onOpenClearConfirm: () => {},
+  onCancelClearConfirm: () => {},
+  onConfirmClear: () => {},
+  clearDisabled: false,
+  clearConfirmOpen: false,
+  elevatedAssistEnabled: false,
+  onToggleElevatedAssist: () => {},
+  onClose: () => {},
+  onDragStart: () => {},
+};
+
 describe("AgentPanelHeader", () => {
   it("renders Hands Off when elevated assist is disabled", () => {
     const html = renderToStaticMarkup(
-      <AgentPanelHeader
-        agent={{
-          agentId: "agent-1",
-          agentName: "Ops Co-worker",
-          agentDescription: "Helps with operations",
-          canAssist: true,
-          sensitivity: "internal",
-          systemPrompt: "prompt",
-          skills: [],
-        }}
-        userContext={{ userId: "user-1", platformRole: "OPS-100", isSuperuser: false }}
-        onSend={() => {}}
-        onClear={() => {}}
-        clearDisabled={false}
-        elevatedAssistEnabled={false}
-        onToggleElevatedAssist={() => {}}
-        onClose={() => {}}
-        onDragStart={() => {}}
-      />,
+      <AgentPanelHeader {...baseProps} />,
     );
 
     expect(html).toContain("Hands Off");
@@ -32,27 +37,23 @@ describe("AgentPanelHeader", () => {
   it("renders a yellow Hands On indicator when elevated assist is enabled", () => {
     const html = renderToStaticMarkup(
       <AgentPanelHeader
-        agent={{
-          agentId: "agent-1",
-          agentName: "Ops Co-worker",
-          agentDescription: "Helps with operations",
-          canAssist: true,
-          sensitivity: "restricted",
-          systemPrompt: "prompt",
-          skills: [],
-        }}
-        userContext={{ userId: "user-1", platformRole: "OPS-100", isSuperuser: false }}
-        onSend={() => {}}
-        onClear={() => {}}
-        clearDisabled={false}
+        {...baseProps}
+        agent={{ ...baseProps.agent, sensitivity: "restricted" }}
         elevatedAssistEnabled
-        onToggleElevatedAssist={() => {}}
-        onClose={() => {}}
-        onDragStart={() => {}}
       />,
     );
 
     expect(html).toContain("Hands On");
     expect(html).toContain("Restricted");
+  });
+
+  it("renders an inline erase confirmation popover when open", () => {
+    const html = renderToStaticMarkup(
+      <AgentPanelHeader {...baseProps} clearConfirmOpen />,
+    );
+
+    expect(html).toContain("Erase this page conversation?");
+    expect(html).toContain("Cancel");
+    expect(html).toContain("Erase now");
   });
 });

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -12,8 +12,11 @@ type Props = {
   agent: AgentInfo;
   userContext: UserContext;
   onSend: (content: string) => void;
-  onClear: () => void;
+  onOpenClearConfirm: () => void;
+  onCancelClearConfirm: () => void;
+  onConfirmClear: () => void;
   clearDisabled: boolean;
+  clearConfirmOpen: boolean;
   elevatedAssistEnabled: boolean;
   onToggleElevatedAssist: () => void;
   onClose: () => void;
@@ -24,8 +27,11 @@ export function AgentPanelHeader({
   agent,
   userContext,
   onSend,
-  onClear,
+  onOpenClearConfirm,
+  onCancelClearConfirm,
+  onConfirmClear,
   clearDisabled,
+  clearConfirmOpen,
   elevatedAssistEnabled,
   onToggleElevatedAssist,
   onClose,
@@ -72,60 +78,47 @@ export function AgentPanelHeader({
           >
             {formatSensitivityLabel(agent.sensitivity)}
           </span>
-          {elevatedAssistEnabled && (
-            <span
-              style={{
-                fontSize: 9,
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-                color: "#241700",
-                background: "#facc15",
-                borderRadius: 999,
-                padding: "2px 6px",
-                fontWeight: 700,
-              }}
-            >
-              Hands On
-            </span>
-          )}
+          <button
+            type="button"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleElevatedAssist();
+            }}
+            title={
+              elevatedAssistEnabled
+                ? "Hands On: this page's coworker can update approved form fields"
+                : "Hands Off: this page's coworker can suggest changes without updating form fields"
+            }
+            style={{
+              fontSize: 9,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: elevatedAssistEnabled ? "#241700" : "rgba(224, 224, 255, 0.78)",
+              background: elevatedAssistEnabled ? "#facc15" : "transparent",
+              border: `1px solid ${elevatedAssistEnabled ? "#facc15" : "rgba(255, 255, 255, 0.12)"}`,
+              borderRadius: 999,
+              padding: "2px 6px",
+              fontWeight: elevatedAssistEnabled ? 700 : 500,
+              cursor: "pointer",
+              lineHeight: 1.2,
+            }}
+          >
+            {elevatedAssistEnabled ? "Hands On" : "Hands Off"}
+          </button>
         </div>
         <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: 12 }}>
           {agent.agentDescription}
         </span>
       </div>
 
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, position: "relative" }}>
         <button
           type="button"
           onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
-            onToggleElevatedAssist();
-          }}
-          title={
-            elevatedAssistEnabled
-              ? "Hands On: this page's coworker can update approved form fields"
-              : "Hands Off: this page's coworker can suggest changes without updating form fields"
-          }
-          style={{
-            background: elevatedAssistEnabled ? "rgba(250, 204, 21, 0.18)" : "none",
-            border: `1px solid ${elevatedAssistEnabled ? "rgba(250, 204, 21, 0.65)" : "rgba(255, 255, 255, 0.12)"}`,
-            color: elevatedAssistEnabled ? "#facc15" : "var(--dpf-muted)",
-            cursor: "pointer",
-            fontSize: 11,
-            padding: "4px 8px",
-            borderRadius: 6,
-            lineHeight: 1,
-          }}
-        >
-          {elevatedAssistEnabled ? "Hands On" : "Hands Off"}
-        </button>
-        <button
-          type="button"
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            onClear();
+            onOpenClearConfirm();
           }}
           disabled={clearDisabled}
           title="Erase current conversation"
@@ -143,6 +136,71 @@ export function AgentPanelHeader({
         >
           Erase
         </button>
+        {clearConfirmOpen && (
+          <div
+            style={{
+              position: "absolute",
+              top: "calc(100% + 8px)",
+              right: 30,
+              width: 220,
+              padding: 10,
+              background: "rgba(26, 26, 46, 0.96)",
+              border: "1px solid rgba(42, 42, 64, 0.8)",
+              borderRadius: 10,
+              boxShadow: "0 10px 28px rgba(0,0,0,0.35)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+              zIndex: 2,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "#e0e0ff", lineHeight: 1.4 }}>
+              Erase this page conversation?
+            </span>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button
+                type="button"
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCancelClearConfirm();
+                }}
+                style={{
+                  background: "none",
+                  border: "1px solid rgba(255, 255, 255, 0.12)",
+                  borderRadius: 6,
+                  color: "var(--dpf-muted)",
+                  cursor: "pointer",
+                  fontSize: 11,
+                  lineHeight: 1,
+                  padding: "5px 8px",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConfirmClear();
+                }}
+                style={{
+                  background: "rgba(239, 68, 68, 0.16)",
+                  border: "1px solid rgba(239, 68, 68, 0.5)",
+                  borderRadius: 6,
+                  color: "#fca5a5",
+                  cursor: "pointer",
+                  fontSize: 11,
+                  lineHeight: 1,
+                  padding: "5px 8px",
+                }}
+              >
+                Erase now
+              </button>
+            </div>
+          </div>
+        )}
         <button
           type="button"
           onMouseDown={(e) => e.stopPropagation()}

--- a/apps/web/components/agent/agent-message-state.test.ts
+++ b/apps/web/components/agent/agent-message-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+import {
+  createOptimisticUserMessage,
+  failOptimisticMessage,
+  reconcileOptimisticMessage,
+  retryOptimisticMessage,
+} from "./agent-message-state";
+
+function makeUserMessage(id: string, content: string): AgentMessageRow {
+  return {
+    id,
+    role: "user",
+    content,
+    agentId: null,
+    routeContext: "/ops",
+    createdAt: "2026-03-14T12:00:00.000Z",
+  };
+}
+
+describe("agent-message-state", () => {
+  it("creates an optimistic user message in sending state", () => {
+    const optimistic = createOptimisticUserMessage("Please update the epic", "/ops");
+
+    expect(optimistic.deliveryState).toBe("sending");
+    expect(optimistic.role).toBe("user");
+    expect(optimistic.content).toBe("Please update the epic");
+  });
+
+  it("marks an optimistic message as failed", () => {
+    const optimistic = createOptimisticUserMessage("Please update the epic", "/ops");
+
+    const failed = failOptimisticMessage(optimistic);
+
+    expect(failed.deliveryState).toBe("failed");
+    expect(failed.content).toBe("Please update the epic");
+  });
+
+  it("reconciles an optimistic message with the server-confirmed user message", () => {
+    const optimistic = createOptimisticUserMessage("Please update the epic", "/ops");
+    const confirmed = makeUserMessage("server-user-1", "Please update the epic");
+
+    const reconciled = reconcileOptimisticMessage(optimistic, confirmed);
+
+    expect(reconciled.id).toBe("server-user-1");
+    expect(reconciled.deliveryState).toBe("sent");
+  });
+
+  it("returns a retryable optimistic message to sending state", () => {
+    const optimistic = failOptimisticMessage(createOptimisticUserMessage("Please update the epic", "/ops"));
+
+    const retried = retryOptimisticMessage(optimistic);
+
+    expect(retried.deliveryState).toBe("sending");
+    expect(retried.content).toBe("Please update the epic");
+  });
+});

--- a/apps/web/components/agent/agent-message-state.ts
+++ b/apps/web/components/agent/agent-message-state.ts
@@ -1,0 +1,54 @@
+import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+
+export type AgentDeliveryState = "sending" | "sent" | "failed";
+
+export type AgentRenderableMessage = AgentMessageRow & {
+  deliveryState?: AgentDeliveryState;
+  retryContent?: string;
+};
+
+export function createOptimisticUserMessage(
+  content: string,
+  routeContext: string,
+  now: Date = new Date(),
+): AgentRenderableMessage {
+  const iso = now.toISOString();
+  const optimisticId = `local-user-${now.getTime()}`;
+  return {
+    id: optimisticId,
+    role: "user",
+    content,
+    agentId: null,
+    routeContext,
+    createdAt: iso,
+    deliveryState: "sending",
+    retryContent: content,
+  };
+}
+
+export function failOptimisticMessage(message: AgentRenderableMessage): AgentRenderableMessage {
+  return {
+    ...message,
+    deliveryState: "failed",
+    retryContent: message.retryContent ?? message.content,
+  };
+}
+
+export function retryOptimisticMessage(message: AgentRenderableMessage): AgentRenderableMessage {
+  return {
+    ...message,
+    deliveryState: "sending",
+    retryContent: message.retryContent ?? message.content,
+  };
+}
+
+export function reconcileOptimisticMessage(
+  message: AgentRenderableMessage,
+  confirmed: AgentMessageRow,
+): AgentRenderableMessage {
+  return {
+    ...confirmed,
+    deliveryState: "sent",
+    retryContent: message.retryContent ?? confirmed.content,
+  };
+}

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -19,6 +19,7 @@ import {
   extractFormAssistResult,
   type AgentFormAssistContext,
 } from "@/lib/agent-form-assist";
+import { getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
@@ -160,13 +161,57 @@ export async function sendMessage(input: {
 
   const populatedPrompt = promptSections.join("\n");
 
+  // Get available tools for this user
+  const availableTools = getAvailableTools({
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  });
+  const toolsForProvider = availableTools.length > 0 ? toolsToOpenAIFormat(availableTools) : undefined;
+
   let responseContent: string;
   let responseProviderId: string | null = null;
   let formAssistUpdate: Record<string, unknown> | undefined;
   let systemMessage: AgentMessageRow | undefined;
 
   try {
-    const result = await callWithFailover(chatHistory, populatedPrompt, agent.sensitivity);
+    const result = await callWithFailover(chatHistory, populatedPrompt, agent.sensitivity, { tools: toolsForProvider });
+
+    // Handle tool calls — create proposals
+    if (result.toolCalls && result.toolCalls.length > 0) {
+      const tc = result.toolCalls[0]!; // v1: one proposal per message
+      const proposalId = "AP-" + Math.random().toString(36).substring(2, 7).toUpperCase();
+
+      // Create the agent message first
+      const agentMsg = await prisma.agentMessage.create({
+        data: {
+          threadId: input.threadId,
+          role: "assistant",
+          content: result.content || `I'd like to ${tc.name.replace(/_/g, " ")} with the following details.`,
+          agentId: agent.agentId,
+          routeContext: input.routeContext,
+          providerId: result.providerId,
+        },
+        select: { id: true, role: true, content: true, agentId: true, routeContext: true, createdAt: true },
+      });
+
+      // Create the proposal linked to the message
+      const proposal = await prisma.agentActionProposal.create({
+        data: {
+          proposalId,
+          threadId: input.threadId,
+          messageId: agentMsg.id,
+          agentId: agent.agentId,
+          actionType: tc.name,
+          parameters: tc.arguments,
+        },
+      });
+
+      return {
+        userMessage: serializeMessage(userMsg),
+        agentMessage: serializeMessage(agentMsg, proposal),
+      };
+    }
+
     responseContent = result.content;
     responseProviderId = result.providerId;
 

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -69,7 +69,7 @@ export async function getOrCreateThreadSnapshot(input: {
 
   return {
     threadId: thread.id,
-    messages: messages.reverse().map(serializeMessage),
+    messages: messages.reverse().map((m) => serializeMessage(m)),
   };
 }
 
@@ -174,7 +174,12 @@ export async function sendMessage(input: {
   let systemMessage: AgentMessageRow | undefined;
 
   try {
-    const result = await callWithFailover(chatHistory, populatedPrompt, agent.sensitivity, { tools: toolsForProvider });
+    const result = await callWithFailover(
+      chatHistory,
+      populatedPrompt,
+      agent.sensitivity,
+      toolsForProvider ? { tools: toolsForProvider } : undefined,
+    );
 
     // Handle tool calls — create proposals
     if (result.toolCalls && result.toolCalls.length > 0) {
@@ -202,7 +207,7 @@ export async function sendMessage(input: {
           messageId: agentMsg.id,
           agentId: agent.agentId,
           actionType: tc.name,
-          parameters: tc.arguments,
+          parameters: tc.arguments as import("@dpf/db").Prisma.InputJsonValue,
         },
       });
 
@@ -345,7 +350,7 @@ export async function loadEarlierMessages(input: {
   const slice = hasMore ? messages.slice(0, limit) : messages;
 
   return {
-    messages: slice.reverse().map(serializeMessage),
+    messages: slice.reverse().map((m) => serializeMessage(m)),
     hasMore,
   };
 }

--- a/apps/web/lib/actions/proposals.ts
+++ b/apps/web/lib/actions/proposals.ts
@@ -47,12 +47,19 @@ export async function approveProposal(
       if (toolResult.success) {
         await tx.agentActionProposal.update({
           where: { proposalId },
-          data: { status: "executed", executedAt: new Date(), resultEntityId: toolResult.entityId },
+          data: {
+            status: "executed",
+            executedAt: new Date(),
+            ...(toolResult.entityId !== undefined ? { resultEntityId: toolResult.entityId } : {}),
+          },
         });
       } else {
         await tx.agentActionProposal.update({
           where: { proposalId },
-          data: { status: "failed", resultError: toolResult.error },
+          data: {
+            status: "failed",
+            ...(toolResult.error !== undefined ? { resultError: toolResult.error } : {}),
+          },
         });
       }
 
@@ -72,7 +79,10 @@ export async function approveProposal(
       },
     });
 
-    return { success: result.success, resultEntityId: result.entityId, error: result.error };
+    const returnVal: { success: boolean; resultEntityId?: string; error?: string } = { success: result.success };
+    if (result.entityId !== undefined) returnVal.resultEntityId = result.entityId;
+    if (result.error !== undefined) returnVal.error = result.error;
+    return returnVal;
   } catch (e) {
     // Transaction failed — proposal stays as "proposed"
     await prisma.agentActionProposal.update({

--- a/apps/web/lib/actions/proposals.ts
+++ b/apps/web/lib/actions/proposals.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { can } from "@/lib/permissions";
+import { PLATFORM_TOOLS, executeTool } from "@/lib/mcp-tools";
+import * as crypto from "crypto";
+
+async function requireAuthUser() {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) throw new Error("Unauthorized");
+  return user;
+}
+
+export async function approveProposal(
+  proposalId: string,
+): Promise<{ success: boolean; resultEntityId?: string; error?: string }> {
+  const user = await requireAuthUser();
+
+  const proposal = await prisma.agentActionProposal.findUnique({
+    where: { proposalId },
+  });
+  if (!proposal) return { success: false, error: "Proposal not found" };
+  if (proposal.status !== "proposed") return { success: false, error: "Proposal already decided" };
+
+  // Check capability
+  const tool = PLATFORM_TOOLS.find((t) => t.name === proposal.actionType);
+  if (tool?.requiredCapability && !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, tool.requiredCapability)) {
+    return { success: false, error: "Insufficient permissions" };
+  }
+
+  // Execute in transaction
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      await tx.agentActionProposal.update({
+        where: { proposalId },
+        data: { status: "approved", decidedAt: new Date(), decidedById: user.id },
+      });
+
+      const toolResult = await executeTool(
+        proposal.actionType,
+        proposal.parameters as Record<string, unknown>,
+        user.id,
+      );
+
+      if (toolResult.success) {
+        await tx.agentActionProposal.update({
+          where: { proposalId },
+          data: { status: "executed", executedAt: new Date(), resultEntityId: toolResult.entityId },
+        });
+      } else {
+        await tx.agentActionProposal.update({
+          where: { proposalId },
+          data: { status: "failed", resultError: toolResult.error },
+        });
+      }
+
+      return toolResult;
+    });
+
+    // Audit log
+    await prisma.authorizationDecisionLog.create({
+      data: {
+        decisionId: `DEC-${crypto.randomUUID()}`,
+        actionKey: proposal.actionType,
+        objectRef: proposalId,
+        actorType: "user",
+        actorRef: user.id,
+        decision: "allow",
+        rationale: { proposalId, parameters: proposal.parameters, result: result.message },
+      },
+    });
+
+    return { success: result.success, resultEntityId: result.entityId, error: result.error };
+  } catch (e) {
+    // Transaction failed — proposal stays as "proposed"
+    await prisma.agentActionProposal.update({
+      where: { proposalId },
+      data: { status: "failed", resultError: e instanceof Error ? e.message : "Execution failed" },
+    });
+    return { success: false, error: e instanceof Error ? e.message : "Execution failed" };
+  }
+}
+
+export async function rejectProposal(
+  proposalId: string,
+  reason?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const user = await requireAuthUser();
+
+  const proposal = await prisma.agentActionProposal.findUnique({
+    where: { proposalId },
+  });
+  if (!proposal) return { success: false, error: "Proposal not found" };
+  if (proposal.status !== "proposed") return { success: false, error: "Proposal already decided" };
+
+  await prisma.agentActionProposal.update({
+    where: { proposalId },
+    data: { status: "rejected", decidedAt: new Date(), decidedById: user.id },
+  });
+
+  await prisma.authorizationDecisionLog.create({
+    data: {
+      decisionId: `DEC-${crypto.randomUUID()}`,
+      actionKey: proposal.actionType,
+      objectRef: proposalId,
+      actorType: "user",
+      actorRef: user.id,
+      decision: "deny",
+      rationale: { proposalId, reason: reason ?? "User rejected" },
+    },
+  });
+
+  return { success: true };
+}

--- a/apps/web/lib/agent-coworker-data.ts
+++ b/apps/web/lib/agent-coworker-data.ts
@@ -63,7 +63,7 @@ export const getRecentMessages = cache(
         createdAt: true,
       },
     });
-    return messages.reverse().map(serializeMessage);
+    return messages.reverse().map((m) => serializeMessage(m));
   },
 );
 

--- a/apps/web/lib/agent-coworker-data.ts
+++ b/apps/web/lib/agent-coworker-data.ts
@@ -2,15 +2,25 @@ import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 
-function serializeMessage(m: {
-  id: string;
-  role: string;
-  content: string;
-  agentId: string | null;
-  routeContext: string | null;
-  createdAt: Date;
-}): AgentMessageRow {
-  return {
+function serializeMessage(
+  m: {
+    id: string;
+    role: string;
+    content: string;
+    agentId: string | null;
+    routeContext: string | null;
+    createdAt: Date;
+  },
+  proposal?: {
+    proposalId: string;
+    actionType: string;
+    parameters: unknown;
+    status: string;
+    resultEntityId: string | null;
+    resultError: string | null;
+  } | null,
+): AgentMessageRow {
+  const row: AgentMessageRow = {
     id: m.id,
     role: (["user", "assistant", "system"] as const).includes(m.role as AgentMessageRow["role"])
       ? (m.role as AgentMessageRow["role"])
@@ -20,6 +30,17 @@ function serializeMessage(m: {
     routeContext: m.routeContext,
     createdAt: m.createdAt.toISOString(),
   };
+  if (proposal) {
+    row.proposal = {
+      proposalId: proposal.proposalId,
+      actionType: proposal.actionType,
+      parameters: proposal.parameters as Record<string, unknown>,
+      status: proposal.status,
+      ...(proposal.resultEntityId ? { resultEntityId: proposal.resultEntityId } : {}),
+      ...(proposal.resultError ? { resultError: proposal.resultError } : {}),
+    };
+  }
+  return row;
 }
 
 /**

--- a/apps/web/lib/agent-coworker-types.ts
+++ b/apps/web/lib/agent-coworker-types.ts
@@ -8,6 +8,14 @@ export type AgentMessageRow = {
   agentId: string | null;
   routeContext: string | null;
   createdAt: string; // ISO string via .toISOString()
+  proposal?: {
+    proposalId: string;
+    actionType: string;
+    parameters: Record<string, unknown>;
+    status: string;
+    resultEntityId?: string;
+    resultError?: string;
+  };
 };
 
 /** Resolved agent info returned by resolveAgentForRoute. */

--- a/apps/web/lib/ai-inference.ts
+++ b/apps/web/lib/ai-inference.ts
@@ -18,6 +18,7 @@ export type InferenceResult = {
   inputTokens: number;
   outputTokens: number;
   inferenceMs: number;
+  toolCalls?: Array<{ name: string; arguments: Record<string, unknown> }>;
 };
 
 // ─── Error Types ─────────────────────────────────────────────────────────────
@@ -142,6 +143,7 @@ export async function callProvider(
   modelId: string,
   messages: ChatMessage[],
   systemPrompt: string,
+  tools?: Array<Record<string, unknown>>,
 ): Promise<InferenceResult> {
   const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
   if (!provider) throw new InferenceError("Provider not found", "provider_error", providerId);
@@ -192,8 +194,11 @@ export async function callProvider(
       ...messages.map((m) => ({ role: m.role, content: m.content })),
     ];
     body = { model: modelId, messages: allMessages, max_tokens: 4096 };
+    if (tools && tools.length > 0) {
+      body.tools = tools;
+    }
     extractText = (d) => {
-      const msg = (d.choices as Array<{ message?: { content?: string; reasoning?: string } }>)?.[0]?.message;
+      const msg = (d.choices as Array<{ message?: { content?: string; reasoning?: string; tool_calls?: Array<{ function?: { name?: string; arguments?: string } }> } }>)?.[0]?.message;
       // Some models (qwen3) use chain-of-thought: content has the answer, reasoning has the thinking
       // If content is empty but reasoning exists, the model may not have finished thinking within token limit
       return msg?.content || msg?.reasoning || "";
@@ -236,11 +241,24 @@ export async function callProvider(
     return 0;
   };
 
+  // Extract tool calls if present (OpenAI-compatible only)
+  let toolCalls: InferenceResult["toolCalls"];
+  const rawMsg = (data.choices as Array<{ message?: { tool_calls?: Array<{ function?: { name?: string; arguments?: string } }> } }>)?.[0]?.message;
+  if (rawMsg?.tool_calls && rawMsg.tool_calls.length > 0) {
+    toolCalls = rawMsg.tool_calls
+      .filter((tc) => tc.function?.name)
+      .map((tc) => ({
+        name: tc.function!.name!,
+        arguments: tc.function?.arguments ? JSON.parse(tc.function.arguments) as Record<string, unknown> : {},
+      }));
+  }
+
   return {
     content: extractText(data),
     inputTokens: readUsageNumber("input_tokens", "prompt_tokens"),
     outputTokens: readUsageNumber("output_tokens", "completion_tokens"),
     inferenceMs,
+    ...(toolCalls !== undefined && { toolCalls }),
   };
 }
 

--- a/apps/web/lib/ai-provider-priority.ts
+++ b/apps/web/lib/ai-provider-priority.ts
@@ -137,6 +137,7 @@ export async function callWithFailover(
   messages: ChatMessage[],
   systemPrompt: string,
   sensitivity: RouteSensitivity = "internal",
+  options?: { tools?: Array<Record<string, unknown>> },
 ): Promise<FailoverResult> {
   const priority = await getProviderPriority();
   const providerPolicy = await getActiveProviderPolicyInfo();
@@ -152,7 +153,7 @@ export async function callWithFailover(
   for (let i = 0; i < limit; i++) {
     const entry = filteredPriority[i]!;
     try {
-      const result = await callProvider(entry.providerId, entry.modelId, messages, systemPrompt);
+      const result = await callProvider(entry.providerId, entry.modelId, messages, systemPrompt, options?.tools);
 
       const downgraded = entry.capabilityTier !== baselineTier && entry.capabilityTier !== "unknown" && baselineTier !== "unknown";
 

--- a/apps/web/lib/mcp-tools.test.ts
+++ b/apps/web/lib/mcp-tools.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { PLATFORM_TOOLS, getAvailableTools, toolsToOpenAIFormat } from "./mcp-tools";
+
+describe("PLATFORM_TOOLS", () => {
+  it("has 5 tools", () => {
+    expect(PLATFORM_TOOLS).toHaveLength(5);
+  });
+
+  it("every tool has name, description, inputSchema, requiredCapability", () => {
+    for (const tool of PLATFORM_TOOLS) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeDefined();
+      expect("requiredCapability" in tool).toBe(true);
+    }
+  });
+});
+
+describe("getAvailableTools", () => {
+  it("superuser sees all tools", () => {
+    const tools = getAvailableTools({ platformRole: "HR-000", isSuperuser: true });
+    expect(tools).toHaveLength(5);
+  });
+
+  it("null role sees only null-capability tools", () => {
+    const tools = getAvailableTools({ platformRole: null, isSuperuser: false });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("report_quality_issue");
+    expect(names).not.toContain("create_backlog_item");
+  });
+
+  it("HR-500 sees manage_backlog tools", () => {
+    const tools = getAvailableTools({ platformRole: "HR-500", isSuperuser: false });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("create_backlog_item");
+    expect(names).toContain("report_quality_issue");
+  });
+});
+
+describe("toolsToOpenAIFormat", () => {
+  it("converts to OpenAI function format", () => {
+    const converted = toolsToOpenAIFormat(PLATFORM_TOOLS.slice(0, 1));
+    expect(converted[0]).toHaveProperty("type", "function");
+    expect(converted[0]).toHaveProperty("function.name", "create_backlog_item");
+    expect(converted[0]).toHaveProperty("function.parameters");
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1,0 +1,200 @@
+import type { CapabilityKey } from "@/lib/permissions";
+import { can, type UserContext } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
+import * as crypto from "crypto";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  requiredCapability: CapabilityKey | null;
+};
+
+export type ToolResult = {
+  success: boolean;
+  entityId?: string;
+  message: string;
+  error?: string;
+};
+
+// ─── Tool Registry ───────────────────────────────────────────────────────────
+
+export const PLATFORM_TOOLS: ToolDefinition[] = [
+  {
+    name: "create_backlog_item",
+    description: "Create a new backlog item in the ops backlog",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Item title" },
+        type: { type: "string", enum: ["portfolio", "product"], description: "Item type" },
+        status: { type: "string", enum: ["open", "in-progress"], description: "Initial status" },
+        body: { type: "string", description: "Detailed description" },
+        epicId: { type: "string", description: "Epic ID to link to (optional)" },
+      },
+      required: ["title", "type"],
+    },
+    requiredCapability: "manage_backlog",
+  },
+  {
+    name: "update_backlog_item",
+    description: "Update an existing backlog item",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "The item ID (e.g., BI-PORT-001)" },
+        title: { type: "string", description: "New title" },
+        status: { type: "string", enum: ["open", "in-progress", "done", "deferred"] },
+        priority: { type: "number", description: "Priority number" },
+        body: { type: "string", description: "Updated description" },
+      },
+      required: ["itemId"],
+    },
+    requiredCapability: "manage_backlog",
+  },
+  {
+    name: "create_digital_product",
+    description: "Register a new digital product in the inventory",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Product name" },
+        productId: { type: "string", description: "Unique product identifier" },
+        lifecycleStage: { type: "string", enum: ["plan", "design", "build", "production", "retirement"] },
+        portfolioSlug: { type: "string", description: "Portfolio slug to assign to" },
+      },
+      required: ["name", "productId"],
+    },
+    requiredCapability: "manage_backlog",
+  },
+  {
+    name: "update_lifecycle",
+    description: "Update a digital product's lifecycle stage and status",
+    inputSchema: {
+      type: "object",
+      properties: {
+        productId: { type: "string", description: "Product identifier" },
+        lifecycleStage: { type: "string", enum: ["plan", "design", "build", "production", "retirement"] },
+        lifecycleStatus: { type: "string", enum: ["draft", "active", "inactive"] },
+      },
+      required: ["productId"],
+    },
+    requiredCapability: "manage_backlog",
+  },
+  {
+    name: "report_quality_issue",
+    description: "Report a bug, suggestion, or question about the platform",
+    inputSchema: {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: ["runtime_error", "user_report", "feedback"], description: "Issue type" },
+        title: { type: "string", description: "Short summary" },
+        description: { type: "string", description: "Detailed description" },
+        severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
+      },
+      required: ["type", "title"],
+    },
+    requiredCapability: null,
+  },
+];
+
+// ─── Capability Filtering ────────────────────────────────────────────────────
+
+export function getAvailableTools(userContext: UserContext): ToolDefinition[] {
+  return PLATFORM_TOOLS.filter(
+    (t) => t.requiredCapability === null || can(userContext, t.requiredCapability),
+  );
+}
+
+// ─── Tool Execution ──────────────────────────────────────────────────────────
+
+export async function executeTool(
+  toolName: string,
+  params: Record<string, unknown>,
+  userId: string,
+): Promise<ToolResult> {
+  switch (toolName) {
+    case "create_backlog_item": {
+      const itemId = `BI-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+      const item = await prisma.backlogItem.create({
+        data: {
+          itemId,
+          title: String(params["title"] ?? "Untitled"),
+          type: String(params["type"] ?? "product"),
+          status: String(params["status"] ?? "open"),
+          ...(typeof params["body"] === "string" ? { body: params["body"] } : {}),
+          ...(typeof params["epicId"] === "string" ? { epicId: params["epicId"] } : {}),
+        },
+      });
+      return { success: true, entityId: item.itemId, message: `Created backlog item ${item.itemId}` };
+    }
+
+    case "update_backlog_item": {
+      const existing = await prisma.backlogItem.findUnique({ where: { itemId: String(params["itemId"]) } });
+      if (!existing) return { success: false, error: "Item not found", message: `Item ${String(params["itemId"])} not found` };
+      const data: Record<string, unknown> = {};
+      if (typeof params["title"] === "string") data["title"] = params["title"];
+      if (typeof params["status"] === "string") data["status"] = params["status"];
+      if (typeof params["priority"] === "number") data["priority"] = params["priority"];
+      if (typeof params["body"] === "string") data["body"] = params["body"];
+      await prisma.backlogItem.update({ where: { itemId: String(params["itemId"]) }, data });
+      return { success: true, entityId: String(params["itemId"]), message: `Updated ${String(params["itemId"])}` };
+    }
+
+    case "create_digital_product": {
+      const product = await prisma.digitalProduct.create({
+        data: {
+          productId: String(params["productId"]),
+          name: String(params["name"]),
+          lifecycleStage: String(params["lifecycleStage"] ?? "plan"),
+          lifecycleStatus: "draft",
+        },
+      });
+      return { success: true, entityId: product.productId, message: `Created product ${product.productId}` };
+    }
+
+    case "update_lifecycle": {
+      const prod = await prisma.digitalProduct.findUnique({ where: { productId: String(params["productId"]) } });
+      if (!prod) return { success: false, error: "Product not found", message: `Product ${String(params["productId"])} not found` };
+      const updates: Record<string, unknown> = {};
+      if (typeof params["lifecycleStage"] === "string") updates["lifecycleStage"] = params["lifecycleStage"];
+      if (typeof params["lifecycleStatus"] === "string") updates["lifecycleStatus"] = params["lifecycleStatus"];
+      await prisma.digitalProduct.update({ where: { productId: String(params["productId"]) }, data: updates });
+      return { success: true, entityId: String(params["productId"]), message: `Updated lifecycle for ${String(params["productId"])}` };
+    }
+
+    case "report_quality_issue": {
+      const reportId = "PIR-" + Math.random().toString(36).substring(2, 7).toUpperCase();
+      await prisma.platformIssueReport.create({
+        data: {
+          reportId,
+          type: String(params["type"] ?? "user_report"),
+          title: String(params["title"] ?? "Untitled"),
+          ...(typeof params["description"] === "string" ? { description: params["description"] } : {}),
+          severity: String(params["severity"] ?? "medium"),
+          reportedById: userId,
+          source: "ai_assisted",
+        },
+      });
+      return { success: true, entityId: reportId, message: `Filed report ${reportId}` };
+    }
+
+    default:
+      return { success: false, error: "Unknown tool", message: `Tool ${toolName} not found` };
+  }
+}
+
+// ─── Convert to provider format ──────────────────────────────────────────────
+
+export function toolsToOpenAIFormat(tools: ToolDefinition[]): Array<Record<string, unknown>> {
+  return tools.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.inputSchema,
+    },
+  }));
+}

--- a/docs/superpowers/plans/2026-03-14-agent-chat-send-polish.md
+++ b/docs/superpowers/plans/2026-03-14-agent-chat-send-polish.md
@@ -1,0 +1,216 @@
+# Agent Chat Send Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the native erase confirmation with a portal-styled popover and make user messages appear immediately with sending and failed states.
+
+**Architecture:** Keep all behavior local to the coworker panel. Introduce a small client-side optimistic message state layer in the panel, surface status rendering through the existing bubble component, and replace `window.confirm` with a lightweight anchored confirmation popover in the header.
+
+**Tech Stack:** Next.js app router, React client components, TypeScript, Vitest
+
+---
+
+## File Map
+
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+  - own optimistic local user message state and erase-confirmation state
+- Modify: `apps/web/components/agent/AgentPanelHeader.tsx`
+  - replace direct erase action with anchored confirmation popover UI
+- Modify: `apps/web/components/agent/AgentMessageBubble.tsx`
+  - render optimistic user message status and retry affordance
+- Modify: `apps/web/components/agent/AgentMessageInput.tsx`
+  - preserve immediate local submit behavior contract if needed
+- Create or modify tests under:
+  - `apps/web/components/agent/AgentCoworkerPanel.test.tsx`
+  - `apps/web/components/agent/AgentPanelHeader.test.tsx`
+  - `apps/web/components/agent/AgentMessageBubble.test.tsx`
+
+## Chunk 1: Erase Confirmation Popover
+
+### Task 1: Add failing header test for styled erase confirmation
+
+**Files:**
+- Modify: `apps/web/components/agent/AgentPanelHeader.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that renders the header, triggers the erase control, and expects inline confirmation content such as `Erase this page conversation?`, `Cancel`, and `Erase`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentPanelHeader.test.tsx --reporter=basic"`
+
+Expected: FAIL because the header still calls the erase handler directly and renders no confirmation popover.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `AgentPanelHeader.tsx` to:
+- track whether the erase popover is open
+- replace direct clear action on first click with popover open
+- render portal-styled confirmation content adjacent to the `Erase` button
+- call `onClear()` only from the confirmation action
+- support `Cancel`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentPanelHeader.test.tsx --reporter=basic"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/AgentPanelHeader.tsx apps/web/components/agent/AgentPanelHeader.test.tsx
+git commit -m "feat: add coworker erase confirmation popover"
+```
+
+## Chunk 2: Optimistic User Message State
+
+### Task 2: Add failing panel test for immediate local echo
+
+**Files:**
+- Modify or Create: `apps/web/components/agent/AgentCoworkerPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that submits a message and immediately expects the user message to appear in the transcript before the mocked server action resolves, with a visible `Sending...` state.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentCoworkerPanel.test.tsx --reporter=basic"`
+
+Expected: FAIL because the panel currently appends the user message only after `sendMessage()` resolves.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `AgentCoworkerPanel.tsx` to:
+- create temporary optimistic user messages on submit
+- append them to local state immediately
+- clear the input immediately through the existing input behavior
+- reconcile optimistic rows with the eventual server response
+- keep server assistant and system message behavior intact
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentCoworkerPanel.test.tsx --reporter=basic"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/AgentCoworkerPanel.tsx apps/web/components/agent/AgentCoworkerPanel.test.tsx
+git commit -m "feat: add optimistic coworker user messages"
+```
+
+### Task 3: Add failing bubble test for sending and failed states
+
+**Files:**
+- Modify or Create: `apps/web/components/agent/AgentMessageBubble.test.tsx`
+- Modify: `apps/web/components/agent/AgentMessageBubble.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add tests that render:
+- a user message with `sending` status and expect `Sending...`
+- a user message with `failed` status and expect `Not sent` plus `Retry`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentMessageBubble.test.tsx --reporter=basic"`
+
+Expected: FAIL because the bubble component does not currently render user message status metadata.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `AgentMessageBubble.tsx` to:
+- accept optional user message delivery status props
+- show inline status text for `sending`
+- show inline failed state plus retry trigger for `failed`
+- avoid changing assistant markdown rendering
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentMessageBubble.test.tsx --reporter=basic"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/AgentMessageBubble.tsx apps/web/components/agent/AgentMessageBubble.test.tsx
+git commit -m "feat: add coworker message send states"
+```
+
+### Task 4: Add failing retry test and implement resend
+
+**Files:**
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.test.tsx`
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that forces `sendMessage()` to fail, verifies the message remains with `Not sent`, clicks `Retry`, and expects the original content to be resubmitted.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentCoworkerPanel.test.tsx --reporter=basic"`
+
+Expected: FAIL because failed messages currently are not retained or retryable.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend `AgentCoworkerPanel.tsx` to:
+- preserve failed optimistic messages
+- expose a retry callback into `AgentMessageBubble`
+- resend using the original message content
+- flip state back to `sending` during retry
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentCoworkerPanel.test.tsx --reporter=basic"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/AgentCoworkerPanel.tsx apps/web/components/agent/AgentCoworkerPanel.test.tsx
+git commit -m "feat: add coworker failed message retry"
+```
+
+## Chunk 3: Focused Verification
+
+### Task 5: Run focused verification and prepare handoff
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run focused agent component tests**
+
+Run:
+
+```bash
+cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentPanelHeader.test.tsx components/agent/AgentCoworkerPanel.test.tsx components/agent/AgentMessageBubble.test.tsx --reporter=basic"
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run web typecheck**
+
+Run:
+
+```bash
+cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\tsc.CMD --noEmit"
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit any final verification-driven fixes**
+
+```bash
+git add <files>
+git commit -m "fix: finish coworker send polish verification"
+```
+
+Only if needed.

--- a/docs/superpowers/specs/2026-03-14-agent-chat-send-polish-design.md
+++ b/docs/superpowers/specs/2026-03-14-agent-chat-send-polish-design.md
@@ -1,0 +1,160 @@
+# Agent Chat Send Polish Design
+
+## Overview
+
+The coworker panel currently has two UX problems:
+
+- erasing a chat uses the browser's native `confirm()` dialog, which does not match the portal visual language and appears detached from the user's click target
+- user messages are only shown after the server round-trip completes, which makes the panel feel laggy and obscures whether a message is still sending or has failed
+
+This slice replaces the native confirmation with a portal-styled popover anchored to the `Erase` control and adds optimistic local echo with visible message send states.
+
+## Goals
+
+- keep destructive confirmation inside the portal UX
+- place the erase confirmation near the `Erase` action
+- show the user's typed message immediately after submit
+- represent send state inline in the chat transcript
+- keep failed messages visible and retryable
+
+## Non-Goals
+
+- delivery and read receipts across providers
+- full offline sync
+- multi-device reconciliation
+- proposal approval UX changes
+
+## UX Design
+
+### Erase Confirmation
+
+The `Erase` action in the coworker header opens a lightweight popover anchored to the header control.
+
+Behavior:
+
+- clicking `Erase` opens the popover instead of `window.confirm`
+- the popover uses the portal visual style
+- the popover includes:
+  - short warning text
+  - `Cancel`
+  - `Erase`
+- clicking away or pressing `Escape` closes the popover
+- confirming runs the existing server action and shows the existing `Erasing...` pending state
+
+This keeps the confirmation local to the interaction and visually consistent with the rest of the portal.
+
+### Optimistic User Messages
+
+When the user sends a message:
+
+1. the message is inserted into the transcript immediately
+2. it is marked as `sending`
+3. the input is cleared immediately
+4. the server request runs in the background
+5. on success, the optimistic message becomes `sent`
+6. on failure, the optimistic message becomes `failed`
+
+The user should never have to wait for the assistant response to see their own message appear in the conversation.
+
+### Message States
+
+For MVP the user message supports three visible states:
+
+- `sending`
+- `sent`
+- `failed`
+
+Presentation:
+
+- `sending`
+  - same user bubble shape
+  - slightly muted opacity
+  - small inline status label such as `Sending...`
+- `sent`
+  - normal user bubble
+- `failed`
+  - user bubble remains visible
+  - inline status such as `Not sent`
+  - retry affordance next to the status
+
+State must not rely on color alone.
+
+## Component Changes
+
+### `AgentCoworkerPanel`
+
+Responsibilities added:
+
+- maintain optimistic local user messages
+- reconcile optimistic messages with server-confirmed messages
+- track pending and failed send state
+- own erase-confirmation open state
+
+Recommended local message shape:
+
+- use the existing `AgentMessageRow` data for server messages
+- augment local rendering with a small client-only status layer keyed by a temporary local id
+
+### `AgentMessageBubble`
+
+Responsibilities added:
+
+- render optional message status metadata for user messages
+- render a retry affordance for failed user messages
+
+The assistant markdown rendering remains unchanged.
+
+### `AgentPanelHeader`
+
+Responsibilities added:
+
+- render the anchored erase-confirmation popover
+- keep `Erase` as the entry point for the confirmation flow
+
+## Data Flow
+
+### Send Flow
+
+1. user submits text
+2. panel creates optimistic user message with temporary id and `sending` status
+3. optimistic message is appended locally
+4. server action executes
+5. success path:
+   - optimistic entry is replaced or reconciled with the server-created user message
+   - assistant and optional system messages append normally
+6. failure path:
+   - optimistic entry remains
+   - status changes to `failed`
+   - retry reuses the same content
+
+### Clear Flow
+
+1. user clicks `Erase`
+2. local popover opens by the control
+3. user confirms
+4. server action clears the current thread
+5. transcript resets on success
+
+## Error Handling
+
+- send failures do not remove the user's message
+- retry should preserve the original content
+- clear failures leave the existing transcript intact and only close the popover if explicitly desired
+- if thread context is unavailable, send remains disabled as it is today
+
+## Testing
+
+Focused tests should cover:
+
+- erase opens a styled confirmation flow instead of native confirm usage
+- optimistic user message appears immediately after send
+- optimistic message transitions to `sent` on success
+- optimistic message transitions to `failed` on server error
+- failed message exposes retry
+- retry resubmits the original content
+
+## Implementation Notes
+
+- reuse existing panel visual tokens rather than introducing a new dialog system
+- keep the state model local to the coworker panel for this slice
+- avoid schema changes; this is a client interaction improvement layered onto the existing server actions

--- a/packages/db/prisma/migrations/20260314170000_agent_action_proposal/migration.sql
+++ b/packages/db/prisma/migrations/20260314170000_agent_action_proposal/migration.sql
@@ -1,0 +1,61 @@
+-- CreateTable
+CREATE TABLE "AgentActionProposal" (
+    "id" TEXT NOT NULL,
+    "proposalId" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "actionType" TEXT NOT NULL,
+    "parameters" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'proposed',
+    "proposedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "decidedAt" TIMESTAMP(3),
+    "decidedById" TEXT,
+    "executedAt" TIMESTAMP(3),
+    "resultEntityId" TEXT,
+    "resultError" TEXT,
+
+    CONSTRAINT "AgentActionProposal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApiToken" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ApiToken_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "ModelProfile" ADD COLUMN "supportsToolUse" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentActionProposal_proposalId_key" ON "AgentActionProposal"("proposalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentActionProposal_messageId_key" ON "AgentActionProposal"("messageId");
+
+-- CreateIndex
+CREATE INDEX "AgentActionProposal_threadId_idx" ON "AgentActionProposal"("threadId");
+
+-- CreateIndex
+CREATE INDEX "AgentActionProposal_status_idx" ON "AgentActionProposal"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiToken_token_key" ON "ApiToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "AgentActionProposal" ADD CONSTRAINT "AgentActionProposal_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "AgentThread"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentActionProposal" ADD CONSTRAINT "AgentActionProposal_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "AgentMessage"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentActionProposal" ADD CONSTRAINT "AgentActionProposal_decidedById_fkey" FOREIGN KEY ("decidedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApiToken" ADD CONSTRAINT "ApiToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -24,6 +24,8 @@ model User {
   passwordResetTokens  PasswordResetToken[] @relation("PasswordResetForUser")
   requestedPasswordResetTokens PasswordResetToken[] @relation("PasswordResetRequestedBy")
   issueReports    PlatformIssueReport[]
+  approvedProposals AgentActionProposal[] @relation("ProposalDecisions")
+  apiTokens       ApiToken[]
 }
 
 model UserGroup {
@@ -288,19 +290,20 @@ model DiscoveredModel {
 }
 
 model ModelProfile {
-  id             String   @id @default(cuid())
-  providerId     String
-  modelId        String
-  friendlyName   String
-  summary        String
-  capabilityTier String
-  costTier       String
-  bestFor        Json
-  avoidFor       Json
-  contextWindow  String?
-  speedRating    String?
-  generatedBy    String
-  generatedAt    DateTime @default(now())
+  id               String   @id @default(cuid())
+  providerId       String
+  modelId          String
+  friendlyName     String
+  summary          String
+  capabilityTier   String
+  costTier         String
+  bestFor          Json
+  avoidFor         Json
+  contextWindow    String?
+  speedRating      String?
+  supportsToolUse  Boolean  @default(false)
+  generatedBy      String
+  generatedAt      DateTime @default(now())
 
   @@unique([providerId, modelId])
 }
@@ -630,6 +633,7 @@ model AgentThread {
   user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   contextKey String @default("coworker")
   messages   AgentMessage[]
+  proposals  AgentActionProposal[]
   createdAt  DateTime       @default(now())
   updatedAt  DateTime       @updatedAt
 
@@ -647,9 +651,45 @@ model AgentMessage {
   routeContext String?     // route pathname when message was sent
   providerId   String?     // provider that handled this inference
   createdAt    DateTime    @default(now())
+  proposal     AgentActionProposal?
 
   @@index([threadId])
   @@index([createdAt])
+}
+
+// ─── Agent Action Proposals ──────────────────────────────────────────────────
+
+model AgentActionProposal {
+  id             String       @id @default(cuid())
+  proposalId     String       @unique
+  threadId       String
+  thread         AgentThread  @relation(fields: [threadId], references: [id])
+  messageId      String       @unique
+  message        AgentMessage @relation(fields: [messageId], references: [id])
+  agentId        String
+  actionType     String
+  parameters     Json
+  status         String       @default("proposed")
+  proposedAt     DateTime     @default(now())
+  decidedAt      DateTime?
+  decidedById    String?
+  decidedBy      User?        @relation("ProposalDecisions", fields: [decidedById], references: [id])
+  executedAt     DateTime?
+  resultEntityId String?
+  resultError    String?      @db.Text
+
+  @@index([threadId])
+  @@index([status])
+}
+
+model ApiToken {
+  id        String    @id @default(cuid())
+  token     String    @unique
+  userId    String
+  user      User      @relation(fields: [userId], references: [id])
+  name      String
+  expiresAt DateTime?
+  createdAt DateTime  @default(now())
 }
 
 // ─── Platform Issue Reporting ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- replace the native erase confirm with an in-panel confirmation popover
- show user chat messages immediately with sending and failed states
- move Hands On and Hands Off into the header pill row and remove the redundant button

## Testing
- focused agent vitest suite
- web TypeScript no-emit check
- web production build