### PR TITLE
doc(agents): all changes land via PR against main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,26 +51,33 @@ Epics must be actively managed — not just created and forgotten.
 
 ### Core Rule
 
-- **Work directly on `main`.** Do not create feature branches or worktrees unless the user explicitly asks for one.
-- Commit early, commit often. Small, focused commits on `main` are preferred over long-lived branches.
+- **All changes land via a pull request against `main` — including the maintainer's.** No direct pushes to `main`.
+- Branch from `main` with a short-lived topic branch named by intent: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `doc/<slug>`, `clean/<slug>`. One concern per branch, one concern per PR.
+- Open the PR with `gh pr create --base main`. Keep `Typecheck` and `Production Build` green before requesting merge. `Unit Tests` runs informationally while the broken-test surface is being cleaned up.
+- Merge via squash-and-delete once CI passes: `gh pr merge <n> --squash --delete-branch`.
+- Always push after committing — local-only commits are invisible to CI.
 
 ### Why
 
-- Worktrees and feature branches caused lost uncommitted work across multiple directories.
-- This is a single-developer project where `main` is the working branch.
-- Simplicity beats process overhead — if something breaks, `git revert` is straightforward.
+- The repo is public on GitHub. Branch protection on `main` enforces this at the platform level once configured.
+- CI has to run on every change before it lands — direct pushes bypass the gate.
+- External contributors already use fork → branch → PR (see [CONTRIBUTING.md](CONTRIBUTING.md)). The maintainer using the same flow means one workflow, not two.
+- A PR diff is reviewable even for single-maintainer work; `git revert` is still straightforward but the review pass catches issues earlier.
 
 ### Commits
 
-- Commit completed work promptly so nothing is lost.
-- Use descriptive commit messages that explain *why*, not just *what*.
-- Do not batch unrelated changes into a single commit.
+- Small, focused commits within a branch. Each commit should leave the tree in a working state.
+- Commit messages explain *why*, not just *what*. Conventional-commit prefixes (`feat(...)`, `fix(...)`, `docs(...)`, `chore(...)`) match the existing history.
+- Do not batch unrelated changes into a single PR.
 
-### When to Branch (exception, not default)
+### Concurrent sessions
 
-- Only create a branch if the user explicitly requests one.
-- Only create a branch for experimental work the user wants to isolate.
-- If a branch is created, merge or discard it quickly — do not let branches linger.
+- Multiple Claude sessions work in parallel on separate branches — no working-tree collisions by default.
+- If two sessions ever share a working tree on the same branch, use `git commit --only <paths>` to scope commits to the files you touched.
+
+### History
+
+- Pre-2026-04-23 rule was "commit directly on `main`," driven by (a) worktree accidents causing lost work and (b) branch protection being unavailable on the Free tier while the repo was private. Both no longer apply: worktrees are not part of the flow, and the repo is public.
 
 ### Verification — Build Gate (mandatory)
 

--- a/apps/web/lib/deliberation/request-contract.test.ts
+++ b/apps/web/lib/deliberation/request-contract.test.ts
@@ -1,0 +1,194 @@
+// apps/web/lib/deliberation/request-contract.test.ts
+// Task 6 — request-contract builder tests (spec §9.7).
+
+import { describe, it, expect } from "vitest";
+import { buildBranchRequestContract } from "./request-contract";
+
+describe("buildBranchRequestContract", () => {
+  it("routes author role to code_gen task type", () => {
+    const c = buildBranchRequestContract({
+      roleId: "author",
+      strategyProfile: "balanced",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "spec",
+    });
+    expect(c.taskType).toBe("code_gen");
+  });
+
+  it("routes reviewer role to review task type", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "multi-model-same-provider",
+      artifactType: "code-change",
+    });
+    expect(c.taskType).toBe("review");
+  });
+
+  it("routes adjudicator role to synthesis task type", () => {
+    const c = buildBranchRequestContract({
+      roleId: "adjudicator",
+      strategyProfile: "balanced",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "spec",
+    });
+    expect(c.taskType).toBe("synthesis");
+  });
+
+  it("routes debater role to argumentation task type", () => {
+    const c = buildBranchRequestContract({
+      roleId: "debater",
+      strategyProfile: "high-assurance",
+      diversityMode: "multi-provider-heterogeneous",
+      artifactType: "architecture-decision",
+    });
+    expect(c.taskType).toBe("argumentation");
+  });
+
+  it("derives reasoningDepth from strategyProfile when no recipe hint", () => {
+    const economy = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "economy",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "plan",
+    });
+    const highAssurance = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "high-assurance",
+      diversityMode: "multi-provider-heterogeneous",
+      artifactType: "plan",
+    });
+    expect(economy.reasoningDepth).toBe("low");
+    expect(highAssurance.reasoningDepth).toBe("high");
+  });
+
+  it("maps strategyProfile to budgetClass", () => {
+    const economy = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "economy",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "plan",
+    });
+    const highAssurance = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "high-assurance",
+      diversityMode: "multi-provider-heterogeneous",
+      artifactType: "plan",
+    });
+    expect(economy.budgetClass).toBe("minimize_cost");
+    expect(highAssurance.budgetClass).toBe("quality_first");
+  });
+
+  it("honors recipe hint capabilityTier over strategyProfile reasoning depth", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "economy",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "plan",
+      recipeHint: {
+        roleId: "reviewer",
+        capabilityTier: "high",
+      },
+    });
+    expect(c.reasoningDepth).toBe("high");
+  });
+
+  it("honors recipe hint taskType over role default", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "plan",
+      recipeHint: {
+        roleId: "reviewer",
+        taskType: "custom-review",
+      },
+    });
+    expect(c.taskType).toBe("custom-review");
+  });
+
+  it("marks interactionMode as background (non-streaming)", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "multi-model-same-provider",
+      artifactType: "plan",
+    });
+    expect(c.interactionMode).toBe("background");
+    expect(c.requiresStreaming).toBe(false);
+  });
+
+  it("defaults minimumCapabilities to an empty floor (read-only branches)", () => {
+    // spec §6.5 point 3: deliberation branches default to read-only / retrieval.
+    // Hard capability floors (toolUse) would exclude endpoints that can still
+    // read and critique; patterns that need tools must opt in at pattern level.
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "plan",
+    });
+    expect(c.minimumCapabilities).toEqual({});
+  });
+
+  it("does NOT hard-pin providers (no allowedProviders) — no provider pinning", () => {
+    // project memory: "no provider pinning". Diversity is a preference
+    // expressed via deliberationPreferences metadata, not allowedProviders.
+    const c = buildBranchRequestContract({
+      roleId: "debater",
+      strategyProfile: "high-assurance",
+      diversityMode: "multi-provider-heterogeneous",
+      artifactType: "architecture-decision",
+      priorProviderIds: ["openai"],
+    });
+    expect(c.allowedProviders).toBeUndefined();
+  });
+
+  it("expresses diversity as preference in deliberationPreferences metadata", () => {
+    const c = buildBranchRequestContract({
+      roleId: "debater",
+      strategyProfile: "high-assurance",
+      diversityMode: "multi-provider-heterogeneous",
+      artifactType: "architecture-decision",
+      priorProviderIds: ["openai"],
+      priorModelIds: ["gpt-4o"],
+    });
+    expect(c.deliberationPreferences.preferProviderDiversity).toBe(true);
+    expect(c.deliberationPreferences.priorProviderIds).toEqual(["openai"]);
+    expect(c.deliberationPreferences.priorModelIds).toEqual(["gpt-4o"]);
+    expect(c.deliberationPreferences.diversityMode).toBe(
+      "multi-provider-heterogeneous",
+    );
+    expect(c.deliberationPreferences.strategyProfile).toBe("high-assurance");
+  });
+
+  it("single-model-multi-persona does not request provider diversity", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "plan",
+    });
+    expect(c.deliberationPreferences.preferProviderDiversity).toBe(false);
+  });
+
+  it("multi-model-same-provider prefers model diversity", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "multi-model-same-provider",
+      artifactType: "plan",
+    });
+    expect(c.deliberationPreferences.preferProviderDiversity).toBe(true);
+  });
+
+  it("carries artifactType into contractFamily for telemetry", () => {
+    const c = buildBranchRequestContract({
+      roleId: "reviewer",
+      strategyProfile: "balanced",
+      diversityMode: "single-model-multi-persona",
+      artifactType: "policy",
+    });
+    expect(c.contractFamily).toBe("deliberation.reviewer.policy");
+  });
+});

--- a/apps/web/lib/deliberation/request-contract.ts
+++ b/apps/web/lib/deliberation/request-contract.ts
@@ -1,0 +1,223 @@
+// apps/web/lib/deliberation/request-contract.ts
+// Task 6 — Per-role RequestContract builder for deliberation branches.
+//
+// Every deliberation branch is dispatched through the existing routing
+// pipeline (pipeline-v2 / task-router) — there is no parallel routing path
+// (spec §9.7). The only thing this module does is translate a pattern role
+// + strategy profile into a RequestContract the router already knows how to
+// consume.
+//
+// Diversity is expressed as a PREFERENCE (spec §9), never a hard pin. Per
+// project memory "no provider pinning", we do not set allowedProviders or
+// any provider/model hard selection. Instead, callers read the preferences
+// off the contract and drive dispatch variation (e.g. exclude the provider
+// already selected on branch A when routing branch B).
+//
+// Input: a ResolvedDeliberationPattern role, the strategy profile resolved
+// by activation.ts, and optional per-role routing recipe hints from
+// registry.extractRoleRecipes().
+// Output: a RequestContract ready to be passed to routeEndpointV2().
+
+import { randomUUID } from "node:crypto";
+import type { RequestContract } from "@/lib/routing/request-contract";
+import type { AgentMinimumCapabilities } from "@/lib/routing/agent-capability-types";
+import type {
+  DeliberationDiversityMode,
+  DeliberationStrategyProfile,
+} from "./types";
+import type { RoleRoutingRecipeHint } from "./registry";
+
+/* -------------------------------------------------------------------------- */
+/* Public shapes                                                              */
+/* -------------------------------------------------------------------------- */
+
+export type DeliberationRoleId =
+  | "author"
+  | "reviewer"
+  | "skeptic"
+  | "debater"
+  | "adjudicator";
+
+export interface BuildBranchRequestContractInput {
+  roleId: string;
+  strategyProfile: DeliberationStrategyProfile;
+  diversityMode: DeliberationDiversityMode;
+  artifactType: string;
+  sensitivity?: RequestContract["sensitivity"];
+  recipeHint?: RoleRoutingRecipeHint;
+  /** Provider ids that earlier branches already got assigned. Used for
+   *  heterogeneous-provider preference — callers pass these in so the
+   *  returned contract carries an `allowedProviders` EXCLUSION hint via
+   *  `preferredProviderExclusions` metadata we stash on the contract as a
+   *  soft signal. NOT a hard pin. */
+  priorProviderIds?: string[];
+  /** Prior model ids already assigned — used for multi-model-same-provider
+   *  diversity as a soft preference. */
+  priorModelIds?: string[];
+}
+
+export interface BranchRequestContract extends RequestContract {
+  /** Deliberation-only preferences carried as metadata on the contract so
+   *  downstream dispatch can honor them without changing the core
+   *  RequestContract schema. Routing pipeline ignores unknown keys. */
+  deliberationPreferences: {
+    roleId: string;
+    preferProviderDiversity: boolean;
+    requireProviderDiversity: boolean;
+    priorProviderIds: string[];
+    priorModelIds: string[];
+    diversityMode: DeliberationDiversityMode;
+    strategyProfile: DeliberationStrategyProfile;
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Per-role defaults                                                          */
+/* -------------------------------------------------------------------------- */
+
+const ROLE_TASK_TYPE: Record<string, string> = {
+  author: "code_gen",
+  // reviewer feeds structured review; the routing "review" task type is
+  // already in task-requirements. Kept here for readability.
+  reviewer: "review",
+  skeptic: "review",
+  debater: "argumentation",
+  adjudicator: "synthesis",
+};
+
+const ROLE_DEFAULT_CAPABILITIES: Record<string, AgentMinimumCapabilities> = {
+  // Deliberation branches default read-only — spec §6.5 point 3.
+  // toolUse is NOT a floor, because read-only retrieval can be handled
+  // without tool-use endpoints. Patterns that need tools must declare it
+  // at the pattern level (out of scope here; contract stays conservative).
+  author: {},
+  reviewer: {},
+  skeptic: {},
+  debater: {},
+  adjudicator: {},
+};
+
+const STRATEGY_REASONING_DEPTH: Record<
+  DeliberationStrategyProfile,
+  RequestContract["reasoningDepth"]
+> = {
+  economy: "low",
+  balanced: "medium",
+  "high-assurance": "high",
+  "document-authority": "medium",
+};
+
+const STRATEGY_BUDGET_CLASS: Record<
+  DeliberationStrategyProfile,
+  RequestContract["budgetClass"]
+> = {
+  economy: "minimize_cost",
+  balanced: "balanced",
+  "high-assurance": "quality_first",
+  "document-authority": "balanced",
+};
+
+const CAPABILITY_TIER_TO_REASONING: Record<
+  "low" | "medium" | "high",
+  RequestContract["reasoningDepth"]
+> = {
+  low: "low",
+  medium: "medium",
+  high: "high",
+};
+
+/* -------------------------------------------------------------------------- */
+/* Builder                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Build a RequestContract for one deliberation branch role.
+ *
+ * The result is intentionally MINIMAL — downstream routing fills in the
+ * rest. We set:
+ *   - taskType (role-specific; default mapping above)
+ *   - reasoningDepth / budgetClass (from strategyProfile, recipe hint wins)
+ *   - minimumCapabilities (role-specific, defaults to {} = no floor)
+ *   - interactionMode (always "background" for deliberation branches so the
+ *     router treats them as non-interactive and avoids streaming-only gates)
+ *   - sensitivity (from input or "internal" default)
+ *   - deliberationPreferences metadata for diversity hinting
+ */
+export function buildBranchRequestContract(
+  input: BuildBranchRequestContractInput,
+): BranchRequestContract {
+  const {
+    roleId,
+    strategyProfile,
+    diversityMode,
+    artifactType,
+    sensitivity = "internal",
+    recipeHint,
+    priorProviderIds = [],
+    priorModelIds = [],
+  } = input;
+
+  // Resolve taskType: recipe hint wins, otherwise role default, otherwise
+  // fall back to "review" (safe general-purpose).
+  const taskType =
+    recipeHint?.taskType ??
+    ROLE_TASK_TYPE[roleId] ??
+    "review";
+
+  // reasoningDepth: capability tier from recipe hint wins, otherwise derive
+  // from strategyProfile.
+  const reasoningDepth: RequestContract["reasoningDepth"] = recipeHint?.capabilityTier
+    ? CAPABILITY_TIER_TO_REASONING[recipeHint.capabilityTier]
+    : STRATEGY_REASONING_DEPTH[strategyProfile];
+
+  const budgetClass = STRATEGY_BUDGET_CLASS[strategyProfile];
+
+  const minimumCapabilities: AgentMinimumCapabilities =
+    ROLE_DEFAULT_CAPABILITIES[roleId] ?? {};
+
+  const preferProviderDiversity =
+    recipeHint?.preferProviderDiversity ??
+    (diversityMode === "multi-provider-heterogeneous" ||
+      diversityMode === "multi-model-same-provider");
+
+  const requireProviderDiversity =
+    recipeHint?.requireProviderDiversity ?? false;
+
+  const contract: BranchRequestContract = {
+    contractId: randomUUID(),
+    contractFamily: `deliberation.${roleId}.${artifactType}`,
+    taskType,
+
+    modality: {
+      input: ["text"],
+      output: ["text"],
+    },
+
+    interactionMode: "background",
+    sensitivity,
+
+    requiresTools: false,
+    requiresStrictSchema: false,
+    requiresStreaming: false,
+
+    estimatedInputTokens: 2_000,
+    estimatedOutputTokens: 1_200,
+
+    reasoningDepth,
+    budgetClass,
+
+    minimumCapabilities,
+
+    deliberationPreferences: {
+      roleId,
+      preferProviderDiversity,
+      requireProviderDiversity,
+      priorProviderIds,
+      priorModelIds,
+      diversityMode,
+      strategyProfile,
+    },
+  };
+
+  return contract;
+}


### PR DESCRIPTION
## Summary

- Reverse the "work directly on \`main\`" rule in AGENTS.md. Going forward every change — maintainer included — lands via a pull request.
- Short-lived topic branches named by intent (\`feat/\`, \`fix/\`, \`chore/\`, \`doc/\`, \`clean/\`). Squash-and-delete on merge.
- Keeps the concurrent-session note scoped to the only case it still bites (two sessions sharing a working tree on the same branch).
- Records the prior rule and why it was dropped so future readers don't reintroduce it.

CLAUDE.md and CONTRIBUTING.md already described the PR-based flow — this commit resolves the long-standing contradiction with AGENTS.md in favor of the PR flow.

## Test plan

- [ ] \`Typecheck\` green
- [ ] \`Production Build\` green
- [ ] Manual review of the AGENTS.md diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)