### PR TITLE
spec(coworkers): persona audit — schema + CI gate (PR 1 of staged rollout)

### DIFF
--- a/.github/workflows/audit-coworker-personas.yml
+++ b/.github/workflows/audit-coworker-personas.yml
@@ -1,0 +1,80 @@
+name: Coworker Personas Audit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/db/data/agent_registry.json"
+      - "prompts/route-persona/**"
+      - "prompts/specialist/**"
+      - "apps/web/scripts/audit-coworker-personas.ts"
+      - "docs/superpowers/audits/2026-04-27-coworker-persona-audit.json"
+      - ".github/workflows/audit-coworker-personas.yml"
+  push:
+    branches: [main]
+
+concurrency:
+  group: audit-coworker-personas-${{ github.ref }}
+  cancel-in-progress: true
+
+# What this guard does
+# --------------------
+# Runs apps/web/scripts/audit-coworker-personas.ts against the canonical
+# coworker registry and persona files (static — no DB). Compares against a
+# tracked baseline at docs/superpowers/audits/2026-04-27-coworker-persona-audit.json
+# and fails ONLY when NEW error-level violations appear — pre-existing
+# violations in the baseline are tracked as backfill items and do not block
+# merges.
+#
+# This is the staged-rollout gate from the spec at
+# docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §5:
+#   PR 1 (this one): script + workflow + baseline. Gate is live; existing
+#                    violations are grandfathered.
+#   PR 2..N: backfill personas one tier or value stream at a time. Each PR
+#            shrinks the baseline by passing --json-out and committing the
+#            updated baseline alongside the persona changes.
+#   PR final: when baseline reaches zero, no special action is needed — the
+#             gate already blocks every new error.
+#
+# When fixing a baseline violation, regenerate the baseline:
+#   pnpm --filter web exec tsx scripts/audit-coworker-personas.ts \
+#     --json-out docs/superpowers/audits/2026-04-27-coworker-persona-audit.json
+# and commit the updated baseline alongside the fix.
+
+jobs:
+  audit:
+    name: Coworker Personas Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run coworker-persona audit (with baseline)
+        # Exits 0 if findings match the baseline (or are a subset).
+        # Exits 1 if NEW error-level violations appear vs. the baseline — fails the PR.
+        # Stdout is the structured JSON report; stderr is the diff summary.
+        run: |
+          pnpm --filter web exec tsx \
+            scripts/audit-coworker-personas.ts \
+            --baseline docs/superpowers/audits/2026-04-27-coworker-persona-audit.json \
+            > audit-current.json
+        continue-on-error: false
+
+      - name: Upload audit report (always, for inspection)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coworker-personas-audit
+          path: audit-current.json
+          retention-days: 14

--- a/apps/web/scripts/audit-coworker-personas.ts
+++ b/apps/web/scripts/audit-coworker-personas.ts
@@ -1,0 +1,616 @@
+/**
+ * Coworker persona audit
+ * (docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md).
+ *
+ * Walks every entry in packages/db/data/agent_registry.json and every persona
+ * file under prompts/route-persona/ and prompts/specialist/, then runs the
+ * spec's §4.2 invariants. Static — no DB. Read-only — no edits.
+ *
+ * Usage (local):
+ *   pnpm --filter web exec tsx scripts/audit-coworker-personas.ts
+ *
+ * Usage (CI): wired into .github/workflows/audit-coworker-personas.yml
+ *
+ * Output: JSON report on stdout. Exit code 0 if no findings, 1 if any.
+ *   --baseline <path>  compare against a prior report; exit 1 only if NEW
+ *                      findings appeared (existing findings are tolerated as
+ *                      already-tracked backfill items).
+ *   --json-out <path>  write the structured report to a file in addition to
+ *                      stdout.
+ *
+ * Why this script exists
+ * ----------------------
+ * 53 agents in the registry, 21 persona files on disk. The mismatch is
+ * invisible without an audit, and the existing 21 personas have drifted from
+ * the registry in fields the prompt-loader does not check (tool lists, value
+ * stream, delegates_to). This script promotes "every coworker has a coherent
+ * job description" from intention to a CI gate.
+ */
+
+import { readFileSync, existsSync, writeFileSync, readdirSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type Severity = "error" | "warn";
+
+interface Finding {
+  invariantId: string;
+  severity: Severity;
+  agentId: string | null;
+  file: string | null;
+  summary: string;
+  detail: string;
+}
+
+interface Report {
+  generatedAt: string;
+  spec: string;
+  invariantsChecked: number;
+  errorCount: number;
+  warnCount: number;
+  findings: Finding[];
+}
+
+const findings: Finding[] = [];
+
+function record(
+  invariantId: string,
+  severity: Severity,
+  agentId: string | null,
+  file: string | null,
+  summary: string,
+  detail: string,
+): void {
+  findings.push({ invariantId, severity, agentId, file, summary, detail });
+}
+
+// ─── Repo root resolution ──────────────────────────────────────────────────
+
+function repoRoot(): string {
+  let dir = process.cwd();
+  while (dir !== "/" && dir !== resolve(dir, "..")) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+    dir = resolve(dir, "..");
+  }
+  return process.cwd();
+}
+
+const ROOT = repoRoot();
+
+// ─── Frontmatter / section parser ──────────────────────────────────────────
+//
+// Personas are markdown with YAML frontmatter delimited by `---` lines.
+// We avoid a YAML dependency: the frontmatter shape we care about is flat
+// scalars and short flow-style lists (`[a, b, c]`). Anything more exotic in
+// existing files will surface as a parse failure and become a finding.
+
+interface Persona {
+  filePath: string;          // absolute
+  relPath: string;           // repo-relative, forward slashes
+  category: "route-persona" | "specialist";
+  slug: string;              // filename without .prompt.md
+  frontmatter: Record<string, string | string[]>;
+  body: string;              // markdown after second `---`
+  composedBody: string;      // body with composesFrom resolved
+}
+
+function parseFrontmatter(text: string, relPath: string): { fm: Record<string, string | string[]>; body: string } | null {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
+    return null;
+  }
+  const end = text.indexOf("\n---", 4);
+  if (end < 0) return null;
+  const yaml = text.slice(4, end).replace(/\r\n/g, "\n");
+  const after = text.slice(end + 4);
+  const body = after.startsWith("\n") ? after.slice(1) : after.startsWith("\r\n") ? after.slice(2) : after;
+
+  const fm: Record<string, string | string[]> = {};
+  const lines = yaml.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let raw = m[2].trim();
+    if (raw === "" || raw === "[]") {
+      // Multi-line block scalar: accumulate following indented lines as a list
+      const list: string[] = [];
+      while (i + 1 < lines.length && /^\s+-\s+/.test(lines[i + 1])) {
+        i++;
+        const item = lines[i].replace(/^\s+-\s+/, "").trim().replace(/^["']|["']$/g, "");
+        if (item) list.push(item);
+      }
+      fm[key] = raw === "[]" ? [] : list.length > 0 ? list : "";
+      continue;
+    }
+    // Flow-style list: [a, b, c] or ["a", "b"]
+    if (raw.startsWith("[") && raw.endsWith("]")) {
+      const inner = raw.slice(1, -1).trim();
+      if (inner === "") {
+        fm[key] = [];
+      } else {
+        fm[key] = inner.split(",").map((s) => s.trim().replace(/^["']|["']$/g, "")).filter(Boolean);
+      }
+      continue;
+    }
+    // Quoted scalar
+    if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+      fm[key] = raw.slice(1, -1);
+      continue;
+    }
+    fm[key] = raw;
+  }
+  void relPath;
+  return { fm, body };
+}
+
+function loadPersona(category: "route-persona" | "specialist", slug: string): Persona | null {
+  const relPath = `prompts/${category}/${slug}.prompt.md`;
+  const filePath = join(ROOT, relPath);
+  if (!existsSync(filePath)) return null;
+  const text = readFileSync(filePath, "utf8");
+  const parsed = parseFrontmatter(text, relPath);
+  if (!parsed) return null;
+  return {
+    filePath,
+    relPath: relPath.replace(/\\/g, "/"),
+    category,
+    slug,
+    frontmatter: parsed.fm,
+    body: parsed.body,
+    composedBody: parsed.body, // resolved below
+  };
+}
+
+function resolveComposes(persona: Persona, depth = 0): string {
+  if (depth > 5) return persona.body;
+  const composes = persona.frontmatter.composesFrom;
+  if (!Array.isArray(composes) || composes.length === 0) return persona.body;
+  let body = persona.body;
+  for (const ref of composes) {
+    const m = ref.match(/^([a-zA-Z_-]+)\/([a-zA-Z0-9_-]+)$/);
+    if (!m) continue;
+    const [, refCat, refSlug] = m;
+    if (refCat !== "route-persona" && refCat !== "specialist") continue;
+    const target = loadPersona(refCat as "route-persona" | "specialist", refSlug);
+    if (!target) continue;
+    const targetBody = resolveComposes(target, depth + 1);
+    body = body.replace(`{{include:${ref}}}`, targetBody);
+  }
+  return body;
+}
+
+function listPersonas(): Persona[] {
+  const personas: Persona[] = [];
+  for (const cat of ["route-persona", "specialist"] as const) {
+    const dir = join(ROOT, "prompts", cat);
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      if (!entry.endsWith(".prompt.md")) continue;
+      const slug = entry.replace(/\.prompt\.md$/, "");
+      const p = loadPersona(cat, slug);
+      if (p) {
+        p.composedBody = resolveComposes(p);
+        personas.push(p);
+      }
+    }
+  }
+  return personas;
+}
+
+// ─── Registry ──────────────────────────────────────────────────────────────
+
+interface RegistryAgent {
+  agent_id: string;
+  agent_name: string;
+  tier: string;
+  value_stream: string;
+  capability_domain: string;
+  human_supervisor_id: string;
+  hitl_tier_default: number;
+  delegates_to: string[];
+  escalates_to: string;
+  config_profile: {
+    tool_grants: string[];
+  };
+}
+
+function loadRegistry(): RegistryAgent[] {
+  const raw = readFileSync(join(ROOT, "packages/db/data/agent_registry.json"), "utf8");
+  const parsed = JSON.parse(raw) as { agents: RegistryAgent[] };
+  return parsed.agents;
+}
+
+// ─── Required body sections ───────────────────────────────────────────────
+//
+// Per spec §3.2 — six headed sections in order. We accept H1 (`# `) at the
+// beginning of a line. Section presence is what's checked; order is checked
+// by index-of comparison.
+
+const REQUIRED_SECTIONS = [
+  "# Role",
+  "# Accountable For",
+  "# Interfaces With",
+  "# Out Of Scope",
+  "# Tools Available",
+  "# Operating Rules",
+] as const;
+
+function findSectionIndex(body: string, heading: string): number {
+  // Match heading at start of line (anchor), case-sensitive, allow trailing whitespace.
+  const re = new RegExp(`^${heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "m");
+  const m = body.match(re);
+  return m && m.index !== undefined ? m.index : -1;
+}
+
+// ─── Invariant checks ──────────────────────────────────────────────────────
+
+function checkPersona001(registry: RegistryAgent[], personaByAgentId: Map<string, Persona>): void {
+  for (const agent of registry) {
+    if (!personaByAgentId.has(agent.agent_id)) {
+      record(
+        "PERSONA-001",
+        "error",
+        agent.agent_id,
+        null,
+        `Registry agent ${agent.agent_id} (${agent.agent_name}) has no persona file`,
+        `No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: ${agent.agent_id}.\n\nFix: create prompts/${agent.tier === "orchestrator" ? "route-persona" : "specialist"}/<slug>.prompt.md following the schema in the persona-audit spec §3.`,
+      );
+    }
+  }
+}
+
+function checkPersona002(registry: RegistryAgent[], personas: Persona[]): void {
+  const registryIds = new Set(registry.map((a) => a.agent_id));
+  for (const p of personas) {
+    const aid = p.frontmatter.agent_id;
+    if (typeof aid !== "string" || !aid) {
+      // Reported under PERSONA-003
+      continue;
+    }
+    if (!registryIds.has(aid)) {
+      record(
+        "PERSONA-002",
+        "error",
+        aid,
+        p.relPath,
+        `Persona ${p.relPath} references agent_id ${aid} which is not in the registry`,
+        `Frontmatter agent_id must match an entry in packages/db/data/agent_registry.json. Either add the agent to the registry or correct the persona's agent_id.`,
+      );
+    }
+  }
+}
+
+function checkPersona003(personas: Persona[]): void {
+  const required: Array<{ key: string; type: "string" | "list" | "number" }> = [
+    { key: "name", type: "string" },
+    { key: "displayName", type: "string" },
+    { key: "description", type: "string" },
+    { key: "category", type: "string" },
+    { key: "version", type: "string" },
+    { key: "agent_id", type: "string" },
+    { key: "reports_to", type: "string" },
+    { key: "delegates_to", type: "list" },
+    { key: "value_stream", type: "string" },
+    { key: "hitl_tier", type: "string" },
+    { key: "status", type: "string" },
+  ];
+  for (const p of personas) {
+    const missing: string[] = [];
+    for (const f of required) {
+      const v = p.frontmatter[f.key];
+      if (v === undefined) {
+        missing.push(`${f.key} (absent)`);
+        continue;
+      }
+      if (f.type === "list" && !Array.isArray(v)) {
+        missing.push(`${f.key} (not a list)`);
+      } else if (f.type === "string" && typeof v !== "string") {
+        missing.push(`${f.key} (not a scalar)`);
+      } else if (f.type === "string" && v === "" && f.key !== "value_stream") {
+        // value_stream may be empty for cross-cutting agents (per spec §3.1)
+        missing.push(`${f.key} (empty)`);
+      }
+    }
+    if (missing.length > 0) {
+      record(
+        "PERSONA-003",
+        "error",
+        (p.frontmatter.agent_id as string) ?? null,
+        p.relPath,
+        `Persona ${p.relPath} missing required frontmatter fields`,
+        `Missing or invalid: ${missing.join(", ")}.\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1.`,
+      );
+    }
+  }
+}
+
+function checkPersona004(registry: RegistryAgent[], personaByAgentId: Map<string, Persona>): void {
+  for (const agent of registry) {
+    const p = personaByAgentId.get(agent.agent_id);
+    if (!p) continue; // covered by PERSONA-001
+
+    const drifts: string[] = [];
+
+    const personaVS = p.frontmatter.value_stream;
+    if (typeof personaVS === "string" && personaVS !== "" && personaVS !== agent.value_stream) {
+      drifts.push(`value_stream: persona='${personaVS}' registry='${agent.value_stream}'`);
+    }
+
+    const personaHitl = p.frontmatter.hitl_tier;
+    if (typeof personaHitl === "string" && personaHitl !== "" && Number(personaHitl) !== agent.hitl_tier_default) {
+      drifts.push(`hitl_tier: persona='${personaHitl}' registry=${agent.hitl_tier_default}`);
+    }
+
+    const personaDelegates = p.frontmatter.delegates_to;
+    if (Array.isArray(personaDelegates)) {
+      const personaSet = new Set(personaDelegates);
+      const registrySet = new Set(agent.delegates_to);
+      const missingFromPersona = [...registrySet].filter((x) => !personaSet.has(x));
+      const extraInPersona = [...personaSet].filter((x) => !registrySet.has(x));
+      if (missingFromPersona.length > 0 || extraInPersona.length > 0) {
+        drifts.push(
+          `delegates_to: persona=[${[...personaSet].join(",")}] registry=[${[...registrySet].join(",")}]`,
+        );
+      }
+    }
+
+    if (drifts.length > 0) {
+      record(
+        "PERSONA-004",
+        "error",
+        agent.agent_id,
+        p.relPath,
+        `Persona frontmatter drifts from registry for ${agent.agent_id}`,
+        drifts.map((d) => `  ${d}`).join("\n") +
+          "\n\nFix: registry is canonical. Update persona frontmatter to match.",
+      );
+    }
+  }
+}
+
+function checkPersona005(personas: Persona[]): void {
+  for (const p of personas) {
+    const missing: string[] = [];
+    let lastIdx = -1;
+    let outOfOrder = false;
+    for (const heading of REQUIRED_SECTIONS) {
+      const idx = findSectionIndex(p.composedBody, heading);
+      if (idx < 0) {
+        missing.push(heading);
+      } else if (idx < lastIdx) {
+        outOfOrder = true;
+      } else {
+        lastIdx = idx;
+      }
+    }
+    if (missing.length > 0 || outOfOrder) {
+      record(
+        "PERSONA-005",
+        "error",
+        (p.frontmatter.agent_id as string) ?? null,
+        p.relPath,
+        `Persona ${p.relPath} missing or misordered required body sections`,
+        (missing.length > 0 ? `Missing: ${missing.join(", ")}\n` : "") +
+          (outOfOrder ? `Sections present but out of order. Required order: ${REQUIRED_SECTIONS.join(" → ")}\n` : "") +
+          "\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2.",
+      );
+    }
+  }
+}
+
+function checkPersona006(registry: RegistryAgent[], personaByAgentId: Map<string, Persona>): void {
+  const registryIds = new Set(registry.map((a) => a.agent_id));
+  for (const p of personaByAgentId.values()) {
+    const interfacesIdx = findSectionIndex(p.composedBody, "# Interfaces With");
+    if (interfacesIdx < 0) continue;
+    // Slice from start of "# Interfaces With" to next H1 heading.
+    const tail = p.composedBody.slice(interfacesIdx);
+    const nextH1 = tail.slice(2).search(/^# /m);
+    const section = nextH1 < 0 ? tail : tail.slice(0, nextH1 + 2);
+    const refs = [...section.matchAll(/\bAGT-[A-Z0-9-]+\b/g)].map((m) => m[0]);
+    const unknown = refs.filter((r) => !registryIds.has(r));
+    if (unknown.length > 0) {
+      record(
+        "PERSONA-006",
+        "error",
+        (p.frontmatter.agent_id as string) ?? null,
+        p.relPath,
+        `Persona ${p.relPath} '# Interfaces With' references unknown agent_id(s)`,
+        `Unknown: ${[...new Set(unknown)].join(", ")}.\n\nFix: every agent_id named in '# Interfaces With' must exist in the registry. Either fix the typo or add the agent.`,
+      );
+    }
+  }
+}
+
+function checkPersona007(registry: RegistryAgent[], personaByAgentId: Map<string, Persona>): void {
+  // Warn-only here — promoted to error in the tool-grant audit (GRANT-006).
+  for (const agent of registry) {
+    const p = personaByAgentId.get(agent.agent_id);
+    if (!p) continue;
+    const idx = findSectionIndex(p.composedBody, "# Tools Available");
+    if (idx < 0) continue; // covered by PERSONA-005
+    const tail = p.composedBody.slice(idx);
+    const nextH1 = tail.slice(2).search(/^# /m);
+    const section = nextH1 < 0 ? tail : tail.slice(0, nextH1 + 2);
+    // Bulleted grant keys like "- backlog_read" or "- backlog_read — read backlog items"
+    const personaGrants = [...section.matchAll(/^\s*[-*]\s+([a-z][a-z0-9_]*)\b/gm)].map((m) => m[1]);
+    if (personaGrants.length === 0) continue; // section exists but is freeform — let it pass for now
+    const personaSet = new Set(personaGrants);
+    const registrySet = new Set(agent.config_profile.tool_grants);
+    const missing = [...registrySet].filter((x) => !personaSet.has(x));
+    const extra = [...personaSet].filter((x) => !registrySet.has(x));
+    if (missing.length > 0 || extra.length > 0) {
+      record(
+        "PERSONA-007",
+        "warn",
+        agent.agent_id,
+        p.relPath,
+        `Persona '# Tools Available' for ${agent.agent_id} drifts from registry tool_grants`,
+        `Missing from persona: ${missing.join(", ") || "(none)"}\nExtra in persona: ${extra.join(", ") || "(none)"}\n\nFix: regenerate this section from the registry (see tool-grant spec §6).`,
+      );
+    }
+  }
+}
+
+function checkPersona008(personas: Persona[]): void {
+  for (const p of personas) {
+    const desc = p.frontmatter.description;
+    if (typeof desc === "string" && desc.length > 120) {
+      record(
+        "PERSONA-008",
+        "warn",
+        (p.frontmatter.agent_id as string) ?? null,
+        p.relPath,
+        `Persona description exceeds 120 chars (${desc.length})`,
+        `Soft cap. Tighten or move detail into the body.`,
+      );
+    }
+  }
+}
+
+function checkPersona010(personas: Persona[]): void {
+  const allFiles = new Set(personas.map((p) => `${p.category}/${p.slug}`));
+  for (const p of personas) {
+    const composes = p.frontmatter.composesFrom;
+    if (!Array.isArray(composes)) continue;
+    for (const ref of composes) {
+      if (!allFiles.has(ref)) {
+        record(
+          "PERSONA-010",
+          "warn",
+          (p.frontmatter.agent_id as string) ?? null,
+          p.relPath,
+          `composesFrom target '${ref}' does not exist`,
+          `Listed in ${p.relPath} but no file at prompts/${ref}.prompt.md.`,
+        );
+      }
+    }
+  }
+}
+
+// ─── Baseline diff ─────────────────────────────────────────────────────────
+
+interface BaselineDiff {
+  newViolations: Finding[];
+  resolvedViolations: Finding[];
+  unchanged: Finding[];
+}
+
+function findingKey(f: Finding): string {
+  return `${f.invariantId}::${f.agentId ?? ""}::${f.file ?? ""}`;
+}
+
+function diffAgainstBaseline(current: Finding[], baselinePath: string): BaselineDiff | null {
+  if (!existsSync(baselinePath)) return null;
+  const raw = readFileSync(baselinePath, "utf8");
+  const baseline = JSON.parse(raw) as Report;
+  const baselineKeys = new Set(baseline.findings.map(findingKey));
+  const currentKeys = new Set(current.map(findingKey));
+  return {
+    newViolations: current.filter((f) => !baselineKeys.has(findingKey(f))),
+    resolvedViolations: baseline.findings.filter((f) => !currentKeys.has(findingKey(f))),
+    unchanged: current.filter((f) => baselineKeys.has(findingKey(f))),
+  };
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const args = process.argv.slice(2);
+  let baselinePath: string | null = null;
+  let jsonOutPath: string | null = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--baseline" && args[i + 1]) {
+      baselinePath = args[i + 1];
+      i++;
+    } else if (args[i] === "--json-out" && args[i + 1]) {
+      jsonOutPath = args[i + 1];
+      i++;
+    }
+  }
+
+  if (baselinePath && !baselinePath.match(/^([a-zA-Z]:[\\/]|\/)/)) {
+    baselinePath = join(ROOT, baselinePath);
+  }
+  if (jsonOutPath && !jsonOutPath.match(/^([a-zA-Z]:[\\/]|\/)/)) {
+    jsonOutPath = join(ROOT, jsonOutPath);
+  }
+
+  const registry = loadRegistry();
+  const personas = listPersonas();
+  const personaByAgentId = new Map<string, Persona>();
+  for (const p of personas) {
+    const aid = p.frontmatter.agent_id;
+    if (typeof aid === "string" && aid) personaByAgentId.set(aid, p);
+  }
+
+  checkPersona001(registry, personaByAgentId);
+  checkPersona002(registry, personas);
+  checkPersona003(personas);
+  checkPersona004(registry, personaByAgentId);
+  checkPersona005(personas);
+  checkPersona006(registry, personaByAgentId);
+  checkPersona007(registry, personaByAgentId);
+  checkPersona008(personas);
+  checkPersona010(personas);
+
+  const errorCount = findings.filter((f) => f.severity === "error").length;
+  const warnCount = findings.filter((f) => f.severity === "warn").length;
+
+  const report: Report = {
+    generatedAt: new Date().toISOString(),
+    spec: "docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md",
+    invariantsChecked: 9,
+    errorCount,
+    warnCount,
+    findings,
+  };
+
+  // Stable serialization: sort findings so JSON diffs are meaningful.
+  report.findings.sort((a, b) => {
+    const k = findingKey(a).localeCompare(findingKey(b));
+    return k;
+  });
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (jsonOutPath) {
+    writeFileSync(jsonOutPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+    console.error(`[audit] wrote ${jsonOutPath}`);
+  }
+
+  let exitCode = 0;
+  if (baselinePath) {
+    const diff = diffAgainstBaseline(findings, baselinePath);
+    if (diff === null) {
+      console.error(`[audit] baseline ${baselinePath} not found — treating all findings as new`);
+      exitCode = errorCount > 0 ? 1 : 0;
+    } else {
+      console.error(`[audit] baseline diff: unchanged=${diff.unchanged.length} resolved=${diff.resolvedViolations.length} new=${diff.newViolations.length}`);
+      const newErrors = diff.newViolations.filter((f) => f.severity === "error");
+      if (newErrors.length > 0) {
+        console.error(`\n[audit] NEW ERROR-LEVEL VIOLATIONS BLOCK MERGE:`);
+        for (const f of newErrors) {
+          console.error(`  [${f.invariantId}] ${f.summary}`);
+        }
+        exitCode = 1;
+      }
+      if (diff.resolvedViolations.length > 0) {
+        console.error(`\n[audit] resolved (these can be removed from the baseline):`);
+        for (const f of diff.resolvedViolations) {
+          console.error(`  [${f.invariantId}] ${f.summary}`);
+        }
+      }
+    }
+  } else {
+    exitCode = errorCount > 0 ? 1 : 0;
+  }
+
+  void basename; // silence unused if any future import shifts
+  process.exit(exitCode);
+}
+
+main();

--- a/docs/superpowers/audits/2026-04-27-coworker-persona-audit.json
+++ b/docs/superpowers/audits/2026-04-27-coworker-persona-audit.json
@@ -1,0 +1,745 @@
+{
+  "generatedAt": "2026-04-28T05:31:03.528Z",
+  "spec": "docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md",
+  "invariantsChecked": 9,
+  "errorCount": 92,
+  "warnCount": 0,
+  "findings": [
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-100",
+      "file": null,
+      "summary": "Registry agent AGT-100 (policy-enforcement-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-100.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-101",
+      "file": null,
+      "summary": "Registry agent AGT-101 (strategy-alignment-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-101.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-102",
+      "file": null,
+      "summary": "Registry agent AGT-102 (portfolio-backlog-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-102.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-110",
+      "file": null,
+      "summary": "Registry agent AGT-110 (portfolio-rationalization-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-110.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-111",
+      "file": null,
+      "summary": "Registry agent AGT-111 (investment-analysis-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-111.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-112",
+      "file": null,
+      "summary": "Registry agent AGT-112 (gap-analysis-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-112.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-113",
+      "file": null,
+      "summary": "Registry agent AGT-113 (scope-agreement-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-113.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-120",
+      "file": null,
+      "summary": "Registry agent AGT-120 (product-backlog-prioritization-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-120.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-121",
+      "file": null,
+      "summary": "Registry agent AGT-121 (architecture-definition-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-121.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-122",
+      "file": null,
+      "summary": "Registry agent AGT-122 (roadmap-assembly-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-122.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-130",
+      "file": null,
+      "summary": "Registry agent AGT-130 (release-planning-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-130.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-131",
+      "file": null,
+      "summary": "Registry agent AGT-131 (sbom-management-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-131.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-132",
+      "file": null,
+      "summary": "Registry agent AGT-132 (release-acceptance-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-132.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-140",
+      "file": null,
+      "summary": "Registry agent AGT-140 (deployment-planning-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-140.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-141",
+      "file": null,
+      "summary": "Registry agent AGT-141 (resource-reservation-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-141.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-142",
+      "file": null,
+      "summary": "Registry agent AGT-142 (iac-execution-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-142.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-150",
+      "file": null,
+      "summary": "Registry agent AGT-150 (service-offer-definition-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-150.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-151",
+      "file": null,
+      "summary": "Registry agent AGT-151 (catalog-publication-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-151.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-152",
+      "file": null,
+      "summary": "Registry agent AGT-152 (subscription-management-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-152.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-160",
+      "file": null,
+      "summary": "Registry agent AGT-160 (consumer-onboarding-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-160.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-161",
+      "file": null,
+      "summary": "Registry agent AGT-161 (order-fulfillment-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-161.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-162",
+      "file": null,
+      "summary": "Registry agent AGT-162 (service-support-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-162.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-170",
+      "file": null,
+      "summary": "Registry agent AGT-170 (monitoring-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-170.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-171",
+      "file": null,
+      "summary": "Registry agent AGT-171 (incident-detection-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-171.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-172",
+      "file": null,
+      "summary": "Registry agent AGT-172 (incident-resolution-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-172.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-180",
+      "file": null,
+      "summary": "Registry agent AGT-180 (constraint-validation-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-180.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-181",
+      "file": null,
+      "summary": "Registry agent AGT-181 (architecture-guardrail-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-181.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-182",
+      "file": null,
+      "summary": "Registry agent AGT-182 (evidence-chain-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-182.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-190",
+      "file": null,
+      "summary": "Registry agent AGT-190 (security-auditor-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-190.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-900",
+      "file": null,
+      "summary": "Registry agent AGT-900 (finance-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-900.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-901",
+      "file": null,
+      "summary": "Registry agent AGT-901 (architecture-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-901.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-902",
+      "file": null,
+      "summary": "Registry agent AGT-902 (data-governance-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-902.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-903",
+      "file": null,
+      "summary": "Registry agent AGT-903 (ux-accessibility-agent) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-903.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-904",
+      "file": null,
+      "summary": "Registry agent AGT-904 (documentation-specialist) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-904.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-BUILD-DA",
+      "file": null,
+      "summary": "Registry agent AGT-BUILD-DA (build-data-architect) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-BUILD-DA.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-BUILD-FE",
+      "file": null,
+      "summary": "Registry agent AGT-BUILD-FE (build-frontend-engineer) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-BUILD-FE.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-BUILD-QA",
+      "file": null,
+      "summary": "Registry agent AGT-BUILD-QA (build-qa-engineer) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-BUILD-QA.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-BUILD-SE",
+      "file": null,
+      "summary": "Registry agent AGT-BUILD-SE (build-software-engineer) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-BUILD-SE.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-000",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-000 (coo-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-000.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-100",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-100 (evaluate-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-100.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-200",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-200 (explore-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-200.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-300",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-300 (integrate-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-300.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-400",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-400 (deploy-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-400.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-500",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-500 (release-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-500.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-600",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-600 (consume-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-600.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-700",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-700 (operate-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-700.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-ORCH-800",
+      "file": null,
+      "summary": "Registry agent AGT-ORCH-800 (governance-orchestrator) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-ORCH-800.\n\nFix: create prompts/route-persona/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-R2D-PB",
+      "file": null,
+      "summary": "Registry agent AGT-R2D-PB (product-backlog-specialist) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-R2D-PB.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-S2P-PFB",
+      "file": null,
+      "summary": "Registry agent AGT-S2P-PFB (portfolio-backlog-specialist) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-S2P-PFB.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-001",
+      "severity": "error",
+      "agentId": "AGT-S2P-POL",
+      "file": null,
+      "summary": "Registry agent AGT-S2P-POL (policy-specialist) has no persona file",
+      "detail": "No persona file under prompts/route-persona/ or prompts/specialist/ declares agent_id: AGT-S2P-POL.\n\nFix: create prompts/specialist/<slug>.prompt.md following the schema in the persona-audit spec §3."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/admin-assistant.prompt.md",
+      "summary": "Persona prompts/route-persona/admin-assistant.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/build-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/build-specialist.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/coo.prompt.md",
+      "summary": "Persona prompts/route-persona/coo.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/customer-advisor.prompt.md",
+      "summary": "Persona prompts/route-persona/customer-advisor.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/ea-architect.prompt.md",
+      "summary": "Persona prompts/route-persona/ea-architect.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/finance-agent.prompt.md",
+      "summary": "Persona prompts/route-persona/finance-agent.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/hr-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/hr-specialist.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/inventory-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/inventory-specialist.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/marketing-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/marketing-specialist.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/onboarding-coo.prompt.md",
+      "summary": "Persona prompts/route-persona/onboarding-coo.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/ops-coordinator.prompt.md",
+      "summary": "Persona prompts/route-persona/ops-coordinator.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/platform-engineer.prompt.md",
+      "summary": "Persona prompts/route-persona/platform-engineer.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/portfolio-advisor.prompt.md",
+      "summary": "Persona prompts/route-persona/portfolio-advisor.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/data-architect.prompt.md",
+      "summary": "Persona prompts/specialist/data-architect.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/discovery-taxonomy-gap-triage.prompt.md",
+      "summary": "Persona prompts/specialist/discovery-taxonomy-gap-triage.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/frontend-engineer.prompt.md",
+      "summary": "Persona prompts/specialist/frontend-engineer.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/hive-scout-archetype-gap.prompt.md",
+      "summary": "Persona prompts/specialist/hive-scout-archetype-gap.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/qa-engineer.prompt.md",
+      "summary": "Persona prompts/specialist/qa-engineer.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/shared-identity.prompt.md",
+      "summary": "Persona prompts/specialist/shared-identity.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/software-engineer.prompt.md",
+      "summary": "Persona prompts/specialist/software-engineer.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-003",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/ux-accessibility.prompt.md",
+      "summary": "Persona prompts/specialist/ux-accessibility.prompt.md missing required frontmatter fields",
+      "detail": "Missing or invalid: agent_id (absent), reports_to (absent), delegates_to (absent), value_stream (absent), hitl_tier (absent), status (absent).\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.1."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/admin-assistant.prompt.md",
+      "summary": "Persona prompts/route-persona/admin-assistant.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/build-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/build-specialist.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/coo.prompt.md",
+      "summary": "Persona prompts/route-persona/coo.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/customer-advisor.prompt.md",
+      "summary": "Persona prompts/route-persona/customer-advisor.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/ea-architect.prompt.md",
+      "summary": "Persona prompts/route-persona/ea-architect.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/finance-agent.prompt.md",
+      "summary": "Persona prompts/route-persona/finance-agent.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/hr-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/hr-specialist.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/inventory-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/inventory-specialist.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/marketing-specialist.prompt.md",
+      "summary": "Persona prompts/route-persona/marketing-specialist.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/onboarding-coo.prompt.md",
+      "summary": "Persona prompts/route-persona/onboarding-coo.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/ops-coordinator.prompt.md",
+      "summary": "Persona prompts/route-persona/ops-coordinator.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/platform-engineer.prompt.md",
+      "summary": "Persona prompts/route-persona/platform-engineer.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/route-persona/portfolio-advisor.prompt.md",
+      "summary": "Persona prompts/route-persona/portfolio-advisor.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/data-architect.prompt.md",
+      "summary": "Persona prompts/specialist/data-architect.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/discovery-taxonomy-gap-triage.prompt.md",
+      "summary": "Persona prompts/specialist/discovery-taxonomy-gap-triage.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/frontend-engineer.prompt.md",
+      "summary": "Persona prompts/specialist/frontend-engineer.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/hive-scout-archetype-gap.prompt.md",
+      "summary": "Persona prompts/specialist/hive-scout-archetype-gap.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/qa-engineer.prompt.md",
+      "summary": "Persona prompts/specialist/qa-engineer.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/shared-identity.prompt.md",
+      "summary": "Persona prompts/specialist/shared-identity.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/software-engineer.prompt.md",
+      "summary": "Persona prompts/specialist/software-engineer.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    },
+    {
+      "invariantId": "PERSONA-005",
+      "severity": "error",
+      "agentId": null,
+      "file": "prompts/specialist/ux-accessibility.prompt.md",
+      "summary": "Persona prompts/specialist/ux-accessibility.prompt.md missing or misordered required body sections",
+      "detail": "Missing: # Role, # Accountable For, # Interfaces With, # Out Of Scope, # Tools Available, # Operating Rules\n\nFix: see schema in docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md §3.2."
+    }
+  ]
+}

--- a/docs/superpowers/audits/2026-04-27-coworker-persona-audit.md
+++ b/docs/superpowers/audits/2026-04-27-coworker-persona-audit.md
@@ -1,0 +1,110 @@
+# Coworker Persona Audit — Initial Report
+
+| Field | Value |
+|-------|-------|
+| **Spec** | [docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md](../specs/2026-04-27-coworker-persona-audit-design.md) |
+| **Generated** | 2026-04-28 |
+| **Errors** | 92 |
+| **Warnings** | 0 |
+| **Baseline** | [2026-04-27-coworker-persona-audit.json](./2026-04-27-coworker-persona-audit.json) |
+
+This report is the day-one snapshot. CI uses the JSON baseline alongside it to enforce *no new violations* — every existing finding is grandfathered as known backfill work. As personas are filled in (PR 2..N per the spec's §5 staged rollout), each fix shrinks both files in lockstep.
+
+To regenerate after a persona change:
+
+```sh
+pnpm --filter web exec tsx scripts/audit-coworker-personas.ts \
+  --json-out docs/superpowers/audits/2026-04-27-coworker-persona-audit.json
+```
+
+Then update this markdown report's counts and lists by hand, or rerun the report-generation step.
+
+---
+
+## Findings by invariant
+
+### PERSONA-001 — Registry agent has no persona file (50 errors)
+
+50 of the 50 agents in [agent_registry.json](../../../packages/db/data/agent_registry.json) have no matching persona file. The 21 existing files in `prompts/route-persona/` and `prompts/specialist/` do not yet declare an `agent_id` frontmatter field, so the audit cannot link them to registry entries. All registry agents are reported as missing until the new frontmatter is added (see PERSONA-003) and a persona file is created for each (see backfill plan below).
+
+**Orchestrators (9):** AGT-ORCH-000, AGT-ORCH-100, AGT-ORCH-200, AGT-ORCH-300, AGT-ORCH-400, AGT-ORCH-500, AGT-ORCH-600, AGT-ORCH-700, AGT-ORCH-800.
+
+**Evaluate VS specialists (4):** AGT-100, AGT-101, AGT-102, AGT-190.
+
+**Explore VS specialists (4):** AGT-110, AGT-111, AGT-112, AGT-113.
+
+**Integrate VS specialists (3):** AGT-120, AGT-121, AGT-122.
+
+**Deploy VS specialists (3):** AGT-130, AGT-131, AGT-132.
+
+**Release VS specialists (3):** AGT-140, AGT-141, AGT-142.
+
+**Consume VS specialists (3):** AGT-150, AGT-151, AGT-152.
+
+**Operate VS specialists (3):** AGT-160, AGT-161, AGT-162.
+
+**Govern VS specialists (3):** AGT-170, AGT-171, AGT-172.
+
+**Detect / Respond (3):** AGT-180, AGT-181, AGT-182.
+
+**Infrastructure (5):** AGT-900, AGT-901, AGT-902, AGT-903, AGT-904.
+
+**Build sub-agents (4):** AGT-BUILD-DA, AGT-BUILD-SE, AGT-BUILD-FE, AGT-BUILD-QA.
+
+**Recipient-pattern specialists (3):** AGT-S2P-POL, AGT-S2P-PFB, AGT-R2D-PB.
+
+### PERSONA-003 — Persona missing required frontmatter fields (21 errors)
+
+All 21 persona files predate the schema and lack the new required fields (`agent_id`, `reports_to`, `delegates_to`, `value_stream`, `hitl_tier`, `status`). Listed for reference; one fix per file in the backfill PRs.
+
+- prompts/route-persona/admin-assistant.prompt.md
+- prompts/route-persona/build-specialist.prompt.md
+- prompts/route-persona/coo.prompt.md
+- prompts/route-persona/customer-advisor.prompt.md
+- prompts/route-persona/ea-architect.prompt.md
+- prompts/route-persona/finance-agent.prompt.md
+- prompts/route-persona/hr-specialist.prompt.md
+- prompts/route-persona/inventory-specialist.prompt.md
+- prompts/route-persona/marketing-specialist.prompt.md
+- prompts/route-persona/onboarding-coo.prompt.md
+- prompts/route-persona/ops-coordinator.prompt.md
+- prompts/route-persona/platform-engineer.prompt.md
+- prompts/route-persona/portfolio-advisor.prompt.md
+- prompts/specialist/data-architect.prompt.md
+- prompts/specialist/discovery-taxonomy-gap-triage.prompt.md
+- prompts/specialist/frontend-engineer.prompt.md
+- prompts/specialist/hive-scout-archetype-gap.prompt.md
+- prompts/specialist/qa-engineer.prompt.md
+- prompts/specialist/shared-identity.prompt.md
+- prompts/specialist/software-engineer.prompt.md
+- prompts/specialist/ux-accessibility.prompt.md
+
+Note: `shared-identity.prompt.md` is a composition fragment, not a coworker persona. The schema may need a special-case `kind: fragment` exemption — flagged as a refinement under spec §6 Open Questions.
+
+### PERSONA-005 — Persona missing required body sections (21 errors)
+
+Same 21 files as above. None currently have the `# Role / # Accountable For / # Interfaces With / # Out Of Scope / # Tools Available / # Operating Rules` structure. Existing prose maps reasonably well into `# Operating Rules`; the other five sections are the backfill work.
+
+---
+
+## Backfill plan
+
+The spec's §5 staged rollout schedules backfill in tier/value-stream batches. Suggested PR sequence:
+
+1. **Backfill orchestrators (1 PR, 9 personas)** — AGT-ORCH-000 through AGT-ORCH-800. The COO persona already exists at [coo.prompt.md](../../../prompts/route-persona/coo.prompt.md) and only needs schema migration; the other eight need full authorship from the registry's `capability_domain` and IT4IT section pointers.
+
+2. **Backfill build sub-agents (1 PR, 4 personas)** — AGT-BUILD-DA/SE/FE/QA. The four matching specialist personas already exist and only need migration to the new schema plus the four required sections beyond `# Operating Rules`.
+
+3. **Backfill specialists by value stream (8 PRs, ~30 personas)** — one PR per VS: evaluate, explore, integrate, deploy, release, consume, operate, govern + detect/respond.
+
+4. **Backfill infrastructure agents (1 PR, 5 personas)** — AGT-900..904.
+
+5. **Backfill recipient-pattern specialists (1 PR, 3 personas)** — AGT-S2P-POL, AGT-S2P-PFB, AGT-R2D-PB.
+
+Each backfill PR runs the audit with `--json-out` and commits both the JSON baseline and an updated count in this markdown report. When the baseline reaches zero errors, the gate is silently in full effect for everything new.
+
+## What is *not* in this report
+
+- **Tool-grant correctness.** The companion spec ([2026-04-27-coworker-tool-grant-spec-design.md](../specs/2026-04-27-coworker-tool-grant-spec-design.md)) audits whether each coworker has the right tools. PERSONA-007 in this audit is warn-only; the same check is promoted to error under GRANT-006 once that audit lands.
+- **A2A communication.** Tracked separately, see the standalone prompt at [docs/prompts/a2a-coworker-substrate-prompt.md](../../prompts/a2a-coworker-substrate-prompt.md).
+- **Runtime persona overrides.** Admin > Prompts can override `PromptTemplate.content` at runtime; the audit only checks the seed (canonical source).

--- a/docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md
+++ b/docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md
@@ -1,0 +1,178 @@
+# AI Coworker Persona & Job-Description Audit — Design Spec
+
+| Field | Value |
+|-------|-------|
+| **Epic** | Platform / AI Coworkers / Governance |
+| **Status** | Draft |
+| **Created** | 2026-04-27 |
+| **Author** | Claude Opus 4.7 for Mark Bodman |
+| **Scope** | `packages/db/data/agent_registry.json`, `prompts/route-persona/`, `prompts/specialist/`, `apps/web/lib/tak/prompt-loader.ts`, `apps/web/scripts/audit-coworker-personas.ts` (new), `.github/workflows/audit-coworker-personas.yml` (new) |
+| **Companion specs** | [2026-04-27-coworker-tool-grant-spec-design.md](./2026-04-27-coworker-tool-grant-spec-design.md) — runs second, depends on this spec's persona schema |
+| **Out of scope** | A2A communication substrate (separate thread / spec), runtime persona overrides via Admin > Prompts, model binding, token budgets |
+| **Primary goal** | Every agent in the registry has a complete, machine-checkable job description that names its role, accountability, peers, and out-of-scope work — and that fact is enforced by CI, not maintained by hope. |
+
+---
+
+## 1. Problem Statement
+
+The agent registry at [packages/db/data/agent_registry.json](../../packages/db/data/agent_registry.json) declares **53 coworkers** across orchestrator, specialist, and infrastructure tiers. Each registry entry carries a `capability_domain` string (a sentence fragment of duties) plus structured fields for tier, value stream, supervisor, delegation targets, and IT4IT sections.
+
+The narrative persona — what the model actually *reads* when invoked — lives in markdown files under `prompts/route-persona/` (13 files) and `prompts/specialist/` (8 files). That covers **21 personas for 53 agents**. The remaining ~32 agents have only their registry sentence to define them; when invoked, the prompt-loader either falls back to a generic persona or leaves the model to infer its role from context.
+
+Three concrete failure modes follow from this gap:
+
+1. **Hallucinated role boundaries.** An agent without a persona file infers what it does from the user's question rather than from a job description. Two invocations of the same agent on different topics behave like two different agents — no stable accountability.
+
+2. **Drift between registry and persona.** Where personas exist, they are hand-written and not cross-checked against the registry. [coo.prompt.md](../../prompts/route-persona/coo.prompt.md:35-43) lists tool names in prose (`query_backlog`, `propose_file_change`, `read_project_file`) that do not match the registry's grant keys (`backlog_read`, `backlog_write`, `registry_read`). The model is told it has tools the platform never grants, and is not told about tools it actually has. (The grant-side fix lives in the companion tool-grant spec; this spec ensures the persona file *exists* and has the structural slot for tool listing.)
+
+3. **No way to audit at scale.** Asking "does every coworker have a coherent job description?" today requires opening 53 entries by hand and reading each prompt file. There is no canonical schema to check completeness against, and no CI gate to keep it that way as new coworkers are added.
+
+This is the same pattern the routing-spec boot-invariant audit fixed for routing ([2026-04-27-routing-spec-boot-invariants.md](../audits/2026-04-27-routing-spec-boot-invariants.md), CI workflow `.github/workflows/audit-routing-invariants.yml`): formalize the invariants, write a script that fails the build when they drift, run it on every PR. We apply the same shape here.
+
+## 2. Non-Goals
+
+- **Rewriting the personas.** This spec defines the schema and the audit. Filling in the missing persona files is follow-up work, surfaced as backlog items by the audit.
+- **Runtime persona editing.** Admin > Prompts already lets operators override `PromptTemplate.content` at runtime; that path is unchanged. The audit reads the seed (canonical source), not the runtime override.
+- **Tool-grant correctness.** Whether a coworker's tool list is the right list for its job is the [companion spec's](./2026-04-27-coworker-tool-grant-spec-design.md) problem. This spec only requires the persona to *have a tool-listing section* of the right structural shape.
+- **A2A / inter-agent messaging.** Out of scope by request — see the standalone prompt for that thread.
+- **Model binding.** Whether AGT-ORCH-300 should run on Opus 4.6 vs. Opus 4.7 is a routing concern, settled by the routing control-plane spec.
+- **Adding new coworkers.** This spec audits the existing 53; it doesn't decide whether the roster is right.
+
+## 3. Canonical Persona Schema
+
+A persona file lives at `prompts/<category>/<slug>.prompt.md` where `category ∈ {route-persona, specialist}`. It uses YAML frontmatter plus a markdown body with mandatory sections.
+
+### 3.1 Frontmatter (required fields)
+
+```yaml
+---
+name: <slug>                          # matches filename, e.g. "coo"
+displayName: <human-readable>         # e.g. "COO"
+description: <one-line summary>       # one line, ≤ 120 chars
+category: route-persona | specialist
+version: <integer>                    # bump when content changes meaningfully
+
+# NEW — required by this spec, additive to existing frontmatter
+agent_id: <AGT-…>                     # exact match to agent_registry.json agent_id
+reports_to: <HR-…> | <AGT-…> | null   # human supervisor or parent orchestrator
+delegates_to: [<AGT-…>, …]            # mirrors registry; persona-side cross-check
+value_stream: <slug>                  # mirrors registry; "" only for cross-cutting
+hitl_tier: 0 | 1 | 2 | 3              # mirrors registry hitl_tier_default
+status: active | draft | retired      # persona authoring status, distinct from registry status
+
+# Existing optional fields kept as-is
+composesFrom: [<category>/<slug>, …]
+contentFormat: markdown
+variables: []
+sensitivity: public | internal | confidential
+perspective: <one-sentence frame>
+heuristics: <comma-separated decision frames>
+interpretiveModel: <one-sentence success criterion>
+---
+```
+
+The five new fields make the persona file a **first-class declaration of the agent's identity**, not a loose markdown blob. They are the join keys between the persona and the registry.
+
+### 3.2 Body sections (required, in order)
+
+The audit checks for these six headed sections by literal heading match. Wording inside each section is the author's; presence is mandatory.
+
+1. **`# Role`** — one paragraph: who this coworker is, in role terms.
+   Example: *"You are the Integrate Orchestrator. You own the build coordination, release planning, and acceptance-gate workflow for the Integrate value stream."*
+
+2. **`# Accountable For`** — bulleted list of outcomes this coworker owns. Outcomes, not activities.
+   Example: *"Build plan exists for every approved spec," "Release gate decision is recorded with rationale," "SBOM is current at every release."*
+
+3. **`# Interfaces With`** — bulleted list naming each peer/parent/child by `agent_id` and the nature of the interface (delegates work to, escalates to, reports to, consumes artifacts from).
+   Example: *"AGT-BUILD-SE — delegates implementation tasks to," "AGT-ORCH-200 — receives approved specs from."*
+
+4. **`# Out Of Scope`** — bulleted list of things this coworker explicitly does **not** do, especially boundaries with neighboring roles. This section is what stops role drift at runtime.
+   Example: *"Does not author specs (that is AGT-ORCH-200)," "Does not run deployments (that is AGT-ORCH-400)."*
+
+5. **`# Tools Available`** — bulleted list of grant keys this coworker has, mirroring the registry's `tool_grants` exactly. The companion tool-grant spec generates this section; this spec only requires its presence and that it parses as a bulleted list of grant keys.
+
+6. **`# Operating Rules`** — free-form markdown for heuristics, conversation rules, escalation triggers, refusal patterns. This is where the bulk of existing prompt content lands.
+
+The first four sections together are the **job description**. The fifth is the **tool envelope**. The sixth is the **playbook**. Together they answer "who, what, with whom, and how" in a way the audit can check by structure rather than by reading.
+
+### 3.3 Compatibility with existing prompt-loader
+
+[apps/web/lib/tak/prompt-loader.ts](../../apps/web/lib/tak/prompt-loader.ts) reads the markdown body via `PromptTemplate.content` and the frontmatter as JSON via `PromptTemplate.metadata`. The new frontmatter fields land in `metadata` automatically; no schema change required on the runtime path. The body still renders as a single string to the model; the section headings become part of the rendered prompt and add structure the model can lean on.
+
+`composesFrom` continues to work — `specialist/shared-identity` is included by reference, and the audit checks the *fully-composed* output for required sections, not just the leaf file.
+
+## 4. Audit Script
+
+A new script `apps/web/scripts/audit-coworker-personas.ts` runs the invariants. Modeled on [audit-routing-spec-boot-invariants.ts](../../apps/web/scripts/audit-routing-spec-boot-invariants.ts) — same exit-code discipline, same finding-table format.
+
+### 4.1 Inputs
+
+- `packages/db/data/agent_registry.json` — full agent list, source of truth for `agent_id`, `tier`, `value_stream`, `hitl_tier_default`, `delegates_to`, `human_supervisor_id`.
+- `prompts/route-persona/*.prompt.md` and `prompts/specialist/*.prompt.md` — persona files on disk.
+- `prompts/specialist/shared-identity.prompt.md` and any other `composesFrom` targets — resolved during composition.
+
+The script does **not** read the database. The audit runs against the seed at PR time; runtime overrides are out of scope (operators can drift their override at their own risk).
+
+### 4.2 Invariants (in order of severity)
+
+| ID | Severity | Invariant | Check |
+|----|----------|-----------|-------|
+| **PERSONA-001** | error | Every registry agent has a persona file | For every `agent_id` in registry, there exists a persona file whose frontmatter `agent_id` matches |
+| **PERSONA-002** | error | Every persona file maps to a registry agent | For every persona file, frontmatter `agent_id` exists in registry (orphan personas blocked) |
+| **PERSONA-003** | error | Frontmatter has all required fields | All fields in §3.1 marked required are present and non-empty |
+| **PERSONA-004** | error | Frontmatter mirrors registry truthfully | `value_stream`, `hitl_tier`, `delegates_to` in persona match registry; mismatches block merge |
+| **PERSONA-005** | error | All six body sections present | Composed body contains the six headings of §3.2 in order |
+| **PERSONA-006** | error | `# Interfaces With` references resolve | Every `AGT-…` mentioned in this section exists in the registry |
+| **PERSONA-007** | warn | `# Tools Available` matches registry grants | Bulleted grant keys are a permutation of the registry's `tool_grants` for this agent. Severity is `warn` here because the companion tool-grant spec promotes it to `error` once that spec lands |
+| **PERSONA-008** | warn | `description` ≤ 120 chars | Soft length cap on the one-liner |
+| **PERSONA-009** | warn | Persona `status: draft` requires a backlog item | If persona is `draft`, expect a tracking row; advisory only |
+| **PERSONA-010** | warn | `composesFrom` targets exist | Every referenced `category/slug` resolves to a real file |
+
+`error` findings exit non-zero and block CI. `warn` findings print to the report but do not block.
+
+### 4.3 Output
+
+Two artifacts, mirroring the routing audit:
+
+1. **Console table** — one row per finding, columns `id | severity | agent_id | file | message`. Printed grouped by severity, errors first.
+2. **Markdown report** at `docs/superpowers/audits/2026-04-27-coworker-persona-audit.md` — generated when run with `--write-report`, committed alongside the script in the bootstrapping PR. Subsequent runs in CI print to console only; the report is regenerated on demand.
+
+Exit codes: `0` clean, `1` errors found, `2` script-internal failure (file unreadable, registry malformed).
+
+### 4.4 CI integration
+
+New workflow `.github/workflows/audit-coworker-personas.yml` mirroring [audit-routing-invariants.yml](../../.github/workflows/audit-routing-invariants.yml):
+
+- Triggers: pull_request on paths `packages/db/data/agent_registry.json`, `prompts/route-persona/**`, `prompts/specialist/**`, `apps/web/scripts/audit-coworker-personas.ts`.
+- Steps: checkout, pnpm install, run `pnpm --filter @dpf/web exec tsx scripts/audit-coworker-personas.ts`.
+- A failing audit blocks merge once the workflow is added to required checks (separate operator step in branch protection settings).
+
+## 5. Bootstrapping the Backfill
+
+The first audit run will produce a large number of findings — roughly 32 missing persona files, plus drift in the existing 21. The plan to land cleanly:
+
+1. **PR 1 — Schema, script, and CI gate, no errors.** Land the schema (§3) as documentation, the audit script (§4) running in **report-only mode** (always exit 0), and the workflow at `continue-on-error: true`. Generate the initial audit report at `docs/superpowers/audits/2026-04-27-coworker-persona-audit.md` so the gap is visible.
+
+2. **PR 2..N — Backfill personas.** Each backfill PR adds persona files for one tier or value stream at a time (e.g., "all evaluate-VS specialists," "all build-VS specialists"). Audit report shrinks with each PR. The author of each backfill PR uses the registry entry plus the canonical schema as a writing template; one persona per file, no batched mega-PRs.
+
+3. **PR final — Promote audit to blocking.** Flip the script to error-on-violation and remove `continue-on-error` from the workflow. From then on, adding a coworker without a persona is a CI failure.
+
+This is the same staged-rollout pattern used for the routing audit. It avoids a merge-blocking PR-1 and keeps the work shippable in pieces.
+
+## 6. Open Questions
+
+- **Should `# Operating Rules` have any structural sub-headings?** The current proposal leaves it free-form. An alternative is to mandate sub-sections like `## Escalation Triggers`, `## Refusal Patterns`, `## Conversation Style`. Recommendation: keep free-form for v1; revisit if persona drift recurs in the rules section specifically.
+- **Where do persona authoring guidelines live?** A separate `docs/superpowers/guides/writing-coworker-personas.md` is probably the right home; out of scope for this spec but should be the first artifact produced during PR 2.
+- **Do orchestrator personas need a different schema than specialist personas?** The current proposal uses one schema for both, with `tier` distinguishing. If orchestrators end up needing additional structured fields (e.g., a `coordinates_value_stream_stages: [§5.3.1, §5.3.2]` list), revise the schema in v2.
+
+## 7. Acceptance Criteria
+
+This spec is implemented when:
+
+- [ ] `apps/web/scripts/audit-coworker-personas.ts` exists and runs.
+- [ ] `.github/workflows/audit-coworker-personas.yml` exists and runs on PRs touching the relevant paths.
+- [ ] An initial report at `docs/superpowers/audits/2026-04-27-coworker-persona-audit.md` is committed.
+- [ ] Every existing persona file under `prompts/route-persona/` and `prompts/specialist/` either passes the audit or has a tracked backfill item.
+- [ ] Every agent in `agent_registry.json` either has a persona file or is listed in the audit report as a known-missing item with a tracked backfill.
+- [ ] The schema in §3 is the only authoritative description of a persona file's shape; no competing definition exists in code or docs.
+- [ ] Once backfill is complete, the workflow is promoted to a required check in branch protection.


### PR DESCRIPTION
## Summary

- Define a canonical persona schema (frontmatter + six required body sections) that joins every coworker persona to its `agent_registry.json` entry.
- Land a static audit script (9 invariants) and a CI workflow that blocks **new** error-level violations while grandfathering existing findings via a baseline JSON — same pattern as the routing-invariants gate (#311).
- Commit the day-one baseline (92 errors) and a human-readable report grouping the gap into a 10-PR backfill plan.

## Why

Registry has 50 coworkers; only 21 have persona files, and those 21 are hand-written without cross-checks against the registry. The result is silent role drift — coworkers inferring their job from context, persona prose listing tool names that don't match runtime grant keys, no canonical schema to check completeness against.

## Spec

- [docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md](docs/superpowers/specs/2026-04-27-coworker-persona-audit-design.md)

Companion specs:
- Tool-grant audit (next PR, depends on this spec's `# Tools Available` section as the join slot).
- A2A communication substrate (separate thread).

## Day-one baseline

- 50 PERSONA-001 (registry agents missing persona files)
- 21 PERSONA-003 (existing personas need new frontmatter fields)
- 21 PERSONA-005 (existing personas need the six required body sections)

Backfill plan in [docs/superpowers/audits/2026-04-27-coworker-persona-audit.md](docs/superpowers/audits/2026-04-27-coworker-persona-audit.md): one PR per tier or value-stream batch. Each backfill PR shrinks the baseline by passing `--json-out`.

## Test plan

- [x] `pnpm --filter web exec tsx scripts/audit-coworker-personas.ts --baseline ...` exits 0 (unchanged=92 resolved=0 new=0)
- [x] Pre-commit typecheck hook passed locally
- [ ] Audit workflow runs green in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)