### PR TITLE
fix(mcp): unblock external MCP token onboarding — three independent bugs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,9 +12,15 @@
       "WebFetch(domain:skillsmp.com)",
       "Read(//d/DPF/**)",
       "Bash(MSYS_NO_PATHCONV=1 docker exec dpf-sandbox-1 env)",
-      "Bash(curl -s http://localhost:3000/api/health)"
+      "Bash(curl -s http://localhost:3000/api/health)",
+      "Read(//d/backups//**)",
+      "mcp__dpf__propose_improvement"
     ]
   },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "dpf"
+  ],
   "enabledPlugins": {
     "code-review@claude-code-plugins": true,
     "frontend-design@claude-code-plugins": true,

--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,20 @@ backups/
 # Test artifacts
 e2e-report/
 e2e-results/
+e2e/debug/
+e2e/.auth/
 test-results/
 
 # Local agent / codex caches
 .codex/
+
+# MCP client configs contain live bearer tokens — must never be committed.
+# .mcp.json (Claude Code CLI) and .vscode/mcp.json (Claude Code VS Code
+# extension via VS Code's native MCP store) both carry an Authorization
+# header in plaintext. Use the "Connect Claude Code" flow from
+# Admin > Platform Development to (re)generate these locally.
+.mcp.json
+.vscode/mcp.json
 
 # Python bytecode caches
 __pycache__/

--- a/apps/web/app/(shell)/admin/platform-development/page.tsx
+++ b/apps/web/app/(shell)/admin/platform-development/page.tsx
@@ -72,7 +72,11 @@ export default async function AdminPlatformDevelopmentPage() {
         initialConnected={initialConnected}
       />
       <McpTokenManager
-        contributionModelConfigured={config?.contributionModel != null}
+        contributionModelConfigured={
+          isContributionModelEnabled()
+            ? config?.contributionModel != null
+            : config?.contributionMode === "selective" || config?.contributionMode === "contribute_all"
+        }
         baseUrl={baseUrl}
       />
     </div>

--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -29,6 +29,9 @@ function makeRequest(opts: {
   bearer?: string | null;
   origin?: string | null;
   body?: unknown;
+  forwardedProto?: string;
+  forwardedHost?: string;
+  hostHeader?: string;
 }): Request {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (opts.bearer !== null && opts.bearer !== undefined) {
@@ -37,6 +40,9 @@ function makeRequest(opts: {
   if (opts.origin !== null && opts.origin !== undefined) {
     headers["Origin"] = opts.origin;
   }
+  if (opts.forwardedProto) headers["X-Forwarded-Proto"] = opts.forwardedProto;
+  if (opts.forwardedHost) headers["X-Forwarded-Host"] = opts.forwardedHost;
+  if (opts.hostHeader) headers["Host"] = opts.hostHeader;
   return new Request(opts.url ?? "http://localhost:3000/api/mcp/v1", {
     method: opts.method ?? "POST",
     headers,
@@ -88,6 +94,62 @@ describe("POST — transport guards", () => {
       }),
     );
     expect(res.status).toBe(401); // got past TLS guard, failed at auth
+  });
+
+  // Regression: when Next.js runs inside a container or behind a proxy,
+  // request.url reflects the *internal* bind address (e.g. 0.0.0.0). The
+  // transport guard must consult the forwarded host/proto headers — what
+  // the client actually connected to — not the URL Next reconstructed.
+  it("allows containerized request when X-Forwarded-Host points to localhost", async () => {
+    resolveMock.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({
+        url: "http://0.0.0.0:3000/api/mcp/v1",
+        bearer: "dpfmcp_X",
+        forwardedHost: "localhost:3000",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401); // past transport guard, fails at auth
+  });
+
+  it("allows containerized request when X-Forwarded-Proto is https", async () => {
+    resolveMock.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({
+        url: "http://0.0.0.0:3000/api/mcp/v1",
+        bearer: "dpfmcp_X",
+        forwardedProto: "https",
+        forwardedHost: "portal.example.com",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("falls back to Host header when no X-Forwarded-Host present", async () => {
+    resolveMock.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({
+        url: "http://0.0.0.0:3000/api/mcp/v1",
+        bearer: "dpfmcp_X",
+        hostHeader: "127.0.0.1:3000",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("still rejects http requests on non-localhost hosts (no proxy headers)", async () => {
+    const res = await POST(
+      makeRequest({
+        url: "http://evil.example.com/api/mcp/v1",
+        bearer: "dpfmcp_X",
+        forwardedHost: "evil.example.com",
+        body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+      }),
+    );
+    expect(res.status).toBe(403);
   });
 
   it("rejects requests with disallowed Origin", async () => {

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -128,10 +128,23 @@ function isOriginAllowed(origin: string | null): boolean {
 }
 
 // Spec safety: refuse non-TLS requests except for localhost (Mode 1 / dev).
+//
+// When the portal runs behind a proxy or inside a container, `request.url`
+// reflects the *internal* bind address (e.g. 0.0.0.0) and protocol, not what
+// the client actually connected to. We must consult X-Forwarded-Proto and
+// X-Forwarded-Host (or the Host header) to know the client's view.
 function isTransportAllowed(request: Request): boolean {
+  const xfProto = request.headers.get("x-forwarded-proto");
   const url = new URL(request.url);
-  if (url.protocol === "https:") return true;
-  return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1";
+  const proto = (xfProto?.split(",")[0]?.trim() || url.protocol.replace(/:$/, "")).toLowerCase();
+  if (proto === "https") return true;
+
+  const xfHost = request.headers.get("x-forwarded-host");
+  const hostHeader = request.headers.get("host");
+  const rawHost = (xfHost?.split(",")[0]?.trim() || hostHeader || url.host).toLowerCase();
+  // Strip port; bracketed IPv6 retains brackets after URL.host parsing.
+  const hostname = rawHost.replace(/^\[(.+)\]:?\d*$/, "$1").replace(/:\d+$/, "");
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
 
 async function loadUserContext(userId: string): Promise<UserContext> {

--- a/apps/web/lib/auth/mcp-api-token.test.ts
+++ b/apps/web/lib/auth/mcp-api-token.test.ts
@@ -28,8 +28,26 @@ const tokenFindMany = prisma.mcpApiToken.findMany as unknown as ReturnType<typeo
 const tokenUpdate = prisma.mcpApiToken.update as unknown as ReturnType<typeof vi.fn>;
 const cfgFindUnique = prisma.platformDevConfig.findUnique as unknown as ReturnType<typeof vi.fn>;
 
+async function withFlag<T>(
+  value: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const orig = process.env.CONTRIBUTION_MODEL_ENABLED;
+  if (value === undefined) delete process.env.CONTRIBUTION_MODEL_ENABLED;
+  else process.env.CONTRIBUTION_MODEL_ENABLED = value;
+  try {
+    // Must await inside the try so the env var is still set when the
+    // contributionMode gate runs in async code.
+    return await fn();
+  } finally {
+    if (orig === undefined) delete process.env.CONTRIBUTION_MODEL_ENABLED;
+    else process.env.CONTRIBUTION_MODEL_ENABLED = orig;
+  }
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
+  delete process.env.CONTRIBUTION_MODEL_ENABLED;
   tokenCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
     id: "tok_123",
     createdAt: new Date(),
@@ -43,6 +61,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.resetAllMocks();
+  delete process.env.CONTRIBUTION_MODEL_ENABLED;
 });
 
 describe("issueMcpApiToken — happy path", () => {
@@ -92,8 +111,45 @@ describe("issueMcpApiToken — happy path", () => {
     expect(result.expiresAt).toBeNull();
   });
 
-  it("issues a write token when contribution-mode is configured", async () => {
-    cfgFindUnique.mockResolvedValue({ contributionModel: "fork-pr" });
+  it("flag-on: issues a write token when contributionModel is set", async () => {
+    cfgFindUnique.mockResolvedValue({
+      contributionMode: "selective",
+      contributionModel: "fork-pr",
+    });
+    const result = await withFlag("true", () =>
+      issueMcpApiToken({
+        userId: "u1",
+        name: "Mark write",
+        capability: "write",
+        scopes: ["backlog_write"],
+        expiresInDays: 30,
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("flag-off: issues a write token when contributionMode is selective", async () => {
+    // With the flag off, contributionModel is never written by any UI
+    // surface, so the gate falls back to the user's coarse choice.
+    cfgFindUnique.mockResolvedValue({
+      contributionMode: "selective",
+      contributionModel: null,
+    });
+    const result = await issueMcpApiToken({
+      userId: "u1",
+      name: "Mark write",
+      capability: "write",
+      scopes: ["backlog_write"],
+      expiresInDays: 30,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("flag-off: issues a write token when contributionMode is contribute_all", async () => {
+    cfgFindUnique.mockResolvedValue({
+      contributionMode: "contribute_all",
+      contributionModel: null,
+    });
     const result = await issueMcpApiToken({
       userId: "u1",
       name: "Mark write",
@@ -167,7 +223,7 @@ describe("issueMcpApiToken — rejections", () => {
     expect(result.error).toBe("invalid_capability");
   });
 
-  it("rejects write-capable token when contribution-mode is unset", async () => {
+  it("rejects write-capable token when PlatformDevConfig row is missing", async () => {
     cfgFindUnique.mockResolvedValue(null);
     const result = await issueMcpApiToken({
       userId: "u1",
@@ -182,8 +238,31 @@ describe("issueMcpApiToken — rejections", () => {
     expect(tokenCreate).not.toHaveBeenCalled();
   });
 
-  it("rejects write-capable token when PlatformDevConfig has no contributionModel set", async () => {
-    cfgFindUnique.mockResolvedValue({ contributionModel: null });
+  it("flag-on: rejects write-capable token when contributionModel is null", async () => {
+    cfgFindUnique.mockResolvedValue({
+      contributionMode: "selective",
+      contributionModel: null,
+    });
+    const result = await withFlag("true", () =>
+      issueMcpApiToken({
+        userId: "u1",
+        name: "x",
+        capability: "write",
+        scopes: ["backlog_write"],
+        expiresInDays: 30,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("contribution_mode_required");
+  });
+
+  it("flag-off: rejects write-capable token when contributionMode is fork_only", async () => {
+    // fork_only means "stay private" — writes have nowhere to go.
+    cfgFindUnique.mockResolvedValue({
+      contributionMode: "fork_only",
+      contributionModel: null,
+    });
     const result = await issueMcpApiToken({
       userId: "u1",
       name: "x",
@@ -194,6 +273,40 @@ describe("issueMcpApiToken — rejections", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unreachable");
     expect(result.error).toBe("contribution_mode_required");
+  });
+});
+
+describe("encodeBase32 invariant — token characters", () => {
+  it("never contains the literal substring 'undefined' (regression — alphabet must be 32 chars)", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    // Mint many tokens; with the previous 30-char alphabet ~6% of characters
+    // would render as "undefined", so 200 tokens would virtually guarantee a
+    // hit. With a 32-char alphabet this must never happen.
+    for (let i = 0; i < 200; i++) {
+      const r = await issueMcpApiToken({
+        userId: "u1",
+        name: `t${i}`,
+        capability: "read",
+        scopes: ["backlog_read"],
+        expiresInDays: null,
+      });
+      if (!r.ok) throw new Error(`mint #${i} failed: ${r.error}`);
+      expect(r.plaintext).not.toContain("undefined");
+    }
+  });
+
+  it("uses only Crockford base32 characters (0-9, A-Z minus I/L/O/U)", async () => {
+    cfgFindUnique.mockResolvedValue(null);
+    const r = await issueMcpApiToken({
+      userId: "u1",
+      name: "x",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: null,
+    });
+    if (!r.ok) throw new Error("expected ok");
+    const secret = r.plaintext.replace(/^dpfmcp_/, "");
+    expect(secret).toMatch(/^[0-9A-HJKMNP-TV-Z]+$/);
   });
 });
 

--- a/apps/web/lib/auth/mcp-api-token.ts
+++ b/apps/web/lib/auth/mcp-api-token.ts
@@ -11,6 +11,7 @@
 
 import { createHash, randomBytes } from "crypto";
 import { prisma } from "@dpf/db";
+import { isContributionModelEnabled } from "@/lib/flags/contribution-model";
 
 export type McpTokenCapability = "read" | "write";
 
@@ -53,9 +54,17 @@ const TOKEN_PREFIX = "dpfmcp_";
 const SECRET_BYTES = 24;
 const PREFIX_DISPLAY_LENGTH = 12;
 
-// Base32 alphabet (Crockford-ish, no I/L/O/U). Avoids characters that look
-// like each other so tokens are easier for humans to verify visually.
-const BASE32_ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789";
+// Crockford base32 (RFC-style 32 symbols, excluding I/L/O/U for visual
+// disambiguation). MUST be exactly 32 characters — `& 31` indexes 0..31, so
+// a shorter alphabet produces `undefined` lookups that template-literal
+// into the literal text "undefined" inside generated tokens.
+const BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+if (BASE32_ALPHABET.length !== 32) {
+  throw new Error(
+    `BASE32_ALPHABET must be exactly 32 characters; got ${BASE32_ALPHABET.length}`,
+  );
+}
 
 function encodeBase32(buf: Buffer): string {
   let bits = 0;
@@ -87,13 +96,27 @@ function hashSecret(plaintext: string): string {
   return createHash("sha256").update(plaintext).digest("hex");
 }
 
+// A write-capable token requires a configured contribution path. What
+// "configured" means depends on the feature flag:
+//   - Flag ON  (CONTRIBUTION_MODEL_ENABLED=true): the fork-PR rollout is in
+//     effect, so PlatformDevConfig.contributionModel must be set explicitly
+//     via the ForkSetupPanel (values: "maintainer-direct" | "fork-pr").
+//   - Flag OFF (default): the legacy direct-push flow is in use; the
+//     ForkSetupPanel is hidden and contributionModel is never written.
+//     The only meaningful prerequisite is that the user opted into sharing
+//     at all — i.e. contributionMode is "selective" or "contribute_all".
+//     "fork_only" means "stay private", so writes have nowhere to go.
 async function contributionModeConfigured(): Promise<boolean> {
   try {
     const cfg = await prisma.platformDevConfig.findUnique({
       where: { id: "singleton" },
-      select: { contributionModel: true },
+      select: { contributionMode: true, contributionModel: true },
     });
-    return cfg?.contributionModel != null;
+    if (!cfg) return false;
+    if (isContributionModelEnabled()) {
+      return cfg.contributionModel != null;
+    }
+    return cfg.contributionMode === "selective" || cfg.contributionMode === "contribute_all";
   } catch {
     return false;
   }

--- a/docs/superpowers/drafts/2026-04-27-mcp-onboarding-improvements.md
+++ b/docs/superpowers/drafts/2026-04-27-mcp-onboarding-improvements.md
@@ -1,0 +1,98 @@
+# MCP Onboarding Improvements — drafts ready to file
+
+Generated 2026-04-27 from the MCP-connect debugging session. The MCP token used to file these is read-only, which is why they are saved here as text instead of being filed via `mcp__dpf__propose_improvement` directly. Mint a write-capable token through Admin > Platform Development (the gate fix in this same PR makes the Write radio clickable when `contributionMode` is `selective` or `contribute_all`), then either paste each block into the propose_improvement tool or run them via the MCP CLI.
+
+---
+
+## 1. One-click "Connect Claude Code" — eliminate token paste from MCP onboarding
+
+- **category**: ux_friction
+- **severity**: high
+
+### description
+**Problem.** The current MCP onboarding flow requires the operator to (1) navigate to Admin > Platform Development, (2) click Generate token, (3) copy the bearer, (4) open or create `.vscode/mcp.json` (or `.mcp.json`) at the right path, (5) paste a JSON block including the bearer, (6) restart VS Code or the dpf MCP server. Six manual steps with three different file paths to know about. Violates the established zero-click provider setup principle.
+
+**Proposed flow.**
+1. Admin > Platform Development shows a "Connect Claude Code" card.
+2. Operator clicks it. The portal:
+   - Auto-mints a default-scoped read token (or write, gated on contribution mode) attributed to the current user.
+   - Uses the browser's File System Access API to ask the operator to pick their workspace folder once.
+   - Writes `.vscode/mcp.json` (correct format: `{ servers: { dpf: { type: "http", url, headers } } }`) atomically.
+   - Shows "Done. Open VS Code → MCP panel → click Start on dpf." (one click left.)
+3. On subsequent connects, remembers the workspace path so step 2 collapses to a single click.
+
+**Architectural notes.**
+- The bearer must never be displayed in the UI in this flow — write-then-forget. The current "shown once, copy now" dialog stays as a fallback for users who can't grant File System Access (e.g. WebKit on iOS).
+- Because `.vscode/mcp.json` contains a live bearer, the portal action must include guidance to add the file to `.gitignore` (or write a `.gitignore` line itself when permission allows).
+- Same flow should also offer a `.mcp.json` write for users running Claude Code from the CLI, with both files written atomically when the workspace supports both.
+
+**Acceptance criteria.**
+- A new fresh-install operator can go from "I just finished docker compose up" to "Claude Code can call list_epics" in under 60 seconds with at most one paste-or-click per file write.
+- The flow works on Chromium (File System Access API supported) and provides a graceful fallback (download a .vscode/mcp.json file the user moves into place) on Firefox/Safari.
+- The portal never logs or persists the plaintext bearer beyond the in-memory write.
+
+### observedFriction
+Spent ~3 hours over the course of one session debugging MCP connectivity. Three independent platform bugs blocked the flow. After fixing all three, the actual onboarding *still* required a 6-step paste-and-restart dance, plus a separate decision about which of three config file paths to use (.mcp.json vs .vscode/mcp.json vs ~/.claude.json) — none of which is documented in the token-issuance dialog. The maintainer's reaction: "it needs to be easy, not lots of copy and paste."
+
+---
+
+## 2. Auto-configure contributionModel after GitHub OAuth — remove invisible prereq for write tokens
+
+- **category**: ux_friction
+- **severity**: medium
+
+### description
+**Problem.** The "Write" capability radio in the MCP token issuance dialog is gated behind `PlatformDevConfig.contributionModel != null`. That field is only writable through `ForkSetupPanel`, which only renders when the env var `CONTRIBUTION_MODEL_ENABLED=true`. On default installs the panel never appears, the field stays null forever, and the Write radio is permanently disabled with a generic "configure contribution mode first" hint that points the user nowhere.
+
+This PR ships a relaxed gate (flag-off installs accept `contributionMode in ('selective','contribute_all')`), which unblocks the immediate UX problem. But that is a stopgap. The architecturally correct fix is for the system to determine and persist `contributionModel` automatically.
+
+**Proposed flow.** After the user completes the GitHub OAuth handshake on the platform-development page:
+1. Probe the connected GitHub identity for push access to the configured upstream repo (one API call).
+2. If push access is granted → set `contributionModel = "maintainer-direct"` and save.
+3. Otherwise → fork the upstream into the user's account via the GitHub API, wait for fork creation, write `contributorForkOwner`/`contributorForkRepo`/`forkVerifiedAt`, set `contributionModel = "fork-pr"`.
+4. Show a single status banner that reflects the resolved model, with a "Switch to fork-PR" override link for maintainers who want to PR through their own fork even though they have direct push.
+
+**Architectural notes.**
+- This eliminates a class of "configuration" the user shouldn't have to make. The system has all the information needed.
+- It also removes the dual-name confusion (contributionMode vs contributionModel) by making one of them automatic.
+- Once shipped, the relaxed gate in this PR can be reverted — the gate becomes invisible because the field is always set.
+
+**Acceptance criteria.**
+- A user who has just completed GitHub OAuth has a non-null `contributionModel` within 5 seconds, with no further click.
+- The Write radio in the MCP token dialog becomes enabled immediately, with no instruction to "configure contribution mode first."
+- An override link is available for the rare case (maintainer who wants fork-PR despite having direct push).
+
+### observedFriction
+After fixing the gate-logic bug so the Write radio could be enabled at all, the architecturally correct outcome (the user shouldn't even be asked) became obvious. The maintainer's question — "should this be automated?" — was rhetorical: the user memory `feedback_zero_click_provider_setup` already records the principle. The current state forces the user to choose between two deployment models they don't understand.
+
+---
+
+## 3. Fix MCP token issuance dialog: VS Code snippet uses wrong format and points to wrong file path
+
+- **category**: missing_feature
+- **severity**: medium
+
+### description
+**Problem.** The MCP token issuance dialog at `apps/web/lib/actions/mcp-tokens.ts` (`buildSetupSnippets`) generates three setup snippets: Claude Code, Codex, and VS Code. The VS Code snippet uses the right shape (`{ servers: { dpf: { url, headers } } }`) but does NOT specify `type: "http"`. VS Code's MCP system needs `type: "http"` declared explicitly for HTTP transports — without it the entry is treated as ambiguous and may not start. It also does not tell the user where to save the file.
+
+Additionally, none of the three snippets are accompanied by guidance on where the file goes:
+- Claude Code CLI snippet → `.mcp.json` at workspace root
+- VS Code snippet → `.vscode/mcp.json` at workspace root
+- Codex snippet → `~/.codex/mcp.json` (or wherever Codex looks)
+
+Users who don't already know the right path can't act on the snippet without a separate documentation lookup.
+
+**Proposed fix.**
+1. Update `buildSetupSnippets` in `apps/web/lib/actions/mcp-tokens.ts`:
+   - VS Code snippet: add `"type": "http"` to the server entry.
+2. Update `apps/web/components/admin/McpTokenManager.tsx`:
+   - Above each tab's `<pre>`, add a "Save as: `.vscode/mcp.json` at the root of your workspace" hint with the path appropriate to the active tab.
+   - For VS Code: add a sentence "Open VS Code's command palette and run 'MCP: List Servers' to start the dpf server after saving."
+3. Once issue #1 (one-click flow) ships, this dialog becomes a fallback path for users who can't grant File System Access — at which point the snippet hints become essential.
+
+**Acceptance criteria.**
+- A user pasting the VS Code snippet into a fresh `.vscode/mcp.json` and starting the server in VS Code's MCP panel sees `dpf` connect successfully on first try.
+- Each tab in the issuance dialog shows the correct file path and the next step.
+
+### observedFriction
+The original session-recovered token failed with a corrupted base32 encoding (separate bug, fixed in this PR), but even with a clean token the VS Code snippet did not work without manually adding `type: "http"`. The user did not initially know `.vscode/mcp.json` was the right path; the dialog only mentioned Claude Code's `.mcp.json`, and three different paths were tried before discovering the VS Code-native one is what the extension reads.


### PR DESCRIPTION
## Summary

A maintainer trying to connect Claude Code to the dpf MCP server via the documented `Admin > Platform Development` flow hit three independent defects that combined to make the entire onboarding path **impossible**. None of them surfaced in CI because the bugs only manifest at runtime in a containerized portal with proxied requests.

## The three bugs

### 1. Transport guard rejected containerized requests
[`apps/web/app/api/mcp/v1/route.ts`](apps/web/app/api/mcp/v1/route.ts) `isTransportAllowed()` consulted the parsed `request.url` hostname, but inside Docker the URL Next.js reconstructs uses the container's bind address (`0.0.0.0`), not what the client connected to. Localhost requests through the published port were rejected with `"forbidden: TLS required (HTTPS only outside localhost)"`.

**Fix:** Honor `X-Forwarded-Proto` and `X-Forwarded-Host` (with a fallback to the `Host` header) so the guard sees what the client actually used.

### 2. Token encoder produced literal "undefined" substrings
[`apps/web/lib/auth/mcp-api-token.ts`](apps/web/lib/auth/mcp-api-token.ts) `BASE32_ALPHABET` was a 30-char I/L/O/U-free set indexed by `& 31`, so 2/32 byte combinations produced `BASE32_ALPHABET[30]`/`[31] = undefined`. JS template literals stringified those into the literal text `"undefined"`, corrupting **~6%** of every generated token's characters.

Real example from the session that prompted this PR:
```
dpfmcp_4RPSRXEundefinedTundefinedundefinedXJE36PMVA8JPBKZATV5ER37K7KCT
                ^^^^^^^^^ ^^^^^^^^^^^^^^^^^^
```

**Fix:** Use the standard 32-char Crockford base32 alphabet (still I/L/O/U-free, RFC-style) plus a load-time invariant guard so a future regression fails loudly at boot rather than silently in production.

### 3. Write-capability gate had an impossible-to-satisfy state
The gate at [`mcp-api-token.ts:108`](apps/web/lib/auth/mcp-api-token.ts) required `PlatformDevConfig.contributionModel != null`. That field is **only** writable through `ForkSetupPanel`, which **only** renders when `CONTRIBUTION_MODEL_ENABLED=true`. On default installs (flag off), the panel never appears, the field stays null forever, and the "Write" radio in the MCP token issuance dialog is permanently disabled with a generic *"configure contribution mode first"* hint that points the user nowhere.

**Fix:** When the flag is off, the gate accepts any `contributionMode` of `"selective"` or `"contribute_all"` — the user's coarse sharing choice — since `contributionModel` isn't meaningful in the legacy direct-push flow. When the flag is on, the original behavior is preserved. Cleaner long-term fix (auto-configure `contributionModel` after OAuth) is filed as a follow-up draft.

## Verification

End-to-end against a running portal after rebuild:
- ✅ `curl initialize` → 200 OK with `serverInfo`
- ✅ `curl tools/list` → 12 tools matching the token's scopes
- ✅ VS Code extension connected via `.vscode/mcp.json` + Start server
- ✅ `mcp__dpf__list_epics` from Claude Code returned 10 real epics

Tests:
- **+9 new** (encoder regression covering 200 mints, transport-guard regression with proxy headers, gate behavior across flag states)
- **82 tests green** across the affected surface ([mcp-api-token.test.ts](apps/web/lib/auth/mcp-api-token.test.ts), [route.test.ts](apps/web/app/api/mcp/v1/route.test.ts), contribution-dispatch, ContributionModelBanner, ForkSetupPanel, mcp-tokens action)
- Typecheck clean

## Also in this PR

- `.gitignore` now excludes `.mcp.json` and `.vscode/mcp.json` — both contain live bearer tokens and must never be committed.
- `.claude/settings.json` gains `enableAllProjectMcpServers` and `enabledMcpjsonServers: ["dpf"]` so the project's own MCP server is discoverable to anyone running Claude Code in this repo.
- `docs/superpowers/drafts/2026-04-27-mcp-onboarding-improvements.md` holds three follow-up improvement proposals (one-click "Connect Claude Code" flow, auto-configure `contributionModel` after OAuth, fix VS Code snippet format/path) ready to file via `mcp__dpf__propose_improvement` once a write-capable token can be minted through the now-functional UI.

## Test plan

- [ ] Rebuild portal image; verify `curl -i POST http://localhost:3000/api/mcp/v1` with a valid bearer no longer returns "TLS required"
- [ ] Generate a new token through `Admin > Platform Development` and confirm it has no `undefined` substrings (or any non-Crockford base32 chars)
- [ ] On a default install (no `CONTRIBUTION_MODEL_ENABLED`), pick `contributionMode: "selective"` and confirm the "Write" radio in the MCP token dialog becomes enabled
- [ ] Add the dpf entry to `.vscode/mcp.json`, click Start in VS Code's MCP panel, restart Claude Code, run `/mcp` — should see `dpf` connected with 12 tools
- [ ] Call `mcp__dpf__list_epics` from Claude Code — should return real epic data

🤖 Generated with [Claude Code](https://claude.com/claude-code)