### PR TITLE
fix: remove stale codex pinning from seed

### DIFF
--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1253,7 +1253,7 @@ async function seedAgentModelDefaults(): Promise<void> {
     pinnedProviderId?: string;
     pinnedModelId?: string;
   }> = [
-      { agentId: "build-specialist",    minimumTier: "strong",   budgetClass: "quality_first", pinnedProviderId: "codex" },
+      { agentId: "build-specialist",    minimumTier: "strong",   budgetClass: "quality_first" },
     { agentId: "coo",                 minimumTier: "strong",   budgetClass: "balanced" },
     { agentId: "platform-engineer",   minimumTier: "strong",   budgetClass: "balanced" },
     { agentId: "admin-assistant",     minimumTier: "strong",   budgetClass: "balanced" },


### PR DESCRIPTION
## Summary
- Seed hard-coded `pinnedProviderId: "codex"` for build-specialist which doesn't match any active provider
- Re-applied on every portal restart, causing fallback warnings on every build turn
- Removed the pinning — build-specialist now uses normal routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)