### PR TITLE
feat: show project branch in Build Studio

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -5,6 +5,21 @@ import { getFeatureBuilds } from "@/lib/feature-build-data";
 import { getPortfoliosForSelect } from "@/lib/backlog-data";
 import { BuildStudio } from "@/components/build/BuildStudio";
 import Link from "next/link";
+import { execSync } from "child_process";
+
+function getProjectBranch(): string | null {
+  try {
+    // /workspace is the source volume (bootstrapped or user-managed)
+    return execSync("git -C /workspace rev-parse --abbrev-ref HEAD", { encoding: "utf-8", timeout: 2000 }).trim() || null;
+  } catch {
+    try {
+      // Shared workspace mode: CWD is the repo
+      return execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf-8", timeout: 2000 }).trim() || null;
+    } catch {
+      return null;
+    }
+  }
+}
 
 export default async function BuildPage() {
   const session = await auth();
@@ -40,10 +55,12 @@ export default async function BuildPage() {
     getPortfoliosForSelect(),
   ]);
 
+  const projectBranch = getProjectBranch();
+
   // Break out of the shell's max-w-7xl + p-6 container for full-bleed layout
   return (
     <div className="fixed inset-0 top-[48px]">
-      <BuildStudio builds={builds} portfolios={portfolios} dpfEnvironment={process.env.DPF_ENVIRONMENT ?? "production"} />
+      <BuildStudio builds={builds} portfolios={portfolios} dpfEnvironment={process.env.DPF_ENVIRONMENT ?? "production"} projectBranch={projectBranch} />
     </div>
   );
 }

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -18,9 +18,10 @@ type Props = {
   builds: FeatureBuildRow[];
   portfolios: PortfolioForSelect[];
   dpfEnvironment?: string;
+  projectBranch?: string | null;
 };
 
-export function BuildStudio({ builds, portfolios, dpfEnvironment }: Props) {
+export function BuildStudio({ builds, portfolios, dpfEnvironment, projectBranch }: Props) {
   const router = useRouter();
   const [activeBuild, setActiveBuild] = useState<FeatureBuildRow | null>(
     builds.find((b) => b.phase !== "complete" && b.phase !== "failed") ?? null,
@@ -235,7 +236,18 @@ export function BuildStudio({ builds, portfolios, dpfEnvironment }: Props) {
                     <h2 className="text-base font-bold text-[var(--dpf-text)] m-0">{activeBuild.title}</h2>
                     <ClaimBadge agentId={activeBuild.claimedByAgentId ?? null} claimStatus={activeBuild.claimStatus ?? null} claimedAt={activeBuild.claimedAt ?? null} />
                   </div>
-                  <span className="text-xs text-[var(--dpf-muted)]">{activeBuild.buildId}</span>
+                  <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
+                    <span>{activeBuild.buildId}</span>
+                    {projectBranch && (
+                      <>
+                        <span>&middot;</span>
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] font-mono" title="Project branch">
+                          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.5 2.5 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" /></svg>
+                          {projectBranch}
+                        </span>
+                      </>
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -296,6 +308,12 @@ export function BuildStudio({ builds, portfolios, dpfEnvironment }: Props) {
               <div className="text-center max-w-md px-8">
                 <div className="text-5xl mb-4 opacity-20">&#128736;</div>
                 <h2 className="text-lg font-bold text-[var(--dpf-text)] mb-3">Product Development Studio</h2>
+                {projectBranch && (
+                  <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-xs font-mono text-[var(--dpf-muted)] mb-4">
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.5 2.5 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z" /></svg>
+                    {projectBranch}
+                  </div>
+                )}
                 <p className="text-sm text-[var(--dpf-muted)] leading-relaxed mb-6">
                   Build features without writing code. Describe what you want, and your AI Coworker will design, build, and deploy it.
                 </p>


### PR DESCRIPTION
## Summary
- Displays the current git branch in the Build Studio header (with branch icon)
- Shows next to the build ID when a build is active
- Shows on the landing page when no build is selected
- Reads from `/workspace` git repo (bootstrapped volume) or CWD (shared workspace mode)

Gives users branch context for contribution mode without leaving Build Studio.

## Test plan
- [x] Type check passes
- [ ] Manual: verify branch badge shows `my-changes` in production mode
- [ ] Manual: verify branch badge shows `main` in shared workspace mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)