### PR TITLE
fix(stream): replay recently-completed TaskRun progress to SSE

### DIFF
--- a/apps/web/app/api/agent/stream/route.ts
+++ b/apps/web/app/api/agent/stream/route.ts
@@ -11,17 +11,42 @@ import { prisma } from "@dpf/db";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Window during which terminal-status TaskRuns are still replayed.
+ * Short-lived async jobs (e.g. brand extract completes in ~7s) finish
+ * before the browser's EventSource connects. If we only replay
+ * status="active", the subscriber misses the terminal event entirely
+ * and the panel sits on "Working on it..." until the user refreshes
+ * and the server-rendered state takes over.
+ *
+ * Including recently-completed/failed runs in replay gives the panel a
+ * last-write-wins view of the latest progress event, regardless of
+ * whether the producer outraced the subscriber.
+ */
+const TERMINAL_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+
 async function loadReplayEvents(
   threadId: string,
 ): Promise<Array<Record<string, unknown>>> {
   try {
-    const activeRuns = await prisma.taskRun.findMany({
-      where: { threadId, status: "active", progressPayload: { not: null as never } },
+    const terminalFloor = new Date(Date.now() - TERMINAL_REPLAY_WINDOW_MS);
+    const runs = await prisma.taskRun.findMany({
+      where: {
+        threadId,
+        progressPayload: { not: null as never },
+        OR: [
+          { status: "active" },
+          {
+            status: { in: ["completed", "failed"] },
+            updatedAt: { gte: terminalFloor },
+          },
+        ],
+      },
       select: { progressPayload: true, updatedAt: true },
       orderBy: { updatedAt: "desc" },
       take: 5,
     });
-    return activeRuns
+    return runs
       .map((r) => r.progressPayload as Record<string, unknown> | null)
       .filter((p): p is Record<string, unknown> => p !== null);
   } catch {


### PR DESCRIPTION
## Summary

Brand extract (and any similarly short-lived async job) finishes before the browser's EventSource connects. The SSE replay was limited to `status="active"`, so the terminal event was persisted but never replayed — the panel sat on "Working on it..." until the user refreshed.

Extended the replay to also surface TaskRuns whose status is `completed` or `failed` and whose last progress update landed within the last 5 minutes. Last-write-wins regardless of whether the producer outraced the subscriber.

## Test plan

- [x] Typecheck clean
- [ ] Manual: re-click brand extract, verify panel updates without refresh (will do after merge + restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)