### PR TITLE
chore(hooks): add postinstall to set core.hooksPath automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "db:studio": "pnpm --filter @dpf/db studio",
     "graph:init": "pnpm --filter @dpf/db exec tsx scripts/init-neo4j.ts",
     "test:endpoints": "tsx scripts/test-endpoints.ts",
-    "docs:tak": "node docs/architecture/generate-tak-docx.mjs"
+    "docs:tak": "node docs/architecture/generate-tak-docx.mjs",
+    "postinstall": "node scripts/set-hooks-path.mjs"
   },
   "engines": {
     "node": ">=20",

--- a/scripts/set-hooks-path.mjs
+++ b/scripts/set-hooks-path.mjs
@@ -1,0 +1,8 @@
+import { execSync } from 'node:child_process';
+
+try {
+  execSync('git config core.hooksPath .githooks', { stdio: 'ignore' });
+} catch {
+  // Not a git repo (Docker build, tarball install, CI extract) — silently ignore.
+  // The pre-commit typecheck gate only matters in developer clones.
+}


### PR DESCRIPTION
## Summary

Closes the "AGENTS.md claims a postinstall script exists but it doesn't" gap I found while auditing post-public-flip state.

**Before:** `core.hooksPath` was only set by `scripts/setup.sh` / `scripts/setup.ps1` / `scripts/fresh-install.ps1`. A contributor who just `git clone && pnpm install` silently skipped the pre-commit typecheck gate (documented in [AGENTS.md#typecheck-gate—local-before-commit-mandatory](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md)) and could commit broken imports that CI caught later.

**After:** Root `package.json` has a `postinstall` script that runs `git config core.hooksPath .githooks` after every `pnpm install`. The script is cross-platform (uses Node, not shell) and silently no-ops when `.git` isn't available (Docker builds `.dockerignore` `.git`; tarball installs have no repo).

## Verified end-to-end

```
git config --unset core.hooksPath
git config --get core.hooksPath   # (empty)
pnpm install
git config --get core.hooksPath   # .githooks
```

## Test plan

- [x] postinstall fires on `pnpm install`
- [x] sets `core.hooksPath` to `.githooks`
- [x] silently succeeds in a git-less context (uses try/catch around execSync)
- [ ] CI: Typecheck (unaffected by the added files)
- [ ] CI: Production Build (unaffected)
- [ ] CI: DCO (signoff present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)