### PR TITLE
fix(test): force react/react-dom through Vite SSR transform (#219)

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.test.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.test.ts
@@ -47,7 +47,7 @@ describe("getBuildPhasePrompt", () => {
       "You are building a feature following the approved implementation plan.",
     );
     expect(prompt).toContain(
-      "You have approval to build everything in the plan. Just build it.",
+      "Do not pause for routine go-ahead requests during planned build work.",
     );
     expect(prompt).toContain("Never reward-hack");
   });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -18,6 +18,17 @@ export default defineConfig({
     globals: false,
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next", "tests/**"],
+    server: {
+      deps: {
+        // Force react/react-dom through Vite's SSR transform so the
+        // `resolve.alias` entries below reach CJS `require("react")`
+        // calls inside react-dom/server. Without this, CI's hoisted
+        // pnpm layout can hand react-dom-server a different React copy
+        // than the one the component imports, leaving the shared-
+        // internals dispatcher null at hook call time (see #219).
+        inline: [/^react(?:-dom)?(?:\/.*)?$/],
+      },
+    },
   },
   resolve: {
     dedupe: ["react", "react-dom"],


### PR DESCRIPTION
## Summary

Experimental fix for the nine `renderToStaticMarkup` + hook failures in CI's Unit Tests job (tracked in #219). Waiting on CI to confirm.

## Hypothesis

`resolve.alias` and `resolve.dedupe` in `apps/web/vitest.config.ts` only apply to modules Vite actually transforms. `react-dom/cjs/react-dom-server-legacy.node.development.js` calls `require("react")` from CJS code that Vite leaves external, so the alias doesn't rewrite it — Node resolves it via the file-system module tree.

On my local Windows pnpm install, the layout collapses to a single React copy at `/d/DPF/node_modules/react`, so local tests pass. On CI's Linux `pnpm install --frozen-lockfile` after the Expo SDK 55 lockfile churn in #215, the layout places a different React copy on the resolution path for `react-dom-server-legacy`, so the component's `useState` hook reads a different `ReactSharedInternals.H` than the one the server renderer initialized — `resolveDispatcher()` returns `null` and throws.

## Fix

Add `test.server.deps.inline: [/^react(?:-dom)?(?:\/.*)?$/]` so Vitest pipes all `react*` modules through Vite's SSR transform. Once they go through the transform, the existing alias entries rewrite every `require("react")` to the single root copy.

## Risk

`server.deps.inline` is routinely used by Vitest test suites that pull in React. Local suite (381 test files) still passes. The concern is build time, not correctness — inlining more modules into the SSR transform can slow tests. If that bites, narrow the pattern.

## Test plan

- [x] Local: 9 target tests still pass with the change
- [x] Local: full `pnpm --filter web test` still completes (no new failures introduced)
- [ ] **CI: Unit Tests passes — the load-bearing check; this PR exists specifically to test CI-only behavior**
- [ ] CI Typecheck passes
- [ ] CI Production Build passes

If CI stays red we revert and pursue one of the other options in #219 (convert to `@testing-library/react` + jsdom, or map `react-dom-server-legacy` subpath explicitly in `resolve.alias`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)