### PR TITLE
fix(ci): sync pnpm lockfile and pin package manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -53,7 +53,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -81,7 +81,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -104,7 +104,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 22
 
       - name: Install pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@testing-library/react-native": "^12.0.0",
     "@types/jest": "^30.0.0",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19",
     "jest": "^29.7.0",
     "jest-expo": "~53.0.0",
     "msw": "^2.13.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dpf",
   "private": true,
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "pnpm --filter web dev",
     "build": "pnpm --filter web build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/react':
-        specifier: ^19.2.14
+        specifier: ^19
         version: 19.2.14
       jest:
         specifier: ^29.7.0


### PR DESCRIPTION
## Summary
- align the mobile React types specifier with the workspace override so the lockfile is frozen-install safe
- pin the repo package manager to pnpm 10.33.2
- stop GitHub Actions from floating to pnpm@latest

## Verification
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm --filter web exec vitest run lib/routing/tier-contract.test.ts
- pnpm test
- cd apps/web && npx next build