### PR TITLE
feat(build-studio): ideate phase conversational intent gate

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -96,8 +96,21 @@ const PHASE_PROMPTS: Record<string, string> = {
 
 ${PROJECT_CONTEXT}
 
-DO THIS NOW — no questions, no asking for clarification.
-Execute these steps IN ORDER. Do NOT skip steps. Do NOT save the design doc before completing steps 1-2.
+STEP 0 — INTENT GATE (do this FIRST, before any tools):
+  Ask yourself: do I have enough to design from?
+  You need at minimum: (a) what problem this solves or who uses it, AND (b) roughly what it does.
+
+  IF NOT ENOUGH — user gave a vague, exploratory, or one-line message:
+    Ask ONE clarifying question. Max 2 sentences. Do NOT call any tools yet.
+    Pick the question that unlocks the most: who uses it, what triggers it, or what success looks like.
+    Examples:
+      "Who uses this — internal staff, external customers, or both?"
+      "What triggers this — a user action or an automated/external event?"
+      "What does success look like — what can someone do after this that they can't do today?"
+    Wait for the answer before proceeding to Step 1.
+
+  IF ENOUGH — user gave context, answered your question, or said "just build it" / "make assumptions":
+    Skip to Step 1 immediately.
 
 STEP 1 — MANDATORY CODEBASE RESEARCH (do this FIRST, before anything else):
   a) Call search_project_files to find existing features similar to what the user wants.

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -14,7 +14,7 @@ YOUR JOB: Act, don't talk. Use your tools. Keep responses to 2-4 sentences.
 
 MANDATORY BEHAVIORS:
 - The user is ALWAYS talking about their current screen. Never ask "which page?" or "which component?"
-- DO NOT ASK CLARIFYING QUESTIONS. Make reasonable assumptions and act. If you're wrong, the user will correct you. Asking questions wastes time and frustrates users.
+- DO NOT ASK CLARIFYING QUESTIONS — except in Build Studio (/build ideate phase), where one clarifying question is allowed and expected before starting design research. Everywhere else: make reasonable assumptions and act. If you're wrong, the user will correct you.
 - When the user uploads a file: the file content appears in this conversation. READ IT. Never say "I can't see the file" — the data is right here.
 - When the user reports a problem: search the code yourself, then create a backlog item. Do NOT ask the user for technical details.
 - When the user asks you to build something: propose a design in 2-3 sentences and create a backlog item. Don't ask 5 rounds of questions first.

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -108,8 +108,12 @@ export function detectFabrication(
 // Pattern: response is a short clarifying question asking for a required field.
 // System prompt rule 13 allows ONE round of "I need X and Y" before acting.
 // Nudging these responses toward tools breaks legitimate HR / data-entry flows
-// (e.g. "What's the employee's last name?" after "add John as employee").
-const CLARIFYING_QUESTION_PATTERN = /^[^.!]*\?[\s]*$/;
+// (e.g. "What's the employee's last name?" after "add John as employee") and
+// ideate-phase conversational gates where the model asks one clarifying question
+// before starting research (e.g. "Happy to help. Who is the primary user?").
+// The old strict pattern required the entire response to be a bare question —
+// that rejected valid mixed responses. The new check: short + contains "?".
+const CLARIFYING_QUESTION_PATTERN = /\?/;
 
 export function shouldNudge(params: {
   continuationNudges: number;


### PR DESCRIPTION
## Summary
- Adds a Step 0 intent gate to the ideate phase prompt — vague prompts get one clarifying question before any tools fire
- Carves out `/build` ideate from the global "no clarifying questions" rule in PLATFORM_PREAMBLE
- Relaxes `shouldNudge()` pattern so mixed statement+question responses (e.g. "Happy to help. Who uses this?") correctly suppress tool-use nudge

## Problem
"Help me define this feature" was triggering the full 5-step research pipeline (300s of silent tool execution) instead of a quick clarifying question. Root cause: ideate prompt said `DO THIS NOW — no questions` and mandated 3+ tool calls before any response.

## Test plan
- [ ] Send "help me define this feature" in Build Studio — should get a clarifying question within a few seconds, no tool calls
- [ ] Send a detailed description ("I need X with roles A/B/C, triggered by Y") — should skip Step 0 and go straight to codebase research
- [ ] Answer a clarifying question — research pipeline should start automatically on the follow-up
- [ ] Say "just build it" — should bypass the gate and start research immediately

Spec: `docs/superpowers/specs/2026-04-06-ideate-conversational-gate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)