### PR TITLE
fix: real-time Build Studio progress indicators

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -41,18 +41,33 @@ export function BuildStudio({ builds, portfolios, dpfEnvironment, projectBranch 
   }, [activeBuild?.buildId]);
 
   // SSE subscription for live refresh when agent updates the build.
-  // Debounced: refetches on any event type (not just phase changes) so that
-  // sandbox port allocation and file generation are picked up promptly.
+  // Phase-change events refresh immediately; other events are debounced
+  // to avoid excessive DB queries during rapid tool execution.
   useEffect(() => {
     if (!activeBuild?.threadId) return;
     const es = new EventSource(`/api/agent/stream?threadId=${activeBuild.threadId}`);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    es.onmessage = async () => {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(async () => {
-        const fresh = await getFeatureBuild(activeBuild.buildId);
-        if (fresh) setActiveBuild(fresh);
-      }, 2_000);
+    const refetch = async () => {
+      const fresh = await getFeatureBuild(activeBuild.buildId);
+      if (fresh) setActiveBuild(fresh);
+    };
+    es.onmessage = async (e) => {
+      // Phase changes and evidence saves refresh immediately — user should
+      // see progress the moment it happens, not after a debounce delay.
+      let isUrgent = false;
+      try {
+        const data = JSON.parse(e.data);
+        isUrgent = data.type === "phase:change" || data.type === "evidence:saved"
+          || data.type === "orchestrator:task_complete" || data.type === "sandbox:ready";
+      } catch { /* non-JSON event — debounce */ }
+
+      if (isUrgent) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        await refetch();
+      } else {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(refetch, 800);
+      }
     };
     return () => {
       es.close();

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -135,6 +135,19 @@ export async function advanceBuildPhase(
     data: { phase: targetPhase },
   });
 
+  // Notify the UI immediately so progress indicators update without waiting for debounce
+  try {
+    const updatedBuild = await prisma.featureBuild.findUnique({ where: { buildId }, select: { threadId: true } });
+    if (updatedBuild?.threadId) {
+      const { agentEventBus } = await import("@/lib/agent-event-bus");
+      agentEventBus.emit(updatedBuild.threadId, {
+        type: "phase:change",
+        buildId,
+        phase: targetPhase,
+      } as import("@/lib/agent-event-bus").AgentEvent);
+    }
+  } catch { /* best-effort — don't block phase transition */ }
+
   // Write PhaseHandoff document — structured context for the next phase's agent
   try {
     const PHASE_AGENT: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Phase-change, evidence-saved, task-complete, and sandbox-ready SSE events now trigger immediate UI refresh (was 2-second debounce for all events)
- Routine events debounced at 800ms (down from 2000ms)
- `advanceBuildPhase()` now emits `phase:change` event so the UI is notified without waiting for the next agent event

## Test plan
- [ ] Manual: watch phase indicator during a build — should update within ~100ms of phase transition
- [ ] Manual: verify no excessive DB queries during rapid tool execution (routine events still debounced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)