### PR TITLE
chore(db): add PlatformNotification model

### DIFF
--- a/packages/db/prisma/migrations/20260424180000_add_platform_notification/migration.sql
+++ b/packages/db/prisma/migrations/20260424180000_add_platform_notification/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "PlatformNotification" (
+    "id" TEXT NOT NULL,
+    "severity" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "subjectId" TEXT,
+    "message" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "PlatformNotification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PlatformNotification_category_resolvedAt_idx" ON "PlatformNotification"("category", "resolvedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2597,6 +2597,18 @@ model Notification {
   @@index([createdAt])
 }
 
+model PlatformNotification {
+  id         String    @id @default(cuid())
+  severity   String    // "info" | "warning" | "critical" | "expired"
+  category   String    // e.g. "token-expiry"
+  subjectId  String?   // e.g. CredentialEntry.providerId
+  message    String    @db.Text
+  createdAt  DateTime  @default(now())
+  resolvedAt DateTime?
+
+  @@index([category, resolvedAt])
+}
+
 model PushDeviceRegistration {
   id        String   @id @default(cuid())
   userId    String


### PR DESCRIPTION
## Summary

- Adds `PlatformNotification` Prisma model as the prerequisite for Phase 6 (token expiry monitoring daily job + admin banner).
- Fields: `id`, `severity` ("info" | "warning" | "critical" | "expired"), `category`, `subjectId?`, `message`, `createdAt`, `resolvedAt?`. Indexed on `(category, resolvedAt)` for the monitor's daily scan.
- No callers in this PR — consumers land in Phase 6. AGENTS.md one-concern-per-PR.

## Test plan

- [x] `pnpm --filter @dpf/db exec prisma validate` clean
- [x] `pnpm --filter @dpf/db exec prisma generate` regenerates client
- [x] `pnpm --filter web exec tsc --noEmit` clean
- [x] Migration SQL touches only the new table (no unrelated drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)