### PR TITLE
Fix Responses tool-call history formatting

### DIFF
--- a/apps/web/lib/inference/ai-inference-toolcalls.test.ts
+++ b/apps/web/lib/inference/ai-inference-toolcalls.test.ts
@@ -4,6 +4,7 @@ import {
   extractOpenAIToolCalls,
   formatMessageForAnthropic,
   formatMessageForOpenAI,
+  formatMessageForResponses,
 } from "./ai-inference";
 import type { ChatMessage } from "./ai-inference";
 
@@ -132,6 +133,43 @@ describe("formatMessagesForProvider", () => {
       const msg: ChatMessage = { role: "user", content: "hello" };
       const formatted = formatMessageForOpenAI(msg);
       expect(formatted).toEqual({ role: "user", content: "hello" });
+    });
+  });
+
+  describe("Responses API", () => {
+    it("formats assistant tool calls as separate function_call items", () => {
+      const msg: ChatMessage = {
+        role: "assistant",
+        content: "Searching...",
+        toolCalls: [{ id: "call_abc", name: "search", arguments: { q: "agent" } }],
+      };
+
+      expect(formatMessageForResponses(msg)).toEqual([
+        { role: "assistant", content: "Searching..." },
+        {
+          type: "function_call",
+          call_id: "call_abc",
+          name: "search",
+          arguments: '{"q":"agent"}',
+        },
+      ]);
+    });
+
+    it("formats tool role message as function_call_output", () => {
+      const msg: ChatMessage = {
+        role: "tool",
+        content: "Found 3 files",
+        toolCallId: "call_abc",
+      };
+
+      expect(formatMessageForResponses(msg)).toEqual([
+        { type: "function_call_output", call_id: "call_abc", output: "Found 3 files" },
+      ]);
+    });
+
+    it("passes plain messages through as a single input item", () => {
+      const msg: ChatMessage = { role: "user", content: "hello" };
+      expect(formatMessageForResponses(msg)).toEqual([{ role: "user", content: "hello" }]);
     });
   });
 });

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -222,6 +222,29 @@ export function formatMessageForOpenAI(msg: ChatMessage): Record<string, unknown
   return { role: msg.role, content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content) };
 }
 
+/** Format a ChatMessage for the OpenAI Responses API input array */
+export function formatMessageForResponses(msg: ChatMessage): Array<Record<string, unknown>> {
+  const textContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+
+  if (msg.role === "tool" && msg.toolCallId) {
+    return [{ type: "function_call_output", call_id: msg.toolCallId, output: textContent }];
+  }
+
+  if (msg.role === "assistant" && msg.toolCalls && msg.toolCalls.length > 0) {
+    return [
+      ...(textContent ? [{ role: "assistant", content: textContent }] : []),
+      ...msg.toolCalls.map((tc) => ({
+        type: "function_call",
+        call_id: tc.id,
+        name: tc.name,
+        arguments: JSON.stringify(tc.arguments),
+      })),
+    ];
+  }
+
+  return [{ role: msg.role, content: textContent }];
+}
+
 // ─── callProvider ────────────────────────────────────────────────────────────
 
 export async function callProvider(

--- a/apps/web/lib/routing/chat-adapter.test.ts
+++ b/apps/web/lib/routing/chat-adapter.test.ts
@@ -109,6 +109,25 @@ vi.mock("@/lib/ai-inference", () => {
     return { role: msg.role, content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content) };
   }
 
+  function formatMessageForResponses(msg: ChatMessage) {
+    const textContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+    if (msg.role === "tool" && msg.toolCallId) {
+      return [{ type: "function_call_output", call_id: msg.toolCallId, output: textContent }];
+    }
+    if (msg.role === "assistant" && msg.toolCalls && msg.toolCalls.length > 0) {
+      return [
+        ...(textContent ? [{ role: "assistant", content: textContent }] : []),
+        ...msg.toolCalls.map((tc: { id: string; name: string; arguments: Record<string, unknown> }) => ({
+          type: "function_call",
+          call_id: tc.id,
+          name: tc.name,
+          arguments: JSON.stringify(tc.arguments),
+        })),
+      ];
+    }
+    return [{ role: msg.role, content: textContent }];
+  }
+
   return {
     InferenceError,
     classifyHttpError,
@@ -116,6 +135,7 @@ vi.mock("@/lib/ai-inference", () => {
     extractOpenAIToolCalls,
     formatMessageForAnthropic,
     formatMessageForOpenAI,
+    formatMessageForResponses,
   };
 });
 
@@ -652,6 +672,57 @@ describe("chatAdapter", () => {
 
     expect(result.text).toBe("Subscription fallback works.");
     expect(result.usage).toEqual({ inputTokens: 8, outputTokens: 5 });
+  });
+
+  it("ChatGPT: formats tool history as Responses items instead of nested tool_calls", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => [
+        'data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"Done."}]}],"usage":{"input_tokens":12,"output_tokens":4}}}',
+        "data: [DONE]",
+      ].join("\n"),
+      headers: new Headers(),
+    });
+
+    await chatAdapter.execute(makeRequest({
+      providerId: "chatgpt",
+      modelId: "gpt-5.4",
+      plan: makePlan({
+        providerId: "chatgpt",
+        modelId: "gpt-5.4",
+      }),
+      provider: {
+        baseUrl: "https://chatgpt.com/backend-api",
+        headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
+      },
+      messages: [
+        { role: "user", content: "Find the complaint tracker." },
+        {
+          role: "assistant",
+          content: "Searching...",
+          toolCalls: [{ id: "call_search_1", name: "search_project_files", arguments: { query: "complaint tracker" } }],
+        },
+        { role: "tool", content: "[\"app/complaints/page.tsx\"]", toolCallId: "call_search_1" },
+      ],
+    }));
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.input).toEqual([
+      { role: "user", content: "Find the complaint tracker." },
+      { role: "assistant", content: "Searching..." },
+      {
+        type: "function_call",
+        call_id: "call_search_1",
+        name: "search_project_files",
+        arguments: "{\"query\":\"complaint tracker\"}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_search_1",
+        output: "[\"app/complaints/page.tsx\"]",
+      },
+    ]);
   });
 
   // ── Adapter type is "chat" ──

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -20,6 +20,7 @@ import {
   extractOpenAIToolCalls,
   formatMessageForAnthropic,
   formatMessageForOpenAI,
+  formatMessageForResponses,
 } from "@/lib/ai-inference";
 import { isAnthropic } from "./provider-utils";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
@@ -162,7 +163,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
       chatUrl = `${baseUrl}/codex/responses`;
 
       // Responses API format: input array + instructions (system prompt)
-      const input = messages.map((m) => formatMessageForOpenAI(m));
+      const input = messages.flatMap((m) => formatMessageForResponses(m));
 
       body = {
         model: modelId,

--- a/apps/web/lib/routing/responses-adapter.test.ts
+++ b/apps/web/lib/routing/responses-adapter.test.ts
@@ -52,28 +52,28 @@ vi.mock("@/lib/ai-inference", () => {
     toolCallId?: string;
   };
 
-  function formatMessageForOpenAI(msg: ChatMessage) {
+  function formatMessageForResponses(msg: ChatMessage) {
     if (msg.role === "tool" && msg.toolCallId) {
-      return { role: "tool", tool_call_id: msg.toolCallId, content: msg.content };
+      return [{ type: "function_call_output", call_id: msg.toolCallId, output: msg.content }];
     }
     if (msg.role === "assistant" && msg.toolCalls && msg.toolCalls.length > 0) {
-      return {
-        role: "assistant",
-        content: msg.content,
-        tool_calls: msg.toolCalls.map((tc) => ({
-          id: tc.id,
-          type: "function",
-          function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
+      return [
+        ...(msg.content ? [{ role: "assistant", content: msg.content }] : []),
+        ...msg.toolCalls.map((tc) => ({
+          type: "function_call",
+          call_id: tc.id,
+          name: tc.name,
+          arguments: JSON.stringify(tc.arguments),
         })),
-      };
+      ];
     }
-    return { role: msg.role, content: msg.content };
+    return [{ role: msg.role, content: msg.content }];
   }
 
   return {
     InferenceError,
     classifyHttpError,
-    formatMessageForOpenAI,
+    formatMessageForResponses,
   };
 });
 
@@ -236,6 +236,49 @@ describe("responsesAdapter", () => {
     expect(result.text).toBe("Checking...");
     expect(result.toolCalls).toEqual([
       { id: "call_123", name: "read_file", arguments: { path: "README.md" } },
+    ]);
+  });
+
+  it("formats tool history using Responses input items instead of nested tool_calls", async () => {
+    stubFetchOk({
+      output: [
+        { type: "message", content: [{ type: "output_text", text: "Done." }] },
+      ],
+      usage: { input_tokens: 14, output_tokens: 7 },
+    });
+
+    await responsesAdapter.execute(
+      makeRequest({
+        tools: [{ type: "function", function: { name: "search_project_files", description: "Search files", parameters: {} } }],
+        messages: [
+          { role: "user", content: "Find the customer complaint tracker files." },
+          {
+            role: "assistant",
+            content: "Searching the repo.",
+            toolCalls: [{ id: "call_search_1", name: "search_project_files", arguments: { query: "customer complaint tracker" } }],
+          },
+          { role: "tool", content: "[\"app/complaints/page.tsx\"]", toolCallId: "call_search_1" },
+          { role: "user", content: "Summarize what you found." },
+        ],
+      }),
+    );
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody.input).toEqual([
+      { role: "user", content: "Find the customer complaint tracker files." },
+      { role: "assistant", content: "Searching the repo." },
+      {
+        type: "function_call",
+        call_id: "call_search_1",
+        name: "search_project_files",
+        arguments: "{\"query\":\"customer complaint tracker\"}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_search_1",
+        output: "[\"app/complaints/page.tsx\"]",
+      },
+      { role: "user", content: "Summarize what you found." },
     ]);
   });
 

--- a/apps/web/lib/routing/responses-adapter.ts
+++ b/apps/web/lib/routing/responses-adapter.ts
@@ -7,7 +7,7 @@ import type { AdapterRequest, AdapterResult, ExecutionAdapterHandler, ToolCallEn
 import {
   InferenceError,
   classifyHttpError,
-  formatMessageForOpenAI,
+  formatMessageForResponses,
 } from "@/lib/ai-inference";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 
@@ -141,7 +141,7 @@ export const responsesAdapter: ExecutionAdapterHandler = {
 
     const body: Record<string, unknown> = {
       model: modelId,
-      input: messages.map((message) => formatMessageForOpenAI(message)),
+      input: messages.flatMap((message) => formatMessageForResponses(message)),
       store: false,
     };
 


### PR DESCRIPTION
## Summary
- fix Responses API history formatting for Codex and ChatGPT backends by sending `function_call` and `function_call_output` items instead of nested `tool_calls`
- use the shared Responses formatter in both the dedicated responses adapter and the ChatGPT `/codex/responses` fallback path
- add regression coverage for tool-history serialization in adapter and inference tests

## Test Plan
- [x] `cd apps/web && npx vitest run lib/routing/responses-adapter.test.ts lib/routing/chat-adapter.test.ts lib/inference/ai-inference-toolcalls.test.ts`
- [x] `cd apps/web && npx next build`
