### PR TITLE
fix(coworker): drain queued auto-message inside thread load to avoid stale-threadId race

### DIFF
--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -120,6 +120,14 @@ export function AgentCoworkerShell({ userContext }: Props) {
     ? `${pathname}#${activeBuildId}`
     : pathname;
 
+  // Keep a ref in sync so the async load effect below can read the latest
+  // queue without needing queuedAutoMessage in its dependency array (adding
+  // it would cancel the in-flight load every time a message is queued).
+  const queuedAutoMessageRef = useRef<typeof queuedAutoMessage>(null);
+  useEffect(() => {
+    queuedAutoMessageRef.current = queuedAutoMessage;
+  }, [queuedAutoMessage]);
+
   useEffect(() => {
     let active = true;
     setThreadId(null);
@@ -130,6 +138,18 @@ export function AgentCoworkerShell({ userContext }: Props) {
       if (!active) return;
       setThreadId(snapshot?.threadId ?? null);
       setInitialMessages(snapshot?.messages ?? []);
+
+      // Release a queued auto-message targeted at THIS build now that its
+      // thread is loaded. Draining inside the load callback avoids the race
+      // where a separate effect fires with activeBuildId already updated
+      // but threadId still holding the previous build's id, which would
+      // submit the message to the wrong thread.
+      const queued = queuedAutoMessageRef.current;
+      const expectedBuildId = activeBuildId && pathname === "/build" ? activeBuildId : null;
+      if (queued && snapshot?.threadId && queued.targetBuildId === expectedBuildId) {
+        setPendingAutoMessage(queued.message);
+        setQueuedAutoMessage(null);
+      }
     })().catch((error) => {
       console.warn("getOrCreateThreadSnapshot error:", error);
       if (!active) return;
@@ -140,19 +160,7 @@ export function AgentCoworkerShell({ userContext }: Props) {
     return () => {
       active = false;
     };
-  }, [threadContext]);
-
-  // Release a queued auto-message once the thread context has switched to
-  // its target build. Without this, a new build's "help me define it"
-  // prompt fires against the previously-active thread because the event
-  // lands before the thread swap completes. See BuildStudio.handleCreate.
-  useEffect(() => {
-    if (!queuedAutoMessage) return;
-    if (!threadId) return; // thread still switching — wait
-    if (queuedAutoMessage.targetBuildId && queuedAutoMessage.targetBuildId !== activeBuildId) return;
-    setPendingAutoMessage(queuedAutoMessage.message);
-    setQueuedAutoMessage(null);
-  }, [queuedAutoMessage, threadId, activeBuildId]);
+  }, [threadContext]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleOpen() {
     setIsOpen(true);


### PR DESCRIPTION
## Summary

#119's queue-and-drain still races. The drain effect fires on state changes — and activeBuildId updates one render cycle BEFORE threadId is cleared, so for a moment the drain sees a stale (non-null) threadId combined with the new activeBuildId that matches targetBuildId. It drains, submits to the PREVIOUS build's thread, and the new build's coworker panel stays empty.

Mark confirmed with a screenshot: new feature created, phase indicator rendered, coworker panel has nothing.

## Fix

Move the drain inside the same async callback that performs the snapshot load and sets threadId. At that point, the snapshot is FOR the current threadContext (which was derived from activeBuildId), so matching targetBuildId against activeBuildId at that moment unambiguously means the message belongs to this just-loaded thread.

Use a ref (`queuedAutoMessageRef`) to read the latest queue from inside the async callback without adding `queuedAutoMessage` to the effect's dependency array — doing so would cancel the in-flight load every time a message is queued.

## Test plan

- [x] Typecheck clean
- [ ] Manual: create new feature on /build, verify the "I just created..." prompt fires in the new build's thread without refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)