### PR TITLE
fix: remove unknown devMode property from sendMessage call

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -174,7 +174,6 @@ export function AgentCoworkerPanel({
         routeContext: pathname,
         coworkerMode: devMode ? "act" as const : coworkerMode,
         externalAccessEnabled: devMode || coworkerMode === "act" ? true : externalAccessEnabled,
-        devMode,
         elevatedFormFillEnabled: elevatedAssistEnabled,
         ...(formAssistContext ? { formAssistContext } : {}),
         ...(activeBuildId ? { buildId: activeBuildId } : {}),


### PR DESCRIPTION
The devMode flag is already handled by the caller — it adjusts coworkerMode and externalAccessEnabled before calling sendMessage. Passing devMode itself to sendMessage causes a TS error since the server action doesn't accept that property.

https://claude.ai/code/session_01LUPsGN9wYKxYdewmJgv8GA