### PR TITLE
docs(pages): add user-guide section index, fix broken /README link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -286,14 +286,14 @@
   </section>
 
   <section>
-    <h2>User guide &mdash; in-product help, also browsable on GitHub</h2>
-    <p class="sub">These pages are bundled into the platform's in-app help and also live in the source tree. Start at the index and follow the section that matches your role.</p>
+    <h2>User guide &mdash; in-product help, also published here</h2>
+    <p class="sub">These pages are bundled into the platform's in-app help and also live in the source tree. Start at the User Guide index and follow the section that matches your role.</p>
     <table class="guide">
       <thead>
-        <tr><th style="width:30%;">Section</th><th>Read on GitHub</th></tr>
+        <tr><th style="width:30%;">Section</th><th>Read</th></tr>
       </thead>
       <tbody>
-        <tr><td>Documentation index</td><td><a href="/README">docs/README</a></td></tr>
+        <tr><td>User Guide index</td><td><a href="/user-guide/">user-guide/</a></td></tr>
         <tr><td>Getting started</td><td><a href="/user-guide/getting-started/">user-guide/getting-started</a></td></tr>
         <tr><td>AI coworker</td><td><a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a></td></tr>
         <tr><td>Roles &amp; access</td><td><a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a></td></tr>

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,0 +1,44 @@
+---
+title: "User Guide"
+description: "Day-to-day operating guide for the Open Digital Product Factory platform — getting started, AI coworkers, Build Studio, compliance, finance, HR, customers, and more."
+lastUpdated: 2026-04-26
+---
+
+The User Guide is the day-to-day operating manual for everyone who works in the platform. The same pages are bundled into the portal's in-app help at runtime, so what you see here matches what you see when you press the help button inside the product.
+
+If you're brand new, start at [Getting Started](getting-started/). The other sections are organized by the work you do, not by the screens you click.
+
+## Start here
+
+- [Getting Started](getting-started/) — what the platform does, how navigation works, and where your AI coworker lives.
+- [Roles & Access](getting-started/roles-and-access) — the platform roles and what each one can do.
+- [AI Coworker](getting-started/ai-coworker) — working with the context-aware assistant on every screen.
+- [Development Workspace](development-workspace) — how Build Studio, VS Code, policy states, and validation environments fit together.
+
+## Domain guides
+
+Each of these is the operating manual for one part of the platform. The pages are written for the people doing the work — admins for admin-only screens, finance leads for finance, and so on.
+
+| Section | What it covers |
+|---------|----------------|
+| [AI Workforce](ai-workforce/) | Provider configuration, model routing lifecycle, per-provider notes (Anthropic, Codex, Ollama). |
+| [Build Studio](build-studio/) | The guided five-phase pipeline (intake, design, build, review, ship), sandbox, and deployment. |
+| [Compliance](compliance/) | Regulations, controls, evidence, audits, incidents, regulatory submissions. |
+| [Customers](customers/) | Customer accounts, sales pipeline, marketing. |
+| [Finance](finance/) | Invoicing, AP/AR, banking and reconciliation, AI spend, controls and automation, reporting. |
+| [HR](hr/) | Employees, roles, lifecycle scaffolding. |
+| [Operations](operations/) | Delivery backlog, infrastructure discovery, value-stream operations. |
+| [Platform](platform/) | AI operations, identity & access, authority & audit, tools & integrations. |
+| [Portfolios](portfolios/) | Portfolio management, health metrics, investment tracking. |
+| [Products](products/) | Product inventory, lifecycle stages, business-model roles. |
+| [Storefront](storefront/) | Public-facing storefront — setup, catalog, inbox, fulfilment, business and operations settings. |
+| [Workspace](workspace/) | The personal workspace — your daily view. |
+| [Admin](admin/) | Admin-only configuration screens. |
+
+## Architecture and standards
+
+The runtime architecture, the Trusted AI Kernel (TAK), the Global AI Agent Identification & Governance (GAID) standard, and the platform's conformance assessment live under the [Architecture section](../architecture/platform-overview/).
+
+## Specifications and plans
+
+Long-form design specs and implementation plans are kept in the source repository under [`docs/superpowers/`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers). They are historical records of how each capability was built, not onboarding material — useful if you want to understand a design decision but not necessary to use the platform.


### PR DESCRIPTION
## Summary
Two related fixes for landing-page links that 404'd after PR #293 went live:

1. **\`/user-guide/\` returned 404** because there was no \`docs/user-guide/index.md\`. The layout's primary nav links to \`/user-guide/\`, so this 404 was hit from every rendered page. Adds a section landing page that links to each domain area's index, plus pointers to architecture and the specs directory on GitHub.
2. **The \`/README\` link in the landing-page link table was broken.** GitHub Pages' Jekyll treats \`README.md\` as a repo-display file, not a publishable page, and its default exclude list keeps it out of the build. Rather than fight that default, the row now points at the new \`/user-guide/\` index — which is what readers actually want as a "documentation index."

Also relabels the link-table heading from "Read on GitHub" to "Read" since those rows now point at the rendered Pages site, not GitHub source view.

## Test plan
- [ ] After merge: \`gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/pages | jq .status\` returns \`"built"\`.
- [ ] \`curl -sIL https://opendigitalproductfactory.com/user-guide/\` returns final \`200\`.
- [ ] \`https://opendigitalproductfactory.com/user-guide/\` renders with the branded layout and shows the new section index.
- [ ] Clicking "User guide" in the primary nav from any rendered page lands on the new index instead of 404.
- [ ] The "User Guide index" row in the landing page's link table works.
- [ ] No regression: every previously-working URL (\`/user-guide/getting-started/\`, \`/user-guide/build-studio/\`, etc.) still returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)