### PR TITLE
fix(ci): fix prisma.promotion at line 295 in build-lifecycle test

### DIFF
--- a/apps/web/tests/build-lifecycle.test.ts
+++ b/apps/web/tests/build-lifecycle.test.ts
@@ -292,8 +292,8 @@ describe("Build Studio full lifecycle", () => {
       return;
     }
 
-    const promotion = await prisma.promotion.findFirst({
-      where: { digitalProductId: build.digitalProductId },
+    const promotion = await prisma.changePromotion.findFirst({
+      where: { productVersion: { digitalProductId: build.digitalProductId } },
       orderBy: { createdAt: "desc" },
       select: { id: true },
     });


### PR DESCRIPTION
## Summary

- `prisma.promotion` does not exist — the model is `changePromotion`
- `ChangePromotion` has no `digitalProductId` directly; must query through the nested `productVersion` relation
- This is the one instance that was pushed to the previous PR branch after it had already been merged

## Fix

```ts
// Before
const promotion = await prisma.promotion.findFirst({
  where: { digitalProductId: build.digitalProductId },
  ...
});

// After
const promotion = await prisma.changePromotion.findFirst({
  where: { productVersion: { digitalProductId: build.digitalProductId } },
  ...
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)