### PR TITLE
fix: resolve SE agent looping in Build Studio

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.test.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { bumpVersion } from "@/lib/feature-build-types";
 import { getBuildPhasePrompt, getBuildContextSection } from "./build-agent-prompts";
+import { SPECIALIST_TOOLS } from "./specialist-prompts";
 import type { FeatureBrief } from "@/lib/feature-build-types";
 
 describe("bumpVersion", () => {
@@ -57,6 +58,21 @@ describe("getBuildPhasePrompt", () => {
   it("returns empty string for terminal phases", () => {
     expect(getBuildPhasePrompt("complete")).toBe("");
     expect(getBuildPhasePrompt("failed")).toBe("");
+  });
+});
+
+describe("SPECIALIST_TOOLS", () => {
+  it("software-engineer has describe_model for schema lookups", () => {
+    expect(SPECIALIST_TOOLS["software-engineer"]).toContain("describe_model");
+  });
+  it("data-architect has both describe_model and validate_schema", () => {
+    expect(SPECIALIST_TOOLS["data-architect"]).toContain("describe_model");
+    expect(SPECIALIST_TOOLS["data-architect"]).toContain("validate_schema");
+  });
+  it("all specialists have read_sandbox_file", () => {
+    for (const [role, tools] of Object.entries(SPECIALIST_TOOLS)) {
+      expect(tools, `${role} missing read_sandbox_file`).toContain("read_sandbox_file");
+    }
   });
 });
 

--- a/apps/web/lib/integrate/build-orchestrator.test.ts
+++ b/apps/web/lib/integrate/build-orchestrator.test.ts
@@ -1,5 +1,100 @@
 import { describe, it, expect } from "vitest";
-import { formatPhaseMessage, formatBuildCompleteMessage } from "./build-orchestrator";
+import { formatPhaseMessage, formatBuildCompleteMessage, classifyOutcome } from "./build-orchestrator";
+import type { AgenticResult } from "@/lib/agentic-loop";
+
+function mockResult(overrides: Partial<AgenticResult> = {}): AgenticResult {
+  return {
+    content: overrides.content ?? "",
+    providerId: "test",
+    modelId: "test",
+    downgraded: false,
+    downgradeMessage: null,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    executedTools: overrides.executedTools ?? [],
+    proposal: null,
+  };
+}
+
+describe("classifyOutcome", () => {
+  it("returns BLOCKED when tool errors indicate sandbox is not running", () => {
+    const result = mockResult({
+      content: "I tried to read the schema but encountered an error.",
+      executedTools: [
+        { name: "read_sandbox_file", args: { path: "schema.prisma" }, result: { success: false, error: "Sandbox not running.", message: "No sandbox." } },
+      ],
+    });
+    expect(classifyOutcome(result, "software-engineer")).toBe("BLOCKED");
+  });
+
+  it("returns BLOCKED when sandbox slots are exhausted", () => {
+    const result = mockResult({
+      content: "Could not proceed.",
+      executedTools: [
+        { name: "describe_model", args: { model_name: "User" }, result: { success: false, error: "All sandbox slots are in use.", message: "No sandbox slots available." } },
+      ],
+    });
+    expect(classifyOutcome(result, "data-architect")).toBe("BLOCKED");
+  });
+
+  it("returns BLOCKED when model not found and no build tools called", () => {
+    const result = mockResult({
+      content: "The Complaint model does not exist in the schema.",
+      executedTools: [
+        { name: "describe_model", args: { model_name: "Complaint" }, result: { success: false, error: "Model \"Complaint\" not found in schema.", message: "No model." } },
+        { name: "read_sandbox_file", args: { path: "schema.prisma" }, result: { success: true, message: "ok" } },
+      ],
+    });
+    expect(classifyOutcome(result, "software-engineer")).toBe("BLOCKED");
+  });
+
+  it("returns DONE_WITH_CONCERNS when prerequisite missing but build tools were called", () => {
+    const result = mockResult({
+      content: "Created the API routes. Note: Complaint model not found, used placeholder.",
+      executedTools: [
+        { name: "describe_model", args: { model_name: "Complaint" }, result: { success: false, error: "Model \"Complaint\" not found in schema.", message: "No model." } },
+        { name: "generate_code", args: { instruction: "create route" }, result: { success: true, message: "ok" } },
+      ],
+    });
+    expect(classifyOutcome(result, "software-engineer")).toBe("DONE_WITH_CONCERNS");
+  });
+
+  it("returns DONE when build tools succeed with no errors", () => {
+    const result = mockResult({
+      content: "Created API routes and wired imports.",
+      executedTools: [
+        { name: "read_sandbox_file", args: { path: "schema.prisma" }, result: { success: true, message: "ok" } },
+        { name: "generate_code", args: { instruction: "create route" }, result: { success: true, message: "ok" } },
+      ],
+    });
+    expect(classifyOutcome(result, "software-engineer")).toBe("DONE");
+  });
+
+  it("returns BLOCKED when content says cannot proceed", () => {
+    const result = mockResult({
+      content: "I cannot proceed because the database schema is not ready.",
+      executedTools: [
+        { name: "read_sandbox_file", args: { path: "schema.prisma" }, result: { success: true, message: "ok" } },
+      ],
+    });
+    expect(classifyOutcome(result, "software-engineer")).toBe("BLOCKED");
+  });
+
+  it("returns BLOCKED when no tools called at all (stalled)", () => {
+    const result = mockResult({ content: "I need to think about this." });
+    expect(classifyOutcome(result, "frontend-engineer")).toBe("BLOCKED");
+  });
+
+  it("returns DONE for QA even with errors (test results are informational)", () => {
+    const result = mockResult({
+      content: "Typecheck passed. 8 tests pass, 2 failed.",
+      executedTools: [
+        { name: "run_sandbox_tests", result: { success: false, error: "2 tests failed", message: "8 pass, 2 fail" } },
+      ],
+    });
+    expect(classifyOutcome(result, "qa-engineer")).toBe("DONE_WITH_CONCERNS");
+  });
+});
 
 describe("orchestrator communication templates", () => {
   it("formats specialist completion message", () => {

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -74,14 +74,40 @@ export type SpecialistOutcome =
   | "BLOCKED"             // Task cannot proceed — needs human or dependency resolution
   | "NEEDS_CONTEXT";      // Task needs additional information from orchestrator
 
+/** Error patterns that indicate infrastructure issues vs. task-level failures. */
+export const INFRA_ERROR_PATTERNS = [
+  "sandbox not running", "sandbox initialization failed", "all sandbox slots",
+  "sandbox container not found", "no sandbox", "could not initialize sandbox",
+];
+export const MISSING_PREREQUISITE_PATTERNS = [
+  "not found in schema", "file not found", "no model named",
+];
+
 /** Classify a specialist's agentic result into a structured outcome. */
-function classifyOutcome(result: AgenticResult, role: SpecialistRole): SpecialistOutcome {
+export function classifyOutcome(result: AgenticResult, role: SpecialistRole): SpecialistOutcome {
   const content = result.content.toLowerCase();
   const calledBuildTools = result.executedTools.some(t =>
-    t.name !== "read_sandbox_file" && t.name !== "search_sandbox" && t.name !== "list_sandbox_files"
+    t.name !== "read_sandbox_file" && t.name !== "search_sandbox" && t.name !== "list_sandbox_files" && t.name !== "describe_model"
   );
   const hasErrors = result.executedTools.some(t => !t.result.success);
   const isQA = role === "qa-engineer";
+
+  // Check tool errors for infrastructure blockers (sandbox down, slots exhausted)
+  const toolErrors = result.executedTools
+    .filter(t => !t.result.success)
+    .map(t => (t.result.error ?? "").toLowerCase());
+  const hasInfraError = toolErrors.some(err =>
+    INFRA_ERROR_PATTERNS.some(pat => err.includes(pat))
+  );
+  if (hasInfraError) return "BLOCKED";
+
+  // Check for missing prerequisites (model/file doesn't exist yet)
+  // Only classify as BLOCKED if ALL tool calls failed with prerequisite errors
+  // (the agent couldn't find what it needed and made no successful mutations)
+  const hasMissingPrereq = toolErrors.some(err =>
+    MISSING_PREREQUISITE_PATTERNS.some(pat => err.includes(pat))
+  );
+  if (hasMissingPrereq && !calledBuildTools) return "BLOCKED";
 
   // Blocked: explicit blocker signals or no tools called (stalled)
   if (content.includes("blocked") || content.includes("cannot proceed") || content.includes("missing prerequisite")) {

--- a/apps/web/lib/integrate/specialist-prompts.ts
+++ b/apps/web/lib/integrate/specialist-prompts.ts
@@ -239,7 +239,7 @@ export const SPECIALIST_TOOLS: Record<SpecialistRole, string[]> = {
   "software-engineer": [
     "read_sandbox_file", "edit_sandbox_file", "write_sandbox_file",
     "search_sandbox", "list_sandbox_files", "run_sandbox_command",
-    "generate_code",
+    "generate_code", "describe_model",
   ],
   "frontend-engineer": [
     "read_sandbox_file", "edit_sandbox_file", "write_sandbox_file",

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -3026,8 +3026,25 @@ Output ONLY the HTML. Start with <!DOCTYPE html>. NO markdown.`;
     case "describe_model": {
       const buildId = await resolveActiveBuildId(userId);
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
-      const dmBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true } });
-      if (!dmBuild?.sandboxId) return { success: false, error: "Sandbox not running.", message: "No sandbox." };
+      let dmBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true } });
+
+      // Auto-init sandbox if not running (same pattern as file tools above)
+      if (!dmBuild?.sandboxId) {
+        const { isSandboxRunning, initializeSandboxWorkspace: sbInit } = await import("@/lib/sandbox");
+        const { acquireSandbox, initializePool } = await import("@/lib/sandbox-pool");
+        await initializePool().catch(() => {});
+        const slot = await acquireSandbox(buildId, userId);
+        if (!slot) return { success: false, error: "All sandbox slots are in use.", message: "No sandbox slots available. Try again shortly." };
+        const running = await isSandboxRunning(slot.containerId).catch(() => false);
+        if (!running) return { success: false, error: `Sandbox ${slot.containerId} not running.`, message: "Sandbox container not found." };
+        try { await sbInit(slot.containerId); } catch (e) { console.error(`[describe_model] auto-init failed: ${(e as Error).message?.slice(0, 200)}`); }
+        try {
+          const { startSandboxDevServer } = await import("@/lib/sandbox");
+          await startSandboxDevServer(slot.containerId);
+        } catch { /* non-fatal */ }
+        dmBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true } });
+        if (!dmBuild?.sandboxId) return { success: false, error: "Sandbox initialization failed.", message: "Could not initialize sandbox." };
+      }
 
       const modelName = String(params.model_name ?? "");
       if (!modelName) return { success: false, error: "model_name is required.", message: "Provide the model name (PascalCase)." };
@@ -3042,7 +3059,7 @@ Output ONLY the HTML. Start with <!DOCTYPE html>. NO markdown.`;
         const desc = describeModel(schemaContent, modelName);
 
         if (!desc) {
-          return { success: false, error: `Model "${modelName}" not found in schema.`, message: `No model named "${modelName}" exists. Check spelling (PascalCase).` };
+          return { success: false, error: `Model "${modelName}" not found in schema.`, message: `No model named "${modelName}" exists. Check spelling (PascalCase). Use read_sandbox_file on packages/db/prisma/schema.prisma to see available models.` };
         }
 
         const formatted = formatModelDescription(desc);
@@ -3055,8 +3072,25 @@ Output ONLY the HTML. Start with <!DOCTYPE html>. NO markdown.`;
     case "validate_schema": {
       const buildId = await resolveActiveBuildId(userId);
       if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
-      const vsBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true } });
-      if (!vsBuild?.sandboxId) return { success: false, error: "Sandbox not running.", message: "No sandbox." };
+      let vsBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true } });
+
+      // Auto-init sandbox if not running (same pattern as file tools above)
+      if (!vsBuild?.sandboxId) {
+        const { isSandboxRunning, initializeSandboxWorkspace: sbInit } = await import("@/lib/sandbox");
+        const { acquireSandbox, initializePool } = await import("@/lib/sandbox-pool");
+        await initializePool().catch(() => {});
+        const slot = await acquireSandbox(buildId, userId);
+        if (!slot) return { success: false, error: "All sandbox slots are in use.", message: "No sandbox slots available. Try again shortly." };
+        const running = await isSandboxRunning(slot.containerId).catch(() => false);
+        if (!running) return { success: false, error: `Sandbox ${slot.containerId} not running.`, message: "Sandbox container not found." };
+        try { await sbInit(slot.containerId); } catch (e) { console.error(`[validate_schema] auto-init failed: ${(e as Error).message?.slice(0, 200)}`); }
+        try {
+          const { startSandboxDevServer } = await import("@/lib/sandbox");
+          await startSandboxDevServer(slot.containerId);
+        } catch { /* non-fatal */ }
+        vsBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { sandboxId: true } });
+        if (!vsBuild?.sandboxId) return { success: false, error: "Sandbox initialization failed.", message: "Could not initialize sandbox." };
+      }
 
       try {
         const { execInSandbox } = await import("@/lib/sandbox");


### PR DESCRIPTION
## Summary
- **SE tool mismatch**: Added `describe_model` to Software Engineer specialist's tool list — the prompt already instructed the agent to use it, but it wasn't in the allowed set, causing fallback loops on `read_sandbox_file`
- **Sandbox auto-init for schema tools**: `describe_model` and `validate_schema` now auto-initialize the sandbox (acquire from pool, init workspace, start dev server) instead of failing immediately with "Sandbox not running"
- **Tool-error-aware outcome classification**: `classifyOutcome` now inspects actual tool error messages for infrastructure blockers ("sandbox not running", "all sandbox slots") and missing prerequisites ("not found in schema"), correctly returning `BLOCKED` instead of misclassifying as `DONE_WITH_CONCERNS`

These were gaps left by the Phase 1 fix (57846561) which correctly addressed phase gates and routing degradation but didn't reach the specialist tool access and sandbox init layers.

## Test plan
- [x] 8 new `classifyOutcome` tests covering: infra errors, slot exhaustion, missing prerequisites, mixed success/failure, stalled agents, QA edge cases
- [x] 3 new `SPECIALIST_TOOLS` tests verifying SE has `describe_model`, DA has both schema tools, all specialists have `read_sandbox_file`
- [x] All 22 pre-existing tests still pass
- [ ] Manual: trigger a Build Studio feature build that includes schema work and verify the SE agent can call `describe_model` without looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)