### PR TITLE
chore(codex-cli): archive dispatched prompts for post-mortem

### DIFF
--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -191,6 +191,16 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
 
       // 5. Spawn the CLI process
       console.log(`[codex-cli-adapter] Dispatching: model=${modelId}, provider=${providerId}, messages=${messages.length}`);
+      console.log(`[tool-trace] adapter=codex-cli PROMPT-FILE ${promptFile} slug=${slug} promptChars=${prompt.length}`);
+
+      // Preserve prompt to a durable location BEFORE spawning codex so we
+      // can inspect what hung if the process times out and the finally
+      // block cleans up the regular temp file. Keep the last 20 to bound
+      // disk use.
+      await execAsync(
+        `docker exec ${SANDBOX_CONTAINER} sh -c 'mkdir -p /tmp/codex-dispatch-archive && cp ${promptFile} /tmp/codex-dispatch-archive/${slug}.txt && ls -1t /tmp/codex-dispatch-archive/*.txt 2>/dev/null | tail -n +21 | xargs -r rm -f'`,
+        { timeout: 5_000 },
+      ).catch(() => {});
 
       const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
         const proc = spawnCb("docker", [


### PR DESCRIPTION
## Summary
Codex CLI hangs for the full 180s timeout on some plan-phase prompts (observed 2026-04-20 on FB-21EEA510's plan-draft turn). Trivial prompts work in 5s, long padding prompts work in 5s — the hang is **content-specific** to the live build-studio dispatch. The regular prompt temp file is cleaned up by the \`finally\` block, so when codex times out we lose the exact input that caused the hang.

## Change
- Copy every prompt to \`/tmp/codex-dispatch-archive/<slug>.txt\` in the sandbox before spawning codex
- Keep the last 20 (O(KB) each; bounded disk use)
- Log a \`[tool-trace] PROMPT-FILE\` line so the slug/char count appears alongside the existing dispatch logs

## Post-mortem workflow
\`\`\`bash
docker exec dpf-sandbox-1 ls -lt /tmp/codex-dispatch-archive/
docker exec dpf-sandbox-1 cat /tmp/codex-dispatch-archive/<slug>.txt
\`\`\`

## Test plan
- [x] Typecheck passes
- [ ] Next coworker turn: archive directory populated
- [ ] Next stuck dispatch: exact prompt recoverable from archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)