### PR TITLE
fix: make describe_model available in ideate phase

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -675,7 +675,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "view_platform",
     executionMode: "immediate",
     sideEffect: false,
-    buildPhases: ["plan", "build", "review"],
+    buildPhases: ["ideate", "plan", "build", "review"],
   },
   {
     name: "validate_schema",


### PR DESCRIPTION
## Summary
- `describe_model` tool had `buildPhases: ["plan", "build", "review"]` but the ideate prompt instructs agents to call it for codebase research
- Added `"ideate"` to the buildPhases array so the tool is available when the prompt references it
- Root cause of agents asking users to paste schema definitions instead of looking them up

## Test plan
- [ ] Manual: start a fresh Build Studio feature, verify agent calls describe_model during ideate

🤖 Generated with [Claude Code](https://claude.com/claude-code)