### PR TITLE
feat(ccm): phase 4 — contribute_to_hive model dispatch

### DIFF
--- a/apps/web/lib/integrate/contribution-dispatch.test.ts
+++ b/apps/web/lib/integrate/contribution-dispatch.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveContributionDispatch } from "./contribution-dispatch";
+
+const UPSTREAM_OWNER = "OpenDigitalProductFactory";
+const UPSTREAM_REPO = "opendigitalproductfactory";
+
+function withFlag<T>(value: string | undefined, fn: () => T): T {
+  const orig = process.env.CONTRIBUTION_MODEL_ENABLED;
+  if (value === undefined) delete process.env.CONTRIBUTION_MODEL_ENABLED;
+  else process.env.CONTRIBUTION_MODEL_ENABLED = value;
+  try {
+    return fn();
+  } finally {
+    if (orig === undefined) delete process.env.CONTRIBUTION_MODEL_ENABLED;
+    else process.env.CONTRIBUTION_MODEL_ENABLED = orig;
+  }
+}
+
+describe("resolveContributionDispatch", () => {
+  const baseInput = {
+    upstreamOwner: UPSTREAM_OWNER,
+    upstreamRepo: UPSTREAM_REPO,
+    contributorForkOwner: null as string | null,
+    contributorForkRepo: null as string | null,
+    forkVerifiedAt: null as Date | null,
+  };
+
+  beforeEach(() => {
+    delete process.env.CONTRIBUTION_MODEL_ENABLED;
+  });
+  afterEach(() => {
+    delete process.env.CONTRIBUTION_MODEL_ENABLED;
+  });
+
+  it("flag OFF — direct path with head === base, regardless of contributionModel", () => {
+    const result = withFlag(undefined, () =>
+      resolveContributionDispatch({ ...baseInput, contributionModel: "fork-pr" }),
+    );
+    expect(result).toEqual({
+      kind: "direct",
+      headOwner: UPSTREAM_OWNER,
+      headRepo: UPSTREAM_REPO,
+      baseOwner: UPSTREAM_OWNER,
+      baseRepo: UPSTREAM_REPO,
+    });
+  });
+
+  it("flag ON + contributionModel === null — returns error, no dispatch", () => {
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({ ...baseInput, contributionModel: null }),
+    );
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") expect(result.error).toMatch(/not configured/i);
+  });
+
+  it("flag ON + maintainer-direct — direct path with head === base", () => {
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({ ...baseInput, contributionModel: "maintainer-direct" }),
+    );
+    expect(result).toEqual({
+      kind: "direct",
+      headOwner: UPSTREAM_OWNER,
+      headRepo: UPSTREAM_REPO,
+      baseOwner: UPSTREAM_OWNER,
+      baseRepo: UPSTREAM_REPO,
+    });
+  });
+
+  it("flag ON + fork-pr + fork config missing — returns error", () => {
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({ ...baseInput, contributionModel: "fork-pr" }),
+    );
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") expect(result.error).toMatch(/fork is configured|fork setup/i);
+  });
+
+  it("flag ON + fork-pr + verified within 24h — fork path, no reverification, needs merge-upstream", () => {
+    const now = new Date("2026-04-24T10:00:00Z");
+    const verified = new Date(now.getTime() - 60 * 60 * 1000); // 1 h ago
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({
+        ...baseInput,
+        contributionModel: "fork-pr",
+        contributorForkOwner: "jane-dev",
+        contributorForkRepo: UPSTREAM_REPO,
+        forkVerifiedAt: verified,
+        now,
+      }),
+    );
+    expect(result.kind).toBe("fork");
+    if (result.kind === "fork") {
+      expect(result.headOwner).toBe("jane-dev");
+      expect(result.headRepo).toBe(UPSTREAM_REPO);
+      expect(result.baseOwner).toBe(UPSTREAM_OWNER);
+      expect(result.baseRepo).toBe(UPSTREAM_REPO);
+      expect(result.needsForkReverification).toBe(false);
+      expect(result.needsMergeUpstream).toBe(true);
+    }
+  });
+
+  it("flag ON + fork-pr + verified more than 24h ago — fork path with reverification flag set", () => {
+    const now = new Date("2026-04-24T10:00:00Z");
+    const verified = new Date(now.getTime() - 25 * 60 * 60 * 1000); // 25 h ago
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({
+        ...baseInput,
+        contributionModel: "fork-pr",
+        contributorForkOwner: "jane-dev",
+        contributorForkRepo: UPSTREAM_REPO,
+        forkVerifiedAt: verified,
+        now,
+      }),
+    );
+    expect(result.kind).toBe("fork");
+    if (result.kind === "fork") expect(result.needsForkReverification).toBe(true);
+  });
+
+  it("flag ON + fork-pr + forkVerifiedAt null — fork path with reverification flag set (fresh or deferred)", () => {
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({
+        ...baseInput,
+        contributionModel: "fork-pr",
+        contributorForkOwner: "jane-dev",
+        contributorForkRepo: UPSTREAM_REPO,
+        forkVerifiedAt: null,
+      }),
+    );
+    expect(result.kind).toBe("fork");
+    if (result.kind === "fork") expect(result.needsForkReverification).toBe(true);
+  });
+
+  it("flag ON + unrecognized contributionModel — error", () => {
+    const result = withFlag("true", () =>
+      resolveContributionDispatch({ ...baseInput, contributionModel: "mystery-mode" }),
+    );
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") expect(result.error).toMatch(/unrecognized/i);
+  });
+});

--- a/apps/web/lib/integrate/contribution-dispatch.ts
+++ b/apps/web/lib/integrate/contribution-dispatch.ts
@@ -1,0 +1,115 @@
+// Dispatch decision for contribute_to_hive: given the current flag + config,
+// returns what the PR target repos look like and what prep work is needed
+// before calling createBranchAndPR. Pure function — no side effects, no I/O
+// — so the dispatch contract is unit-testable independent of the surrounding
+// contribute_to_hive control flow.
+//
+// See docs/superpowers/specs/2026-04-23-public-contribution-mode-design.md §"contribute_to_hive — model dispatch"
+
+import { isContributionModelEnabled } from "@/lib/flags/contribution-model";
+
+export type ContributionDispatchInput = {
+  contributionModel: string | null;
+  upstreamOwner: string;
+  upstreamRepo: string;
+  contributorForkOwner: string | null;
+  contributorForkRepo: string | null;
+  forkVerifiedAt: Date | null;
+  /** Injected for deterministic unit tests; defaults to Date.now(). */
+  now?: Date;
+};
+
+export type ContributionDispatchResult =
+  | {
+      kind: "direct";
+      headOwner: string;
+      headRepo: string;
+      baseOwner: string;
+      baseRepo: string;
+    }
+  | {
+      kind: "fork";
+      headOwner: string;
+      headRepo: string;
+      baseOwner: string;
+      baseRepo: string;
+      /** True when forkVerifiedAt is stale or missing — caller must re-verify before proceeding. */
+      needsForkReverification: boolean;
+      /** True for fork-pr — caller must sync the fork's base from upstream before pushing. */
+      needsMergeUpstream: true;
+    }
+  | { kind: "error"; error: string };
+
+/**
+ * 24 h staleness threshold. Past this, the dispatcher signals re-verification
+ * so contribute_to_hive catches forks that have been deleted or renamed since
+ * setup.
+ */
+const FORK_VERIFICATION_TTL_MS = 24 * 60 * 60 * 1000;
+
+export function resolveContributionDispatch(
+  input: ContributionDispatchInput,
+): ContributionDispatchResult {
+  const { contributionModel, upstreamOwner, upstreamRepo } = input;
+
+  // Flag off — existing direct-push behavior, regardless of contributionModel.
+  // The flag is the kill switch: phases 1-3 can live on main with zero
+  // runtime change until operations is ready to flip it.
+  if (!isContributionModelEnabled()) {
+    return {
+      kind: "direct",
+      headOwner: upstreamOwner,
+      headRepo: upstreamRepo,
+      baseOwner: upstreamOwner,
+      baseRepo: upstreamRepo,
+    };
+  }
+
+  // Flag on — contributionModel must be explicitly configured.
+  if (contributionModel === null) {
+    return {
+      kind: "error",
+      error:
+        "Contribution model is not configured. Open Admin > Platform Development and configure the contribution model before running contribute_to_hive.",
+    };
+  }
+
+  if (contributionModel === "maintainer-direct") {
+    return {
+      kind: "direct",
+      headOwner: upstreamOwner,
+      headRepo: upstreamRepo,
+      baseOwner: upstreamOwner,
+      baseRepo: upstreamRepo,
+    };
+  }
+
+  if (contributionModel === "fork-pr") {
+    const { contributorForkOwner, contributorForkRepo, forkVerifiedAt } = input;
+    if (!contributorForkOwner || !contributorForkRepo) {
+      return {
+        kind: "error",
+        error:
+          "Fork-pr contribution model selected but no fork is configured. Open Admin > Platform Development and run fork setup before retrying.",
+      };
+    }
+    const now = input.now ?? new Date();
+    const needsReverification =
+      !forkVerifiedAt ||
+      now.getTime() - forkVerifiedAt.getTime() > FORK_VERIFICATION_TTL_MS;
+    return {
+      kind: "fork",
+      headOwner: contributorForkOwner,
+      headRepo: contributorForkRepo,
+      baseOwner: upstreamOwner,
+      baseRepo: upstreamRepo,
+      needsForkReverification: needsReverification,
+      needsMergeUpstream: true,
+    };
+  }
+
+  return {
+    kind: "error",
+    error: `Unrecognized contributionModel: ${JSON.stringify(contributionModel)}. Expected "maintainer-direct" or "fork-pr".`,
+  };
+}

--- a/apps/web/lib/integrate/github-fork.test.ts
+++ b/apps/web/lib/integrate/github-fork.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createForkAndWait, forkExistsAndIsFork } from "./github-fork";
+import { createForkAndWait, forkExistsAndIsFork, syncForkFromUpstream } from "./github-fork";
 
 const UPSTREAM = { owner: "OpenDigitalProductFactory", repo: "opendigitalproductfactory" };
 
@@ -215,5 +215,62 @@ describe("createForkAndWait", () => {
         maxAttempts: 2,
       }),
     ).rejects.toThrow(/403/);
+  });
+});
+
+describe("syncForkFromUpstream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("resolves on 200 success", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(okJson({ message: "Successfully fetched and fast-forwarded" }));
+
+    await expect(
+      syncForkFromUpstream({
+        forkOwner: "jane-dev",
+        forkRepo: UPSTREAM.repo,
+        branch: "main",
+        token: "ghp_test",
+      }),
+    ).resolves.toBeUndefined();
+
+    const fetchMock = vi.mocked(globalThis.fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.github.com/repos/jane-dev/opendigitalproductfactory/merge-upstream");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init!.body as string)).toEqual({ branch: "main" });
+  });
+
+  it("throws an actionable conflict error on 409", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      errResponse(409, "merge conflict"),
+    );
+
+    await expect(
+      syncForkFromUpstream({
+        forkOwner: "jane-dev",
+        forkRepo: UPSTREAM.repo,
+        branch: "main",
+        token: "ghp_test",
+      }),
+    ).rejects.toThrow(/merge-upstream conflict/i);
+  });
+
+  it("throws with status and body on other non-ok responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      errResponse(422, "unprocessable"),
+    );
+
+    await expect(
+      syncForkFromUpstream({
+        forkOwner: "jane-dev",
+        forkRepo: UPSTREAM.repo,
+        branch: "main",
+        token: "ghp_test",
+      }),
+    ).rejects.toThrow(/422/);
   });
 });

--- a/apps/web/lib/integrate/github-fork.ts
+++ b/apps/web/lib/integrate/github-fork.ts
@@ -1,15 +1,21 @@
-// Fork detection + creation helpers for the fork-based PR contribution model
-// (see docs/superpowers/specs/2026-04-23-public-contribution-mode-design.md).
+// Fork detection + creation + sync helpers for the fork-based PR contribution
+// model (see docs/superpowers/specs/2026-04-23-public-contribution-mode-design.md).
 //
 // These helpers wrap the GitHub REST endpoints:
-//   GET  /repos/{owner}/{repo}           — check existence + fork-of relation
-//   POST /repos/{owner}/{repo}/forks     — create a fork under the token owner's account
+//   GET  /repos/{owner}/{repo}             — check existence + fork-of relation
+//   POST /repos/{owner}/{repo}/forks       — create a fork under the token owner's account
+//   POST /repos/{owner}/{repo}/merge-upstream — pull upstream default branch into the fork
 //
 // Forks are created asynchronously by GitHub. The documented upper bound is
 // five minutes; typical is 1-5 seconds. createForkAndWait polls for readiness
 // and returns "deferred" when readiness is not observed within the polling
 // window — callers should surface this as "fork is being created, retry soon"
 // rather than treating it as a failure.
+//
+// syncForkFromUpstream is called before every contribute_to_hive fork-pr
+// contribution to keep the fork's base branch in lockstep with upstream.
+// Staleness manifests as merge conflicts at PR time, not push time, so the
+// pre-push sync is a cheap guard against a common failure mode.
 
 function getHeaders(token: string): Record<string, string> {
   return {
@@ -117,4 +123,40 @@ export async function createForkAndWait(params: {
   }
 
   return { status: "deferred", forkOwner, forkRepo };
+}
+
+/**
+ * Pull the upstream default branch into the fork's same branch.
+ *
+ * Used before every fork-pr contribution so the new branch is parented off
+ * an up-to-date base — a stale fork manifests as merge conflicts at PR time,
+ * not push time, and the UX is worse when it happens late. Called by
+ * contribute_to_hive's fork-pr dispatch in Phase 4.
+ *
+ * 409 is surfaced as an actionable conflict error — the admin needs to
+ * resolve divergence manually (typically by rebasing or deleting the
+ * conflicting fork branch).
+ */
+export async function syncForkFromUpstream(params: {
+  forkOwner: string;
+  forkRepo: string;
+  branch: string;
+  token: string;
+}): Promise<void> {
+  const { forkOwner, forkRepo, branch, token } = params;
+  const url = `https://api.github.com/repos/${forkOwner}/${forkRepo}/merge-upstream`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { ...getHeaders(token), "Content-Type": "application/json" },
+    body: JSON.stringify({ branch }),
+  });
+
+  if (res.ok) return;
+  const body = await res.text();
+  if (res.status === 409) {
+    throw new Error(
+      `Fork merge-upstream conflict on ${forkOwner}/${forkRepo}@${branch}: ${body.slice(0, 200)}`,
+    );
+  }
+  throw new Error(`POST ${url}: ${res.status} ${body.slice(0, 200)}`);
 }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -5314,7 +5314,16 @@ export async function executeTool(
 
       const devConfig = await prisma.platformDevConfig.findUnique({
         where: { id: "singleton" },
-        select: { contributionMode: true, upstreamRemoteUrl: true, dcoAcceptedAt: true, gitRemoteUrl: true },
+        select: {
+          contributionMode: true,
+          upstreamRemoteUrl: true,
+          dcoAcceptedAt: true,
+          gitRemoteUrl: true,
+          contributionModel: true,
+          contributorForkOwner: true,
+          contributorForkRepo: true,
+          forkVerifiedAt: true,
+        },
       });
       const { getPlatformDevPolicyState } = await import("@/lib/platform-dev-policy");
       const policyState = getPlatformDevPolicyState(devConfig);
@@ -5446,9 +5455,10 @@ export async function executeTool(
         });
       }
 
-      // Create upstream PR via direct branch push (Option B).
-      // Anonymous identity pushes dpf/<hash>/<slug> branch directly to the upstream repo.
-      // No customer fork needed — the hive token provides write access.
+      // Upstream PR creation — flag-off keeps the legacy direct-push flow;
+      // flag-on dispatches on PlatformDevConfig.contributionModel via
+      // resolveContributionDispatch (which also signals fork reverification
+      // and merge-upstream needs for the fork-pr path).
       let prUrl: string | null = null;
       let prError: string | null = null;
       try {
@@ -5465,6 +5475,58 @@ export async function executeTool(
           if (!upstreamMatch) {
             prError = `upstreamRemoteUrl "${upstreamUrl}" is not a recognizable GitHub URL.`;
           } else {
+            const [, upstreamOwner, upstreamRepo] = upstreamMatch;
+
+            // Dispatch on contributionModel (flag-gated internally).
+            const { resolveContributionDispatch } = await import("@/lib/integrate/contribution-dispatch");
+            const dispatch = resolveContributionDispatch({
+              contributionModel: devConfig?.contributionModel ?? null,
+              upstreamOwner,
+              upstreamRepo,
+              contributorForkOwner: devConfig?.contributorForkOwner ?? null,
+              contributorForkRepo: devConfig?.contributorForkRepo ?? null,
+              forkVerifiedAt: devConfig?.forkVerifiedAt ?? null,
+            });
+
+            if (dispatch.kind === "error") {
+              prError = dispatch.error;
+              throw new Error(dispatch.error);
+            }
+
+            // Fork-specific prep: verify the fork still exists (if stale or
+            // never verified) and sync its base branch from upstream so our
+            // new commit parents off an up-to-date sha. Either step's failure
+            // produces an actionable prError and aborts before createBranchAndPR.
+            if (dispatch.kind === "fork") {
+              const { forkExistsAndIsFork, syncForkFromUpstream } = await import("@/lib/integrate/github-fork");
+
+              if (dispatch.needsForkReverification) {
+                const check = await forkExistsAndIsFork({
+                  owner: dispatch.headOwner,
+                  repo: dispatch.headRepo,
+                  upstreamOwner,
+                  upstreamRepo,
+                  token: hiveToken,
+                });
+                if (!check.exists || !check.isFork) {
+                  const msg = `Fork ${dispatch.headOwner}/${dispatch.headRepo} is no longer a fork of ${upstreamOwner}/${upstreamRepo} (or has been deleted). Re-run fork setup before retrying.`;
+                  prError = msg;
+                  throw new Error(msg);
+                }
+                await prisma.platformDevConfig.update({
+                  where: { id: "singleton" },
+                  data: { forkVerifiedAt: new Date() },
+                });
+              }
+
+              await syncForkFromUpstream({
+                forkOwner: dispatch.headOwner,
+                forkRepo: dispatch.headRepo,
+                branch: "main",
+                token: hiveToken,
+              });
+            }
+
             const { createBranchAndPR } = await import("@/lib/integrate/github-api-commit");
 
             const branchName = generatePrivateBranchName(platformId.clientId, build.title);
@@ -5498,13 +5560,10 @@ export async function executeTool(
             if (!securityScan.passed) labels.push("security-review-needed");
 
             const prResult = await createBranchAndPR({
-              // Phase 3: caller still passes head === base. Phase 4 will switch
-              // to head = contributor fork / base = upstream when
-              // contributionModel === "fork-pr".
-              headOwner: upstreamMatch[1],
-              headRepo: upstreamMatch[2],
-              baseOwner: upstreamMatch[1],
-              baseRepo: upstreamMatch[2],
+              headOwner: dispatch.headOwner,
+              headRepo: dispatch.headRepo,
+              baseOwner: dispatch.baseOwner,
+              baseRepo: dispatch.baseRepo,
               branchName,
               commitMessage,
               diff,


### PR DESCRIPTION
## Summary

Phase 4 of the public-contribution-mode plan. Wires \`contribute_to_hive\` to the fork-based PR flow when \`CONTRIBUTION_MODEL_ENABLED=true\`. Flag off → byte-identical to pre-phase-4 behavior (direct push to upstream).

**Two commits, both signed-off:**

- \`feat(github-fork): add syncForkFromUpstream helper\` — wraps \`POST /repos/{fork}/merge-upstream\`. Surfaces 409 as an actionable conflict error. 3 new tests (14 total in the github-fork suite).
- \`feat(contribute-to-hive): dispatch on contributionModel\` — extracts \`resolveContributionDispatch\` as a pure function (8 unit tests, covers every branch). The contribute_to_hive case now consults the dispatcher, runs fork reverification when \`forkVerifiedAt\` is stale/null, and syncs the fork before pushing. Adds the new \`contributionModel\`/fork-metadata fields to the devConfig select.

## Dispatch matrix

| Flag | contributionModel | Behavior |
|------|-------------------|----------|
| off  | anything          | Direct push (legacy) |
| on   | null              | Actionable "not configured" error |
| on   | \`maintainer-direct\` | Direct push (token needs upstream write) |
| on   | \`fork-pr\` verified ≤ 24h | merge-upstream → push branch to fork → PR upstream |
| on   | \`fork-pr\` verified > 24h (or null) | reverify fork → update \`forkVerifiedAt\` → merge-upstream → push → PR |
| on   | unrecognized value | Actionable "unrecognized" error |

## Test plan

- [x] \`pnpm typecheck\` green
- [x] \`pnpm --filter web build\` green (✓ Compiled successfully)
- [x] \`contribution-dispatch\` 8/8 tests pass (all branches of the dispatch matrix)
- [x] \`github-fork\` 14/14 tests pass (3 new for \`syncForkFromUpstream\`)
- [x] \`github-api-commit\` 4/4 tests pass (no regression from Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)