### PR TITLE
fix: block ungrounded Build Studio plan completion claims

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -145,6 +145,26 @@ describe("detectFabrication", () => {
     expect(detectFabrication("SHIPPED TO STAGING. Feature live at /build.", 0, false)).toBe(true);
   });
 
+  it("detects plan-ready claims with zero tools executed", () => {
+    expect(
+      detectFabrication(
+        "Planning is done; the next required action is approving Start Implementation for FB-9B19098C in the product UI.",
+        0,
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("detects plan-summary narration with zero tools executed", () => {
+    expect(
+      detectFabrication(
+        "I refined the plan to 5 small UI-only tasks across 4 existing files and the next approval in the product UI is Start Implementation for FB-9B19098C.",
+        0,
+        false,
+      ),
+    ).toBe(true);
+  });
+
   it("detects narration with only read tools (no build tools)", () => {
     expect(detectFabrication(
       "Here's the exact code to add to agent-routing.ts:\n```{ label: 'Analyze' }```",

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -63,12 +63,14 @@ const MAX_TEXT_MESSAGE_CHARS = 4_000;
 // ─── Extracted for testability ──────────────────────────────────────────────
 
 /** Determine whether the loop should nudge the model to use tools. */
-const COMPLETION_CLAIM_PATTERN = /\b(built|deployed|shipped|created|implemented|saved|configured|tested|fixed|completed|installed|launched|starting up|initializing|applying|generating)\b|tests?\s+pass/i;
+const COMPLETION_CLAIM_PATTERN =
+  /\b(built|deployed|shipped|created|implemented|saved|configured|tested|fixed|completed|installed|launched|starting up|initializing|applying|generating)\b|tests?\s+pass|plan(?:ning)?\s+(?:is\s+done|ready)|building\s+now|start\s+implementation/i;
 
 // Narration patterns: agent describes code or announces intent instead of calling tools.
 // Includes preamble narration ("Let me check", "I need to fix") and intent announcements
 // ("I'd like to generate...", "I would like to call...") that precede but do not replace tool use.
-const NARRATION_PATTERN = /(?:here(?:'s| is) (?:the |exactly |what )|code (?:to add|change|pattern)|add (?:this |the following )|insert (?:this |before )|exact (?:lines|code|changes)|manually|copy[- ]paste|(?:let me|I (?:need to|should|will|'ll|can see)) (?:check|fix|add|read|look|verify|update|create|modify|examine|review|search|generate|call|run|fetch)|(?:I(?:'d| would) like to|I(?:'m going to| am going to)) (?:check|fix|add|read|look|verify|update|create|modify|examine|review|search|generate|call|run|fetch|use|get|pull|grab|query|scan|find|load|save|send))/i;
+const NARRATION_PATTERN =
+  /(?:here(?:'s| is) (?:the |exactly |what )|code (?:to add|change|pattern)|add (?:this |the following )|insert (?:this |before )|exact (?:lines|code|changes)|manually|copy[- ]paste|I refined the plan|(?:let me|I (?:need to|should|will|'ll|can see)) (?:check|fix|add|read|look|verify|update|create|modify|examine|review|search|generate|call|run|fetch)|(?:I(?:'d| would) like to|I(?:'m going to| am going to)) (?:check|fix|add|read|look|verify|update|create|modify|examine|review|search|generate|call|run|fetch|use|get|pull|grab|query|scan|find|load|save|send))/i;
 
 // Permission-seeking patterns: agent asks user to approve each step instead of acting.
 // During build phases, the agent should proceed autonomously — not ask "should I?" every step.


### PR DESCRIPTION
## Summary
- block Build Studio coworker replies that claim plan completion or implementation readiness without any tool execution
- extend the anti-fabrication detection to catch the live plan-phase narration patterns we saw on FB-9B19098C
- add regression tests for the exact failure mode so future prompt drift does not reopen the seam

## Verification
- 
px vitest run lib/tak/agentic-loop.test.ts
- pnpm --filter web typecheck
- cd apps/web && npx next build
- Docker-served browser QA on http://localhost:3000/build after login: Build Studio loaded, FB-9B19098C still truthfully showed phase=plan, Start Implementation, and An implementation plan is required before building.

## Context
This fixes the product guardrail identified during the FB-9B19098C investigation: the coworker could claim plan readiness without persisting the authoritative plan artifacts that the UI gates on.