### PR TITLE
feat(mcp): expose code-graph tools on external MCP surface

### DIFF
--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -286,4 +286,10 @@ describe("getToolGrantMapping reflects all entries", () => {
     expect(mapping["contribute_to_hive"]).toEqual(["backlog_write"]);
     expect(mapping["apply_platform_update"]).toEqual(["admin_write"]);
   });
+
+  it("includes code graph tools", () => {
+    const mapping = getToolGrantMapping();
+    expect(mapping["get_code_graph_freshness"]).toEqual(["code_graph_read"]);
+    expect(mapping["inspect_build_code_impact"]).toEqual(["code_graph_read"]);
+  });
 });

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -105,6 +105,10 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   propose_file_change: ["file_read"],
   propose_improvement: ["decision_record_create"],
 
+  // Code graph (file-level coverage today; symbol-level deferred)
+  get_code_graph_freshness: ["code_graph_read"],
+  inspect_build_code_impact: ["code_graph_read"],
+
   // Provider management
   add_provider: ["agent_control_read"],
   update_provider_category: ["agent_control_read"],


### PR DESCRIPTION
## Summary
- Adds `code_graph_read` grant entries for `get_code_graph_freshness` and `inspect_build_code_impact` in `TOOL_TO_GRANTS`.
- These two tools were already registered in `PLATFORM_TOOLS` but had no grant mapping, so the external `/api/mcp/v1` route's default-deny gate rejected them regardless of token scope.
- Mode 2 dev tools (Claude Code CLI, Codex CLI, MCP-aware VS Code extensions) pointed at a `dpfmcp_` token issued with `code_graph_read` scope can now call both tools.

## Why this slice, why this small
Previous design discussion considered a larger symbol-indexing slice (find_symbol / find_references / get_dependents). That spec exists locally as a deferred document. The decision was: file-level coverage is sufficient for the questions Build Studio asks today, and the marginal value of symbol indexing on top of `Grep` + `Read` does not justify a sprint right now. Slice 1 — exposing the existing tools — is cheap, preserves optionality, and makes the platform's existing code-graph capability reachable from external dev tools.

## Auth path
- External path (`/api/mcp/v1`): the new grant scope shows up automatically in the token issuance UI at `/admin/platform-development` because `listAvailableMcpScopes` derives the list from `TOOL_TO_GRANTS`.
- In-platform path: unchanged. The two tools have always run from non-agent code paths (e.g., the build-review-verification Inngest handler), where `governedExecuteTool`'s agent-grant check is skipped because no `agentId` is in context. Adding the entry hardens that — if a coworker is later wired to call them with `agentId` in context, it will succeed via `code_graph_read` rather than silently default-deny.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/tak/agent-grants.test.ts` (46 passed, including new code-graph mapping assertion)
- [x] `pnpm --filter web exec vitest run lib/actions/mcp-tokens.test.ts` (10 passed)
- [x] Pre-commit scoped typecheck passes
- [ ] CI: Typecheck, Production Build, DCO

## Out of scope (deferred)
- Symbol-level tools: `find_symbol`, `find_references`, `get_dependents`, `get_symbol_definition`
- Local stdio MCP server in `services/code-graph-mcp/`
- IDE extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)