### PR TITLE
chore(credential-crypto): fail-loud on missing encryption key in production

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -17,7 +17,10 @@ NEO4J_AUTH=neo4j/dpf_dev_password
 # Auth.js secret (REQUIRED -- must be a random value)
 AUTH_SECRET=<generate with: openssl rand -base64 32>
 
-# Credential encryption key (REQUIRED -- must be a random value)
+# REQUIRED in production. 64 hex chars = 32 bytes.
+# Generate with: openssl rand -hex 32
+# If unset in production AND credentials exist in DB, the portal refuses to start.
+# Development mode (NODE_ENV=development) falls back to plaintext.
 CREDENTIAL_ENCRYPTION_KEY=<generate with: openssl rand -hex 32>
 
 # Default admin password (used by portal-init seed -- change for non-local deployments)

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -129,5 +129,14 @@ export async function register() {
         await pgPool.end().catch(() => {});
       }
     }, STARTUP_DELAY_MS);
+
+    // ── CREDENTIAL_ENCRYPTION_KEY fail-loud guard ──────────────────────────
+    // Refuses to boot in production when the credential store contains
+    // secrets but the encryption key is unset — that combination would cause
+    // silent plaintext storage (data-at-rest vulnerability).
+    // Dev mode short-circuits immediately; zero overhead outside production.
+    // See docs/superpowers/specs/2026-04-24-github-auth-2fa-readiness-design.md
+    const { assertCredentialEncryptionKeyIsSet } = await import("@/lib/govern/credential-crypto");
+    await assertCredentialEncryptionKeyIsSet();
   }
 }

--- a/apps/web/lib/govern/credential-crypto.assert.test.ts
+++ b/apps/web/lib/govern/credential-crypto.assert.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { assertCredentialEncryptionKeyIsSet } from "./credential-crypto";
+
+vi.mock("@dpf/db", () => ({
+  prisma: { credentialEntry: { count: vi.fn() } },
+}));
+
+describe("assertCredentialEncryptionKeyIsSet", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("throws in production when key missing AND credentials exist", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CREDENTIAL_ENCRYPTION_KEY", "");
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.credentialEntry.count).mockResolvedValue(3);
+    await expect(assertCredentialEncryptionKeyIsSet()).rejects.toThrow(/FATAL: CREDENTIAL_ENCRYPTION_KEY/);
+  });
+
+  it("passes in production when key is set, without querying the DB", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CREDENTIAL_ENCRYPTION_KEY", "a".repeat(64));
+    const { prisma } = await import("@dpf/db");
+    await expect(assertCredentialEncryptionKeyIsSet()).resolves.toBeUndefined();
+    expect(prisma.credentialEntry.count).not.toHaveBeenCalled();
+  });
+
+  it("passes in production when key missing AND no credentials exist", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CREDENTIAL_ENCRYPTION_KEY", "");
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.credentialEntry.count).mockResolvedValue(0);
+    await expect(assertCredentialEncryptionKeyIsSet()).resolves.toBeUndefined();
+  });
+
+  it("passes in development regardless", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CREDENTIAL_ENCRYPTION_KEY", "");
+    await expect(assertCredentialEncryptionKeyIsSet()).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/lib/govern/credential-crypto.ts
+++ b/apps/web/lib/govern/credential-crypto.ts
@@ -65,6 +65,26 @@ export function decryptSecret(stored: string): string | null {
   }
 }
 
+/**
+ * Startup guard. Refuses to run in production if the credential store contains
+ * secrets but CREDENTIAL_ENCRYPTION_KEY is not set — that combination means
+ * existing credentials are stored plaintext or new writes would degrade silently.
+ * Development mode falls back to plaintext per dev-mode convenience; see
+ * docs/superpowers/specs/2026-04-24-github-auth-2fa-readiness-design.md
+ */
+export async function assertCredentialEncryptionKeyIsSet(): Promise<void> {
+  if (process.env.NODE_ENV !== "production") return;
+  if (getEncryptionKey()) return;
+  const { prisma } = await import("@dpf/db");
+  const count = await prisma.credentialEntry.count({ where: { secretRef: { not: null } } });
+  if (count === 0) return;
+  throw new Error(
+    "FATAL: CREDENTIAL_ENCRYPTION_KEY is not set, but the credential store\n" +
+    "contains secrets that would be read/written in plaintext. Set this variable\n" +
+    "(64 hex chars = 32 bytes) before restarting. For dev, set NODE_ENV=development."
+  );
+}
+
 /** Encrypt a structured value by JSON-stringifying it first. Shape-agnostic — use for polymorphic
  *  integration credential blobs where the fields vary by provider. */
 export function encryptJson<T>(value: T): string {


### PR DESCRIPTION
## Summary

- Production deploys now refuse to start when `CREDENTIAL_ENCRYPTION_KEY` is missing AND the credential store contains non-null secrets. Prevents the silent plaintext-storage footgun in `credential-crypto.ts`.
- Development mode (`NODE_ENV=development`) is unchanged — plaintext fallback preserved for dev convenience.
- Boot-time assertion lives in `apps/web/instrumentation.ts`; dev-mode short-circuit means zero overhead there.
- `.env.docker.example` updated to flag the variable as REQUIRED in production with remediation copy.

## Breaking

Production deploys that have never set `CREDENTIAL_ENCRYPTION_KEY` AND have existing `CredentialEntry` rows will refuse to start after this merges. Set `CREDENTIAL_ENCRYPTION_KEY=<openssl rand -hex 32>` in prod env before deploying. See `docs/superpowers/specs/2026-04-24-github-auth-2fa-readiness-design.md`.

## Test plan

- [x] `pnpm --filter @dpf/web test credential-crypto` — 4 new test cases pass
- [x] `pnpm --filter @dpf/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @dpf/web build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)