### PR TITLE
fix(evidence): drop mirrorDeliberationRetrievalEvent re-export from "use server" module

### DIFF
--- a/apps/web/lib/actions/external-evidence.ts
+++ b/apps/web/lib/actions/external-evidence.ts
@@ -24,13 +24,9 @@ export async function recordExternalEvidence(input: {
   });
 }
 
-// Deliberation (spec §8) is retrieval-first: when a branch performs public-web
-// fetches, file reads, or other external research to support a claim, we mirror
-// that activity into the existing external-evidence stream so the platform can
-// observe all external-research activity in one place without overloading
-// ExternalEvidenceRecord with deliberation-only columns. The helper
-// `mirrorDeliberationRetrievalEvent` lives in
-// `apps/web/lib/deliberation/evidence.ts` (where the evidence policy owns it)
-// and is re-exported here so callers in the actions layer can import
-// `recordExternalEvidence` and the deliberation mirror side by side.
-export { mirrorDeliberationRetrievalEvent } from "../deliberation/evidence";
+// Deliberation's retrieval-mirror helper lives at `@/lib/deliberation/evidence`
+// as `mirrorDeliberationRetrievalEvent` — import it from there directly. It
+// cannot be re-exported from this module because `"use server"` files may only
+// export async functions, and the deliberation module also exports sync
+// helpers + types; a wildcard re-export causes Next.js RSC to treat this file
+// as having no exports at all.


### PR DESCRIPTION
## Summary

- Removes the re-export line at the bottom of `apps/web/lib/actions/external-evidence.ts` that was breaking the Production Build gate on `main`.
- Replaces it with a short comment pointing callers at the canonical import path.

## Why the build was red

`external-evidence.ts` starts with `"use server"`, and Next.js's RSC compiler requires such files to export only async functions. The re-export `export { mirrorDeliberationRetrievalEvent } from "../deliberation/evidence"` pulled in a module that also exports synchronous helpers and types — the compiler rejected the whole file with:

> The export recordExternalEvidence was not found in module ... The module has no exports at all.

That cascaded into brand extraction, admin proposal execution, the Inngest route, and the AI provider page (see the import traces in run 24817671025).

## Why this fix is safe

The only existing caller of `mirrorDeliberationRetrievalEvent` is its own test file (`apps/web/lib/deliberation/evidence.test.ts:24`), which already imports from `@/lib/deliberation/evidence` directly — not via the re-export. No call sites need updating.

## Test plan

- [x] `pnpm --filter web build` compiles successfully (13.1s, 83/83 pages)
- [ ] CI `Typecheck` green
- [ ] CI `Production Build` green
- [ ] Merge unblocks queued `feat(adp)` work on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)