### PR TITLE
feat: add external site access for coworker branding

### DIFF
--- a/apps/web/components/admin/BrandingConfigurator.tsx
+++ b/apps/web/components/admin/BrandingConfigurator.tsx
@@ -1,7 +1,9 @@
 ﻿"use client";
 
-import { ChangeEvent, useMemo, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { saveActiveThemePreset, saveThemePreset } from "@/lib/actions/branding";
+import { registerActiveFormAssist } from "@/lib/agent-form-assist";
+import { applyBrandingFormAssistUpdates } from "./branding-form-assist";
 
 type ThemeTokenInput = {
   version: string;
@@ -296,6 +298,41 @@ export function BrandingConfigurator({
     }
     setUploadedLogoName("");
   };
+
+  useEffect(() => {
+    return registerActiveFormAssist({
+      routeContext: "/admin",
+      formId: "branding-configurator",
+      formName: "Branding configurator",
+      fields: [
+        { key: "companyName", label: "Company name", type: "text" },
+        { key: "logoUrl", label: "Logo URL", type: "text" },
+        { key: "paletteAccent", label: "Accent color", type: "text" },
+        { key: "paletteBg", label: "Page background", type: "text", shareCurrentValue: false },
+        { key: "typographyFontFamily", label: "Body font", type: "text", shareCurrentValue: false },
+      ],
+      getValues: () => ({
+        companyName,
+        logoUrl,
+        paletteAccent: tokens.palette_accent,
+        paletteBg: tokens.palette_bg,
+        typographyFontFamily: tokens.typography_fontFamily,
+      }),
+      applyFieldUpdates: (updates) => {
+        const next = applyBrandingFormAssistUpdates(
+          {
+            companyName,
+            logoUrl,
+            tokens,
+          },
+          updates,
+        );
+        setCompanyName(next.companyName);
+        setLogoSourceFromUrl(next.logoUrl);
+        setTokens(next.tokens as ThemeTokenInput);
+      },
+    });
+  }, [companyName, logoUrl, tokens]);
 
   const renderTokenField = (field: FieldDef): JSX.Element => {
     const value = tokens[field.key];

--- a/apps/web/components/admin/branding-form-assist.test.ts
+++ b/apps/web/components/admin/branding-form-assist.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyBrandingFormAssistUpdates,
+  type BrandingFormState,
+} from "./branding-form-assist";
+
+const baseState: BrandingFormState = {
+  companyName: "Open Digital Product Factory",
+  logoUrl: "/logos/dpf.svg",
+  tokens: {
+    palette_accent: "#7c8cf8",
+    palette_bg: "#080814",
+    typography_fontFamily: "Space Grotesk",
+  },
+};
+
+describe("branding form assist", () => {
+  it("applies allowed branding field updates", () => {
+    const next = applyBrandingFormAssistUpdates(baseState, {
+      companyName: "Jack Jack's Pack",
+      logoUrl: "https://jackjackspack.org/logo.svg",
+      paletteAccent: "#4f46e5",
+    });
+
+    expect(next.companyName).toBe("Jack Jack's Pack");
+    expect(next.logoUrl).toBe("https://jackjackspack.org/logo.svg");
+    expect(next.tokens.palette_accent).toBe("#4f46e5");
+  });
+
+  it("ignores unknown fields", () => {
+    const next = applyBrandingFormAssistUpdates(baseState, {
+      companyName: "Jack Jack's Pack",
+      unknownField: "ignored",
+    });
+
+    expect(next.companyName).toBe("Jack Jack's Pack");
+    expect("unknownField" in next).toBe(false);
+  });
+});

--- a/apps/web/components/admin/branding-form-assist.ts
+++ b/apps/web/components/admin/branding-form-assist.ts
@@ -1,0 +1,44 @@
+export type BrandingFormState = {
+  companyName: string;
+  logoUrl: string;
+  tokens: Record<string, string>;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function applyBrandingFormAssistUpdates(
+  current: BrandingFormState,
+  updates: Record<string, unknown>,
+): BrandingFormState {
+  const next: BrandingFormState = {
+    companyName: current.companyName,
+    logoUrl: current.logoUrl,
+    tokens: {
+      ...current.tokens,
+    },
+  };
+
+  if (isNonEmptyString(updates.companyName)) {
+    next.companyName = updates.companyName.trim();
+  }
+
+  if (isNonEmptyString(updates.logoUrl)) {
+    next.logoUrl = updates.logoUrl.trim();
+  }
+
+  if (isNonEmptyString(updates.paletteAccent)) {
+    next.tokens.palette_accent = updates.paletteAccent.trim();
+  }
+
+  if (isNonEmptyString(updates.paletteBg)) {
+    next.tokens.palette_bg = updates.paletteBg.trim();
+  }
+
+  if (isNonEmptyString(updates.typographyFontFamily)) {
+    next.tokens.typography_fontFamily = updates.typographyFontFamily.trim();
+  }
+
+  return next;
+}

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -15,6 +15,10 @@ import {
   saveElevatedAssistPreference,
 } from "./agent-form-assist-prefs";
 import {
+  loadExternalAccessSessionState,
+  saveExternalAccessSessionState,
+} from "./agent-external-access-session";
+import {
   buildAgentFormAssistContext,
   getActiveFormAssist,
 } from "@/lib/agent-form-assist";
@@ -61,6 +65,7 @@ export function AgentCoworkerPanel({
   const [isPending, startTransition] = useTransition();
   const [isClearing, startClearing] = useTransition();
   const [elevatedAssistEnabled, setElevatedAssistEnabled] = useState(false);
+  const [externalAccessEnabled, setExternalAccessEnabled] = useState(false);
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -78,12 +83,21 @@ export function AgentCoworkerPanel({
 
   useEffect(() => {
     setElevatedAssistEnabled(loadElevatedAssistPreference(preferenceUserKey, pathname));
+    setExternalAccessEnabled(loadExternalAccessSessionState(preferenceUserKey, pathname));
   }, [pathname, preferenceUserKey]);
 
   function handleToggleElevatedAssist() {
     setElevatedAssistEnabled((prev) => {
       const next = !prev;
       saveElevatedAssistPreference(preferenceUserKey, pathname, next);
+      return next;
+    });
+  }
+
+  function handleToggleExternalAccess() {
+    setExternalAccessEnabled((prev) => {
+      const next = !prev;
+      saveExternalAccessSessionState(preferenceUserKey, pathname, next);
       return next;
     });
   }
@@ -231,6 +245,8 @@ export function AgentCoworkerPanel({
         clearConfirmOpen={clearConfirmOpen}
         elevatedAssistEnabled={elevatedAssistEnabled}
         onToggleElevatedAssist={handleToggleElevatedAssist}
+        externalAccessEnabled={externalAccessEnabled}
+        onToggleExternalAccess={handleToggleExternalAccess}
         onClose={onClose}
         onDragStart={onDragStart}
       />

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -119,6 +119,7 @@ export function AgentCoworkerPanel({
         threadId,
         content,
         routeContext: pathname,
+        externalAccessEnabled,
         elevatedFormFillEnabled: elevatedAssistEnabled,
         ...(formAssistContext ? { formAssistContext } : {}),
       });

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -21,6 +21,8 @@ const baseProps = {
   clearConfirmOpen: false,
   elevatedAssistEnabled: false,
   onToggleElevatedAssist: () => {},
+  externalAccessEnabled: false,
+  onToggleExternalAccess: () => {},
   onClose: () => {},
   onDragStart: () => {},
 };
@@ -32,6 +34,7 @@ describe("AgentPanelHeader", () => {
     );
 
     expect(html).toContain("Hands Off");
+    expect(html).toContain("External Off");
   });
 
   it("renders a yellow Hands On indicator when elevated assist is enabled", () => {
@@ -45,6 +48,17 @@ describe("AgentPanelHeader", () => {
 
     expect(html).toContain("Hands On");
     expect(html).toContain("Restricted");
+  });
+
+  it("renders External On when external access is enabled", () => {
+    const html = renderToStaticMarkup(
+      <AgentPanelHeader
+        {...baseProps}
+        externalAccessEnabled
+      />,
+    );
+
+    expect(html).toContain("External On");
   });
 
   it("renders an inline erase confirmation popover when open", () => {

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -19,6 +19,8 @@ type Props = {
   clearConfirmOpen: boolean;
   elevatedAssistEnabled: boolean;
   onToggleElevatedAssist: () => void;
+  externalAccessEnabled: boolean;
+  onToggleExternalAccess: () => void;
   onClose: () => void;
   onDragStart: (e: React.MouseEvent) => void;
 };
@@ -34,6 +36,8 @@ export function AgentPanelHeader({
   clearConfirmOpen,
   elevatedAssistEnabled,
   onToggleElevatedAssist,
+  externalAccessEnabled,
+  onToggleExternalAccess,
   onClose,
   onDragStart,
 }: Props) {
@@ -105,6 +109,34 @@ export function AgentPanelHeader({
             }}
           >
             {elevatedAssistEnabled ? "Hands On" : "Hands Off"}
+          </button>
+          <button
+            type="button"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleExternalAccess();
+            }}
+            title={
+              externalAccessEnabled
+                ? "External On: this page's coworker can use approved public web search and fetch tools during this session"
+                : "External Off: this page's coworker cannot access approved public web search and fetch tools during this session"
+            }
+            style={{
+              fontSize: 9,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: externalAccessEnabled ? "#a7f3d0" : "rgba(224, 224, 255, 0.78)",
+              background: externalAccessEnabled ? "rgba(16, 185, 129, 0.16)" : "transparent",
+              border: `1px solid ${externalAccessEnabled ? "rgba(16, 185, 129, 0.55)" : "rgba(255, 255, 255, 0.12)"}`,
+              borderRadius: 999,
+              padding: "2px 6px",
+              fontWeight: externalAccessEnabled ? 700 : 500,
+              cursor: "pointer",
+              lineHeight: 1.2,
+            }}
+          >
+            {externalAccessEnabled ? "External On" : "External Off"}
           </button>
         </div>
         <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: 12 }}>

--- a/apps/web/components/agent/agent-external-access-session.test.ts
+++ b/apps/web/components/agent/agent-external-access-session.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getExternalAccessSessionKey,
+  loadExternalAccessSessionState,
+  saveExternalAccessSessionState,
+} from "./agent-external-access-session";
+
+const store = new Map<string, string>();
+
+const sessionStorageMock = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    store.set(key, value);
+  },
+  clear: () => {
+    store.clear();
+  },
+};
+
+describe("agent external access session", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: sessionStorageMock,
+      configurable: true,
+    });
+    sessionStorageMock.clear();
+  });
+
+  it("defaults to disabled for a user and route", () => {
+    expect(loadExternalAccessSessionState("user-1", "/admin")).toBe(false);
+  });
+
+  it("stores state by user and route for the current session", () => {
+    saveExternalAccessSessionState("user-1", "/admin", true);
+
+    expect(loadExternalAccessSessionState("user-1", "/admin")).toBe(true);
+    expect(loadExternalAccessSessionState("user-1", "/ops")).toBe(false);
+    expect(loadExternalAccessSessionState("user-2", "/admin")).toBe(false);
+  });
+
+  it("uses a session-scoped storage key", () => {
+    expect(getExternalAccessSessionKey("user-1", "/admin")).toBe(
+      "agent-external-access-session:user-1:/admin",
+    );
+  });
+});

--- a/apps/web/components/agent/agent-external-access-session.ts
+++ b/apps/web/components/agent/agent-external-access-session.ts
@@ -1,0 +1,19 @@
+export function getExternalAccessSessionKey(userId: string, routeContext: string): string {
+  return `agent-external-access-session:${userId}:${routeContext}`;
+}
+
+export function loadExternalAccessSessionState(userId: string, routeContext: string): boolean {
+  try {
+    return sessionStorage.getItem(getExternalAccessSessionKey(userId, routeContext)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function saveExternalAccessSessionState(
+  userId: string,
+  routeContext: string,
+  enabled: boolean,
+): void {
+  sessionStorage.setItem(getExternalAccessSessionKey(userId, routeContext), String(enabled));
+}

--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-routing", () => ({
+  resolveAgentForRoute: vi.fn(),
+  generateCannedResponse: vi.fn(),
+}));
+
+vi.mock("@/lib/ai-provider-priority", () => ({
+  callWithFailover: vi.fn(),
+  NoAllowedProvidersForSensitivityError: class extends Error {},
+  NoProvidersAvailableError: class extends Error {},
+}));
+
+vi.mock("@/lib/ai-inference", () => ({
+  logTokenUsage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/mcp-tools", () => ({
+  getAvailableTools: vi.fn(),
+  toolsToOpenAIFormat: vi.fn(),
+  executeTool: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    agentThread: {
+      findUnique: vi.fn(),
+    },
+    agentMessage: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { auth } from "@/lib/auth";
+import { resolveAgentForRoute } from "@/lib/agent-routing";
+import { callWithFailover } from "@/lib/ai-provider-priority";
+import { executeTool, getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
+import { prisma } from "@dpf/db";
+import { sendMessage } from "./agent-coworker";
+
+const mockAuth = auth as ReturnType<typeof vi.fn>;
+const mockResolveAgentForRoute = resolveAgentForRoute as ReturnType<typeof vi.fn>;
+const mockCallWithFailover = callWithFailover as ReturnType<typeof vi.fn>;
+const mockGetAvailableTools = getAvailableTools as ReturnType<typeof vi.fn>;
+const mockToolsToOpenAIFormat = toolsToOpenAIFormat as ReturnType<typeof vi.fn>;
+const mockExecuteTool = executeTool as ReturnType<typeof vi.fn>;
+const mockPrisma = prisma as any;
+
+describe("agent coworker external access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: {
+        id: "user-1",
+        platformRole: "HR-000",
+        isSuperuser: false,
+      },
+    });
+    mockResolveAgentForRoute.mockReturnValue({
+      agentId: "admin-assistant",
+      agentName: "Admin Assistant",
+      agentDescription: "Admin help",
+      canAssist: true,
+      sensitivity: "restricted",
+      systemPrompt: "Prompt",
+      skills: [],
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({ id: "user-1" });
+    mockPrisma.agentThread.findUnique.mockResolvedValue({ id: "thread-1", userId: "user-1" });
+    mockPrisma.agentMessage.findMany.mockResolvedValue([]);
+    mockPrisma.agentMessage.create
+      .mockResolvedValueOnce({
+        id: "user-msg-1",
+        role: "user",
+        content: "Analyze this site",
+        agentId: null,
+        routeContext: "/admin",
+        createdAt: new Date("2026-03-14T00:00:00.000Z"),
+      })
+      .mockResolvedValueOnce({
+        id: "agent-msg-1",
+        role: "assistant",
+        content: "Derived branding suggestions for Jack Jack's Pack.",
+        agentId: "admin-assistant",
+        routeContext: "/admin",
+        createdAt: new Date("2026-03-14T00:00:01.000Z"),
+      });
+    mockToolsToOpenAIFormat.mockReturnValue([]);
+  });
+
+  it("passes external access state into available tool filtering", async () => {
+    mockGetAvailableTools.mockReturnValue([]);
+    mockCallWithFailover.mockResolvedValue({
+      content: "No tools used.",
+      providerId: "ollama-local",
+      inputTokens: 1,
+      outputTokens: 1,
+      inferenceMs: 10,
+    });
+
+    await sendMessage({
+      threadId: "thread-1",
+      content: "Analyze this site",
+      routeContext: "/admin",
+      externalAccessEnabled: true,
+    });
+
+    expect(mockGetAvailableTools).toHaveBeenCalledWith(
+      {
+        platformRole: "HR-000",
+        isSuperuser: false,
+      },
+      { externalAccessEnabled: true },
+    );
+  });
+
+  it("executes read-only branding analysis tools immediately", async () => {
+    mockGetAvailableTools.mockReturnValue([
+      {
+        name: "analyze_public_website_branding",
+        description: "Analyze branding",
+        inputSchema: {},
+        requiredCapability: "manage_branding",
+        requiresExternalAccess: true,
+        executionMode: "immediate",
+      },
+    ]);
+    mockCallWithFailover.mockResolvedValue({
+      content: "",
+      providerId: "ollama-local",
+      inputTokens: 1,
+      outputTokens: 1,
+      inferenceMs: 10,
+      toolCalls: [
+        {
+          name: "analyze_public_website_branding",
+          arguments: {
+            url: "https://jackjackspack.org",
+          },
+        },
+      ],
+    });
+    mockExecuteTool.mockResolvedValue({
+      success: true,
+      message: "Derived branding suggestions for Jack Jack's Pack.",
+      data: {
+        companyName: "Jack Jack's Pack",
+        logoUrl: "https://jackjackspack.org/logo.svg",
+        paletteAccent: "#4f46e5",
+      },
+    });
+
+    const result = await sendMessage({
+      threadId: "thread-1",
+      content: "Analyze this site",
+      routeContext: "/admin",
+      externalAccessEnabled: true,
+      elevatedFormFillEnabled: true,
+      formAssistContext: {
+        formId: "branding-configurator",
+        formName: "Branding configurator",
+        fields: [
+          { key: "companyName", label: "Company name", type: "text" },
+          { key: "logoUrl", label: "Logo URL", type: "text" },
+          { key: "paletteAccent", label: "Accent color", type: "text" },
+        ],
+      },
+    });
+
+    expect(mockExecuteTool).toHaveBeenCalledWith(
+      "analyze_public_website_branding",
+      { url: "https://jackjackspack.org" },
+      "user-1",
+      { routeContext: "/admin" },
+    );
+    expect(result).not.toHaveProperty("error");
+    if (!("error" in result)) {
+      expect(result.formAssistUpdate).toEqual({
+        companyName: "Jack Jack's Pack",
+        logoUrl: "https://jackjackspack.org/logo.svg",
+        paletteAccent: "#4f46e5",
+      });
+    }
+  });
+});

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -19,7 +19,7 @@ import {
   extractFormAssistResult,
   type AgentFormAssistContext,
 } from "@/lib/agent-form-assist";
-import { getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
+import { executeTool, getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
@@ -86,6 +86,7 @@ export async function sendMessage(input: {
   threadId: string;
   content: string;
   routeContext: string;
+  externalAccessEnabled?: boolean;
   elevatedFormFillEnabled?: boolean;
   formAssistContext?: AgentFormAssistContext;
 }): Promise<
@@ -165,6 +166,8 @@ export async function sendMessage(input: {
   const availableTools = getAvailableTools({
     platformRole: user.platformRole,
     isSuperuser: user.isSuperuser,
+  }, {
+    externalAccessEnabled: input.externalAccessEnabled === true,
   });
   const toolsForProvider = availableTools.length > 0 ? toolsToOpenAIFormat(availableTools) : undefined;
 
@@ -181,9 +184,38 @@ export async function sendMessage(input: {
       toolsForProvider ? { tools: toolsForProvider } : undefined,
     );
 
-    // Handle tool calls — create proposals
+    // Handle tool calls — execute read-only tools immediately, propose side-effecting tools.
     if (result.toolCalls && result.toolCalls.length > 0) {
       const tc = result.toolCalls[0]!; // v1: one proposal per message
+      const toolDefinition = availableTools.find((tool) => tool.name === tc.name);
+
+      if (toolDefinition?.executionMode === "immediate") {
+        const toolResult = await executeTool(
+          tc.name,
+          tc.arguments,
+          user.id,
+          { routeContext: input.routeContext },
+        );
+
+        const agentMsg = await prisma.agentMessage.create({
+          data: {
+            threadId: input.threadId,
+            role: "assistant",
+            content: toolResult.message,
+            agentId: agent.agentId,
+            routeContext: input.routeContext,
+            providerId: result.providerId,
+          },
+          select: { id: true, role: true, content: true, agentId: true, routeContext: true, createdAt: true },
+        });
+
+        return {
+          userMessage: serializeMessage(userMsg),
+          agentMessage: serializeMessage(agentMsg),
+          ...(toolResult.data !== undefined ? { formAssistUpdate: toolResult.data } : {}),
+        };
+      }
+
       const proposalId = "AP-" + Math.random().toString(36).substring(2, 7).toUpperCase();
 
       // Create the agent message first

--- a/apps/web/lib/actions/external-evidence.test.ts
+++ b/apps/web/lib/actions/external-evidence.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    externalEvidenceRecord: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { recordExternalEvidence } from "./external-evidence";
+
+const mockPrisma = prisma as any;
+
+describe("external evidence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes a normalized external evidence record", async () => {
+    mockPrisma.externalEvidenceRecord.create.mockResolvedValue({
+      id: "evidence-1",
+      routeContext: "/admin",
+      operationType: "branding_analysis",
+      target: "https://jackjackspack.org/",
+      provider: "public_fetch",
+      resultSummary: "Derived branding proposal",
+    });
+
+    await recordExternalEvidence({
+      actorUserId: "user-1",
+      routeContext: "/admin",
+      operationType: "branding_analysis",
+      target: "https://jackjackspack.org/",
+      provider: "public_fetch",
+      resultSummary: "Derived branding proposal",
+      details: {
+        companyName: "Jack Jack's Pack",
+      },
+    });
+
+    expect(mockPrisma.externalEvidenceRecord.create).toHaveBeenCalledWith({
+      data: {
+        actorUserId: "user-1",
+        routeContext: "/admin",
+        operationType: "branding_analysis",
+        target: "https://jackjackspack.org/",
+        provider: "public_fetch",
+        resultSummary: "Derived branding proposal",
+        details: {
+          companyName: "Jack Jack's Pack",
+        },
+      },
+    });
+  });
+});

--- a/apps/web/lib/actions/external-evidence.ts
+++ b/apps/web/lib/actions/external-evidence.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { prisma, type Prisma } from "@dpf/db";
+
+export async function recordExternalEvidence(input: {
+  actorUserId: string;
+  routeContext: string;
+  operationType: string;
+  target: string;
+  provider: string;
+  resultSummary: string;
+  details?: Prisma.InputJsonValue;
+}) {
+  return prisma.externalEvidenceRecord.create({
+    data: {
+      actorUserId: input.actorUserId,
+      routeContext: input.routeContext,
+      operationType: input.operationType,
+      target: input.target,
+      provider: input.provider,
+      resultSummary: input.resultSummary,
+      ...(input.details !== undefined ? { details: input.details } : {}),
+    },
+  });
+}

--- a/apps/web/lib/agent-routing.test.ts
+++ b/apps/web/lib/agent-routing.test.ts
@@ -54,6 +54,12 @@ describe("resolveAgentForRoute", () => {
     expect(result.agentDescription).toBeTruthy();
   });
 
+  it("mentions public website branding analysis in the admin assistant prompt", () => {
+    const result = resolveAgentForRoute("/admin", superuser);
+    expect(result.systemPrompt).toContain("public website");
+    expect(result.systemPrompt).toContain("branding");
+  });
+
   it("returns a non-empty systemPrompt", () => {
     const result = resolveAgentForRoute("/portfolio", superuser);
     expect(result.systemPrompt).toBeTruthy();

--- a/apps/web/lib/agent-routing.ts
+++ b/apps/web/lib/agent-routing.ts
@@ -188,11 +188,12 @@ Guidelines:
 
 Role: You help with platform administration — user management, role assignments, and system configuration.
 
-You understand user account lifecycle, platform role assignments (HR-000 through HR-500), capability-based access control, branding configuration, and system-wide settings.
+You understand user account lifecycle, platform role assignments (HR-000 through HR-500), capability-based access control, branding configuration, system-wide settings, and how to analyze a public website for branding signals when external access is enabled for the current session.
 
 Guidelines:
 - Be concise and helpful
 - Prefer short paragraphs and flat bullet lists over walls of text
+- When the user provides a public website URL for branding setup and external access is enabled, use the public website branding analysis tool instead of refusing
 - If you cannot help with something, suggest which area of the portal might
 - Do not make up data — if you don't know, say so`,
     skills: [

--- a/apps/web/lib/mcp-tools.test.ts
+++ b/apps/web/lib/mcp-tools.test.ts
@@ -1,47 +1,26 @@
-import { describe, it, expect } from "vitest";
-import { PLATFORM_TOOLS, getAvailableTools, toolsToOpenAIFormat } from "./mcp-tools";
+import { describe, expect, it } from "vitest";
+import { getAvailableTools } from "./mcp-tools";
 
-describe("PLATFORM_TOOLS", () => {
-  it("has 5 tools", () => {
-    expect(PLATFORM_TOOLS).toHaveLength(5);
+describe("mcp tools", () => {
+  const adminUser = {
+    userId: "user-1",
+    platformRole: "HR-000",
+    isSuperuser: false,
+  };
+
+  it("hides external tools when external access is off", () => {
+    const tools = getAvailableTools(adminUser, { externalAccessEnabled: false });
+
+    expect(tools.some((tool) => tool.name === "search_public_web")).toBe(false);
+    expect(tools.some((tool) => tool.name === "fetch_public_website")).toBe(false);
+    expect(tools.some((tool) => tool.name === "analyze_public_website_branding")).toBe(false);
   });
 
-  it("every tool has name, description, inputSchema, requiredCapability", () => {
-    for (const tool of PLATFORM_TOOLS) {
-      expect(tool.name).toBeTruthy();
-      expect(tool.description).toBeTruthy();
-      expect(tool.inputSchema).toBeDefined();
-      expect("requiredCapability" in tool).toBe(true);
-    }
-  });
-});
+  it("shows external tools when external access is on", () => {
+    const tools = getAvailableTools(adminUser, { externalAccessEnabled: true });
 
-describe("getAvailableTools", () => {
-  it("superuser sees all tools", () => {
-    const tools = getAvailableTools({ platformRole: "HR-000", isSuperuser: true });
-    expect(tools).toHaveLength(5);
-  });
-
-  it("null role sees only null-capability tools", () => {
-    const tools = getAvailableTools({ platformRole: null, isSuperuser: false });
-    const names = tools.map((t) => t.name);
-    expect(names).toContain("report_quality_issue");
-    expect(names).not.toContain("create_backlog_item");
-  });
-
-  it("HR-500 sees manage_backlog tools", () => {
-    const tools = getAvailableTools({ platformRole: "HR-500", isSuperuser: false });
-    const names = tools.map((t) => t.name);
-    expect(names).toContain("create_backlog_item");
-    expect(names).toContain("report_quality_issue");
-  });
-});
-
-describe("toolsToOpenAIFormat", () => {
-  it("converts to OpenAI function format", () => {
-    const converted = toolsToOpenAIFormat(PLATFORM_TOOLS.slice(0, 1));
-    expect(converted[0]).toHaveProperty("type", "function");
-    expect(converted[0]).toHaveProperty("function.name", "create_backlog_item");
-    expect(converted[0]).toHaveProperty("function.parameters");
+    expect(tools.some((tool) => tool.name === "search_public_web")).toBe(true);
+    expect(tools.some((tool) => tool.name === "fetch_public_website")).toBe(true);
+    expect(tools.some((tool) => tool.name === "analyze_public_website_branding")).toBe(true);
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2,6 +2,12 @@ import type { CapabilityKey } from "@/lib/permissions";
 import { can, type UserContext } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import * as crypto from "crypto";
+import {
+  analyzePublicWebsiteBranding,
+  fetchPublicWebsiteEvidence,
+  searchPublicWeb,
+} from "@/lib/public-web-tools";
+import { recordExternalEvidence } from "@/lib/actions/external-evidence";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -10,6 +16,8 @@ export type ToolDefinition = {
   description: string;
   inputSchema: Record<string, unknown>;
   requiredCapability: CapabilityKey | null;
+  requiresExternalAccess?: boolean;
+  executionMode?: "proposal" | "immediate";
 };
 
 export type ToolResult = {
@@ -17,6 +25,7 @@ export type ToolResult = {
   entityId?: string;
   message: string;
   error?: string;
+  data?: Record<string, unknown>;
 };
 
 // ─── Tool Registry ───────────────────────────────────────────────────────────
@@ -98,13 +107,60 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: null,
   },
+  {
+    name: "search_public_web",
+    description: "Search the public web for relevant pages or facts",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query" },
+      },
+      required: ["query"],
+    },
+    requiredCapability: null,
+    requiresExternalAccess: true,
+    executionMode: "immediate",
+  },
+  {
+    name: "fetch_public_website",
+    description: "Fetch a public website and summarize visible branding and metadata",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "Public http or https URL" },
+      },
+      required: ["url"],
+    },
+    requiredCapability: null,
+    requiresExternalAccess: true,
+    executionMode: "immediate",
+  },
+  {
+    name: "analyze_public_website_branding",
+    description: "Analyze a public website and propose branding values such as company name, logo, and accent color",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "Public http or https URL" },
+      },
+      required: ["url"],
+    },
+    requiredCapability: "manage_branding",
+    requiresExternalAccess: true,
+    executionMode: "immediate",
+  },
 ];
 
 // ─── Capability Filtering ────────────────────────────────────────────────────
 
-export function getAvailableTools(userContext: UserContext): ToolDefinition[] {
+export function getAvailableTools(
+  userContext: UserContext,
+  options?: { externalAccessEnabled?: boolean },
+): ToolDefinition[] {
   return PLATFORM_TOOLS.filter(
-    (t) => t.requiredCapability === null || can(userContext, t.requiredCapability),
+    (tool) =>
+      (!tool.requiresExternalAccess || options?.externalAccessEnabled === true)
+      && (tool.requiredCapability === null || can(userContext, tool.requiredCapability)),
   );
 }
 
@@ -114,6 +170,7 @@ export async function executeTool(
   toolName: string,
   params: Record<string, unknown>,
   userId: string,
+  context?: { routeContext?: string },
 ): Promise<ToolResult> {
   switch (toolName) {
     case "create_backlog_item": {
@@ -179,6 +236,80 @@ export async function executeTool(
         },
       });
       return { success: true, entityId: reportId, message: `Filed report ${reportId}` };
+    }
+
+    case "search_public_web": {
+      const query = String(params["query"] ?? "").trim();
+      const results = await searchPublicWeb(query);
+      if (context?.routeContext) {
+        await recordExternalEvidence({
+          actorUserId: userId,
+          routeContext: context.routeContext,
+          operationType: "public_web_search",
+          target: query,
+          provider: "brave_search",
+          resultSummary: `Found ${results.length} public search result(s)`,
+          details: results as import("@dpf/db").Prisma.InputJsonValue,
+        });
+      }
+      return {
+        success: true,
+        message: results.length > 0
+          ? `Found ${results.length} public search result(s). Top result: ${results[0]!.title} (${results[0]!.url})`
+          : "No public search results were found.",
+        data: { results },
+      };
+    }
+
+    case "fetch_public_website": {
+      const url = String(params["url"] ?? "").trim();
+      const evidence = await fetchPublicWebsiteEvidence(url);
+      if (context?.routeContext) {
+        await recordExternalEvidence({
+          actorUserId: userId,
+          routeContext: context.routeContext,
+          operationType: "public_web_fetch",
+          target: evidence.finalUrl,
+          provider: "public_fetch",
+          resultSummary: `Fetched public website evidence for ${evidence.finalUrl}`,
+          details: evidence as unknown as import("@dpf/db").Prisma.InputJsonValue,
+        });
+      }
+      return {
+        success: true,
+        message: `Fetched ${evidence.finalUrl}${evidence.title ? ` (${evidence.title})` : ""}.`,
+        data: evidence,
+      };
+    }
+
+    case "analyze_public_website_branding": {
+      const url = String(params["url"] ?? "").trim();
+      const evidence = await fetchPublicWebsiteEvidence(url);
+      const branding = analyzePublicWebsiteBranding(evidence);
+      if (context?.routeContext) {
+        await recordExternalEvidence({
+          actorUserId: userId,
+          routeContext: context.routeContext,
+          operationType: "branding_analysis",
+          target: evidence.finalUrl,
+          provider: "public_fetch",
+          resultSummary: `Derived branding proposal for ${evidence.finalUrl}`,
+          details: {
+            evidence,
+            branding,
+          } as import("@dpf/db").Prisma.InputJsonValue,
+        });
+      }
+      return {
+        success: true,
+        message: `Derived branding suggestions for ${branding.companyName ?? evidence.finalUrl}.`,
+        data: {
+          companyName: branding.companyName,
+          logoUrl: branding.logoUrl,
+          paletteAccent: branding.paletteAccent,
+          notes: branding.notes,
+        },
+      };
     }
 
     default:

--- a/apps/web/lib/public-web-tools.test.ts
+++ b/apps/web/lib/public-web-tools.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzePublicWebsiteBranding,
+  assertAllowedPublicUrl,
+  normalizeBraveSearchResults,
+  normalizePublicFetchUrl,
+} from "./public-web-tools";
+
+describe("public web tools", () => {
+  it("blocks localhost and private network targets", () => {
+    expect(() => assertAllowedPublicUrl("http://localhost:3000")).toThrow(/not allowed/i);
+    expect(() => assertAllowedPublicUrl("http://127.0.0.1:3000")).toThrow(/not allowed/i);
+    expect(() => assertAllowedPublicUrl("http://10.0.0.25")).toThrow(/not allowed/i);
+    expect(() => assertAllowedPublicUrl("http://192.168.1.10")).toThrow(/not allowed/i);
+  });
+
+  it("normalizes public fetch targets to https urls", () => {
+    expect(normalizePublicFetchUrl("example.com/brand")).toBe("https://example.com/brand");
+    expect(normalizePublicFetchUrl(" https://jackjackspack.org ")).toBe("https://jackjackspack.org/");
+  });
+
+  it("normalizes brave search results into a stable shape", () => {
+    const normalized = normalizeBraveSearchResults({
+      web: {
+        results: [
+          {
+            title: "Jack Jack's Pack",
+            url: "https://jackjackspack.org",
+            description: "Care packages and community support.",
+          },
+        ],
+      },
+    });
+
+    expect(normalized).toEqual([
+      {
+        title: "Jack Jack's Pack",
+        url: "https://jackjackspack.org",
+        snippet: "Care packages and community support.",
+      },
+    ]);
+  });
+
+  it("derives a branding proposal from fetched public page evidence", () => {
+    const proposal = analyzePublicWebsiteBranding({
+      url: "https://jackjackspack.org",
+      finalUrl: "https://jackjackspack.org/",
+      title: "Jack Jack's Pack",
+      description: "Compassion packs for children and families.",
+      textExcerpt: "Jack Jack's Pack provides comfort packs for families in crisis.",
+      themeColor: "#4f46e5",
+      logoCandidates: [
+        "https://jackjackspack.org/logo.svg",
+      ],
+    });
+
+    expect(proposal.companyName).toBe("Jack Jack's Pack");
+    expect(proposal.logoUrl).toBe("https://jackjackspack.org/logo.svg");
+    expect(proposal.paletteAccent).toBe("#4f46e5");
+  });
+});

--- a/apps/web/lib/public-web-tools.ts
+++ b/apps/web/lib/public-web-tools.ts
@@ -1,0 +1,200 @@
+type BraveSearchApiResult = {
+  web?: {
+    results?: Array<{
+      title?: string;
+      url?: string;
+      description?: string;
+    }>;
+  };
+};
+
+export type NormalizedSearchResult = {
+  title: string;
+  url: string;
+  snippet: string;
+};
+
+export type PublicWebsiteEvidence = {
+  url: string;
+  finalUrl: string;
+  title: string | null;
+  description: string | null;
+  textExcerpt: string | null;
+  themeColor: string | null;
+  logoCandidates: string[];
+};
+
+export type BrandingAnalysisResult = {
+  companyName: string | null;
+  logoUrl: string | null;
+  paletteAccent: string | null;
+  notes: string[];
+};
+
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./,
+  /^\[?::1\]?$/i,
+  /^\[?fc/i,
+  /^\[?fd/i,
+];
+
+function extractTextExcerpt(html: string): string | null {
+  const stripped = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return stripped.length > 0 ? stripped.slice(0, 500) : null;
+}
+
+function extractMetaContent(html: string, key: string): string | null {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const patterns = [
+    new RegExp(`<meta[^>]+name=["']${escapedKey}["'][^>]+content=["']([^"']+)["']`, "i"),
+    new RegExp(`<meta[^>]+property=["']${escapedKey}["'][^>]+content=["']([^"']+)["']`, "i"),
+    new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+name=["']${escapedKey}["']`, "i"),
+    new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+property=["']${escapedKey}["']`, "i"),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  return null;
+}
+
+function extractLogoCandidates(html: string, baseUrl: string): string[] {
+  const candidates = new Set<string>();
+
+  const linkMatches = html.matchAll(/<link[^>]+rel=["'][^"']*(icon|apple-touch-icon)[^"']*["'][^>]+href=["']([^"']+)["']/gi);
+  for (const match of linkMatches) {
+    const href = match[2]?.trim();
+    if (href) {
+      candidates.add(new URL(href, baseUrl).href);
+    }
+  }
+
+  const imageMatches = html.matchAll(/<img[^>]+(?:src|data-logo)=["']([^"']+)["'][^>]*(?:alt=["']([^"']*)["'])?/gi);
+  for (const match of imageMatches) {
+    const src = match[1]?.trim();
+    const alt = (match[2] ?? "").toLowerCase();
+    if (src && (alt.includes("logo") || /logo/i.test(src))) {
+      candidates.add(new URL(src, baseUrl).href);
+    }
+  }
+
+  return [...candidates];
+}
+
+export function assertAllowedPublicUrl(input: string): URL {
+  const url = new URL(normalizePublicFetchUrl(input));
+
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new Error("Only public http and https URLs are allowed");
+  }
+
+  const hostname = url.hostname.replace(/\.$/, "");
+  if (PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(hostname))) {
+    throw new Error("This target is not allowed for public external access");
+  }
+
+  return url;
+}
+
+export function normalizePublicFetchUrl(input: string): string {
+  const trimmed = input.trim();
+  const withProtocol = /^[a-z][a-z\d+\-.]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  return new URL(withProtocol).href;
+}
+
+export function normalizeBraveSearchResults(raw: BraveSearchApiResult): NormalizedSearchResult[] {
+  return (raw.web?.results ?? [])
+    .filter((result) => typeof result.title === "string" && typeof result.url === "string")
+    .map((result) => ({
+      title: result.title!.trim(),
+      url: result.url!.trim(),
+      snippet: typeof result.description === "string" ? result.description.trim() : "",
+    }));
+}
+
+export async function searchPublicWeb(query: string): Promise<NormalizedSearchResult[]> {
+  const apiKey = process.env.BRAVE_SEARCH_API_KEY;
+  if (!apiKey) {
+    throw new Error("BRAVE_SEARCH_API_KEY is not configured");
+  }
+
+  const response = await fetch(`https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}`, {
+    headers: {
+      Accept: "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Brave Search failed with HTTP ${response.status}`);
+  }
+
+  const raw = await response.json() as BraveSearchApiResult;
+  return normalizeBraveSearchResults(raw);
+}
+
+export async function fetchPublicWebsiteEvidence(url: string): Promise<PublicWebsiteEvidence> {
+  const validatedUrl = assertAllowedPublicUrl(url);
+  const response = await fetch(validatedUrl.href, {
+    headers: {
+      "User-Agent": "DigitalProductFactory/1.0 (+public-web-fetch)",
+      Accept: "text/html,application/xhtml+xml",
+    },
+    redirect: "follow",
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Public website fetch failed with HTTP ${response.status}`);
+  }
+
+  const html = await response.text();
+  const finalUrl = response.url || validatedUrl.href;
+  const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+
+  return {
+    url: validatedUrl.href,
+    finalUrl,
+    title: titleMatch?.[1]?.trim() ?? null,
+    description: extractMetaContent(html, "description") ?? extractMetaContent(html, "og:description"),
+    textExcerpt: extractTextExcerpt(html),
+    themeColor: extractMetaContent(html, "theme-color"),
+    logoCandidates: extractLogoCandidates(html, finalUrl),
+  };
+}
+
+export function analyzePublicWebsiteBranding(
+  evidence: PublicWebsiteEvidence,
+): BrandingAnalysisResult {
+  const companyName = evidence.title?.trim() || evidence.description?.split(/[.|-]/)[0]?.trim() || null;
+  const logoUrl = evidence.logoCandidates[0] ?? null;
+  const paletteAccent = evidence.themeColor;
+  const notes = [
+    evidence.description ? `Description: ${evidence.description}` : null,
+    evidence.textExcerpt ? `Excerpt: ${evidence.textExcerpt}` : null,
+  ].filter((value): value is string => value !== null);
+
+  return {
+    companyName,
+    logoUrl,
+    paletteAccent,
+    notes,
+  };
+}

--- a/docs/superpowers/plans/2026-03-14-external-site-access.md
+++ b/docs/superpowers/plans/2026-03-14-external-site-access.md
@@ -1,0 +1,347 @@
+# External Site Access Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add session-scoped external-site access to the coworker, implement public search and fetch capabilities with evidence logging, and wire branding analysis into the admin branding workflow.
+
+**Architecture:** Extend the existing coworker tool/proposal system rather than creating a parallel web-access path. Use a page-aware session toggle to gate public search/fetch tools, implement server-side adapters for Brave Search and public page fetch, persist evidence records, and expose a branding-analysis path that can populate the admin branding form when `Hands On` is enabled.
+
+**Tech Stack:** Next.js app router, React client components, TypeScript, Prisma, Vitest, server-side fetch
+
+---
+
+## File Map
+
+- Modify: `apps/web/components/agent/AgentPanelHeader.tsx`
+  - add `External Off / External On` pill UI
+- Modify: `apps/web/components/agent/AgentPanelHeader.test.tsx`
+  - cover the new external-access pill rendering
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+  - surface external access session state into the coworker flow
+- Create: `apps/web/components/agent/agent-external-access-session.ts`
+  - session-scoped route-aware external access helpers
+- Modify: `apps/web/lib/mcp-tools.ts`
+  - add read-only public web search/fetch/branding tools
+- Create: `apps/web/lib/public-web-tools.ts`
+  - Brave Search and public fetch adapters plus SSRF-safe validation
+- Create: `apps/web/lib/public-web-tools.test.ts`
+  - verify normalization and URL blocking logic
+- Modify: `apps/web/lib/actions/agent-coworker.ts`
+  - expose external tools only when session access is enabled
+- Modify: `apps/web/components/admin/BrandingConfigurator.tsx`
+  - register branding form assist and consume branding-analysis suggestions
+- Create: `apps/web/components/admin/branding-form-assist.ts`
+  - safe field update application for branding fields
+- Create: `apps/web/lib/actions/external-evidence.ts`
+  - evidence logging helpers
+- Add Prisma migration and schema changes in `packages/db`
+  - evidence record model for public search/fetch operations
+
+## Chunk 1: External Access Session Toggle
+
+### Task 1: Add failing header test for external access pill
+
+**Files:**
+- Modify: `apps/web/components/agent/AgentPanelHeader.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add coverage that expects the header to render `External Off` by default and `External On` when enabled.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/AgentPanelHeader.test.tsx --reporter=basic"
+```
+
+Expected: FAIL because the header does not yet render an external-access pill.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `AgentPanelHeader.tsx` to:
+- render a second pill for external access
+- show `External Off` / `External On`
+- call a new toggle callback
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same `vitest` command.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/AgentPanelHeader.tsx apps/web/components/agent/AgentPanelHeader.test.tsx
+git commit -m "feat: add coworker external access pill"
+```
+
+### Task 2: Add failing tests for session-scoped external access state
+
+**Files:**
+- Create: `apps/web/components/agent/agent-external-access-session.ts`
+- Create: `apps/web/components/agent/agent-external-access-session.test.ts`
+- Modify: `apps/web/components/agent/AgentCoworkerPanel.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for a helper that:
+- stores external access state by `user + route + session`
+- defaults to disabled
+- does not imply long-term persistence
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run components/agent/agent-external-access-session.test.ts --reporter=basic"
+```
+
+Expected: FAIL because the helper does not yet exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create the helper and wire `AgentCoworkerPanel.tsx` to use it for the current route and session.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same `vitest` command.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/agent/agent-external-access-session.ts apps/web/components/agent/agent-external-access-session.test.ts apps/web/components/agent/AgentCoworkerPanel.tsx
+git commit -m "feat: add session-scoped coworker external access state"
+```
+
+## Chunk 2: Public Search and Fetch Foundation
+
+### Task 3: Add failing tests for public web validation and normalization
+
+**Files:**
+- Create: `apps/web/lib/public-web-tools.ts`
+- Create: `apps/web/lib/public-web-tools.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for:
+- blocking localhost and private-network targets
+- normalizing public fetch inputs
+- normalizing search results into a stable shape
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\vitest.CMD run lib/public-web-tools.test.ts --reporter=basic"
+```
+
+Expected: FAIL because the adapter file does not yet exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create:
+- URL validation helpers
+- public fetch normalization
+- Brave Search result normalization
+
+Do not add the full branding analysis yet.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same `vitest` command.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/public-web-tools.ts apps/web/lib/public-web-tools.test.ts
+git commit -m "feat: add public web search and fetch foundation"
+```
+
+### Task 4: Add evidence schema and logging helpers
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: migration under `packages/db/prisma/migrations/...`
+- Create: `apps/web/lib/actions/external-evidence.ts`
+- Add tests in `packages/db` or `apps/web` as appropriate
+
+- [ ] **Step 1: Write the failing test**
+
+Add a small test for evidence creation or serialization shape.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the focused test command you add for this evidence helper.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add an evidence record model with fields for:
+- operation type
+- actor user id
+- route
+- query/url
+- result summary
+- source/provider
+- created timestamp
+
+Then add a helper to write records from search/fetch flows.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same focused test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations apps/web/lib/actions/external-evidence.ts <test files>
+git commit -m "feat: add external evidence logging"
+```
+
+## Chunk 3: Coworker Tool Integration
+
+### Task 5: Add failing tests for gated external tool availability
+
+**Files:**
+- Modify: `apps/web/lib/mcp-tools.ts`
+- Modify or Create tests for tool availability and coworker action gating
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests showing:
+- external tools are hidden when `External Off`
+- external tools are available when `External On`
+- tools remain read-only and capability-scoped
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the focused test command for the modified files.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update:
+- `mcp-tools.ts` to register read-only public web tools
+- `agent-coworker.ts` to pass external tools only when the external access session state is enabled
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same focused tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/mcp-tools.ts apps/web/lib/actions/agent-coworker.ts <test files>
+git commit -m "feat: gate external coworker tools by session access"
+```
+
+## Chunk 4: Branding Analysis and Form Wiring
+
+### Task 6: Add failing tests for branding form assist registration
+
+**Files:**
+- Modify: `apps/web/components/admin/BrandingConfigurator.tsx`
+- Create: `apps/web/components/admin/branding-form-assist.ts`
+- Add tests under `apps/web/components/admin`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests showing:
+- branding fields can be registered for assist
+- structured field updates only affect allowed branding fields
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the focused admin component test command.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Wire the branding configurator into `registerActiveFormAssist` and add a helper to safely apply:
+- company name
+- logo URL
+- selected token fields
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same focused tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/admin/BrandingConfigurator.tsx apps/web/components/admin/branding-form-assist.ts <test files>
+git commit -m "feat: add branding form assist wiring"
+```
+
+### Task 7: Add branding-analysis tool flow
+
+**Files:**
+- Modify: `apps/web/lib/public-web-tools.ts`
+- Modify: `apps/web/lib/mcp-tools.ts`
+- Add focused tests
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for a branding-analysis helper that transforms fetched public page evidence into:
+- company name candidate
+- logo URL candidate
+- color candidates
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the focused test command.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement a read-only `analyze_public_website_branding` flow on top of the public fetch adapter and evidence logging.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same focused test command.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/public-web-tools.ts apps/web/lib/mcp-tools.ts <test files>
+git commit -m "feat: add branding analysis from public websites"
+```
+
+## Chunk 5: Focused Verification
+
+### Task 8: Run branch-level verification
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run focused vitest suite**
+
+Run all newly added or modified focused tests for:
+- agent header/session
+- public web tools
+- coworker tool gating
+- branding form assist
+
+- [ ] **Step 2: Run web typecheck**
+
+Run:
+
+```bash
+cmd /c "D:\OpenDigitalProductFactory\apps\web\node_modules\.bin\tsc.CMD --noEmit"
+```
+
+- [ ] **Step 3: Run web build**
+
+Run:
+
+```bash
+$env:DATABASE_URL='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter web build
+```
+
+- [ ] **Step 4: Commit final verification-driven fixes if needed**
+
+```bash
+git add <files>
+git commit -m "fix: complete external site access verification"
+```
+
+Only if needed.

--- a/docs/superpowers/specs/2026-03-14-external-site-access-design.md
+++ b/docs/superpowers/specs/2026-03-14-external-site-access-design.md
@@ -1,0 +1,277 @@
+# External Site Access Design
+
+## Overview
+
+The Digital Product Factory needs a controlled way for AI co-workers to access public external websites for research and configuration assistance. The first concrete use case is branding setup on the admin page, where a user wants to provide a website URL and have the platform derive branding suggestions from it.
+
+This capability should not give models unrestricted internet access. The platform acts as the intermediary: it performs the external request, extracts normalized evidence, logs what happened, and only then provides structured results to the agent for reasoning and optional form assistance.
+
+## Goals
+
+- allow a user to temporarily enable external-site access for the current session on the current page
+- support public web search as a generic platform capability
+- support public URL fetch and extraction as a generic platform capability
+- record evidence for external search/fetch operations
+- enable a branding-analysis flow on top of public fetch for the admin branding form
+- keep external content read-only and human-visible
+
+## Non-Goals
+
+- authenticated external website access
+- side-effecting browser automation such as payments or form submissions on third-party sites
+- persistent user preference for external access beyond the current session
+- full-site crawling or deep scraping
+- autonomous application of branding changes without human review
+
+## User Experience
+
+### External Access Pill
+
+Add an `External Off / External On` pill to the coworker header on pages that can use external-site tools.
+
+Behavior:
+
+- default state is `External Off`
+- the user explicitly turns it on
+- the toggle is remembered for the current authenticated session and current page
+- it resets on logout or session timeout
+- the pill remains visible while enabled so the human is aware that public external access is available to the coworker
+
+This is intentionally temporary so users do not forget that external access is enabled.
+
+### Scope
+
+The first slice should be page-aware rather than global. This allows `/admin` branding work to enable external access without implying all other pages should use the same setting.
+
+### Branding Flow
+
+On the admin branding page:
+
+1. user enables `External On`
+2. user provides a public website URL or asks the coworker to analyze a URL
+3. the platform fetches and extracts branding evidence
+4. the coworker proposes branding values
+5. if `Hands On` is enabled and the form is registered for assist, the coworker can populate the branding form fields for review
+6. the human reviews and clicks apply/save
+
+## Capability Phases
+
+### Phase 1: Public Web Search
+
+Add a normalized search capability for public internet results.
+
+Candidate provider:
+
+- Brave Search
+
+Output should be normalized and provider-agnostic:
+
+- title
+- url
+- snippet
+- rank
+
+This is a generic capability that can later support research, navigation, and evidence gathering across multiple pages.
+
+### Phase 2: Public Web Fetch
+
+Add a normalized public fetch capability for a specific URL.
+
+The platform performs the fetch server-side and extracts:
+
+- canonical URL
+- page title
+- metadata
+- visible text summary
+- candidate image assets such as logos and icons
+- linked stylesheet references if useful
+
+This is read-only and bounded.
+
+### Phase 3: Evidence Logging
+
+Every external search/fetch operation should create an evidence record.
+
+Captured metadata should include:
+
+- actor user id
+- route/page
+- timestamp
+- operation type
+- query or URL
+- normalized result summary
+- status
+- content hash or extraction hash where helpful
+
+The goal is auditability and later review, not full archival of the public web.
+
+### Phase 4: Branding Analysis
+
+Build a specialized branding-analysis step on top of public fetch.
+
+Expected structured output:
+
+- company name candidate
+- logo candidate URL
+- primary and secondary color candidates
+- optional font hints
+- rationale / evidence summary
+- confidence
+
+This should be consumable by the branding configurator rather than remaining free-form chat text.
+
+## Governance and Safety
+
+### Platform as Intermediary
+
+The platform is the conduit for public web access.
+
+The model does not directly browse the internet. Instead:
+
+1. the platform validates and fetches the target
+2. the platform extracts normalized evidence
+3. the model receives controlled data, not raw browsing autonomy
+
+This is the correct architecture because it enables policy enforcement, logging, caching, and future governance.
+
+### Untrusted Content
+
+Fetched website content is always untrusted input data, never instructions.
+
+The system must not treat site text as prompt authority. Prompt injection embedded in site content should be ignored by treating the fetched content as evidence only.
+
+### Public Targets Only
+
+MVP public fetch must allow only public `http` and `https` targets.
+
+Block:
+
+- localhost
+- private IP ranges
+- link-local addresses
+- cloud metadata endpoints
+- non-http protocols
+
+This is necessary to prevent SSRF and internal-network access.
+
+### Bounded Fetching
+
+Keep the fetch constrained:
+
+- one explicit user-provided URL at a time
+- size/time limits
+- limited asset extraction
+- no recursive crawling in the first slice
+
+### Sensitivity Interaction
+
+Route sensitivity still matters. Restricted pages can expose the external-access pill, but only when the human explicitly enables it for the session.
+
+This is different from provider sensitivity:
+
+- the page may remain `restricted`
+- the external fetch is still performed by the platform under explicit human control
+- downstream model/provider usage should still respect the page's provider policy
+
+## Architecture
+
+### Session Access State
+
+Add a session-scoped page-aware external access state, likely using a server-backed session key or a secure route-local session preference rather than a long-lived browser preference.
+
+Required properties:
+
+- `user`
+- `route`
+- `enabled`
+- implicit expiry on session end
+
+### Tooling Layer
+
+Extend the existing agent tool/proposal system rather than creating a parallel execution path.
+
+Relevant integration points:
+
+- `apps/web/lib/mcp-tools.ts`
+- `apps/web/lib/actions/agent-coworker.ts`
+- `apps/web/lib/actions/proposals.ts`
+
+Add read-only tools such as:
+
+- `search_public_web`
+- `fetch_public_web_page`
+- later `analyze_public_website_branding`
+
+The first two can be direct read capabilities. Branding analysis may either be:
+
+- a specialized tool, or
+- an orchestration step that calls fetch and then derives structured branding output
+
+### Evidence Model
+
+Add a new persistence model for external evidence rather than overloading generic message tables.
+
+Suggested concepts:
+
+- evidence record id
+- operation type
+- actor user id
+- route context
+- query/url
+- extracted summary
+- provider/source
+- created timestamp
+- optional content hash
+
+The exact schema can stay modest in the first slice.
+
+## Admin Branding Integration
+
+The branding page currently has manual configuration fields but no form-assist registration and no website analysis workflow.
+
+To support the target behavior:
+
+- register the branding form for coworker assist
+- add a public URL input for brand analysis if needed
+- allow the coworker to populate form fields when both:
+  - `External On` is enabled
+  - `Hands On` is enabled
+
+The human still performs the final save/apply action.
+
+## Future Evolution
+
+This design intentionally separates:
+
+- public website read
+- authenticated website read
+- authenticated website action
+
+Future authenticated access would require:
+
+- credential vault / connection management
+- session isolation
+- approval flows
+- stronger audit controls
+- likely proposal-based execution for side effects
+
+That should be treated as a later capability, not folded into the MVP public access slice.
+
+## Testing Strategy
+
+Focused testing for the MVP slice should cover:
+
+- external access session toggle behavior
+- search adapter normalization
+- public fetch URL validation and SSRF blocking
+- evidence logging on search/fetch
+- branding extraction result normalization
+- admin branding form assist population from extracted branding suggestions
+
+## Recommended MVP Order
+
+1. session-scoped external access pill
+2. Brave Search integration
+3. public web fetch adapter
+4. evidence logging
+5. branding analysis and admin form wiring

--- a/packages/db/prisma/migrations/20260314210000_add_external_evidence_record/migration.sql
+++ b/packages/db/prisma/migrations/20260314210000_add_external_evidence_record/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "ExternalEvidenceRecord" (
+    "id" TEXT NOT NULL,
+    "actorUserId" TEXT NOT NULL,
+    "routeContext" TEXT NOT NULL,
+    "operationType" TEXT NOT NULL,
+    "target" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "resultSummary" TEXT NOT NULL,
+    "details" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ExternalEvidenceRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ExternalEvidenceRecord_actorUserId_createdAt_idx" ON "ExternalEvidenceRecord"("actorUserId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ExternalEvidenceRecord_routeContext_operationType_idx" ON "ExternalEvidenceRecord"("routeContext", "operationType");
+
+-- CreateIndex
+CREATE INDEX "ExternalEvidenceRecord_operationType_createdAt_idx" ON "ExternalEvidenceRecord"("operationType", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ExternalEvidenceRecord" ADD CONSTRAINT "ExternalEvidenceRecord_actorUserId_fkey" FOREIGN KEY ("actorUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   passwordResetTokens  PasswordResetToken[] @relation("PasswordResetForUser")
   requestedPasswordResetTokens PasswordResetToken[] @relation("PasswordResetRequestedBy")
   issueReports    PlatformIssueReport[]
+  externalEvidenceRecords ExternalEvidenceRecord[]
   approvedProposals AgentActionProposal[] @relation("ProposalDecisions")
   apiTokens       ApiToken[]
 }
@@ -713,6 +714,23 @@ model PlatformIssueReport {
   source           String   @default("manual")
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
+}
+
+model ExternalEvidenceRecord {
+  id            String   @id @default(cuid())
+  actorUserId    String
+  actorUser      User     @relation(fields: [actorUserId], references: [id], onDelete: Cascade)
+  routeContext   String
+  operationType  String
+  target         String
+  provider       String
+  resultSummary  String
+  details        Json?
+  createdAt      DateTime @default(now())
+
+  @@index([actorUserId, createdAt])
+  @@index([routeContext, operationType])
+  @@index([operationType, createdAt])
 }
 
 // ─── Platform Configuration ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a session-scoped External On/Off coworker toggle and gate public web tools behind it
- add public website search/fetch and branding analysis with evidence logging
- wire the admin branding configurator into hands-on form assist so website branding proposals can populate approved fields

## Test Plan
- [x] pnpm --filter @dpf/db generate
- [x] pnpm --filter web test -- components/agent/AgentPanelHeader.test.tsx components/agent/agent-external-access-session.test.ts components/admin/branding-form-assist.test.ts lib/public-web-tools.test.ts lib/mcp-tools.test.ts lib/actions/external-evidence.test.ts lib/actions/agent-coworker-external.test.ts lib/agent-routing.test.ts
- [x] pnpm --filter web typecheck
- [x] $env:DATABASE_URL='postgresql://dpf:dpf_dev@localhost:5432/dpf'; pnpm --filter web build
