### PR TITLE
fix(ci): resolve three TypeScript errors from merged routing PRs

### DIFF
--- a/apps/web/lib/routing/task-dispatcher.ts
+++ b/apps/web/lib/routing/task-dispatcher.ts
@@ -13,8 +13,6 @@ import {
   InferenceError,
   type ChatMessage,
 } from "@/lib/ai-inference";
-import { observe } from "@/lib/process-observer";
-
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /** The payload passed to callProvider for each attempt. */
@@ -90,7 +88,7 @@ export async function callWithFallbackChain(
             : decision.reason,
       };
 
-      const decisionLog = await persistDecision(finalDecision, candidate, context, fallbacksUsed);
+      await persistDecision(finalDecision, candidate, context, fallbacksUsed);
 
       await logTokenUsage({
         agentId: context.agentId,
@@ -100,8 +98,6 @@ export async function callWithFallbackChain(
         outputTokens: result.outputTokens,
         inferenceMs: result.inferenceMs,
       });
-
-      observe("ai_call_succeeded", { decisionLogId: decisionLog.id });
 
       return result;
     } catch (error) {

--- a/apps/web/lib/routing/task-router.test.ts
+++ b/apps/web/lib/routing/task-router.test.ts
@@ -156,7 +156,7 @@ describe("routeTask — Stage 1: Hard Filter", () => {
 
   const endpoints = [
     makeEndpoint({ id: "ep-active",      name: "Active",               status: "active",   qualityTier: "frontier" }),
-    makeEndpoint({ id: "ep-inactive",    name: "Inactive",             status: "inactive", qualityTier: "frontier" }),
+    makeEndpoint({ id: "ep-inactive",    name: "Inactive",             status: "disabled", qualityTier: "frontier" }),
     makeEndpoint({ id: "ep-retired",     name: "Retired",              retiredAt: new Date(), qualityTier: "frontier" }),
     makeEndpoint({ id: "ep-noclearance", name: "No Clearance",         sensitivityClearance: ["internal"], qualityTier: "frontier" }),
     makeEndpoint({ id: "ep-notool",      name: "No Tool Support",      supportsToolUse: false, qualityTier: "frontier" }),

--- a/apps/web/tests/build-lifecycle.test.ts
+++ b/apps/web/tests/build-lifecycle.test.ts
@@ -122,9 +122,7 @@ describe("Build Studio full lifecycle", () => {
       // Clean up digital product if created
       const build = await prisma.featureBuild.findUnique({ where: { buildId: testBuildId }, select: { digitalProductId: true } });
       if (build?.digitalProductId) {
-        await prisma.backlogItem.deleteMany({ where: { epic: { digitalProductId: build.digitalProductId } } });
-        await prisma.epic.deleteMany({ where: { digitalProductId: build.digitalProductId } });
-        await prisma.promotion.deleteMany({ where: { digitalProductId: build.digitalProductId } });
+        await prisma.backlogItem.deleteMany({ where: { digitalProductId: build.digitalProductId } });
         await prisma.digitalProduct.delete({ where: { id: build.digitalProductId } }).catch(() => {});
       }
       await prisma.featureBuild.delete({ where: { buildId: testBuildId } });


### PR DESCRIPTION
## Summary

- **task-dispatcher.ts**: Remove `observe()` import and call — `@/lib/process-observer` does not export `observe` (exports `analyzeConversation`, `inferHumanScore`, etc.)
- **task-router.test.ts**: Change `status: "inactive"` → `status: "disabled"` — `"inactive"` is not a valid `EndpointManifest` status value
- **build-lifecycle.test.ts**: Fix `afterAll` cleanup — `Epic` model has no `digitalProductId` field, `prisma.promotion` doesn't exist (model is `ChangePromotion`); replaced with `backlogItem.deleteMany({ where: { digitalProductId: ... } })` which matches the actual schema

## Test plan
- [ ] CI TypeScript check passes on this PR
- [ ] `task-router.test.ts` still passes (disabled endpoint correctly excluded in hard filter stage)
- [ ] `build-lifecycle.test.ts` compiles and cleanup runs without schema errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)