### PR TITLE
docs(pages): turn on Jekyll rendering with branded layout

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,63 @@
+title: Open Digital Product Factory
+description: An open-source, AI-native digital product management platform.
+url: https://opendigitalproductfactory.com
+repository: OpenDigitalProductFactory/opendigitalproductfactory
+
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  hard_wrap: false
+
+permalink: pretty
+
+# Don't run Jekyll over content that contains Liquid template markers
+# (the prompt loader uses {{include:...}} that Liquid would try to parse)
+# or content we don't want as part of the public site.
+exclude:
+  - superpowers
+  - Reference
+  - "*.docx"
+  - "Trusted-AI-Kernel-Architecture.docx"
+  - "GAID.docx"
+  - "Trusted-AI-Agent-Governance-White-Paper.docx"
+  - dark-theme-development-guidelines.md
+  - architecture/ea-diagrams
+  - architecture/gaid-diagrams
+  - architecture/tak-diagrams
+  - architecture/monitoring-diagrams
+  - architecture/generate-tak-docx.mjs
+  - architecture/generate-gaid-docx.mjs
+  - architecture/generate-docx-from-markdown.mjs
+  - architecture/generate-agent-standards-white-paper-docx.mjs
+  - architecture/agent-standards-style-notes.md
+
+# Apply the default layout to Markdown pages but explicitly opt index.html
+# OUT of the layout — it is a bespoke landing page with its own embedded
+# styles and should not be wrapped in the doc-site chrome.
+defaults:
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: default
+  - scope:
+      path: "index.html"
+      type: pages
+    values:
+      layout: null
+
+# Jekyll plugins available on GitHub Pages by default
+plugins:
+  - jekyll-relative-links
+  - jekyll-optional-front-matter
+
+# Make [foo](bar.md) links resolve to the rendered .html
+relative_links:
+  enabled: true
+  collections: false
+
+# Apply the layout to .md files that don't have YAML frontmatter
+# (e.g. architecture/platform-overview.md, README.md)
+optional_front_matter:
+  remove_originals: false

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{% if page.title %}{{ page.title }} &middot; {% endif %}{{ site.title }}</title>
+{% if page.description or site.description %}<meta name="description" content="{{ page.description | default: site.description }}" />{% endif %}
+<link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}" />
+</head>
+<body>
+<header class="site-header">
+  <div class="wrap site-header-inner">
+    <a class="site-brand" href="{{ '/' | relative_url }}">
+      <span class="site-brand-mark" aria-hidden="true">ODPF</span>
+      <span class="site-brand-name">Open Digital Product Factory</span>
+    </a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="{{ '/user-guide/getting-started/' | relative_url }}">Getting started</a>
+      <a href="{{ '/user-guide/' | relative_url }}">User guide</a>
+      <a href="{{ '/architecture/platform-overview' | relative_url }}">Architecture</a>
+      <a href="https://github.com/{{ site.repository }}" rel="noopener">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap doc-main">
+  {% if page.title %}
+    <header class="doc-page-header">
+      <h1>{{ page.title }}</h1>
+      {% if page.lastUpdated %}<p class="doc-meta">Last updated {{ page.lastUpdated }}{% if page.updatedBy %} &middot; {{ page.updatedBy }}{% endif %}</p>{% endif %}
+    </header>
+  {% endif %}
+
+  <article class="doc-content">
+    {{ content }}
+  </article>
+
+  <p class="doc-edit-link"><a href="https://github.com/{{ site.repository }}/edit/main/docs/{{ page.path }}" rel="noopener">Edit this page on GitHub</a></p>
+</main>
+
+<footer class="site-footer">
+  <div class="wrap">
+    <p>
+      <a href="{{ '/' | relative_url }}">{{ site.title }}</a> &middot;
+      <a href="https://github.com/{{ site.repository }}" rel="noopener">GitHub repository</a>
+    </p>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1,0 +1,187 @@
+:root {
+  --bg: #0b0d10;
+  --surface: #14181d;
+  --surface-2: #1b2027;
+  --border: #262d36;
+  --fg: #e6e8eb;
+  --fg-muted: #a4adb8;
+  --accent: #6aa9ff;
+  --accent-2: #8be0c7;
+  --code-bg: #0e1216;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f7f8fa;
+    --surface: #ffffff;
+    --surface-2: #f0f3f7;
+    --border: #d9dde3;
+    --fg: #1a1f25;
+    --fg-muted: #515b66;
+    --accent: #1f5fbf;
+    --accent-2: #1f7a5a;
+    --code-bg: #f4f6f8;
+  }
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.wrap { max-width: 960px; margin: 0 auto; padding: 0 24px; }
+
+/* header */
+.site-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: saturate(140%) blur(8px);
+}
+.site-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+.site-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--fg);
+  font-weight: 600;
+}
+.site-brand:hover { text-decoration: none; }
+.site-brand-mark {
+  display: inline-block;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #0b0d10;
+  font-weight: 700;
+}
+.site-brand-name { font-size: 15px; }
+.site-nav { display: flex; gap: 18px; flex-wrap: wrap; }
+.site-nav a {
+  color: var(--fg-muted);
+  font-size: 14px;
+  font-weight: 500;
+}
+.site-nav a:hover { color: var(--fg); text-decoration: none; }
+
+/* page */
+.doc-main { padding: 32px 24px 64px; }
+.doc-page-header {
+  margin: 8px 0 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.doc-page-header h1 {
+  font-size: clamp(26px, 3.5vw, 36px);
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+.doc-meta { color: var(--fg-muted); font-size: 13px; margin: 0; }
+
+.doc-content h1 { font-size: 28px; margin: 32px 0 12px; line-height: 1.25; letter-spacing: -0.005em; }
+.doc-content h2 { font-size: 22px; margin: 28px 0 10px; line-height: 1.3; padding-bottom: 4px; border-bottom: 1px solid var(--border); }
+.doc-content h3 { font-size: 18px; margin: 24px 0 8px; }
+.doc-content h4 { font-size: 16px; margin: 20px 0 6px; color: var(--fg-muted); }
+.doc-content p, .doc-content ul, .doc-content ol { margin: 0 0 14px; }
+.doc-content li { margin-bottom: 4px; }
+.doc-content blockquote {
+  margin: 0 0 14px;
+  padding: 8px 14px;
+  border-left: 3px solid var(--accent);
+  background: var(--surface-2);
+  color: var(--fg-muted);
+  border-radius: 4px;
+}
+.doc-content code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.doc-content pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  overflow-x: auto;
+  margin: 0 0 16px;
+  font: 13px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.doc-content pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+.doc-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 14px;
+}
+.doc-content th, .doc-content td {
+  text-align: left;
+  vertical-align: top;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.doc-content th { background: var(--surface-2); font-weight: 600; }
+.doc-content tr:last-child td { border-bottom: none; }
+.doc-content img { max-width: 100%; height: auto; border-radius: 6px; }
+.doc-content hr { border: none; border-top: 1px solid var(--border); margin: 28px 0; }
+
+.doc-edit-link {
+  margin-top: 36px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+}
+.doc-edit-link a { color: var(--fg-muted); }
+.doc-edit-link a:hover { color: var(--accent); }
+
+/* footer */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 20px 24px;
+  color: var(--fg-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+/* Rouge syntax-highlighting palette (subset, matches dark/light) */
+.highlight .c, .highlight .c1, .highlight .cm { color: #6a737d; font-style: italic; }
+.highlight .k, .highlight .kd, .highlight .kn { color: #d73a49; }
+@media (prefers-color-scheme: dark) {
+  .highlight .k, .highlight .kd, .highlight .kn { color: #ff7b72; }
+  .highlight .c, .highlight .c1, .highlight .cm { color: #8b949e; }
+}
+.highlight .s, .highlight .s1, .highlight .s2 { color: #032f62; }
+@media (prefers-color-scheme: dark) {
+  .highlight .s, .highlight .s1, .highlight .s2 { color: #a5d6ff; }
+}
+.highlight .n, .highlight .nx { color: var(--fg); }
+.highlight .nb { color: #6f42c1; }
+@media (prefers-color-scheme: dark) {
+  .highlight .nb { color: #d2a8ff; }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -293,24 +293,24 @@
         <tr><th style="width:30%;">Section</th><th>Read on GitHub</th></tr>
       </thead>
       <tbody>
-        <tr><td>Documentation index</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/README.md">docs/README.md</a></td></tr>
-        <tr><td>Getting started</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/getting-started">user-guide/getting-started</a></td></tr>
-        <tr><td>AI coworker</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/user-guide/getting-started/ai-coworker.md">getting-started/ai-coworker.md</a></td></tr>
-        <tr><td>Roles &amp; access</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/user-guide/getting-started/roles-and-access.md">getting-started/roles-and-access.md</a></td></tr>
-        <tr><td>Development workspace</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/user-guide/development-workspace.md">user-guide/development-workspace.md</a></td></tr>
-        <tr><td>AI workforce &amp; providers</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/ai-workforce">user-guide/ai-workforce</a></td></tr>
-        <tr><td>Build Studio</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/build-studio">user-guide/build-studio</a></td></tr>
-        <tr><td>Compliance</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/compliance">user-guide/compliance</a></td></tr>
-        <tr><td>Customers</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/customers">user-guide/customers</a></td></tr>
-        <tr><td>Finance</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/finance">user-guide/finance</a></td></tr>
-        <tr><td>HR</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/hr">user-guide/hr</a></td></tr>
-        <tr><td>Operations</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/operations">user-guide/operations</a></td></tr>
-        <tr><td>Platform &amp; AI ops</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/platform">user-guide/platform</a></td></tr>
-        <tr><td>Portfolios</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/portfolios">user-guide/portfolios</a></td></tr>
-        <tr><td>Products</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/products">user-guide/products</a></td></tr>
-        <tr><td>Storefront</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/storefront">user-guide/storefront</a></td></tr>
-        <tr><td>Workspace</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/workspace">user-guide/workspace</a></td></tr>
-        <tr><td>Admin</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/user-guide/admin">user-guide/admin</a></td></tr>
+        <tr><td>Documentation index</td><td><a href="/README">docs/README</a></td></tr>
+        <tr><td>Getting started</td><td><a href="/user-guide/getting-started/">user-guide/getting-started</a></td></tr>
+        <tr><td>AI coworker</td><td><a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a></td></tr>
+        <tr><td>Roles &amp; access</td><td><a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a></td></tr>
+        <tr><td>Development workspace</td><td><a href="/user-guide/development-workspace">user-guide/development-workspace</a></td></tr>
+        <tr><td>AI workforce &amp; providers</td><td><a href="/user-guide/ai-workforce/">user-guide/ai-workforce</a></td></tr>
+        <tr><td>Build Studio</td><td><a href="/user-guide/build-studio/">user-guide/build-studio</a></td></tr>
+        <tr><td>Compliance</td><td><a href="/user-guide/compliance/">user-guide/compliance</a></td></tr>
+        <tr><td>Customers</td><td><a href="/user-guide/customers/">user-guide/customers</a></td></tr>
+        <tr><td>Finance</td><td><a href="/user-guide/finance/">user-guide/finance</a></td></tr>
+        <tr><td>HR</td><td><a href="/user-guide/hr/">user-guide/hr</a></td></tr>
+        <tr><td>Operations</td><td><a href="/user-guide/operations/">user-guide/operations</a></td></tr>
+        <tr><td>Platform &amp; AI ops</td><td><a href="/user-guide/platform/">user-guide/platform</a></td></tr>
+        <tr><td>Portfolios</td><td><a href="/user-guide/portfolios/">user-guide/portfolios</a></td></tr>
+        <tr><td>Products</td><td><a href="/user-guide/products/">user-guide/products</a></td></tr>
+        <tr><td>Storefront</td><td><a href="/user-guide/storefront/">user-guide/storefront</a></td></tr>
+        <tr><td>Workspace</td><td><a href="/user-guide/workspace/">user-guide/workspace</a></td></tr>
+        <tr><td>Admin</td><td><a href="/user-guide/admin/">user-guide/admin</a></td></tr>
       </tbody>
     </table>
   </section>
@@ -325,13 +325,13 @@
         <tr><th style="width:42%;">Document</th><th>Read on GitHub</th></tr>
       </thead>
       <tbody>
-        <tr><td>Platform overview</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/platform-overview.md">architecture/platform-overview.md</a></td></tr>
-        <tr><td>Trusted AI Kernel (TAK)</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/trusted-ai-kernel.md">architecture/trusted-ai-kernel.md</a></td></tr>
-        <tr><td>Global AI Agent Identification &amp; Governance (GAID)</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/GAID.md">architecture/GAID.md</a></td></tr>
-        <tr><td>Trusted AI Agent Governance white paper</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/2026-04-18-trusted-ai-agent-governance-white-paper.md">white paper (markdown)</a></td></tr>
-        <tr><td>Standards conformance assessment</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/agent-standards-dpf-conformance.md">agent-standards-dpf-conformance.md</a></td></tr>
-        <tr><td>AI coworker development principles</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/ai-coworker-development-principles.md">ai-coworker-development-principles.md</a></td></tr>
-        <tr><td>Platform usability standards</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/platform-usability-standards.md">platform-usability-standards.md</a></td></tr>
+        <tr><td>Platform overview</td><td><a href="/architecture/platform-overview">architecture/platform-overview</a></td></tr>
+        <tr><td>Trusted AI Kernel (TAK)</td><td><a href="/architecture/trusted-ai-kernel">architecture/trusted-ai-kernel</a></td></tr>
+        <tr><td>Global AI Agent Identification &amp; Governance (GAID)</td><td><a href="/architecture/GAID">architecture/GAID</a></td></tr>
+        <tr><td>Trusted AI Agent Governance white paper</td><td><a href="/architecture/2026-04-18-trusted-ai-agent-governance-white-paper">white paper (markdown)</a></td></tr>
+        <tr><td>Standards conformance assessment</td><td><a href="/architecture/agent-standards-dpf-conformance">agent-standards-dpf-conformance</a></td></tr>
+        <tr><td>AI coworker development principles</td><td><a href="/architecture/ai-coworker-development-principles">ai-coworker-development-principles</a></td></tr>
+        <tr><td>Platform usability standards</td><td><a href="/platform-usability-standards">platform-usability-standards</a></td></tr>
       </tbody>
     </table>
     <p class="sub" style="margin-top:14px;">


### PR DESCRIPTION
## Summary
Switches \`docs/\` from raw static serving (the \`.nojekyll\` workaround) to Jekyll-rendered Markdown with a branded layout. After merge, Markdown files in \`user-guide/\`, \`architecture/\`, and the docs root will serve as styled HTML at \`https://opendigitalproductfactory.com/<path>/\` instead of raw text.

**Draft on purpose:** I want to confirm the Pages build succeeds and the rendered pages look right before this is merge-ready. After push, the build runs against this branch's content via the existing Pages config (source: \`main\` / \`/docs\`). I'll mark ready once the build is green.

## What's in
- **\`docs/_config.yml\`** — kramdown+GFM, pretty permalinks, \`jekyll-relative-links\` so \`[foo](bar.md)\` resolves to rendered \`.html\`, \`jekyll-optional-front-matter\` so files without YAML frontmatter still get the layout. Excludes \`superpowers/\`, \`Reference/\`, \`*.docx\`, the diagram-source dirs, the docx-generation \`.mjs\` scripts, and \`dark-theme-development-guidelines.md\` (JSX-style \`{{ ... }}\` attributes Liquid would try to parse).
- **\`docs/_layouts/default.html\`** — site-wide chrome: brand-marked header, page header that uses \`page.title\` / \`page.lastUpdated\` frontmatter, "Edit this page on GitHub" link, footer.
- **\`docs/assets/css/site.css\`** — branding to match \`docs/index.html\` (dark-default with light fallback via \`prefers-color-scheme\`, consistent typography, sticky header, Rouge syntax highlighting).
- **\`docs/index.html\`** — keeps its bespoke styling (\`defaults\` rule pins it to \`layout: null\`). Link tables retargeted: user-guide and architecture entries now point at \`/user-guide/...\` and \`/architecture/...\` (rendered). Specs / Reference / Build Studio specs keep their GitHub source-view URLs since those folders are deliberately excluded from the site.
- **\`docs/.nojekyll\`** — removed. Was needed when Pages tried to render the spec content; now that those dirs are excluded via \`_config.yml\`, Jekyll runs cleanly.

## Test plan
- [ ] After this branch is pulled into a Pages preview (or after merge): \`gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/pages | jq .status\` returns \`"built"\`, no errors in the latest build.
- [ ] \`https://opendigitalproductfactory.com/\` still serves the bespoke landing page (no layout chrome wrapped around it).
- [ ] \`https://opendigitalproductfactory.com/user-guide/getting-started/\` renders the Getting Started markdown with the branded layout.
- [ ] \`https://opendigitalproductfactory.com/architecture/platform-overview\` renders correctly even though its source has no YAML frontmatter (relies on \`jekyll-optional-front-matter\`).
- [ ] Internal links in rendered pages (\`[Dev Setup](developer-setup.md)\` etc.) navigate to the rendered \`.html\`, not 404.
- [ ] \`https://opendigitalproductfactory.com/superpowers/\` returns 404 (excluded from build, intentional).

## Risk
- If \`jekyll-relative-links\` or \`jekyll-optional-front-matter\` aren't on the GitHub Pages plugin allowlist this build will fail. Both are documented as supported, but if it errors I'll drop them and switch to manually adding frontmatter to the few files that need it.
- The link retarget in \`docs/index.html\` assumes pretty permalinks resolve as expected. If any 404 after deploy, I'll fix the path style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)