### PR TITLE
feat(admin-ui): OAuth Device Flow Connect GitHub card

### DIFF
--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -3,6 +3,7 @@ import { ForkSetupPanel } from "@/components/admin/ForkSetupPanel";
 import LegacyTokenOverrideBanner from "@/components/admin/LegacyTokenOverrideBanner";
 import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
 import {
+  getGitHubConnectedState,
   getPlatformDevConfig,
   getUntrackedFeatureCount,
   hasContributionToken,
@@ -23,6 +24,10 @@ export default async function AdminPlatformDevelopmentPage() {
   // Pseudonym is only defined once the install has seeded its client identity.
   // Catch: during the first boot the identity may not be ready yet.
   const pseudonym = await getDisplayPseudonym().catch(() => null);
+  // initialConnected is non-null only for `gho_`-prefixed Device Flow tokens;
+  // paste-mode PATs are surfaced via the Advanced disclosure but not as
+  // "Connected as @user" since we don't proactively verify their owner.
+  const initialConnected = await getGitHubConnectedState().catch(() => null);
 
   return (
     <div>
@@ -51,6 +56,7 @@ export default async function AdminPlatformDevelopmentPage() {
         hasGitCredential={hasCredential}
         hasContributionToken={hasContribToken}
         pseudonym={pseudonym}
+        initialConnected={initialConnected}
       />
     </div>
   );

--- a/apps/web/components/admin/AdvancedTokenPaste.test.tsx
+++ b/apps/web/components/admin/AdvancedTokenPaste.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/platform-dev-config", () => ({
+  saveContributionSetup: vi.fn(),
+}));
+
+import { AdvancedTokenPaste } from "@/components/admin/AdvancedTokenPaste";
+
+describe("AdvancedTokenPaste", () => {
+  it("renders the disclosure as a <details> element (collapsed by default)", () => {
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    // <details> without `open` attribute is collapsed by default in browsers.
+    expect(html).toMatch(/^<details[^>]*>/);
+    expect(html).not.toMatch(/<details[^>]*\bopen\b/);
+    expect(html).toContain("Advanced: paste a token");
+  });
+
+  it("renders the fine-grained PAT section with help copy and an input", () => {
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    expect(html).toContain('data-testid="fine-grained-pat-section"');
+    expect(html).toMatch(/Fine-grained PAT \(advanced\)/);
+    expect(html).toMatch(/fine-grained PAT at github\.com\/settings\/personal-access-tokens/i);
+    expect(html).toMatch(/Contents: read and write/);
+    expect(html).toContain('data-testid="fine-grained-pat-input"');
+    expect(html).toContain('data-testid="fine-grained-pat-submit"');
+  });
+
+  it("renders the classic PAT section with the no-expiry warning", () => {
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="contribute_all" />);
+    expect(html).toContain('data-testid="classic-pat-section"');
+    expect(html).toMatch(/Classic PAT \(emergency\)/);
+    expect(html).toMatch(/Classic PATs have no expiry/i);
+    expect(html).toMatch(/Prefer Device Flow or fine-grained PATs/i);
+    expect(html).toContain('data-testid="classic-pat-input"');
+    expect(html).toContain('data-testid="classic-pat-submit"');
+  });
+
+  it("renders both sections regardless of mode prop", () => {
+    const fork = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    const all = renderToStaticMarkup(<AdvancedTokenPaste mode="contribute_all" />);
+    expect(fork).toContain('data-testid="fine-grained-pat-section"');
+    expect(fork).toContain('data-testid="classic-pat-section"');
+    expect(all).toContain('data-testid="fine-grained-pat-section"');
+    expect(all).toContain('data-testid="classic-pat-section"');
+  });
+
+  it("uses distinct placeholder formats for each token tier", () => {
+    const html = renderToStaticMarkup(<AdvancedTokenPaste mode="selective" />);
+    // Fine-grained PATs use the github_pat_ prefix; classic PATs use ghp_.
+    expect(html).toMatch(/placeholder="github_pat_/);
+    expect(html).toMatch(/placeholder="ghp_/);
+  });
+});

--- a/apps/web/components/admin/AdvancedTokenPaste.tsx
+++ b/apps/web/components/admin/AdvancedTokenPaste.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { saveContributionSetup } from "@/lib/actions/platform-dev-config";
+
+// Advanced token-paste disclosure — Tier 2 / Tier 3 of the 2026-04-24 GitHub
+// auth 2FA readiness spec. Demoted from the primary form path; collapsed by
+// default. Two labeled sections (fine-grained PAT, classic PAT) with
+// tier-appropriate copy. Both submit through the existing
+// `saveContributionSetup` action.
+//
+// The two forms intentionally share a single submit action — auth-method
+// detection happens server-side in `validateGitHubToken` via prefix
+// inspection. The labels just steer the user toward the right token type.
+
+type ContributionMode = "fork_only" | "selective" | "contribute_all";
+
+const FINE_GRAINED_HELP =
+  "Create a fine-grained PAT at github.com/settings/personal-access-tokens with Repository Access limited to your fork and Contents: read and write. Expiry: 90 days or more.";
+
+const CLASSIC_WARNING =
+  "Classic PATs have no expiry and broad scope. Prefer Device Flow or fine-grained PATs. Continue only if your environment requires this.";
+
+export interface AdvancedTokenPasteProps {
+  /** Mode the install is in. Persisted alongside the token. */
+  mode: ContributionMode;
+}
+
+interface SectionState {
+  token: string;
+  pending: boolean;
+  error: string | null;
+  username: string | null;
+}
+
+const emptySection: SectionState = {
+  token: "",
+  pending: false,
+  error: null,
+  username: null,
+};
+
+export function AdvancedTokenPaste({ mode }: AdvancedTokenPasteProps) {
+  const [fineGrained, setFineGrained] = useState<SectionState>(emptySection);
+  const [classic, setClassic] = useState<SectionState>(emptySection);
+  const [, startTransition] = useTransition();
+
+  const submitToken = (
+    section: "fine-grained" | "classic",
+    state: SectionState,
+    setState: (s: SectionState) => void,
+  ) => {
+    const token = state.token.trim();
+    if (!token) return;
+    setState({ ...state, pending: true, error: null, username: null });
+    startTransition(async () => {
+      const result = await saveContributionSetup({ token, mode });
+      if (!result.success) {
+        setState({
+          ...state,
+          pending: false,
+          error: result.error ?? "Token validation failed.",
+          username: null,
+        });
+        return;
+      }
+      setState({
+        token: "",
+        pending: false,
+        error: null,
+        username: result.username ?? null,
+      });
+    });
+  };
+
+  return (
+    <details
+      className="rounded-lg border border-[var(--dpf-border)] p-4"
+      data-testid="advanced-token-paste"
+    >
+      <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-text)]">
+        Advanced: paste a token
+      </summary>
+      <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+        For policy-restricted environments, machine users, or air-gapped installs that
+        can't use the primary OAuth Device Flow path.
+      </p>
+
+      {/* ─── Fine-grained PAT ─────────────────────────────────────────────── */}
+      <section
+        className="mt-4 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+        data-testid="fine-grained-pat-section"
+      >
+        <h4 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">
+          Fine-grained PAT (advanced)
+        </h4>
+        <p className="text-xs text-[var(--dpf-muted)] leading-relaxed mb-3">
+          {FINE_GRAINED_HELP}
+        </p>
+        <input
+          type="password"
+          value={fineGrained.token}
+          onChange={(e) =>
+            setFineGrained({ ...fineGrained, token: e.target.value, error: null })
+          }
+          placeholder="github_pat_xxxxxxxxxxxxxxxxxxxxxx"
+          className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-xs text-[var(--dpf-text)]"
+          data-testid="fine-grained-pat-input"
+        />
+        {fineGrained.error && (
+          <p
+            className="mt-2 text-xs text-red-600 dark:text-red-400"
+            data-testid="fine-grained-pat-error"
+          >
+            {fineGrained.error}
+          </p>
+        )}
+        {fineGrained.username && (
+          <p
+            className="mt-2 text-xs text-green-600 dark:text-green-400"
+            data-testid="fine-grained-pat-success"
+          >
+            Saved. Connected as <strong>{fineGrained.username}</strong>.
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={() => submitToken("fine-grained", fineGrained, setFineGrained)}
+          disabled={fineGrained.pending || !fineGrained.token.trim()}
+          className="mt-3 rounded border border-[var(--dpf-accent)] bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+          data-testid="fine-grained-pat-submit"
+        >
+          {fineGrained.pending ? "Saving…" : "Save fine-grained PAT"}
+        </button>
+      </section>
+
+      {/* ─── Classic PAT ─────────────────────────────────────────────────── */}
+      <section
+        className="mt-4 rounded border border-amber-500/40 bg-amber-500/10 p-3"
+        data-testid="classic-pat-section"
+      >
+        <h4 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">
+          Classic PAT (emergency)
+        </h4>
+        <p className="text-xs text-amber-700 dark:text-amber-300 leading-relaxed mb-3">
+          {CLASSIC_WARNING}
+        </p>
+        <input
+          type="password"
+          value={classic.token}
+          onChange={(e) => setClassic({ ...classic, token: e.target.value, error: null })}
+          placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-xs text-[var(--dpf-text)]"
+          data-testid="classic-pat-input"
+        />
+        {classic.error && (
+          <p
+            className="mt-2 text-xs text-red-600 dark:text-red-400"
+            data-testid="classic-pat-error"
+          >
+            {classic.error}
+          </p>
+        )}
+        {classic.username && (
+          <p
+            className="mt-2 text-xs text-green-600 dark:text-green-400"
+            data-testid="classic-pat-success"
+          >
+            Saved. Connected as <strong>{classic.username}</strong>.
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={() => submitToken("classic", classic, setClassic)}
+          disabled={classic.pending || !classic.token.trim()}
+          className="mt-3 rounded border border-amber-500 bg-amber-500 px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+          data-testid="classic-pat-submit"
+        >
+          {classic.pending ? "Saving…" : "Save classic PAT"}
+        </button>
+      </section>
+    </details>
+  );
+}

--- a/apps/web/components/admin/ConnectGitHubCard.test.tsx
+++ b/apps/web/components/admin/ConnectGitHubCard.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// Mock the server actions so the import graph doesn't pull "server-only" /
+// next-auth into the test runtime. The dynamic-state tests below interact
+// with React state directly via the component's exported behavior.
+vi.mock("@/lib/actions/github-device-flow", () => ({
+  initiateDeviceFlow: vi.fn(),
+  pollDeviceFlow: vi.fn(),
+  disconnectGitHub: vi.fn(),
+}));
+
+import { ConnectGitHubCard } from "@/components/admin/ConnectGitHubCard";
+
+describe("ConnectGitHubCard", () => {
+  it("renders the Connect button when initialConnected is null", () => {
+    const html = renderToStaticMarkup(<ConnectGitHubCard initialConnected={null} />);
+    expect(html).toContain("Connect GitHub");
+    expect(html).toContain('data-testid="connect-github-button"');
+    // Idle copy explains Device Flow.
+    expect(html).toMatch(/OAuth Device Flow/i);
+  });
+
+  it("renders the pseudonymity disclosure near the Connect button", () => {
+    const html = renderToStaticMarkup(<ConnectGitHubCard initialConnected={null} />);
+    expect(html).toContain('data-testid="pseudonymity-disclosure"');
+    expect(html).toMatch(/GitHub username will be visible/i);
+    expect(html).toMatch(/pseudonymous GitHub account/i);
+  });
+
+  it("renders 'Connected as @username, since <date>' when initialConnected is set", () => {
+    const html = renderToStaticMarkup(
+      <ConnectGitHubCard
+        initialConnected={{
+          username: "jane-dev",
+          connectedAt: new Date("2026-04-24T12:00:00Z"),
+        }}
+      />,
+    );
+    expect(html).toContain("GitHub connected");
+    expect(html).toContain("@jane-dev");
+    expect(html).toMatch(/since/i);
+    expect(html).toContain('data-testid="disconnect-github-button"');
+    expect(html).toContain("Disconnect");
+  });
+
+  it("does not render the Connect button when already connected", () => {
+    const html = renderToStaticMarkup(
+      <ConnectGitHubCard
+        initialConnected={{
+          username: "jane-dev",
+          connectedAt: new Date("2026-04-24T12:00:00Z"),
+        }}
+      />,
+    );
+    expect(html).not.toContain('data-testid="connect-github-button"');
+  });
+
+  it("uses the 'Open GitHub' anchor target='_blank' pattern (verified via static idle markup absence)", () => {
+    // The awaiting state opens GitHub in a new tab; until the user clicks
+    // Connect we shouldn't see device-code markup. This guards against a
+    // regression where the awaiting markup accidentally renders by default.
+    const html = renderToStaticMarkup(<ConnectGitHubCard initialConnected={null} />);
+    expect(html).not.toContain('data-testid="device-user-code"');
+    expect(html).not.toContain('data-testid="copy-device-code"');
+  });
+});

--- a/apps/web/components/admin/ConnectGitHubCard.tsx
+++ b/apps/web/components/admin/ConnectGitHubCard.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  disconnectGitHub,
+  initiateDeviceFlow,
+  pollDeviceFlow,
+} from "@/lib/actions/github-device-flow";
+
+// Connect GitHub card — Tier 1 (OAuth Device Flow) of the 2026-04-24 GitHub
+// auth 2FA readiness spec. The user clicks Connect, sees a short user code +
+// the github.com/login/device URL, and authorizes our OAuth App in their
+// normal browser session. We never see the user's GitHub password or 2FA
+// challenge — that lives entirely between the user and GitHub.
+//
+// Polling is GitHub-supplied-interval-driven. On `slow_down` we cancel the
+// current interval and restart at the new (slower) cadence. When the page
+// unmounts mid-flight the interval is cleared.
+
+const PSEUDONYMITY_DISCLOSURE =
+  "Your GitHub username will be visible on every PR you contribute. Use a pseudonymous GitHub account if that's not acceptable.";
+
+type ViewState =
+  | { kind: "idle" }
+  | { kind: "initiating" }
+  | {
+      kind: "awaiting";
+      sessionId: string;
+      userCode: string;
+      verificationUri: string;
+      interval: number;
+      copied: boolean;
+    }
+  | { kind: "success"; username: string }
+  | { kind: "error"; message: string };
+
+export interface ConnectedState {
+  username: string;
+  connectedAt: Date;
+}
+
+export interface ConnectGitHubCardProps {
+  /**
+   * Server-resolved snapshot of the currently-stored credential. `null` means
+   * "not connected" — the card renders the Connect button. Non-null renders
+   * the "Connected as @username" state with a Disconnect action.
+   */
+  initialConnected: ConnectedState | null;
+}
+
+export function ConnectGitHubCard({ initialConnected }: ConnectGitHubCardProps) {
+  const [view, setView] = useState<ViewState>({ kind: "idle" });
+  const [connected, setConnected] = useState<ConnectedState | null>(initialConnected);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearPolling = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  // Cleanup any in-flight poll when the component unmounts.
+  useEffect(() => () => clearPolling(), []);
+
+  const startPolling = (sessionId: string, intervalSec: number) => {
+    clearPolling();
+    intervalRef.current = setInterval(async () => {
+      let pollResult;
+      try {
+        pollResult = await pollDeviceFlow(sessionId);
+      } catch (err) {
+        clearPolling();
+        setView({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Polling failed.",
+        });
+        return;
+      }
+
+      if (pollResult.status === "pending") return;
+      if (pollResult.status === "slow_down") {
+        // Reschedule at the slower interval. The current interval-callback
+        // returns; the *next* tick is on the new schedule.
+        startPolling(sessionId, pollResult.interval);
+        return;
+      }
+      clearPolling();
+      if (pollResult.status === "success") {
+        const now = new Date();
+        setConnected({ username: pollResult.username, connectedAt: now });
+        setView({ kind: "success", username: pollResult.username });
+        return;
+      }
+      // status === "error"
+      setView({ kind: "error", message: pollResult.error });
+    }, intervalSec * 1000);
+  };
+
+  const onConnect = async () => {
+    setView({ kind: "initiating" });
+    let result;
+    try {
+      result = await initiateDeviceFlow();
+    } catch (err) {
+      setView({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Could not start Device Flow.",
+      });
+      return;
+    }
+    if (!result.success) {
+      setView({ kind: "error", message: result.error });
+      return;
+    }
+    const { sessionId, userCode, verificationUri, interval } = result.data;
+    setView({
+      kind: "awaiting",
+      sessionId,
+      userCode,
+      verificationUri,
+      interval,
+      copied: false,
+    });
+    startPolling(sessionId, interval);
+  };
+
+  const onCopyCode = async (code: string) => {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(code);
+      }
+      setView((prev) => (prev.kind === "awaiting" ? { ...prev, copied: true } : prev));
+      // Reset the "Copied" label after a short delay so a second click works.
+      setTimeout(() => {
+        setView((prev) =>
+          prev.kind === "awaiting" ? { ...prev, copied: false } : prev,
+        );
+      }, 1500);
+    } catch {
+      // Clipboard API may be unavailable (insecure context, restricted
+      // permissions). Silently no-op — the code is still selectable in the UI.
+    }
+  };
+
+  const onCancel = () => {
+    clearPolling();
+    setView({ kind: "idle" });
+  };
+
+  const onRetry = () => {
+    clearPolling();
+    setView({ kind: "idle" });
+  };
+
+  const onDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      const result = await disconnectGitHub();
+      if (!result.success) {
+        setView({ kind: "error", message: result.error ?? "Disconnect failed." });
+        return;
+      }
+      setConnected(null);
+      setView({ kind: "idle" });
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  // ─── Connected state ─────────────────────────────────────────────────────
+  if (connected && view.kind !== "initiating" && view.kind !== "awaiting") {
+    return (
+      <section
+        aria-labelledby="connect-github-heading"
+        className="rounded-lg border border-green-500/30 bg-green-500/5 p-4"
+        data-testid="connect-github-card"
+      >
+        <h3
+          id="connect-github-heading"
+          className="text-sm font-semibold text-[var(--dpf-text)] mb-1"
+        >
+          GitHub connected
+        </h3>
+        <p className="text-xs text-[var(--dpf-text)] leading-relaxed">
+          Connected as{" "}
+          <span className="font-mono text-[var(--dpf-accent)]">@{connected.username}</span>
+          {", since "}
+          {connected.connectedAt.toLocaleDateString()}.
+        </p>
+        <div className="mt-3 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onDisconnect}
+            disabled={disconnecting}
+            className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-border)] transition-colors disabled:opacity-50"
+            data-testid="disconnect-github-button"
+          >
+            {disconnecting ? "Disconnecting…" : "Disconnect"}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  // ─── Awaiting (poll-in-flight) ───────────────────────────────────────────
+  if (view.kind === "awaiting") {
+    return (
+      <section
+        aria-labelledby="connect-github-heading"
+        className="rounded-lg border border-[var(--dpf-accent)]/30 bg-[var(--dpf-accent)]/5 p-4"
+        data-testid="connect-github-card"
+      >
+        <h3
+          id="connect-github-heading"
+          className="text-sm font-semibold text-[var(--dpf-text)] mb-1"
+        >
+          Authorize on GitHub
+        </h3>
+        <p className="text-xs text-[var(--dpf-text)] leading-relaxed mb-3">
+          Visit{" "}
+          <a
+            href={view.verificationUri}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-[var(--dpf-accent)] hover:underline"
+          >
+            {view.verificationUri}
+          </a>{" "}
+          and enter this code:
+        </p>
+        <div className="flex items-center gap-3 mb-3">
+          <code
+            className="select-all rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-base tracking-widest text-[var(--dpf-text)]"
+            data-testid="device-user-code"
+          >
+            {view.userCode}
+          </code>
+          <button
+            type="button"
+            onClick={() => onCopyCode(view.userCode)}
+            className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-border)] transition-colors"
+            data-testid="copy-device-code"
+          >
+            {view.copied ? "Copied" : "Copy code"}
+          </button>
+          <a
+            href={view.verificationUri}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded border border-[var(--dpf-accent)] bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 transition-opacity"
+          >
+            Open GitHub
+          </a>
+        </div>
+        <p className="text-xs text-[var(--dpf-muted)] mb-3" data-testid="awaiting-status">
+          Waiting for you to authorize on GitHub…
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs text-[var(--dpf-muted)] hover:underline"
+        >
+          Cancel
+        </button>
+      </section>
+    );
+  }
+
+  // ─── Initiating ──────────────────────────────────────────────────────────
+  if (view.kind === "initiating") {
+    return (
+      <section
+        aria-labelledby="connect-github-heading"
+        className="rounded-lg border border-[var(--dpf-border)] p-4"
+        data-testid="connect-github-card"
+      >
+        <h3
+          id="connect-github-heading"
+          className="text-sm font-semibold text-[var(--dpf-text)] mb-1"
+        >
+          Connect GitHub
+        </h3>
+        <p className="text-xs text-[var(--dpf-muted)]">Requesting a device code from GitHub…</p>
+      </section>
+    );
+  }
+
+  // ─── Success (transient — caller usually replaces with the connected card
+  //     on the next render via initialConnected refresh) ──────────────────
+  if (view.kind === "success") {
+    return (
+      <section
+        aria-labelledby="connect-github-heading"
+        className="rounded-lg border border-green-500/30 bg-green-500/5 p-4"
+        data-testid="connect-github-card"
+      >
+        <h3
+          id="connect-github-heading"
+          className="text-sm font-semibold text-[var(--dpf-text)] mb-1"
+        >
+          GitHub connected
+        </h3>
+        <p className="text-xs text-[var(--dpf-text)]">
+          Connected as{" "}
+          <span className="font-mono text-[var(--dpf-accent)]">@{view.username}</span>.
+        </p>
+      </section>
+    );
+  }
+
+  // ─── Error ───────────────────────────────────────────────────────────────
+  if (view.kind === "error") {
+    return (
+      <section
+        aria-labelledby="connect-github-heading"
+        className="rounded-lg border border-red-400/50 bg-red-400/10 p-4"
+        data-testid="connect-github-card"
+      >
+        <h3
+          id="connect-github-heading"
+          className="text-sm font-semibold text-[var(--dpf-text)] mb-1"
+        >
+          Connect GitHub
+        </h3>
+        <p className="text-xs text-red-600 dark:text-red-400 mb-3" data-testid="connect-error">
+          {view.message}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded border border-[var(--dpf-accent)] bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 transition-opacity"
+          data-testid="retry-connect"
+        >
+          Retry
+        </button>
+      </section>
+    );
+  }
+
+  // ─── Idle (default) ──────────────────────────────────────────────────────
+  return (
+    <section
+      aria-labelledby="connect-github-heading"
+      className="rounded-lg border border-[var(--dpf-border)] p-4"
+      data-testid="connect-github-card"
+    >
+      <h3
+        id="connect-github-heading"
+        className="text-sm font-semibold text-[var(--dpf-text)] mb-1"
+      >
+        Connect GitHub
+      </h3>
+      <p className="text-xs text-[var(--dpf-text)] leading-relaxed mb-3">
+        Authorize Digital Product Factory to push contribution branches under your GitHub
+        account. We use the OAuth Device Flow — your password and 2FA challenge stay
+        between you and GitHub.
+      </p>
+      <p className="text-xs text-[var(--dpf-muted)] mb-3" data-testid="pseudonymity-disclosure">
+        {PSEUDONYMITY_DISCLOSURE}
+      </p>
+      <button
+        type="button"
+        onClick={onConnect}
+        className="rounded border border-[var(--dpf-accent)] bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white hover:opacity-90 transition-opacity"
+        data-testid="connect-github-button"
+      >
+        Connect GitHub
+      </button>
+    </section>
+  );
+}

--- a/apps/web/components/admin/PlatformDevelopmentForm.test.tsx
+++ b/apps/web/components/admin/PlatformDevelopmentForm.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/platform-dev-config", () => ({
+  savePlatformDevConfig: vi.fn(),
+  acceptDco: vi.fn(),
+  saveContributionSetup: vi.fn(),
+  validateGitHubToken: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/github-device-flow", () => ({
+  initiateDeviceFlow: vi.fn(),
+  pollDeviceFlow: vi.fn(),
+  disconnectGitHub: vi.fn(),
+}));
+
+import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
+
+const baseProps = {
+  policyState: "policy_pending" as const,
+  currentMode: null,
+  configuredAt: null,
+  configuredByEmail: null,
+  gitRemoteUrl: null,
+  dcoAcceptedAt: null,
+  dcoAcceptedByEmail: null,
+  untrackedFeatureCount: 0,
+  hasGitCredential: false,
+  hasContributionToken: false,
+  pseudonym: "dpf-agent-acme123" as string | null,
+  initialConnected: null as null | { username: string; connectedAt: Date },
+};
+
+describe("PlatformDevelopmentForm", () => {
+  it("renders the three contribution-mode options", () => {
+    const html = renderToStaticMarkup(<PlatformDevelopmentForm {...baseProps} />);
+    expect(html).toContain("Keep everything here");
+    expect(html).toContain("Share selectively");
+    expect(html).toContain("Share everything");
+  });
+
+  it("does not render the Connect card before mode is contribution and DCO is accepted", () => {
+    const html = renderToStaticMarkup(<PlatformDevelopmentForm {...baseProps} />);
+    // Default selected is `selective`, but the wizard starts at "mode" until
+    // DCO is accepted — so neither connect card nor advanced paste should be
+    // visible yet.
+    expect(html).not.toContain('data-testid="github-connect-block"');
+    expect(html).not.toContain('data-testid="connect-github-card"');
+  });
+
+  it("renders the Connect card and Advanced paste once DCO is accepted (done state)", () => {
+    const html = renderToStaticMarkup(
+      <PlatformDevelopmentForm
+        {...baseProps}
+        currentMode="selective"
+        dcoAcceptedAt="2026-04-24T12:00:00Z"
+      />,
+    );
+    expect(html).toContain('data-testid="github-connect-block"');
+    expect(html).toContain('data-testid="connect-github-card"');
+    expect(html).toContain('data-testid="advanced-token-paste"');
+  });
+
+  it("preserves the pseudonym disclosure in the explain step", () => {
+    // To reach the explain card via SSR alone we render with already-set-up
+    // = false (no DCO) and selective mode; the wizard starts at "mode".
+    // The pseudonym surface in the wizard is the "explain" card, which
+    // SSR can't reach without state — so instead assert the form passes
+    // pseudonym through correctly via the connected/done path below.
+    const html = renderToStaticMarkup(
+      <PlatformDevelopmentForm
+        {...baseProps}
+        currentMode="contribute_all"
+        dcoAcceptedAt="2026-04-24T12:00:00Z"
+      />,
+    );
+    // Once on the done state we expose the connect block — the pseudonymity
+    // disclosure inside ConnectGitHubCard is the new primary surface.
+    expect(html).toMatch(/GitHub username will be visible/i);
+  });
+
+  it("renders the fork-only backup form when mode=fork_only", () => {
+    const html = renderToStaticMarkup(
+      <PlatformDevelopmentForm {...baseProps} currentMode="fork_only" />,
+    );
+    expect(html).toContain("Backup your work (optional)");
+    expect(html).toContain("Repository URL");
+    // The contribution Connect card is gated on contribution mode; should not
+    // appear in fork_only.
+    expect(html).not.toContain('data-testid="github-connect-block"');
+  });
+
+  it("shows 'Sharing is set up' when DCO is accepted and mode is contribution", () => {
+    const html = renderToStaticMarkup(
+      <PlatformDevelopmentForm
+        {...baseProps}
+        currentMode="selective"
+        dcoAcceptedAt="2026-04-24T12:00:00Z"
+        dcoAcceptedByEmail="admin@example.com"
+      />,
+    );
+    expect(html).toContain("Sharing is set up");
+    expect(html).toContain("Contributor agreement accepted");
+    expect(html).toContain("admin@example.com");
+  });
+
+  it("propagates initialConnected through to ConnectGitHubCard when DCO accepted", () => {
+    const html = renderToStaticMarkup(
+      <PlatformDevelopmentForm
+        {...baseProps}
+        currentMode="selective"
+        dcoAcceptedAt="2026-04-24T12:00:00Z"
+        initialConnected={{
+          username: "jane-dev",
+          connectedAt: new Date("2026-04-24T12:00:00Z"),
+        }}
+      />,
+    );
+    expect(html).toContain("@jane-dev");
+    expect(html).toContain("GitHub connected");
+  });
+
+  it("renders the Last configured caption when configuredAt is present", () => {
+    const html = renderToStaticMarkup(
+      <PlatformDevelopmentForm
+        {...baseProps}
+        configuredAt="2026-04-24T12:00:00Z"
+        configuredByEmail="admin@example.com"
+      />,
+    );
+    expect(html).toContain("Last configured");
+    expect(html).toContain("admin@example.com");
+  });
+});

--- a/apps/web/components/admin/PlatformDevelopmentForm.tsx
+++ b/apps/web/components/admin/PlatformDevelopmentForm.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { useState, useTransition } from "react";
+
+import { AdvancedTokenPaste } from "@/components/admin/AdvancedTokenPaste";
 import {
-  savePlatformDevConfig,
+  ConnectGitHubCard,
+  type ConnectedState,
+} from "@/components/admin/ConnectGitHubCard";
+import {
   acceptDco,
-  saveContributionSetup,
-  validateGitHubToken,
+  savePlatformDevConfig,
 } from "@/lib/actions/platform-dev-config";
 
 type ContributionMode = "fork_only" | "selective" | "contribute_all";
@@ -16,23 +20,30 @@ const MODE_OPTIONS: { value: ContributionMode; label: string; description: strin
   {
     value: "fork_only",
     label: "Keep everything here",
-    description: "Changes you make in Build Studio stay on your platform only. Nothing is shared externally.",
+    description:
+      "Changes you make in Build Studio stay on your platform only. Nothing is shared externally.",
   },
   {
     value: "selective",
     label: "Share selectively",
-    description: "After building a feature, the AI will ask if you'd like to share it with the community. You decide each time.",
+    description:
+      "After building a feature, the AI will ask if you'd like to share it with the community. You decide each time.",
   },
   {
     value: "contribute_all",
     label: "Share everything",
-    description: "Features you build are shared with the community by default. You can still keep individual ones private.",
+    description:
+      "Features you build are shared with the community by default. You can still keep individual ones private.",
   },
 ];
 
 // ─── Wizard Steps for Contribution Setup ────────────────────────────────────
-
-type WizardStep = "mode" | "explain" | "github-account" | "create-token" | "paste-token" | "dco" | "done";
+//
+// 2026-04-24 GitHub auth 2FA readiness spec (Phase 5): the create-token and
+// paste-token wizard steps are removed. Token acquisition now happens through
+// ConnectGitHubCard (Device Flow primary) or AdvancedTokenPaste (paste fallback)
+// surfaces, both rendered after DCO acceptance.
+type WizardStep = "mode" | "explain" | "github-account" | "connect" | "dco" | "done";
 
 // ─── DCO Items ──────────────────────────────────────────────────────────────
 
@@ -61,6 +72,13 @@ interface PlatformDevelopmentFormProps {
   hasGitCredential?: boolean;
   hasContributionToken?: boolean;
   pseudonym?: string | null;
+  /**
+   * Server-resolved snapshot of the current GitHub credential. Non-null only
+   * when the stored token is a Device-Flow token (`gho_` prefix) — paste-mode
+   * PATs are not surfaced as "connected as @user" because we don't proactively
+   * probe their owner. See the parent page for the resolution logic.
+   */
+  initialConnected?: ConnectedState | null;
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -74,9 +92,6 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
   const isContributionMode = selected === "selective" || selected === "contribute_all";
   const isAlreadySetUp = isContributionMode && !!props.dcoAcceptedAt;
   const [wizardStep, setWizardStep] = useState<WizardStep>(isAlreadySetUp ? "done" : "mode");
-  const [token, setToken] = useState("");
-  const [tokenError, setTokenError] = useState<string | null>(null);
-  const [githubUsername, setGithubUsername] = useState<string | null>(null);
   const [dcoError, setDcoError] = useState<string | null>(null);
 
   // Fork-only git backup state
@@ -115,36 +130,11 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
     setWizardStep("explain");
   };
 
-  const handleValidateToken = () => {
-    setTokenError(null);
-    startTransition(async () => {
-      const result = await validateGitHubToken(token.trim());
-      if (result.valid) {
-        setGithubUsername(result.username ?? null);
-        setWizardStep("dco");
-      } else {
-        setTokenError(result.error ?? "Token validation failed.");
-      }
-    });
-  };
-
   const handleCompleteDco = () => {
     setDcoError(null);
     startTransition(async () => {
-      if (token.trim()) {
-        // Attributed mode: customer provided their own GitHub token
-        const setupResult = await saveContributionSetup({
-          token: token.trim(),
-          mode: selected,
-        });
-        if (!setupResult.success) {
-          setDcoError(setupResult.error ?? "Setup failed.");
-          return;
-        }
-      } else {
-        // Anonymous mode: no customer token needed — save mode only
-        await savePlatformDevConfig(selected);
-      }
+      // Persist contribution mode if not already saved.
+      await savePlatformDevConfig(selected);
 
       const dcoResult = await acceptDco();
       if (!dcoResult.accepted) {
@@ -157,16 +147,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
   };
 
   const handleReconfigure = () => {
-    // Reconfigure routes into the GitHub-token entry path so users who
-    // accepted DCO without setting up a token can add/rotate one later.
-    // Previously this jumped to the "explain" step whose Next button
-    // skipped straight to DCO — leaving no way to reach the paste-token
-    // input after initial setup. (Regression from pseudonymous-by-default
-    // rework, commit a232d0d6.)
-    setWizardStep("github-account");
-    setToken("");
-    setTokenError(null);
-    setGithubUsername(null);
+    // Route into the connect step so admins can rotate / replace their token.
+    setWizardStep("connect");
   };
 
   return (
@@ -177,7 +159,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
           Platform development policy
         </h2>
         <p className="text-xs text-[var(--dpf-muted)]">
-          This governs how features move from the shared development workspace into production and, if enabled, into community contribution workflows.
+          This governs how features move from the shared development workspace into production
+          and, if enabled, into community contribution workflows.
         </p>
       </div>
 
@@ -187,8 +170,9 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
             Finish this before shipping features
           </h3>
           <p className="text-xs text-[var(--dpf-text)] leading-relaxed">
-            Build Studio and, in customizable installs, VS Code can both work in the same shared workspace before this is configured.
-            Production promotion and Hive Mind contribution stay blocked until you choose how this install should be governed.
+            Build Studio and, in customizable installs, VS Code can both work in the same shared
+            workspace before this is configured. Production promotion and Hive Mind contribution
+            stay blocked until you choose how this install should be governed.
           </p>
         </div>
       )}
@@ -215,10 +199,10 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
             />
             <div>
               <span className="text-sm font-medium text-[var(--dpf-text)]">{opt.label}</span>
-            <p className="text-xs text-[var(--dpf-muted)] mt-0.5">{opt.description}</p>
-          </div>
-        </label>
-      ))}
+              <p className="text-xs text-[var(--dpf-muted)] mt-0.5">{opt.description}</p>
+            </div>
+          </label>
+        ))}
       </div>
 
       {/* ─── Fork Only: Git Backup ──────────────────────────────────────── */}
@@ -229,8 +213,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
               Backup your work (optional)
             </h3>
             <p className="text-xs text-[var(--dpf-muted)]">
-              Save completed features to an online repository for safekeeping.
-              If anything happens to your system, your work is protected.
+              Save completed features to an online repository for safekeeping. If anything happens
+              to your system, your work is protected.
             </p>
           </div>
 
@@ -241,7 +225,10 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
             <input
               type="url"
               value={gitUrl}
-              onChange={(e) => { setGitUrl(e.target.value); setSaved(false); }}
+              onChange={(e) => {
+                setGitUrl(e.target.value);
+                setSaved(false);
+              }}
               placeholder="https://github.com/your-name/your-repo.git"
               className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none"
             />
@@ -255,7 +242,10 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
               <input
                 type="password"
                 value={gitToken}
-                onChange={(e) => { setGitToken(e.target.value); setSaved(false); }}
+                onChange={(e) => {
+                  setGitToken(e.target.value);
+                  setSaved(false);
+                }}
                 placeholder="ghp_... or glpat-..."
                 className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none"
               />
@@ -268,7 +258,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
           {!gitUrl && (props.untrackedFeatureCount ?? 0) > 0 && (
             <div className="rounded border border-amber-400/50 bg-amber-400/10 px-3 py-2">
               <p className="text-xs text-amber-600 dark:text-amber-400">
-                {props.untrackedFeatureCount} completed feature{props.untrackedFeatureCount === 1 ? "" : "s"} not yet backed up.
+                {props.untrackedFeatureCount} completed feature
+                {props.untrackedFeatureCount === 1 ? "" : "s"} not yet backed up.
               </p>
             </div>
           )}
@@ -294,10 +285,10 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
       {/* ─── Contribution Modes: Guided Wizard ──────────────────────────── */}
       {isContributionMode && wizardStep === "mode" && !isAlreadySetUp && (
         <div className="rounded-lg border border-[var(--dpf-accent)]/30 bg-[var(--dpf-accent)]/5 p-4">
-            <p className="text-sm text-[var(--dpf-text)] mb-3">
-            To share features with the community, we need to connect your platform
-            to GitHub. Your code still lives in this install's shared workspace;
-            GitHub is only used when you choose to contribute governed changes upstream.
+          <p className="text-sm text-[var(--dpf-text)] mb-3">
+            To share features with the community, we need to connect your platform to GitHub. Your
+            code still lives in this install&apos;s shared workspace; GitHub is only used when you
+            choose to contribute governed changes upstream.
           </p>
           <button
             onClick={handleStartWizard}
@@ -310,32 +301,29 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
 
       {/* Step 1: Explain what contributions are */}
       {isContributionMode && wizardStep === "explain" && (
-        <WizardCard
-          step={1}
-          total={2}
-          title="How sharing works"
-        >
+        <WizardCard step={1} total={3} title="How sharing works">
           <div className="space-y-2 text-xs text-[var(--dpf-text)] leading-relaxed">
             <p>
-              When the AI Coworker finishes building a feature for you, it can
-              propose sharing that feature with the wider community of platform users.
-              The shared workspace for this install remains your system of local record.
+              When the AI Coworker finishes building a feature for you, it can propose sharing
+              that feature with the wider community of platform users. The shared workspace for
+              this install remains your system of local record.
             </p>
             <p>
-              Shared features are submitted as a <strong>proposed change</strong> to
-              the community repository. A maintainer reviews the proposal
-              before it becomes available to others.
+              Shared features are submitted as a <strong>proposed change</strong> to the community
+              repository. A maintainer reviews the proposal before it becomes available to others.
             </p>
             <p>
               Your contributions are <strong>pseudonymous</strong>
               {props.pseudonym ? (
-                <> — they appear on the community repository as <span className="font-mono text-[var(--dpf-accent)]">{props.pseudonym}</span>.</>
+                <>
+                  {" "}— they appear on the community repository as{" "}
+                  <span className="font-mono text-[var(--dpf-accent)]">{props.pseudonym}</span>.
+                </>
               ) : (
-                <> — they appear on the community repository under a stable handle derived from this install.</>
+                <> — they appear under a stable handle derived from this install.</>
               )}{" "}
-              The handle is the same across all your contributions so the community
-              can recognize repeat contributors, but reveals nothing about you or your
-              organization. No GitHub account is needed.
+              The handle is the same across all your contributions so the community can recognize
+              repeat contributors, but reveals nothing about you or your organization.
             </p>
             <p>
               {selected === "selective"
@@ -360,31 +348,19 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
         </WizardCard>
       )}
 
-      {/* Step 2: GitHub account */}
+      {/* Step 2: GitHub account info (informational only) */}
       {isContributionMode && wizardStep === "github-account" && (
-        <WizardCard
-          step={2}
-          total={4}
-          title="GitHub account"
-        >
+        <WizardCard step={2} total={3} title="GitHub account">
           <div className="space-y-3 text-xs text-[var(--dpf-text)] leading-relaxed">
             <p>
-              Contributions are submitted through <strong>GitHub</strong>, a free service
-              used by millions of developers to collaborate on software.
+              Contributions are submitted through <strong>GitHub</strong>. If you don&apos;t have
+              an account yet, create one first at{" "}
+              <span className="font-mono text-[var(--dpf-accent)]">github.com/signup</span>.
             </p>
             <p>
-              If you don't have an account yet, create one first:
+              Once you have an account, click <strong>Next</strong> to authorize this install via
+              GitHub&apos;s standard Device Flow — no copy-pasting tokens.
             </p>
-            <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-              <ol className="list-decimal list-inside space-y-1.5 text-xs">
-                <li>
-                  Go to{" "}
-                  <span className="font-mono text-[var(--dpf-accent)]">github.com/signup</span>
-                </li>
-                <li>Follow the steps to create a free account</li>
-                <li>Come back here when you're done</li>
-              </ol>
-            </div>
           </div>
           <div className="flex justify-between mt-4">
             <button
@@ -394,142 +370,19 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
               Back
             </button>
             <button
-              onClick={() => setWizardStep("create-token")}
+              onClick={() => setWizardStep("dco")}
               className="rounded px-4 py-1.5 text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-colors"
             >
-              I have a GitHub account
+              Next
             </button>
           </div>
         </WizardCard>
       )}
 
-      {/* Step 3: Create a token */}
-      {isContributionMode && wizardStep === "create-token" && (
-        <WizardCard
-          step={3}
-          total={4}
-          title="Create an access token"
-        >
-          <div className="space-y-3 text-xs text-[var(--dpf-text)] leading-relaxed">
-            <p>
-              GitHub uses <strong>personal access tokens</strong> instead of passwords.
-              This gives the platform permission to submit contributions on your behalf.
-            </p>
-            <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-              <ol className="list-decimal list-inside space-y-2 text-xs">
-                <li>
-                  Go to{" "}
-                  <span className="font-mono text-[var(--dpf-accent)]">github.com/settings/tokens/new</span>
-                  <br />
-                  <span className="text-[var(--dpf-muted)] ml-4">
-                    (or: GitHub menu &gt; Settings &gt; Developer settings &gt; Personal access tokens &gt; Tokens (classic) &gt; Generate new token)
-                  </span>
-                </li>
-                <li>
-                  Set the name to{" "}
-                  <span className="font-mono bg-[var(--dpf-bg)] px-1 rounded">Digital Product Factory</span>
-                </li>
-                <li>
-                  Under <strong>Select scopes</strong>, check the box next to{" "}
-                  <span className="font-mono bg-[var(--dpf-bg)] px-1 rounded">repo</span>
-                  <br />
-                  <span className="text-[var(--dpf-muted)] ml-4">(this allows creating branches and pull requests)</span>
-                </li>
-                <li>
-                  Click <strong>Generate token</strong> at the bottom of the page
-                </li>
-                <li>
-                  <strong>Copy the token</strong> (it starts with{" "}
-                  <span className="font-mono">ghp_</span>)
-                  <br />
-                  <span className="text-[var(--dpf-muted)] ml-4">
-                    GitHub only shows it once, so copy it before leaving the page
-                  </span>
-                </li>
-              </ol>
-            </div>
-          </div>
-          <div className="flex justify-between mt-4">
-            <button
-              onClick={() => setWizardStep("github-account")}
-              className="rounded px-3 py-1.5 text-sm font-medium border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-border)] transition-colors"
-            >
-              Back
-            </button>
-            <button
-              onClick={() => setWizardStep("paste-token")}
-              className="rounded px-4 py-1.5 text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-colors"
-            >
-              I've created a token
-            </button>
-          </div>
-        </WizardCard>
-      )}
-
-      {/* Step 3b: Paste the token */}
-      {isContributionMode && wizardStep === "paste-token" && (
-        <WizardCard
-          step={3}
-          total={4}
-          title="Paste your token"
-        >
-          <div className="space-y-3">
-            <p className="text-xs text-[var(--dpf-text)] leading-relaxed">
-              Paste the token you just created. It will be encrypted and stored securely
-              on your platform — it's never shared with anyone.
-            </p>
-            <input
-              type="password"
-              value={token}
-              onChange={(e) => { setToken(e.target.value); setTokenError(null); }}
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-              className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 text-sm font-mono text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none"
-              autoFocus
-            />
-            {tokenError && (
-              <div className="rounded border border-red-400/50 bg-red-400/10 px-3 py-2">
-                <p className="text-xs text-red-600 dark:text-red-400">{tokenError}</p>
-              </div>
-            )}
-          </div>
-          <div className="flex justify-between mt-4">
-            <button
-              onClick={() => setWizardStep("create-token")}
-              className="rounded px-3 py-1.5 text-sm font-medium border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-border)] transition-colors"
-            >
-              Back
-            </button>
-            <button
-              onClick={handleValidateToken}
-              disabled={isPending || !token.trim()}
-              className={[
-                "rounded px-4 py-1.5 text-sm font-medium transition-colors",
-                isPending || !token.trim()
-                  ? "bg-[var(--dpf-border)] text-[var(--dpf-muted)] cursor-not-allowed"
-                  : "bg-[var(--dpf-accent)] text-white hover:opacity-90",
-              ].join(" ")}
-            >
-              {isPending ? "Checking..." : "Verify token"}
-            </button>
-          </div>
-        </WizardCard>
-      )}
-
-      {/* Step 2: DCO acceptance */}
+      {/* Step: DCO acceptance */}
       {isContributionMode && wizardStep === "dco" && (
-        <WizardCard
-          step={2}
-          total={2}
-          title="Contributor agreement"
-        >
+        <WizardCard step={3} total={3} title="Contributor agreement">
           <div className="space-y-3">
-            {githubUsername && (
-              <div className="rounded border border-green-500/50 bg-green-500/10 px-3 py-2">
-                <p className="text-xs text-green-600 dark:text-green-400">
-                  Connected to GitHub as <strong>{githubUsername}</strong>
-                </p>
-              </div>
-            )}
             {props.pseudonym && (
               <div className="rounded border border-[var(--dpf-accent)]/40 bg-[var(--dpf-accent)]/5 px-3 py-2">
                 <p className="text-xs text-[var(--dpf-text)] leading-relaxed">
@@ -543,7 +396,10 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
             </p>
             <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 space-y-2">
               {buildDcoItems(props.pseudonym ?? null).map((item, i) => (
-                <div key={i} className="flex items-start gap-2 text-xs text-[var(--dpf-text)]">
+                <div
+                  key={i}
+                  className="flex items-start gap-2 text-xs text-[var(--dpf-text)]"
+                >
                   <span className="text-[var(--dpf-accent)] font-bold mt-0.5">{i + 1}.</span>
                   <span>{item}</span>
                 </div>
@@ -578,15 +434,21 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
         </WizardCard>
       )}
 
-      {/* Done state */}
+      {/* Step / state: Connect GitHub (Device Flow primary, Advanced paste fallback) */}
+      {isContributionMode && (wizardStep === "connect" || wizardStep === "done") && (
+        <div className="space-y-4" data-testid="github-connect-block">
+          <ConnectGitHubCard initialConnected={props.initialConnected ?? null} />
+          <AdvancedTokenPaste mode={selected} />
+        </div>
+      )}
+
+      {/* Done state — sharing summary, configured by */}
       {isContributionMode && wizardStep === "done" && (
         <div className="rounded-lg border border-green-500/30 bg-green-500/5 p-4 space-y-3">
           <div className="flex items-start gap-2">
             <span className="text-green-500 text-lg leading-none">*</span>
             <div>
-              <h3 className="text-sm font-semibold text-[var(--dpf-text)]">
-                Sharing is set up
-              </h3>
+              <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Sharing is set up</h3>
               <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
                 {selected === "selective"
                   ? "When the AI Coworker finishes building a feature, it will ask if you'd like to share it with the community."
@@ -604,32 +466,10 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
             </p>
           )}
 
-          {/* Prominent CTA when DCO is accepted but no token is on file.
-              Previously the only way back to the token entry step was the
-              small "Reconfigure sharing settings" text link below — too
-              easy to miss, and contribute_to_hive failed loudly at the
-              next PR attempt instead. Surfacing this up front closes the
-              gap between "sharing is set up" and "contributions actually
-              work." */}
-          {props.dcoAcceptedAt && props.hasContributionToken === false && (
-            <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 space-y-2">
-              <p className="text-xs font-semibold text-[var(--dpf-text)]">
-                Add a GitHub token to enable contributions
-              </p>
-              <p className="text-xs text-[var(--dpf-muted)]">
-                The contributor agreement is accepted but no token is on file
-                yet, so upstream pull requests will fail. Add one now — it
-                takes about a minute.
-              </p>
-              <button
-                onClick={handleReconfigure}
-                className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
-              >
-                Add or rotate GitHub token
-              </button>
-            </div>
-          )}
-
+          {/* Lightweight reset hook for admins who want to walk through the
+              wizard again (mode change, DCO re-acceptance, etc). The Connect
+              card above is the primary token surface; this just gives an
+              escape hatch back to the explain step. */}
           <button
             onClick={handleReconfigure}
             className="text-xs text-[var(--dpf-accent)] hover:underline"
@@ -642,7 +482,8 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
       {/* Last configured info */}
       {props.configuredAt && (
         <p className="text-xs text-[var(--dpf-muted)]">
-          Last configured {new Date(props.configuredAt).toLocaleDateString()} by {props.configuredByEmail ?? "unknown"}
+          Last configured {new Date(props.configuredAt).toLocaleDateString()} by{" "}
+          {props.configuredByEmail ?? "unknown"}
         </p>
       )}
     </div>
@@ -660,9 +501,7 @@ function WizardCard(props: {
   return (
     <div className="rounded-lg border border-[var(--dpf-border)] p-4 space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-[var(--dpf-text)]">
-          {props.title}
-        </h3>
+        <h3 className="text-sm font-semibold text-[var(--dpf-text)]">{props.title}</h3>
         <span className="text-xs text-[var(--dpf-muted)]">
           Step {props.step} of {props.total}
         </span>

--- a/apps/web/lib/actions/github-device-flow.test.ts
+++ b/apps/web/lib/actions/github-device-flow.test.ts
@@ -18,6 +18,7 @@ vi.mock("@dpf/db", () => ({
     },
     credentialEntry: {
       upsert: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
 }));
@@ -43,7 +44,7 @@ import {
   requestDeviceCode,
 } from "@/lib/integrate/github-oauth";
 import { validateGitHubToken } from "@/lib/actions/platform-dev-config";
-import { initiateDeviceFlow, pollDeviceFlow } from "./github-device-flow";
+import { disconnectGitHub, initiateDeviceFlow, pollDeviceFlow } from "./github-device-flow";
 
 // Convenience helper: mock the auth() call shape — vitest's mocked() chain is
 // type-noisy on the NextAuth type, so we cast through unknown once here.
@@ -323,5 +324,48 @@ describe("pollDeviceFlow", () => {
     });
     expect(prisma.credentialEntry.upsert).not.toHaveBeenCalled();
     expect(prisma.deviceCodeSession.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("disconnectGitHub", () => {
+  it("returns Not authenticated when no session", async () => {
+    setAuth(null);
+    const result = await disconnectGitHub();
+    expect(result).toEqual({ success: false, error: "Not authenticated" });
+    expect(prisma.credentialEntry.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns Unauthorized when caller lacks manage_platform", async () => {
+    vi.mocked(can).mockReturnValueOnce(false);
+    const result = await disconnectGitHub();
+    expect(result).toEqual({ success: false, error: "Unauthorized" });
+    expect(prisma.credentialEntry.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("clears the hive-contribution credential and returns success", async () => {
+    vi.mocked(prisma.credentialEntry.updateMany).mockResolvedValueOnce({ count: 1 });
+
+    const result = await disconnectGitHub();
+
+    expect(prisma.credentialEntry.updateMany).toHaveBeenCalledWith({
+      where: { providerId: "hive-contribution" },
+      data: {
+        secretRef: null,
+        status: "unconfigured",
+        scope: null,
+        tokenExpiresAt: null,
+        cachedToken: null,
+      },
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("succeeds quietly when the credential row does not exist", async () => {
+    // updateMany on a non-existent row resolves with count: 0 — no throw.
+    vi.mocked(prisma.credentialEntry.updateMany).mockResolvedValueOnce({ count: 0 });
+
+    const result = await disconnectGitHub();
+
+    expect(result).toEqual({ success: true });
   });
 });

--- a/apps/web/lib/actions/github-device-flow.ts
+++ b/apps/web/lib/actions/github-device-flow.ts
@@ -187,3 +187,37 @@ export async function pollDeviceFlow(sessionId: string): Promise<PollActionResul
 
   return { status: "success", username: validation.username ?? "unknown" };
 }
+
+/**
+ * Disconnect the currently-stored GitHub credential.
+ *
+ * Clears `secretRef`, marks the row `unconfigured`, and zeroes auxiliary
+ * OAuth-shaped fields so the next connect starts from a clean slate. Used by
+ * the "Disconnect" action on the Connect GitHub card. Caller must hold
+ * `manage_platform`, same gate as the rest of this module.
+ */
+export async function disconnectGitHub(): Promise<{ success: boolean; error?: string }> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) return { success: false, error: "Not authenticated" };
+
+  if (!can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_platform")) {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  // Use updateMany so absence of the row is a no-op (zero-count update),
+  // not a thrown P2025 — disconnect from a never-connected install should
+  // succeed silently.
+  await prisma.credentialEntry.updateMany({
+    where: { providerId: "hive-contribution" },
+    data: {
+      secretRef: null,
+      status: "unconfigured",
+      scope: null,
+      tokenExpiresAt: null,
+      cachedToken: null,
+    },
+  });
+
+  return { success: true };
+}

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -221,6 +221,56 @@ export async function getStoredGitHubToken(): Promise<string | null> {
   }
 }
 
+/**
+ * Resolve the "Connected as @username, since <date>" snapshot for the admin
+ * UI's Connect GitHub card.
+ *
+ * Returns non-null only when the stored hive-contribution credential is a
+ * Device-Flow OAuth token (`gho_` prefix). Paste-mode PATs are deliberately
+ * not surfaced as "connected" — we don't want to imply Device-Flow-equivalent
+ * status for tokens whose owner we never verified at save time.
+ *
+ * Probes GET /user to read the authenticated username. If the probe fails
+ * (token revoked, network unreachable), returns null so the UI falls back to
+ * the disconnected state — safer than misreporting a stale username.
+ */
+export async function getGitHubConnectedState(): Promise<{
+  username: string;
+  connectedAt: Date;
+} | null> {
+  const cred = await prisma.credentialEntry.findUnique({
+    where: { providerId: "hive-contribution" },
+    select: { secretRef: true, status: true, updatedAt: true },
+  });
+  if (!cred || cred.status !== "active" || !cred.secretRef) return null;
+
+  let token: string | null;
+  try {
+    const { decryptSecret } = await import("@/lib/credential-crypto");
+    token = decryptSecret(cred.secretRef);
+  } catch {
+    return null;
+  }
+
+  if (!token || !token.startsWith("gho_")) return null;
+
+  try {
+    const response = await fetch("https://api.github.com/user", {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { login?: string };
+    if (!data.login) return null;
+    return { username: data.login, connectedAt: cred.updatedAt };
+  } catch {
+    return null;
+  }
+}
+
 // ─── GitHub token validation ─────────────────────────────────────────────────
 //
 // Extended validator for the 2026-04-24 GitHub auth 2FA readiness spec. The


### PR DESCRIPTION
Refactors PlatformDevelopmentForm to surface OAuth Device Flow as the primary GitHub auth path. Paste-a-token is demoted to an Advanced disclosure with two labeled sections (fine-grained PAT, classic PAT).

- New ConnectGitHubCard client component: polls initiateDeviceFlow + pollDeviceFlow from Phase 4. Displays user code + verification URI, copy-to-clipboard, pseudonymity disclosure, retry-on-error, and Disconnect when initialConnected is set. Handles slow_down by rescheduling polling at the new interval; clears interval on unmount.
- New AdvancedTokenPaste component: <details>-based disclosure (collapsed by default) with fine-grained-PAT and classic-PAT sections. Both submit through the existing saveContributionSetup action.
- New disconnectGitHub server action: clears CredentialEntry secretRef, marks status unconfigured, and zeroes auxiliary OAuth fields. Uses updateMany so absence of the row is a no-op.
- New getGitHubConnectedState server helper: probes GET /user with the stored token to derive { username, connectedAt }, but only when the prefix is gho_ (Device Flow). Paste-mode PATs are not surfaced as "connected as @user" since we don't proactively verify their owner.
- PlatformDevelopmentForm refactored: create-token and paste-token wizard steps removed (replaced by ConnectGitHubCard + AdvancedTokenPaste). Wizard now flows mode -> explain -> github-account -> dco -> done. Connect surfaces render in the done state and via the Reconfigure path.

Tests cover the new disconnect action, the four ConnectGitHubCard view-state surfaces (idle/connected/awaiting-not-rendered/connected with date), the AdvancedTokenPaste two-section structure, and PlatformDevelopmentForm's prop-driven SSR markup. Typecheck and production build are clean.

Manual browser verification deferred: the running portal container is bound to D:/DPF main, not this worktree. Per docker-explicit-approval guidance the maintainer will rebuild the portal image and exercise the UI before merge.

Stacked on #241 (Phase 4). Part of the 2026-04-24 GitHub auth 2FA readiness spec.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
