### PR TITLE
feat(adp): implement adp_get_pay_statements MCP tool

### DIFF
--- a/services/adp/src/server.ts
+++ b/services/adp/src/server.ts
@@ -3,10 +3,14 @@
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { listWorkers, TOOL_DEFINITION as LIST_WORKERS_DEF } from "./tools/list-workers.js";
+import {
+  getPayStatements,
+  TOOL_DEFINITION as GET_PAY_STATEMENTS_DEF,
+} from "./tools/get-pay-statements.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? "8600", 10);
 const SERVICE_NAME = "adp";
-const SERVICE_VERSION = "0.2.0";
+const SERVICE_VERSION = "0.3.0";
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -33,9 +37,21 @@ interface ToolsCallParams {
 
 type ToolHandler = (args: unknown, ctx: { coworkerId: string; userId: string | null }) => Promise<unknown>;
 
+interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+    additionalProperties?: boolean;
+  };
+}
+
 // Registry of callable tools. Add new tools here as they land.
-const TOOLS: Record<string, { definition: typeof LIST_WORKERS_DEF; handler: ToolHandler }> = {
+const TOOLS: Record<string, { definition: ToolDefinition; handler: ToolHandler }> = {
   adp_list_workers: { definition: LIST_WORKERS_DEF, handler: listWorkers },
+  adp_get_pay_statements: { definition: GET_PAY_STATEMENTS_DEF, handler: getPayStatements },
 };
 
 async function readBody(req: IncomingMessage): Promise<string> {

--- a/services/adp/src/tools/get-pay-statements.test.ts
+++ b/services/adp/src/tools/get-pay-statements.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { MockAgent } from "undici";
+
+const fakeCredential = {
+  id: "cred-test-1",
+  environment: "sandbox" as const,
+  accessToken: "fake-bearer-token",
+  certPem: "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+  privateKeyPem: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+};
+
+vi.mock("../lib/creds.js", async () => {
+  const actual = await vi.importActual<typeof import("../lib/creds.js")>("../lib/creds.js");
+  return {
+    ...actual,
+    getActiveCredential: vi.fn(async () => fakeCredential),
+    recordToolCall: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../lib/db.js", () => ({
+  getSql: () => ({} as unknown),
+  setSqlForTesting: () => {},
+}));
+
+import { getPayStatements } from "./get-pay-statements.js";
+import { recordToolCall } from "../lib/creds.js";
+
+describe("adp_get_pay_statements", () => {
+  let mockAgent: MockAgent;
+
+  beforeEach(() => {
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await mockAgent.close();
+  });
+
+  it("returns mapped statements with bank fields redacted and records success audit", async () => {
+    const spy = vi.spyOn(await import("../lib/adp-client.js"), "adpGet");
+    spy.mockResolvedValue({
+      payStatements: [
+        {
+          statementID: "PS-2026-0415",
+          payDate: "2026-04-15",
+          grossPayAmount: { amountValue: 4500, currencyCode: "USD" },
+          netPayAmount: { amountValue: 3187.4, currencyCode: "USD" },
+          earnings: [{ earningCode: { codeValue: "REGULAR" }, amount: { amountValue: 4500 } }],
+          deductions: [
+            { deductionCode: { codeValue: "HEALTH" }, amount: { amountValue: 280 } },
+            { deductionCode: { codeValue: "401K" }, amount: { amountValue: 450 } },
+          ],
+          taxes: [{ taxCode: { codeValue: "FIT" }, amount: { amountValue: 412.6 } }],
+          directDeposits: [
+            {
+              bankAccountNumber: "1234567890",
+              routingNumber: "021000021",
+              accountNumber: "9876543210",
+            },
+          ],
+        } as any,
+      ],
+      meta: { continuationToken: "opaque-next-page" },
+    } as any);
+
+    const result = await getPayStatements(
+      { workerId: "EMP0042", fromDate: "2026-04-01", toDate: "2026-04-30" },
+      { coworkerId: "payroll-specialist", userId: "user_1" },
+    );
+
+    expect(result.payStatements).toHaveLength(1);
+    expect(result.payStatements[0]).toMatchObject({
+      statementId: "PS-2026-0415",
+      payDate: "2026-04-15",
+      grossPay: 4500,
+      netPay: 3187.4,
+      currency: "USD",
+    });
+    expect(result.payStatements[0]!.earnings[0]).toEqual({ code: "REGULAR", amount: 4500 });
+    expect(result.payStatements[0]!.deductions).toHaveLength(2);
+    expect(result.payStatements[0]!.taxes[0]).toEqual({ code: "FIT", amount: 412.6 });
+    expect(result.nextCursor).toBe("opaque-next-page");
+
+    expect(recordToolCall).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(recordToolCall).mock.calls[0]![1];
+    expect(auditCall.toolName).toBe("adp_get_pay_statements");
+    expect(auditCall.responseKind).toBe("success");
+    expect(auditCall.resultCount).toBe(1);
+
+    spy.mockRestore();
+  });
+
+  it("rejects invalid workerId format", async () => {
+    await expect(
+      getPayStatements(
+        { workerId: "bad id with spaces", fromDate: "2026-04-01", toDate: "2026-04-30" },
+        { coworkerId: "payroll-specialist", userId: null },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rejects invalid date formats", async () => {
+    await expect(
+      getPayStatements(
+        { workerId: "EMP0042", fromDate: "04/01/2026", toDate: "2026-04-30" },
+        { coworkerId: "payroll-specialist", userId: null },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rejects toDate before fromDate", async () => {
+    await expect(
+      getPayStatements(
+        { workerId: "EMP0042", fromDate: "2026-04-30", toDate: "2026-04-01" },
+        { coworkerId: "payroll-specialist", userId: null },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rejects ranges > 366 days", async () => {
+    await expect(
+      getPayStatements(
+        { workerId: "EMP0042", fromDate: "2024-01-01", toDate: "2026-01-01" },
+        { coworkerId: "payroll-specialist", userId: null },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("records rate-limited audit row on RATE_LIMITED AdpApiError", async () => {
+    const { AdpApiError } = await import("../lib/adp-client.js");
+    const spy = vi.spyOn(await import("../lib/adp-client.js"), "adpGet");
+    spy.mockRejectedValue(new AdpApiError("rate limited", 429, "RATE_LIMITED"));
+
+    await expect(
+      getPayStatements(
+        { workerId: "EMP0042", fromDate: "2026-04-01", toDate: "2026-04-30" },
+        { coworkerId: "payroll-specialist", userId: null },
+      ),
+    ).rejects.toMatchObject({ code: "RATE_LIMITED" });
+
+    const auditCall = vi.mocked(recordToolCall).mock.calls[0]![1];
+    expect(auditCall.responseKind).toBe("rate-limited");
+    expect(auditCall.errorCode).toBe("RATE_LIMITED");
+
+    spy.mockRestore();
+  });
+
+  it("records NOT_CONNECTED error audit when credential is missing", async () => {
+    const { getActiveCredential, AdpNotConnectedError } = await import("../lib/creds.js");
+    vi.mocked(getActiveCredential).mockRejectedValueOnce(
+      new AdpNotConnectedError("ADP is not connected"),
+    );
+
+    await expect(
+      getPayStatements(
+        { workerId: "EMP0042", fromDate: "2026-04-01", toDate: "2026-04-30" },
+        { coworkerId: "payroll-specialist", userId: null },
+      ),
+    ).rejects.toThrow(/not connected/i);
+
+    const auditCall = vi.mocked(recordToolCall).mock.calls[0]![1];
+    expect(auditCall.errorCode).toBe("NOT_CONNECTED");
+  });
+
+  it("returns nextCursor=null when ADP omits continuationToken", async () => {
+    const spy = vi.spyOn(await import("../lib/adp-client.js"), "adpGet");
+    spy.mockResolvedValue({ payStatements: [] } as any);
+
+    const result = await getPayStatements(
+      { workerId: "EMP0042", fromDate: "2026-04-01", toDate: "2026-04-30" },
+      { coworkerId: "payroll-specialist", userId: null },
+    );
+    expect(result.nextCursor).toBeNull();
+    expect(result.payStatements).toHaveLength(0);
+
+    spy.mockRestore();
+  });
+
+  it("passes cursor through to ADP query when supplied", async () => {
+    const spy = vi.spyOn(await import("../lib/adp-client.js"), "adpGet");
+    spy.mockResolvedValue({ payStatements: [] } as any);
+
+    await getPayStatements(
+      {
+        workerId: "EMP0042",
+        fromDate: "2026-04-01",
+        toDate: "2026-04-30",
+        cursor: "prev-page-token",
+      },
+      { coworkerId: "payroll-specialist", userId: null },
+    );
+
+    const callArgs = spy.mock.calls[0]![0];
+    expect(callArgs.query).toMatchObject({ continuationToken: "prev-page-token" });
+
+    spy.mockRestore();
+  });
+});

--- a/services/adp/src/tools/get-pay-statements.ts
+++ b/services/adp/src/tools/get-pay-statements.ts
@@ -1,0 +1,217 @@
+// adp_get_pay_statements — MCP tool returning paginated pay statements for a worker,
+// with bank routing and account numbers redacted before the LLM sees the result.
+
+import { z } from "zod";
+import { getSql } from "../lib/db.js";
+import { getActiveCredential, recordToolCall, AdpNotConnectedError } from "../lib/creds.js";
+import { adpGet, AdpApiError } from "../lib/adp-client.js";
+import { redact } from "../lib/redact.js";
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_RANGE_DAYS = 366; // one year, plus leap-year fudge
+const WORKER_ID_PATTERN = /^[A-Za-z0-9_-]{3,64}$/;
+
+export const GetPayStatementsArgsSchema = z
+  .object({
+    workerId: z
+      .string()
+      .regex(WORKER_ID_PATTERN, "workerId must be 3-64 alphanumeric/_/- characters"),
+    fromDate: z.string().regex(ISO_DATE_PATTERN, "fromDate must be YYYY-MM-DD"),
+    toDate: z.string().regex(ISO_DATE_PATTERN, "toDate must be YYYY-MM-DD"),
+    cursor: z.string().optional(),
+  })
+  .strict()
+  .refine(
+    (args) => {
+      const from = Date.parse(args.fromDate);
+      const to = Date.parse(args.toDate);
+      if (!Number.isFinite(from) || !Number.isFinite(to)) return false;
+      if (to < from) return false;
+      const days = (to - from) / (1000 * 60 * 60 * 24);
+      return days <= MAX_RANGE_DAYS;
+    },
+    { message: `date range must be valid and ≤ ${MAX_RANGE_DAYS} days` },
+  );
+
+export type GetPayStatementsArgs = z.infer<typeof GetPayStatementsArgsSchema>;
+
+export interface PayStatementSummary {
+  statementId: string;
+  payDate: string | null;
+  grossPay: number | null;
+  netPay: number | null;
+  currency: string | null;
+  earnings: Array<{ code: string | null; amount: number | null }>;
+  deductions: Array<{ code: string | null; amount: number | null }>;
+  taxes: Array<{ code: string | null; amount: number | null }>;
+}
+
+export interface GetPayStatementsResult {
+  payStatements: PayStatementSummary[];
+  nextCursor: string | null;
+  suspiciousContentDetected: boolean;
+}
+
+// Shape consumed from ADP's /payroll/v1/workers/{aoid}/pay-statements endpoint.
+// ADP returns a richer payload (direct-deposit details, YTD accruals, etc.) —
+// we cherry-pick what the Payroll Specialist coworker needs.
+interface AdpPayStatementsResponse {
+  payStatements?: Array<{
+    statementID?: string;
+    payDate?: string;
+    grossPayAmount?: { amountValue?: number; currencyCode?: string };
+    netPayAmount?: { amountValue?: number; currencyCode?: string };
+    earnings?: Array<{
+      earningCode?: { codeValue?: string };
+      amount?: { amountValue?: number };
+    }>;
+    deductions?: Array<{
+      deductionCode?: { codeValue?: string };
+      amount?: { amountValue?: number };
+    }>;
+    taxes?: Array<{
+      taxCode?: { codeValue?: string };
+      amount?: { amountValue?: number };
+    }>;
+    // directDeposits, YTD accruals, etc. — not mapped; we rely on the redactor
+    // to scrub any bank/account fields that might leak via the whole-object
+    // redact pass even though the downstream consumer never reads them.
+  }>;
+  meta?: {
+    totalNumber?: number;
+    continuationToken?: string;
+  };
+}
+
+export interface GetPayStatementsContext {
+  coworkerId: string;
+  userId: string | null;
+}
+
+export async function getPayStatements(
+  rawArgs: unknown,
+  ctx: GetPayStatementsContext,
+): Promise<GetPayStatementsResult> {
+  const args = GetPayStatementsArgsSchema.parse(rawArgs);
+  const sql = getSql();
+  const startedAt = Date.now();
+
+  try {
+    const credential = await getActiveCredential(sql);
+
+    const response = await adpGet<AdpPayStatementsResponse>({
+      credential,
+      path: `/payroll/v1/workers/${encodeURIComponent(args.workerId)}/pay-statements`,
+      query: {
+        "statementDate.start": args.fromDate,
+        "statementDate.end": args.toDate,
+        ...(args.cursor ? { continuationToken: args.cursor } : {}),
+      },
+    });
+
+    const mapped: PayStatementSummary[] = (response.payStatements ?? []).map((s) => ({
+      statementId: s.statementID ?? "",
+      payDate: s.payDate ?? null,
+      grossPay: s.grossPayAmount?.amountValue ?? null,
+      netPay: s.netPayAmount?.amountValue ?? null,
+      currency:
+        s.grossPayAmount?.currencyCode ?? s.netPayAmount?.currencyCode ?? null,
+      earnings: (s.earnings ?? []).map((e) => ({
+        code: e.earningCode?.codeValue ?? null,
+        amount: e.amount?.amountValue ?? null,
+      })),
+      deductions: (s.deductions ?? []).map((d) => ({
+        code: d.deductionCode?.codeValue ?? null,
+        amount: d.amount?.amountValue ?? null,
+      })),
+      taxes: (s.taxes ?? []).map((t) => ({
+        code: t.taxCode?.codeValue ?? null,
+        amount: t.amount?.amountValue ?? null,
+      })),
+    }));
+
+    const redacted = redact({ payStatements: mapped });
+
+    const result: GetPayStatementsResult = {
+      payStatements: redacted.value.payStatements,
+      nextCursor: response.meta?.continuationToken ?? null,
+      suspiciousContentDetected: redacted.suspiciousContentDetected,
+    };
+
+    await recordToolCall(sql, {
+      coworkerId: ctx.coworkerId,
+      userId: ctx.userId,
+      toolName: "adp_get_pay_statements",
+      args,
+      responseKind: "success",
+      resultCount: mapped.length,
+      durationMs: Date.now() - startedAt,
+      errorCode: null,
+      errorMessage: null,
+    });
+
+    console.log(
+      `[tool-trace] adp_get_pay_statements coworker=${ctx.coworkerId} workerId=${args.workerId} resultCount=${mapped.length} duration=${Date.now() - startedAt}ms`,
+    );
+
+    return result;
+  } catch (err) {
+    const { errorCode, errorMessage, responseKind } = classifyError(err);
+    await recordToolCall(sql, {
+      coworkerId: ctx.coworkerId,
+      userId: ctx.userId,
+      toolName: "adp_get_pay_statements",
+      args,
+      responseKind,
+      resultCount: null,
+      durationMs: Date.now() - startedAt,
+      errorCode,
+      errorMessage,
+    });
+    console.log(
+      `[tool-trace] adp_get_pay_statements coworker=${ctx.coworkerId} kind=${responseKind} code=${errorCode} duration=${Date.now() - startedAt}ms`,
+    );
+    throw err;
+  }
+}
+
+function classifyError(err: unknown): {
+  errorCode: string;
+  errorMessage: string;
+  responseKind: "error" | "rate-limited";
+} {
+  if (err instanceof AdpApiError) {
+    return {
+      errorCode: err.code,
+      errorMessage: err.message,
+      responseKind: err.code === "RATE_LIMITED" ? "rate-limited" : "error",
+    };
+  }
+  if (err instanceof AdpNotConnectedError) {
+    return { errorCode: "NOT_CONNECTED", errorMessage: err.message, responseKind: "error" };
+  }
+  if (err instanceof Error) {
+    return { errorCode: "UNKNOWN", errorMessage: err.message, responseKind: "error" };
+  }
+  return { errorCode: "UNKNOWN", errorMessage: "unknown error", responseKind: "error" };
+}
+
+export const TOOL_DEFINITION = {
+  name: "adp_get_pay_statements",
+  description:
+    "Retrieve paginated pay statements for a single worker within a date range. Returns gross pay, net pay, currency, and itemized earnings/deductions/taxes per statement. Bank account numbers, routing numbers, and other PII are redacted before reaching the LLM. Use the nextCursor field to page through long ranges.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      workerId: {
+        type: "string",
+        description: "ADP worker ID (associateOID or employee number) — 3-64 alphanumeric/_/- characters",
+      },
+      fromDate: { type: "string", description: "Range start (YYYY-MM-DD)" },
+      toDate: { type: "string", description: "Range end (YYYY-MM-DD). Range must be ≤ 366 days." },
+      cursor: { type: "string", description: "Opaque pagination token from a previous call's nextCursor" },
+    },
+    required: ["workerId", "fromDate", "toDate"],
+    additionalProperties: false,
+  },
+};


### PR DESCRIPTION
## Summary

- Second read tool in the ADP adapter: `adp_get_pay_statements` — paginated pay statements for a single worker in a date range.
- Bank account numbers, routing numbers, and every `*accountNumber`/`*routingNumber` field are scrubbed via the shared `redact()` pass before the payload reaches LLM context.
- Generalizes the server registry to hold tools with differently-shaped input schemas.

## What the tool returns

```ts
{
  payStatements: [{
    statementId, payDate, grossPay, netPay, currency,
    earnings: [{ code, amount }],
    deductions: [{ code, amount }],
    taxes: [{ code, amount }],
  }],
  nextCursor: string | null,
  suspiciousContentDetected: boolean,
}
```

## Input validation (zod)

- `workerId` — 3-64 `[A-Za-z0-9_-]` characters, URL-encoded into the path.
- `fromDate` / `toDate` — `YYYY-MM-DD`; `toDate >= fromDate`; range ≤ 366 days.
- `cursor` — optional opaque continuation token from a previous call.

## ADP endpoint

`GET /payroll/v1/workers/{aoid}/pay-statements` with `statementDate.start`, `statementDate.end`, and `continuationToken` query params.

## Test plan

- [x] 9 new unit tests — mapping + redaction, 4 zod rejection paths (workerId regex, date format, reversed range, >366-day range), RATE_LIMITED audit, NOT_CONNECTED audit, cursor passthrough, missing-continuationToken fallback.
- [x] `pnpm --filter dpf-adp-mcp test` — 15/15 (both tools) green.
- [x] `pnpm --filter dpf-adp-mcp typecheck` clean.
- [x] Pre-commit typecheck gate (PR #181) fired and passed on the commit.
- [x] `docker compose build adp` + `docker compose up -d adp` → healthy at v0.3.0.
- [x] `POST /mcp tools/list` advertises both `adp_list_workers` and `adp_get_pay_statements` with full input schemas.
- [ ] Live sandbox call — pending real ADP API Central credentials.

## Progress against plan

| Phase | Status |
|---|---|
| P0 Foundation | ✅ Merged |
| P1 Connect flow | ✅ Merged |
| P2.1 PII redaction | ✅ Merged |
| P2.2 `adp_list_workers` | ✅ Merged |
| **P2.3 `adp_get_pay_statements`** | **this PR** |
| P2.4 `adp_get_time_cards` + `adp_get_deductions` | Next |
| P2.5 `/admin/integrations/audit` view | Queued |
| P3 Payroll Specialist coworker | Queued |

Generated with Claude Code