### PR TITLE
docs(contributing): reflect active branch protection and add DCO HOW

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for wanting to contribute. This project is built to grow through communit
 4. CI gates typecheck, unit tests, and a production build. Keep them green.
 5. A maintainer reviews and merges once the checks pass.
 
-External contributors always use fork → branch → PR. The maintainer uses the same workflow from topic branches named by intent (`clean/*`, `doc/*`, `feat/*`, `fix/*`, `chore/*`). The required CI checks (`Typecheck` and `Production Build`) must pass before merge; `Unit Tests` runs informationally while the broken-test surface is being cleaned up. GitHub branch protection activates automatically once the repo flips to public — until then, the workflow is maintained by discipline.
+External contributors always use fork → branch → PR. The maintainer uses the same workflow from topic branches named by intent (`clean/*`, `doc/*`, `feat/*`, `fix/*`, `chore/*`). Branch protection on `main` is active and enforced at the GitHub platform level: the required status checks `Typecheck`, `Production Build`, and `DCO` must all pass before merge; PR required; linear history; no force-push. `Unit Tests` runs informationally while the broken-test surface is being cleaned up.
 
 ## Branch naming
 
@@ -27,13 +27,36 @@ One concern per branch, one concern per PR. If you find a refactor that's adjace
 
 ## Repo bootstrap (contributors)
 
-Once cloned, enable the in-repo git hooks so the Prisma migration guard runs locally:
+Running `pnpm install` in the repo root auto-configures the in-repo git hooks (Prisma migration guard + local typecheck gate) via a `postinstall` script. No manual setup is required for the typical `git clone && pnpm install` flow.
+
+If you cloned with `--no-scripts` or a tarball that doesn't run postinstall, set the hooks path manually:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-`scripts/fresh-install.ps1` and `scripts/setup.ps1` / `scripts/setup.sh` configure this automatically when you use them to set the repo up. Run the one-liner above manually if you cloned without those helpers.
+The installer scripts (`scripts/fresh-install.ps1`, `scripts/setup.ps1`, `scripts/setup.sh`) also configure this path when used.
+
+## Signing commits (DCO)
+
+Every commit in every PR must carry a `Signed-off-by:` trailer certifying the contribution under the [Developer Certificate of Origin](https://developercertificate.org/). This is a required status check on `main` — the `DCO` bot fails the PR until every commit has a matching trailer.
+
+The easiest way to add the trailer is the `-s` flag on `git commit`:
+
+```bash
+git commit -s -m "your message"
+```
+
+This appends `Signed-off-by: Your Name <your-email@example.com>` using your `user.name` and `user.email` git config. The email in the trailer must match the commit author's email.
+
+**If you forget and DCO fails your PR:**
+
+- Last commit only: `git commit --amend -s --no-edit && git push --force-with-lease`
+- Multiple commits: `git rebase --signoff main && git push --force-with-lease`
+
+Force-pushing to your own feature branch is fine — branch protection only blocks it on `main`.
+
+Dependabot PRs are auto-signed by a repo workflow; you don't need to do anything special for those.
 
 ## Before you start
 


### PR DESCRIPTION
## Summary

CONTRIBUTING.md is the canonical entry point for external contributors. After today's public flip and DCO wiring, it had three gaps that would directly damage a first-time contributor's experience.

### Fixed

1. **Stale TL;DR claim** — said "branch protection activates automatically once the repo flips to public — until then, the workflow is maintained by discipline." Protection is now live; updated to name the three required checks (`Typecheck`, `Production Build`, `DCO`) and the enforced rules (PR required, linear history, no force-push).

2. **Missing DCO HOW** — line 86 mentioned DCO *acceptance* (the legal statement) but never told contributors to use `git commit -s`. A first-time external contributor would legitimately agree to DCO, commit normally, and then fail the required DCO check with no clue why. Added a dedicated "Signing commits (DCO)" section covering:
   - Why it's required (branch protection check)
   - How to sign (`git commit -s`)
   - Email-match rule (trailer email must match commit author email)
   - Recovery path (`amend --signoff` / `rebase --signoff` + force-push-with-lease)
   - Note that Dependabot PRs are auto-signed by the [workflow added in PR #208](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/208) — contributors shouldn't try to "help" with bot commits

3. **Repo bootstrap section was postinstall-unaware** — described the manual `git config core.hooksPath` one-liner as the primary path. With the [postinstall added in PR #205](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/205), `pnpm install` handles it automatically. Reframed the manual step as the fallback (for `--no-scripts` or tarball installs).

## Why this matters

The #1 way a public repo loses first-time contributors is when the "obvious" first commit fails a required check with no explanation. The combination of required DCO + no HOW in CONTRIBUTING.md was exactly that trap. This closes it.

## Test plan

- [x] Diff scoped to CONTRIBUTING.md, 26 insertions / 3 deletions
- [x] Signoff on commit
- [ ] CI: Typecheck (unaffected)
- [ ] CI: Production Build (unaffected)
- [ ] CI: DCO (signoff present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)