### PR TITLE
fix(routing): remove all seeded provider pins + boot audit

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -42,6 +42,38 @@ export async function register() {
       }, 3_000);
     }
 
+    // ── Pin audit invariant ────────────────────────────────────────────────
+    // Principle: routing must pick the right LLM dynamically from capability
+    // tier + task type — no hard pins (see feedback_no_provider_pinning).
+    // Pin rows are not removed on read, so a stray one from a legacy seed
+    // or manual admin change would silently override routing for that agent.
+    // Surface any surviving pins loudly so they get noticed and cleared.
+    setTimeout(async () => {
+      try {
+        const { prisma } = await import("@dpf/db");
+        const pinnedAgents = await prisma.agentModelConfig.findMany({
+          where: {
+            OR: [
+              { pinnedProviderId: { not: null } },
+              { pinnedModelId: { not: null } },
+            ],
+          },
+          select: { agentId: true, pinnedProviderId: true, pinnedModelId: true },
+        });
+        if (pinnedAgents.length > 0) {
+          console.warn(
+            `[pin-audit] ${pinnedAgents.length} AgentModelConfig row(s) carry a pin. Routing should be tier-based; pins override it. Clear them or document why: ` +
+              pinnedAgents
+                .map((a) => `${a.agentId}=${a.pinnedProviderId ?? "?"}/${a.pinnedModelId ?? "?"}`)
+                .join(", "),
+          );
+        }
+      } catch (err) {
+        // Non-fatal; guard is advisory.
+        console.warn("[pin-audit] check failed:", err);
+      }
+    }, 20_000);
+
     // ── First-boot auto-provisioning ───────────────────────────────────────
     // Runs 15s after startup. Detects active providers with zero model
     // profiles (the exact state after a fresh install where the seed +

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1374,13 +1374,24 @@ async function seedCodexModels(): Promise<void> {
     },
   });
 
-  // Pin build-specialist to codex/gpt-5.4 so it gets MCP tools.
-  // anthropic-sub uses the CLI adapter which has no tool execution.
-  await prisma.agentModelConfig.upsert({
-    where: { agentId: "build-specialist" },
-    create: { agentId: "build-specialist", pinnedProviderId: "codex", pinnedModelId: "gpt-5.4" },
-    update: { pinnedProviderId: "codex", pinnedModelId: "gpt-5.4" },
-  });
+  // INTENTIONALLY NO PIN for build-specialist.
+  //
+  // Previous seed pinned build-specialist to codex/gpt-5.4 so "it gets MCP
+  // tools". That framing was obsolete after two shipments:
+  //   * #107 introduced provider-tier preference so user-configured
+  //     providers always beat bundled local in routing — no pin needed to
+  //     keep build-specialist off Gemma4.
+  //   * #112 and #118 broadened the codex-cli and claude-cli tool_use
+  //     parsers so anthropic-sub can also execute MCP tools — no reason
+  //     to force codex specifically.
+  //
+  // Per feedback_no_provider_pinning: routing picks the right LLM for the
+  // job from capability tier + task type. Pins are a lie about the world —
+  // they force one model regardless of health, superseded by better ones,
+  // or actual task fit. No agent in the system should have a seeded pin.
+  // If build-specialist needs specific capabilities, encode them in
+  // minimumCapabilities / minimumTier / requiredModelClass (done below in
+  // seedAgentModelDefaults).
 
   const provider = await prisma.modelProvider.findFirst({ where: { providerId: "codex" } });
   if (!provider) return;
@@ -1709,16 +1720,20 @@ async function ensureBuildStudioModelConfig(): Promise<void> {
  * Uses upsert — existing admin overrides are NOT clobbered.
  */
 async function seedAgentModelDefaults(): Promise<void> {
+  // No pinnedProviderId / pinnedModelId fields here by design.
+  // See feedback_no_provider_pinning: routing picks the right LLM
+  // dynamically from capability tier + task type. Pins would overwrite
+  // routing's decision and drag agents down to stale models as the
+  // provider landscape shifts. Encode real requirements as
+  // minimumTier / minimumCapabilities / minimumContextTokens.
   const defaults: Array<{
     agentId: string;
     minimumTier: string;
     budgetClass: string;
-    pinnedProviderId?: string;
-    pinnedModelId?: string;
     minimumCapabilities?: Record<string, boolean>;
     minimumContextTokens?: number;
   }> = [
-    { agentId: "build-specialist",    minimumTier: "strong",   budgetClass: "quality_first", pinnedModelId: "claude-sonnet-4-6", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
+    { agentId: "build-specialist",    minimumTier: "strong",   budgetClass: "quality_first", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
     { agentId: "coo",                 minimumTier: "strong",   budgetClass: "balanced",      minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
     { agentId: "platform-engineer",   minimumTier: "strong",   budgetClass: "balanced",      minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
     { agentId: "admin-assistant",     minimumTier: "strong",   budgetClass: "balanced",      minimumCapabilities: { toolUse: true }, minimumContextTokens: 16000 },
@@ -1743,21 +1758,16 @@ async function seedAgentModelDefaults(): Promise<void> {
     });
     if (existing) {
       // Admin-configured rows are preserved for tier/budget.
-      // But capability floor and context minimum ARE backfilled if null —
+      // Only capability floor and context minimum are backfilled if null —
       // these are system defaults, not admin choices.
-      const needsPinUpdate =
-        (d.pinnedProviderId && !existing.pinnedProviderId) ||
-        (d.pinnedModelId && !existing.pinnedModelId);
       const needsCapUpdate =
         (d.minimumCapabilities !== undefined && existing.minimumCapabilities === null) ||
         (d.minimumContextTokens !== undefined && existing.minimumContextTokens === null);
 
-      if (needsPinUpdate || needsCapUpdate) {
+      if (needsCapUpdate) {
         await prisma.agentModelConfig.update({
           where: { agentId: d.agentId },
           data: {
-            ...(d.pinnedProviderId && !existing.pinnedProviderId ? { pinnedProviderId: d.pinnedProviderId } : {}),
-            ...(d.pinnedModelId && !existing.pinnedModelId ? { pinnedModelId: d.pinnedModelId } : {}),
             ...(d.minimumCapabilities !== undefined && existing.minimumCapabilities === null
               ? { minimumCapabilities: d.minimumCapabilities }
               : {}),
@@ -1776,8 +1786,8 @@ async function seedAgentModelDefaults(): Promise<void> {
         agentId: d.agentId,
         minimumTier: d.minimumTier,
         budgetClass: d.budgetClass,
-        pinnedProviderId: d.pinnedProviderId ?? null,
-        pinnedModelId: d.pinnedModelId ?? null,
+        // pinnedProviderId / pinnedModelId deliberately left null —
+        // see feedback_no_provider_pinning.
         ...(d.minimumCapabilities !== undefined ? { minimumCapabilities: d.minimumCapabilities } : {}),
         minimumContextTokens: d.minimumContextTokens ?? null,
         configuredAt: new Date(),


### PR DESCRIPTION
## Summary

Mark's directive: no hard pins anywhere. Routing picks the right LLM for the job dynamically from capability tier + task type so the system adapts as models come and go.

See [feedback_no_provider_pinning](C:\Users\Mark Bodman\.claude\projects\d--DPF\memory\feedback_no_provider_pinning.md) (memory).

## Changes

### \`packages/db/src/seed.ts\`
- Delete the dedicated build-specialist pin block (codex/gpt-5.4). Obsolete since #107 (tier preference) and #112/#118 (Claude CLI tool parser rescue).
- Drop \`pinnedProviderId\` / \`pinnedModelId\` from \`seedAgentModelDefaults\` entries and from the create-branch. Agents are seeded with capability floors only.
- Preserve admin-configured rows untouched.

### \`apps/web/instrumentation.ts\`
- 20s-delayed \`[pin-audit]\` boot check. Queries \`AgentModelConfig\` for any row with a non-null pin and logs a \`warn\` line naming each surviving pinned agent. Future regressions become visible in portal logs.

## Companion memory

- \`feedback_no_provider_pinning\` — No hard pins. If the right model isn't being picked, the fix is on the tiering side, not a pin.
- \`feedback_evidence_before_diagnosis\` — For the other feedback Mark gave me today.

## Test plan

- [x] Typecheck clean
- [ ] After rebuild + restart, portal logs show no \`[pin-audit]\` warn line (confirming zero pins)
- [ ] Build Studio routes to codex when healthy, falls cleanly to anthropic-sub when codex is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)