### PR TITLE
feat(mcp): governed backlog surface — 8 domain tools + audit-gap fix

### DIFF
--- a/apps/web/app/api/mcp/call/route.test.ts
+++ b/apps/web/app/api/mcp/call/route.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-governed-execute", () => ({
+  governedExecuteTool: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import { governedExecuteTool } from "@/lib/mcp-governed-execute";
+import { POST } from "./route";
+
+const authMock = auth as unknown as ReturnType<typeof vi.fn>;
+const govMock = governedExecuteTool as unknown as ReturnType<typeof vi.fn>;
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/mcp/call", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  authMock.mockReset();
+  govMock.mockReset();
+});
+
+afterEach(() => {
+  authMock.mockReset();
+  govMock.mockReset();
+});
+
+describe("POST /api/mcp/call", () => {
+  it("returns 401 when there is no session", async () => {
+    authMock.mockResolvedValue(null);
+    const res = await POST(makeRequest({ name: "query_backlog" }));
+    expect(res.status).toBe(401);
+    expect(govMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when tool name is missing", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    expect(govMock).not.toHaveBeenCalled();
+  });
+
+  it("calls governedExecuteTool with source='rest' and the user's identity", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    govMock.mockResolvedValue({ success: true, message: "ok" });
+
+    const res = await POST(
+      makeRequest({
+        name: "query_backlog",
+        arguments: { status: "open" },
+        agentId: "AGT-100",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(govMock).toHaveBeenCalledOnce();
+    const callArg = govMock.mock.calls[0]![0];
+    expect(callArg.toolName).toBe("query_backlog");
+    expect(callArg.userId).toBe("u1");
+    expect(callArg.source).toBe("rest");
+    expect(callArg.context.agentId).toBe("AGT-100");
+  });
+
+  it("maps unknown_tool to 404", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "unknown_tool",
+      message: "Unknown tool: bogus",
+      governance: { rejected: "unknown_tool" },
+    });
+    const res = await POST(makeRequest({ name: "bogus" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("maps forbidden_capability to 403", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "viewer", isSuperuser: false },
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "forbidden_capability",
+      message: "rejected",
+      governance: { rejected: "forbidden_capability" },
+    });
+    const res = await POST(makeRequest({ name: "create_backlog_item" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("maps forbidden_grant to 403", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "forbidden_grant",
+      message: "rejected",
+      governance: { rejected: "forbidden_grant" },
+    });
+    const res = await POST(
+      makeRequest({ name: "create_backlog_item", agentId: "AGT-NoGrant" }),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/web/app/api/mcp/call/route.ts
+++ b/apps/web/app/api/mcp/call/route.ts
@@ -1,8 +1,9 @@
 import { auth } from "@/lib/auth";
-import { can } from "@/lib/permissions";
-// Lazy-load mcp-tools to avoid bundling child_process at module init.
-// Uses a normal dynamic import (NOT turbopackIgnore) so Turbopack resolves @/lib correctly.
-const getMcpTools = () => import("@/lib/mcp-tools");
+
+// Lazy-load mcp-governed-execute (and through it, mcp-tools) to avoid bundling
+// child_process at module init. Uses a normal dynamic import so Turbopack
+// resolves @/lib correctly.
+const getGovernedExecute = () => import("@/lib/mcp-governed-execute");
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -10,28 +11,47 @@ export async function POST(request: Request) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = (await request.json()) as { name?: string; arguments?: Record<string, unknown> };
+  const body = (await request.json()) as {
+    name?: string;
+    arguments?: Record<string, unknown>;
+    agentId?: string;
+    threadId?: string;
+    routeContext?: string;
+  };
   if (!body.name) {
     return Response.json({ error: "Missing tool name" }, { status: 400 });
   }
 
-  const { PLATFORM_TOOLS, executeTool } = await getMcpTools();
+  const { governedExecuteTool } = await getGovernedExecute();
 
-  const tool = PLATFORM_TOOLS.find((t) => t.name === body.name);
-  if (!tool) {
-    return Response.json({ error: `Unknown tool: ${body.name}` }, { status: 404 });
+  const result = await governedExecuteTool({
+    toolName: body.name,
+    rawParams: body.arguments ?? {},
+    userId: session.user.id,
+    userContext: {
+      platformRole: session.user.platformRole,
+      isSuperuser: session.user.isSuperuser,
+    },
+    context: {
+      agentId: body.agentId,
+      threadId: body.threadId,
+      routeContext: body.routeContext,
+    },
+    source: "rest",
+  });
+
+  // Map governance rejections to HTTP status codes for REST callers that key
+  // off status. The body still carries the structured ToolResult for clients
+  // that prefer the JSON shape.
+  if (result.governance?.rejected === "unknown_tool") {
+    return Response.json(result, { status: 404 });
   }
-
   if (
-    tool.requiredCapability &&
-    !can(
-      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
-      tool.requiredCapability,
-    )
+    result.governance?.rejected === "forbidden_capability" ||
+    result.governance?.rejected === "forbidden_grant"
   ) {
-    return Response.json({ error: "Insufficient permissions" }, { status: 403 });
+    return Response.json(result, { status: 403 });
   }
 
-  const result = await executeTool(body.name, body.arguments ?? {}, session.user.id);
   return Response.json(result);
 }

--- a/apps/web/lib/backlog/recommend.test.ts
+++ b/apps/web/lib/backlog/recommend.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { rankCandidates, type RecommendCandidate } from "./recommend";
+
+const baseDate = new Date("2026-04-25T12:00:00Z");
+
+function candidate(overrides: Partial<RecommendCandidate>): RecommendCandidate {
+  return {
+    itemId: "BI-DEFAULT",
+    title: "Default item",
+    status: "open",
+    priority: null,
+    effortSize: null,
+    triageOutcome: null,
+    hasActiveBuild: false,
+    claimedById: null,
+    claimedByAgentId: null,
+    epicId: null,
+    epicStatus: null,
+    hasSpec: false,
+    hasPlan: false,
+    updatedAt: baseDate,
+    ...overrides,
+  };
+}
+
+describe("rankCandidates — eligibility", () => {
+  it("filters out done and deferred items", () => {
+    const items = [
+      candidate({ itemId: "BI-1", status: "done" }),
+      candidate({ itemId: "BI-2", status: "deferred" }),
+      candidate({ itemId: "BI-3", status: "open" }),
+    ];
+    const result = rankCandidates(items);
+    expect(result.map((r) => r.itemId)).toEqual(["BI-3"]);
+  });
+
+  it("includes triaging items (they are pickable for triage work)", () => {
+    const items = [candidate({ itemId: "BI-T", status: "triaging" })];
+    expect(rankCandidates(items)).toHaveLength(1);
+  });
+
+  it("excludes items claimed by a user", () => {
+    const items = [
+      candidate({ itemId: "BI-Claimed", claimedById: "user-1" }),
+      candidate({ itemId: "BI-Free" }),
+    ];
+    expect(rankCandidates(items).map((r) => r.itemId)).toEqual(["BI-Free"]);
+  });
+
+  it("excludes items claimed by another agent unless forAgentId matches", () => {
+    const items = [candidate({ itemId: "BI-Mine", claimedByAgentId: "AGT-100" })];
+    expect(rankCandidates(items, { forAgentId: "AGT-100" })).toHaveLength(1);
+    expect(rankCandidates(items, { forAgentId: "AGT-999" })).toHaveLength(0);
+    expect(rankCandidates(items)).toHaveLength(0);
+  });
+
+  it("honours excludeItemIds", () => {
+    const items = [
+      candidate({ itemId: "BI-A" }),
+      candidate({ itemId: "BI-B" }),
+    ];
+    expect(
+      rankCandidates(items, { excludeItemIds: ["BI-A"] }).map((r) => r.itemId),
+    ).toEqual(["BI-B"]);
+  });
+});
+
+describe("rankCandidates — scoring", () => {
+  it("ranks an item with a spec above one without", () => {
+    const items = [
+      candidate({ itemId: "BI-NoSpec", title: "no spec" }),
+      candidate({ itemId: "BI-Spec", title: "with spec", hasSpec: true }),
+    ];
+    const ranked = rankCandidates(items);
+    expect(ranked[0]?.itemId).toBe("BI-Spec");
+    expect(ranked[0]?.signals.hasSpec).toBe(true);
+    expect(ranked[0]?.rationale).toContain("has-spec");
+  });
+
+  it("penalises items with active builds", () => {
+    const items = [
+      candidate({ itemId: "BI-Active", hasActiveBuild: true, hasSpec: true }),
+      candidate({ itemId: "BI-Free" }),
+    ];
+    const ranked = rankCandidates(items);
+    expect(ranked[0]?.itemId).toBe("BI-Active");
+    expect(ranked[0]?.signals.hasActiveBuild).toBe(true);
+    expect(ranked[1]?.itemId).toBe("BI-Free");
+    expect(ranked[0]!.score).toBeGreaterThan(ranked[1]!.score);
+  });
+
+  it("ranks triaged-for-build above untriaged when other signals tie", () => {
+    const items = [
+      candidate({ itemId: "BI-Untriaged" }),
+      candidate({ itemId: "BI-Triaged", triageOutcome: "build" }),
+    ];
+    const ranked = rankCandidates(items);
+    expect(ranked[0]?.itemId).toBe("BI-Triaged");
+  });
+
+  it("uses priority as the tie-breaker (lower number = higher priority)", () => {
+    const items = [
+      candidate({ itemId: "BI-Low", priority: 50 }),
+      candidate({ itemId: "BI-High", priority: 10 }),
+    ];
+    const ranked = rankCandidates(items);
+    // Both items gain the same flat +2 priority bonus. Tie-break by priority
+    // asc puts the lower-numbered (higher-priority) item first.
+    expect(ranked[0]?.itemId).toBe("BI-High");
+  });
+
+  it("respects count cap", () => {
+    const items = Array.from({ length: 15 }, (_, i) =>
+      candidate({ itemId: `BI-${i}`, priority: i }),
+    );
+    expect(rankCandidates(items, { count: 5 })).toHaveLength(5);
+    expect(rankCandidates(items, { count: 999 })).toHaveLength(10);
+    expect(rankCandidates(items, { count: 0 })).toHaveLength(1);
+  });
+
+  it("returns an empty list when nothing is eligible", () => {
+    const items = [candidate({ itemId: "BI-Done", status: "done" })];
+    expect(rankCandidates(items)).toEqual([]);
+  });
+});

--- a/apps/web/lib/backlog/recommend.ts
+++ b/apps/web/lib/backlog/recommend.ts
@@ -1,0 +1,139 @@
+export type RecommendCandidate = {
+  itemId: string;
+  title: string;
+  status: string;
+  priority: number | null;
+  effortSize: string | null;
+  triageOutcome: string | null;
+  hasActiveBuild: boolean;
+  claimedById: string | null;
+  claimedByAgentId: string | null;
+  epicId: string | null;
+  epicStatus: string | null;
+  hasSpec: boolean;
+  hasPlan: boolean;
+  updatedAt: Date;
+};
+
+export type RankedCandidate = {
+  itemId: string;
+  title: string;
+  rationale: string;
+  rank: number;
+  score: number;
+  signals: {
+    hasSpec: boolean;
+    hasPlan: boolean;
+    hasActiveBuild: boolean;
+    claimedByOther: boolean;
+    effortSize: string | null;
+    priority: number | null;
+    epicStatus: string | null;
+  };
+};
+
+export type RankOptions = {
+  excludeItemIds?: readonly string[];
+  forAgentId?: string | null;
+  count?: number;
+};
+
+const DEFAULT_COUNT = 3;
+const MAX_COUNT = 10;
+
+function isPickable(item: RecommendCandidate, forAgentId: string | null | undefined): boolean {
+  if (item.status !== "open" && item.status !== "triaging") return false;
+  if (item.claimedById != null) return false;
+  if (item.claimedByAgentId != null) {
+    return forAgentId != null && item.claimedByAgentId === forAgentId;
+  }
+  return true;
+}
+
+function scoreCandidate(item: RecommendCandidate): { score: number; firedSignals: string[] } {
+  let score = 0;
+  const fired: string[] = [];
+
+  if (item.hasSpec) {
+    score += 5;
+    fired.push("has-spec");
+  }
+  if (item.hasPlan) {
+    score += 3;
+    fired.push("has-plan");
+  }
+  if (item.priority != null) {
+    // Flat bonus for being prioritised at all. Lower-priority-number-is-higher
+    // ordering is handled by the explicit tie-break in the sort.
+    score += 2;
+    fired.push(`priority=${item.priority}`);
+  }
+  if (item.effortSize === "small" || item.effortSize === "medium") {
+    score += 1;
+    fired.push(`size=${item.effortSize}`);
+  }
+  if (item.triageOutcome === "build") {
+    score += 1;
+    fired.push("triaged-for-build");
+  }
+  if (item.hasActiveBuild) {
+    score -= 2;
+    fired.push("active-build (someone is on it)");
+  }
+
+  return { score, firedSignals: fired };
+}
+
+function buildRationale(firedSignals: string[]): string {
+  if (firedSignals.length === 0) return "no strong signals; ranked by recency";
+  return firedSignals.join(", ");
+}
+
+export function rankCandidates(
+  items: readonly RecommendCandidate[],
+  opts: RankOptions = {},
+): RankedCandidate[] {
+  const exclude = new Set(opts.excludeItemIds ?? []);
+  const count = Math.max(1, Math.min(opts.count ?? DEFAULT_COUNT, MAX_COUNT));
+  const forAgentId = opts.forAgentId ?? null;
+
+  const eligible = items.filter(
+    (item) => !exclude.has(item.itemId) && isPickable(item, forAgentId),
+  );
+
+  const scored = eligible.map((item) => {
+    const { score, firedSignals } = scoreCandidate(item);
+    return {
+      item,
+      score,
+      firedSignals,
+    };
+  });
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const ap = a.item.priority ?? Number.POSITIVE_INFINITY;
+    const bp = b.item.priority ?? Number.POSITIVE_INFINITY;
+    if (ap !== bp) return ap - bp;
+    return b.item.updatedAt.getTime() - a.item.updatedAt.getTime();
+  });
+
+  return scored.slice(0, count).map((entry, idx) => ({
+    itemId: entry.item.itemId,
+    title: entry.item.title,
+    rationale: buildRationale(entry.firedSignals),
+    rank: idx + 1,
+    score: Math.round(entry.score * 100) / 100,
+    signals: {
+      hasSpec: entry.item.hasSpec,
+      hasPlan: entry.item.hasPlan,
+      hasActiveBuild: entry.item.hasActiveBuild,
+      claimedByOther:
+        entry.item.claimedById != null ||
+        (entry.item.claimedByAgentId != null && entry.item.claimedByAgentId !== forAgentId),
+      effortSize: entry.item.effortSize,
+      priority: entry.item.priority,
+      epicStatus: entry.item.epicStatus,
+    },
+  }));
+}

--- a/apps/web/lib/backlog/spec-plan-search.test.ts
+++ b/apps/web/lib/backlog/spec-plan-search.test.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _resetSpecPlanCachesForTests, searchSpecsAndPlans } from "./spec-plan-search";
+
+let tmpRoot: string;
+let originalCwd: string;
+
+async function writeFixture(rel: string, body: string): Promise<void> {
+  const abs = path.join(tmpRoot, rel);
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, body, "utf-8");
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "spec-plan-search-"));
+  originalCwd = process.cwd();
+  process.chdir(tmpRoot);
+  _resetSpecPlanCachesForTests();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  _resetSpecPlanCachesForTests();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("searchSpecsAndPlans", () => {
+  it("finds a spec by title text and returns a snippet around the match", async () => {
+    await writeFixture(
+      "docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md",
+      "# Governed MCP Backlog Surface — Design Spec\n\nLong body text that has the keyword somewhere here. Lots of context around it.",
+    );
+    const results = await searchSpecsAndPlans({ query: "keyword" });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.kind).toBe("spec");
+    expect(results[0]!.title).toBe("Governed MCP Backlog Surface — Design Spec");
+    expect(results[0]!.date).toBe("2026-04-25");
+    expect(results[0]!.snippet).toContain("keyword");
+  });
+
+  it("filters by kind=plan", async () => {
+    await writeFixture(
+      "docs/superpowers/specs/2026-04-25-foo-design.md",
+      "# Foo\n\nfoo keyword here",
+    );
+    await writeFixture(
+      "docs/superpowers/plans/2026-04-25-foo.md",
+      "# Foo Plan\n\nfoo keyword here",
+    );
+    const results = await searchSpecsAndPlans({ query: "keyword", kind: "plan" });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.kind).toBe("plan");
+  });
+
+  it("extracts referenced backlog and epic IDs", async () => {
+    await writeFixture(
+      "docs/superpowers/specs/2026-04-25-x-design.md",
+      "# X\n\nThis touches BI-PORT-001 and BI-FOO-9 and EP-BUILD-9F749C and BI-PORT-001 again.",
+    );
+    const [r] = await searchSpecsAndPlans({ query: "touches" });
+    expect(r!.referencedItemIds).toEqual(["BI-FOO-9", "BI-PORT-001"]);
+    expect(r!.referencedEpicIds).toEqual(["EP-BUILD-9F749C"]);
+  });
+
+  it("matches by itemId when query alone misses", async () => {
+    await writeFixture(
+      "docs/superpowers/specs/2026-04-25-x-design.md",
+      "# X\n\nThis spec covers BI-PORT-001 work.",
+    );
+    const results = await searchSpecsAndPlans({
+      query: "nothing-matches-here",
+      itemId: "BI-PORT-001",
+    });
+    expect(results).toHaveLength(1);
+  });
+
+  it("matches by epicId when query alone misses", async () => {
+    await writeFixture(
+      "docs/superpowers/plans/2026-04-25-x.md",
+      "# Y\n\nPart of EP-LAB-6A91C2.",
+    );
+    const results = await searchSpecsAndPlans({
+      query: "nope",
+      epicId: "EP-LAB-6A91C2",
+    });
+    expect(results).toHaveLength(1);
+  });
+
+  it("respects matches cap", async () => {
+    for (let i = 0; i < 12; i++) {
+      await writeFixture(
+        `docs/superpowers/specs/2026-04-${String(i + 1).padStart(2, "0")}-spec-${i}-design.md`,
+        `# Spec ${i}\n\nkeyword ${i}`,
+      );
+    }
+    const results = await searchSpecsAndPlans({ query: "keyword", matches: 5 });
+    expect(results).toHaveLength(5);
+  });
+
+  it("clamps matches above MAX_MATCHES", async () => {
+    for (let i = 0; i < 30; i++) {
+      await writeFixture(
+        `docs/superpowers/specs/2026-04-${String((i % 28) + 1).padStart(2, "0")}-x${i}-design.md`,
+        `# x${i}\n\nkeyword`,
+      );
+    }
+    const results = await searchSpecsAndPlans({ query: "keyword", matches: 1000 });
+    expect(results.length).toBeLessThanOrEqual(25);
+  });
+
+  it("prefers frontmatter title over first H1", async () => {
+    await writeFixture(
+      "docs/superpowers/specs/2026-04-25-fm-design.md",
+      "---\ntitle: Frontmatter Title\n---\n# H1 Title\n\nkeyword",
+    );
+    const [r] = await searchSpecsAndPlans({ query: "keyword" });
+    expect(r!.title).toBe("Frontmatter Title");
+  });
+
+  it("falls back to filename when no title found", async () => {
+    await writeFixture(
+      "docs/superpowers/specs/2026-04-25-bare-design.md",
+      "Just plain body with keyword",
+    );
+    const [r] = await searchSpecsAndPlans({ query: "keyword" });
+    expect(r!.title).toBe("2026-04-25-bare-design");
+  });
+
+  it("returns empty when nothing matches", async () => {
+    await writeFixture("docs/superpowers/specs/2026-04-25-x-design.md", "# X\n\nbody");
+    const results = await searchSpecsAndPlans({ query: "absent-needle" });
+    expect(results).toEqual([]);
+  });
+
+  it("returns empty when target dirs do not exist", async () => {
+    const results = await searchSpecsAndPlans({ query: "anything" });
+    expect(results).toEqual([]);
+  });
+});

--- a/apps/web/lib/backlog/spec-plan-search.ts
+++ b/apps/web/lib/backlog/spec-plan-search.ts
@@ -201,6 +201,33 @@ export async function searchSpecsAndPlans(
   return results.slice(0, matchesCap);
 }
 
+// Reverse index: which IDs (BI-* and EP-*) are referenced anywhere under
+// docs/superpowers/{specs,plans}? Used by get_next_recommended_work to flag
+// items that already have a design or plan attached.
+export async function buildSpecPlanReferenceIndex(): Promise<{
+  specs: Set<string>;
+  plans: Set<string>;
+}> {
+  const root = repoRoot();
+  const specs = new Set<string>();
+  const plans = new Set<string>();
+  const specFiles = await listMarkdown(path.join(root, SPEC_DIR));
+  for (const file of specFiles) {
+    const entry = await loadFile(file);
+    if (!entry) continue;
+    for (const id of entry.refs.items) specs.add(id);
+    for (const id of entry.refs.epics) specs.add(id);
+  }
+  const planFiles = await listMarkdown(path.join(root, PLAN_DIR));
+  for (const file of planFiles) {
+    const entry = await loadFile(file);
+    if (!entry) continue;
+    for (const id of entry.refs.items) plans.add(id);
+    for (const id of entry.refs.epics) plans.add(id);
+  }
+  return { specs, plans };
+}
+
 // Test seam — clears in-memory caches between scenarios.
 export function _resetSpecPlanCachesForTests(): void {
   cache.clear();

--- a/apps/web/lib/backlog/spec-plan-search.ts
+++ b/apps/web/lib/backlog/spec-plan-search.ts
@@ -1,0 +1,208 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export type SpecPlanKind = "spec" | "plan";
+
+export type SpecPlanResult = {
+  path: string;
+  kind: SpecPlanKind;
+  title: string;
+  date: string | null;
+  snippet: string;
+  referencedItemIds: string[];
+  referencedEpicIds: string[];
+};
+
+export type SpecPlanSearchOptions = {
+  query: string;
+  kind?: SpecPlanKind;
+  matches?: number;
+  itemId?: string;
+  epicId?: string;
+};
+
+const DEFAULT_MATCHES = 10;
+const MAX_MATCHES = 25;
+const SNIPPET_RADIUS = 120;
+
+const SPEC_DIR = path.posix.join("docs", "superpowers", "specs");
+const PLAN_DIR = path.posix.join("docs", "superpowers", "plans");
+
+const ID_REGEX = /\b(BI|EP)-[A-Z0-9-]+\b/g;
+const FRONTMATTER_TITLE = /^title:\s*['"]?(.+?)['"]?\s*$/m;
+const FIRST_H1 = /^#\s+(.+)$/m;
+const FILENAME_DATE = /^(\d{4}-\d{2}-\d{2})/;
+
+type CacheEntry = {
+  mtimeMs: number;
+  title: string;
+  date: string | null;
+  body: string;
+  bodyLower: string;
+  refs: { items: string[]; epics: string[] };
+};
+
+const cache = new Map<string, CacheEntry>();
+
+function repoRoot(): string {
+  const cwdResolved = path.resolve(process.cwd());
+  const docsMarker = path.join(cwdResolved, "docs", "superpowers");
+  if (existsSyncCached(docsMarker)) return cwdResolved;
+  // apps/web/<...> dev scenarios — climb to repo root.
+  const climbed = path.resolve(cwdResolved, "..", "..");
+  return climbed;
+}
+
+const existsCache = new Map<string, boolean>();
+function existsSyncCached(p: string): boolean {
+  if (existsCache.has(p)) return existsCache.get(p)!;
+  try {
+    require("fs").statSync(p);
+    existsCache.set(p, true);
+    return true;
+  } catch {
+    existsCache.set(p, false);
+    return false;
+  }
+}
+
+function extractTitle(body: string, fallback: string): string {
+  const fm = body.match(FRONTMATTER_TITLE);
+  if (fm) return fm[1]!.trim();
+  const h1 = body.match(FIRST_H1);
+  if (h1) return h1[1]!.trim();
+  return fallback;
+}
+
+function extractDate(filename: string): string | null {
+  const m = filename.match(FILENAME_DATE);
+  return m ? m[1]! : null;
+}
+
+function extractRefs(body: string): { items: string[]; epics: string[] } {
+  const items = new Set<string>();
+  const epics = new Set<string>();
+  for (const match of body.matchAll(ID_REGEX)) {
+    const id = match[0];
+    if (id.startsWith("BI-")) items.add(id);
+    else if (id.startsWith("EP-")) epics.add(id);
+  }
+  return { items: [...items].sort(), epics: [...epics].sort() };
+}
+
+function makeSnippet(body: string, matchIndex: number): string {
+  if (matchIndex < 0) {
+    return body.slice(0, SNIPPET_RADIUS * 2).replace(/\s+/g, " ").trim();
+  }
+  const start = Math.max(0, matchIndex - SNIPPET_RADIUS);
+  const end = Math.min(body.length, matchIndex + SNIPPET_RADIUS);
+  let s = body.slice(start, end).replace(/\s+/g, " ").trim();
+  if (start > 0) s = "..." + s;
+  if (end < body.length) s = s + "...";
+  return s;
+}
+
+async function loadFile(filePath: string): Promise<CacheEntry | null> {
+  let stat;
+  try {
+    stat = await fs.stat(filePath);
+  } catch {
+    return null;
+  }
+  const cached = cache.get(filePath);
+  if (cached && cached.mtimeMs === stat.mtimeMs) return cached;
+
+  let body: string;
+  try {
+    body = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  const filename = path.basename(filePath);
+  const entry: CacheEntry = {
+    mtimeMs: stat.mtimeMs,
+    title: extractTitle(body, filename.replace(/\.md$/, "")),
+    date: extractDate(filename),
+    body,
+    bodyLower: body.toLowerCase(),
+    refs: extractRefs(body),
+  };
+  cache.set(filePath, entry);
+  return entry;
+}
+
+async function listMarkdown(absDir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(absDir);
+  } catch {
+    return [];
+  }
+  return entries.filter((f) => f.endsWith(".md")).map((f) => path.join(absDir, f));
+}
+
+export async function searchSpecsAndPlans(
+  opts: SpecPlanSearchOptions,
+): Promise<SpecPlanResult[]> {
+  const root = repoRoot();
+  const matchesCap = Math.max(1, Math.min(opts.matches ?? DEFAULT_MATCHES, MAX_MATCHES));
+  const queryLower = opts.query.toLowerCase();
+  const itemNeedle = opts.itemId?.toLowerCase() ?? null;
+  const epicNeedle = opts.epicId?.toLowerCase() ?? null;
+
+  const dirs: Array<{ kind: SpecPlanKind; path: string }> = [];
+  if (opts.kind == null || opts.kind === "spec") {
+    dirs.push({ kind: "spec", path: path.join(root, SPEC_DIR) });
+  }
+  if (opts.kind == null || opts.kind === "plan") {
+    dirs.push({ kind: "plan", path: path.join(root, PLAN_DIR) });
+  }
+
+  const results: SpecPlanResult[] = [];
+  for (const dir of dirs) {
+    const files = await listMarkdown(dir.path);
+    for (const file of files) {
+      const entry = await loadFile(file);
+      if (!entry) continue;
+
+      const titleLower = entry.title.toLowerCase();
+      const queryHit =
+        queryLower.length > 0 &&
+        (titleLower.includes(queryLower) || entry.bodyLower.includes(queryLower));
+      const itemHit = itemNeedle != null && entry.bodyLower.includes(itemNeedle);
+      const epicHit = epicNeedle != null && entry.bodyLower.includes(epicNeedle);
+
+      if (!queryHit && !itemHit && !epicHit) continue;
+
+      const matchIndex = queryLower.length > 0 ? entry.bodyLower.indexOf(queryLower) : -1;
+      const relPath = path
+        .relative(root, file)
+        .replace(/\\/g, "/");
+
+      results.push({
+        path: relPath,
+        kind: dir.kind,
+        title: entry.title,
+        date: entry.date,
+        snippet: makeSnippet(entry.body, matchIndex),
+        referencedItemIds: entry.refs.items,
+        referencedEpicIds: entry.refs.epics,
+      });
+    }
+  }
+
+  results.sort((a, b) => {
+    const ad = a.date ?? "";
+    const bd = b.date ?? "";
+    if (ad !== bd) return bd.localeCompare(ad);
+    return a.path.localeCompare(b.path);
+  });
+
+  return results.slice(0, matchesCap);
+}
+
+// Test seam — clears in-memory caches between scenarios.
+export function _resetSpecPlanCachesForTests(): void {
+  cache.clear();
+  existsCache.clear();
+}

--- a/apps/web/lib/backlog/transitions.test.ts
+++ b/apps/web/lib/backlog/transitions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  BACKLOG_STATUSES,
+  describeTransition,
+  isBacklogStatus,
+  isLegalTransition,
+  requiresAdminGrant,
+} from "./transitions";
+
+describe("isBacklogStatus", () => {
+  it("accepts canonical values", () => {
+    for (const s of BACKLOG_STATUSES) expect(isBacklogStatus(s)).toBe(true);
+  });
+  it("rejects synonyms and underscored variants", () => {
+    expect(isBacklogStatus("todo")).toBe(false);
+    expect(isBacklogStatus("in_progress")).toBe(false);
+    expect(isBacklogStatus("complete")).toBe(false);
+    expect(isBacklogStatus(null)).toBe(false);
+    expect(isBacklogStatus(undefined)).toBe(false);
+  });
+});
+
+describe("isLegalTransition", () => {
+  it("treats same-status as a no-op success", () => {
+    for (const s of BACKLOG_STATUSES) expect(isLegalTransition(s, s)).toBe(true);
+  });
+
+  it("permits triage exits to open and deferred only", () => {
+    expect(isLegalTransition("triaging", "open")).toBe(true);
+    expect(isLegalTransition("triaging", "deferred")).toBe(true);
+    expect(isLegalTransition("triaging", "in-progress")).toBe(false);
+    expect(isLegalTransition("triaging", "done")).toBe(false);
+  });
+
+  it("permits open ↔ in-progress and forward to done/deferred", () => {
+    expect(isLegalTransition("open", "in-progress")).toBe(true);
+    expect(isLegalTransition("in-progress", "open")).toBe(true);
+    expect(isLegalTransition("open", "done")).toBe(true);
+    expect(isLegalTransition("in-progress", "done")).toBe(true);
+    expect(isLegalTransition("open", "deferred")).toBe(true);
+    expect(isLegalTransition("in-progress", "deferred")).toBe(true);
+  });
+
+  it("permits deferred reactivation", () => {
+    expect(isLegalTransition("deferred", "open")).toBe(true);
+    expect(isLegalTransition("deferred", "in-progress")).toBe(true);
+    expect(isLegalTransition("deferred", "triaging")).toBe(false);
+    expect(isLegalTransition("deferred", "done")).toBe(false);
+  });
+
+  it("locks done as terminal except for admin reopen", () => {
+    expect(isLegalTransition("done", "done")).toBe(true);
+    expect(isLegalTransition("done", "open")).toBe(false);
+    expect(isLegalTransition("done", "in-progress")).toBe(false);
+  });
+});
+
+describe("requiresAdminGrant", () => {
+  it("flags any move out of done", () => {
+    expect(requiresAdminGrant("done", "open")).toBe(true);
+    expect(requiresAdminGrant("done", "in-progress")).toBe(true);
+    expect(requiresAdminGrant("done", "deferred")).toBe(true);
+  });
+  it("does not flag the done → done no-op", () => {
+    expect(requiresAdminGrant("done", "done")).toBe(false);
+  });
+  it("does not flag normal forward moves", () => {
+    expect(requiresAdminGrant("open", "done")).toBe(false);
+    expect(requiresAdminGrant("triaging", "open")).toBe(false);
+  });
+});
+
+describe("describeTransition", () => {
+  it("renders no-op, legal, illegal", () => {
+    expect(describeTransition("open", "open")).toContain("no-op");
+    expect(describeTransition("open", "done")).toBe("open → done");
+    expect(describeTransition("triaging", "done")).toContain("illegal");
+  });
+});

--- a/apps/web/lib/backlog/transitions.ts
+++ b/apps/web/lib/backlog/transitions.ts
@@ -1,0 +1,38 @@
+export const BACKLOG_STATUSES = [
+  "triaging",
+  "open",
+  "in-progress",
+  "done",
+  "deferred",
+] as const;
+
+export type BacklogStatus = (typeof BACKLOG_STATUSES)[number];
+
+export function isBacklogStatus(value: unknown): value is BacklogStatus {
+  return typeof value === "string" && (BACKLOG_STATUSES as readonly string[]).includes(value);
+}
+
+const LEGAL: Record<BacklogStatus, ReadonlySet<BacklogStatus>> = {
+  triaging: new Set<BacklogStatus>(["open", "deferred"]),
+  open: new Set<BacklogStatus>(["in-progress", "done", "deferred"]),
+  "in-progress": new Set<BacklogStatus>(["open", "done", "deferred"]),
+  done: new Set<BacklogStatus>(["done"]),
+  deferred: new Set<BacklogStatus>(["open", "in-progress"]),
+};
+
+export function isLegalTransition(from: BacklogStatus, to: BacklogStatus): boolean {
+  if (from === to) return true;
+  return LEGAL[from].has(to);
+}
+
+export function requiresAdminGrant(from: BacklogStatus, to: BacklogStatus): boolean {
+  return from === "done" && to !== "done";
+}
+
+export function describeTransition(from: BacklogStatus, to: BacklogStatus): string {
+  if (from === to) return `no-op (${from})`;
+  if (!isLegalTransition(from, to)) {
+    return `illegal: ${from} → ${to}`;
+  }
+  return `${from} → ${to}`;
+}

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _setGovernanceForTests,
+  governedExecuteTool,
+} from "./mcp-governed-execute";
+import type { ToolResult } from "./mcp-tools";
+
+type AuditRow = Record<string, unknown>;
+
+function captureAudit(rows: AuditRow[]) {
+  return async (data: AuditRow) => {
+    rows.push(data);
+  };
+}
+
+const NORMAL_USER = {
+  platformRole: "ceo",
+  isSuperuser: true,
+};
+
+type ExecuteFn = (
+  toolName: string,
+  params: Record<string, unknown>,
+  userId: string,
+  ctx?: {
+    agentId?: string;
+    threadId?: string;
+    routeContext?: string;
+    taskRunId?: string;
+  },
+) => Promise<ToolResult>;
+
+let auditRows: AuditRow[];
+let executeMock: ReturnType<typeof vi.fn> & ExecuteFn;
+
+beforeEach(() => {
+  auditRows = [];
+  executeMock = vi.fn(
+    async (): Promise<ToolResult> => ({
+      success: true,
+      message: "ok",
+      entityId: "BI-FAKE",
+    }),
+  ) as ReturnType<typeof vi.fn> & ExecuteFn;
+  _setGovernanceForTests({
+    resolveAgentGrants: async () => ["backlog_read", "backlog_write"],
+    isAllowedByGrants: () => true,
+    executeTool: executeMock,
+    toolExecutionCreate: captureAudit(auditRows),
+  });
+});
+
+afterEach(() => {
+  _setGovernanceForTests({
+    resolveAgentGrants: null,
+    isAllowedByGrants: null,
+    executeTool: null,
+    toolExecutionCreate: null,
+  });
+});
+
+describe("governedExecuteTool — happy path", () => {
+  it("invokes executeTool, audits with the correct executionMode, and returns the result", async () => {
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: { status: "open" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-100", threadId: "thread-1" },
+      source: "rest",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("ok");
+    expect(executeMock).toHaveBeenCalledOnce();
+    expect(executeMock).toHaveBeenCalledWith(
+      "query_backlog",
+      { status: "open" },
+      "user-1",
+      expect.objectContaining({ agentId: "AGT-100", threadId: "thread-1" }),
+    );
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]!.toolName).toBe("query_backlog");
+    expect(auditRows[0]!.executionMode).toBe("rest");
+    expect(auditRows[0]!.success).toBe(true);
+    expect(auditRows[0]!.userId).toBe("user-1");
+    expect(auditRows[0]!.agentId).toBe("AGT-100");
+  });
+
+  it("propagates the source field unchanged for each transport", async () => {
+    for (const source of ["rest", "jsonrpc", "external-jsonrpc", "agentic-loop"] as const) {
+      auditRows.length = 0;
+      await governedExecuteTool({
+        toolName: "query_backlog",
+        rawParams: {},
+        userId: "u",
+        userContext: NORMAL_USER,
+        source,
+      });
+      expect(auditRows[0]?.executionMode).toBe(source);
+    }
+  });
+});
+
+describe("governedExecuteTool — rejection paths", () => {
+  it("returns unknown_tool without invoking executeTool", async () => {
+    const result = await governedExecuteTool({
+      toolName: "totally_made_up_tool",
+      rawParams: {},
+      userId: "u",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("unknown_tool");
+    expect(executeMock).not.toHaveBeenCalled();
+    // unknown_tool is rejected before audit write
+    expect(auditRows).toHaveLength(0);
+  });
+
+  it("rejects on forbidden_grant and audits the failure (executeTool never runs)", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["registry_read"], // no backlog_write
+      isAllowedByGrants: () => false,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+    });
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "x", type: "product", source: "user-request" },
+      userId: "u",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-100" },
+      source: "rest",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("forbidden_grant");
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.success).toBe(false);
+    expect(auditRows[0]?.toolName).toBe("create_backlog_item");
+  });
+
+  it("rejects on forbidden_capability and audits the failure", async () => {
+    const lowPrivilege = { platformRole: "viewer", isSuperuser: false };
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "x", type: "product", source: "user-request" },
+      userId: "u",
+      userContext: lowPrivilege,
+      source: "rest",
+    });
+    // viewer doesn't have manage_backlog
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("forbidden_capability");
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.success).toBe(false);
+  });
+});
+
+describe("governedExecuteTool — resilience", () => {
+  it("does not throw to the caller when audit write fails", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_read"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: async () => {
+        throw new Error("DB exploded");
+      },
+    });
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "u",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+    // Tool ran successfully even though audit write failed
+    expect(result.success).toBe(true);
+  });
+
+  it("converts a thrown executeTool into a structured failure result + audit", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_read"],
+      isAllowedByGrants: () => true,
+      executeTool: async () => {
+        throw new Error("kaboom");
+      },
+      toolExecutionCreate: captureAudit(auditRows),
+    });
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "u",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("tool_threw");
+    expect(result.message).toContain("kaboom");
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.success).toBe(false);
+  });
+});

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -1,0 +1,282 @@
+// Single governed entry point for tool execution.
+//
+// All MCP-style callers (REST /api/mcp/call, the future JSON-RPC route, and
+// the in-platform agentic loop) should funnel through here so that the three
+// governance layers — user capability, agent grants, audit — are enforced in
+// one place. Today only agentic-loop writes ToolExecution rows; this wrapper
+// closes the audit gap on the REST and JSON-RPC paths and gives the future
+// external-MCP transport a stable hook.
+
+import { prisma } from "@dpf/db";
+import { can, type CapabilityKey, type UserContext } from "./permissions";
+import {
+  PLATFORM_TOOLS,
+  executeTool,
+  type ToolDefinition,
+  type ToolResult,
+} from "./mcp-tools";
+import { deriveAuditClassForTool, deriveCapabilityId } from "./tool-audit-helpers";
+
+export type GovernedExecuteSource =
+  | "rest"
+  | "jsonrpc"
+  | "external-jsonrpc"
+  | "agentic-loop";
+
+export type GovernedExecuteContext = {
+  agentId?: string;
+  threadId?: string;
+  routeContext?: string;
+  taskRunId?: string;
+  apiTokenId?: string;
+};
+
+export type GovernedExecuteArgs = {
+  toolName: string;
+  rawParams: Record<string, unknown>;
+  userId: string;
+  userContext: UserContext;
+  context?: GovernedExecuteContext;
+  source: GovernedExecuteSource;
+};
+
+export type GovernedExecuteRejection =
+  | "unknown_tool"
+  | "forbidden_capability"
+  | "forbidden_grant";
+
+export type GovernedExecuteResult = ToolResult & {
+  governance?: {
+    rejected?: GovernedExecuteRejection;
+    durationMs?: number;
+  };
+};
+
+// Test seam — production uses the imported real grant resolver. Tests can
+// override these without mocking the import system.
+export type GrantResolver = (agentId: string) => Promise<string[]>;
+export type GrantPredicate = (toolName: string, grants: string[]) => boolean;
+
+let _resolveAgentGrants: GrantResolver | null = null;
+let _isAllowedByGrants: GrantPredicate | null = null;
+
+export function _setGovernanceForTests(overrides: {
+  resolveAgentGrants?: GrantResolver | null;
+  isAllowedByGrants?: GrantPredicate | null;
+  executeTool?: ((
+    toolName: string,
+    params: Record<string, unknown>,
+    userId: string,
+    ctx?: { agentId?: string; threadId?: string; routeContext?: string; taskRunId?: string },
+  ) => Promise<ToolResult>) | null;
+  toolExecutionCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
+}): void {
+  _resolveAgentGrants = overrides.resolveAgentGrants ?? null;
+  _isAllowedByGrants = overrides.isAllowedByGrants ?? null;
+  _executeToolOverride = overrides.executeTool ?? null;
+  _toolExecutionCreateOverride = overrides.toolExecutionCreate ?? null;
+}
+
+let _executeToolOverride:
+  | ((
+      toolName: string,
+      params: Record<string, unknown>,
+      userId: string,
+      ctx?: {
+        agentId?: string;
+        threadId?: string;
+        routeContext?: string;
+        taskRunId?: string;
+      },
+    ) => Promise<ToolResult>)
+  | null = null;
+
+let _toolExecutionCreateOverride:
+  | ((data: Record<string, unknown>) => Promise<unknown>)
+  | null = null;
+
+async function resolveGrants(agentId: string): Promise<string[]> {
+  if (_resolveAgentGrants) return _resolveAgentGrants(agentId);
+  const { getAgentToolGrantsAsync } = await import("./tak/agent-grants");
+  return getAgentToolGrantsAsync(agentId);
+}
+
+async function isAllowedByGrants(toolName: string, grants: string[]): Promise<boolean> {
+  if (_isAllowedByGrants) return _isAllowedByGrants(toolName, grants);
+  const { isToolAllowedByGrants } = await import("./tak/agent-grants");
+  return isToolAllowedByGrants(toolName, grants);
+}
+
+async function callExecuteTool(
+  toolName: string,
+  params: Record<string, unknown>,
+  userId: string,
+  ctx?: {
+    agentId?: string;
+    threadId?: string;
+    routeContext?: string;
+    taskRunId?: string;
+  },
+): Promise<ToolResult> {
+  if (_executeToolOverride) return _executeToolOverride(toolName, params, userId, ctx);
+  return executeTool(toolName, params, userId, ctx);
+}
+
+async function writeAudit(data: {
+  toolName: string;
+  rawParams: Record<string, unknown>;
+  result: ToolResult;
+  userId: string;
+  source: GovernedExecuteSource;
+  context?: GovernedExecuteContext;
+  durationMs: number;
+}): Promise<void> {
+  const auditClass = deriveAuditClassForTool(data.toolName);
+  const capabilityId = deriveCapabilityId(data.toolName);
+  const isMetricsOnly = auditClass === "metrics_only";
+  const row = {
+    threadId: data.context?.threadId ?? "",
+    agentId: data.context?.agentId ?? "unknown",
+    userId: data.userId,
+    taskRunId: data.context?.taskRunId ?? null,
+    toolName: data.toolName,
+    parameters: isMetricsOnly ? {} : (data.rawParams as object),
+    result: isMetricsOnly ? {} : (data.result as unknown as object),
+    success: data.result.success,
+    executionMode: data.source,
+    routeContext: data.context?.routeContext ?? null,
+    durationMs: data.durationMs,
+    auditClass,
+    capabilityId,
+    summary: isMetricsOnly
+      ? `${data.toolName}: ${data.result.success ? "ok" : "failed"}` +
+        (data.durationMs ? ` (${data.durationMs}ms)` : "")
+      : null,
+    // apiTokenId is plumbed through GovernedExecuteContext but not yet written
+    // — the column lands in spec §13 (external-client transport).
+  };
+  try {
+    if (_toolExecutionCreateOverride) {
+      await _toolExecutionCreateOverride(row);
+    } else {
+      await prisma.toolExecution.create({ data: row });
+    }
+  } catch (err) {
+    // Audit MUST NOT silently fail. Log with enough context to investigate
+    // without throwing back to the caller (which would mask successful tool
+    // execution).
+    console.error(
+      `[governed-execute] audit write failed tool=${data.toolName} source=${data.source}:`,
+      err,
+    );
+  }
+}
+
+function findTool(toolName: string): ToolDefinition | undefined {
+  return PLATFORM_TOOLS.find((t) => t.name === toolName);
+}
+
+function rejectionResult(
+  toolName: string,
+  rejection: GovernedExecuteRejection,
+  detail: string,
+): GovernedExecuteResult {
+  const message = `${toolName} rejected: ${detail}`;
+  return {
+    success: false,
+    error: rejection,
+    message,
+    governance: { rejected: rejection },
+  };
+}
+
+export async function governedExecuteTool(
+  args: GovernedExecuteArgs,
+): Promise<GovernedExecuteResult> {
+  const tool = findTool(args.toolName);
+  if (!tool) {
+    return {
+      success: false,
+      error: "unknown_tool",
+      message: `Unknown tool: ${args.toolName}`,
+      governance: { rejected: "unknown_tool" },
+    };
+  }
+
+  // Capability check — user must have the platform role required by the tool.
+  if (tool.requiredCapability) {
+    const allowed = can(args.userContext, tool.requiredCapability as CapabilityKey);
+    if (!allowed) {
+      const result = rejectionResult(
+        args.toolName,
+        "forbidden_capability",
+        `user lacks capability ${tool.requiredCapability}`,
+      );
+      await writeAudit({
+        toolName: args.toolName,
+        rawParams: args.rawParams,
+        result,
+        userId: args.userId,
+        source: args.source,
+        context: args.context,
+        durationMs: 0,
+      });
+      return result;
+    }
+  }
+
+  // Agent grant check — when an agentId is in the context, the agent must
+  // have a grant that authorises this tool.
+  if (args.context?.agentId) {
+    const grants = await resolveGrants(args.context.agentId);
+    const allowed = await isAllowedByGrants(args.toolName, grants);
+    if (!allowed) {
+      const result = rejectionResult(
+        args.toolName,
+        "forbidden_grant",
+        `agent ${args.context.agentId} lacks a required grant for ${args.toolName}`,
+      );
+      await writeAudit({
+        toolName: args.toolName,
+        rawParams: args.rawParams,
+        result,
+        userId: args.userId,
+        source: args.source,
+        context: args.context,
+        durationMs: 0,
+      });
+      return result;
+    }
+  }
+
+  const t0 = Date.now();
+  let result: ToolResult;
+  try {
+    result = await callExecuteTool(args.toolName, args.rawParams, args.userId, {
+      agentId: args.context?.agentId,
+      threadId: args.context?.threadId,
+      routeContext: args.context?.routeContext,
+      taskRunId: args.context?.taskRunId,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown tool error";
+    result = {
+      success: false,
+      error: "tool_threw",
+      message: `${args.toolName} threw: ${message}`,
+    };
+  }
+  const durationMs = Date.now() - t0;
+
+  await writeAudit({
+    toolName: args.toolName,
+    rawParams: args.rawParams,
+    result,
+    userId: args.userId,
+    source: args.source,
+    context: args.context,
+    durationMs,
+  });
+
+  return { ...result, governance: { durationMs } };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -324,6 +324,152 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: false,
     buildPhases: ["ideate"],
   },
+  // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────────
+  {
+    name: "list_epics",
+    description: "List epics with item-count rollups. Read-only. Filterable by status and whether the epic has open items. Returned epicId is the semantic id (EP-*), not the internal cuid.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["open", "in-progress", "done"], description: "Filter by epic status" },
+        hasOpenItems: { type: "boolean", description: "Only return epics that have at least one non-done item" },
+        limit: { type: "number", description: "Max results (default 25, max 100)" },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "list_backlog_items",
+    description: "List backlog items filtered by status, type, epic, claim state, or active-build state. Read-only. Returns semantic IDs (BI-*, EP-*) — never cuids.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["triaging", "open", "in-progress", "done", "deferred"] },
+        type: { type: "string", enum: ["portfolio", "product"] },
+        epicId: { type: "string", description: "Semantic epic id (EP-*) to filter to" },
+        unclaimed: { type: "boolean", description: "Only items with no user/agent claim" },
+        hasActiveBuild: { type: "boolean", description: "Only items currently linked to a Build Studio build" },
+        limit: { type: "number", description: "Max results (default 25, max 100)" },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "get_backlog_item",
+    description: "Fetch one backlog item by semantic id with linked epic, digital product, active build, and the most recent activity entries. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "Semantic backlog item id (e.g. BI-PORT-005)" },
+      },
+      required: ["itemId"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "update_backlog_item_status",
+    description: "Move a backlog item between lifecycle statuses (triaging|open|in-progress|done|deferred). Enforces legal-transition table; same-status calls are no-op successes. Sets completedAt and may auto-close the parent epic when the last item reaches done. Writes a status_change activity row.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "Semantic backlog item id" },
+        status: { type: "string", enum: ["open", "in-progress", "done", "deferred"] },
+        reason: { type: "string", description: "Free-text rationale captured in the activity row" },
+        resolution: { type: "string", description: "Outcome summary, required when status=done" },
+      },
+      required: ["itemId", "status"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "link_backlog_item_to_epic",
+    description: "Link a backlog item to an epic (or unlink with epicId=null). Recomputes target epic status — if a done epic gains a new open item, it flips back to open. Writes an epic_link activity row.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "Semantic backlog item id" },
+        epicId: { type: "string", description: "Semantic epic id (EP-*), or empty string / 'null' to unlink" },
+      },
+      required: ["itemId"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "search_specs_and_plans",
+    description: "Search design specs (docs/superpowers/specs) and implementation plans (docs/superpowers/plans) by title and body, with optional itemId/epicId narrowing. Returns paths, titles, dates, snippets, and the BI-/EP- references found in each match. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Free-text query (case-insensitive substring match on title and body)" },
+        kind: { type: "string", enum: ["spec", "plan"], description: "Restrict to one tree" },
+        matches: { type: "number", description: "Max results (default 10, max 25)" },
+        itemId: { type: "string", description: "Also include files that mention this BI- id" },
+        epicId: { type: "string", description: "Also include files that mention this EP- id" },
+      },
+      required: ["query"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+  {
+    name: "record_execution_evidence",
+    description: "Attach an evidence record to a backlog item (test pass/fail, build pass/fail, ux verification, spec review, manual check, external link). Writes an evidence activity row; the cross-cutting audit lives in ToolExecution. Side-effecting.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "Semantic backlog item id" },
+        kind: {
+          type: "string",
+          enum: [
+            "test_pass",
+            "test_fail",
+            "build_pass",
+            "build_fail",
+            "ux_verified",
+            "spec_review",
+            "manual_check",
+            "external_link",
+          ],
+          description: "Evidence kind",
+        },
+        summary: { type: "string", description: "Headline for the timeline (<= 240 chars)" },
+        url: { type: "string", description: "Link to PR / CI run / screenshot" },
+        body: { type: "string", description: "Longer notes (<= 8000 chars)" },
+        toolExecutionId: { type: "string", description: "Audit row id when this evidence was produced by a prior tool call" },
+      },
+      required: ["itemId", "kind", "summary"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "get_next_recommended_work",
+    description: "Return a short ranked list of backlog items the caller could pick up next. Ranks by spec/plan presence, triage outcome, effort size, priority, and active-build state. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        count: { type: "number", description: "How many recommendations to return (default 3, max 10)" },
+        epicId: { type: "string", description: "Restrict to one epic" },
+        forAgentId: { type: "string", description: "Only items grant-claimable by this agent" },
+        excludeItemIds: { type: "array", items: { type: "string" }, description: "Items to skip (already considered or rejected)" },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
   {
     name: "report_quality_issue",
     description: "Report a bug, suggestion, or question about the platform. Available to ALL employees regardless of role — anyone can report a problem.",
@@ -2600,6 +2746,558 @@ export async function executeTool(
           epics: epics.map((e) => ({ epicId: e.epicId, title: e.title, status: e.status })),
           items: items.map((i) => ({ itemId: i.itemId, title: i.title, status: i.status, type: i.type, priority: i.priority, epicId: i.epicId })),
         },
+      };
+    }
+
+    // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────
+    case "list_epics": {
+      const where: Record<string, unknown> = {};
+      if (typeof params["status"] === "string") where["status"] = params["status"];
+      const limit = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+      const epics = await prisma.epic.findMany({
+        where,
+        take: limit,
+        orderBy: [{ updatedAt: "desc" }],
+        select: {
+          id: true,
+          epicId: true,
+          title: true,
+          status: true,
+          updatedAt: true,
+          items: { select: { status: true } },
+        },
+      });
+      const wantOpenItems = params["hasOpenItems"] === true;
+      const { buildSpecPlanReferenceIndex } = await import("@/lib/backlog/spec-plan-search");
+      const refIndex = await buildSpecPlanReferenceIndex();
+      const data = epics
+        .map((e) => {
+          const total = e.items.length;
+          const open = e.items.filter((it) => it.status === "open").length;
+          const inProgress = e.items.filter((it) => it.status === "in-progress").length;
+          const done = e.items.filter((it) => it.status === "done").length;
+          return {
+            epicId: e.epicId,
+            title: e.title,
+            status: e.status,
+            itemCount: { total, open, inProgress, done },
+            hasSpec: refIndex.specs.has(e.epicId) || refIndex.plans.has(e.epicId),
+            updatedAt: e.updatedAt.toISOString(),
+            _hasOpen: open + inProgress > 0,
+          };
+        })
+        .filter((row) => (wantOpenItems ? row._hasOpen : true))
+        .map((row) => {
+          const { _hasOpen, ...rest } = row;
+          void _hasOpen;
+          return rest;
+        });
+      return {
+        success: true,
+        message: `Listed ${data.length} epic(s).`,
+        data: { epics: data },
+      };
+    }
+
+    case "list_backlog_items": {
+      const where: Record<string, unknown> = {};
+      if (typeof params["status"] === "string") where["status"] = params["status"];
+      if (typeof params["type"] === "string") where["type"] = params["type"];
+      if (typeof params["epicId"] === "string" && params["epicId"].trim()) {
+        const epicRow = await prisma.epic.findFirst({
+          where: { OR: [{ epicId: params["epicId"].trim() }, { id: params["epicId"].trim() }] },
+          select: { id: true },
+        });
+        if (epicRow) where["epicId"] = epicRow.id;
+        else
+          return {
+            success: false,
+            error: "epic_not_found",
+            message: `No epic matched ${params["epicId"]}`,
+          };
+      }
+      if (params["unclaimed"] === true) {
+        where["claimedById"] = null;
+        where["claimedByAgentId"] = null;
+      }
+      if (params["hasActiveBuild"] === true) where["activeBuildId"] = { not: null };
+      else if (params["hasActiveBuild"] === false) where["activeBuildId"] = null;
+
+      const limit = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+      const items = await prisma.backlogItem.findMany({
+        where,
+        take: limit,
+        orderBy: [{ priority: "asc" }, { updatedAt: "desc" }],
+        select: {
+          itemId: true,
+          title: true,
+          status: true,
+          type: true,
+          priority: true,
+          effortSize: true,
+          activeBuildId: true,
+          updatedAt: true,
+          triageOutcome: true,
+          epic: { select: { epicId: true } },
+          activeBuild: { select: { phase: true, draftApprovedAt: true } },
+        },
+      });
+      const { deriveLifecycleLabel } = await import("@/lib/governed-backlog-workflow");
+      const data = items.map((i) => ({
+        itemId: i.itemId,
+        title: i.title,
+        status: i.status,
+        type: i.type,
+        priority: i.priority,
+        effortSize: i.effortSize,
+        triageOutcome: i.triageOutcome,
+        epicId: i.epic?.epicId ?? null,
+        hasActiveBuild: i.activeBuildId != null,
+        lifecycleLabel: deriveLifecycleLabel({
+          backlogItem: { status: i.status, triageOutcome: i.triageOutcome, activeBuildId: i.activeBuildId },
+          featureBuild: i.activeBuild
+            ? { phase: i.activeBuild.phase, draftApprovedAt: i.activeBuild.draftApprovedAt }
+            : null,
+          governedBacklogEnabled: true,
+        }),
+        updatedAt: i.updatedAt.toISOString(),
+      }));
+      return {
+        success: true,
+        message: `Listed ${data.length} backlog item(s).`,
+        data: { items: data },
+      };
+    }
+
+    case "get_backlog_item": {
+      const itemIdRaw = String(params["itemId"] ?? "").trim();
+      if (!itemIdRaw)
+        return { success: false, error: "missing_itemId", message: "itemId is required" };
+      const item = await prisma.backlogItem.findUnique({
+        where: { itemId: itemIdRaw },
+        include: {
+          epic: { select: { epicId: true, title: true, status: true } },
+          digitalProduct: { select: { productId: true, name: true } },
+          activeBuild: {
+            select: {
+              buildId: true,
+              phase: true,
+              draftApprovedAt: true,
+              sandboxId: true,
+              createdAt: true,
+            },
+          },
+          activities: {
+            orderBy: { recordedAt: "desc" },
+            take: 10,
+          },
+        },
+      });
+      if (!item)
+        return { success: false, error: "not_found", message: `Item ${itemIdRaw} not found` };
+      const { deriveLifecycleLabel } = await import("@/lib/governed-backlog-workflow");
+      const { searchSpecsAndPlans } = await import("@/lib/backlog/spec-plan-search");
+      const specPlanRefs = await searchSpecsAndPlans({
+        query: itemIdRaw,
+        itemId: itemIdRaw,
+        matches: 10,
+      });
+      return {
+        success: true,
+        message: `Loaded ${item.itemId}`,
+        data: {
+          itemId: item.itemId,
+          title: item.title,
+          status: item.status,
+          type: item.type,
+          priority: item.priority,
+          effortSize: item.effortSize,
+          triageOutcome: item.triageOutcome,
+          body: item.body ?? null,
+          createdAt: item.createdAt.toISOString(),
+          updatedAt: item.updatedAt.toISOString(),
+          completedAt: item.completedAt ? item.completedAt.toISOString() : null,
+          lifecycleLabel: deriveLifecycleLabel({
+            backlogItem: {
+              status: item.status,
+              triageOutcome: item.triageOutcome,
+              activeBuildId: item.activeBuildId,
+            },
+            featureBuild: item.activeBuild
+              ? { phase: item.activeBuild.phase, draftApprovedAt: item.activeBuild.draftApprovedAt }
+              : null,
+            governedBacklogEnabled: true,
+          }),
+          epic: item.epic
+            ? { epicId: item.epic.epicId, title: item.epic.title, status: item.epic.status }
+            : null,
+          digitalProduct: item.digitalProduct
+            ? { productId: item.digitalProduct.productId, name: item.digitalProduct.name }
+            : null,
+          activeBuild: item.activeBuild
+            ? {
+                buildId: item.activeBuild.buildId,
+                phase: item.activeBuild.phase,
+                draftApprovedAt: item.activeBuild.draftApprovedAt
+                  ? item.activeBuild.draftApprovedAt.toISOString()
+                  : null,
+                sandboxId: item.activeBuild.sandboxId,
+              }
+            : null,
+          specPlanFiles: specPlanRefs.map((r) => ({
+            path: r.path,
+            kind: r.kind,
+            title: r.title,
+            date: r.date,
+          })),
+          recentActivity: item.activities.map((a) => ({
+            id: a.id,
+            kind: a.kind,
+            summary: a.summary,
+            recordedAt: a.recordedAt.toISOString(),
+            payload: a.payload,
+          })),
+        },
+      };
+    }
+
+    case "update_backlog_item_status": {
+      const { isLegalTransition, isBacklogStatus } = await import("@/lib/backlog/transitions");
+      const itemIdRaw = String(params["itemId"] ?? "").trim();
+      const target = String(params["status"] ?? "");
+      if (!itemIdRaw)
+        return { success: false, error: "missing_itemId", message: "itemId is required" };
+      if (!isBacklogStatus(target))
+        return {
+          success: false,
+          error: "invalid_status",
+          message: `status must be one of triaging|open|in-progress|done|deferred, got ${target}`,
+        };
+      if (target === "triaging")
+        return {
+          success: false,
+          error: "invalid_status",
+          message: "use triage_backlog_item to move items through triage; this tool moves items already triaged",
+        };
+      const reason = typeof params["reason"] === "string" ? params["reason"] : null;
+      const resolution = typeof params["resolution"] === "string" ? params["resolution"] : null;
+      if (target === "done" && !resolution)
+        return {
+          success: false,
+          error: "missing_resolution",
+          message: "resolution is required when status=done",
+        };
+      const item = await prisma.backlogItem.findUnique({
+        where: { itemId: itemIdRaw },
+        select: { id: true, status: true, epicId: true },
+      });
+      if (!item)
+        return { success: false, error: "not_found", message: `Item ${itemIdRaw} not found` };
+      if (!isBacklogStatus(item.status))
+        return {
+          success: false,
+          error: "corrupt_current_status",
+          message: `Item ${itemIdRaw} has non-canonical status ${item.status}`,
+        };
+      if (!isLegalTransition(item.status, target))
+        return {
+          success: false,
+          error: "illegal_transition",
+          message: `cannot move ${itemIdRaw} from ${item.status} to ${target}`,
+        };
+      if (item.status === target) {
+        return {
+          success: true,
+          entityId: itemIdRaw,
+          message: `${itemIdRaw} already at status=${target} (no-op)`,
+        };
+      }
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const next = await tx.backlogItem.update({
+          where: { id: item.id },
+          data: {
+            status: target,
+            ...(target === "done" ? { completedAt: new Date(), resolution } : {}),
+          },
+          select: { itemId: true, status: true, epicId: true, completedAt: true },
+        });
+        await tx.backlogItemActivity.create({
+          data: {
+            backlogItemId: item.id,
+            kind: "status_change",
+            summary: `${item.status} → ${target}` + (reason ? ` — ${reason.slice(0, 160)}` : ""),
+            payload: {
+              from: item.status,
+              to: target,
+              reason: reason ?? null,
+              resolution: resolution ?? null,
+            },
+            recordedById: userId,
+            recordedByAgentId: context?.agentId ?? null,
+          },
+        });
+        // Epic auto-close: when this item just reached done and every sibling is done/deferred,
+        // flip the epic to done. Mirrors AGENTS.md Epic Lifecycle Stewardship.
+        if (target === "done" && item.epicId) {
+          const remaining = await tx.backlogItem.count({
+            where: {
+              epicId: item.epicId,
+              id: { not: item.id },
+              status: { notIn: ["done", "deferred"] },
+            },
+          });
+          if (remaining === 0) {
+            await tx.epic.update({
+              where: { id: item.epicId },
+              data: { status: "done", completedAt: new Date() },
+            });
+          }
+        }
+        return next;
+      });
+      return {
+        success: true,
+        entityId: updated.itemId,
+        message: `${updated.itemId}: ${item.status} → ${updated.status}`,
+        data: { itemId: updated.itemId, status: updated.status, completedAt: updated.completedAt },
+      };
+    }
+
+    case "link_backlog_item_to_epic": {
+      const itemIdRaw = String(params["itemId"] ?? "").trim();
+      if (!itemIdRaw)
+        return { success: false, error: "missing_itemId", message: "itemId is required" };
+      const epicRaw = params["epicId"];
+      const wantUnlink =
+        epicRaw == null ||
+        (typeof epicRaw === "string" && (epicRaw.trim() === "" || epicRaw.trim().toLowerCase() === "null"));
+      let targetEpicCuid: string | null = null;
+      let targetEpicSemantic: string | null = null;
+      if (!wantUnlink) {
+        const epicRow = await prisma.epic.findFirst({
+          where: { OR: [{ epicId: String(epicRaw).trim() }, { id: String(epicRaw).trim() }] },
+          select: { id: true, epicId: true, status: true },
+        });
+        if (!epicRow)
+          return { success: false, error: "epic_not_found", message: `No epic matched ${epicRaw}` };
+        targetEpicCuid = epicRow.id;
+        targetEpicSemantic = epicRow.epicId;
+      }
+      const item = await prisma.backlogItem.findUnique({
+        where: { itemId: itemIdRaw },
+        select: { id: true, epicId: true, status: true, epic: { select: { epicId: true } } },
+      });
+      if (!item)
+        return { success: false, error: "not_found", message: `Item ${itemIdRaw} not found` };
+      const priorEpicSemantic = item.epic?.epicId ?? null;
+      if (item.epicId === targetEpicCuid) {
+        return {
+          success: true,
+          entityId: itemIdRaw,
+          message: `${itemIdRaw} already linked to ${targetEpicSemantic ?? "no epic"} (no-op)`,
+        };
+      }
+
+      await prisma.$transaction(async (tx) => {
+        await tx.backlogItem.update({
+          where: { id: item.id },
+          data: { epicId: targetEpicCuid },
+        });
+        await tx.backlogItemActivity.create({
+          data: {
+            backlogItemId: item.id,
+            kind: "epic_link",
+            summary: `${priorEpicSemantic ?? "(no epic)"} → ${targetEpicSemantic ?? "(no epic)"}`,
+            payload: {
+              fromEpicId: priorEpicSemantic,
+              toEpicId: targetEpicSemantic,
+            },
+            recordedById: userId,
+            recordedByAgentId: context?.agentId ?? null,
+          },
+        });
+        // Reopen epic if we just attached an open/in-progress item to a done epic
+        if (targetEpicCuid && (item.status === "open" || item.status === "in-progress")) {
+          const target = await tx.epic.findUnique({
+            where: { id: targetEpicCuid },
+            select: { status: true },
+          });
+          if (target?.status === "done") {
+            await tx.epic.update({
+              where: { id: targetEpicCuid },
+              data: { status: "open", completedAt: null },
+            });
+          }
+        }
+      });
+      return {
+        success: true,
+        entityId: itemIdRaw,
+        message: `Linked ${itemIdRaw} to ${targetEpicSemantic ?? "(no epic)"}`,
+        data: { itemId: itemIdRaw, epicId: targetEpicSemantic },
+      };
+    }
+
+    case "search_specs_and_plans": {
+      const { searchSpecsAndPlans } = await import("@/lib/backlog/spec-plan-search");
+      const query = String(params["query"] ?? "").trim();
+      if (!query && !params["itemId"] && !params["epicId"])
+        return {
+          success: false,
+          error: "missing_query",
+          message: "query is required (or itemId/epicId)",
+        };
+      const kind = params["kind"] === "spec" || params["kind"] === "plan" ? params["kind"] : undefined;
+      const matches = typeof params["matches"] === "number" ? params["matches"] : undefined;
+      const itemId = typeof params["itemId"] === "string" ? params["itemId"] : undefined;
+      const epicId = typeof params["epicId"] === "string" ? params["epicId"] : undefined;
+      const results = await searchSpecsAndPlans({ query, kind, matches, itemId, epicId });
+      return {
+        success: true,
+        message: `Found ${results.length} match(es).`,
+        data: { results },
+      };
+    }
+
+    case "record_execution_evidence": {
+      const itemIdRaw = String(params["itemId"] ?? "").trim();
+      const kindRaw = String(params["kind"] ?? "");
+      const summaryRaw = String(params["summary"] ?? "").slice(0, 240);
+      const url = typeof params["url"] === "string" ? params["url"] : null;
+      const body = typeof params["body"] === "string" ? params["body"].slice(0, 8000) : null;
+      const toolExecutionId =
+        typeof params["toolExecutionId"] === "string" ? params["toolExecutionId"] : null;
+      const ALLOWED_KINDS = new Set([
+        "test_pass",
+        "test_fail",
+        "build_pass",
+        "build_fail",
+        "ux_verified",
+        "spec_review",
+        "manual_check",
+        "external_link",
+      ]);
+      if (!itemIdRaw || !kindRaw || !summaryRaw)
+        return {
+          success: false,
+          error: "missing_required",
+          message: "itemId, kind, summary are all required",
+        };
+      if (!ALLOWED_KINDS.has(kindRaw))
+        return { success: false, error: "invalid_kind", message: `kind=${kindRaw} not allowed` };
+      const item = await prisma.backlogItem.findUnique({
+        where: { itemId: itemIdRaw },
+        select: { id: true },
+      });
+      if (!item)
+        return { success: false, error: "not_found", message: `Item ${itemIdRaw} not found` };
+      const activity = await prisma.backlogItemActivity.create({
+        data: {
+          backlogItemId: item.id,
+          kind: "evidence",
+          summary: summaryRaw,
+          payload: {
+            evidenceKind: kindRaw,
+            url,
+            body,
+            toolExecutionId,
+          },
+          recordedById: userId,
+          recordedByAgentId: context?.agentId ?? null,
+          toolExecutionId,
+        },
+      });
+      return {
+        success: true,
+        entityId: activity.id,
+        message: `Recorded ${kindRaw} evidence for ${itemIdRaw}`,
+        data: { activityId: activity.id, recordedAt: activity.recordedAt.toISOString() },
+      };
+    }
+
+    case "get_next_recommended_work": {
+      const { rankCandidates } = await import("@/lib/backlog/recommend");
+      const { buildSpecPlanReferenceIndex } = await import("@/lib/backlog/spec-plan-search");
+
+      const count = typeof params["count"] === "number" ? params["count"] : undefined;
+      const epicIdRaw = typeof params["epicId"] === "string" ? params["epicId"].trim() : "";
+      const forAgentId = typeof params["forAgentId"] === "string" ? params["forAgentId"] : null;
+      const excludeItemIds = Array.isArray(params["excludeItemIds"])
+        ? (params["excludeItemIds"] as unknown[]).filter((x): x is string => typeof x === "string")
+        : [];
+
+      const where: Record<string, unknown> = {
+        status: { in: ["open", "triaging"] },
+      };
+      if (epicIdRaw) {
+        const epicRow = await prisma.epic.findFirst({
+          where: { OR: [{ epicId: epicIdRaw }, { id: epicIdRaw }] },
+          select: { id: true },
+        });
+        if (epicRow) where["epicId"] = epicRow.id;
+        else
+          return {
+            success: false,
+            error: "epic_not_found",
+            message: `No epic matched ${epicIdRaw}`,
+          };
+      }
+
+      const items = await prisma.backlogItem.findMany({
+        where,
+        take: 200,
+        orderBy: [{ priority: "asc" }, { updatedAt: "desc" }],
+        select: {
+          itemId: true,
+          title: true,
+          status: true,
+          priority: true,
+          effortSize: true,
+          triageOutcome: true,
+          activeBuildId: true,
+          claimedById: true,
+          claimedByAgentId: true,
+          updatedAt: true,
+          epic: { select: { epicId: true, status: true } },
+        },
+      });
+
+      const refIndex = await buildSpecPlanReferenceIndex();
+      const candidates = items.map((i) => {
+        const semanticEpic = i.epic?.epicId ?? null;
+        const hasSpec =
+          refIndex.specs.has(i.itemId) || (semanticEpic ? refIndex.specs.has(semanticEpic) : false);
+        const hasPlan =
+          refIndex.plans.has(i.itemId) || (semanticEpic ? refIndex.plans.has(semanticEpic) : false);
+        return {
+          itemId: i.itemId,
+          title: i.title,
+          status: i.status,
+          priority: i.priority,
+          effortSize: i.effortSize,
+          triageOutcome: i.triageOutcome,
+          hasActiveBuild: i.activeBuildId != null,
+          claimedById: i.claimedById,
+          claimedByAgentId: i.claimedByAgentId,
+          epicId: semanticEpic,
+          epicStatus: i.epic?.status ?? null,
+          hasSpec,
+          hasPlan,
+          updatedAt: i.updatedAt,
+        };
+      });
+
+      const ranked = rankCandidates(candidates, {
+        excludeItemIds,
+        forAgentId,
+        count,
+      });
+
+      return {
+        success: true,
+        message: `Recommending ${ranked.length} item(s).`,
+        data: { recommendations: ranked },
       };
     }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -15,6 +15,16 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   query_backlog: ["backlog_read"],
   report_quality_issue: ["backlog_write"],
 
+  // Governed MCP backlog surface (spec 2026-04-25)
+  list_epics: ["backlog_read"],
+  list_backlog_items: ["backlog_read"],
+  get_backlog_item: ["backlog_read"],
+  update_backlog_item_status: ["backlog_write"],
+  link_backlog_item_to_epic: ["backlog_write"],
+  search_specs_and_plans: ["spec_plan_read", "backlog_read"],
+  record_execution_evidence: ["backlog_write"],
+  get_next_recommended_work: ["backlog_read"],
+
   // Registry / Products
   create_digital_product: ["registry_read", "backlog_write"],
   update_lifecycle: ["backlog_write"],

--- a/apps/web/lib/tool-audit-helpers.ts
+++ b/apps/web/lib/tool-audit-helpers.ts
@@ -1,0 +1,17 @@
+import { PLATFORM_TOOLS } from "./mcp-tools";
+import type { AuditClass } from "./audit-classes";
+
+export function deriveAuditClassForTool(toolName: string): AuditClass {
+  const tool = PLATFORM_TOOLS.find((t) => t.name === toolName);
+  if (!tool) return "journal";
+  if ("auditClass" in tool && (tool as { auditClass?: AuditClass }).auditClass) {
+    return (tool as { auditClass?: AuditClass }).auditClass!;
+  }
+  if (tool.sideEffect) return "ledger";
+  if (tool.requiresExternalAccess) return "journal";
+  return "metrics_only";
+}
+
+export function deriveCapabilityId(toolName: string): string {
+  return `platform:${toolName}`;
+}

--- a/docs/superpowers/plans/2026-04-25-governed-mcp-backlog-surface.md
+++ b/docs/superpowers/plans/2026-04-25-governed-mcp-backlog-surface.md
@@ -1,0 +1,404 @@
+# Plan — Governed MCP Backlog Surface
+
+| Field | Value |
+| ----- | ----- |
+| **Spec** | [2026-04-25-governed-mcp-backlog-surface-design.md](../specs/2026-04-25-governed-mcp-backlog-surface-design.md) |
+| **Branch** | `feat/mcp-backlog-surface` (one branch per the AGENTS.md PR workflow) |
+| **Estimated PRs** | 1 — single coherent surface, ships together |
+| **Dependencies** | None blocking. Aligns with but does not require the [Platform MCP Tool Server](../specs/2026-04-11-platform-mcp-tool-server-design.md) JSON-RPC implementation. |
+
+---
+
+## 0. Pre-flight
+
+- Confirm working directory is the per-session worktree, not `d:\DPF` directly (per [feedback memory](../../../C:/Users/Mark%20Bodman/.claude/projects/d--DPF/memory/feedback_worktree_per_session.md)). For this implementation, since no concurrent session is active, working in `d:\DPF` on a feature branch is acceptable.
+- `git checkout -b feat/mcp-backlog-surface` from `main`. **Do not commit on `main`** (AGENTS.md core rule).
+- Confirm pre-commit hook: `git config core.hooksPath` returns `.githooks`.
+
+## 1. Schema migration — `BacklogItemActivity`
+
+File: new migration `packages/db/prisma/migrations/<timestamp>_backlog_item_activity/migration.sql`.
+
+Steps:
+
+1. Add the model to [packages/db/prisma/schema.prisma](../../../packages/db/prisma/schema.prisma) per spec §4.5. Also add the inverse relation `activities BacklogItemActivity[]` to `BacklogItem`.
+2. `pnpm --filter @dpf/db exec prisma migrate dev --name backlog_item_activity` to generate the DDL. **Do not** use `npx prisma` (CLAUDE.md).
+3. The migration is purely additive (new table + indexes); no backfill SQL is needed.
+4. Verify the migration applies cleanly against the live dev DB.
+
+## 2. Data normalization — one-time `BacklogItem.type` cleanup
+
+The DB scan found `type = "feature"` rows. Add a separate data-only migration `<timestamp>_normalize_backlogitem_type` that runs:
+
+```sql
+UPDATE "BacklogItem" SET "type" = 'product' WHERE "type" = 'feature';
+```
+
+This migration must commit **before** the type-narrowed tool definitions land, so the new tool schemas are consistent with the data. Per AGENTS.md schema rules, the SQL is inline in the migration file.
+
+## 3. New module: `apps/web/lib/backlog/transitions.ts`
+
+Pure-function module exporting:
+
+```ts
+export const BACKLOG_STATUSES = ["triaging", "open", "in-progress", "done", "deferred"] as const;
+export type BacklogStatus = (typeof BACKLOG_STATUSES)[number];
+
+export function isLegalTransition(from: BacklogStatus, to: BacklogStatus): boolean;
+export function requiresAdminGrant(from: BacklogStatus, to: BacklogStatus): boolean; // done -> *
+```
+
+Tests in `transitions.test.ts` cover every legal pair from the spec table and a sampling of illegal pairs.
+
+## 4. New module: `apps/web/lib/backlog/recommend.ts`
+
+Pure-function ranking module per spec §3.9. Inputs:
+
+```ts
+type Candidate = {
+  itemId: string;
+  title: string;
+  status: string;
+  priority: number | null;
+  effortSize: string | null;
+  triageOutcome: string | null;
+  hasActiveBuild: boolean;
+  claimedById: string | null;
+  claimedByAgentId: string | null;
+  epicId: string | null;
+  epicStatus: string | null;
+  hasSpec: boolean;
+  hasPlan: boolean;
+  updatedAt: Date;
+};
+
+export function rankCandidates(items: Candidate[], opts: { excludeItemIds?: string[]; forAgentId?: string }): RankedCandidate[];
+```
+
+The DB query that produces `Candidate[]` lives in the tool handler (§5), not here. This module is just the ranking math, so it is trivially unit-testable with fixtures.
+
+## 5. New module: `apps/web/lib/backlog/spec-plan-search.ts`
+
+Pure file-system reader exporting:
+
+```ts
+export async function searchSpecsAndPlans(opts: {
+  query: string;
+  kind?: "spec" | "plan";
+  matches?: number;
+  itemId?: string;
+  epicId?: string;
+}): Promise<SpecPlanResult[]>;
+```
+
+Implementation:
+
+- Read `docs/superpowers/specs/*.md` and `docs/superpowers/plans/*.md` from disk via `fs/promises.readdir` + `readFile`. Repo root resolved via `process.cwd()` — the portal runs from the repo root in dev and from `/app` in Docker, both of which contain `docs/superpowers/`.
+- For each file: extract title (frontmatter `title:` if present, else first H1 heading, else filename), date (filename prefix `YYYY-MM-DD` if present), and the body.
+- Match: case-insensitive substring on title and body. If `itemId` or `epicId` is supplied, also match on those (literal).
+- Snippet: 240 chars centered on first match, with `...` ellipses.
+- Reference extraction: regex `/\b(BI|EP)-[A-Z0-9-]+\b/g` over the body.
+- Cache by file mtime — re-read on cache miss only.
+
+Tests cover: title extraction, date extraction, snippet windowing on edge cases (match at start/end), reference extraction, cache invalidation by mtime.
+
+## 6. New module: `apps/web/lib/mcp-governed-execute.ts`
+
+Per spec §4.4. Surface:
+
+```ts
+export type GovernedExecuteSource = "rest" | "jsonrpc" | "agentic-loop";
+
+export async function governedExecuteTool(args: {
+  toolName: string;
+  rawParams: Record<string, unknown>;
+  userId: string;
+  userContext: { platformRole: string; isSuperuser: boolean };
+  context?: { agentId?: string; threadId?: string; routeContext?: string; taskRunId?: string };
+  source: GovernedExecuteSource;
+}): Promise<ToolResult>;
+```
+
+Steps inside:
+
+1. `const tool = PLATFORM_TOOLS.find(t => t.name === toolName);` — return `{ success: false, error: "unknown_tool" }` if missing.
+2. If `tool.requiredCapability` and `!can(userContext, tool.requiredCapability)` — return `{ success: false, error: "forbidden_capability" }`. Audit the failure (so the rejection is itself logged).
+3. If `context.agentId` is present, `const grants = await getAgentToolGrantsAsync(context.agentId)` and `if (!isToolAllowedByGrants(toolName, grants))` — return `{ success: false, error: "forbidden_grant" }`. Audit the failure.
+4. `const t0 = Date.now(); const result = await executeTool(toolName, rawParams, userId, context); const durationMs = Date.now() - t0;`
+5. `prisma.toolExecution.create({ data: { ... executionMode: source, ... } }).catch(err => console.error("[governed-execute] audit write failed", err));` — never silent.
+6. `return result;`
+
+Tests:
+
+- Mocked `executeTool` returns `{ success: true }`; assert audit row written with correct `executionMode`.
+- Capability rejection writes audit with `success: false` and never invokes `executeTool`.
+- Grant rejection same.
+- Audit write failure does not throw to caller (but does log).
+
+## 7. New tool definitions in `mcp-tools.ts`
+
+Add the seven new tools to `PLATFORM_TOOLS` per spec §3, in this order (grouped near the existing backlog tools):
+
+1. `list_epics`
+2. `list_backlog_items`
+3. `get_backlog_item`
+4. `update_backlog_item_status`
+5. `link_backlog_item_to_epic`
+6. `search_specs_and_plans`
+7. `record_execution_evidence`
+8. `get_next_recommended_work`
+
+For each tool:
+
+- Add the `ToolDefinition` to `PLATFORM_TOOLS`.
+- Add the `case "tool_name":` block to `executeTool()`.
+- The handlers delegate domain logic to the new modules (`transitions.ts`, `recommend.ts`, `spec-plan-search.ts`) or to a thin Prisma read.
+- All write-side handlers also write a `BacklogItemActivity` row in the same transaction as their primary write (use `prisma.$transaction` so the activity is consistent with the state change).
+
+For `update_backlog_item_status`:
+
+- Resolve the item by `itemId` (semantic).
+- Check `isLegalTransition(item.status, newStatus)`. If illegal, return `{ success: false, error: "illegal_transition", message: "..." }`.
+- If `newStatus = "done"` set `completedAt`. Run epic-auto-close: if every other item in the same epic is `done`/`deferred`, flip the epic to `done`.
+- Write the `BacklogItem` update and the `BacklogItemActivity` row in one transaction.
+
+For `link_backlog_item_to_epic`:
+
+- Resolve `epicId` semantic→cuid (or null for unlink).
+- Read prior `epicId` for the activity payload.
+- Update item, recompute target epic status (re-open if it was `done` and we just attached an open item), write the activity row — all in one transaction.
+
+For `record_execution_evidence`:
+
+- Verify `itemId` exists.
+- Validate `kind` against the enum.
+- Write a `BacklogItemActivity` row with `kind: "evidence"` and `payload: { kind, summary, url, body, toolExecutionId }`.
+
+## 8. Grant map updates in `agent-grants.ts`
+
+Add the new entries per spec §4.2 to `TOOL_TO_GRANTS`:
+
+```ts
+list_epics:                 ["backlog_read"],
+list_backlog_items:         ["backlog_read"],
+get_backlog_item:           ["backlog_read"],
+update_backlog_item_status: ["backlog_write"],
+link_backlog_item_to_epic:  ["backlog_write"],
+search_specs_and_plans:     ["spec_plan_read"],
+record_execution_evidence:  ["backlog_write"],
+get_next_recommended_work:  ["backlog_read"],
+```
+
+Update [packages/db/data/agent_registry.json](../../../packages/db/data/agent_registry.json): for every agent that already has `backlog_read`, also add `spec_plan_read`. This keeps existing agents productive on day one.
+
+The grant seeding loop in `packages/db/src/seed.ts` reads from this JSON, so no separate code change to the seed is needed beyond the JSON edit.
+
+## 9. Wire the new wrapper into call sites
+
+Three edits, each small:
+
+a. [apps/web/app/api/mcp/call/route.ts](../../../apps/web/app/api/mcp/call/route.ts):
+
+- Replace direct `executeTool(...)` call with `governedExecuteTool({ ..., source: "rest" })`.
+- Remove the inline `can(...)` check (the wrapper does it).
+- Pass `userContext: { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser }`.
+
+b. [apps/web/lib/tak/agentic-loop.ts](../../../apps/web/lib/tak/agentic-loop.ts) line ~920–973:
+
+- Behind a `DPF_USE_GOVERNED_WRAPPER` env flag (default `true` in dev, default `false` in production until verified):
+  - When enabled, replace the `executeTool` + `prisma.toolExecution.create` block with a single `governedExecuteTool({ ..., source: "agentic-loop" })`.
+  - When disabled, keep the existing path verbatim.
+- The flag is removed in a follow-up PR after one release on dev.
+
+c. The forthcoming `/api/mcp/jsonrpc` route (out of scope here) is documented to call `governedExecuteTool({ ..., source: "jsonrpc" })`. Add a one-line comment in the wrapper module pointing to the spec.
+
+## 10. Tests
+
+All new test files live next to their modules. We use Vitest, the project's existing convention.
+
+| File | Coverage |
+| ---- | -------- |
+| `apps/web/lib/backlog/transitions.test.ts` | Legal/illegal transitions; admin-only transitions |
+| `apps/web/lib/backlog/recommend.test.ts` | Ranking with/without spec, with active build, with claim, with epic narrowing |
+| `apps/web/lib/backlog/spec-plan-search.test.ts` | Title/date extraction; snippet windowing; reference regex; mtime cache |
+| `apps/web/lib/mcp-governed-execute.test.ts` | Capability rejection, grant rejection, success path, audit write under each `source` value, audit failure does not throw |
+| `apps/web/lib/mcp-tools.backlog.test.ts` | One integration test per new tool: happy path + one failure case (illegal transition for status; missing item for evidence; epicId resolution for link; etc.) |
+
+Existing `agent-grants.test.ts` gets new assertions for the new grant entries (default-deny when grant is absent; allowed when present).
+
+`/api/mcp/call` route gets a focused integration test that asserts a successful tool call writes a `ToolExecution` row with `executionMode = "rest"` (the audit gap closure).
+
+## 11. Verification
+
+Per AGENTS.md verification gate:
+
+1. `pnpm --filter web typecheck` — must pass cleanly. Done before every commit by the pre-commit hook; run manually before PR open as a belt-and-suspenders check.
+2. `pnpm --filter web vitest run apps/web/lib/backlog apps/web/lib/mcp-governed-execute apps/web/lib/mcp-tools.backlog` — all green.
+3. `cd apps/web && npx next build` — must complete with zero errors.
+4. **Manual UX check (optional but recommended):** spin up the portal, open the AI coworker on the Build Studio backlog page, and confirm the existing tools still work (regression check on `query_backlog`, `create_backlog_item`).
+5. Fresh-DB sanity: rebuild the portal-init container so the new migration applies; confirm seed runs without warnings about missing tools or grants.
+
+## 12. PR
+
+- Title: `feat(mcp): governed backlog surface — list/get/status/link/search/evidence/recommend`
+- Body sections (per AGENTS.md commit-message convention):
+  - **Summary** — three bullets covering: new tools added, audit gap closed, no breaking changes to existing tools.
+  - **Spec / plan links** — to the two new docs.
+  - **Migration** — explicit callout that two migrations land (new table + data normalization) and they are purely additive.
+  - **Test plan** — checklist with the verification steps above.
+- Every commit signed off (`git commit -s`) per the DCO requirement.
+
+## 13. External Client Support (spec §11) — additional implementation
+
+This sub-plan delivers the Mode 1 external-client surface described in spec §11. It can ship in the same PR as the rest, or split into a follow-up PR if the diff is too large for one review — the core surface (§§1–12 above) is independently useful.
+
+### 13.1 Schema migration — `AgentApiToken` and `ToolExecution.apiTokenId`
+
+New migration `<timestamp>_agent_api_token`:
+
+1. Add `AgentApiToken` model per spec §11.3 (User has-many).
+2. Add nullable `apiTokenId String?` column to `ToolExecution` plus index `@@index([apiTokenId])`.
+3. No backfill — both are additive.
+
+### 13.2 New module: `apps/web/lib/auth/agent-api-token.ts`
+
+Surface:
+
+```ts
+export async function issueAgentApiToken(input: {
+  userId: string;
+  name: string;
+  capability: "read" | "write";
+  scopes: string[];
+  expiresInDays: number | null;
+  agentId?: string;
+}): Promise<{ tokenId: string; plaintext: string }>;
+
+export async function revokeAgentApiToken(tokenId: string, reason: string): Promise<void>;
+
+export async function resolveAgentApiToken(plaintext: string): Promise<{
+  tokenId: string;
+  userId: string;
+  agentId: string | null;
+  scopes: string[];
+  capability: "read" | "write";
+} | null>;
+```
+
+`issueAgentApiToken`:
+
+- Generates 24 random bytes, encodes base32, prefixes `dpfmcp_`.
+- Hashes with sha256 (Node `crypto.createHash`).
+- Computes `expiresAt = capability==="write" ? gate-checks contribution-mode : ...`
+- Inserts row with `tokenHash` only — plaintext returned to caller exactly once and never persisted.
+- If `capability === "write"`, reads `PlatformDevConfig` and throws if `contributionModel` is null.
+
+`resolveAgentApiToken`:
+
+- Hashes input, single `findUnique({ tokenHash })` query.
+- Returns null if missing, revoked (`revokedAt != null`), or expired (`expiresAt < now()`).
+- Updates `lastUsedAt` (fire-and-forget).
+
+Tests in `agent-api-token.test.ts`:
+
+- Issue read token without contribution-mode set → succeeds.
+- Issue write token without contribution-mode set → throws with the expected message.
+- Issue write token with contribution-mode set → succeeds.
+- Revoke then resolve → returns null.
+- Expired token → returns null.
+- Tampered plaintext (one char off) → returns null without throwing.
+
+### 13.3 New endpoint: `apps/web/app/api/mcp/external/jsonrpc/route.ts`
+
+JSON-RPC 2.0 handler. POST only. Steps per spec §11.4:
+
+1. Read `Authorization: Bearer <token>` header. If absent → JSON-RPC error `{ code: -32001, message: "unauthorized" }`.
+2. `resolveAgentApiToken(plaintext)`. If null → same error.
+3. Parse JSON-RPC envelope. Support methods: `initialize`, `notifications/initialized`, `tools/list`, `tools/call`. Mirrors the future internal JSON-RPC spec so external clients see one stable contract.
+4. For `tools/list`: load `User`, call `getAvailableTools(userContext, { agentId: token.agentId, unifiedMode: true })`, intersect with `token.scopes` (a tool is included only if `TOOL_TO_GRANTS[tool.name]` shares at least one entry with `token.scopes`).
+5. For `tools/call`: invoke `governedExecuteTool({ source: "external-jsonrpc", userContext, context: { agentId: token.agentId, apiTokenId: token.tokenId }, ... })`. Wrapper additionally rejects if the tool's required grants do not intersect `token.scopes`.
+6. TLS guard: reject when `request.url.startsWith("http://")` and host is not `localhost` / `127.0.0.1`. Returns JSON-RPC `{ code: -32002, message: "tls_required" }`.
+
+The wrapper signature gets a `context.apiTokenId?: string` field; the audit write includes `apiTokenId` and sets `executionMode: "external-jsonrpc"`.
+
+Tests in `apps/web/app/api/mcp/external/jsonrpc/route.test.ts`:
+
+- Missing bearer → `-32001`.
+- Bad bearer → `-32001`.
+- Valid read token, `tools/list` → returns only tools whose grants intersect token scopes.
+- Valid write token, `tools/call` on `update_backlog_item_status` → succeeds, audit row written with `apiTokenId` set and `executionMode = "external-jsonrpc"`.
+- Read-only token, `tools/call` on `update_backlog_item_status` → `forbidden_grant` and audited as a failure.
+- HTTP request to non-localhost host → `tls_required`.
+
+### 13.4 Settings UI — `External Coding Agent Access` section
+
+File: extend `apps/web/app/(shell)/admin/platform-development/page.tsx` and add a new client component `apps/web/components/admin/AgentApiTokenManager.tsx`.
+
+UI:
+
+- "External Coding Agent Access" card under the existing contribution-mode card.
+- Status indicator: contribution mode wired (yes/no) — links to the same page's contribution-mode card if not.
+- Existing tokens table (server-fetched): `name`, `prefix`, `capability`, `scopes` (chips), `lastUsedAt`, `expiresAt`, "Revoke" button.
+- "Generate token" button → modal:
+  - `name` (text)
+  - `capability` (radio: read / write — write disabled with explainer copy when contribution-mode unset)
+  - `scopes` (multi-select, defaulted to current user's grants)
+  - `expiresIn` (dropdown: 30/60/90/180 days/never)
+  - optional `agentId` (dropdown of agents the user can act as)
+- On submit: server action returns `{ tokenId, plaintext }`. Modal switches to "copy once" view with the plaintext, the prefix, and a tabbed "Setup snippet" (Claude Code / Codex / VS Code) with the user's URL pre-filled. After dismissal, plaintext is gone.
+
+Tests:
+
+- Component renders existing tokens.
+- Modal disables "write" radio when contribution-mode unset; renders the explainer.
+- Generate flow returns plaintext into the copy-once view.
+- Revoke calls the server action and refreshes the list.
+
+### 13.5 Audit-log viewer surfacing of external sources
+
+The existing `/platform/ai/authority` Tool Execution Log already filters by `agentId`/`userId`/`toolName`. Add a filter chip for `executionMode IN ("rest", "external-jsonrpc", "agentic-loop", "jsonrpc")` and a column showing the masked token prefix when `apiTokenId` is set. This is a small UI extension, not a redesign.
+
+### 13.6 Verification additions for §11
+
+In addition to the §11 verifications already listed:
+
+- Spin up the portal in dev. Issue a read-only token from `/admin/platform-development`. Configure Claude Code with the printed `mcp.json`. Run `claude --mcp dpf` and call `list_backlog_items` — confirm rows return and a `ToolExecution` row with `executionMode = "external-jsonrpc"` lands.
+- Issue a write token after configuring contribution mode. Call `record_execution_evidence` from Claude Code. Confirm the activity row is written and the audit row carries `apiTokenId`.
+- Revoke the token from the UI; the next call from Claude Code returns `unauthorized`.
+
+### 13.7 Updated PR description
+
+The PR now also notes:
+
+- New external MCP endpoint at `/api/mcp/external/jsonrpc` (bearer-token authenticated).
+- New `AgentApiToken` model with token issuance UI co-located with contribution mode.
+- Write tokens gated on contribution mode being configured.
+- All external traffic audited with the new `apiTokenId` column on `ToolExecution`.
+
+If the diff exceeds reviewable size, split as: PR 1 = §§1–12 (domain surface + audit-gap fix), PR 2 = §13 (external client). Both behind the same epic.
+
+---
+
+## 14. Out-of-scope follow-up tickets to file at PR time
+
+These should be raised as new backlog items on PR open so they are not lost:
+
+1. JSON-RPC `/api/mcp/jsonrpc` route delivering this surface to external CLI clients (Codex, VS Code MCP) — gated on the [Platform MCP Tool Server](../specs/2026-04-11-platform-mcp-tool-server-design.md) work.
+2. Restricting `admin_query_db` to superuser-only via a new grant `arbitrary_sql_read`, now that the domain coverage reduces the need.
+3. Splitting `update_backlog_item` into `update_backlog_item_metadata` + the new `update_backlog_item_status`, then deprecating the broad-patch surface.
+4. Periodic `BacklogItemActivity` archival policy if volume becomes a concern (not expected in the first six months).
+
+---
+
+## Implementation order (do not parallelize within this PR)
+
+1. Schema migration (table) — commit
+2. Data migration (type normalization) — commit
+3. `transitions.ts` + tests — commit
+4. `recommend.ts` + tests — commit
+5. `spec-plan-search.ts` + tests — commit
+6. `mcp-governed-execute.ts` + tests — commit
+7. New tool definitions + handlers + grant entries — commit (largest commit; one tool per logical sub-step is fine but a single commit is acceptable since they share a registry)
+8. Wire `/api/mcp/call` to the wrapper, integration test asserting audit row written — commit
+9. Wire `agentic-loop.ts` to the wrapper behind the env flag — commit
+10. PR open

--- a/docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md
+++ b/docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md
@@ -1,0 +1,605 @@
+# Governed MCP Backlog Surface — Design Spec
+
+| Field | Value |
+|-------|-------|
+| **Epic** | Platform Infrastructure / Build Studio Governance |
+| **Status** | Draft |
+| **Created** | 2026-04-25 |
+| **Author** | Claude Opus 4.7 for Mark Bodman |
+| **Scope** | `apps/web/lib/mcp-tools.ts`, `apps/web/lib/tak/agent-grants.ts`, `apps/web/app/api/mcp/`, `apps/web/lib/backlog/` (new), `packages/db/prisma/schema.prisma` |
+| **Aligns with** | [2026-04-11-platform-mcp-tool-server-design.md](./2026-04-11-platform-mcp-tool-server-design.md) (delivery transport), [2026-04-21-backlog-triage-build-studio-design.md](./2026-04-21-backlog-triage-build-studio-design.md) (lifecycle), [2026-04-23-build-studio-governed-backlog-delivery-design.md](./2026-04-23-build-studio-governed-backlog-delivery-design.md) (governed lifecycle) |
+| **Distinct from** | TAK / GAID Standards Family ([2026-04-18-tak-gaid-standards-family-design.md](./2026-04-18-tak-gaid-standards-family-design.md)) — this spec consumes TAK identity / authority contracts but does not modify them |
+| **Primary Goal** | A single domain-level MCP surface for backlog and planning workflows usable by both in-platform AI coworkers and external coding agents (Claude CLI, Codex, VS Code MCP), governed by the same auth, grants, and audit pipeline. |
+
+---
+
+## 1. Problem Statement
+
+The repository has a strong domain layer for backlog work — `Epic`, `BacklogItem`, `FeatureBuild`, the lifecycle state machine in [governed-backlog-workflow.ts](../../apps/web/lib/governed-backlog-workflow.ts), the TAK grant model, and `ToolExecution` audit. But the **agent-facing contract** for that domain is fragmented and partially missing:
+
+1. **The MCP surface for backlog is incomplete.** The existing tools cover create/update/triage/promote/query, but lack: a single-item read, an explicit epic/item link operation, spec/plan search, evidence capture, and a "next recommended work" entry point that mirrors how a human PM picks the next item. External coding agents (Codex, VS Code MCP, Claude CLI) need these to be productive without inventing their own workflow.
+2. **Audit is uneven.** [agentic-loop.ts:953](../../apps/web/lib/tak/agentic-loop.ts#L953) writes `ToolExecution` rows for tools called inside the in-platform agentic loop. The REST gateway at [/api/mcp/call](../../apps/web/app/api/mcp/call/route.ts) does **not** write `ToolExecution`, and an MCP JSON-RPC endpoint (per the [Platform MCP Tool Server spec](./2026-04-11-platform-mcp-tool-server-design.md)) is not yet implemented. A tool called by an external coding agent today would land an effect on the DB without an audit row.
+3. **Domain semantics leak into raw CRUD.** `update_backlog_item` accepts arbitrary patch fields. `create_backlog_item` with `epicId` performs a string-to-cuid resolution inline. Without explicit domain operations like `link_backlog_item_to_epic`, agents end up doing table-shaped writes and the lifecycle invariants in `governed-backlog-workflow.ts` are easy to bypass.
+4. **No single "what should I work on next?" surface.** AGENTS.md tells agents to consider items with existing designs first, then dependencies, then impact — but that's prose. There is no callable tool that returns a ranked list grounded in the spec/plan inventory and the live backlog state.
+5. **Live drift confirms the contract is loose.** `BacklogItem.type` already has a `feature` value in the DB even though the canonical enum is `{portfolio, product}` — that's the kind of corruption a domain-shaped contract is supposed to prevent.
+
+This spec defines a **governed MCP backlog surface**: nine tools that together cover read, write, link, search, evidence, and recommendation, all enforced through the existing TAK grant model and a new shared governed-execution wrapper that centralizes audit so direct REST and JSON-RPC paths get the same audit trail as the in-platform agentic loop.
+
+## 2. Non-Goals
+
+- **Replacing the Platform MCP Tool Server.** That spec defines the *transport* (JSON-RPC, session tokens, agent-scoped tool listing). This spec defines the *contents* of the backlog domain on that transport. The two compose; neither blocks the other.
+- **Unifying with TAK/GAID identity refresh.** This spec consumes the `Agent` / `AgentToolGrant` model as it stands today. If the TAK/GAID work later renames `agentId` semantics or adds GAID-compliant identifiers, the grant call site and audit row will pick that up automatically because both already live behind `getAgentToolGrantsAsync()`. We do not refactor the identity layer here.
+- **Inventing a new prioritization framework (WSJF, ICE, RICE).** `get_next_recommended_work` ranks using fields and signals that already exist (`priority`, `effortSize`, has-spec, has-active-build, lifecycle stage). A future spec can replace the ranking function without changing the tool contract.
+- **External arbitrary SQL.** `admin_query_db` is an existing escape hatch and stays out of scope; the goal is to remove the *need* for arbitrary SQL by exposing complete domain operations.
+- **Replacing existing tools.** `create_backlog_item`, `update_backlog_item`, `triage_backlog_item`, `promote_to_build_studio`, `query_backlog`, `create_build_epic` keep their names and current semantics. New tools are additive.
+
+## 3. Tool Surface
+
+The backlog surface is the following nine tools. Existing tools that already cover a goal are reused as-is; gaps are filled by new tools. All tools live in [mcp-tools.ts](../../apps/web/lib/mcp-tools.ts) so that the in-platform `/api/mcp/call` REST gateway, the planned JSON-RPC MCP server, and the in-platform agentic loop all dispatch through the same registry.
+
+| Goal | Tool | Status | Required grant |
+|------|------|--------|----------------|
+| `list_epics` | `list_epics` (new) | New | `backlog_read` |
+| `list_backlog_items` | `list_backlog_items` (new) | New, replaces shape of `query_backlog` for items | `backlog_read` |
+| `get_backlog_item` | `get_backlog_item` (new) | New | `backlog_read` |
+| `create_backlog_item` | `create_backlog_item` | Existing — kept | `backlog_write` |
+| `update_backlog_item_status` | `update_backlog_item_status` (new) | New, narrower than `update_backlog_item` | `backlog_write` |
+| `link_backlog_item_to_epic` | `link_backlog_item_to_epic` (new) | New | `backlog_write` |
+| `search_specs_and_plans` | `search_specs_and_plans` (new) | New | `spec_plan_read` (new grant) |
+| `record_execution_evidence` | `record_execution_evidence` (new) | New | `backlog_write` + writes ToolExecution |
+| `get_next_recommended_work` | `get_next_recommended_work` (new) | New | `backlog_read` |
+
+`query_backlog` and `update_backlog_item` are kept for backward compatibility — Build Studio and several coworkers already call them. The new tools provide narrower, intent-explicit alternatives that external agents should prefer.
+
+### 3.1 `list_epics`
+
+Returns epics filtered by status, with item-count rollups. Read-only, no side effects.
+
+Input:
+```ts
+{
+  status?: "open" | "in-progress" | "done";   // default: any non-done if omitted
+  hasOpenItems?: boolean;                     // narrow to actively worked epics
+  limit?: number;                              // default 25, max 100
+}
+```
+
+Output:
+```ts
+{
+  success: true,
+  epics: Array<{
+    epicId: string;          // semantic, e.g. "EP-BUILD-9F749C"
+    title: string;
+    status: "open" | "in-progress" | "done";
+    itemCount: { total: number; open: number; inProgress: number; done: number };
+    hasSpec: boolean;        // any spec/plan file references this epicId
+    updatedAt: string;       // ISO
+  }>;
+}
+```
+
+### 3.2 `list_backlog_items`
+
+Returns items filtered by status, type, epic, or claim. The replacement for `query_backlog` for items (epics get their own tool above). Read-only.
+
+Input:
+```ts
+{
+  status?: "open" | "in-progress" | "done" | "deferred" | "triaging";
+  type?: "portfolio" | "product";
+  epicId?: string;                  // semantic id; resolved server-side
+  unclaimed?: boolean;              // claimedById = null AND claimedByAgentId = null
+  hasActiveBuild?: boolean;
+  limit?: number;                   // default 25, max 100
+}
+```
+
+Output: array of item summaries with `itemId`, `title`, `status`, `type`, `priority`, `effortSize`, `epicId`, `lifecycleLabel` (computed via `deriveLifecycleLabel`), `hasActiveBuild`, `updatedAt`.
+
+### 3.3 `get_backlog_item`
+
+Returns a single item with full relations needed for an agent to act on it. Read-only.
+
+Input: `{ itemId: string }` (semantic id, e.g. `BI-PORT-005`).
+
+Output: full DTO including: item core fields, lifecycle label, linked epic summary, linked digital product, linked active `FeatureBuild` summary (id, phase, draftApprovedAt, sandboxId), spec/plan files that reference the itemId or its epic (paths only — body is fetched via `read_project_file`), and recent `BacklogItemActivity` entries (last 10).
+
+If the item is missing, returns `{ success: false, error: "not_found" }` — never throws.
+
+### 3.4 `create_backlog_item` (existing — kept)
+
+No contract changes. The `type` enum is enforced at the schema level (`portfolio` / `product`) so agent calls cannot reintroduce the `feature` drift seen in the live DB. A separate one-line migration normalizes existing `feature` rows to `product` and is part of the implementation plan, not this spec.
+
+### 3.5 `update_backlog_item_status`
+
+A narrower alternative to `update_backlog_item` that only changes status, captures a reason, and runs the lifecycle invariants. Side-effecting.
+
+Input:
+```ts
+{
+  itemId: string;
+  status: "open" | "in-progress" | "done" | "deferred";
+  reason?: string;                   // free-text rationale for audit
+  resolution?: string;               // required when status=done
+}
+```
+
+Behavior:
+- Rejects illegal transitions (e.g., `done` → `triaging`). Legal transitions are enumerated in §4.2.
+- When `status=done`, sets `completedAt`, attempts an epic-completion check (auto-close epic if all items reach `done`/`deferred` — this matches the AGENTS.md stewardship rule).
+- When `status=in-progress` without an active build, allows it (the user may be tracking work that isn't a Build Studio job) but emits a warning in the result.
+- Writes a `BacklogItemActivity` row tagged `kind: "status_change"` with the prior and new status.
+
+`update_backlog_item` (existing) keeps its broader patch surface for callers that need it (Build Studio, internal coworkers); external agents are pointed at `update_backlog_item_status` for the common case so their writes are easier to reason about.
+
+### 3.6 `link_backlog_item_to_epic`
+
+Explicit linkage operation. Side-effecting.
+
+Input:
+```ts
+{
+  itemId: string;
+  epicId: string | null;       // null unlinks
+}
+```
+
+Behavior:
+- Resolves `epicId` (semantic) to the cuid via the existing pattern.
+- Updates `BacklogItem.epicId`.
+- Recomputes the source and target epic's open-item count and, if the target epic is currently `done` and we just attached an open item, flips it back to `open` (mirrors AGENTS.md's "stale open items cause the epic to appear incomplete" stewardship — same logic in reverse).
+- Writes a `BacklogItemActivity` row tagged `kind: "epic_link"` capturing prior and new epic.
+
+This replaces the inline `epicId`-passing in `create_backlog_item` for the post-create case, where today an agent has to use `update_backlog_item` (broader surface) just to link an item.
+
+### 3.7 `search_specs_and_plans`
+
+Searches the design-spec and implementation-plan files under `docs/superpowers/specs/` and `docs/superpowers/plans/`. Read-only. Returns matched files, title (from frontmatter or first H1), date, and a snippet around the first match per file.
+
+Input:
+```ts
+{
+  query: string;                     // free text; matched against title and body
+  kind?: "spec" | "plan";            // restrict to one tree
+  matches?: number;                  // max results, default 10, max 25
+  itemId?: string;                   // optional: also match files referencing this BI- id
+  epicId?: string;                   // optional: also match files referencing this EP- id
+}
+```
+
+Output:
+```ts
+{
+  success: true,
+  results: Array<{
+    path: string;                    // relative to repo root
+    kind: "spec" | "plan";
+    title: string;
+    date: string;                    // YYYY-MM-DD inferred from filename or frontmatter
+    snippet: string;                 // ~240 chars around first match
+    referencedItemIds: string[];     // BI-... ids found anywhere in the file
+    referencedEpicIds: string[];     // EP-... ids found anywhere in the file
+  }>;
+}
+```
+
+Implementation notes (informational — see Plan):
+- Files are read from disk on each call. Counts are small enough (<200 markdown files) that a full text scan is fine. If this becomes hot we add the same Postgres FTS index we use for backlog semantic memory.
+- Matching is a case-insensitive substring scan over title + body. We do not embed semantic search here — `search_knowledge_base` already exists for semantic and is a different surface.
+- `referencedItemIds` / `referencedEpicIds` are extracted via regex `/\b(BI|EP)-[A-Z0-9-]+/g` so an agent can correlate a spec to live backlog state with `get_backlog_item`.
+
+### 3.8 `record_execution_evidence`
+
+Attaches an evidence record to a backlog item — a structured artifact that says "this happened, here's the proof." Side-effecting.
+
+Input:
+```ts
+{
+  itemId: string;
+  kind: "test_pass" | "test_fail" | "build_pass" | "build_fail"
+      | "ux_verified" | "spec_review" | "manual_check" | "external_link";
+  summary: string;                   // short headline, <= 240 chars
+  url?: string;                      // links to artifact (PR, CI run, screenshot, etc.)
+  body?: string;                     // longer notes, <= 8000 chars
+  toolExecutionId?: string;          // when the evidence was produced by a prior tool call
+}
+```
+
+Output: `{ success: true, activityId: string, recordedAt: string }`.
+
+Behavior:
+- Writes a `BacklogItemActivity` row tagged `kind: "evidence"` with a `payload` JSON capturing the structured fields above.
+- The audit row in `ToolExecution` (written by the governed wrapper, §4.4) is the canonical proof of the call. The activity row is the per-item view used by the UI.
+- This is the **shared successor** alluded to in the goals: `ToolExecution` for the cross-cutting audit, `BacklogItemActivity` for the per-entity timeline. We do NOT extend `EvidenceBundle` (which is scoped to deliberation runs in Build Studio) for this — see §6.
+
+### 3.9 `get_next_recommended_work`
+
+Returns a short ranked list of items the caller could pick up. Read-only.
+
+Input:
+```ts
+{
+  count?: number;                    // default 3, max 10
+  epicId?: string;                   // narrow to one epic
+  forAgentId?: string;               // optional — only items grant-claimable by this agent
+  excludeItemIds?: string[];         // items already considered or rejected
+}
+```
+
+Output:
+```ts
+{
+  success: true,
+  recommendations: Array<{
+    itemId: string;
+    title: string;
+    rationale: string;               // human-readable why-this-rank
+    rank: number;                    // 1-based
+    score: number;                   // opaque float, monotonic
+    signals: {
+      hasSpec: boolean;
+      hasPlan: boolean;
+      hasActiveBuild: boolean;
+      claimedByOther: boolean;
+      effortSize: string | null;
+      priority: number | null;
+      epicStatus: string | null;
+    };
+  }>;
+}
+```
+
+Ranking function v1 (exposed as `apps/web/lib/backlog/recommend.ts`):
+
+1. Filter to items with `status ∈ { open, triaging }` and `claimedById IS NULL` and `claimedByAgentId IS NULL` (or matching `forAgentId`).
+2. Drop items in `excludeItemIds`.
+3. Score (higher is better):
+   - `+5` if a spec file under `docs/superpowers/specs/` references the itemId or its epic.
+   - `+3` if a plan file under `docs/superpowers/plans/` references the itemId or its epic.
+   - `+2` if `priority IS NOT NULL` (small bonus, then `+priority/10` capped at `+2`).
+   - `+1` if `effortSize IN { small, medium }` (preference for shippable chunks).
+   - `+1` if `triageOutcome = "build"` (already triaged toward a build).
+   - `-2` if `hasActiveBuild=true` (someone else is already working it).
+4. Sort by score desc, then by `priority` asc (lower number = higher priority), then `updatedAt` desc.
+5. Return top `count` with `rationale` derived from which signals fired.
+
+This is intentionally simple and tunable. It mirrors AGENTS.md's stated heuristic ("items with existing designs first, then dependencies between items, then impact"). When the platform's prioritization model improves, only this ranking function changes.
+
+## 4. Governance Architecture
+
+### 4.1 Three layers of enforcement (unchanged)
+
+The existing model — User capability ⨉ Agent grants ⨉ Tool definition — is correct and stays. This spec adds rows to the existing tables, not new tables.
+
+```
+                   /api/mcp/call (REST, session cookie)
+                                ▼
+       /api/mcp (JSON-RPC, session token — see Platform MCP Tool Server)
+                                ▼
+                   in-platform agentic-loop.ts
+                                ▼
+              +---------------------------------+
+              |   governedExecuteTool(...)      |   ← NEW (§4.4)
+              |  user cap → agent grant →       |
+              |  audit row (ToolExecution) →    |
+              |  executeTool(...)               |
+              +---------------------------------+
+                                ▼
+                      mcp-tools.ts dispatcher
+```
+
+Today, only the agentic-loop path writes `ToolExecution`. The new wrapper centralizes that so REST and JSON-RPC get audit "for free."
+
+### 4.2 New grants and the lifecycle invariant
+
+`TOOL_TO_GRANTS` in [agent-grants.ts](../../apps/web/lib/tak/agent-grants.ts) gets these entries:
+
+```ts
+list_epics:                  ["backlog_read"],
+list_backlog_items:          ["backlog_read"],
+get_backlog_item:            ["backlog_read"],
+update_backlog_item_status:  ["backlog_write"],
+link_backlog_item_to_epic:   ["backlog_write"],
+search_specs_and_plans:      ["spec_plan_read"],
+record_execution_evidence:   ["backlog_write"],
+get_next_recommended_work:   ["backlog_read"],
+```
+
+`spec_plan_read` is a new grant key. Most coworkers that have `backlog_read` should also receive `spec_plan_read` — this is a seed change in [packages/db/data/agent_registry.json](../../packages/db/data/agent_registry.json) and the `seed.ts` grant assignment loop. Default-deny stays in force; tools omitted from the map are still rejected by `isToolAllowedByGrants`.
+
+Legal status transitions enforced by `update_backlog_item_status` (and shared from `apps/web/lib/backlog/transitions.ts`):
+
+```
+triaging ──▶ open ──▶ in-progress ──▶ done
+   │          │            │
+   ▼          ▼            ▼
+deferred   deferred      deferred
+   │          │            │
+   ▼          ▼            ▼
+discarded  open          open       (re-open from deferred is allowed)
+```
+
+`done → done` is a no-op success. `done → anything` requires `backlog_admin_write` (a new grant gated on superuser by default). `triaging → done` is rejected — the triage step exists for a reason.
+
+### 4.3 No table-shaped APIs leak out
+
+`list_backlog_items` returns `epicId` as the **semantic** id (`EP-...`), not the cuid. `link_backlog_item_to_epic` accepts the semantic id. The cuid is an internal join key and never appears in the agent-facing contract. This matches the [memory note](../../C:/Users/Mark%20Bodman/.claude/projects/d--DPF/memory/project_backlog_epic_fk_pitfall.md) where Prisma FK confusion has bitten the project before.
+
+### 4.4 Governed execution wrapper
+
+A new module `apps/web/lib/mcp-governed-execute.ts` exposes:
+
+```ts
+export async function governedExecuteTool(args: {
+  toolName: string;
+  rawParams: Record<string, unknown>;
+  userId: string;
+  context?: { agentId?: string; threadId?: string; routeContext?: string; taskRunId?: string };
+  source: "rest" | "jsonrpc" | "agentic-loop";  // for audit attribution
+}): Promise<ToolResult>;
+```
+
+Behavior:
+
+1. Look up tool def in `PLATFORM_TOOLS`. Reject `not_found`.
+2. If `tool.requiredCapability` is set and `context.userContext` cannot satisfy it, reject `forbidden_capability`.
+3. If `context.agentId` is set, resolve `getAgentToolGrantsAsync(agentId)` and reject via `isToolAllowedByGrants` — `forbidden_grant`.
+4. Time the call. Invoke `executeTool(...)`.
+5. Always write a `ToolExecution` row (fire-and-forget but with error logging — never silent on the audit path itself), with `success`, `parameters`, `result`, `durationMs`, `auditClass`, `capabilityId`, and `executionMode = source`.
+6. Return the `ToolResult`.
+
+The **agentic loop keeps its own audit write**, but it stops doing the grant check itself (it already calls `executeTool` directly today and grants are checked elsewhere — see existing flow). The cleanest move is for `agentic-loop.ts` to call `governedExecuteTool` instead of `executeTool` and remove its inline `prisma.toolExecution.create`. That collapses three audit/permission paths into one. This change is small but worth doing in this spec because it closes the audit gap that motivates the work.
+
+Three call sites change:
+
+- [apps/web/app/api/mcp/call/route.ts](../../apps/web/app/api/mcp/call/route.ts) — replace `executeTool(...)` with `governedExecuteTool({ source: "rest", ... })` and remove the inline `can(...)` call (the wrapper does it).
+- [apps/web/lib/tak/agentic-loop.ts](../../apps/web/lib/tak/agentic-loop.ts) line 953 region — replace direct `executeTool` + `toolExecution.create` with `governedExecuteTool({ source: "agentic-loop", ... })`.
+- The forthcoming JSON-RPC route from the Platform MCP Tool Server spec — its `tools/call` handler calls `governedExecuteTool({ source: "jsonrpc", ... })`. That route is not delivered by *this* spec, but the wrapper is ready for it.
+
+### 4.5 BacklogItemActivity model
+
+`BacklogItemActivity` is a new lightweight model. It is **not** a generic event log — it is the per-item timeline that the UI and `get_backlog_item` read.
+
+```prisma
+model BacklogItemActivity {
+  id              String      @id @default(cuid())
+  backlogItemId   String      // FK to BacklogItem.id
+  kind            String      // "status_change" | "epic_link" | "evidence" | "claim" | "comment"
+  summary         String      // <= 240 chars, headline for the UI timeline
+  payload         Json        // structured per-kind detail
+  recordedAt      DateTime    @default(now())
+  recordedById    String?     // User.id, optional — null when agent-only
+  recordedByAgentId String?   // Agent.agentId
+  toolExecutionId String?     // FK to ToolExecution.id when produced by a tool call
+
+  backlogItem     BacklogItem @relation(fields: [backlogItemId], references: [id], onDelete: Cascade)
+  @@index([backlogItemId, recordedAt(sort: Desc)])
+  @@index([kind, recordedAt(sort: Desc)])
+}
+```
+
+This is added in a Prisma migration with no backfill (new table). It complements but does not replace `ToolExecution` (cross-cutting audit) or `EvidenceBundle` (Build Studio deliberation evidence).
+
+## 5. External Coding Agent Use
+
+External use is enabled by the Platform MCP Tool Server spec's transport. This spec ensures every tool added here is well-shaped for that transport:
+
+- **Stable names.** All nine tools have agent-friendly names that match the spec table above. They will not be renamed once shipped — the names are the contract.
+- **JSON-Schema input schemas** with `enum` constraints on every status/type/kind field, so MCP-capable clients can render dropdowns or validate before sending.
+- **Idempotency where possible.** `update_backlog_item_status` with `status` already at the requested value is a no-op success. `link_backlog_item_to_epic` to the current epic is a no-op success. `record_execution_evidence` is intentionally not idempotent — duplicate evidence is fine.
+- **`autoApproveWhen` on the new mutations.** The existing `executionMode: "proposal"` flow can still be used by HITL-tier agents. For the Codex / VS Code agents that work autonomously inside a Build Studio sandbox, we set `autoApproveWhen` on `update_backlog_item_status` and `link_backlog_item_to_epic` so they execute immediately when the agent has the right grants — this is exactly the [proposal-trap memory](../../C:/Users/Mark%20Bodman/.claude/projects/d--DPF/memory/project_proposal_trap_silent_failure.md) lesson applied.
+
+## 6. Why not `EvidenceBundle` for `record_execution_evidence`?
+
+`EvidenceBundle` is keyed to `deliberationRunId`, which is the Build Studio deliberation/branch graph. It records "claim-source" pairs for a structured argument, not "this build passed." Forcing backlog evidence through it would either require fabricating a deliberation run or denormalizing the evidence model. `BacklogItemActivity` is the right shape: cheap to write, indexed for timeline reads, and clearly per-item.
+
+`ToolExecution` remains the audit record of record. `BacklogItemActivity` is the user-visible timeline. They are written together in the governed wrapper.
+
+## 7. Live State Reconciliation (one-time, in implementation)
+
+The pre-implementation DB scan (run during research) found:
+
+- `BacklogItem.type = "feature"` exists in live data — non-canonical. A small data migration normalizes `feature → product`. The `type` enum on `create_backlog_item` already only allows `portfolio | product`, so once normalized this drift cannot reappear via tool calls.
+- All sample `BacklogItem` rows have `epicId = NULL`. This is allowed by the schema and not a corruption — it's just visible scope for `link_backlog_item_to_epic`.
+- 354 `AgentToolGrant` rows seeded; no `epic_*` grant keys. Backlog/epic operations all gate on `backlog_read` / `backlog_write`. We keep that — splitting the grant further is more governance overhead than it pays for at this scale.
+
+Both are addressed in the implementation plan, not in this spec body.
+
+## 8. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Audit-wrapper change in `agentic-loop.ts` regresses the in-platform agent path | Phased migration: wrapper added alongside the existing `executeTool` call; switch over only after the new wrapper passes parity tests; keep the old code path behind a `DPF_USE_GOVERNED_WRAPPER` env flag for one release. |
+| `search_specs_and_plans` reads ~200 markdown files per call | Acceptable today (sub-100ms on the dev box). If it becomes hot, the same Postgres FTS pattern used for backlog semantic memory is the next step. |
+| Ranking in `get_next_recommended_work` is naive and may surface bad recommendations | The function lives in `apps/web/lib/backlog/recommend.ts` and is unit-tested with explicit fixtures. It is replaceable without changing the tool contract. |
+| External coding agents may attempt arbitrary SQL via `admin_query_db` after this lands | Out of scope here, but the existence of this surface reduces the *justification* for using the SQL escape hatch. A future restriction on `admin_query_db` (e.g., superuser only via grants) is now safe to make. |
+| `BacklogItemActivity` grows unbounded | Indexed `(backlogItemId, recordedAt desc)`; UI and tool reads always paginate. Long-term TTL is a future concern. |
+
+## 9. Test Plan (informational — full plan in implementation document)
+
+- Unit: ranking function with fixtures (no spec, with spec, with active build, with claim).
+- Unit: legal/illegal status transitions in `update_backlog_item_status`.
+- Unit: `link_backlog_item_to_epic` semantic→cuid resolution and the epic auto-reopen behavior.
+- Unit: `search_specs_and_plans` regex extraction of `BI-*` / `EP-*` references; snippet windowing.
+- Integration: `governedExecuteTool` writes a `ToolExecution` row for each of REST, JSON-RPC, and agentic-loop sources, with correct `executionMode` field.
+- Integration: agent without `backlog_read` is rejected at the wrapper before `executeTool` runs (no DB read happens, no `BacklogItem` row is loaded).
+- Integration: agent with `backlog_read` but not `backlog_write` is rejected on `record_execution_evidence` and the failure itself is audited.
+- Lifecycle: end-to-end `create_backlog_item → link_backlog_item_to_epic → update_backlog_item_status(in-progress) → record_execution_evidence(test_pass) → update_backlog_item_status(done)` produces a clean activity timeline and a closed epic if it was the last item.
+
+## 10. Out-of-Scope Follow-ups (recorded for later)
+
+- Migrating the existing `update_backlog_item` callers to either `update_backlog_item_status` or `update_backlog_item_metadata` (a future split). Today the patch surface is too broad.
+- Restricting `admin_query_db` to superuser-only via grants once the domain coverage here is exercised.
+- Adding `apps/web/lib/backlog/transitions.ts` as the canonical transition table consumed by both `update_backlog_item_status` and the existing `update_backlog_item` write path so they stay aligned.
+- Splitting `backlog_write` into `backlog_create`, `backlog_update`, `backlog_evidence_write` if the scale of agents and audit volume warrants finer-grained governance.
+
+---
+
+## 11. External Client Use — Mode 1 Installation
+
+The same nine-tool surface is exposed to **external** MCP clients (Claude Code, Codex CLI, VS Code MCP) running on the user's host. This is the Mode 1 unlock: a fresh install gives the user a working backlog interface from their preferred coding agent, not just from inside the portal's Build Studio.
+
+### 11.1 Why a separate transport from the in-portal one
+
+The [Platform MCP Tool Server spec](./2026-04-11-platform-mcp-tool-server-design.md) defines an internal JSON-RPC endpoint with short-lived (5-minute) session tokens, intentionally bound to `localhost` inside the Docker network. That endpoint is for the platform calling its own CLI processes (e.g. `claude -p` inside the sandbox). It is the wrong shape for an external coding agent on the user's laptop, which needs:
+
+- A long-lived bearer credential (paste once into Claude Code's MCP config).
+- A reachable URL the desktop client can hit (`http://localhost:3000/api/mcp/external/jsonrpc` for Mode 1; TLS-fronted for deployed installs).
+- An identity that resolves to a real `User` row, not an in-portal session cookie.
+
+We add a sibling endpoint at `/api/mcp/external/jsonrpc` that mirrors the protocol of the internal endpoint but authenticates by `Authorization: Bearer <token>` and resolves the token to the issuing user. Both endpoints call the same `governedExecuteTool` so tools, grants, and audit are one pipeline.
+
+### 11.2 Credentials and identity — relationship to contribution mode
+
+DPF's contribution-mode work added an install-level GitHub credential in [PlatformDevConfig](../../packages/db/prisma/schema.prisma) — singleton row with `clientId` (per-install UUID), `gitAgentEmail` (`agent-<sha256(clientId)[:16]>@hive.dpf`), `contributionModel` (`maintainer-direct` | `fork-pr`), and an encrypted GitHub token via [platform-dev-config.ts](../../apps/web/lib/actions/platform-dev-config.ts). That credential is **outbound**: it authenticates the install to GitHub when the contribution pipeline pushes code or opens PRs.
+
+The MCP API token is **inbound**: it authenticates an external client to DPF when it calls the backlog tools.
+
+These cannot be the same literal token (different audiences, different validators), but they are the same shape of problem and they share three concrete things:
+
+1. **One identity model.** Both ride the same `User` row. The MCP token is issued to a logged-in user; the contribution pipeline runs commits attributed to the install's `gitAgentEmail` but signed-off by the user who triggered the work. When an external-MCP write becomes a contribution, the audit chain is unbroken: `MCP token → User → install GitHub bind → upstream PR`. This is the strong-attribution chain the [obfuscated-not-anonymous](../../C:/Users/Mark%20Bodman/.claude/projects/d--DPF/memory/feedback_obfuscated_not_anonymous.md) rule wants.
+2. **One settings surface.** `/admin/platform-development` already hosts contribution-mode config. We co-locate MCP token issuance there as a sibling section ("External Coding Agent Access"). Same admin view, same revoke flow, same audit.
+3. **One write-attribution gate.** Read-only MCP tokens issue freely. **Write-capable** MCP tokens require `PlatformDevConfig.contributionModel` to be set (i.e., the contribution path is wired). This guarantees that any external-MCP write that ever turns into code can be attributed end-to-end. If contribution mode is not configured, write-capable tokens are blocked at issuance with a pointer to set it up first.
+
+### 11.3 Token model — `AgentApiToken`
+
+A new Prisma model:
+
+```prisma
+model AgentApiToken {
+  id              String    @id @default(cuid())
+  userId          String                 // issuing user
+  agentId         String?                // optional: bind to a specific agent identity
+  name            String                 // human label, e.g. "Mark's Claude Code (laptop)"
+  tokenHash       String    @unique      // sha256 of the secret; secret never stored
+  prefix          String                 // first 8 chars, for display (like dpfmcp_aB12...)
+  scopes          String[]  @default([]) // grant keys the token may exercise (subset of user's grants)
+  capability      String    @default("read") // "read" | "write" — write requires contribution-mode
+  lastUsedAt      DateTime?
+  expiresAt       DateTime?              // null = no expiry; UI defaults to 90 days
+  revokedAt       DateTime?
+  revokedReason   String?
+  createdAt       DateTime  @default(now())
+  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([tokenHash])
+}
+```
+
+Token format: `dpfmcp_<24 random bytes base32>`. Stored as `sha256(secret)`; the plaintext is shown to the user **once** at issuance and never recoverable — same pattern as GitHub PATs.
+
+`scopes` is a subset of the user's effective grants, chosen at issuance. A user with `backlog_read`, `backlog_write`, `spec_plan_read` can mint a token with only `backlog_read` for a low-trust laptop. The MCP request's effective grants are `tokenScopes ∩ userGrants ∩ (agentGrants if agentId set)`.
+
+### 11.4 External JSON-RPC endpoint
+
+`apps/web/app/api/mcp/external/jsonrpc/route.ts`:
+
+```http
+POST /api/mcp/external/jsonrpc
+Authorization: Bearer dpfmcp_...
+Content-Type: application/json
+
+{ "jsonrpc": "2.0", "id": 1, "method": "tools/list" }
+```
+
+Handler steps:
+
+1. Parse `Authorization: Bearer` header. If absent or malformed → JSON-RPC error `-32001 unauthorized`.
+2. `sha256(secret)` and `prisma.agentApiToken.findUnique({ tokenHash })`. Reject if not found, revoked, or expired.
+3. Update `lastUsedAt` (fire-and-forget).
+4. Resolve `userId` → load `User` (platformRole, isSuperuser).
+5. For `tools/list`: call `getAvailableTools(userContext, { agentId: token.agentId, unifiedMode: true })` and additionally filter by `token.scopes` (intersect with each tool's required grants). Return only tools the token can actually invoke — mirrors the in-portal MCP scoping.
+6. For `tools/call`: invoke `governedExecuteTool({ source: "external-jsonrpc", userContext, context: { agentId: token.agentId }, ... })`. Pass the token's scope set as an additional grant filter so a token-scope mismatch fails fast with `forbidden_grant`.
+7. The audit row in `ToolExecution` records `executionMode: "external-jsonrpc"` and a new field `apiTokenId` (added in the same migration as `AgentApiToken`) so each external write is traceable to a specific token.
+
+The contract surface (the JSON-RPC method names, the tool schemas) is identical to the internal MCP endpoint. An external client doesn't need to know it's a different transport.
+
+### 11.5 Issuance flow
+
+Settings page at `/admin/platform-development` gains a new section:
+
+- **External Coding Agent Access**
+  - Status: contribution-mode wired? (Yes/No, with a "configure" link)
+  - Existing tokens table: name, prefix, capability (read/write), scopes, last used, expires, revoke button
+  - "Generate token" button →
+    - Modal: `name`, `capability` (radio: read / write — write disabled with explainer if contribution-mode unset), `scopes` (multi-select, defaulted from user's grants), `expiresIn` (dropdown: 30/60/90/180 days/never, default 90), optional `agentId` (dropdown of agents the user can act as)
+    - Submit → server action mints secret, hashes, persists, returns plaintext **once** to the modal with copy button and a setup snippet for Claude Code / Codex / VS Code (see §11.6)
+
+The server action lives at `apps/web/lib/actions/agent-api-tokens.ts`:
+
+```ts
+export async function issueAgentApiToken(input: {
+  name: string;
+  capability: "read" | "write";
+  scopes: string[];
+  expiresInDays: number | null;
+  agentId?: string;
+}): Promise<{ tokenId: string; plaintext: string }>;
+
+export async function revokeAgentApiToken(tokenId: string, reason: string): Promise<void>;
+```
+
+`issueAgentApiToken` enforces the contribution-mode gate when `capability=write`:
+
+```ts
+if (input.capability === "write") {
+  const cfg = await prisma.platformDevConfig.findUnique({ where: { id: "singleton" } });
+  if (!cfg?.contributionModel) {
+    throw new Error("Configure contribution mode before issuing write-capable tokens");
+  }
+}
+```
+
+### 11.6 Setup snippets (returned to the user at issuance)
+
+For Claude Code (`~/.claude/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "dpf": {
+      "url": "http://localhost:3000/api/mcp/external/jsonrpc",
+      "headers": { "Authorization": "Bearer dpfmcp_<your-token>" }
+    }
+  }
+}
+```
+
+For Codex CLI / VS Code MCP: equivalent `.mcp.json` with the same URL and bearer header. The portal returns the snippet pre-filled with the user's token at issuance time. The token is shown **once**.
+
+### 11.7 Mode 1 vs deployed installs
+
+| Concern | Mode 1 (single install on user's box) | Deployed (multi-user, hosted) |
+| ------- | ------------------------------------- | ----------------------------- |
+| Endpoint URL | `http://localhost:3000/api/mcp/external/jsonrpc` | `https://<host>/api/mcp/external/jsonrpc` (TLS required) |
+| Token transport | HTTP (local-only) | HTTPS — endpoint refuses non-TLS via `request.url.startsWith("http://")` check (allowed for `localhost` only) |
+| Token expiry | Default 90 days, "never" allowed | Default 90 days, "never" disabled in UI for non-superusers |
+| Rate limiting | Lax (single user) | Per-token rate limit (out of scope here, tracked as follow-up) |
+| Network exposure | Bound to `localhost`/`127.0.0.1` by default | Behind the existing portal's reverse proxy / TLS |
+
+The endpoint code path is identical for both — only the policy guards and infra fronting differ.
+
+### 11.8 What this gives you on day one
+
+After this lands, on a fresh install:
+
+1. User runs the install, completes setup wizard.
+2. User configures contribution mode (existing flow).
+3. User clicks "Generate MCP token" on the same admin page, picks "write," gets a token.
+4. User pastes the token into Claude Code's `mcp.json`.
+5. From Claude Code on their laptop, the user can `list_backlog_items`, `get_next_recommended_work`, `record_execution_evidence`, etc. — every action is audited via `ToolExecution` with the issuing user, the token id, and `executionMode: "external-jsonrpc"`.
+6. If they then ask Claude Code to make a code change that lands as a contribution PR, the chain `MCP token → user → install GitHub bind → PR` is intact.
+
+This is the Mode 1 backlog interface the spec set out to deliver.
+
+### 11.9 Risks and mitigations specific to §11
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Stolen token gives full backlog write access | Tokens are scoped at issuance (subset of user grants), expirable, and revocable from the same admin page. `lastUsedAt` is shown in the UI so unused tokens are easy to spot and revoke. |
+| Long-lived tokens drift from current grants | The MCP request resolves `tokenScopes ∩ userGrants` at every call — if the user loses a grant, every token loses it too on the next call. |
+| External writes bypass contribution attribution | Write-capable tokens cannot be issued unless `PlatformDevConfig.contributionModel` is set. Read tokens never need this. |
+| Token plaintext leaks via logs | Endpoint never logs the `Authorization` header. Audit row stores `apiTokenId`, not the plaintext or hash. |
+| TLS bypass on a deployed install | The endpoint refuses non-TLS requests except when the host is `localhost`/`127.0.0.1` (Mode 1). |

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -47,7 +47,8 @@
           "role_registry_read",
           "policy_read",
           "strategy_read",
-          "budget_read"
+          "budget_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -101,7 +102,8 @@
           "agent_control_read",
           "role_registry_read",
           "investment_proposal_create",
-          "gap_analysis_read"
+          "gap_analysis_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -154,7 +156,8 @@
           "role_registry_read",
           "backlog_write",
           "roadmap_create",
-          "architecture_read"
+          "architecture_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -215,7 +218,8 @@
           "sbom_read",
           "release_gate_create",
           "build_plan_write",
-          "backlog_write"
+          "backlog_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -271,7 +275,8 @@
           "role_registry_read",
           "iac_execute",
           "deployment_plan_create",
-          "resource_reservation_read"
+          "resource_reservation_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -326,7 +331,8 @@
           "role_registry_read",
           "service_offer_read",
           "catalog_publish",
-          "subscription_read"
+          "subscription_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -380,7 +386,8 @@
           "role_registry_read",
           "consumer_onboard",
           "order_create",
-          "incident_read"
+          "incident_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -433,7 +440,8 @@
           "role_registry_read",
           "telemetry_read",
           "incident_create",
-          "change_event_emit"
+          "change_event_emit",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -486,7 +494,8 @@
           "role_registry_read",
           "constraint_validate",
           "architecture_guardrail_read",
-          "evidence_chain_read"
+          "evidence_chain_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -533,7 +542,8 @@
           "backlog_read",
           "policy_read",
           "policy_write",
-          "violation_report_create"
+          "violation_report_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -581,7 +591,8 @@
           "backlog_read",
           "strategy_read",
           "strategy_write",
-          "decision_record_create"
+          "decision_record_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -627,7 +638,8 @@
           "registry_read",
           "backlog_read",
           "backlog_write",
-          "portfolio_backlog_read"
+          "portfolio_backlog_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -672,7 +684,8 @@
           "backlog_read",
           "portfolio_read",
           "rationalization_report_create",
-          "decision_record_create"
+          "decision_record_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -721,7 +734,8 @@
           "financial_read",
           "tool_evaluation_read",
           "tool_verdict_create",
-          "risk_score_create"
+          "risk_score_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -768,7 +782,8 @@
           "criteria_read",
           "gap_analysis_create",
           "external_registry_search",
-          "tool_evaluation_create"
+          "tool_evaluation_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -812,7 +827,8 @@
           "registry_read",
           "backlog_read",
           "scope_agreement_create",
-          "decision_record_create"
+          "decision_record_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -862,7 +878,8 @@
           "credential_scan",
           "dependency_audit",
           "supply_chain_verify",
-          "finding_create"
+          "finding_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "persistent",
@@ -907,7 +924,8 @@
           "registry_read",
           "backlog_read",
           "backlog_write",
-          "scoring_model_read"
+          "scoring_model_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -955,7 +973,8 @@
           "architecture_write",
           "decision_record_create",
           "ea_graph_write",
-          "ea_graph_read"
+          "ea_graph_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1001,7 +1020,8 @@
           "backlog_read",
           "roadmap_create",
           "release_plan_read",
-          "decision_record_create"
+          "decision_record_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1046,7 +1066,8 @@
           "registry_read",
           "backlog_read",
           "release_plan_create",
-          "schedule_write"
+          "schedule_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1096,7 +1117,8 @@
           "dependency_graph_read",
           "sandbox_execute",
           "tool_evaluation_read",
-          "integration_test_create"
+          "integration_test_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1143,7 +1165,8 @@
           "backlog_read",
           "release_gate_create",
           "acceptance_package_write",
-          "decision_record_create"
+          "decision_record_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1190,7 +1213,8 @@
           "backlog_read",
           "deployment_plan_create",
           "rollback_plan_create",
-          "decision_record_create"
+          "decision_record_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1236,7 +1260,8 @@
           "registry_read",
           "backlog_read",
           "resource_reservation_write",
-          "order_create"
+          "order_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1281,7 +1306,8 @@
           "backlog_read",
           "iac_execute",
           "change_event_emit",
-          "product_instance_write"
+          "product_instance_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1327,7 +1353,8 @@
           "registry_read",
           "backlog_read",
           "service_offer_write",
-          "contract_read"
+          "contract_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1373,7 +1400,8 @@
           "registry_read",
           "backlog_read",
           "catalog_publish",
-          "service_offer_read"
+          "service_offer_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1419,7 +1447,8 @@
           "backlog_read",
           "subscription_write",
           "contract_write",
-          "chargeback_write"
+          "chargeback_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1463,7 +1492,8 @@
           "registry_read",
           "backlog_read",
           "consumer_write",
-          "entitlement_provision"
+          "entitlement_provision",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1507,7 +1537,8 @@
           "registry_read",
           "backlog_read",
           "product_instance_write",
-          "order_write"
+          "order_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1553,7 +1584,8 @@
           "backlog_read",
           "incident_create",
           "sla_compliance_write",
-          "clip_route"
+          "clip_route",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1597,7 +1629,8 @@
           "registry_read",
           "backlog_read",
           "telemetry_read",
-          "change_event_emit"
+          "change_event_emit",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1642,7 +1675,8 @@
           "backlog_read",
           "incident_create",
           "telemetry_read",
-          "escalation_trigger"
+          "escalation_trigger",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1688,7 +1722,8 @@
           "backlog_read",
           "runbook_execute",
           "incident_write",
-          "evidence_artifact_create"
+          "evidence_artifact_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1732,7 +1767,8 @@
           "registry_read",
           "backlog_read",
           "constraint_validate",
-          "violation_report_create"
+          "violation_report_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1781,7 +1817,8 @@
           "guardrail_validate",
           "decision_record_create",
           "tool_evaluation_read",
-          "trust_boundary_map"
+          "trust_boundary_map",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1825,7 +1862,8 @@
           "registry_read",
           "backlog_read",
           "evidence_chain_validate",
-          "audit_report_create"
+          "audit_report_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1869,7 +1907,8 @@
           "registry_read",
           "backlog_read",
           "policy_read",
-          "policy_write"
+          "policy_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -1915,7 +1954,8 @@
           "backlog_read",
           "budget_read",
           "chargeback_write",
-          "financial_report_create"
+          "financial_report_create",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "none",
@@ -1962,7 +2002,8 @@
           "architecture_read",
           "adr_create",
           "conway_validate",
-          "ea_graph_read"
+          "ea_graph_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "none",
@@ -2010,7 +2051,8 @@
           "sbom_read",
           "license_check",
           "regulatory_compliance_check",
-          "tool_evaluation_read"
+          "tool_evaluation_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "none",
@@ -2099,7 +2141,8 @@
           "registry_read",
           "backlog_read",
           "portfolio_backlog_write",
-          "pbi_status_write"
+          "pbi_status_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -2144,7 +2187,8 @@
           "registry_read",
           "backlog_read",
           "backlog_write",
-          "prod_status_write"
+          "prod_status_write",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",
@@ -2188,7 +2232,8 @@
           "backlog_read",
           "backlog_write",
           "decision_record_create",
-          "architecture_read"
+          "architecture_read",
+          "spec_plan_read"
         ],
         "memory": {
           "type": "session",

--- a/packages/db/prisma/migrations/20260425180000_backlog_item_activity/migration.sql
+++ b/packages/db/prisma/migrations/20260425180000_backlog_item_activity/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "BacklogItemActivity" (
+    "id" TEXT NOT NULL,
+    "backlogItemId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "payload" JSONB NOT NULL DEFAULT '{}',
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "recordedById" TEXT,
+    "recordedByAgentId" TEXT,
+    "toolExecutionId" TEXT,
+
+    CONSTRAINT "BacklogItemActivity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BacklogItemActivity_backlogItemId_recordedAt_idx" ON "BacklogItemActivity"("backlogItemId", "recordedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "BacklogItemActivity_kind_recordedAt_idx" ON "BacklogItemActivity"("kind", "recordedAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "BacklogItemActivity" ADD CONSTRAINT "BacklogItemActivity_backlogItemId_fkey" FOREIGN KEY ("backlogItemId") REFERENCES "BacklogItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260425180100_normalize_backlogitem_type/migration.sql
+++ b/packages/db/prisma/migrations/20260425180100_normalize_backlogitem_type/migration.sql
@@ -1,0 +1,5 @@
+-- Data normalization: BacklogItem.type is a canonical enum {portfolio, product}.
+-- Live data has drifted to include "feature"; normalize to "product" so the
+-- TS-level enum (enforced by the new MCP tool input schemas) stays consistent
+-- with what's in the database.
+UPDATE "BacklogItem" SET "type" = 'product' WHERE "type" = 'feature';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -893,6 +893,25 @@ model BacklogItem {
   featureBuilds         FeatureBuild[]   @relation("BacklogItemOriginator")
   submittedBy           User?            @relation("BacklogSubmissions", fields: [submittedById], references: [id])
   taxonomyNode          TaxonomyNode?    @relation(fields: [taxonomyNodeId], references: [id])
+  activities            BacklogItemActivity[]
+}
+
+// Per-item timeline. Cross-cutting tool audit lives in ToolExecution; this is
+// the entity-scoped view used by get_backlog_item and the UI.
+model BacklogItemActivity {
+  id                String      @id @default(cuid())
+  backlogItemId     String
+  kind              String
+  summary           String
+  payload           Json        @default("{}")
+  recordedAt        DateTime    @default(now())
+  recordedById      String?
+  recordedByAgentId String?
+  toolExecutionId   String?
+  backlogItem       BacklogItem @relation(fields: [backlogItemId], references: [id], onDelete: Cascade)
+
+  @@index([backlogItemId, recordedAt(sort: Desc)])
+  @@index([kind, recordedAt(sort: Desc)])
 }
 
 model Epic {


### PR DESCRIPTION
## Summary

- Adds a domain-level MCP surface for backlog and planning workflows: `list_epics`, `list_backlog_items`, `get_backlog_item`, `update_backlog_item_status`, `link_backlog_item_to_epic`, `search_specs_and_plans`, `record_execution_evidence`, `get_next_recommended_work` — usable by every transport (REST, future JSON-RPC, in-platform agentic loop).
- **Closes the audit gap completely.** A new `governedExecuteTool` wrapper centralizes user-capability + agent-grant enforcement and writes a `ToolExecution` row for every tool call, regardless of caller. Both `/api/mcp/call` (REST) **and** the in-platform agentic loop are wired through it; the inline audit path in agentic-loop is removed. One audit code path, not two.
- New `BacklogItemActivity` table is the per-item timeline (status changes, epic links, evidence). `ToolExecution` keeps owning the cross-cutting audit; the two complement each other.
- Includes a one-time data normalization migration for `BacklogItem.type='feature'` rows that had drifted from the canonical `{portfolio, product}` enum.

Spec: [docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md](docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md)
Plan: [docs/superpowers/plans/2026-04-25-governed-mcp-backlog-surface.md](docs/superpowers/plans/2026-04-25-governed-mcp-backlog-surface.md)

## What's deferred (intentional)

- **§13 External-client transport** (Claude Code / Codex / VS Code MCP on the user's host) — `AgentApiToken` model, `/api/mcp/external/jsonrpc` route, settings UI co-located with contribution-mode. Substantial coherent scope; the plan called out the split. The wrapper already accepts `apiTokenId` in context and supports `executionMode: "external-jsonrpc"`; only the route + token model are missing.

## Migration notes

Two purely-additive migrations:

- `20260425180000_backlog_item_activity` — new table + indexes + FK with cascade-delete.
- `20260425180100_normalize_backlogitem_type` — `UPDATE "BacklogItem" SET type='product' WHERE type='feature'` (1 row in the dev DB; production may have more).

`spec_plan_read` is a new grant key. Every coworker that already had `backlog_read` is given `spec_plan_read` in `agent_registry.json` (45 agents) so existing readers don't lose reach.

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] Vitest: 132/132 passing across `lib/backlog/*`, `lib/mcp-governed-execute*`, `lib/tak/agent-grants*`, `lib/tak/agentic-loop*`, `app/api/mcp/call/*`
- [x] `pnpm --filter web build` — production build succeeds
- [ ] (post-merge) Smoke from in-portal coworker: `query_backlog`, `create_backlog_item`, `record_execution_evidence` against the wrapper path
- [ ] (post-merge) Verify `ToolExecution.executionMode` rows split cleanly across `"rest"`, `"agentic-loop"` per traffic source

## Notes for reviewers

- The wrapper writes audit rows for **rejected** calls too (capability/grant denials), so the audit log is complete on permission failures. Tests assert this.
- All agent-facing IDs are semantic (`BI-…`, `EP-…`); cuids never leak into tool inputs or outputs.
- `update_backlog_item_status` enforces the canonical lifecycle table from `lib/backlog/transitions.ts`. `done` is terminal except via admin grant. Same-status calls are no-op successes (idempotent).
- `link_backlog_item_to_epic` recomputes the target epic's status — a done epic that gains an open item flips back to open, mirroring the AGENTS.md Epic Lifecycle Stewardship rule in reverse.
- `get_next_recommended_work` calls `buildSpecPlanReferenceIndex` once per call so per-item `hasSpec` / `hasPlan` checks are O(1) regardless of backlog size.
- **Agentic-loop wiring**: `executionMode` on existing audit rows changes from `"immediate"` to `"agentic-loop"` going forward (the two consumers are display-only — `CapabilityJournalClient` and `ToolExecutionLogClient` — neither filters on the value). The probe-chatter aggregation that suppresses repetitive `metrics_only` rows is preserved via a new `skipAudit` wrapper option; rejection rows still land regardless of that flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)