### PR TITLE
docs(agents): flag BS Typecheck Gate as unimplemented vs. mandated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,14 +116,21 @@ New clones inherit this automatically via the repo's `postinstall` script. Verif
 
 **Subagent dispatchers:** include "run `pnpm --filter web typecheck` before committing and fix any errors" in every task prompt that modifies TypeScript. Subagents do not read AGENTS.md.
 
-### Typecheck Gate — Build Studio (mandatory)
+### Typecheck Gate — Build Studio (policy + implementation status)
 
-The platform's own Build Studio feature-building lifecycle must apply the same gate to the sandbox it builds in. Two additions:
+The platform's own Build Studio feature-building lifecycle must apply the same gate to the sandbox it builds in. The policy has two parts:
 
 1. **Per-task verification step** — after every Build Studio task execution in the sandbox, run `pnpm --filter web typecheck` and `pnpm --filter web build` inside the sandbox container. If either fails, the task status is `failed` and the coworker must fix the error before the phase advances. Mirrors the local pre-commit gate.
-2. **Pre-ship verification** — the review-phase verification pass (currently UX-only via browser-use) must include typecheck + production build as mandatory passes. The build never leaves the sandbox without passing what CI would run. Implementation landing spot: [apps/web/lib/queue/functions/build-review-verification.ts](apps/web/lib/queue/functions/build-review-verification.ts).
+2. **Pre-ship verification** — the review-phase verification pass must include typecheck + production build as mandatory passes. The build never leaves the sandbox without passing what CI would run.
 
 Together these mean a Build-Studio-produced PR cannot fail CI typecheck — if it would, it never leaves the sandbox.
+
+**Implementation status — NOT YET LANDED (audited 2026-04-24):**
+
+- Per-task verification does **not** run typecheck or build. Instead, [apps/web/lib/integrate/build-orchestrator.ts:375-401](apps/web/lib/integrate/build-orchestrator.ts#L375-L401) classifies outcome by string-matching the CLI's stdout for keywords like `"error"` / `"typecheck.*fail"`. A task whose CLI summary omits those words can silently pass even if typecheck is red. The landing spot for the real gate is after [`classifyOutcome()` returns at build-orchestrator.ts:583](apps/web/lib/integrate/build-orchestrator.ts#L583): before writing status `"DONE"`, exec the two `pnpm --filter web …` commands inside the sandbox container and override to `"BLOCKED"` on non-zero exit.
+- Pre-ship verification in [apps/web/lib/queue/functions/build-review-verification.ts](apps/web/lib/queue/functions/build-review-verification.ts) runs browser-use UX tests only. Typecheck + production build must be added as sibling `step.run(...)` blocks, with failures persisted alongside `uxTestResults` and `checkPhaseGate` extended to block ship until both are green.
+
+Until both are implemented, a Build Studio PR can still be typecheck-red or build-red when it leaves the sandbox. CI catches it on the PR (the merge gates on `main` hold), but the stated goal is to catch it at the sandbox boundary, not at merge time. Tracked in the repo's issue tracker.
 
 ### Concurrent Sessions — Per-Thread Worktree (mandatory when >1 session)
 


### PR DESCRIPTION
Audit on 2026-04-24 confirmed neither half of the "Typecheck Gate — Build Studio" section is actually implemented:

- Per-task verification does not run typecheck/build; build-orchestrator classifyOutcome() just string-matches the CLI stdout for "error" / "typecheck.*fail". A task can silently pass even with a red typecheck if the CLI summary omits those keywords.
- Pre-ship verification in build-review-verification.ts runs browser-use UX tests only. No typecheck or build step.

Rather than weaken the policy to "planned", keeps the full mandate and adds an explicit "Implementation status" block that:
- Names what's missing, file:line accurate
- Names the landing spots for the real fix
- States the interim risk (sandbox can hand a typecheck-red build to CI; CI still catches it, but sandbox gate is the stated goal)

Preserves governance intent while being honest about reality. A separate GitHub issue will track the actual implementation work.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
