### PR TITLE
feat(mcp): real MCP JSON-RPC at /api/mcp/v1 — Mode 1 unlock for VS Code / Claude Code / Codex

### DIFF
--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -1,6 +1,9 @@
+import { headers } from "next/headers";
+
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { ForkSetupPanel } from "@/components/admin/ForkSetupPanel";
 import LegacyTokenOverrideBanner from "@/components/admin/LegacyTokenOverrideBanner";
+import { McpTokenManager } from "@/components/admin/McpTokenManager";
 import { PlatformDevelopmentForm } from "@/components/admin/PlatformDevelopmentForm";
 import TokenExpiryBanner from "@/components/admin/TokenExpiryBanner";
 import {
@@ -29,6 +32,14 @@ export default async function AdminPlatformDevelopmentPage() {
   // paste-mode PATs are surfaced via the Advanced disclosure but not as
   // "Connected as @user" since we don't proactively verify their owner.
   const initialConnected = await getGitHubConnectedState().catch(() => null);
+
+  // Best-effort base URL for token setup snippets shown in the UI. Prefer the
+  // forwarded Host header (which respects any reverse proxy); fall back to
+  // localhost:3000 for the dev case.
+  const hdrs = await headers();
+  const proto = hdrs.get("x-forwarded-proto") ?? "http";
+  const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
+  const baseUrl = `${proto}://${host}`;
 
   return (
     <div>
@@ -59,6 +70,10 @@ export default async function AdminPlatformDevelopmentPage() {
         hasContributionToken={hasContribToken}
         pseudonym={pseudonym}
         initialConnected={initialConnected}
+      />
+      <McpTokenManager
+        contributionModelConfigured={config?.contributionModel != null}
+        baseUrl={baseUrl}
       />
     </div>
   );

--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -1,0 +1,472 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/mcp-api-token", () => ({
+  resolveMcpApiToken: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-governed-execute", () => ({
+  governedExecuteTool: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { resolveMcpApiToken } from "@/lib/auth/mcp-api-token";
+import { governedExecuteTool } from "@/lib/mcp-governed-execute";
+import { GET, POST } from "./route";
+
+const resolveMock = resolveMcpApiToken as unknown as ReturnType<typeof vi.fn>;
+const govMock = governedExecuteTool as unknown as ReturnType<typeof vi.fn>;
+const userMock = prisma.user.findUnique as unknown as ReturnType<typeof vi.fn>;
+
+function makeRequest(opts: {
+  url?: string;
+  method?: string;
+  bearer?: string | null;
+  origin?: string | null;
+  body?: unknown;
+}): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (opts.bearer !== null && opts.bearer !== undefined) {
+    headers["Authorization"] = `Bearer ${opts.bearer}`;
+  }
+  if (opts.origin !== null && opts.origin !== undefined) {
+    headers["Origin"] = opts.origin;
+  }
+  return new Request(opts.url ?? "http://localhost:3000/api/mcp/v1", {
+    method: opts.method ?? "POST",
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  userMock.mockResolvedValue({
+    isSuperuser: true,
+    groups: [{ platformRole: { roleId: "HR-000" } }],
+  } as never);
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("GET", () => {
+  it("returns 405 with Allow header", () => {
+    const res = GET();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+});
+
+describe("POST — transport guards", () => {
+  it("rejects HTTPS-required violations on non-localhost http URLs", async () => {
+    const res = await POST(
+      makeRequest({
+        url: "http://evil.example.com/api/mcp/v1",
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/TLS required/i);
+  });
+
+  it("allows http on localhost (Mode 1)", async () => {
+    resolveMock.mockResolvedValue(null); // pretend token is bad to short-circuit at auth
+    const res = await POST(
+      makeRequest({
+        url: "http://localhost:3000/api/mcp/v1",
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401); // got past TLS guard, failed at auth
+  });
+
+  it("rejects requests with disallowed Origin", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        origin: "https://evil.example.com",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows requests with no Origin (CLI clients)", async () => {
+    resolveMock.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        origin: null,
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401); // past origin guard, fails at auth
+  });
+});
+
+describe("POST — auth", () => {
+  it("returns 401 with WWW-Authenticate when Authorization header missing", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: null,
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toMatch(/^Bearer realm="DPF MCP"/);
+  });
+
+  it("returns 401 when token resolves to null", async () => {
+    resolveMock.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_BAD",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toContain("invalid_token");
+  });
+});
+
+describe("POST — JSON-RPC envelope", () => {
+  beforeEach(() => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read", "backlog_write"],
+      capability: "write",
+    });
+  });
+
+  it("returns -32700 parse error on invalid JSON body", async () => {
+    const res = await POST(
+      new Request("http://localhost:3000/api/mcp/v1", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer dpfmcp_X",
+        },
+        body: "not valid json{",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32700);
+  });
+
+  it("returns -32600 invalid request when jsonrpc field is wrong", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "1.0", id: 1, method: "initialize" },
+      }),
+    );
+    const body = await res.json();
+    expect(body.error.code).toBe(-32600);
+  });
+
+  it("returns -32601 method not found for unknown methods", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 1, method: "totally_unknown_method" },
+      }),
+    );
+    const body = await res.json();
+    expect(body.error.code).toBe(-32601);
+  });
+
+  it("returns 202 Accepted with no body for notifications/initialized", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", method: "notifications/initialized" }, // no id = notification
+      }),
+    );
+    expect(res.status).toBe(202);
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns 202 for unknown notifications (no id)", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", method: "some/random/notification" },
+      }),
+    );
+    expect(res.status).toBe(202);
+  });
+});
+
+describe("POST — initialize", () => {
+  beforeEach(() => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+  });
+
+  it("returns the protocol version, server info, and tools capability", async () => {
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBe(1);
+    expect(body.result.protocolVersion).toBe("2025-11-25");
+    expect(body.result.serverInfo.name).toBe("dpf-platform");
+    expect(body.result.capabilities.tools).toBeDefined();
+  });
+});
+
+describe("POST — tools/list", () => {
+  it("returns only tools the token's scopes can use", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"], // read-only scope
+      capability: "read",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const toolNames = body.result.tools.map((t: { name: string }) => t.name);
+    // Read-scoped tools should appear
+    expect(toolNames).toContain("query_backlog");
+    expect(toolNames).toContain("list_epics");
+    // Write-scoped tools should NOT appear
+    expect(toolNames).not.toContain("create_backlog_item");
+    expect(toolNames).not.toContain("update_backlog_item_status");
+  });
+
+  it("includes annotations on every returned tool", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 3, method: "tools/list" },
+      }),
+    );
+    const body = await res.json();
+    for (const tool of body.result.tools) {
+      expect(tool.annotations).toBeDefined();
+      expect(typeof tool.annotations.readOnlyHint).toBe("boolean");
+      expect(typeof tool.annotations.destructiveHint).toBe("boolean");
+    }
+  });
+});
+
+describe("POST — tools/call", () => {
+  it("returns invalid_params when name is missing", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 4, method: "tools/call", params: {} },
+      }),
+    );
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+  });
+
+  it("returns isError:true with helpful message for unknown tools", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/call",
+          params: { name: "totally_made_up_tool" },
+        },
+      }),
+    );
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toContain("Unknown tool");
+  });
+
+  it("rejects scope mismatch with isError:true and a clear message (does not call governedExecuteTool)", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"], // no backlog_write
+      capability: "read",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 6,
+          method: "tools/call",
+          params: { name: "create_backlog_item", arguments: {} },
+        },
+      }),
+    );
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/lacks the required scope/i);
+    expect(govMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects side-effecting calls from read-capable tokens (defense-in-depth)", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read", "backlog_write"], // scopes allow it
+      capability: "read", // but token capability is read-only
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: { name: "create_backlog_item", arguments: {} },
+        },
+      }),
+    );
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/read-only/i);
+    expect(govMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches to governedExecuteTool with source=external-jsonrpc and apiTokenId", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_abc",
+      userId: "u1",
+      agentId: "AGT-100",
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    govMock.mockResolvedValue({
+      success: true,
+      message: "ok",
+      data: { items: [{ itemId: "BI-X", title: "X" }] },
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 8,
+          method: "tools/call",
+          params: { name: "list_backlog_items", arguments: { limit: 5 } },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(govMock).toHaveBeenCalledOnce();
+    const call = govMock.mock.calls[0]![0];
+    expect(call.toolName).toBe("list_backlog_items");
+    expect(call.userId).toBe("u1");
+    expect(call.context.agentId).toBe("AGT-100");
+    expect(call.context.apiTokenId).toBe("tok_abc");
+    expect(call.source).toBe("external-jsonrpc");
+
+    const body = await res.json();
+    expect(body.result.isError).toBe(false);
+    expect(body.result.content[0].type).toBe("text");
+    expect(body.result.content[0].text).toContain("ok");
+    // structuredContent mirrors the ToolResult.data
+    expect(body.result.structuredContent.items[0].itemId).toBe("BI-X");
+  });
+
+  it("returns isError:true and serialized failure when the tool returns success:false", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "not_found",
+      message: "Item BI-NOPE not found",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 9,
+          method: "tools/call",
+          params: { name: "get_backlog_item", arguments: { itemId: "BI-NOPE" } },
+        },
+      }),
+    );
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toContain("not_found");
+  });
+});
+
+describe("POST — ping", () => {
+  it("returns empty object for ping", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: { jsonrpc: "2.0", id: 10, method: "ping" },
+      }),
+    );
+    const body = await res.json();
+    expect(body.result).toEqual({});
+  });
+});

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -1,0 +1,406 @@
+// Real MCP JSON-RPC 2.0 transport for external coding agents (Claude Code,
+// Codex CLI, VS Code MCP) on the user's host. Spec snapshot in
+// docs/Reference/mcp/spec/ (version 2025-11-25).
+//
+// This is the canonical MCP endpoint. The bespoke REST endpoints at
+// /api/mcp/tools and /api/mcp/call remain for in-portal coworker chat
+// (which speaks its own contract, not MCP); this route is what an MCP
+// client points at.
+//
+// Auth: Authorization: Bearer dpfmcp_<token>. Tokens are issued from
+// /admin/platform-development. We do NOT implement OAuth 2.1 resource-
+// server discovery (the GitHub-PAT pattern, intentionally) but we still
+// return a WWW-Authenticate header on 401 so clients that perform
+// discovery don't fail mysteriously.
+
+import { resolveMcpApiToken, type ResolvedMcpToken } from "@/lib/auth/mcp-api-token";
+import { governedExecuteTool } from "@/lib/mcp-governed-execute";
+import { PLATFORM_TOOLS, resolveAnnotations, type ToolDefinition } from "@/lib/mcp-tools";
+import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import { can, type CapabilityKey, type UserContext } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
+
+const PROTOCOL_VERSION = "2025-11-25";
+const SERVER_NAME = "dpf-platform";
+const SERVER_VERSION = "1.0.0";
+
+// JSON-RPC 2.0 standard error codes
+const JSONRPC_PARSE_ERROR = -32700;
+const JSONRPC_INVALID_REQUEST = -32600;
+const JSONRPC_METHOD_NOT_FOUND = -32601;
+const JSONRPC_INVALID_PARAMS = -32602;
+const JSONRPC_INTERNAL_ERROR = -32603;
+
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+type JsonRpcResponse =
+  | {
+      jsonrpc: "2.0";
+      id: JsonRpcId;
+      result: unknown;
+    }
+  | {
+      jsonrpc: "2.0";
+      id: JsonRpcId;
+      error: { code: number; message: string; data?: unknown };
+    };
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function jsonRpcError(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+  httpStatus = 200,
+): Response {
+  const body: JsonRpcResponse = {
+    jsonrpc: "2.0",
+    id,
+    error: { code, message, ...(data !== undefined ? { data } : {}) },
+  };
+  return jsonResponse(body, httpStatus);
+}
+
+function jsonRpcOk(id: JsonRpcId, result: unknown): Response {
+  return jsonResponse({ jsonrpc: "2.0", id, result } satisfies JsonRpcResponse);
+}
+
+function unauthorizedResponse(detail: string): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: JSONRPC_INVALID_REQUEST, message: `unauthorized: ${detail}` },
+    }),
+    {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+        "WWW-Authenticate": `Bearer realm="DPF MCP", error="invalid_token", error_description="${detail}"`,
+      },
+    },
+  );
+}
+
+function forbiddenResponse(detail: string, host: string | null): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: JSONRPC_INVALID_REQUEST, message: `forbidden: ${detail}` },
+    }),
+    {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+// Spec MUST: validate Origin header to prevent DNS rebinding attacks.
+function isOriginAllowed(origin: string | null): boolean {
+  if (!origin) return true; // non-browser clients (Claude Code, Codex CLI) don't send Origin
+  try {
+    const url = new URL(origin);
+    const host = url.hostname.toLowerCase();
+    if (host === "localhost" || host === "127.0.0.1" || host === "::1") return true;
+    // Same-host as the portal (when a browser-based MCP client is on the same domain).
+    if (process.env.MCP_ALLOWED_ORIGIN_HOSTS) {
+      const allowed = process.env.MCP_ALLOWED_ORIGIN_HOSTS.split(",").map((h) => h.trim().toLowerCase());
+      if (allowed.includes(host)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// Spec safety: refuse non-TLS requests except for localhost (Mode 1 / dev).
+function isTransportAllowed(request: Request): boolean {
+  const url = new URL(request.url);
+  if (url.protocol === "https:") return true;
+  return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1";
+}
+
+async function loadUserContext(userId: string): Promise<UserContext> {
+  const row = await prisma.user
+    .findUnique({
+      where: { id: userId },
+      select: {
+        isSuperuser: true,
+        groups: { include: { platformRole: true }, take: 1 },
+      },
+    })
+    .catch(() => null);
+  return {
+    userId,
+    platformRole: row?.groups[0]?.platformRole.roleId ?? null,
+    isSuperuser: row?.isSuperuser ?? false,
+  };
+}
+
+// Tool is included in tools/list iff:
+//   1. The user has the tool's required capability (defense-in-depth)
+//   2. The token's scopes intersect the tool's required grants
+//   3. (When token is bound to an agent) the agent's grants permit it — but
+//      the wrapper handles this on tools/call; for the listing we just use
+//      the token scopes since the agent-grant filter is identical at runtime.
+function tokenCanUseTool(
+  tool: ToolDefinition,
+  token: ResolvedMcpToken,
+  userContext: UserContext,
+  grantMap: Record<string, string[]>,
+): boolean {
+  if (tool.requiredCapability && !can(userContext, tool.requiredCapability as CapabilityKey)) {
+    return false;
+  }
+  const required = grantMap[tool.name];
+  if (!required) return false; // default-deny tools without a grant entry
+  return required.some((g) => token.scopes.includes(g));
+}
+
+function annotateTool(tool: ToolDefinition) {
+  const ann = resolveAnnotations(tool);
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    annotations: {
+      title: tool.name.replace(/_/g, " "),
+      readOnlyHint: ann.readOnlyHint,
+      destructiveHint: ann.destructiveHint,
+      idempotentHint: ann.idempotentHint,
+      openWorldHint: ann.openWorldHint,
+    },
+  };
+}
+
+async function handleInitialize(id: JsonRpcId): Promise<Response> {
+  return jsonRpcOk(id, {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      tools: { listChanged: false },
+    },
+    serverInfo: {
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
+    },
+    instructions:
+      "Domain-level MCP surface for the Digital Product Factory. Use tools/list to discover the backlog and planning tools available to your token.",
+  });
+}
+
+async function handleToolsList(
+  id: JsonRpcId,
+  token: ResolvedMcpToken,
+): Promise<Response> {
+  const userContext = await loadUserContext(token.userId);
+  const grantMap = getToolGrantMapping();
+  const tools = PLATFORM_TOOLS.filter((t) =>
+    tokenCanUseTool(t, token, userContext, grantMap),
+  ).map(annotateTool);
+  return jsonRpcOk(id, { tools });
+}
+
+async function handleToolsCall(
+  id: JsonRpcId,
+  token: ResolvedMcpToken,
+  params: Record<string, unknown> | undefined,
+): Promise<Response> {
+  if (!params || typeof params["name"] !== "string") {
+    return jsonRpcError(id, JSONRPC_INVALID_PARAMS, "tools/call requires params.name (string)");
+  }
+  const toolName = params["name"];
+  const args = (params["arguments"] as Record<string, unknown> | undefined) ?? {};
+
+  // Token-scope gate. The wrapper also rejects on grant mismatch when an
+  // agentId is in context, but we want a fast pre-check here so an external
+  // client gets a clear "your token can't do this" instead of a generic
+  // forbidden_grant from the wrapper's agent-grant path.
+  const grantMap = getToolGrantMapping();
+  const required = grantMap[toolName];
+  if (!required) {
+    return jsonRpcOk(id, {
+      content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
+      isError: true,
+    });
+  }
+  const tokenAllowed = required.some((g) => token.scopes.includes(g));
+  if (!tokenAllowed) {
+    return jsonRpcOk(id, {
+      content: [
+        {
+          type: "text",
+          text: `Token lacks the required scope for ${toolName}. Required: one of ${required.join(", ")}; token has: ${token.scopes.join(", ")}.`,
+        },
+      ],
+      isError: true,
+    });
+  }
+
+  // Capability check on the tool's write-capable subset: read-capable tokens
+  // can never invoke a side-effecting tool, regardless of token scopes.
+  const toolDef = PLATFORM_TOOLS.find((t) => t.name === toolName);
+  if (toolDef?.sideEffect && token.capability === "read") {
+    return jsonRpcOk(id, {
+      content: [
+        {
+          type: "text",
+          text: `${toolName} is a side-effecting tool; this token is read-only. Re-issue a write-capable token to call it.`,
+        },
+      ],
+      isError: true,
+    });
+  }
+
+  const userContext = await loadUserContext(token.userId);
+  const result = await governedExecuteTool({
+    toolName,
+    rawParams: args,
+    userId: token.userId,
+    userContext,
+    context: {
+      agentId: token.agentId ?? undefined,
+      apiTokenId: token.tokenId,
+    },
+    source: "external-jsonrpc",
+  });
+
+  // Convert ToolResult into MCP tools/call response shape:
+  //   - content[]: a single text block carrying a JSON serialization of the
+  //     ToolResult so MCP clients see structured data without us inventing
+  //     a non-standard return shape
+  //   - isError: true on any non-success
+  //   - structuredContent: the raw ToolResult.data when present, so clients
+  //     that support structured content (per the 2025-11-25 spec) can use it
+  //     directly without re-parsing the text block
+  const text = JSON.stringify(
+    {
+      success: result.success,
+      message: result.message,
+      ...(result.entityId ? { entityId: result.entityId } : {}),
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.data ? { data: result.data } : {}),
+    },
+    null,
+    2,
+  );
+  const responseBody: Record<string, unknown> = {
+    content: [{ type: "text", text }],
+    isError: !result.success,
+  };
+  if (result.data !== undefined) {
+    responseBody["structuredContent"] = result.data;
+  }
+  return jsonRpcOk(id, responseBody);
+}
+
+export async function POST(request: Request): Promise<Response> {
+  // Transport guards
+  if (!isTransportAllowed(request)) {
+    return forbiddenResponse(
+      "TLS required (HTTPS only outside localhost)",
+      new URL(request.url).hostname,
+    );
+  }
+  const origin = request.headers.get("origin");
+  if (!isOriginAllowed(origin)) {
+    return forbiddenResponse(`Origin ${origin} not allowed`, origin);
+  }
+
+  // Auth
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return unauthorizedResponse("missing Bearer token");
+  }
+  const plaintext = authHeader.slice("bearer ".length).trim();
+  const token = await resolveMcpApiToken(plaintext);
+  if (!token) {
+    return unauthorizedResponse("invalid or expired token");
+  }
+
+  // Parse JSON-RPC envelope
+  let body: JsonRpcRequest;
+  try {
+    body = (await request.json()) as JsonRpcRequest;
+  } catch {
+    return jsonRpcError(null, JSONRPC_PARSE_ERROR, "invalid JSON in request body");
+  }
+  if (body.jsonrpc !== "2.0" || typeof body.method !== "string") {
+    return jsonRpcError(
+      body.id ?? null,
+      JSONRPC_INVALID_REQUEST,
+      "request must have jsonrpc='2.0' and method string",
+    );
+  }
+
+  // Notifications (no id) — return 202 Accepted, no body, per spec.
+  const isNotification = body.id === undefined;
+
+  try {
+    switch (body.method) {
+      case "initialize":
+        if (isNotification) {
+          return new Response(null, { status: 202 });
+        }
+        return await handleInitialize(body.id ?? null);
+
+      case "notifications/initialized":
+        return new Response(null, { status: 202 });
+
+      case "tools/list":
+        if (isNotification) {
+          return new Response(null, { status: 202 });
+        }
+        return await handleToolsList(body.id ?? null, token);
+
+      case "tools/call":
+        if (isNotification) {
+          return new Response(null, { status: 202 });
+        }
+        return await handleToolsCall(body.id ?? null, token, body.params);
+
+      case "ping":
+        if (isNotification) {
+          return new Response(null, { status: 202 });
+        }
+        return jsonRpcOk(body.id ?? null, {});
+
+      default:
+        if (isNotification) {
+          // Unknown notifications are silently accepted per JSON-RPC 2.0.
+          return new Response(null, { status: 202 });
+        }
+        return jsonRpcError(body.id ?? null, JSONRPC_METHOD_NOT_FOUND, `unknown method: ${body.method}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown internal error";
+    return jsonRpcError(
+      body.id ?? null,
+      JSONRPC_INTERNAL_ERROR,
+      `internal error: ${message}`,
+    );
+  }
+}
+
+// GET on the MCP endpoint is reserved for SSE in the Streamable HTTP spec.
+// We don't implement SSE (single-POST flow is sufficient for tool calls);
+// clients that try GET should get a clean 405.
+export function GET(): Response {
+  return new Response("Method Not Allowed — use POST", {
+    status: 405,
+    headers: { Allow: "POST" },
+  });
+}

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import {
+  issueMyMcpToken,
+  listAvailableMcpScopes,
+  listMyMcpTokens,
+  revokeMyMcpToken,
+} from "@/lib/actions/mcp-tokens";
+
+export interface McpTokenManagerProps {
+  contributionModelConfigured: boolean;
+  baseUrl: string;
+}
+
+type TokenRow = {
+  id: string;
+  name: string;
+  prefix: string;
+  capability: "read" | "write";
+  scopes: string[];
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+};
+
+type Issued = {
+  tokenId: string;
+  plaintext: string;
+  prefix: string;
+  expiresAt: string | null;
+  setupSnippets: { claudeCode: string; codex: string; vscode: string };
+};
+
+type View =
+  | { kind: "idle" }
+  | { kind: "form"; error: string | null }
+  | { kind: "issued"; payload: Issued; activeTab: "claudeCode" | "vscode" | "codex" };
+
+export function McpTokenManager(props: McpTokenManagerProps) {
+  const [tokens, setTokens] = useState<TokenRow[]>([]);
+  const [scopes, setScopes] = useState<string[]>([]);
+  const [view, setView] = useState<View>({ kind: "idle" });
+  const [pending, startTransition] = useTransition();
+
+  // Form state
+  const [formName, setFormName] = useState("");
+  const [formCapability, setFormCapability] = useState<"read" | "write">("read");
+  const [formScopes, setFormScopes] = useState<Set<string>>(new Set(["backlog_read"]));
+  const [formExpires, setFormExpires] = useState<string>("90");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [tokensResult, scopesResult] = await Promise.all([
+        listMyMcpTokens(),
+        listAvailableMcpScopes(),
+      ]);
+      if (cancelled) return;
+      if (tokensResult.ok) setTokens(tokensResult.tokens);
+      setScopes(scopesResult.scopes);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function refresh() {
+    startTransition(async () => {
+      const result = await listMyMcpTokens();
+      if (result.ok) setTokens(result.tokens);
+    });
+  }
+
+  function openForm() {
+    setFormName("");
+    setFormCapability("read");
+    setFormScopes(new Set(["backlog_read"]));
+    setFormExpires("90");
+    setView({ kind: "form", error: null });
+  }
+
+  function toggleScope(s: string) {
+    setFormScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+  }
+
+  function submit() {
+    startTransition(async () => {
+      const expiresInDays = formExpires === "never" ? null : parseInt(formExpires, 10);
+      const result = await issueMyMcpToken({
+        name: formName.trim(),
+        capability: formCapability,
+        scopes: [...formScopes],
+        expiresInDays,
+        baseUrl: props.baseUrl,
+      });
+      if (!result.ok) {
+        setView({ kind: "form", error: result.message });
+        return;
+      }
+      setView({ kind: "issued", payload: result, activeTab: "claudeCode" });
+      refresh();
+    });
+  }
+
+  function revoke(tokenId: string) {
+    if (!confirm("Revoke this token? Any client using it will be disconnected on next call.")) {
+      return;
+    }
+    startTransition(async () => {
+      await revokeMyMcpToken({ tokenId, reason: "revoked from admin UI" });
+      refresh();
+    });
+  }
+
+  return (
+    <section className="mt-6 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--dpf-text)]">External Coding Agent Access</h2>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            Personal access tokens for the MCP endpoint at <code>/api/mcp/v1</code>.
+            Use these to point Claude Code, Codex CLI, or VS Code MCP at this DPF install.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openForm}
+          disabled={pending}
+          className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+        >
+          Generate token
+        </button>
+      </div>
+
+      {!props.contributionModelConfigured && (
+        <div className="mt-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs text-[var(--dpf-muted)]">
+          Write-capable tokens require contribution mode to be configured first
+          (so any external write that becomes a code contribution is traceable
+          to a real GitHub identity). Read-only tokens can issue freely.
+        </div>
+      )}
+
+      {tokens.length === 0 ? (
+        <p className="mt-4 text-sm text-[var(--dpf-muted)]">No tokens yet.</p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {tokens.map((t) => {
+            const revoked = t.revokedAt != null;
+            const expired = t.expiresAt != null && new Date(t.expiresAt).getTime() < Date.now();
+            return (
+              <li
+                key={t.id}
+                className="flex items-center justify-between gap-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-[var(--dpf-text)]">{t.name}</span>
+                    <code className="rounded bg-[var(--dpf-surface-1)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
+                      {t.prefix}…
+                    </code>
+                    <span
+                      className={`rounded px-1.5 py-0.5 text-xs ${
+                        t.capability === "write"
+                          ? "bg-[var(--dpf-accent)] text-white"
+                          : "border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+                      }`}
+                    >
+                      {t.capability}
+                    </span>
+                    {revoked && (
+                      <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
+                        revoked
+                      </span>
+                    )}
+                    {expired && !revoked && (
+                      <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
+                        expired
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-xs text-[var(--dpf-muted)]">
+                    Scopes: {t.scopes.join(", ") || "none"} · Last used:{" "}
+                    {t.lastUsedAt ? new Date(t.lastUsedAt).toLocaleString() : "never"} ·
+                    Expires: {t.expiresAt ? new Date(t.expiresAt).toLocaleString() : "never"}
+                  </div>
+                </div>
+                {!revoked && (
+                  <button
+                    type="button"
+                    onClick={() => revoke(t.id)}
+                    disabled={pending}
+                    className="rounded border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
+                  >
+                    Revoke
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {view.kind === "form" && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setView({ kind: "idle" })}
+        >
+          <div
+            className="w-full max-w-md rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Generate MCP token</h3>
+
+            <div className="mt-4 space-y-3">
+              <label className="block text-sm">
+                <span className="text-[var(--dpf-text)]">Name</span>
+                <input
+                  type="text"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="Mark's laptop (Claude Code)"
+                  className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
+                />
+              </label>
+
+              <fieldset className="text-sm">
+                <legend className="text-[var(--dpf-text)]">Capability</legend>
+                <label className="mt-1 mr-4 inline-flex items-center gap-1.5 text-[var(--dpf-text)]">
+                  <input
+                    type="radio"
+                    name="cap"
+                    value="read"
+                    checked={formCapability === "read"}
+                    onChange={() => setFormCapability("read")}
+                  />
+                  Read-only
+                </label>
+                <label
+                  className={`mt-1 inline-flex items-center gap-1.5 ${
+                    props.contributionModelConfigured
+                      ? "text-[var(--dpf-text)]"
+                      : "text-[var(--dpf-muted)]"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="cap"
+                    value="write"
+                    checked={formCapability === "write"}
+                    disabled={!props.contributionModelConfigured}
+                    onChange={() => setFormCapability("write")}
+                  />
+                  Write
+                  {!props.contributionModelConfigured && (
+                    <span className="text-xs">(configure contribution mode first)</span>
+                  )}
+                </label>
+              </fieldset>
+
+              <fieldset className="text-sm">
+                <legend className="text-[var(--dpf-text)]">Scopes</legend>
+                <div className="mt-1 grid max-h-40 grid-cols-2 gap-1 overflow-y-auto rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+                  {scopes.map((s) => (
+                    <label key={s} className="inline-flex items-center gap-1.5 text-xs text-[var(--dpf-text)]">
+                      <input
+                        type="checkbox"
+                        checked={formScopes.has(s)}
+                        onChange={() => toggleScope(s)}
+                      />
+                      {s}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              <label className="block text-sm">
+                <span className="text-[var(--dpf-text)]">Expires</span>
+                <select
+                  value={formExpires}
+                  onChange={(e) => setFormExpires(e.target.value)}
+                  className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
+                >
+                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="30">In 30 days</option>
+                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="60">In 60 days</option>
+                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="90">In 90 days</option>
+                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="180">In 180 days</option>
+                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="never">Never</option>
+                </select>
+              </label>
+
+              {view.error && (
+                <p className="text-sm text-[var(--dpf-accent)]">{view.error}</p>
+              )}
+            </div>
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setView({ kind: "idle" })}
+                className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={pending || !formName.trim() || formScopes.size === 0}
+                className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              >
+                {pending ? "Generating…" : "Generate"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {view.kind === "issued" && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+        >
+          <div className="w-full max-w-2xl rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Token issued — copy now</h3>
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              The full secret is shown <strong>once</strong>. After you close this dialog, only the prefix is recoverable.
+            </p>
+
+            <div className="mt-3 break-all rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 font-mono text-xs text-[var(--dpf-text)]">
+              {view.payload.plaintext}
+            </div>
+
+            <div className="mt-5">
+              <div className="flex gap-2 border-b border-[var(--dpf-border)]">
+                {(["claudeCode", "vscode", "codex"] as const).map((tab) => (
+                  <button
+                    key={tab}
+                    type="button"
+                    onClick={() => setView({ kind: "issued", payload: view.payload, activeTab: tab })}
+                    className={`px-3 py-1.5 text-xs ${
+                      view.activeTab === tab
+                        ? "border-b-2 border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                        : "text-[var(--dpf-muted)]"
+                    }`}
+                  >
+                    {tab === "claudeCode" ? "Claude Code" : tab === "vscode" ? "VS Code" : "Codex"}
+                  </button>
+                ))}
+              </div>
+              <pre className="mt-2 overflow-auto rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs text-[var(--dpf-text)]">
+                {view.payload.setupSnippets[view.activeTab]}
+              </pre>
+            </div>
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setView({ kind: "idle" })}
+                className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/mcp-api-token", () => ({
+  issueMcpApiToken: vi.fn(),
+  revokeMcpApiToken: vi.fn(),
+  listMcpApiTokens: vi.fn(),
+}));
+
+vi.mock("@/lib/tak/agent-grants", () => ({
+  getToolGrantMapping: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import {
+  issueMcpApiToken,
+  listMcpApiTokens,
+  revokeMcpApiToken,
+} from "@/lib/auth/mcp-api-token";
+import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import {
+  issueMyMcpToken,
+  listAvailableMcpScopes,
+  listMyMcpTokens,
+  revokeMyMcpToken,
+} from "./mcp-tokens";
+
+const authMock = auth as unknown as ReturnType<typeof vi.fn>;
+const issueMock = issueMcpApiToken as unknown as ReturnType<typeof vi.fn>;
+const revokeMock = revokeMcpApiToken as unknown as ReturnType<typeof vi.fn>;
+const listMock = listMcpApiTokens as unknown as ReturnType<typeof vi.fn>;
+const grantMapMock = getToolGrantMapping as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("listAvailableMcpScopes", () => {
+  it("returns empty for unauthenticated requests", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await listAvailableMcpScopes();
+    expect(result.scopes).toEqual([]);
+  });
+
+  it("returns sorted unique grant keys when authenticated", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    grantMapMock.mockReturnValue({
+      tool_a: ["backlog_read", "spec_plan_read"],
+      tool_b: ["backlog_write"],
+      tool_c: ["backlog_read"], // duplicate
+    });
+    const result = await listAvailableMcpScopes();
+    expect(result.scopes).toEqual(["backlog_read", "backlog_write", "spec_plan_read"]);
+  });
+});
+
+describe("listMyMcpTokens", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await listMyMcpTokens();
+    expect(result.ok).toBe(false);
+    expect(result.tokens).toEqual([]);
+  });
+
+  it("returns serialized token list for the current user", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    const now = new Date("2026-04-25T12:00:00Z");
+    listMock.mockResolvedValue([
+      {
+        id: "tok_1",
+        name: "Mark's laptop",
+        prefix: "dpfmcp_ABC1",
+        capability: "read",
+        scopes: ["backlog_read"],
+        lastUsedAt: now,
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: now,
+      },
+    ]);
+    const result = await listMyMcpTokens();
+    expect(result.ok).toBe(true);
+    expect(result.tokens).toHaveLength(1);
+    expect(result.tokens[0]?.lastUsedAt).toBe(now.toISOString());
+    expect(result.tokens[0]?.expiresAt).toBeNull();
+    expect(listMock).toHaveBeenCalledWith("u1");
+  });
+});
+
+describe("issueMyMcpToken", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await issueMyMcpToken({
+      name: "x",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: 30,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("unauthorized");
+    expect(issueMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates underlying issue failures (e.g. contribution_mode_required)", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    issueMock.mockResolvedValue({
+      ok: false,
+      error: "contribution_mode_required",
+      message: "Configure contribution mode first",
+    });
+    const result = await issueMyMcpToken({
+      name: "x",
+      capability: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 30,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("contribution_mode_required");
+  });
+
+  it("on success returns plaintext + setup snippets pre-filled with the token", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    issueMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_x",
+      plaintext: "dpfmcp_SECRET",
+      prefix: "dpfmcp_SECR",
+      expiresAt: new Date("2026-07-25T00:00:00Z"),
+    });
+    const result = await issueMyMcpToken({
+      name: "Mark's laptop",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: 90,
+      baseUrl: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.plaintext).toBe("dpfmcp_SECRET");
+    expect(result.setupSnippets.claudeCode).toContain("http://localhost:3000/api/mcp/v1");
+    expect(result.setupSnippets.claudeCode).toContain("Bearer dpfmcp_SECRET");
+    expect(result.setupSnippets.vscode).toContain("Bearer dpfmcp_SECRET");
+    expect(result.setupSnippets.codex).toContain("Bearer dpfmcp_SECRET");
+  });
+});
+
+describe("revokeMyMcpToken", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+    const result = await revokeMyMcpToken({ tokenId: "tok_x", reason: "test" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unauthorized");
+  });
+
+  it("rejects revoke for tokens not owned by the caller", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([{ id: "tok_owned", name: "x" }]);
+    const result = await revokeMyMcpToken({ tokenId: "tok_someone_else", reason: "test" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("not_found_or_not_yours");
+    expect(revokeMock).not.toHaveBeenCalled();
+  });
+
+  it("revokes when the caller owns the token", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([{ id: "tok_x", name: "x" }]);
+    revokeMock.mockResolvedValue({ ok: true });
+    const result = await revokeMyMcpToken({ tokenId: "tok_x", reason: "leaked" });
+    expect(result.ok).toBe(true);
+    expect(revokeMock).toHaveBeenCalledWith("tok_x", "leaked");
+  });
+});

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -1,0 +1,173 @@
+"use server";
+
+import { auth } from "@/lib/auth";
+import {
+  issueMcpApiToken,
+  listMcpApiTokens,
+  revokeMcpApiToken,
+  type IssueMcpTokenResult,
+  type McpTokenCapability,
+} from "@/lib/auth/mcp-api-token";
+import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+
+/**
+ * Returns the set of distinct grant keys this user could possibly include
+ * in a token's scopes. Today this is the union of every grant key that
+ * appears in TOOL_TO_GRANTS — the per-user filter happens at issue time
+ * via the platform-role capability check inside governedExecuteTool, not
+ * at scope-selection time. The settings UI uses this to populate the
+ * scope multi-select.
+ */
+export async function listAvailableMcpScopes(): Promise<{
+  scopes: string[];
+}> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { scopes: [] };
+  }
+  const map = getToolGrantMapping();
+  const set = new Set<string>();
+  for (const grants of Object.values(map)) {
+    for (const g of grants) set.add(g);
+  }
+  return { scopes: [...set].sort() };
+}
+
+export async function listMyMcpTokens() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false as const, error: "unauthorized", tokens: [] };
+  }
+  const tokens = await listMcpApiTokens(session.user.id);
+  return {
+    ok: true as const,
+    tokens: tokens.map((t) => ({
+      id: t.id,
+      name: t.name,
+      prefix: t.prefix,
+      capability: t.capability,
+      scopes: t.scopes,
+      lastUsedAt: t.lastUsedAt?.toISOString() ?? null,
+      expiresAt: t.expiresAt?.toISOString() ?? null,
+      revokedAt: t.revokedAt?.toISOString() ?? null,
+      createdAt: t.createdAt.toISOString(),
+    })),
+  };
+}
+
+export type IssueTokenActionResult =
+  | {
+      ok: true;
+      tokenId: string;
+      plaintext: string;
+      prefix: string;
+      expiresAt: string | null;
+      setupSnippets: {
+        claudeCode: string;
+        codex: string;
+        vscode: string;
+      };
+    }
+  | {
+      ok: false;
+      error: string;
+      message: string;
+    };
+
+function buildSetupSnippets(plaintext: string, baseUrl: string): {
+  claudeCode: string;
+  codex: string;
+  vscode: string;
+} {
+  const url = `${baseUrl}/api/mcp/v1`;
+  const claudeCode = JSON.stringify(
+    {
+      mcpServers: {
+        dpf: {
+          url,
+          headers: { Authorization: `Bearer ${plaintext}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+  // Codex CLI uses similar JSON config
+  const codex = JSON.stringify(
+    {
+      mcpServers: {
+        dpf: {
+          url,
+          headers: { Authorization: `Bearer ${plaintext}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+  // VS Code MCP `.vscode/mcp.json`
+  const vscode = JSON.stringify(
+    {
+      servers: {
+        dpf: {
+          url,
+          headers: { Authorization: `Bearer ${plaintext}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+  return { claudeCode, codex, vscode };
+}
+
+export async function issueMyMcpToken(input: {
+  name: string;
+  capability: McpTokenCapability;
+  scopes: string[];
+  expiresInDays: number | null;
+  agentId?: string | null;
+  baseUrl: string;
+}): Promise<IssueTokenActionResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false, error: "unauthorized", message: "Sign in first" };
+  }
+  const result: IssueMcpTokenResult = await issueMcpApiToken({
+    userId: session.user.id,
+    name: input.name,
+    capability: input.capability,
+    scopes: input.scopes,
+    expiresInDays: input.expiresInDays,
+    agentId: input.agentId ?? null,
+  });
+  if (!result.ok) {
+    return { ok: false, error: result.error, message: result.message };
+  }
+  return {
+    ok: true,
+    tokenId: result.tokenId,
+    plaintext: result.plaintext,
+    prefix: result.prefix,
+    expiresAt: result.expiresAt?.toISOString() ?? null,
+    setupSnippets: buildSetupSnippets(result.plaintext, input.baseUrl),
+  };
+}
+
+export async function revokeMyMcpToken(input: {
+  tokenId: string;
+  reason: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false, error: "unauthorized" };
+  }
+  // Lookup-then-check to make sure the user owns the token (defense against
+  // direct API calls bypassing the UI listing).
+  const tokens = await listMcpApiTokens(session.user.id);
+  const owned = tokens.find((t) => t.id === input.tokenId);
+  if (!owned) {
+    return { ok: false, error: "not_found_or_not_yours" };
+  }
+  return revokeMcpApiToken(input.tokenId, input.reason);
+}

--- a/apps/web/lib/auth/mcp-api-token.test.ts
+++ b/apps/web/lib/auth/mcp-api-token.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    mcpApiToken: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    platformDevConfig: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import {
+  issueMcpApiToken,
+  listMcpApiTokens,
+  resolveMcpApiToken,
+  revokeMcpApiToken,
+} from "./mcp-api-token";
+
+const tokenCreate = prisma.mcpApiToken.create as unknown as ReturnType<typeof vi.fn>;
+const tokenFindUnique = prisma.mcpApiToken.findUnique as unknown as ReturnType<typeof vi.fn>;
+const tokenFindMany = prisma.mcpApiToken.findMany as unknown as ReturnType<typeof vi.fn>;
+const tokenUpdate = prisma.mcpApiToken.update as unknown as ReturnType<typeof vi.fn>;
+const cfgFindUnique = prisma.platformDevConfig.findUnique as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  tokenCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+    id: "tok_123",
+    createdAt: new Date(),
+    revokedAt: null,
+    lastUsedAt: null,
+    revokedReason: null,
+    ...data,
+  }));
+  tokenUpdate.mockResolvedValue({} as never);
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("issueMcpApiToken — happy path", () => {
+  it("issues a read-only token even when contribution-mode is unset", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "Mark's laptop",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: 90,
+    });
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
+    expect(result.plaintext).toMatch(/^dpfmcp_/);
+    expect(result.prefix).toMatch(/^dpfmcp_/);
+    expect(result.expiresAt).toBeInstanceOf(Date);
+    expect(tokenCreate).toHaveBeenCalledOnce();
+    const data = tokenCreate.mock.calls[0]![0].data;
+    expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(data.tokenHash).not.toContain(result.plaintext);
+  });
+
+  it("never persists the plaintext token", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "x",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: null,
+    });
+    if (!result.ok) throw new Error("expected ok");
+    const data = tokenCreate.mock.calls[0]![0].data;
+    expect(JSON.stringify(data)).not.toContain(result.plaintext);
+  });
+
+  it("uses null expiresAt when expiresInDays is null", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "forever",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: null,
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.expiresAt).toBeNull();
+  });
+
+  it("issues a write token when contribution-mode is configured", async () => {
+    cfgFindUnique.mockResolvedValue({ contributionModel: "fork-pr" });
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "Mark write",
+      capability: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("generates a different token each call (cryptographic randomness)", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const a = await issueMcpApiToken({
+      userId: "u1",
+      name: "a",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: 30,
+    });
+    const b = await issueMcpApiToken({
+      userId: "u1",
+      name: "b",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: 30,
+    });
+    if (!a.ok || !b.ok) throw new Error("expected ok");
+    expect(a.plaintext).not.toBe(b.plaintext);
+  });
+});
+
+describe("issueMcpApiToken — rejections", () => {
+  it("rejects empty name", async () => {
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "   ",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("missing_name");
+    expect(tokenCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty scopes array", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "x",
+      capability: "read",
+      scopes: [],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("empty_scopes");
+  });
+
+  it("rejects unknown capability", async () => {
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "x",
+      capability: "admin" as unknown as "write",
+      scopes: ["backlog_read"],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("invalid_capability");
+  });
+
+  it("rejects write-capable token when contribution-mode is unset", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "x",
+      capability: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("contribution_mode_required");
+    expect(tokenCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects write-capable token when PlatformDevConfig has no contributionModel set", async () => {
+    cfgFindUnique.mockResolvedValue({ contributionModel: null });
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "x",
+      capability: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("contribution_mode_required");
+  });
+});
+
+describe("resolveMcpApiToken", () => {
+  it("returns null for malformed token (no prefix)", async () => {
+    const result = await resolveMcpApiToken("not-a-token");
+    expect(result).toBeNull();
+    expect(tokenFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no row matches", async () => {
+    tokenFindUnique.mockResolvedValue(null);
+    const result = await resolveMcpApiToken("dpfmcp_BOGUS123");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for revoked tokens", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+      revokedAt: new Date(),
+      expiresAt: null,
+    });
+    const result = await resolveMcpApiToken("dpfmcp_X");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for expired tokens", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_x",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+      revokedAt: null,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const result = await resolveMcpApiToken("dpfmcp_X");
+    expect(result).toBeNull();
+  });
+
+  it("returns the resolved record for a valid token and updates lastUsedAt", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_x",
+      userId: "u1",
+      agentId: "AGT-100",
+      scopes: ["backlog_read", "backlog_write"],
+      capability: "write",
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 1_000_000),
+    });
+    const result = await resolveMcpApiToken("dpfmcp_GOOD");
+    expect(result).not.toBeNull();
+    expect(result?.tokenId).toBe("tok_x");
+    expect(result?.userId).toBe("u1");
+    expect(result?.agentId).toBe("AGT-100");
+    expect(result?.scopes).toEqual(["backlog_read", "backlog_write"]);
+    expect(result?.capability).toBe("write");
+    // lastUsedAt update is fire-and-forget; allow microtask to flush
+    await new Promise((r) => setImmediate(r));
+    expect(tokenUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("revokeMcpApiToken", () => {
+  it("returns not_found when token doesn't exist", async () => {
+    tokenFindUnique.mockResolvedValue(null);
+    const result = await revokeMcpApiToken("nope", "test");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("not_found");
+  });
+
+  it("is idempotent — already-revoked returns ok without re-revoking", async () => {
+    tokenFindUnique.mockResolvedValue({ revokedAt: new Date() });
+    const result = await revokeMcpApiToken("tok_x", "test");
+    expect(result.ok).toBe(true);
+    expect(tokenUpdate).not.toHaveBeenCalled();
+  });
+
+  it("revokes an active token with the given reason", async () => {
+    tokenFindUnique.mockResolvedValue({ revokedAt: null });
+    const result = await revokeMcpApiToken("tok_x", "leaked");
+    expect(result.ok).toBe(true);
+    expect(tokenUpdate).toHaveBeenCalledWith({
+      where: { id: "tok_x" },
+      data: { revokedAt: expect.any(Date), revokedReason: "leaked" },
+    });
+  });
+});
+
+describe("listMcpApiTokens", () => {
+  it("returns rows for the given user with capability defaulted", async () => {
+    tokenFindMany.mockResolvedValue([
+      {
+        id: "tok_1",
+        name: "x",
+        prefix: "dpfmcp_X",
+        capability: "read",
+        scopes: ["backlog_read"],
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: new Date(),
+      },
+    ]);
+    const list = await listMcpApiTokens("u1");
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("tok_1");
+    expect(list[0]?.capability).toBe("read");
+  });
+});

--- a/apps/web/lib/auth/mcp-api-token.ts
+++ b/apps/web/lib/auth/mcp-api-token.ts
@@ -1,0 +1,238 @@
+// Personal-access-token model for the external MCP transport at /api/mcp/v1.
+//
+// Issued from the portal admin UI (settings/platform-development), shown to
+// the user exactly once at issuance time, then stored only as sha256(secret).
+// Resolution path: client sends Authorization: Bearer <secret>; server hashes
+// and looks up by tokenHash. Lazy lastUsedAt update on success.
+//
+// Write-capable tokens require contribution-mode to be configured first so
+// every external MCP write is end-to-end traceable to a real GitHub identity
+// if it ever becomes a contribution PR.
+
+import { createHash, randomBytes } from "crypto";
+import { prisma } from "@dpf/db";
+
+export type McpTokenCapability = "read" | "write";
+
+export type IssueMcpTokenInput = {
+  userId: string;
+  name: string;
+  capability: McpTokenCapability;
+  scopes: string[];
+  expiresInDays: number | null;
+  agentId?: string | null;
+};
+
+export type IssueMcpTokenResult =
+  | {
+      ok: true;
+      tokenId: string;
+      plaintext: string;
+      prefix: string;
+      expiresAt: Date | null;
+    }
+  | {
+      ok: false;
+      error:
+        | "missing_name"
+        | "empty_scopes"
+        | "contribution_mode_required"
+        | "invalid_capability";
+      message: string;
+    };
+
+export type ResolvedMcpToken = {
+  tokenId: string;
+  userId: string;
+  agentId: string | null;
+  scopes: string[];
+  capability: McpTokenCapability;
+};
+
+const TOKEN_PREFIX = "dpfmcp_";
+const SECRET_BYTES = 24;
+const PREFIX_DISPLAY_LENGTH = 12;
+
+// Base32 alphabet (Crockford-ish, no I/L/O/U). Avoids characters that look
+// like each other so tokens are easier for humans to verify visually.
+const BASE32_ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789";
+
+function encodeBase32(buf: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return out;
+}
+
+function generateToken(): { plaintext: string; hash: string; prefix: string } {
+  const secret = encodeBase32(randomBytes(SECRET_BYTES));
+  const plaintext = `${TOKEN_PREFIX}${secret}`;
+  const hash = createHash("sha256").update(plaintext).digest("hex");
+  const prefix = plaintext.slice(0, PREFIX_DISPLAY_LENGTH);
+  return { plaintext, hash, prefix };
+}
+
+function hashSecret(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+async function contributionModeConfigured(): Promise<boolean> {
+  try {
+    const cfg = await prisma.platformDevConfig.findUnique({
+      where: { id: "singleton" },
+      select: { contributionModel: true },
+    });
+    return cfg?.contributionModel != null;
+  } catch {
+    return false;
+  }
+}
+
+export async function issueMcpApiToken(
+  input: IssueMcpTokenInput,
+): Promise<IssueMcpTokenResult> {
+  const name = input.name?.trim();
+  if (!name) {
+    return { ok: false, error: "missing_name", message: "name is required" };
+  }
+  if (input.capability !== "read" && input.capability !== "write") {
+    return {
+      ok: false,
+      error: "invalid_capability",
+      message: `capability must be "read" or "write"`,
+    };
+  }
+  if (!Array.isArray(input.scopes) || input.scopes.length === 0) {
+    return {
+      ok: false,
+      error: "empty_scopes",
+      message: "at least one scope is required",
+    };
+  }
+  if (input.capability === "write") {
+    const ok = await contributionModeConfigured();
+    if (!ok) {
+      return {
+        ok: false,
+        error: "contribution_mode_required",
+        message:
+          "Configure contribution mode (Admin > Platform Development) before issuing write-capable MCP tokens",
+      };
+    }
+  }
+
+  const { plaintext, hash, prefix } = generateToken();
+  const expiresAt =
+    input.expiresInDays != null
+      ? new Date(Date.now() + input.expiresInDays * 24 * 60 * 60 * 1000)
+      : null;
+
+  const row = await prisma.mcpApiToken.create({
+    data: {
+      userId: input.userId,
+      agentId: input.agentId ?? null,
+      name,
+      tokenHash: hash,
+      prefix,
+      scopes: input.scopes,
+      capability: input.capability,
+      expiresAt,
+    },
+  });
+
+  return {
+    ok: true,
+    tokenId: row.id,
+    plaintext,
+    prefix,
+    expiresAt,
+  };
+}
+
+export async function revokeMcpApiToken(
+  tokenId: string,
+  reason: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const existing = await prisma.mcpApiToken.findUnique({
+    where: { id: tokenId },
+    select: { revokedAt: true },
+  });
+  if (!existing) return { ok: false, error: "not_found" };
+  if (existing.revokedAt) return { ok: true };
+  await prisma.mcpApiToken.update({
+    where: { id: tokenId },
+    data: { revokedAt: new Date(), revokedReason: reason },
+  });
+  return { ok: true };
+}
+
+export async function resolveMcpApiToken(
+  plaintext: string,
+): Promise<ResolvedMcpToken | null> {
+  if (typeof plaintext !== "string" || !plaintext.startsWith(TOKEN_PREFIX)) {
+    return null;
+  }
+  const hash = hashSecret(plaintext);
+  const row = await prisma.mcpApiToken.findUnique({ where: { tokenHash: hash } });
+  if (!row) return null;
+  if (row.revokedAt != null) return null;
+  if (row.expiresAt != null && row.expiresAt.getTime() < Date.now()) return null;
+
+  // Lazy lastUsedAt — fire-and-forget, never block the request.
+  prisma.mcpApiToken
+    .update({ where: { id: row.id }, data: { lastUsedAt: new Date() } })
+    .catch(() => {});
+
+  return {
+    tokenId: row.id,
+    userId: row.userId,
+    agentId: row.agentId,
+    scopes: row.scopes,
+    capability: (row.capability as McpTokenCapability) ?? "read",
+  };
+}
+
+export async function listMcpApiTokens(userId: string): Promise<
+  Array<{
+    id: string;
+    name: string;
+    prefix: string;
+    capability: McpTokenCapability;
+    scopes: string[];
+    lastUsedAt: Date | null;
+    expiresAt: Date | null;
+    revokedAt: Date | null;
+    createdAt: Date;
+  }>
+> {
+  const rows = await prisma.mcpApiToken.findMany({
+    where: { userId },
+    orderBy: [{ revokedAt: { sort: "asc", nulls: "first" } }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      name: true,
+      prefix: true,
+      capability: true,
+      scopes: true,
+      lastUsedAt: true,
+      expiresAt: true,
+      revokedAt: true,
+      createdAt: true,
+    },
+  });
+  return rows.map((r) => ({
+    ...r,
+    capability: (r.capability as McpTokenCapability) ?? "read",
+  }));
+}

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -100,6 +100,29 @@ describe("governedExecuteTool — happy path", () => {
       expect(auditRows[0]?.executionMode).toBe(source);
     }
   });
+
+  it("writes apiTokenId from context when set (external-jsonrpc transport)", async () => {
+    await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "u",
+      userContext: NORMAL_USER,
+      context: { apiTokenId: "tok_abc" },
+      source: "external-jsonrpc",
+    });
+    expect(auditRows[0]?.apiTokenId).toBe("tok_abc");
+  });
+
+  it("writes apiTokenId=null when context has no token (in-portal transports)", async () => {
+    await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "u",
+      userContext: NORMAL_USER,
+      source: "agentic-loop",
+    });
+    expect(auditRows[0]?.apiTokenId).toBeNull();
+  });
 });
 
 describe("governedExecuteTool — rejection paths", () => {

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -152,8 +152,7 @@ async function writeAudit(data: {
       ? `${data.toolName}: ${data.result.success ? "ok" : "failed"}` +
         (data.durationMs ? ` (${data.durationMs}ms)` : "")
       : null,
-    // apiTokenId is plumbed through GovernedExecuteContext but not yet written
-    // — the column lands in spec §13 (external-client transport).
+    apiTokenId: data.context?.apiTokenId ?? null,
   };
   try {
     if (_toolExecutionCreateOverride) {

--- a/docs/superpowers/plans/2026-04-25-governed-mcp-backlog-surface.md
+++ b/docs/superpowers/plans/2026-04-25-governed-mcp-backlog-surface.md
@@ -252,20 +252,20 @@ Per AGENTS.md verification gate:
 
 This sub-plan delivers the Mode 1 external-client surface described in spec §11. It can ship in the same PR as the rest, or split into a follow-up PR if the diff is too large for one review — the core surface (§§1–12 above) is independently useful.
 
-### 13.1 Schema migration — `AgentApiToken` and `ToolExecution.apiTokenId`
+### 13.1 Schema migration — `McpApiToken` and `ToolExecution.apiTokenId`
 
-New migration `<timestamp>_agent_api_token`:
+Migration `20260425230000_mcp_api_token`:
 
-1. Add `AgentApiToken` model per spec §11.3 (User has-many).
-2. Add nullable `apiTokenId String?` column to `ToolExecution` plus index `@@index([apiTokenId])`.
+1. Add `McpApiToken` model per spec §11.3 (User has-many; cascade delete on user removal).
+2. Add nullable `apiTokenId String?` column to `ToolExecution` plus `@@index([apiTokenId, createdAt(sort: Desc)])`.
 3. No backfill — both are additive.
 
-### 13.2 New module: `apps/web/lib/auth/agent-api-token.ts`
+### 13.2 New module: `apps/web/lib/auth/mcp-api-token.ts`
 
 Surface:
 
 ```ts
-export async function issueAgentApiToken(input: {
+export async function issueMcpApiToken(input: {
   userId: string;
   name: string;
   capability: "read" | "write";
@@ -274,9 +274,9 @@ export async function issueAgentApiToken(input: {
   agentId?: string;
 }): Promise<{ tokenId: string; plaintext: string }>;
 
-export async function revokeAgentApiToken(tokenId: string, reason: string): Promise<void>;
+export async function revokeMcpApiToken(tokenId: string, reason: string): Promise<void>;
 
-export async function resolveAgentApiToken(plaintext: string): Promise<{
+export async function resolveMcpApiToken(plaintext: string): Promise<{
   tokenId: string;
   userId: string;
   agentId: string | null;
@@ -285,7 +285,7 @@ export async function resolveAgentApiToken(plaintext: string): Promise<{
 } | null>;
 ```
 
-`issueAgentApiToken`:
+`issueMcpApiToken`:
 
 - Generates 24 random bytes, encodes base32, prefixes `dpfmcp_`.
 - Hashes with sha256 (Node `crypto.createHash`).
@@ -293,13 +293,13 @@ export async function resolveAgentApiToken(plaintext: string): Promise<{
 - Inserts row with `tokenHash` only — plaintext returned to caller exactly once and never persisted.
 - If `capability === "write"`, reads `PlatformDevConfig` and throws if `contributionModel` is null.
 
-`resolveAgentApiToken`:
+`resolveMcpApiToken`:
 
 - Hashes input, single `findUnique({ tokenHash })` query.
 - Returns null if missing, revoked (`revokedAt != null`), or expired (`expiresAt < now()`).
 - Updates `lastUsedAt` (fire-and-forget).
 
-Tests in `agent-api-token.test.ts`:
+Tests in `mcp-api-token.test.ts`:
 
 - Issue read token without contribution-mode set → succeeds.
 - Issue write token without contribution-mode set → throws with the expected message.
@@ -308,12 +308,12 @@ Tests in `agent-api-token.test.ts`:
 - Expired token → returns null.
 - Tampered plaintext (one char off) → returns null without throwing.
 
-### 13.3 New endpoint: `apps/web/app/api/mcp/external/jsonrpc/route.ts`
+### 13.3 New endpoint: `apps/web/app/api/mcp/v1/route.ts`
 
 JSON-RPC 2.0 handler. POST only. Steps per spec §11.4:
 
 1. Read `Authorization: Bearer <token>` header. If absent → JSON-RPC error `{ code: -32001, message: "unauthorized" }`.
-2. `resolveAgentApiToken(plaintext)`. If null → same error.
+2. `resolveMcpApiToken(plaintext)`. If null → same error.
 3. Parse JSON-RPC envelope. Support methods: `initialize`, `notifications/initialized`, `tools/list`, `tools/call`. Mirrors the future internal JSON-RPC spec so external clients see one stable contract.
 4. For `tools/list`: load `User`, call `getAvailableTools(userContext, { agentId: token.agentId, unifiedMode: true })`, intersect with `token.scopes` (a tool is included only if `TOOL_TO_GRANTS[tool.name]` shares at least one entry with `token.scopes`).
 5. For `tools/call`: invoke `governedExecuteTool({ source: "external-jsonrpc", userContext, context: { agentId: token.agentId, apiTokenId: token.tokenId }, ... })`. Wrapper additionally rejects if the tool's required grants do not intersect `token.scopes`.
@@ -321,7 +321,7 @@ JSON-RPC 2.0 handler. POST only. Steps per spec §11.4:
 
 The wrapper signature gets a `context.apiTokenId?: string` field; the audit write includes `apiTokenId` and sets `executionMode: "external-jsonrpc"`.
 
-Tests in `apps/web/app/api/mcp/external/jsonrpc/route.test.ts`:
+Tests in `apps/web/app/api/mcp/v1/route.test.ts`:
 
 - Missing bearer → `-32001`.
 - Bad bearer → `-32001`.
@@ -332,7 +332,7 @@ Tests in `apps/web/app/api/mcp/external/jsonrpc/route.test.ts`:
 
 ### 13.4 Settings UI — `External Coding Agent Access` section
 
-File: extend `apps/web/app/(shell)/admin/platform-development/page.tsx` and add a new client component `apps/web/components/admin/AgentApiTokenManager.tsx`.
+File: extend `apps/web/app/(shell)/admin/platform-development/page.tsx` and add a new client component `apps/web/components/admin/McpTokenManager.tsx` plus session-scoped server actions in `apps/web/lib/actions/mcp-tokens.ts` (separate from the underlying `lib/auth/mcp-api-token.ts` primitives).
 
 UI:
 
@@ -370,8 +370,8 @@ In addition to the §11 verifications already listed:
 
 The PR now also notes:
 
-- New external MCP endpoint at `/api/mcp/external/jsonrpc` (bearer-token authenticated).
-- New `AgentApiToken` model with token issuance UI co-located with contribution mode.
+- New external MCP endpoint at `/api/mcp/v1` (bearer-token authenticated).
+- New `McpApiToken` model with token issuance UI co-located with contribution mode.
 - Write tokens gated on contribution mode being configured.
 - All external traffic audited with the new `apiTokenId` column on `ToolExecution`.
 

--- a/docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md
+++ b/docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md
@@ -442,13 +442,16 @@ The same nine-tool surface is exposed to **external** MCP clients (Claude Code, 
 
 ### 11.1 Why a separate transport from the in-portal one
 
-The [Platform MCP Tool Server spec](./2026-04-11-platform-mcp-tool-server-design.md) defines an internal JSON-RPC endpoint with short-lived (5-minute) session tokens, intentionally bound to `localhost` inside the Docker network. That endpoint is for the platform calling its own CLI processes (e.g. `claude -p` inside the sandbox). It is the wrong shape for an external coding agent on the user's laptop, which needs:
+The existing endpoints at `/api/mcp/tools` (POST list) and `/api/mcp/call` (POST execute) are the in-portal coworker chat's bespoke REST contract — despite the URL, they are not actual MCP-protocol endpoints. The chat UI calls them, no need to churn that surface. The [Platform MCP Tool Server spec](./2026-04-11-platform-mcp-tool-server-design.md) had additionally proposed an internal JSON-RPC endpoint scoped to `localhost` inside the Docker network for the platform's own CLI processes (e.g. `claude -p` inside the sandbox).
 
-- A long-lived bearer credential (paste once into Claude Code's MCP config).
-- A reachable URL the desktop client can hit (`http://localhost:3000/api/mcp/external/jsonrpc` for Mode 1; TLS-fronted for deployed installs).
+For an external coding agent on the user's laptop, neither fits. We need:
+
+- A real **MCP JSON-RPC 2.0** endpoint (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) that any MCP-capable client (Claude Code, Codex CLI, VS Code MCP) can talk to without translation.
+- A reachable URL the desktop client can hit (`http://localhost:3000/api/mcp/v1` for Mode 1; TLS-fronted for deployed installs).
+- A long-lived bearer credential (paste once into the client's `mcp.json`).
 - An identity that resolves to a real `User` row, not an in-portal session cookie.
 
-We add a sibling endpoint at `/api/mcp/external/jsonrpc` that mirrors the protocol of the internal endpoint but authenticates by `Authorization: Bearer <token>` and resolves the token to the issuing user. Both endpoints call the same `governedExecuteTool` so tools, grants, and audit are one pipeline.
+We add a new endpoint at `/api/mcp/v1` that speaks the canonical protocol (per the in-tree spec snapshot at [docs/Reference/mcp/](../../docs/Reference/mcp/), version `2025-11-25`), authenticates by `Authorization: Bearer <token>`, and routes through the same `governedExecuteTool` as the in-portal paths so tools, grants, and audit are one pipeline.
 
 ### 11.2 Credentials and identity — relationship to contribution mode
 
@@ -462,18 +465,18 @@ These cannot be the same literal token (different audiences, different validator
 2. **One settings surface.** `/admin/platform-development` already hosts contribution-mode config. We co-locate MCP token issuance there as a sibling section ("External Coding Agent Access"). Same admin view, same revoke flow, same audit.
 3. **One write-attribution gate.** Read-only MCP tokens issue freely. **Write-capable** MCP tokens require `PlatformDevConfig.contributionModel` to be set (i.e., the contribution path is wired). This guarantees that any external-MCP write that ever turns into code can be attributed end-to-end. If contribution mode is not configured, write-capable tokens are blocked at issuance with a pointer to set it up first.
 
-### 11.3 Token model — `AgentApiToken`
+### 11.3 Token model — `McpApiToken`
 
-A new Prisma model:
+A new Prisma model. The name is intentionally MCP-transport-specific (not `AgentApiToken` — the token is owned by a User, not an Agent — and not just `ApiToken` because that name is already taken by the V1 customer-portal JWT-refresh model).
 
 ```prisma
-model AgentApiToken {
+model McpApiToken {
   id              String    @id @default(cuid())
   userId          String                 // issuing user
   agentId         String?                // optional: bind to a specific agent identity
   name            String                 // human label, e.g. "Mark's Claude Code (laptop)"
   tokenHash       String    @unique      // sha256 of the secret; secret never stored
-  prefix          String                 // first 8 chars, for display (like dpfmcp_aB12...)
+  prefix          String                 // first 12 chars, for display (e.g. dpfmcp_AB12)
   scopes          String[]  @default([]) // grant keys the token may exercise (subset of user's grants)
   capability      String    @default("read") // "read" | "write" — write requires contribution-mode
   lastUsedAt      DateTime?
@@ -488,16 +491,21 @@ model AgentApiToken {
 }
 ```
 
-Token format: `dpfmcp_<24 random bytes base32>`. Stored as `sha256(secret)`; the plaintext is shown to the user **once** at issuance and never recoverable — same pattern as GitHub PATs.
+Token format: `dpfmcp_<24 random bytes base32>`. Base32 alphabet is Crockford-ish (no I/L/O/U) so tokens are easier for humans to verify visually. Stored as `sha256(secret)`; the plaintext is shown to the user **once** at issuance and never recoverable — same pattern as GitHub PATs.
 
 `scopes` is a subset of the user's effective grants, chosen at issuance. A user with `backlog_read`, `backlog_write`, `spec_plan_read` can mint a token with only `backlog_read` for a low-trust laptop. The MCP request's effective grants are `tokenScopes ∩ userGrants ∩ (agentGrants if agentId set)`.
 
 ### 11.4 External JSON-RPC endpoint
 
-`apps/web/app/api/mcp/external/jsonrpc/route.ts`:
+`apps/web/app/api/mcp/v1/route.ts` implements MCP JSON-RPC 2.0 per the in-tree spec snapshot at [docs/Reference/mcp/](../../docs/Reference/mcp/) (version `2025-11-25`). Specifically:
+
+- [docs/Reference/mcp/spec/basic/lifecycle.mdx](../../docs/Reference/mcp/spec/basic/lifecycle.mdx) — `initialize` handshake, `notifications/initialized`
+- [docs/Reference/mcp/spec/basic/transports.mdx](../../docs/Reference/mcp/spec/basic/transports.mdx) — Streamable HTTP (we use the single-POST flow, not SSE)
+- [docs/Reference/mcp/spec/server/tools.mdx](../../docs/Reference/mcp/spec/server/tools.mdx) — `tools/list`, `tools/call`, annotations
+- [docs/Reference/mcp/schema/schema.ts](../../docs/Reference/mcp/schema/schema.ts) — canonical types
 
 ```http
-POST /api/mcp/external/jsonrpc
+POST /api/mcp/v1
 Authorization: Bearer dpfmcp_...
 Content-Type: application/json
 
@@ -506,15 +514,30 @@ Content-Type: application/json
 
 Handler steps:
 
-1. Parse `Authorization: Bearer` header. If absent or malformed → JSON-RPC error `-32001 unauthorized`.
-2. `sha256(secret)` and `prisma.agentApiToken.findUnique({ tokenHash })`. Reject if not found, revoked, or expired.
-3. Update `lastUsedAt` (fire-and-forget).
-4. Resolve `userId` → load `User` (platformRole, isSuperuser).
-5. For `tools/list`: call `getAvailableTools(userContext, { agentId: token.agentId, unifiedMode: true })` and additionally filter by `token.scopes` (intersect with each tool's required grants). Return only tools the token can actually invoke — mirrors the in-portal MCP scoping.
-6. For `tools/call`: invoke `governedExecuteTool({ source: "external-jsonrpc", userContext, context: { agentId: token.agentId }, ... })`. Pass the token's scope set as an additional grant filter so a token-scope mismatch fails fast with `forbidden_grant`.
-7. The audit row in `ToolExecution` records `executionMode: "external-jsonrpc"` and a new field `apiTokenId` (added in the same migration as `AgentApiToken`) so each external write is traceable to a specific token.
+1. **Transport guards** (per spec MUST):
+   - Validate `Origin` header when present (DNS rebinding protection); CLI clients with no Origin are allowed.
+   - Refuse non-TLS requests except when the host is `localhost`/`127.0.0.1` (Mode 1).
+2. Parse `Authorization: Bearer` header. If absent → 401 with `WWW-Authenticate: Bearer realm="DPF MCP"`.
+3. `resolveMcpApiToken(plaintext)` (sha256 + lookup). Reject revoked or expired with 401 + `WWW-Authenticate`. Lazy `lastUsedAt` update on success.
+4. Parse JSON-RPC envelope. Standard JSON-RPC error codes: `-32700` (parse), `-32600` (invalid request), `-32601` (method not found), `-32602` (invalid params), `-32603` (internal). Notifications (no `id`) → 202 Accepted with no body.
+5. **`initialize`** → `{ protocolVersion: "2025-11-25", serverInfo, capabilities: { tools: { listChanged: false } }, instructions }`.
+6. **`tools/list`** → load `User` (platformRole, isSuperuser); return tools where the user has the required capability **and** the token's scopes intersect the tool's required grants. Each tool carries `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) per the MCP spec.
+7. **`tools/call`** → token-scope pre-check (clear `isError:true` message on mismatch, no wrapper roundtrip); side-effecting tools rejected with `isError:true` for read-only tokens; otherwise `governedExecuteTool({ source: "external-jsonrpc", context: { agentId: token.agentId, apiTokenId: token.tokenId }, ... })`. Response shape: `{ content: [{ type: "text", text: <JSON-serialized ToolResult> }], isError: !success, structuredContent: result.data }` — text block carries the full structured result for clients without structured-content support; structured field mirrors `ToolResult.data` for clients that read it directly (per the 2025-11-25 spec).
+8. **`ping`** → empty result.
+9. The audit row in `ToolExecution` records `executionMode: "external-jsonrpc"` and the `apiTokenId` so each external call is traceable to a specific token.
 
-The contract surface (the JSON-RPC method names, the tool schemas) is identical to the internal MCP endpoint. An external client doesn't need to know it's a different transport.
+`GET /api/mcp/v1` returns 405 with `Allow: POST` — we don't implement SSE since stateless single-POST is sufficient for synchronous tool calls and matches the spec's "stateless server" pattern.
+
+### 11.4a Authorization model — GitHub PAT, not OAuth 2.1
+
+The MCP spec requires OAuth 2.0 resource-server discovery via Protected Resource Metadata for fully compliant authorization. We **intentionally** use the GitHub-PAT pattern instead — tokens are issued by an admin from inside the portal, not via OAuth flow. The trade-off:
+
+- Real-world MCP clients (Claude Code, Codex CLI, VS Code MCP) accept arbitrary `Authorization: Bearer X` in their `mcp.json`, so the user experience works.
+- We return `WWW-Authenticate: Bearer realm="DPF MCP"` on 401 so clients that perform OAuth discovery don't fail with an opaque error — they just won't find the discovery document and fall back to the prompt-the-user path.
+- We do not implement `/.well-known/oauth-protected-resource`, do not advertise an authorization server, and do not validate token audience via RFC 8707.
+- A future PR can add an OAuth flow alongside if any client requires it. The token model already separates issuance (`issueMcpApiToken`) from resolution (`resolveMcpApiToken`), so an OAuth issuer would just add a new issuance entry point.
+
+This is documented as the install's authorization model so reviewers and downstream maintainers know it is a deliberate design decision, not a missing feature.
 
 ### 11.5 Issuance flow
 
@@ -527,27 +550,32 @@ Settings page at `/admin/platform-development` gains a new section:
     - Modal: `name`, `capability` (radio: read / write — write disabled with explainer if contribution-mode unset), `scopes` (multi-select, defaulted from user's grants), `expiresIn` (dropdown: 30/60/90/180 days/never, default 90), optional `agentId` (dropdown of agents the user can act as)
     - Submit → server action mints secret, hashes, persists, returns plaintext **once** to the modal with copy button and a setup snippet for Claude Code / Codex / VS Code (see §11.6)
 
-The server action lives at `apps/web/lib/actions/agent-api-tokens.ts`:
+The token primitives live at [apps/web/lib/auth/mcp-api-token.ts](../../apps/web/lib/auth/mcp-api-token.ts):
 
 ```ts
-export async function issueAgentApiToken(input: {
+export async function issueMcpApiToken(input: {
+  userId: string;
   name: string;
   capability: "read" | "write";
   scopes: string[];
   expiresInDays: number | null;
-  agentId?: string;
-}): Promise<{ tokenId: string; plaintext: string }>;
+  agentId?: string | null;
+}): Promise<IssueMcpTokenResult>;     // ok|error union including contribution_mode_required
 
-export async function revokeAgentApiToken(tokenId: string, reason: string): Promise<void>;
+export async function revokeMcpApiToken(tokenId: string, reason: string): Promise<{ ok: boolean }>;
+
+export async function resolveMcpApiToken(plaintext: string): Promise<ResolvedMcpToken | null>;
 ```
 
-`issueAgentApiToken` enforces the contribution-mode gate when `capability=write`:
+The session-scoped server actions wrap these with NextAuth identity in [apps/web/lib/actions/mcp-tokens.ts](../../apps/web/lib/actions/mcp-tokens.ts) — they are what the settings UI calls.
+
+`issueMcpApiToken` enforces the contribution-mode gate when `capability=write`:
 
 ```ts
 if (input.capability === "write") {
   const cfg = await prisma.platformDevConfig.findUnique({ where: { id: "singleton" } });
   if (!cfg?.contributionModel) {
-    throw new Error("Configure contribution mode before issuing write-capable tokens");
+    return { ok: false, error: "contribution_mode_required", message: "..." };
   }
 }
 ```
@@ -560,7 +588,7 @@ For Claude Code (`~/.claude/mcp.json`):
 {
   "mcpServers": {
     "dpf": {
-      "url": "http://localhost:3000/api/mcp/external/jsonrpc",
+      "url": "http://localhost:3000/api/mcp/v1",
       "headers": { "Authorization": "Bearer dpfmcp_<your-token>" }
     }
   }
@@ -573,7 +601,7 @@ For Codex CLI / VS Code MCP: equivalent `.mcp.json` with the same URL and bearer
 
 | Concern | Mode 1 (single install on user's box) | Deployed (multi-user, hosted) |
 | ------- | ------------------------------------- | ----------------------------- |
-| Endpoint URL | `http://localhost:3000/api/mcp/external/jsonrpc` | `https://<host>/api/mcp/external/jsonrpc` (TLS required) |
+| Endpoint URL | `http://localhost:3000/api/mcp/v1` | `https://<host>/api/mcp/v1` (TLS required) |
 | Token transport | HTTP (local-only) | HTTPS — endpoint refuses non-TLS via `request.url.startsWith("http://")` check (allowed for `localhost` only) |
 | Token expiry | Default 90 days, "never" allowed | Default 90 days, "never" disabled in UI for non-superusers |
 | Rate limiting | Lax (single user) | Per-token rate limit (out of scope here, tracked as follow-up) |
@@ -593,6 +621,8 @@ After this lands, on a fresh install:
 6. If they then ask Claude Code to make a code change that lands as a contribution PR, the chain `MCP token → user → install GitHub bind → PR` is intact.
 
 This is the Mode 1 backlog interface the spec set out to deliver.
+
+> **Implementation note (2026-04-26):** §11 shipped in the PR that introduced this section's edits. Token model, JSON-RPC route, settings UI, and contribution-mode gate are all live. The `AgentApiToken` name in the original draft was renamed to `McpApiToken` (the token is User-owned, not Agent-owned, and the name is now MCP-transport-specific). The endpoint settled on `/api/mcp/v1` rather than the verbose `/api/mcp/external/jsonrpc` because the URL is the canonical MCP endpoint going forward — the `external/jsonrpc` qualifier was misleading since the same endpoint can also accept session-cookie auth in a future iteration if we want to migrate the in-portal chat UI off its bespoke REST.
 
 ### 11.9 Risks and mitigations specific to §11
 

--- a/packages/db/prisma/migrations/20260425230000_mcp_api_token/migration.sql
+++ b/packages/db/prisma/migrations/20260425230000_mcp_api_token/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable
+ALTER TABLE "ToolExecution" ADD COLUMN "apiTokenId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ToolExecution_apiTokenId_createdAt_idx" ON "ToolExecution"("apiTokenId", "createdAt" DESC);
+
+-- CreateTable
+CREATE TABLE "McpApiToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "agentId" TEXT,
+    "name" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "capability" TEXT NOT NULL DEFAULT 'read',
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "revokedReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "McpApiToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "McpApiToken_tokenHash_key" ON "McpApiToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "McpApiToken_userId_revokedAt_idx" ON "McpApiToken"("userId", "revokedAt");
+
+-- CreateIndex
+CREATE INDEX "McpApiToken_tokenHash_idx" ON "McpApiToken"("tokenHash");
+
+-- AddForeignKey
+ALTER TABLE "McpApiToken" ADD CONSTRAINT "McpApiToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   approvedProposals            AgentActionProposal[]         @relation("ProposalDecisions")
   agentThreads                 AgentThread[]
   apiTokens                    ApiToken[]
+  mcpApiTokens                 McpApiToken[]
   backlogSubmissions           BacklogItem[]                 @relation("BacklogSubmissions")
   customEvalDimsApproved       CustomEvalDimension[]         @relation("CustomEvalDimensionApprover")
   customEvalDimsCreated        CustomEvalDimension[]         @relation("CustomEvalDimensionCreator")
@@ -2781,6 +2782,9 @@ model ToolExecution {
   auditClass    String?
   capabilityId  String?
   summary       String?
+  // External MCP transport (spec §13) — set when the tool call originated from
+  // a Bearer-token authenticated request through /api/mcp/v1.
+  apiTokenId    String?
 
   @@index([agentId, createdAt])
   @@index([userId, createdAt])
@@ -2788,6 +2792,31 @@ model ToolExecution {
   @@index([threadId])
   @@index([auditClass, createdAt(sort: Desc)])
   @@index([capabilityId, createdAt(sort: Desc)])
+  @@index([apiTokenId, createdAt(sort: Desc)])
+}
+
+// Personal access token for the external MCP transport at /api/mcp/v1.
+// User-owned (the human issues it from /admin/platform-development), hashed
+// at rest, scoped to a subset of the user's grants, optionally bound to a
+// specific Agent identity for grant-narrowing.
+model McpApiToken {
+  id              String    @id @default(cuid())
+  userId          String
+  agentId         String?
+  name            String
+  tokenHash       String    @unique
+  prefix          String
+  scopes          String[]  @default([])
+  capability      String    @default("read")
+  lastUsedAt      DateTime?
+  expiresAt       DateTime?
+  revokedAt       DateTime?
+  revokedReason   String?
+  createdAt       DateTime  @default(now())
+  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([tokenHash])
 }
 
 model AgentAttachment {


### PR DESCRIPTION
## Summary

Implements the §13 external-client transport from the [governed MCP backlog spec](docs/superpowers/specs/2026-04-25-governed-mcp-backlog-surface-design.md). After this lands, you point Claude Code / Codex CLI / VS Code MCP at `http://localhost:3000/api/mcp/v1` with a personal-access token from the portal admin UI and you get the nine governed backlog tools (and any other tool the token's scopes permit) with the same audit, grants, and capability checks as the in-portal coworker.

This is the **Mode 1 unlock**: a fresh DPF install gives the user a working backlog interface from their preferred coding agent, not just from inside the portal's Build Studio.

- **Real MCP JSON-RPC 2.0** at `/api/mcp/v1` per spec snapshot in [docs/Reference/mcp/](docs/Reference/mcp/) version `2025-11-25` — `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `ping`. Standard JSON-RPC error codes. Annotations on every listed tool (`readOnlyHint`, `destructiveHint`, etc.).
- **Bearer-token auth** (GitHub-PAT pattern). New `McpApiToken` model: hashed at rest, scoped, expirable, revocable. Plaintext shown once at issuance.
- **Write-token contribution-mode gate**: write-capable tokens cannot be issued unless `PlatformDevConfig.contributionModel` is set, so any external-MCP write that becomes a code contribution is end-to-end traceable.
- **Audit completeness**: `ToolExecution.apiTokenId` column lit up so every external call is traceable to a specific token (and through it to the issuing user).
- **Settings UI** at `/admin/platform-development` for issuing / listing / revoking tokens, with copy-once setup snippets pre-filled for Claude Code, VS Code MCP, and Codex CLI.

## Files

| Area | Change |
| ---- | ------ |
| Schema | `McpApiToken` model + `ToolExecution.apiTokenId` column |
| Token primitives | [apps/web/lib/auth/mcp-api-token.ts](apps/web/lib/auth/mcp-api-token.ts) — `issueMcpApiToken`, `revokeMcpApiToken`, `resolveMcpApiToken`, `listMcpApiTokens` |
| Wrapper | [apps/web/lib/mcp-governed-execute.ts](apps/web/lib/mcp-governed-execute.ts) — activate `apiTokenId` write to audit row |
| JSON-RPC route | [apps/web/app/api/mcp/v1/route.ts](apps/web/app/api/mcp/v1/route.ts) — full MCP protocol handler |
| Server actions | [apps/web/lib/actions/mcp-tokens.ts](apps/web/lib/actions/mcp-tokens.ts) — session-scoped issue / revoke / list |
| UI | [apps/web/components/admin/McpTokenManager.tsx](apps/web/components/admin/McpTokenManager.tsx) + wiring into the platform-development page |

## Authorization model — note for reviewers

The MCP spec recommends OAuth 2.1 resource-server discovery via Protected Resource Metadata. We **intentionally** use the GitHub-PAT pattern instead — issue from the portal admin UI, not via OAuth flow. We still return `WWW-Authenticate: Bearer realm="DPF MCP"` on 401 so OAuth-discovery clients fail gracefully. Documented in spec §11.4a as a deliberate design decision so it doesn't read as a missing feature.

Real-world clients (Claude Code, Codex CLI, VS Code MCP) all accept arbitrary `Authorization: Bearer X` in their `mcp.json`, so the Mode 1 user experience works with this approach. A future PR can add a real OAuth flow alongside if any client requires it — the token model already separates issuance from resolution, so an OAuth issuer is just a new entry point.

## Relationship to other PRs

- **Built on #278** (governed backlog surface, MERGED to main). Uses the `governedExecuteTool` wrapper introduced there.
- **Pairs with #282** (MCP spec reference snapshot, OPEN). The spec docs in §11.4 link to `docs/Reference/mcp/spec/...` paths that are introduced by #282. If #282 lands first, those links resolve in main; if this lands first, they resolve once #282 merges. Either order works.

## What changed vs the original spec draft

- `AgentApiToken` → `McpApiToken` (the token is User-owned, not Agent-owned; the new name is MCP-transport-specific).
- `/api/mcp/external/jsonrpc` → `/api/mcp/v1` (the v1 path is the canonical MCP endpoint; the "external/jsonrpc" qualifier was misleading since the same route can later accept session-cookie auth too).
- Added §11.4a on the GitHub-PAT vs OAuth decision.

Spec + plan updated in this PR to match (last commit).

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] Vitest: 206/206 across `lib/auth/*`, `lib/actions/mcp-tokens*`, `lib/mcp-governed-execute*`, `lib/backlog/*`, `lib/tak/agent-grants*`, `lib/tak/agentic-loop*`, `app/api/mcp/*`
- [x] `pnpm --filter web build` — production build succeeds
- [ ] (post-merge) Generate a token from `/admin/platform-development` and verify Claude Code on the host connects to `/api/mcp/v1` with the printed `mcp.json` and lists / calls a tool successfully
- [ ] (post-merge) Verify `ToolExecution.executionMode = "external-jsonrpc"` and `apiTokenId` are populated on the audit row

## Notes

- Origin header validation runs (DNS-rebinding protection per spec MUST). CLI clients without an Origin header are allowed; browser clients from disallowed hosts get 403.
- TLS guard refuses non-localhost http requests; localhost is allowed for Mode 1 / dev.
- Read-only tokens cannot invoke side-effecting tools even when their scopes allow it (defense-in-depth via the `capability` field). Returns `isError: true` with a clear "re-issue a write-capable token" message.
- The bespoke REST endpoints at `/api/mcp/tools` and `/api/mcp/call` are unchanged — they remain the in-portal coworker chat's contract. `/api/mcp/v1` is what external MCP clients should use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)