### PR TITLE
fix: unblock fresh-install onboarding (Inngest sync + provider-tier preference)

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -10,6 +10,38 @@ export async function register() {
       console.error("[instrumentation] Failed to register discovery jobs:", err),
     );
 
+    // Self-sync our function catalog with the Inngest server.
+    // In self-hosted mode (INNGEST_DEV=0) the Inngest server does NOT auto-
+    // discover apps — events are silently acked with no dispatch target,
+    // which manifests as UI flows stuck in "Working on it..." forever.
+    // Hitting our own PUT /api/inngest triggers the serve() handler to
+    // register/refresh the app with the Inngest server. Runs after a small
+    // delay to give Next.js time to bind the HTTP listener.
+    if (process.env.INNGEST_BASE_URL) {
+      const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+      setTimeout(async () => {
+        let lastErr: unknown = null;
+        for (let i = 0; i < 6; i++) {
+          try {
+            const res = await fetch(`${appUrl}/api/inngest`, { method: "PUT" });
+            if (res.ok) {
+              const body = await res.json().catch(() => ({}));
+              console.log(`[inngest-sync] Registered with Inngest server: ${JSON.stringify(body)}`);
+              return;
+            }
+            lastErr = `HTTP ${res.status}`;
+          } catch (err) {
+            lastErr = err instanceof Error ? err.message : String(err);
+          }
+          await new Promise((r) => setTimeout(r, 2_000));
+        }
+        console.error(
+          `[inngest-sync] Failed to register with Inngest server after 6 attempts: ${String(lastErr)}. ` +
+          `Background jobs (brand extract, evals, etc.) will not dispatch until this succeeds.`,
+        );
+      }, 3_000);
+    }
+
     // ── First-boot auto-provisioning ───────────────────────────────────────
     // Runs 15s after startup. Detects active providers with zero model
     // profiles (the exact state after a fresh install where the seed +

--- a/apps/web/lib/routing/cost-ranking.test.ts
+++ b/apps/web/lib/routing/cost-ranking.test.ts
@@ -24,6 +24,7 @@ function makeEndpoint(overrides: Partial<EndpointManifest>): EndpointManifest {
     name: "Default Endpoint",
     endpointType: "chat",
     status: "active",
+    providerTier: "user_configured",
     sensitivityClearance: ["public", "internal"],
     supportsToolUse: true,
     supportsStructuredOutput: true,

--- a/apps/web/lib/routing/execution-plan.test.ts
+++ b/apps/web/lib/routing/execution-plan.test.ts
@@ -59,6 +59,7 @@ function makeEndpoint(overrides: Partial<EndpointManifest> = {}): EndpointManife
     name: "GPT-4o",
     endpointType: "chat",
     status: "active",
+    providerTier: "user_configured",
     sensitivityClearance: ["public", "internal"],
     supportsToolUse: true,
     supportsStructuredOutput: true,

--- a/apps/web/lib/routing/loader.test.ts
+++ b/apps/web/lib/routing/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveToolUse } from "./loader";
+import { resolveToolUse, classifyProviderTier } from "./loader";
 
 const baseProfile = {
   profileSource: "seed",
@@ -43,5 +43,28 @@ describe("resolveToolUse", () => {
   it("returns null when everything unknown", () => {
     const profile = { ...baseProfile, profileSource: "seed", capabilities: {}, supportsToolUse: null, provider: { supportsToolUse: null } };
     expect(resolveToolUse(profile as any)).toBeNull();
+  });
+});
+
+describe("classifyProviderTier", () => {
+  it("classifies local Docker Model Runner as bundled", () => {
+    expect(classifyProviderTier("local")).toBe("bundled");
+  });
+
+  it("classifies ollama as bundled", () => {
+    expect(classifyProviderTier("ollama")).toBe("bundled");
+  });
+
+  it("classifies external OAuth providers as user_configured", () => {
+    expect(classifyProviderTier("anthropic-sub")).toBe("user_configured");
+    expect(classifyProviderTier("codex")).toBe("user_configured");
+    expect(classifyProviderTier("chatgpt")).toBe("user_configured");
+  });
+
+  it("classifies unknown providers as user_configured by default", () => {
+    // Any provider that isn't explicitly a bundled-default is treated as
+    // user_configured — keeps the rule durable as new providers are added.
+    expect(classifyProviderTier("xai")).toBe("user_configured");
+    expect(classifyProviderTier("mistral")).toBe("user_configured");
   });
 });

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -5,11 +5,24 @@
 import { prisma } from "@dpf/db";
 import type {
   EndpointManifest,
+  ProviderTier,
   TaskRequirementContract,
   PolicyRuleEval,
   EndpointOverride,
   SensitivityLevel,
 } from "./types";
+
+/**
+ * Providers that ship with DPF and require no user action to be usable.
+ * All other providers are classified as `user_configured` — the user
+ * had to actively connect them (OAuth or API key), and that action
+ * expresses a preference the router must honour over bundled defaults.
+ */
+const BUNDLED_PROVIDER_IDS = new Set<string>(["local", "ollama"]);
+
+export function classifyProviderTier(providerId: string): ProviderTier {
+  return BUNDLED_PROVIDER_IDS.has(providerId) ? "bundled" : "user_configured";
+}
 import type { QualityTier } from "./quality-tiers";
 import type { ModelCardCapabilities, ModelCardPricing } from "./model-card-types";
 import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
@@ -91,6 +104,7 @@ export async function loadEndpointManifests(): Promise<EndpointManifest[]> {
     status: (mp.modelStatus === "degraded" || mp.provider.status === "degraded"
       ? "degraded"
       : mp.provider.status) as EndpointManifest["status"],
+    providerTier: classifyProviderTier(mp.providerId),
     sensitivityClearance: mp.provider.sensitivityClearance as SensitivityLevel[],
     supportsToolUse: resolveToolUse(mp) ?? false,
     supportsStructuredOutput: mp.provider.supportsStructuredOutput,

--- a/apps/web/lib/routing/pipeline-v2.capability.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.capability.test.ts
@@ -11,6 +11,7 @@ function activeEp(overrides: Partial<EndpointManifest> = {}): EndpointManifest {
     name: "GPT-5.3",
     endpointType: "chat",
     status: "active",
+    providerTier: "user_configured",
     sensitivityClearance: ["public", "internal", "confidential", "restricted"],
     supportsToolUse: true,
     supportsStructuredOutput: true,

--- a/apps/web/lib/routing/pipeline-v2.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.test.ts
@@ -27,6 +27,7 @@ function makeEndpoint(overrides: Partial<EndpointManifest> = {}): EndpointManife
     name: "Default Endpoint",
     endpointType: "chat",
     status: "active",
+    providerTier: "user_configured",
     sensitivityClearance: ["public", "internal"],
     supportsToolUse: true,
     supportsStructuredOutput: true,
@@ -597,5 +598,107 @@ describe("routeEndpointV2", () => {
     });
     const decision = await routeEndpointV2([ep], makeContract(), [], []);
     expect(decision.explorationMode).toBe("champion");
+  });
+});
+
+describe("routeEndpointV2 — provider-tier preference", () => {
+  // Principle: when the user has configured an external provider (OAuth or
+  // API key saved), that explicit action signals preference. Bundled local
+  // defaults stay available as fallback but never win over user-configured
+  // endpoints — otherwise fresh installs silently route to the bundled
+  // default because paid providers have no pricing/eval metadata yet.
+  //
+  // Regression guards the onboarding flow: with Codex + Claude configured,
+  // admin-assistant must hit them, not the bundled Docker Model Runner.
+
+  it("prefers user_configured over bundled even when bundled is free and scores high", async () => {
+    // Bundled local: free (best cost-per-success) but lower quality scores
+    const bundled = makeEndpoint({
+      id: "ep-bundled",
+      providerId: "local",
+      modelId: "gemma4",
+      name: "Local Gemma",
+      providerTier: "bundled",
+      sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+      reasoning: 60, codegen: 55, toolFidelity: 55, instructionFollowing: 60,
+      structuredOutput: 55, conversational: 65, contextRetention: 60,
+      costPerOutputMToken: 0,
+      pricing: { ...EMPTY_PRICING, inputPerMToken: 0, outputPerMToken: 0 },
+    });
+
+    // User-configured paid: no pricing seeded yet (the fresh-install state).
+    // Before this fix, `cost === null` got rankScore * 50 — losing to bundled.
+    const userConfigured = makeEndpoint({
+      id: "ep-user",
+      providerId: "anthropic-sub",
+      modelId: "claude-opus-4-7",
+      name: "Claude Opus",
+      providerTier: "user_configured",
+      reasoning: 85, codegen: 85, toolFidelity: 80, instructionFollowing: 85,
+      structuredOutput: 80, conversational: 85, contextRetention: 80,
+      costPerOutputMToken: null,
+      pricing: EMPTY_PRICING,
+    });
+
+    const decision = await routeEndpointV2(
+      [bundled, userConfigured],
+      makeContract(),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-user");
+    expect(decision.fallbackChain).toContain("ep-bundled");
+  });
+
+  it("falls back to bundled when no user_configured endpoint is eligible", async () => {
+    const bundled = makeEndpoint({
+      id: "ep-bundled-only",
+      providerId: "local",
+      providerTier: "bundled",
+      sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+      costPerOutputMToken: 0,
+      pricing: { ...EMPTY_PRICING, inputPerMToken: 0, outputPerMToken: 0 },
+    });
+
+    const decision = await routeEndpointV2(
+      [bundled],
+      makeContract(),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-bundled-only");
+  });
+
+  it("preserves rankScore order within the user_configured tier", async () => {
+    const cheap = makeEndpoint({
+      id: "ep-cheap-user",
+      providerId: "openai",
+      modelId: "gpt-4o-mini",
+      providerTier: "user_configured",
+      reasoning: 60, codegen: 60,
+      costPerOutputMToken: 0.6,
+      pricing: { ...EMPTY_PRICING, inputPerMToken: 0.15, outputPerMToken: 0.6 },
+    });
+    const expensive = makeEndpoint({
+      id: "ep-expensive-user",
+      providerId: "anthropic",
+      modelId: "opus",
+      providerTier: "user_configured",
+      reasoning: 90, codegen: 88,
+      costPerOutputMToken: 75,
+      pricing: { ...EMPTY_PRICING, inputPerMToken: 15, outputPerMToken: 75 },
+    });
+
+    const decision = await routeEndpointV2(
+      [cheap, expensive],
+      makeContract({ budgetClass: "minimize_cost" }),
+      [],
+      [],
+    );
+
+    // Tier is the same for both — cost-per-success rules, cheap wins.
+    expect(decision.selectedEndpoint).toBe("ep-cheap-user");
   });
 });

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -361,6 +361,21 @@ export async function routeEndpointV2(
   }
   ranked.sort((a, b) => b.rankScore - a.rankScore);
 
+  // ── Stage 5b: Provider-tier preference ─────────────────────────────────
+  // Architectural principle: when the user has configured an external
+  // provider (OAuth completed or API key saved), that explicit action
+  // signals the user's preference. Bundled local defaults remain available
+  // as fallback, but never win over a user-configured endpoint — otherwise
+  // fresh installs silently route to the bundled default because paid
+  // providers have no pricing/eval metadata yet and are penalized by
+  // cost-per-success ranking.
+  //
+  // Stable-sort puts user_configured ahead of bundled while preserving
+  // rankScore order within each tier. No-op when only one tier is present.
+  const tierOrder = (ep: EndpointManifest): number =>
+    ep.providerTier === "user_configured" ? 0 : 1;
+  ranked.sort((a, b) => tierOrder(a.endpoint) - tierOrder(b.endpoint));
+
   // ── Stage 6: Select winner + build fallback chain ──────────────────────
   const winner = ranked[0]!;
   // Select up to 3 fallbacks, preferring provider diversity.

--- a/apps/web/lib/routing/pipeline.test.ts
+++ b/apps/web/lib/routing/pipeline.test.ts
@@ -23,6 +23,7 @@ function makeEndpoint(overrides: Partial<EndpointManifest>): EndpointManifest {
     name: "Default Endpoint",
     endpointType: "chat",
     status: "active",
+    providerTier: "user_configured",
     sensitivityClearance: ["public", "internal"],
     supportsToolUse: true,
     supportsStructuredOutput: true,

--- a/apps/web/lib/routing/scoring.test.ts
+++ b/apps/web/lib/routing/scoring.test.ts
@@ -17,6 +17,7 @@ const BASE_ENDPOINT: EndpointManifest = {
   name: "Base",
   endpointType: "chat",
   status: "active",
+  providerTier: "user_configured",
   sensitivityClearance: ["public", "internal"],
   supportsToolUse: true,
   supportsStructuredOutput: true,

--- a/apps/web/lib/routing/task-router.test.ts
+++ b/apps/web/lib/routing/task-router.test.ts
@@ -14,6 +14,7 @@ function makeEndpoint(overrides: Partial<EndpointManifest>): EndpointManifest {
     name: "Mock Endpoint",
     endpointType: "llm",
     status: "active",
+    providerTier: "user_configured",
     sensitivityClearance: ["internal", "confidential"],
     supportsToolUse: true,
     supportsStructuredOutput: true,

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -11,6 +11,21 @@ export type SensitivityLevel = "public" | "internal" | "confidential" | "restric
 
 // ── Endpoint Manifest (loaded from ModelProfile joined with ModelProvider) ──
 
+/**
+ * Provider tier for routing preference.
+ *
+ * `bundled` — providers that ship with DPF and require no user action
+ *   to be usable (Docker Model Runner, Ollama). Treated as a fallback
+ *   default: always available, but never preferred when a user has
+ *   explicitly configured an external provider.
+ * `user_configured` — providers the user had to actively connect (OAuth
+ *   completed or API key saved). Preferred over bundled because the user's
+ *   configuration action expresses an explicit preference that the routing
+ *   layer must honour on fresh installs — before any eval or pricing
+ *   metadata has populated.
+ */
+export type ProviderTier = "bundled" | "user_configured";
+
 export interface EndpointManifest {
   // Identity
   id: string;
@@ -19,6 +34,7 @@ export interface EndpointManifest {
   name: string;
   endpointType: string;
   status: "active" | "degraded" | "disabled" | "unconfigured" | "retired";
+  providerTier: ProviderTier;
 
   // Hard constraints
   sensitivityClearance: SensitivityLevel[];


### PR DESCRIPTION
## Summary

Two complementary fixes for the pattern of fresh installs routinely failing at the onboarding step — observed most recently when the brand-extraction step hung on "Working on it…" and the admin-assistant kept routing to the bundled local model despite Claude + Codex being configured.

- **Inngest self-sync on boot** — in self-hosted mode the Inngest server does not auto-discover the portal app, so events fire into the void on every fresh install until someone manually PUTs `/api/inngest`. The Next.js `instrumentation.register()` hook now does this automatically (with retry + loud failure log) so the brand extract + every other queued job actually dispatches.
- **`providerTier` preference in routing** — encodes "a user-configured provider beats a bundled default" as a first-class rule rather than relying on cost-per-success ranking, which penalises unprofiled paid providers and rewards free local defaults. Adds `providerTier: "bundled" | "user_configured"` to `EndpointManifest`, classifies `local`/`ollama` as bundled and everything else as user_configured, and stable-sorts ranked candidates by tier before selecting the winner. Bundled providers stay in the fallback chain.

Independent of seed data, pricing metadata, and eval state — closes the cold-start race that has made onboarding unreliable across installs.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec next build` clean
- [x] Routing unit tests: 163/163 pass across all files I touched (`pipeline-v2`, `pipeline-v2.capability`, `cost-ranking`, `loader`, `pipeline`, `scoring`, `execution-plan`, `task-router`)
- [x] New tests added:
  - `pipeline-v2.test.ts` → `"routeEndpointV2 — provider-tier preference"` block: user_configured wins over cheaper/higher-scoring bundled; falls back to bundled when no user_configured eligible; within-tier rankScore order preserved.
  - `loader.test.ts` → `classifyProviderTier` block: `local`/`ollama` → bundled, everything else → user_configured.
- [ ] Manual: rebuild portal image and verify onboarding brand-extraction step dispatches + admin-assistant hits Claude/Codex instead of local gemma4 on fresh install.

Pre-existing unit test failures (`fallback`, `cli-adapter`, `rate-recovery`, `task-dispatcher`, `task-requirements`, `adapter-ollama`, `adapter-registry`, `recipe-seeder`) are outside the files touched and tracked under the broken-tests effort — CI marks Unit Tests as continue-on-error per `fix(ci): mark Unit Tests job as continue-on-error until #104 is drained`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)