### PR TITLE
fix(sandbox): extractDiff pathspec misses apps/web/.next and .pnpm-store

### DIFF
--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -254,14 +254,30 @@ export async function getSandboxLogs(containerId: string, tail: number = 50): Pr
 export async function extractDiff(containerId: string): Promise<string> {
   // Stage ALL changes (including new untracked files) so git diff --cached sees them.
   // Without this, new files created by write_sandbox_file are untracked and invisible.
-  // Filter out node_modules, .next, lock files — they produce a 200MB+ diff.
+  //
+  // Filter out build artifacts and caches — they produce a 200MB+ diff AND trigger
+  // false positives in assess_contribution (e.g. minified bundles in .next/ contain
+  // the word "token" thousands of times, which looks like an API-key leak).
+  //
+  // Pathspec gotcha: `:!node_modules` matches only a top-level `node_modules/`
+  // directory, NOT `apps/web/node_modules/`. Same for `:!.next`. Use `:!**/X/**`
+  // to match at any depth. pnpm v10 added `.pnpm-store/` at repo root — exclude
+  // that too.
   await execInSandbox(containerId,
-    "cd /workspace && git add -A -- ':!node_modules' ':!.next' ':!*.tsbuildinfo' ':!pnpm-lock*'",
+    "cd /workspace && git add -A -- " +
+    "':!**/node_modules/**' ':!node_modules/**' " +
+    "':!**/.next/**' ':!.next/**' " +
+    "':!.pnpm-store/**' " +
+    "':!**/*.tsbuildinfo' " +
+    "':!pnpm-lock*'",
   );
 
-  // Get the list of staged source files
+  // Get the list of staged source files (defense in depth — the pathspec above
+  // should have excluded these, but `grep -v` catches any that slipped through).
   const changedFiles = await execInSandbox(containerId,
-    "cd /workspace && git diff --cached --name-only | grep -v node_modules | grep -v '.next/' | grep -v '.tsbuildinfo' | grep -v 'pnpm-lock'",
+    "cd /workspace && git diff --cached --name-only | " +
+    "grep -v node_modules | grep -v '.next/' | grep -v '.pnpm-store/' | " +
+    "grep -v '.tsbuildinfo' | grep -v 'pnpm-lock'",
   );
   const files = changedFiles.trim().split("\n").filter(Boolean);
   if (files.length === 0) return "";


### PR DESCRIPTION
## Summary
The exclude list in \`extractDiff\` — \`:!node_modules :!.next :!*.tsbuildinfo :!pnpm-lock*\` — only filters at repo root. It does NOT exclude:
- \`apps/web/.next/**\` — Next.js build artifacts/minified bundles with thousands of "token" occurrences that trigger \`assess_contribution\`'s API-key regex
- \`.pnpm-store/**\` — pnpm v10 cache, many MB of dependency blobs

## Observed impact
FB-21EEA510 ship flow: the clean 5-file subnet-graph build diff appeared as 17 files to assess_contribution. Got flagged:
- "Contains references to API keys or secrets" → from minified bundle text
- "Pricing or financial constants" → from CSS \`margin\` declarations and inlined style strings

Recommendation was \`contribute_with_mods\` instead of clean pass, blocking the hive PR on false positives.

## Fix
- Change pathspec patterns to \`:!**/X/**\` so they match at any depth
- Add \`.pnpm-store/**\` to the exclude list
- Keep the \`grep -v\` fallback as defense in depth

## Test plan
- [x] Typecheck passes
- [x] Manual verification: same build, re-stage with new pathspec → staged file count drops from 17 to 11 (all legitimate subnet-graph work); \`token\` occurrences drop from 3,975 → 2 (both legitimate \`scopeToken\` references); pricing/margin hits drop to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)