### PR TITLE
fix(routing): close the tier-contract gap — pricing, web-search, tier floor

### DIFF
--- a/apps/web/lib/routing/request-contract.ts
+++ b/apps/web/lib/routing/request-contract.ts
@@ -131,8 +131,17 @@ export async function inferContract(
   const requiresStreaming = interactionMode === "sync" && !routeContext?.requiredModelClass && !TASK_MODEL_CLASS[taskType];
 
   // ── Capability requirements ────────────────────────────────────────────
+  //
+  // Note: "requiresWebSearch" is the NATIVE capability (e.g. Gemini search-
+  // grounding, OpenAI web_search tool built into the provider). A task type
+  // of "web-search" does NOT automatically need this — almost every model
+  // can perform web search when given an MCP search tool, and the contract
+  // already demands `toolUse` for web-search via BUILT_IN_TASK_REQUIREMENTS.
+  // Only set requiresWebSearch when the caller explicitly asks for native
+  // grounding, otherwise the hard filter excludes every model that doesn't
+  // declare capabilities.webSearch (which is virtually all of them).
   const requiresCodeExecution = routeContext?.requiresCodeExecution === true;
-  const requiresWebSearch = taskType === "web-search" || routeContext?.requiresWebSearch === true;
+  const requiresWebSearch = routeContext?.requiresWebSearch === true;
   const requiresComputerUse = routeContext?.requiresComputerUse === true;
 
   // ── Input modality detection ──────────────────────────────────────────
@@ -240,6 +249,35 @@ export async function inferContract(
   if (routeContext?.residencyPolicy !== undefined) {
     contract.residencyPolicy = routeContext.residencyPolicy as
       RequestContract["residencyPolicy"];
+  }
+
+  // ── Tier floor from task requirements ───────────────────────────────────
+  // BUILT_IN_TASK_REQUIREMENTS (and the DB-overridable TaskRequirement table
+  // below) sets a `minimumTier` per task type — "code-gen" is frontier,
+  // "summarization" is adequate, etc. That tier choice encodes a dimension-
+  // score floor (TIER_MINIMUM_DIMENSIONS). Translate it into contract.
+  // minimumDimensions so pipeline-v2's hard filter excludes anything that
+  // doesn't meet the floor, and cost-per-success ranking can't route a
+  // frontier task to a strong-tier model just because it's cheaper.
+  try {
+    const [{ getTaskRequirement }, { TIER_MINIMUM_DIMENSIONS, isValidTier }] = await Promise.all([
+      import("./task-requirements"),
+      import("./quality-tiers"),
+    ]);
+    const req = await getTaskRequirement(taskType);
+    const tier = req?.minimumTier;
+    if (tier && isValidTier(tier)) {
+      const tierFloor = TIER_MINIMUM_DIMENSIONS[tier];
+      if (Object.keys(tierFloor).length > 0) {
+        contract.minimumDimensions = {
+          ...tierFloor,
+          ...(contract.minimumDimensions ?? {}),
+        };
+      }
+    }
+  } catch {
+    // Non-fatal: if the tier lookup fails, contract continues without
+    // a tier floor (defaulting to existing behaviour).
   }
 
   return contract;

--- a/apps/web/lib/routing/task-requirements.ts
+++ b/apps/web/lib/routing/task-requirements.ts
@@ -127,13 +127,20 @@ export async function getTaskRequirement(
     return taskRequirementCache.get(taskType);
   }
 
-  const dbRow = await prisma.taskRequirement.findUnique({ where: { taskType } });
-  if (dbRow) {
-    // Prisma returns Json fields as `unknown`. We control the shape via seed + UI,
-    // so the cast is safe.
-    const requirement = dbRow as unknown as TaskRequirement;
-    taskRequirementCache.set(taskType, requirement);
-    return requirement;
+  // Try DB first; fall back to the built-in catalogue if the query fails
+  // (e.g. tests running without a provisioned Prisma client, or a transient
+  // connection blip). BUILT_IN_TASK_REQUIREMENTS is the canonical fallback
+  // so routing always gets a contract — missing DB must never break tier
+  // enforcement.
+  try {
+    const dbRow = await prisma.taskRequirement.findUnique({ where: { taskType } });
+    if (dbRow) {
+      const requirement = dbRow as unknown as TaskRequirement;
+      taskRequirementCache.set(taskType, requirement);
+      return requirement;
+    }
+  } catch {
+    // Fall through to built-in.
   }
 
   const builtIn = BUILT_IN_TASK_REQUIREMENTS[taskType];

--- a/apps/web/lib/routing/tier-contract.test.ts
+++ b/apps/web/lib/routing/tier-contract.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tier-contract regression test — asserts that for every task type in
+ * BUILT_IN_TASK_REQUIREMENTS, the V2 routing pipeline selects a model
+ * whose qualityTier meets or exceeds the task's declared minimumTier,
+ * satisfies all required capabilities, and clears the tier-floor
+ * dimension thresholds.
+ *
+ * This is the executable form of the "right LLM for the right job"
+ * principle (feedback_no_provider_pinning). Failures here always mean
+ * one of:
+ *   - A model's qualityTier is wrong / unset in seed data
+ *   - A model's dimension score is wrong
+ *   - A task's minimumTier or requiredCapabilities is wrong
+ *   - A pricing seed row is missing (collapses ranking)
+ *   - A pin re-appeared somewhere (see pin-audit in instrumentation.ts)
+ *
+ * Uses mocked manifests rather than the live DB so the test is
+ * deterministic and runs in CI without a provisioned provider stack.
+ * Live-DB equivalent: apps/web/scripts/probe-tier-contract.ts.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { EndpointManifest } from "./types";
+import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
+import { routeEndpointV2 } from "./pipeline-v2";
+import { inferContract } from "./request-contract";
+import { BUILT_IN_TASK_REQUIREMENTS } from "./task-requirements";
+import type { QualityTier } from "./quality-tiers";
+
+// Mock champion-challenger so selectRecipeWithExploration returns null recipe.
+vi.mock("./champion-challenger", () => ({
+  selectRecipeWithExploration: vi.fn().mockResolvedValue({
+    recipe: null,
+    explorationMode: "champion",
+  }),
+}));
+
+const TIER_ORDER: Record<QualityTier, number> = {
+  basic: 0,
+  adequate: 1,
+  strong: 2,
+  frontier: 3,
+};
+
+// ─── Fixture manifests — shape mirrors production ──────────────────────────
+// Anthropic subscription family with real dimension scores + pricing so the
+// probe behaves the same way as the live install.
+
+function ep(overrides: Partial<EndpointManifest>): EndpointManifest {
+  return {
+    id: overrides.id ?? "ep-default",
+    providerId: "anthropic-sub",
+    modelId: "default",
+    name: "default",
+    endpointType: "chat",
+    status: "active",
+    providerTier: "user_configured",
+    sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+    supportsToolUse: true,
+    supportsStructuredOutput: true,
+    supportsStreaming: true,
+    maxContextTokens: 200000,
+    maxOutputTokens: 8192,
+    modelRestrictions: [],
+    reasoning: 75,
+    codegen: 75,
+    toolFidelity: 75,
+    instructionFollowing: 75,
+    structuredOutput: 72,
+    conversational: 75,
+    contextRetention: 72,
+    customScores: {},
+    avgLatencyMs: 1000,
+    recentFailureRate: 0,
+    costPerOutputMToken: 5,
+    profileSource: "seed",
+    profileConfidence: "high",
+    retiredAt: null,
+    qualityTier: "strong",
+    modelClass: "chat",
+    modelFamily: "claude",
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    capabilities: {
+      ...EMPTY_CAPABILITIES,
+      toolUse: true,
+      structuredOutput: true,
+      streaming: true,
+    },
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 1, outputPerMToken: 5 },
+    supportedParameters: [],
+    deprecationDate: null,
+    metadataSource: "seed",
+    metadataConfidence: "high",
+    perRequestLimits: null,
+    ...overrides,
+  };
+}
+
+const MANIFESTS: EndpointManifest[] = [
+  ep({
+    id: "ep-haiku",
+    modelId: "claude-haiku-4-5-20251001",
+    name: "Claude Haiku 4.5",
+    qualityTier: "strong",
+    reasoning: 75, codegen: 75, toolFidelity: 75,
+    costPerOutputMToken: 5,
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 1, outputPerMToken: 5 },
+  }),
+  ep({
+    id: "ep-sonnet-46",
+    modelId: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    qualityTier: "frontier",
+    reasoning: 95, codegen: 95, toolFidelity: 95,
+    costPerOutputMToken: 15,
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 3, outputPerMToken: 15 },
+  }),
+  ep({
+    id: "ep-opus-47",
+    modelId: "claude-opus-4-7",
+    name: "Claude Opus 4.7",
+    qualityTier: "frontier",
+    reasoning: 95, codegen: 92, toolFidelity: 90,
+    costPerOutputMToken: 75,
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 15, outputPerMToken: 75 },
+  }),
+  ep({
+    id: "ep-local",
+    providerId: "local",
+    providerTier: "bundled",
+    modelId: "docker.io/ai/gemma4:latest",
+    name: "Local Gemma 4",
+    qualityTier: "adequate",
+    reasoning: 62, codegen: 58, toolFidelity: 55,
+    costPerOutputMToken: 0,
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 0, outputPerMToken: 0 },
+  }),
+];
+
+describe("tier contract — each task type gets an appropriate model", () => {
+  const canonicalMessage: Record<string, string> = {
+    greeting: "Hello there",
+    "status-query": "What's the status of order #12345?",
+    summarization: "Summarize this text: The meeting covered Q4 plans.",
+    "data-extraction": "Extract the name and email from: John Smith, john@acme.com",
+    "web-search": "Search the web for recent news about Kubernetes.",
+    creative: "Write a tagline for a sustainable clothing brand.",
+    reasoning: "If A implies B and B implies C, and not-C, what about A?",
+    "code-gen": "Write a TypeScript function that deduplicates an array.",
+    "tool-action": "Use the get_weather tool to check today's forecast.",
+  };
+
+  for (const [taskType, req] of Object.entries(BUILT_IN_TASK_REQUIREMENTS)) {
+    it(`${taskType} routes to a model satisfying minimumTier=${req.minimumTier}`, async () => {
+      const contract = await inferContract(
+        taskType,
+        [{ role: "user", content: canonicalMessage[taskType] ?? "test" }],
+      );
+      const decision = await routeEndpointV2(MANIFESTS, contract, [], []);
+
+      expect(decision.selectedEndpoint, `${taskType}: ${decision.reason}`).toBeTruthy();
+
+      const selected = MANIFESTS.find((m) => m.id === decision.selectedEndpoint);
+      expect(selected, `selected endpoint ${decision.selectedEndpoint} should be in manifests`).toBeDefined();
+      if (!selected) return;
+
+      // Tier floor
+      const minTier = req.minimumTier as QualityTier | undefined;
+      if (minTier) {
+        const actualTier = selected.qualityTier;
+        expect(
+          actualTier && TIER_ORDER[actualTier] >= TIER_ORDER[minTier],
+          `${taskType}: selected ${selected.providerId}/${selected.modelId} is ${actualTier ?? "(unset)"}, ` +
+            `required minimumTier ${minTier}`,
+        ).toBeTruthy();
+      }
+
+      // Required capabilities
+      const reqCaps = req.requiredCapabilities ?? {};
+      if (reqCaps.supportsToolUse) {
+        expect(selected.supportsToolUse, `${taskType}: model must support toolUse`).toBe(true);
+      }
+      if (reqCaps.supportsStructuredOutput) {
+        expect(
+          selected.capabilities.structuredOutput === true,
+          `${taskType}: model must support structuredOutput`,
+        ).toBe(true);
+      }
+      if (reqCaps.supportsStreaming) {
+        expect(
+          selected.capabilities.streaming === true,
+          `${taskType}: model must support streaming`,
+        ).toBe(true);
+      }
+
+      // preferredMinScores (soft-preferred dimensions)
+      const minScores = (req.preferredMinScores ?? {}) as Record<string, number>;
+      for (const [dim, min] of Object.entries(minScores)) {
+        const actual = (selected as unknown as Record<string, number>)[dim];
+        if (typeof actual === "number") {
+          expect(
+            actual >= min,
+            `${taskType}: dim ${dim}=${actual} below preferred floor ${min} for selected ${selected.modelId}`,
+          ).toBe(true);
+        }
+      }
+    });
+  }
+});

--- a/apps/web/scripts/probe-tier-contract.ts
+++ b/apps/web/scripts/probe-tier-contract.ts
@@ -1,0 +1,190 @@
+/**
+ * Tier-contract probe — runs the full routing pipeline for each task type
+ * in BUILT_IN_TASK_REQUIREMENTS against the LIVE model registry and prints
+ * whether the selection satisfies the task's declared minimum tier and
+ * required capabilities.
+ *
+ * This is the executable form of the "right LLM for the right job" principle.
+ * Failures here are specific and fixable: either a model's qualityTier / scores
+ * are wrong, a call-site's taskType tag is wrong, or the task's minimum
+ * thresholds are wrong. Not a redesign — a truing-up.
+ *
+ * Usage inside the portal container:
+ *   pnpm --filter web exec tsx scripts/probe-tier-contract.ts
+ */
+import { loadEndpointManifests, loadPolicyRules, loadOverrides } from "@/lib/routing/loader";
+import { routeEndpointV2 } from "@/lib/routing/pipeline-v2";
+import { inferContract } from "@/lib/routing/request-contract";
+import { BUILT_IN_TASK_REQUIREMENTS } from "@/lib/routing/task-requirements";
+import { TIER_MINIMUM_DIMENSIONS } from "@/lib/routing/quality-tiers";
+import type { QualityTier } from "@/lib/routing/quality-tiers";
+
+const TIER_ORDER: Record<QualityTier, number> = {
+  basic: 0,
+  adequate: 1,
+  strong: 2,
+  frontier: 3,
+};
+
+const CANONICAL_MESSAGES: Record<string, string> = {
+  greeting: "Hello there",
+  "status-query": "What's the status of order #12345?",
+  summarization: "Summarize this text: The meeting discussed Q4 plans, focusing on product launches and staffing needs.",
+  "data-extraction": "Extract the name, email, and company from this signature: John Smith, CEO, Acme Corp, john@acme.com",
+  "web-search": "Search the web for recent news about Kubernetes.",
+  creative: "Write a 2-sentence tagline for a sustainable clothing brand.",
+  reasoning: "If A implies B, and B implies C, and we observe not-C, what can we conclude about A?",
+  "code-gen": "Write a TypeScript function that deduplicates an array while preserving order.",
+  "tool-action": "Use the get_weather tool to check today's forecast for Seattle.",
+};
+
+const COLORS = {
+  ok: "\u001b[32m",     // green
+  warn: "\u001b[33m",   // yellow
+  fail: "\u001b[31m",   // red
+  reset: "\u001b[0m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+};
+
+type CheckResult = {
+  taskType: string;
+  passed: boolean;
+  selectedModel: string;
+  selectedTier: string;
+  requiredTier: string;
+  violations: string[];
+};
+
+async function runProbe(): Promise<void> {
+  const [manifests, policies, overrides] = await Promise.all([
+    loadEndpointManifests(),
+    loadPolicyRules(),
+    loadOverrides("default"),
+  ]);
+
+  console.log(`\n${COLORS.bold}Tier-contract probe${COLORS.reset}`);
+  console.log(`  Manifests loaded: ${manifests.length}`);
+  console.log(`  Tier distribution: ${summarizeTiers(manifests)}`);
+  console.log("");
+
+  const results: CheckResult[] = [];
+
+  for (const [taskType, req] of Object.entries(BUILT_IN_TASK_REQUIREMENTS)) {
+    const message = CANONICAL_MESSAGES[taskType] ?? `(no canonical message for ${taskType})`;
+    const violations: string[] = [];
+    let selectedModel = "(none)";
+    let selectedTier = "(none)";
+
+    try {
+      const contract = await inferContract(taskType, [{ role: "user", content: message }]);
+
+      const decision = await routeEndpointV2(manifests, contract, policies, overrides);
+
+      if (!decision.selectedEndpoint) {
+        violations.push(`NO ELIGIBLE ENDPOINT: ${decision.reason}`);
+      } else {
+        const selected = manifests.find((m) => m.id === decision.selectedEndpoint);
+        if (!selected) {
+          violations.push(`selected endpoint ${decision.selectedEndpoint} not in manifests`);
+        } else {
+          selectedModel = `${selected.providerId}/${selected.modelId}`;
+          selectedTier = selected.qualityTier ?? "(unset)";
+
+          // Check 1: qualityTier floor
+          const reqTier = req.minimumTier as QualityTier | undefined;
+          if (reqTier) {
+            const actualTierOrder = selected.qualityTier ? TIER_ORDER[selected.qualityTier] : -1;
+            const requiredTierOrder = TIER_ORDER[reqTier];
+            if (actualTierOrder < requiredTierOrder) {
+              violations.push(
+                `TIER BELOW FLOOR: selected ${selected.qualityTier ?? "(unset)"} < required ${reqTier}`,
+              );
+            }
+          }
+
+          // Check 2: required capabilities present
+          const reqCaps = req.requiredCapabilities ?? {};
+          if (reqCaps.supportsToolUse && !selected.supportsToolUse) {
+            violations.push("MISSING supportsToolUse");
+          }
+          if (reqCaps.supportsStructuredOutput && selected.capabilities.structuredOutput !== true) {
+            violations.push("MISSING supportsStructuredOutput");
+          }
+          if (reqCaps.supportsStreaming && selected.capabilities.streaming !== true) {
+            violations.push("MISSING supportsStreaming");
+          }
+
+          // Check 3: preferred min scores
+          const minScores = (req.preferredMinScores ?? {}) as Record<string, number>;
+          for (const [dim, min] of Object.entries(minScores)) {
+            const actual = (selected as unknown as Record<string, number>)[dim];
+            if (typeof actual === "number" && actual < min) {
+              violations.push(`DIMENSION BELOW ${dim}: ${actual} < ${min}`);
+            }
+          }
+
+          // Check 4: tier-dimension floor (more aggressive than preferredMinScores)
+          if (reqTier && TIER_MINIMUM_DIMENSIONS[reqTier]) {
+            for (const [dim, min] of Object.entries(TIER_MINIMUM_DIMENSIONS[reqTier])) {
+              const actual = (selected as unknown as Record<string, number>)[dim];
+              if (typeof actual === "number" && actual < min) {
+                violations.push(`TIER-FLOOR ${dim}: ${actual} < ${min} (tier ${reqTier})`);
+              }
+            }
+          }
+        }
+      }
+    } catch (err) {
+      violations.push(`EXCEPTION: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const result: CheckResult = {
+      taskType,
+      passed: violations.length === 0,
+      selectedModel,
+      selectedTier,
+      requiredTier: req.minimumTier ?? "(none)",
+      violations,
+    };
+    results.push(result);
+
+    const badge = result.passed ? `${COLORS.ok}PASS${COLORS.reset}` : `${COLORS.fail}FAIL${COLORS.reset}`;
+    console.log(
+      `  ${badge} ${taskType.padEnd(18)} → ${selectedModel.padEnd(40)} ${COLORS.dim}tier=${selectedTier} (req ${result.requiredTier})${COLORS.reset}`,
+    );
+    for (const v of violations) {
+      console.log(`        ${COLORS.warn}✗ ${v}${COLORS.reset}`);
+    }
+  }
+
+  console.log("");
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.length - passed;
+  const color = failed === 0 ? COLORS.ok : COLORS.fail;
+  console.log(`${color}${COLORS.bold}${passed}/${results.length} task types satisfy their tier contract${COLORS.reset}`);
+
+  if (failed > 0) {
+    console.log("\nSummary of failures:");
+    for (const r of results.filter((r) => !r.passed)) {
+      console.log(`  ${r.taskType}:`);
+      for (const v of r.violations) console.log(`    - ${v}`);
+    }
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+function summarizeTiers(manifests: Array<{ qualityTier?: string }>): string {
+  const counts = new Map<string, number>();
+  for (const m of manifests) {
+    const tier = m.qualityTier ?? "(unset)";
+    counts.set(tier, (counts.get(tier) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([t, n]) => `${t}=${n}`).join(", ");
+}
+
+runProbe().catch((err) => {
+  console.error("Probe crashed:", err);
+  process.exit(2);
+});

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1638,6 +1638,90 @@ async function seedModelProfiles(): Promise<void> {
    * This runs on every seed to fix profiles that may have been incorrectly
    * set by model discovery or provider sync.
    */
+/**
+ * Seed known per-M-token pricing for recognized model-name patterns.
+ *
+ * Why this matters: cost-per-success ranking in pipeline-v2 compares
+ * paid candidates by `pricing.inputPerMToken` + `outputPerMToken`.
+ * When pricing is null (as it was for every paid model in model-profiles.json
+ * before this seed), every paid candidate gets the same penalized
+ * rank of `successProb * 50`, they all tie, and routing picks whichever
+ * is first in the list. Net effect: summarization on Opus, code-gen on
+ * Opus, greeting on Opus — every task lands on the same model.
+ *
+ * Using public API rates as proxy values works even for subscription-
+ * backed providers (anthropic-sub, codex). The routing uses RELATIVE
+ * cost ordering, so as long as Haiku < Sonnet < Opus and cheaper coder
+ * models < frontier generalist models, the ranking picks the right
+ * model for the job. Real subscription users pay a flat fee; the
+ * ranking just tells the router to prefer the cheapest capable option.
+ *
+ * Only touches rows where pricing.inputPerMToken is currently null —
+ * admin-tuned prices are preserved.
+ */
+async function seedModelPricing(): Promise<void> {
+  // Public API rates (per 1M tokens) as of early 2026.
+  // Pattern matching is substring-on-modelId — new model versions pick
+  // up the right bracket automatically.
+  const priceBrackets: Array<{
+    match: (providerId: string, modelId: string) => boolean;
+    inputPerMToken: number;
+    outputPerMToken: number;
+  }> = [
+    // Anthropic Claude family
+    { match: (p, m) => p === "anthropic-sub" && m.includes("haiku"), inputPerMToken: 1, outputPerMToken: 5 },
+    { match: (p, m) => p === "anthropic-sub" && m.includes("sonnet"), inputPerMToken: 3, outputPerMToken: 15 },
+    { match: (p, m) => p === "anthropic-sub" && m.includes("opus"), inputPerMToken: 15, outputPerMToken: 75 },
+    // Anthropic direct API
+    { match: (p, m) => p === "anthropic" && m.includes("haiku"), inputPerMToken: 1, outputPerMToken: 5 },
+    { match: (p, m) => p === "anthropic" && m.includes("sonnet"), inputPerMToken: 3, outputPerMToken: 15 },
+    { match: (p, m) => p === "anthropic" && m.includes("opus"), inputPerMToken: 15, outputPerMToken: 75 },
+    // OpenAI subscription (codex CLI) + ChatGPT
+    { match: (p, m) => (p === "codex" || p === "chatgpt") && m.includes("codex"), inputPerMToken: 5, outputPerMToken: 20 },
+    { match: (p, m) => (p === "codex" || p === "chatgpt") && m.startsWith("gpt-5"), inputPerMToken: 10, outputPerMToken: 40 },
+    { match: (p, m) => (p === "codex" || p === "chatgpt") && m.startsWith("gpt-4"), inputPerMToken: 5, outputPerMToken: 15 },
+    // OpenAI direct
+    { match: (p, m) => p === "openai" && m.startsWith("gpt-5"), inputPerMToken: 10, outputPerMToken: 40 },
+    { match: (p, m) => p === "openai" && m.startsWith("gpt-4"), inputPerMToken: 5, outputPerMToken: 15 },
+    // Bundled local — always free
+    { match: (p) => p === "local" || p === "ollama", inputPerMToken: 0, outputPerMToken: 0 },
+  ];
+
+  const profiles = await prisma.modelProfile.findMany({
+    select: { id: true, providerId: true, modelId: true, pricing: true },
+  });
+
+  let updated = 0;
+  let skipped = 0;
+  for (const mp of profiles) {
+    const currentPricing = (mp.pricing as Record<string, unknown>) ?? {};
+    // Preserve admin-tuned values: skip if input/output per M is already non-null.
+    if (currentPricing.inputPerMToken != null && currentPricing.outputPerMToken != null) {
+      skipped++;
+      continue;
+    }
+    const bracket = priceBrackets.find((b) => b.match(mp.providerId, mp.modelId));
+    if (!bracket) {
+      skipped++;
+      continue;
+    }
+    await prisma.modelProfile.update({
+      where: { id: mp.id },
+      data: {
+        pricing: {
+          ...currentPricing,
+          inputPerMToken: bracket.inputPerMToken,
+          outputPerMToken: bracket.outputPerMToken,
+        } as never,
+        inputPricePerMToken: bracket.inputPerMToken,
+        outputPricePerMToken: bracket.outputPerMToken,
+      },
+    });
+    updated++;
+  }
+  console.log(`  Seeded pricing for ${updated} model profiles (${skipped} already set or unknown)`);
+}
+
 async function ensureBuildStudioModelConfig(): Promise<void> {
   // ── Ensure all current Anthropic models have correct status ──────────────
   // Sonnet 4.6 and Opus 4.6 are the primary models for Build Studio and
@@ -1864,6 +1948,7 @@ async function main(): Promise<void> {
   await seedLocalModels();
   await seedModelProfiles();
   await ensureBuildStudioModelConfig();
+  await seedModelPricing();
   await seedAgentModelDefaults();
   await seedPlatformConfig();
   await seedClientIdentity();


### PR DESCRIPTION
## Summary

The "right LLM for right job" principle was instrumented throughout the codebase (tiers, BUILT_IN_TASK_REQUIREMENTS, dimension scores, cost-per-success ranking) but three feeds were broken. Every task was landing on Opus regardless of need; web-search couldn't route at all; frontier-required tasks were landing on Haiku when I added pricing.

## Results

New regression test `tier-contract.test.ts` — 9/9 passing:

| Task | Selected | Why |
|---|---|---|
| greeting / status-query / summarization | Claude Haiku 4.5 | strong+cheap, adequate-tier task |
| data-extraction / web-search / creative | Claude Haiku 4.5 | strong+cheap, strong-tier task |
| reasoning / code-gen / tool-action | Claude Sonnet 4.5 | frontier, frontier-tier task |

Local Gemma4 stays as fallback only.

## Three fixes

### 1. Pricing seed (`packages/db/src/seed.ts`)
Every paid model had `pricing.inputPerMToken = null`. Cost-per-success collapsed to `successProb*50` for everything, they all tied, first wins (Opus). Added `seedModelPricing()` that fills in public-API-rate proxies for recognised patterns (claude-haiku/sonnet/opus, gpt-5.x, codex). Preserves admin-tuned values.

### 2. Stop auto-requiring webSearch capability (`request-contract.ts`)
inferContract was setting `requiresWebSearch=true` when taskType=="web-search", but no model declares `capabilities.webSearch=true` (it's a TOOL, not a native capability). Every endpoint was excluded. Changed so `requiresWebSearch` only fires when explicitly set via routeContext.

### 3. Translate minimumTier into minimumDimensions (`request-contract.ts`)
BUILT_IN_TASK_REQUIREMENTS sets `minimumTier: "frontier"` for code-gen etc., but that never flowed into the V2 contract's hard filter. After the pricing fix, cost-ranking would pick Haiku for frontier tasks because it was cheapest. Now the tier floor is injected into `contract.minimumDimensions` (via `TIER_MINIMUM_DIMENSIONS`) and the hard filter enforces it.

### Also
- `getTaskRequirement` falls back to BUILT_IN_TASK_REQUIREMENTS when the DB query throws (tests without DB, cold start)
- Live-DB probe at `apps/web/scripts/probe-tier-contract.ts` — the same contract against the real registry. Useful diagnostic.

## Test plan

- [x] Typecheck clean
- [x] `pnpm exec vitest run lib/routing/tier-contract.test.ts` — 9/9 passing
- [x] Live probe against this install — 9/9 passing
- [ ] Portal manual: next coworker turn should route simple chat to Haiku, code-gen to Sonnet

## Remaining follow-ups (separate PRs)

- **Error → blank panel** — when an agentic-loop call errors, the coworker panel clears messages instead of showing the error. Mark observed this today; separate fix.
- **Ship the regression test as merge-blocking in CI** — today the Unit Tests job is continue-on-error; consider promoting this single test to required.
- **Design docs consolidation** — 8 routing design docs exist; mark superseded ones as such, promote the current state to the primary spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)