### PR TITLE
fix(ci): add missing dotenv dep for web build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.5.0",
+    "dotenv": "^17.2.3",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.10)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.4.2
       postcss:
         specifier: ^8.5.10
         version: 8.5.10


### PR DESCRIPTION
## Summary
- add the missing dotenv dependency to the web workspace
- sync the lockfile so containerized installs resolve the same graph as local builds
- restore the Docker publish build path that was failing inside pnpm --filter web build

## Verification
- pnpm install --frozen-lockfile
- cd apps/web && npx next build
- docker build --target runner -t dpf-portal-ci-check .