### PR TITLE
fix(claude-cli): rescue tool_use blocks emitted as assistant text

### DIFF
--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -21,6 +21,7 @@ import { InferenceError } from "@/lib/ai-inference";
 import { getDecryptedCredential, getProviderBearerToken } from "@/lib/inference/ai-provider-internals";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { extractToolCalls as extractToolCallsFromText } from "./extract-tool-calls";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 180_000; // 3 minutes — matches chat adapter's AbortSignal.timeout
@@ -125,8 +126,20 @@ function parseCliStreamOutput(output: string): {
     }
   }
 
+  const finalText = textParts.join("");
+  // Rescue: if the model emitted tool_use JSON as assistant text instead of
+  // a structured tool_use event (observed on anthropic-sub CLI when Claude
+  // writes the canonical {"type":"tool_use",…} JSON in a chat turn),
+  // extract the tool calls from the text so the agentic loop dispatches.
+  if (toolCalls.length === 0 && finalText.includes('"tool_use"')) {
+    const rescued = extractToolCallsFromText(finalText);
+    if (rescued.length > 0) {
+      toolCalls.push(...rescued);
+    }
+  }
+
   return {
-    text: textParts.join(""),
+    text: finalText,
     toolCalls,
     usage: { inputTokens, outputTokens },
   };
@@ -162,6 +175,15 @@ function parseCliJsonOutput(output: string): {
 
     const usage = parsed.usage as { input_tokens?: number; output_tokens?: number } | undefined;
 
+    // Same rescue as parseCliStreamOutput: tool_use may appear in the text
+    // instead of in a content-block tool_use entry.
+    if (toolCalls.length === 0 && text.includes('"tool_use"')) {
+      const rescued = extractToolCallsFromText(text);
+      if (rescued.length > 0) {
+        toolCalls.push(...rescued);
+      }
+    }
+
     return {
       text,
       toolCalls,
@@ -171,10 +193,14 @@ function parseCliJsonOutput(output: string): {
       },
     };
   } catch {
-    // Not JSON — return raw text
+    // Not JSON — return raw text. Try to extract tool calls from the raw
+    // text before giving up; the CLI occasionally prints a single JSON
+    // tool_use block with no wrapper.
+    const raw = output.trim();
+    const rescued = raw.includes('"tool_use"') ? extractToolCallsFromText(raw) : [];
     return {
-      text: output.trim(),
-      toolCalls: [],
+      text: raw,
+      toolCalls: rescued,
       usage: { inputTokens: 0, outputTokens: 0 },
     };
   }
@@ -225,7 +251,19 @@ export const cliAdapter: ExecutionAdapterHandler = {
         }
         return `- ${JSON.stringify(t)}`;
       });
-      toolContext = `\n\nAvailable tools (respond with tool_use blocks to invoke):\n${toolDescriptions.join("\n")}`;
+      // Be explicit about the tool_use JSON shape. The Claude CLI's
+      // stream-json parser only recognises STRUCTURED tool_use events emitted
+      // as top-level stream entries — tool_use JSON embedded inside
+      // assistant-text content leaks through as plain chat (observed on
+      // /build with anthropic-sub). The downstream fallback extractor below
+      // rescues such cases; the prompt still asks for the canonical shape.
+      toolContext =
+        `\n\nAvailable tools. To invoke a tool, output ONE JSON object per ` +
+        `invocation using exactly this shape:\n` +
+        `{"type":"tool_use","id":"<unique_id>","name":"<tool_name>","input":{<args>}}\n` +
+        `Do NOT wrap in XML tags, markdown code fences, or rename the keys. ` +
+        `Output only the JSON (no surrounding prose) when invoking a tool.\n\n` +
+        `Tools:\n${toolDescriptions.join("\n")}`;
     }
 
     const fullSystemPrompt = systemPrompt + toolContext;

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -20,6 +20,7 @@ import { InferenceError } from "@/lib/ai-inference";
 import { getDecryptedCredential, getProviderBearerToken } from "@/lib/inference/ai-provider-internals";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { extractToolCalls as sharedExtractToolCalls } from "./extract-tool-calls";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 180_000; // 3 minutes
@@ -278,135 +279,12 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
 };
 
 /**
- * Extract tool_use blocks from Codex CLI text output.
- *
- * The model emits several shapes in practice, and each variant has to be
- * accepted or the agentic loop silently drops the call and the coworker
- * "explains" that the tool isn't available. Shapes handled:
- *
- *   1. {"type":"tool_use","id":"x","name":"t","input":{...}}   (spec)
- *   2. {"name":"t","input":{...}}                              (missing type/id)
- *   3. {"tool":"t","arguments":{...}}                          (alt key names)
- *   4. <tool_use>{...}</tool_use>                              (XML-ish wrapper)
- *   5. ```json\n{...}\n```                                     (markdown fence)
- *
- * Any recognisable object is normalised to ToolCallEntry. We look for
- * candidate JSON objects inside the entire text (fenced, tagged, or
- * inline) and accept the first valid shape each.
+ * Thin wrapper re-export so the unit test file continues to work without
+ * being rewritten. The actual logic lives in extract-tool-calls.ts so both
+ * codex-cli and claude cli-adapter can use it.
  */
-/**
- * Deterministic JSON stringify with sorted object keys — used to build a
- * content-based dedup key for tool calls that the same response expresses
- * in two different wrappers (e.g. XML-ish + inline).
- */
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map((v) => stableStringify(v)).join(",")}]`;
-  const keys = Object.keys(value as Record<string, unknown>).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`).join(",")}}`;
-}
-
-/**
- * Returns the index of the `}` that closes the object starting at `openIdx`,
- * or -1 if the object is not well-balanced. Respects JSON string literals so
- * braces inside strings don't throw off the depth counter.
- */
-function findBalancedEnd(text: string, openIdx: number): number {
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  for (let i = openIdx; i < text.length; i++) {
-    const ch = text[i]!;
-    if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === "\\") escaped = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') inString = true;
-    else if (ch === "{") depth++;
-    else if (ch === "}") {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-  return -1;
-}
-
 export function extractToolCalls(text: string): ToolCallEntry[] {
-  const toolCalls: ToolCallEntry[] = [];
-  const seen = new Set<string>();
-
-  // Strip XML-ish <tool_use>...</tool_use> and markdown ```json ... ``` wrappers
-  // by collecting their inner content as candidate JSON strings. Then also
-  // scan the raw text for inline JSON objects.
-  const candidates: string[] = [];
-
-  // a) <tool_use>...</tool_use> blocks
-  const xmlPattern = /<tool_use>\s*([\s\S]*?)\s*<\/tool_use>/gi;
-  for (let m; (m = xmlPattern.exec(text)) !== null; ) {
-    if (m[1]) candidates.push(m[1].trim());
-  }
-
-  // b) ```json ... ``` fenced blocks (accept 'json', 'tool_use', or unlabeled)
-  const fencePattern = /```(?:json|tool_use)?\s*([\s\S]*?)```/g;
-  for (let m; (m = fencePattern.exec(text)) !== null; ) {
-    if (m[1]) candidates.push(m[1].trim());
-  }
-
-  // c) Raw inline JSON objects in the text. Regex can't balance braces across
-  //    nested objects, so scan for `{` then walk forward counting brace depth
-  //    (respecting strings) to find the matching close. Start only at braces
-  //    whose first key looks like a tool call — `type`, `name`, or `tool`.
-  const keyStartPattern = /\{\s*"(?:type|name|tool)"\s*:/g;
-  for (let start; (start = keyStartPattern.exec(text)) !== null; ) {
-    const end = findBalancedEnd(text, start.index);
-    if (end > start.index) candidates.push(text.slice(start.index, end + 1));
-  }
-
-  for (const raw of candidates) {
-    let parsed: Record<string, unknown> | null = null;
-    try {
-      parsed = JSON.parse(raw) as Record<string, unknown>;
-    } catch {
-      continue;
-    }
-    if (!parsed || typeof parsed !== "object") continue;
-
-    // Normalise variants into {name, input}
-    const name =
-      (typeof parsed.name === "string" && parsed.name) ||
-      (typeof parsed.tool === "string" && parsed.tool) ||
-      null;
-    const input =
-      (parsed.input && typeof parsed.input === "object" ? parsed.input : null) ??
-      (parsed.arguments && typeof parsed.arguments === "object" ? parsed.arguments : null) ??
-      {};
-    if (!name) continue;
-
-    // Accept either type:"tool_use" or no type (when the shape is clear)
-    if (parsed.type !== undefined && parsed.type !== "tool_use") continue;
-
-    const id =
-      (typeof parsed.id === "string" && parsed.id) ||
-      `call_${toolCalls.length}_${name}`;
-
-    // Dedupe by semantic content (same name + same args) so the XML wrapper
-    // candidate and the inline-JSON candidate of the same call don't both
-    // get dispatched. The auto-generated id differs between candidates so
-    // it can't be part of the dedup key.
-    const semanticKey = `${name}:${stableStringify(input)}`;
-    if (seen.has(semanticKey)) continue;
-    seen.add(semanticKey);
-
-    toolCalls.push({
-      id,
-      name,
-      arguments: input as Record<string, unknown>,
-    });
-  }
-
-  return toolCalls;
+  return sharedExtractToolCalls(text);
 }
 
 // ── Auto-register at import time ─────────────────────────────────────────────

--- a/apps/web/lib/routing/extract-tool-calls.ts
+++ b/apps/web/lib/routing/extract-tool-calls.ts
@@ -1,0 +1,123 @@
+// apps/web/lib/routing/extract-tool-calls.ts
+
+/**
+ * Cross-adapter tool_use extractor.
+ *
+ * Pulls tool_use invocations out of CLI-style LLM text output that isn't
+ * already a structured tool_call from the provider's native API. Models
+ * emit several variants when asked to "respond with tool_use blocks":
+ *
+ *   1. {"type":"tool_use","id":"x","name":"t","input":{...}}   (Claude/Anthropic spec)
+ *   2. {"name":"t","input":{...}}                              (no type/id)
+ *   3. {"tool":"t","arguments":{...}}                          (alt key names)
+ *   4. <tool_use>{...}</tool_use>                              (XML-ish wrapper)
+ *   5. ```json\n{...}\n```                                     (markdown fence)
+ *
+ * Shared by `codex-cli-adapter.ts` and `cli-adapter.ts` (Claude CLI) so
+ * neither adapter silently drops tool calls when the model picks a
+ * non-canonical shape.
+ */
+
+import type { ToolCallEntry } from "./adapter-types";
+
+/** Deterministic JSON stringify with sorted object keys for content-based dedup. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((v) => stableStringify(v)).join(",")}]`;
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`).join(",")}}`;
+}
+
+/**
+ * Returns the index of the `}` that closes the object starting at `openIdx`,
+ * or -1 if not well-balanced. Respects JSON string literals so braces inside
+ * strings don't throw off the depth counter.
+ */
+function findBalancedEnd(text: string, openIdx: number): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = openIdx; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+export function extractToolCalls(text: string): ToolCallEntry[] {
+  const toolCalls: ToolCallEntry[] = [];
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+
+  // a) <tool_use>...</tool_use>
+  const xmlPattern = /<tool_use>\s*([\s\S]*?)\s*<\/tool_use>/gi;
+  for (let m; (m = xmlPattern.exec(text)) !== null; ) {
+    if (m[1]) candidates.push(m[1].trim());
+  }
+
+  // b) ```json | ```tool_use | ``` fenced blocks
+  const fencePattern = /```(?:json|tool_use)?\s*([\s\S]*?)```/g;
+  for (let m; (m = fencePattern.exec(text)) !== null; ) {
+    if (m[1]) candidates.push(m[1].trim());
+  }
+
+  // c) Inline JSON objects whose first key is type | name | tool. Brace-
+  //    balancing walk rather than non-greedy regex so nested args parse.
+  const keyStartPattern = /\{\s*"(?:type|name|tool)"\s*:/g;
+  for (let start; (start = keyStartPattern.exec(text)) !== null; ) {
+    const end = findBalancedEnd(text, start.index);
+    if (end > start.index) candidates.push(text.slice(start.index, end + 1));
+  }
+
+  for (const raw of candidates) {
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+
+    const name =
+      (typeof parsed.name === "string" && parsed.name) ||
+      (typeof parsed.tool === "string" && parsed.tool) ||
+      null;
+    const input =
+      (parsed.input && typeof parsed.input === "object" ? parsed.input : null) ??
+      (parsed.arguments && typeof parsed.arguments === "object" ? parsed.arguments : null) ??
+      {};
+    if (!name) continue;
+
+    // Accept type:"tool_use" or no type (when shape is clear)
+    if (parsed.type !== undefined && parsed.type !== "tool_use") continue;
+
+    const id =
+      (typeof parsed.id === "string" && parsed.id) ||
+      `call_${toolCalls.length}_${name}`;
+
+    // Dedupe by (name, canonical args) — the same call in both XML-wrapped
+    // and inline shapes shouldn't fire twice.
+    const semanticKey = `${name}:${stableStringify(input)}`;
+    if (seen.has(semanticKey)) continue;
+    seen.add(semanticKey);
+
+    toolCalls.push({
+      id,
+      name,
+      arguments: input as Record<string, unknown>,
+    });
+  }
+
+  return toolCalls;
+}


### PR DESCRIPTION
## Summary

On \`anthropic-sub\`, the Claude CLI's stream-json output only surfaces structured \`tool_use\` as top-level events. When Claude writes the canonical tool_use JSON **inside a regular assistant content chunk**, the JSON leaks through to the user as raw chat text and the agentic loop never dispatches the tool.

Captured verbatim from Mark's Build Studio turn on "Fix the graph view to update and filter when a subnet is selected":

\`\`\`
{"type":"tool_use","id":"toolu_update_feature_brief_001","name":"update_feature_brief","input":{...}}
\`\`\`

Rendered verbatim in the coworker panel. No tool executed. Phase stuck.

## Changes

1. Share the variant-tolerant \`extractToolCalls\` helper between codex-cli and claude-cli adapters. New module \`apps/web/lib/routing/extract-tool-calls.ts\`. codex-cli keeps a test-surface re-export.
2. After stream-json and non-streaming JSON parsers run, if \`toolCalls\` is empty but the text contains \`"tool_use"\`, extract blocks from the text as fallback.
3. Tighten the Claude CLI prompt with the explicit shape spec codex-cli got in #112.

## Variants now handled

- canonical \`{type, id, name, input}\`
- \`{name, input}\` (type/id missing)
- \`{tool, arguments}\`
- \`<tool_use>…</tool_use>\`
- \` \`\`\`json … \`\`\` \` fences

## Test plan

- [x] Typecheck clean
- [x] Existing extractor tests pass (6/6)
- [ ] Manual: retry the "Fix the graph view…" turn on anthropic-sub; expect \`update_feature_brief\` to execute, feature brief UI to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)