### PR TITLE
fix(hooks): pre-commit auto-regenerates Prisma client on schema drift

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,7 +39,31 @@ if [ -n "$MODIFIED_MIGRATIONS" ]; then
   exit 1
 fi
 
-# ─── Guard 2: typecheck gate ────────────────────────────────────────────────
+# ─── Guard 2: stale Prisma client refresh ───────────────────────────────────
+# When `git pull` brings in a newer schema.prisma, the generated Prisma client
+# in packages/db/generated/client stays at the old shape until someone runs
+# `pnpm install` (which fires the postinstall: prisma generate). The
+# typecheck below will then fail with "Property X does not exist" errors that
+# look like main is broken — they're actually just local staleness.
+#
+# Detect the drift and regenerate transparently. Fast (~1s) and idempotent.
+
+SCHEMA="packages/db/prisma/schema.prisma"
+CLIENT="packages/db/generated/client/client.ts"
+
+if [ -f "$SCHEMA" ] && [ -f "$CLIENT" ] && [ "$SCHEMA" -nt "$CLIENT" ]; then
+  echo "[pre-commit] schema.prisma is newer than generated client — regenerating..."
+  if ! pnpm --filter @dpf/db exec prisma generate >/tmp/pre-commit-prisma.log 2>&1; then
+    echo ""
+    echo "ERROR: prisma generate failed. Check /tmp/pre-commit-prisma.log."
+    cat /tmp/pre-commit-prisma.log | tail -20
+    echo ""
+    exit 1
+  fi
+  echo "[pre-commit] Prisma client refreshed."
+fi
+
+# ─── Guard 3: typecheck gate ────────────────────────────────────────────────
 
 if [ "$DPF_SKIP_TYPECHECK" = "1" ]; then
   echo "[pre-commit] DPF_SKIP_TYPECHECK=1 — skipping typecheck gate."


### PR DESCRIPTION
## Symptom

After pulling main with a newer schema.prisma, local typecheck fails with errors like:

```
lib/inference/ai-provider-internals.ts(498,11): error TS2561: Object literal may only specify known properties, but 'capabilityCategory' does not exist in type ... Did you mean to write 'capabilityTier'?
```

Looks like main is broken. It isn't. The local Prisma client at packages/db/generated/client/ is stale — it reflects the pre-pull schema. CI is fine because the workflow runs prisma generate every time; local-dev only fires it via packages/db's `postinstall` hook, which runs on `pnpm install`, not on `git pull`.

I tripped on this today while landing the auth-cookie fix (post #318 capabilityCategory rename). Anyone pulling main and not running `pnpm install` will hit it again.

## Fix

Add a third guard to the existing tracked pre-commit hook:

| Guard | Order | Purpose |
| ----- | ----- | ------- |
| Migration immutability | 1 (existing) | Reject edits to committed migrations |
| Prisma client refresh  | 2 (new)      | Regenerate if schema.prisma is newer than the generated client |
| Typecheck gate         | 3 (existing) | Fail commit on TS errors |

The new guard is fast (~1s), idempotent, and only runs when there's actual drift (schema mtime > client mtime). When everything is in sync it's a no-op.

## Test plan

- [x] Self-test: touched schema.prisma to force schema-newer-than-client, this PR's commit exercised the guard:

```
[pre-commit] schema.prisma is newer than generated client — regenerating...
[pre-commit] Prisma client refreshed.
```

- [x] When schema.prisma and client are in sync, the new block exits silently
- [ ] CI: Typecheck green
- [ ] CI: Production Build green
- [ ] CI: DCO green

## Why not handle it post-merge instead?

The existing post-merge / post-checkout / post-commit / pre-push hooks in `.githooks/` are Git LFS shims (untracked, owned by the LFS install), not project hooks. The tracked pre-commit is the right place — it already gates typecheck, which is the failure mode this prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)