### PR TITLE
chore(adapters): durable tool-call extraction trace (codex + claude CLI)

### DIFF
--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -401,6 +401,24 @@ export const cliAdapter: ExecutionAdapterHandler = {
         `${parsed.toolCalls.length} tool calls, ${inferenceMs}ms`,
       );
 
+      // ── Durable tool-call extraction trace (mirrors codex-cli-adapter) ──
+      // See note there. Kept on until tool dispatch is 100% reliable.
+      const toolKeywordPattern = /\b(read_sandbox_file|write_sandbox_file|edit_sandbox_file|search_sandbox|list_sandbox_files|run_sandbox_command|check_sandbox|start_sandbox|saveBuildEvidence|save_build_notes|save_phase_handoff|reviewDesignDoc|reviewBuildPlan|search_project_files|read_project_file|list_project_directory|generate_design_system|search_design_intelligence|describe_model|deploy_feature|execute_promotion)\b/g;
+      const mentionedNames = Array.from(new Set(parsed.text.match(toolKeywordPattern) ?? []));
+      const extractedNames = parsed.toolCalls.map((c) => c.name);
+      console.log(
+        `[tool-trace] adapter=claude-cli extracted=${parsed.toolCalls.length} names=${JSON.stringify(extractedNames)} mentioned=${JSON.stringify(mentionedNames)}`,
+      );
+      if (parsed.toolCalls.length === 0 && mentionedNames.length > 0) {
+        console.log(
+          `[tool-trace] adapter=claude-cli NO-CALL-BUT-MENTIONED raw=${JSON.stringify(parsed.text.slice(0, 8000))}`,
+        );
+      } else if (parsed.toolCalls.length > 0) {
+        console.log(
+          `[tool-trace] adapter=claude-cli CALLS-PARSED head=${JSON.stringify(parsed.text.slice(0, 600))}`,
+        );
+      }
+
       return {
         text: parsed.text,
         toolCalls: parsed.toolCalls,

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -262,6 +262,39 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
       // Attempt to extract tool calls if the model responded with tool_use blocks
       const toolCalls = extractToolCalls(text);
 
+      // ── Durable tool-call extraction trace ────────────────────────────
+      // Every codex response is logged under a single `[tool-trace]` prefix
+      // so we can see the full extraction path end-to-end: raw output, which
+      // tool-name keywords the text mentions, and what the parser returned.
+      // Kept on until tool dispatch is 100% reliable — when it is, this can
+      // be gated behind a DEBUG_TOOL_TRACE env flag rather than removed
+      // outright. Meanwhile every stuck-agent incident produces the exact
+      // data needed to tell "model emitted an unrecognized shape" from
+      // "model hallucinated a tool call it never emitted".
+      const toolKeywordPattern = /\b(read_sandbox_file|write_sandbox_file|edit_sandbox_file|search_sandbox|list_sandbox_files|run_sandbox_command|check_sandbox|start_sandbox|saveBuildEvidence|save_build_notes|save_phase_handoff|reviewDesignDoc|reviewBuildPlan|search_project_files|read_project_file|list_project_directory|generate_design_system|search_design_intelligence|describe_model|deploy_feature|execute_promotion)\b/g;
+      const mentionedNames = Array.from(new Set(text.match(toolKeywordPattern) ?? []));
+      const extractedNames = toolCalls.map((c) => c.name);
+      console.log(
+        `[tool-trace] extracted=${toolCalls.length} names=${JSON.stringify(extractedNames)} mentioned=${JSON.stringify(mentionedNames)}`,
+      );
+
+      // Full dump on the diagnostically-interesting mismatches: the text
+      // references a tool name but the parser returned nothing — this is
+      // the classic "stuck agent" signature. 8k chars covers any realistic
+      // codex response.
+      if (toolCalls.length === 0 && mentionedNames.length > 0) {
+        console.log(
+          `[tool-trace] NO-CALL-BUT-MENTIONED raw=${JSON.stringify(text.slice(0, 8000))}`,
+        );
+      } else if (toolCalls.length > 0) {
+        // Also log a compact head of the raw text when calls DID parse —
+        // lets us correlate "the model meant to call N things and we got N-1"
+        // style bugs without the full dump every turn.
+        console.log(
+          `[tool-trace] CALLS-PARSED head=${JSON.stringify(text.slice(0, 600))}`,
+        );
+      }
+
       return {
         text: toolCalls.length > 0 ? text.replace(/```json\n?\{[\s\S]*?```/g, "").trim() : text,
         toolCalls,


### PR DESCRIPTION
## Summary
Stays on until Build Studio's tool dispatch is 100% reliable. Every CLI response logs under a single \`[tool-trace]\` prefix so stuck-agent incidents produce the exact data needed to distinguish:
- **(A) Parser bug** — model emitted tool_use in an unrecognized shape; fix the extractor
- **(B) Prompt bug** — model emitted prose mentioning a tool but no JSON; fix the system prompt
- **(C) Genuine stall** — model emitted no tool_use and didn't mention any tool name

## Log shape
\`\`\`
[tool-trace] extracted=N names=[...] mentioned=[...]
[tool-trace] NO-CALL-BUT-MENTIONED raw=<first 8000 chars>   # stuck case
[tool-trace] CALLS-PARSED head=<first 600 chars>            # happy path
\`\`\`

Mirrored across \`codex-cli-adapter\` and \`cli-adapter\` (claude-cli) so both provider paths produce the same trace shape. Pairs cleanly with the existing \`[agentic-tool]\` CALL/RESULT/NOT_AVAILABLE lines for full end-to-end visibility.

## Test plan
- [x] Typecheck passes
- [ ] Trigger a build-studio interaction; confirm \`[tool-trace]\` line appears for every CLI response
- [ ] On next stuck-agent incident, \`NO-CALL-BUT-MENTIONED\` should dump the raw output, and that output tells us which of (A)/(B)/(C) happened

🤖 Generated with [Claude Code](https://claude.com/claude-code)