### PR TITLE
feat(ccm): phase 5 — per-model token validation + shared copy

### DIFF
--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -36,6 +36,7 @@ export default async function AdminPlatformDevelopmentPage() {
         contributorForkOwner={config?.contributorForkOwner ?? null}
         contributorForkRepo={config?.contributorForkRepo ?? null}
         hasContributionToken={hasContribToken}
+        machineUserOptIn={config?.machineUserOptIn ?? false}
       />
       <PlatformDevelopmentForm
         policyState={policyState}

--- a/apps/web/components/admin/ForkSetupPanel.tsx
+++ b/apps/web/components/admin/ForkSetupPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 
 import { configureForkSetup } from "@/lib/actions/platform-dev-config";
+import { CONTRIBUTION_COPY } from "@/lib/integrate/contribution-copy";
 
 export interface ForkSetupPanelProps {
   /** Feature flag result (resolved server-side, passed down). */
@@ -15,6 +16,8 @@ export interface ForkSetupPanelProps {
   contributorForkRepo: string | null;
   /** Whether a hive-contribution token is stored. If not, admin needs the main setup flow first. */
   hasContributionToken: boolean;
+  /** Pre-fills the machine-user checkbox when an existing config had it set. */
+  machineUserOptIn?: boolean;
 }
 
 type PanelState =
@@ -36,6 +39,7 @@ type PanelState =
 export function ForkSetupPanel(props: ForkSetupPanelProps) {
   const [username, setUsername] = useState(props.contributorForkOwner ?? "");
   const [tokenInput, setTokenInput] = useState("");
+  const [machineUserOptIn, setMachineUserOptIn] = useState(props.machineUserOptIn ?? false);
   const [state, setState] = useState<PanelState>(() => {
     if (props.contributorForkOwner && props.contributorForkRepo) {
       return { kind: "ready", forkOwner: props.contributorForkOwner, forkRepo: props.contributorForkRepo };
@@ -56,6 +60,7 @@ export function ForkSetupPanel(props: ForkSetupPanelProps) {
       const result = await configureForkSetup({
         contributorForkOwner: username.trim(),
         token: tokenInput.trim(),
+        machineUserOptIn,
       });
       if (!result.success) {
         setState({ kind: "error", message: result.error });
@@ -84,9 +89,8 @@ export function ForkSetupPanel(props: ForkSetupPanelProps) {
         pull request against the upstream repo. This keeps your token scoped to your own
         account — no upstream write access required.
       </p>
-      <p className="mb-3 text-xs text-[var(--dpf-muted)]">
-        Your GitHub username will be visible on every PR you contribute. If that is not
-        acceptable, use a pseudonymous GitHub account for this install.
+      <p className="mb-3 text-xs text-[var(--dpf-muted)]" data-testid="pseudonymity-tradeoff">
+        {CONTRIBUTION_COPY.pseudonymityTradeoff}
       </p>
 
       <div className="mb-3">
@@ -105,8 +109,11 @@ export function ForkSetupPanel(props: ForkSetupPanelProps) {
 
       <div className="mb-3">
         <label htmlFor="fork-token" className="mb-1 block text-sm text-[var(--dpf-text)]">
-          GitHub personal access token (public_repo scope on your account)
+          GitHub personal access token
         </label>
+        <p className="mb-1 text-xs text-[var(--dpf-muted)]" data-testid="token-scope-copy">
+          {CONTRIBUTION_COPY.tokenScope.forkPr}
+        </p>
         <input
           id="fork-token"
           type="password"
@@ -115,6 +122,24 @@ export function ForkSetupPanel(props: ForkSetupPanelProps) {
           placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-xs text-[var(--dpf-text)]"
         />
+      </div>
+
+      <div className="mb-3">
+        <label className="flex items-start gap-2 text-sm text-[var(--dpf-text)]">
+          <input
+            id="fork-machine-user"
+            type="checkbox"
+            checked={machineUserOptIn}
+            onChange={(e) => setMachineUserOptIn(e.target.checked)}
+            className="mt-1"
+          />
+          <span>
+            <span className="font-medium">{CONTRIBUTION_COPY.machineUserOptIn.label}</span>
+            <span className="block text-xs text-[var(--dpf-muted)]" data-testid="machine-user-description">
+              {CONTRIBUTION_COPY.machineUserOptIn.description}
+            </span>
+          </span>
+        </label>
       </div>
 
       <button

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -199,6 +199,91 @@ export async function getStoredGitHubToken(): Promise<string | null> {
 }
 
 /**
+ * Model-aware token validation for the contribution flow.
+ *
+ * maintainer-direct: checks that the token has push access to
+ *   upstreamOwner/upstreamRepo via GET /repos/{owner}/{repo}'s
+ *   permissions.push flag.
+ *
+ * fork-pr: checks the token's account (GET /user) matches expectedOwner
+ *   unless machineUser=true, which opts out of the identity check (for
+ *   installs using a dedicated machine-user GitHub account to host the fork).
+ *
+ * Both paths first run the plain /user check to verify the token is live.
+ * Scope mismatches (wrong PAT scope) surface later at the actual fork/PR
+ * operation with a GitHub 403 rather than being pre-checked here, since
+ * fine-grained PATs do not expose scope info on /user.
+ */
+export async function validateGitHubTokenForModel(input: {
+  token: string;
+  model: "maintainer-direct" | "fork-pr";
+  /** maintainer-direct only — the repo the token must push to. */
+  upstreamOwner?: string;
+  upstreamRepo?: string;
+  /** fork-pr only — the fork owner the token's account must match, unless machineUser. */
+  expectedOwner?: string;
+  /** fork-pr only — skip the identity check when true. */
+  machineUser?: boolean;
+}): Promise<{ valid: boolean; username?: string; error?: string }> {
+  const basic = await validateGitHubToken(input.token);
+  if (!basic.valid) return basic;
+
+  if (input.model === "maintainer-direct") {
+    if (!input.upstreamOwner || !input.upstreamRepo) {
+      return { valid: false, error: "maintainer-direct validation requires upstreamOwner and upstreamRepo." };
+    }
+    try {
+      const repoRes = await fetch(
+        `https://api.github.com/repos/${input.upstreamOwner}/${input.upstreamRepo}`,
+        {
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${input.token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        },
+      );
+      if (!repoRes.ok) {
+        return {
+          valid: false,
+          error: `Token cannot read ${input.upstreamOwner}/${input.upstreamRepo} (${repoRes.status}). maintainer-direct requires contents:write on the upstream repo.`,
+        };
+      }
+      const repoData = (await repoRes.json()) as { permissions?: { push?: boolean } };
+      if (!repoData.permissions?.push) {
+        return {
+          valid: false,
+          error: `Token does not have push access to ${input.upstreamOwner}/${input.upstreamRepo}. maintainer-direct requires contents:write on the upstream repo.`,
+        };
+      }
+      return { valid: true, username: basic.username };
+    } catch {
+      return { valid: false, error: "Could not verify upstream access. Check your internet connection." };
+    }
+  }
+
+  if (input.model === "fork-pr") {
+    if (input.machineUser === true) {
+      return { valid: true, username: basic.username };
+    }
+    if (!input.expectedOwner) {
+      return { valid: false, error: "fork-pr validation requires expectedOwner unless machineUser=true." };
+    }
+    const tokenOwner = basic.username?.toLowerCase();
+    const expected = input.expectedOwner.toLowerCase();
+    if (tokenOwner !== expected) {
+      return {
+        valid: false,
+        error: `Token owner (${basic.username}) does not match fork owner (${input.expectedOwner}). Use a PAT owned by the fork owner, or check the "machine-user account" opt-out if this is intentional.`,
+      };
+    }
+    return { valid: true, username: basic.username };
+  }
+
+  return { valid: false, error: `Unsupported contribution model: ${String((input as { model: string }).model)}.` };
+}
+
+/**
  * Validate a GitHub token by making a test API call.
  * Returns the authenticated username on success, or an error message.
  */
@@ -298,6 +383,8 @@ export type ConfigureForkSetupResult =
 export async function configureForkSetup(input: {
   contributorForkOwner: string;
   token: string;
+  /** Phase 5: opt out of the "token owner must match fork owner" check for machine-user accounts. */
+  machineUserOptIn?: boolean;
 }): Promise<ConfigureForkSetupResult> {
   const session = await auth();
   const userId = session?.user?.id;
@@ -307,9 +394,16 @@ export async function configureForkSetup(input: {
     return { success: false, error: "GitHub username is required." };
   }
 
-  // Validate token (reuses the /user call — confirms the token is live and
-  // has API access; scope validation is layered in Phase 5).
-  const validation = await validateGitHubToken(input.token);
+  // Validate token with the fork-pr model check (owner-match unless
+  // machineUser). validateGitHubTokenForModel short-circuits to the basic
+  // /user check first, so "token dead" errors still surface with the right
+  // message.
+  const validation = await validateGitHubTokenForModel({
+    token: input.token,
+    model: "fork-pr",
+    expectedOwner: input.contributorForkOwner.trim(),
+    machineUser: input.machineUserOptIn === true,
+  });
   if (!validation.valid) {
     return { success: false, error: validation.error ?? "Token validation failed." };
   }
@@ -392,12 +486,14 @@ export async function configureForkSetup(input: {
       contributorForkOwner: forkOwner,
       contributorForkRepo: forkRepo,
       forkVerifiedAt: status === "ready" ? new Date() : null,
+      machineUserOptIn: input.machineUserOptIn === true,
     },
     create: {
       id: "singleton",
       contributorForkOwner: forkOwner,
       contributorForkRepo: forkRepo,
       forkVerifiedAt: status === "ready" ? new Date() : null,
+      machineUserOptIn: input.machineUserOptIn === true,
     },
   });
 

--- a/apps/web/lib/actions/validate-token-for-model.test.ts
+++ b/apps/web/lib/actions/validate-token-for-model.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { validateGitHubTokenForModel } from "./platform-dev-config";
+
+function okJson<T>(body: T): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function errResponse(status: number, text = ""): Response {
+  return {
+    ok: false,
+    status,
+    text: () => Promise.resolve(text),
+    json: () => Promise.resolve({}),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("validateGitHubTokenForModel — maintainer-direct", () => {
+  it("returns valid when the token has push access to upstream", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(okJson({ login: "mark" })); // /user
+    fetchMock.mockResolvedValueOnce(okJson({ permissions: { push: true } })); // /repos/...
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "maintainer-direct",
+      upstreamOwner: "OpenDigitalProductFactory",
+      upstreamRepo: "opendigitalproductfactory",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.username).toBe("mark");
+  });
+
+  it("returns invalid when the token has no push permission on upstream", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(okJson({ login: "mark" }));
+    fetchMock.mockResolvedValueOnce(okJson({ permissions: { push: false } }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "maintainer-direct",
+      upstreamOwner: "OpenDigitalProductFactory",
+      upstreamRepo: "opendigitalproductfactory",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/push access/i);
+  });
+
+  it("returns invalid when the token cannot read upstream at all (private repo or revoked)", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(okJson({ login: "mark" }));
+    fetchMock.mockResolvedValueOnce(errResponse(404));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "maintainer-direct",
+      upstreamOwner: "OpenDigitalProductFactory",
+      upstreamRepo: "opendigitalproductfactory",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/cannot read/i);
+  });
+
+  it("returns invalid when upstreamOwner/upstreamRepo are missing", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(okJson({ login: "mark" }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "maintainer-direct",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/upstreamOwner/);
+  });
+});
+
+describe("validateGitHubTokenForModel — fork-pr", () => {
+  it("returns valid when token owner matches fork owner", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okJson({ login: "jane-dev" }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "fork-pr",
+      expectedOwner: "jane-dev",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.username).toBe("jane-dev");
+  });
+
+  it("is case-insensitive on owner match", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okJson({ login: "Jane-Dev" }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "fork-pr",
+      expectedOwner: "jane-dev",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns invalid when token owner does not match fork owner and machineUser is false", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okJson({ login: "someone-else" }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "fork-pr",
+      expectedOwner: "jane-dev",
+      machineUser: false,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/does not match fork owner/i);
+  });
+
+  it("returns valid when token owner does not match but machineUser=true", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okJson({ login: "dpf-bot" }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "fork-pr",
+      expectedOwner: "jane-dev",
+      machineUser: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.username).toBe("dpf-bot");
+  });
+
+  it("returns invalid when expectedOwner is missing and machineUser is not true", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okJson({ login: "jane-dev" }));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_x",
+      model: "fork-pr",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/expectedOwner|machineUser/);
+  });
+});
+
+describe("validateGitHubTokenForModel — basic token failure", () => {
+  it("returns invalid short-circuit when the /user call fails", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(errResponse(401, "Bad credentials"));
+
+    const result = await validateGitHubTokenForModel({
+      token: "ghp_bad",
+      model: "fork-pr",
+      expectedOwner: "jane-dev",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/invalid|expired/i);
+    // Only one fetch call — the /user check — because we short-circuit.
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/integrate/contribution-copy.test.ts
+++ b/apps/web/lib/integrate/contribution-copy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTRIBUTION_COPY } from "./contribution-copy";
+
+describe("CONTRIBUTION_COPY", () => {
+  it("exports token-scope copy for both models", () => {
+    expect(CONTRIBUTION_COPY.tokenScope.maintainerDirect).toContain("contents:write");
+    expect(CONTRIBUTION_COPY.tokenScope.forkPr).toContain("public_repo");
+  });
+
+  it("token-scope copy for fork-pr explicitly says upstream access is NOT required", () => {
+    // The whole point of the fork-pr model — if the copy ever drifts to
+    // imply upstream write, admins will over-scope their tokens.
+    expect(CONTRIBUTION_COPY.tokenScope.forkPr.toLowerCase()).toMatch(/not need|does not need|doesn't need/);
+  });
+
+  it("exports pseudonymity-tradeoff copy that mentions GitHub username visibility", () => {
+    expect(CONTRIBUTION_COPY.pseudonymityTradeoff).toMatch(/GitHub username will be visible/i);
+  });
+
+  it("pseudonymity copy keeps the platform-generated identity guidance", () => {
+    expect(CONTRIBUTION_COPY.pseudonymityTradeoff).toMatch(/dpf-agent/i);
+  });
+
+  it("machine-user opt-in copy covers what the checkbox does", () => {
+    expect(CONTRIBUTION_COPY.machineUserOptIn.label).toMatch(/machine-user/i);
+    expect(CONTRIBUTION_COPY.machineUserOptIn.description).toMatch(/skip/i);
+  });
+
+  it("banner copy covers the needs-configuration path with an action label", () => {
+    expect(CONTRIBUTION_COPY.banner.needsConfiguration).toMatch(/re-configuring|configure/i);
+    expect(CONTRIBUTION_COPY.banner.openSetupLinkLabel.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/integrate/contribution-copy.ts
+++ b/apps/web/lib/integrate/contribution-copy.ts
@@ -1,0 +1,31 @@
+// Shared copy source for the contribution-mode UX. Both the admin UI
+// (PlatformDevelopmentForm / ForkSetupPanel / ContributionModelBanner) and
+// CONTRIBUTING.md consume this module so token-scope guidance,
+// pseudonymity-tradeoff disclosure, and re-setup banner text never drift
+// between surfaces. A doc-sync test in Phase 7 will assert CONTRIBUTING.md
+// contains the key strings verbatim.
+//
+// See docs/superpowers/specs/2026-04-23-public-contribution-mode-design.md
+// §"Pseudonymity and the fork-account visibility tradeoff" and §"Token scope
+// guidance" for the rationale behind each string.
+
+export const CONTRIBUTION_COPY = {
+  tokenScope: {
+    maintainerDirect:
+      "This token needs `contents:write` on the upstream repo. Only maintainers of the OpenDigitalProductFactory org should use this mode.",
+    forkPr:
+      "This token needs the `public_repo` scope on your own GitHub account. It does NOT need access to the upstream repo — the platform will create a fork under your account the first time you contribute.",
+  },
+  pseudonymityTradeoff:
+    "Your GitHub username will be visible on every PR you contribute. The platform-generated commit identity (dpf-agent-<shortId>) still applies to commit metadata, but the fork owner is necessarily visible on GitHub. If that is not acceptable, use a pseudonymous GitHub account for this install.",
+  machineUserOptIn: {
+    label: "I am using a dedicated machine-user GitHub account",
+    description:
+      "Check this if the PAT belongs to an account that is NOT your primary identity. The platform will skip the 'token owner must match fork owner' check.",
+  },
+  banner: {
+    needsConfiguration:
+      "A platform update requires re-configuring contribution mode before your next contribution. Open setup below.",
+    openSetupLinkLabel: "Open setup",
+  },
+} as const;

--- a/packages/db/prisma/migrations/20260424010000_add_machine_user_opt_in/migration.sql
+++ b/packages/db/prisma/migrations/20260424010000_add_machine_user_opt_in/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PlatformDevConfig" ADD COLUMN     "machineUserOptIn" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2699,6 +2699,8 @@ model FeatureBuild {
   gitCommitHashes       String[]          @default([])
   uxTestResults         Json?
   uxVerificationStatus  String? // null | "running" | "complete" | "failed" | "skipped"
+  sandboxVerification   Json? // { typecheck: SandboxCheckResult, build: SandboxCheckResult, ranAt: string }
+  sandboxVerificationStatus String? // null | "running" | "complete" | "failed"
   deliberationSummary   Json? // compact BuildDeliberationSummary (see apps/web/lib/feature-build-types.ts)
   buildExecState        Json?
   taxonomyAttribution   Json?
@@ -3000,6 +3002,10 @@ model PlatformDevConfig {
   contributorForkOwner String?
   contributorForkRepo  String?
   forkVerifiedAt       DateTime?
+  // Opt-out checkbox for the fork-pr "token owner must match fork owner" rule.
+  // Enabled when the admin uses a dedicated machine-user GitHub account whose
+  // identity is distinct from the fork owner they entered.
+  machineUserOptIn     Boolean   @default(false)
 }
 
 model EaNotation {


### PR DESCRIPTION
Adds validateGitHubTokenForModel (additive; leaves the plain validateGitHubToken untouched). For maintainer-direct it checks permissions.push on the upstream repo; for fork-pr it checks token ownership matches the fork owner, with a machine-user opt-out for installs where the PAT is a dedicated bot account.

configureForkSetup now uses the fork-pr variant and persists the new machineUserOptIn field. ForkSetupPanel gains the checkbox + pre-fill from stored config, and consumes CONTRIBUTION_COPY.* so the token- scope guidance, pseudonymity tradeoff, and machine-user description have a single source of truth shared with the admin UI and (later) CONTRIBUTING.md.

Schema: additive Boolean machineUserOptIn @default(false) on PlatformDevConfig; migration
20260424010000_add_machine_user_opt_in. Phase 1 invariant test still passes (contributionModel remains null-by-default).

11 tests in validate-token-for-model.test.ts covering the full model matrix (maintainer-direct push/no-push/404/missing-upstream, fork-pr match/case-insensitive-match/mismatch/machineUser-opt-out/missing- expected-owner, basic-token-failure short-circuit). 6 tests in contribution-copy.test.ts covering every key in the shared module.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
