### PR TITLE
fix: sandbox preview navigation stays inside proxy

### DIFF
--- a/apps/web/app/api/sandbox/preview/route.ts
+++ b/apps/web/app/api/sandbox/preview/route.ts
@@ -76,12 +76,77 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       signal: AbortSignal.timeout(5_000),
     });
 
+    const contentType = upstream.headers.get("Content-Type") ?? "text/html";
+
+    // For HTML responses: inject a navigation interceptor so links stay inside
+    // the sandbox proxy instead of escaping to the main portal.
+    if (contentType.includes("text/html")) {
+      let html = await upstream.text();
+
+      // Script intercepts clicks on <a> tags and client-side navigation,
+      // rewriting them to go through the proxy endpoint.
+      const navScript = `<script data-sandbox-nav>
+(function(){
+  var bid = ${JSON.stringify(buildId)};
+  var proxyBase = "/api/sandbox/preview?buildId=" + encodeURIComponent(bid) + "&path=";
+  var blocked = ["/build", "/platform"];
+
+  function rewrite(path) {
+    if (blocked.some(function(b){ return path.indexOf(b) === 0; })) path = "/";
+    return proxyBase + encodeURIComponent(path);
+  }
+
+  // Intercept link clicks
+  document.addEventListener("click", function(e) {
+    var a = e.target.closest ? e.target.closest("a[href]") : null;
+    if (!a) return;
+    var href = a.getAttribute("href");
+    if (!href || href.indexOf("://") !== -1 || href.indexOf("mailto:") === 0 || href.indexOf("#") === 0) return;
+    if (href.indexOf("/api/sandbox/preview") === 0) return;
+    e.preventDefault();
+    window.location.href = rewrite(href);
+  }, true);
+
+  // Intercept history.pushState / replaceState (Next.js client nav)
+  var origPush = history.pushState;
+  var origReplace = history.replaceState;
+  history.pushState = function(s, t, url) {
+    if (url && typeof url === "string" && url.indexOf("/api/sandbox/preview") === -1) {
+      window.location.href = rewrite(url);
+      return;
+    }
+    return origPush.apply(this, arguments);
+  };
+  history.replaceState = function(s, t, url) {
+    if (url && typeof url === "string" && url.indexOf("/api/sandbox/preview") === -1) {
+      window.location.href = rewrite(url);
+      return;
+    }
+    return origReplace.apply(this, arguments);
+  };
+})();
+</script>`;
+
+      // Inject before </head> or at start of <body>
+      if (html.includes("</head>")) {
+        html = html.replace("</head>", navScript + "</head>");
+      } else if (html.includes("<body")) {
+        html = html.replace(/<body([^>]*)>/, "<body$1>" + navScript);
+      } else {
+        html = navScript + html;
+      }
+
+      return new NextResponse(html, {
+        status: upstream.status,
+        headers: { "Content-Type": contentType },
+      });
+    }
+
+    // Non-HTML (CSS, JS, images) — pass through as-is
     const body = await upstream.arrayBuffer();
     return new NextResponse(body, {
       status: upstream.status,
-      headers: {
-        "Content-Type": upstream.headers.get("Content-Type") ?? "text/html",
-      },
+      headers: { "Content-Type": contentType },
     });
   } catch {
     // Sandbox exists but no web server is running yet — auto-refresh until it's up

--- a/apps/web/components/build/SandboxPreview.tsx
+++ b/apps/web/components/build/SandboxPreview.tsx
@@ -26,46 +26,65 @@ export function SandboxPreview({ buildId, phase, sandboxPort }: Props) {
     setCurrentPath("/");
   }, []);
 
-  // Track iframe navigation and block recursive paths (e.g. /build inside sandbox)
+  // Track iframe navigation and extract the sandbox path from proxy URLs
   const handleIframeLoad = useCallback(() => {
     setIframeLoaded(true);
     try {
       const win = iframeRef.current?.contentWindow;
       if (!win) return;
-      const path = win.location.pathname;
-      setCurrentPath(path);
+      const fullPath = win.location.pathname;
 
-      // Block Build Studio and Platform admin inside sandbox — they cause infinite recursion
-      if (BLOCKED_PATHS.some(bp => path.startsWith(bp))) {
-        win.location.replace("/");
-        setCurrentPath("/");
-        return;
+      // Extract sandbox path from proxy URL query param
+      let displayPath: string;
+      if (fullPath.startsWith("/api/sandbox/preview")) {
+        const params = new URLSearchParams(win.location.search);
+        displayPath = params.get("path") ?? "/";
+      } else {
+        displayPath = fullPath;
       }
+      setCurrentPath(displayPath);
     } catch {
       // Cross-origin or security restriction — ignore
     }
   }, []);
 
-  // Poll for path changes from in-iframe navigation (clicks, form submits)
+  // Poll for path changes from in-iframe navigation (clicks, form submits).
+  // The injected nav script routes clicks through the proxy, but this catches
+  // any escapes (client-side routing, direct URL changes) and updates the address bar.
   useEffect(() => {
     if (!iframeLoaded || !iframeRef.current) return;
+    const proxyPrefix = "/api/sandbox/preview";
     const interval = setInterval(() => {
       try {
-        const path = iframeRef.current?.contentWindow?.location.pathname;
-        if (path && path !== currentPath) {
-          if (BLOCKED_PATHS.some(bp => path.startsWith(bp))) {
-            iframeRef.current?.contentWindow?.location.replace("/");
-            setCurrentPath("/");
-          } else {
-            setCurrentPath(path);
+        const win = iframeRef.current?.contentWindow;
+        if (!win) return;
+        const fullPath = win.location.pathname;
+        const search = win.location.search;
+
+        // If iframe is on a proxy URL, extract the sandbox path from ?path=
+        let displayPath: string;
+        if (fullPath.startsWith(proxyPrefix)) {
+          const params = new URLSearchParams(search);
+          displayPath = params.get("path") ?? "/";
+        } else {
+          // Iframe escaped the proxy — redirect it back through the proxy
+          displayPath = fullPath;
+          if (BLOCKED_PATHS.some(bp => fullPath.startsWith(bp))) {
+            displayPath = "/";
           }
+          const proxyUrl = `${proxyPrefix}?buildId=${encodeURIComponent(buildId)}&path=${encodeURIComponent(displayPath)}`;
+          win.location.replace(proxyUrl);
+        }
+
+        if (displayPath !== currentPath) {
+          setCurrentPath(displayPath);
         }
       } catch {
         // Cross-origin — ignore
       }
     }, 500);
     return () => clearInterval(interval);
-  }, [iframeLoaded, currentPath]);
+  }, [iframeLoaded, currentPath, buildId]);
 
   if (!isRunning) {
     return (


### PR DESCRIPTION
## Summary
- Links in the sandbox preview escaped to the main portal (e.g. /s/bob loaded the real portal storefront)
- Proxy now injects a navigation interceptor script into HTML responses that rewrites clicks and pushState calls through the proxy
- SandboxPreview component detects proxy escapes and redirects back
- Address bar correctly shows the sandbox path, not the proxy URL

## Test plan
- [ ] Manual: click a storefront link in sandbox preview, verify it stays in sandbox
- [ ] Manual: verify address bar shows /s/bob, not /api/sandbox/preview?...

🤖 Generated with [Claude Code](https://claude.com/claude-code)