### PR TITLE
fix(portal): derive URL from request headers, not hardcoded env

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -17,6 +17,14 @@ NEO4J_AUTH=neo4j/dpf_dev_password
 # Auth.js secret (REQUIRED -- must be a random value)
 AUTH_SECRET=<generate with: openssl rand -base64 32>
 
+# Optional: explicit public URL for outbound flows (emails, webhooks).
+# Leave UNSET for localhost or LAN access — the portal derives its URL
+# from the incoming request's Host header (AUTH_TRUST_HOST=true).
+# Set this only when running behind a public domain and you need
+# absolute URLs in places without a request context (notification
+# emails, outbound webhook payloads).
+# PUBLIC_URL=https://dpf.example.com
+
 # REQUIRED in production. 64 hex chars = 32 bytes.
 # Generate with: openssl rand -hex 32
 # If unset in production AND credentials exist in DB, the portal refuses to start.

--- a/apps/web/app/api/v1/auth/provider-oauth/callback/route.ts
+++ b/apps/web/app/api/v1/auth/provider-oauth/callback/route.ts
@@ -1,23 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { getPortalUrl } from "@/lib/portal-url";
 import {
   buildProviderOAuthErrorPath,
   exchangeOAuthCode,
   findPendingOAuthProviderId,
 } from "@/lib/provider-oauth";
 
-// Inside Docker, request.url resolves to http://0.0.0.0:3000 which browsers can't reach.
-function appBase(): string {
-  return process.env.NEXTAUTH_URL ?? process.env.APP_URL ?? "http://localhost:3000";
-}
-
 export async function GET(request: NextRequest) {
+  const appBase = await getPortalUrl();
   const state = request.nextUrl.searchParams.get("state");
   const pendingProviderId = await findPendingOAuthProviderId(state);
   // Verify admin is authenticated
   const session = await auth();
   if (!session?.user) {
-    return NextResponse.redirect(new URL("/login?error=unauthorized", appBase()));
+    return NextResponse.redirect(new URL("/login?error=unauthorized", appBase));
   }
 
   const code = request.nextUrl.searchParams.get("code");
@@ -25,20 +22,20 @@ export async function GET(request: NextRequest) {
 
   // Provider returned an error (e.g., user denied consent)
   if (error) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, error), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, error), appBase));
   }
 
   if (!code || !state) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, "missing_params"), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, "missing_params"), appBase));
   }
 
   const result = await exchangeOAuthCode(state, code);
 
   if ("error" in result) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, result.error), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, result.error), appBase));
   }
 
   return NextResponse.redirect(
-    new URL(`/platform/ai/providers/${result.providerId}?oauth=success`, appBase()),
+    new URL(`/platform/ai/providers/${result.providerId}?oauth=success`, appBase),
   );
 }

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getPortalUrl } from "@/lib/portal-url";
 import {
   buildProviderOAuthErrorPath,
   exchangeOAuthCode,
@@ -9,31 +10,28 @@ import {
 // session cookie from port 3000 isn't available. The OAuthPendingFlow
 // state parameter provides CSRF protection instead of session auth.
 
-function appBase(): string {
-  return process.env.NEXTAUTH_URL ?? process.env.APP_URL ?? "http://localhost:3000";
-}
-
 export async function GET(request: NextRequest) {
+  const appBase = await getPortalUrl();
   const code = request.nextUrl.searchParams.get("code");
   const state = request.nextUrl.searchParams.get("state");
   const error = request.nextUrl.searchParams.get("error");
   const pendingProviderId = await findPendingOAuthProviderId(state);
 
   if (error) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, error), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, error), appBase));
   }
 
   if (!code || !state) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, "missing_params"), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, "missing_params"), appBase));
   }
 
   const result = await exchangeOAuthCode(state, code);
 
   if ("error" in result) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, result.error), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, result.error), appBase));
   }
 
   return NextResponse.redirect(
-    new URL(`/platform/ai/providers/${result.providerId}?oauth=success`, appBase()),
+    new URL(`/platform/ai/providers/${result.providerId}?oauth=success`, appBase),
   );
 }

--- a/apps/web/app/callback/route.ts
+++ b/apps/web/app/callback/route.ts
@@ -5,44 +5,40 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { getPortalUrl } from "@/lib/portal-url";
 import {
   buildProviderOAuthErrorPath,
   exchangeOAuthCode,
   findPendingOAuthProviderId,
 } from "@/lib/provider-oauth";
 
-// Inside Docker, request.url resolves to http://0.0.0.0:3000 which browsers can't reach.
-// Use the configured app URL for redirects instead.
-function appBase(): string {
-  return process.env.NEXTAUTH_URL ?? process.env.APP_URL ?? "http://localhost:3000";
-}
-
 export async function GET(request: NextRequest) {
+  const appBase = await getPortalUrl();
   const state = request.nextUrl.searchParams.get("state");
   const pendingProviderId = await findPendingOAuthProviderId(state);
   const session = await auth();
   if (!session?.user) {
-    return NextResponse.redirect(new URL("/login?error=unauthorized", appBase()));
+    return NextResponse.redirect(new URL("/login?error=unauthorized", appBase));
   }
 
   const code = request.nextUrl.searchParams.get("code");
   const error = request.nextUrl.searchParams.get("error");
 
   if (error) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, error), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, error), appBase));
   }
 
   if (!code || !state) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, "missing_params"), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, "missing_params"), appBase));
   }
 
   const result = await exchangeOAuthCode(state, code);
 
   if ("error" in result) {
-    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, result.error), appBase()));
+    return NextResponse.redirect(new URL(buildProviderOAuthErrorPath(pendingProviderId, result.error), appBase));
   }
 
   return NextResponse.redirect(
-    new URL(`/platform/ai/providers/${result.providerId}?oauth=success`, appBase()),
+    new URL(`/platform/ai/providers/${result.providerId}?oauth=success`, appBase),
   );
 }

--- a/apps/web/lib/govern/provider-oauth.ts
+++ b/apps/web/lib/govern/provider-oauth.ts
@@ -31,9 +31,10 @@ const FLOW_TTL_MS = 10 * 60 * 1000; // 10 minutes
  *  3. Default → our full API callback route */
 const LOCALHOST_RESTRICTED_HOSTS = ["claude.ai"];
 
-function getOAuthRedirectUri(provider: { oauthRedirectUri?: string | null; authorizeUrl?: string | null }): string {
+async function getOAuthRedirectUri(provider: { oauthRedirectUri?: string | null; authorizeUrl?: string | null }): Promise<string> {
   if (provider.oauthRedirectUri) return provider.oauthRedirectUri;
-  const appUrl = process.env.NEXTAUTH_URL ?? process.env.APP_URL ?? "http://localhost:3000";
+  const { getPortalUrl } = await import("@/lib/portal-url");
+  const appUrl = await getPortalUrl();
   // Providers whose OAuth clients restrict redirect URIs to short localhost/callback paths
   if (provider.authorizeUrl && LOCALHOST_RESTRICTED_HOSTS.some(h => provider.authorizeUrl!.includes(h))) {
     return `${appUrl}/callback`;
@@ -60,7 +61,7 @@ export async function createOAuthFlow(providerId: string): Promise<{ authorizeUr
     data: { state, codeVerifier, providerId },
   });
 
-  const redirectUri = getOAuthRedirectUri(provider as { oauthRedirectUri?: string | null; authorizeUrl?: string | null });
+  const redirectUri = await getOAuthRedirectUri(provider as { oauthRedirectUri?: string | null; authorizeUrl?: string | null });
 
   const params = new URLSearchParams({
     response_type: "code",
@@ -120,7 +121,7 @@ export async function exchangeOAuthCode(
     return { error: "provider_misconfigured" };
   }
 
-  const redirectUri = getOAuthRedirectUri(provider as { oauthRedirectUri?: string | null; authorizeUrl?: string | null });
+  const redirectUri = await getOAuthRedirectUri(provider as { oauthRedirectUri?: string | null; authorizeUrl?: string | null });
 
   // Anthropic requires JSON + state; OpenAI requires form-encoded without state
   const isAnthropicToken = provider.tokenUrl.includes("claude.com") || provider.tokenUrl.includes("anthropic.com");

--- a/apps/web/lib/portal-url.ts
+++ b/apps/web/lib/portal-url.ts
@@ -1,0 +1,39 @@
+// Resolves the portal's externally-reachable base URL.
+//
+// Rationale: hardcoding AUTH_URL/APP_URL to a single value (e.g. localhost:3000)
+// breaks LAN access — a remote browser hits the portal's LAN IP, logs in, then
+// gets redirected to its own loopback. The right pattern (per Auth.js v5,
+// Next.js 16, Gitea, Outline, etc.) is to trust the request's Host header and
+// derive the URL at request time. AUTH_TRUST_HOST=true on the portal container
+// makes Auth.js do this automatically; this helper does the same for any code
+// that needs an absolute URL outside Auth.js's own paths.
+//
+// Resolution order:
+//   1. PUBLIC_URL env var (explicit override; required for outbound async flows
+//      like emails/webhooks where there's no in-flight request)
+//   2. x-forwarded-host + x-forwarded-proto (behind a reverse proxy)
+//   3. host header (direct connection)
+//   4. http://localhost:3000 (last-resort fallback for boot-time call paths)
+//
+// See AGENTS.md §13 (Login & Local QA) and the portal-URL design notes.
+
+import { headers } from "next/headers";
+
+function normalize(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/** Derive the portal's externally-reachable base URL from the in-flight request.
+ *  Must be called from a server component, route handler, or server action. */
+export async function getPortalUrl(): Promise<string> {
+  if (process.env.PUBLIC_URL) return normalize(process.env.PUBLIC_URL);
+
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  if (!host) return "http://localhost:3000";
+
+  const proto =
+    h.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") || host.startsWith("127.0.0.1") ? "http" : "https");
+  return `${proto}://${host}`;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,15 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://dpf:dpf_dev@postgres:5432/dpf}
       AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET must be set - run scripts/setup.ps1 or scripts/setup.sh first}
+      # AUTH_TRUST_HOST tells Auth.js to trust the request's Host /
+      # X-Forwarded-Host header so callbacks resolve to whatever URL the
+      # browser used (localhost, LAN IP, dpf.local, public domain). No
+      # hardcoded URL — the portal works in all three modes (localhost,
+      # LAN with mDNS, public with reverse proxy) without env edits.
+      # Optional override: PUBLIC_URL — required only for outbound async
+      # flows (emails, webhooks) where there's no in-flight request.
       AUTH_TRUST_HOST: "true"
-      AUTH_URL: http://localhost:3000
-      APP_URL: http://localhost:3000
+      PUBLIC_URL: ${PUBLIC_URL:-}
       CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:?CREDENTIAL_ENCRYPTION_KEY must be set - run scripts/setup.ps1 or scripts/setup.sh first}
       NEO4J_URI: ${NEO4J_URI:-bolt://neo4j:7687}
       NEO4J_USER: neo4j


### PR DESCRIPTION
## Summary

Hardcoding AUTH_URL=APP_URL=http://localhost:3000 broke every mode except "single machine, only the host accesses it." This PR adopts the standard pattern (per Auth.js v5, Next.js 16, Gitea, Outline, Coolify): **trust the request's Host header and derive the URL at request time.** No hardcoded URL. Three modes work with zero env edits when the IP changes.

| Mode | Setup | Env |
| ---- | ----- | --- |
| **localhost** | docker compose up | AUTH_TRUST_HOST=true (default) |
| **LAN** | browse http://<host-ip>:3000 or http://dpf.local:3000 (mDNS on host) | same — no edit when IP changes |
| **public** | front with Caddy/Traefik/Cloudflare Tunnel | optionally PUBLIC_URL for outbound emails/webhooks |

## What changed

- **docker-compose.yml**: deleted AUTH_URL=http://localhost:3000 and APP_URL=http://localhost:3000. Kept AUTH_TRUST_HOST=true. Added optional PUBLIC_URL passthrough.
- **apps/web/lib/portal-url.ts** (new): canonical resolver. Order: PUBLIC_URL env -> x-forwarded-host + x-forwarded-proto -> host header -> http://localhost:3000 fallback.
- **apps/web/app/callback/route.ts**, **apps/web/app/auth/callback/route.ts**, **apps/web/app/api/v1/auth/provider-oauth/callback/route.ts**: replaced local appBase() helpers with getPortalUrl().
- **apps/web/lib/govern/provider-oauth.ts**: getOAuthRedirectUri is now async; updated both call sites.
- **.env.docker.example**: documented PUBLIC_URL as optional, with guidance on when it is required.

## Sources

- [Auth.js v5 deployment docs](https://authjs.dev/getting-started/deployment) — "AUTH_URL is mostly unnecessary with v5 as the host is inferred from the request headers"
- [Next.js 16 headers()](https://nextjs.org/docs/app/api-reference/functions/headers)
- [Gitea ROOT_URL / PUBLIC_URL_DETECTION=auto](https://github.com/go-gitea/gitea/blob/main/custom/conf/app.example.ini)
- [Outline single URL pattern](https://github.com/outline/outline/blob/main/.env.sample)
- [Coolify Traefik-fronted, app-URL-agnostic](https://github.com/coollabsio/coolify/blob/main/docker-compose.yml)

## Test plan

- [ ] CI: Typecheck green (passed locally via pre-commit hook)
- [ ] CI: Production Build green
- [ ] CI: DCO green
- [ ] Manual: docker compose up -d portal, browse http://localhost:3000, log in, confirm post-login redirect stays on localhost
- [ ] Manual: from another machine on the LAN, browse http://<host-ip>:3000, log in, confirm post-login redirect stays on the LAN address
- [ ] Manual: with PUBLIC_URL=https://example.com set, confirm getPortalUrl() returns the override

## Out of scope

- Reverse-proxy + mDNS one-page docs (separate doc/three-modes-of-running-dpf branch)
- OAuth provider callback registration (provider-side OAuth constraint, not a portal one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)