### PR TITLE
feat(setup): auto-fill business context + operating hours from URL im…

### DIFF
--- a/apps/web/app/(shell)/admin/business-context/page.tsx
+++ b/apps/web/app/(shell)/admin/business-context/page.tsx
@@ -1,11 +1,15 @@
 import { prisma } from "@dpf/db";
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { BusinessContextForm } from "@/components/admin/BusinessContextForm";
+import { getSetupContext } from "@/lib/actions/setup-progress";
 
 export default async function AdminBusinessContextPage() {
-  const org = await prisma.organization.findFirst({
-    select: { id: true, email: true, phone: true },
-  });
+  const [org, setupContext] = await Promise.all([
+    prisma.organization.findFirst({
+      select: { id: true, email: true, phone: true },
+    }),
+    getSetupContext(),
+  ]);
 
   const bc = org
     ? await prisma.businessContext.findUnique({
@@ -13,16 +17,32 @@ export default async function AdminBusinessContextPage() {
       })
     : null;
 
+  // Only apply suggestions during initial setup (no existing business context record)
+  const suggestions = !bc && setupContext ? {
+    industry: setupContext.suggestedIndustry ?? "",
+    description: setupContext.suggestedDescription ?? "",
+    contactEmail: setupContext.suggestedContactEmail ?? "",
+    contactPhone: setupContext.suggestedContactPhone ?? "",
+    geographicScope: setupContext.suggestedGeographicScope ?? null,
+  } : null;
+
   const initial = {
-    description: bc?.description ?? "",
+    description: bc?.description ?? suggestions?.description ?? "",
     targetMarket: bc?.targetMarket ?? "",
-    industry: bc?.industry ?? "",
+    industry: bc?.industry ?? suggestions?.industry ?? "",
     companySize: bc?.companySize ?? null,
-    geographicScope: bc?.geographicScope ?? null,
+    geographicScope: bc?.geographicScope ?? suggestions?.geographicScope ?? null,
     revenueModel: bc?.revenueModel ?? "",
-    contactEmail: org?.email ?? "",
-    contactPhone: org?.phone ?? "",
+    contactEmail: org?.email ?? suggestions?.contactEmail ?? "",
+    contactPhone: org?.phone ?? suggestions?.contactPhone ?? "",
   };
+
+  // Track which fields were auto-filled from URL import
+  const autoFilledFields = suggestions
+    ? Object.entries(suggestions)
+        .filter(([, v]) => v != null && v !== "")
+        .map(([k]) => k)
+    : [];
 
   return (
     <div>
@@ -36,7 +56,7 @@ export default async function AdminBusinessContextPage() {
       <AdminTabNav />
 
       <div className="mt-6">
-        <BusinessContextForm initial={initial} isEdit={!!bc} />
+        <BusinessContextForm initial={initial} isEdit={!!bc} autoFilledFields={autoFilledFields} />
       </div>
     </div>
   );

--- a/apps/web/app/(shell)/admin/operating-hours/page.tsx
+++ b/apps/web/app/(shell)/admin/operating-hours/page.tsx
@@ -2,13 +2,20 @@ import { getOperatingHours, saveOperatingHours } from "@/lib/actions/operating-h
 import { OperatingHoursEditor } from "@/components/admin/OperatingHoursEditor";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
+import { getSetupContext } from "@/lib/actions/setup-progress";
 
 export default async function OperatingHoursPage() {
   const session = await auth();
   if (!session?.user) redirect("/login");
 
+  const setupContext = await getSetupContext();
+
   // Smart defaults handled inside getOperatingHours (archetype > industry > fallback)
-  const { schedule, timezone } = await getOperatingHours();
+  // Pass suggested timezone and industry from URL import for better defaults during setup
+  const { schedule, timezone } = await getOperatingHours({
+    suggestedTimezone: setupContext?.suggestedTimezone,
+    suggestedIndustry: setupContext?.suggestedIndustry,
+  });
 
   async function handleSave(newSchedule: Parameters<typeof saveOperatingHours>[0]["schedule"]) {
     "use server";

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -46,16 +46,32 @@ type BusinessContextFormProps = {
   initial: BusinessContextData;
   /** When true, show the compact quick-edit layout (returning user). */
   isEdit?: boolean;
+  /** Fields that were auto-populated from URL import during setup. */
+  autoFilledFields?: string[];
 };
 
-export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProps) {
+function AutoFillHint({ field, editedFields }: { field: string; editedFields: Set<string> }) {
+  if (editedFields.has(field)) return null;
+  return (
+    <div style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 4, display: "flex", alignItems: "center", gap: 4 }}>
+      <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--dpf-accent)", opacity: 0.6, flexShrink: 0 }} />
+      Pre-filled from your website — edit if needed
+    </div>
+  );
+}
+
+export function BusinessContextForm({ initial, isEdit, autoFilledFields }: BusinessContextFormProps) {
   const [data, setData] = useState<BusinessContextData>(initial);
   const [submitting, setSubmitting] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [editedFields, setEditedFields] = useState<Set<string>>(new Set());
+
+  const hasAutoFill = (autoFilledFields?.length ?? 0) > 0;
 
   function update<K extends keyof BusinessContextData>(field: K, value: BusinessContextData[K]) {
     setData((prev) => ({ ...prev, [field]: value }));
+    setEditedFields((prev) => new Set(prev).add(field));
     setSaved(false);
   }
 
@@ -106,6 +122,18 @@ export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProp
         </>
       )}
 
+      {hasAutoFill && !isEdit && (
+        <div style={{
+          borderLeft: "4px solid var(--dpf-accent)",
+          paddingLeft: 12,
+          marginBottom: 16,
+          fontSize: 12,
+          color: "var(--dpf-muted)",
+        }}>
+          We pre-filled some fields from your website. Review and adjust anything that doesn&apos;t look right.
+        </div>
+      )}
+
       <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
         {/* Industry */}
         <label style={labelStyle}>
@@ -122,6 +150,7 @@ export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProp
               </option>
             ))}
           </select>
+          {autoFilledFields?.includes("industry") && <AutoFillHint field="industry" editedFields={editedFields} />}
         </label>
 
         {/* Description */}
@@ -137,6 +166,7 @@ export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProp
           <div style={hintStyle}>
             Your AI coworker uses this to understand your business when building features and providing guidance.
           </div>
+          {autoFilledFields?.includes("description") && <AutoFillHint field="description" editedFields={editedFields} />}
         </label>
 
         {/* Target market */}
@@ -206,6 +236,7 @@ export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProp
               </button>
             ))}
           </div>
+          {autoFilledFields?.includes("geographicScope") && <AutoFillHint field="geographicScope" editedFields={editedFields} />}
         </div>
 
         {/* Contact details */}
@@ -219,6 +250,7 @@ export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProp
               placeholder="info@example.com"
               style={inputStyle}
             />
+            {autoFilledFields?.includes("contactEmail") && <AutoFillHint field="contactEmail" editedFields={editedFields} />}
           </label>
           <label style={labelStyle}>
             <div style={fieldLabelStyle}>Contact phone</div>
@@ -229,6 +261,7 @@ export function BusinessContextForm({ initial, isEdit }: BusinessContextFormProp
               placeholder="+1 555 000 0000"
               style={inputStyle}
             />
+            {autoFilledFields?.includes("contactPhone") && <AutoFillHint field="contactPhone" editedFields={editedFields} />}
           </label>
         </div>
 

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -65,6 +65,9 @@ type Props = {
   pendingAutoMessage?: string | null;
   onAutoMessageConsumed?: () => void;
   onConversationCleared?: () => void;
+  /** When set, overrides pathname for agent routing and message routeContext.
+   *  Used during setup so all steps route to the onboarding-coo agent. */
+  routeContextOverride?: string;
 };
 
 function filterMessages(messages: AgentMessageRow[]): AgentMessageRow[] {
@@ -91,8 +94,11 @@ export function AgentCoworkerPanel({
   pendingAutoMessage,
   onAutoMessageConsumed,
   onConversationCleared,
+  routeContextOverride,
 }: Props) {
   const pathname = usePathname();
+  // During setup, use the override so the onboarding-coo agent handles all steps
+  const effectiveRoute = routeContextOverride ?? pathname;
   const [messages, setMessages] = useState<AgentRenderableMessage[]>(() => filterMessages(initialMessages));
   // EP-ASYNC-COWORKER-001: isBusy replaces useTransition's isPending for message flow.
   // This is a plain useState — it does NOT block the Next.js router or prevent navigation.
@@ -113,7 +119,7 @@ export function AgentCoworkerPanel({
   const [marketingSkillRules, setMarketingSkillRules] = useState<Record<string, { visible?: boolean; label?: string; reframe?: string }> | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const routeAgent: AgentInfo = resolveAgentForRouteSync(pathname, userContext);
+  const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
   const agent = routeAgent;
   const canUseDev = userContext.isSuperuser || userContext.platformRole === "HR-000" || userContext.platformRole === "HR-300";
   const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
@@ -204,7 +210,7 @@ export function AgentCoworkerPanel({
             role: "system" as const,
             content: data.message ?? "An error occurred during agent execution.",
             agentId: agent.agentId,
-            routeContext: pathname,
+            routeContext: effectiveRoute,
             createdAt: new Date().toISOString(),
           }]);
         }
@@ -224,7 +230,7 @@ export function AgentCoworkerPanel({
           }
 
           // Refresh messages from DB — authoritative source
-          getOrCreateThreadSnapshot({ routeContext: pathname }).then((snapshot) => {
+          getOrCreateThreadSnapshot({ routeContext: effectiveRoute }).then((snapshot) => {
             if (snapshot) {
               setMessages(filterMessages(snapshot.messages));
             }
@@ -258,7 +264,7 @@ export function AgentCoworkerPanel({
     // Periodic recovery: check DB every 15 seconds while busy.
     // Catches missed SSE "done" events (connection drops, server restart, etc.)
     const recoveryInterval = setInterval(() => {
-      getOrCreateThreadSnapshot({ routeContext: pathname }).then((snapshot) => {
+      getOrCreateThreadSnapshot({ routeContext: effectiveRoute }).then((snapshot) => {
         if (!snapshot) return;
         const latestMsg = snapshot.messages[snapshot.messages.length - 1];
         if (latestMsg && (latestMsg.role === "assistant" || latestMsg.role === "system")) {
@@ -356,7 +362,7 @@ export function AgentCoworkerPanel({
 
   function submitMessage(
     content: string,
-    optimisticMessage = createOptimisticUserMessage(content, pathname),
+    optimisticMessage = createOptimisticUserMessage(content, effectiveRoute),
     appendOptimistic = true,
   ) {
     if (!threadId) return;
@@ -381,7 +387,7 @@ export function AgentCoworkerPanel({
       body: JSON.stringify({
         threadId,
         content,
-        routeContext: pathname,
+        routeContext: effectiveRoute,
         coworkerMode: devMode || pathname.startsWith("/build") ? "act" : coworkerMode,
         externalAccessEnabled: devMode || coworkerMode === "act" ? true : externalAccessEnabled,
         elevatedFormFillEnabled: elevatedAssistEnabled,

--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -85,6 +85,22 @@ export function AgentCoworkerShell({ userContext }: Props) {
     return () => window.removeEventListener("resize", handleResize);
   }, [userKey]);
 
+  // Detect setup overlay — when active, all messages route to onboarding-coo
+  // via the "/setup" route context instead of the actual pathname.
+  const [isSetupActive, setIsSetupActive] = useState(false);
+  useEffect(() => {
+    function check() {
+      setIsSetupActive(document.documentElement.hasAttribute("data-setup-active"));
+    }
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-setup-active"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
   // Track active build ID from Build Studio — each build gets its own thread
   const [activeBuildId, setActiveBuildId] = useState<string | null>(null);
   useEffect(() => {
@@ -97,9 +113,13 @@ export function AgentCoworkerShell({ userContext }: Props) {
 
   // Thread-per-build: when on /build with an active build, scope the thread to that build.
   // This prevents 30+ messages from prior builds polluting the context (saves ~15K tokens/call).
-  const threadContext = activeBuildId && pathname === "/build"
-    ? `${pathname}#${activeBuildId}`
-    : pathname;
+  // Setup override: all setup steps share the "/setup" thread so the onboarding COO
+  // maintains context across steps (branding → business context → platform dev → etc.)
+  const threadContext = isSetupActive
+    ? "/setup"
+    : activeBuildId && pathname === "/build"
+      ? `${pathname}#${activeBuildId}`
+      : pathname;
 
   useEffect(() => {
     let active = true;
@@ -272,6 +292,7 @@ export function AgentCoworkerShell({ userContext }: Props) {
             pendingAutoMessage={pendingAutoMessage}
             onAutoMessageConsumed={() => setPendingAutoMessage(null)}
             onConversationCleared={() => setInitialMessages([])}
+            routeContextOverride={isSetupActive ? "/setup" : undefined}
           />
           <div
             onMouseDown={handleResizeStart}

--- a/apps/web/components/setup/SetupOverlay.tsx
+++ b/apps/web/components/setup/SetupOverlay.tsx
@@ -18,15 +18,17 @@ import { advanceStep, skipStep, pauseSetup, completeSetup } from "@/lib/actions/
 function buildStepTrigger(step: string, ctx: Record<string, string>): string {
   const org = ctx.orgName ? `Organisation: ${ctx.orgName}` : "Organisation: not yet entered";
   const archetype = ctx.suggestedArchetypeName ? `Business type: ${ctx.suggestedArchetypeName}` : "";
-  const industry = ctx.industry ? `Industry: ${ctx.industry}` : "";
+  const industry = ctx.industry || ctx.suggestedIndustry ? `Industry: ${ctx.industry || ctx.suggestedIndustry}` : "";
+  const country = ctx.suggestedCountryCode ? `Country: ${ctx.suggestedCountryCode}` : "";
+  const timezone = ctx.suggestedTimezone ? `Timezone: ${ctx.suggestedTimezone}` : "";
 
-  const contextLine = [org, archetype, industry].filter(Boolean).join(" | ");
+  const contextLine = [org, archetype, industry, country, timezone].filter(Boolean).join(" | ");
 
   const stepLabels: Record<string, string> = {
     "ai-providers": "AI Providers — configure inference engines",
     "branding": "Branding — logo, colours, tagline",
     "business-context": "Your Business — describe what you do and who you serve",
-    "operating-hours": "Operating Hours — when your business is open",
+    "operating-hours": "Operating Hours — when your business is open, and in what timezone",
     "storefront": "Storefront — customer-facing portal",
     "platform-development": "Platform Development — contribution and governance mode",
     "build-studio": "Build Studio — custom feature development",
@@ -34,6 +36,19 @@ function buildStepTrigger(step: string, ctx: Record<string, string>): string {
   };
 
   const label = stepLabels[step] ?? step;
+
+  // Build Studio is a preview-only step during setup — the user will come back
+  // to actually build features after the wizard completes.
+  if (step === "build-studio") {
+    return `[Setup step: ${label}]\n${contextLine}\n\nThis is a preview step. Introduce Build Studio briefly — explain what it does (self-development: the platform can build new features for itself) and that the user will return here after setup is complete to create their first feature. Do NOT ask the user to build anything now. Keep it to 2-3 sentences.`;
+  }
+
+  // Workspace is the final step — welcome the user and orient them, but do NOT
+  // create epics, backlog items, or start building anything.
+  if (step === "workspace") {
+    return `[Setup step: ${label}]\n${contextLine}\n\nThis is the final setup step. Welcome the user to their workspace. Briefly explain that this is where they will manage day-to-day operations — viewing their backlog, talking to coworkers, and monitoring work. Congratulate them on completing setup. Do NOT create any epics, backlog items, or guardrails. Do NOT start building or decomposing anything. Keep it to 2-3 sentences.`;
+  }
+
   return `[Setup step: ${label}]\n${contextLine}\n\nGuide me through this step.`;
 }
 

--- a/apps/web/lib/actions/branding.ts
+++ b/apps/web/lib/actions/branding.ts
@@ -6,6 +6,8 @@ import { deriveThemeTokens, validateTokenContrast, type Correction, type ThemeTo
 import {
   fetchPublicWebsiteEvidence,
   analyzePublicWebsiteBranding,
+  ARCHETYPE_TO_INDUSTRY,
+  COUNTRY_TO_TIMEZONE,
   type BrandingAnalysisResult,
 } from "@/lib/public-web-tools";
 import { updateSetupContext } from "@/lib/actions/setup-progress";
@@ -181,6 +183,9 @@ export type BrandImportResult = {
   archetypeConfidence: "high" | "medium" | null;
   suggestedCurrency: string | null;
   suggestedCountryCode: string | null;
+  suggestedDescription: string | null;
+  suggestedContactEmail: string | null;
+  suggestedContactPhone: string | null;
 } | {
   ok: false;
   error: string;
@@ -222,6 +227,14 @@ export async function importBrandFromUrl(url: string): Promise<BrandImportResult
       logoForDarkBg = logoForLightBg;
     }
 
+    // Derive industry from archetype and timezone from country
+    const suggestedIndustry = analysis.suggestedArchetypeId
+      ? ARCHETYPE_TO_INDUSTRY[analysis.suggestedArchetypeId] ?? null
+      : null;
+    const suggestedTimezone = analysis.suggestedCountryCode
+      ? COUNTRY_TO_TIMEZONE[analysis.suggestedCountryCode] ?? null
+      : null;
+
     // Write suggestions to the active setup progress context (fire-and-forget, no throw on error)
     const contextPatch: Record<string, string> = {};
     if (analysis.companyName) contextPatch.suggestedCompanyName = analysis.companyName;
@@ -230,6 +243,13 @@ export async function importBrandFromUrl(url: string): Promise<BrandImportResult
     if (analysis.archetypeConfidence) contextPatch.archetypeConfidence = analysis.archetypeConfidence;
     if (analysis.suggestedCurrency) contextPatch.suggestedCurrency = analysis.suggestedCurrency;
     if (analysis.suggestedCountryCode) contextPatch.suggestedCountryCode = analysis.suggestedCountryCode;
+    if (suggestedIndustry) contextPatch.suggestedIndustry = suggestedIndustry;
+    if (analysis.suggestedDescription) contextPatch.suggestedDescription = analysis.suggestedDescription;
+    if (analysis.suggestedContactEmail) contextPatch.suggestedContactEmail = analysis.suggestedContactEmail;
+    if (analysis.suggestedContactPhone) contextPatch.suggestedContactPhone = analysis.suggestedContactPhone;
+    if (suggestedTimezone) contextPatch.suggestedTimezone = suggestedTimezone;
+    // Most SMBs on this platform are local businesses
+    if (analysis.suggestedCountryCode) contextPatch.suggestedGeographicScope = "local";
     contextPatch.brandingSourceUrl = url;
     await updateSetupContext(contextPatch).catch(() => undefined);
 
@@ -244,6 +264,9 @@ export async function importBrandFromUrl(url: string): Promise<BrandImportResult
       archetypeConfidence: analysis.archetypeConfidence,
       suggestedCurrency: analysis.suggestedCurrency,
       suggestedCountryCode: analysis.suggestedCountryCode,
+      suggestedDescription: analysis.suggestedDescription,
+      suggestedContactEmail: analysis.suggestedContactEmail,
+      suggestedContactPhone: analysis.suggestedContactPhone,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to analyze URL";

--- a/apps/web/lib/actions/operating-hours.ts
+++ b/apps/web/lib/actions/operating-hours.ts
@@ -160,7 +160,10 @@ function deriveDeploymentWindows(
 
 // ─── getOperatingHours ───────────────────────────────────────────────────
 
-export async function getOperatingHours(): Promise<{
+export async function getOperatingHours(opts?: {
+  suggestedTimezone?: string;
+  suggestedIndustry?: string;
+}): Promise<{
   schedule: WeeklySchedule;
   timezone: string;
   isConfirmed: boolean;
@@ -172,12 +175,17 @@ export async function getOperatingHours(): Promise<{
     select: { businessHours: true, timezone: true, hoursConfirmedAt: true },
   });
 
+  // Resolve timezone: confirmed profile > suggested from URL import > UTC fallback
+  const resolvedTimezone = profile?.timezone && profile.timezone !== "UTC"
+    ? profile.timezone
+    : opts?.suggestedTimezone ?? profile?.timezone ?? "UTC";
+
   // Priority 1: Existing confirmed hours
   if (profile?.hoursConfirmedAt) {
     const businessHours = profile.businessHours as Record<string, { open: string; close: string } | null>;
     return {
       schedule: profileHoursToSchedule(businessHours),
-      timezone: profile.timezone,
+      timezone: resolvedTimezone,
       isConfirmed: true,
     };
   }
@@ -186,11 +194,14 @@ export async function getOperatingHours(): Promise<{
   const config = await prisma.storefrontConfig.findFirst({
     select: { archetypeId: true },
   });
-  if (config?.archetypeId) {
-    const category = config.archetypeId.split("/")[0];
+  const archetypeCategory = config?.archetypeId?.split("/")[0];
+  // Use storefront archetype if available, otherwise fall back to suggested industry from URL
+  const categoryForDefaults = archetypeCategory ?? opts?.suggestedIndustry;
+
+  if (categoryForDefaults) {
     return {
-      schedule: await getDefaultHoursForArchetype(category),
-      timezone: profile?.timezone ?? "UTC",
+      schedule: await getDefaultHoursForArchetype(categoryForDefaults),
+      timezone: resolvedTimezone,
       isConfirmed: false,
     };
   }
@@ -198,7 +209,7 @@ export async function getOperatingHours(): Promise<{
   // Priority 4: Generic fallback
   return {
     schedule: { ...GENERIC_DEFAULTS },
-    timezone: profile?.timezone ?? "UTC",
+    timezone: resolvedTimezone,
     isConfirmed: false,
   };
 }

--- a/apps/web/lib/actions/setup-constants.ts
+++ b/apps/web/lib/actions/setup-constants.ts
@@ -55,4 +55,11 @@ export type SetupContext = {
   suggestedCurrency?: string;
   suggestedCountryCode?: string;
   brandingSourceUrl?: string;
+  // Populated by importBrandFromUrl — derived from archetype + page scrape
+  suggestedIndustry?: string;
+  suggestedDescription?: string;
+  suggestedContactEmail?: string;
+  suggestedContactPhone?: string;
+  suggestedGeographicScope?: string;
+  suggestedTimezone?: string;
 };

--- a/apps/web/lib/public-web-tools.test.ts
+++ b/apps/web/lib/public-web-tools.test.ts
@@ -17,6 +17,8 @@ function makeEvidence(overrides: Partial<PublicWebsiteEvidence> = {}): PublicWeb
     themeColor: null,
     logoCandidates: [],
     colorCandidates: [],
+    contactEmailCandidates: [],
+    contactPhoneCandidates: [],
     ...overrides,
   };
 }
@@ -57,7 +59,7 @@ describe("public web tools", () => {
   });
 
   it("derives a branding proposal from fetched public page evidence", () => {
-    const proposal = analyzePublicWebsiteBranding({
+    const proposal = analyzePublicWebsiteBranding(makeEvidence({
       url: "https://jackjackspack.org",
       finalUrl: "https://jackjackspack.org/",
       title: "Jack Jack's Pack",
@@ -68,7 +70,7 @@ describe("public web tools", () => {
         "https://jackjackspack.org/logo.svg",
       ],
       colorCandidates: ["#4f46e5"],
-    });
+    }));
 
     expect(proposal.companyName).toBe("Jack Jack's Pack");
     expect(proposal.logoUrl).toBe("https://jackjackspack.org/logo.svg");

--- a/apps/web/lib/public-web-tools.ts
+++ b/apps/web/lib/public-web-tools.ts
@@ -23,6 +23,8 @@ export type PublicWebsiteEvidence = {
   themeColor: string | null;
   logoCandidates: string[];
   colorCandidates: string[];
+  contactEmailCandidates: string[];
+  contactPhoneCandidates: string[];
 };
 
 export type BrandingAnalysisResult = {
@@ -35,6 +37,9 @@ export type BrandingAnalysisResult = {
   archetypeConfidence: "high" | "medium" | null;
   suggestedCountryCode: string | null;
   suggestedCurrency: string | null;
+  suggestedDescription: string | null;
+  suggestedContactEmail: string | null;
+  suggestedContactPhone: string | null;
 };
 
 const PRIVATE_HOST_PATTERNS = [
@@ -262,6 +267,77 @@ export async function searchPublicWeb(query: string): Promise<NormalizedSearchRe
   return normalizeBraveSearchResults(raw);
 }
 
+const SYSTEM_EMAIL_PATTERNS = /^(noreply|no-reply|donotreply|do-not-reply|webmaster|postmaster|mailer-daemon|hostmaster|abuse)@/i;
+
+/** Extract contact email addresses from HTML — mailto: links first, then visible text. */
+function extractContactEmails(html: string): string[] {
+  const seen = new Set<string>();
+  const priority: string[] = [];
+  const secondary: string[] = [];
+
+  function add(email: string, isPriority: boolean) {
+    const lower = email.toLowerCase().trim();
+    if (!lower || seen.has(lower) || SYSTEM_EMAIL_PATTERNS.test(lower)) return;
+    seen.add(lower);
+    (isPriority ? priority : secondary).push(lower);
+  }
+
+  // 1. mailto: links (highest confidence — explicitly published as contact)
+  const mailtoMatches = html.matchAll(/<a[^>]+href=["']mailto:([^"'?]+)/gi);
+  for (const m of mailtoMatches) {
+    if (m[1]) add(m[1], true);
+  }
+
+  // 2. Visible text email patterns (strip tags first)
+  const stripped = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ");
+  const textMatches = stripped.matchAll(/\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Z]{2,}\b/gi);
+  for (const m of textMatches) {
+    add(m[0], false);
+  }
+
+  return [...priority, ...secondary].slice(0, 3);
+}
+
+/** Extract contact phone numbers from HTML — tel: links first, then visible text patterns. */
+function extractContactPhones(html: string): string[] {
+  const seen = new Set<string>();
+  const priority: string[] = [];
+  const secondary: string[] = [];
+
+  function normalizePhone(raw: string): string {
+    return raw.replace(/[\s\-().]/g, "").replace(/^tel:/i, "");
+  }
+
+  function add(phone: string, isPriority: boolean) {
+    const normalized = normalizePhone(phone);
+    if (!normalized || normalized.length < 7 || seen.has(normalized)) return;
+    seen.add(normalized);
+    // Store the original (human-readable) form
+    (isPriority ? priority : secondary).push(phone.trim());
+  }
+
+  // 1. tel: links (highest confidence — explicitly clickable)
+  const telMatches = html.matchAll(/<a[^>]+href=["']tel:([^"']+)/gi);
+  for (const m of telMatches) {
+    if (m[1]) add(m[1], true);
+  }
+
+  // 2. Visible text phone patterns (reuse PHONE_PATTERNS for extraction)
+  const stripped = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ");
+  for (const { pattern } of PHONE_PATTERNS) {
+    const match = stripped.match(pattern);
+    if (match?.[0]) add(match[0], false);
+  }
+
+  return [...priority, ...secondary].slice(0, 3);
+}
+
 const FETCH_HEADERS = {
   "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
@@ -311,6 +387,8 @@ export async function fetchPublicWebsiteEvidence(url: string): Promise<PublicWeb
     themeColor: extractMetaContent(html, "theme-color"),
     logoCandidates: extractLogoCandidates(html, finalUrl),
     colorCandidates: extractColorCandidates(html),
+    contactEmailCandidates: extractContactEmails(html),
+    contactPhoneCandidates: extractContactPhones(html),
   };
 }
 
@@ -578,6 +656,82 @@ function detectCountryAndCurrency(
   return null;
 }
 
+/** Maps detected archetype ID → industry dropdown value used in BusinessContextForm. */
+export const ARCHETYPE_TO_INDUSTRY: Record<string, string> = {
+  "dental-practice": "healthcare-wellness",
+  "optician": "healthcare-wellness",
+  "physiotherapy-clinic": "healthcare-wellness",
+  "gp-surgery": "healthcare-wellness",
+  "pharmacy": "healthcare-wellness",
+  "hair-salon": "beauty-personal-care",
+  "beauty-salon": "beauty-personal-care",
+  "tattoo-studio": "beauty-personal-care",
+  "fitness-gym": "fitness-recreation",
+  "yoga-pilates-studio": "fitness-recreation",
+  "restaurant": "food-hospitality",
+  "cafe-coffeeshop": "food-hospitality",
+  "bakery": "food-hospitality",
+  "bar-pub": "food-hospitality",
+  "fast-food": "food-hospitality",
+  "hotel": "food-hospitality",
+  "holiday-lettings": "food-hospitality",
+  "estate-agent": "hoa-property-management",
+  "law-firm": "professional-services",
+  "accountancy-firm": "professional-services",
+  "financial-adviser": "professional-services",
+  "mortgage-broker": "professional-services",
+  "insurance-broker": "professional-services",
+  "recruitment-agency": "professional-services",
+  "marketing-agency": "professional-services",
+  "web-design-agency": "professional-services",
+  "it-managed-services": "professional-services",
+  "consulting-firm": "professional-services",
+  "architecture-firm": "professional-services",
+  "interior-design": "professional-services",
+  "photography-studio": "professional-services",
+  "events-venue": "professional-services",
+  "childcare-nursery": "education-training",
+  "tutoring-centre": "education-training",
+  "retail-fashion": "retail-goods",
+  "retail-homeware": "retail-goods",
+  "ecommerce-general": "retail-goods",
+  "nonprofit": "nonprofit-community",
+};
+
+/** Maps ISO 3166-1 alpha-2 country code → primary IANA timezone. */
+export const COUNTRY_TO_TIMEZONE: Record<string, string> = {
+  GB: "Europe/London",
+  IE: "Europe/Dublin",
+  DE: "Europe/Berlin",
+  FR: "Europe/Paris",
+  ES: "Europe/Madrid",
+  IT: "Europe/Rome",
+  NL: "Europe/Amsterdam",
+  BE: "Europe/Brussels",
+  AT: "Europe/Vienna",
+  PT: "Europe/Lisbon",
+  CH: "Europe/Zurich",
+  SE: "Europe/Stockholm",
+  NO: "Europe/Oslo",
+  DK: "Europe/Copenhagen",
+  FI: "Europe/Helsinki",
+  PL: "Europe/Warsaw",
+  CZ: "Europe/Prague",
+  AU: "Australia/Sydney",
+  NZ: "Pacific/Auckland",
+  CA: "America/Toronto",
+  US: "America/New_York",
+  JP: "Asia/Tokyo",
+  CN: "Asia/Shanghai",
+  IN: "Asia/Kolkata",
+  SG: "Asia/Singapore",
+  ZA: "Africa/Johannesburg",
+  AE: "Asia/Dubai",
+  BR: "America/Sao_Paulo",
+  MX: "America/Mexico_City",
+  EU: "Europe/Brussels",
+};
+
 export function analyzePublicWebsiteBranding(
   evidence: PublicWebsiteEvidence,
 ): BrandingAnalysisResult {
@@ -612,5 +766,8 @@ export function analyzePublicWebsiteBranding(
     archetypeConfidence: archetypeMatch?.confidence ?? null,
     suggestedCountryCode: locationMatch?.countryCode ?? null,
     suggestedCurrency: locationMatch?.currency ?? null,
+    suggestedDescription: evidence.description ?? null,
+    suggestedContactEmail: evidence.contactEmailCandidates[0] ?? null,
+    suggestedContactPhone: evidence.contactPhoneCandidates[0] ?? null,
   };
 }

--- a/prompts/route-persona/onboarding-coo.prompt.md
+++ b/prompts/route-persona/onboarding-coo.prompt.md
@@ -49,7 +49,9 @@ Quick step. Ask whether they have fixed hours or whether it varies by service or
 Ask if they serve customers directly (and need a customer-facing portal) or if this platform is internal-only. If internal-only, skip is fine.
 
 **platform-development**
-Keep simple. Ask if they expect to customise the platform themselves, or use it as delivered. Their answer guides which contribution mode makes sense.
+This page controls how features built in Build Studio are governed — kept private, or shared with the community.
+There are three modes: "Keep everything here" (private, with optional git backup), "Share selectively" (asked each time), and "Share everything" (shared by default, can opt out per feature). Sharing modes require a short, plain-language contributor agreement (not a legal contract).
+Ask one question: "Do you plan to build custom features, or use the platform as delivered?" If as delivered, recommend "Keep everything here" — they can change it later. If they want to build, ask whether they'd like to share what they create. Guide them to the right mode from there. Do not list all three options upfront.
 
 **build-studio**
 This is a "what if" moment. Give one concrete example of something Build Studio could build for their specific business type. Then explain they can try it now or explore later.
@@ -66,3 +68,5 @@ Final step. Congratulate them by name. Explain Hands Off / Hands On in one sente
 5. Do not list all available options. Pick the most relevant one for their context.
 6. End every initial step greeting with exactly one question.
 7. When the user responds, acknowledge what they said specifically before continuing.
+8. Never assume emotions. Do not say "I understand your frustration" or similar — the user is simply going through setup.
+9. If you lack information about a step, guide the user based on what the page shows. Do not pivot to unrelated queries (listing departments, querying ontology). Stay on-task.

--- a/skills/admin/setup-platform-development.skill.md
+++ b/skills/admin/setup-platform-development.skill.md
@@ -1,0 +1,71 @@
+---
+name: setup-platform-development
+description: "Help set up the platform development policy — contribution mode, governance, and sharing"
+category: admin
+assignTo: ["onboarding-coo"]
+capability: "manage_platform_config"
+taskType: "conversation"
+triggerPattern: "platform development|contribution|governance|sharing|fork|contribute"
+userInvocable: true
+agentInvocable: true
+allowedTools: []
+composesFrom: []
+contextRequirements: []
+riskBand: low
+---
+
+# Set Up Platform Development Policy
+
+Guide the user through choosing how their platform handles features built in Build Studio.
+
+## What This Page Does
+
+This page controls how features move from the shared development workspace into production, and whether finished features are shared back with the community of platform users.
+
+The user sees three radio buttons (contribution modes) and, for sharing modes, a short setup wizard.
+
+## The Three Modes
+
+### Keep everything here (fork_only)
+- Features stay on this install only. Nothing leaves.
+- Optional: the user can add a git repository URL and access token for backup.
+- Best for: organisations that want total privacy, or are just getting started and want to decide later.
+- No further steps needed — just save.
+
+### Share selectively (selective)
+- After Build Studio finishes a feature, it asks "Would you like to share this with the community?"
+- The user decides each time. They can always say no.
+- Requires accepting a short contributor agreement (DCO).
+- Best for: organisations that want to give back but stay in control.
+
+### Share everything (contribute_all)
+- Features are shared by default. The user can still keep any individual feature private.
+- Also requires the contributor agreement.
+- Best for: organisations that believe in open collaboration and want to maximise community benefit.
+
+## The Contributor Agreement (DCO)
+
+For sharing modes (selective or contribute_all), the user accepts three statements:
+1. The features they share are their original work or work they have the right to share.
+2. They give permission under the Apache License 2.0.
+3. Contributions are anonymous — the platform uses a pseudonymous identity, not personal information.
+
+This is NOT a legal contract — it is a lightweight Developer Certificate of Origin, standard in open source.
+
+## What You Should NOT Do
+
+- Do not explain what the UI looks like — the user can see it.
+- Do not list all three options. Ask one question to identify which fits.
+- Do not use legal jargon. Keep it plain language.
+- Do not mention GitHub accounts or tokens — the anonymous contribution flow no longer requires one.
+- Do not say "I understand your frustration" or assume emotions.
+
+## Guidance Strategy
+
+1. Ask one question: "Do you plan to customise the platform with your own features, or use it as delivered?"
+   - If "as delivered" → recommend **Keep everything here**. They can change this later.
+   - If they want to customise → ask: "Would you like to share the features you build with other platform users, or keep them private?"
+     - Private → **Keep everything here**
+     - Share → ask whether they want to decide each time (**Share selectively**) or share by default (**Share everything**)
+2. Once they choose, explain what happens next in one sentence.
+3. If they chose a sharing mode, let them know they will see a short contributor agreement — three plain-language statements, no legal complexity.


### PR DESCRIPTION
…port

Extends the branding URL scraper to extract contact email, phone, and description, then carries those signals (plus derived industry, timezone, and geographic scope) through the setup context to pre-fill the "Your Business" and "Operating Hours" steps.

- Scraper: extractContactEmails, extractContactPhones, ARCHETYPE_TO_INDUSTRY, COUNTRY_TO_TIMEZONE maps
- Business context form: pre-filled fields with provenance hints that disappear on edit
- Operating hours: uses suggested timezone + industry for smarter defaults
- COO trigger prompt: now includes country and timezone context