### PR TITLE
fix(auth): gate session-cookie Secure flag on PUBLIC_URL scheme, not NODE_ENV

### DIFF
--- a/apps/web/lib/govern/auth.ts
+++ b/apps/web/lib/govern/auth.ts
@@ -84,11 +84,27 @@ export type DpfSession = {
 //
 // Fix: give the sandbox a distinct cookie name. Portal keeps the default
 // so existing sessions survive, sandbox gets its own cookie that never
-// collides. `secure: false` because both run over plain http in dev.
+// collides.
 const isSandboxEnv = process.env.DPF_ENVIRONMENT === "sandbox";
 const sessionCookieName = isSandboxEnv
   ? "authjs.session-token.sandbox"
   : "authjs.session-token";
+
+// `secure: true` on a cookie tells the browser to drop it over plain HTTP.
+// In a self-hosted deploy, the portal can be reached three ways:
+//   - http://localhost:3000           (single-machine dev)
+//   - http://<lan-ip>:3000            (LAN / mDNS, plain HTTP)
+//   - https://dpf.example.com         (public domain behind reverse proxy)
+//
+// Gating on NODE_ENV breaks the LAN case: the production build sets
+// NODE_ENV=production, secure=true, the cookie is dropped over HTTP, every
+// click after login sees no session and bounces back to /login.
+//
+// Gate on the *protocol* instead: secure only when the operator has
+// explicitly declared an HTTPS public URL. This is the same convention
+// used by Gitea, Outline, and other self-hosted Next.js / Auth.js apps.
+const publicUrl = process.env.PUBLIC_URL ?? "";
+const isHttps = publicUrl.startsWith("https://");
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   trustHost: true,
@@ -101,7 +117,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         httpOnly: true,
         sameSite: "lax",
         path: "/",
-        secure: process.env.NODE_ENV === "production",
+        secure: isHttps,
       },
     },
   },


### PR DESCRIPTION
## Symptom

Logging into the portal from a remote machine over the LAN IP (e.g. http://192.168.0.200:3000) succeeds — workspace renders once. Every subsequent click bounces back to /login, no matter where you click.

## Cause

The session cookie was configured with:

```ts
secure: process.env.NODE_ENV === "production"
```

The Docker production build sets NODE_ENV=production, so secure=true. A Secure cookie is dropped by the browser on plain-HTTP responses. The login POST sets the cookie; the browser stores it but flags it HTTPS-only; every following GET arrives without the cookie — so the server sees no session and redirects to /login.

This broke all three "no hardcoding" modes shipped in #314 the moment the connection is plain HTTP, which today is everything except public-domain deployments behind a TLS-terminating reverse proxy.

## Fix

Gate `secure` on the operator's declared PUBLIC_URL scheme, not on NODE_ENV:

| PUBLIC_URL | secure | Cookie behavior |
| ---------- | ------ | --------------- |
| https://... | true | Browser refuses to leak the cookie over plain HTTP. Correct for HTTPS deployments. |
| unset or http://... | false | Cookie works over the plain-HTTP connection the operator actually deployed. |

Same convention as Gitea, Outline, and other self-hosted Next.js / Auth.js apps. The operator opts into Secure cookies by declaring an HTTPS URL, not by accident of build mode.

## Test plan

- [x] All 522 test files pass locally (vitest run, full suite)
- [x] Typecheck passes locally (Prisma client needed regenerate after recent capabilityCategory rename — separate concern, unrelated to this fix)
- [ ] CI: Typecheck green
- [ ] CI: Production Build green
- [ ] CI: Unit Tests green
- [ ] CI: DCO green
- [ ] Manual: rebuild portal (`docker compose build portal && docker compose up -d portal`), log in over LAN IP from a remote machine, click around the workspace — session persists, no login bounces

🤖 Generated with [Claude Code](https://claude.com/claude-code)