### PR TITLE
fix(coworker): refresh panel by threadId, not by route context

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { resolveAgentForRouteSync, AGENT_NAME_MAP } from "@/lib/agent-routing";
-import { clearConversation, getOrCreateThreadSnapshot, getMarketingSkillRules } from "@/lib/actions/agent-coworker";
+import { clearConversation, getOrCreateThreadSnapshot, getThreadSnapshotById, getMarketingSkillRules } from "@/lib/actions/agent-coworker";
 import { approveProposal, rejectProposal } from "@/lib/actions/proposals";
 import { AgentPanelHeader } from "./AgentPanelHeader";
 import { AgentMessageBubble } from "./AgentMessageBubble";
@@ -257,15 +257,24 @@ export function AgentCoworkerPanel({
             activeFormAssistRef.current.applyFieldUpdates(data.formAssistUpdate);
           }
 
-          // Refresh messages from DB — authoritative source
-          getOrCreateThreadSnapshot({ routeContext: effectiveRoute }).then((snapshot) => {
-            if (snapshot) {
-              setMessages(filterMessages(snapshot.messages));
-            }
+          // Refresh messages from DB — authoritative source.
+          // Fetch by threadId (which we already have as a prop) rather than
+          // by routeContext. The thread may be bound to a sub-context like
+          // "/build#FB-xxx" while pathname is just "/build"; fetching by
+          // routeContext would return the wrong (empty) thread and blow
+          // the panel's message list away.
+          if (threadId) {
+            getThreadSnapshotById({ threadId }).then((snapshot) => {
+              if (snapshot) {
+                setMessages(filterMessages(snapshot.messages));
+              }
+              setIsBusy(false);
+            }).catch(() => {
+              setIsBusy(false);
+            });
+          } else {
             setIsBusy(false);
-          }).catch(() => {
-            setIsBusy(false);
-          });
+          }
         }
 
         // Relay build-relevant events to BuildStudio via DOM event.
@@ -291,8 +300,10 @@ export function AgentCoworkerPanel({
 
     // Periodic recovery: check DB every 15 seconds while busy.
     // Catches missed SSE "done" events (connection drops, server restart, etc.)
+    // Fetches by threadId for the same reason as the "done" handler above.
     const recoveryInterval = setInterval(() => {
-      getOrCreateThreadSnapshot({ routeContext: effectiveRoute }).then((snapshot) => {
+      if (!threadId) return;
+      getThreadSnapshotById({ threadId }).then((snapshot) => {
         if (!snapshot) return;
         const latestMsg = snapshot.messages[snapshot.messages.length - 1];
         if (latestMsg && (latestMsg.role === "assistant" || latestMsg.role === "system")) {

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -48,6 +48,53 @@ async function requireAuthUser() {
 
 // ─── Server Actions ─────────────────────────────────────────────────────────
 
+/**
+ * Load a thread's messages by its DB id (not by route context).
+ *
+ * Use this when the caller already knows which thread it's displaying
+ * (e.g. AgentCoworkerPanel has `threadId` as a prop). The generic
+ * `getOrCreateThreadSnapshot({routeContext})` lookup can land on a
+ * DIFFERENT thread when the route context differs from the thread's
+ * original context — e.g. on /build the panel is bound to
+ * `/build#FB-xxx` via the Shell, but `pathname === "/build"`, and
+ * fetching by route context would return the empty generic /build
+ * thread, blowing away the active-build messages. This overload
+ * binds the fetch to the actual thread id.
+ */
+export async function getThreadSnapshotById(input: {
+  threadId: string;
+}): Promise<{ threadId: string; messages: AgentMessageRow[] } | null> {
+  const user = await requireAuthUser();
+
+  const thread = await prisma.agentThread.findFirst({
+    where: { id: input.threadId, userId: user.id },
+    select: { id: true },
+  });
+  if (!thread) return null;
+
+  const messages = await prisma.agentMessage.findMany({
+    where: { threadId: thread.id },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      agentId: true,
+      routeContext: true,
+      createdAt: true,
+      attachments: {
+        select: { id: true, fileName: true, mimeType: true, sizeBytes: true, parsedContent: true },
+      },
+    },
+  });
+
+  return {
+    threadId: thread.id,
+    messages: messages.reverse().map((m) => serializeMessage(m)),
+  };
+}
+
 export async function getOrCreateThreadSnapshot(input: {
   routeContext: string;
 }): Promise<{ threadId: string; messages: AgentMessageRow[] } | null> {


### PR DESCRIPTION
## Summary

When an agentic-loop call finished or the 15s recovery poll fired, the coworker panel refreshed its message list via \`getOrCreateThreadSnapshot({ routeContext: pathname })\`. On \`/build\`, the panel is actually displaying the thread bound to \`/build#FB-xxx\` (thread-per-build), but the lookup goes by plain \`/build\` and finds (or creates) an empty generic thread. \`setMessages(filterMessages([]))\` blows the panel away.

Mark observed this today: agent errored out ("Invalid API key"), message rendered for a moment, then the "done" SSE event refreshed → blank.

## Fix

New server action \`getThreadSnapshotById(threadId)\`. The panel already has \`threadId\` as a prop — use it. Both refresh sites (SSE done + recovery poll) switch to the by-id loader. No behaviour change elsewhere — the route-context lookup stays for initial-load paths that don't know a threadId yet.

## Test plan

- [x] Typecheck clean
- [ ] Manual: agent error no longer blanks the panel; response (even an error response) stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)