### PR TITLE
fix(routing): relocate and fix agent-dropped routing files + EP-INF-012 tier gate

### DIFF
--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -10,6 +10,7 @@ import type {
   EndpointOverride,
   SensitivityLevel,
 } from "./types";
+import type { QualityTier } from "./quality-tiers";
 import type { ModelCardCapabilities, ModelCardPricing } from "./model-card-types";
 import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
 
@@ -64,6 +65,7 @@ export async function loadEndpointManifests(): Promise<EndpointManifest[]> {
     profileSource: mp.profileSource as EndpointManifest["profileSource"],
     profileConfidence: mp.profileConfidence as EndpointManifest["profileConfidence"],
     retiredAt: mp.retiredAt,
+    qualityTier: (mp.qualityTier as QualityTier | null) ?? undefined,
 
     // EP-INF-003: ModelCard fields
     modelClass: mp.modelClass ?? "chat",

--- a/apps/web/lib/routing/task-dispatcher.test.ts
+++ b/apps/web/lib/routing/task-dispatcher.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { callWithFallbackChain, NoEndpointAvailableError } from "./task-dispatcher";
+import type { TaskRouteDecision, CandidateTrace } from "./task-router-types";
+import type { ProviderCallPayload, DispatchContext } from "./task-dispatcher";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Must match the actual import path in task-dispatcher.ts
+const mockPrisma = {
+  modelProvider: { update: vi.fn() },
+  routeDecisionLog: { create: vi.fn().mockResolvedValue({ id: "log-1" }) },
+};
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+
+const mockCallProvider = vi.fn();
+const mockLogTokenUsage = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/ai-inference", () => ({
+  callProvider: (...args: unknown[]) => mockCallProvider(...args),
+  logTokenUsage: (...args: unknown[]) => mockLogTokenUsage(...args),
+  InferenceError: class extends Error {
+    code: string;
+    providerId: string;
+    constructor(message: string, code: string, providerId = "ep-1") {
+      super(message);
+      this.name = "InferenceError";
+      this.code = code;
+      this.providerId = providerId;
+    }
+  },
+}));
+
+const mockObserve = vi.fn();
+vi.mock("@/lib/process-observer", () => ({ observe: mockObserve }));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeCandidate(overrides: Partial<CandidateTrace> = {}): CandidateTrace {
+  return {
+    endpointId: "ep-1",
+    providerId: "provider-1",
+    modelId: "model-a",
+    endpointName: "Endpoint 1",
+    fitnessScore: 100,
+    dimensionScores: {},
+    costPerOutputMToken: 3.0,
+    excluded: false,
+    ...overrides,
+  };
+}
+
+const mockDecision: TaskRouteDecision = {
+  selectedEndpointId: "ep-1",
+  selectedProviderId: "provider-1",
+  selectedModelId: "model-a",
+  fallbackChain: ["ep-2", "ep-3"],
+  candidates: [
+    makeCandidate({ endpointId: "ep-1", providerId: "provider-1", modelId: "model-a", fitnessScore: 100 }),
+    makeCandidate({ endpointId: "ep-2", providerId: "provider-2", modelId: "model-b", fitnessScore: 90 }),
+    makeCandidate({ endpointId: "ep-3", providerId: "provider-3", modelId: "model-c", fitnessScore: 80 }),
+  ],
+  reason: "test routing",
+  excludedCount: 0,
+  excludedReasons: {},
+  policyRulesApplied: [],
+  taskType: "test",
+  sensitivity: "internal",
+  timestamp: new Date(),
+};
+
+const mockPayload: ProviderCallPayload = {
+  modelId: "model-a",
+  messages: [{ role: "user", content: "Hello" }],
+  systemPrompt: "You are a test assistant.",
+};
+
+const mockContext: DispatchContext = {
+  agentId: "test-agent",
+  agentMessageId: "msg-1",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("callWithFallbackChain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.routeDecisionLog.create.mockResolvedValue({ id: "log-1" });
+  });
+
+  it("calls callProvider with correct (providerId, modelId, messages, systemPrompt) args and returns on success", async () => {
+    mockCallProvider.mockResolvedValueOnce({
+      content: "success",
+      inputTokens: 10,
+      outputTokens: 20,
+      inferenceMs: 500,
+    });
+
+    const result = await callWithFallbackChain(mockDecision, mockPayload, mockContext);
+
+    expect(result.content).toBe("success");
+    expect(mockCallProvider).toHaveBeenCalledOnce();
+    expect(mockCallProvider).toHaveBeenCalledWith(
+      "provider-1",
+      "model-a",
+      mockPayload.messages,
+      mockPayload.systemPrompt,
+      undefined, // no tools
+    );
+    expect(mockPrisma.routeDecisionLog.create).toHaveBeenCalledOnce();
+    expect(mockObserve).toHaveBeenCalledWith("ai_call_succeeded", expect.any(Object));
+  });
+
+  it("logs token usage with correct shape after success", async () => {
+    mockCallProvider.mockResolvedValueOnce({
+      content: "ok",
+      inputTokens: 5,
+      outputTokens: 15,
+      inferenceMs: 300,
+    });
+
+    await callWithFallbackChain(mockDecision, mockPayload, mockContext);
+
+    expect(mockLogTokenUsage).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      providerId: "provider-1",
+      contextKey: "msg-1",
+      inputTokens: 5,
+      outputTokens: 15,
+      inferenceMs: 300,
+    });
+  });
+
+  it("tries fallback chain in order on transient failure", async () => {
+    mockCallProvider
+      .mockRejectedValueOnce(new Error("Transient failure"))
+      .mockResolvedValueOnce({ content: "fallback success", inputTokens: 1, outputTokens: 1, inferenceMs: 100 });
+
+    const result = await callWithFallbackChain(mockDecision, mockPayload, mockContext);
+
+    expect(result.content).toBe("fallback success");
+    expect(mockCallProvider).toHaveBeenCalledTimes(2);
+    expect(mockCallProvider).toHaveBeenNthCalledWith(1, "provider-1", expect.any(String), expect.any(Array), expect.any(String), undefined);
+    expect(mockCallProvider).toHaveBeenNthCalledWith(2, "provider-2", expect.any(String), expect.any(Array), expect.any(String), undefined);
+  });
+
+  it("marks provider as degraded on rate_limit error then tries next", async () => {
+    const { InferenceError } = await import("@/lib/ai-inference");
+    mockCallProvider
+      .mockRejectedValueOnce(new InferenceError("Rate limited", "rate_limit", "provider-1"))
+      .mockResolvedValueOnce({ content: "ok", inputTokens: 1, outputTokens: 1, inferenceMs: 100 });
+
+    await callWithFallbackChain(mockDecision, mockPayload, mockContext);
+
+    expect(mockPrisma.modelProvider.update).toHaveBeenCalledWith({
+      where: { providerId: "provider-1" },
+      data: { status: "degraded" },
+    });
+    expect(mockCallProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks provider as disabled on auth error and tries next", async () => {
+    const { InferenceError } = await import("@/lib/ai-inference");
+    mockCallProvider
+      .mockRejectedValueOnce(new InferenceError("Auth failed", "auth", "provider-1"))
+      .mockResolvedValueOnce({ content: "ok", inputTokens: 1, outputTokens: 1, inferenceMs: 100 });
+
+    await callWithFallbackChain(mockDecision, mockPayload, mockContext);
+
+    expect(mockPrisma.modelProvider.update).toHaveBeenCalledWith({
+      where: { providerId: "provider-1" },
+      data: { status: "disabled" },
+    });
+  });
+
+  it("throws NoEndpointAvailableError when entire chain fails", async () => {
+    mockCallProvider.mockRejectedValue(new Error("Persistent failure"));
+
+    await expect(
+      callWithFallbackChain(mockDecision, mockPayload, mockContext),
+    ).rejects.toThrow(NoEndpointAvailableError);
+
+    // All 3 endpoints tried
+    expect(mockCallProvider).toHaveBeenCalledTimes(3);
+    // Failure log persisted with empty sentinel for selectedEndpointId
+    const logData = mockPrisma.routeDecisionLog.create.mock.calls[0][0].data;
+    expect(logData.selectedEndpointId).toBe("");
+    expect(JSON.parse(logData.fallbacksUsed)).toHaveLength(3);
+  });
+});

--- a/apps/web/lib/routing/task-dispatcher.ts
+++ b/apps/web/lib/routing/task-dispatcher.ts
@@ -1,0 +1,176 @@
+/**
+ * EP-INF-012: Task dispatcher — executes a TaskRouteDecision with fallback chain.
+ *
+ * Calls callProvider from @/lib/ai-inference, handles InferenceError codes to
+ * update provider status in the DB, and persists a RouteDecisionLog audit entry.
+ */
+
+import { prisma } from "@dpf/db";
+import type { TaskRouteDecision, CandidateTrace } from "./task-router-types";
+import {
+  callProvider,
+  logTokenUsage,
+  InferenceError,
+  type ChatMessage,
+} from "@/lib/ai-inference";
+import { observe } from "@/lib/process-observer";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** The payload passed to callProvider for each attempt. */
+export interface ProviderCallPayload {
+  modelId: string;
+  messages: ChatMessage[];
+  systemPrompt: string;
+  tools?: Array<Record<string, unknown>>;
+}
+
+/** Context forwarded from the agent call site for logging. */
+export interface DispatchContext {
+  agentId: string;
+  agentMessageId?: string;
+  shadowMode?: boolean;
+}
+
+// ── Custom error ──────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when every endpoint in the fallback chain has failed.
+ * Includes the final routing decision for debugging.
+ */
+export class NoEndpointAvailableError extends Error {
+  public decision: TaskRouteDecision;
+  constructor(message: string, decision: TaskRouteDecision) {
+    super(message);
+    this.name = "NoEndpointAvailableError";
+    this.decision = decision;
+  }
+}
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+
+/**
+ * Executes an AI call based on a routing decision, walking the fallback chain
+ * on transient failures and updating provider status on hard failures.
+ *
+ * @throws {NoEndpointAvailableError} if every endpoint in the chain fails.
+ */
+export async function callWithFallbackChain(
+  decision: TaskRouteDecision,
+  payload: ProviderCallPayload,
+  context: DispatchContext,
+) {
+  const endpointIds = [decision.selectedEndpointId, ...decision.fallbackChain].filter(
+    (id): id is string => id !== null,
+  );
+
+  const fallbacksUsed: { endpointId: string; error: string; timestamp: string }[] = [];
+
+  for (const endpointId of endpointIds) {
+    const candidate = decision.candidates.find((c) => c.endpointId === endpointId);
+    if (!candidate) continue; // should never happen — defensive
+
+    try {
+      const result = await callProvider(
+        candidate.providerId,
+        payload.modelId || candidate.modelId,
+        payload.messages,
+        payload.systemPrompt,
+        payload.tools,
+      );
+
+      const finalDecision: TaskRouteDecision = {
+        ...decision,
+        selectedEndpointId: endpointId,
+        selectedProviderId: candidate.providerId,
+        selectedModelId: candidate.modelId,
+        reason:
+          fallbacksUsed.length > 0
+            ? `Success via fallback to ${candidate.endpointName}. Original reason: ${decision.reason}`
+            : decision.reason,
+      };
+
+      const decisionLog = await persistDecision(finalDecision, candidate, context, fallbacksUsed);
+
+      await logTokenUsage({
+        agentId: context.agentId,
+        providerId: candidate.providerId,
+        contextKey: context.agentMessageId ?? "task-router",
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        inferenceMs: result.inferenceMs,
+      });
+
+      observe("ai_call_succeeded", { decisionLogId: decisionLog.id });
+
+      return result;
+    } catch (error) {
+      fallbacksUsed.push({
+        endpointId,
+        error: error instanceof Error ? error.message : String(error),
+        timestamp: new Date().toISOString(),
+      });
+
+      if (error instanceof InferenceError) {
+        switch (error.code) {
+          case "rate_limit":
+            await prisma.modelProvider.update({
+              where: { providerId: candidate.providerId },
+              data: { status: "degraded" },
+            });
+            break;
+          case "auth":
+          case "model_not_found":
+            await prisma.modelProvider.update({
+              where: { providerId: candidate.providerId },
+              data: { status: "disabled" },
+            });
+            break;
+        }
+      }
+      // Continue to next endpoint in chain
+    }
+  }
+
+  // All endpoints failed — persist the failure log and throw.
+  const failedDecision: TaskRouteDecision = {
+    ...decision,
+    selectedEndpointId: null,
+    selectedProviderId: null,
+    selectedModelId: null,
+  };
+  await persistDecision(failedDecision, null, context, fallbacksUsed);
+  throw new NoEndpointAvailableError(
+    `All ${endpointIds.length} endpoint(s) in the chain failed.`,
+    failedDecision,
+  );
+}
+
+// ── Persistence ───────────────────────────────────────────────────────────────
+
+async function persistDecision(
+  decision: TaskRouteDecision,
+  selectedCandidate: CandidateTrace | null,
+  context: DispatchContext,
+  fallbacksUsed: { endpointId: string; error: string; timestamp: string }[],
+) {
+  return prisma.routeDecisionLog.create({
+    data: {
+      agentMessageId: context.agentMessageId,
+      // Schema requires selectedEndpointId String (not nullable).
+      // Use empty string as sentinel when all endpoints failed.
+      selectedEndpointId: selectedCandidate?.endpointId ?? "",
+      taskType: decision.taskType,
+      sensitivity: decision.sensitivity,
+      reason: decision.reason,
+      fitnessScore: selectedCandidate?.fitnessScore ?? 0,
+      candidateTrace: JSON.stringify(decision.candidates.filter((c) => !c.excluded)),
+      excludedTrace: JSON.stringify(decision.candidates.filter((c) => c.excluded)),
+      policyRulesApplied: decision.policyRulesApplied,
+      fallbackChain: decision.fallbackChain,
+      fallbacksUsed: JSON.stringify(fallbacksUsed),
+      shadowMode: context.shadowMode ?? false,
+      selectedModelId: selectedCandidate?.modelId ?? null,
+    },
+  });
+}

--- a/apps/web/lib/routing/task-requirements.test.ts
+++ b/apps/web/lib/routing/task-requirements.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getTaskRequirement, BUILT_IN_TASK_REQUIREMENTS } from "./task-requirements";
+
+const mockPrisma = {
+  taskRequirement: {
+    findUnique: vi.fn(),
+  },
+};
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+
+describe("BUILT_IN_TASK_REQUIREMENTS", () => {
+  it("assigns adequate tier to simple conversation tasks", () => {
+    expect(BUILT_IN_TASK_REQUIREMENTS["greeting"]?.minimumTier).toBe("adequate");
+    expect(BUILT_IN_TASK_REQUIREMENTS["status-query"]?.minimumTier).toBe("adequate");
+    expect(BUILT_IN_TASK_REQUIREMENTS["summarization"]?.minimumTier).toBe("adequate");
+  });
+
+  it("assigns strong tier to moderate tasks", () => {
+    expect(BUILT_IN_TASK_REQUIREMENTS["data-extraction"]?.minimumTier).toBe("strong");
+    expect(BUILT_IN_TASK_REQUIREMENTS["web-search"]?.minimumTier).toBe("strong");
+    expect(BUILT_IN_TASK_REQUIREMENTS["creative"]?.minimumTier).toBe("strong");
+  });
+
+  it("assigns frontier tier to complex tasks", () => {
+    expect(BUILT_IN_TASK_REQUIREMENTS["reasoning"]?.minimumTier).toBe("frontier");
+    expect(BUILT_IN_TASK_REQUIREMENTS["code-gen"]?.minimumTier).toBe("frontier");
+    expect(BUILT_IN_TASK_REQUIREMENTS["tool-action"]?.minimumTier).toBe("frontier");
+  });
+
+  it("marks cheap tasks as preferCheap=true", () => {
+    expect(BUILT_IN_TASK_REQUIREMENTS["greeting"]?.preferCheap).toBe(true);
+    expect(BUILT_IN_TASK_REQUIREMENTS["status-query"]?.preferCheap).toBe(true);
+    expect(BUILT_IN_TASK_REQUIREMENTS["web-search"]?.preferCheap).toBe(true);
+  });
+
+  it("marks complex tasks as preferCheap=false", () => {
+    expect(BUILT_IN_TASK_REQUIREMENTS["reasoning"]?.preferCheap).toBe(false);
+    expect(BUILT_IN_TASK_REQUIREMENTS["code-gen"]?.preferCheap).toBe(false);
+    expect(BUILT_IN_TASK_REQUIREMENTS["tool-action"]?.preferCheap).toBe(false);
+  });
+});
+
+describe("getTaskRequirement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset module-level cache between tests
+    vi.resetModules();
+  });
+
+  it("returns undefined for an unknown task type", async () => {
+    mockPrisma.taskRequirement.findUnique.mockResolvedValueOnce(null);
+    const { getTaskRequirement: get } = await import("./task-requirements");
+    const result = await get("nonexistent-task");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns built-in requirement when DB returns null", async () => {
+    mockPrisma.taskRequirement.findUnique.mockResolvedValueOnce(null);
+    const { getTaskRequirement: get } = await import("./task-requirements");
+    const result = await get("greeting");
+    expect(result?.taskType).toBe("greeting");
+    expect(result?.minimumTier).toBe("adequate");
+  });
+
+  it("returns DB row when one exists, overriding built-in", async () => {
+    const dbRow = {
+      taskType: "greeting",
+      description: "Custom greeting from DB",
+      selectionRationale: "DB override",
+      requiredCapabilities: {},
+      preferredMinScores: { conversational: 60 },
+      minimumTier: "strong",  // admin upgraded the tier
+      preferCheap: false,
+      origin: "user",
+    };
+    mockPrisma.taskRequirement.findUnique.mockResolvedValueOnce(dbRow);
+    const { getTaskRequirement: get } = await import("./task-requirements");
+    const result = await get("greeting");
+    expect(result?.minimumTier).toBe("strong");
+    expect(result?.description).toBe("Custom greeting from DB");
+  });
+});

--- a/apps/web/lib/routing/task-requirements.ts
+++ b/apps/web/lib/routing/task-requirements.ts
@@ -1,0 +1,142 @@
+/**
+ * EP-INF-012: Built-in task requirement contracts + DB-backed loader.
+ *
+ * minimumTier maps to the "thinking cap" analogy from Anthropic's adaptive-model
+ * guidance: simple tasks (adequate) never touch frontier-tier endpoints; complex
+ * tasks (frontier) demand the best available reasoning and tool-calling.
+ *
+ *   greeting / status-query / summarization → adequate (Haiku-equivalent, effort=low)
+ *   data-extraction / web-search / creative  → strong  (Sonnet-equivalent, effort=medium)
+ *   reasoning / code-gen / tool-action       → frontier (Opus/Sonnet, effort=high)
+ */
+
+import { prisma } from "@dpf/db";
+import type { TaskRequirement } from "./task-router-types";
+
+// ── In-memory cache ────────────────────────────────────────────────────────────
+
+const taskRequirementCache = new Map<string, TaskRequirement>();
+
+// ── Built-in definitions ───────────────────────────────────────────────────────
+
+export const BUILT_IN_TASK_REQUIREMENTS: Record<string, TaskRequirement> = {
+  greeting: {
+    taskType: "greeting",
+    description: "Simple conversational greeting or acknowledgement.",
+    selectionRationale: "Simple dialog — any capable model works.",
+    requiredCapabilities: {},
+    preferredMinScores: { conversational: 40 },
+    minimumTier: "adequate",
+    preferCheap: true,
+    origin: "system",
+  },
+  "status-query": {
+    taskType: "status-query",
+    description: "Factual data lookup and status reporting.",
+    selectionRationale: "Data lookup — needs accuracy, not depth.",
+    requiredCapabilities: {},
+    preferredMinScores: { instructionFollowing: 40 },
+    minimumTier: "adequate",
+    preferCheap: true,
+    origin: "system",
+  },
+  summarization: {
+    taskType: "summarization",
+    description: "Summarizing a block of text.",
+    selectionRationale: "Needs to follow formatting instructions.",
+    requiredCapabilities: {},
+    preferredMinScores: { instructionFollowing: 50 },
+    minimumTier: "adequate",
+    preferCheap: true,
+    origin: "system",
+  },
+  "data-extraction": {
+    taskType: "data-extraction",
+    description: "Extracting structured data (e.g., JSON) from unstructured text.",
+    selectionRationale: "Must produce valid structured output reliably.",
+    requiredCapabilities: { supportsStructuredOutput: true },
+    preferredMinScores: { structuredOutput: 70 },
+    minimumTier: "strong",
+    preferCheap: true,
+    origin: "system",
+  },
+  "web-search": {
+    taskType: "web-search",
+    description: "Using a search tool to answer a question.",
+    selectionRationale: "Must call search tools correctly.",
+    requiredCapabilities: { supportsToolUse: true },
+    preferredMinScores: { toolFidelity: 60 },
+    minimumTier: "strong",
+    preferCheap: true,
+    origin: "system",
+  },
+  creative: {
+    taskType: "creative",
+    description: "Creative writing, brainstorming, or open-ended ideation.",
+    selectionRationale: "Needs both creativity and coherence.",
+    requiredCapabilities: {},
+    preferredMinScores: { conversational: 60, reasoning: 50 },
+    minimumTier: "strong",
+    preferCheap: false,
+    origin: "system",
+  },
+  reasoning: {
+    taskType: "reasoning",
+    description: "Complex, multi-step analytical reasoning.",
+    selectionRationale: "Complex analysis needs strong reasoning — frontier only.",
+    requiredCapabilities: {},
+    preferredMinScores: { reasoning: 80 },
+    minimumTier: "frontier",
+    preferCheap: false,
+    origin: "system",
+  },
+  "code-gen": {
+    taskType: "code-gen",
+    description: "Generating or modifying source code.",
+    selectionRationale: "Code quality is critical — frontier only.",
+    requiredCapabilities: { supportsToolUse: true },
+    preferredMinScores: { codegen: 75, instructionFollowing: 60 },
+    minimumTier: "frontier",
+    preferCheap: false,
+    origin: "system",
+  },
+  "tool-action": {
+    taskType: "tool-action",
+    description: "Multi-step tool use with external APIs.",
+    selectionRationale: "Requires tool-calling fidelity — frontier only.",
+    requiredCapabilities: { supportsToolUse: true },
+    preferredMinScores: { toolFidelity: 70 },
+    minimumTier: "frontier",
+    preferCheap: false,
+    origin: "system",
+  },
+};
+
+// ── Loader ────────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieves a task requirement contract, prioritising the database then falling
+ * back to built-in definitions. Results are cached in memory for the process lifetime.
+ *
+ * DB rows win over built-ins so admins can tune task requirements without code changes.
+ */
+export async function getTaskRequirement(
+  taskType: string,
+): Promise<TaskRequirement | undefined> {
+  if (taskRequirementCache.has(taskType)) {
+    return taskRequirementCache.get(taskType);
+  }
+
+  const dbRow = await prisma.taskRequirement.findUnique({ where: { taskType } });
+  if (dbRow) {
+    // Prisma returns Json fields as `unknown`. We control the shape via seed + UI,
+    // so the cast is safe.
+    const requirement = dbRow as unknown as TaskRequirement;
+    taskRequirementCache.set(taskType, requirement);
+    return requirement;
+  }
+
+  const builtIn = BUILT_IN_TASK_REQUIREMENTS[taskType];
+  if (builtIn) taskRequirementCache.set(taskType, builtIn);
+  return builtIn;
+}

--- a/apps/web/lib/routing/task-router-types.ts
+++ b/apps/web/lib/routing/task-router-types.ts
@@ -1,0 +1,120 @@
+/**
+ * EP-INF-012: Type definitions for the TaskRequirement-based routing layer.
+ *
+ * These types form the "demand side" of the task router. They are intentionally
+ * separate from the pipeline-v2 RequestContract types to allow the task router
+ * to be used independently of the full contract pipeline.
+ *
+ * EndpointManifest is re-exported from ./types — there is exactly one definition.
+ */
+
+import type { SensitivityLevel } from "./types";
+import type { QualityTier } from "./quality-tiers";
+
+// Re-export so consumers only need one import source.
+export type { EndpointManifest } from "./types";
+
+// ── Task Requirement ───────────────────────────────────────────────────────────
+
+/**
+ * A contract declaring what a task type needs from an endpoint.
+ * This is the "demand side" of the task routing equation.
+ */
+export interface TaskRequirement {
+  // Identity
+  taskType: string;
+  description: string;
+  selectionRationale: string;
+
+  // Hard requirements (endpoint must satisfy ALL or it is excluded)
+  requiredCapabilities: {
+    supportsToolUse?: boolean;
+    supportsStructuredOutput?: boolean;
+    supportsStreaming?: boolean;
+    minContextTokens?: number;
+  };
+
+  // Soft requirements (scored — higher is better, not disqualifying)
+  preferredMinScores: Record<string, number>;
+
+  // EP-INF-012: Tier gate — endpoints below this tier are excluded before scoring.
+  // Maps to TIER_MINIMUM_DIMENSIONS thresholds.
+  // "frontier" = complex tool-calling, code-gen; "adequate" = simple conversation.
+  minimumTier?: QualityTier;
+
+  // Operational preferences
+  maxLatencyMs?: number;
+  preferCheap?: boolean;
+
+  // Metadata
+  defaultInstructions?: string;
+  evaluationTokenLimit?: number;
+  origin: "system" | "user";
+  createdBy?: string;
+  approvedBy?: string;
+  approvedAt?: Date;
+}
+
+// ── Policy Rule ───────────────────────────────────────────────────────────────
+
+/**
+ * An organisation-level routing constraint driven by compliance or internal policy.
+ * Conditions are evaluated as simple field comparisons against EndpointManifest.
+ */
+export interface PolicyRule {
+  id: string;
+  name: string;
+  description: string;
+  condition: {
+    field: string;
+    operator: "in" | "not_in";
+    value: unknown[];
+  };
+  action: "exclude";
+  isActive: boolean;
+}
+
+// ── Candidate Trace ───────────────────────────────────────────────────────────
+
+/**
+ * The scored trace of a single endpoint evaluated during a routing decision.
+ * Carries providerId + modelId so the dispatcher can call callProvider without
+ * a secondary DB lookup.
+ */
+export interface CandidateTrace {
+  endpointId: string;    // ModelProfile.id (routing key)
+  providerId: string;    // ModelProvider.providerId (for callProvider)
+  modelId: string;       // ModelProfile.modelId (for callProvider)
+  endpointName: string;
+  fitnessScore: number;
+  dimensionScores: Record<string, number>;
+  costPerOutputMToken: number;
+  excluded: boolean;
+  excludedReason?: string;
+}
+
+// ── Task Route Decision ───────────────────────────────────────────────────────
+
+/**
+ * The full auditable trace of a task routing decision.
+ * Named TaskRouteDecision to avoid collision with the pipeline RouteDecision type.
+ */
+export interface TaskRouteDecision {
+  // Selection
+  selectedEndpointId: string | null;
+  selectedProviderId: string | null;
+  selectedModelId: string | null;
+  reason: string;
+  fallbackChain: string[];  // endpointIds of next-best candidates
+
+  // Full trace
+  candidates: CandidateTrace[];
+  excludedCount: number;
+  excludedReasons: Record<string, number>;  // reason → count
+  policyRulesApplied: string[];
+
+  // Context
+  taskType: string;
+  sensitivity: SensitivityLevel;
+  timestamp: Date;
+}

--- a/apps/web/lib/routing/task-router.test.ts
+++ b/apps/web/lib/routing/task-router.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import { routeTask } from "./task-router";
+import { BUILT_IN_TASK_REQUIREMENTS } from "./task-requirements";
+import type { EndpointManifest } from "./types";
+import type { TaskRequirement, PolicyRule } from "./task-router-types";
+
+// ── Shared mock factories ──────────────────────────────────────────────────────
+
+function makeEndpoint(overrides: Partial<EndpointManifest>): EndpointManifest {
+  return {
+    id: "ep-default",
+    providerId: "mock-provider",
+    modelId: "mock-model",
+    name: "Mock Endpoint",
+    endpointType: "llm",
+    status: "active",
+    sensitivityClearance: ["internal", "confidential"],
+    supportsToolUse: true,
+    supportsStructuredOutput: true,
+    supportsStreaming: true,
+    maxContextTokens: 8000,
+    maxOutputTokens: 4096,
+    modelRestrictions: [],
+    reasoning: 80,
+    codegen: 80,
+    toolFidelity: 80,
+    instructionFollowing: 80,
+    structuredOutput: 80,
+    conversational: 80,
+    contextRetention: 80,
+    customScores: {},
+    avgLatencyMs: 1000,
+    recentFailureRate: 0.02,
+    costPerOutputMToken: 3.0,
+    profileSource: "seed",
+    profileConfidence: "high",
+    retiredAt: null,
+    qualityTier: "strong",
+    modelClass: "chat",
+    modelFamily: null,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    capabilities: { toolUse: true, streaming: true, structuredOutput: true } as any,
+    pricing: {} as any,
+    supportedParameters: [],
+    deprecationDate: null,
+    metadataSource: "seed",
+    metadataConfidence: "high",
+    perRequestLimits: null,
+    ...overrides,
+  };
+}
+
+// ── Stage 0: Policy filter ────────────────────────────────────────────────────
+
+describe("routeTask — Stage 0: Policy Filter", () => {
+  const endpoints = [
+    makeEndpoint({ id: "ep-cloud", name: "Cloud Model", providerId: "anthropic", qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-local", name: "Local Model", providerId: "local-ollama", qualityTier: "basic" }),
+  ];
+
+  const noCloudRule: PolicyRule = {
+    id: "policy-no-cloud",
+    name: "No Cloud Providers",
+    description: "On-premise only.",
+    isActive: true,
+    action: "exclude",
+    condition: { field: "providerId", operator: "in", value: ["anthropic", "openai"] },
+  };
+
+  const inactiveRule: PolicyRule = {
+    id: "policy-inactive",
+    name: "Inactive Rule",
+    description: "Should be ignored.",
+    isActive: false,
+    action: "exclude",
+    condition: { field: "id", operator: "in", value: ["ep-local"] },
+  };
+
+  const task = BUILT_IN_TASK_REQUIREMENTS["status-query"]!;
+
+  it("excludes endpoints that match an active policy rule", () => {
+    const decision = routeTask(endpoints, task, "internal", [noCloudRule]);
+    const cloud = decision.candidates.find((c) => c.endpointId === "ep-cloud")!;
+    expect(cloud.excluded).toBe(true);
+    expect(cloud.excludedReason).toMatch(/Excluded by policy: No Cloud Providers/);
+    expect(decision.policyRulesApplied).toContain("policy-no-cloud");
+  });
+
+  it("does not apply inactive policy rules", () => {
+    const decision = routeTask(endpoints, task, "internal", [inactiveRule]);
+    const local = decision.candidates.find((c) => c.endpointId === "ep-local")!;
+    expect(local.excluded).toBe(false);
+    expect(decision.policyRulesApplied).not.toContain("policy-inactive");
+  });
+});
+
+// ── Stage 0.5: Tier gate ──────────────────────────────────────────────────────
+
+describe("routeTask — Stage 0.5: Tier Gate", () => {
+  const frontierEndpoint = makeEndpoint({ id: "ep-frontier", name: "Frontier", qualityTier: "frontier" });
+  const strongEndpoint   = makeEndpoint({ id: "ep-strong",   name: "Strong",   qualityTier: "strong"   });
+  const adequateEndpoint = makeEndpoint({ id: "ep-adequate", name: "Adequate", qualityTier: "adequate" });
+  const basicEndpoint    = makeEndpoint({ id: "ep-basic",    name: "Basic",    qualityTier: "basic"    });
+
+  const allEndpoints = [frontierEndpoint, strongEndpoint, adequateEndpoint, basicEndpoint];
+
+  it("excludes endpoints below minimumTier=frontier", () => {
+    const task: TaskRequirement = { ...BUILT_IN_TASK_REQUIREMENTS["code-gen"]!, minimumTier: "frontier" };
+    const decision = routeTask(allEndpoints, task, "internal", []);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-strong")?.excluded).toBe(true);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-adequate")?.excluded).toBe(true);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-basic")?.excluded).toBe(true);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-frontier")?.excluded).toBe(false);
+  });
+
+  it("excludes endpoints below minimumTier=strong but keeps frontier", () => {
+    const task: TaskRequirement = { ...BUILT_IN_TASK_REQUIREMENTS["web-search"]!, minimumTier: "strong" };
+    const decision = routeTask(allEndpoints, task, "internal", []);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-frontier")?.excluded).toBe(false);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-strong")?.excluded).toBe(false);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-adequate")?.excluded).toBe(true);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-basic")?.excluded).toBe(true);
+  });
+
+  it("allows all endpoints when minimumTier=adequate", () => {
+    const task: TaskRequirement = { ...BUILT_IN_TASK_REQUIREMENTS["greeting"]!, minimumTier: "adequate" };
+    const decision = routeTask(allEndpoints, task, "internal", []);
+    expect(decision.candidates.filter((c) => c.excluded)).toHaveLength(1); // only basic
+    expect(decision.candidates.find((c) => c.endpointId === "ep-basic")?.excluded).toBe(true);
+  });
+
+  it("excludes nothing when no minimumTier is set", () => {
+    const task: TaskRequirement = { ...BUILT_IN_TASK_REQUIREMENTS["greeting"]!, minimumTier: undefined };
+    const decision = routeTask(allEndpoints, task, "internal", []);
+    expect(decision.candidates.every((c) => !c.excluded)).toBe(true);
+  });
+
+  it("tier exclusion reason is descriptive", () => {
+    const task: TaskRequirement = { ...BUILT_IN_TASK_REQUIREMENTS["code-gen"]!, minimumTier: "frontier" };
+    const decision = routeTask(allEndpoints, task, "internal", []);
+    const strong = decision.candidates.find((c) => c.endpointId === "ep-strong")!;
+    expect(strong.excludedReason).toContain("strong");
+    expect(strong.excludedReason).toContain("frontier");
+  });
+});
+
+// ── Stage 1: Hard filter ──────────────────────────────────────────────────────
+
+describe("routeTask — Stage 1: Hard Filter", () => {
+  const toolTask = BUILT_IN_TASK_REQUIREMENTS["tool-action"]!;
+  const contextTask: TaskRequirement = {
+    ...BUILT_IN_TASK_REQUIREMENTS["reasoning"]!,
+    requiredCapabilities: { minContextTokens: 4000 },
+  };
+
+  const endpoints = [
+    makeEndpoint({ id: "ep-active",      name: "Active",               status: "active",   qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-inactive",    name: "Inactive",             status: "inactive", qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-retired",     name: "Retired",              retiredAt: new Date(), qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-noclearance", name: "No Clearance",         sensitivityClearance: ["internal"], qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-notool",      name: "No Tool Support",      supportsToolUse: false, qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-smallctx",   name: "Small Context",         maxContextTokens: 2000, qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-degraded",   name: "Degraded",              status: "degraded", qualityTier: "frontier" }),
+  ];
+
+  it("excludes inactive and retired endpoints", () => {
+    const decision = routeTask(endpoints, toolTask, "internal", []);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-inactive")?.excluded).toBe(true);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-retired")?.excluded).toBe(true);
+  });
+
+  it("excludes endpoints with insufficient sensitivity clearance", () => {
+    const decision = routeTask(endpoints, toolTask, "confidential", []);
+    const c = decision.candidates.find((c) => c.endpointId === "ep-noclearance")!;
+    expect(c.excluded).toBe(true);
+    expect(c.excludedReason).toMatch(/sensitivity/);
+  });
+
+  it("excludes endpoints without tool support when task requires it", () => {
+    const decision = routeTask(endpoints, toolTask, "internal", []);
+    const c = decision.candidates.find((c) => c.endpointId === "ep-notool")!;
+    expect(c.excluded).toBe(true);
+    expect(c.excludedReason).toMatch(/tool support/);
+  });
+
+  it("excludes endpoints with context window too small", () => {
+    const decision = routeTask(endpoints, contextTask, "internal", []);
+    const c = decision.candidates.find((c) => c.endpointId === "ep-smallctx")!;
+    expect(c.excluded).toBe(true);
+    expect(c.excludedReason).toMatch(/context window/);
+  });
+
+  it("includes active and degraded endpoints that pass all checks", () => {
+    const decision = routeTask(endpoints, toolTask, "internal", []);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-active")?.excluded).toBe(false);
+    expect(decision.candidates.find((c) => c.endpointId === "ep-degraded")?.excluded).toBe(false);
+  });
+});
+
+// ── Stage 2 & 3: Score & Rank ─────────────────────────────────────────────────
+
+const scoringEndpoints: EndpointManifest[] = [
+  makeEndpoint({ id: "ep-quality",  name: "Quality King",    reasoning: 95, codegen: 92, instructionFollowing: 90, costPerOutputMToken: 15.0, recentFailureRate: 0.01, avgLatencyMs: 800,  qualityTier: "frontier" }),
+  makeEndpoint({ id: "ep-cost",     name: "Cost Saver",      reasoning: 70, codegen: 65, instructionFollowing: 70, costPerOutputMToken: 0.8,  recentFailureRate: 0.05, avgLatencyMs: 1200, qualityTier: "frontier" }),
+  makeEndpoint({ id: "ep-balanced", name: "Balanced Choice", reasoning: 85, codegen: 80, instructionFollowing: 82, costPerOutputMToken: 3.0,  recentFailureRate: 0.02, avgLatencyMs: 900,  qualityTier: "frontier" }),
+  makeEndpoint({ id: "ep-degraded", name: "Degraded King",   reasoning: 95, codegen: 92, instructionFollowing: 90, costPerOutputMToken: 15.0, recentFailureRate: 0.25, avgLatencyMs: 2500, qualityTier: "frontier", status: "degraded" }),
+  makeEndpoint({ id: "ep-tiebreak", name: "Tie Breaker",     reasoning: 85, codegen: 80, instructionFollowing: 82, costPerOutputMToken: 3.0,  recentFailureRate: 0.01, avgLatencyMs: 850,  qualityTier: "frontier" }),
+];
+
+const qualityTask: TaskRequirement = {
+  ...BUILT_IN_TASK_REQUIREMENTS["code-gen"]!,
+  preferCheap: false,
+  preferredMinScores: { codegen: 80, instructionFollowing: 70 },
+  minimumTier: undefined, // disable tier gate so all endpoints compete
+};
+
+const cheapTask: TaskRequirement = { ...qualityTask, preferCheap: true };
+
+describe("routeTask — Stage 2 & 3: Score & Rank", () => {
+  it("selects highest quality endpoint when preferCheap=false", () => {
+    const decision = routeTask(scoringEndpoints, qualityTask, "internal", []);
+    expect(decision.selectedEndpointId).toBe("ep-quality");
+  });
+
+  it("selects cheapest-viable endpoint when preferCheap=true", () => {
+    const decision = routeTask(scoringEndpoints, cheapTask, "internal", []);
+    expect(decision.selectedEndpointId).toBe("ep-cost");
+  });
+
+  it("applies 30% penalty to degraded endpoints", () => {
+    const decision = routeTask(scoringEndpoints, qualityTask, "internal", []);
+    const degraded = decision.candidates.find((c) => c.endpointId === "ep-degraded")!;
+    const quality  = decision.candidates.find((c) => c.endpointId === "ep-quality")!;
+    expect(degraded.fitnessScore).toBeLessThan(quality.fitnessScore);
+    expect(degraded.fitnessScore).toBeCloseTo(quality.fitnessScore * 0.7, 1);
+  });
+
+  it("breaks ties by failure rate then latency", () => {
+    const decision = routeTask(scoringEndpoints, qualityTask, "internal", []);
+    const ranked = decision.candidates.filter((c) => !c.excluded);
+    const tiebreakerRank = ranked.findIndex((c) => c.endpointId === "ep-tiebreak");
+    const balancedRank   = ranked.findIndex((c) => c.endpointId === "ep-balanced");
+    // Both have same dimension scores; ep-tiebreak has lower failure rate → ranked higher
+    expect(tiebreakerRank).toBeLessThan(balancedRank);
+  });
+
+  it("decision includes providerId and modelId on selected candidate", () => {
+    const decision = routeTask(scoringEndpoints, qualityTask, "internal", []);
+    expect(decision.selectedProviderId).toBeTruthy();
+    expect(decision.selectedModelId).toBeTruthy();
+  });
+});
+
+// ── Snapshot regression ───────────────────────────────────────────────────────
+
+describe("routeTask — Regression Snapshots", () => {
+  it("produces a stable decision for quality-first task", () => {
+    const decision = routeTask(scoringEndpoints, qualityTask, "internal", []);
+    const stable = {
+      ...decision,
+      timestamp: "mock-timestamp",
+      candidates: decision.candidates.map((c) => ({
+        ...c,
+        fitnessScore: parseFloat(c.fitnessScore.toFixed(2)),
+      })),
+    };
+    expect(stable).toMatchSnapshot();
+  });
+
+  it("produces a stable decision for cost-first task", () => {
+    const decision = routeTask(scoringEndpoints, cheapTask, "internal", []);
+    const stable = {
+      ...decision,
+      timestamp: "mock-timestamp",
+      candidates: decision.candidates.map((c) => ({
+        ...c,
+        fitnessScore: parseFloat(c.fitnessScore.toFixed(2)),
+      })),
+    };
+    expect(stable).toMatchSnapshot();
+  });
+});

--- a/apps/web/lib/routing/task-router.ts
+++ b/apps/web/lib/routing/task-router.ts
@@ -1,0 +1,243 @@
+/**
+ * EP-INF-012: TaskRequirement-based endpoint router.
+ *
+ * Four-stage pipeline:
+ *   Stage 0:   Policy filter   — compliance/governance exclusions
+ *   Stage 0.5: Tier gate       — exclude endpoints below minimumTier (EP-INF-012)
+ *   Stage 1:   Hard filter     — binary capability and status checks
+ *   Stage 2:   Score           — weighted dimension fitness + cost blend
+ *   Stage 3:   Rank            — fitness → cost → failure rate → latency
+ *   Stage 4:   Select + Explain
+ *
+ * The tier gate (0.5) is the routing equivalent of the "thinking cap": simple tasks
+ * (adequate) never compete against frontier endpoints, keeping cost optimised without
+ * sacrificing quality for tasks that genuinely need it.
+ */
+
+import type { EndpointManifest, SensitivityLevel } from "./types";
+import { TIER_MINIMUM_DIMENSIONS, QUALITY_TIERS } from "./quality-tiers";
+import type { QualityTier } from "./quality-tiers";
+import type {
+  TaskRequirement,
+  PolicyRule,
+  CandidateTrace,
+  TaskRouteDecision,
+} from "./task-router-types";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function evaluateCondition(
+  endpoint: EndpointManifest,
+  condition: PolicyRule["condition"],
+): boolean {
+  const endpointValue = (endpoint as unknown as Record<string, unknown>)[condition.field];
+  switch (condition.operator) {
+    case "in":
+      return condition.value.includes(endpointValue);
+    case "not_in":
+      return !condition.value.includes(endpointValue);
+  }
+}
+
+function getDimensionScore(endpoint: EndpointManifest, dimension: string): number {
+  // Built-in named dimensions map directly to EndpointManifest fields.
+  const directFields: Record<string, keyof EndpointManifest> = {
+    reasoning: "reasoning",
+    codegen: "codegen",
+    toolFidelity: "toolFidelity",
+    instructionFollowing: "instructionFollowing",
+    structuredOutput: "structuredOutput",
+    conversational: "conversational",
+    contextRetention: "contextRetention",
+  };
+  if (dimension in directFields) {
+    const val = endpoint[directFields[dimension]!];
+    return typeof val === "number" ? val : 0;
+  }
+  return endpoint.customScores?.[dimension] ?? 0;
+}
+
+function calculateDimensionWeights(
+  scores: Record<string, number>,
+): Record<string, number> {
+  const total = Object.values(scores).reduce((sum, s) => sum + s, 0);
+  if (total === 0) return {};
+  return Object.fromEntries(
+    Object.entries(scores).map(([dim, score]) => [dim, score / total]),
+  );
+}
+
+/**
+ * Returns the ordinal rank of a tier (lower = worse).
+ * Used to decide whether an endpoint clears the minimumTier gate.
+ */
+function tierRank(tier: QualityTier): number {
+  return QUALITY_TIERS.indexOf(tier); // frontier=0, strong=1, adequate=2, basic=3
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+export function routeTask(
+  endpoints: EndpointManifest[],
+  taskRequirement: TaskRequirement,
+  sensitivity: SensitivityLevel,
+  policyRules: PolicyRule[],
+): TaskRouteDecision {
+  const candidates: CandidateTrace[] = [];
+  const excludedReasons: Record<string, number> = {};
+
+  // ── Stage 0: Policy filter ────────────────────────────────────────────────
+  const policyRulesApplied: string[] = [];
+  const policyExcluded = new Map<string, string>(); // endpointId → reason
+
+  for (const rule of policyRules) {
+    if (!rule.isActive) continue;
+    policyRulesApplied.push(rule.id);
+    for (const endpoint of endpoints) {
+      if (!policyExcluded.has(endpoint.id) && evaluateCondition(endpoint, rule.condition)) {
+        policyExcluded.set(endpoint.id, `Excluded by policy: ${rule.name}`);
+      }
+    }
+  }
+
+  // ── Stage 0.5: Tier gate ──────────────────────────────────────────────────
+  const tierGateExcluded = new Map<string, string>(); // endpointId → reason
+  if (taskRequirement.minimumTier) {
+    const minRank = tierRank(taskRequirement.minimumTier);
+    for (const endpoint of endpoints) {
+      const epTier = endpoint.qualityTier ?? "adequate";
+      if (tierRank(epTier) > minRank) {
+        tierGateExcluded.set(
+          endpoint.id,
+          `Excluded: tier '${epTier}' is below required '${taskRequirement.minimumTier}'`,
+        );
+      }
+    }
+  }
+
+  // ── Stage 1: Hard filter ──────────────────────────────────────────────────
+  for (const endpoint of endpoints) {
+    let excluded = false;
+    let reason = "";
+
+    const policyReason = policyExcluded.get(endpoint.id);
+    const tierReason = tierGateExcluded.get(endpoint.id);
+
+    if (policyReason) {
+      excluded = true;
+      reason = policyReason;
+    } else if (tierReason) {
+      excluded = true;
+      reason = tierReason;
+    } else if (endpoint.status !== "active" && endpoint.status !== "degraded") {
+      excluded = true;
+      reason = `Excluded: status is '${endpoint.status}'`;
+    } else if (endpoint.retiredAt) {
+      excluded = true;
+      reason = "Excluded: endpoint is retired";
+    } else if (!endpoint.sensitivityClearance.includes(sensitivity)) {
+      excluded = true;
+      reason = `Excluded: sensitivity clearance insufficient for '${sensitivity}'`;
+    } else if (taskRequirement.requiredCapabilities.supportsToolUse && !endpoint.supportsToolUse) {
+      excluded = true;
+      reason = "Excluded: task requires tool support";
+    } else if (taskRequirement.requiredCapabilities.supportsStructuredOutput && !endpoint.supportsStructuredOutput) {
+      excluded = true;
+      reason = "Excluded: task requires structured output";
+    } else if (
+      taskRequirement.requiredCapabilities.minContextTokens !== undefined &&
+      endpoint.maxContextTokens !== null &&
+      endpoint.maxContextTokens < taskRequirement.requiredCapabilities.minContextTokens
+    ) {
+      excluded = true;
+      reason = `Excluded: context window ${endpoint.maxContextTokens} < required ${taskRequirement.requiredCapabilities.minContextTokens}`;
+    }
+
+    if (excluded) {
+      excludedReasons[reason] = (excludedReasons[reason] ?? 0) + 1;
+    }
+
+    candidates.push({
+      endpointId: endpoint.id,
+      providerId: endpoint.providerId,
+      modelId: endpoint.modelId,
+      endpointName: endpoint.name,
+      fitnessScore: 0,
+      dimensionScores: {},
+      costPerOutputMToken: endpoint.costPerOutputMToken ?? 0,
+      excluded,
+      excludedReason: reason || undefined,
+    });
+  }
+
+  // ── Stage 2: Score ────────────────────────────────────────────────────────
+  const eligibleCandidates = candidates.filter((c) => !c.excluded);
+  const eligibleEndpoints = endpoints.filter((e) =>
+    eligibleCandidates.some((c) => c.endpointId === e.id),
+  );
+
+  if (eligibleEndpoints.length > 0) {
+    const { preferredMinScores, preferCheap } = taskRequirement;
+    const dimensionWeights = calculateDimensionWeights(preferredMinScores);
+
+    const maxCost = preferCheap
+      ? Math.max(...eligibleEndpoints.map((e) => e.costPerOutputMToken ?? 0), 0)
+      : 0;
+
+    for (const candidate of eligibleCandidates) {
+      const endpoint = eligibleEndpoints.find((e) => e.id === candidate.endpointId)!;
+
+      let qualityFitness = 0;
+      for (const [dimension, weight] of Object.entries(dimensionWeights)) {
+        const score = getDimensionScore(endpoint, dimension);
+        qualityFitness += score * weight;
+        candidate.dimensionScores[dimension] = score;
+      }
+
+      // Degraded endpoints take a 30% fitness penalty — they pass but score lower.
+      const statusMultiplier = endpoint.status === "degraded" ? 0.7 : 1.0;
+      let finalFitness = qualityFitness * statusMultiplier;
+
+      if (preferCheap && maxCost > 0) {
+        const costFactor = 1 - ((endpoint.costPerOutputMToken ?? 0) / maxCost);
+        // Blend: 60% quality, 40% cost efficiency.
+        finalFitness = 0.6 * finalFitness + 0.4 * costFactor * 100;
+      }
+
+      candidate.fitnessScore = finalFitness;
+    }
+  }
+
+  // ── Stage 3: Rank ─────────────────────────────────────────────────────────
+  const rankedCandidates = [...eligibleCandidates].sort((a, b) => {
+    if (a.fitnessScore !== b.fitnessScore) return b.fitnessScore - a.fitnessScore;
+    if (a.costPerOutputMToken !== b.costPerOutputMToken) return a.costPerOutputMToken - b.costPerOutputMToken;
+    const epA = eligibleEndpoints.find((e) => e.id === a.endpointId)!;
+    const epB = eligibleEndpoints.find((e) => e.id === b.endpointId)!;
+    if ((epA.recentFailureRate ?? 0) !== (epB.recentFailureRate ?? 0)) {
+      return (epA.recentFailureRate ?? 0) - (epB.recentFailureRate ?? 0);
+    }
+    return (epA.avgLatencyMs ?? 0) - (epB.avgLatencyMs ?? 0);
+  });
+
+  // ── Stage 4: Select + Explain ─────────────────────────────────────────────
+  const selected = rankedCandidates[0] ?? null;
+  const reason = selected
+    ? `Selected ${selected.endpointName} (${selected.providerId}/${selected.modelId}) for '${taskRequirement.taskType}': fitness ${selected.fitnessScore.toFixed(1)}. ${taskRequirement.selectionRationale}`
+    : "No suitable endpoint found that meets all criteria.";
+
+  return {
+    selectedEndpointId: selected?.endpointId ?? null,
+    selectedProviderId: selected?.providerId ?? null,
+    selectedModelId: selected?.modelId ?? null,
+    reason,
+    fallbackChain: rankedCandidates.slice(1, 4).map((c) => c.endpointId),
+    candidates,
+    excludedCount: candidates.length - rankedCandidates.length,
+    excludedReasons,
+    policyRulesApplied,
+    taskType: taskRequirement.taskType,
+    sensitivity,
+    timestamp: new Date(),
+  };
+}

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -3,6 +3,8 @@
  * See: docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md
  */
 
+import type { QualityTier } from "./quality-tiers";
+
 // ── Sensitivity ──
 
 export type SensitivityLevel = "public" | "internal" | "confidential" | "restricted";
@@ -48,6 +50,9 @@ export interface EndpointManifest {
 
   // Lifecycle
   retiredAt: Date | null;
+
+  // EP-INF-012: Quality tier (frontier / strong / adequate / basic)
+  qualityTier?: QualityTier;
 
   // EP-INF-003: ModelCard fields
   modelClass: string;

--- a/docs/superpowers/plans/2026-04-06-fix-routing-agent-output.md
+++ b/docs/superpowers/plans/2026-04-06-fix-routing-agent-output.md
@@ -1,0 +1,167 @@
+# Fix Routing Agent Output — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Relocate and fix the 7 root-level routing files a previous agent dropped in the wrong place, resolve all code bugs, add quality-tier gate, and align with EP-INF-012 + Anthropic adaptive-model guidance.
+**Architecture:** The new files belong in `apps/web/lib/routing/` alongside the existing pipeline. `task-router.ts` is a lightweight `TaskRequirement`-contract router that wraps the existing `EndpointManifest` type system. `task-dispatcher.ts` calls the existing `callProvider` / `logTokenUsage` from `@/lib/ai-inference`.
+**Tech Stack:** TypeScript, Prisma (`@dpf/db`), Vitest, Next.js path aliases (`@/lib/...`)
+
+---
+
+## Bugs Fixed
+
+| File | Bug | Fix |
+|------|-----|-----|
+| root `types.ts` | `EndpointManifest` duplicates existing; `SensitivityLevel` from wrong package | Delete; re-export from `./types` |
+| root `task-requirements.ts` | Async function body embedded after `return` (dead code, TS error) | Collapse into single async function |
+| root `router.test.ts` | Duplicate `import` lines 4–5; `c.id` not on `CandidateTrace` | Remove line 4; fix to `c.endpointId` |
+| root `dispatcher.ts` | `logTokenUsage` wrong call signature; `selectedEndpointId` null violates schema | Fix both |
+| root `dispatcher.test.ts` | Mocks `"@/lib/db"` but module imports `"@dpf/db"` | Fix mock path |
+| root `seed.ts` | Uses raw `PrismaClient` outside workspace package | Move to `packages/db/prisma/`, use `@dpf/db` |
+| All root files | Wrong directory — `@/` aliases and `@dpf/db` don't resolve from repo root | Move to `apps/web/lib/routing/` |
+
+## Spec Gap Closed (EP-INF-012 + Anthropic Adaptive Guidance)
+
+- `minimumTier` field added to `TaskRequirement`; built-in requirements pre-populated.
+- Stage 0.5 tier gate in `task-router.ts` excludes endpoints below `minimumTier` before dimension scoring. This is the routing equivalent of the "thinking cap" — simple tasks never even see frontier-tier endpoints.
+- `qualityTier` added to `EndpointManifest` and mapped in `loader.ts`.
+- `CandidateTrace` now carries `providerId`+`modelId` so dispatcher avoids N+1 lookup.
+
+---
+
+### Task 1: Add `qualityTier` to `EndpointManifest` + loader
+
+**Files:**
+- Modify: `apps/web/lib/routing/types.ts` — add `qualityTier?: QualityTier`
+- Modify: `apps/web/lib/routing/loader.ts` — map `mp.qualityTier` into manifest
+
+- [ ] Add `import type { QualityTier } from "./quality-tiers"` to `types.ts`
+- [ ] Add `qualityTier?: QualityTier` to the `EndpointManifest` interface
+- [ ] In `loader.ts`, map `qualityTier: (mp.qualityTier as QualityTier | null) ?? undefined`
+- [ ] Commit: `feat(routing): add qualityTier to EndpointManifest`
+
+---
+
+### Task 2: Create `task-router-types.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-router-types.ts`
+
+- [ ] Re-export `EndpointManifest` from `./types` (no duplication)
+- [ ] Import `SensitivityLevel` from `./types`
+- [ ] Import `QualityTier` from `./quality-tiers`
+- [ ] Define `TaskRequirement` with `minimumTier?: QualityTier`
+- [ ] Define `PolicyRule` (condition as structured Record)
+- [ ] Define `CandidateTrace` with `providerId` + `modelId` fields
+- [ ] Define `TaskRouteDecision` (renamed to avoid collision with existing `RouteDecision`)
+
+---
+
+### Task 3: Create `task-requirements.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-requirements.ts`
+
+- [ ] Import `prisma` from `@dpf/db`
+- [ ] Import `QualityTier` from `./quality-tiers`; `TaskRequirement` from `./task-router-types`
+- [ ] Define `BUILT_IN_TASK_REQUIREMENTS` with `minimumTier` per task type:
+  - `greeting`, `status-query`, `summarization` → `adequate`
+  - `data-extraction`, `web-search`, `creative` → `strong`
+  - `reasoning`, `code-gen`, `tool-action` → `frontier`
+- [ ] Implement single `export async function getTaskRequirement(taskType)`: cache → DB → built-in
+- [ ] Commit: `feat(routing): task-requirements — async DB-first with tier awareness`
+
+---
+
+### Task 4: Create `task-requirements.test.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-requirements.test.ts`
+- Test: same file
+
+- [ ] Mock `@dpf/db` prisma
+- [ ] Test: built-in returns correct `minimumTier` for each tier level
+- [ ] Test: DB row takes precedence over built-in
+- [ ] Test: unknown taskType returns undefined
+- [ ] Test: result is cached on second call (prisma called once)
+
+---
+
+### Task 5: Create `task-router.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-router.ts`
+
+- [ ] Import `EndpointManifest`, `SensitivityLevel` from `./types`
+- [ ] Import `TIER_MINIMUM_DIMENSIONS`, `QualityTier` from `./quality-tiers`
+- [ ] Import `TaskRequirement`, `PolicyRule`, `CandidateTrace`, `TaskRouteDecision` from `./task-router-types`
+- [ ] Stage 0: policy filter (existing logic, correct)
+- [ ] Stage 0.5: tier gate — exclude endpoints whose `qualityTier` is below `minimumTier`
+- [ ] Stage 1: hard filter (status, retiredAt, sensitivityClearance, capabilities, context)
+- [ ] Stage 2: dimension scoring with `preferCheap` blend
+- [ ] Stage 3: rank (fitness → cost → failure rate → latency)
+- [ ] Stage 4: select + explain, return `TaskRouteDecision`
+
+---
+
+### Task 6: Create `task-router.test.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-router.test.ts`
+
+- [ ] Fix duplicate import (single import from `./task-router-types`)
+- [ ] Fix `c.id` → `c.endpointId` in tie-breaker test
+- [ ] Add tests for Stage 0.5 tier gate: endpoint below minimumTier is excluded
+
+---
+
+### Task 7: Create `task-dispatcher.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-dispatcher.ts`
+
+- [ ] Import `callProvider`, `logTokenUsage`, `InferenceError` from `@/lib/ai-inference`
+- [ ] Import `observe` from `@/lib/process-observer`
+- [ ] Import `prisma` from `@dpf/db`
+- [ ] Define `ProviderCallPayload` type matching `callProvider` args
+- [ ] Fix `callWithFallbackChain`: resolve `providerId`+`modelId` from `candidates` array
+- [ ] Fix `logTokenUsage` call: use `{agentId, providerId, contextKey, inputTokens, outputTokens, inferenceMs}`
+- [ ] Fix `persistDecision`: use `selectedCandidate.providerId` for DB lookup; use `""` not `null` for selectedEndpointId when all fail
+- [ ] Commit: `feat(routing): task-dispatcher — fixed imports and call signatures`
+
+---
+
+### Task 8: Create `task-dispatcher.test.ts`
+
+**Files:**
+- Create: `apps/web/lib/routing/task-dispatcher.test.ts`
+
+- [ ] Change mock path from `"@/lib/db"` → `"@dpf/db"`
+- [ ] Update mock `callProvider` signature to match actual args `(providerId, modelId, messages, systemPrompt)`
+- [ ] Verify all 5 test cases still pass as written
+
+---
+
+### Task 9: Move seed script
+
+**Files:**
+- Create: `packages/db/prisma/seed-task-requirements.ts`
+- Delete: `seed.ts` (root)
+
+- [ ] Change `import { PrismaClient } from "@prisma/client"` → `import { prisma } from "@dpf/db"`
+- [ ] Remove manual `prisma.$disconnect()` (managed by `@dpf/db`)
+- [ ] Keep identical upsert logic
+
+---
+
+### Task 10: Delete root-level files
+
+- [ ] `git rm` all 8 root files: `types.ts router.ts router.test.ts dispatcher.ts dispatcher.test.ts task-requirements.ts task-requirements.test.ts seed.ts`
+- [ ] Commit: `fix(routing): remove misplaced root-level files`
+
+---
+
+### Task 11: Open PR
+
+- [ ] `git push -u origin feat/fix-routing-agent-output`
+- [ ] `gh pr create` with summary of bugs fixed + spec additions

--- a/packages/db/prisma/seed-task-requirements.ts
+++ b/packages/db/prisma/seed-task-requirements.ts
@@ -1,0 +1,116 @@
+/**
+ * Seed script: built-in task requirement contracts.
+ *
+ * Run with:
+ *   pnpm --filter @dpf/db exec ts-node prisma/seed-task-requirements.ts
+ *
+ * The source of truth for BUILT_IN_TASK_REQUIREMENTS is
+ * apps/web/lib/routing/task-requirements.ts. This script duplicates the
+ * data to avoid cross-package imports in a standalone seed context.
+ * If you add a task type in task-requirements.ts, add it here too.
+ */
+
+import { prisma } from "@dpf/db";
+
+const BUILT_IN_TASK_REQUIREMENTS = [
+  {
+    taskType: "greeting",
+    description: "Simple conversational greeting or acknowledgement.",
+    selectionRationale: "Simple dialog — any capable model works.",
+    requiredCapabilities: {},
+    preferredMinScores: { conversational: 40 },
+    preferCheap: true,
+    origin: "system",
+  },
+  {
+    taskType: "status-query",
+    description: "Factual data lookup and status reporting.",
+    selectionRationale: "Data lookup — needs accuracy, not depth.",
+    requiredCapabilities: {},
+    preferredMinScores: { instructionFollowing: 40 },
+    preferCheap: true,
+    origin: "system",
+  },
+  {
+    taskType: "summarization",
+    description: "Summarizing a block of text.",
+    selectionRationale: "Needs to follow formatting instructions.",
+    requiredCapabilities: {},
+    preferredMinScores: { instructionFollowing: 50 },
+    preferCheap: true,
+    origin: "system",
+  },
+  {
+    taskType: "data-extraction",
+    description: "Extracting structured data (e.g., JSON) from unstructured text.",
+    selectionRationale: "Must produce valid structured output reliably.",
+    requiredCapabilities: { supportsStructuredOutput: true },
+    preferredMinScores: { structuredOutput: 70 },
+    preferCheap: true,
+    origin: "system",
+  },
+  {
+    taskType: "web-search",
+    description: "Using a search tool to answer a question.",
+    selectionRationale: "Must call search tools correctly.",
+    requiredCapabilities: { supportsToolUse: true },
+    preferredMinScores: { toolFidelity: 60 },
+    preferCheap: true,
+    origin: "system",
+  },
+  {
+    taskType: "creative",
+    description: "Creative writing, brainstorming, or open-ended ideation.",
+    selectionRationale: "Needs both creativity and coherence.",
+    requiredCapabilities: {},
+    preferredMinScores: { conversational: 60, reasoning: 50 },
+    preferCheap: false,
+    origin: "system",
+  },
+  {
+    taskType: "reasoning",
+    description: "Complex, multi-step analytical reasoning.",
+    selectionRationale: "Complex analysis needs strong reasoning — frontier only.",
+    requiredCapabilities: {},
+    preferredMinScores: { reasoning: 80 },
+    preferCheap: false,
+    origin: "system",
+  },
+  {
+    taskType: "code-gen",
+    description: "Generating or modifying source code.",
+    selectionRationale: "Code quality is critical — frontier only.",
+    requiredCapabilities: { supportsToolUse: true },
+    preferredMinScores: { codegen: 75, instructionFollowing: 60 },
+    preferCheap: false,
+    origin: "system",
+  },
+  {
+    taskType: "tool-action",
+    description: "Multi-step tool use with external APIs.",
+    selectionRationale: "Requires tool-calling fidelity — frontier only.",
+    requiredCapabilities: { supportsToolUse: true },
+    preferredMinScores: { toolFidelity: 70 },
+    preferCheap: false,
+    origin: "system",
+  },
+];
+
+async function main() {
+  console.log(`Seeding ${BUILT_IN_TASK_REQUIREMENTS.length} built-in task requirements...`);
+  for (const req of BUILT_IN_TASK_REQUIREMENTS) {
+    const { taskType, ...data } = req;
+    await prisma.taskRequirement.upsert({
+      where: { taskType },
+      update: data,
+      create: { taskType, ...data },
+    });
+    console.log(`  upserted: ${taskType}`);
+  }
+  console.log("Done.");
+}
+
+main().catch((e) => {
+  console.error("Seed failed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

A previous agent created 7 routing files at the repo root (`d:\DPF\`) where `@/` path aliases and `@dpf/db` workspace imports don't resolve. This PR fixes all bugs, moves the files to their correct location, and closes the EP-INF-012 quality-tier gap.

**Bugs fixed:**
- `task-requirements.ts` — async function body was dead code embedded after a `return` inside the sync function; collapsed into single async DB-first loader
- `router.test.ts` — duplicate import lines 4–5; `c.id` → `c.endpointId` (field doesn't exist on `CandidateTrace`)
- `dispatcher.ts` — `logTokenUsage` called with wrong positional args; `null selectedEndpointId` violates `NOT NULL` schema constraint (use `""` sentinel)
- `dispatcher.test.ts` — mocked `"@/lib/db"` but module imports from `"@dpf/db"` — mock never intercepted prisma
- `types.ts` — `SensitivityLevel` imported from `@dpf/db` (not exported there); `EndpointManifest` duplicated the existing routing type
- `seed.ts` — used raw `PrismaClient` outside workspace package; moved to `packages/db/prisma/`

**New (EP-INF-012 + Anthropic adaptive-model guidance):**
- `minimumTier` field on `TaskRequirement` — built-in contracts pre-populated (adequate/strong/frontier per task complexity)
- Stage 0.5 tier gate in `task-router.ts` — endpoints below `minimumTier` are excluded before dimension scoring. Simple tasks (`greeting`, `status-query`) never compete against frontier endpoints.
- `qualityTier` added to `EndpointManifest` interface and mapped in `loader.ts` from `ModelProfile.qualityTier`
- `CandidateTrace` now carries `providerId` + `modelId` so dispatcher calls `callProvider` correctly without a secondary DB lookup

## Test plan

- [ ] `pnpm --filter @dpf/web test apps/web/lib/routing/task-router.test.ts` — all stages pass
- [ ] `pnpm --filter @dpf/web test apps/web/lib/routing/task-dispatcher.test.ts` — all 5 cases pass
- [ ] `pnpm --filter @dpf/web test apps/web/lib/routing/task-requirements.test.ts` — tier assertions + DB-first behaviour pass
- [ ] Verify no `.ts` files remain at repo root (only `playwright*.config.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)