### PR TITLE
fix(grants): allow start_scout_research for build-studio coworkers

### DIFF
--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -144,6 +144,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   start_sandbox:              ["sandbox_execute"],
   start_build:                ["sandbox_execute"],
   start_ideate_research:      ["sandbox_execute", "file_read"],
+  start_scout_research:       ["sandbox_execute", "file_read", "web_search"],
   create_portal_pr:           ["sandbox_execute"],
   suggest_taxonomy_placement: ["registry_read"],
   confirm_taxonomy_placement: ["backlog_write"],


### PR DESCRIPTION
## Summary

The Software Engineer (build-specialist) coworker in Build Studio is expected to call \`start_scout_research\` the moment the user describes a feature (see [build-agent-prompts.ts:113](apps/web/lib/integrate/build-agent-prompts.ts#L113)). The tool was registered and implemented, but missing from [agent-grants.ts](apps/web/lib/tak/agent-grants.ts)' \`TOOL_TO_GRANTS\` map — and the map default is deny.

Result: the agent replies *"I don't have the \`start_scout_research\` action available in this chat, so I can't trigger the required scout from here"*, the ideate phase stalls, and no phase advances.

Mirrors \`start_ideate_research\`'s grant set (\`sandbox_execute\`, \`file_read\`) and adds \`web_search\` since scout fetches URLs mentioned by the user.

## Surfaced by

Running \`e2e/onboarding-build-studio-ascension.spec.ts\` against a real Build Studio session. Agent reply verbatim captured in the failure screenshot.

## Regression class

Matches the \`project_agent_grant_seeding_gap\` pattern (2026-04-18). Any new tool added to \`mcp-tools.ts\` MUST also be added to \`TOOL_TO_GRANTS\` or it's silently denied. Long-term fix: an invariant guard that fails at boot if any registered tool has no grant mapping — tracked separately.

## Test plan

- [x] Typecheck clean
- [ ] Manual: re-run P2 e2e after merge + portal restart; expect scout to execute and phase to advance past intake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)