### PR TITLE
fix(coworker): route build-create auto-messages to the new thread

### DIFF
--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -53,6 +53,14 @@ export function AgentCoworkerShell({ userContext }: Props) {
   const [pendingAutoMessage, setPendingAutoMessage] = useState<string | null>(null);
   const [dockedFrame, setDockedFrame] = useState<DockedPanelFrame | null>(null);
   const lastAutoMessageRef = useRef<string | null>(null);
+  // Queue auto-messages whose target thread hasn't loaded yet. The panel
+  // can't submit to a thread until threadId is set; if the open-agent-panel
+  // event arrives while the thread is mid-switch, we hold the message
+  // here and release it when the thread context stabilises.
+  const [queuedAutoMessage, setQueuedAutoMessage] = useState<{
+    message: string;
+    targetBuildId: string | null;
+  } | null>(null);
   const positionRef = useRef(position);
   const sizeRef = useRef(size);
   const dragRef = useRef<{ startX: number; startY: number; startPosX: number; startPosY: number } | null>(null);
@@ -134,6 +142,18 @@ export function AgentCoworkerShell({ userContext }: Props) {
     };
   }, [threadContext]);
 
+  // Release a queued auto-message once the thread context has switched to
+  // its target build. Without this, a new build's "help me define it"
+  // prompt fires against the previously-active thread because the event
+  // lands before the thread swap completes. See BuildStudio.handleCreate.
+  useEffect(() => {
+    if (!queuedAutoMessage) return;
+    if (!threadId) return; // thread still switching — wait
+    if (queuedAutoMessage.targetBuildId && queuedAutoMessage.targetBuildId !== activeBuildId) return;
+    setPendingAutoMessage(queuedAutoMessage.message);
+    setQueuedAutoMessage(null);
+  }, [queuedAutoMessage, threadId, activeBuildId]);
+
   function handleOpen() {
     setIsOpen(true);
     savePanelOpen(userKey, true);
@@ -149,10 +169,19 @@ export function AgentCoworkerShell({ userContext }: Props) {
     function handleOpenPanel(e: Event) {
       setIsOpen(true);
       savePanelOpen(userKey, true);
-      const detail = (e as CustomEvent<{ autoMessage?: string; welcomeMessage?: string } | undefined>).detail;
+      const detail = (e as CustomEvent<{ autoMessage?: string; welcomeMessage?: string; targetBuildId?: string } | undefined>).detail;
       if (detail?.autoMessage && detail.autoMessage !== lastAutoMessageRef.current) {
         lastAutoMessageRef.current = detail.autoMessage;
-        setPendingAutoMessage(detail.autoMessage);
+        // If the event targets a specific build, queue the message until the
+        // Shell's threadContext advances to that build. Otherwise submit
+        // immediately (legacy behaviour — route-level auto-messages, e.g.
+        // the onboarding COO introducing each setup step, don't have a
+        // targetBuildId and must fire right away).
+        if (detail.targetBuildId) {
+          setQueuedAutoMessage({ message: detail.autoMessage, targetBuildId: detail.targetBuildId });
+        } else {
+          setPendingAutoMessage(detail.autoMessage);
+        }
       }
       // welcomeMessage: inject a pre-written assistant message without LLM call
       if (detail?.welcomeMessage) {

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -199,9 +199,17 @@ export function BuildStudio({ builds, portfolios, dpfEnvironment, projectBranch 
       });
       setNewTitle("");
       router.refresh();
-      // Open the co-worker panel and auto-prompt about the new feature
+      // Open the co-worker panel and auto-prompt about the new feature.
+      // Include targetBuildId so Shell can queue the message until its
+      // thread context matches the new build — without the guard, the
+      // auto-message can fire against the previously-active thread
+      // because Shell's thread switch lags the panel's receipt of the
+      // event by one React render cycle.
       document.dispatchEvent(new CustomEvent("open-agent-panel", {
-        detail: { autoMessage: `I just created a new feature called "${title}". Help me define it.` },
+        detail: {
+          autoMessage: `I just created a new feature called "${title}". Help me define it.`,
+          targetBuildId: buildId,
+        },
       }));
     } finally {
       setCreating(false);


### PR DESCRIPTION
## Summary

Direct fix for Mark's report:

> I started a new build studio effort, and when I entered it, the AI coworker display didn't update with it. I refreshed the screen to see the AI coworker panel start working.

### Root cause

`BuildStudio.handleCreate` calls `setActiveBuild(newBuild)` and **synchronously** dispatches `open-agent-panel` with the auto-prompt. The Shell receives the event immediately and calls `setPendingAutoMessage(msg)`. The panel's submission effect fires as soon as `(pendingAutoMessage && threadId)` are both truthy — but at that moment `threadId` is still the PREVIOUS build's thread id. The Shell's own thread swap only happens on the next render, after `BuildStudio`'s `useEffect([activeBuild?.buildId])` re-dispatches `build-studio-active-build` and the Shell processes that event.

So the prompt "I just created a new feature..." for build B fires against build A's thread.

### Fix

Attach `targetBuildId` to the `open-agent-panel` event and **queue** the auto-message in the Shell until:
1. `threadId` becomes non-null (new thread loaded), AND
2. `activeBuildId` matches `targetBuildId`

Legacy auto-messages that don't target a specific build (onboarding COO introducing each setup step, feedback prompts) continue to fire immediately — the queue only activates when `targetBuildId` is set.

Pairs with #118 which fixed the claude-cli tool_use rescue (the OTHER half of what Mark saw).

## Test plan

- [x] Typecheck clean
- [ ] Manual: create a new feature on /build, verify the "help me define it" prompt fires in the NEW build's thread without a page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)