### PR TITLE
fix(build): let Turbopack bundle codebase-tools module

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -5026,7 +5026,7 @@ export async function executeTool(
     }
 
     case "list_project_directory": {
-      const { listProjectDirectory } = await import(/* turbopackIgnore: true */ "./integrate/codebase-tools");
+      const { listProjectDirectory } = await import("./integrate/codebase-tools");
       const result = await listProjectDirectory(String(params.path ?? "."));
       if ("error" in result) return { success: false, error: result.error, message: result.error };
       const summary = result.entries.map((e) => `${e.type === "dir" ? "[dir]" : "     "} ${e.path}`).join("\n");
@@ -5034,7 +5034,7 @@ export async function executeTool(
     }
 
     case "read_project_file": {
-      const { readProjectFile } = await import(/* turbopackIgnore: true */ "./integrate/codebase-tools");
+      const { readProjectFile } = await import("./integrate/codebase-tools");
       const opts: { startLine?: number; endLine?: number } = {};
       if (typeof params.startLine === "number") opts.startLine = params.startLine;
       if (typeof params.endLine === "number") opts.endLine = params.endLine;
@@ -5139,7 +5139,7 @@ export async function executeTool(
     }
 
     case "search_project_files": {
-      const { searchProjectFiles } = await import(/* turbopackIgnore: true */ "./integrate/codebase-tools");
+      const { searchProjectFiles } = await import("./integrate/codebase-tools");
       let query = String(params.query ?? "");
       const opts: { glob?: string; maxResults?: number } = {};
 
@@ -5228,7 +5228,7 @@ export async function executeTool(
     }
 
     case "generate_codebase_manifest": {
-      const { isDevInstance } = await import(/* turbopackIgnore: true */ "./integrate/codebase-tools");
+      const { isDevInstance } = await import("./integrate/codebase-tools");
       if (!isDevInstance()) return { success: false, error: "Manifest generation is only available on dev instances.", message: "Dev-only tool." };
 
       const { generateManifest } = await import("@/lib/manifest-generator");
@@ -5277,7 +5277,7 @@ export async function executeTool(
       }
 
       // Fall back to reading the file (dev instances only)
-      const { isDevInstance, readProjectFile } = await import(/* turbopackIgnore: true */ "./integrate/codebase-tools");
+      const { isDevInstance, readProjectFile } = await import("./integrate/codebase-tools");
       if (isDevInstance()) {
         const result = await readProjectFile("codebase-manifest.json");
         if ("content" in result) {
@@ -5336,7 +5336,7 @@ export async function executeTool(
     }
 
     case "propose_file_change": {
-      const { readProjectFile, writeProjectFile, generateSimpleDiff } = await import(/* turbopackIgnore: true */ "./integrate/codebase-tools");
+      const { readProjectFile, writeProjectFile, generateSimpleDiff } = await import("./integrate/codebase-tools");
       const path = String(params.path ?? "");
       const newContent = String(params.newContent ?? "");
       const description = String(params.description ?? "");


### PR DESCRIPTION
## Summary

Six dynamic imports of \`codebase-tools\` (list_project_directory, read_project_file, search_project_files, etc.) were marked \`/* turbopackIgnore: true */\`. In production, the runtime import resolves relative to the chunk file (\`/app/apps/web/.next/server/chunks/\`) instead of the source tree, and fails:

\`\`\`
Cannot find module '/app/apps/web/.next/server/chunks/integrate/codebase-tools'
imported from /app/apps/web/.next/server/chunks/apps_web_lib_0yjor-h._.js
\`\`\`

The ignore directive was there to keep Turbopack/NFT from tracing fs/path/child_process into the client bundle, but [codebase-tools.ts](apps/web/lib/integrate/codebase-tools.ts) already routes those requires through [lazy-node helpers](apps/web/lib/shared/lazy-node.ts) that hide them from static analysis via \`new Function()\` constructions. Turbopack can safely bundle the module now.

## Diff

Logical diff is 6 lines (remove the \`/* turbopackIgnore: true */\` directive from each dynamic import). The huge byte delta is line-ending normalisation from my editor — reviewers can see the real diff with \`git show -w\`.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec next build\` succeeds
- [ ] P2 e2e: agent should call search_project_files / list_project_directory without module-not-found errors

## Surfaced by

P2 Build Studio e2e round 6 — agent tried to audit the codebase, every call to search_project_files / list_project_directory failed with the module-not-found error, design review then flagged the missing audit as a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)