### PR TITLE
fix(test): make build-governed parallel-safe (#256 follow-up to #255)

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -1,19 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockAuth = vi.fn();
-const mockPrisma = {
-  featureBuild: {
-    findUnique: vi.fn(),
-    update: vi.fn(),
-    create: vi.fn(),
+const { mockAuth, mockPrisma } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockPrisma: {
+    featureBuild: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    platformDevConfig: {
+      findUnique: vi.fn(),
+    },
+    buildActivity: {
+      create: vi.fn(),
+    },
   },
-  platformDevConfig: {
-    findUnique: vi.fn(),
-  },
-  buildActivity: {
-    create: vi.fn(),
-  },
-};
+}));
 
 vi.mock("@/lib/auth", () => ({
   auth: mockAuth,
@@ -22,6 +24,8 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@dpf/db", () => ({
   prisma: mockPrisma,
 }));
+
+import { approveBuildStart, advanceBuildPhase } from "./build";
 
 describe("governed build start approvals", () => {
   beforeEach(() => {
@@ -50,7 +54,6 @@ describe("governed build start approvals", () => {
     });
     mockPrisma.featureBuild.update.mockResolvedValue({});
 
-    const { approveBuildStart } = await import("./build");
     const result = await approveBuildStart("FB-123");
 
     expect(result.approvedAt).toBeInstanceOf(Date);
@@ -86,8 +89,6 @@ describe("governed build start approvals", () => {
     mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
       governedBacklogEnabled: true,
     });
-
-    const { advanceBuildPhase } = await import("./build");
 
     await expect(advanceBuildPhase("FB-123", "plan")).rejects.toThrow(
       "Approve Start before moving this governed backlog draft into planning.",


### PR DESCRIPTION
## Summary

Single test fix that PR #255 missed: `apps/web/lib/actions/build-governed.test.ts` only fails under file-parallelism, so it passed in isolation but flaked the full suite.

## Root cause

The dynamic `await import("./build")` inside each test was hitting the 5s test timeout under parallel worker load. The first test's `prisma.featureBuild.update` call was landing late (after the timeout) and showing up in the second test's mock state, failing `not.toHaveBeenCalled()`.

## Fix

- Hoist `mockAuth` / `mockPrisma` via `vi.hoisted()` so the `vi.mock` factory doesn't race against module-scope variable initialisation.
- Switch to static `import { approveBuildStart, advanceBuildPhase } from "./build"` — `vi.mock` is hoisted by vitest so static imports still see the mocks, and we drop the dynamic-import stall entirely.

## Verification

```
CI=true pnpm exec vitest run    # apps/web
```

- 464 web test files pass, 2 skipped, 0 failed (3949 / 14 / 1 todo)
- Confirmed both isolated and full-suite runs deterministic post-fix

## Follow-up

After this lands, `continue-on-error: true` can come off the Unit Tests job in `.github/workflows/ci.yml` and Unit Tests promoted to a required status check on `main` — the goal of #104.

Note: an earlier version of this PR also restored the `loadQuickBooksPreview` wiring that PR #231's squash-merge accidentally deleted (and PR #242's restore missed). PR #255 took the "match the broken page" approach instead. Whether to restore the live-preview feature is left for a separate PR — it's a feature decision, not a CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)