### PR TITLE
docs(license): restore Apache-2.0 appendix placeholders

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       be included on the same "header" page or the beginning of the file
       for printing of the source code.
 
-   Copyright 2026 Mark Bodman
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Fixes GitHub's repo sidebar / REST API reporting `license: NOASSERTION` despite `LICENSE` containing the full Apache-2.0 text and `package.json` declaring `"license": "Apache-2.0"`.

### Root cause

The APPENDIX section of `LICENSE` (lines 182-202) is *instructional* — it tells downstream users how to apply the license to their own source files by pasting the boilerplate into headers or a `NOTICE` file. The canonical Apache-2.0 template from [licensee](https://github.com/licensee/licensee) (the library GitHub uses for license detection) expects the line:

```
   Copyright [yyyy] [name of copyright owner]
```

In this repo, those placeholders were filled in with real values. That single edit diverges from the template enough to drop licensee's similarity score below its ~95% match threshold, so it returns `NOASSERTION`.

### Fix

Restore the two placeholders. This does not change the license — the project remains Apache-2.0 (SPDX declared in `package.json`, full license text is unchanged elsewhere in the file). It only fixes automated detection.

### Verification

After merge, GitHub re-runs licensee on the default branch within minutes. Verify with:

```
gh api repos/OpenDigitalProductFactory/opendigitalproductfactory --jq '.license.spdx_id'
```

Expected: `"Apache-2.0"` (currently `NOASSERTION`).

## Test plan

- [x] One-line diff, no code impact
- [ ] CI: Typecheck (unaffected, should pass)
- [ ] CI: Production Build (unaffected, should pass)
- [ ] Post-merge: `.license.spdx_id` flips to `Apache-2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)