### PR TITLE
doc(orchestration): supersession memo + Codex substrate review

### DIFF
--- a/docs/superpowers/audits/2026-04-29-coworker-substrate-status-review.md
+++ b/docs/superpowers/audits/2026-04-29-coworker-substrate-status-review.md
@@ -1,0 +1,120 @@
+# Coworker substrate status review - 2026-04-29
+
+| Field | Value |
+| --- | --- |
+| Spec under review | [`docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md`](../specs/2026-04-29-coworker-execution-adapter-substrate-design.md) |
+| Evidence note | [`docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md`](./evidence/2026-04-29-codex-jsonl-probe.md) |
+| Source draft reviewed | [`docs/superpowers/specs/2026-04-29-orchestration-primitives-design.md`](../specs/2026-04-29-orchestration-primitives-design.md) |
+| Related prior design | [`docs/superpowers/specs/2026-03-20-execution-adapter-framework-design.md`](../specs/2026-03-20-execution-adapter-framework-design.md) |
+| Generated | 2026-04-29 |
+| Reviewer stance | Architecture review and repair |
+
+## Executive read
+
+The 2026-04-29 orchestration draft is directionally strong. It correctly identifies repeated retry, polling, fan-out, and budget drift as a substrate problem rather than a one-off bug. The draft should not ship as-is, though. It currently mixes three different concerns:
+
+1. coworker/runtime orchestration substrate
+2. older routing-layer "execution adapter" terminology
+3. large migration aspirations that are not yet broken into a safe first slice
+
+This review tightens the architecture around one governing idea:
+
+- DPF should add a small coworker execution substrate for in-process control flow and event semantics
+- that substrate should be explicit about what it owns and what it does not
+- the first implementation slice should prove the substrate on low-risk loops and on Build Studio orchestration internals before touching the highest-blast-radius coworker loop
+
+## Findings
+
+### 1. Naming collision with the existing execution-adapter design
+
+The repo already has an approved "Execution Adapter Framework" design dated 2026-03-20. In that document, an execution adapter means provider-dispatch plumbing inside `callProvider()` and the routing layer, not orchestration semantics.
+
+If the new substrate reuses the same label without qualification, reviewers will confuse:
+
+- routing/provider adapters
+- coworker/runtime orchestration primitives
+
+The repaired spec therefore uses the term `coworker execution substrate` and treats `execution adapter` as a compatibility term only where needed.
+
+### 2. Current repo truth was partially overstated in the source draft
+
+The source draft is correct that event and retry semantics are fragmented, but several repo facts needed correction:
+
+- The canonical event bus implementation is [`apps/web/lib/tak/agent-event-bus.ts`](../../../apps/web/lib/tak/agent-event-bus.ts). The top-level [`apps/web/lib/agent-event-bus.ts`](../../../apps/web/lib/agent-event-bus.ts) is an intentional 2-line shim re-exporting it; substrate work should target the `tak/`-scoped file. (An earlier draft of this audit had the direction inverted; the source draft was correct.)
+- The bus is still thread-keyed, but it already contains `task:status` and `task:artifact` event families. This means Phase 1 should extend a partially task-aware bus, not invent task semantics from zero.
+- Task states already include `submitted`, `working`, `input-required`, `auth-required`, `completed`, `failed`, `canceled`, `rejected`, and `archived` in [`apps/web/lib/tak/task-states.ts`](../../../apps/web/lib/tak/task-states.ts). The new substrate should reuse that vocabulary rather than propose it as net-new.
+
+These are repairable design issues, not reasons to reject the direction.
+
+### 3. The first slice was still too big
+
+The source draft recommended foundation plus polling-loop migration. That is much better than starting with `agentic-loop.ts`, but it still bundled:
+
+- new primitive runtime
+- new event envelope
+- heartbeat semantics
+- governance-profile resolution
+- event-bus compatibility work
+- call-site migration
+
+That is too much to debug at once in a brittle area. The repaired plan splits the work into:
+
+1. pure substrate foundation
+2. low-risk loop migration
+3. Build Studio internal orchestration refactor
+4. provider fallback migration
+5. deliberation migration
+6. coworker loop migration last
+
+### 4. Build Studio needs to be a proving ground before the main coworker loop
+
+Repo evidence points to Build Studio as the better first proving ground:
+
+- `build-orchestrator.ts` already contains explicit sequential phase execution, bounded retries, and batched parallel dispatch.
+- those behaviors are real substrate candidates but are still narrower and easier to observe than the full coworker loop.
+- the user has repeatedly steered this area toward reliability and brittleness reduction before breadth expansion.
+
+The revised plan therefore makes Build Studio the first substantive consumer after low-risk polling loops.
+
+### 5. Refactoring must be first-class, not incidental
+
+This lane will fail if it only adds wrappers while leaving old constants, duplicate retry tables, and stale helper semantics in place. The implementation plan now reserves 20 percent of implementation effort for:
+
+- deleting superseded constants
+- consolidating duplicated loop helpers
+- moving call-site-specific policies into the substrate registry
+- simplifying event-emission branches after migration
+
+That refactor budget is mandatory, not optional cleanup.
+
+## Decision
+
+Proceed, but with the repaired artifact set in this thread instead of the raw 2026-04-29 draft alone.
+
+Recommended active artifacts:
+
+- audit: this file
+- evidence: `docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md`
+- spec: `docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md`
+- plan: `docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md`
+
+Recommended status for `2026-04-29-orchestration-primitives-design.md`:
+
+- keep as useful draft input
+- do not treat it as the implementation-facing canonical artifact without the repairs captured in the new spec and plan
+
+## What changed from the original direction
+
+- narrowed the naming so it no longer collides with routing execution adapters
+- corrected repo-truth statements around the event bus and task states
+- promoted Build Studio to the first real migration target after low-risk loops
+- made compatibility and projection rules explicit
+- added a required 20 percent refactor budget
+
+## What still needs live verification later
+
+- exact Build Studio hot spots that should migrate in the first implementation PR
+- event-envelope compatibility impact on current SSE subscribers
+- whether any current callers depend on ambiguous free-text exhaustion behavior
+
+Those are implementation-time checks, not reasons to block the design.

--- a/docs/superpowers/audits/2026-04-29-orchestration-supersession-decision.md
+++ b/docs/superpowers/audits/2026-04-29-orchestration-supersession-decision.md
@@ -1,0 +1,74 @@
+| Field | Value |
+| --- | --- |
+| Type | Decision memo / handoff brief |
+| Created | 2026-04-29 |
+| Author | Claude (Opus 4.7) for Mark Bodman |
+| Purpose | Single-file handoff so a future thread can resolve the orchestration spec duplication without re-doing the analysis |
+
+# Orchestration spec duplication — decision and handoff
+
+## Situation in one paragraph
+
+On 2026-04-29 two AI co-authors independently produced near-duplicate specs for DPF's in-process orchestration substrate. Claude's spec landed via PR #349 as commit `2d86d2f1` ("spec(orchestration): four-primitive runtime + unified event envelope"); the matching plan landed as `cef51482`. Codex's spec, plan, and audit (which critiques the committed pair) sit uncommitted on disk in `D:/DPF/docs/superpowers/{specs,plans,audits}/2026-04-29-coworker-execution-adapter-substrate-*.md` plus `audits/evidence/2026-04-29-codex-jsonl-probe.md`. The two designs share architecture (four primitives, typed `Outcome`, governance-derived budgets, Inngest-stays-durable) but diverge on naming, migration order, and first-slice scope. A worktree at `D:/DPF-orch-1a` on `feat/orch-phase-1a-skeleton` is actively executing Phase 1A of the committed plan.
+
+## Decision
+
+**Merge into one repaired spec/plan; supersede both current pairs.** The Codex audit is mostly correct and the substrate plan's migration order (Build Studio as first major proving ground, main coworker loop last) is sounder than the committed plan's Phase 1 (16-file bus refactor as the foundation). But two near-identical specs in the repo is exactly the architectural ambiguity that produced this confusion in the first place.
+
+## What's right in the Codex critique
+
+- **Naming collision is real.** `2026-03-20-execution-adapter-framework-design.md` already claims "execution adapter" for routing/provider plumbing. Renaming the in-process layer to "coworker execution substrate" with code under `apps/web/lib/coworker-substrate/` is the right call.
+- **Migration order is better.** Foundation → low-risk loops → Build Studio → fallback → deliberation → main coworker loop last. The committed plan leads with a 16-file/44-site bus refactor, which is the highest-risk slice in the lane and shouldn't be first.
+- **20% refactor budget is mandatory, not optional.** Codex spec is more emphatic about this; aligns with the "approach zero technical debt" principle.
+- **Build Studio as first major proving ground.** Repo evidence (build-orchestrator's `MAX_SPECIALIST_RETRIES`, sequential phase loop, parallel batch dispatch) makes this the highest-signal first migration.
+
+## What the Codex critique gets wrong (corrected on disk 2026-04-29)
+
+- **Event bus path is inverted.** The Codex spec/audit/evidence claimed `apps/web/lib/agent-event-bus.ts` is canonical and `apps/web/lib/tak/agent-event-bus.ts` is wrong. Reality is the opposite: the top-level path is a 2-line shim (`export * from "./tak/agent-event-bus";`); the canonical 120-line implementation is at `lib/tak/agent-event-bus.ts`. The committed orchestration spec had this right. **Fix already applied to all three Codex documents on disk** (uncommitted) — language now states the `tak/`-scoped file is canonical and the top-level path is an intentional shim.
+
+## What the committed spec/plan have that Codex's drafts dropped
+
+A merged version must preserve these from the committed pair:
+
+1. **Cost monotonicity invariant** — cumulative `cost.tokens` and `cost.ms` non-decreasing across events for the same `runId`. Load-bearing observability rule.
+2. **Per-PR test gate checklist** — 9 items including behavior-parity test, terminal-outcome test, event-emission test, heartbeat test, cost monotonicity, typecheck, vitest, build, DCO sign-off.
+3. **Concrete migration inventory with line numbers** — 13 in-process retry/iteration surfaces cited with file+line. Codex spec lists ~7 in tables without lines.
+4. **Inngest boundary discipline detail** — explicit `step.waitForEvent`, durable retries, `retries: N` at function boundary.
+5. **Detailed type contracts with per-primitive worked examples.**
+
+## What the merged plan must add (beyond either current draft)
+
+1. **Heartbeat reset edge-case fix.** Codex spec says "any emitted progress event resets the quiet window" — that's broken for a Loop primitive whose own retries emit progress. The reset must apply only to substrate-emitted progress events, not all bus events the consumer emits inside the primitive.
+2. **`RunContext.runId` ↔ `ToolExecution` linkage.** State that orchestration `runId` will be threaded through `ToolExecution.routeContext` (or equivalent) so receipts (separate spec, `2026-04-27-artifact-provenance-receipts-design.md`) and orchestration runs can be joined for forensics.
+3. **`SubstrateProfile` vs `GovernanceProfile` type-name reconciliation.** Both drafts define five identically-named profiles (`economy | balanced | high-assurance | document-authority | system`) under different type names. Pick one. `GovernanceProfile` matches the Prisma model `AgentGovernanceProfile`; that's the better choice.
+4. **Restore dropped migration targets.** Codex spec drops `build-pipeline.ts:95` (step retry with `MAX_RETRIES`/`RETRY_DELAYS_MS`) and `sandbox-db.ts:50,68` (`while`-loop polling). They're substrate-worthy. Either include them or document why they're excluded.
+5. **Plan rigor pass.** Bring the substrate plan's task structure up to the level of the receipts plan (`2026-04-29-artifact-provenance-receipts-slice-1.md` after this thread's edits): red/green test steps, induced-failure smoke checks, explicit failing test examples, fold Codex's Phase 0 (three checklist items) into Phase 1.
+
+## What the merged artifact set should look like
+
+- One revised spec at `docs/superpowers/specs/2026-04-29-orchestration-primitives-design.md` (rewritten in place at the same path so existing references stay valid). Renamed/scoped using "coworker execution substrate" terminology where appropriate, but the canonical file path stays where it is.
+- One revised plan at `docs/superpowers/plans/2026-04-29-orchestration-primitives.md` (also rewritten in place).
+- Codex's substrate spec, plan, audit, and evidence files: **delete or move to `archive/`** with their content folded into the merged artifacts. The audit's findings are the rationale for the merge; preserving the audit as a historical record is fine, but the substrate spec/plan should not coexist with the merged spec/plan.
+
+## Active executor risk
+
+`D:/DPF-orch-1a` worktree on branch `feat/orch-phase-1a-skeleton` is implementing the committed plan's Phase 1A right now. Phase 1A per the committed plan is the orchestration module skeleton (types, assert-never, governance-profile registry, heartbeat helper) — that work is *consistent* with the merged direction; it's foundational and not specific to the migration order disagreement. **Do not block or whiplash that worktree.** The merge can land while Phase 1A is in flight; the executor's work doesn't depend on which migration target comes second.
+
+## Next-thread brief (copy-paste ready)
+
+> Read these five files in `D:/DPF`:
+>
+> 1. `docs/superpowers/audits/2026-04-29-orchestration-supersession-decision.md` (this file — read first)
+> 2. `docs/superpowers/specs/2026-04-29-orchestration-primitives-design.md` (committed)
+> 3. `docs/superpowers/plans/2026-04-29-orchestration-primitives.md` (committed)
+> 4. `docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md` (uncommitted; has the bus-path fix already applied)
+> 5. `docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md` (uncommitted)
+>
+> Produce a merged spec and plan that incorporates the Codex repairs (renaming, narrower first slice, Build Studio as proving ground, mandatory refactor budget) into the committed pair, preserves the load-bearing details listed in this memo's "What the committed spec/plan have that Codex's drafts dropped" section, and adds the items in "What the merged plan must add." Rewrite the committed files in place at their existing paths. Move the Codex spec/plan to `docs/superpowers/archive/2026-04-29-coworker-substrate-superseded/` with a brief `README.md` noting they were merged into the canonical files. Keep the audit and evidence as-is — they're the historical record of why the merge happened. Do not start implementation work; this is a docs-only change. Open a single PR titled "spec(orchestration): merge substrate repairs into canonical four-primitive design" with DCO sign-off. Do not block the `D:/DPF-orch-1a` worktree's Phase 1A work — that work is consistent with the merged direction.
+
+## Anti-instructions for any future thread
+
+- Do not commit the Codex substrate spec/plan to the repo as parallel artifacts. The merge is the right path, not coexistence.
+- Do not edit the committed orchestration spec to add a "superseded" header *unless the merge has already produced its replacement.* A bare supersession pin without a replacement is worse than the current state.
+- Do not whiplash the `D:/DPF-orch-1a` executor. Their Phase 1A work is consistent with the merged direction.
+- If you find this memo and the merge has already happened, this file becomes the historical record — do not re-execute it.

--- a/docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
+++ b/docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
@@ -1,0 +1,146 @@
+# Codex probe evidence - 2026-04-29
+
+This note captures the repo-grounded probes used to repair the coworker substrate design on 2026-04-29. Despite the filename, this is not a raw session dump. It is the distilled evidence record that the audit and spec cite.
+
+## Scope
+
+- Verify the real event-bus location and current shape
+- Verify the current task-state vocabulary
+- Verify concrete retry, polling, sequential, and fan-out call sites
+- Verify where current code still returns ambiguous timeout/deferred semantics
+- Verify overlap with the older execution-adapter design
+
+## Evidence
+
+### E1. Event bus is already task-aware, but still thread-keyed
+
+Files:
+
+- canonical implementation: [`apps/web/lib/tak/agent-event-bus.ts`](../../../../apps/web/lib/tak/agent-event-bus.ts) (~120 lines)
+- intentional shim: [`apps/web/lib/agent-event-bus.ts`](../../../../apps/web/lib/agent-event-bus.ts) (2 lines, `export * from "./tak/agent-event-bus";`)
+
+Observed:
+
+- subscribers are keyed by `threadId`
+- current API is `subscribe(threadId, handler)` and `emit(threadId, event)`
+- event union already includes `task:status` and `task:artifact`
+- imports across the codebase use both paths; both resolve to the same module via the shim
+
+Implication:
+
+- the substrate should extend the `tak/`-scoped implementation rather than propose a net-new task event family from scratch
+- compatibility shims matter because multiple current event families already exist here, and the top-level path is itself a compatibility shim that callers may still rely on
+
+### E2. Task-state vocabulary already exists and already matches the intended A2A-shaped direction
+
+File:
+
+- [`apps/web/lib/tak/task-states.ts`](../../../apps/web/lib/tak/task-states.ts)
+
+Observed states:
+
+- `submitted`
+- `working`
+- `input-required`
+- `auth-required`
+- `completed`
+- `failed`
+- `canceled`
+- `rejected`
+- `archived`
+
+Implication:
+
+- the substrate should reuse the existing state vocabulary
+- docs should not present these as a fresh proposal
+
+### E3. Build Studio already contains the substrate-worthy patterns
+
+File:
+
+- [`apps/web/lib/integrate/build-orchestrator.ts`](../../../apps/web/lib/integrate/build-orchestrator.ts)
+
+Observed:
+
+- bounded retry constant: `MAX_SPECIALIST_RETRIES = 2`
+- sequential phase execution via `for (const phase of phases)`
+- batched parallel dispatch with `Promise.all(...)`
+- optimistic merge retry path around task-result persistence
+
+Implication:
+
+- Build Studio is the best early proving ground for the substrate after low-risk loops
+- the migration can reduce real duplication immediately without starting at the main coworker loop
+
+### E4. Provider fallback still walks a custom retry/backoff chain
+
+File:
+
+- [`apps/web/lib/routing/fallback.ts`](../../../apps/web/lib/routing/fallback.ts)
+
+Observed:
+
+- fallback chain built from routing decision candidates
+- retry/backoff implemented inline in the loop
+- special handling for rate limits, auth failures, and model retirement lives inside the same call path
+
+Implication:
+
+- this path is a strong later `Loop` consumer
+- it should migrate only after the substrate has already proved itself on lower-risk cases
+
+### E5. GitHub fork readiness still returns an ambiguous `"deferred"` status after polling
+
+File:
+
+- [`apps/web/lib/integrate/github-fork.ts`](../../../apps/web/lib/integrate/github-fork.ts)
+
+Observed:
+
+- fork creation polls until ready
+- timeout returns `{ status: "deferred" }`
+
+Implication:
+
+- this is a clean first migration target for typed exhausted or still-pending outcomes
+- it exercises polling semantics without the blast radius of the main coworker runtime
+
+### E6. Deliberation runner is still sequential and branch-oriented
+
+File:
+
+- [`apps/web/lib/queue/functions/deliberation-run.ts`](../../../apps/web/lib/queue/functions/deliberation-run.ts)
+
+Observed:
+
+- branch nodes are separated into worker branches and adjudicator branches
+- worker branches run through a sequential `for` loop
+- route decisions and diversity degradation are persisted/emitted inline
+
+Implication:
+
+- the future `Branch` primitive should model strategic branch semantics here
+- this lane is a semantic upgrade, not just a wrapper extraction
+
+### E7. Older "execution adapter" already means something else in DPF
+
+Files:
+
+- [`docs/superpowers/specs/2026-03-20-execution-adapter-framework-design.md`](../../specs/2026-03-20-execution-adapter-framework-design.md)
+- [`docs/superpowers/plans/2026-03-20-execution-adapter-framework.md`](../../plans/2026-03-20-execution-adapter-framework.md)
+
+Observed:
+
+- execution adapter there means provider-dispatch adapters around `callProvider()`
+- scope is routing/provider execution, not coworker/runtime orchestration
+
+Implication:
+
+- the new lane needs qualified naming to avoid architecture and PR-review confusion
+
+## Conclusions
+
+1. The substrate problem is real and already visible in the repo.
+2. The 2026-04-29 draft had the right instinct but needed tighter repo grounding.
+3. Build Studio should be the first major consumer after the low-risk loop migrations.
+4. The terminology must separate routing execution adapters from coworker execution substrate work.

--- a/docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md
+++ b/docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md
@@ -1,0 +1,259 @@
+# Coworker Execution Adapter Substrate Plan
+
+> For agentic workers: use a reviewable, checkpointed execution style. Do not start with the main coworker loop. Land the substrate in narrow slices with proof and deletion each time.
+
+**Goal:** Add a coworker execution substrate for in-process orchestration, prove it on low-risk loops and Build Studio internals, then expand to later consumers without destabilizing the main coworker runtime.
+
+**Architecture:** `apps/web/lib/coworker-substrate/` owns primitives, typed outcomes, event-envelope helpers, heartbeat logic, and reviewed runtime budgets. Existing consumers migrate onto it in phases. Inngest stays durable. Routing execution adapters stay in `apps/web/lib/routing/`.
+
+**Refactor budget:** 20 percent of total implementation effort is reserved for refactoring and deletion. Each migration slice must retire at least one superseded constant, helper, or ambiguous status behavior.
+
+**Primary spec:** [`docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md`](../specs/2026-04-29-coworker-execution-adapter-substrate-design.md)
+
+---
+
+## Phase 0: Naming and guardrails
+
+**Objective:** Prevent architecture drift before code lands.
+
+- [ ] Add a short module README or header comment in `apps/web/lib/coworker-substrate/` stating that this substrate is distinct from the routing execution-adapter framework.
+- [ ] In PR descriptions and follow-on docs, use `coworker substrate` or `coworker execution substrate`, not bare `execution adapter`.
+- [ ] Record the migration order in the active epic or backlog item so later work does not jump straight to the main coworker loop.
+
+**Exit criteria:**
+
+- reviewers can distinguish routing adapters from coworker substrate work without reading the whole spec
+
+---
+
+## Phase 1: Foundation
+
+**Objective:** Land the substrate as a tested library with no business call-site migration yet.
+
+**Files:**
+
+- Create: `apps/web/lib/coworker-substrate/index.ts`
+- Create: `apps/web/lib/coworker-substrate/types.ts`
+- Create: `apps/web/lib/coworker-substrate/primitives.ts`
+- Create: `apps/web/lib/coworker-substrate/events.ts`
+- Create: `apps/web/lib/coworker-substrate/budgets.ts`
+- Create: `apps/web/lib/coworker-substrate/heartbeat.ts`
+- Create: `apps/web/lib/coworker-substrate/assert-never.ts`
+- Create tests alongside the module
+
+- [ ] Implement `Outcome`, `RunContext`, `Evidence`, and budget types.
+- [ ] Implement `Loop` first. `Sequential`, `Parallel`, and `Branch` can land in the same PR only if the tests stay tight and readable.
+- [ ] Implement event-envelope helpers that can project onto the existing thread-keyed bus without breaking subscribers.
+- [ ] Implement heartbeat helpers with quiet-window reset semantics.
+- [ ] Add unit tests for:
+  - typed terminal outcomes
+  - heartbeat emission
+  - budget resolution
+  - exhaustive outcome handling
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] `pnpm --filter web exec vitest run apps/web/lib/coworker-substrate`
+
+**Exit criteria:**
+
+- substrate library exists
+- foundation tests pass
+- no runtime call sites depend on it yet
+
+---
+
+## Phase 2: Low-risk loop migration
+
+**Objective:** Prove the substrate on narrow polling semantics before Build Studio.
+
+**Primary target:**
+
+- [`apps/web/lib/integrate/github-fork.ts`](../../../apps/web/lib/integrate/github-fork.ts)
+
+- [ ] Replace custom polling with substrate `Loop`.
+- [ ] Replace ambiguous `"deferred"` timeout semantics with a typed exhausted or pending outcome that callers handle explicitly.
+- [ ] Preserve user-facing meaning while improving internal semantics.
+- [ ] Add focused tests for:
+  - ready path
+  - timeout/exhaustion path
+  - heartbeat behavior if the loop can run long enough to matter
+
+**Refactor budget use:**
+
+- [ ] delete the old local polling helper logic once the substrate-backed path is stable
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] focused Vitest for `github-fork.ts`
+- [ ] `cd apps/web && npx next build`
+
+**Exit criteria:**
+
+- at least one real call site uses the substrate
+- one ambiguous terminal behavior has been retired
+
+---
+
+## Phase 3: Build Studio proving ground
+
+**Objective:** Move the first major orchestration consumer onto the substrate.
+
+**Primary target:**
+
+- [`apps/web/lib/integrate/build-orchestrator.ts`](../../../apps/web/lib/integrate/build-orchestrator.ts)
+
+**Scope for this phase:**
+
+- `Sequential` for phase progression
+- `Parallel` for batched specialist dispatch
+- `Loop` for specialist retry
+- `Loop` for optimistic merge retry where appropriate
+
+- [ ] Extract substrate-backed helpers without changing Build Studio product behavior first.
+- [ ] Migrate one behavior at a time, starting with the least coupled helper.
+- [ ] Keep current progress events visible during the migration. If event semantics improve, preserve the user-facing progress stream instead of requiring UI rewrites in the same PR.
+- [ ] Add or update tests around orchestrator behavior.
+
+**Refactor budget use:**
+
+- [ ] retire `MAX_SPECIALIST_RETRIES` if the budget registry fully supersedes it
+- [ ] remove duplicated retry or merge-loop scaffolding that becomes dead code
+- [ ] simplify event emission branches where the substrate now owns heartbeat or progress cadence
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] focused Vitest for Build Studio orchestration paths
+- [ ] `cd apps/web && npx next build`
+- [ ] UX verification on the running Build Studio path
+
+**Exit criteria:**
+
+- Build Studio is the first major substrate consumer
+- at least one old constant or duplicate helper is deleted, not merely bypassed
+
+---
+
+## Phase 4: Provider fallback migration
+
+**Objective:** Move routing fallback walking onto the substrate only after the substrate has already proved stable elsewhere.
+
+**Primary target:**
+
+- [`apps/web/lib/routing/fallback.ts`](../../../apps/web/lib/routing/fallback.ts)
+
+- [ ] Migrate backoff and retry walking to `Loop`.
+- [ ] Preserve provider-specific side effects such as model degradation, retirement, and auth disablement.
+- [ ] Make terminal outcomes explicit instead of relying on the current mixed control-flow style.
+
+**Refactor budget use:**
+
+- [ ] delete superseded backoff plumbing once substrate-backed behavior is verified
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] focused Vitest for fallback behavior
+- [ ] `cd apps/web && npx next build`
+
+**Exit criteria:**
+
+- substrate now covers both internal orchestration and provider fallback semantics
+
+---
+
+## Phase 5: Deliberation migration
+
+**Objective:** Introduce `Branch` where the code really models strategy branches rather than simple parallelism.
+
+**Primary target:**
+
+- [`apps/web/lib/queue/functions/deliberation-run.ts`](../../../apps/web/lib/queue/functions/deliberation-run.ts)
+
+- [ ] Map worker-branch dispatch and synthesis to `Branch`.
+- [ ] Keep route-decision persistence and diversity-degradation evidence intact.
+- [ ] Be explicit about which branch groups remain ordered and which can truly run in parallel.
+
+**Refactor budget use:**
+
+- [ ] remove duplicated branch-state scaffolding that the substrate now centralizes
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] focused Vitest for deliberation paths
+- [ ] `cd apps/web && npx next build`
+
+**Exit criteria:**
+
+- branch-oriented orchestration has a canonical primitive
+
+---
+
+## Phase 6: Main coworker loop migration
+
+**Objective:** Migrate the highest-risk runtime last, after the substrate is already proven elsewhere.
+
+- [ ] inventory every distinct terminal path before refactoring
+- [ ] map each current terminal path onto typed outcomes explicitly
+- [ ] migrate callers in the same slice where necessary so no one depends on ambiguous free-text exhaustion behavior
+- [ ] add replay-style or fixture-based tests for the highest-risk paths
+
+**Required replay coverage:**
+
+- [ ] normal successful multi-step run
+- [ ] repeated-tool or stuck behavior
+- [ ] cancellation
+- [ ] exhaustion
+- [ ] fatal failure
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] focused Vitest plus replay fixtures
+- [ ] `cd apps/web && npx next build`
+- [ ] UX verification on the running coworker path
+
+**Exit criteria:**
+
+- main coworker loop is substrate-backed
+- compatibility assumptions are explicit instead of hidden
+
+---
+
+## Phase 7: Retirement sweep
+
+**Objective:** Finish the migration as an architectural simplification, not a layering exercise.
+
+- [ ] delete dead constants
+- [ ] delete dead retry helpers
+- [ ] remove stale comments that describe the pre-substrate behavior
+- [ ] add a light review rule or grep-based check so new ad hoc retry loops do not creep back in casually
+
+**Verification:**
+
+- [ ] `pnpm --filter web typecheck`
+- [ ] targeted Vitest for touched areas
+- [ ] `cd apps/web && npx next build`
+
+**Exit criteria:**
+
+- one control-flow vocabulary remains
+- the codebase is smaller and clearer than before the migration
+
+---
+
+## Sequence summary
+
+1. Foundation
+2. Low-risk loop migration
+3. Build Studio proving ground
+4. Provider fallback migration
+5. Deliberation migration
+6. Main coworker loop migration
+7. Retirement sweep
+
+This order is intentional. It reduces brittleness first, proves the substrate where DPF already hurts most, and keeps the highest-blast-radius coworker change until the end.

--- a/docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md
+++ b/docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md
@@ -1,0 +1,463 @@
+# Coworker Execution Adapter Substrate Design
+
+| Field | Value |
+| --- | --- |
+| Status | Draft for review |
+| Created | 2026-04-29 |
+| Author | Codex + Mark Bodman |
+| Primary audience | Platform architecture, coworker runtime, Build Studio orchestration, governance |
+| Related repo areas | `apps/web/lib/agent-event-bus.ts`, `apps/web/lib/integrate/*`, `apps/web/lib/tak/*`, `apps/web/lib/queue/functions/*`, `apps/web/lib/routing/fallback.ts` |
+| Related prior artifacts | `2026-04-29-orchestration-primitives-design.md`, `2026-03-20-execution-adapter-framework-design.md`, `2026-04-23-a2a-aligned-coworker-runtime-design.md` |
+
+## Purpose
+
+Introduce a small coworker execution substrate for DPF that gives in-process agent and workflow execution a single control-flow vocabulary:
+
+- `Sequential`
+- `Parallel`
+- `Loop`
+- `Branch`
+
+This substrate is for coworker and Build Studio runtime behavior. It is not the same thing as the older routing-layer execution-adapter framework around `callProvider()`. The name overlap is historical; the boundaries are different.
+
+The goal is to remove recurring failure classes already visible in the repo:
+
+1. retry and polling semantics scattered across unrelated files
+2. inconsistent terminal behavior at exhaustion boundaries
+3. event and heartbeat behavior implemented ad hoc
+4. budget and patience rules encoded as local constants instead of a reviewed runtime policy
+
+## Executive decision
+
+DPF should add `apps/web/lib/coworker-substrate/` as the canonical home for in-process execution primitives, typed outcomes, event-envelope helpers, and runtime budget resolution.
+
+The architectural split should be:
+
+- Inngest remains the durable outer shell for queued, resumable, cross-restart work.
+- The existing routing execution-adapter framework remains the provider-dispatch abstraction around inference calls.
+- The new coworker execution substrate becomes the single in-process control-flow layer used inside Build Studio orchestration, coworker loops, readiness polling, and branch-oriented deliberation flows.
+
+That gives DPF one durable layer, one provider-adapter layer, and one in-process orchestration layer instead of blurring them together.
+
+## Current repo truth
+
+### Event bus reality
+
+The canonical bus implementation lives at [`apps/web/lib/tak/agent-event-bus.ts`](../../../apps/web/lib/tak/agent-event-bus.ts). The top-level [`apps/web/lib/agent-event-bus.ts`](../../../apps/web/lib/agent-event-bus.ts) is an intentional 2-line shim (`export * from "./tak/agent-event-bus";`) left in place during a Phase 12 refactor so existing imports keep working. Both import paths resolve to the same module; substrate work should evolve the `tak/`-scoped file.
+
+Verified current behavior:
+
+- subscriptions are keyed by `threadId`
+- API shape is `subscribe(threadId, handler)` and `emit(threadId, event)`
+- the union already includes `task:status` and `task:artifact`
+
+Implication:
+
+- Phase 1 should evolve the existing bus, not replace it wholesale
+- task semantics already exist, but the envelope is too weak and too thread-centric
+
+### Task-state reality
+
+The repo already defines the canonical task-state vocabulary in [`apps/web/lib/tak/task-states.ts`](../../../apps/web/lib/tak/task-states.ts):
+
+- `submitted`
+- `working`
+- `input-required`
+- `auth-required`
+- `completed`
+- `failed`
+- `canceled`
+- `rejected`
+- `archived`
+
+This spec reuses that vocabulary.
+
+### Existing control-flow hot spots
+
+Verified substrate-worthy surfaces:
+
+- [`apps/web/lib/integrate/build-orchestrator.ts`](../../../apps/web/lib/integrate/build-orchestrator.ts)
+  - bounded specialist retry
+  - sequential phase progression
+  - batched parallel task dispatch
+  - optimistic merge retry
+- [`apps/web/lib/integrate/github-fork.ts`](../../../apps/web/lib/integrate/github-fork.ts)
+  - poll until ready, then return `"deferred"` on timeout
+- [`apps/web/lib/routing/fallback.ts`](../../../apps/web/lib/routing/fallback.ts)
+  - provider/model fallback chain with backoff and special-case retry handling
+- [`apps/web/lib/queue/functions/deliberation-run.ts`](../../../apps/web/lib/queue/functions/deliberation-run.ts)
+  - sequential branch dispatch with branch-specific persistence and progress events
+
+## Problem statement
+
+DPF has good primitives but weak substrate coherence.
+
+The codebase already contains:
+
+- task states
+- event streaming
+- Build Studio orchestration
+- coworker loops
+- deliberation orchestration
+- durable queue execution
+
+What it lacks is one explicit in-process execution contract. As a result:
+
+- timeouts sometimes degrade into free-text or ambiguous status values
+- heartbeats and progress semantics differ by subsystem
+- retries and polling rules are hard to compare or govern
+- similar logic is reimplemented with different edge-case behavior
+
+## Naming and boundary rule
+
+To avoid collision with the 2026-03-20 routing design:
+
+- `execution adapter` in routing docs still means provider-dispatch adapter
+- `coworker execution substrate` in this doc means in-process control-flow substrate
+
+Implementation paths should reflect that separation:
+
+- routing adapter code stays under `apps/web/lib/routing/`
+- coworker substrate code lands under `apps/web/lib/coworker-substrate/`
+
+## Goals
+
+- provide exactly four in-process control-flow primitives
+- make terminal outcomes explicit and typed
+- centralize heartbeat and event-envelope behavior
+- centralize runtime budget resolution
+- reduce duplicated loop, retry, and fan-out code
+- prove the substrate first in lower-risk and Build Studio surfaces before touching the main coworker loop
+
+## Non-goals
+
+- replacing Inngest durability semantics
+- replacing the routing/provider execution-adapter framework
+- redesigning the coworker UI
+- adding tenant-admin knobs for runtime budgets in V1
+- shipping the highest-blast-radius coworker loop migration first
+
+## Research and benchmarking synthesis
+
+DPF should combine:
+
+- Google ADK's small deterministic workflow vocabulary
+- Inngest's durable-boundary discipline
+- Step Functions and Temporal style explicit terminal semantics
+
+DPF should explicitly not do:
+
+- a graph-DSL-first rewrite
+- a second durable orchestration platform
+- another large framework layer that hides current behavior instead of clarifying it
+
+## Proposed architecture
+
+### Module
+
+Create:
+
+- `apps/web/lib/coworker-substrate/index.ts`
+- `apps/web/lib/coworker-substrate/types.ts`
+- `apps/web/lib/coworker-substrate/primitives.ts`
+- `apps/web/lib/coworker-substrate/events.ts`
+- `apps/web/lib/coworker-substrate/budgets.ts`
+- `apps/web/lib/coworker-substrate/heartbeat.ts`
+- `apps/web/lib/coworker-substrate/assert-never.ts`
+
+### Primitive set
+
+#### Sequential
+
+Use for:
+
+- ordered phase progression
+- ordered review gates
+- any multi-step workflow where first non-success should stop the run
+
+#### Parallel
+
+Use for:
+
+- concurrent task batches
+- independent reviewer or specialist work
+- any fan-out that needs an explicit synthesis policy
+
+#### Loop
+
+Use for:
+
+- bounded retry
+- polling with deadlines
+- fallback walking where inputs evolve between attempts
+
+#### Branch
+
+Use for:
+
+- strategic branch sets
+- deliberation and synthesis
+- cases where branches are semantically distinct roles, not just parallel workers
+
+### Type contracts
+
+```ts
+export type SubstrateProfile =
+  | "economy"
+  | "balanced"
+  | "high-assurance"
+  | "document-authority"
+  | "system";
+
+export type RunContext = {
+  runId: string;
+  userId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  buildId?: string;
+  agentId?: string;
+  routeContext?: string;
+  profile: SubstrateProfile;
+  parentRunId?: string;
+};
+
+export type Outcome<T> =
+  | { status: "succeeded"; value: T; attempts: number; evidence: Evidence[] }
+  | { status: "failed"; error: SubstrateError; attempts: number; evidence: Evidence[] }
+  | { status: "exhausted"; reason: ExhaustionReason; attempts: number; evidence: Evidence[] }
+  | { status: "cancelled"; reason: "user_cancelled" | "upstream_cancelled"; attempts: number; evidence: Evidence[] };
+
+export type ExhaustionReason =
+  | "max_attempts"
+  | "deadline"
+  | "token_budget"
+  | "no_more_strategies"
+  | "external_dependency_not_ready";
+
+export type Evidence = {
+  attemptNumber: number;
+  startedAt: string;
+  endedAt: string;
+  summary: string;
+  detail?: unknown;
+};
+```
+
+### Hard rules
+
+1. No primitive may terminate without returning a typed terminal `Outcome`.
+2. Exhaustion may not be represented as `null`, `"deferred"`, or free-text fallback.
+3. Heartbeat behavior belongs to the substrate, not to each call site.
+4. Call sites must handle all terminal variants explicitly.
+5. New retry or polling logic outside the substrate needs architectural justification.
+
+## Event model
+
+### Principle
+
+Keep the current bus, but upgrade the envelope.
+
+### New envelope
+
+```ts
+export type SubstrateEnvelope = {
+  runId: string;
+  parentRunId?: string;
+  primitive: "sequential" | "parallel" | "loop" | "branch";
+  userId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  buildId?: string;
+  agentId?: string;
+  routeContext?: string;
+  profile: SubstrateProfile;
+  emittedAt: string;
+  cost: {
+    ms: number;
+    attempts: number;
+    tokens?: number;
+  };
+};
+```
+
+### Compatibility strategy
+
+Phase 1 should support:
+
+- legacy `emit(threadId, event)`
+- new substrate-aware emitters that attach a shared envelope before projecting to the thread-keyed bus
+
+Important constraint:
+
+- do not break existing SSE subscribers while foundation work is landing
+
+### Heartbeat contract
+
+Every substrate run gets a quiet-window heartbeat timer.
+
+Rules:
+
+- timer starts on primitive start
+- any emitted progress event resets the quiet window
+- heartbeat emits only after a quiet interval with no other event
+- timer clears in `finally`
+
+UI use:
+
+- recent events mean `working`
+- missed heartbeat windows mean `possibly-stalled`
+
+This is a support signal, not a terminal state.
+
+## Budget resolution
+
+Store reviewed defaults in code:
+
+- `apps/web/lib/coworker-substrate/budgets.ts`
+
+Reason:
+
+- platform behavior, not tenant content
+- easy to review with code changes
+- avoids another seed/runtime drift axis
+
+Suggested defaults:
+
+```ts
+export const SUBSTRATE_BUDGETS = {
+  economy: { maxAttempts: 2, deadlineMs: 60_000, heartbeatMs: 10_000, tokenBudget: 20_000 },
+  balanced: { maxAttempts: 4, deadlineMs: 300_000, heartbeatMs: 10_000, tokenBudget: 80_000 },
+  "high-assurance": { maxAttempts: 6, deadlineMs: 900_000, heartbeatMs: 15_000, tokenBudget: 250_000 },
+  "document-authority": { maxAttempts: 3, deadlineMs: 600_000, heartbeatMs: 10_000, tokenBudget: 120_000 },
+  system: { maxAttempts: 3, deadlineMs: 60_000, heartbeatMs: 5_000, tokenBudget: 0 },
+} as const;
+```
+
+Resolution order:
+
+1. explicit profile from the caller
+2. profile derived from governance posture when present
+3. `system` for infra-only flows
+
+## Migration inventory
+
+### Group A: First consumers
+
+| Surface | Current file | Target |
+| --- | --- | --- |
+| GitHub fork readiness polling | `apps/web/lib/integrate/github-fork.ts` | `Loop` |
+| Low-risk readiness/polling helpers | future small polling sites | `Loop` |
+
+### Group B: First major proving ground
+
+| Surface | Current file | Target |
+| --- | --- | --- |
+| Build phase progression | `apps/web/lib/integrate/build-orchestrator.ts` | `Sequential` |
+| Specialist retry | `apps/web/lib/integrate/build-orchestrator.ts` | `Loop` |
+| Task-batch dispatch | `apps/web/lib/integrate/build-orchestrator.ts` | `Parallel` |
+| Task-result optimistic merge retry | `apps/web/lib/integrate/build-orchestrator.ts` | `Loop` |
+
+### Group C: Later consumers
+
+| Surface | Current file | Target |
+| --- | --- | --- |
+| Provider fallback chain | `apps/web/lib/routing/fallback.ts` | `Loop` |
+| Deliberation branch orchestration | `apps/web/lib/queue/functions/deliberation-run.ts` | `Branch` plus nested primitives |
+
+### Group D: Last migration
+
+| Surface | Current file | Why last |
+| --- | --- | --- |
+| Main coworker/agentic loop | current coworker runtime loop | highest blast radius, most hidden compatibility assumptions |
+
+## Refactoring budget
+
+This work must reserve 20 percent of implementation effort for refactoring and deletion.
+
+That budget is for:
+
+- retiring duplicate retry constants
+- collapsing local backoff tables where the substrate supersedes them
+- removing ambiguous timeout or deferred semantics after migration
+- simplifying call-site event emission once the substrate owns heartbeat behavior
+
+This is not optional cleanup. It is part of the architecture.
+
+## Verification strategy
+
+### Foundation
+
+Required before consumer migration:
+
+1. primitive unit tests
+2. event-envelope tests
+3. heartbeat tests
+4. budget-resolution tests
+5. exhaustive outcome-handling tests
+
+### Per migration PR
+
+Each migration PR must include:
+
+1. behavior tests for the migrated surface
+2. explicit terminal-outcome assertions
+3. event and heartbeat assertions where relevant
+4. `pnpm --filter web typecheck`
+5. focused Vitest runs
+6. `cd apps/web && npx next build`
+
+### UX verification
+
+For Build Studio-facing migrations:
+
+- verify the affected path against the running app
+- verify current progress rendering still behaves coherently after event changes
+
+## Risks
+
+### 1. Naming confusion with routing execution adapters
+
+Mitigation:
+
+- keep code and docs under `coworker-substrate`
+- reserve `routing execution adapter` for provider-dispatch work only
+
+### 2. Compatibility breakage in SSE consumers
+
+Mitigation:
+
+- compatibility shim first
+- migrate emitters incrementally
+- do not combine bus evolution with the riskiest runtime migration
+
+### 3. Wrapper-only migration with no real debt reduction
+
+Mitigation:
+
+- enforce the 20 percent refactor budget
+- require retirement of superseded constants and helpers as part of each migrated surface
+
+### 4. Main coworker loop changes too early
+
+Mitigation:
+
+- Build Studio first
+- provider fallback second
+- deliberation after that
+- main coworker loop last
+
+## Recommended next slice
+
+The smallest architecture-sound first slice is:
+
+1. add `apps/web/lib/coworker-substrate/` with `Loop`, typed `Outcome`, budget registry, and heartbeat helper
+2. add substrate event-envelope helpers that project onto the current thread-keyed bus
+3. migrate `github-fork.ts` polling to `Loop`
+4. add tests for exhausted outcomes and heartbeat behavior
+
+The first major proving-ground slice after that is:
+
+1. move Build Studio phase sequencing, retry, and batched dispatch onto the substrate
+2. spend the reserved refactor budget deleting superseded constants and duplicate retry helpers
+
+That sequence proves the substrate where DPF most needs reliability gains without taking the highest-risk migration first.


### PR DESCRIPTION
## Summary

- Lands Codex's uncommitted orchestration substrate spec/plan/audit/evidence so the duplication with the committed orchestration spec (PR #349, commit 2d86d2f1) is visible in the repo and resolvable, rather than sitting as a tripwire on disk
- Adds a new supersession decision memo at `docs/superpowers/audits/2026-04-29-orchestration-supersession-decision.md` that captures the situation, the decision (merge into one repaired spec/plan), what to preserve from each draft, and a copy-paste-ready brief for the merge thread
- Fixes a factual error in all three Codex documents: the canonical event-bus implementation is `apps/web/lib/tak/agent-event-bus.ts` (~120 lines); the top-level `apps/web/lib/agent-event-bus.ts` is an intentional 2-line shim. Codex's drafts had this inverted; the committed orchestration spec had it right.

## Why this is docs-only and safe to merge

- No modification to the committed orchestration spec/plan from PR #349. The merge is the next step and belongs in its own PR.
- No code changes. Five new doc files, 1062 insertions, 0 deletions.
- The active worktree at `D:/DPF-orch-1a` on `feat/orch-phase-1a-skeleton` is implementing Phase 1A of the committed plan (orchestration module skeleton — types, governance-profile registry, heartbeat helper). That work is foundational and consistent with the merged direction; this PR does not whiplash it.

## What happens after merge

The supersession memo's "Next-thread brief" section is copy-paste-ready for a fresh thread to produce the merged spec/plan. The merge will rewrite the committed orchestration spec/plan in place at their existing paths, and move the Codex spec/plan to `docs/superpowers/archive/` as historical record. Audit and evidence stay where they are.

## Test plan

- [x] Five new doc files staged via explicit `git add` (no other tree state included)
- [x] Commit signed off with `-s` per DCO requirement
- [x] Branched off `origin/main`, not from a feature branch
- [ ] Reviewer reads the supersession memo first; the rest is context

🤖 Generated with [Claude Code](https://claude.com/claude-code)