### PR TITLE
fix(cli): detect auth errors on stdout, stop shipping them as content

### DIFF
--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -401,6 +401,31 @@ export const cliAdapter: ExecutionAdapterHandler = {
         `${parsed.toolCalls.length} tool calls, ${inferenceMs}ms`,
       );
 
+      // Claude Code CLI returns auth errors on STDOUT with exit=0, not stderr.
+      // Observed payloads: "Invalid API key · Fix external API key",
+      // "Please log in with /login", "Authentication failed". Without this
+      // check the 38-char error string gets shipped as assistant content,
+      // the coworker echoes the error verbatim, and fallback never fires
+      // because the adapter thinks the call succeeded.
+      const CLI_AUTH_ERROR_PATTERNS = [
+        /invalid api key/i,
+        /fix external api key/i,
+        /please log in/i,
+        /authentication failed/i,
+        /not authenticated/i,
+      ];
+      const looksLikeAuthError =
+        parsed.toolCalls.length === 0 &&
+        parsed.text.length < 300 &&
+        CLI_AUTH_ERROR_PATTERNS.some((p) => p.test(parsed.text));
+      if (looksLikeAuthError) {
+        throw new InferenceError(
+          `Claude CLI auth error (from stdout): ${parsed.text.slice(0, 200)}`,
+          "auth",
+          providerId,
+        );
+      }
+
       // ── Durable tool-call extraction trace (mirrors codex-cli-adapter) ──
       // See note there. Kept on until tool dispatch is 100% reliable.
       const toolKeywordPattern = /\b(read_sandbox_file|write_sandbox_file|edit_sandbox_file|search_sandbox|list_sandbox_files|run_sandbox_command|check_sandbox|start_sandbox|saveBuildEvidence|save_build_notes|save_phase_handoff|reviewDesignDoc|reviewBuildPlan|search_project_files|read_project_file|list_project_directory|generate_design_system|search_design_intelligence|describe_model|deploy_feature|execute_promotion)\b/g;

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -272,6 +272,31 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
       // Attempt to extract tool calls if the model responded with tool_use blocks
       const toolCalls = extractToolCalls(text);
 
+      // Codex CLI can emit short auth-failure messages on stdout with exit=0
+      // (observed payloads: "Invalid API key · Fix external API key",
+      // "ERROR: unexpected status 401 Unauthorized: Missing bearer..."). The
+      // stderr-keyword check earlier only catches stderr; mirror that logic
+      // on stdout to ensure fallback kicks in instead of the error text
+      // being shipped as assistant content.
+      const CLI_AUTH_ERROR_PATTERNS = [
+        /invalid api key/i,
+        /fix external api key/i,
+        /please log in/i,
+        /401 unauthorized/i,
+        /not authenticated/i,
+      ];
+      const looksLikeAuthError =
+        toolCalls.length === 0 &&
+        text.length < 300 &&
+        CLI_AUTH_ERROR_PATTERNS.some((p) => p.test(text));
+      if (looksLikeAuthError) {
+        throw new InferenceError(
+          `Codex CLI auth error (from stdout): ${text.slice(0, 200)}`,
+          "auth",
+          providerId,
+        );
+      }
+
       // ── Durable tool-call extraction trace ────────────────────────────
       // Every codex response is logged under a single `[tool-trace]` prefix
       // so we can see the full extraction path end-to-end: raw output, which


### PR DESCRIPTION
## Summary
Both CLI adapters check **stderr** for auth/rate-limit strings and throw InferenceError on match. But Claude Code CLI and Codex CLI can emit their auth failures on **stdout** with exit=0.

**Observed payload from Claude CLI:** \`Invalid API key · Fix external API key\` — 38 chars, on stdout, exit=0.

The stderr check misses that entirely: the string gets wrapped as the model's assistant content, the coworker echoes it verbatim to the user ("⚠ Issue: Invalid API key · Fix external API key"), and the fallback chain never fires because the adapter reports success. Observed on FB-21EEA510 plan-phase turn 2026-04-20 02:4X.

## Fix
After parsing stdout, check: if \`toolCalls=0\`, text length \`<300\` chars, and text matches known auth-error patterns → throw \`InferenceError("auth")\` so \`callWithFallbackChain\` fails over to the next endpoint.

Patterns covered:
- \`Invalid API key\`
- \`Fix external API key\`
- \`Please log in\`
- \`Authentication failed\` / \`Not authenticated\`
- \`401 Unauthorized\` (codex variant)

## Test plan
- [x] Typecheck passes
- [ ] Next coworker turn where Claude CLI auth is broken should fail-over to the next provider instead of echoing "Invalid API key..." to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)