### PR TITLE
fix(install): point GHCR pulls at opendigitalproductfactory namespace

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -102,8 +102,8 @@ function Register-DPFStartupTask {
     }
 }
 
-$GHCR_PORTAL = "ghcr.io/markdbodman/dpf-portal"
-$GHCR_SANDBOX = "ghcr.io/markdbodman/dpf-sandbox"
+$GHCR_PORTAL = "ghcr.io/opendigitalproductfactory/dpf-portal"
+$GHCR_SANDBOX = "ghcr.io/opendigitalproductfactory/dpf-sandbox"
 
 $InstallMode = $null  # Set in Step 4: "consumer", "contributor", or "private"
 
@@ -435,7 +435,7 @@ if (-not (Test-StepDone "download")) {
             # Authenticate with GitHub Container Registry (images are private during early access)
             $oldEAP = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
-            docker pull ghcr.io/markdbodman/dpf-portal:latest 2>&1 | Out-Null
+            docker pull ghcr.io/opendigitalproductfactory/dpf-portal:latest 2>&1 | Out-Null
             $needsAuth = ($LASTEXITCODE -ne 0)
             $ErrorActionPreference = $oldEAP
 


### PR DESCRIPTION
## Summary

- Updates the three `ghcr.io/markdbodman/...` references in `install-dpf.ps1` to `ghcr.io/opendigitalproductfactory/...` so the Ready-to-go install path actually pulls working images.
- Stale namespace dates from before the repo moved to the OpenDigitalProductFactory org. `publish-image.yml` lowercases `${GITHUB_REPOSITORY_OWNER}` and has been pushing exclusively to `ghcr.io/opendigitalproductfactory/*` since the move (verified against the v1.22.0 publish run logs from 2026-04-25).
- Compose template references at lines 513, 526, 579, 592 use `$GHCR_PORTAL` / `$GHCR_SANDBOX`, so they inherit the fix automatically — only 3 source lines change.

## Related

- Docs counterpart: #289 (deliberately skipped this file to avoid breaking installs before evidence was confirmed).
- Follow-up needed: the GHCR packages themselves are still **private** (carried over from when the repo was first published under the old namespace). Until they are flipped to Public in the org Packages settings, the script's anonymous-pull probe at line 438 will still fail and fall through to the existing PAT-auth path. The script handles that gracefully, but consumer-mode UX is degraded until visibility is flipped. A separate PR will add an automated visibility step to `publish-image.yml`.

## Test plan

- [ ] `grep -c markdbodman install-dpf.ps1` returns `0`
- [ ] After GHCR package visibility is set to Public: `docker pull ghcr.io/opendigitalproductfactory/dpf-portal:latest` succeeds with no auth
- [ ] Ready-to-go install path on a fresh Windows host completes without the auth fallback being triggered (post-visibility-flip)