### PR TITLE
fix(coworker): stamp current TaskRun ID on agent messages and proposals

### DIFF
--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -116,6 +116,12 @@ vi.mock("@dpf/db", () => ({
     modelProvider: {
       findMany: vi.fn().mockResolvedValue([]),
     },
+    taskRun: {
+      findFirst: vi.fn(),
+    },
+    agentActionProposal: {
+      create: vi.fn(),
+    },
     agentModelConfig: {
       findUnique: vi.fn(),
     },
@@ -164,6 +170,15 @@ describe("agent coworker external access", () => {
     mockPrisma.agentMessage.findMany.mockResolvedValue([]);
     mockPrisma.agentAttachment.findMany.mockResolvedValue([]);
     mockPrisma.agent.findUnique.mockResolvedValue(null);
+    mockPrisma.taskRun.findFirst.mockResolvedValue(null);
+    mockPrisma.agentActionProposal.create.mockResolvedValue({
+      proposalId: "AP-TRACE",
+      actionType: "create_backlog_item",
+      parameters: {},
+      status: "proposed",
+      resultEntityId: null,
+      resultError: null,
+    });
     mockPrisma.agentModelConfig.findUnique.mockResolvedValue(null);
     mockPrisma.toolExecution.create.mockResolvedValue({});
     mockPrisma.agentMessage.create
@@ -310,5 +325,52 @@ describe("agent coworker external access", () => {
         paletteAccent: "#4f46e5",
       });
     }
+  });
+
+  it("stamps the current task run on proposals", async () => {
+    mockPrisma.taskRun.findFirst.mockResolvedValue({ taskRunId: "run-123" });
+    mockGetAvailableTools.mockReturnValue([
+      {
+        name: "create_backlog_item",
+        description: "Create backlog item",
+        inputSchema: {},
+        requiredCapability: "manage_backlog",
+        executionMode: "proposal",
+        sideEffect: true,
+      },
+    ]);
+    mockRouteAndCall.mockResolvedValue({
+      content: "I'd like to create a backlog item for this.",
+      providerId: "ollama-local",
+      modelId: "llama3.1",
+      inputTokens: 1,
+      outputTokens: 1,
+      downgraded: false,
+      downgradeMessage: null,
+      routeDecision: {},
+      toolCalls: [
+        {
+          id: "proposal_tool",
+          name: "create_backlog_item",
+          arguments: {
+            title: "Follow up on provider setup",
+          },
+        },
+      ],
+    });
+
+    await sendMessage({
+      threadId: "thread-1",
+      content: "Create a follow-up backlog item",
+      routeContext: "/admin",
+    });
+
+    expect(mockPrisma.agentActionProposal.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          taskRunId: "run-123",
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -881,6 +881,15 @@ export async function sendMessage(input: {
   let responseModelId: string | null = null;
   let formAssistUpdate: Record<string, unknown> | undefined;
   let systemMessage: AgentMessageRow | undefined;
+  const currentTaskRun = await prisma.taskRun.findFirst({
+    where: {
+      userId: user.id!,
+      threadId: input.threadId,
+      archivedAt: null,
+    },
+    orderBy: [{ startedAt: "desc" }, { createdAt: "desc" }],
+    select: { taskRunId: true },
+  }).catch(() => null);
 
   // EP-AI-WORKFORCE-001: Provider pinning is now via AgentModelConfig.pinnedProviderId
   // (resolved in agentic-loop.ts via agentModelConfig lookup). No need to merge here.
@@ -1024,6 +1033,7 @@ export async function sendMessage(input: {
       const agentMsg = await prisma.agentMessage.create({
         data: {
           threadId: input.threadId, role: "assistant",
+          taskRunId: currentTaskRun?.taskRunId ?? null,
           content: tc.content || `I'd like to ${tc.name.replace(/_/g, " ")} with the following details.`,
           agentId: agent.agentId, routeContext: input.routeContext,
           providerId: agenticResult.providerId,
@@ -1035,6 +1045,7 @@ export async function sendMessage(input: {
       const proposal = await prisma.agentActionProposal.create({
         data: {
           proposalId, threadId: input.threadId, messageId: agentMsg.id,
+          taskRunId: currentTaskRun?.taskRunId ?? null,
           agentId: agent.agentId, actionType: tc.name,
           parameters: tc.arguments as import("@dpf/db").Prisma.InputJsonValue, status: "proposed",
         },
@@ -1397,6 +1408,7 @@ export async function sendMessage(input: {
     data: {
       threadId: input.threadId,
       role: "assistant",
+      taskRunId: currentTaskRun?.taskRunId ?? null,
       content: responseContent,
       agentId: agent.agentId,
       routeContext: input.routeContext,


### PR DESCRIPTION
The `AgentMessage.taskRunId` and `AgentActionProposal.taskRunId` columns and indexes already exist on main (in the schema, with `@@index([taskRunId, createdAt])` and `@@index([taskRunId])` respectively), but the code path that creates these rows from coworker chat — `sendMessage` in `agent-coworker.ts` — never populated them. Every assistant message and every proposal row created from a thread had `taskRunId = NULL`, breaking the audit-trail link between TaskRun and the agent actions spawned during it.

Look up the active TaskRun for the (userId, threadId) pair at the start of `sendMessage`, then stamp its ID on:
  - The AgentMessage row created for the proposal-path assistant response
  - The AgentMessage row created for the regular assistant response
  - Any AgentActionProposal row created from tool calls in that turn

The lookup is best-effort (`.catch(() => null)`); if there's no active TaskRun the fields stay null, matching the existing behavior.

Test added to `agent-coworker-external.test.ts` covers the proposal stamping path with a mocked taskRun.findFirst returning an active run.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
