### PR TITLE
chore(dev-gates): add local typecheck pre-commit gate + worktree discipline to AGENTS.md

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,24 @@
 #!/bin/sh
-# Guard: prevent modification of already-committed Prisma migration files.
 #
-# Migration files are immutable once committed. Modifying them after they've
-# been applied causes DB drift — Prisma detects the checksum mismatch and
-# refuses to run new migrations without a full reset.
+# pre-commit: runs before every local commit. Two guards:
 #
-# To fix drift: use `prisma migrate resolve --applied <name>` to re-sync
-# checksums. Never edit a migration file after it has been committed.
+#   1. Migration immutability — reject commits that modify previously-committed
+#      Prisma migration .sql files (drift prevention).
+#   2. Typecheck gate — when TypeScript files are staged, run `pnpm typecheck`
+#      on the affected workspaces and reject the commit if it fails. Catches
+#      missing imports, symbol drift, and type errors BEFORE they reach CI.
+#
+# The typecheck step is skipped when:
+#   - Only non-TS files are staged (docs-only, config-only, migration-only)
+#   - DPF_SKIP_TYPECHECK=1 is set (emergency escape hatch — use sparingly; CI
+#     will still catch what you let through).
+#
+# Set up: `git config core.hooksPath .githooks` (done automatically at repo setup).
+
+# ─── Guard 1: migration immutability ────────────────────────────────────────
 
 MIGRATIONS_DIR="packages/db/prisma/migrations"
 
-# Get files staged for commit that are MODIFICATIONS (M) inside the migrations dir.
-# New files (A = added) are fine — that's a new migration being created.
 MODIFIED_MIGRATIONS=$(git diff --cached --name-status | grep "^M" | awk '{print $2}' | grep "^$MIGRATIONS_DIR" | grep "\.sql$")
 
 if [ -n "$MODIFIED_MIGRATIONS" ]; then
@@ -32,4 +39,88 @@ if [ -n "$MODIFIED_MIGRATIONS" ]; then
   exit 1
 fi
 
+# ─── Guard 2: typecheck gate ────────────────────────────────────────────────
+
+if [ "$DPF_SKIP_TYPECHECK" = "1" ]; then
+  echo "[pre-commit] DPF_SKIP_TYPECHECK=1 — skipping typecheck gate."
+  exit 0
+fi
+
+STAGED_TS=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|mts|cts)$' || true)
+
+if [ -z "$STAGED_TS" ]; then
+  exit 0
+fi
+
+echo "[pre-commit] TypeScript files staged — running scoped typecheck..."
+echo "[pre-commit] To skip in an emergency: DPF_SKIP_TYPECHECK=1 git commit ..."
+echo ""
+
+# Map staged paths to the affected pnpm workspace(s). Each workspace has its
+# own `typecheck` script (tsc --noEmit). Running only what's affected keeps
+# the hook fast on small commits while still catching cross-file errors
+# within each workspace.
+
+RUN_WEB=0
+RUN_DB=0
+RUN_TYPES=0
+RUN_VALIDATORS=0
+RUN_API_CLIENT=0
+RUN_MOBILE=0
+RUN_ADP_SERVICE=0
+
+while IFS= read -r file; do
+  case "$file" in
+    apps/web/*)                   RUN_WEB=1 ;;
+    packages/db/*)                RUN_DB=1 ;;
+    packages/types/*)             RUN_TYPES=1 ;;
+    packages/validators/*)        RUN_VALIDATORS=1 ;;
+    packages/api-client/*)        RUN_API_CLIENT=1 ;;
+    apps/mobile/*)                RUN_MOBILE=1 ;;
+    services/adp/*)               RUN_ADP_SERVICE=1 ;;
+  esac
+done <<EOF
+$STAGED_TS
+EOF
+
+# A change in a shared package (db, types, validators) can break web. Run web
+# typecheck whenever any upstream workspace is touched.
+if [ "$RUN_DB" = "1" ] || [ "$RUN_TYPES" = "1" ] || [ "$RUN_VALIDATORS" = "1" ]; then
+  RUN_WEB=1
+fi
+
+FAILED=""
+
+run_typecheck() {
+  filter="$1"
+  label="$2"
+  echo "  → $label"
+  if ! pnpm --filter "$filter" typecheck >/tmp/pre-commit-tc.log 2>&1; then
+    echo ""
+    echo "ERROR: typecheck failed for $label"
+    echo ""
+    cat /tmp/pre-commit-tc.log | tail -40
+    echo ""
+    FAILED="$FAILED $label"
+  fi
+}
+
+[ "$RUN_WEB" = "1" ]           && run_typecheck "web"               "apps/web"
+[ "$RUN_DB" = "1" ]            && run_typecheck "@dpf/db"           "packages/db"
+[ "$RUN_TYPES" = "1" ]         && run_typecheck "@dpf/types"        "packages/types"
+[ "$RUN_VALIDATORS" = "1" ]    && run_typecheck "@dpf/validators"   "packages/validators"
+[ "$RUN_API_CLIENT" = "1" ]    && run_typecheck "@dpf/api-client"   "packages/api-client"
+[ "$RUN_MOBILE" = "1" ]        && run_typecheck "mobile"            "apps/mobile"
+[ "$RUN_ADP_SERVICE" = "1" ]   && run_typecheck "dpf-adp-mcp"       "services/adp"
+
+if [ -n "$FAILED" ]; then
+  echo ""
+  echo "Commit rejected. Fix the typecheck errors above or, for an emergency override:"
+  echo "  DPF_SKIP_TYPECHECK=1 git commit ..."
+  echo "(CI will still gate the merge either way.)"
+  echo ""
+  exit 1
+fi
+
+echo "[pre-commit] typecheck ok"
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,69 @@ Epics must be actively managed — not just created and forgotten.
 
 - Pre-2026-04-23 rule was "commit directly on `main`," driven by (a) worktree accidents causing lost work and (b) branch protection being unavailable on the Free tier while the repo was private. Both no longer apply: worktrees are not part of the flow, and the repo is public.
 
+### Typecheck Gate — local, before commit (mandatory)
+
+TypeScript errors must be caught at code time, not as an afterthought. Relying on CI alone has repeatedly broken `main` for all concurrent agents because one session's committed code referenced files another hadn't committed yet. The local pre-commit hook at [.githooks/pre-commit](.githooks/pre-commit) runs `pnpm --filter <affected workspace> typecheck` before every commit that touches `.ts` / `.tsx` / `.mts` / `.cts` files and rejects the commit if typecheck fails.
+
+**Required setup (once per clone):**
+
+```sh
+git config core.hooksPath .githooks
+```
+
+New clones inherit this automatically via the repo's `postinstall` script. Verify with `git config core.hooksPath` — must return `.githooks`. If it doesn't, re-set it.
+
+**How it scopes work:**
+
+- Only TS-affecting commits pay the typecheck cost. Doc-only / migration-only / config-only commits skip the hook.
+- Only affected workspaces are checked (scoped via `pnpm --filter`). A change in `packages/db` also re-checks `apps/web` because web consumes db types. A change in `services/adp` only checks that service.
+- Typical overhead on a focused commit: 15–60 seconds. On a multi-workspace commit: 1–3 minutes.
+
+**Emergency escape:** `DPF_SKIP_TYPECHECK=1 git commit ...` bypasses the gate. Use only when you must commit a known-broken intermediate state (e.g., rebasing in halves). CI will still catch it.
+
+**Authoring discipline — all agents:**
+
+- Before proposing a commit, mentally gate on "will typecheck pass?" — do not commit code that imports symbols you haven't also committed, doesn't populate required properties, or references modules that don't exist yet.
+- If you refactor a shared type in `feature-build-types.ts`, update every consumer in the same commit. Don't leave drift between the type and the data layer.
+- If you create a new file that another committed file imports, `git add` both in the same commit. Untracked-import drift is the single most common cause of "main is red" incidents.
+
+**Subagent dispatchers:** include "run `pnpm --filter web typecheck` before committing and fix any errors" in every task prompt that modifies TypeScript. Subagents do not read AGENTS.md.
+
+### Typecheck Gate — Build Studio (mandatory)
+
+The platform's own Build Studio feature-building lifecycle must apply the same gate to the sandbox it builds in. Two additions:
+
+1. **Per-task verification step** — after every Build Studio task execution in the sandbox, run `pnpm --filter web typecheck` and `pnpm --filter web build` inside the sandbox container. If either fails, the task status is `failed` and the coworker must fix the error before the phase advances. Mirrors the local pre-commit gate.
+2. **Pre-ship verification** — the review-phase verification pass (currently UX-only via browser-use) must include typecheck + production build as mandatory passes. The build never leaves the sandbox without passing what CI would run. Implementation landing spot: [apps/web/lib/queue/functions/build-review-verification.ts](apps/web/lib/queue/functions/build-review-verification.ts).
+
+Together these mean a Build-Studio-produced PR cannot fail CI typecheck — if it would, it never leaves the sandbox.
+
+### Concurrent Sessions — Per-Thread Worktree (mandatory when >1 session)
+
+Two Claude Code sessions editing the same working tree at `d:\DPF` fight over `HEAD`, the index, and the working tree — even if they target different branches. Observed symptoms: commits land on `main` instead of the intended feature branch; `git reflog` shows unexpected `checkout: moving from <feature> to main` entries; one session's staged files sweep into another's commit.
+
+**The fix is a git worktree per session, not just a branch per session.**
+
+**Setup (per topic, run from `d:\DPF`):**
+
+```sh
+git worktree add ../DPF-<topic> -b feat/<topic>-work
+```
+
+Each worktree gets its own working directory, HEAD, branch, and index. The `.git` object database is shared — disk-efficient, concurrency-safe. Open each Claude Code session with its **Primary working directory** pointed at the matching worktree path. One worktree stays on `main` for merges/releases/global inspection; agents never work in that one.
+
+**Cleanup after merge:** `git worktree remove ../DPF-<topic>` — prunes the checkout; the branch ref survives until explicitly deleted via `git branch -d`.
+
+**Signal that this rule is being violated:** a session notices its checkout flipped from a feature branch back to `main` between commands. That means another session is sharing the worktree. Stop, flag to Mark, move to a dedicated worktree before continuing.
+
+**Belt-and-suspenders branch guard in every commit command:**
+
+```sh
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" = "main" ]; then echo "ERROR: on main — abort"; exit 1; fi
+git commit --only <paths> -m "..."
+```
+
 ### Verification — Build Gate (mandatory)
 
 Work is NOT complete until the production build passes and UX-level testing has been run for the affected surfaces. This is non-negotiable.


### PR DESCRIPTION
## Summary

- Extends `.githooks/pre-commit` with a scoped typecheck gate — commits that touch TS files run `pnpm --filter <workspace> typecheck` and are rejected if it fails.
- Documents three concurrent-session rules in `AGENTS.md` that every agent (Claude Code, Build Studio, subagents) must follow.

## Why

Recent main-is-red incidents: one session commits `crm.ts` that imports from `site-address-validation`, another session rebases on top, and CI is the first to notice `site-address-validation.ts` was never `git add`ed. By the time CI fires, every concurrent session has inherited the breakage.

The pre-commit hook catches this class of error at commit time, before push, before CI, before anyone else rebases.

## What changed

### `.githooks/pre-commit`

Kept the existing migration-immutability guard. Added a typecheck stage that:

- Runs only when `.ts`/`.tsx`/`.mts`/`.cts` files are staged (doc-only, config-only, migration-only commits skip it).
- Maps staged paths → affected pnpm workspace(s); runs `pnpm --filter <ws> typecheck` only on what's affected.
- Upstream fan-out: a change in `packages/db`/`types`/`validators` also re-checks `apps/web` because web consumes those types.
- Emergency override: `DPF_SKIP_TYPECHECK=1 git commit ...` for known-broken intermediate states. CI still gates merge.

Typical cost on a focused commit: 15–60 seconds. Multi-workspace commit: 1–3 minutes.

### `AGENTS.md`

Three new sections in the Branching & Workflow area:

1. **Typecheck Gate — local, before commit (mandatory)** — explains setup (`git config core.hooksPath .githooks`), how scoping works, the emergency override, and authoring discipline agents must follow. Explicitly calls out "don't commit code that imports files you haven't also committed" — the root cause of the recent incident.
2. **Typecheck Gate — Build Studio (mandatory)** — mirrors the discipline in the platform's own feature-building sandbox: per-task verification after every task execution, and pre-ship verification that treats typecheck + production build as mandatory review-phase passes. Landing spot: `apps/web/lib/queue/functions/build-review-verification.ts`.
3. **Concurrent Sessions — Per-Thread Worktree (mandatory when >1 session)** — setup commands, cleanup, signals that the rule is being violated, belt-and-suspenders branch-guard for commit commands.

## Test plan

- [x] `sh .githooks/pre-commit` with no staged files → exits 0 silently.
- [x] This PR's commit itself (staged: `.githooks/pre-commit`, `AGENTS.md`) correctly skipped the typecheck stage (no TS files staged).
- [ ] CI `Typecheck` + `Production Build` green (no code paths touched by this change).

## Follow-ons

- Build Studio verification step (spec §3 in AGENTS.md addition) — separate PR; lands in `apps/web/lib/queue/functions/build-review-verification.ts` and the build-pipeline task runner.
- `postinstall` script that re-asserts `git config core.hooksPath .githooks` for drifted checkouts — separate small PR.

Generated with Claude Code