### PR TITLE
fix(docker): bump ADP + integration-test-harness to node:24-alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,35 @@ jobs:
 
       - name: Build web (Next.js production)
         run: pnpm --filter web build
+
+  dockerfile-node-version:
+    name: Dockerfile Node Version
+    runs-on: ubuntu-latest
+    # Guards against the failure mode that landed in PR for ADP: a service
+    # Dockerfile pinned to an older Node major than the rest of the stack,
+    # paired with a dependency (undici@8) that needs a newer one. The
+    # container crash-looped on `webidl.util.markAsUncloneable is not a
+    # function` and broke `docker compose up` for fresh installs. CI now
+    # asserts every Dockerfile uses node:24-alpine (or newer) so this drift
+    # cannot reach main again. Bump the floor here when the platform moves.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Assert all Dockerfiles target node:24-alpine or newer
+        run: |
+          set -euo pipefail
+          floor=24
+          fail=0
+          while IFS= read -r -d '' file; do
+            while IFS= read -r line; do
+              # Match "FROM node:<major>[-...]" — capture the major version.
+              if [[ "$line" =~ ^[[:space:]]*FROM[[:space:]]+node:([0-9]+) ]]; then
+                major="${BASH_REMATCH[1]}"
+                if (( major < floor )); then
+                  echo "::error file=$file::$file uses node:$major (line: $line). Floor is node:$floor-alpine."
+                  fail=1
+                fi
+              fi
+            done < "$file"
+          done < <(find . -type f \( -name 'Dockerfile' -o -name 'Dockerfile.*' \) -not -path './node_modules/*' -not -path './.git/*' -print0)
+          exit $fail

--- a/services/adp/Dockerfile
+++ b/services/adp/Dockerfile
@@ -1,8 +1,12 @@
-# ADP MCP server — standalone Node 20 service.
+# ADP MCP server — standalone Node 24 service.
 # The runtime ships as its own container, but it consumes
 # packages/integration-shared as a local file dependency during the image build.
+#
+# Node 24 is required: undici@8.x calls webidl.util.markAsUncloneable, which
+# was added in Node 22. Keep this aligned with the portal/promoter/sandbox
+# images so a single Node major governs the whole stack.
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY tsconfig.base.json ./tsconfig.base.json
 COPY services/adp ./services/adp
@@ -18,7 +22,7 @@ RUN node -e "const fs = require('node:fs'); const pkg = JSON.parse(fs.readFileSy
   && pnpm install --no-frozen-lockfile \
   && pnpm build
 
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app/services/adp/dist ./dist

--- a/services/integration-test-harness/Dockerfile
+++ b/services/integration-test-harness/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 COPY services/integration-test-harness/package.json ./
 RUN corepack enable && pnpm install
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY services/integration-test-harness/package.json services/integration-test-harness/tsconfig.json ./
@@ -11,7 +11,7 @@ COPY services/integration-test-harness/src ./src
 COPY services/integration-test-harness/vendors ./vendors
 RUN corepack enable && pnpm build
 
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
## Summary

- Fresh `docker compose up` was failing with `dependency failed to start: container dpf-adp-1 is unhealthy`. The ADP container was crash-looping on `TypeError: webidl.util.markAsUncloneable is not a function` — undici@8 needs Node 22+, the Dockerfile was pinned to node:20-alpine.
- Bumped `services/adp/Dockerfile` and `services/integration-test-harness/Dockerfile` to `node:24-alpine`, matching portal/promoter/sandbox.
- Added a `Dockerfile Node Version` CI job that asserts every `Dockerfile`/`Dockerfile.*` is on `node:24-alpine` or newer, so this drift can't reach `main` again.

## Why this happened

- Portal, promoter, and sandbox were upgraded to `node:24-alpine` previously. ADP and integration-test-harness were left on `node:20-alpine`.
- ADP carries `undici@^8.1.0`. undici 8.0 dropped Node 20 support — its `CacheStorage` module calls `webidl.util.markAsUncloneable`, added in Node 22. Cold start hit it on the very first `import`.
- Nothing in CI looked at base-image versions, so the drift landed silently.

## CI guard

The new job parses the `FROM node:<major>` line of every Dockerfile in the repo and fails if any major is below 24. To raise the floor in the future, change one number in `.github/workflows/ci.yml`.

## Test plan

- [x] `docker compose build adp` — clean
- [x] `docker compose up -d adp` → `dpf-adp-1` reaches `healthy`, 0 restarts, log line `[adp] listening on :8600 (v0.4.0)`
- [x] `docker compose up -d portal portal-init` → `dpf-portal-1` reaches `healthy`
- [x] Full stack: 15/15 containers running, all healthcheck-bearing services healthy
- [ ] CI: Typecheck, Production Build, Routing Tier Contract, Dockerfile Node Version all green
- [ ] DCO check green