### PR TITLE
feat(build): evaluate every section, accept 'Not applicable' with reason

### DIFF
--- a/apps/web/components/build/FeatureBriefPanel.tsx
+++ b/apps/web/components/build/FeatureBriefPanel.tsx
@@ -264,6 +264,24 @@ function Section({ label, value }: { label: string; value: string }) {
 }
 
 function DocSection({ label, value }: { label: string; value: string }) {
+  // Sections evaluated by the agent as "Not applicable — <reason>" are rendered
+  // as a single muted line so the reader isn't scanning past a wall of boilerplate
+  // when the answer is "nothing to do here". The agent still had to evaluate the
+  // section to reach this conclusion — we just don't amplify the void.
+  const trimmed = value.trim();
+  const na = /^not\s+applicable\b/i.test(trimmed);
+  if (na) {
+    // Strip leading "Not applicable —" so the muted line reads like prose.
+    const reason = trimmed.replace(/^not\s+applicable\s*[—\-:]*\s*/i, "").trim();
+    return (
+      <div>
+        <span className="text-xs text-[var(--dpf-muted)] uppercase tracking-wider">{label}</span>
+        <p className="text-xs text-[var(--dpf-muted)] mt-0.5 leading-snug italic">
+          Not applicable{reason ? ` — ${reason}` : ""}
+        </p>
+      </div>
+    );
+  }
   return (
     <div>
       <span className="text-xs text-[var(--dpf-muted)] uppercase tracking-wider">{label}</span>

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -40,6 +40,8 @@ ${hasUI ? `8. Does the design consider accessibility? (semantic HTML structure, 
 
 SEVERITY CALIBRATION: Use "critical" ONLY for issues that would cause data loss, security vulnerabilities, or broken functionality. Use "important" for design gaps that should be addressed but don't block implementation. Use "minor" for style, naming, or nice-to-have improvements. A health endpoint or simple utility does NOT need the same rigor as a payment system — calibrate accordingly.
 
+"NOT APPLICABLE" HANDLING: Sections may legitimately not apply to a given feature (e.g. a UI-only fix has no data model change, a standalone utility has no reuse target). When a section's value begins with "Not applicable —" followed by a reason, evaluate only whether that reason is CORRECT for this feature. If the reason is correct, the section passes — do NOT flag it as "missing content", "underspecified", or "needs detail". If the reason is wrong (e.g. the author wrote "Not applicable — UI-only change" but the proposedApproach actually introduces new tables), flag that as an important issue.
+
 CRITICAL INSTRUCTION: You MUST report ALL issues in a SINGLE response. Do not stop after finding the first issue. Review the entire design document comprehensively. A revision cycle costs significant time and tokens. The goal is ZERO surprise issues on a re-review.
 
 RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -184,13 +184,13 @@ YOUR TASK:
 {
   "problemStatement": "What problem this solves, who it affects, and why it matters. Write 2-3 sentences a non-technical stakeholder can understand.",
 
-  "dataModel": "Describe the data model in PLAIN ENGLISH with a structured layout. For each model: name, purpose (one sentence), then list its fields as: fieldName (Type) — description. Use line breaks between models. Example format:\\n\\nCertificationAuthority — Represents an external certification provider.\\n- slug (String, unique) — short identifier, e.g. 'open-group'\\n- displayName (String) — human-readable name\\n- apiBaseUrl (String) — API endpoint for this provider\\n\\nDo NOT use Prisma syntax or code blocks. Do NOT omit fields. List every field with its type and purpose.",
+  "dataModel": "Describe the data model in PLAIN ENGLISH with a structured layout. For each model: name, purpose (one sentence), then list its fields as: fieldName (Type) — description. Use line breaks between models. Example format:\\n\\nCertificationAuthority — Represents an external certification provider.\\n- slug (String, unique) — short identifier, e.g. 'open-group'\\n- displayName (String) — human-readable name\\n- apiBaseUrl (String) — API endpoint for this provider\\n\\nDo NOT use Prisma syntax or code blocks. Do NOT omit fields. List every field with its type and purpose.\\n\\nIf this feature truly requires NO data model change (e.g. a UI-only tweak on existing data), you MUST still evaluate by confirming what existing models will be used, then write exactly: 'Not applicable — <one-sentence reason, naming the existing models being relied on>'. Never leave empty and never skip the evaluation step.",
 
   "existingFunctionalityAudit": "REQUIRED — never leave empty. What existing files, models, and patterns you found in the codebase that this feature will build on. Reference specific file paths (apps/web/...) and model names. If nothing related exists, write: 'No existing implementation found. Searched for [list the exact terms you searched for]. This is a new feature.' That format is accepted — but an empty string is not.",
 
   "proposedApproach": "A clear, readable description of how this will work. Structure it with labeled sections:\\n- Data Model: summarize the models (detail is in the dataModel field)\\n- API Routes: what endpoints, what each does, auth requirements\\n- UI Pages: what pages, what they show, what actions they support\\n- Integration Flow: step-by-step of what happens when the feature is triggered (automatic and manual paths)\\n- Configuration: how admins set up and manage the feature\\nWrite each section so a developer can implement from it without ambiguity.",
 
-  "reusePlan": "What existing code, patterns, and utilities from the codebase will be reused. Be specific — name files and functions.",
+  "reusePlan": "What existing code, patterns, and utilities from the codebase will be reused. Be specific — name files and functions. If this feature genuinely cannot reuse existing code (truly novel surface), write exactly: 'Not applicable — <one-sentence reason>'. Only use this when you have searched and confirmed nothing reusable exists.",
 
   "acceptanceCriteria": ["criterion 1 — written as a testable statement", "criterion 2", "..."],
 
@@ -206,6 +206,7 @@ RULES:
 - Search thoroughly before writing. Your audit must reference real files.
 - existingFunctionalityAudit MUST never be empty or null. If you find nothing relevant, write what you searched for.
 - If reusability scope is "parameterizable", the proposedApproach MUST describe how domain-specific values are stored as configuration, not hardcoded.
+- "Not applicable" convention: you MUST still evaluate every section. For sections that genuinely do not apply to this feature after evaluation (e.g. a UI-only fix has no data model change, a standalone utility has no reuse target), write the section value as exactly: "Not applicable — <one-sentence reason>". The reviewer accepts this format. Never use it to skip work — only when evaluation concluded the section legitimately does not apply.
 - Output ONLY the JSON block. No commentary, no explanations.
 - VALID JSON ONLY: The output must parse with JSON.parse(). Do NOT put double-quote characters inside string values — they break parsing. Version numbers (1.0.0), product names, and file paths must NOT be wrapped in quotes inside a JSON string. WRONG: "assigns version \\"1.0.0\\" to each" — RIGHT: "assigns version 1.0.0 to each". If you need to emphasize something, use parentheses or dashes instead of quotes.`;
 }


### PR DESCRIPTION
## Summary

Build Studio's ideate template requires every design-doc section (dataModel, reusePlan, …) even when a feature doesn't touch that concern. Agents have been filling those with boilerplate ("No schema change is required. The feature will continue to use InventoryEntity nodes...") that readers have to scan past.

Mark's request: still evaluate every section (catches silent gaps), but when evaluation concludes a section doesn't apply, say so explicitly and render compactly.

## Three coordinated changes

1. **Prompt** ([ideate-dispatch.ts](apps/web/lib/integrate/ideate-dispatch.ts)) — for dataModel and reusePlan, instruct the agent to write exactly \`"Not applicable — <one-sentence reason>"\` when evaluation says the section doesn't apply. Added as a top-level RULE so the agent can't skip evaluation and can't invent the N/A phrase to sidestep work.

2. **Reviewer** ([build-reviewers.ts](apps/web/lib/integrate/build-reviewers.ts)) — teaches the reviewer that sections starting with \`"Not applicable —"\` should be judged on whether the REASON is correct for this feature, not on missing content. Wrong reason = important issue. Right reason = passes.

3. **UI** ([FeatureBriefPanel.tsx](apps/web/components/build/FeatureBriefPanel.tsx)) — renders N/A sections as a muted italic one-liner instead of a full paragraph. Label stays (evaluation happened), visual weight matches substance.

## Future-proof

Any other optional section can opt into the convention by accepting N/A in its prompt-level guidance — reviewer and renderer already support it generically (regex-based N/A detection).

## Test plan

- [x] Typecheck clean
- [ ] Manual: next Build Studio feature with a UI-only scope renders Data Model and Reuse Plan as the compact N/A line
- [ ] Manual: a feature that DOES change data model still gets full section content

🤖 Generated with [Claude Code](https://claude.com/claude-code)