### PR TITLE
feat(orchestration): module skeleton — primitives, profiles, heartbeat (Phase 1A)

### DIFF
--- a/apps/web/lib/orchestration/assert-never.ts
+++ b/apps/web/lib/orchestration/assert-never.ts
@@ -1,0 +1,6 @@
+// apps/web/lib/orchestration/assert-never.ts
+// Exhaustiveness helper for discriminated-union pattern matching.
+
+export function assertNever(x: never, ctx?: string): never {
+  throw new Error(`Unhandled variant: ${JSON.stringify(x)}${ctx ? ` (${ctx})` : ""}`);
+}

--- a/apps/web/lib/orchestration/governance-profiles.test.ts
+++ b/apps/web/lib/orchestration/governance-profiles.test.ts
@@ -1,0 +1,97 @@
+// apps/web/lib/orchestration/governance-profiles.test.ts
+
+import { describe, expect, it } from "vitest";
+import {
+  GOVERNANCE_PROFILES,
+  resolveBudget,
+  deriveGovernanceProfile,
+} from "./governance-profiles";
+import type { GovernanceProfile } from "./types";
+
+describe("GOVERNANCE_PROFILES", () => {
+  it("every profile has positive maxAttempts/deadlineMs/heartbeatMs", () => {
+    for (const [slug, budget] of Object.entries(GOVERNANCE_PROFILES)) {
+      expect(budget.maxAttempts, `${slug}.maxAttempts`).toBeGreaterThan(0);
+      expect(budget.deadlineMs, `${slug}.deadlineMs`).toBeGreaterThan(0);
+      expect(budget.heartbeatMs, `${slug}.heartbeatMs`).toBeGreaterThan(0);
+    }
+  });
+
+  it("system.tokenBudget is intentionally 0 (infra polling, not model calls)", () => {
+    expect(GOVERNANCE_PROFILES.system.tokenBudget).toBe(0);
+  });
+
+  it("non-system profiles have positive tokenBudget", () => {
+    const nonSystem: GovernanceProfile[] = [
+      "economy",
+      "balanced",
+      "high-assurance",
+      "document-authority",
+    ];
+    for (const slug of nonSystem) {
+      expect(GOVERNANCE_PROFILES[slug].tokenBudget, `${slug}.tokenBudget`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("deriveGovernanceProfile", () => {
+  it("hitlPolicy 'always' → high-assurance regardless of autonomyLevel", () => {
+    expect(
+      deriveGovernanceProfile({ hitlPolicy: "always", autonomyLevel: "autonomous" }),
+    ).toBe("high-assurance");
+  });
+
+  it("autonomyLevel 'supervised' → high-assurance", () => {
+    expect(
+      deriveGovernanceProfile({ hitlPolicy: "never", autonomyLevel: "supervised" }),
+    ).toBe("high-assurance");
+  });
+
+  it("autonomyLevel 'constrained' → balanced", () => {
+    expect(
+      deriveGovernanceProfile({ hitlPolicy: "never", autonomyLevel: "constrained" }),
+    ).toBe("balanced");
+  });
+
+  it("autonomyLevel 'autonomous' + maxDelegationRiskBand 'low' → economy", () => {
+    expect(
+      deriveGovernanceProfile({
+        hitlPolicy: "never",
+        autonomyLevel: "autonomous",
+        maxDelegationRiskBand: "low",
+      }),
+    ).toBe("economy");
+  });
+
+  it("falls through to balanced for unrecognized combinations", () => {
+    expect(
+      deriveGovernanceProfile({
+        hitlPolicy: "never",
+        autonomyLevel: "autonomous",
+        maxDelegationRiskBand: "high",
+      }),
+    ).toBe("balanced");
+  });
+});
+
+describe("resolveBudget", () => {
+  it("returns the registry entry for a known profile", () => {
+    const budget = resolveBudget({
+      runId: "r1",
+      userId: "u1",
+      governanceProfile: "balanced",
+    });
+    expect(budget).toBe(GOVERNANCE_PROFILES.balanced);
+  });
+
+  it("throws synchronously when the profile slug is not in the registry", () => {
+    expect(() =>
+      resolveBudget({
+        runId: "r1",
+        userId: "u1",
+        // @ts-expect-error — intentionally invalid slug for the negative test
+        governanceProfile: "baalanced",
+      }),
+    ).toThrow(/unknown governance profile/i);
+  });
+});

--- a/apps/web/lib/orchestration/governance-profiles.ts
+++ b/apps/web/lib/orchestration/governance-profiles.ts
@@ -1,0 +1,46 @@
+// apps/web/lib/orchestration/governance-profiles.ts
+// Governance-derived runtime budgets for orchestration primitives.
+// See: docs/superpowers/specs/2026-04-29-orchestration-primitives-design.md §Governance Profile Registry
+
+import type { GovernanceProfile, RunContext } from "./types";
+
+export type ProfileBudget = {
+  maxAttempts: number;
+  tokenBudget: number;
+  deadlineMs: number;
+  heartbeatMs: number;
+};
+
+// Numbers chosen per spec §Governance Profile Registry rationale.
+// Tuned in code under review, not exposed as runtime knobs.
+export const GOVERNANCE_PROFILES: Record<GovernanceProfile, ProfileBudget> = {
+  economy:                { maxAttempts: 2, tokenBudget:  20_000, deadlineMs:  60_000, heartbeatMs: 10_000 },
+  balanced:               { maxAttempts: 4, tokenBudget:  80_000, deadlineMs: 300_000, heartbeatMs: 10_000 },
+  "high-assurance":       { maxAttempts: 6, tokenBudget: 250_000, deadlineMs: 900_000, heartbeatMs: 15_000 },
+  "document-authority":   { maxAttempts: 3, tokenBudget: 120_000, deadlineMs: 600_000, heartbeatMs: 10_000 },
+  // system.tokenBudget: 0 — infra polling, not model calls. Field exists for shape uniformity.
+  system:                 { maxAttempts: 3, tokenBudget:       0, deadlineMs:  60_000, heartbeatMs:  5_000 },
+};
+
+export function resolveBudget(ctx: RunContext): ProfileBudget {
+  const budget = GOVERNANCE_PROFILES[ctx.governanceProfile];
+  if (!budget) {
+    throw new Error(
+      `unknown governance profile: ${String(ctx.governanceProfile)} (valid: ${Object.keys(GOVERNANCE_PROFILES).join(", ")})`,
+    );
+  }
+  return budget;
+}
+
+// Derives a GovernanceProfile from an AgentGovernanceProfile row.
+// document-authority is selected explicitly via Rule 1 (call-site pass-through), not derived.
+export function deriveGovernanceProfile(g: {
+  autonomyLevel: string;
+  hitlPolicy: string;
+  maxDelegationRiskBand?: string | null;
+}): GovernanceProfile {
+  if (g.hitlPolicy === "always" || g.autonomyLevel === "supervised") return "high-assurance";
+  if (g.autonomyLevel === "constrained") return "balanced";
+  if (g.autonomyLevel === "autonomous" && g.maxDelegationRiskBand === "low") return "economy";
+  return "balanced";
+}

--- a/apps/web/lib/orchestration/heartbeat.test.ts
+++ b/apps/web/lib/orchestration/heartbeat.test.ts
@@ -1,0 +1,67 @@
+// apps/web/lib/orchestration/heartbeat.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startHeartbeat, noteActivity, stopHeartbeat } from "./heartbeat";
+
+describe("heartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires onTick after heartbeatMs of quiet", () => {
+    const onTick = vi.fn();
+    startHeartbeat("run-1", 1000, onTick);
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledTimes(1);
+    stopHeartbeat("run-1");
+  });
+
+  it("noteActivity resets the quiet timer", () => {
+    const onTick = vi.fn();
+    startHeartbeat("run-2", 1000, onTick);
+    vi.advanceTimersByTime(700);
+    noteActivity("run-2");
+    vi.advanceTimersByTime(700);
+    expect(onTick).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(400);
+    expect(onTick).toHaveBeenCalledTimes(1);
+    stopHeartbeat("run-2");
+  });
+
+  it("stopHeartbeat clears the timer; subsequent advance does not fire", () => {
+    const onTick = vi.fn();
+    startHeartbeat("run-3", 1000, onTick);
+    stopHeartbeat("run-3");
+    vi.advanceTimersByTime(5000);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it("multiple runs are scoped independently by runId", () => {
+    const tickA = vi.fn();
+    const tickB = vi.fn();
+    startHeartbeat("a", 1000, tickA);
+    startHeartbeat("b", 1000, tickB);
+    vi.advanceTimersByTime(500);
+    noteActivity("a");
+    vi.advanceTimersByTime(600);
+    expect(tickA).not.toHaveBeenCalled();
+    expect(tickB).toHaveBeenCalledTimes(1);
+    stopHeartbeat("a");
+    stopHeartbeat("b");
+  });
+
+  it("starting a second heartbeat for the same runId replaces the first", () => {
+    const tick1 = vi.fn();
+    const tick2 = vi.fn();
+    startHeartbeat("r", 1000, tick1);
+    startHeartbeat("r", 1000, tick2);
+    vi.advanceTimersByTime(1500);
+    expect(tick1).not.toHaveBeenCalled();
+    expect(tick2).toHaveBeenCalledTimes(1);
+    stopHeartbeat("r");
+  });
+});

--- a/apps/web/lib/orchestration/heartbeat.ts
+++ b/apps/web/lib/orchestration/heartbeat.ts
@@ -1,0 +1,55 @@
+// apps/web/lib/orchestration/heartbeat.ts
+// runId-scoped heartbeat timer for orchestration primitives.
+// See: spec §Heartbeat Contract — interval scoped to runId, started at primitive entry,
+// cleared in finally before return, reset by any event activity for the same runId.
+
+type Timeout = ReturnType<typeof setTimeout>;
+
+type HeartbeatEntry = {
+  timer: Timeout;
+  heartbeatMs: number;
+  onTick: () => void;
+  stopped: boolean;
+};
+
+const heartbeats = new Map<string, HeartbeatEntry>();
+
+function schedule(runId: string, entry: HeartbeatEntry): void {
+  entry.timer = setTimeout(() => {
+    if (entry.stopped) return;
+    entry.onTick();
+    schedule(runId, entry);
+  }, entry.heartbeatMs);
+}
+
+export function startHeartbeat(runId: string, heartbeatMs: number, onTick: () => void): void {
+  // Replace any existing heartbeat for this runId — defensive against
+  // re-entry where a primitive is restarted with the same runId.
+  stopHeartbeat(runId);
+
+  const entry: HeartbeatEntry = {
+    heartbeatMs,
+    onTick,
+    stopped: false,
+    timer: undefined as unknown as Timeout,
+  };
+  heartbeats.set(runId, entry);
+  schedule(runId, entry);
+}
+
+// Resets the quiet timer. Equivalent to: any event activity for the same
+// runId pushes the next heartbeat firing back by heartbeatMs.
+export function noteActivity(runId: string): void {
+  const entry = heartbeats.get(runId);
+  if (!entry || entry.stopped) return;
+  clearTimeout(entry.timer);
+  schedule(runId, entry);
+}
+
+export function stopHeartbeat(runId: string): void {
+  const entry = heartbeats.get(runId);
+  if (!entry) return;
+  entry.stopped = true;
+  clearTimeout(entry.timer);
+  heartbeats.delete(runId);
+}

--- a/apps/web/lib/orchestration/index.ts
+++ b/apps/web/lib/orchestration/index.ts
@@ -14,3 +14,17 @@ export type {
 } from "./types";
 
 export { assertNever } from "./assert-never";
+
+export {
+  GOVERNANCE_PROFILES,
+  resolveBudget,
+  deriveGovernanceProfile,
+  type ProfileBudget,
+} from "./governance-profiles";
+
+export { startHeartbeat, noteActivity, stopHeartbeat } from "./heartbeat";
+
+export { Sequential, type Step } from "./primitives/sequential";
+export { Parallel, type ParallelOpts } from "./primitives/parallel";
+export { Loop, type LoopStep, type LoopOpts } from "./primitives/loop";
+export { Branch, type BranchSpec, type BranchOpts } from "./primitives/branch";

--- a/apps/web/lib/orchestration/index.ts
+++ b/apps/web/lib/orchestration/index.ts
@@ -1,0 +1,16 @@
+// apps/web/lib/orchestration/index.ts
+// Public surface of the orchestration module.
+// See: docs/superpowers/specs/2026-04-29-orchestration-primitives-design.md
+
+export type {
+  GovernanceProfile,
+  RunContext,
+  Outcome,
+  Evidence,
+  ExhaustionReason,
+  CancellationReason,
+  OrchestrationError,
+  TerminalStatus,
+} from "./types";
+
+export { assertNever } from "./assert-never";

--- a/apps/web/lib/orchestration/primitives/branch.test.ts
+++ b/apps/web/lib/orchestration/primitives/branch.test.ts
@@ -1,0 +1,166 @@
+// apps/web/lib/orchestration/primitives/branch.test.ts
+
+import { describe, expect, it, vi } from "vitest";
+import { Branch } from "./branch";
+import type { Outcome, RunContext } from "../types";
+
+const ctx: RunContext = {
+  runId: "test-run",
+  userId: "u1",
+  governanceProfile: "balanced",
+};
+
+const ok = <T>(value: T): Outcome<T> => ({
+  status: "succeeded",
+  value,
+  evidence: [],
+});
+
+const fail = (message: string): Outcome<never> => ({
+  status: "failed",
+  error: { name: "TestError", message },
+  evidence: [],
+});
+
+const collectValues = <T>(outcomes: Outcome<T>[]): T[] =>
+  outcomes
+    .filter((o): o is Extract<Outcome<T>, { status: "succeeded" }> => o.status === "succeeded")
+    .map((o) => o.value);
+
+describe("Branch", () => {
+  it("all branches succeed: merge invoked with all outcomes; returns merged success", async () => {
+    const merge = vi.fn(
+      (outcomes: Outcome<string>[]): Outcome<string[]> => ({
+        status: "succeeded",
+        value: collectValues(outcomes),
+        evidence: [],
+      }),
+    );
+    const result = await Branch<string, string[]>(
+      [
+        { name: "A", step: async () => ok("a") },
+        { name: "B", step: async () => ok("b") },
+        { name: "C", step: async () => ok("c") },
+      ],
+      { merge, dispatchMode: "parallel" },
+      ctx,
+    );
+    expect(result.status).toBe("succeeded");
+    expect(merge).toHaveBeenCalledTimes(1);
+    if (result.status === "succeeded") {
+      expect(result.value.sort()).toEqual(["a", "b", "c"]);
+    }
+  });
+
+  it("mixed outcomes: merge receives all; merge logic decides terminal", async () => {
+    const merge = (outcomes: Outcome<string>[]): Outcome<string[]> => {
+      const succeeded = collectValues(outcomes);
+      return succeeded.length >= 2
+        ? { status: "succeeded", value: succeeded, evidence: [] }
+        : {
+            status: "failed",
+            error: { name: "InsufficientSuccesses", message: `${succeeded.length} succeeded` },
+            evidence: [],
+          };
+    };
+
+    const passes = await Branch<string, string[]>(
+      [
+        { name: "A", step: async () => ok("a") },
+        { name: "B", step: async () => ok("b") },
+        { name: "C", step: async () => fail("x") },
+      ],
+      { merge, dispatchMode: "parallel" },
+      ctx,
+    );
+    expect(passes.status).toBe("succeeded");
+
+    const failsToMeet = await Branch<string, string[]>(
+      [
+        { name: "A", step: async () => ok("a") },
+        { name: "B", step: async () => fail("x") },
+        { name: "C", step: async () => fail("y") },
+      ],
+      { merge, dispatchMode: "parallel" },
+      ctx,
+    );
+    expect(failsToMeet.status).toBe("failed");
+  });
+
+  it("exitEarly: first satisfying branch wins; remaining branches receive cancelled outcome from runtime", async () => {
+    const slowSteps = {
+      A: vi.fn(async (): Promise<Outcome<string>> => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return ok("a-fast");
+      }),
+      B: vi.fn(async (): Promise<Outcome<string>> => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return ok("b-slow");
+      }),
+      C: vi.fn(async (): Promise<Outcome<string>> => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return ok("c-slow");
+      }),
+    };
+    const result = await Branch<string, string>(
+      [
+        { name: "A", step: slowSteps.A },
+        { name: "B", step: slowSteps.B },
+        { name: "C", step: slowSteps.C },
+      ],
+      {
+        merge: (outcomes): Outcome<string> => {
+          const winner = outcomes.find((o) => o.status === "succeeded");
+          return winner && winner.status === "succeeded"
+            ? { status: "succeeded", value: winner.value, evidence: [] }
+            : { status: "failed", error: { name: "NoWinner", message: "" }, evidence: [] };
+        },
+        dispatchMode: "parallel",
+        exitEarly: (o) => o.status === "succeeded",
+      },
+      ctx,
+    );
+    expect(result.status).toBe("succeeded");
+    if (result.status === "succeeded") {
+      expect(result.value).toBe("a-fast");
+    }
+  });
+
+  it("dispatchMode 'sequential' runs branches one at a time", async () => {
+    const order: string[] = [];
+    const result = await Branch<string, string[]>(
+      [
+        {
+          name: "A",
+          step: async () => {
+            order.push("A-start");
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            order.push("A-end");
+            return ok("a");
+          },
+        },
+        {
+          name: "B",
+          step: async () => {
+            order.push("B-start");
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            order.push("B-end");
+            return ok("b");
+          },
+        },
+      ],
+      {
+        merge: (outcomes): Outcome<string[]> => ({
+          status: "succeeded",
+          value: collectValues(outcomes),
+          evidence: [],
+        }),
+        dispatchMode: "sequential",
+      },
+      ctx,
+    );
+    expect(result.status).toBe("succeeded");
+    // Sequential dispatch: A finishes before B starts.
+    expect(order).toEqual(["A-start", "A-end", "B-start", "B-end"]);
+  });
+});

--- a/apps/web/lib/orchestration/primitives/branch.ts
+++ b/apps/web/lib/orchestration/primitives/branch.ts
@@ -1,0 +1,114 @@
+// apps/web/lib/orchestration/primitives/branch.ts
+// Branch primitive — competing strategies that merge into a single outcome.
+// See: spec §Branch — Semantics
+
+import type { Outcome, RunContext } from "../types";
+import type { Step } from "./sequential";
+
+export type BranchSpec<T> = {
+  name: string;
+  step: Step<T>;
+};
+
+export type BranchOpts<T, U> = {
+  merge: (outcomes: Outcome<T>[]) => Outcome<U>;
+  // V1 dispatchMode toggle resolves spec Open Question #1: deliberation
+  // preserves sequential dispatch; parallel is the natural default elsewhere.
+  dispatchMode: "parallel" | "sequential";
+  // exitEarly: if provided, the first branch outcome satisfying the predicate
+  // cancels remaining branches before merge. Only meaningful for parallel.
+  exitEarly?: (outcome: Outcome<T>) => boolean;
+};
+
+export async function Branch<T, U>(
+  branches: BranchSpec<T>[],
+  opts: BranchOpts<T, U>,
+  ctx: RunContext,
+): Promise<Outcome<U>> {
+  if (opts.dispatchMode === "sequential") {
+    const outcomes: Outcome<T>[] = [];
+    for (const branch of branches) {
+      const outcome = await branch.step(ctx);
+      outcomes.push(outcome);
+      // Sequential exitEarly: stop dispatching further branches; remaining
+      // branches receive an upstream-cancelled stub.
+      if (opts.exitEarly && opts.exitEarly(outcome)) {
+        for (const remaining of branches.slice(outcomes.length)) {
+          void remaining;
+          outcomes.push({
+            status: "cancelled",
+            reason: "upstream_cancelled",
+            evidence: [],
+            attempts: 0,
+          });
+        }
+        break;
+      }
+    }
+    return opts.merge(outcomes);
+  }
+
+  // Parallel dispatch.
+  if (!opts.exitEarly) {
+    const outcomes = await Promise.all(branches.map((b) => b.step(ctx)));
+    return opts.merge(outcomes);
+  }
+
+  // Parallel with exitEarly: race branches; first satisfier wins. Remaining
+  // branches synthesize as upstream-cancelled in the merged result. Real
+  // AbortController plumbing into step bodies is a follow-up; the primitive's
+  // contract today is "cancelled outcomes appear in the merge input."
+  const settled: Outcome<T>[] = [];
+  let resolved = false;
+  let winnerIndex = -1;
+
+  await new Promise<void>((resolve) => {
+    branches.forEach((branch, idx) => {
+      branch
+        .step(ctx)
+        .then((outcome) => {
+          if (resolved) return;
+          settled[idx] = outcome;
+          if (opts.exitEarly && opts.exitEarly(outcome)) {
+            resolved = true;
+            winnerIndex = idx;
+            // Fill any unsettled slots with cancelled.
+            for (let i = 0; i < branches.length; i++) {
+              if (!settled[i]) {
+                settled[i] = {
+                  status: "cancelled",
+                  reason: "upstream_cancelled",
+                  evidence: [],
+                  attempts: 0,
+                };
+              }
+            }
+            resolve();
+          } else {
+            // Check if all branches have now settled.
+            if (settled.filter(Boolean).length === branches.length && !resolved) {
+              resolved = true;
+              resolve();
+            }
+          }
+        })
+        .catch(() => {
+          // Step authors return Outcomes, not throws. A throw here is a
+          // contract violation — surface as failed.
+          if (resolved) return;
+          settled[idx] = {
+            status: "failed",
+            error: { name: "BranchStepThrew", message: `branch ${branch.name} threw` },
+            evidence: [],
+          };
+          if (settled.filter(Boolean).length === branches.length && !resolved) {
+            resolved = true;
+            resolve();
+          }
+        });
+    });
+  });
+
+  void winnerIndex;
+  return opts.merge(settled);
+}

--- a/apps/web/lib/orchestration/primitives/loop.test.ts
+++ b/apps/web/lib/orchestration/primitives/loop.test.ts
@@ -1,0 +1,157 @@
+// apps/web/lib/orchestration/primitives/loop.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Loop } from "./loop";
+import type { Outcome, RunContext } from "../types";
+
+const ctx = (overrides: Partial<RunContext> = {}): RunContext => ({
+  runId: "test-run",
+  userId: "u1",
+  governanceProfile: "balanced",
+  ...overrides,
+});
+
+const ok = <T>(value: T, tokensUsed = 0): Outcome<T> & { tokensUsed?: number } => ({
+  status: "succeeded",
+  value,
+  evidence: [],
+  tokensUsed,
+});
+
+const fail = (message: string, tokensUsed = 0): Outcome<never> & { tokensUsed?: number } => ({
+  status: "failed",
+  error: { name: "TestError", message },
+  evidence: [],
+  tokensUsed,
+});
+
+describe("Loop", () => {
+  it("succeeds when exitWhen returns true", async () => {
+    let attempts = 0;
+    const result = await Loop<string>(
+      async () => {
+        attempts += 1;
+        return attempts === 2 ? ok("done") : fail("not yet");
+      },
+      {
+        exitWhen: (o) => o.status === "succeeded",
+        strategy: () => ({}),
+      },
+      ctx(),
+    );
+    expect(result.status).toBe("succeeded");
+    expect(attempts).toBe(2);
+  });
+
+  it("exhausts with reason 'max_attempts' when budget hits maxAttempts; evidence trail covers all attempts", async () => {
+    const result = await Loop<string>(
+      async () => fail("never"),
+      {
+        exitWhen: (o) => o.status === "succeeded",
+        strategy: () => ({}),
+      },
+      // economy profile has maxAttempts=2
+      ctx({ governanceProfile: "economy" }),
+    );
+    expect(result.status).toBe("exhausted");
+    if (result.status === "exhausted") {
+      expect(result.reason).toBe("max_attempts");
+      expect(result.attempts).toBe(2);
+      expect(result.evidence.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("exhausts with reason 'deadline' when deadlineMs elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = Loop<string>(
+        async () => {
+          // simulate slow step by advancing wall-clock per attempt
+          vi.advanceTimersByTime(35_000);
+          return fail("slow");
+        },
+        {
+          exitWhen: (o) => o.status === "succeeded",
+          strategy: () => ({}),
+        },
+        // system profile has deadlineMs=60_000
+        ctx({ governanceProfile: "system" }),
+      );
+      // Drain microtasks while ticking time forward.
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result.status).toBe("exhausted");
+      if (result.status === "exhausted") {
+        expect(result.reason).toBe("deadline");
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("exhausts with reason 'token_budget' when cumulative tokensUsed exceeds budget", async () => {
+    let attempts = 0;
+    const result = await Loop<string>(
+      async () => {
+        attempts += 1;
+        return fail(`attempt ${attempts}`, 15_000); // economy.tokenBudget = 20_000
+      },
+      {
+        exitWhen: (o) => o.status === "succeeded",
+        strategy: () => ({}),
+      },
+      ctx({ governanceProfile: "economy" }),
+    );
+    expect(result.status).toBe("exhausted");
+    if (result.status === "exhausted") {
+      expect(result.reason).toBe("token_budget");
+      // Two attempts at 15k each → 30k > 20k, exhausted on second.
+      expect(attempts).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("strategy is invoked with prior outcomes + attempt number; attempt 0 receives empty priors", async () => {
+    const strategy = vi.fn<(priors: Outcome<string>[], attemptNumber: number) => unknown>(
+      () => ({}),
+    );
+    let attempts = 0;
+    await Loop<string>(
+      async () => {
+        attempts += 1;
+        return attempts === 3 ? ok("done") : fail("not yet");
+      },
+      {
+        exitWhen: (o) => o.status === "succeeded",
+        strategy,
+      },
+      ctx(),
+    );
+    expect(strategy).toHaveBeenCalledTimes(3);
+    // Attempt 0: empty priors
+    expect(strategy.mock.calls[0]?.[0]).toEqual([]);
+    expect(strategy.mock.calls[0]?.[1]).toBe(0);
+    // Attempt 1: one prior, attemptNumber=1
+    expect(strategy.mock.calls[1]?.[0]).toHaveLength(1);
+    expect(strategy.mock.calls[1]?.[1]).toBe(1);
+    // Attempt 2: two priors
+    expect(strategy.mock.calls[2]?.[0]).toHaveLength(2);
+    expect(strategy.mock.calls[2]?.[1]).toBe(2);
+  });
+
+  it("step returning Outcome.cancelled propagates as Loop cancellation", async () => {
+    const result = await Loop<string>(
+      async () => ({
+        status: "cancelled",
+        reason: "user_cancelled",
+        evidence: [],
+        attempts: 1,
+      }),
+      {
+        exitWhen: (o) => o.status === "succeeded",
+        strategy: () => ({}),
+      },
+      ctx(),
+    );
+    expect(result.status).toBe("cancelled");
+  });
+});

--- a/apps/web/lib/orchestration/primitives/loop.ts
+++ b/apps/web/lib/orchestration/primitives/loop.ts
@@ -1,0 +1,133 @@
+// apps/web/lib/orchestration/primitives/loop.ts
+// Loop primitive — iterate-with-strategy until success, typed failure, exhaustion, or cancellation.
+// See: spec §Loop — Semantics, §Governance Profile Registry
+
+import { startHeartbeat, stopHeartbeat } from "../heartbeat";
+import { resolveBudget } from "../governance-profiles";
+import type { Outcome, RunContext, Evidence, ExhaustionReason } from "../types";
+
+// Loop steps may attach a tokensUsed marker to their outcome so the runtime
+// can enforce token-budget exhaustion. Steps that don't call models simply
+// omit the field; resolveBudget's tokenBudget=0 (system profile) means the
+// check is skipped for infra polling loops.
+type LoopStepOutcome<T> = Outcome<T> & { tokensUsed?: number };
+
+export type LoopStep<T> = (
+  ctx: RunContext,
+  inputs: unknown,
+  attemptNumber: number,
+) => Promise<LoopStepOutcome<T>>;
+
+export type LoopOpts<T> = {
+  exitWhen: (outcome: Outcome<T>, attemptNumber: number) => boolean;
+  strategy: (priorOutcomes: Outcome<T>[], attemptNumber: number) => unknown;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function buildEvidence<T>(
+  outcome: Outcome<T>,
+  attemptNumber: number,
+  startedAt: string,
+): Evidence {
+  return {
+    attemptNumber,
+    startedAt,
+    endedAt: nowIso(),
+    summary:
+      outcome.status === "succeeded"
+        ? "succeeded"
+        : outcome.status === "failed"
+          ? `failed: ${outcome.error.message}`
+          : outcome.status === "exhausted"
+            ? `exhausted: ${outcome.reason}`
+            : `cancelled: ${outcome.reason}`,
+    outcome:
+      outcome.status === "succeeded"
+        ? "succeeded"
+        : outcome.status === "cancelled"
+          ? "cancelled"
+          : "failed",
+  };
+}
+
+function exhausted<T>(
+  reason: ExhaustionReason,
+  evidence: Evidence[],
+  attempts: number,
+): Outcome<T> {
+  return { status: "exhausted", reason, evidence, attempts };
+}
+
+export async function Loop<T>(
+  step: LoopStep<T>,
+  opts: LoopOpts<T>,
+  ctx: RunContext,
+): Promise<Outcome<T>> {
+  const budget = resolveBudget(ctx);
+  const startedAt = Date.now();
+  const evidence: Evidence[] = [];
+  const priorOutcomes: Outcome<T>[] = [];
+  let cumulativeTokens = 0;
+
+  startHeartbeat(ctx.runId, budget.heartbeatMs, () => {
+    /* heartbeat tick — wired to the event bus in Phase 1B Task 1B.4 */
+  });
+
+  try {
+    for (let attemptNumber = 0; attemptNumber < budget.maxAttempts; attemptNumber++) {
+      // Deadline check at attempt boundary.
+      if (Date.now() - startedAt >= budget.deadlineMs) {
+        return exhausted<T>("deadline", evidence, attemptNumber);
+      }
+
+      // Snapshot priors so strategy callers can't observe mutation if they
+      // hold the reference, and so test assertions on call args are stable.
+      const inputs = opts.strategy([...priorOutcomes], attemptNumber);
+      const attemptStartedAt = nowIso();
+      const outcome = await step(ctx, inputs, attemptNumber);
+
+      evidence.push(buildEvidence(outcome, attemptNumber, attemptStartedAt));
+      priorOutcomes.push(outcome);
+
+      // Token accounting (only meaningful when budget.tokenBudget > 0).
+      if (typeof outcome.tokensUsed === "number") {
+        cumulativeTokens += outcome.tokensUsed;
+      }
+
+      // Cancellation propagation: a step returning cancelled ends the loop
+      // with cancelled. Phase 1C wires bus-level cancellation; this path
+      // covers the step-internal route.
+      if (outcome.status === "cancelled") {
+        return {
+          status: "cancelled",
+          reason: outcome.reason,
+          evidence,
+          attempts: attemptNumber + 1,
+        };
+      }
+
+      if (opts.exitWhen(outcome, attemptNumber)) {
+        return outcome;
+      }
+
+      // Token-budget exhaustion check after the attempt — gives the just-
+      // completed attempt a chance to succeed before we give up.
+      if (budget.tokenBudget > 0 && cumulativeTokens >= budget.tokenBudget) {
+        return exhausted<T>("token_budget", evidence, attemptNumber + 1);
+      }
+
+      // Deadline check after the attempt too — long single attempts shouldn't
+      // get a free second iteration.
+      if (Date.now() - startedAt >= budget.deadlineMs) {
+        return exhausted<T>("deadline", evidence, attemptNumber + 1);
+      }
+    }
+
+    return exhausted<T>("max_attempts", evidence, budget.maxAttempts);
+  } finally {
+    stopHeartbeat(ctx.runId);
+  }
+}

--- a/apps/web/lib/orchestration/primitives/parallel.test.ts
+++ b/apps/web/lib/orchestration/primitives/parallel.test.ts
@@ -1,0 +1,138 @@
+// apps/web/lib/orchestration/primitives/parallel.test.ts
+
+import { describe, expect, it, vi } from "vitest";
+import { Parallel } from "./parallel";
+import type { Outcome, RunContext } from "../types";
+
+const ctx: RunContext = {
+  runId: "test-run",
+  userId: "u1",
+  governanceProfile: "balanced",
+};
+
+const ok = <T>(value: T): Outcome<T> => ({
+  status: "succeeded",
+  value,
+  evidence: [],
+});
+
+const fail = (message: string): Outcome<never> => ({
+  status: "failed",
+  error: { name: "TestError", message },
+  evidence: [],
+});
+
+const collectValues = <T>(outcomes: Outcome<T>[]): T[] =>
+  outcomes
+    .filter((o): o is Extract<Outcome<T>, { status: "succeeded" }> => o.status === "succeeded")
+    .map((o) => o.value);
+
+describe("Parallel", () => {
+  it("all_must_succeed: any failure returns failed with full trail", async () => {
+    const s1 = vi.fn(async () => ok("a"));
+    const s2 = vi.fn(async () => fail("boom"));
+    const s3 = vi.fn(async () => ok("c"));
+
+    const result = await Parallel(
+      [s1, s2, s3],
+      {
+        errorPolicy: "all_must_succeed",
+        synthesize: (outcomes) => ({
+          status: "succeeded",
+          value: collectValues(outcomes),
+          evidence: [],
+        }),
+      },
+      ctx,
+    );
+
+    expect(result.status).toBe("failed");
+    // All three steps still ran (Promise.allSettled semantics).
+    expect(s1).toHaveBeenCalled();
+    expect(s2).toHaveBeenCalled();
+    expect(s3).toHaveBeenCalled();
+  });
+
+  it("best_effort: synthesizes over succeeded; zero-succeeded returns failed", async () => {
+    const partial = await Parallel(
+      [async () => ok("a"), async () => fail("x"), async () => ok("c")],
+      {
+        errorPolicy: "best_effort",
+        synthesize: (outcomes) => ({
+          status: "succeeded",
+          value: collectValues(outcomes),
+          evidence: [],
+        }),
+      },
+      ctx,
+    );
+    expect(partial.status).toBe("succeeded");
+    if (partial.status === "succeeded") {
+      expect(partial.value).toEqual(["a", "c"]);
+    }
+
+    const allFailed = await Parallel(
+      [async () => fail("x"), async () => fail("y")],
+      {
+        errorPolicy: "best_effort",
+        synthesize: (outcomes) => ({
+          status: "succeeded",
+          value: collectValues(outcomes),
+          evidence: [],
+        }),
+      },
+      ctx,
+    );
+    expect(allFailed.status).toBe("failed");
+  });
+
+  it("quorum: passes at minSucceeded, fails below", async () => {
+    const passes = await Parallel(
+      [async () => ok("a"), async () => ok("b"), async () => fail("x")],
+      {
+        errorPolicy: "quorum",
+        minSucceeded: 2,
+        synthesize: (outcomes) => ({
+          status: "succeeded",
+          value: collectValues(outcomes),
+          evidence: [],
+        }),
+      },
+      ctx,
+    );
+    expect(passes.status).toBe("succeeded");
+
+    const fails = await Parallel(
+      [async () => ok("a"), async () => fail("x"), async () => fail("y")],
+      {
+        errorPolicy: "quorum",
+        minSucceeded: 2,
+        synthesize: (outcomes) => ({
+          status: "succeeded",
+          value: collectValues(outcomes),
+          evidence: [],
+        }),
+      },
+      ctx,
+    );
+    expect(fails.status).toBe("failed");
+  });
+
+  it("quorum without minSucceeded throws at construction", async () => {
+    // The discriminated union enforces minSucceeded at compile time. To exercise the
+    // runtime guard (defense in depth — the type can be subverted via `as` or JS callers),
+    // we cast through `unknown` to a malformed shape.
+    const malformedOpts = {
+      errorPolicy: "quorum" as const,
+      synthesize: (outcomes: Outcome<string>[]) => ({
+        status: "succeeded" as const,
+        value: collectValues(outcomes),
+        evidence: [],
+      }),
+    } as unknown as Parameters<typeof Parallel<string, string[]>>[1];
+
+    await expect(
+      Parallel([async () => ok("a")], malformedOpts, ctx),
+    ).rejects.toThrow(/minSucceeded/i);
+  });
+});

--- a/apps/web/lib/orchestration/primitives/parallel.ts
+++ b/apps/web/lib/orchestration/primitives/parallel.ts
@@ -1,0 +1,82 @@
+// apps/web/lib/orchestration/primitives/parallel.ts
+// Parallel primitive — run independent work concurrently, synthesize via explicit policy.
+// See: spec §Parallel — Semantics
+
+import type { Outcome, RunContext } from "../types";
+import type { Step } from "./sequential";
+
+export type ParallelOpts<T, U> =
+  | {
+      errorPolicy: "all_must_succeed";
+      synthesize: (outcomes: Outcome<T>[]) => Outcome<U>;
+    }
+  | {
+      errorPolicy: "best_effort";
+      synthesize: (outcomes: Outcome<T>[]) => Outcome<U>;
+    }
+  | {
+      errorPolicy: "quorum";
+      minSucceeded: number;
+      synthesize: (outcomes: Outcome<T>[]) => Outcome<U>;
+    };
+
+export async function Parallel<T, U>(
+  steps: Step<T>[],
+  opts: ParallelOpts<T, U>,
+  ctx: RunContext,
+): Promise<Outcome<U>> {
+  // Validate construction-time invariants. quorum without minSucceeded is a
+  // contract violation; fail loud at the boundary rather than silently
+  // proceeding with an undefined threshold.
+  if (opts.errorPolicy === "quorum" && typeof opts.minSucceeded !== "number") {
+    throw new Error("Parallel quorum policy requires opts.minSucceeded (number)");
+  }
+
+  // Run all branches concurrently. Step functions return Outcomes (not throw),
+  // so allSettled is overkill — Promise.all suffices given the contract that
+  // step authors handle their own errors and produce typed outcomes.
+  const outcomes = await Promise.all(steps.map((step) => step(ctx)));
+
+  const succeededCount = outcomes.filter((o) => o.status === "succeeded").length;
+
+  switch (opts.errorPolicy) {
+    case "all_must_succeed":
+      if (succeededCount < outcomes.length) {
+        return {
+          status: "failed",
+          error: {
+            name: "ParallelPartialFailure",
+            message: `${outcomes.length - succeededCount} of ${outcomes.length} branches failed under all_must_succeed`,
+          },
+          evidence: outcomes.flatMap((o) => o.evidence),
+        };
+      }
+      return opts.synthesize(outcomes);
+
+    case "best_effort":
+      if (succeededCount === 0) {
+        return {
+          status: "failed",
+          error: {
+            name: "ParallelAllFailed",
+            message: "All branches failed under best_effort policy",
+          },
+          evidence: outcomes.flatMap((o) => o.evidence),
+        };
+      }
+      return opts.synthesize(outcomes);
+
+    case "quorum":
+      if (succeededCount < opts.minSucceeded) {
+        return {
+          status: "failed",
+          error: {
+            name: "ParallelQuorumNotMet",
+            message: `quorum policy required ${opts.minSucceeded} successes; got ${succeededCount}`,
+          },
+          evidence: outcomes.flatMap((o) => o.evidence),
+        };
+      }
+      return opts.synthesize(outcomes);
+  }
+}

--- a/apps/web/lib/orchestration/primitives/sequential.test.ts
+++ b/apps/web/lib/orchestration/primitives/sequential.test.ts
@@ -1,0 +1,97 @@
+// apps/web/lib/orchestration/primitives/sequential.test.ts
+
+import { describe, expect, it, vi } from "vitest";
+import { Sequential } from "./sequential";
+import type { Outcome, RunContext } from "../types";
+
+const ctx: RunContext = {
+  runId: "test-run",
+  userId: "u1",
+  governanceProfile: "balanced",
+};
+
+const ok = <T>(value: T): Outcome<T> => ({
+  status: "succeeded",
+  value,
+  evidence: [
+    {
+      attemptNumber: 0,
+      startedAt: "2026-04-29T00:00:00Z",
+      endedAt: "2026-04-29T00:00:01Z",
+      summary: "ok",
+      outcome: "succeeded",
+    },
+  ],
+});
+
+const fail = (message: string): Outcome<never> => ({
+  status: "failed",
+  error: { name: "TestError", message },
+  evidence: [],
+});
+
+const exhausted = (): Outcome<never> => ({
+  status: "exhausted",
+  reason: "max_attempts",
+  evidence: [],
+  attempts: 3,
+});
+
+const cancelled = (): Outcome<never> => ({
+  status: "cancelled",
+  reason: "user_cancelled",
+  evidence: [],
+  attempts: 1,
+});
+
+describe("Sequential", () => {
+  it("all-succeed: returns Outcome.succeeded with array of values, evidence per step", async () => {
+    const s1 = vi.fn(async () => ok("a"));
+    const s2 = vi.fn(async () => ok("b"));
+    const s3 = vi.fn(async () => ok("c"));
+
+    const result = await Sequential([s1, s2, s3], ctx);
+
+    expect(result.status).toBe("succeeded");
+    if (result.status === "succeeded") {
+      expect(result.value).toEqual(["a", "b", "c"]);
+      expect(result.evidence).toHaveLength(3);
+    }
+    expect(s1).toHaveBeenCalledTimes(1);
+    expect(s2).toHaveBeenCalledTimes(1);
+    expect(s3).toHaveBeenCalledTimes(1);
+  });
+
+  it("first-fails: short-circuits, returns the failure unchanged, remaining steps not invoked", async () => {
+    const s1 = vi.fn(async () => ok("a"));
+    const s2 = vi.fn(async () => fail("boom"));
+    const s3 = vi.fn(async () => ok("c"));
+
+    const result = await Sequential([s1, s2, s3], ctx);
+
+    expect(result.status).toBe("failed");
+    expect(s1).toHaveBeenCalledTimes(1);
+    expect(s2).toHaveBeenCalledTimes(1);
+    expect(s3).not.toHaveBeenCalled();
+  });
+
+  it("first-exhausts: short-circuits, returns the exhaustion unchanged", async () => {
+    const s1 = vi.fn(async () => exhausted());
+    const s2 = vi.fn(async () => ok("b"));
+
+    const result = await Sequential([s1, s2], ctx);
+
+    expect(result.status).toBe("exhausted");
+    expect(s2).not.toHaveBeenCalled();
+  });
+
+  it("first-cancelled: short-circuits with cancelled", async () => {
+    const s1 = vi.fn(async () => cancelled());
+    const s2 = vi.fn(async () => ok("b"));
+
+    const result = await Sequential([s1, s2], ctx);
+
+    expect(result.status).toBe("cancelled");
+    expect(s2).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/orchestration/primitives/sequential.ts
+++ b/apps/web/lib/orchestration/primitives/sequential.ts
@@ -1,0 +1,35 @@
+// apps/web/lib/orchestration/primitives/sequential.ts
+// Sequential primitive — run ordered steps, short-circuit on first non-success terminal.
+// See: spec §Sequential — Semantics
+
+import { assertNever } from "../assert-never";
+import type { Outcome, RunContext } from "../types";
+
+export type Step<T> = (ctx: RunContext) => Promise<Outcome<T>>;
+
+export async function Sequential<T>(
+  steps: Step<T>[],
+  ctx: RunContext,
+): Promise<Outcome<T[]>> {
+  const values: T[] = [];
+  const evidence = [];
+
+  for (const step of steps) {
+    const outcome = await step(ctx);
+    switch (outcome.status) {
+      case "succeeded":
+        values.push(outcome.value);
+        evidence.push(...outcome.evidence);
+        break;
+      case "failed":
+      case "exhausted":
+      case "cancelled":
+        // Short-circuit: return the non-success outcome unchanged.
+        return outcome as Outcome<T[]>;
+      default:
+        assertNever(outcome, "Sequential outcome");
+    }
+  }
+
+  return { status: "succeeded", value: values, evidence };
+}

--- a/apps/web/lib/orchestration/structural.test.ts
+++ b/apps/web/lib/orchestration/structural.test.ts
@@ -1,0 +1,25 @@
+// apps/web/lib/orchestration/structural.test.ts
+// Structural invariant: every primitive code path must emit exactly one
+// terminal event per runId. Implemented as a runtime-instrumented test
+// wrapper observing emit calls (per spec §Verification Plan).
+//
+// Activates in Phase 1B Task 1B.5 once primitives are wired to the bus.
+// Until then, these are it.todo placeholders so the structural intent is
+// recorded in code, not just in the spec.
+
+import { describe, it } from "vitest";
+
+describe("Structural: primitives emit exactly one terminal event per runId (Phase 1B Task 1B.5)", () => {
+  it.todo("Sequential succeeded — emits sequential:succeeded exactly once");
+  it.todo("Sequential failed — emits sequential:failed exactly once");
+  it.todo("Parallel synthesized — emits parallel:synthesized exactly once");
+  it.todo("Parallel failed — emits parallel:failed exactly once");
+  it.todo("Loop succeeded — emits loop:succeeded exactly once");
+  it.todo("Loop exhausted (max_attempts) — emits loop:exhausted exactly once");
+  it.todo("Loop exhausted (deadline) — emits loop:exhausted exactly once");
+  it.todo("Loop exhausted (token_budget) — emits loop:exhausted exactly once");
+  it.todo("Loop cancelled — emits loop:cancelled exactly once");
+  it.todo("Branch merged — emits branch:merged exactly once");
+  it.todo("Branch failed — emits branch:failed exactly once");
+  it.todo("Heartbeat: quiet Loop emits loop:still_working within 1.5x heartbeatMs");
+});

--- a/apps/web/lib/orchestration/types.ts
+++ b/apps/web/lib/orchestration/types.ts
@@ -1,0 +1,53 @@
+// apps/web/lib/orchestration/types.ts
+// Core type contracts for the orchestration runtime.
+// See: docs/superpowers/specs/2026-04-29-orchestration-primitives-design.md §Type Contracts
+
+export type GovernanceProfile =
+  | "economy"
+  | "balanced"
+  | "high-assurance"
+  | "document-authority"
+  | "system";
+
+export type RunContext = {
+  runId: string;
+  userId: string;
+  threadId?: string;
+  taskRunId?: string;
+  agentId?: string;
+  governanceProfile: GovernanceProfile;
+  parentRunId?: string;
+  routeContext?: string;
+};
+
+export type ExhaustionReason =
+  | "max_attempts"
+  | "deadline"
+  | "token_budget"
+  | "sandbox_unavailable"
+  | "no_more_strategies";
+
+export type CancellationReason = "user_cancelled" | "upstream_cancelled";
+
+export type Evidence = {
+  attemptNumber: number;
+  startedAt: string;
+  endedAt: string;
+  summary: string;
+  outcome: "succeeded" | "failed" | "cancelled";
+  detail?: unknown;
+};
+
+export type OrchestrationError = {
+  name: string;
+  message: string;
+  cause?: unknown;
+};
+
+export type Outcome<T> =
+  | { status: "succeeded"; value: T; evidence: Evidence[] }
+  | { status: "failed"; error: OrchestrationError; evidence: Evidence[] }
+  | { status: "exhausted"; reason: ExhaustionReason; evidence: Evidence[]; attempts: number }
+  | { status: "cancelled"; reason: CancellationReason; evidence: Evidence[]; attempts: number };
+
+export type TerminalStatus = Outcome<unknown>["status"];


### PR DESCRIPTION
## Summary

Phase 1A of the orchestration primitives plan ([docs/superpowers/plans/2026-04-29-orchestration-primitives.md](docs/superpowers/plans/2026-04-29-orchestration-primitives.md), spec #349). Lands the new \`apps/web/lib/orchestration/\` module: type contracts, governance profile registry, runId-scoped heartbeat helper, and the four primitives (Sequential / Parallel / Loop / Branch).

**No call-site migrations yet.** The module is callable but unused. Bus refactor lands in Phase 1B; first call-site migrations land in Phase 2.

## Changes

- \`types.ts\` — \`GovernanceProfile\`, \`RunContext\`, \`Outcome<T>\`, \`Evidence\`, \`ExhaustionReason\`, \`CancellationReason\`, \`OrchestrationError\`
- \`assert-never.ts\` — exhaustiveness helper
- \`governance-profiles.ts\` — \`GOVERNANCE_PROFILES\` constant (5 profiles), \`resolveBudget()\`, \`deriveGovernanceProfile()\` projecting from \`AgentGovernanceProfile\` fields without a schema migration
- \`heartbeat.ts\` — runId-scoped self-rescheduling \`setTimeout\` chain (started at primitive entry, cleared in \`finally\`)
- \`primitives/sequential.ts\` — short-circuits on first non-success
- \`primitives/parallel.ts\` — \`all_must_succeed\` / \`best_effort\` / \`quorum\` policies; quorum without \`minSucceeded\` throws at construction
- \`primitives/loop.ts\` — three exhaustion reasons (\`max_attempts\`, \`deadline\`, \`token_budget\`); strategy required; priors snapshotted per attempt
- \`primitives/branch.ts\` — \`dispatchMode\` resolves spec Open Question #1; \`exitEarly\` cancels remaining branches (V1: synthesizes upstream-cancelled stubs; AbortController plumbing is a follow-up)
- \`structural.test.ts\` — 12 \`it.todo\` placeholders for the structural terminal-event invariant; activates in Phase 1B Task 1B.5
- \`index.ts\` — public surface

## Process notes

- Heartbeat: started with \`setInterval\`, but it ticked at fixed boundaries and one activity-reset test mis-fired. Switched to a self-scheduling \`setTimeout\` chain so any reset genuinely shifts next firing forward.
- Loop strategy contract: had to clone \`priorOutcomes\` before passing to the strategy callback — otherwise tests asserting \`mock.calls[0]?.[0]\` saw the live mutated array.
- Parallel quorum guard: pre-commit caught a \`@ts-expect-error\` placement issue; reworked the negative test to cast through \`unknown\` so \`tsc --noEmit\` is happy alongside vitest.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web exec vitest run lib/orchestration/\` — 33 passing, 12 todo
- [x] \`cd apps/web && npx next build\` clean
- [x] DCO sign-off on every commit
- [x] Behavior parity test — N/A (foundation, no migration yet)
- [x] Terminal-outcome test — every primitive returns typed \`Outcome<T>\`
- [x] Event emission test — N/A (events wire in 1B.4)
- [x] Heartbeat test — \`heartbeat.test.ts\`
- [x] Cost monotonicity test — N/A until events ship in 1B

## Tests (33 passing, 12 todo)

- \`governance-profiles.test.ts\` — 10 tests
- \`heartbeat.test.ts\` — 5 tests
- \`primitives/sequential.test.ts\` — 4 tests
- \`primitives/parallel.test.ts\` — 4 tests
- \`primitives/loop.test.ts\` — 6 tests
- \`primitives/branch.test.ts\` — 4 tests
- \`structural.test.ts\` — 12 \`it.todo\` (activate in 1B.5)

## Related issues

Phase 1A of #349. Phase 1B (bus refactor), 1C (cancellation), and Phases 2–7 land in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)