### PR TITLE
test(web): make prompt-assembler assertions DB-state-invariant

### DIFF
--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -205,16 +205,12 @@ describe("assembleSystemPrompt", () => {
   // EP-SELF-DEV-002: Evidence-first action rule
   it("includes evidence-first action rule", async () => {
     const prompt = await assembleSystemPrompt(fullInput);
-    expect(prompt).toContain(
-      "start with the most relevant evidence-gathering or action tool",
-    );
+    expect(prompt).toContain("start with the most relevant");
   });
 
   it("includes calm under pressure and anti-reward-hacking guidance", async () => {
     const prompt = await assembleSystemPrompt(fullInput);
     expect(prompt).toContain("Stay calm under pressure");
-    expect(prompt).toContain(
-      "Do NOT game tests, acceptance criteria, approval flows, or tooling",
-    );
+    expect(prompt).toContain("game tests, acceptance criteria");
   });
 });


### PR DESCRIPTION
## Summary

Two assertions in `prompt-assembler.test.ts` on main check for TS-constant-only wording that PR #217 removed when it reconciled the TS fallback with the `.prompt.md` source-of-truth. The test file wasn't updated to match, so CI Unit Tests is red on main right now:

```
AssertionError: expected '...' to contain 'start with the most relevant evidence-gathering or action tool'
AssertionError: expected '...' to contain 'Do NOT game tests, acceptance criteria, approval flows, or tooling'
```

(Verified on [run 24876320210 for #217](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/24876320210/job/72833657582).)

## Fix

Assert on substrings that appear in **both** the `.prompt.md` source (served in local/DB-available environments) and the TS fallback `IDENTITY_BLOCK` (served in CI where there is no DB):

- `"start with the most relevant"` — in both `prompts/platform-identity/identity-block.prompt.md` rule 5 and `prompt-assembler.ts` rule 16.
- `"game tests, acceptance criteria"` — in both `.prompt.md` rule 11 and `prompt-assembler.ts` rule 18.

This makes the test DB-state-invariant: it passes whether `loadPrompts()` returns the DB/`.prompt.md` content or falls through to the hardcoded TS constant.

## Verification

```
pnpm exec vitest run lib/tak/prompt-assembler.test.ts
→ Test Files  1 passed (1)
  Tests  16 passed (16)
```

## Scope note on remaining red

With this PR landed, `lib/tak/prompt-assembler.test.ts` is green. Nine CI-only failures remain in `ForkSetupPanel.test.tsx`, `ToolExecutionLogClient.test.tsx`, and `app/(shell)/platform/identity/page.test.tsx` — all `TypeError: Cannot read properties of null (reading 'useState')` from `renderToStaticMarkup` on hook-using components. Those are a multi-React-copy / hoisting bug, not drift. Tracked in #219 — out of scope here.

## Follow-up (not this PR)

`prompts/platform-identity/identity-block.prompt.md` and `IDENTITY_BLOCK` in `apps/web/lib/tak/prompt-assembler.ts` still have structural drift — the .md has 14 grouped rules; the TS constant has 20 ungrouped rules. PR #217 reconciled the two sentences the tests check; reconciling the rest is a prompt-content review, separate from this fix.

## Test plan

- [x] `pnpm exec vitest run lib/tak/prompt-assembler.test.ts` — 16/16 passing locally (DB serving `.prompt.md`)
- [ ] CI Unit Tests passes on `lib/tak/prompt-assembler.test.ts` (CI uses TS fallback — covered by the substring choice)
- [ ] CI Typecheck passes
- [ ] CI Production Build passes
- [ ] DCO passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)