### PR TITLE
fix(inngest): set INNGEST_SERVE_HOST so dispatch reaches portal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,14 @@ services:
       INNGEST_EVENT_KEY: ${INNGEST_EVENT_KEY:-deadbeefcafebabe}
       INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-abcdef0123456789}
       INNGEST_DEV: ${INNGEST_DEV:-0}
+      # Tell Inngest's serve() the externally-reachable URL for this app so
+      # sync registrations announce the Docker-DNS hostname (not the Host
+      # header of the /api/inngest PUT, which would be "localhost:3000"
+      # when the instrumentation hook self-syncs from inside the container).
+      # Without this, Inngest records the app URL as localhost:3000, then
+      # retries forever against itself when dispatching queued steps —
+      # symptom: events publish + initialize but never execute, UI hangs.
+      INNGEST_SERVE_HOST: http://portal:3000
     extra_hosts:
       - "host.docker.internal:host-gateway"   # ensures host reachable on all platforms
     depends_on:


### PR DESCRIPTION
## Summary

Follow-up to #107. The self-sync hook made Inngest aware of the portal app, but the URL it registered was `http://localhost:3000/api/inngest` — the Host header of the PUT made from inside the portal container. From the Inngest container, `localhost:3000` is itself, so every dispatch fails with `Unable to reach SDK URL` and retries silently. Events publish, function initializes, dispatch loops — UI stays on "Working on it…".

Setting `INNGEST_SERVE_HOST=http://portal:3000` tells the Next.js `serve()` handler to announce the Docker-DNS hostname during sync, which is reachable from every service on the `dpf_default` network.

## Repro / proof in logs

```
{"level":"INFO","msg":"publishing event","event_name":"brand/extract.run"}
{"level":"INFO","msg":"received event"}
{"level":"INFO","msg":"initializing fn","function":"brand/extract"}
{"level":"WARN","msg":"EOF writing request to SDK",
 "url":"http://localhost:3000/api/inngest?fnId=dpf-platform-brand%2Fextract"}
{"level":"ERROR","msg":"error handling queue item","error":"Unable to reach SDK URL"}
```

## Test plan

- [x] Lint/typecheck/build unaffected (no source code changes; docker-compose.yml only)
- [ ] Manual: after merge, `docker compose up -d portal` (env change only, no rebuild), trigger brand extract, verify `[brand/extract]` dispatches and progress events appear on the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)