### PR TITLE
docs(identity): expand enterprise workspace and guidance spec

### DIFF
--- a/docs/superpowers/plans/2026-04-22-enterprise-auth-directory-federation.md
+++ b/docs/superpowers/plans/2026-04-22-enterprise-auth-directory-federation.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement a coherent enterprise identity stack for DPF that hardens current auth, adds manager-aware authorization, syncs ADP workforce hierarchy, introduces an identity edge for LDAP/OIDC/SAML/SCIM, and aligns HR/Finance coworkers with the same access model.
+**Goal:** Implement a coherent enterprise identity stack for DPF that hardens current auth, adds manager-aware authorization, syncs ADP workforce hierarchy, introduces an identity edge for LDAP/OIDC/SAML/SCIM, surfaces a unified `/platform/identity` workspace, and aligns HR/Finance coworkers with the same access model.
 
 **Architecture:** DPF remains the source of truth for principal identity, employee-manager hierarchy, route capabilities, and coworker grants. An incorporated identity edge runtime publishes standards surfaces. Delivery is phased so the platform first fixes its current auth seams, then adds workforce hierarchy and principal modeling, then layers federation and directory protocols on top.
 
-**Tech Stack:** Next.js 16, Auth.js, Prisma 7, PostgreSQL, Docker Compose, TypeScript, ADP MCP service, authentik (new service), LDAP/OIDC/SAML/SCIM.
+**Tech Stack:** Next.js 16, Auth.js, Prisma 7, PostgreSQL, Docker Compose, TypeScript, ADP MCP service, authentik (new service), Microsoft Entra (upstream optional authority), LDAP/OIDC/SAML/SCIM.
 
 **Authoritative spec:** [docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md](../specs/2026-04-22-enterprise-auth-directory-federation-design.md)
 
@@ -32,14 +32,24 @@ Expected files and responsibilities before task execution:
   - capability + scope evaluation
 - `apps/web/lib/identity/*`
   - new principal, alias, provisioning, and access-evaluator helpers
+- `apps/web/lib/tak/*`
+  - projected attestation and coworker trust helpers
 - `apps/web/lib/integrate/adp/*`
   - ADP workforce sync and hierarchy reconciliation
+- `apps/web/lib/integrate/entra/*`
+  - Entra authority connection and future sync helpers
 - `apps/web/app/api/integrations/adp/*`
   - ADP sync/test endpoints
-- `apps/web/app/(shell)/admin/settings/*` or adjacent settings routes
-  - admin UI for directory/federation settings
+- `apps/web/app/api/integrations/entra/*`
+  - Entra connect/test endpoints
+- `apps/web/app/(shell)/platform/identity/*`
+  - unified identity workspace routes
 - `apps/web/components/integrations/*`
   - UI panels for identity edge, federation, and app provisioning
+- `apps/web/components/platform/identity/*`
+  - identity workspace panels, nav, and object-detail surfaces
+- `apps/web/components/docs/*`
+  - clean docs links and embedded page help affordances
 - `docker-compose.yml`
   - add identity edge service
 - `tests` / `*.test.ts` / `*.test.tsx`
@@ -760,6 +770,184 @@ git commit -m "feat(coworkers): align HR and finance coworker access with manage
 
 ---
 
+## Chunk 9: Platform Identity Workspace
+
+### Task 9.1: Add the Identity & Access platform family and route shell
+
+**Files:**
+- Modify: `apps/web/components/platform/platform-nav.ts`
+- Modify: `apps/web/components/platform/PlatformTabNav.tsx`
+- Create: `apps/web/components/platform/identity/IdentityTabNav.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/layout.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/page.tsx`
+
+- [ ] **Step 1: Write the failing navigation tests**
+
+```ts
+it("renders Identity & Access in the platform family nav", () => {
+  expect(screen.getByText("Identity & Access")).toBeInTheDocument();
+});
+
+it("renders the identity workspace landing page", async () => {
+  const html = await renderRoute("/platform/identity");
+  expect(html).toContain("Identity & Access");
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm --filter web test apps/web/components/platform`
+
+- [ ] **Step 3: Implement the platform family and route shell**
+
+Add the new family and make `/platform/identity` the canonical authority workspace.
+
+- [ ] **Step 4: Re-run the tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/platform/platform-nav.ts apps/web/components/platform/PlatformTabNav.tsx apps/web/components/platform/identity/IdentityTabNav.tsx apps/web/app/(shell)/platform/identity/layout.tsx apps/web/app/(shell)/platform/identity/page.tsx
+git commit -m "feat(identity-ui): add platform identity workspace shell and nav"
+```
+
+### Task 9.2: Build the identity overview and management surfaces
+
+**Files:**
+- Create: `apps/web/app/(shell)/platform/identity/principals/page.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/groups/page.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/directory/page.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/federation/page.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/applications/page.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/authorization/page.tsx`
+- Create: `apps/web/app/(shell)/platform/identity/agents/page.tsx`
+- Create: `apps/web/components/platform/identity/IdentityOverviewPanel.tsx`
+- Create: `apps/web/components/platform/identity/PrincipalDirectoryPanel.tsx`
+- Create: `apps/web/components/platform/identity/GroupMembershipPanel.tsx`
+- Create: `apps/web/components/platform/identity/DirectoryAuthoritiesPanel.tsx`
+- Create: `apps/web/components/platform/identity/ApplicationAssignmentsPanel.tsx`
+- Create: `apps/web/components/platform/identity/AuthorizationBundlePanel.tsx`
+- Create: `apps/web/components/platform/identity/AgentIdentityPanel.tsx`
+
+- [ ] **Step 1: Write the failing page/panel tests**
+
+```ts
+it("shows people, contractors, agents, and services on the principals page", () => {
+  expect(screen.getByText("Principals")).toBeInTheDocument();
+});
+
+it("shows route bundles and coworker associations on the authorization page", () => {
+  expect(screen.getByText("Authorization")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+- [ ] **Step 3: Implement the workspace surfaces**
+
+Keep the UI task-oriented:
+- overview and health first
+- objects and assignments second
+- protocol detail deeper in the page
+
+- [ ] **Step 4: Re-run the tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/(shell)/platform/identity apps/web/components/platform/identity
+git commit -m "feat(identity-ui): add identity workspace management surfaces"
+```
+
+### Task 9.3: Integrate Microsoft Entra as a first-class upstream authority
+
+**Files:**
+- Modify: `apps/web/app/(shell)/platform/identity/federation/page.tsx`
+- Modify: `apps/web/components/integrations/EntraConnectPanel.tsx`
+- Create: `apps/web/components/platform/identity/FederationAuthorityCard.tsx`
+- Create: `apps/web/components/platform/identity/FederationAuthorityCard.test.tsx`
+
+- [ ] **Step 1: Write the failing federation card tests**
+
+```ts
+it("renders Microsoft Entra as an available upstream authority", () => {
+  expect(screen.getByText("Microsoft Entra")).toBeInTheDocument();
+});
+
+it("shows connection state and mapping guidance for Entra", () => {
+  expect(screen.getByText("Upstream authority")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+- [ ] **Step 3: Implement the federation authority cards**
+
+Show:
+- connection health
+- last sync / connection state
+- what the authority owns upstream
+- what DPF still owns locally
+
+- [ ] **Step 4: Re-run the tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/(shell)/platform/identity/federation/page.tsx apps/web/components/integrations/EntraConnectPanel.tsx apps/web/components/platform/identity/FederationAuthorityCard.tsx apps/web/components/platform/identity/FederationAuthorityCard.test.tsx
+git commit -m "feat(identity-ui): add Entra-first federation authority experience"
+```
+
+### Task 9.4: Add clean docs links and first-use coworker guidance state
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_page_guide_state/migration.sql`
+- Create: `apps/web/lib/identity/page-guide-state.ts`
+- Create: `apps/web/lib/identity/page-guide-state.test.ts`
+- Modify: `apps/web/components/docs/HelpLink.tsx`
+- Modify: `apps/web/components/agent/AgentCoworkerShell.tsx`
+- Create: `apps/web/components/platform/identity/IdentityWorkspaceHelp.tsx`
+
+- [ ] **Step 1: Write the failing guide-state tests**
+
+```ts
+it("stores first-seen and dismissed state per user and route", async () => {
+  const state = await markPageGuideSeen(sampleUserId, "/platform/identity", "identity-overview", "v1");
+  expect(state.firstSeenAt).toBeDefined();
+});
+
+it("auto-opens guidance only on first use or when the guide version changes", async () => {
+  expect(await shouldAutoOpenGuide(sampleUserId, "/platform/identity", "identity-overview", "v1")).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+- [ ] **Step 3: Add the schema model and migration**
+
+Use a durable per-user, per-route, per-guide record so the experience survives across devices and sessions.
+
+- [ ] **Step 4: Implement the docs/help and coworker behavior**
+
+Requirements:
+- visible docs link opens a clean operator guide
+- coworker can use the deeper spec/design context privately
+- auto-open on first use
+- stay dismissed after dismissal
+- re-open or re-badge when guidance version changes materially
+
+- [ ] **Step 5: Re-run the tests**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations apps/web/lib/identity/page-guide-state.ts apps/web/lib/identity/page-guide-state.test.ts apps/web/components/docs/HelpLink.tsx apps/web/components/agent/AgentCoworkerShell.tsx apps/web/components/platform/identity/IdentityWorkspaceHelp.tsx
+git commit -m "feat(identity-ui): add docs links and first-use coworker guidance state"
+```
+
+---
+
 ## Verification
 
 After each chunk, run the smallest relevant tests first. After each merged chunk, run the production build gate.
@@ -808,6 +996,10 @@ Minimum scenarios:
 - HR operator sees broader workforce views by role
 - ADP-connected manager can use scoped HR/Finance coworker queries
 - downstream app receives expected federated groups/claims
+- `/platform/identity` overview loads with the Identity & Access family nav
+- the docs link opens clean operator-facing guidance rather than raw spec text
+- the coworker auto-opens on first use and remains dismissed afterward
+- the federation page shows Microsoft Entra as an upstream authority option with setup guidance
 
 ---
 

--- a/docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md
+++ b/docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md
@@ -431,6 +431,7 @@ The platform must distinguish three separate concerns:
 
 1. **Identity kind**
    - human
+   - contractor
    - service
    - agent
 
@@ -460,6 +461,88 @@ Examples:
 - a manager can view approved fields for direct reports, but not organization-wide payroll data
 - an HR operator can view workforce-wide data because of role, not because they happen to manage someone
 - a finance coworker may summarize payroll counts for a manager only over the manager’s allowed employee scope
+- a contractor accountant may access finance payables routes and approvals without gaining broad HR or platform admin visibility
+
+---
+
+## Platform Identity Workspace
+
+Identity and authorization should be operated from one platform workspace rather than being scattered across Admin, HR, AI, and integrations.
+
+### Canonical route family
+
+The canonical authority workspace should live under:
+
+- `/platform/identity`
+- `/platform/identity/principals`
+- `/platform/identity/groups`
+- `/platform/identity/directory`
+- `/platform/identity/federation`
+- `/platform/identity/applications`
+- `/platform/identity/authorization`
+- `/platform/identity/agents`
+
+This workspace becomes the operational home for:
+
+- principal inventory
+- groups and memberships
+- OU / directory publication structure
+- upstream federation authorities
+- downstream application federation
+- route bundles and authorization mappings
+- AI workforce identity projection and trust state
+
+### Workspace boundary
+
+The boundary should be explicit:
+
+- **Platform Identity owns authority**
+  - who exists
+  - principal type
+  - group membership
+  - app assignments
+  - route bundles
+  - trusted upstream authorities
+- **HR consumes authority**
+  - workforce operations
+  - org chart and people workflows
+  - approvals that depend on assigned authority
+- **AI Workforce consumes and extends authority**
+  - coworker identity projection
+  - `GAID`
+  - `TAK` trust markers
+  - model/runtime posture
+  - but not a separate parallel identity system
+
+This keeps HR adjacent but not authoritative for platform identity, while also ensuring AI coworkers are first-class principals inside the same control plane.
+
+### UX model
+
+The workspace should feel like an identity operations center rather than a raw directory schema editor.
+
+The best-in-class patterns to borrow are:
+
+- unified left-nav identity centers such as Microsoft Entra
+- task-oriented setup and connection health patterns such as WorkOS Admin Portal / Directory Sync
+- application assignment workflows where users, groups, and apps are managed together
+- progressive disclosure that keeps protocol detail available without making it the default operator experience
+
+The workspace should therefore optimize for:
+
+- **status-first overview**
+  - counts, broken syncs, validation issues, and pending setup work
+- **assignment-first workflows**
+  - principals to groups
+  - groups to routes/apps
+  - coworkers to approval or operating contexts
+- **object detail pages with relationship context**
+  - memberships, route access, app access, linked identities, and AI trust state in one place
+- **small-company operator simplicity**
+  - `Owner`
+  - `Admin`
+  - `Employee`
+
+Contractors and AI coworkers should be visible alongside employees, but clearly typed and filterable.
 
 ---
 
@@ -710,6 +793,54 @@ This keeps payroll/HRIS truth where it belongs without letting an HRIS define pl
 
 ---
 
+## Upstream Federation Authorities
+
+DPF should support more than one upstream identity authority while remaining the canonical platform authorization brain.
+
+### Authority categories
+
+The first categories to support are:
+
+- Microsoft Entra
+- LDAP / Active Directory
+- other compatible workforce authorities over time
+
+### Microsoft Entra
+
+Microsoft Entra should be treated as a **first-class optional upstream authority**, not as the canonical owner of DPF identity semantics.
+
+That means Entra may provide:
+
+- human sign-in bootstrap
+- upstream group and directory data
+- tenant identity starting point for companies already centered on Microsoft
+
+But DPF still owns:
+
+- platform-specific groups and memberships
+- route authorization
+- coworker associations
+- AI coworker identity, `GAID`, and `TAK` trust state
+- downstream application authorization semantics
+
+Operationally, Entra should appear as a guided path inside `/platform/identity/federation`, alongside LDAP/AD and other future directory sources.
+
+### Authority precedence
+
+To avoid conflicts:
+
+- upstream authorities may own source facts such as workforce identity, employment state, or baseline groups
+- DPF owns platform meaning:
+  - local groups
+  - route bundles
+  - coworker grants
+  - downstream app assignments
+- imported claims or groups must map into DPF-managed semantics rather than directly overriding them
+
+This preserves one coherent company authority model even when external identity systems are present.
+
+---
+
 ## Coworker, Skills, MCP, And Route Access
 
 HR and Finance coworkers should not bypass the enterprise identity model. They should consume it.
@@ -811,6 +942,70 @@ This is the bridge between enterprise auth and actual application behavior.
 
 ---
 
+## In-Product Documentation And First-Use Guidance
+
+The identity workspace should be self-explaining, but it should not expose raw specs by default.
+
+### Operator-facing docs
+
+The visible `Docs` affordance should open a clean operator-facing explanation that summarizes:
+
+- what this workspace manages
+- what DPF owns
+- what Entra / LDAP / other upstream authorities own
+- what the next likely setup step is
+
+This should use the same lightweight documentation affordance pattern already established by [apps/web/components/docs/HelpLink.tsx](../../../apps/web/components/docs/HelpLink.tsx).
+
+### AI coworker guidance model
+
+The AI coworker should use the deeper source material privately:
+
+- the clean page doc
+- the related spec(s)
+- route context
+- current tenant configuration state
+
+That lets the coworker behave like a knowledgeable implementation guide without forcing operators to read raw architecture documents.
+
+Recommended first-use behavior:
+
+- auto-open the coworker the first time a user lands on `/platform/identity` or one of its major sub-pages
+- provide a short role-aware summary
+- recommend the next likely setup action
+- stay dismissed after the user closes it
+- re-open or re-badge only when the guidance version changes materially
+
+### Per-user guide state
+
+This likely needs a durable per-user per-page guide-state model rather than local storage alone.
+
+Illustrative shape:
+
+```prisma
+model PageGuideState {
+  id              String   @id @default(cuid())
+  userId          String
+  routeKey        String
+  guideKey        String
+  guideVersion    String
+  firstSeenAt     DateTime @default(now())
+  lastSeenAt      DateTime @updatedAt
+  summaryShownAt  DateTime?
+  autoOpenedAt    DateTime?
+  dismissedAt     DateTime?
+  completedAt     DateTime?
+  statePayload    Json?
+
+  @@unique([userId, routeKey, guideKey])
+  @@index([userId, routeKey])
+}
+```
+
+That model would let the platform remember what each user has already seen, while still allowing the coworker to re-engage when the page or setup posture has materially changed.
+
+---
+
 ## Security And Trust Boundaries
 
 ### Credential authority
@@ -870,12 +1065,19 @@ Long-term:
 - expose groups/role-as-group mappings
 - enable SCIM provisioning for downstream apps
 
-### Phase 6: External product federation
+### Phase 6: Identity workspace and guidance
+
+- introduce `/platform/identity` as the unified authority workspace
+- add principals, groups, directory, federation, applications, authorization, and agent identity pages
+- surface Entra as a first-class upstream authority option
+- add clean docs links and first-use coworker guidance state
+
+### Phase 7: External product federation
 
 - add downstream application registry and claim/group mapping
 - issue OIDC/SAML to external products
 
-### Phase 7: Coworker and MCP alignment
+### Phase 8: Coworker and MCP alignment
 
 - connect HR and Finance coworkers to manager-aware and route-aware auth context
 - gate ADP and future finance MCP tools through the new access evaluator
@@ -899,7 +1101,13 @@ Long-term:
 5. **Manager access is scope-driven, not role-only.**
    This is required for correct employee versus manager separation.
 
-6. **Coworkers consume the same authority model as humans.**
+6. **Identity and authorization live in one platform workspace.**
+   HR and AI operations consume that workspace; they do not replace it with parallel policy editors.
+
+7. **Microsoft Entra is a first-class optional upstream authority.**
+   It may bootstrap workforce identity and groups, but DPF remains the authority core.
+
+8. **Coworkers consume the same authority model as humans.**
    No parallel auth stack should be created for HR or Finance coworkers.
 
 ---


### PR DESCRIPTION
## Summary
- expand the enterprise auth spec with the unified /platform/identity workspace
- add Entra as a first-class optional upstream authority in the architecture and plan
- define in-product docs and first-use coworker guidance state for the identity workspace

## Verification
- cd apps/web && npx next build