### PR TITLE
fix: allow deleting in-progress feature builds

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -445,6 +445,7 @@ export async function deleteFeatureBuild(buildId: string): Promise<void> {
   if (build.createdById !== userId) throw new Error("Forbidden");
 
   // Delete related records first (foreign key constraints)
+  await prisma.phaseHandoff.deleteMany({ where: { buildId } });
   await prisma.buildActivity.deleteMany({ where: { buildId } });
   await prisma.featureBuild.delete({ where: { buildId } });
 }


### PR DESCRIPTION
## Summary
- `deleteFeatureBuild` failed on builds with phase handoffs due to FK constraint on `phaseHandoff.buildId`
- Now deletes `phaseHandoff` records before the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)