### PR TITLE
feat(validate-github-token): scope + expiry + prefix auth-method detection

### DIFF
--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -198,17 +198,119 @@ export async function getStoredGitHubToken(): Promise<string | null> {
   }
 }
 
-/**
- * Validate a GitHub token by making a test API call.
- * Returns the authenticated username on success, or an error message.
- */
-export async function validateGitHubToken(token: string): Promise<{
+// ─── GitHub token validation ─────────────────────────────────────────────────
+//
+// Extended validator for the 2026-04-24 GitHub auth 2FA readiness spec. The
+// single-arg form `validateGitHubToken(token)` is preserved for back-compat;
+// the object form gains scope + expiry + prefix-based auth-method detection,
+// plus an optional per-repo probe for fine-grained PATs where scopes are
+// carried out-of-band (empty X-OAuth-Scopes header).
+//
+// `model` and `machineUser` are reserved for the 2026-04-23 public-contribution
+// -mode plan (Task 5.2), which can land before or after this change. They are
+// accepted here so callers that already pass them don't break the compile.
+
+export interface ValidateTokenInput {
+  token: string;
+  requiredScope?: "public_repo" | "repo" | "contents:write";
+  expectedOwner?: string;
+  requireNonExpired?: boolean;
+  authMethod?: "oauth-device" | "fine-grained-pat" | "classic-pat" | "auto";
+  model?: "maintainer-direct" | "fork-pr";
+  machineUser?: boolean;
+}
+
+export interface ValidateTokenResult {
   valid: boolean;
   username?: string;
+  scope?: string;
+  expiresAt?: Date | null;
+  authMethod?: "oauth-device" | "fine-grained-pat" | "classic-pat";
   error?: string;
-}> {
+}
+
+/** Hard-coded fallback when PlatformDevConfig doesn't carry an upstream URL. */
+const UPSTREAM_OWNER_REPO_FALLBACK = "OpenDigitalProductFactory/opendigitalproductfactory";
+
+function detectAuthMethod(
+  token: string,
+): "oauth-device" | "fine-grained-pat" | "classic-pat" | null {
+  if (token.startsWith("gho_")) return "oauth-device";
+  if (token.startsWith("github_pat_")) return "fine-grained-pat";
+  if (token.startsWith("ghp_")) return "classic-pat";
+  return null; // ghs_ (app install), ghr_ (refresh), or malformed
+}
+
+function parseScopesHeader(headerValue: string | null): Set<string> {
+  if (!headerValue) return new Set();
+  return new Set(
+    headerValue
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Does the token carry enough scope for the caller's requirement?
+ *
+ * GitHub's classic-PAT scopes form a small hierarchy: `repo` is a superset of
+ * `public_repo`, and (at the repo level) also grants write on file contents
+ * which is what `contents:write` represents for fine-grained PATs. We treat
+ * `repo` as satisfying any of our three required values.
+ */
+function scopeSatisfies(granted: Set<string>, required: ValidateTokenInput["requiredScope"]): boolean {
+  if (!required) return true;
+  if (granted.has("repo")) return true;
+  return granted.has(required);
+}
+
+function parseExpiryHeader(headerValue: string | null): Date | null {
+  if (!headerValue) return null;
+  const parsed = new Date(headerValue);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
+/**
+ * Validate a GitHub token by making a test API call.
+ *
+ * Single-arg form (back-compat): `validateGitHubToken(token)` — returns the
+ * minimal legacy shape `{ valid, username?, error? }`.
+ *
+ * Object form: accepts additional constraints (scope, owner, expiry, auth
+ * method) and returns the extended shape.
+ */
+export async function validateGitHubToken(
+  token: string,
+): Promise<{ valid: boolean; username?: string; error?: string }>;
+export async function validateGitHubToken(
+  input: ValidateTokenInput,
+): Promise<ValidateTokenResult>;
+export async function validateGitHubToken(
+  arg: string | ValidateTokenInput,
+): Promise<ValidateTokenResult> {
+  const input: ValidateTokenInput = typeof arg === "string" ? { token: arg } : arg;
+  const { token } = input;
+
+  // Auth-method detection. "auto" (and "undefined" from the single-arg form)
+  // both dispatch to the prefix detector; explicit values bypass detection.
+  let resolvedAuthMethod: "oauth-device" | "fine-grained-pat" | "classic-pat" | undefined;
+  if (input.authMethod && input.authMethod !== "auto") {
+    resolvedAuthMethod = input.authMethod;
+  } else {
+    const detected = detectAuthMethod(token);
+    if (input.authMethod === "auto" && !detected) {
+      return {
+        valid: false,
+        error: "Token format not recognized. Expected gho_, github_pat_, or ghp_ prefix.",
+      };
+    }
+    resolvedAuthMethod = detected ?? undefined;
+  }
+
   try {
-    const response = await fetch("https://api.github.com/user", {
+    const userResponse = await fetch("https://api.github.com/user", {
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${token}`,
@@ -216,14 +318,101 @@ export async function validateGitHubToken(token: string): Promise<{
       },
     });
 
-    if (!response.ok) {
-      if (response.status === 401) return { valid: false, error: "Token is invalid or expired." };
-      return { valid: false, error: `GitHub returned status ${response.status}.` };
+    if (!userResponse.ok) {
+      if (userResponse.status === 401) {
+        return { valid: false, error: "Token is invalid or expired." };
+      }
+      return { valid: false, error: `GitHub returned status ${userResponse.status}.` };
     }
 
-    const data = await response.json() as { login?: string };
-    return { valid: true, username: data.login ?? "unknown" };
-  } catch (err) {
+    const data = (await userResponse.json()) as { login?: string };
+    const username = data.login ?? "unknown";
+
+    const scopesHeader = userResponse.headers.get("X-OAuth-Scopes");
+    const grantedScopes = parseScopesHeader(scopesHeader);
+    const expiresAt = parseExpiryHeader(
+      userResponse.headers.get("github-authentication-token-expiration"),
+    );
+
+    // Owner check — unless machineUser opt-out explicitly allows mismatch.
+    if (input.expectedOwner && !input.machineUser && username !== input.expectedOwner) {
+      return {
+        valid: false,
+        username,
+        authMethod: resolvedAuthMethod,
+        error: `Token owner (${username}) does not match expected owner (${input.expectedOwner}). If this token belongs to a machine user, set machineUser: true.`,
+      };
+    }
+
+    // Scope check (classic PAT). For fine-grained PATs, GitHub does not return
+    // scopes via X-OAuth-Scopes; we verify access via a per-repo probe below.
+    if (resolvedAuthMethod === "classic-pat" && input.requiredScope) {
+      if (!scopeSatisfies(grantedScopes, input.requiredScope)) {
+        return {
+          valid: false,
+          username,
+          authMethod: resolvedAuthMethod,
+          scope: scopesHeader ?? undefined,
+          expiresAt,
+          error: `Token is missing required scope '${input.requiredScope}'. Granted: ${scopesHeader || "(none)"}.`,
+        };
+      }
+    }
+
+    // Expiry gate — only enforced if requireNonExpired was passed. A fine-
+    // grained PAT expiring in less than 30 days is rejected; we still surface
+    // expiresAt so callers can warn the user ahead of time.
+    if (input.requireNonExpired && expiresAt) {
+      const msPerDay = 24 * 60 * 60 * 1000;
+      const daysLeft = Math.floor((expiresAt.getTime() - Date.now()) / msPerDay);
+      if (daysLeft < 30) {
+        return {
+          valid: false,
+          username,
+          authMethod: resolvedAuthMethod,
+          scope: scopesHeader ?? undefined,
+          expiresAt,
+          error: `Token expires in ${daysLeft} day(s). Rotate to a token with at least 30 days remaining.`,
+        };
+      }
+    }
+
+    // Per-repo probe (fine-grained PAT). Fine-grained tokens don't report
+    // their scopes via X-OAuth-Scopes — the only reliable signal is whether
+    // the token can actually reach the repo it's meant to act on.
+    if (resolvedAuthMethod === "fine-grained-pat") {
+      const probeOwner = input.expectedOwner ?? UPSTREAM_OWNER_REPO_FALLBACK.split("/")[0];
+      const probeRepo = UPSTREAM_OWNER_REPO_FALLBACK.split("/")[1];
+      const probeUrl = `https://api.github.com/repos/${probeOwner}/${probeRepo}`;
+
+      const repoResponse = await fetch(probeUrl, {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      });
+
+      if (!repoResponse.ok) {
+        return {
+          valid: false,
+          username,
+          authMethod: resolvedAuthMethod,
+          scope: scopesHeader ?? undefined,
+          expiresAt,
+          error: `Token can't access the fork repo ${probeOwner}/${probeRepo} (status ${repoResponse.status}). Check that the fine-grained PAT grants Contents: read/write on that repository.`,
+        };
+      }
+    }
+
+    return {
+      valid: true,
+      username,
+      authMethod: resolvedAuthMethod,
+      scope: scopesHeader ?? undefined,
+      expiresAt,
+    };
+  } catch {
     return { valid: false, error: "Could not reach GitHub. Check your internet connection." };
   }
 }

--- a/apps/web/lib/actions/platform-dev-config.validate.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.validate.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Next.js server-action plumbing so the module can import cleanly in a
+// pure-node test environment. validateGitHubToken itself is a pure fetch
+// wrapper — it doesn't touch auth / prisma / revalidatePath — but the file's
+// top-level "use server" + imports need to be silenceable.
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "test-user-1" } }),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformDevConfig: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    credentialEntry: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/lib/platform-dev-policy", () => ({
+  getPlatformDevPolicyState: vi.fn(),
+}));
+
+import { validateGitHubToken } from "./platform-dev-config";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function userResponse(body: { login?: string }, extraHeaders: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    headers: new Headers({
+      "X-OAuth-Scopes": "",
+      ...extraHeaders,
+    }),
+  } as unknown as Response;
+}
+
+function repoResponse(status: number) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({}),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function mockFetchByUrl(handler: (url: string) => Response | Promise<Response>) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url);
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("validateGitHubToken — back-compat single-arg form", () => {
+  it("accepts a raw string token and returns username", async () => {
+    mockFetchByUrl(() =>
+      userResponse({ login: "octocat" }, { "X-OAuth-Scopes": "public_repo" }),
+    );
+
+    const result = await validateGitHubToken("ghp_abc");
+
+    expect(result.valid).toBe(true);
+    expect(result.username).toBe("octocat");
+  });
+
+  it("returns valid:false with error message on 401", async () => {
+    mockFetchByUrl(() => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+      headers: new Headers(),
+    }) as unknown as Response);
+
+    const result = await validateGitHubToken("ghp_bad");
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/invalid or expired/i);
+  });
+});
+
+describe("validateGitHubToken — prefix-based auth method detection", () => {
+  it("detects oauth-device from gho_ prefix", async () => {
+    mockFetchByUrl(() =>
+      userResponse({ login: "alice" }, { "X-OAuth-Scopes": "public_repo" }),
+    );
+
+    const result = await validateGitHubToken({ token: "gho_xxx", authMethod: "auto" });
+
+    expect(result.valid).toBe(true);
+    expect(result.authMethod).toBe("oauth-device");
+  });
+
+  it("detects fine-grained-pat from github_pat_ prefix", async () => {
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse({ login: "alice" }, {});
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({ token: "github_pat_xyz", authMethod: "auto" });
+
+    expect(result.valid).toBe(true);
+    expect(result.authMethod).toBe("fine-grained-pat");
+  });
+
+  it("detects classic-pat from ghp_ prefix", async () => {
+    mockFetchByUrl(() =>
+      userResponse({ login: "alice" }, { "X-OAuth-Scopes": "public_repo" }),
+    );
+
+    const result = await validateGitHubToken({ token: "ghp_classic", authMethod: "auto" });
+
+    expect(result.valid).toBe(true);
+    expect(result.authMethod).toBe("classic-pat");
+  });
+
+  it("rejects unknown prefixes (e.g. ghs_ app install)", async () => {
+    mockFetchByUrl(() => userResponse({ login: "ignored" }, {}));
+
+    const result = await validateGitHubToken({ token: "ghs_appinstall", authMethod: "auto" });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Token format not recognized/i);
+  });
+});
+
+describe("validateGitHubToken — scope validation (classic PAT)", () => {
+  it("accepts public_repo when required scope is public_repo", async () => {
+    mockFetchByUrl(() =>
+      userResponse({ login: "alice" }, { "X-OAuth-Scopes": "public_repo" }),
+    );
+
+    const result = await validateGitHubToken({
+      token: "ghp_a",
+      requiredScope: "public_repo",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts repo as superset of public_repo", async () => {
+    mockFetchByUrl(() =>
+      userResponse({ login: "alice" }, { "X-OAuth-Scopes": "repo" }),
+    );
+
+    const result = await validateGitHubToken({
+      token: "ghp_a",
+      requiredScope: "public_repo",
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects read:user when public_repo is required", async () => {
+    mockFetchByUrl(() =>
+      userResponse({ login: "alice" }, { "X-OAuth-Scopes": "read:user" }),
+    );
+
+    const result = await validateGitHubToken({
+      token: "ghp_a",
+      requiredScope: "public_repo",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/scope/i);
+    expect(result.error).toMatch(/public_repo/i);
+  });
+});
+
+describe("validateGitHubToken — expiry (fine-grained PAT)", () => {
+  it("populates expiresAt when header present, valid without requireNonExpired", async () => {
+    const future = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString(); // +60d
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse(
+          { login: "alice" },
+          { "github-authentication-token-expiration": future },
+        );
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({ token: "github_pat_ok" });
+
+    expect(result.valid).toBe(true);
+    expect(result.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects tokens expiring in <30 days when requireNonExpired is set", async () => {
+    const soon = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(); // +10d
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse(
+          { login: "alice" },
+          { "github-authentication-token-expiration": soon },
+        );
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({
+      token: "github_pat_soon",
+      requireNonExpired: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/expires/i);
+  });
+
+  it("still populates expiresAt even when requireNonExpired is false", async () => {
+    const soon = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString();
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse(
+          { login: "alice" },
+          { "github-authentication-token-expiration": soon },
+        );
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({
+      token: "github_pat_soon",
+      requireNonExpired: false,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.expiresAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("validateGitHubToken — owner mismatch", () => {
+  it("rejects when token owner doesn't match expectedOwner", async () => {
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse(
+          { login: "jane" },
+          { "X-OAuth-Scopes": "public_repo" },
+        );
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({
+      token: "ghp_a",
+      expectedOwner: "jane-dev",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/owner/i);
+  });
+
+  it("allows mismatch when machineUser opt-out is set", async () => {
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse(
+          { login: "bot-account" },
+          { "X-OAuth-Scopes": "public_repo" },
+        );
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({
+      token: "ghp_a",
+      expectedOwner: "jane-dev",
+      machineUser: true,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateGitHubToken — per-repo probe (fine-grained PAT)", () => {
+  it("probes the fork repo when expectedOwner is set (200 → valid)", async () => {
+    const calls: string[] = [];
+    mockFetchByUrl((url) => {
+      calls.push(url);
+      if (url.includes("/user")) {
+        return userResponse({ login: "jane-dev" }, {});
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({
+      token: "github_pat_fg",
+      expectedOwner: "jane-dev",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(calls.some((u) => u.includes("/repos/jane-dev/opendigitalproductfactory"))).toBe(true);
+  });
+
+  it("probes the fork repo when expectedOwner is set (404 → invalid)", async () => {
+    mockFetchByUrl((url) => {
+      if (url.includes("/user")) {
+        return userResponse({ login: "jane-dev" }, {});
+      }
+      return repoResponse(404);
+    });
+
+    const result = await validateGitHubToken({
+      token: "github_pat_fg",
+      expectedOwner: "jane-dev",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/fork/i);
+  });
+
+  it("probes upstream repo when expectedOwner is not set", async () => {
+    const calls: string[] = [];
+    mockFetchByUrl((url) => {
+      calls.push(url);
+      if (url.includes("/user")) {
+        return userResponse({ login: "alice" }, {});
+      }
+      return repoResponse(200);
+    });
+
+    const result = await validateGitHubToken({ token: "github_pat_fg" });
+
+    expect(result.valid).toBe(true);
+    expect(
+      calls.some((u) =>
+        u.includes("/repos/OpenDigitalProductFactory/opendigitalproductfactory"),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `validateGitHubToken` with object-form signature, back-compat overload preserved
- Prefix-based auth method detection (`gho_` / `github_pat_` / `ghp_`)
- Scope validation from `X-OAuth-Scopes` header (treats `repo` as superset of `public_repo` and `contents:write`)
- Fine-grained PAT expiry from `github-authentication-token-expiration` header; optional `requireNonExpired` gate at 30 days
- Per-repo probe for fine-grained PATs (empty `X-OAuth-Scopes` requires an actual repo access check)
- Owner-mismatch detection with `machineUser` opt-out reserved for 2026-04-23 Phase 5 composition

## Composition note

Reserves `model` and `machineUser` fields on the input type for the 2026-04-23 public-contribution-mode plan's Task 5.2, which can land in either order. Single-arg callers (existing code) unchanged.

## Test plan

- [x] `pnpm --filter @dpf/web test platform-dev-config`
- [x] `pnpm --filter @dpf/web exec tsc --noEmit`
- [x] `pnpm --filter @dpf/web build`
- [x] Repo-wide caller audit passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)