### PR TITLE
chore(ci): auto-add DCO signoff to Dependabot PRs

### DIFF
--- a/.github/workflows/dco-signoff-dependabot.yml
+++ b/.github/workflows/dco-signoff-dependabot.yml
@@ -1,0 +1,68 @@
+name: DCO sign-off for Dependabot
+
+# Why this exists:
+#   The repo's DCO required check (branch protection on main) demands every
+#   commit in every PR carry a `Signed-off-by:` trailer. Dependabot cannot add
+#   such a trailer to its commits, so every Dependabot PR would be unmergeable
+#   without this workflow. Here we amend Dependabot's commits on open/update
+#   with a signoff using Dependabot's own bot identity — DCO Probot then
+#   validates the trailer against the commit author and reports success.
+#
+# Safety:
+#   `pull_request_target` runs in the base-repo context with repo secrets.
+#   We gate every step on `github.actor == 'dependabot[bot]'`; GitHub
+#   authenticates the actor, so a malicious contributor cannot impersonate
+#   the bot.
+#
+# Scope:
+#   This only touches Dependabot PRs. Human contributors still need to sign
+#   their own commits (`git commit -s`) — that requirement stands.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  signoff:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head with full history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Skip if all commits already signed
+        id: check
+        run: |
+          UNSIGNED=0
+          while IFS= read -r sha; do
+            if ! git show -s --format=%B "$sha" | grep -qE "^Signed-off-by: "; then
+              UNSIGNED=$((UNSIGNED + 1))
+            fi
+          done < <(git log origin/${{ github.event.pull_request.base.ref }}..HEAD --format=%H)
+
+          if [ "$UNSIGNED" -eq 0 ]; then
+            echo "All commits on this branch are signed. Nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$UNSIGNED commit(s) lack a Signed-off-by trailer. Will re-sign."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-sign commits with Dependabot identity
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git rebase --signoff "origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Force-push signed commits back to the PR branch
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git push --force-with-lease origin "HEAD:${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
## Summary

Branch protection on `main` now requires a passing `DCO` check on every PR. Dependabot commits are authored by `dependabot[bot]` with no `Signed-off-by:` trailer, which means every Dependabot PR would fail DCO and be unmergeable — blocking up to 11 weekly dependency PRs (5 npm + 3 github-actions + 3 docker, per [.github/dependabot.yml](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/.github/dependabot.yml)).

This workflow closes that gap by auto-signing Dependabot's commits with Dependabot's own bot identity.

### Flow

1. Dependabot opens/updates a PR (triggers `pull_request_target`)
2. Workflow checks: does every commit on the branch already have a `Signed-off-by:` trailer? If yes, skip (idempotent).
3. If not: rebase with `--signoff` using `dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>` and force-push back to the PR branch.
4. DCO Probot re-runs on the synchronize event and reports green.

### Why not `.github/dco.yml` with a bot allowlist?

Two reasons: (1) I wasn't confident about the exact Probot config keys for `dependabot[bot]` — easy to silently ship a no-op exemption. (2) Signing the commits means the audit trail is actually DCO-compliant, not exempted. Treats bots like any other contributor.

### Security

`pull_request_target` runs in base-repo context with access to secrets. The `if: github.actor == 'dependabot[bot]'` guard is enforced by GitHub's own actor authentication — a malicious contributor cannot impersonate the bot. Only Dependabot PRs touch this workflow.

### Scope

This only touches Dependabot PRs. Human contributors still sign their own commits with `git commit -s` — that rule stands.

## Test plan

- [x] YAML syntactically valid (workflow file parses)
- [x] Actor guard on every step that does work
- [x] Idempotent (skips if all commits already signed)
- [ ] CI: Typecheck (unaffected, should pass)
- [ ] CI: Production Build (unaffected, should pass)
- [ ] CI: DCO (signoff present on this PR's commit)
- [ ] End-to-end: next Dependabot PR auto-signs and merges. This validates after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)