### PR TITLE
fix(build): allow scoutFindings in saveBuildEvidence allowlist

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2740,7 +2740,7 @@ export async function executeTool(
       const buildId = await resolveActiveBuildId(userId);
       if (!buildId) return { success: false, error: "No active build found.", message: "No active build." };
       const field = String(params.field ?? "");
-      const allowedFields = ["designDoc", "designReview", "buildPlan", "planReview", "taskResults", "verificationOut", "acceptanceMet"];
+      const allowedFields = ["designDoc", "designReview", "buildPlan", "planReview", "taskResults", "verificationOut", "acceptanceMet", "scoutFindings"];
       if (!allowedFields.includes(field)) return { success: false, error: `Invalid field: ${field}`, message: `Field must be one of: ${allowedFields.join(", ")}` };
       const topLevelValue = Object.fromEntries(
         Object.entries(params).filter(([key]) => key !== "field" && key !== "value"),


### PR DESCRIPTION
## Summary

Scout runs, agent dispatches, coworker post-turn hook calls \`executeTool("saveBuildEvidence", { field: "scoutFindings", value })\` — but the MCP tool's \`allowedFields\` hardcoded array never included \`scoutFindings\`, so the write is rejected with "Invalid field".

Result: DB row stays \`scoutFindings=null\` forever, agent's next prompt never includes scout context, phase never advances past ideate.

Surfaced live in P2 e2e: portal log \`[coworker] Scout success: 0 models, 1 gaps, complexity=high\` followed by DB SELECT returning null.

One-word allowlist addition. Field validation preserved.

## Test plan

- [x] Typecheck clean
- [ ] P2 e2e — expect scoutFindings to persist and phase to advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)