### PR TITLE
fix: Build Studio polls for threadId to bootstrap SSE connection

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -75,6 +75,20 @@ export function BuildStudio({ builds, portfolios, dpfEnvironment, projectBranch 
     };
   }, [activeBuild?.threadId, activeBuild?.buildId]);
 
+  // Poll for threadId + phase changes until SSE connects.
+  // The coworker writes threadId to the build on first message, but SSE
+  // can't connect until we know it. Also catches phase changes while
+  // SSE is disconnected (before threadId is set).
+  useEffect(() => {
+    if (!activeBuild) return;
+    if (activeBuild.threadId && activeBuild.phase !== "ideate" && activeBuild.phase !== "plan") return;
+    const interval = setInterval(async () => {
+      const fresh = await getFeatureBuild(activeBuild.buildId);
+      if (fresh) setActiveBuild(fresh);
+    }, 2_000);
+    return () => clearInterval(interval);
+  }, [activeBuild?.buildId, activeBuild?.threadId, activeBuild?.phase]);
+
   // Poll for sandbox port when phase is "build" or "review" but port is unknown.
   // This covers the gap between phase transition and sandbox allocation.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- New builds start with \`threadId: null\` — SSE subscription requires it to connect
- Coworker writes threadId on first message, but BuildStudio had no way to discover it
- Added 2-second poll during ideate/plan (or when threadId missing) to pick up threadId + phase changes
- Once threadId exists, SSE connects and the poll condition stops matching
- Root cause of phase indicator stuck on ideate while coworker reported being in plan/build

## Test plan
- [ ] Manual: create a new build, verify phase indicator starts updating within 2 seconds of first coworker message

🤖 Generated with [Claude Code](https://claude.com/claude-code)