### PR TITLE
test(consume): update barrel snapshot for new triage exports

### DIFF
--- a/apps/web/lib/consume/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/consume/__snapshots__/index.test.ts.snap
@@ -4,8 +4,10 @@ exports[`consume barrel export > exports all public symbols 1`] = `
 [
   "buildOnboardingPrompt",
   "getChecklists",
+  "getDiscoveryTriageDecisionHistory",
   "getInventoryEntitiesForPage",
   "getInventoryEntitiesGroupedBySubnet",
+  "getInventoryTriageQueues",
   "getLatestDiscoveryRun",
   "getNeedsReviewEntities",
   "getOpenPortfolioQualityIssues",


### PR DESCRIPTION
## Summary
- PR #272 added `getDiscoveryTriageDecisionHistory` and `getInventoryTriageQueues` to the consume barrel via `discovery-data.ts`, but `apps/web/lib/consume/__snapshots__/index.test.ts.snap` wasn't refreshed in that PR
- Unit Tests are informational so PR #272 merged with the failure; the broken snapshot now lives on `main` ([failing run](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/24940341130/job/73032914820?pr=272))
- This regenerates the snapshot to match the actual exports — no behavior change

## Test plan
- [x] `pnpm --filter web exec vitest run lib/consume/index.test.ts` passes locally (2/2)
- [ ] CI on this PR: `Unit Tests` job goes from failing to green
- [ ] No other suites affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)