### PR TITLE
fix(scout): make start_scout_research idempotent to break re-call loop

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -5084,13 +5084,40 @@ export async function executeTool(
       const activeBuild = await prisma.featureBuild.findFirst({
         where: { phase: "ideate" },
         orderBy: { updatedAt: "desc" },
-        select: { buildId: true },
+        select: { buildId: true, buildExecState: true, scoutFindings: true },
       });
       if (!activeBuild) {
         return { success: false, message: "No active ideate build found." };
       }
 
-      const current = (await prisma.featureBuild.findUnique({ where: { buildId: activeBuild.buildId }, select: { buildExecState: true } }))?.buildExecState as Record<string, unknown> | null;
+      const current = activeBuild.buildExecState as Record<string, unknown> | null;
+
+      // Idempotency: if scout has already delivered findings, do NOT re-run.
+      // The agentic loop otherwise re-calls this tool every iteration because
+      // the initial response says "results will appear on the next turn" and
+      // the model doesn't see the findings in its prompt context. The stuck-
+      // detector eventually bails, but not before burning 4-5 iterations and
+      // preventing phase advance. Tell the agent plainly the work is done.
+      if (activeBuild.scoutFindings !== null && activeBuild.scoutFindings !== undefined) {
+        return {
+          success: true,
+          message:
+            "Scout already ran for this build. Findings are saved to Build Studio Context — proceed with ideate using the existing scout results; do NOT call start_scout_research again.",
+          data: { alreadyComplete: true },
+        };
+      }
+
+      // Idempotency: if a scout request is already pending dispatch (flag set
+      // by a prior call but not yet cleared by the coworker post-turn hook),
+      // don't stack up another request. Same guidance.
+      if (current?.scoutResearchRequested === true) {
+        return {
+          success: true,
+          message:
+            "Scout already requested and is running now. Wait for the next turn to see findings — do NOT call start_scout_research again.",
+          data: { alreadyRequested: true },
+        };
+      }
 
       await prisma.featureBuild.update({
         where: { buildId: activeBuild.buildId },
@@ -5106,7 +5133,7 @@ export async function executeTool(
 
       return {
         success: true,
-        message: "Scout started. Codebase search and URL parsing running in background — takes about 30 seconds. Results will appear in your Build Studio Context on the next turn.",
+        message: "Scout started. Codebase search and URL parsing running in background — takes about 30 seconds. Results will appear in your Build Studio Context on the next turn. Do NOT call start_scout_research again; wait for the results.",
         data: { urlCount: externalUrls.length },
       };
     }


### PR DESCRIPTION
## Summary

Build Studio ideate phase was stalling because the agent re-called \`start_scout_research\` on every iteration. Root cause:

- First call responds "results will appear on the next turn"
- \`scoutFindings\` is saved to the DB after the agent's turn completes (in the coworker post-turn hook)
- The agent's next prompt doesn't include the findings yet
- The agent sees no evidence scout ran and calls it again

The agentic-loop stuck-detector bails at 5 repeats — so the loop terminates — but 4-5 iterations are burned before that and phase advance is blocked. Captured live in the portal monitor while running the P2 e2e.

## Changes

1. **Idempotent on completion**: if \`scoutFindings\` is non-null, return success with explicit "findings are in context — do NOT call this again." A different response message is enough for the model to recognise the state and stop.
2. **Idempotent on pending dispatch**: if \`scoutResearchRequested\` is still set, short-circuit with "already requested, wait" rather than re-flagging.
3. **First-call response made directive**: "Do NOT call start_scout_research again; wait for the results."

## Test plan

- [x] Typecheck clean
- [ ] Re-run P2 Build Studio e2e after merge + rebuild; expect scout to fire once, phase to advance past ideate

🤖 Generated with [Claude Code](https://claude.com/claude-code)