### PR TITLE
Fix ollama container crash: force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.xlsx filter=lfs diff=lfs merge=lfs -text
 *.docx filter=lfs diff=lfs merge=lfs -text
 docker-entrypoint.sh text eol=lf
+scripts/ollama-entrypoint.sh text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
The ollama-entrypoint.sh was not listed in .gitattributes, so git on Windows checked it out with CRLF endings. Bash inside the Linux container fails on the \r characters, causing the container to crash immediately (before the health check even starts).

Added *.sh glob rule so all current and future shell scripts are protected.

https://claude.ai/code/session_01LUPsGN9wYKxYdewmJgv8GA