### PR TITLE
chore(sec): bump lodash to 4.18.0 (GHSA-r5fr-rjxr-66jc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
       "@expo/cli@0.24.24>picomatch": "3.0.2",
       "minimatch@3.1.5>brace-expansion": "1.1.13",
       "minimatch@9.0.9>brace-expansion": "2.0.3",
+      "lodash": "4.18.0",
       "lodash-es": "4.18.0",
       "@tootallnate/once": "3.0.1",
       "@xmldom/xmldom": "0.8.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@expo/cli@0.24.24>picomatch': 3.0.2
   minimatch@3.1.5>brace-expansion: 1.1.13
   minimatch@9.0.9>brace-expansion: 2.0.3
+  lodash: 4.18.0
   lodash-es: 4.18.0
   '@tootallnate/once': 3.0.1
   '@xmldom/xmldom': 0.8.13
@@ -6141,8 +6142,9 @@ packages:
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.0:
+    resolution: {integrity: sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==}
+    deprecated: Bad release. Please use lodash@4.17.21 instead.
 
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
@@ -12484,7 +12486,7 @@ snapshots:
       html-to-image: 1.11.13
       immer: 10.2.0
       jotai: 2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.5)
-      lodash: 4.17.21
+      lodash: 4.18.0
       marked: 4.3.0
       pako: 2.1.0
       pino: 8.21.0
@@ -13481,7 +13483,7 @@ snapshots:
   dagre@0.8.5:
     dependencies:
       graphlib: 2.1.8
-      lodash: 4.17.21
+      lodash: 4.18.0
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -14307,7 +14309,7 @@ snapshots:
 
   graphlib@2.1.8:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.0
 
   graphmatch@1.1.1: {}
 
@@ -14868,7 +14870,7 @@ snapshots:
       jest-watch-select-projects: 2.0.0
       jest-watch-typeahead: 2.2.1(jest@30.3.0(@types/node@24.12.2))
       json5: 2.2.3
-      lodash: 4.17.21
+      lodash: 4.18.0
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
       react-test-renderer: 19.0.0(react@18.3.1)
       server-only: 0.0.1
@@ -15448,7 +15450,7 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
-  lodash@4.17.21: {}
+  lodash@4.18.0: {}
 
   log-symbols@2.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add a root pnpm override for lodash 4.18.0
- regenerate the lockfile on top of current main
- verify web typecheck and production build still pass

## Verification
- pnpm why -r lodash
- pnpm --filter web typecheck
- pnpm --filter web build

## Note
npm marks lodash 4.18.0 as deprecated, but GitHub Dependabot currently lists 4.18.0 as the patched version for the remaining open lodash advisories in this repository, so this PR uses the smallest version that should actually clear those alerts.