### PR TITLE
feat(token-expiry): daily monitoring + admin banner

### DIFF
--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -2,6 +2,7 @@ import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { ForkSetupPanel } from "@/components/admin/ForkSetupPanel";
 import LegacyTokenOverrideBanner from "@/components/admin/LegacyTokenOverrideBanner";
 import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
+import TokenExpiryBanner from "@/components/admin/TokenExpiryBanner";
 import {
   getGitHubConnectedState,
   getPlatformDevConfig,
@@ -36,6 +37,7 @@ export default async function AdminPlatformDevelopmentPage() {
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">Platform Development</p>
       </div>
       <AdminTabNav />
+      <TokenExpiryBanner />
       <LegacyTokenOverrideBanner />
       <ForkSetupPanel
         enabled={isContributionModelEnabled()}

--- a/apps/web/components/admin/PlatformDevelopmentForm.tsx
+++ b/apps/web/components/admin/PlatformDevelopmentForm.tsx
@@ -437,8 +437,14 @@ export function PlatformDevelopmentForm(props: PlatformDevelopmentFormProps) {
       {/* Step / state: Connect GitHub (Device Flow primary, Advanced paste fallback) */}
       {isContributionMode && (wizardStep === "connect" || wizardStep === "done") && (
         <div className="space-y-4" data-testid="github-connect-block">
-          <ConnectGitHubCard initialConnected={props.initialConnected ?? null} />
-          <AdvancedTokenPaste mode={selected} />
+          {/* Anchor target for TokenExpiryBanner's "Reconnect GitHub" link. */}
+          <div id="connect-github">
+            <ConnectGitHubCard initialConnected={props.initialConnected ?? null} />
+          </div>
+          {/* Anchor target for TokenExpiryBanner's "Update token" link. */}
+          <div id="advanced-token">
+            <AdvancedTokenPaste mode={selected} />
+          </div>
         </div>
       )}
 

--- a/apps/web/components/admin/TokenExpiryBanner.test.tsx
+++ b/apps/web/components/admin/TokenExpiryBanner.test.tsx
@@ -1,0 +1,104 @@
+// apps/web/components/admin/TokenExpiryBanner.test.tsx
+// Phase 6 of the 2026-04-24 GitHub auth 2FA readiness spec.
+//
+// Banner is server-rendered; we mock prisma.platformNotification.findFirst
+// and assert the returned element. `info`-only severity is intentionally
+// quiet (no banner) — only warning/critical/expired surface.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformNotification: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import TokenExpiryBanner from "./TokenExpiryBanner";
+
+const mockFindFirst = vi.mocked(prisma.platformNotification.findFirst);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function notification(severity: string, message: string) {
+  return {
+    id: "n1",
+    severity,
+    category: "token-expiry",
+    subjectId: "github-contribution",
+    message,
+    createdAt: new Date("2026-04-24T09:00:00.000Z"),
+    resolvedAt: null,
+  } as Awaited<ReturnType<typeof prisma.platformNotification.findFirst>>;
+}
+
+describe("TokenExpiryBanner", () => {
+  it("renders nothing when there is no active notification", async () => {
+    mockFindFirst.mockResolvedValueOnce(null);
+    const element = await TokenExpiryBanner();
+    expect(element).toBeNull();
+  });
+
+  it("queries for warning/critical/expired only (info is too quiet for a banner)", async () => {
+    mockFindFirst.mockResolvedValueOnce(null);
+    await TokenExpiryBanner();
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: {
+        category: "token-expiry",
+        resolvedAt: null,
+        severity: { in: ["warning", "critical", "expired"] },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  });
+
+  it("renders a yellow warning banner with the message body", async () => {
+    mockFindFirst.mockResolvedValueOnce(
+      notification(
+        "warning",
+        "Your GitHub token expires in 14 days. Reconnect soon.",
+      ),
+    );
+    const element = await TokenExpiryBanner();
+    expect(element).not.toBeNull();
+    const html = renderToStaticMarkup(element as React.ReactElement);
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Your GitHub token expires in 14 days");
+    expect(html).toContain("yellow");
+    expect(html).toContain("#connect-github");
+    expect(html).toContain("#advanced-token");
+  });
+
+  it("renders a red critical banner", async () => {
+    mockFindFirst.mockResolvedValueOnce(
+      notification(
+        "critical",
+        "Your GitHub token expires in 7 days. Reconnect now to avoid disruption.",
+      ),
+    );
+    const element = await TokenExpiryBanner();
+    expect(element).not.toBeNull();
+    const html = renderToStaticMarkup(element as React.ReactElement);
+    expect(html).toContain("Your GitHub token expires in 7 days");
+    expect(html).toContain("red");
+  });
+
+  it("renders a red expired banner with 'expired' copy", async () => {
+    mockFindFirst.mockResolvedValueOnce(
+      notification(
+        "expired",
+        "Your GitHub token has expired. Reconnect to resume contributing.",
+      ),
+    );
+    const element = await TokenExpiryBanner();
+    expect(element).not.toBeNull();
+    const html = renderToStaticMarkup(element as React.ReactElement);
+    expect(html).toContain("expired");
+    expect(html).toContain("red");
+  });
+});

--- a/apps/web/components/admin/TokenExpiryBanner.tsx
+++ b/apps/web/components/admin/TokenExpiryBanner.tsx
@@ -1,0 +1,54 @@
+import { prisma } from "@dpf/db";
+
+/**
+ * Admin banner surfaced on Platform Development when the install's stored
+ * GitHub token is approaching expiry (Tier 2 fine-grained PAT). Driven by
+ * `PlatformNotification` rows written by the daily `tokenExpiryMonitor`
+ * Inngest function.
+ *
+ * Severity tiers
+ *   - `info`  → not shown here (too quiet for a banner; lives in admin notifications list)
+ *   - `warning`  → yellow banner
+ *   - `critical` → red banner
+ *   - `expired`  → red banner
+ *
+ * Action links scroll to the existing remediation surfaces — Reconnect via
+ * OAuth (ConnectGitHubCard) or Update token (AdvancedTokenPaste) — both
+ * rendered by `PlatformDevelopmentForm`.
+ *
+ * Phase 6 of the 2026-04-24 GitHub auth 2FA readiness spec.
+ */
+export default async function TokenExpiryBanner() {
+  const notification = await prisma.platformNotification.findFirst({
+    where: {
+      category: "token-expiry",
+      resolvedAt: null,
+      severity: { in: ["warning", "critical", "expired"] },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  if (!notification) return null;
+
+  const isRed =
+    notification.severity === "critical" || notification.severity === "expired";
+  const colorClass = isRed
+    ? "border-red-500 bg-red-50 text-red-900"
+    : "border-yellow-500 bg-yellow-50 text-yellow-900";
+
+  return (
+    <div
+      role="alert"
+      className={`mb-4 rounded-md border ${colorClass} p-4 text-sm`}
+    >
+      <p>{notification.message}</p>
+      <div className="mt-2 flex gap-3">
+        <a href="#connect-github" className="underline">
+          Reconnect GitHub
+        </a>
+        <a href="#advanced-token" className="underline">
+          Update token
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -12,6 +12,7 @@ import { hiveScoutIngest } from "./hive-scout-ingest";
 import { brandExtract } from "./brand-extract";
 import { buildReviewVerification } from "./build-review-verification";
 import { deliberationRun } from "./deliberation-run";
+import { tokenExpiryMonitor } from "./token-expiry-monitor";
 
 export const allFunctions = [
   prometheusPoll,
@@ -31,4 +32,5 @@ export const allFunctions = [
   brandExtract,
   buildReviewVerification,
   deliberationRun,
+  tokenExpiryMonitor,
 ];

--- a/apps/web/lib/queue/functions/token-expiry-monitor.test.ts
+++ b/apps/web/lib/queue/functions/token-expiry-monitor.test.ts
@@ -1,0 +1,230 @@
+// apps/web/lib/queue/functions/token-expiry-monitor.test.ts
+// Phase 6 — Token Expiry Monitor (Inngest scheduled fn).
+//
+// Covers:
+//   - 40 days to expiry → no new notification + any prior token-expiry
+//     notification gets resolvedAt set
+//   - 30 / 14 / 7 / 0 days → correct severity tier and message text
+//   - Re-running on the same day at the same severity → idempotent (no
+//     duplicate notification rows created)
+//   - Severity escalation (existing `warning` notification, current state is
+//     `critical` → old resolved + new `critical` row created)
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  credentialFindMany: vi.fn(),
+  notificationFindFirst: vi.fn(),
+  notificationCreate: vi.fn(),
+  notificationUpdateMany: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    credentialEntry: { findMany: mocks.credentialFindMany },
+    platformNotification: {
+      findFirst: mocks.notificationFindFirst,
+      create: mocks.notificationCreate,
+      updateMany: mocks.notificationUpdateMany,
+    },
+  },
+}));
+
+import { runTokenExpiryScan } from "./token-expiry-monitor";
+
+const FIXED_NOW = new Date("2026-04-24T12:00:00.000Z");
+
+function daysFromNow(days: number): Date {
+  return new Date(FIXED_NOW.getTime() + days * 86400000);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+  mocks.credentialFindMany.mockResolvedValue([]);
+  mocks.notificationFindFirst.mockResolvedValue(null);
+  mocks.notificationCreate.mockResolvedValue({});
+  mocks.notificationUpdateMany.mockResolvedValue({ count: 0 });
+});
+
+describe("runTokenExpiryScan", () => {
+  it("does not write a notification when token is 40 days from expiry, and resolves any prior token-expiry notification for that subject", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(40),
+        status: "active",
+      },
+    ]);
+    // Pretend an old notification existed
+    mocks.notificationUpdateMany.mockResolvedValue({ count: 1 });
+
+    await runTokenExpiryScan();
+
+    expect(mocks.notificationCreate).not.toHaveBeenCalled();
+    expect(mocks.notificationUpdateMany).toHaveBeenCalledWith({
+      where: {
+        category: "token-expiry",
+        subjectId: "github-contribution",
+        resolvedAt: null,
+      },
+      data: { resolvedAt: FIXED_NOW },
+    });
+  });
+
+  it("emits an info notification at exactly 30 days", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(30),
+        status: "active",
+      },
+    ]);
+
+    await runTokenExpiryScan();
+
+    expect(mocks.notificationCreate).toHaveBeenCalledTimes(1);
+    const arg = mocks.notificationCreate.mock.calls[0][0];
+    expect(arg.data.severity).toBe("info");
+    expect(arg.data.category).toBe("token-expiry");
+    expect(arg.data.subjectId).toBe("github-contribution");
+    expect(arg.data.message).toBe(
+      "Your GitHub token expires in 30 days. Reconnect ahead of expiry.",
+    );
+  });
+
+  it("emits a warning notification at 14 days", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(14),
+        status: "active",
+      },
+    ]);
+
+    await runTokenExpiryScan();
+
+    expect(mocks.notificationCreate).toHaveBeenCalledTimes(1);
+    const arg = mocks.notificationCreate.mock.calls[0][0];
+    expect(arg.data.severity).toBe("warning");
+    expect(arg.data.message).toBe(
+      "Your GitHub token expires in 14 days. Reconnect soon.",
+    );
+  });
+
+  it("emits a critical notification at 7 days", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(7),
+        status: "active",
+      },
+    ]);
+
+    await runTokenExpiryScan();
+
+    expect(mocks.notificationCreate).toHaveBeenCalledTimes(1);
+    const arg = mocks.notificationCreate.mock.calls[0][0];
+    expect(arg.data.severity).toBe("critical");
+    expect(arg.data.message).toBe(
+      "Your GitHub token expires in 7 days. Reconnect now to avoid disruption.",
+    );
+  });
+
+  it("emits an expired notification when the token has already expired (0 or negative days)", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(0),
+        status: "active",
+      },
+    ]);
+
+    await runTokenExpiryScan();
+
+    expect(mocks.notificationCreate).toHaveBeenCalledTimes(1);
+    const arg = mocks.notificationCreate.mock.calls[0][0];
+    expect(arg.data.severity).toBe("expired");
+    expect(arg.data.message).toBe(
+      "Your GitHub token has expired. Reconnect to resume contributing.",
+    );
+  });
+
+  it("is idempotent: re-running on the same day at the same severity does not create a second notification", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(7),
+        status: "active",
+      },
+    ]);
+    // Simulate an existing critical notification at the same severity
+    mocks.notificationFindFirst.mockResolvedValue({
+      id: "n-existing",
+      severity: "critical",
+      category: "token-expiry",
+      subjectId: "github-contribution",
+      message: "stale",
+      resolvedAt: null,
+      createdAt: FIXED_NOW,
+    });
+
+    await runTokenExpiryScan();
+
+    expect(mocks.notificationCreate).not.toHaveBeenCalled();
+    // No resolve either — same severity, no-op.
+    expect(mocks.notificationUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("escalates severity: existing warning at 14 days, re-running at 7 days resolves the warning and creates a critical row", async () => {
+    mocks.credentialFindMany.mockResolvedValue([
+      {
+        providerId: "github-contribution",
+        tokenExpiresAt: daysFromNow(7),
+        status: "active",
+      },
+    ]);
+    // Simulate prior warning notification
+    mocks.notificationFindFirst.mockResolvedValue({
+      id: "n-warning",
+      severity: "warning",
+      category: "token-expiry",
+      subjectId: "github-contribution",
+      message: "old warning",
+      resolvedAt: null,
+      createdAt: new Date(FIXED_NOW.getTime() - 7 * 86400000),
+    });
+
+    await runTokenExpiryScan();
+
+    // Old one resolved
+    expect(mocks.notificationUpdateMany).toHaveBeenCalledWith({
+      where: {
+        category: "token-expiry",
+        subjectId: "github-contribution",
+        resolvedAt: null,
+      },
+      data: { resolvedAt: FIXED_NOW },
+    });
+    // New critical row created
+    expect(mocks.notificationCreate).toHaveBeenCalledTimes(1);
+    const arg = mocks.notificationCreate.mock.calls[0][0];
+    expect(arg.data.severity).toBe("critical");
+  });
+
+  it("only queries CredentialEntry rows with non-null tokenExpiresAt and active status", async () => {
+    await runTokenExpiryScan();
+    expect(mocks.credentialFindMany).toHaveBeenCalledWith({
+      where: {
+        tokenExpiresAt: { not: null },
+        status: "active",
+      },
+      select: {
+        providerId: true,
+        tokenExpiresAt: true,
+        status: true,
+      },
+    });
+  });
+});

--- a/apps/web/lib/queue/functions/token-expiry-monitor.ts
+++ b/apps/web/lib/queue/functions/token-expiry-monitor.ts
@@ -1,0 +1,161 @@
+// apps/web/lib/queue/functions/token-expiry-monitor.ts
+// Phase 6 of the 2026-04-24 GitHub auth 2FA readiness spec.
+//
+// Daily scheduled scan over CredentialEntry rows that carry a known
+// `tokenExpiresAt` timestamp. For each, compute days-until-expiry, map to a
+// severity tier, and upsert a `PlatformNotification` row keyed on
+// (category="token-expiry", subjectId=providerId).
+//
+// Severity tiers
+//   > 30 days       → no notification (resolve any prior open one)
+//   <= 30 && > 14   → info
+//   <= 14 && >  7   → warning
+//   <=  7 && >  0   → critical
+//   <=  0           → expired
+//
+// Idempotency
+//   - Same severity as the existing open notification → no-op (no new row).
+//   - Different severity → resolve the old (set resolvedAt=now) AND create
+//     a fresh row at the new severity.
+//
+// Note on tiers
+//   Tier 1 (Device Flow OAuth-app tokens) have no expiry and are never
+//   recorded with tokenExpiresAt; the query simply skips them. Tier 3
+//   (classic PATs) usually have no expiry. Only Tier 2 (fine-grained PAT
+//   with the `github-authentication-token-expiration` header captured by
+//   `validateGitHubToken`, Phase 3) populates tokenExpiresAt and so is the
+//   only tier this monitor actually fires on.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+
+type Severity = "info" | "warning" | "critical" | "expired";
+
+interface SeverityDecision {
+  severity: Severity | null;
+  daysUntilExpiry: number;
+}
+
+export function classifyExpiry(now: Date, expiresAt: Date): SeverityDecision {
+  const daysUntilExpiry = Math.floor(
+    (expiresAt.getTime() - now.getTime()) / 86_400_000,
+  );
+  if (daysUntilExpiry > 30) return { severity: null, daysUntilExpiry };
+  if (daysUntilExpiry > 14) return { severity: "info", daysUntilExpiry };
+  if (daysUntilExpiry > 7) return { severity: "warning", daysUntilExpiry };
+  if (daysUntilExpiry > 0) return { severity: "critical", daysUntilExpiry };
+  return { severity: "expired", daysUntilExpiry };
+}
+
+export function buildMessage(severity: Severity, daysUntilExpiry: number): string {
+  switch (severity) {
+    case "info":
+      return `Your GitHub token expires in ${daysUntilExpiry} days. Reconnect ahead of expiry.`;
+    case "warning":
+      return `Your GitHub token expires in ${daysUntilExpiry} days. Reconnect soon.`;
+    case "critical":
+      return `Your GitHub token expires in ${daysUntilExpiry} days. Reconnect now to avoid disruption.`;
+    case "expired":
+      return "Your GitHub token has expired. Reconnect to resume contributing.";
+  }
+}
+
+/**
+ * The actual scan logic, exported separately so unit tests can drive it
+ * without going through the Inngest harness. The Inngest function below is
+ * a thin wrapper that calls this inside `step.run`.
+ */
+export async function runTokenExpiryScan(): Promise<{
+  scanned: number;
+  notificationsCreated: number;
+  notificationsResolved: number;
+}> {
+  const { prisma } = await import("@dpf/db");
+  const now = new Date();
+
+  const credentials = await prisma.credentialEntry.findMany({
+    where: {
+      tokenExpiresAt: { not: null },
+      status: "active",
+    },
+    select: {
+      providerId: true,
+      tokenExpiresAt: true,
+      status: true,
+    },
+  });
+
+  let notificationsCreated = 0;
+  let notificationsResolved = 0;
+
+  for (const cred of credentials) {
+    if (!cred.tokenExpiresAt) continue;
+
+    const decision = classifyExpiry(now, cred.tokenExpiresAt);
+
+    // Above the 30-day window — make sure no stale open notification lingers.
+    if (decision.severity === null) {
+      const result = await prisma.platformNotification.updateMany({
+        where: {
+          category: "token-expiry",
+          subjectId: cred.providerId,
+          resolvedAt: null,
+        },
+        data: { resolvedAt: now },
+      });
+      notificationsResolved += result.count;
+      continue;
+    }
+
+    // Within an alert tier — look for an existing open notification.
+    const existing = await prisma.platformNotification.findFirst({
+      where: {
+        category: "token-expiry",
+        subjectId: cred.providerId,
+        resolvedAt: null,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (existing && existing.severity === decision.severity) {
+      // Same tier as last time — no-op (idempotent).
+      continue;
+    }
+
+    if (existing) {
+      // Different tier — resolve the old open notification(s) for this subject.
+      const result = await prisma.platformNotification.updateMany({
+        where: {
+          category: "token-expiry",
+          subjectId: cred.providerId,
+          resolvedAt: null,
+        },
+        data: { resolvedAt: now },
+      });
+      notificationsResolved += result.count;
+    }
+
+    await prisma.platformNotification.create({
+      data: {
+        severity: decision.severity,
+        category: "token-expiry",
+        subjectId: cred.providerId,
+        message: buildMessage(decision.severity, decision.daysUntilExpiry),
+      },
+    });
+    notificationsCreated += 1;
+  }
+
+  return {
+    scanned: credentials.length,
+    notificationsCreated,
+    notificationsResolved,
+  };
+}
+
+export const tokenExpiryMonitor = inngest.createFunction(
+  { id: "ops/token-expiry-monitor", retries: 2, triggers: [cron("0 9 * * *")] },
+  async ({ step }) => {
+    return await step.run("scan-token-expiry", async () => runTokenExpiryScan());
+  },
+);


### PR DESCRIPTION
## Summary

- New Inngest scheduled function `tokenExpiryMonitor` (cron `0 9 * * *`) scans `CredentialEntry` rows where `tokenExpiresAt` is set and `status="active"`, computes days-until-expiry, and upserts tiered `PlatformNotification` rows: `info` (<=30d), `warning` (<=14d), `critical` (<=7d), `expired` (<=0d). Idempotent at the same severity; resolves the prior open notification when severity escalates or when the token moves back outside the 30-day window.
- New `TokenExpiryBanner` async server component renders `warning`/`critical`/`expired` notifications above the Platform Development form, with anchor links to `ConnectGitHubCard` (Reconnect GitHub) and `AdvancedTokenPaste` (Update token).
- Adds `id="connect-github"` and `id="advanced-token"` anchors around the existing connect surfaces in `PlatformDevelopmentForm`.

Tier 1 (Device Flow) tokens never carry an expiry; Tier 3 (classic PAT) usually doesn't. Only Tier 2 (fine-grained PAT, populated by the Phase 3 validator) is actively monitored.

Part of the 2026-04-24 GitHub auth 2FA readiness spec (Phase 6). Depends on Phase 3 (validator now writes `tokenExpiresAt`) and Phase 6a (`PlatformNotification` model exists).

## Test plan

- [x] `pnpm --filter web test token-expiry-monitor TokenExpiryBanner` (13/13 pass)
- [x] `pnpm --filter web exec tsc --noEmit` (clean)
- [x] `pnpm --filter web build` (clean)
- [ ] Manual: confirm banner renders on `/admin/platform-development` after seeding a `PlatformNotification` row with severity `warning`
- [ ] Manual: confirm anchor links scroll to ConnectGitHubCard / AdvancedTokenPaste

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-24-github-auth-2fa-readiness-design.md` (Token expiry monitoring)
- Plan: `docs/superpowers/plans/2026-04-24-github-auth-2fa-readiness.md` (Phase 6)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>