### PR TITLE
fix: guard Build Studio data arrays

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -47,8 +47,10 @@ export function BuildStudio({
   submissionBranchShortId,
 }: Props) {
   const router = useRouter();
+  const buildRows = Array.isArray(builds) ? builds : [];
+  const portfolioRows = Array.isArray(portfolios) ? portfolios : [];
   const [activeBuild, setActiveBuild] = useState<FeatureBuildRow | null>(
-    builds.find((b) => b.phase !== "complete" && b.phase !== "failed") ?? null,
+    buildRows.find((b) => b.phase !== "complete" && b.phase !== "failed") ?? null,
   );
   const [creating, setCreating] = useState(false);
   const [newTitle, setNewTitle] = useState("");
@@ -335,7 +337,7 @@ export function BuildStudio({
           )}
 
           <div className="flex-1 overflow-auto p-2">
-            {builds.length === 0 ? (
+            {buildRows.length === 0 ? (
               <div className="p-6 text-center">
                 <div className="text-3xl mb-3 opacity-20">&#128161;</div>
                 <p className="text-sm text-[var(--dpf-muted)] mb-2">No builds yet</p>
@@ -344,7 +346,7 @@ export function BuildStudio({
                 </p>
               </div>
             ) : (
-              builds.map((build, idx) => {
+              buildRows.map((build, idx) => {
                 const lifecycleLabel = deriveLifecycleLabel({
                   backlogItem: build.originator
                     ? {
@@ -491,7 +493,7 @@ export function BuildStudio({
                     <ReleaseDecisionPanel
                       build={activeBuild}
                       flowState={flowState}
-                      portfolios={portfolios}
+                      portfolios={portfolioRows}
                       onCompleted={() => refreshActiveBuildState(activeBuild.buildId)}
                     />
                   </div>

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -115,6 +115,21 @@ function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
 }
 
 describe("BuildStudio active-build header layout", () => {
+  it("renders the empty state instead of crashing when server data arrays are missing", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={undefined as unknown as FeatureBuildRow[]}
+        portfolios={undefined as unknown as []}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain("Product Development Studio");
+    expect(html).toContain("No builds yet");
+  });
+
   it("keeps the active-build title and metadata lane shrinkable for long submission branches", () => {
     const html = renderToStaticMarkup(
       <BuildStudio


### PR DESCRIPTION
## Summary
- Guard Build Studio's top-level build and portfolio arrays before any client render dereferences them
- Reuse normalized arrays for empty-state rendering, build-list rendering, and release decision portfolio data
- Add a regression test for missing server data arrays so /build falls back to the empty state instead of crashing

## Backlog
- BI-PIR-cca00fdc

## Verification
- pnpm --filter web exec vitest run components/build/BuildStudioHeaderLayout.test.tsx
- pnpm --filter web typecheck
- pnpm --filter web exec next build
- Browser QA on standalone build at http://127.0.0.1:3100/build after login: route rendered Build Studio empty state; no Cannot read properties of undefined / reading length page error observed