### PR TITLE
fix(build-studio): block ungrounded plan-ready plan gating claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ Epics must be actively managed — not just created and forgotten.
 - **All changes land via a pull request against `main` — including the maintainer's.** No direct pushes to `main`.
 - Branch from `main` with a short-lived topic branch named by intent: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `doc/<slug>`, `clean/<slug>`. One concern per branch, one concern per PR.
 - Open the PR with `gh pr create --base main`. Keep `Typecheck` and `Production Build` green before requesting merge. `Unit Tests` runs informationally while the broken-test surface is being cleaned up.
+- A PR is the delivery vehicle for a completed change slice, not a status label for the entire body of work. If the slice in the branch is ready for review and CI, open a normal PR even if adjacent follow-up work will happen in later PRs.
+- Do not open a draft PR merely to signal that broader work remains. If the branch's slice is not ready for review yet, keep working privately until it is; if it is ready, open or convert it to a normal ready-for-review PR and note any separate follow-up slices in the PR body.
 - Merge via squash-and-delete once CI passes: `gh pr merge <n> --squash --delete-branch`.
 - Always push after committing — local-only commits are invisible to CI.
 

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -172,6 +172,15 @@ describe("detectFabrication", () => {
     )).toBe(true);
   });
 
+  it("detects plan-ready claims when only read tools were executed", () => {
+    expect(detectFabrication(
+      "Plan ready — 5 tasks across 4 files, and Start Implementation is the correct next approval in the product UI.",
+      2,
+      false,
+      ["list_project_directory", "search_project_files"],
+    )).toBe(true);
+  });
+
   it("does not flag narration when build tools were used", () => {
     expect(detectFabrication(
       "Here's what I added to the code.",
@@ -645,6 +654,33 @@ describe("runAgenticLoop", () => {
     const thirdCallMessages = mockRoute.mock.calls[2]?.[0] ?? [];
     const lastUserMessage = [...thirdCallMessages].reverse().find((m: any) => m.role === "user");
     expect(lastUserMessage?.content).toContain("Do not pause with status-only updates");
+  });
+
+  it("does not allow plan-ready claims after read-only tool use without build-plan persistence", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    const mockExecuteTool = vi.mocked(executeTool);
+
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Checking the existing Build Studio workflow files.",
+        toolCalls: [{ id: "toolu_read_1", name: "search_project_files", arguments: { query: "BuildStudio workflow actions" } }],
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "Plan ready — 5 tasks across 4 files, and Start Implementation is the correct next approval in the product UI.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "Plan ready — 5 tasks across 4 files, and Start Implementation is the correct next approval in the product UI.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "",
+      }));
+
+    mockExecuteTool.mockResolvedValueOnce({ success: true, message: "Found Build Studio workflow files." });
+
+    const result = await runAgenticLoop(baseParams);
+
+    expect(result.content).not.toContain("Plan ready");
+    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
   });
 
   it("nudges build agent to use fallback steps after failed read stalls", async () => {

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -125,10 +125,15 @@ export function detectFabrication(
   // If no tools were called at all, any completion claim is fabrication
   if (executedToolCount === 0) return COMPLETION_CLAIM_PATTERN.test(response);
 
-  // If tools were called but none were BUILD tools (only read/search), and the
-  // response narrates code for the user — that's still fabrication
+  // If tools were called but none were BUILD tools (only read/search), the
+  // agent still cannot claim completion or narrate implementation as if it
+  // persisted build-state evidence. Read-only investigation is not enough to
+  // say a plan is ready, implementation started, or code was changed.
   const usedBuildTool = executedToolNames?.some((n) => BUILD_TOOL_NAMES.has(n)) ?? false;
-  if (!usedBuildTool && NARRATION_PATTERN.test(response)) return true;
+  if (!usedBuildTool && (
+    COMPLETION_CLAIM_PATTERN.test(response) ||
+    NARRATION_PATTERN.test(response)
+  )) return true;
 
   return false;
 }
@@ -717,13 +722,22 @@ export async function runAgenticLoop(params: {
         }
       }
 
-      if (shouldNudgeNow) {
-        // Preserve the best text-only response before nudging, in case the
-        // nudge produces an empty response (common with ChatGPT/gpt-5.4).
-        if (trimmed.length > bestPreNudgeContent.length) {
-          bestPreNudgeContent = trimmed;
-        }
-        continuationNudges++;
+        if (shouldNudgeNow) {
+          // Preserve the best text-only response before nudging, in case the
+          // nudge produces an empty response (common with ChatGPT/gpt-5.4).
+          // Never preserve content that already looks fabricated — otherwise a
+          // later empty retry can resurrect an ungrounded "plan ready" / "built"
+          // claim as the fallback response.
+          const looksFabricated = detectFabrication(
+            trimmed,
+            executedTools.length,
+            false,
+            executedTools.map((t) => t.name),
+          );
+          if (!looksFabricated && trimmed.length > bestPreNudgeContent.length) {
+            bestPreNudgeContent = trimmed;
+          }
+          continuationNudges++;
 
         // Permission-seeking gets a specific nudge — tell it to act, not ask.
         // Allow up to 3 permission nudges (not just 1) since models persist.


### PR DESCRIPTION
Regression fix for the Build Studio governed plan flow.

## What this fixes
- blocks "plan ready / Start Implementation" completion claims when the coworker only performed read/search work and never persisted build-state evidence
- prevents the pre-nudge fallback path from resurrecting fabricated "plan ready" text after a later empty retry
- clarifies `AGENTS.md` so PR readiness applies to the completed slice in the branch, not the entire surrounding body of work

## Regression evidence
- live DB for `FB-9B19098C` shows `phase = 'plan'` with `buildPlan = null` and `planReview = null`
- live UI on `http://localhost:3000/build` stays in `plan`, which matches the persisted state
- recent coworker narration claimed planning was done even though no `saveBuildEvidence(buildPlan)` / `reviewBuildPlan` persistence occurred

## Verification
- `pnpm --filter web test -- lib/tak/agentic-loop.test.ts`
- `pnpm --filter web typecheck`
- `cd apps/web && npx next build`
- browser QA on the current Docker runtime reproduced the broken state for `FB-9B19098C` and confirmed the UI was correctly reading the persisted gate state

## Notes
- existing stuck builds like `FB-9B19098C` do not auto-recover from this fix alone; they still need a repair path to persist `buildPlan` and `planReview`
- that repair path can land separately from this regression fix PR
