### PR TITLE
[codex] align workflow guidance with PR publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,26 +51,30 @@ Epics must be actively managed — not just created and forgotten.
 
 ### Core Rule
 
-- **Work directly on `main`.** Do not create feature branches or worktrees unless the user explicitly asks for one.
-- Commit early, commit often. Small, focused commits on `main` are preferred over long-lived branches.
+- **All changes go through pull requests**, including maintainer work.
+- **Do not push directly to `main`.** Use a short-lived branch and open a PR so CI validates the change before merge.
+- **Maintainer work uses intent-named branches:** `feat/*`, `fix/*`, `chore/*`, `doc/*`, `clean/*`.
+- **External contributors** use fork -> branch from `main` -> PR back to `main`.
 
 ### Why
 
-- Worktrees and feature branches caused lost uncommitted work across multiple directories.
-- This is a single-developer project where `main` is the working branch.
-- Simplicity beats process overhead — if something breaks, `git revert` is straightforward.
+- The repo is being prepared for public/open-source contribution, so maintainer work needs the same PR + CI path as external work.
+- CI catches breakage on maintainer changes too, not just on community submissions.
+- Short-lived, single-concern branches keep review, rollback, and merge risk manageable.
 
 ### Commits
 
 - Commit completed work promptly so nothing is lost.
 - Use descriptive commit messages that explain *why*, not just *what*.
-- Do not batch unrelated changes into a single commit.
+- Do not batch unrelated changes into a single branch or PR.
+- Push after committing so CI can validate the branch.
 
-### When to Branch (exception, not default)
+### Branch Shape
 
-- Only create a branch if the user explicitly requests one.
-- Only create a branch for experimental work the user wants to isolate.
-- If a branch is created, merge or discard it quickly — do not let branches linger.
+- One concern per branch, one concern per PR.
+- Name the branch by intent, not by ticket number.
+- Merge or close short-lived branches quickly — do not let them linger after the PR resolves.
+- Future customer-specific contribution flows may use persistent `customer/<id>` branches, but maintainer work should continue to use short-lived intent branches.
 
 ### Verification — Build Gate (mandatory)
 
@@ -78,8 +82,8 @@ Work is NOT complete until the production build passes. This is non-negotiable.
 
 **Required checks before claiming any task, epic, or session is done:**
 
-1. **Unit tests pass** — `npx vitest run` for affected test files (at minimum)
-2. **Production build succeeds** — `cd apps/web && npx next build` must complete with zero errors
+1. **Unit tests pass** — `pnpm --filter web exec vitest run` for affected suites (at minimum)
+2. **Production build succeeds** — `pnpm --filter web exec next build` must complete with zero errors
 3. **Migration applies cleanly** — if a migration was added, verify it applies without drift
 
 **When to run the build:**
@@ -94,7 +98,7 @@ Work is NOT complete until the production build passes. This is non-negotiable.
 - Do not defer build fixes to a later session
 - If the failure is pre-existing (not caused by your changes), note it explicitly but still fix if feasible
 
-**Subagent dispatchers:** When dispatching implementation subagents for the final task in an epic, include "run `cd apps/web && npx next build` and fix any errors" as part of the task.
+**Subagent dispatchers:** When dispatching implementation subagents for the final task in an epic, include "run `pnpm --filter web exec next build` and fix any errors" as part of the task.
 
 ### Communication
 

--- a/apps/web/tests/build-lifecycle.test.ts
+++ b/apps/web/tests/build-lifecycle.test.ts
@@ -9,7 +9,7 @@
  * the tool would call routeAndCall() for AI review. Everything else
  * uses the real tool pipeline.
  *
- * Run: cd apps/web && npx vitest run tests/build-lifecycle.test.ts
+ * Run: pnpm --filter web exec vitest run tests/build-lifecycle.test.ts
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { prisma } from "@dpf/db";

--- a/docs/superpowers/plans/2026-04-04-collaborative-work-queue-phase1.md
+++ b/docs/superpowers/plans/2026-04-04-collaborative-work-queue-phase1.md
@@ -116,7 +116,7 @@
 
 - [ ] **Step 1: Install inngest**
   ```bash
-  cd h:\opendigitalproductfactory && pnpm --filter @dpf/web add inngest
+  cd h:\opendigitalproductfactory && pnpm --filter web add inngest
   ```
 
 - [ ] **Step 2: Create Inngest client with typed events**
@@ -167,7 +167,7 @@
 
 - [ ] **Step 5: Verify build compiles**
   ```bash
-  cd h:\opendigitalproductfactory && pnpm --filter @dpf/web build
+  cd h:\opendigitalproductfactory && pnpm --filter web build
   ```
   Expected: Build succeeds with no type errors.
 
@@ -240,7 +240,7 @@
 
 - [ ] **Step 6: Verify build compiles**
   ```bash
-  cd h:\opendigitalproductfactory && pnpm --filter @dpf/web build
+  cd h:\opendigitalproductfactory && pnpm --filter web build
   ```
 
 - [ ] **Step 7: Commit**
@@ -328,7 +328,7 @@
 
 - [ ] **Step 6: Verify build compiles**
   ```bash
-  cd h:\opendigitalproductfactory && pnpm --filter @dpf/web build
+  cd h:\opendigitalproductfactory && pnpm --filter web build
   ```
 
 - [ ] **Step 7: Update existing test files**
@@ -1087,7 +1087,7 @@
 
 - [ ] **Step 1: Full build**
   ```bash
-  cd h:\opendigitalproductfactory && pnpm --filter @dpf/web build
+  cd h:\opendigitalproductfactory && pnpm --filter web build
   ```
   Expected: No type errors, no missing imports.
 

--- a/docs/superpowers/plans/2026-04-04-provider-activation-routing-reconciliation.md
+++ b/docs/superpowers/plans/2026-04-04-provider-activation-routing-reconciliation.md
@@ -99,7 +99,7 @@ it("codex catalog uses canonical code model class and includes GPT-5-Codex", () 
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/auto-discover.test.ts
+pnpm --filter web exec vitest run apps/web/lib/auto-discover.test.ts
 ```
 
 Expected:
@@ -143,7 +143,7 @@ Do not change unrelated provider seeds.
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/auto-discover.test.ts
+pnpm --filter web exec vitest run apps/web/lib/auto-discover.test.ts
 ```
 
 Expected:
@@ -183,7 +183,7 @@ Prefer mocking Prisma and `autoDiscoverAndProfile()` rather than using a real DB
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/govern/provider-oauth.test.ts
+pnpm --filter web exec vitest run apps/web/lib/govern/provider-oauth.test.ts
 ```
 
 Expected:
@@ -200,7 +200,7 @@ If needed, patch `apps/web/lib/govern/provider-oauth.ts` so successful OAuth act
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/govern/provider-oauth.test.ts
+pnpm --filter web exec vitest run apps/web/lib/govern/provider-oauth.test.ts
 ```
 
 Expected:
@@ -228,7 +228,7 @@ Also assert auth failures do not trigger reconciliation.
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run apps/web/lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -245,7 +245,7 @@ If any success path does not trigger reconciliation, update `apps/web/lib/action
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run apps/web/lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -297,7 +297,7 @@ it("does not exclude code-class endpoints for coding-oriented requests", () => {
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/routing/pipeline-v2.test.ts
+pnpm --filter web exec vitest run apps/web/lib/routing/pipeline-v2.test.ts
 ```
 
 Expected:
@@ -325,7 +325,7 @@ This is the least invasive fix because it:
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/routing/pipeline-v2.test.ts
+pnpm --filter web exec vitest run apps/web/lib/routing/pipeline-v2.test.ts
 ```
 
 Expected:
@@ -354,7 +354,7 @@ it("prefers codex for the build route by default", () => {
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/tak/agent-routing.test.ts
+pnpm --filter web exec vitest run apps/web/lib/tak/agent-routing.test.ts
 ```
 
 Expected:
@@ -377,7 +377,7 @@ This gives Build Studio Codex-first behavior while still allowing runtime fallba
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/tak/agent-routing.test.ts
+pnpm --filter web exec vitest run apps/web/lib/tak/agent-routing.test.ts
 ```
 
 Expected:
@@ -436,7 +436,7 @@ describe("shouldReconcileProviderAfterError", () => {
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/inference/provider-reconciliation.test.ts
+pnpm --filter web exec vitest run apps/web/lib/inference/provider-reconciliation.test.ts
 ```
 
 Expected:
@@ -467,7 +467,7 @@ Do not embed DB writes in this helper. It should only make decisions.
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/inference/provider-reconciliation.test.ts
+pnpm --filter web exec vitest run apps/web/lib/inference/provider-reconciliation.test.ts
 ```
 
 Expected:
@@ -505,7 +505,7 @@ it("degrades and reconciles a model after interface drift", async () => {
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/routing/fallback.test.ts
+pnpm --filter web exec vitest run apps/web/lib/routing/fallback.test.ts
 ```
 
 Expected:
@@ -532,7 +532,7 @@ Do not change the existing `model_not_found` retirement behavior.
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run apps/web/lib/routing/fallback.test.ts
+pnpm --filter web exec vitest run apps/web/lib/routing/fallback.test.ts
 ```
 
 Expected:
@@ -560,7 +560,7 @@ git commit -m "feat(routing): reconcile provider drift after runtime failures"
 Run:
 
 ```bash
-pnpm --filter @dpf/web exec vitest run \
+pnpm --filter web exec vitest run \
   apps/web/lib/auto-discover.test.ts \
   apps/web/lib/govern/provider-oauth.test.ts \
   apps/web/lib/actions/ai-providers.test.ts \

--- a/docs/superpowers/plans/2026-04-04-provider-catalog-reconciler.md
+++ b/docs/superpowers/plans/2026-04-04-provider-catalog-reconciler.md
@@ -60,7 +60,7 @@ Cover:
 Run:
 
 ```bash
-cd apps/web && npx vitest run lib/provider-catalog-reconciliation.test.ts
+pnpm --filter web exec vitest run lib/provider-catalog-reconciliation.test.ts
 ```
 
 Expected:
@@ -80,7 +80,7 @@ Create `apps/web/lib/provider-catalog-reconciliation.ts` with:
 Run:
 
 ```bash
-cd apps/web && npx vitest run lib/provider-catalog-reconciliation.test.ts
+pnpm --filter web exec vitest run lib/provider-catalog-reconciliation.test.ts
 ```
 
 Expected:
@@ -108,7 +108,7 @@ Cover:
 Run:
 
 ```bash
-cd apps/web && npx vitest run lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run lib/actions/ai-providers.test.ts
 ```
 
 - [ ] **Step 3: Implement the action wiring**
@@ -123,7 +123,7 @@ Add:
 Run:
 
 ```bash
-cd apps/web && npx vitest run lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -151,7 +151,7 @@ Cover:
 Run:
 
 ```bash
-cd apps/web && npx vitest run lib/provider-catalog-reconciliation.test.ts
+pnpm --filter web exec vitest run lib/provider-catalog-reconciliation.test.ts
 ```
 
 - [ ] **Step 3: Implement minimal safe retirement/reseed behavior**
@@ -166,7 +166,7 @@ Update activation/reconciliation so:
 Run:
 
 ```bash
-cd apps/web && npx vitest run lib/provider-catalog-reconciliation.test.ts lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run lib/provider-catalog-reconciliation.test.ts lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -194,7 +194,7 @@ Document:
 Run:
 
 ```bash
-npx tsc --noEmit -p apps/web/tsconfig.json
+pnpm --filter web exec tsc --noEmit
 ```
 
 Expected:
@@ -205,7 +205,7 @@ Expected:
 Run:
 
 ```bash
-cd apps/web && npx next build
+pnpm --filter web exec next build
 ```
 
 Expected:

--- a/docs/superpowers/plans/2026-04-05-continuous-improvement-flywheel.md
+++ b/docs/superpowers/plans/2026-04-05-continuous-improvement-flywheel.md
@@ -153,7 +153,7 @@ Include tests for:
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run apps/web/lib/improve/improvement-signal.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/improve/improvement-signal.test.ts`
 Expected: FAIL because the module does not exist yet
 
 - [ ] **Step 3: Implement minimal normalization code**
@@ -167,7 +167,7 @@ Create:
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run apps/web/lib/improve/improvement-signal.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/improve/improvement-signal.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -196,7 +196,7 @@ Add cases proving:
 
 - [ ] **Step 2: Run focused tests to verify failures**
 
-Run: `npx vitest run apps/web/lib/operate/process-observer-triage.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/operate/process-observer-triage.test.ts`
 Expected: FAIL on missing signal behavior
 
 - [ ] **Step 3: Implement minimal source-to-signal hooks**
@@ -205,7 +205,7 @@ Do not over-automate yet. Add thin emission points only where the source already
 
 - [ ] **Step 4: Re-run focused tests**
 
-Run: `npx vitest run apps/web/lib/operate/process-observer-triage.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/operate/process-observer-triage.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -236,7 +236,7 @@ Cover:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `npx vitest run apps/web/lib/improve/improvement-evaluator.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/improve/improvement-evaluator.test.ts`
 Expected: FAIL because evaluator is missing
 
 - [ ] **Step 3: Implement minimal evaluator**
@@ -249,7 +249,7 @@ Implement:
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `npx vitest run apps/web/lib/improve/improvement-evaluator.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/improve/improvement-evaluator.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -278,7 +278,7 @@ Add cases for:
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run apps/web/lib/explore/backlog.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/explore/backlog.test.ts`
 Expected: FAIL on unsupported status or metadata
 
 - [ ] **Step 3: Implement minimal proposal persistence**
@@ -291,7 +291,7 @@ Add:
 
 - [ ] **Step 4: Run tests to verify it passes**
 
-Run: `npx vitest run apps/web/lib/explore/backlog.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/explore/backlog.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -321,7 +321,7 @@ Cover:
 
 - [ ] **Step 2: Run tests to verify failures**
 
-Run: `npx vitest run apps/web/lib/improve/improvement-execution-candidate.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/improve/improvement-execution-candidate.test.ts`
 Expected: FAIL because the module is missing
 
 - [ ] **Step 3: Implement minimal candidate generator**
@@ -337,7 +337,7 @@ Generate a brief JSON object containing:
 
 - [ ] **Step 4: Run tests to verify passes**
 
-Run: `npx vitest run apps/web/lib/improve/improvement-execution-candidate.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/improve/improvement-execution-candidate.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -360,7 +360,7 @@ Add a focused test proving a candidate brief can be consumed by Build Studio as 
 
 - [ ] **Step 2: Run the focused test to verify failure**
 
-Run: `npx vitest run apps/web/lib/explore/feature-build-data.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/explore/feature-build-data.test.ts`
 Expected: FAIL on missing candidate support
 
 - [ ] **Step 3: Implement minimal Build Studio handoff**
@@ -369,7 +369,7 @@ Pass the candidate brief into the build context without launching builds automat
 
 - [ ] **Step 4: Re-run the focused test**
 
-Run: `npx vitest run apps/web/lib/explore/feature-build-data.test.ts`
+Run: `pnpm --filter web exec vitest run apps/web/lib/explore/feature-build-data.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -401,7 +401,7 @@ Cover:
 
 - [ ] **Step 2: Run the failing tests**
 
-Run: `npx vitest run apps/web/components/ops/improvement-flywheel-dashboard.test.tsx`
+Run: `pnpm --filter web exec vitest run apps/web/components/ops/improvement-flywheel-dashboard.test.tsx`
 Expected: FAIL because the UI is missing
 
 - [ ] **Step 3: Implement minimal theme-aware UI**
@@ -411,8 +411,8 @@ Use existing CSS variables only and follow the established ops/portfolio page pa
 - [ ] **Step 4: Run tests and build check**
 
 Run:
-- `npx vitest run apps/web/components/ops/improvement-flywheel-dashboard.test.tsx`
-- `cd apps/web && npx next build`
+- `pnpm --filter web exec vitest run apps/web/components/ops/improvement-flywheel-dashboard.test.tsx`
+- `pnpm --filter web exec next build`
 
 Expected:
 - tests PASS
@@ -471,7 +471,7 @@ git commit -m "docs: add continuous improvement flywheel guide"
 Run:
 
 ```bash
-npx vitest run apps/web/lib/improve/improvement-signal.test.ts apps/web/lib/improve/improvement-evaluator.test.ts apps/web/lib/improve/improvement-execution-candidate.test.ts apps/web/lib/explore/backlog.test.ts apps/web/lib/operate/process-observer-triage.test.ts
+pnpm --filter web exec vitest run apps/web/lib/improve/improvement-signal.test.ts apps/web/lib/improve/improvement-evaluator.test.ts apps/web/lib/improve/improvement-execution-candidate.test.ts apps/web/lib/explore/backlog.test.ts apps/web/lib/operate/process-observer-triage.test.ts
 ```
 
 Expected: PASS
@@ -491,7 +491,7 @@ Expected: PASS
 Run:
 
 ```bash
-cd apps/web && npx next build
+pnpm --filter web exec next build
 ```
 
 Expected: build succeeds with no new errors

--- a/docs/superpowers/plans/2026-04-05-db-github-delivery-sync-implementation.md
+++ b/docs/superpowers/plans/2026-04-05-db-github-delivery-sync-implementation.md
@@ -1,6 +1,6 @@
 # DB to GitHub Delivery Sync Implementation Plan
 
-> **For implementation after approval:** use branch/PR workflow for this spec. Create a feature branch from `main`, keep commits focused, open a draft PR early, and do not mark the work complete until targeted Vitest coverage and `cd apps/web && npx next build` both pass.
+> **For implementation after approval:** use the branch/PR workflow for this spec. Create one short-lived intent-named branch from `main`, keep commits focused, open a draft PR early, and do not mark the work complete until targeted Vitest coverage and `pnpm --filter web exec next build` both pass.
 
 **Spec:** `docs/superpowers/specs/2026-04-05-db-github-delivery-sync-design.md`
 
@@ -226,9 +226,9 @@ This keeps GitHub execution state flowing back into the backlog without turning 
 
 ## Verification Gate
 
-- [ ] Run focused tests for the touched files with `npx vitest run ...`
+- [ ] Run focused tests for the touched files with `pnpm --filter web exec vitest run ...`
 - [ ] If a migration is added, verify it applies cleanly without drift
-- [ ] Run `cd apps/web && npx next build`
+- [ ] Run `pnpm --filter web exec next build`
 - [ ] Do not claim completion until all three are green or any pre-existing blocker is explicitly identified
 
 ## Assumptions

--- a/docs/superpowers/plans/2026-04-05-provider-reconciliation-automation.md
+++ b/docs/superpowers/plans/2026-04-05-provider-reconciliation-automation.md
@@ -112,8 +112,7 @@ Add tests that expect the orchestrator to classify representative failures as:
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/inference/provider-reconciliation-orchestrator.test.ts
+pnpm --filter web exec vitest run lib/inference/provider-reconciliation-orchestrator.test.ts
 ```
 
 Expected:
@@ -143,8 +142,7 @@ The minimal implementation should:
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/inference/provider-reconciliation-orchestrator.test.ts
+pnpm --filter web exec vitest run lib/inference/provider-reconciliation-orchestrator.test.ts
 ```
 
 Expected:
@@ -188,8 +186,7 @@ Extend `ai-providers.test.ts` to assert that a successful `testProviderAuth(prov
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/govern/provider-oauth.test.ts lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run lib/govern/provider-oauth.test.ts lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -213,8 +210,7 @@ Update `apps/web/lib/actions/ai-providers.ts` so successful provider test/config
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/govern/provider-oauth.test.ts lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run lib/govern/provider-oauth.test.ts lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -268,8 +264,7 @@ If a scheduled job default is required:
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/actions/ai-providers.test.ts
+pnpm --filter web exec vitest run lib/actions/ai-providers.test.ts
 ```
 
 Expected:
@@ -339,8 +334,7 @@ If a schema change is truly required:
 Run:
 
 ```bash
-cd apps/web
-npx vitest run components/platform/ProviderDetailForm.test.tsx components/monitoring/CoworkerHealthStatus.test.tsx
+pnpm --filter web exec vitest run components/platform/ProviderDetailForm.test.tsx components/monitoring/CoworkerHealthStatus.test.tsx
 ```
 
 Expected:
@@ -377,8 +371,7 @@ Add or extend tests so `Run full reconciliation` invokes the shared orchestrator
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/routing/fallback.test.ts components/platform/ProviderDetailForm.test.tsx
+pnpm --filter web exec vitest run lib/routing/fallback.test.ts components/platform/ProviderDetailForm.test.tsx
 ```
 
 Expected:
@@ -404,8 +397,7 @@ so:
 Run:
 
 ```bash
-cd apps/web
-npx vitest run lib/routing/fallback.test.ts components/platform/ProviderDetailForm.test.tsx
+pnpm --filter web exec vitest run lib/routing/fallback.test.ts components/platform/ProviderDetailForm.test.tsx
 ```
 
 Expected:
@@ -431,8 +423,7 @@ git commit -m "feat(ai): unify manual and automatic provider reconciliation"
 Run:
 
 ```bash
-cd apps/web
-npx vitest run \
+pnpm --filter web exec vitest run \
   lib/inference/provider-reconciliation-orchestrator.test.ts \
   lib/govern/provider-oauth.test.ts \
   lib/actions/ai-providers.test.ts \
@@ -452,7 +443,7 @@ Expected:
 Run:
 
 ```bash
-npx tsc --noEmit -p apps/web/tsconfig.json
+pnpm --filter web exec tsc --noEmit
 ```
 
 Expected:
@@ -464,8 +455,7 @@ Expected:
 Run:
 
 ```bash
-cd apps/web
-npx next build
+pnpm --filter web exec next build
 ```
 
 Expected:

--- a/docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md
+++ b/docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md
@@ -414,7 +414,7 @@ But do not claim the full spec is done until proposal tools work.
   - any updated agentic loop tests
 
 - [ ] Run production build gate
-  - `cd apps/web && npx next build`
+  - `pnpm --filter web exec next build`
 
 - [ ] If any migration or seed behavior changed materially, verify the affected DB workflow still applies cleanly
 
@@ -491,7 +491,7 @@ This work is done when all of the following are true:
 - Proposal tools return approval-needed results and persist proposals.
 - The agentic loop does not double-execute tools after native-MCP CLI calls.
 - Affected Vitest coverage passes.
-- `cd apps/web && npx next build` passes cleanly.
+- `pnpm --filter web exec next build` passes cleanly.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-13-build-studio-happy-path-rescue.md
+++ b/docs/superpowers/plans/2026-04-13-build-studio-happy-path-rescue.md
@@ -109,7 +109,7 @@ If a nearby test file exists, add a case that verifies null-safe defaults and ty
 
 Run:
 ```bash
-npx vitest run apps/web/lib/explore/feature-build-data.test.ts
+pnpm --filter web exec vitest run apps/web/lib/explore/feature-build-data.test.ts
 ```
 
 Expected: FAIL because the state is not yet projected or normalized.
@@ -136,7 +136,7 @@ Update all code paths that materialize build rows so the UI and actions read a c
 
 Run:
 ```bash
-npx vitest run apps/web/lib/explore/feature-build-data.test.ts
+pnpm --filter web exec vitest run apps/web/lib/explore/feature-build-data.test.ts
 ```
 
 Expected: PASS
@@ -166,7 +166,7 @@ Add a test that attempts to advance a build without full intake anchors and expe
 
 Run:
 ```bash
-npx vitest run apps/web/lib/actions/build.test.ts
+pnpm --filter web exec vitest run apps/web/lib/actions/build.test.ts
 ```
 
 Expected: FAIL because missing intake does not yet block progression.
@@ -198,7 +198,7 @@ Do not just throw an opaque error. Update state so the UI can show the missing p
 
 Run:
 ```bash
-npx vitest run apps/web/lib/actions/build.test.ts
+pnpm --filter web exec vitest run apps/web/lib/actions/build.test.ts
 ```
 
 Expected: PASS
@@ -239,7 +239,7 @@ Add tests that verify:
 
 Run:
 ```bash
-npx vitest run apps/web/lib/mcp-tools.test.ts
+pnpm --filter web exec vitest run apps/web/lib/mcp-tools.test.ts
 ```
 
 Expected: FAIL on the new intake persistence expectations.
@@ -256,7 +256,7 @@ When the Build Studio tools resolve taxonomy or backlog/epic information, persis
 
 Run:
 ```bash
-npx vitest run apps/web/lib/mcp-tools.test.ts
+pnpm --filter web exec vitest run apps/web/lib/mcp-tools.test.ts
 ```
 
 Expected: PASS
@@ -291,7 +291,7 @@ Add tests that cover:
 
 Run:
 ```bash
-npx vitest run apps/web/lib/integrate/build-studio-config.test.ts
+pnpm --filter web exec vitest run apps/web/lib/integrate/build-studio-config.test.ts
 ```
 
 Expected: FAIL on the new cases.
@@ -304,7 +304,7 @@ Ensure the returned config is deterministic and safe for a per-run engine lock.
 
 Run:
 ```bash
-npx vitest run apps/web/lib/integrate/build-studio-config.test.ts
+pnpm --filter web exec vitest run apps/web/lib/integrate/build-studio-config.test.ts
 ```
 
 Expected: PASS
@@ -336,7 +336,7 @@ Cover:
 
 Run:
 ```bash
-npx vitest run apps/web/lib/integrate/build-orchestrator.test.ts
+pnpm --filter web exec vitest run apps/web/lib/integrate/build-orchestrator.test.ts
 ```
 
 Expected: FAIL on the new assertions.
@@ -368,7 +368,7 @@ Implement logic that can tell the caller whether a failure can be retried at the
 
 Run:
 ```bash
-npx vitest run apps/web/lib/integrate/build-orchestrator.test.ts
+pnpm --filter web exec vitest run apps/web/lib/integrate/build-orchestrator.test.ts
 ```
 
 Expected: PASS
@@ -457,7 +457,7 @@ git commit -m "feat(build-studio): surface rescue-path intake and execution stat
 
 Run:
 ```bash
-npx vitest run \
+pnpm --filter web exec vitest run \
   apps/web/lib/integrate/build-studio-config.test.ts \
   apps/web/lib/integrate/build-orchestrator.test.ts \
   apps/web/lib/mcp-tools.test.ts \
@@ -474,7 +474,7 @@ If a test fails, fix the minimal affected code before continuing.
 
 Run:
 ```bash
-cd apps/web && npx next build
+pnpm --filter web exec next build
 ```
 
 Expected: PASS with zero errors

--- a/docs/superpowers/plans/2026-04-13-build-studio-process-visualization.md
+++ b/docs/superpowers/plans/2026-04-13-build-studio-process-visualization.md
@@ -38,7 +38,7 @@
 - For process graph role/phase colors, add dedicated `--pg-*` variables in the shared theme layer and pass those CSS variable strings through node data.
 - `text-white` is allowed only on solid accent/error/success badges and buttons.
 
-**Test command:** `pnpm --filter @dpf/web test` (run from `d:/DPF`)
+**Test command:** `pnpm --filter web test` (run from `d:/DPF`)
 **TypeScript check:** `cd apps/web && pnpm tsc --noEmit 2>&1 | head -30`
 
 ---
@@ -334,7 +334,7 @@ describe("buildTaskGraph", () => {
 - [ ] **Step 2: Run tests to verify they fail**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test lib/build/process-graph-builder 2>&1 | tail -20
+cd d:/DPF && pnpm --filter web test lib/build/process-graph-builder 2>&1 | tail -20
 ```
 
 Expected: `Cannot find module` or similar — file doesn't exist yet.
@@ -829,7 +829,7 @@ export function buildTaskGraph(
 - [ ] **Step 4: Run tests to verify they pass**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test lib/build/process-graph-builder 2>&1 | tail -20
+cd d:/DPF && pnpm --filter web test lib/build/process-graph-builder 2>&1 | tail -20
 ```
 
 Expected: all tests pass.
@@ -1847,7 +1847,7 @@ cd d:/DPF/apps/web && pnpm tsc --noEmit 2>&1 | head -30
 - [ ] **Step 8: Run tests**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test 2>&1 | tail -10
+cd d:/DPF && pnpm --filter web test 2>&1 | tail -10
 ```
 
 - [ ] **Step 9: Commit**
@@ -1952,7 +1952,7 @@ cd d:/DPF/apps/web && pnpm tsc --noEmit 2>&1 | head -30
 - [ ] **Step 4: Run tests**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test 2>&1 | tail -10
+cd d:/DPF && pnpm --filter web test 2>&1 | tail -10
 ```
 
 - [ ] **Step 5: Commit**
@@ -2182,7 +2182,7 @@ cd d:/DPF/apps/web && pnpm tsc --noEmit 2>&1 | head -30
 - [ ] **Step 6: Run tests**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test 2>&1 | tail -10
+cd d:/DPF && pnpm --filter web test 2>&1 | tail -10
 ```
 
 - [ ] **Step 7: Commit**
@@ -2367,7 +2367,7 @@ cd d:/DPF/apps/web && pnpm tsc --noEmit 2>&1 | head -30
 - [ ] **Step 5: Run tests**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test 2>&1 | tail -10
+cd d:/DPF && pnpm --filter web test 2>&1 | tail -10
 ```
 
 - [ ] **Step 6: Commit**
@@ -2385,7 +2385,7 @@ cd d:/DPF && git add apps/web/lib/actions/ea-traversal.ts apps/web/components/ea
 - [ ] **Step 1: Run full test suite**
 
 ```bash
-cd d:/DPF && pnpm --filter @dpf/web test 2>&1 | tail -10
+cd d:/DPF && pnpm --filter web test 2>&1 | tail -10
 ```
 
 Expected: all tests pass.

--- a/docs/superpowers/plans/2026-04-13-model-capability-lifecycle.md
+++ b/docs/superpowers/plans/2026-04-13-model-capability-lifecycle.md
@@ -21,7 +21,7 @@
 - `ModelProfile.profileSource` defaults to `"seed"`. Values: `"seed"`, `"auto-discover"`, `"evaluated"`, `"admin"`. New value `"catalog"` added by this plan.
 - `ModelProfile.supportsToolUse` is currently `Boolean @default(false)` — non-nullable. This plan makes it nullable.
 - Migration timestamp convention: `YYYYMMDDHHMMSS_snake_case_name`. Latest existing: `20260412230000_reset_codex_tool_fidelity_scores`. New migrations use `202604130NNNNN_...`.
-- Tests live alongside source files as `*.test.ts`. Run with `pnpm --filter @dpf/web test` (vitest).
+- Tests live alongside source files as `*.test.ts`. Run with `pnpm --filter web test` (vitest).
 
 ---
 
@@ -609,7 +609,7 @@
 - [ ] **Step 2: Run to confirm tests fail**
 
   ```bash
-  pnpm --filter @dpf/web test loader
+  pnpm --filter web test loader
   ```
 
   Expected: `Cannot find 'resolveToolUse'` or test failures.
@@ -681,7 +681,7 @@
 - [ ] **Step 5: Run tests to verify they pass**
 
   ```bash
-  pnpm --filter @dpf/web test loader
+  pnpm --filter web test loader
   ```
 
   Expected: all 7 tests pass.
@@ -738,7 +738,7 @@
 - [ ] **Step 4: Verify TypeScript compiles clean**
 
   ```bash
-  pnpm --filter @dpf/web exec tsc --noEmit
+  pnpm --filter web exec tsc --noEmit
   ```
 
   Expected: no errors. If `supportsToolUse: boolean | null` type mismatch appears, the schema change from Task 1 must be regenerated first (Step 5 of Task 1).
@@ -1136,7 +1136,7 @@
 - [ ] **Step 6: Verify no TypeScript errors**
 
   ```bash
-  pnpm --filter @dpf/web exec tsc --noEmit
+  pnpm --filter web exec tsc --noEmit
   ```
 
 - [ ] **Step 7: Commit**

--- a/docs/superpowers/plans/2026-04-17-business-first-workflow-consolidation-phase1.md
+++ b/docs/superpowers/plans/2026-04-17-business-first-workflow-consolidation-phase1.md
@@ -627,7 +627,7 @@ git commit -m "feat(finance): introduce workflow hubs and compact shell rail"
 
 ## Notes For The Implementer
 
-- Work directly on `main` in this repository. Do **not** create a branch or worktree unless the user explicitly asks for it.
+- Use the PR workflow in this repository. Create one short-lived intent-named branch (`feat/*`, `fix/*`, `chore/*`, `doc/*`, or `clean/*`) for this slice, and do not push directly to `main`.
 - The workspace is already dirty with unrelated local files and in-progress coworker layout work. Do not stage or revert:
   - `.admin-credentials`
   - `.host-profile.json`

--- a/docs/superpowers/plans/2026-04-18-build-studio-shell-native-refactor.md
+++ b/docs/superpowers/plans/2026-04-18-build-studio-shell-native-refactor.md
@@ -27,7 +27,7 @@ Do **not** fold Admin regrouping or unrelated Platform IA work into this plan. R
 
 ## Constraints
 
-- Work directly on `main`.
+- Use the PR workflow for this slice. Create one short-lived intent-named branch and do not push directly to `main`.
 - Do not touch unrelated dirty files already present in the worktree:
   - `.admin-credentials`
   - `.host-profile.json`

--- a/docs/superpowers/plans/2026-04-18-purpose-first-product-estate-phase1.md
+++ b/docs/superpowers/plans/2026-04-18-purpose-first-product-estate-phase1.md
@@ -772,7 +772,7 @@ git commit -m "feat(estate): introduce discovery operations and purpose-first es
 
 ## Notes For The Implementer
 
-- Work directly on `main`. Do **not** create a branch or worktree unless the user explicitly asks for one.
+- Use the PR workflow in this repository. Create one short-lived intent-named branch (`feat/*`, `fix/*`, `chore/*`, `doc/*`, or `clean/*`) for this slice, and do not push directly to `main`.
 - The workspace is already dirty with unrelated local changes. Leave them untouched.
 - Follow the absorption rule from the approved spec:
   - discovery, vulnerability, version, and posture capabilities feed one shared estate model

--- a/docs/superpowers/plans/2026-04-19-build-studio-code-intelligence-graph.md
+++ b/docs/superpowers/plans/2026-04-19-build-studio-code-intelligence-graph.md
@@ -1,0 +1,171 @@
+# Build Studio Code Intelligence Graph — Implementation Plan
+
+**Goal:** Add a DPF-native source-code intelligence graph that improves Build Studio impact analysis, context narrowing, and review quality without turning Build Studio into a graph explorer.
+
+**Architecture:** Build a DPF-specific code graph pipeline that extracts source-code structure from the shared workspace, persists it in the existing Neo4j deployment under a dedicated code namespace, and exposes graph-backed impact/context services to Build Studio phases. The graph informs ideate, plan, review, and ship outputs, while the existing Build Studio process graph and the operational/runtime dependency graph remain separate.
+
+**Reference Input:** `https://github.com/tirth8205/code-review-graph` is the conceptual benchmark for structural parsing, incremental updates, blast-radius queries, and minimal-context tooling. This plan ports those ideas into DPF; it does not embed the upstream Python MCP server.
+
+**Tech Stack:** Next.js App Router, TypeScript, Neo4j 5, Prisma, TypeScript compiler API or `ts-morph`, Vitest, Playwright, existing Build Studio tool/prompt infrastructure.
+
+---
+
+## Summary
+
+- Create a **DPF-specific source-code intelligence graph** to support Build Studio impact analysis, context narrowing, and review support.
+- Make it an **AI Coworker capability first**: ideate, plan, review, and ship should cite impact findings and affected code/tests in their results. Do **not** add a graph UI inside Build Studio in v1.
+- Persist the graph in the **existing Neo4j deployment**, but keep it as a **separate code namespace** from the current operational/runtime graph.
+- Cover **DPF Core only** in v1: TypeScript/TSX, Prisma schema/migrations, prompts, routes/components, and tool references.
+- Start implementation by creating a **new epic + backlog item** in the live DB, since the current live backlog has no matching epic for this work.
+
+## Product Decisions Locked
+
+- **First slice:** Build Studio impact analysis first, not a general repository explorer.
+- **Persistence model:** Neo4j first.
+- **Build Studio UX:** AI-coworker/tool capability first; show impact summaries in Build Studio outputs, not a graph.
+- **Future UI placement:** If a graph explorer is added later, it should live under portfolio/taxonomy analysis for the platform itself, not inside Build Studio.
+- **Coverage:** DPF Core only in v1.
+- **Isolation from existing Neo4j graphs (v1):** The code graph stands on its own merit and must not share nodes or edges with the existing `DigitalProduct` / `TaxonomyNode` / `Portfolio` / `InfraCI` sub-graph. No cross-label edges. No `Code*` node reuses an existing key space. Cross-graph bridges (e.g. `CodeRoute` → `DigitalProduct`, `CodePrismaModel` → `InfraCI`) are **explicitly deferred** — they may become valuable later for operational-to-code blast-radius traces, but v1 proves the code graph in isolation first. This keeps the failure mode of a bad code-graph rebuild contained: it can't corrupt runtime/operational impact analysis.
+
+## Key Changes
+
+### 1. Code Graph Model And Storage
+
+- Extend the Neo4j schema with a dedicated code namespace using labels such as `CodeFile`, `CodeSymbol`, `CodeRoute`, `CodePrompt`, `CodeSkill`, `CodePrismaModel`, `CodeTest`, and `CodeTool`.
+- Add relationship types such as `CODE_CONTAINS`, `CODE_IMPORTS`, `CODE_CALLS`, `CODE_DEFINES_ROUTE`, `CODE_USES_MODEL`, `CODE_REFERENCES_PROMPT`, `CODE_REFERENCES_SKILL`, `CODE_INVOKES_TOOL`, and `CODE_COVERS`.
+- Keep runtime and source-code traversal separate: existing `InfraCI` and operational impact queries must remain unchanged.
+- Store graph identities as stable repo-relative paths and qualified symbol IDs so incremental rebuilds can replace a file's subgraph safely.
+- Declare schema additions in [packages/db/src/neo4j-schema.ts](packages/db/src/neo4j-schema.ts) following the existing `CREATE CONSTRAINT … REQUIRE … IS UNIQUE` + `CREATE INDEX … IF NOT EXISTS` style. Uniqueness keys:
+  - `CodeFile.path` (repo-relative), `CodeSymbol.qualifiedId`, `CodeRoute.routePath`, `CodePrompt.slug`, `CodeSkill.name`, `CodePrismaModel.name`, `CodeTest.path`, `CodeTool.name`.
+  - Secondary indexes on `CodeFile.pkg`, `CodeSymbol.kind`, `CodeSymbol.file`, `CodeTest.kind` (unit|e2e).
+- Persist per-file content hashes for incremental rebuild in Postgres via a new Prisma model `CodeGraphFileHash { path @id, sha256, lastIndexedAt, graphVersion }`. Neo4j stores derived structure; Postgres stores the control plane. Migration lives in `packages/db/prisma/migrations/` per CLAUDE.md rules.
+
+### 2. Native DPF Port, Not The Upstream Runtime
+
+- Implement the port in the DPF stack instead of running the upstream Python MCP service.
+- Use the TypeScript compiler API or `ts-morph` for TS/TSX symbol, import, route, and component extraction.
+- Add DPF-specific enrichers for:
+  - Prisma models and relation references from `schema.prisma`
+  - migration risk markers from migration SQL
+  - prompts from `prompts/**/*.prompt.md` and Build Studio prompt modules
+  - skills from `skills/**/*.skill.md` (frontmatter + `composesFrom`, `allowedTools`)
+  - tool references from `apps/web/lib/mcp-tools.ts` and coworker tool-invocation sites
+  - test coverage links from Vitest and Playwright naming/import patterns
+- Support **full rebuild** and **incremental rebuild by changed files + hashes**. Hashes live in the Postgres `CodeGraphFileHash` model (see §1). A rebuild cycle: diff `CodeGraphFileHash` vs. on-disk sha256s → for each changed path, delete that file's outgoing subgraph in Neo4j → re-extract → upsert → update hash row.
+- **Parsing target:** the install's existing shared workspace resolved from `PROJECT_ROOT` (currently `/workspace` in the portal container). Reuse the same mounted codebase that Build Studio and codebase tools already read from; do **not** introduce a parallel `/app/source` bind in v1. Build Studio sandboxes are **not** parsed in v1 — sandbox code is ephemeral and has a separate review loop. A later slice may add per-sandbox graphs keyed by `buildId`.
+- **Triggers in v1 (all on-demand, no watchers/hooks):**
+  1. Admin API route `POST /api/admin/code-graph/rebuild` (mode=full|incremental) — gated to admin role.
+  2. Coworker tool `code_graph_rebuild` declared in [apps/web/lib/mcp-tools.ts](apps/web/lib/mcp-tools.ts) with `enum` on `mode` per CLAUDE.md enum mandate.
+  3. Portal-init bootstraps an initial full build on first startup if `CODE_GRAPH_ENABLED=true` and `CodeGraphFileHash` is empty. If this trigger is kept, extend `portal-init` to use the same `PROJECT_ROOT=/workspace`, `NEO4J_*` env, and `depends_on: neo4j` wiring as the main portal container.
+- **Performance budget (v1 targets on DPF Core scale ~= low thousands of files):**
+  - Full rebuild: ≤ 90 s warm, ≤ 180 s cold.
+  - Incremental rebuild for ≤ 20 changed files: ≤ 3 s p95.
+  - Query latency for `analyzeCodeImpact` on a typical diff: ≤ 500 ms p95.
+  - Neo4j node ceiling: 200k nodes / 1M relationships before we revisit partitioning.
+  - Exceeding any budget fails the nightly perf-smoke workflow and keeps `CODE_GRAPH_ENABLED` default-off until the budget is met.
+
+### 3. Build Studio Integration
+
+- Add a code-intelligence service layer that exposes:
+  - `buildCodeGraph(mode, changedFiles?)`
+  - `getMinimalCodeContext(goal, changedFiles?)`
+  - `analyzeCodeImpact(entryFiles?, diff?, buildId?)`
+  - `findAffectedTests(changedFilesOrSymbols)`
+- Wire this into Build Studio flows:
+  - ideate/scout: identify related routes, models, prompts, tools, and likely reuse points
+  - plan: provide minimal file/symbol context and dependency hotspots for the planner
+  - review: surface affected tests, risky symbols, and cross-cutting areas to inspect
+  - ship: enrich the existing impact report with code-level blast radius while keeping current route/schema/role impact behavior
+- Keep the existing workflow/process graph unchanged in v1. The new code graph informs analysis; it does not replace the current Build Studio process graph or orchestration UI.
+
+### 4. Interfaces And Output Contracts
+
+- Extend existing impact/reporting shapes rather than inventing a new user-facing graph payload.
+- Add optional fields to Build Studio evidence outputs such as:
+  - `codeImpactSummary`
+  - `relatedFiles`
+  - `relatedSymbols`
+  - `affectedTests`
+  - `riskSignals`
+  - `reasoningPaths`
+  - `graphFreshness`
+- Keep `change-impact.ts` backward-compatible for current RFC/change-management consumers, but make it graph-backed when code intelligence is available and heuristic-backed when it is not.
+- Add coworker/tool access only where needed for Build Studio phases; do not expose a generic graph explorer tool to end users in v1.
+- **Feature flag:** gate the entire slice behind `CODE_GRAPH_ENABLED` (env, default `false` until perf/quality validated). Each Build Studio phase (ideate, plan, review, ship) reads the flag and falls back to current heuristics when off or when Neo4j is unreachable. Flag must be logged at phase start so review output indicates whether graph enrichment was active.
+- **`reasoningPaths` shape:** array of `{ from: qualifiedId, to: qualifiedId, via: Array<{ relType, nodeId }>, rationale: string }`. Bounded to top-N paths (N=5) per impact report to keep payloads small.
+
+### 5. UI Boundary
+
+- Do not add a new Build Studio graph tab or in-studio explorer in v1.
+- Show graph results only as **summarized evidence** in coworker responses and Build Studio phase artifacts.
+- Treat a future interactive graph view as a **portfolio/taxonomy analysis feature** under the platform's own taxonomy area, not as part of Build Studio proper.
+
+## Public Interfaces And Types
+
+- **Neo4j schema additions:** new code-graph labels and relationship types only; no breaking changes to existing runtime graph labels or traversal contracts.
+- **Build Studio service API:** new internal code-intelligence service functions for build, query, impact, and test selection.
+- **Impact report shape:** additive fields only. Existing consumers must continue working if code-graph enrichment is absent.
+- **Tooling contract:** Build Studio tools may request code-graph evidence, but end-user route surfaces remain summary-based in v1.
+
+## Test Plan
+
+- Unit tests for TS/TSX extraction of symbols, imports, route definitions, and component links.
+- Unit tests for Prisma, prompt, skill, tool, and test enrichers using DPF-style fixtures.
+- Integration tests for Neo4j projection:
+  - full rebuild creates expected nodes and edges
+  - incremental rebuild updates only changed file subgraphs (verified via `CodeGraphFileHash` diff)
+  - code namespace does not interfere with existing `InfraCI` graph queries
+- Build Studio integration tests proving:
+  - scout findings include graph-backed related code
+  - review and ship outputs include affected tests and risk signals
+  - fallback behavior works when `CODE_GRAPH_ENABLED=false` and when Neo4j is unreachable (two distinct cases)
+- Regression tests for existing change-management flows to confirm old callers still accept the enriched impact report shape.
+- **Perf-smoke test** that asserts the §2 performance budget (full/incremental/query latency) on a fixture repo sized to DPF Core order-of-magnitude; runs in CI nightly, not per PR.
+- Verification before completion (per CLAUDE.md — never `npx`):
+  - `pnpm --filter web exec vitest run` for affected suites at minimum
+  - `pnpm --filter web exec next build`
+  - add or update QA cases in `tests/e2e/platform-qa-plan.md` for Phase 10 (Build Studio) and Phase 12 (AI Coworker Cross-Cutting)
+
+## Assumptions And Defaults
+
+- v1 is **Build Studio impact analysis first**, not a general-purpose repository exploration product.
+- Neo4j is the primary persisted graph store for this slice, but the graph remains **derived from workspace files**, not business authority data.
+- DPF Core coverage is enough for the first useful release; broad polyglot support is deferred.
+- Existing task scheduling in `task-dependency-graph.ts` stays as-is in v1; the code graph supplies better context and risk information, not a scheduler rewrite.
+- If the graph is stale or unavailable, Build Studio must degrade gracefully to current heuristics and explicitly label the result as reduced-confidence.
+
+## Current Repo Grounding
+
+- Existing Build Studio workflow graph: `apps/web/components/build/ProcessGraph.tsx`
+- Existing Build Studio process graph builder: `apps/web/lib/build/process-graph-builder.ts`
+- Existing operational/runtime graph schema and traversal: `packages/db/src/neo4j-schema.ts`, `packages/db/src/neo4j-graph.ts`
+- Existing Build Studio impact analysis entrypoint to enrich: `apps/web/lib/integrate/change-impact.ts`
+- Existing task orchestration heuristic that should stay separate in v1: `apps/web/lib/integrate/task-dependency-graph.ts`
+
+## Live Backlog Note
+
+- Live DB check on 2026-04-19 found:
+  - `Epic`: 0 rows
+  - `BacklogItem`: 4 rows
+  - `FeatureBuild`: 1 row, currently in `ideate`
+- No existing epic matched this work, so implementation should create a dedicated epic and linked backlog item before development begins.
+- **Canonical enum compliance (per CLAUDE.md "Strongly-Typed String Enums — MANDATORY"):**
+  - `Epic.status` must be one of `"open" | "in-progress" | "done"` (start with `"open"`).
+  - `BacklogItem.status` must be one of `"open" | "in-progress" | "done" | "deferred"`.
+  - `BacklogItem.type` must be `"portfolio"` for this work (platform-facing capability, not a customer product).
+  - Hyphens only (`"in-progress"`, never `"in_progress"`).
+- **FK pitfall:** `BacklogItem.epicId` is the Prisma `cuid` on `Epic.id` — **not** the semantic `EP-…` key. Create the Epic first, read back `Epic.id`, then insert the BacklogItem FK. Do not hand-type `"EP-CODE-GRAPH-001"` into `epicId`.
+
+## Task Decomposition (Ordered, One PR Each)
+
+Per [CLAUDE.md](../../../CLAUDE.md) and [CONTRIBUTING.md](../../../CONTRIBUTING.md) — short-lived intent-named branches, one concern per PR, with Typecheck and Production Build as the required merge gates today.
+
+1. **`feat/code-graph-schema`** — Neo4j schema additions (labels, constraints, indexes) in `neo4j-schema.ts` + Prisma migration adding `CodeGraphFileHash`. No extractors yet. Includes a CI assertion (Cypher-based, run in the integration test suite) verifying **graph isolation**: no edge exists where one endpoint is a `Code*` node and the other is `DigitalProduct | TaxonomyNode | Portfolio | InfraCI`, and no `Code*` node carries any existing runtime label. Merge when migration applies cleanly on fresh install, `initNeo4jSchema()` is idempotent, and the isolation assertion passes on a seeded fixture.
+2. **`feat/code-graph-extractors-core`** — TS/TSX extractor (symbols, imports, routes, components) + Prisma enricher. Writes to graph. Unit fixtures only.
+3. **`feat/code-graph-extractors-dpf`** — Prompt, skill, tool, and test enrichers. Completes DPF Core coverage.
+4. **`feat/code-graph-service`** — Service layer (`buildCodeGraph`, `getMinimalCodeContext`, `analyzeCodeImpact`, `findAffectedTests`) + admin API route + `code_graph_rebuild` tool declaration with enum contracts.
+5. **`feat/code-graph-change-impact`** — Enrich `change-impact.ts` with graph-backed fields; keep heuristic path as fallback. Additive schema only.
+6. **`feat/code-graph-build-studio-wiring`** — Wire ideate/plan/review/ship phases through `CODE_GRAPH_ENABLED` flag. Log flag state at phase start.
+7. **`feat/code-graph-perf-smoke`** — Nightly CI perf-smoke asserting §2 budget. Tune or defer budget constants if real-world numbers diverge materially.
+
+Each PR must update the relevant docs and tests in the same PR, per the expectations in [CONTRIBUTING.md](../../../CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- align `AGENTS.md` with the repo's PR-only workflow and the real `pnpm --filter web exec ...` commands
- normalize recent April implementation plans so they no longer instruct people to work directly on `main` or use stale `npx` / `@dpf/web` examples
- add the Build Studio code-intelligence-graph plan and update the Build Studio lifecycle test header comment to the same command convention

## Validation
- `pnpm --filter web exec next build` 
  - failed with a Turbopack internal panic in `apps/web/app/globals.css` (`os error 10054` while processing CSS)
  - this branch does not modify `apps/web/app/globals.css`; the failure is recorded here rather than being misreported as green
- `git diff --check -- AGENTS.md apps/web/tests/build-lifecycle.test.ts docs/superpowers/plans/2026-04-04-collaborative-work-queue-phase1.md docs/superpowers/plans/2026-04-04-provider-activation-routing-reconciliation.md docs/superpowers/plans/2026-04-04-provider-catalog-reconciler.md docs/superpowers/plans/2026-04-05-continuous-improvement-flywheel.md docs/superpowers/plans/2026-04-05-db-github-delivery-sync-implementation.md docs/superpowers/plans/2026-04-05-provider-reconciliation-automation.md docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md docs/superpowers/plans/2026-04-13-build-studio-happy-path-rescue.md docs/superpowers/plans/2026-04-13-build-studio-process-visualization.md docs/superpowers/plans/2026-04-13-model-capability-lifecycle.md docs/superpowers/plans/2026-04-17-business-first-workflow-consolidation-phase1.md docs/superpowers/plans/2026-04-18-build-studio-shell-native-refactor.md docs/superpowers/plans/2026-04-18-purpose-first-product-estate-phase1.md docs/superpowers/plans/2026-04-19-build-studio-code-intelligence-graph.md`