### PR TITLE
fix(build): add explicit accessibility field to design doc schema

### DIFF
--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -49,6 +49,11 @@ export type BuildDesignDoc = {
   proposedApproach: string;
   acceptanceCriteria: string[];
   reusabilityAnalysis?: ReusabilityAnalysis;
+  /** Accessibility requirements (or "Not applicable — <reason>"). The
+   *  review prompt checks this explicit field rather than re-asking
+   *  the reviewer to derive a11y on every run, which was producing
+   *  review-rejection loops. */
+  accessibility?: string;
 };
 
 export type BuildPlanDoc = {

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -23,6 +23,7 @@ Reuse Plan: ${doc.reusePlan}
 Proposed Approach: ${doc.proposedApproach}
 Acceptance Criteria: ${Array.isArray(doc.acceptanceCriteria) ? doc.acceptanceCriteria.join("; ") : doc.acceptanceCriteria ?? "Not specified"}
 ${doc.reusabilityAnalysis ? `Reusability Analysis: Scope=${doc.reusabilityAnalysis.scope}, Entities=${doc.reusabilityAnalysis.domainEntities.map((e) => `${e.hardcodedValue}->${e.parameterName}`).join(", ") || "none"}, Boundary="${doc.reusabilityAnalysis.abstractionBoundary}", Readiness=${doc.reusabilityAnalysis.contributionReadiness}` : ""}
+${(doc as { accessibility?: string }).accessibility ? `Accessibility: ${(doc as { accessibility?: string }).accessibility}` : ""}
 
 PROJECT CONTEXT:
 ${projectContext}
@@ -35,7 +36,7 @@ REVIEW CHECKLIST — evaluate EVERY item before responding:
 5. Is new code justified where reuse wasn't possible?
 6. Is the proposed approach sound?
 7. Are acceptance criteria testable and specific?
-${hasUI ? `8. Does the design consider accessibility? (semantic HTML structure, keyboard-navigable interactions, ARIA labels for non-text interactive elements, color not the sole conveyor of meaning)` : `8. (Accessibility review skipped — this feature has no user-facing UI components.)`}
+${hasUI ? `8. Does the design's "Accessibility" field explicitly address a11y? (semantic HTML, keyboard operability, ARIA labels, visible focus, color-not-sole-conveyor.) If the Accessibility field is present and covers these points, accept it — do NOT re-demand the same criteria as a failure reason. If the Accessibility field is missing or says "Not applicable" despite obvious UI surface, THAT's a critical issue.` : `8. (Accessibility review skipped — this feature has no user-facing UI components.)`}
 9. If reusabilityAnalysis exists and scope is "parameterizable", does the proposed approach actually parameterize the identified domain entities? Flag any entity listed in domainEntities that appears hardcoded in the proposedApproach rather than stored as configuration.
 
 SEVERITY CALIBRATION: Use "critical" ONLY for issues that would cause data loss, security vulnerabilities, or broken functionality. Use "important" for design gaps that should be addressed but don't block implementation. Use "minor" for style, naming, or nice-to-have improvements. A health endpoint or simple utility does NOT need the same rigor as a payment system — calibrate accordingly.

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -194,6 +194,8 @@ YOUR TASK:
 
   "acceptanceCriteria": ["criterion 1 — written as a testable statement", "criterion 2", "..."],
 
+  "accessibility": "REQUIRED for any feature with UI changes. Explicit, testable accessibility requirements: semantic HTML structure, keyboard-operable interactions (tab order, focus states, Enter/Escape handlers), ARIA labels and live regions for non-text affordances, color-is-not-the-sole-conveyor-of-meaning, visible focus indicators. If the feature has NO user-facing UI at all (pure backend / API-only / cron / utility), write exactly: 'Not applicable — <one-sentence reason, e.g. backend-only, no UI surface>'. The review rejects UI features that omit accessibility; this field is how you demonstrate you considered it.",
+
   "reusabilityAnalysis": {
     "scope": "${params.reusabilityScope}",
     "domainEntities": [{"hardcodedValue": "example", "parameterName": "exampleParam", "otherInstances": ["other1"]}],


### PR DESCRIPTION
## Summary

Design review loops on UI features because:

1. ideate-research produces design docs without accessibility content
2. Reviewer correctly demands "add accessibility requirements"
3. Agent revises other parts
4. Reviewer demands a11y again → loop

Observed live today on Mark's subnet-filter build — review rejected for ~2 hours on this exact basis.

## Fix

Schema change: add optional \`accessibility\` field to \`BuildDesignDoc\`.

- ideate-research prompt requires the agent to fill it with concrete, testable a11y criteria (keyboard operability, semantic structure, ARIA, visible focus, non-color signals, live announcements) OR "Not applicable — <reason>" for backend-only features
- Reviewer prompt evaluates the explicit field rather than re-deriving a11y from prose every run. Present + adequate → pass. Missing on a UI feature → critical.

## Test plan

- [x] Typecheck clean
- [ ] Mark's stuck build (FB-21EEA510) — design doc already manually patched with explicit a11y; next reviewDesignDoc should pass, anchors auto-create (#130), phase advance to plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)