### PR TITLE
fix: increase build coworker context to prevent research loops

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -246,11 +246,12 @@ export async function sendMessage(input: {
     isSuperuser: user.isSuperuser,
   }, useUnified);
 
-  // Build inference context: short recent window + semantic recall for older context.
-  // Keep only last 8 messages as raw history — Qdrant semantic recall fills in
-  // relevant older context. This prevents long confused conversations from poisoning
-  // the response and keeps the context window focused.
-  const RECENT_WINDOW = 8;
+  // Build inference context: recent window + semantic recall for older context.
+  // Build phases need more context (research findings, schema details, tool results)
+  // because the agentic loop's tool call results aren't persisted in messages.
+  // Conversation phases use a shorter window to prevent context poisoning.
+  const isBuildPhase = input.routeContext === "/build";
+  const RECENT_WINDOW = isBuildPhase ? 20 : 8;
   const recentMessages = await prisma.agentMessage.findMany({
     where: { threadId: input.threadId },
     orderBy: { createdAt: "desc" },


### PR DESCRIPTION
## Summary
- Build coworker loaded only last 8 messages between turns, losing all research from the agentic loop (tool results aren't persisted in messages)
- Agent restarted schema research from scratch every turn, going in circles for 15+ interactions
- Build phases now use 20-message window; conversation phases keep 8

Root cause of the "I found StorefrontConfig / I can't find StorefrontConfig" loop.

## Test plan
- [ ] Manual: start a build, verify agent retains research findings across "ok" responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)