### PR TITLE
fix(sandbox): explicitly disable codex curated Gmail/GitHub plugins

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -11,9 +11,21 @@ RUN git config --global user.email "sandbox@dpf.local" \
  && git config --global user.name "DPF Sandbox"
 # Codex CLI defaults: bypass internal sandbox (Docker IS the sandbox),
 # no approval prompts for non-interactive use.
+#
+# Plugins: explicitly disable the OpenAI-curated Gmail + GitHub plugins.
+# On first invocation codex auto-enables these, which adds ~6000 tokens
+# of plugin tool definitions to every call and may trigger plugin init
+# HTTP traffic on each codex exec run. Neither is used by Build Studio.
+# Explicit enabled=false here overrides the auto-enable behaviour.
 RUN mkdir -p /root/.codex && printf '%s\n' \
   'sandbox_mode = "danger-full-access"' \
   'approval_policy = "never"' \
+  '' \
+  '[plugins."gmail@openai-curated"]' \
+  'enabled = false' \
+  '' \
+  '[plugins."github@openai-curated"]' \
+  'enabled = false' \
   > /root/.codex/config.toml
 WORKDIR /workspace
 # No secrets, no Docker socket


### PR DESCRIPTION
## Summary
Codex CLI auto-enables \`gmail@openai-curated\` and \`github@openai-curated\` on first invocation, which:
- adds ~6,000 tokens of plugin tool definitions to every \`codex exec\` call (verified: trivial "say READY" prompt dropped from 21,075 → 15,020 tokens after disabling)
- may trigger plugin init HTTP traffic on each invocation

Neither is used by Build Studio — our tool surface is MCP-defined via portal, not codex plugins.

## Fix
Explicit \`enabled = false\` entries in the seeded \`config.toml\` override the auto-enable path, so the token overhead is never paid.

## Test plan
- [x] Verified manually: tokens used dropped 21075 → 15020 after manual config edit
- [ ] Confirm after \`docker compose build sandbox && docker compose up -d sandbox\` that new container starts with plugins disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)