### PR TITLE
docs(pages): add CNAME for opendigitalproductfactory.com

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+opendigitalproductfactory.com


### PR DESCRIPTION
## Summary
GitHub Pages tried to commit `docs/CNAME` automatically when the custom domain was set in Settings → Pages, but branch protection on `main` blocks the direct write. This PR adds the file via the supported path.

Once merged, the existing Pages deployment will serve `docs/` at `https://opendigitalproductfactory.com/`. GitHub provisions HTTPS via Let's Encrypt automatically after DNS validates.

## DNS prerequisites (set at the registrar — independent of this PR)
- A records for the apex `@` pointing to `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`
- AAAA records for the apex pointing to `2606:50c0:8000::153` through `2606:50c0:8003::153`
- CNAME for `www` pointing to `opendigitalproductfactory.github.io`

## Test plan
- [ ] DNS records resolve to the GitHub Pages IPs (`dig opendigitalproductfactory.com +short`).
- [ ] Settings → Pages shows a green check next to the custom domain.
- [ ] After cert issuance, tick "Enforce HTTPS" in Settings → Pages.
- [ ] `curl -sI https://opendigitalproductfactory.com/` returns `HTTP/2 200`.
- [ ] `https://opendigitalproductfactory.github.io/opendigitalproductfactory/` redirects to the apex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)