### PR TITLE
fix(coworker): read review.decision (not tool.success) for ideate summary

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1194,9 +1194,11 @@ export async function sendMessage(input: {
                 console.log(`[coworker] reviewDesignDoc result: success=${reviewResult.success}, msg=${reviewResult.message?.slice(0, 100)}`);
                 agentEventBus.emit(input.threadId, { type: "tool:complete", tool: "design_review", success: reviewResult.success });
 
+                const reviewDecision = (reviewResult.data as { review?: { decision?: string }; blocked?: boolean } | undefined);
+                const reviewPassed = reviewDecision?.review?.decision === "pass" && !reviewDecision?.blocked;
                 responseContent = await summariseIdeateOutcome(
                   approach,
-                  reviewResult.success,
+                  reviewPassed,
                   resolvedBuildId,
                 );
               }
@@ -1228,9 +1230,11 @@ export async function sendMessage(input: {
                     agentEventBus.emit(input.threadId, { type: "tool:start", tool: "design_review", iteration: 0 });
                     const reviewResult = await executeTool("reviewDesignDoc", {}, user.id!, { routeContext: input.routeContext });
                     agentEventBus.emit(input.threadId, { type: "tool:complete", tool: "design_review", success: reviewResult.success });
+                    const reviewDecision = (reviewResult.data as { review?: { decision?: string }; blocked?: boolean } | undefined);
+                    const reviewPassed = reviewDecision?.review?.decision === "pass" && !reviewDecision?.blocked;
                     responseContent = await summariseIdeateOutcome(
                       approach,
-                      reviewResult.success,
+                      reviewPassed,
                       resolvedBuildId,
                     );
                   }


### PR DESCRIPTION
## Summary
- \`summariseIdeateOutcome\` received \`reviewResult.success\` as \`reviewPassed\`, but \`reviewDesignDoc\` returns \`success: true\` on both the **fail** and **pass** paths (the failed branch returns structured recovery instructions, not an error).
- As a result the coworker told users "Design review passed" even when the review was still failing on critical issues, sending them in circles on the "Ready to move to planning?" loop while the underlying review kept failing.

## Fix
Extract the real decision from \`reviewResult.data.review.decision\` and \`reviewResult.data.blocked\` at both call sites in \`apps/web/lib/actions/agent-coworker.ts\` and pass the correct boolean into \`summariseIdeateOutcome\`.

## Test plan
- [x] Typecheck passes
- [ ] Next ideate run on an in-flight build shows the correct message (fail → "flagged some issues", pass → "Design review passed and we're now in the Plan phase")

🤖 Generated with [Claude Code](https://claude.com/claude-code)