### PR TITLE
feat(storefront): DPF on DPF — Customer 0 production instance foundation

### DIFF
--- a/apps/web/app/(shell)/storefront/inbox/page.tsx
+++ b/apps/web/app/(shell)/storefront/inbox/page.tsx
@@ -6,7 +6,7 @@ export default async function InboxPage() {
   const config = await prisma.storefrontConfig.findFirst({ select: { id: true } });
   if (!config) redirect("/storefront/setup");
 
-  const [inquiries, bookings, orders, donations, providerList] = await Promise.all([
+  const [inquiries, bookings, orders, donations, providerList, digitalProducts] = await Promise.all([
     prisma.storefrontInquiry.findMany({
       where: { storefrontId: config.id },
       orderBy: { createdAt: "desc" },
@@ -65,6 +65,15 @@ export default async function InboxPage() {
       select: { id: true, name: true },
       orderBy: { sortOrder: "asc" },
     }),
+    prisma.digitalProduct.findMany({
+      select: {
+        id: true,
+        name: true,
+        lifecycleStage: true,
+      },
+      orderBy: [{ name: "asc" }],
+      take: 20,
+    }),
   ]);
 
   type InboxEntry = {
@@ -77,7 +86,23 @@ export default async function InboxPage() {
     createdAt: string;
     providerName: string | null;
     status: string;
+    backlogItemId?: string | null;
   };
+
+  const inquiryBacklogItemIds = new Map(
+    (
+      await prisma.backlogItem.findMany({
+        where: {
+          itemId: {
+            in: inquiries.map((inquiry) => `BI-SFI-${inquiry.inquiryRef.replace(/[^a-zA-Z0-9]/g, "").toUpperCase()}`),
+          },
+        },
+        select: {
+          itemId: true,
+        },
+      })
+    ).map((item) => [item.itemId, item.itemId]),
+  );
 
   const entries: InboxEntry[] = [
     ...inquiries.map((inquiry) => ({
@@ -90,6 +115,10 @@ export default async function InboxPage() {
       createdAt: inquiry.createdAt.toISOString(),
       providerName: null,
       status: "",
+      backlogItemId:
+        inquiryBacklogItemIds.get(
+          `BI-SFI-${inquiry.inquiryRef.replace(/[^a-zA-Z0-9]/g, "").toUpperCase()}`,
+        ) ?? null,
     })),
     ...bookings.map((booking) => ({
       id: booking.id,
@@ -126,5 +155,20 @@ export default async function InboxPage() {
     })),
   ].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-  return <StorefrontInbox entries={entries} providers={providerList} />;
+  const defaultDigitalProduct =
+    digitalProducts.find((product) => product.name === "Open Digital Product Factory") ??
+    digitalProducts[0] ??
+    null;
+
+  return (
+    <StorefrontInbox
+      entries={entries}
+      providers={providerList}
+      defaultDigitalProduct={
+        defaultDigitalProduct
+          ? { id: defaultDigitalProduct.id, name: defaultDigitalProduct.name }
+          : null
+      }
+    />
+  );
 }

--- a/apps/web/app/(shell)/storefront/settings/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { redirect } from "next/navigation";
+import { applyDpfProductionInstancePreset } from "@/lib/actions/dpf-production-instance";
 
 export default async function StorefrontSettingsPage() {
   const config = await prisma.storefrontConfig.findFirst({
@@ -16,6 +17,12 @@ export default async function StorefrontSettingsPage() {
     },
   });
   if (!config) redirect("/storefront/setup");
+
+  async function applyDpfPreset() {
+    "use server";
+    await applyDpfProductionInstancePreset();
+    redirect("/storefront/settings");
+  }
 
   async function updateSettings(formData: FormData) {
     "use server";
@@ -125,6 +132,40 @@ export default async function StorefrontSettingsPage() {
       >
         Save Changes
       </button>
+
+      <div
+        style={{
+          marginTop: 16,
+          padding: "16px",
+          borderRadius: 8,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-1)",
+        }}
+      >
+        <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4, color: "var(--dpf-text)" }}>
+          DPF production-instance preset
+        </div>
+        <p style={{ fontSize: 12, color: "var(--dpf-muted)", marginBottom: 12 }}>
+          Internal support action for converting this install toward Open Digital Product Factory customer-zero truth. This does not change archetype; use the admin archetype reset first when needed.
+        </p>
+        <form action={applyDpfPreset}>
+          <button
+            type="submit"
+            style={{
+              padding: "8px 20px",
+              borderRadius: 6,
+              border: "1px solid var(--dpf-border)",
+              background: "var(--dpf-surface-2)",
+              color: "var(--dpf-text)",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            Apply DPF preset
+          </button>
+        </form>
+      </div>
 
       <div
         style={{

--- a/apps/web/app/(storefront)/s/[slug]/inquire/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/page.tsx
@@ -18,9 +18,18 @@ export default async function InquirePage({
   const storefront = await getPublicStorefront(slug);
   if (!storefront) notFound();
 
+  const isSoftwarePlatform = storefront.archetypeId === "software-platform";
+
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 24 }}>Get in Touch</h1>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>
+        {isSoftwarePlatform ? "Start a DPF conversation" : "Get in Touch"}
+      </h1>
+      <p style={{ fontSize: 14, color: "var(--dpf-muted)", marginBottom: 24 }}>
+        {isSoftwarePlatform
+          ? "Tell us about your current product operation, delivery workflow, or customer-zero goals and we will route the conversation through the platform."
+          : "Share what you need and we will route your inquiry to the right team."}
+      </p>
       <InquiryForm orgSlug={slug} formSchema={DEFAULT_INQUIRY_SCHEMA} />
     </div>
   );

--- a/apps/web/app/(storefront)/s/[slug]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/page.tsx
@@ -13,6 +13,29 @@ export default async function StorefrontHomePage({
 
   return (
     <div>
+      {storefront.archetypeId === "software-platform" && (
+        <section
+          style={{
+            margin: "0 auto 32px",
+            maxWidth: 960,
+            padding: "20px 24px",
+            borderRadius: 16,
+            border: "1px solid var(--dpf-border)",
+            background: "linear-gradient(135deg, var(--dpf-surface-1), var(--dpf-surface-2))",
+            color: "var(--dpf-text)",
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--dpf-muted)" }}>
+            Customer-Zero Production Instance
+          </div>
+          <h1 style={{ margin: "8px 0 10px", fontSize: 32, lineHeight: 1.1 }}>
+            {storefront.orgName}
+          </h1>
+          <p style={{ margin: 0, maxWidth: 720, fontSize: 16, color: "var(--dpf-muted)" }}>
+            {storefront.description ?? storefront.tagline ?? "Run your digital product operation on the platform that runs itself."}
+          </p>
+        </section>
+      )}
       {storefront.sections.map((section) => (
         <SectionRenderer
           key={section.id}

--- a/apps/web/app/api/storefront/admin/archetype-reset/route.test.ts
+++ b/apps/web/app/api/storefront/admin/archetype-reset/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { mockAuth, mockOrganization, mockReset } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockOrganization: { findFirst: vi.fn() },
+  mockReset: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
+vi.mock("@dpf/db", () => ({
+  prisma: { organization: mockOrganization },
+}));
+vi.mock("@/lib/storefront/archetype-reset", () => ({
+  resetStorefrontArchetype: mockReset,
+}));
+
+import { POST } from "./route";
+
+function makeReq(body: unknown): NextRequest {
+  return new Request("http://test/api/storefront/admin/archetype-reset", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockOrganization.findFirst.mockReset();
+  mockReset.mockReset();
+
+  mockAuth.mockResolvedValue({ user: { type: "admin" } });
+  mockOrganization.findFirst.mockResolvedValue({ id: "org_1" });
+  mockReset.mockResolvedValue({
+    storefrontId: "sf_1",
+    archetypeId: "software-platform",
+    category: "software-platform",
+    sectionsCreated: 2,
+    itemsCreated: 3,
+  });
+});
+
+describe("POST /api/storefront/admin/archetype-reset", () => {
+  it("returns 401 for non-admin", async () => {
+    mockAuth.mockResolvedValue({ user: { type: "user" } });
+    const res = await POST(makeReq({ targetArchetypeId: "software-platform" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when target archetype is missing", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with reset summary for admin", async () => {
+    const res = await POST(makeReq({ targetArchetypeId: "software-platform" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.result.archetypeId).toBe("software-platform");
+    expect(mockReset).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      targetArchetypeId: "software-platform",
+      mode: "replace-seeded-content",
+    });
+  });
+});

--- a/apps/web/app/api/storefront/admin/archetype-reset/route.ts
+++ b/apps/web/app/api/storefront/admin/archetype-reset/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { resetStorefrontArchetype } from "@/lib/storefront/archetype-reset";
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { targetArchetypeId } = (await req.json()) as {
+    targetArchetypeId?: string;
+  };
+
+  if (!targetArchetypeId) {
+    return NextResponse.json({ error: "targetArchetypeId is required" }, { status: 400 });
+  }
+
+  const organization = await prisma.organization.findFirst({
+    select: { id: true },
+  });
+
+  if (!organization) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 400 });
+  }
+
+  try {
+    const result = await resetStorefrontArchetype({
+      organizationId: organization.id,
+      targetArchetypeId,
+      mode: "replace-seeded-content",
+    });
+
+    return NextResponse.json({ success: true, result });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Archetype reset failed" },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts
+++ b/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const {
+  mockAuth,
+  mockCan,
+  mockStorefrontInquiry,
+  mockDigitalProduct,
+  mockBacklogItem,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+  mockStorefrontInquiry: { findUnique: vi.fn() },
+  mockDigitalProduct: { findUnique: vi.fn() },
+  mockBacklogItem: { findUnique: vi.fn(), create: vi.fn() },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/permissions", () => ({ can: mockCan }));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    storefrontInquiry: mockStorefrontInquiry,
+    digitalProduct: mockDigitalProduct,
+    backlogItem: mockBacklogItem,
+  },
+}));
+
+import { POST } from "./route";
+
+function makeReq(body: unknown): NextRequest {
+  return new Request("http://test/api/storefront/admin/inquiries/inquiry_1/product-backlog", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockCan.mockReset();
+  mockStorefrontInquiry.findUnique.mockReset();
+  mockDigitalProduct.findUnique.mockReset();
+  mockBacklogItem.findUnique.mockReset();
+  mockBacklogItem.create.mockReset();
+
+  mockAuth.mockResolvedValue({
+    user: { id: "user_1", platformRole: "HR-000", isSuperuser: true },
+  });
+  mockCan.mockReturnValue(true);
+  mockStorefrontInquiry.findUnique.mockResolvedValue({
+    id: "inquiry_1",
+    inquiryRef: "INQ-0001",
+    customerName: "Jane Prospect",
+    customerEmail: "jane@example.com",
+    message: "I want to use DPF to run product operations.",
+    storefront: {
+      businessName: "Open Digital Product Factory",
+      publicSlug: "open-digital-product-factory",
+    },
+  });
+  mockDigitalProduct.findUnique.mockResolvedValue({
+    id: "dp_1",
+    name: "Open Digital Product Factory",
+  });
+  mockBacklogItem.findUnique.mockResolvedValue(null);
+  mockBacklogItem.create.mockResolvedValue({
+    id: "backlog_1",
+    itemId: "BI-SFI-INQ0001",
+    title: "Customer-zero product inquiry INQ-0001",
+    status: "triaging",
+  });
+});
+
+describe("POST /api/storefront/admin/inquiries/[id]/product-backlog", () => {
+  it("returns 401 when the user cannot manage backlog", async () => {
+    mockCan.mockReturnValue(false);
+
+    const res = await POST(makeReq({ digitalProductId: "dp_1" }), {
+      params: Promise.resolve({ id: "inquiry_1" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when digitalProductId is missing", async () => {
+    const res = await POST(makeReq({}), {
+      params: Promise.resolve({ id: "inquiry_1" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a triaging backlog item from the inquiry", async () => {
+    const res = await POST(makeReq({ digitalProductId: "dp_1" }), {
+      params: Promise.resolve({ id: "inquiry_1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.created).toBe(true);
+    expect(body.backlogItem.itemId).toBe("BI-SFI-INQ0001");
+    expect(mockBacklogItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "triaging",
+          source: "user-request",
+          digitalProductId: "dp_1",
+        }),
+      }),
+    );
+  });
+
+  it("returns the existing backlog item instead of duplicating it", async () => {
+    mockBacklogItem.findUnique.mockResolvedValue({
+      id: "backlog_1",
+      itemId: "BI-SFI-INQ0001",
+      title: "Customer-zero product inquiry INQ-0001",
+      status: "triaging",
+    });
+
+    const res = await POST(makeReq({ digitalProductId: "dp_1" }), {
+      params: Promise.resolve({ id: "inquiry_1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.created).toBe(false);
+    expect(mockBacklogItem.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.ts
+++ b/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { createStorefrontInquiryBacklogDraft } from "@/lib/governed-backlog-workflow";
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "manage_backlog",
+    )
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const body = (await req.json().catch(() => ({}))) as {
+    digitalProductId?: string;
+  };
+
+  if (!body.digitalProductId) {
+    return NextResponse.json(
+      { error: "digitalProductId is required to create a product backlog item" },
+      { status: 400 },
+    );
+  }
+
+  const [inquiry, digitalProduct] = await Promise.all([
+    prisma.storefrontInquiry.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        inquiryRef: true,
+        customerName: true,
+        customerEmail: true,
+        message: true,
+      },
+    }),
+    prisma.digitalProduct.findUnique({
+      where: { id: body.digitalProductId },
+      select: { id: true, name: true },
+    }),
+  ]);
+
+  if (!inquiry) {
+    return NextResponse.json({ error: "Inquiry not found" }, { status: 404 });
+  }
+
+  if (!digitalProduct) {
+    return NextResponse.json({ error: "Digital product not found" }, { status: 400 });
+  }
+
+  const draft = createStorefrontInquiryBacklogDraft({
+    inquiryId: inquiry.id,
+    inquiryRef: inquiry.inquiryRef,
+    customerName: inquiry.customerName,
+    customerEmail: inquiry.customerEmail,
+    message: inquiry.message,
+    itemLabel: digitalProduct.name,
+  });
+
+  const existing = await prisma.backlogItem.findUnique({
+    where: { itemId: draft.itemId },
+    select: { id: true, itemId: true, title: true, status: true },
+  });
+
+  if (existing) {
+    return NextResponse.json({
+      success: true,
+      created: false,
+      backlogItem: existing,
+      signal: draft.signalLabel,
+    });
+  }
+
+  const backlogItem = await prisma.backlogItem.create({
+    data: {
+      itemId: draft.itemId,
+      title: draft.title,
+      type: draft.type,
+      status: draft.status,
+      source: draft.source,
+      priority: draft.priority,
+      body: draft.body,
+      digitalProductId: digitalProduct.id,
+      submittedById: user.id,
+    },
+    select: {
+      id: true,
+      itemId: true,
+      title: true,
+      status: true,
+    },
+  });
+
+  return NextResponse.json({
+    success: true,
+    created: true,
+    backlogItem,
+    signal: draft.signalLabel,
+    recommendedTriageOutcome: draft.recommendedTriageOutcome,
+  });
+}

--- a/apps/web/components/storefront-admin/SetupWizard.tsx
+++ b/apps/web/components/storefront-admin/SetupWizard.tsx
@@ -312,7 +312,7 @@ export function SetupWizard({
           >
             <div style={{ fontWeight: 600, marginBottom: 4 }}>Can't find your business?</div>
             <div style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
-              Define a custom business model. Your template can also be contributed back to help others.
+              Define a custom operating model. Your template can also be contributed back to help others, including software-platform and customer-zero installs.
             </div>
           </button>
         </div>
@@ -325,9 +325,9 @@ export function SetupWizard({
   if (step === "custom") {
     return (
       <div style={{ maxWidth: 520, color: "var(--dpf-text)" }}>
-        <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 4 }}>Define your business model</h2>
+        <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 4 }}>Define your operating model</h2>
         <p style={{ fontSize: 13, color: "var(--dpf-muted)", marginBottom: 16 }}>
-          Tell us about your business and we'll create a custom template.
+          Tell us about your business or platform and we'll create a template that matches how you operate and what you sell.
         </p>
 
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -11,6 +11,7 @@ type Entry = {
   createdAt: string;
   providerName: string | null;
   status: string;
+  backlogItemId?: string | null;
 };
 
 const TYPE_LABELS: Record<string, string> = {
@@ -40,12 +41,16 @@ function StatusBadge({ status }: { status: string }) {
 export function StorefrontInbox({
   entries,
   providers = [],
+  defaultDigitalProduct,
 }: {
   entries: Entry[];
   providers?: { id: string; name: string }[];
+  defaultDigitalProduct?: { id: string; name: string } | null;
 }) {
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [providerFilter, setProviderFilter] = useState<string>("all");
+  const [productBacklogState, setProductBacklogState] = useState<Record<string, string>>({});
+  const [pendingInquiryId, setPendingInquiryId] = useState<string | null>(null);
 
   const filtered = entries.filter((e) => {
     if (typeFilter !== "all" && e.type !== typeFilter) return false;
@@ -71,8 +76,69 @@ export function StorefrontInbox({
     window.location.reload();
   }
 
+  async function sendInquiryToProductBacklog(id: string) {
+    if (!defaultDigitalProduct) return;
+    setPendingInquiryId(id);
+    try {
+      const res = await fetch(`/api/storefront/admin/inquiries/${id}/product-backlog`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ digitalProductId: defaultDigitalProduct.id }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        throw new Error(body.error ?? "Failed to create backlog item");
+      }
+      setProductBacklogState((current) => ({
+        ...current,
+        [id]: body.backlogItem?.itemId ?? "Created",
+      }));
+    } catch (error) {
+      setProductBacklogState((current) => ({
+        ...current,
+        [id]: error instanceof Error ? error.message : "Failed to create backlog item",
+      }));
+    } finally {
+      setPendingInquiryId(null);
+    }
+  }
+
   return (
     <div>
+      {defaultDigitalProduct ? (
+        <div
+          style={{
+            marginBottom: 16,
+            padding: "12px 14px",
+            borderRadius: 8,
+            border: "1px solid var(--dpf-border)",
+            background: "var(--dpf-surface-2)",
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 700, color: "var(--dpf-text)" }}>
+            Customer-zero inquiry intake is wired to product backlog triage
+          </div>
+          <div style={{ marginTop: 4, fontSize: 12, color: "var(--dpf-muted)" }}>
+            Use <strong>Send to product backlog</strong> to capture DPF sales or product signals as triaging work for{" "}
+            {defaultDigitalProduct.name}.
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            marginBottom: 16,
+            padding: "12px 14px",
+            borderRadius: 8,
+            border: "1px solid var(--dpf-border)",
+            background: "var(--dpf-surface-2)",
+            color: "var(--dpf-muted)",
+            fontSize: 12,
+          }}
+        >
+          No digital product is configured yet, so storefront inquiries cannot be routed into the product backlog.
+        </div>
+      )}
+
       <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap", alignItems: "center" }}>
         {["all", "inquiry", "booking", "order", "donation"].map((t) => (
           <button
@@ -121,6 +187,19 @@ export function StorefrontInbox({
               <span style={{ fontSize: 11, fontWeight: 700, padding: "1px 6px", borderRadius: 3, background: "var(--dpf-surface-2)" }}>
                 {TYPE_LABELS[e.type] ?? e.type}
               </span>
+              {e.type === "inquiry" && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: "1px 7px",
+                    borderRadius: 10,
+                    background: "color-mix(in srgb, var(--dpf-accent) 14%, transparent)",
+                    color: "var(--dpf-accent)",
+                  }}
+                >
+                  Customer-zero signal
+                </span>
+              )}
               <span style={{ fontSize: 12, fontFamily: "monospace" }}>{e.ref}</span>
               {e.type === "booking" && e.status && <StatusBadge status={e.status} />}
               {e.type === "booking" && e.providerName && (
@@ -134,6 +213,45 @@ export function StorefrontInbox({
             </div>
             <div style={{ fontSize: 13 }}>{e.name ?? "Anonymous"} · {e.email}</div>
             {e.detail && <div style={{ fontSize: 12, color: "var(--dpf-muted)", marginTop: 2 }}>{e.detail}</div>}
+            {e.type === "inquiry" && (
+              <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
+                <button
+                  onClick={() => sendInquiryToProductBacklog(e.id)}
+                  disabled={!defaultDigitalProduct || pendingInquiryId === e.id}
+                  style={{
+                    padding: "3px 10px",
+                    borderRadius: 4,
+                    border: "1px solid var(--dpf-accent)",
+                    background: "none",
+                    color: "var(--dpf-accent)",
+                    cursor: !defaultDigitalProduct || pendingInquiryId === e.id ? "not-allowed" : "pointer",
+                    fontSize: 12,
+                    opacity: !defaultDigitalProduct || pendingInquiryId === e.id ? 0.6 : 1,
+                  }}
+                >
+                  {pendingInquiryId === e.id ? "Sending..." : "Send to product backlog"}
+                </button>
+                {e.backlogItemId && (
+                  <span style={{ fontSize: 12, color: "var(--dpf-success, #22c55e)" }}>
+                    Backlog item {e.backlogItemId}
+                  </span>
+                )}
+                {!e.backlogItemId && productBacklogState[e.id] && (
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: productBacklogState[e.id].startsWith("BI-")
+                        ? "var(--dpf-success, #22c55e)"
+                        : "var(--dpf-error, #ef4444)",
+                    }}
+                  >
+                    {productBacklogState[e.id].startsWith("BI-")
+                      ? `Backlog item ${productBacklogState[e.id]}`
+                      : productBacklogState[e.id]}
+                  </span>
+                )}
+              </div>
+            )}
             {e.type === "booking" && (
               <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
                 {e.status === "pending" && (

--- a/apps/web/components/storefront/InquiryForm.tsx
+++ b/apps/web/components/storefront/InquiryForm.tsx
@@ -89,7 +89,7 @@ export function InquiryForm({
       ))}
       <button type="submit" disabled={loading}
         style={{
-          padding: "10px 20px", background: "var(--dpf-accent, #4f46e5)", color: "var(--dpf-text)",
+          padding: "10px 20px", background: "var(--dpf-accent, #4f46e5)", color: "#fff",
           border: "none", borderRadius: 6, fontSize: 14, fontWeight: 600,
           cursor: loading ? "not-allowed" : "pointer",
         }}>

--- a/apps/web/lib/actions/dpf-production-instance.test.ts
+++ b/apps/web/lib/actions/dpf-production-instance.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    organization: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    businessContext: {
+      upsert: vi.fn(),
+    },
+    storefrontConfig: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+}));
+
+import { applyDpfProductionInstancePreset } from "./dpf-production-instance";
+
+describe("applyDpfProductionInstancePreset", () => {
+  beforeEach(() => {
+    mockPrisma.organization.findFirst.mockReset();
+    mockPrisma.organization.update.mockReset();
+    mockPrisma.businessContext.upsert.mockReset();
+    mockPrisma.storefrontConfig.findFirst.mockReset();
+    mockPrisma.storefrontConfig.update.mockReset();
+
+    mockPrisma.organization.findFirst.mockResolvedValue({ id: "org_1", slug: "managing-digital" });
+    mockPrisma.storefrontConfig.findFirst.mockResolvedValue({ id: "sf_1", organizationId: "org_1" });
+    mockPrisma.organization.update.mockImplementation(async ({ data }) => ({ id: "org_1", ...data }));
+    mockPrisma.businessContext.upsert.mockImplementation(async ({ create, update }) => ({ id: "bc_1", ...create, ...update }));
+    mockPrisma.storefrontConfig.update.mockImplementation(async ({ data }) => ({ id: "sf_1", ...data }));
+  });
+
+  it("updates Organization name, slug, and contact fields to DPF truth", async () => {
+    await applyDpfProductionInstancePreset();
+
+    expect(mockPrisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      data: expect.objectContaining({
+        name: "Open Digital Product Factory",
+        slug: "open-digital-product-factory",
+        website: "https://opendigitalproductfactory.com",
+        industry: "software-platform",
+      }),
+    });
+  });
+
+  it("updates BusinessContext to DPF operating-business truth", async () => {
+    await applyDpfProductionInstancePreset();
+
+    const call = mockPrisma.businessContext.upsert.mock.calls[0]?.[0];
+    expect(call?.where).toEqual({ organizationId: "org_1" });
+    expect(call?.create.organizationId).toBe("org_1");
+    expect(call?.create.description).toContain("Open Digital Product Factory");
+    expect(call?.create.targetMarket.toLowerCase()).toContain("organizations");
+    expect(call?.create.revenueModel).toBe("Platform subscriptions and services");
+    expect(call?.update.description).toContain("Open Digital Product Factory");
+    expect(call?.update.targetMarket.toLowerCase()).toContain("organizations");
+  });
+
+  it("updates StorefrontConfig presentation fields", async () => {
+    await applyDpfProductionInstancePreset();
+
+    expect(mockPrisma.storefrontConfig.update).toHaveBeenCalledWith({
+      where: { id: "sf_1" },
+      data: expect.objectContaining({
+        tagline: "Run your digital product operation on the platform that runs itself.",
+        contactEmail: "hello@opendigitalproductfactory.com",
+      }),
+    });
+  });
+
+  it("is idempotent when run twice", async () => {
+    const first = await applyDpfProductionInstancePreset();
+    const second = await applyDpfProductionInstancePreset();
+
+    expect(first.organization.slug).toBe("open-digital-product-factory");
+    expect(second.organization.slug).toBe("open-digital-product-factory");
+    expect(mockPrisma.organization.update).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.businessContext.upsert).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.storefrontConfig.update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/actions/dpf-production-instance.ts
+++ b/apps/web/lib/actions/dpf-production-instance.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+
+const DPF_PRESET = {
+  organization: {
+    name: "Open Digital Product Factory",
+    slug: "open-digital-product-factory",
+    website: "https://opendigitalproductfactory.com",
+    email: "hello@opendigitalproductfactory.com",
+    industry: "software-platform",
+  },
+  businessContext: {
+    description:
+      "Open Digital Product Factory uses DPF to market, sell, govern, and improve DPF as a real customer-zero production instance.",
+    targetMarket:
+      "Organizations that need an AI-native platform for governed digital product operations, delivery, and improvement.",
+    companySize: "small",
+    geographicScope: "international",
+    revenueModel: "Platform subscriptions and services",
+  },
+  storefront: {
+    tagline: "Run your digital product operation on the platform that runs itself.",
+    description:
+      "DPF is the AI-native operating platform for digital products, and this instance is the real production system Open Digital Product Factory uses to run and improve DPF itself.",
+    contactEmail: "hello@opendigitalproductfactory.com",
+  },
+} as const;
+
+export async function applyDpfProductionInstancePreset() {
+  const organization = await prisma.organization.findFirst({
+    select: { id: true, slug: true },
+  });
+
+  if (!organization) {
+    throw new Error("Organization not found");
+  }
+
+  const storefrontConfig = await prisma.storefrontConfig.findFirst({
+    where: { organizationId: organization.id },
+    select: { id: true, organizationId: true },
+  });
+
+  if (!storefrontConfig) {
+    throw new Error("Storefront configuration not found");
+  }
+
+  const updatedOrganization = await prisma.organization.update({
+    where: { id: organization.id },
+    data: DPF_PRESET.organization,
+  });
+
+  const updatedBusinessContext = await prisma.businessContext.upsert({
+    where: { organizationId: organization.id },
+    create: {
+      organizationId: organization.id,
+      customerSegments: [],
+      ...DPF_PRESET.businessContext,
+    },
+    update: DPF_PRESET.businessContext,
+  });
+
+  const updatedStorefront = await prisma.storefrontConfig.update({
+    where: { id: storefrontConfig.id },
+    data: DPF_PRESET.storefront,
+  });
+
+  return {
+    organization: updatedOrganization,
+    businessContext: updatedBusinessContext,
+    storefront: updatedStorefront,
+  };
+}

--- a/apps/web/lib/governed-backlog-workflow.test.ts
+++ b/apps/web/lib/governed-backlog-workflow.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { deriveLifecycleLabel } from "@/lib/governed-backlog-workflow";
+import {
+  createStorefrontInquiryBacklogDraft,
+  deriveLifecycleLabel,
+} from "@/lib/governed-backlog-workflow";
 
 describe("deriveLifecycleLabel", () => {
   it("returns Captured for triaging items without an outcome", () => {
@@ -80,5 +83,27 @@ describe("deriveLifecycleLabel", () => {
         governedBacklogEnabled: false,
       }),
     ).toBe("In Progress");
+  });
+
+  it("maps a storefront inquiry into customer-zero governed backlog intake metadata", () => {
+    expect(
+      createStorefrontInquiryBacklogDraft({
+        inquiryId: "inquiry_1",
+        inquiryRef: "INQ-1001",
+        customerName: "Jane Prospect",
+        customerEmail: "jane@example.com",
+        message: "We want to run our own digital product operation on DPF.",
+        storefrontLabel: "Open Digital Product Factory",
+        itemLabel: "Open Digital Product Factory",
+      }),
+    ).toMatchObject({
+      itemId: "BI-SFI-INQ1001",
+      title: "Customer-zero product inquiry INQ-1001",
+      type: "product",
+      status: "triaging",
+      source: "user-request",
+      signalLabel: "customer-zero",
+      recommendedTriageOutcome: "build",
+    });
   });
 });

--- a/apps/web/lib/governed-backlog-workflow.ts
+++ b/apps/web/lib/governed-backlog-workflow.ts
@@ -7,6 +7,28 @@ export type LifecycleLabel =
   | "Ready to Release"
   | "Done";
 
+type StorefrontInquirySignal = {
+  inquiryId: string;
+  inquiryRef: string;
+  customerName: string | null;
+  customerEmail: string;
+  message?: string | null;
+  storefrontLabel?: string | null;
+  itemLabel?: string | null;
+};
+
+export type StorefrontInquiryBacklogDraft = {
+  itemId: string;
+  title: string;
+  type: "product";
+  status: "triaging";
+  source: "user-request";
+  priority: number;
+  body: string;
+  recommendedTriageOutcome: "build";
+  signalLabel: "customer-zero";
+};
+
 type LifecycleBacklogItem = {
   status: string;
   triageOutcome?: string | null;
@@ -61,4 +83,40 @@ export function deriveLifecycleLabel(input: {
   }
 
   return null;
+}
+
+export function createStorefrontInquiryBacklogDraft(
+  inquiry: StorefrontInquirySignal,
+): StorefrontInquiryBacklogDraft {
+  const normalizedRef = inquiry.inquiryRef.replace(/[^a-zA-Z0-9]/g, "").toUpperCase();
+  const storefrontLine = inquiry.storefrontLabel
+    ? `Storefront: ${inquiry.storefrontLabel}`
+    : null;
+  const itemLine = inquiry.itemLabel ? `Interested item: ${inquiry.itemLabel}` : null;
+  const messageLine = inquiry.message?.trim()
+    ? `Inquiry detail:\n${inquiry.message.trim()}`
+    : "Inquiry detail:\nNo additional message provided.";
+
+  return {
+    itemId: `BI-SFI-${normalizedRef}`,
+    title: `Customer-zero product inquiry ${inquiry.inquiryRef}`,
+    type: "product",
+    status: "triaging",
+    source: "user-request",
+    priority: 2,
+    recommendedTriageOutcome: "build",
+    signalLabel: "customer-zero",
+    body: [
+      "Customer-zero intake captured from the storefront inquiry flow.",
+      `Inquiry ref: ${inquiry.inquiryRef}`,
+      `Inquiry row: ${inquiry.inquiryId}`,
+      `Prospect: ${inquiry.customerName?.trim() || "Unknown contact"} <${inquiry.customerEmail}>`,
+      storefrontLine,
+      itemLine,
+      messageLine,
+      "Recommended next step: triage as product work and decide whether it should become a governed Build Studio effort.",
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+  };
 }

--- a/apps/web/lib/release/storefront-data.test.ts
+++ b/apps/web/lib/release/storefront-data.test.ts
@@ -83,4 +83,34 @@ describe("getPublicStorefront", () => {
     expect(result?.items).toHaveLength(1);
     expect(result?.items[0]?.name).toBe("Active");
   });
+
+  it("returns published software-platform storefront data without special-case breakage", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
+      ...mockStorefront,
+      tagline: "Run your digital product operation on the platform that runs itself.",
+      archetype: { archetypeId: "software-platform" },
+      items: [
+        {
+          id: "1",
+          itemId: "itm-1",
+          name: "Open Digital Product Factory",
+          ctaType: "inquiry",
+          sortOrder: 0,
+          description: "AI-native platform for governed delivery",
+          category: "Platform",
+          priceAmount: null,
+          priceCurrency: "GBP",
+          priceType: "quote",
+          imageUrl: null,
+          ctaLabel: "Start a conversation",
+          bookingConfig: null,
+        },
+      ],
+    } as never);
+
+    const result = await getPublicStorefront("acme-vet");
+    expect(result?.archetypeId).toBe("software-platform");
+    expect(result?.items[0]?.ctaType).toBe("inquiry");
+    expect(result?.items[0]?.name).toBe("Open Digital Product Factory");
+  });
 });

--- a/apps/web/lib/storefront/archetype-reset.test.ts
+++ b/apps/web/lib/storefront/archetype-reset.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockNanoid,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    $transaction: vi.fn(),
+  },
+  mockNanoid: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("nanoid", () => ({
+  nanoid: mockNanoid,
+}));
+
+import { resetStorefrontArchetype } from "./archetype-reset";
+
+describe("resetStorefrontArchetype", () => {
+  beforeEach(() => {
+    mockNanoid.mockReset();
+    mockPrisma.$transaction.mockReset();
+    mockNanoid.mockReturnValue("abcd1234");
+  });
+
+  it("re-syncs Organization.industry and BusinessContext.industry from the new archetype", async () => {
+    const tx = {
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({ id: "org_1", slug: "managing-digital", email: "ops@example.com", phone: "123" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({ id: "sf_1", organizationId: "org_1" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      businessContext: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "arch_1",
+          category: "software-platform",
+          ctaType: "inquiry",
+          sectionTemplates: [{ type: "hero", title: "Hero", sortOrder: 0 }],
+          itemTemplates: [{ name: "Open Digital Product Factory", description: "Platform", priceType: "quote", ctaType: "inquiry" }],
+        }),
+      },
+      storefrontSection: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 4 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontItem: {
+        findMany: vi.fn().mockResolvedValue([]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 6 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      providerService: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      bookingHold: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    await resetStorefrontArchetype({
+      organizationId: "org_1",
+      targetArchetypeId: "software-platform",
+      mode: "replace-seeded-content",
+    });
+
+    expect(tx.organization.update).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      data: { industry: "software-platform" },
+    });
+    expect(tx.businessContext.updateMany).toHaveBeenCalledWith({
+      where: { organizationId: "org_1" },
+      data: { industry: "software-platform", ctaType: "inquiry" },
+    });
+  });
+
+  it("replaces seeded items and sections when reset is run in replace mode", async () => {
+    const tx = {
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({ id: "org_1", slug: "old-slug", email: null, phone: null }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({ id: "sf_1", organizationId: "org_1" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      businessContext: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "arch_1",
+          category: "software-platform",
+          ctaType: "inquiry",
+          sectionTemplates: [
+            { type: "hero", title: "Hero", sortOrder: 0 },
+            { type: "items", title: "Platform Offers", sortOrder: 1 },
+          ],
+          itemTemplates: [
+            { name: "Open Digital Product Factory", description: "Platform", priceType: "quote", ctaType: "inquiry" },
+            { name: "Enablement", description: "Services", priceType: "quote", ctaType: "inquiry" },
+          ],
+        }),
+      },
+      storefrontSection: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 4 }),
+        createMany: vi.fn().mockResolvedValue({ count: 2 }),
+      },
+      storefrontItem: {
+        findMany: vi.fn().mockResolvedValue([{ id: "item_1" }, { id: "item_2" }]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 2 }),
+        createMany: vi.fn().mockResolvedValue({ count: 2 }),
+      },
+      providerService: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 2 }),
+      },
+      bookingHold: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    const result = await resetStorefrontArchetype({
+      organizationId: "org_1",
+      targetArchetypeId: "software-platform",
+      mode: "replace-seeded-content",
+    });
+
+    expect(tx.storefrontSection.deleteMany).toHaveBeenCalledWith({ where: { storefrontId: "sf_1" } });
+    expect(tx.storefrontSection.createMany).toHaveBeenCalled();
+    expect(tx.storefrontItem.deleteMany).toHaveBeenCalledWith({ where: { storefrontId: "sf_1" } });
+    expect(tx.storefrontItem.createMany).toHaveBeenCalled();
+    expect(result.sectionsCreated).toBe(2);
+    expect(result.itemsCreated).toBe(2);
+  });
+
+  it("preserves manually managed contact fields and org slug", async () => {
+    const tx = {
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({ id: "org_1", slug: "open-digital-product-factory", email: "ops@dpf.local", phone: "555-1234" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({ id: "sf_1", organizationId: "org_1" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      businessContext: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "arch_1",
+          category: "software-platform",
+          ctaType: "inquiry",
+          sectionTemplates: [{ type: "hero", title: "Hero", sortOrder: 0 }],
+          itemTemplates: [{ name: "Open Digital Product Factory", description: "Platform", priceType: "quote", ctaType: "inquiry" }],
+        }),
+      },
+      storefrontSection: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      storefrontItem: {
+        findMany: vi.fn().mockResolvedValue([]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      providerService: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      bookingHold: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    await resetStorefrontArchetype({
+      organizationId: "org_1",
+      targetArchetypeId: "software-platform",
+      mode: "replace-seeded-content",
+    });
+
+    expect(tx.organization.update).toHaveBeenCalledWith({
+      where: { id: "org_1" },
+      data: { industry: "software-platform" },
+    });
+  });
+
+  it("refuses to run when the target archetype is missing", async () => {
+    const tx = {
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({ id: "org_1" }),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn().mockResolvedValue({ id: "sf_1", organizationId: "org_1" }),
+      },
+      storefrontArchetype: {
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+    };
+
+    mockPrisma.$transaction.mockImplementation(async (fn: (trx: typeof tx) => Promise<unknown>) => fn(tx));
+
+    await expect(
+      resetStorefrontArchetype({
+        organizationId: "org_1",
+        targetArchetypeId: "software-platform",
+        mode: "replace-seeded-content",
+      }),
+    ).rejects.toThrow(/target archetype/i);
+  });
+});

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -1,0 +1,144 @@
+import { prisma } from "@dpf/db";
+import { nanoid } from "nanoid";
+
+type ResetMode = "replace-seeded-content";
+
+export async function resetStorefrontArchetype(input: {
+  organizationId: string;
+  targetArchetypeId: string;
+  mode: ResetMode;
+}) {
+  const { organizationId, targetArchetypeId, mode } = input;
+
+  return prisma.$transaction(async (tx) => {
+    const organization = await tx.organization.findUnique({
+      where: { id: organizationId },
+      select: { id: true },
+    });
+
+    if (!organization) {
+      throw new Error(`Organization ${organizationId} not found`);
+    }
+
+    const storefront = await tx.storefrontConfig.findUnique({
+      where: { organizationId },
+      select: { id: true, organizationId: true },
+    });
+
+    if (!storefront) {
+      throw new Error(`Storefront for organization ${organizationId} not found`);
+    }
+
+    const targetArchetype = await tx.storefrontArchetype.findUnique({
+      where: { archetypeId: targetArchetypeId },
+      select: {
+        id: true,
+        category: true,
+        ctaType: true,
+        sectionTemplates: true,
+        itemTemplates: true,
+      },
+    });
+
+    if (!targetArchetype) {
+      throw new Error(`Target archetype ${targetArchetypeId} not found`);
+    }
+
+    await tx.storefrontConfig.update({
+      where: { id: storefront.id },
+      data: { archetypeId: targetArchetype.id },
+    });
+
+    await tx.organization.update({
+      where: { id: organizationId },
+      data: { industry: targetArchetype.category },
+    });
+
+    await tx.businessContext.updateMany({
+      where: { organizationId },
+      data: {
+        industry: targetArchetype.category,
+        ctaType: targetArchetype.ctaType,
+      },
+    });
+
+    let sectionsCreated = 0;
+    let itemsCreated = 0;
+
+    if (mode === "replace-seeded-content") {
+      const existingItems = await tx.storefrontItem.findMany({
+        where: { storefrontId: storefront.id },
+        select: { id: true },
+      });
+      const existingItemIds = existingItems.map((item) => item.id);
+
+      if (existingItemIds.length > 0) {
+        await tx.providerService.deleteMany({
+          where: { itemId: { in: existingItemIds } },
+        });
+        await tx.bookingHold.deleteMany({
+          where: { itemId: { in: existingItemIds } },
+        });
+      }
+
+      await tx.storefrontSection.deleteMany({
+        where: { storefrontId: storefront.id },
+      });
+      await tx.storefrontItem.deleteMany({
+        where: { storefrontId: storefront.id },
+      });
+
+      const sectionTemplates = targetArchetype.sectionTemplates as Array<{
+        type: string;
+        title?: string | null;
+        sortOrder: number;
+      }>;
+      const itemTemplates = targetArchetype.itemTemplates as Array<{
+        name: string;
+        description?: string | null;
+        category?: string | null;
+        priceType?: string | null;
+        ctaType?: string | null;
+        ctaLabel?: string | null;
+      }>;
+
+      const sectionResult = await tx.storefrontSection.createMany({
+        data: sectionTemplates.map((section) => ({
+          storefrontId: storefront.id,
+          type: section.type,
+          title: section.title ?? null,
+          content: {},
+          sortOrder: section.sortOrder,
+          isVisible: true,
+        })),
+      });
+
+      const itemResult = await tx.storefrontItem.createMany({
+        data: itemTemplates.map((item, index) => ({
+          storefrontId: storefront.id,
+          itemId: `itm-${nanoid(8)}`,
+          name: item.name,
+          description: item.description ?? null,
+          category: item.category ?? null,
+          priceType: item.priceType ?? null,
+          priceCurrency: "GBP",
+          ctaType: item.ctaType ?? targetArchetype.ctaType,
+          ctaLabel: item.ctaLabel ?? null,
+          sortOrder: index,
+          isActive: true,
+        })),
+      });
+
+      sectionsCreated = sectionResult.count;
+      itemsCreated = itemResult.count;
+    }
+
+    return {
+      storefrontId: storefront.id,
+      archetypeId: targetArchetypeId,
+      category: targetArchetype.category,
+      sectionsCreated,
+      itemsCreated,
+    };
+  });
+}

--- a/apps/web/lib/storefront/industries.test.ts
+++ b/apps/web/lib/storefront/industries.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { INDUSTRY_OPTIONS, INDUSTRY_SLUGS, isIndustrySlug, industryLabel } from "./industries";
 
 describe("industries", () => {
-  it("exposes exactly the 11 canonical industries", () => {
-    expect(INDUSTRY_OPTIONS).toHaveLength(11);
+  it("exposes exactly the 12 canonical industries", () => {
+    expect(INDUSTRY_OPTIONS).toHaveLength(12);
     expect(INDUSTRY_SLUGS).toContain("healthcare-wellness");
     expect(INDUSTRY_SLUGS).toContain("hoa-property-management");
+    expect(INDUSTRY_SLUGS).toContain("software-platform");
   });
 
   it("slugs are kebab-case, never underscore", () => {
@@ -25,6 +26,7 @@ describe("industries", () => {
 
   it("industryLabel returns the label for known slugs, slug itself for unknown", () => {
     expect(industryLabel("beauty-personal-care")).toBe("Beauty & Personal Care");
+    expect(industryLabel("software-platform")).toBe("Software Platform");
     expect(industryLabel("unknown-slug")).toBe("unknown-slug");
     expect(industryLabel(null)).toBe("");
     expect(industryLabel(undefined)).toBe("");

--- a/apps/web/lib/storefront/industries.ts
+++ b/apps/web/lib/storefront/industries.ts
@@ -3,6 +3,7 @@ export const INDUSTRY_OPTIONS = [
   { value: "beauty-personal-care", label: "Beauty & Personal Care" },
   { value: "trades-maintenance", label: "Trades & Maintenance" },
   { value: "professional-services", label: "Professional Services" },
+  { value: "software-platform", label: "Software Platform" },
   { value: "education-training", label: "Education & Training" },
   { value: "pet-services", label: "Pet Services" },
   { value: "food-hospitality", label: "Food & Hospitality" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       postgres:
         condition: service_healthy
 
+  # Production-served runtime for the real install. Keep localhost:3000 reserved
+  # for this surface so customer-zero verification always targets the live path.
   portal:
     build:
       context: .
@@ -170,6 +172,7 @@ services:
   # Pool of N sandbox containers, each with its own workspace volume.
   # Pool size configurable via DPF_SANDBOX_POOL_SIZE env (default: 3).
   # Legacy dpf-sandbox-1 on port 3035 remains as fallback.
+  # This is the isolated build/runtime surface, not the production-served app.
   sandbox:
     build:
       context: .
@@ -373,6 +376,8 @@ services:
       postgres:
         condition: service_healthy
 
+  # Developer runtime surface. Use localhost:3001 for local non-production app
+  # work so localhost:3000 remains the production-served portal.
   dev-portal:
     build:
       context: .

--- a/docs/operations/dpf-production-runtime.md
+++ b/docs/operations/dpf-production-runtime.md
@@ -1,0 +1,19 @@
+# DPF Production Runtime
+
+This install runs with three distinct local runtime roles:
+
+- `http://localhost:3000` = production-served portal
+- `http://localhost:3001` = `dev-portal` developer runtime
+- `http://localhost:3035` = sandbox runtime / Build Studio isolation
+
+## Rules
+
+- Never use ad hoc `pnpm dev`, `next dev`, or `next start` on port `3000` for customer-zero verification.
+- Verify shipped behavior against the Docker `portal` service on `http://localhost:3000`.
+- Use `dev-portal` on `3001` for interactive developer runtime work when you need a local non-production app surface.
+- Use sandbox on `3035` for isolated Build Studio / governed build behavior.
+- Promote changes through branch, PR, verification, and rebuild flow rather than treating the production-served runtime as a scratch environment.
+
+## Why This Matters
+
+This machine hosts the real Open Digital Product Factory production instance. The runtime split is therefore not just a local developer convenience; it is part of the operating model DPF expects customers to follow as well.

--- a/docs/superpowers/plans/2026-04-25-dpf-on-dpf-production-instance.md
+++ b/docs/superpowers/plans/2026-04-25-dpf-on-dpf-production-instance.md
@@ -1,0 +1,698 @@
+# DPF on DPF Production Instance Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert this install into the real Open Digital Product Factory production instance, keep production runtime isolated from dev/build runtime, and use existing DPF surfaces to market, capture demand, and route customer-zero product work.
+
+**Architecture:** Keep the first slice narrow and truth-first. Reuse the existing storefront stack (`StorefrontConfig`, `StorefrontItem`, inquiry pages, inbox) for the sold-product layer, add a new canonical `software-platform` industry/archetype foundation so DPF is not forced into the training taxonomy, and introduce an admin/support reset path that safely re-homes an already-initialized install without pretending archetype is end-user editable. The runtime boundary stays aligned with Docker production on `localhost:3000`, dev overlay on `dev-portal` / `3001`, and sandbox runtime on `3035`.
+
+**Tech Stack:** Next.js App Router, TypeScript, Prisma/Postgres, Vitest, Docker Compose, existing storefront templates + setup routes
+
+---
+
+## Resolved Planning Decisions
+
+1. **Starter prospect loop:** `/s/[slug]` public storefront -> `/s/[slug]/inquire` inquiry capture -> `/storefront/inbox` operator handling -> governed backlog workflow for product follow-up.
+2. **Sold-product model for phase 1:** use existing `StorefrontItem` / `StorefrontSection` / `StorefrontConfig` instead of inventing a new product package model immediately.
+3. **Archetype collision resolution:** add a new canonical `software-platform` industry slug and a built-in DPF-oriented archetype rather than forcing `professional-services` or building a full user-facing archetype reset flow first.
+
+## File Map
+
+### Existing files to modify
+
+- `docker-compose.yml`
+  - Production/dev/sandbox runtime boundary already exists here; make it explicit and safe to operate.
+- `package.json`
+  - Add clear runtime scripts so local work does not default to production-port behavior.
+- `apps/web/lib/storefront/industries.ts`
+  - Canonical industry slug list.
+- `apps/web/lib/storefront/industries.test.ts`
+  - Verifies canonical industry slugs.
+- `packages/storefront-templates/src/archetypes/index.ts`
+  - Built-in archetype registry.
+- `packages/storefront-templates/src/archetypes/archetypes.test.ts`
+  - Verifies archetype catalog integrity.
+- `packages/db/src/seed-storefront-archetypes.ts`
+  - Upserts built-in storefront archetypes into the DB.
+- `packages/db/src/seed-storefront-archetypes.test.ts`
+  - Verifies seeding behavior / marketing skill defaults.
+- `apps/web/app/api/storefront/admin/setup/route.ts`
+  - Setup flow that seeds `StorefrontConfig`, `StorefrontItem`, `StorefrontSection`, and derived industry values.
+- `apps/web/app/api/business-context/setup/route.ts`
+  - Canonical business-context persistence used by settings.
+- `apps/web/components/admin/BusinessContextForm.tsx`
+  - Business identity / context form.
+- `apps/web/app/(shell)/storefront/settings/page.tsx`
+  - Live storefront presentation and org slug/settings.
+- `apps/web/app/(shell)/storefront/settings/business/page.tsx`
+  - Business-side settings page that hosts `BusinessContextForm`.
+- `apps/web/components/storefront-admin/SetupWizard.tsx`
+  - Setup copy and archetype selection UX.
+- `apps/web/components/storefront-admin/ItemsManager.tsx`
+  - Existing item-management surface that can host phase-1 sold-product content editing.
+- `apps/web/app/(storefront)/s/[slug]/page.tsx`
+  - Public storefront home.
+- `apps/web/app/(storefront)/s/[slug]/inquire/page.tsx`
+  - Public inquiry entry point.
+- `apps/web/components/storefront-admin/StorefrontInbox.tsx`
+  - Operator handling of inquiries/orders/bookings.
+- `apps/web/lib/governed-backlog-workflow.ts`
+  - Existing product-work conversion logic.
+- `tests/e2e/platform-qa-plan.md`
+  - Add customer-zero / storefront / setup verification cases.
+
+### New files to create
+
+- `packages/storefront-templates/src/archetypes/software-platform.ts`
+  - Built-in archetype/template for DPF as a software-platform seller/operator.
+- `apps/web/lib/storefront/archetype-reset.ts`
+  - Admin/support helper to swap an existing install from one archetype to another and re-sync derived fields safely.
+- `apps/web/lib/storefront/archetype-reset.test.ts`
+  - Unit tests for reset behavior and guardrails.
+- `apps/web/app/api/storefront/admin/archetype-reset/route.ts`
+  - Admin/support-only route to trigger the reset on an initialized install.
+- `apps/web/app/api/storefront/admin/archetype-reset/route.test.ts`
+  - Route auth/validation tests.
+- `apps/web/lib/actions/dpf-production-instance.ts`
+  - One focused server-side operation that applies the DPF production-instance preset (org/business/storefront/item truth) after archetype support exists.
+- `apps/web/lib/actions/dpf-production-instance.test.ts`
+  - Tests for preset application and idempotency.
+- `docs/operations/dpf-production-runtime.md`
+  - Operator doc explaining `3000` production, `3001` dev-portal, `3035` sandbox, and promotion flow.
+
+---
+
+## Chunk 1: Runtime Boundary and Canonical DPF Archetype
+
+### Task 1: Codify the production/dev runtime boundary
+
+**Files:**
+- Create: `docs/operations/dpf-production-runtime.md`
+- Modify: `docker-compose.yml`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the operator runtime matrix doc**
+
+Write `docs/operations/dpf-production-runtime.md` with:
+
+```md
+# DPF Production Runtime
+
+- `http://localhost:3000` = production-served portal
+- `http://localhost:3001` = `dev-portal` developer runtime
+- `http://localhost:3035` = sandbox runtime / Build Studio isolation
+
+Rules:
+- Never use `pnpm dev` on port 3000 for customer-zero verification
+- Verify shipped behavior against Docker `portal`
+- Promote changes through branch/PR + rebuild flow
+```
+
+- [ ] **Step 2: Make the boundary obvious in Compose**
+
+Update `docker-compose.yml` comments around:
+
+- `portal` (`3000`, `1455`)
+- `sandbox` (`3035`)
+- `dev-portal` (`3001`)
+
+Add a short comment block near `dev-portal` and `portal` that explicitly says `3000` is production-served and `3001` is the developer runtime.
+
+- [ ] **Step 3: Add explicit package scripts**
+
+Extend `package.json` scripts with names that match the runtime roles, for example:
+
+```json
+{
+  "scripts": {
+    "dev:web": "pnpm --filter web dev",
+    "dev:portal": "docker compose up -d dev-portal",
+    "dev:prod-runtime": "docker compose up -d portal",
+    "dev:sandbox": "docker compose up -d sandbox"
+  }
+}
+```
+
+Keep existing scripts intact; this task adds clarity, not a repo-wide script rename.
+
+- [ ] **Step 4: Verify the compose/runtime config**
+
+Run:
+
+```bash
+docker compose config > NUL
+pnpm --filter web typecheck
+```
+
+Expected:
+
+- `docker compose config` exits `0`
+- web typecheck still passes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/operations/dpf-production-runtime.md docker-compose.yml package.json
+git commit -s -m "docs(ops): codify DPF production runtime boundary"
+```
+
+### Task 2: Add a canonical `software-platform` industry and DPF archetype
+
+**Files:**
+- Modify: `apps/web/lib/storefront/industries.ts`
+- Modify: `apps/web/lib/storefront/industries.test.ts`
+- Create: `packages/storefront-templates/src/archetypes/software-platform.ts`
+- Modify: `packages/storefront-templates/src/archetypes/index.ts`
+- Modify: `packages/storefront-templates/src/archetypes/archetypes.test.ts`
+- Modify: `packages/db/src/seed-storefront-archetypes.ts`
+- Modify: `packages/db/src/seed-storefront-archetypes.test.ts`
+
+- [ ] **Step 1: Write the failing industry test**
+
+Add a case to `apps/web/lib/storefront/industries.test.ts`:
+
+```ts
+it("includes software-platform as a canonical industry slug", () => {
+  expect(INDUSTRY_SLUGS).toContain("software-platform");
+  expect(industryLabel("software-platform")).toBe("Software Platform");
+});
+```
+
+- [ ] **Step 2: Run the industry test to see it fail**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/storefront/industries.test.ts
+```
+
+Expected: failure because `software-platform` is not yet in `INDUSTRY_OPTIONS`.
+
+- [ ] **Step 3: Add the new industry slug**
+
+Update `apps/web/lib/storefront/industries.ts`:
+
+```ts
+{ value: "software-platform", label: "Software Platform" },
+```
+
+Keep the strongly-typed `IndustrySlug` pattern intact.
+
+- [ ] **Step 4: Write the failing archetype tests**
+
+Add test cases in:
+
+- `packages/storefront-templates/src/archetypes/archetypes.test.ts`
+- `packages/db/src/seed-storefront-archetypes.test.ts`
+
+Example expectations:
+
+```ts
+expect(ALL_ARCHETYPES.some((a) => a.category === "software-platform")).toBe(true);
+expect(ALL_ARCHETYPES.find((a) => a.category === "software-platform")?.ctaType).toBe("inquiry");
+```
+
+- [ ] **Step 5: Run the archetype tests to see them fail**
+
+Run:
+
+```bash
+pnpm --filter @dpf/storefront-templates exec vitest run src/archetypes/archetypes.test.ts
+pnpm --filter @dpf/db exec vitest run src/seed-storefront-archetypes.test.ts
+```
+
+Expected: failure because no `software-platform` archetype exists.
+
+- [ ] **Step 6: Add the built-in DPF archetype**
+
+Create `packages/storefront-templates/src/archetypes/software-platform.ts` with a focused template:
+
+```ts
+export const SOFTWARE_PLATFORM_ARCHETYPE = {
+  archetypeId: "software-platform",
+  name: "Software Platform",
+  category: "software-platform",
+  ctaType: "inquiry",
+  sectionTemplates: [
+    { type: "hero", title: "Hero", sortOrder: 0 },
+    { type: "features", title: "Capabilities", sortOrder: 1 },
+    { type: "proof", title: "Customer Zero", sortOrder: 2 },
+  ],
+  itemTemplates: [
+    { name: "Open Digital Product Factory", description: "AI-native platform for operating and improving digital products", priceType: "quote", ctaType: "inquiry" },
+  ],
+  tags: ["software", "platform", "operations", "ai"],
+  ...
+} as const;
+```
+
+Then export it from `packages/storefront-templates/src/archetypes/index.ts`.
+
+- [ ] **Step 7: Update DB seed expectations**
+
+In `packages/db/src/seed-storefront-archetypes.ts`, verify `MARKETING_SKILL_RULES` safely handles the new category. Add an explicit empty/default mapping only if needed for readability; do not special-case behavior without evidence.
+
+- [ ] **Step 8: Re-run archetype and industry tests**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/storefront/industries.test.ts
+pnpm --filter @dpf/storefront-templates exec vitest run src/archetypes/archetypes.test.ts
+pnpm --filter @dpf/db exec vitest run src/seed-storefront-archetypes.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/lib/storefront/industries.ts apps/web/lib/storefront/industries.test.ts packages/storefront-templates/src/archetypes/software-platform.ts packages/storefront-templates/src/archetypes/index.ts packages/storefront-templates/src/archetypes/archetypes.test.ts packages/db/src/seed-storefront-archetypes.ts packages/db/src/seed-storefront-archetypes.test.ts
+git commit -s -m "feat(storefront): add software platform archetype"
+```
+
+---
+
+## Chunk 2: Safe Reset and DPF Production-Instance Preset
+
+### Task 3: Add an admin/support archetype reset operation for initialized installs
+
+**Files:**
+- Create: `apps/web/lib/storefront/archetype-reset.ts`
+- Create: `apps/web/lib/storefront/archetype-reset.test.ts`
+- Create: `apps/web/app/api/storefront/admin/archetype-reset/route.ts`
+- Create: `apps/web/app/api/storefront/admin/archetype-reset/route.test.ts`
+- Modify: `apps/web/app/api/storefront/admin/setup/route.ts`
+
+- [ ] **Step 1: Write the failing reset helper tests**
+
+Create `apps/web/lib/storefront/archetype-reset.test.ts` with cases for:
+
+```ts
+it("re-syncs Organization.industry and BusinessContext.industry from the new archetype");
+it("replaces seeded items/sections when reset is run in replace mode");
+it("preserves manually managed contact fields and org slug");
+it("refuses to run when the target archetype is missing");
+```
+
+- [ ] **Step 2: Run the helper tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/storefront/archetype-reset.test.ts
+```
+
+Expected: failure because helper does not exist.
+
+- [ ] **Step 3: Implement the reset helper**
+
+Create `apps/web/lib/storefront/archetype-reset.ts` with a single entry point such as:
+
+```ts
+export async function resetStorefrontArchetype(input: {
+  organizationId: string;
+  targetArchetypeId: string;
+  mode: "replace-seeded-content";
+}) { ... }
+```
+
+Implementation responsibilities:
+
+- load current `Organization`, `StorefrontConfig`, `BusinessContext`
+- load target `StorefrontArchetype`
+- update `StorefrontConfig.archetypeId`
+- update derived `Organization.industry` / `BusinessContext.industry` / `BusinessContext.ctaType`
+- replace seeded `StorefrontSection` / `StorefrontItem` rows in one transaction
+- preserve org slug, contact details, and non-derived business text unless explicitly overwritten later
+
+- [ ] **Step 4: Add the admin/support route**
+
+Create `apps/web/app/api/storefront/admin/archetype-reset/route.ts`:
+
+```ts
+POST /api/storefront/admin/archetype-reset
+{
+  "targetArchetypeId": "software-platform"
+}
+```
+
+Behavior:
+
+- admin-only auth
+- resolves current organization
+- calls `resetStorefrontArchetype`
+- returns JSON summary of changed rows
+
+- [ ] **Step 5: Add route tests**
+
+Create `route.test.ts` covering:
+
+```ts
+it("returns 401 for non-admin");
+it("returns 400 when target archetype is missing");
+it("returns 200 with reset summary for admin");
+```
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/storefront/archetype-reset.test.ts apps/web/app/api/storefront/admin/archetype-reset/route.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: tests and typecheck pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/storefront/archetype-reset.ts apps/web/lib/storefront/archetype-reset.test.ts apps/web/app/api/storefront/admin/archetype-reset/route.ts apps/web/app/api/storefront/admin/archetype-reset/route.test.ts apps/web/app/api/storefront/admin/setup/route.ts
+git commit -s -m "feat(storefront): add admin archetype reset operation"
+```
+
+### Task 4: Add an idempotent DPF production-instance preset action
+
+**Files:**
+- Create: `apps/web/lib/actions/dpf-production-instance.ts`
+- Create: `apps/web/lib/actions/dpf-production-instance.test.ts`
+- Modify: `apps/web/app/api/business-context/setup/route.ts`
+- Modify: `apps/web/app/(shell)/storefront/settings/page.tsx`
+- Modify: `apps/web/app/(shell)/storefront/settings/business/page.tsx`
+
+- [ ] **Step 1: Write the failing preset tests**
+
+Create tests for:
+
+```ts
+it("updates Organization name/slug/contact fields to DPF truth");
+it("updates BusinessContext to DPF operating-business truth");
+it("updates StorefrontConfig presentation fields");
+it("is idempotent when run twice");
+```
+
+- [ ] **Step 2: Run the preset tests to see them fail**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/actions/dpf-production-instance.test.ts
+```
+
+- [ ] **Step 3: Implement the preset action**
+
+Create `apps/web/lib/actions/dpf-production-instance.ts` with a shape like:
+
+```ts
+export async function applyDpfProductionInstancePreset() {
+  return prisma.$transaction(async (tx) => {
+    // Update Organization
+    // Update BusinessContext
+    // Update StorefrontConfig
+    // Leave archetype reset to Task 3 helper
+  });
+}
+```
+
+Phase-1 preset content should include:
+
+- org name: `Open Digital Product Factory`
+- slug: a DPF slug agreed in execution (`open-digital-product-factory` unless live URL constraints require otherwise)
+- business description / target market / revenue model oriented around DPF as operator + sold platform
+- storefront tagline/description/contact fields aligned with the product
+
+- [ ] **Step 4: Expose it in an internal settings surface**
+
+Add a clearly labeled admin/support action on one existing settings page, for example:
+
+- `apps/web/app/(shell)/storefront/settings/page.tsx` or
+- `apps/web/app/(shell)/storefront/settings/business/page.tsx`
+
+The UI should make clear this is an internal support operation for the DPF install, not a generic end-user flow.
+
+- [ ] **Step 5: Preserve existing edit paths**
+
+Update `apps/web/app/api/business-context/setup/route.ts` only as needed so later manual edits do not undo archetype-derived rules. Keep industry derived from archetype, but allow DPF business text/contact fields to be edited safely.
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/actions/dpf-production-instance.test.ts apps/web/app/api/business-context/setup/route.test.ts
+pnpm --filter web typecheck
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/actions/dpf-production-instance.ts apps/web/lib/actions/dpf-production-instance.test.ts apps/web/app/api/business-context/setup/route.ts apps/web/app/(shell)/storefront/settings/page.tsx apps/web/app/(shell)/storefront/settings/business/page.tsx
+git commit -s -m "feat(storefront): add DPF production instance preset"
+```
+
+---
+
+## Chunk 3: Public Product Truth and Customer-Zero Flow
+
+### Task 5: Replace training-example storefront content with DPF product truth
+
+**Files:**
+- Modify: `apps/web/components/storefront-admin/ItemsManager.tsx`
+- Modify: `apps/web/components/storefront-admin/SetupWizard.tsx`
+- Modify: `apps/web/app/(storefront)/s/[slug]/page.tsx`
+- Modify: `apps/web/app/(storefront)/s/[slug]/inquire/page.tsx`
+- Modify: `apps/web/lib/release/storefront-data.test.ts`
+
+- [ ] **Step 1: Write the failing storefront-data test**
+
+Add or extend a test in `apps/web/lib/release/storefront-data.test.ts` to assert the storefront can carry software-platform copy without breaking public-storefront loading:
+
+```ts
+it("returns published software-platform storefront items and sections for the public slug", async () => {
+  expect(result?.items[0]?.ctaType).toBe("inquiry");
+});
+```
+
+- [ ] **Step 2: Run the storefront-data test**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/release/storefront-data.test.ts
+```
+
+- [ ] **Step 3: Tighten setup copy**
+
+Update `apps/web/components/storefront-admin/SetupWizard.tsx` so copy around business model / template selection does not imply only a generic SMB/services setup. Keep the template-first structure, but make room for “software platform” and “operator + sold product” language where appropriate.
+
+- [ ] **Step 4: Improve the public storefront experience for DPF**
+
+Update:
+
+- `apps/web/app/(storefront)/s/[slug]/page.tsx`
+- `apps/web/app/(storefront)/s/[slug]/inquire/page.tsx`
+
+Goals:
+
+- make the sold product legible as DPF, not a generic training offer
+- keep the first CTA focused on inquiry/demo/contact
+- ensure the inquiry page asks for the right product-conversation context
+
+Do not introduce a brand-new public IA in this task; stay within the existing storefront shape.
+
+- [ ] **Step 5: Ensure catalog editing is manageable**
+
+Update `apps/web/components/storefront-admin/ItemsManager.tsx` only if needed to make DPF item content easy to maintain after the preset runs. Keep the UI theme-aware and avoid introducing a new one-off editor.
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/release/storefront-data.test.ts
+pnpm --filter web typecheck
+pnpm --filter web build
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/components/storefront-admin/ItemsManager.tsx apps/web/components/storefront-admin/SetupWizard.tsx apps/web/app/(storefront)/s/[slug]/page.tsx apps/web/app/(storefront)/s/[slug]/inquire/page.tsx apps/web/lib/release/storefront-data.test.ts
+git commit -s -m "feat(storefront): convert public DPF product content"
+```
+
+### Task 6: Close the first customer-zero loop from inquiry to product work
+
+**Files:**
+- Modify: `apps/web/components/storefront-admin/StorefrontInbox.tsx`
+- Modify: `apps/web/app/(shell)/storefront/inbox/page.tsx`
+- Modify: `apps/web/lib/governed-backlog-workflow.ts`
+- Modify: `tests/e2e/platform-qa-plan.md`
+
+- [ ] **Step 1: Write the failing governed-backlog test**
+
+Add a focused test in the existing governed backlog test file or create one if needed to assert that a storefront inquiry can be normalized into product-work intake metadata.
+
+Example:
+
+```ts
+it("maps a storefront inquiry into a governed backlog intake payload tagged as customer-zero signal");
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/governed-backlog-workflow.test.ts
+```
+
+- [ ] **Step 3: Add the product-signal bridge**
+
+Extend `apps/web/lib/governed-backlog-workflow.ts` with a minimal adapter/helper that can accept storefront inquiry metadata and classify it as a customer-zero product signal. Keep this additive; do not redesign the whole governed backlog flow.
+
+- [ ] **Step 4: Make inbox handling legible**
+
+Update inbox surface files:
+
+- `apps/web/components/storefront-admin/StorefrontInbox.tsx`
+- `apps/web/app/(shell)/storefront/inbox/page.tsx`
+
+Add a small, explicit affordance for product/sales inquiries related to DPF (for example: tags, filter label, or “send to product backlog” action). Keep changes narrow and internal-facing.
+
+- [ ] **Step 5: Add QA cases**
+
+Add platform QA cases to `tests/e2e/platform-qa-plan.md` for:
+
+- DPF production runtime boundary check
+- storefront inquiry flow for DPF product interest
+- inbox handling of DPF inquiry
+- conversion of one DPF inquiry into governed backlog/product follow-up
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/governed-backlog-workflow.test.ts
+pnpm --filter web typecheck
+pnpm --filter web build
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/components/storefront-admin/StorefrontInbox.tsx apps/web/app/(shell)/storefront/inbox/page.tsx apps/web/lib/governed-backlog-workflow.ts tests/e2e/platform-qa-plan.md
+git commit -s -m "feat(storefront): connect DPF inquiries to product work"
+```
+
+---
+
+## Chunk 4: Live Conversion and Verification
+
+### Task 7: Apply the reset/preset to the live install and verify production paths
+
+**Files:**
+- Modify: none expected unless verification reveals a bug
+- Test: live runtime + DB checks
+
+- [ ] **Step 1: Seed the new archetype**
+
+Run:
+
+```bash
+pnpm --filter @dpf/db seed
+```
+
+Expected: `software-platform` archetype exists in the DB.
+
+- [ ] **Step 2: Rebuild the production runtime**
+
+Run:
+
+```bash
+docker compose build --no-cache portal portal-init sandbox
+docker compose up -d portal-init sandbox
+docker compose up -d portal
+```
+
+Expected: `portal` healthy on `http://localhost:3000`, sandbox healthy on `http://localhost:3035`.
+
+- [ ] **Step 3: Apply the admin/support reset + preset**
+
+Use the new internal route/action to:
+
+1. reset the install from `Corporate Training` to `software-platform`
+2. apply the DPF production-instance preset
+
+Then verify in DB:
+
+```sql
+SELECT name, slug, industry FROM "Organization";
+SELECT industry, "ctaType", "revenueModel" FROM "BusinessContext";
+SELECT "isPublished", tagline, description FROM "StorefrontConfig";
+SELECT name, "ctaType" FROM "StorefrontItem" ORDER BY "createdAt";
+```
+
+- [ ] **Step 4: Run focused automated checks**
+
+Run:
+
+```bash
+pnpm --filter web typecheck
+pnpm --filter web build
+```
+
+Expected: both pass before claiming completion.
+
+- [ ] **Step 5: Run UX verification against production**
+
+Verify against `http://localhost:3000`:
+
+1. `/storefront/settings` shows DPF truth
+2. `/storefront/settings/business` shows DPF business context
+3. `/s/<slug>` presents DPF as the sold product
+4. `/s/<slug>/inquire` captures a product inquiry
+5. `/storefront/inbox` shows the inquiry
+
+Also verify dev/runtime separation:
+
+1. `http://localhost:3000` remains the Docker production-served runtime
+2. `http://localhost:3001` serves dev-portal (if started)
+3. `http://localhost:3035` remains sandbox
+
+- [ ] **Step 6: Update backlog live**
+
+Create the epic:
+
+- `DPF on DPF: Production Instance and Customer-Zero Operationalization`
+
+Then create the first-slice backlog items that match this plan and mark completed items done as work lands.
+
+- [ ] **Step 7: Final commit / handoff**
+
+```bash
+git status
+```
+
+If clean and verified, either:
+
+- open/update PR for the branch, or
+- move into execution using `superpowers:subagent-driven-development`
+
+---
+
+## Verification Checklist
+
+- `pnpm --filter web exec vitest run apps/web/lib/storefront/industries.test.ts`
+- `pnpm --filter @dpf/storefront-templates exec vitest run src/archetypes/archetypes.test.ts`
+- `pnpm --filter @dpf/db exec vitest run src/seed-storefront-archetypes.test.ts`
+- `pnpm --filter web exec vitest run apps/web/lib/storefront/archetype-reset.test.ts apps/web/app/api/storefront/admin/archetype-reset/route.test.ts`
+- `pnpm --filter web exec vitest run apps/web/lib/actions/dpf-production-instance.test.ts apps/web/app/api/business-context/setup/route.test.ts`
+- `pnpm --filter web exec vitest run apps/web/lib/release/storefront-data.test.ts apps/web/lib/governed-backlog-workflow.test.ts`
+- `pnpm --filter web typecheck`
+- `pnpm --filter web build`
+- Manual UX verification on `http://localhost:3000`
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-25-dpf-on-dpf-production-instance.md`. Ready to execute?

--- a/docs/superpowers/specs/2026-04-25-dpf-on-dpf-production-instance-design.md
+++ b/docs/superpowers/specs/2026-04-25-dpf-on-dpf-production-instance-design.md
@@ -328,6 +328,8 @@ Define three explicit runtime roles:
 
 The user's concern about port `3000` is correct and should become policy.
 
+This formalizes guidance that already exists in `AGENTS.md` § "Portal Runtime & Navigation", which states that production-path verification must use the Docker-served app at `http://localhost:3000` and not stale ad hoc `next dev` / `next start` sessions. This spec extends that rule from a verification convention into an operating boundary for the install.
+
 Target rule:
 
 1. `localhost:3000` is reserved for the production-served runtime of this install
@@ -415,7 +417,21 @@ The sold-product representation should be treated as product/storefront/catalog 
 
 Current evidence suggests the live install still relies heavily on `StorefrontItem`-style catalog records rather than a broader first-class product packaging model. That is acceptable for the first slice if the content becomes truthful, but a later refactor may be needed so DPF product/package semantics are more explicit and reusable.
 
-### 10.4 Publication Boundary
+Planning prerequisite: open question 15.2 (whether the first sold-product representation can ride on `StorefrontItem` or needs a more explicit product/package model immediately) must be resolved before the first-slice replacement work in section 11.1 item 3 can be tasked. It is not a deferrable open question — the planner cannot write the catalog-replacement task without picking a model.
+
+### 10.4 Archetype Constraint and DPF Identity
+
+`StorefrontConfig.archetypeId` is the single source of truth for portal industry category and is treated as effectively write-once per the project rule in `CLAUDE.md` § "Portal Archetype". The live install's archetype is `Corporate Training` in category `education-training`, and none of the 11 canonical industries in `apps/web/lib/storefront/industries.ts` cleanly represents "software platform" or "digital product factory".
+
+This means converting business and sold-product identity from `Managing Digital`/training to Open Digital Product Factory cannot be done by editing copy alone — it collides with the archetype rule. The implementation plan must pick one of:
+
+1. add a new canonical industry slug (e.g. `software-platform` or `digital-products`) to `industries.ts` and seed a matching built-in archetype for DPF
+2. classify DPF under `professional-services` as the closest existing fit and accept the imprecision in vocabulary/finance defaults
+3. build the admin/support archetype-reset operation that `CLAUDE.md` describes but does not yet exist as a user-facing flow
+
+This is captured as a new open question in section 15.
+
+### 10.5 Publication Boundary
 
 Because `MarketingPublishedSnapshot` is not live in the current database, this design treats publication-boundary work as a dependency or follow-on slice, not as already available infrastructure.
 
@@ -426,9 +442,9 @@ The first slice should be a `customer-zero production spine`, not a full redesig
 ### 11.1 Scope
 
 1. establish runtime separation rules and local production/dev posture
-2. convert canonical business identity from generic/example state to Open Digital Product Factory
-3. convert sold-product storefront/catalog truth from training-example content to DPF product truth
-4. identify and route the initial real marketing/customer/sales loop through DPF-native surfaces
+2. convert canonical business identity from generic/example state to Open Digital Product Factory (gated on resolving the archetype-rule collision in section 10.4 and open question 15.5)
+3. convert sold-product storefront/catalog truth from training-example content to DPF product truth (gated on resolving the catalog-model decision in open question 15.2)
+4. identify and route the initial real marketing/customer/sales loop through DPF-native surfaces (see section 12 starter set)
 5. document how Build Studio and isolated development fit this install's production posture
 
 ### 11.2 Why this slice
@@ -444,6 +460,8 @@ This is the smallest slice that makes the install real:
 
 This work should be tracked under a new epic rather than folded into unrelated open epics.
 
+Overlap check: open and recently merged epic-adjacent work was reviewed against this scope, including the 2026-04-18 purpose-first product estate design, the customer marketing workspace phase 1 plan (2026-04-24), the external customer AI coworker design (2026-04-24), the build-studio governed backlog delivery design (2026-04-23), and the backlog → triage → Build Studio integration spec. Each of those is upstream infrastructure that this customer-zero work will exercise; none of them owns the operator/sold-product identity conversion or the production-vs-dev runtime boundary. A new epic is therefore appropriate.
+
 Recommended epic theme:
 
 - `DPF on DPF: Production Instance and Customer-Zero Operationalization`
@@ -456,6 +474,14 @@ Recommended first backlog items:
 4. define the minimum DPF-native marketing/customer/sales operating loop for this instance
 5. align Build Studio/local workflow guidance so production changes follow the same governed pattern sold to customers
 6. audit current setup UX for generic/example copy that conflicts with DPF-on-DPF operation
+
+Starter set for item 4 ("DPF-native surfaces"): the first prospect-to-customer loop should land on surfaces that already exist in the current branch/runtime truth, not on net-new concepts invented by the plan. Baseline candidates to evaluate during planning are:
+
+1. the public storefront/catalog as the prospect entry point
+2. the existing storefront inquiry/order flows and internal storefront inbox surfaces for conversion handling
+3. the governed backlog workflow (`apps/web/lib/governed-backlog-workflow.ts`) for converting customer signal into product work
+
+Adjacent in-progress work such as customer-assistant or customer-marketing modules may become follow-on candidates after they land, but they are not assumed as present in this plan's baseline. Open question 15.1 picks the concrete starter set.
 
 ## 13. Risks and Constraints
 
@@ -487,9 +513,10 @@ This first design is successful when:
 
 ## 15. Open Questions for Planning
 
-These are implementation-plan questions, not blockers for this design:
+These are implementation-plan questions. Items marked `(planning prerequisite)` must be answered before the corresponding first-slice work in section 11.1 can be tasked; the rest may be deferred into the plan itself.
 
-1. which exact DPF-native surfaces should own the first real prospect-to-customer loop
-2. whether the first sold-product representation can ride on `StorefrontItem` or needs a more explicit product/package model immediately
+1. which exact DPF-native surfaces should own the first real prospect-to-customer loop — pick from or extend the starter set in section 12 `(planning prerequisite for 11.1 item 4)`
+2. whether the first sold-product representation can ride on `StorefrontItem` or needs a more explicit product/package model immediately `(planning prerequisite for 11.1 item 3)`
 3. what the default local/external developer runtime matrix should be for this install
 4. how strongly the public-facing UX should narrate `DPF on DPF` in phase 1 versus letting it appear more subtly as proof
+5. how to satisfy the archetype-rule collision in section 10.4: add a new canonical industry slug for software/platform offerings, classify DPF under `professional-services`, or build the admin/support archetype-reset operation `(planning prerequisite for 11.1 item 2)`

--- a/docs/superpowers/specs/2026-04-25-dpf-on-dpf-production-instance-design.md
+++ b/docs/superpowers/specs/2026-04-25-dpf-on-dpf-production-instance-design.md
@@ -1,0 +1,495 @@
+| Field | Value |
+| --- | --- |
+| Date | 2026-04-25 |
+| Status | Draft |
+| Author | Codex + Mark Bodman |
+| Scope | Establish this install as the real Open Digital Product Factory production instance, separate it from development/runtime interference, and use it as customer-zero proof by running marketing, customer management, sales, and improvement work through DPF itself |
+
+## 1. Problem Statement
+
+This install is currently caught between two identities:
+
+1. a generic business using DPF
+2. the real Open Digital Product Factory business using DPF to market, sell, deliver, and improve DPF itself
+
+The user direction for this work is explicit:
+
+1. this instance should become the real production instance for Open Digital Product Factory
+2. DPF should be represented here both as the business operating the instance and as a sold product in the market taxonomy
+3. development activity must stop interfering with the production-served runtime on this machine
+4. the team should begin using DPF as customer zero, including Hive Mind and governed delivery patterns, so the platform improves by being used the way customers are expected to use it
+
+The primary goal is not storytelling polish. The primary goal is operational truth:
+
+1. production and development must be distinct
+2. DPF must be modeled correctly as the operator and sold product
+3. this instance must actually be used to market, manage customers, and sell
+4. the customer-zero story should emerge from that reality as a proof point
+
+## 2. Inputs and Grounding
+
+This spec is grounded in:
+
+- `AGENTS.md`
+- `docs/platform-usability-standards.md`
+- `docs/superpowers/specs/2026-04-18-purpose-first-product-estate-design.md`
+- `packages/db/prisma/schema.prisma`
+- `apps/web/components/storefront-admin/SetupWizard.tsx`
+
+Live runtime checks were performed against the Docker-backed PostgreSQL database on 2026-04-25.
+
+Verified live state:
+
+1. the only live `Organization` row is `Managing Digital` with slug `managing-digital`
+2. the live `StorefrontConfig` is published
+3. the live storefront archetype is `Corporate Training` in category `education-training`
+4. the live storefront still contains six training-oriented `StorefrontItem` rows such as `Leadership Training` and `Compliance Training`
+5. the live backlog has no dedicated epic yet for this production-instance / customer-zero work
+6. the current setup UX still contains generic business-model language such as `Define your business model`
+7. the current runtime schema file includes `MarketingPublishedSnapshot`, but the live database does not yet contain that table, so publication-boundary plans that depend on it are not live-ready yet
+
+Operational implication:
+
+- this install is still behaving more like a generic training-business example than the real Open Digital Product Factory production business
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+1. establish this install as the canonical production instance for Open Digital Product Factory
+2. keep production runtime and development/runtime experimentation clearly separated on the same machine
+3. model DPF as both:
+   - the real operating business on this install
+   - a sold product offering in the market taxonomy
+4. use DPF itself for real marketing, customer, sales, and internal improvement work
+5. make customer-zero operation a source of product truth and platform improvement
+6. align Build Studio and related governed-delivery behavior with the same isolation model customers should adopt
+
+### Non-Goals
+
+1. redesigning every product, CRM, or portal surface in one pass
+2. fully solving pricing, packaging, checkout, and release-management for all future DPF offerings
+3. pretending that incomplete publication-boundary features are already live
+4. merging business identity, sold-product taxonomy, and runtime workflow into one undifferentiated model
+
+## 4. Research & Benchmarking
+
+This design must follow the repo rule that new feature/system design be benchmarked before finalization.
+
+### 4.1 Open source systems reviewed
+
+#### GitLab
+
+Sources:
+
+- [GitLab dogfooding](https://about.gitlab.com/direction/dogfooding/)
+- [GitLab review apps](https://docs.gitlab.com/ci/review_apps/)
+- [Using review apps in the development of GitLab](https://docs.gitlab.com/development/testing_guide/review_apps/)
+
+What it teaches:
+
+1. dogfooding is strongest when it is tracked as a first-class operating practice, not just a marketing claim
+2. per-branch or per-merge isolated preview environments are a practical pattern for preventing development from colliding with production
+3. stakeholder-visible preview URLs reduce the temptation to test unfinished work against the production surface
+
+Patterns adopted:
+
+1. treat customer-zero usage as a managed operating model
+2. require isolated development/build environments before promotion to the production-served instance
+
+Patterns rejected:
+
+1. using the live production route as the default development sandbox
+
+#### ERPNext
+
+Sources:
+
+- [ERPNext homepage](https://erpnext.com/homepage)
+- [ERPNext docs](https://docs.erpnext.com/)
+
+What it teaches:
+
+1. a business platform becomes more credible when it clearly covers the real operating loop of the company using it
+2. product credibility rises when the platform is visibly used for order, customer, and operational workflows rather than only described abstractly
+
+Patterns adopted:
+
+1. this install should be used for real business operations, not remain a sample data shell
+2. the sold-product story should connect directly to operational modules and customer handling
+
+Patterns rejected:
+
+1. a purely brochure-style product story detached from the actual operating system
+
+#### Odoo
+
+Sources:
+
+- [Odoo](https://www.odoo.com/en_US)
+
+What it teaches:
+
+1. a unified business platform can legitimately present the same system as both business operating stack and productized offering
+2. the value proposition becomes clearer when marketing, CRM, sales, operations, and customization live in one coherent platform story
+
+Patterns adopted:
+
+1. keep one platform story across marketing, CRM, sales, and operations
+2. make the relationship between operating the business and selling the platform explicit rather than accidental
+
+Patterns rejected:
+
+1. forcing the user to mentally stitch together separate systems to understand how the business runs
+
+### 4.2 Commercial systems reviewed
+
+#### ServiceNow
+
+Sources:
+
+- [How ServiceNow uses ServiceNow](https://www.servicenow.com/company/how-servicenow-uses-servicenow.html)
+- [Customer zero: 4 ways we use ServiceNow tech internally](https://www.servicenow.com/blogs/2023/4-ways-we-use-servicenow-tech-internally)
+
+What it teaches:
+
+1. `customer zero` can be a credible operating principle when the company uses its own platform across customer experience, operations, and internal service delivery
+2. the strongest proof point is not just that the product is used internally, but that the company can point to specific operating loops run on it
+
+Patterns adopted:
+
+1. position DPF-on-DPF as real operating truth, not as a demo label
+2. make customer-facing and internal operations both part of the customer-zero scope
+
+Patterns rejected:
+
+1. vague claims of internal use without concrete workflow and governance implications
+
+#### Salesforce
+
+Sources:
+
+- [Salesforce on Salesforce](https://www.salesforce.com/salesforce-on-salesforce)
+- [Salesforce on Salesforce series](https://www.salesforce.com/blog/salesforce-on-salesforce/)
+
+What it teaches:
+
+1. a platform company can explicitly present itself as customer zero while also using that fact to drive conversion and trust
+2. unified data and workflow become more persuasive when internal use directly improves customer-facing experiences and sales execution
+
+Patterns adopted:
+
+1. use real internal adoption to improve lead handling, customer support, and product presentation
+2. let sales and operating truth reinforce each other
+
+Patterns rejected:
+
+1. keeping customer-facing sales flows separate from the operating system that should power them
+
+#### Atlassian
+
+Source:
+
+- [Dogfooding and frequent internal releases](https://www.atlassian.com/blog/archives/agile_development_dogfooding_and_frequent_internal_releases%24)
+
+What it teaches:
+
+1. external customer-visible systems should not be treated the same as rough internal milestone environments
+2. controlled external exposure matters when unfinished changes can alter customer trust
+
+Patterns adopted:
+
+1. preserve a stricter boundary for the customer-visible production-served runtime
+2. let earlier experimentation happen in isolated non-production environments
+
+Patterns rejected:
+
+1. assuming every internal dogfooding environment is suitable for public-facing use
+
+## 5. Current-State Diagnosis
+
+### 5.1 Identity mismatch
+
+The live install is still branded and modeled as `Managing Digital`, not Open Digital Product Factory.
+
+### 5.2 Sold-product mismatch
+
+The live storefront content still represents training offerings rather than DPF as the product being sold.
+
+### 5.3 Runtime-role mismatch
+
+The machine currently hosts a production-served portal at port `3000`, but the user explicitly called out that development behavior still risks interfering with that production path. The current repo workflow and Build Studio design already point toward isolated development/runtime paths, but this install is not yet operationalized around that rule.
+
+### 5.4 Customer-zero mismatch
+
+DPF is not yet being used here strongly enough as the real system for:
+
+1. product marketing
+2. customer management
+3. sales and inquiry handling
+4. governed self-improvement
+
+### 5.5 Publication-boundary mismatch
+
+The schema suggests movement toward a curated publication boundary (`MarketingPublishedSnapshot`), but the live DB proves that boundary is not yet active on this install. The design therefore cannot assume a finished publish pipeline for customer-safe product context.
+
+## 6. Design Principles
+
+### 6.1 Production First, Narrative Second
+
+The instance must first become the real operating production instance. The customer-zero story is evidence of that truth, not a substitute for it.
+
+### 6.2 One Business, Two Legitimate Roles
+
+DPF appears here in two roles:
+
+1. as the business operating the platform
+2. as a sold product offering in the market taxonomy
+
+These are related but must not be collapsed.
+
+### 6.3 Distinct Runtime Roles
+
+Production runtime, development runtime, and governed promotion flow are different concerns and must behave differently.
+
+### 6.4 Customer-Zero as Product Validation
+
+The platform should improve because DPF uses it to run itself, not because the team keeps bypassing platform workflows with ad hoc external tooling.
+
+### 6.5 Canonical Data Before Curated Copy
+
+Business identity, sold-product taxonomy, and operating workflows must be canonical in the data model before optimizing sales copy and narrative polish.
+
+### 6.6 Build Studio Is Part of the Proof
+
+The same isolation and governed-delivery behavior sold to customers should be exercised here. This includes isolated build/dev paths, promotion discipline, and protection of the production-served runtime.
+
+## 7. Target Model
+
+### 7.1 Three-Layer Instance Model
+
+This install should be understood through three layers.
+
+#### Layer 1: Operating Business Identity
+
+`Organization` remains the canonical model for the business running this install.
+
+Target state:
+
+1. the live organization should represent Open Digital Product Factory
+2. business context should describe the real business, market, and operating model of DPF
+
+#### Layer 2: Sold Product Taxonomy
+
+The sold-product layer should represent DPF as an offering, not as a side effect of the operator identity.
+
+Target state:
+
+1. the storefront/product taxonomy should present DPF offerings
+2. public-facing catalog and inquiry paths should reflect what DPF actually sells
+3. the public product story should make clear that DPF is available as a product/platform for other organizations
+
+#### Layer 3: Runtime and Improvement System
+
+The instance should visibly function as the system DPF uses to run and improve itself.
+
+Target state:
+
+1. marketing, customer, sales, and delivery work happen here
+2. governed change, Build Studio, and Hive Mind workflows are exercised here
+3. production remains protected while development occurs in isolated environments
+
+### 7.2 Canonical Relationship Between the Layers
+
+The UX and architecture should communicate:
+
+`Open Digital Product Factory uses DPF to build, run, market, sell, and improve DPF.`
+
+This is not duplication. It is customer-zero operation.
+
+## 8. Runtime Architecture and Environment Posture
+
+### 8.1 Runtime Roles
+
+Define three explicit runtime roles:
+
+1. `production-served runtime`
+   - customer- and operator-trusted live surface
+   - canonical local production route
+   - should remain stable and protected
+2. `development/build runtime`
+   - isolated local or external environment for active changes
+   - never the default customer-facing path
+3. `promotion path`
+   - the governed route from dev/build into production
+   - aligned with Build Studio, branch/PR, and validation rules
+
+### 8.2 Local Port and Surface Policy
+
+The user's concern about port `3000` is correct and should become policy.
+
+Target rule:
+
+1. `localhost:3000` is reserved for the production-served runtime of this install
+2. local development must use separate ports and/or separate isolated environments
+3. development workflows must not assume they can casually replace or hijack the production-served port
+
+This is both a local safety rule and a product requirement, because customers using DPF will need the same separation.
+
+### 8.3 Environment Isolation Expectations
+
+Supported development shapes should include:
+
+1. external development environments
+2. isolated local dev ports
+3. sandbox/build containers
+4. per-branch/workflow preview environments where applicable
+
+The important design constraint is not one specific tool. It is that production and in-progress work are never ambiguous.
+
+### 8.4 Build Studio Alignment
+
+Build Studio was designed to support this kind of governed separation. This install should use the same pattern it sells:
+
+1. isolated work/build path
+2. explicit verification
+3. governed promotion to production
+
+That makes DPF-on-DPF a real validation loop instead of an exception-ridden maintainer workflow.
+
+## 9. UX and Workflow Implications
+
+### 9.1 Business Setup
+
+The setup and business identity flow should stop feeling like a generic-company bootstrap.
+
+Target behavior:
+
+1. the instance identifies as Open Digital Product Factory
+2. setup language no longer implies a random example business
+3. the operating business and sold-product roles are both visible, but clearly distinguished
+
+### 9.2 Public Product Surface
+
+The public-facing surface should present DPF as the product offering.
+
+Target behavior:
+
+1. the live storefront/catalog no longer reads as a training-company example
+2. prospects can understand what DPF is, what it helps run, and how it is adopted
+3. inquiry/demo/contact or similar conversion paths align with the real product
+
+### 9.3 Customer and Sales Operations
+
+This instance should actually be used to manage real customer/prospect flow.
+
+Target behavior:
+
+1. inquiries and customer records are handled in DPF-native surfaces
+2. sales/customer workflows are not left in external ad hoc systems by default
+3. the customer-facing and internal business loops strengthen each other
+
+### 9.4 Customer-Zero Proof
+
+The public/customer-visible narrative should be curated, not noisy.
+
+Target behavior:
+
+1. buyers can understand that DPF runs on DPF
+2. the proof is visible as confidence and maturity
+3. unfinished internal experimentation is not exposed as if it were production truth
+
+## 10. Data Model Stewardship
+
+### 10.1 Canonical Operator Identity
+
+`Organization` remains the canonical business identity model.
+
+### 10.2 Canonical Business Context
+
+`BusinessContext` should describe the real DPF business rather than stale example-business content.
+
+### 10.3 Sold Product Representation
+
+The sold-product representation should be treated as product/storefront/catalog truth, not overloaded into `Organization` copy alone.
+
+Current evidence suggests the live install still relies heavily on `StorefrontItem`-style catalog records rather than a broader first-class product packaging model. That is acceptable for the first slice if the content becomes truthful, but a later refactor may be needed so DPF product/package semantics are more explicit and reusable.
+
+### 10.4 Publication Boundary
+
+Because `MarketingPublishedSnapshot` is not live in the current database, this design treats publication-boundary work as a dependency or follow-on slice, not as already available infrastructure.
+
+## 11. First Slice Recommendation
+
+The first slice should be a `customer-zero production spine`, not a full redesign.
+
+### 11.1 Scope
+
+1. establish runtime separation rules and local production/dev posture
+2. convert canonical business identity from generic/example state to Open Digital Product Factory
+3. convert sold-product storefront/catalog truth from training-example content to DPF product truth
+4. identify and route the initial real marketing/customer/sales loop through DPF-native surfaces
+5. document how Build Studio and isolated development fit this install's production posture
+
+### 11.2 Why this slice
+
+This is the smallest slice that makes the install real:
+
+1. it protects production
+2. it gives the business the correct identity
+3. it gives the sold product the correct identity
+4. it starts using DPF operationally
+
+## 12. Backlog Shape
+
+This work should be tracked under a new epic rather than folded into unrelated open epics.
+
+Recommended epic theme:
+
+- `DPF on DPF: Production Instance and Customer-Zero Operationalization`
+
+Recommended first backlog items:
+
+1. define and enforce local production-vs-dev runtime/port separation for this install
+2. update canonical organization and business context to Open Digital Product Factory live truth
+3. replace current training-example storefront/catalog content with DPF sold-product content
+4. define the minimum DPF-native marketing/customer/sales operating loop for this instance
+5. align Build Studio/local workflow guidance so production changes follow the same governed pattern sold to customers
+6. audit current setup UX for generic/example copy that conflicts with DPF-on-DPF operation
+
+## 13. Risks and Constraints
+
+### 13.1 Overloading one model
+
+If operator identity and sold-product taxonomy are merged into one data object, the system will become harder to reason about and extend.
+
+### 13.2 Fake customer-zero
+
+If the team keeps doing core marketing, sales, and improvement work outside DPF, the instance may tell a customer-zero story without actually validating the platform.
+
+### 13.3 Runtime confusion
+
+If local or external dev work continues to hijack the production-served route, this install will remain untrustworthy as a production reference.
+
+### 13.4 Assuming future-state infrastructure is already live
+
+The current gap between schema and live DB on publication-boundary tables is a reminder not to write aspirational architecture as if it is already enforced.
+
+## 14. Success Criteria
+
+This first design is successful when:
+
+1. the production-served runtime is distinct from development/build runtime in practice
+2. the live instance is canonically Open Digital Product Factory rather than a generic example business
+3. DPF is presented as the sold product in the market-facing taxonomy
+4. this instance is actually used to market, manage customers, and sell through DPF-native flows
+5. customer-zero proof emerges from real operation rather than curated theater
+
+## 15. Open Questions for Planning
+
+These are implementation-plan questions, not blockers for this design:
+
+1. which exact DPF-native surfaces should own the first real prospect-to-customer loop
+2. whether the first sold-product representation can ride on `StorefrontItem` or needs a more explicit product/package model immediately
+3. what the default local/external developer runtime matrix should be for this install
+4. how strongly the public-facing UX should narrate `DPF on DPF` in phase 1 versus letting it appear more subtly as proof

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "pnpm --filter web dev",
+    "dev:web": "pnpm --filter web dev",
+    "dev:portal": "docker compose up -d dev-portal",
+    "dev:prod-runtime": "docker compose up -d portal",
+    "dev:sandbox": "docker compose up -d sandbox",
     "build": "pnpm --filter web build",
     "test": "pnpm --filter web test && pnpm --filter @dpf/db test && pnpm --filter mobile test",
     "test:e2e": "playwright test",

--- a/packages/db/src/seed-storefront-archetypes.test.ts
+++ b/packages/db/src/seed-storefront-archetypes.test.ts
@@ -27,4 +27,28 @@ describe("seedStorefrontArchetypes", () => {
       profileType: "managed-service-provider",
     });
   });
+
+  it("upserts the software-platform archetype for DPF product installs", async () => {
+    const upsert = vi.fn().mockResolvedValue(undefined);
+    const prisma = {
+      storefrontArchetype: {
+        upsert,
+      },
+    } as never;
+
+    await seedStorefrontArchetypes(prisma);
+
+    const softwarePlatformCall = upsert.mock.calls.find(
+      ([args]) => args.where.archetypeId === "software-platform",
+    );
+
+    expect(softwarePlatformCall).toBeDefined();
+    expect(softwarePlatformCall?.[0].create.category).toBe("software-platform");
+    expect(softwarePlatformCall?.[0].create.ctaType).toBe("inquiry");
+    expect(softwarePlatformCall?.[0].create.itemTemplates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Open Digital Product Factory" }),
+      ]),
+    );
+  });
 });

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -48,4 +48,12 @@ describe("archetype catalog", () => {
     expect(msp?.activationProfile?.seededConfigurationItemTypes?.some((item) => item.key === "endpoint-security-license")).toBe(true);
     expect(msp?.activationProfile?.seededChargeModels?.some((model) => model.key === "pass_through")).toBe(true);
   });
+
+  it("includes a software-platform archetype for DPF-style product sellers", () => {
+    const softwarePlatform = ALL_ARCHETYPES.find((a) => a.archetypeId === "software-platform");
+    expect(softwarePlatform).toBeDefined();
+    expect(softwarePlatform?.category).toBe("software-platform");
+    expect(softwarePlatform?.ctaType).toBe("inquiry");
+    expect(softwarePlatform?.itemTemplates.some((item) => item.name === "Open Digital Product Factory")).toBe(true);
+  });
 });

--- a/packages/storefront-templates/src/archetypes/index.ts
+++ b/packages/storefront-templates/src/archetypes/index.ts
@@ -2,6 +2,7 @@ import { healthcareWellnessArchetypes } from "./healthcare-wellness";
 import { beautyPersonalCareArchetypes } from "./beauty-personal-care";
 import { tradesMaintenanceArchetypes } from "./trades-maintenance";
 import { professionalServicesArchetypes } from "./professional-services";
+import { softwarePlatformArchetypes } from "./software-platform";
 import { educationTrainingArchetypes } from "./education-training";
 import { petServicesArchetypes } from "./pet-services";
 import { foodHospitalityArchetypes } from "./food-hospitality";
@@ -15,6 +16,7 @@ export const ALL_ARCHETYPES = [
   ...beautyPersonalCareArchetypes,
   ...tradesMaintenanceArchetypes,
   ...professionalServicesArchetypes,
+  ...softwarePlatformArchetypes,
   ...educationTrainingArchetypes,
   ...petServicesArchetypes,
   ...foodHospitalityArchetypes,

--- a/packages/storefront-templates/src/archetypes/software-platform.ts
+++ b/packages/storefront-templates/src/archetypes/software-platform.ts
@@ -1,0 +1,61 @@
+import type { ArchetypeDefinition } from "../types";
+
+const PLATFORM_CONTACT_FIELDS = [
+  { name: "name", label: "Full name", type: "text" as const, required: true },
+  { name: "email", label: "Work email", type: "email" as const, required: true },
+  { name: "companyName", label: "Company name", type: "text" as const, required: false },
+  {
+    name: "teamSize",
+    label: "Team size",
+    type: "select" as const,
+    required: false,
+    options: ["1-10", "11-50", "51-200", "201-1000", "1000+"],
+  },
+  {
+    name: "currentSituation",
+    label: "What are you trying to improve?",
+    type: "textarea" as const,
+    required: false,
+  },
+];
+
+export const softwarePlatformArchetypes: ArchetypeDefinition[] = [
+  {
+    archetypeId: "software-platform",
+    name: "Software Platform",
+    category: "software-platform",
+    ctaType: "inquiry",
+    tags: ["software", "platform", "operations", "ai", "workflow"],
+    itemTemplates: [
+      {
+        name: "Open Digital Product Factory",
+        description: "AI-native platform for operating, improving, and governing digital product delivery.",
+        priceType: "quote",
+        ctaType: "inquiry",
+        ctaLabel: "Start a conversation",
+      },
+      {
+        name: "DPF Customer-Zero Workshop",
+        description: "Map your runtime, delivery, and customer-zero operating model before rollout.",
+        priceType: "quote",
+        ctaType: "inquiry",
+        ctaLabel: "Plan adoption",
+      },
+      {
+        name: "Governed Build Studio Enablement",
+        description: "Stand up isolated build, verification, and promotion flow for your product teams.",
+        priceType: "quote",
+        ctaType: "inquiry",
+        ctaLabel: "Review workflow",
+      },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Platform Offers", sortOrder: 1 },
+      { type: "about", title: "How DPF Runs DPF", sortOrder: 2 },
+      { type: "testimonials", title: "Proof & Outcomes", sortOrder: 3 },
+      { type: "contact", title: "Talk to Us", sortOrder: 4 },
+    ],
+    formSchema: PLATFORM_CONTACT_FIELDS,
+  },
+];

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -14,6 +14,7 @@ export type ArchetypeCategory =
   | "beauty-personal-care"
   | "trades-maintenance"
   | "professional-services"
+  | "software-platform"
   | "education-training"
   | "pet-services"
   | "food-hospitality"

--- a/tests/e2e/platform-qa-plan.md
+++ b/tests/e2e/platform-qa-plan.md
@@ -222,6 +222,10 @@ Valid `outcome` values per `TRIAGE_OUTCOMES` in [packages/db/src/discovery-triag
 | STORE-13 | Open the coworker panel on `/storefront` | Marketing Specialist agent loads for the portal workspace and shows portal-specific skills |
 | STORE-14 | Navigate to `/storefront/settings/business` | Settings sub-nav shows Portal, Your Business, and Operating Hours; Your Business is active and the business context form loads |
 | STORE-15 | Navigate to `/storefront/settings/operations` | Settings sub-nav shows Portal, Your Business, and Operating Hours; Operating Hours is active and the schedule editor loads |
+| STORE-16 | With the Docker-served portal running, open `http://localhost:3000` and `http://localhost:3001` | `3000` remains the production-served runtime and `3001` remains the isolated developer runtime; they do not collide |
+| STORE-17 | On `/s/<slug>/inquire`, submit a DPF product inquiry with name, email, and a message about using DPF internally | Inquiry is captured successfully and returns a reference number without exposing internal-only workflow controls |
+| STORE-18 | Navigate to `/storefront/inbox`, find the new inquiry, and click `Send to product backlog` | The inbox shows the inquiry as a customer-zero signal and creates or reuses a triaging backlog item tied to the configured digital product |
+| STORE-19 | Navigate to `/ops` after sending the inquiry to backlog | A triaging backlog item exists with the inquiry reference in the title/body and notes that it came from the storefront customer-zero intake flow |
 
 ## Phase 12: AI Coworker Cross-Cutting
 


### PR DESCRIPTION
## Summary

Implements **Chunks 1-3** of the DPF-on-DPF production instance plan (`docs/superpowers/plans/2026-04-25-dpf-on-dpf-production-instance.md`), which converts this install into the foundation for running Open Digital Product Factory as its own first customer ("Customer 0").

**Chunk 4 — live conversion + UX verification — is intentionally NOT in this PR.** That runs after this lands and after the install is rebuilt.

## What's in here (3 chunks → 1 PR)

### Chunk 1: Runtime boundary + canonical software-platform archetype
- New `docs/operations/dpf-production-runtime.md` codifying `:3000` = production-served portal, `:3001` = dev-portal, `:3035` = sandbox
- `docker-compose.yml` comments at `portal`/`sandbox`/`dev-portal` so the boundary is legible at the source
- `package.json` adds `dev:web`, `dev:portal`, `dev:prod-runtime`, `dev:sandbox` scripts
- New `software-platform` industry slug + DPF-specific archetype with platform-appropriate inquiry fields
- Wired into `ALL_ARCHETYPES`, picked up automatically by `seedStorefrontArchetypes`

### Chunk 2: Safe archetype reset + DPF preset
- New transactional `archetype-reset.ts` helper — re-homes an already-initialized install from one archetype to another (updates `StorefrontConfig.archetypeId`, derived `Organization.industry` / `BusinessContext.industry`, replaces seeded sections/items, preserves slug + custom fields)
- New `POST /api/storefront/admin/archetype-reset` admin route
- New idempotent `dpf-production-instance.ts` server action — applies the DPF identity preset (org name/slug/contacts, business context, storefront presentation) after archetype-reset has run

### Chunk 3: Public storefront content + inquiry → governed-backlog loop
- `software-platform`-aware Customer-Zero hero on `/s/[slug]`
- `governed-backlog-workflow.ts` gains a `StorefrontInquiryBacklogDraft` normalizer
- New `POST /api/storefront/admin/inquiries/[id]/product-backlog` admin route turns an inquiry into a triaging backlog item tagged `customer-zero`
- `StorefrontInbox.tsx` gets a "Send to product backlog" action with optimistic state
- 4 new e2e QA cases in `tests/e2e/platform-qa-plan.md`

## Test plan
All test sets called out in the plan's Verification Checklist pass locally:
- [x] `apps/web/lib/storefront/industries.test.ts` (4 passed)
- [x] `packages/storefront-templates/src/archetypes/archetypes.test.ts` (7 passed)
- [x] `packages/db/src/seed-storefront-archetypes.test.ts` (2 passed)
- [x] `apps/web/lib/storefront/archetype-reset.test.ts` + `route.test.ts` (7 passed)
- [x] `apps/web/lib/actions/dpf-production-instance.test.ts` (4 passed)
- [x] `apps/web/lib/governed-backlog-workflow.test.ts` + `storefront-data.test.ts` (13 passed)
- [x] `apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts` (4 passed)
- [x] `pnpm --filter web typecheck` (passed; pre-commit hook ran scoped typecheck across `apps/web` + `packages/db`)
- [ ] CI: Typecheck, Production Build, DCO

## Post-merge — Chunk 4 / Task 7 runbook
After this lands and the operator rebuilds the install:
1. `pnpm --filter @dpf/db seed` (seeds the new `software-platform` archetype)
2. `docker compose build --no-cache portal portal-init sandbox && docker compose up -d portal-init sandbox && docker compose up -d portal`
3. `POST /api/storefront/admin/archetype-reset` with `{ "targetArchetypeId": "software-platform" }`
4. Trigger the DPF production-instance preset action from `/storefront/settings`
5. UX verify per the plan's Task 7 Step 5 checklist (`/storefront/settings`, `/storefront/settings/business`, `/s/<slug>`, `/s/<slug>/inquire`, `/storefront/inbox`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)