### PR TITLE
audit(routing): A1 — PR #318 rename drift surfaces + sequencing plan

### DIFF
--- a/docs/superpowers/audits/2026-04-28-rename-318-drift-surfaces.md
+++ b/docs/superpowers/audits/2026-04-28-rename-318-drift-surfaces.md
@@ -1,0 +1,222 @@
+# PR #318 Rename — Drift Surface Audit (A1)
+
+| Field | Value |
+|-------|-------|
+| **Plan item** | A1 (Wave 1, Track A) of [2026-04-28 sequencing plan](../plans/2026-04-28-coworker-and-routing-sequencing-plan.md) |
+| **PR audited** | [#318 — fix(routing): rename ModelProfile.capabilityTier → capabilityCategory (Phase B)](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/318) |
+| **Generated** | 2026-04-28 |
+| **Author** | Claude Opus 4.7 for Mark Bodman |
+| **Scope** | Evidence-only. Enumerate every runtime surface that reads or writes the renamed field, map every deployment path against where `prisma migrate deploy` runs, and characterize the failure class the user observed (marketing coworker → `column ModelProfile.capabilityCategory does not exist`). |
+| **Out of scope** | Fixing the drift. The deployment-path decision record is **A2**, the next item; the structural answer is **B1** (Routing Phase A). This document is input to both. |
+
+---
+
+## 1. The user-visible failure
+
+Reported 2026-04-28: starting a marketing strategy session through the marketing coworker fails with:
+
+```
+Invalid prisma.modelProfile.findMany() invocation:
+  column "ModelProfile.capabilityCategory" does not exist
+```
+
+This is the **first observed runtime symptom** of PR #318's drift surface. It will not be the last unless A2 (deployment-path contract) and B1 (control-plane substrate) land first. Memory `feedback_db_seed_migration_sync.md` predicted this class precisely: a schema rename without a runtime substrate that owns the rename's publication boundary creates seed-vs-runtime drift.
+
+**This audit does not propose a fix.** Per the plan's §11, the fix shape depends on B1 (Routing Phase A), and the sequencing rule is "no irreversible architectural choices before evidence." This document is the evidence.
+
+---
+
+## 2. The rename itself
+
+PR #318 made two source-side changes and one schema change:
+
+1. **Schema:** `ModelProfile.capabilityTier` → `capabilityCategory` ([packages/db/prisma/schema.prisma:1220](../../../packages/db/prisma/schema.prisma)).
+2. **Migration:** [`packages/db/prisma/migrations/20260428000000_rename_modelprofile_capabilitytier_to_capabilitycategory/migration.sql`](../../../packages/db/prisma/migrations/20260428000000_rename_modelprofile_capabilitytier_to_capabilitycategory/migration.sql) — a single `ALTER TABLE "ModelProfile" RENAME COLUMN "capabilityTier" TO "capabilityCategory";`.
+3. **Source-side cleanup:** code in 11 files updated to read the new column name.
+
+### 2.1 What was deliberately *not* renamed
+
+- **`ModelProvider.capabilityTier`** ([packages/db/prisma/schema.prisma:1164](../../../packages/db/prisma/schema.prisma)) — a different concept (MCP service capability sensitivity, paired with `costBand` / `taskTags` / `sensitivityClearance`). The PR commit message documents this exclusion correctly.
+- **`RoleRoutingRecipe.capabilityTier`** (in [apps/web/lib/routing/recipe-types.ts:63](../../../apps/web/lib/routing/recipe-types.ts)) — a routing-input vocabulary (`"low" | "medium" | "high"`). The routing spec's §7.2 calls for switching this to canonical `qualityTier` in a separate phase; it was not in #318's scope.
+
+These are the two legitimate surviving uses of the string `capabilityTier`. Anything else still using the name is suspect — and the survey below shows there is more than the existing INV-6b audit reports.
+
+---
+
+## 3. Drift class A — code that still references the *old* `ModelProfile` field name
+
+These are real drift sites. Each one is either (a) an internal type that mirrors the now-renamed column under the old name, (b) test fixtures using the old name, or (c) a write site that will throw at runtime against a migrated DB. The third subclass is the most dangerous.
+
+### 3.1 The smoking gun (write-side runtime error)
+
+[**packages/db/scripts/reconcile-catalog-capabilities.ts:118, 252-254**](../../../packages/db/scripts/reconcile-catalog-capabilities.ts):
+
+```ts
+// line 38 — internal struct still uses old name
+type CatalogChangeFields = {
+  // ...
+  capabilityTier: string;    // ← old name, not renamed
+  costTier: string;
+  qualityTier: string;
+  // ...
+};
+
+// line 118 — builder produces an object keyed by the old name
+return {
+  // ...
+  capabilityTier: entry.capabilityTier,    // ← old name
+  // ...
+};
+
+// line 252-254 — write site. The `as Parameters<...>` cast suppresses
+// the type error that would have caught this.
+await prisma.modelProfile.updateMany({
+  where: { ... },
+  data: { catalogHash: hash, profileSource: "catalog", ...changedFields }
+    as Parameters<typeof prisma.modelProfile.updateMany>[0]["data"],
+});
+```
+
+The cast was added to keep types passing during the mechanical rename. Without it, TypeScript would have refused the update because `capabilityTier` is no longer a `ModelProfile` field. With it, the error moved from compile time to runtime — the catalog reconciler runs in [docker-entrypoint.sh:36-39](../../../docker-entrypoint.sh) on every container start (step 3b of init), and it will throw the exact error the user saw whenever `changedFields` is non-empty (i.e. whenever any catalog drift exists).
+
+**Memory `feedback_check_tool_signals.md`: don't blame the model; check tool return values.** The TypeScript signal said "this field doesn't exist on this row." The cast silenced it. Fixing #318 would have required either renaming the struct in tandem (deferred — would have widened the PR) or removing the cast and letting types fail until the rename was complete. Neither happened.
+
+### 3.2 Internal type and adapter-layer fictions
+
+These compile and run today, but they tell a lie: the source-of-truth column is `capabilityCategory`, the in-memory struct is `capabilityTier`. Every consumer downstream of these structs is reading vocabulary that doesn't match the schema.
+
+| File | Line(s) | What it does |
+|---|---|---|
+| [apps/web/lib/inference/ai-provider-priority.ts](../../../apps/web/lib/inference/ai-provider-priority.ts) | 99, 501 | Reads `profile.capabilityCategory` from the DB, then immediately renames it back to `capabilityTier` inside the priority struct: `capabilityTier: profile.capabilityCategory ?? "unknown"` |
+| [apps/web/lib/inference/ai-provider-priority.ts](../../../apps/web/lib/inference/ai-provider-priority.ts) | 19, 119, 176, 189, 398, 534-535 | Type and accessors all use the old name |
+| [apps/web/lib/inference/ai-provider-types.ts](../../../apps/web/lib/inference/ai-provider-types.ts) | 76 | `capabilityTier: string` in a profile-shaped type |
+| [apps/web/lib/inference/ai-profiling.ts](../../../apps/web/lib/inference/ai-profiling.ts) | 21, 43 | LLM profiling prompt and output schema both use the old vocabulary `"deep-thinker" / "fast-worker" / ...` |
+| [apps/web/lib/actions/ai-providers.ts](../../../apps/web/lib/actions/ai-providers.ts) | 886, 900, 912 | Server action input type uses `capabilityTier: string` for profile updates |
+| [apps/web/lib/integrate/coding-agent.ts](../../../apps/web/lib/integrate/coding-agent.ts) | 53 | Reads `best.capabilityTier` from the priority struct (downstream of 3.2 row 1) |
+
+The adapter-layer fiction is what kept the rename "functionally working" for everything that doesn't write back to the DB. The catalog reconciler is the only writer that flowed through the unrenamed struct.
+
+### 3.3 Test fixtures and dead seed scripts
+
+These reference the old name but do not run in production. Cleaning them is mechanical; not fixing them is a future maintenance landmine.
+
+| File | Line(s) | Notes |
+|---|---|---|
+| [apps/web/lib/inference/ai-profiling.test.ts](../../../apps/web/lib/inference/ai-profiling.test.ts) | 47, 64 | Tests the LLM profiling generator |
+| [apps/web/lib/inference/ai-provider-priority.test.ts](../../../apps/web/lib/inference/ai-provider-priority.test.ts) | 20, 61, 62, 66, 67 | Test fixtures |
+| [packages/db/scripts/migrate-capability-tiers.ts](../../../packages/db/scripts/migrate-capability-tiers.ts) | 15-21 | A migration helper authored before #318. Reads `p.capabilityTier`, writes `data: { capabilityTier: newTier }`. Will throw if invoked against a migrated DB. **Should be deleted or renamed by the rename PR.** |
+| [packages/db/scripts/seed-service-endpoints.ts](../../../packages/db/scripts/seed-service-endpoints.ts) | 9, 22, 35, 53, 63 | Seeds `capabilityTier` on what looks like a `ModelProvider` row. Class 1 (legitimate `ModelProvider.capabilityTier`) — verify, don't auto-rename |
+| [packages/db/scripts/seed-endpoint-manifests.ts](../../../packages/db/scripts/seed-endpoint-manifests.ts) | 14 | Same — verify which row the field is on |
+
+### 3.4 Recipe / deliberation surface (separate concern)
+
+The `RoleRoutingRecipe.capabilityTier` and the deliberation registry's recipe-derived hints are the spec's own "Phase B remainder" work — they're correctly named for *that* concept (a routing input on the recipe, distinct from the ModelProfile field that was just renamed). They should not be touched by #318's drift cleanup. They are:
+
+- [apps/web/lib/routing/recipe-types.ts:63](../../../apps/web/lib/routing/recipe-types.ts) — recipe shape
+- [apps/web/lib/deliberation/registry.ts:61, 296-300](../../../apps/web/lib/deliberation/registry.ts) — recipe-derived hints
+- [apps/web/lib/deliberation/request-contract.ts:169-170](../../../apps/web/lib/deliberation/request-contract.ts) — recipe → reasoning depth mapping
+- Plus their tests.
+
+The existing INV-6b audit ([apps/web/scripts/audit-routing-spec-boot-invariants.ts:312-347](../../../apps/web/scripts/audit-routing-spec-boot-invariants.ts)) flags `recipe-types.ts` correctly under that scope. It does not flag the §3.1/§3.2/§3.3 sites because its scan is limited to `apps/web/lib/routing/`. **The current audit is structurally insufficient as a guard against #318's full drift surface.**
+
+---
+
+## 4. Drift class B — code reading the *new* `ModelProfile` field name
+
+For completeness, the file inventory of the rename's reach. Anywhere this field is read against an unmigrated DB will throw the user's exact error.
+
+| File | Line(s) | Operation |
+|---|---|---|
+| [packages/db/prisma/schema.prisma](../../../packages/db/prisma/schema.prisma) | 1220 | Schema declaration |
+| [packages/db/src/seed.ts](../../../packages/db/src/seed.ts) | 1387, 1523, 1604 | Seed inserts |
+| [packages/db/data/model-profiles.json](../../../packages/db/data/model-profiles.json) | many | Static catalog data — keys updated by #318 |
+| [apps/web/lib/inference/ai-provider-priority.ts](../../../apps/web/lib/inference/ai-provider-priority.ts) | 73, 78, 84, 250, 264, 483, 487 | Reads via `findMany({ select: { capabilityCategory: true } })` |
+| [apps/web/lib/inference/ai-provider-internals.ts](../../../apps/web/lib/inference/ai-provider-internals.ts) | 498, 530, 559, 587, 733, 759, 1036 | Reads, computed values, writes |
+| [apps/web/lib/inference/ai-provider-types.ts](../../../apps/web/lib/inference/ai-provider-types.ts) | 154 | Type definition |
+| [apps/web/lib/actions/endpoint-performance.ts](../../../apps/web/lib/actions/endpoint-performance.ts) | 49 | `findFirst({ select: { capabilityCategory: true } })` |
+| [apps/web/lib/routing/known-provider-models.ts](../../../apps/web/lib/routing/known-provider-models.ts) | 29, 72, 111, 150, 184, 222, 255, 290, 330 | Static catalog data |
+| [apps/web/components/platform/EndpointPerformancePanel.tsx](../../../apps/web/components/platform/EndpointPerformancePanel.tsx) | 52, 124 | UI display |
+| [apps/web/scripts/audit-routing-spec-boot-invariants.ts](../../../apps/web/scripts/audit-routing-spec-boot-invariants.ts) | 280-290, 318 | Audit logic that handles either name (defensive) |
+
+Other call sites that hit `prisma.modelProfile.findMany`/`findFirst` (any of which can trigger the user's error if their `select` includes `capabilityCategory`):
+
+- [apps/web/lib/actions/ai-providers.ts:552](../../../apps/web/lib/actions/ai-providers.ts)
+- [apps/web/lib/actions/endpoint-performance.ts:45, 113, 182](../../../apps/web/lib/actions/endpoint-performance.ts)
+- [apps/web/lib/explore/feature-build-data.ts:205](../../../apps/web/lib/explore/feature-build-data.ts)
+- [apps/web/lib/operate/endpoint-test-runner.ts:203](../../../apps/web/lib/operate/endpoint-test-runner.ts)
+- [apps/web/app/api/diagnostics/preflight/route.ts:147](../../../apps/web/app/api/diagnostics/preflight/route.ts)
+- [apps/web/lib/inference/ai-provider-data.ts:193, 223](../../../apps/web/lib/inference/ai-provider-data.ts)
+- [apps/web/app/api/agent/health/route.ts:13](../../../apps/web/app/api/agent/health/route.ts)
+- [apps/web/lib/inference/ai-provider-priority.ts:76, 179, 243, 481](../../../apps/web/lib/inference/ai-provider-priority.ts)
+- [apps/web/lib/routing/loader.ts:83](../../../apps/web/lib/routing/loader.ts)
+- [apps/web/lib/inference/ai-provider-internals.ts:817, 951](../../../apps/web/lib/inference/ai-provider-internals.ts)
+- [apps/web/lib/routing/eval-runner.ts:162, 391](../../../apps/web/lib/routing/eval-runner.ts)
+
+**18 distinct query sites.** Each is a potential "marketing coworker" — different code path, same error class, against an unmigrated DB.
+
+---
+
+## 5. Deployment-path matrix
+
+Where does `prisma migrate deploy` actually run? This is the question A2 (the next plan item) must answer; A1's job is only to map the current state honestly.
+
+| Path | Where defined | Runs `migrate deploy`? | First-call behavior on stale DB |
+|---|---|---|---|
+| **Production runner container** | [docker-entrypoint.sh:6-24](../../../docker-entrypoint.sh) | ✅ Yes — 5-retry loop with 3s backoff at every container start | Migrates correctly; no drift visible to runtime. |
+| **Build-Studio sandbox container** | [docker-compose.yml:362](../../../docker-compose.yml) `command:` line | ✅ Yes — explicit `pnpm --filter @dpf/db exec prisma migrate deploy` | Migrates correctly. |
+| **Dev container (Dockerfile dev stage)** | [Dockerfile:11](../../../Dockerfile) | ❌ **No** — only runs `prisma generate`, then `pnpm --filter web dev` | Schema rename is in the generated client; DB still has old column; **every query that selects `capabilityCategory` errors at runtime.** This is the user's observed failure path. |
+| **Host dev (`pnpm dev` against host DB)** | No automation | ❌ Manual only — developer runs `pnpm --filter @dpf/db migrate:deploy` | Same failure mode as dev container. |
+| **Pre-commit hook (PR #321)** | [.git/hooks/pre-commit (via git core.hookspath)](../../../) | Generates the Prisma client only | **Does not run migrate deploy.** Closes the client-vs-schema drift surface; does **not** close the schema-vs-DB surface. |
+| **Promoter / image build** | [Dockerfile.promoter](../../../Dockerfile.promoter) | Inherits production runner behavior | Migrates on container start. |
+
+**Summary:** the only deployment paths that auto-apply migrations are the production-shape paths (runner, sandbox, promoter). The two paths most active in *development* (dev container, host dev) require manual `migrate deploy`. The user is on one of these.
+
+The pre-commit hook from #321 — `auto-regenerates Prisma client on schema drift` — closes a different drift class (client-out-of-sync-with-schema). It is helpful but it is **not the answer to this audit**; the rename's runtime errors come from schema-out-of-sync-with-DB, which only `migrate deploy` resolves.
+
+---
+
+## 6. Why the existing audit didn't catch this
+
+The boot-invariant audit ([apps/web/scripts/audit-routing-spec-boot-invariants.ts](../../../apps/web/scripts/audit-routing-spec-boot-invariants.ts), shipped in PR #310, baselined in PR #311) has two relevant invariants:
+
+- **INV-6** — checks live DB rows for the legacy LLM-grading vocabulary (`deep-thinker`, `fast-worker`, etc.). Currently flags 15 rows with the legacy values. *Does not detect the column-name drift.*
+- **INV-6b** — scans `apps/web/lib/routing/` for any remaining `capabilityTier` references. Currently flags 1 file (`recipe-types.ts`). *Scope is narrow — misses every site outside `lib/routing/`.*
+
+The drift in §3 lives in `lib/inference/`, `lib/actions/`, `lib/integrate/`, `lib/deliberation/`, and `packages/db/scripts/`. INV-6b's directory restriction is what let #318 ship without surfacing the drift.
+
+**Implication for B1 (Routing Phase A) design:** the substrate must include an audit-or-equivalent surface that scans the **whole** codebase for vocabulary drift, not just one directory. A boot-invariant that only checks routing source code is a misleading green light for the rest of the platform.
+
+---
+
+## 7. Failure-class summary (input to A2 and B1)
+
+The marketing-coworker error decomposes into three distinct failure modes that #318 introduced:
+
+1. **Schema-vs-DB drift in non-runner deployment paths.** The dev container and host-dev path do not auto-run `migrate deploy`. Any rename or additive column change ships broken to those paths until the developer runs the command manually. **A2 must answer: until the substrate exists, what is the contract for schema-changing PRs in those paths?**
+
+2. **Type-cast suppression of compile-time signals.** [reconcile-catalog-capabilities.ts:252-254](../../../packages/db/scripts/reconcile-catalog-capabilities.ts) writes a stale field name to the DB through a `Parameters<...>` cast. The cast made the rename look complete; the runtime error proves it wasn't. **A2 should constrain how schema-changing PRs handle types: no `as` casts on Prisma input data unless explicitly justified, because they suppress the rename signal.**
+
+3. **Adapter-layer vocabulary fictions.** Internal structs continue to use the old field name long after the schema renamed it. Functionally fine until someone writes the struct back to the DB; brittle by design. **B1 (Routing Phase A) is the right place to fix this — the publication boundary is where vocabulary translation either becomes explicit or becomes invisible.**
+
+The plan's §11 is correct that the fix sequence is A2 → B1, not "fix the marketing coworker today."
+
+---
+
+## 8. What this audit did *not* do
+
+- **Did not propose a migration-deploy automation in any deployment path.** That's A2's call, and A2 has to weigh whether to add it to the dev container's CMD versus solving it differently.
+- **Did not delete or rename the dead seed script** [migrate-capability-tiers.ts](../../../packages/db/scripts/migrate-capability-tiers.ts). It will throw if invoked, but it is not invoked by any current code path. Cleanup belongs in C1/C3 hygiene work, not in a containment audit.
+- **Did not edit the typecast in [reconcile-catalog-capabilities.ts:252-254](../../../packages/db/scripts/reconcile-catalog-capabilities.ts).** Removing the cast surfaces the type error that #318 should have surfaced. Fixing the underlying field name in the struct is straightforward but is not "evidence" — it is "fix." The fix lands in A2's contract or B1's substrate, not here.
+- **Did not run any database queries.** This audit is fully static — file reads only. It is safe to run against any DB state.
+
+## 9. Inputs A2 should consume from this audit
+
+When A2 (deployment-path decision record) is written, the questions it must answer are:
+
+1. **Until B1 ships, do schema-changing PRs require a verified `migrate deploy` step in the dev container's CMD?** §5 shows the dev container does not currently run it.
+2. **Do schema-changing PRs require a sweep of the whole codebase for vocabulary references, not just one directory?** §6 shows INV-6b's scope was insufficient.
+3. **Do schema-changing PRs require a `git grep` for the old field name and removal of any internal struct using it?** §3.2 shows the adapter layer fictions exist; whether to ban them in renames is a decision call.
+4. **Do schema-changing PRs require the absence of `as Parameters<...>` casts on Prisma input data?** §3.1 shows the cast is what suppressed the type signal.
+5. **Do schema-changing PRs require a CI check that runs the migration against an empty DB and exercises representative read paths?** §4 lists 18 query sites; a rename-aware smoke test is bounded scope but real coverage.
+
+A2 picks which of these become the interim contract. B1 (Routing Phase A) decides which become structurally enforced through the substrate.

--- a/docs/superpowers/plans/2026-04-28-coworker-and-routing-sequencing-plan.md
+++ b/docs/superpowers/plans/2026-04-28-coworker-and-routing-sequencing-plan.md
@@ -1,0 +1,408 @@
+# DPF Sequencing Plan - Coworker Roster + Routing Substrate
+
+| Field | Value |
+|-------|-------|
+| **Created** | 2026-04-28 |
+| **Revised** | 2026-04-28 |
+| **Author** | Claude Opus 4.7 for Mark Bodman |
+| **Review refactor** | Codex architectural review and rewrite |
+| **Status** | Draft for review - no new PRs should start from this document until Mark approves the sequence |
+| **Scope** | Sequence the routing-substrate work, coworker-roster correction work, and seed/runtime-boundary work into one dependency-aware execution plan with explicit gates, outputs, and ownership choices |
+| **Why this exists** | Several solid specs and audits landed in 24 hours, but they landed as adjacent tracks rather than one execution contract. The result was predictable: PR #318 shipped a mechanical rename before the control-plane substrate it depended on existed, and the first visible symptom was the marketing coworker runtime failure against an unmigrated DB. The missing artifact was not another fix PR; it was a sequencing plan that distinguishes containment, substrate, hygiene, and expansion. |
+
+---
+
+## 1. Executive architectural judgment
+
+The current draft had the right instinct but mixed four different kinds of work into one queue:
+
+1. **Containment work** - make current drift visible and bounded.
+2. **Substrate work** - build the control-plane/runtime architecture that prevents repeat drift.
+3. **Hygiene work** - align registry, persona, and grant catalogs so the roster is internally coherent.
+4. **Expansion work** - implement the missing coworker capabilities that unlock new value streams.
+
+Those are not interchangeable. If we let expansion run before substrate, we will reproduce the same failure class with a larger blast radius. If we let hygiene wait until after expansion, we will build against a misleading registry. The sequence below corrects that.
+
+This revision also corrects one factual issue in the earlier draft:
+
+- **A2A is not "prompt only" anymore.** This worktree already contains both [2026-04-23-a2a-aligned-coworker-runtime.md](./2026-04-23-a2a-aligned-coworker-runtime.md) and [2026-04-23-a2a-aligned-coworker-runtime-design.md](../specs/2026-04-23-a2a-aligned-coworker-runtime-design.md). What is missing is approval and implementation sequencing, not authorship from scratch.
+
+---
+
+## 2. Ground truth snapshot
+
+### 2.1 What actually landed on 2026-04-28
+
+| PR | Subject | State assessment |
+|---|---|---|
+| #309 | Routing substrate fixes + cost capture + spec | Important spec and partial fixes landed; architecture not yet realized |
+| #310 | Routing boot-invariant audit | Good evidence layer landed |
+| #311 | CI gate for routing audit | Good detection layer landed |
+| #312 | Eliminate seed-as-data-load | Spec only; no implementation |
+| #313 | AGENTS.md canonicalization | Complete mechanical cleanup |
+| #314 | Portal URL from request headers | Complete bug fix |
+| #316 | Coworker persona audit | Audit + CI gate; persona corpus still materially incomplete |
+| #317 | Coworker tool-grant audit + grant catalog | Audit + CI gate; major reconciliation backlog remains |
+| #318 | `capabilityTier` -> `capabilityCategory` rename | Mechanical schema/code change landed before its architectural prerequisite |
+| #319 | Portal URL helper split | Complete bug fix |
+| #320 | Session-cookie Secure flag | Complete bug fix |
+| #321 | Pre-commit auto-regen Prisma client | Developer convenience only; not a deployment/migration answer |
+| #322 | Coworker self-assessment Phase 1 | Discovery complete; Phase 2 implementation batches still need honest sequencing |
+
+### 2.2 What is broken right now
+
+- **Marketing coworker fails** with `column ModelProfile.capabilityCategory does not exist`.
+- Root cause is not merely "migration not applied." The deeper failure is that a mechanical rename shipped before the runtime/control-plane publication model in [2026-04-27-routing-control-data-plane-design.md](../specs/2026-04-27-routing-control-data-plane-design.md) existed.
+- [2026-04-27-routing-spec-boot-invariants.md](../audits/2026-04-27-routing-spec-boot-invariants.md) already established that seed/runtime drift is systemic, not incidental.
+
+### 2.3 What is committed but still under-sequenced
+
+- Routing control/data-plane phases A-L
+- Persona audit remediation
+- Tool-grant audit remediation
+- Coworker self-assessment Phase 2
+- Seed-elimination substrate
+- A2A-aligned coworker runtime plan/spec
+- Local LLM grading incremental design
+
+The risk is no longer lack of ideas. The risk is uncontrolled concurrency across shared substrate files: registry, grant catalog, routing control-plane, model/provider state, prompt/persona surfaces, and schema.
+
+---
+
+## 3. Planning principles for this thread
+
+1. **Substrate before expansion.** No new capability family should ship onto the old routing/runtime boundary if it depends on platform state mutation.
+2. **Containment before confidence.** We need one small evidence-and-boundary pass before we make irreversible architectural choices.
+3. **Registry truth before coworker expansion.** Persona, grant, and self-assessment artifacts must agree on what the roster is before we add more verbs.
+4. **Spec before epic.** Any batch that introduces a new durable domain model becomes its own spec+plan pair before implementation.
+5. **Owners are not dependencies.** The plan should identify likely owners, but sequencing must remain correct even if ownership changes.
+6. **UI-visible work must include route discovery and UX verification.** If a batch claims to make a coworker usable through a visible surface, it must discover the actual route/tab/shell and verify it there, not only through code-level reasoning.
+
+---
+
+## 4. Work decomposition
+
+The original "five tracks" framing was useful. It becomes much stronger when the tracks are recast by execution role.
+
+### Track A - Containment and evidence
+
+Purpose: make the current failure class explicit and bounded before substrate edits begin.
+
+- **A1 - Rename drift surface audit.**
+  Output: `docs/superpowers/audits/2026-04-28-rename-318-drift-surfaces.md`
+  Must enumerate: host install, sandbox install, fresh install, upgrade path, running container path, and every runtime surface reading the renamed field.
+- **A2 - Deployment-path decision record.**
+  Output: short ADR-style note answering one question:
+  "Until Phase A exists, what is the approved deployment-path truth for schema-changing PRs?"
+  This is not the permanent architecture; it is the containment contract.
+
+### Track B - Routing substrate critical path
+
+Purpose: build the architecture that makes the current class of drift structurally impossible or at least structurally loud.
+
+- **B1 - Routing Phase A (RIB introduction / publication boundary)**
+- **B2 - Phase B remainder (named state transitions)**
+- **B3 - Phase C (probe daemon)**
+- **B4 - Phase D (compile RIB -> FIB)**
+- **B5 - Phase E (data plane dispatches from FIB)**
+- **B6 - Phase F (remove legacy routing paths)**
+
+This is the true critical path for the routing substrate. The rest of the plan must respect it.
+
+### Track C - Coworker roster hygiene
+
+Purpose: make the coworker roster internally truthful before expansion work starts.
+
+- **C1 - Persona schema migration for the 21 existing personas**
+- **C2 - GRANT-003 reconciliation: add catalog entries for the 10 real checked-but-uncataloged grants**
+- **C3 - AGT-BUILD-* capability-domain differentiation**
+- **C4 - Boundary adjudication changes after supervisor decisions**
+- **C5 - Missing persona authoring backlog for the 50 absent personas**
+
+Important split:
+
+- `C1-C4` are platform hygiene.
+- `C5` is content production and should not block substrate work unless a specific batch depends on a specific missing persona.
+
+### Track D - Coworker capability enablement
+
+Purpose: unblock coworkers by implementing missing tool families only after the substrate and registry are trustworthy enough.
+
+- **D1 - Governance reads**
+- **D2 - Deploy VS rounding**
+- **D3 - SBOM substrate**
+- **D4 - Incident domain**
+- **D5 - Release catalog + subscription domain**
+- **D6 - Consume fulfillment/support domain**
+- **D7 - Governance enforcement domain**
+- **D8 - Evaluate VS domain**
+
+The original draft correctly sensed that D3-D8 are not "batches" in the same sense as D1-D2. This revision makes that explicit:
+
+- `D1-D2` are implementation batches.
+- `D3-D8` are domain programs that each require a spec-backed slice before implementation starts.
+
+### Track E - Adjacent substrate
+
+Purpose: coordinate neighboring architectural work without letting it collide with the routing critical path.
+
+- **E1 - Seed-elimination implementation strategy**
+- **E2 - A2A runtime sequencing**
+- **E3 - Local LLM grading Phase 1**
+- **E4 - Build Studio independent queue**
+
+---
+
+## 5. Dependency matrix
+
+This is the most important correction in the review. The old draft described order mostly in prose. The plan now makes the dependency contract explicit.
+
+| Work item | Depends on | Why |
+|---|---|---|
+| A1 | none | First evidence pass |
+| A2 | A1 | Deployment-path decision should be based on actual drift surfaces |
+| B1 | A1 | Phase A should be informed by the real drift map |
+| B2 | B1 | Named transitions only make sense once the publication boundary exists |
+| B3 | B2 | Probe outcomes must feed the state machine you just formalized |
+| B4 | B3 | FIB compilation depends on real state signals |
+| B5 | B4 | Data plane cannot read a FIB that does not exist |
+| B6 | B5 | Legacy removal only after new path is serving traffic |
+| C1 | none | Safe to run early; mechanical |
+| C2 | none | Safe to run early; mechanical and audit-aligned |
+| C3 | none | Safe to run early; registry correction |
+| C4 | supervisor decisions | Governance call, not engineering uncertainty |
+| C5 | C1 schema shape | Persona authoring should target the stabilized schema |
+| D1 | B2, C2 | First safe enablement slice needs named transitions and a truthful grant catalog |
+| D2 | B2, C2 | Same rationale as D1 |
+| D3-D8 spec authoring | B1, C2 | New domain specs should target the new substrate and current grant truth |
+| D3-D8 implementation | corresponding spec + B6 | Domain implementation should not land while legacy routing remains half-live |
+| E1 decision | B1, B2 | Seed-elimination should align to the actual publication boundary and transition model |
+| E1 implementation | B6 or an explicitly approved earlier slice | Avoid interleaving two substrate rewrites blindly |
+| E2 implementation | D-track midpoint + approved existing spec | A2A is already designed; timing is the real question |
+| E3 implementation | B4 | Local grading overlaps routing/profile selection and should target the compiled routing architecture |
+
+---
+
+## 6. Execution sequence
+
+This plan now uses **waves**, not a falsely serial numbered list. Some work is parallel-safe; some work is not.
+
+### Wave 0 - Review and freeze
+
+Goal: stop new opportunistic PRs from racing this plan.
+
+Exit criteria:
+
+- Mark approves or redirects this plan.
+- No new Claude PRs start from the old batch lists while this decision is open.
+
+### Wave 1 - Containment and evidence
+
+1. **A1 - Rename drift surface audit**
+2. **A2 - Deployment-path decision record**
+3. **B1 - Routing Phase A plan confirmation and owner selection**
+
+Artifacts:
+
+- Drift-surface audit document
+- Short decision record on schema-change deployment truth
+- Confirmed Phase A owner and slice plan
+
+Exit criteria:
+
+- The team can explain exactly where the rename can still fail.
+- The team has one explicit interim rule for schema-changing PRs.
+- Phase A is ready to start with no ambiguity about what it must protect.
+
+### Wave 2 - Parallel-safe hygiene lane
+
+These items can proceed while Phase A is being built because they reduce ambiguity without deepening substrate coupling.
+
+1. **C1 - Persona schema migration for the 21 existing personas**
+2. **C2 - GRANT-003 reconciliation**
+3. **C3 - AGT-BUILD-* capability-domain differentiation**
+
+Artifacts:
+
+- Lower persona-audit error floor
+- Honest grant catalog for the already-real checked grants
+- Build-agent registry no longer misdescribes four distinct roles as one
+
+Exit criteria:
+
+- Persona audit is reduced to missing-content work rather than mixed schema/content noise.
+- Tool-grant audit no longer has the checked-but-uncataloged class for the 10 confirmed grants.
+
+### Wave 3 - Routing substrate critical path
+
+1. **B1 - Phase A**
+2. **B2 - Phase B remainder**
+3. **B3 - Phase C**
+4. **B4 - Phase D**
+5. **B5 - Phase E**
+6. **B6 - Phase F**
+
+Important gate refinement:
+
+- The previous draft required a full production day after every phase. That is too blunt.
+- New rule:
+  - **B1 and B5 require explicit soak gates** because they change publication/dispatch behavior materially.
+  - **B2-B4 and B6 require verification gates**, not automatic 24-hour holds, unless they expose production instability during rollout.
+
+Artifacts:
+
+- RIB publication boundary
+- Named transition layer
+- Probe signal path
+- FIB compiler
+- FIB-backed dispatch
+- Legacy routing removal
+
+Exit criteria:
+
+- Boot-invariant audit reaches zero errors for routing-substrate invariants that these phases are meant to solve.
+- The marketing-coworker error class is structurally prevented or rendered immediately loud by the new publication/deployment contract.
+
+### Wave 4 - First enablement slices
+
+Only after Wave 3 completes:
+
+1. **D1 - Governance reads**
+2. **D2 - Deploy VS rounding**
+3. **C4 - Boundary adjudication PR** after Mark decides the 11 disputed boundaries
+
+Why these first:
+
+- They are the best ratio of unblock value to architectural blast radius.
+- They are good proving grounds for the new sequencing discipline.
+- They do not require inventing a large new durable domain before the team has validated the first enablement pattern.
+
+Exit criteria:
+
+- At least one small coworker-capability family has shipped cleanly on the new substrate.
+- Boundary duplications are reduced through explicit supervisor-approved ownership.
+
+### Wave 5 - Promote epics to spec-backed programs
+
+Before any implementation on the remaining enablement domains:
+
+1. **D3 - SBOM substrate spec confirmation or refinement**
+2. **D4 - Incident domain spec**
+3. **D5 - Release catalog/subscription domain spec**
+4. **D6 - Consume fulfillment/support domain spec**
+5. **D7 - Governance enforcement domain spec**
+6. **D8 - Evaluate VS domain spec**
+
+Important correction from the previous draft:
+
+- These should not be described as "later batches."
+- They are each multi-slice programs with their own data model, workflow, and UX implications.
+
+Exit criteria:
+
+- Each remaining enablement domain has an approved design artifact and a smallest-slice implementation plan.
+
+### Wave 6 - Adjacent substrate alignment
+
+1. **E1 - Seed-elimination re-entry decision**
+2. **E2 - A2A sequencing decision using the already-authored plan/spec**
+3. **E3 - Local LLM grading Phase 1 resume decision**
+
+This wave is intentionally decision-heavy rather than implementation-heavy. The point is to re-enter adjacent architecture from a stable routing base rather than from churn.
+
+### Wave 7 - Program execution beyond the first slices
+
+1. Implement `D3-D8` in approved slice order
+2. Resume `E1-E3` according to the decisions made in Wave 6
+3. Continue routing phases `G-L` after the platform is no longer absorbing foundational churn
+
+---
+
+## 7. What is explicitly paused
+
+- **The 50-persona authoring backlog as a blanket blocker.**
+  It should continue as content work, but it does not sit on the routing critical path.
+- **Any new Phase 2 coworker-implementation batch beyond D1/D2**
+  until the routing substrate critical path is complete.
+- **Treating A2A as a fresh authorship track.**
+  The design exists. Timing and integration decisions are what remain.
+- **Local LLM grading implementation**
+  until the routing substrate reaches at least B4.
+- **Seed-elimination implementation churn**
+  until we decide whether the first slice should be aligned directly to the B1/B2 publication boundary or intentionally held until B6.
+
+---
+
+## 8. Cross-cutting gates
+
+These apply to every implementation PR opened under this plan.
+
+### G1 - Spec-before-epic
+
+Any change that introduces a new durable domain model, new cross-agent workflow, or meaningful schema surface must have an approved spec first.
+
+Examples:
+
+- Incident domain
+- Release/subscription domain
+- Consume fulfillment domain
+- Governance enforcement domain
+
+### G2 - Runtime-proof gate
+
+Any PR that claims to fix a runtime failure or enable a coworker capability must be verified against the actual running install path it affects, not only a unit-test or static audit path.
+
+### G3 - Surface discovery gate for UI-visible coworker work
+
+If a batch claims a coworker is now usable through a visible portal/build/admin surface:
+
+- discover the actual route/tab/shell first
+- verify there
+- record the verification path in the PR or follow-up evidence note
+
+### G4 - Audit regeneration gate
+
+If a PR touches registry, grants, personas, or coworker capabilities, regenerate the relevant audit artifact in the same PR:
+
+- persona audit
+- tool-grant audit
+- self-assessment follow-up where relevant
+
+---
+
+## 9. Recommended ownership defaults
+
+Ownership is secondary to sequence, but default assignment helps execution start cleanly.
+
+| Area | Default owner | Reason |
+|---|---|---|
+| A1-A2 | Claude | evidence and decision-record work |
+| B1-B6 | Build Studio or Mark-directed deep implementation lane | shared routing substrate with high architectural depth |
+| C1-C4 | Claude | mechanical reconciliation and registry hygiene |
+| C5 | Build Studio / content lane | large content-production backlog |
+| D1-D2 | Claude | smallest controlled enablement slices |
+| D3-D8 specs | Claude or Mark | architecture/spec-first work |
+| D3-D8 implementation | Build Studio after specs | larger programs, likely multi-PR |
+| E1-E3 decisions | Mark + architecture lane | cross-cutting product/platform choices |
+
+---
+
+## 10. Open decisions for Mark
+
+1. **Phase A owner:** who owns `B1-B6`?
+2. **Containment rule:** until Phase A lands, do schema-changing PRs require an explicit deployment-path step in the PR contract?
+3. **Persona backlog ownership:** should the 50 missing personas continue in a separate content lane?
+4. **Boundary adjudication format:** do the 11 disputes get one supervisor pass or separate threads by value stream?
+5. **Seed-elimination re-entry point:** do we want the first implementation slice aligned immediately after `B2`, or do we deliberately wait for `B6`?
+6. **A2A timing:** do we treat the existing A2A plan/spec as a Wave 6 decision item, or pull it forward sooner for a specific reason?
+
+---
+
+## 11. Immediate next actions if approved
+
+1. Write **A1**: the rename drift-surface audit.
+2. Write **A2**: the deployment-path decision record.
+3. Start **C1-C3** as the safe hygiene lane.
+4. Confirm owner and slice shape for **B1** before any new enablement PR starts.
+
+That is the smallest architecture-sound next move. It contains the current failure class, improves truthfulness of the coworker roster, and preserves room to make the larger substrate decisions once instead of three times.


### PR DESCRIPTION
## Summary

- A1 of the sequencing plan: evidence-only audit of every drift surface introduced by PR #318 (`ModelProfile.capabilityTier` → `capabilityCategory`).
- Includes the sequencing plan itself in its revised (Codex-reviewed) wave-based form, since A1 references it directly.
- **Docs-only.** No code touched. No DB queried. No fix proposed — that is A2's job and B1's substrate work.

## Why

Mark reported the marketing coworker erroring with `column ModelProfile.capabilityCategory does not exist` when starting a marketing strategy session. Rather than ship an unplanned fix, the agreed approach was: write the plan, freeze new opportunistic PRs, then execute A1 as the first item.

A1 is the evidence pass that lets A2 (the deployment-path decision record) and B1 (Routing Phase A) be designed against ground truth instead of guesswork.

## What the audit found

Three failure-mode classes from the same PR:

1. **Smoking gun: type cast suppressed the rename signal.** [`reconcile-catalog-capabilities.ts:252-254`](packages/db/scripts/reconcile-catalog-capabilities.ts) writes `capabilityTier` (old name) to `prisma.modelProfile.updateMany` through a `Parameters<typeof ...>[0][\"data\"]` cast. The cast made TypeScript stop complaining; the runtime error fires on every container start (catalog reconciler runs in `docker-entrypoint.sh:36-39` step 3b).

2. **Adapter-layer vocabulary fictions.** Six internal struct sites read `profile.capabilityCategory` from the DB, then immediately rename it back to `capabilityTier` in an in-memory shape (`ai-provider-priority.ts:99,501`, `ai-provider-types.ts:76`, etc.). Functionally fine for read-only paths; brittle by design; invisible to the existing audit.

3. **Deployment-path asymmetry.** Of six deployment paths, only three auto-run `prisma migrate deploy`: production runner, sandbox container, promoter. The two paths most active in dev — Dockerfile line 11 (dev container) and host-dev (`pnpm dev`) — require manual migration. The user's failure is a path-3 failure.

## What's also notable

- The existing boot-invariant audit's INV-6b only scans `apps/web/lib/routing/` (1 file flagged). The real drift surface is across `lib/inference/`, `lib/actions/`, `lib/integrate/`, `lib/deliberation/`, and `packages/db/scripts/` — outside that scan. **The current audit is structurally insufficient as a guard against rename drift.** Implication noted for B1's substrate design.
- The `as Parameters<...>` cast pattern is the most dangerous thing #318 left behind — it means *every* future schema rename can be silently incomplete unless the contract bans it. Captured as input #4 for A2.

## What's in this PR

- [docs/superpowers/plans/2026-04-28-coworker-and-routing-sequencing-plan.md](docs/superpowers/plans/2026-04-28-coworker-and-routing-sequencing-plan.md) — the plan itself (revised wave-based shape).
- [docs/superpowers/audits/2026-04-28-rename-318-drift-surfaces.md](docs/superpowers/audits/2026-04-28-rename-318-drift-surfaces.md) — the A1 audit.

## What's deliberately NOT in this PR

- No fix to the catalog reconciler's type cast.
- No migration-deploy automation in any deployment path.
- No deletion of the dead seed script `migrate-capability-tiers.ts`.
- No DB queries — fully static, file-reads only.

Each of these belongs in A2 (deployment-path decision record), C-track hygiene PRs, or B1 (Phase A substrate). Per plan §11.

## Five concrete inputs A2 should answer

(Detailed in §9 of the audit doc.)

1. Until B1 ships, do schema-changing PRs require a verified `migrate deploy` step in the dev container?
2. Do schema-changing PRs require a whole-codebase sweep for vocabulary references, not just one directory?
3. Do schema-changing PRs require removal of any internal struct still using the old field name?
4. Do schema-changing PRs require absence of `as Parameters<...>` casts on Prisma input data?
5. Do schema-changing PRs require a rename-aware smoke test in CI that exercises representative read paths against an empty migrated DB?

## Test plan

- [x] Pre-commit hook ran clean (typecheck, no Prisma client regen needed)
- [x] Audit document references resolve (every linked file/line exists in the worktree)
- [ ] Reviewer reads §3.1 (the smoking gun in `reconcile-catalog-capabilities.ts:252-254`) and confirms classification — the catalog reconciler write site is the runtime path that produces Mark's observed error
- [ ] Reviewer confirms §5 deployment matrix matches their understanding of how DPF is deployed in practice

## Sequence reminder (per plan §11)

1. **A1 (this PR)** — evidence
2. **A2** — deployment-path decision record (next)
3. **C1, C2, C3** — parallel-safe hygiene lane (persona schema migration, GRANT-003 catalog adds, AGT-BUILD-* differentiation)
4. **Confirm B1 owner** before any new enablement PR starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)