### PR TITLE
feat(inference): EP-INF-013 adaptive effort parameter — thinking cap integration

### DIFF
--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -94,6 +94,16 @@ export interface RouteAndCallOptions {
    * workflows where removing tools changes the task semantics.
    */
   requireTools?: boolean;
+  /**
+   * EP-INF-013: Reasoning effort hint for the selected model.
+   *   low    — no extended thinking; fast and cheap (default when omitted)
+   *   medium — moderate thinking budget (~8k tokens for Anthropic)
+   *   high   — extended thinking (~32k tokens; recommended for code-gen / Build Studio)
+   *   max    — maximum budget (~64k tokens; Opus-only)
+   * Translated per-provider: Anthropic → thinking.budget_tokens, OpenAI → reasoning_effort.
+   * Ignored by providers that do not support extended reasoning.
+   */
+  effort?: "low" | "medium" | "high" | "max";
 }
 
 // ─── Main function ──────────────────────────────────────────────────────────
@@ -159,6 +169,20 @@ export async function routeAndCall(
   // 3. V2 routing
   let decision = await routeEndpointV2(manifests, contract, policies, overrides);
   let toolsStripped = false;
+
+  // EP-INF-013: Inject effort into the execution plan so adapters can translate it
+  // to provider-specific parameters (Anthropic thinking, OpenAI reasoning_effort).
+  // Effort is injected here — after routing but before dispatch — so it flows
+  // through callWithFallbackChain into every adapter in the fallback chain.
+  if (options?.effort && decision.executionPlan) {
+    decision.executionPlan = {
+      ...decision.executionPlan,
+      providerSettings: {
+        ...decision.executionPlan.providerSettings,
+        effort: options.effort,
+      },
+    };
+  }
 
   // Graceful degradation: if all endpoints were excluded because they lack tool
   // support, retry without the tools requirement. The model can still converse —

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -81,12 +81,31 @@ export const chatAdapter: ExecutionAdapterHandler = {
           .map((m) => formatMessageForAnthropic(m)),
       };
 
-      // Apply thinking config
+      // EP-INF-013: Map effort → extended thinking for Anthropic.
+      // effort="low" (or absent) → no thinking parameter (default, fast).
+      // effort="medium/high/max" → enable thinking with a token budget.
+      // Explicit providerSettings.thinking takes precedence over effort.
+      const effortBudgets: Record<string, number> = { medium: 8_000, high: 32_000, max: 64_000 };
+      const effort = plan.providerSettings?.effort as string | undefined;
       if (plan.providerSettings?.thinking) {
+        // Explicit thinking config overrides effort
         (body as Record<string, unknown>).thinking = plan.providerSettings.thinking;
+        // Ensure max_tokens accommodates the explicitly set budget
+        const explicitBudget = (plan.providerSettings.thinking as { budget_tokens?: number }).budget_tokens ?? 0;
+        body.max_tokens = Math.max(plan.maxTokens, explicitBudget + 2_048);
+        // Anthropic rejects temperature when thinking is enabled
+        delete (body as Record<string, unknown>).temperature;
+      } else if (effort && effort !== "low" && effortBudgets[effort]) {
+        const budget = effortBudgets[effort]!;
+        (body as Record<string, unknown>).thinking = { type: "enabled", budget_tokens: budget };
+        // max_tokens must be >= budget_tokens; add 2 048 for output headroom
+        body.max_tokens = Math.max(plan.maxTokens, budget + 2_048);
+        // Anthropic rejects temperature when thinking is enabled
+        delete (body as Record<string, unknown>).temperature;
       }
-      // Apply temperature
-      if (plan.temperature !== undefined) {
+
+      // Apply temperature (only when thinking is NOT enabled — handled above)
+      if (plan.temperature !== undefined && !(body as Record<string, unknown>).thinking) {
         (body as Record<string, unknown>).temperature = plan.temperature;
       }
 
@@ -210,9 +229,15 @@ export const chatAdapter: ExecutionAdapterHandler = {
       if (plan.temperature !== undefined) {
         (body as Record<string, unknown>).temperature = plan.temperature;
       }
-      // Apply reasoning_effort
+      // Apply reasoning_effort (explicit setting takes precedence over effort)
+      // EP-INF-013: fall back to deriving from effort when not explicitly set.
+      // OpenAI o-series models support "low"/"medium"/"high"; max → "high".
       if (plan.providerSettings?.reasoning_effort) {
         (body as Record<string, unknown>).reasoning_effort = plan.providerSettings.reasoning_effort;
+      } else if (plan.providerSettings?.effort) {
+        const effortMap: Record<string, string> = { low: "low", medium: "medium", high: "high", max: "high" };
+        const mapped = effortMap[plan.providerSettings.effort as string];
+        if (mapped) (body as Record<string, unknown>).reasoning_effort = mapped;
       }
       // Apply tool_choice
       if (plan.toolPolicy?.toolChoice && tools && tools.length > 0) {

--- a/apps/web/lib/routing/responses-adapter.ts
+++ b/apps/web/lib/routing/responses-adapter.ts
@@ -158,8 +158,13 @@ export const responsesAdapter: ExecutionAdapterHandler = {
     if (plan.temperature !== undefined) {
       body.temperature = plan.temperature;
     }
+    // EP-INF-013: explicit reasoning_effort takes precedence; fall back to effort.
     if (typeof plan.providerSettings?.reasoning_effort === "string") {
       body.reasoning = { effort: plan.providerSettings.reasoning_effort };
+    } else if (typeof plan.providerSettings?.effort === "string" && plan.providerSettings.effort !== "low") {
+      const effortMap: Record<string, string> = { medium: "medium", high: "high", max: "high" };
+      const mapped = effortMap[plan.providerSettings.effort];
+      if (mapped) body.reasoning = { effort: mapped };
     }
     const responseTools = toResponsesTools(tools);
     if (responseTools) {

--- a/apps/web/lib/tak/agent-coworker-types.ts
+++ b/apps/web/lib/tak/agent-coworker-types.ts
@@ -63,6 +63,16 @@ export type AgentModelRequirements = {
   defaultMinimumTier?: "frontier" | "strong" | "adequate" | "basic";
   /** EP-INF-012: Default budget class (fallback when no DB config exists). */
   defaultBudgetClass?: "minimize_cost" | "balanced" | "quality_first";
+  /**
+   * EP-INF-013: Default reasoning effort for this agent.
+   * Maps to Anthropic thinking.budget_tokens and OpenAI reasoning_effort.
+   *   low    — no extended thinking; fast and cheap (COO, status agents)
+   *   medium — moderate thinking budget (data extraction, moderate reasoning)
+   *   high   — extended thinking (code-gen, multi-step tool use, Build Studio)
+   *   max    — maximum budget; Opus-only (reserved for future deep-reasoning agents)
+   * Omit to use the platform default (equivalent to "low").
+   */
+  defaultEffort?: "low" | "medium" | "high" | "max";
 };
 
 /** Entry in the route-to-agent map. */

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -272,6 +272,8 @@ ON THIS PAGE: The user sees the Build Studio with conversation panel, feature br
       defaultMinimumTier: "frontier",
       defaultBudgetClass: "quality_first",
       preferredProviderId: "codex",
+      // EP-INF-013: Multi-step code-gen needs extended thinking to reduce tool-loop failures
+      defaultEffort: "high" as const,
     },
   },
   "/admin": {
@@ -410,6 +412,8 @@ WHAT YOU DO NOT DO:
     modelRequirements: {
       defaultMinimumTier: "strong",
       defaultBudgetClass: "balanced",
+      // EP-INF-013: Routine oversight work — fast responses, no extended thinking needed
+      defaultEffort: "low" as const,
     },
   },
 };

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -346,6 +346,11 @@ export async function runAgenticLoop(params: {
         budgetClass: agentModelConfig.budgetClass as "minimize_cost" | "balanced" | "quality_first",
         preferredProviderId: agentModelConfig.pinnedProviderId ?? undefined,
         preferredModelId: agentModelConfig.pinnedModelId ?? undefined,
+        // EP-INF-013: defaultEffort not yet in AgentModelConfig schema (EP-INF-013b).
+        // Fall through to code-level default when DB row exists.
+        ...(modelRequirements && typeof modelRequirements === "object" && "defaultEffort" in modelRequirements
+          ? { effort: modelRequirements.defaultEffort as "low" | "medium" | "high" | "max" }
+          : {}),
       }
     : {
         // Fall back to code-level modelRequirements (defaultMinimumTier / legacy)
@@ -364,6 +369,10 @@ export async function runAgenticLoop(params: {
           : {}),
         ...(modelRequirements && typeof modelRequirements === "object" && "preferredModelId" in modelRequirements
           ? { preferredModelId: modelRequirements.preferredModelId as string }
+          : {}),
+        // EP-INF-013: Read defaultEffort from code-level modelRequirements
+        ...(modelRequirements && typeof modelRequirements === "object" && "defaultEffort" in modelRequirements
+          ? { effort: modelRequirements.defaultEffort as "low" | "medium" | "high" | "max" }
           : {}),
       };
 

--- a/docs/superpowers/specs/2026-04-06-ep-inf-013-effort-parameter-design.md
+++ b/docs/superpowers/specs/2026-04-06-ep-inf-013-effort-parameter-design.md
@@ -1,0 +1,121 @@
+# EP-INF-013: Adaptive Effort Parameter — Per-Request Thinking Control
+
+**Date:** 2026-04-06
+**Status:** Draft → Implementing
+**Author:** Mark Bodman (CEO) + Claude (design partner)
+**Epic ID:** EP-INF-013
+**IT4IT Alignment:** SS-2 Portfolio Management (resource governance), S2S Run IT (operational efficiency)
+
+**Predecessor specs:**
+- `2026-03-29-model-routing-simplification-design.md` — EP-INF-012 (tier system)
+- Anthropic adaptive-model guidance (April 2026) — effort levels, thinking cap behaviour
+
+---
+
+## Problem Statement
+
+The routing system now correctly gates which models are eligible (quality tier), but all calls to a given model use the same depth of reasoning. This produces two failure modes:
+
+1. **Over-spend on simple tasks.** A COO status-check invokes Claude Sonnet with no thinking budget constraint, consuming the same resources as a complex reasoning task. For subscription providers this has no marginal cost, but it affects latency and token quota.
+
+2. **Under-spend on complex tasks.** Build Studio's code-generation loop runs at the default inference depth. Extended thinking — which materially improves multi-step tool-calling accuracy — is never activated, even though the task warrants it.
+
+Anthropic's adaptive-model guidance introduces the `effort` control (`low` / `medium` / `high` / `max`) that maps to how much the model reasons before responding. This spec integrates that control into the platform without requiring any database migration.
+
+---
+
+## Goals
+
+1. Callers can pass `effort` on every `routeAndCall` invocation.
+2. Agents declare a `defaultEffort` alongside their tier and budget class.
+3. Anthropic providers translate `effort` → `thinking.budget_tokens`.
+4. OpenAI o-series providers translate `effort` → `reasoning_effort`.
+5. All other providers (Gemini, local, Responses API) degrade gracefully — they receive the `effort` hint and apply what they support, or ignore it.
+6. Backward compatibility: callers that pass no `effort` get the current behaviour (no thinking, equivalent to `low`).
+
+---
+
+## Non-Goals
+
+1. `AgentModelConfig.defaultEffort` DB field — deferred to EP-INF-013b. Admin UI override of effort is a next-sprint item.
+2. Dynamic mid-conversation effort escalation (`EscalationPolicy`) — separate epic once production data shows where it's needed.
+3. Automated benchmark comparison across effort levels — EP-INF-006.
+4. Cache-affinity routing (stay on same endpoint+effort for a session) — future enhancement.
+
+---
+
+## Design
+
+### Effort levels
+
+| Level | Anthropic thinking tokens | Anthropic max_tokens floor | OpenAI reasoning_effort | Intended use |
+|-------|--------------------------|---------------------------|------------------------|--------------|
+| `low`  | none (thinking disabled) | plan default              | `"low"`                | Greetings, status queries, COO oversight |
+| `medium` | 8 000                  | 10 048                    | `"medium"`             | Data extraction, moderate reasoning |
+| `high`  | 32 000                  | 34 048                    | `"high"`               | Code generation, multi-step tool use |
+| `max`   | 64 000                  | 66 048                    | `"high"` (capped)      | Build Studio deep reasoning, Opus-only |
+
+**Anthropic constraints when thinking is enabled:**
+- `max_tokens` must be ≥ `budget_tokens`. We set floor = budget + 2 048 for output headroom.
+- `temperature` must not be set (Anthropic returns 422 if it is). We strip it.
+- Supported on: Claude Sonnet 4, Haiku 4.5, Opus 4 (and all claude-3-7-sonnet+). Not on claude-3-haiku or claude-3-opus.
+
+### Integration point
+
+Effort flows through `providerSettings` on `RoutedExecutionPlan`, which already exists and is already read by both adapters. No new type fields on the plan are needed.
+
+```
+routeAndCall({ ..., effort: "high" })
+  → inject into decision.executionPlan.providerSettings.effort
+    → chat-adapter.ts (Anthropic branch):
+         effort=high → thinking.budget_tokens=32000, max_tokens=max(plan,34048)
+    → chat-adapter.ts (OpenAI branch):
+         effort=high → reasoning_effort="high"
+    → responses-adapter.ts:
+         effort=high → reasoning.effort="high"
+    → Gemini / local: providerSettings.effort ignored
+```
+
+### Agent defaults (code-level, no migration)
+
+| Agent | defaultEffort | Rationale |
+|-------|--------------|-----------|
+| `build-specialist` | `high` | Multi-step tool loops, code generation — max reasoning quality |
+| `coo` | `low` | Routine oversight, status summaries — fast and cheap |
+| All others | _(none — inherits `low` default)_ | Moderate tasks that don't need extended thinking |
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/lib/tak/agent-coworker-types.ts` | Add `defaultEffort` to `AgentModelRequirements` |
+| `apps/web/lib/tak/agent-routing.ts` | Set `defaultEffort` on `build-specialist` and `coo` |
+| `apps/web/lib/tak/agentic-loop.ts` | Read `defaultEffort` from code/DB config, include in `routeOptions` as `effort` |
+| `apps/web/lib/inference/routed-inference.ts` | Add `effort` to `RouteAndCallOptions`; inject into `executionPlan.providerSettings` |
+| `apps/web/lib/routing/chat-adapter.ts` | Map `providerSettings.effort` → Anthropic `thinking` + `max_tokens` floor; OpenAI `reasoning_effort` |
+| `apps/web/lib/routing/responses-adapter.ts` | Map `providerSettings.effort` → `reasoning.effort` (already handles `reasoning_effort` — add `effort` fallback) |
+
+---
+
+## What the subscription cost fix looks like
+
+The existing `preferCheap` blend in `task-router.ts` already handles subscription providers correctly:
+- Subscription endpoints report `costPerOutputMToken = 0`.
+- `costFactor = 1 - 0 / maxCost = 1.0` → maximum cost efficiency score.
+- When ALL endpoints are subscription (or free local), `maxCost = 0` and the blend is skipped entirely.
+
+No code change required. The math is sound. A comment is added to document this behaviour.
+
+---
+
+## Backlog items created
+
+| ID | Title | Priority |
+|----|-------|----------|
+| EP-INF-013-001 | Add effort param to RouteAndCallOptions + agentic-loop | 1 |
+| EP-INF-013-002 | Map effort → Anthropic thinking in chat-adapter | 2 |
+| EP-INF-013-003 | Map effort → reasoning_effort in OpenAI/Responses adapters | 3 |
+| EP-INF-013b-001 | Add defaultEffort to AgentModelConfig schema + admin UI | Next sprint |
+| EP-INF-013b-002 | Dynamic escalation policy on TaskRequirement | Deferred |


### PR DESCRIPTION
## Summary

Integrates Anthropic's adaptive-model guidance into the DPF inference stack. Agents can now declare how deeply the model should reason on a per-request basis, without a database migration.

**How it flows:**
```
agent-routing.ts  defaultEffort="high"
  → agentic-loop.ts  routeOptions.effort="high"
    → routeAndCall()  options.effort="high"
      → executionPlan.providerSettings.effort="high"
        → chat-adapter (Anthropic): thinking.budget_tokens=32000, max_tokens floor
        → chat-adapter (OpenAI):    reasoning_effort="high"
        → responses-adapter:        reasoning.effort="high"
        → Gemini / local:           ignored gracefully
```

**Agent defaults set:**
| Agent | defaultEffort | Why |
|-------|--------------|-----|
| `build-specialist` | `high` | Multi-step code-gen loops need extended thinking to reduce tool-loop failures |
| `coo` | `low` | Routine status/oversight — no extended thinking needed, fastest response |
| All others | _(none = low)_ | Backward-compatible default |

**Anthropic constraints handled:**
- `max_tokens` is floored at `budget_tokens + 2048` (Anthropic requires this)
- `temperature` is stripped when thinking is enabled (Anthropic returns 422 otherwise)
- `effort="low"` explicitly disables thinking (no budget_tokens sent)

**Backward compatible:** All callers that pass no `effort` get the current behaviour (no thinking). Existing explicit `providerSettings.thinking` and `providerSettings.reasoning_effort` take precedence over the derived `effort` value.

**Next sprint (EP-INF-013b):**
- Add `defaultEffort` to `AgentModelConfig` schema so admins can override per-agent
- Dynamic escalation policy on TaskRequirement

## Test plan

- [ ] Send a message to Build Studio (`/build`) and verify the Anthropic request includes `thinking.budget_tokens=32000`
- [ ] Send a status query to COO (`/workspace`) and verify no `thinking` field in request
- [ ] Pass `effort="medium"` explicitly to `routeAndCall()` in a unit test and verify `providerSettings.effort` is set on the plan
- [ ] Verify the OpenAI branch sets `reasoning_effort="high"` for o-series models when `effort="high"` is passed
- [ ] Verify the responses adapter sets `reasoning.effort="high"` when `effort="high"`
- [ ] Verify no regression in existing tests (temperature still applied when thinking is off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)