### PR TITLE
fix: add missing fields to NextAuth session type augmentation

### DIFF
--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -6,20 +6,32 @@ declare module "next-auth" {
     user: {
       id: string;
       email: string;
+      type: "admin" | "customer";
       platformRole: string | null;
       isSuperuser: boolean;
+      accountId: string | null;
+      accountName: string | null;
+      contactId: string | null;
     };
   }
 
   interface User {
+    type?: "admin" | "customer";
     platformRole?: string | null;
     isSuperuser?: boolean;
+    accountId?: string | null;
+    accountName?: string | null;
+    contactId?: string | null;
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
+    type?: "admin" | "customer";
     platformRole?: string | null;
     isSuperuser?: boolean;
+    accountId?: string | null;
+    accountName?: string | null;
+    contactId?: string | null;
   }
 }


### PR DESCRIPTION
The NextAuth module augmentation was missing type, accountId, accountName, and contactId fields that are populated by the session callback in auth.ts. This caused a TypeScript build error in the portal layout which accesses session.user.type.

https://claude.ai/code/session_01LUPsGN9wYKxYdewmJgv8GA