### PR TITLE
fix(plan-phase): drop sandbox file-read tools, keep project-file tools

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -667,7 +667,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "read_sandbox_file",
-    description: "Read a file from the project workspace. Returns contents with line numbers. Use offset and limit for large files. Always read a file before editing it.",
+    description: "Read a file from the sandbox working copy (post-build/edit state). For reading pristine source during planning, prefer read_project_file.",
     inputSchema: {
       type: "object",
       properties: {
@@ -680,7 +680,11 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "view_platform",
     executionMode: "immediate",
     sideEffect: false,
-    buildPhases: ["plan", "build", "review"],
+    // Intentionally NOT in "plan" — read_project_file covers planning reads
+    // from the source tree without requiring the portal→sandbox volume
+    // round-trip, and having both tools in the same phase caused codex to
+    // split file reads across them and stall (FB-21EEA510 2026-04-20).
+    buildPhases: ["build", "review"],
   },
   {
     name: "write_sandbox_file",
@@ -721,7 +725,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "search_sandbox",
-    description: "Search for a text pattern across the sandbox workspace. Returns matching file paths, line numbers, and context lines.",
+    description: "Search the sandbox working copy (post-build/edit state). For searching pristine source during planning, prefer search_project_files.",
     inputSchema: {
       type: "object",
       properties: {
@@ -734,11 +738,12 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "view_platform",
     executionMode: "immediate",
     sideEffect: false,
-    buildPhases: ["plan", "build"],
+    // Not in "plan" — search_project_files covers planning search.
+    buildPhases: ["build"],
   },
   {
     name: "list_sandbox_files",
-    description: "List files in the sandbox workspace matching a glob pattern. Returns file paths.",
+    description: "List files in the sandbox working copy (post-build/edit state). For listing pristine source during planning, prefer list_project_directory.",
     inputSchema: {
       type: "object",
       properties: {
@@ -749,7 +754,8 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: "view_platform",
     executionMode: "immediate",
     sideEffect: false,
-    buildPhases: ["plan", "build"],
+    // Not in "plan" — list_project_directory covers planning listing.
+    buildPhases: ["build"],
   },
   {
     name: "run_sandbox_command",


### PR DESCRIPTION
## Summary
Plan-phase coworker had two overlapping file-read tool surfaces:
- **portal-side** (\`read_project_file\`, \`search_project_files\`, \`list_project_directory\`) — reads \`/workspace\`, pristine source, no round-trip
- **sandbox-side** (\`read_sandbox_file\`, \`search_sandbox\`, \`list_sandbox_files\`) — reads \`/sandbox-workspace\`, post-build working copy

During plan phase there's no build output yet — both tool sets return the same content. Codex nevertheless split its reads across both, contributing to the plan-phase hang on FB-21EEA510 (2026-04-20): the model wastes iterations picking between equivalent tools, and the extra tool-definition prompt bloat adds thousands of tokens per turn.

## Change
Remove \`read_sandbox_file\`, \`search_sandbox\`, \`list_sandbox_files\` from the \`plan\` buildPhase. They remain available in \`build\` and \`review\` where the sandbox's post-edit state is the relevant source.

**Plan-phase tool count: 16 → 13.** Single obvious answer for "how do I read a file during planning?".

## Test plan
- [x] Typecheck passes
- [ ] Rebuild portal; next plan-phase coworker turn should only see project-file tools listed
- [ ] Plan-phase dispatches should no longer alternate between the two tool surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)