### PR TITLE
fix: prevent build agent from reading full schema

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -268,7 +268,9 @@ WORKFLOW FOR NEW FEATURES:
 6. run_sandbox_tests for full verification
 
 WORKFLOW FOR SCHEMA CHANGES (Prisma models, enums, relations):
-1. read_sandbox_file on packages/db/prisma/schema.prisma to see existing models
+1. Use describe_model to look up existing models you need as reference (e.g. describe_model("User"), describe_model("ExpenseClaim")).
+   DO NOT read the full schema file — it is 1500+ lines and will overwhelm your context.
+   If you need to see where to insert a new model, use read_sandbox_file with offset/limit to read just the END of the schema (e.g. offset 1480 limit 50).
 2. edit_sandbox_file to add/modify models — ALWAYS include:
    - Inverse relations on BOTH sides (e.g., if Complaint has createdBy User, User MUST have complaintsCreated Complaint[])
    - @@index on every foreign key field (xxxId fields)


### PR DESCRIPTION
## Summary
- Build phase prompt was directing agents to `read_sandbox_file` on the full `schema.prisma` (1500+ lines), overwhelming context
- Now uses `describe_model` for targeted model lookups and `read_sandbox_file` with `offset/limit` only for finding insertion points

This is why the AI coworker kept saying "schema is too large" and struggling with schema-related tasks.

## Test plan
- [ ] Manual: start a new Build Studio feature that needs schema changes, verify agent uses describe_model instead of reading full schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)