### PR TITLE
feat(mcp): add backlog retirement tool

### DIFF
--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -4,6 +4,13 @@ const mockPrisma = {
   backlogItem: {
     findUnique: vi.fn(),
     update: vi.fn(),
+    count: vi.fn(),
+  },
+  backlogItemActivity: {
+    create: vi.fn(),
+  },
+  epic: {
+    update: vi.fn(),
   },
   featureBuild: {
     create: vi.fn(),
@@ -189,5 +196,138 @@ describe("backlog MCP tool execution", () => {
         requestedByAgentId: "AGT-1",
       },
     });
+  });
+
+  it("retire_backlog_item marks duplicate items as deferred with canonical linkage and activity", async () => {
+    const duplicateRow = {
+      id: "duplicate-row-1",
+      itemId: "BI-DUP",
+      status: "open",
+      epicId: "epic-row-1",
+      activeBuildId: null,
+    };
+    const canonicalRow = {
+      id: "canonical-row-1",
+      itemId: "BI-CANON",
+      status: "done",
+    };
+
+    mockPrisma.backlogItem.findUnique
+      .mockResolvedValueOnce(duplicateRow)
+      .mockResolvedValueOnce(canonicalRow);
+    mockPrisma.backlogItem.update.mockResolvedValue({
+      itemId: "BI-DUP",
+      status: "deferred",
+      completedAt: new Date("2026-04-29T12:00:00.000Z"),
+    });
+    mockPrisma.backlogItem.count.mockResolvedValue(0);
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "retire_backlog_item",
+      {
+        itemId: "BI-DUP",
+        outcome: "duplicate",
+        duplicateOfId: "BI-CANON",
+        rationale: "Superseded by the canonical implemented item.",
+      },
+      "user-1",
+      { agentId: "AGT-1" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "duplicate-row-1" },
+        data: expect.objectContaining({
+          status: "deferred",
+          triageOutcome: "duplicate",
+          duplicateOfId: "canonical-row-1",
+          resolution: "Superseded by the canonical implemented item.",
+          abandonReason: "Superseded by the canonical implemented item.",
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "duplicate-row-1",
+          kind: "status_change",
+          recordedById: "user-1",
+          recordedByAgentId: "AGT-1",
+          payload: expect.objectContaining({
+            outcome: "duplicate",
+            duplicateOfId: "BI-CANON",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("retire_backlog_item discards triaging verification fixtures without backlog_triage", async () => {
+    const fixtureRow = {
+      id: "fixture-row-1",
+      itemId: "BI-FIXTURE",
+      status: "triaging",
+      epicId: null,
+      activeBuildId: null,
+    };
+
+    mockPrisma.backlogItem.findUnique.mockResolvedValue(fixtureRow);
+    mockPrisma.backlogItem.update.mockResolvedValue({
+      itemId: "BI-FIXTURE",
+      status: "deferred",
+      completedAt: new Date("2026-04-29T12:00:00.000Z"),
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "retire_backlog_item",
+      {
+        itemId: "BI-FIXTURE",
+        outcome: "discard",
+        rationale: "Verification fixture, not product work.",
+        reason: "Created to exercise the MCP backlog surface.",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "fixture-row-1" },
+        data: expect.objectContaining({
+          status: "deferred",
+          triageOutcome: "discard",
+          duplicateOfId: null,
+          resolution: "Verification fixture, not product work.",
+          abandonReason: "Created to exercise the MCP backlog surface.",
+        }),
+      }),
+    );
+  });
+
+  it("retire_backlog_item requires duplicateOfId for duplicate retirement", async () => {
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({
+      id: "duplicate-row-1",
+      itemId: "BI-DUP",
+      status: "open",
+      activeBuildId: null,
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "retire_backlog_item",
+      {
+        itemId: "BI-DUP",
+        outcome: "duplicate",
+        rationale: "Duplicate row.",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("missing_duplicateOfId");
+    expect(mockPrisma.backlogItem.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -223,6 +223,23 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "retire_backlog_item",
+    description: "Retire an active backlog item from the actionable pool as a duplicate, discard, or defer decision. Use for backlog hygiene and duplicate/noise cleanup when the item should become status=deferred with an audited rationale. Writes a status_change activity row and may auto-close the parent epic.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "Semantic backlog item id to retire" },
+        outcome: { type: "string", enum: ["duplicate", "discard", "defer"], description: "Retirement outcome" },
+        rationale: { type: "string", description: "Outcome summary captured as the item resolution" },
+        duplicateOfId: { type: "string", description: "Canonical semantic item id; required when outcome=duplicate" },
+        reason: { type: "string", description: "Operational reason captured as abandonReason. Defaults to rationale when omitted." },
+      },
+      required: ["itemId", "outcome", "rationale"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "promote_to_build_studio",
     description: "Promote a triaged backlog item (status=open, triageOutcome=build) to a FeatureBuild in Build Studio. Runs the Definition of Ready capacity check under an advisory-lock transaction. Authority-gated via the build_promote grant category.",
     inputSchema: {
@@ -2615,6 +2632,145 @@ export async function executeTool(
         success: true,
         entityId: itemId,
         message: `Triaged ${itemId} as ${outcome}`,
+      };
+    }
+
+    case "retire_backlog_item": {
+      const itemId = String(params["itemId"] ?? "").trim();
+      const outcome = String(params["outcome"] ?? "").trim();
+      const rationale = String(params["rationale"] ?? "").trim();
+      const duplicateOfRaw = typeof params["duplicateOfId"] === "string"
+        ? params["duplicateOfId"].trim()
+        : "";
+      const reason = typeof params["reason"] === "string" && params["reason"].trim()
+        ? params["reason"].trim()
+        : rationale;
+      if (!itemId) {
+        return { success: false, error: "missing_itemId", message: "itemId is required" };
+      }
+      if (!["duplicate", "discard", "defer"].includes(outcome)) {
+        return {
+          success: false,
+          error: "invalid_outcome",
+          message: "outcome must be one of duplicate|discard|defer",
+        };
+      }
+      if (!rationale) {
+        return { success: false, error: "missing_rationale", message: "rationale is required" };
+      }
+      if (outcome === "duplicate" && !duplicateOfRaw) {
+        return {
+          success: false,
+          error: "missing_duplicateOfId",
+          message: "duplicateOfId is required when outcome=duplicate",
+        };
+      }
+
+      const item = await prisma.backlogItem.findUnique({
+        where: { itemId },
+        select: { id: true, itemId: true, status: true, epicId: true, activeBuildId: true },
+      });
+      if (!item) {
+        return { success: false, error: "not_found", message: `Item ${itemId} not found` };
+      }
+      if (!["triaging", "open", "in-progress"].includes(item.status)) {
+        return {
+          success: false,
+          error: "item_not_active",
+          message: `Item ${itemId} is already terminal (${item.status})`,
+        };
+      }
+      if (item.activeBuildId) {
+        return {
+          success: false,
+          error: "active_build_attached",
+          message: `Item ${itemId} has an active Build Studio build; abandon or resolve the build before retiring the backlog item.`,
+        };
+      }
+
+      let canonicalItem: { id: string; itemId: string } | null = null;
+      if (outcome === "duplicate") {
+        canonicalItem = await prisma.backlogItem.findUnique({
+          where: { itemId: duplicateOfRaw },
+          select: { id: true, itemId: true },
+        });
+        if (!canonicalItem) {
+          return {
+            success: false,
+            error: "duplicate_not_found",
+            message: `Canonical duplicate item ${duplicateOfRaw} not found`,
+          };
+        }
+        if (canonicalItem.id === item.id) {
+          return {
+            success: false,
+            error: "duplicate_self_reference",
+            message: "duplicateOfId must point to a different backlog item",
+          };
+        }
+      }
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const completedAt = new Date();
+        const next = await tx.backlogItem.update({
+          where: { id: item.id },
+          data: {
+            status: "deferred",
+            triageOutcome: outcome,
+            effortSize: null,
+            duplicateOfId: canonicalItem?.id ?? null,
+            resolution: rationale,
+            abandonReason: reason,
+            completedAt,
+          },
+          select: { itemId: true, status: true, completedAt: true, epicId: true },
+        });
+        await tx.backlogItemActivity.create({
+          data: {
+            backlogItemId: item.id,
+            kind: "status_change",
+            summary: `${item.status} -> deferred - retired as ${outcome}`,
+            payload: {
+              from: item.status,
+              to: "deferred",
+              outcome,
+              rationale,
+              reason,
+              duplicateOfId: canonicalItem?.itemId ?? null,
+            },
+            recordedById: userId,
+            recordedByAgentId: context?.agentId ?? null,
+          },
+        });
+        if (item.epicId) {
+          const remaining = await tx.backlogItem.count({
+            where: {
+              epicId: item.epicId,
+              id: { not: item.id },
+              status: { notIn: ["done", "deferred"] },
+            },
+          });
+          if (remaining === 0) {
+            await tx.epic.update({
+              where: { id: item.epicId },
+              data: { status: "done", completedAt },
+            });
+          }
+        }
+        return next;
+      });
+
+      return {
+        success: true,
+        entityId: updated.itemId,
+        message: `${updated.itemId}: ${item.status} -> ${updated.status} (${outcome})`,
+        data: {
+          itemId: updated.itemId,
+          status: updated.status,
+          completedAt: updated.completedAt,
+          outcome,
+          duplicateOfId: canonicalItem?.itemId ?? null,
+        },
       };
     }
 

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -163,6 +163,14 @@ describe("default-deny: unmapped tools are blocked", () => {
   });
 });
 
+describe("TOOL_TO_GRANTS — Backlog hygiene entries", () => {
+  it("retire_backlog_item requires backlog_write without broader triage authority", () => {
+    expect(isToolAllowedByGrants("retire_backlog_item", ["backlog_write"])).toBe(true);
+    expect(isToolAllowedByGrants("retire_backlog_item", ["backlog_read"])).toBe(false);
+    expect(isToolAllowedByGrants("retire_backlog_item", ["backlog_triage"])).toBe(false);
+  });
+});
+
 describe("orchestrator with only build-plan grants cannot use sandbox tools", () => {
   const plannerGrants = ["build_plan_write", "backlog_write"];
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -20,6 +20,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   list_backlog_items: ["backlog_read"],
   get_backlog_item: ["backlog_read"],
   update_backlog_item_status: ["backlog_write"],
+  retire_backlog_item: ["backlog_write"],
   link_backlog_item_to_epic: ["backlog_write"],
   search_specs_and_plans: ["spec_plan_read", "backlog_read"],
   record_execution_evidence: ["backlog_write"],

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -140,6 +140,7 @@
         "record_execution_evidence",
         "register_digital_product_from_build",
         "register_tech_debt",
+        "retire_backlog_item",
         "report_quality_issue",
         "saveBuildEvidence",
         "save_build_notes",


### PR DESCRIPTION
## Summary
- Add `retire_backlog_item` MCP tool for audited backlog hygiene: duplicate, discard, and defer outcomes.
- Map the tool to `backlog_write` authority and add it to the grant catalog.
- Cover duplicate retirement, fixture discard cleanup, and grant enforcement with focused tests.

## Verification
- `pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts lib/tak/agent-grants.test.ts lib/backlog-enums.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build` (passes; existing Turbopack NFT warnings remain)