### PR TITLE
fix: normalize prisma env precedence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-# App-level environment — copy to BOTH of these locations:
-#   apps/web/.env.local    (Next.js)
-#   packages/db/.env       (Prisma)
+# App-level environment — copy to:
+#   apps/web/.env.local    (Next.js + local host-side Prisma commands)
+#
+# Optional legacy fallback:
+#   packages/db/.env       (only if you need a package-local Prisma override)
 #
 # For Docker Compose container config, see .env.docker.example instead.
 

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ setup: ## Full first-time setup (install, env, docker, migrate, seed)
 		cp .env.example apps/web/.env.local; \
 		echo "Created apps/web/.env.local — edit AUTH_SECRET before deploying."; \
 	fi
-	@if [ ! -f packages/db/.env ]; then \
-		cp .env.example packages/db/.env; \
-	fi
 	@echo "Starting databases..."
 	docker compose up -d
 	@echo "Waiting for PostgreSQL to be ready..."

--- a/docs/user-guide/getting-started/developer-setup.md
+++ b/docs/user-guide/getting-started/developer-setup.md
@@ -56,12 +56,11 @@ pnpm install
 # 1. Root .env — used by Docker Compose for container credentials
 cp .env.docker.example .env
 
-# 2. App-level .env files — used by Next.js and Prisma for local dev
+# 2. App-level .env file — used by Next.js and local Prisma commands
 cp .env.example apps/web/.env.local
-cp .env.example packages/db/.env
 ```
 
-Then edit `.env`, `apps/web/.env.local`, and `packages/db/.env` to replace the `<generate with: ...>` placeholders with real values. On Windows PowerShell:
+Then edit `.env` and `apps/web/.env.local` to replace the `<generate with: ...>` placeholders with real values. On Windows PowerShell:
 
 ```powershell
 # Generate AUTH_SECRET (base64)
@@ -71,6 +70,8 @@ Then edit `.env`, `apps/web/.env.local`, and `packages/db/.env` to replace the `
 ```
 
 Or use the automated script (Option A) which handles this automatically.
+
+If you have an older install with `packages/db/.env`, Prisma still treats it as a legacy fallback, but new installs should not need it.
 
 **Start databases (with ports exposed to host):**
 

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -993,11 +993,6 @@ if ($InstallMode -eq "customizer" -and -not (Test-StepDone "dev_setup")) {
             $webContent | Set-Content $webEnvPath
             Write-OK "Created apps/web/.env.local"
         }
-        $dbEnvPath = "$DPF_DIR\packages\db\.env"
-        if (-not (Test-Path $dbEnvPath)) {
-            Copy-Item $envExamplePath $dbEnvPath
-            Write-OK "Created packages/db/.env"
-        }
     } else {
         Write-Warn ".env.example not found -- skipping app-level .env creation"
     }

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,5 +1,7 @@
-import "dotenv/config";
 import { defineConfig } from "prisma/config";
+import { loadDbEnv } from "./src/load-env";
+
+loadDbEnv();
 
 export default defineConfig({
   schema: "prisma/schema.prisma",

--- a/packages/db/scripts/seed-dora-backlog.ts
+++ b/packages/db/scripts/seed-dora-backlog.ts
@@ -2,10 +2,12 @@
  * EP-REG-DORA-001: Create backlog items for gaps found during DORA dogfood.
  * Run: cd packages/db && npx tsx scripts/seed-dora-backlog.ts
  */
-import "dotenv/config";
 import { PrismaClient } from "../generated/client/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import * as crypto from "crypto";
+import { loadDbEnv } from "../src/load-env";
+
+loadDbEnv();
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });

--- a/packages/db/scripts/seed-dora-regulation.ts
+++ b/packages/db/scripts/seed-dora-regulation.ts
@@ -7,10 +7,12 @@
  *
  * Run: cd packages/db && npx tsx scripts/seed-dora-regulation.ts
  */
-import "dotenv/config";
 import { PrismaClient } from "../generated/client/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import * as crypto from "crypto";
+import { loadDbEnv } from "../src/load-env";
+
+loadDbEnv();
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });

--- a/packages/db/scripts/verify-dora-compliance.ts
+++ b/packages/db/scripts/verify-dora-compliance.ts
@@ -2,10 +2,12 @@
  * EP-REG-DORA-001: Verify DORA compliance data — gap assessment, posture scoring, snapshot
  * Run: cd packages/db && npx tsx scripts/verify-dora-compliance.ts
  */
-import "dotenv/config";
 import { PrismaClient } from "../generated/client/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import * as crypto from "crypto";
+import { loadDbEnv } from "../src/load-env";
+
+loadDbEnv();
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });

--- a/packages/db/src/backfill-capability-ids.ts
+++ b/packages/db/src/backfill-capability-ids.ts
@@ -9,6 +9,7 @@
 //
 //   pnpm --filter @dpf/db exec tsx src/backfill-capability-ids.ts
 
+import "./load-env.js";
 import { prisma } from "./client.js";
 
 async function main(): Promise<void> {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,5 +1,3 @@
-// packages/db/src/client.ts
-import "dotenv/config";
 import { PrismaClient } from "../generated/client/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 

--- a/packages/db/src/load-env.test.ts
+++ b/packages/db/src/load-env.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { loadDbEnv, resetDbEnvForTests, resolveDbEnvPaths } from "./load-env";
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+
+function writeEnvFile(path: string, databaseUrl: string) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, `DATABASE_URL=${databaseUrl}\n`, "utf8");
+}
+
+afterEach(() => {
+  if (originalDatabaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  }
+  resetDbEnvForTests();
+});
+
+describe("loadDbEnv", () => {
+  it("prefers the shared web env before package-local and root fallbacks", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "dpf-db-env-"));
+    const repoRoot = join(tempRoot, "repo");
+    const packageRoot = join(repoRoot, "packages", "db");
+
+    writeEnvFile(join(repoRoot, "apps", "web", ".env.local"), "postgresql://web");
+    writeEnvFile(join(packageRoot, ".env"), "postgresql://package");
+    writeEnvFile(join(repoRoot, ".env"), "postgresql://root");
+
+    delete process.env.DATABASE_URL;
+
+    const loadedPaths = loadDbEnv({
+      webEnvPath: join(repoRoot, "apps", "web", ".env.local"),
+      packageEnvPath: join(packageRoot, ".env"),
+      rootEnvPath: join(repoRoot, ".env"),
+      forceReload: true,
+    });
+
+    expect(process.env.DATABASE_URL).toBe("postgresql://web");
+    expect(loadedPaths).toEqual(
+      resolveDbEnvPaths({
+        webEnvPath: join(repoRoot, "apps", "web", ".env.local"),
+        packageEnvPath: join(packageRoot, ".env"),
+        rootEnvPath: join(repoRoot, ".env"),
+      }),
+    );
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("falls back to packages/db/.env when the shared web env is absent", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "dpf-db-env-"));
+    const repoRoot = join(tempRoot, "repo");
+    const packageRoot = join(repoRoot, "packages", "db");
+
+    writeEnvFile(join(packageRoot, ".env"), "postgresql://package");
+    writeEnvFile(join(repoRoot, ".env"), "postgresql://root");
+
+    delete process.env.DATABASE_URL;
+
+    loadDbEnv({
+      webEnvPath: join(repoRoot, "apps", "web", ".env.local"),
+      packageEnvPath: join(packageRoot, ".env"),
+      rootEnvPath: join(repoRoot, ".env"),
+      forceReload: true,
+    });
+
+    expect(process.env.DATABASE_URL).toBe("postgresql://package");
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("uses the root env only as a last fallback", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "dpf-db-env-"));
+    const repoRoot = join(tempRoot, "repo");
+    const packageRoot = join(repoRoot, "packages", "db");
+
+    writeEnvFile(join(repoRoot, ".env"), "postgresql://root");
+
+    delete process.env.DATABASE_URL;
+
+    loadDbEnv({
+      webEnvPath: join(repoRoot, "apps", "web", ".env.local"),
+      packageEnvPath: join(packageRoot, ".env"),
+      rootEnvPath: join(repoRoot, ".env"),
+      forceReload: true,
+    });
+
+    expect(process.env.DATABASE_URL).toBe("postgresql://root");
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("never overrides an explicitly supplied shell DATABASE_URL", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "dpf-db-env-"));
+    const repoRoot = join(tempRoot, "repo");
+    const packageRoot = join(repoRoot, "packages", "db");
+
+    writeEnvFile(join(repoRoot, "apps", "web", ".env.local"), "postgresql://web");
+    process.env.DATABASE_URL = "postgresql://shell";
+
+    loadDbEnv({
+      webEnvPath: join(repoRoot, "apps", "web", ".env.local"),
+      packageEnvPath: join(packageRoot, ".env"),
+      rootEnvPath: join(repoRoot, ".env"),
+      forceReload: true,
+    });
+
+    expect(process.env.DATABASE_URL).toBe("postgresql://shell");
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+});

--- a/packages/db/src/load-env.ts
+++ b/packages/db/src/load-env.ts
@@ -1,0 +1,68 @@
+import { config as loadDotenv } from "dotenv";
+import { fileURLToPath } from "url";
+
+const DEFAULT_PATHS = [
+  fileURLToPath(new URL("../../apps/web/.env.local", import.meta.url)),
+  fileURLToPath(new URL("../.env", import.meta.url)),
+  fileURLToPath(new URL("../../.env", import.meta.url)),
+];
+
+let defaultEnvLoaded = false;
+
+export function resolveDbEnvPaths(options?: {
+  webEnvPath?: string;
+  packageEnvPath?: string;
+  rootEnvPath?: string;
+}): string[] {
+  return [
+    options?.webEnvPath ?? DEFAULT_PATHS[0],
+    options?.packageEnvPath ?? DEFAULT_PATHS[1],
+    options?.rootEnvPath ?? DEFAULT_PATHS[2],
+  ];
+}
+
+export function loadDbEnv(options?: {
+  webEnvPath?: string;
+  packageEnvPath?: string;
+  rootEnvPath?: string;
+  forceReload?: boolean;
+}): string[] {
+  if (
+    defaultEnvLoaded &&
+    !options?.forceReload &&
+    !options?.webEnvPath &&
+    !options?.packageEnvPath &&
+    !options?.rootEnvPath
+  ) {
+    return resolveDbEnvPaths();
+  }
+
+  const loadedPaths: string[] = [];
+
+  for (const envPath of resolveDbEnvPaths(options)) {
+    const result = loadDotenv({
+      path: envPath,
+      override: false,
+      quiet: true,
+    });
+
+    if (!result.error) {
+      loadedPaths.push(envPath);
+    }
+  }
+
+  if (
+    !options?.forceReload &&
+    !options?.webEnvPath &&
+    !options?.packageEnvPath &&
+    !options?.rootEnvPath
+  ) {
+    defaultEnvLoaded = true;
+  }
+
+  return loadedPaths;
+}
+
+export function resetDbEnvForTests(): void {
+  defaultEnvLoaded = false;
+}

--- a/packages/db/src/neo4j-rebuild-ea.ts
+++ b/packages/db/src/neo4j-rebuild-ea.ts
@@ -3,6 +3,7 @@
 // Run after Prisma migrations or when Neo4j EA data is suspected stale.
 // Usage: pnpm --filter @dpf/db neo4j:rebuild-ea
 
+import "./load-env.js";
 import { prisma } from "./client.js";
 import { closeNeo4j, runCypher } from "./neo4j.js";
 import { syncEaElement, syncEaRelationship } from "./neo4j-sync.js";

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,4 +1,5 @@
 // packages/db/src/seed.ts
+import "./load-env.js";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { prisma } from "./client.js";

--- a/packages/db/src/test-sync.ts
+++ b/packages/db/src/test-sync.ts
@@ -1,3 +1,4 @@
+import "./load-env.js";
 import { prisma } from "./client.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 

--- a/scripts/fresh-install.ps1
+++ b/scripts/fresh-install.ps1
@@ -114,12 +114,10 @@ DPF_HOST_INSTALL_PATH=$InstallRoot
 
 Write-Host "========================================================" 
 
-Write-Step "Creating app-level .env files (Next.js + Prisma)"
+Write-Step "Creating app-level .env files"
 
 $envExamplePath = Join-Path $InstallRoot ".env.example"
 $webEnvPath     = Join-Path $InstallRoot "apps\web\.env.local"
-$dbEnvPath      = Join-Path $InstallRoot "packages\db\.env"
-
 if (Test-Path $envExamplePath) {
     if (-not (Test-Path $webEnvPath)) {
         Copy-Item $envExamplePath $webEnvPath
@@ -137,13 +135,6 @@ if (Test-Path $envExamplePath) {
         Write-Ok "Created apps/web/.env.local with generated secrets"
     } else {
         Write-Ok "apps/web/.env.local already exists  skipping"
-    }
-
-    if (-not (Test-Path $dbEnvPath)) {
-        Copy-Item $envExamplePath $dbEnvPath
-        Write-Ok "Created packages/db/.env from .env.example"
-    } else {
-        Write-Ok "packages/db/.env already exists  skipping"
     }
 } else {
     Write-Warn ".env.example not found  skipping app-level .env creation"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -74,11 +74,6 @@ else
   ok "apps/web/.env.local already exists -- skipping"
 fi
 
-if [ ! -f packages/db/.env ]; then
-  cp .env.example packages/db/.env
-  ok "Created packages/db/.env"
-fi
-
 # Ensure root .env has real secrets for Docker Compose
 if [ ! -f .env ]; then
   cp .env.docker.example .env


### PR DESCRIPTION
## Summary
- make Prisma CLI prefer apps/web/.env.local before legacy packages/db/.env and root .env fallback
- keep packages/db/.env as a compatibility fallback instead of the default source of truth
- stop setup/install docs from generating redundant package-local env files by default

## Verification
- pnpm --filter @dpf/db test src/load-env.test.ts
- pnpm --filter @dpf/db typecheck
- pnpm --filter web typecheck
- cd apps/web && npx next build