### PR TITLE
docs(site): wire ODPF logo into header and landing hero

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,9 +10,8 @@
 <body>
 <header class="site-header">
   <div class="wrap site-header-inner">
-    <a class="site-brand" href="{{ '/' | relative_url }}">
-      <span class="site-brand-mark" aria-hidden="true">ODPF</span>
-      <span class="site-brand-name">Open Digital Product Factory</span>
+    <a class="site-brand" href="{{ '/' | relative_url }}" aria-label="Open Digital Product Factory home">
+      <img class="site-brand-logo" src="{{ '/assets/logos/open-digital-product-factory-logo.svg' | relative_url }}" alt="Open Digital Product Factory" width="120" height="40" />
     </a>
     <nav class="site-nav" aria-label="Primary">
       <a href="{{ '/user-guide/getting-started/' | relative_url }}">Getting started</a>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -60,17 +60,16 @@ a:hover { text-decoration: underline; }
   font-weight: 600;
 }
 .site-brand:hover { text-decoration: none; }
-.site-brand-mark {
-  display: inline-block;
-  font-size: 11px;
-  letter-spacing: 0.15em;
-  padding: 4px 8px;
-  border-radius: 6px;
-  background: var(--accent);
-  color: #0b0d10;
-  font-weight: 700;
+.site-brand-logo {
+  display: block;
+  height: 32px;
+  width: auto;
 }
-.site-brand-name { font-size: 15px; }
+/* On the light theme the wordmark colour inside the SVG sits low-contrast
+   on a white background; tint the whole logo for legibility. */
+@media (prefers-color-scheme: light) {
+  .site-brand-logo { filter: brightness(0.55) saturate(1.4); }
+}
 .site-nav { display: flex; gap: 18px; flex-wrap: wrap; }
 .site-nav a {
   color: var(--fg-muted);

--- a/docs/assets/logos/open-digital-product-factory-logo.svg
+++ b/docs/assets/logos/open-digital-product-factory-logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" width="120" height="40">
+  <defs>
+    <linearGradient id="dpf-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4f80c7;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#7c8cf8;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="6" width="28" height="28" rx="6" fill="url(#dpf-grad)" opacity="0.9"/>
+  <text x="16" y="25" font-family="Inter, system-ui, sans-serif" font-size="12" font-weight="700" fill="white" text-anchor="middle">DPF</text>
+  <text x="38" y="18" font-family="Inter, system-ui, sans-serif" font-size="9" font-weight="600" fill="#e0e0ff">Open Digital</text>
+  <text x="38" y="30" font-family="Inter, system-ui, sans-serif" font-size="9" font-weight="600" fill="#e0e0ff">Product Factory</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,13 +49,14 @@
       var(--surface);
   }
   .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
-  .eyebrow {
-    display: inline-block;
-    font-size: 12px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--fg-muted);
-    margin-bottom: 12px;
+  .hero-logo {
+    display: block;
+    height: 64px;
+    width: auto;
+    margin-bottom: 18px;
+  }
+  @media (prefers-color-scheme: light) {
+    .hero-logo { filter: brightness(0.55) saturate(1.4); }
   }
   h1 {
     font-size: clamp(28px, 4vw, 44px);
@@ -198,7 +199,7 @@
 <body>
 <header class="hero">
   <div class="wrap">
-    <div class="eyebrow">Open Digital Product Factory</div>
+    <img class="hero-logo" src="assets/logos/open-digital-product-factory-logo.svg" alt="Open Digital Product Factory" width="240" height="80" />
     <h1>An open, AI-native platform that helps your organization build and run itself.</h1>
     <p class="lede">
       A pre-install tour for people who want to understand the platform before they download it. The Open Digital Product Factory (ODPF) gives small teams and regulated enterprises the same digital-product, architecture, compliance, and AI-workforce capabilities that have historically been locked behind expensive enterprise suites &mdash; on your own hardware, governed end-to-end, and extensible by AI coworkers under human approval.


### PR DESCRIPTION
## Summary
Replaces the placeholder text mark / eyebrow on the docs site with the actual ODPF logo from \`apps/web/public/logos/open-digital-product-factory-logo.svg\`.

- **Header** (\`_layouts/default.html\`): the \`ODPF\` text mark + "Open Digital Product Factory" wordmark span are replaced with the SVG, sized to 32px tall.
- **Landing hero** (\`index.html\`): the eyebrow text is replaced with a 64px version of the same logo.
- **CSS** (\`assets/css/site.css\` and the inline style block in \`index.html\`): \`.site-brand-mark\` / \`.site-brand-name\` rules retired. \`.site-brand-logo\` and \`.hero-logo\` rules added.
- **Asset**: SVG duplicated into \`docs/assets/logos/\` so Pages publishes a self-contained tree (no cross-workspace dependency).

## Light-theme contrast handling
The logo's wordmark text colour (\`#e0e0ff\`) is designed for a dark backdrop. On the light theme it falls below WCAG AA contrast against white. As a non-destructive workaround both surfaces apply \`filter: brightness(0.55) saturate(1.4)\` under \`prefers-color-scheme: light\`, which darkens the wordmark for legibility without modifying the asset. If a dedicated light-theme variant of the SVG is preferred, the filter can be dropped and a second asset added.

## Test plan
- [ ] After merge: \`gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/pages | jq .status\` returns \`"built"\`.
- [ ] \`https://opendigitalproductfactory.com/\` shows the logo in the hero (no eyebrow text).
- [ ] \`https://opendigitalproductfactory.com/user-guide/\` shows the logo in the sticky header.
- [ ] Logo links back to \`/\` from inside any rendered page.
- [ ] On light theme (system pref / browser dev tools), the wordmark portion of the logo is legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)