### PR TITLE
feat(github-auth): opportunistic re-encryption + HIVE_CONTRIBUTION_TOKEN deprecation

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -29,11 +29,9 @@ ADMIN_PASSWORD=<set a strong password>
 # Example: D:/DPF (Windows), /opt/dpf (Linux)
 DPF_HOST_INSTALL_PATH=<set to absolute path of this directory on the host>
 
-# Hive Mind contribution token (optional)
-# A GitHub fine-grained PAT scoped to the upstream repo with Contents + Pull Requests write access.
-# Enables Build Studio to create anonymous PRs on the community repository.
-# Not needed for fork_only mode — only for selective/contribute_all.
-# If not set, contributions require a token configured via Admin > Platform Development.
+# DEPRECATED — configure via Admin > Platform Development.
+# Support for this env var will be removed 60 days after the next release.
+# See docs/superpowers/specs/2026-04-24-github-auth-2fa-readiness-design.md
 HIVE_CONTRIBUTION_TOKEN=
 
 # Grafana credentials (monitoring stack starts automatically)

--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -1,5 +1,6 @@
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { ForkSetupPanel } from "@/components/admin/ForkSetupPanel";
+import LegacyTokenOverrideBanner from "@/components/admin/LegacyTokenOverrideBanner";
 import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
 import {
   getPlatformDevConfig,
@@ -30,6 +31,7 @@ export default async function AdminPlatformDevelopmentPage() {
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">Platform Development</p>
       </div>
       <AdminTabNav />
+      <LegacyTokenOverrideBanner />
       <ForkSetupPanel
         enabled={isContributionModelEnabled()}
         contributionModel={config?.contributionModel ?? null}

--- a/apps/web/components/admin/LegacyTokenOverrideBanner.test.tsx
+++ b/apps/web/components/admin/LegacyTokenOverrideBanner.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    credentialEntry: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import LegacyTokenOverrideBanner from "./LegacyTokenOverrideBanner";
+
+const mockFind = vi.mocked(prisma.credentialEntry.findUnique);
+
+describe("LegacyTokenOverrideBanner", () => {
+  let originalEnvToken: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalEnvToken = process.env.HIVE_CONTRIBUTION_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalEnvToken === undefined) delete process.env.HIVE_CONTRIBUTION_TOKEN;
+    else process.env.HIVE_CONTRIBUTION_TOKEN = originalEnvToken;
+  });
+
+  it("renders nothing when HIVE_CONTRIBUTION_TOKEN is unset", async () => {
+    delete process.env.HIVE_CONTRIBUTION_TOKEN;
+    const element = await LegacyTokenOverrideBanner();
+    expect(element).toBeNull();
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when env var is set but no DB credential exists", async () => {
+    process.env.HIVE_CONTRIBUTION_TOKEN = "ghp_env";
+    mockFind.mockResolvedValueOnce(null);
+    const element = await LegacyTokenOverrideBanner();
+    expect(element).toBeNull();
+  });
+
+  it("renders nothing when DB credential is inactive", async () => {
+    process.env.HIVE_CONTRIBUTION_TOKEN = "ghp_env";
+    mockFind.mockResolvedValueOnce({
+      secretRef: "enc:abc:def:ghi",
+      status: "revoked",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+    const element = await LegacyTokenOverrideBanner();
+    expect(element).toBeNull();
+  });
+
+  it("renders the override banner when env var shadows an active DB credential", async () => {
+    process.env.HIVE_CONTRIBUTION_TOKEN = "ghp_env";
+    mockFind.mockResolvedValueOnce({
+      secretRef: "enc:abc:def:ghi",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const element = await LegacyTokenOverrideBanner();
+    expect(element).not.toBeNull();
+    const html = renderToStaticMarkup(element as React.ReactElement);
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Legacy env-var token is overriding your configured credential");
+    expect(html).toContain("HIVE_CONTRIBUTION_TOKEN");
+    expect(html).toContain("Unset the env var");
+  });
+});

--- a/apps/web/components/admin/LegacyTokenOverrideBanner.tsx
+++ b/apps/web/components/admin/LegacyTokenOverrideBanner.tsx
@@ -1,0 +1,35 @@
+import { prisma } from "@dpf/db";
+
+/**
+ * Admin banner surfaced on Platform Development when the deprecated
+ * `HIVE_CONTRIBUTION_TOKEN` env var is overriding a credential that was
+ * configured through the UI. Without this, operators silently lose their
+ * UI-configured token to an env-var shadow and have no feedback.
+ *
+ * Renders nothing when:
+ *   - the env var is not set, OR
+ *   - no active hive-contribution credential exists in the DB.
+ */
+export default async function LegacyTokenOverrideBanner() {
+  const hasEnvToken = !!process.env.HIVE_CONTRIBUTION_TOKEN;
+  if (!hasEnvToken) return null;
+
+  const dbCred = await prisma.credentialEntry.findUnique({
+    where: { providerId: "hive-contribution" },
+    select: { secretRef: true, status: true },
+  });
+  const hasDbToken = !!(dbCred?.status === "active" && dbCred.secretRef);
+  if (!hasDbToken) return null;
+
+  return (
+    <div
+      role="alert"
+      className="mb-4 rounded-md border border-yellow-500 bg-yellow-50 p-4 text-sm text-yellow-900"
+    >
+      <strong>Legacy env-var token is overriding your configured credential.</strong>{" "}
+      <code>HIVE_CONTRIBUTION_TOKEN</code> is set in this install&apos;s environment
+      and takes priority over the token you configured here. Unset the env var to
+      use your UI-configured credential.
+    </div>
+  );
+}

--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { warnIfLegacyHiveTokenEnvSet } from "./instrumentation";
+
+describe("warnIfLegacyHiveTokenEnvSet", () => {
+  let originalEnvToken: string | undefined;
+
+  beforeEach(() => {
+    originalEnvToken = process.env.HIVE_CONTRIBUTION_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalEnvToken === undefined) delete process.env.HIVE_CONTRIBUTION_TOKEN;
+    else process.env.HIVE_CONTRIBUTION_TOKEN = originalEnvToken;
+  });
+
+  it("does nothing when the env var is unset", () => {
+    delete process.env.HIVE_CONTRIBUTION_TOKEN;
+    const warn = vi.fn();
+    const fired = warnIfLegacyHiveTokenEnvSet({ warn });
+    expect(fired).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("emits a deprecation warning when the env var is set", () => {
+    process.env.HIVE_CONTRIBUTION_TOKEN = "ghp_legacy";
+    const warn = vi.fn();
+    const fired = warnIfLegacyHiveTokenEnvSet({ warn });
+    expect(fired).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]![0] as string;
+    expect(message).toContain("[deprecation]");
+    expect(message).toContain("HIVE_CONTRIBUTION_TOKEN");
+    expect(message).toContain("Admin > Platform Development");
+    expect(message).toContain("60 days");
+  });
+});

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,8 +1,31 @@
 // Next.js instrumentation hook — runs once on server startup.
 // See: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
 
+/**
+ * Logs a deprecation notice when HIVE_CONTRIBUTION_TOKEN is set in the
+ * environment. Exported so the instrumentation module's startup behavior
+ * can be exercised by a unit test — invoking `register()` directly runs
+ * a long queue of setTimeouts and DB-bound work that the test does not
+ * care about.
+ */
+export function warnIfLegacyHiveTokenEnvSet(
+  logger: Pick<Console, "warn"> = console,
+): boolean {
+  if (!process.env.HIVE_CONTRIBUTION_TOKEN) return false;
+  logger.warn(
+    "[deprecation] HIVE_CONTRIBUTION_TOKEN is deprecated. Configure GitHub auth via\n" +
+      "Admin > Platform Development (OAuth Device Flow recommended once that phase ships).\n" +
+      "Support for this env var will be removed 60 days after the next release.",
+  );
+  return true;
+}
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs" && process.env.NEXT_PHASE !== "phase-production-build") {
+    // Fire the deprecation warning up front so operators see it on first
+    // boot rather than waiting for a contribution to trip it.
+    warnIfLegacyHiveTokenEnvSet();
+
     // Register ScheduledJob rows so the calendar shows discovery events.
     // Actual execution handled by Inngest cron functions (lib/queue/functions/).
     const { registerScheduledJobs } = await import("@/lib/operate/discovery-scheduler");

--- a/apps/web/lib/actions/platform-dev-config.reencrypt.test.ts
+++ b/apps/web/lib/actions/platform-dev-config.reencrypt.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    credentialEntry: {
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { getStoredGitHubToken } from "./platform-dev-config";
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+
+const TEST_KEY_HEX = "0".repeat(64);
+
+const mockFind = vi.mocked(prisma.credentialEntry.findUnique);
+const mockUpdateMany = vi.mocked(prisma.credentialEntry.updateMany);
+
+describe("getStoredGitHubToken — opportunistic re-encryption", () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalKey = process.env.CREDENTIAL_ENCRYPTION_KEY;
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.CREDENTIAL_ENCRYPTION_KEY;
+    else process.env.CREDENTIAL_ENCRYPTION_KEY = originalKey;
+  });
+
+  it("re-encrypts a plaintext git-backup secretRef when CREDENTIAL_ENCRYPTION_KEY is set", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    mockFind.mockResolvedValueOnce({
+      secretRef: "ghp_plaintext",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await getStoredGitHubToken();
+
+    expect(token).toBe("ghp_plaintext");
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    const call = mockUpdateMany.mock.calls[0]![0];
+    expect(call.where).toMatchObject({
+      providerId: "git-backup",
+      NOT: { secretRef: { startsWith: "enc:" } },
+    });
+    expect(call.data.secretRef).toMatch(/^enc:/);
+  });
+
+  it("does not re-encrypt an already-encrypted secretRef", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    const encrypted = encryptSecret("ghp_already_encrypted");
+    mockFind.mockResolvedValueOnce({
+      secretRef: encrypted,
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await getStoredGitHubToken();
+
+    expect(token).toBe("ghp_already_encrypted");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("leaves the DB untouched in dev-mode (no encryption key)", async () => {
+    delete process.env.CREDENTIAL_ENCRYPTION_KEY;
+    mockFind.mockResolvedValueOnce({
+      secretRef: "ghp_plaintext",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await getStoredGitHubToken();
+
+    expect(token).toBe("ghp_plaintext");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns null when decrypt fails (encryption key rotated)", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    // Malformed enc: value → decryptSecret returns null.
+    mockFind.mockResolvedValueOnce({
+      secretRef: "enc:nope:nope:nope",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await getStoredGitHubToken();
+
+    expect(token).toBeNull();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -182,6 +182,12 @@ export async function hasContributionToken(): Promise<boolean> {
  * Retrieve the stored GitHub token (decrypted). Used by the contribution
  * pipeline when process.env.GITHUB_TOKEN is not set.
  * Returns null if no credential is stored or decryption fails.
+ *
+ * When the stored value is plaintext (no `enc:` prefix) AND
+ * `CREDENTIAL_ENCRYPTION_KEY` is set, the row is opportunistically
+ * re-encrypted in place. The `updateMany` guard clause makes the write
+ * concurrent-safe — a simultaneous second caller lands a count=0 no-op
+ * rather than double-encrypting.
  */
 export async function getStoredGitHubToken(): Promise<string | null> {
   const cred = await prisma.credentialEntry.findUnique({
@@ -190,9 +196,26 @@ export async function getStoredGitHubToken(): Promise<string | null> {
   });
   if (!cred || cred.status !== "active" || !cred.secretRef) return null;
 
+  const stored = cred.secretRef;
   try {
-    const { decryptSecret } = await import("@/lib/credential-crypto");
-    return decryptSecret(cred.secretRef);
+    const { decryptSecret, encryptSecret } = await import("@/lib/credential-crypto");
+    const decrypted = stored.startsWith("enc:") ? decryptSecret(stored) : stored;
+    if (decrypted === null) return null;
+
+    if (!stored.startsWith("enc:") && process.env.CREDENTIAL_ENCRYPTION_KEY) {
+      const encrypted = encryptSecret(decrypted);
+      if (encrypted.startsWith("enc:")) {
+        await prisma.credentialEntry.updateMany({
+          where: {
+            providerId: "git-backup",
+            NOT: { secretRef: { startsWith: "enc:" } },
+          },
+          data: { secretRef: encrypted },
+        });
+      }
+    }
+
+    return decrypted;
   } catch {
     return null;
   }

--- a/apps/web/lib/integrate/identity-privacy.reencrypt.test.ts
+++ b/apps/web/lib/integrate/identity-privacy.reencrypt.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformDevConfig: {
+      findUnique: vi.fn(),
+    },
+    credentialEntry: {
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { resolveHiveToken } from "./identity-privacy";
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+
+const TEST_KEY_HEX = "0".repeat(64);
+
+const mockHiveFind = vi.mocked(prisma.credentialEntry.findUnique);
+const mockUpdateMany = vi.mocked(prisma.credentialEntry.updateMany);
+
+describe("resolveHiveToken — opportunistic re-encryption", () => {
+  let originalKey: string | undefined;
+  let originalEnvToken: string | undefined;
+  let originalGithubToken: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalKey = process.env.CREDENTIAL_ENCRYPTION_KEY;
+    originalEnvToken = process.env.HIVE_CONTRIBUTION_TOKEN;
+    originalGithubToken = process.env.GITHUB_TOKEN;
+    // Ensure env-var priorities don't short-circuit the DB read.
+    delete process.env.HIVE_CONTRIBUTION_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    // Default: updateMany resolves to a count-shape response.
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.CREDENTIAL_ENCRYPTION_KEY;
+    else process.env.CREDENTIAL_ENCRYPTION_KEY = originalKey;
+    if (originalEnvToken === undefined) delete process.env.HIVE_CONTRIBUTION_TOKEN;
+    else process.env.HIVE_CONTRIBUTION_TOKEN = originalEnvToken;
+    if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalGithubToken;
+  });
+
+  it("re-encrypts a plaintext hive-contribution secretRef when CREDENTIAL_ENCRYPTION_KEY is set", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    mockHiveFind.mockResolvedValueOnce({
+      secretRef: "ghp_plaintext",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await resolveHiveToken();
+
+    expect(token).toBe("ghp_plaintext");
+    // updateMany was called with a guard clause that prevents re-encrypting
+    // an already-encrypted row. Any concurrent second write becomes a no-op.
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    const call = mockUpdateMany.mock.calls[0]![0];
+    expect(call.where).toMatchObject({
+      providerId: "hive-contribution",
+      NOT: { secretRef: { startsWith: "enc:" } },
+    });
+    expect(call.data.secretRef).toMatch(/^enc:/);
+  });
+
+  it("does not re-encrypt an already-encrypted hive-contribution secretRef", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    const encrypted = encryptSecret("ghp_already_encrypted");
+    mockHiveFind.mockResolvedValueOnce({
+      secretRef: encrypted,
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await resolveHiveToken();
+
+    expect(token).toBe("ghp_already_encrypted");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("leaves the DB untouched when no encryption key is set (dev-mode no-op)", async () => {
+    delete process.env.CREDENTIAL_ENCRYPTION_KEY;
+    mockHiveFind.mockResolvedValueOnce({
+      secretRef: "ghp_plaintext",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await resolveHiveToken();
+
+    expect(token).toBe("ghp_plaintext");
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("is concurrent-call safe: two simultaneous reads both return the decrypted value", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    // Both calls see the pre-encryption plaintext row (simulates a race where
+    // two reads land before either write finishes).
+    mockHiveFind.mockResolvedValue({
+      secretRef: "ghp_plaintext",
+      status: "active",
+    } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+    // Second updateMany returns count=0 because the guard clause (secretRef
+    // NOT starts-with "enc:") no longer matches after the first write.
+    mockUpdateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    const [a, b] = await Promise.all([resolveHiveToken(), resolveHiveToken()]);
+
+    expect(a).toBe("ghp_plaintext");
+    expect(b).toBe("ghp_plaintext");
+    expect(mockUpdateMany).toHaveBeenCalledTimes(2);
+    // Both calls carry the guard clause — this is what makes the second
+    // write a no-op at the DB level rather than a double-encrypt.
+    for (const call of mockUpdateMany.mock.calls) {
+      expect(call[0].where).toMatchObject({
+        providerId: "hive-contribution",
+        NOT: { secretRef: { startsWith: "enc:" } },
+      });
+    }
+  });
+
+  it("re-encrypts a plaintext git-backup secretRef when hive-contribution is absent", async () => {
+    process.env.CREDENTIAL_ENCRYPTION_KEY = TEST_KEY_HEX;
+    // Priority 2 (hive-contribution) miss, priority 4 (git-backup) hit.
+    mockHiveFind
+      .mockResolvedValueOnce(null) // hive-contribution slot empty
+      .mockResolvedValueOnce({
+        secretRef: "ghp_backup_plaintext",
+        status: "active",
+      } as Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>);
+
+    const token = await resolveHiveToken();
+
+    expect(token).toBe("ghp_backup_plaintext");
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    const call = mockUpdateMany.mock.calls[0]![0];
+    expect(call.where).toMatchObject({
+      providerId: "git-backup",
+      NOT: { secretRef: { startsWith: "enc:" } },
+    });
+    expect(call.data.secretRef).toMatch(/^enc:/);
+  });
+});

--- a/apps/web/lib/integrate/identity-privacy.ts
+++ b/apps/web/lib/integrate/identity-privacy.ts
@@ -162,13 +162,49 @@ export function generatePrivateBranchName(
 // ─── Hive Token Resolution ──────────────────────────────────────────────────
 
 /**
+ * Opportunistic re-encryption: if a stored credential is plaintext (no
+ * `enc:` prefix) AND `CREDENTIAL_ENCRYPTION_KEY` is set, re-write it
+ * encrypted on the next read. The `updateMany` guard clause (`NOT secretRef
+ * starts-with "enc:"`) makes this concurrent-safe — a simultaneous second
+ * write lands a count=0 no-op rather than double-encrypting.
+ */
+async function maybeReencryptInPlace(
+  providerId: "hive-contribution" | "git-backup",
+  storedValue: string,
+  decryptedValue: string,
+): Promise<void> {
+  if (storedValue.startsWith("enc:")) return;
+  if (!process.env.CREDENTIAL_ENCRYPTION_KEY) return;
+
+  const { encryptSecret } = await import("@/lib/govern/credential-crypto");
+  const encrypted = encryptSecret(decryptedValue);
+  // encryptSecret returns plaintext when no key is set — belt-and-braces
+  // against a race between the env-check and the key read.
+  if (!encrypted.startsWith("enc:")) return;
+
+  await prisma.credentialEntry.updateMany({
+    where: {
+      providerId,
+      NOT: { secretRef: { startsWith: "enc:" } },
+    },
+    data: { secretRef: encrypted },
+  });
+}
+
+/**
  * Resolve the token for pushing branches to the upstream hive repo.
  *
  * Priority:
- *   1. HIVE_CONTRIBUTION_TOKEN env var (explicit hive token)
+ *   1. HIVE_CONTRIBUTION_TOKEN env var (explicit hive token — DEPRECATED,
+ *      removal planned 60 days after the next release)
  *   2. hive-contribution CredentialEntry (seeded or admin-configured)
  *   3. GITHUB_TOKEN env var (legacy fallback)
  *   4. git-backup CredentialEntry (customer's own PAT — fork_only backup)
+ *
+ * When a DB credential is read as plaintext and `CREDENTIAL_ENCRYPTION_KEY`
+ * is set, the row is opportunistically re-encrypted in place. This lets
+ * installs that predate encryption migrate transparently without a
+ * dedicated backfill step.
  *
  * Returns null if no token is available.
  */
@@ -184,13 +220,12 @@ export async function resolveHiveToken(): Promise<string | null> {
     select: { secretRef: true, status: true },
   });
   if (hiveCred?.status === "active" && hiveCred.secretRef) {
-    // May be encrypted — try decryption, fall back to raw
-    try {
-      const { decryptSecret } = await import("@/lib/credential-crypto");
-      return decryptSecret(hiveCred.secretRef);
-    } catch {
-      return hiveCred.secretRef;
-    }
+    const stored = hiveCred.secretRef;
+    const { decryptSecret } = await import("@/lib/govern/credential-crypto");
+    const decrypted = stored.startsWith("enc:") ? decryptSecret(stored) : stored;
+    if (decrypted === null) return null; // key rotated — cannot decrypt
+    await maybeReencryptInPlace("hive-contribution", stored, decrypted);
+    return decrypted;
   }
 
   // 3. GITHUB_TOKEN env var (legacy)
@@ -204,12 +239,12 @@ export async function resolveHiveToken(): Promise<string | null> {
     select: { secretRef: true, status: true },
   });
   if (backupCred?.status === "active" && backupCred.secretRef) {
-    try {
-      const { decryptSecret } = await import("@/lib/credential-crypto");
-      return decryptSecret(backupCred.secretRef);
-    } catch {
-      return backupCred.secretRef;
-    }
+    const stored = backupCred.secretRef;
+    const { decryptSecret } = await import("@/lib/govern/credential-crypto");
+    const decrypted = stored.startsWith("enc:") ? decryptSecret(stored) : stored;
+    if (decrypted === null) return null;
+    await maybeReencryptInPlace("git-backup", stored, decrypted);
+    return decrypted;
   }
 
   return null;


### PR DESCRIPTION
## Summary

- Opportunistic re-encryption: `resolveHiveToken` + `getStoredGitHubToken` re-write plaintext credentials encrypted on read when `CREDENTIAL_ENCRYPTION_KEY` is set; guarded `updateMany` is concurrent-safe.
- Startup deprecation warning when `HIVE_CONTRIBUTION_TOKEN` env var is set.
- Admin banner when env var is shadowing a configured DB credential.
- `.env.docker.example` flags the env var deprecated; removal planned 60 days after the next release.

## Test plan

- [x] `pnpm --filter @dpf/web test identity-privacy LegacyTokenOverrideBanner`
- [x] `pnpm --filter @dpf/web exec tsc --noEmit`
- [x] `pnpm --filter @dpf/web build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)