### PR TITLE
fix(web): restore unit test contracts

### DIFF
--- a/apps/web/app/(shell)/platform/identity/agents/page.test.tsx
+++ b/apps/web/app/(shell)/platform/identity/agents/page.test.tsx
@@ -9,6 +9,12 @@ vi.mock("@dpf/db", () => ({
     principalAlias: {
       findMany: vi.fn(),
     },
+    agentModelConfig: {
+      findMany: vi.fn(),
+    },
+    userFact: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -24,6 +30,12 @@ describe("PlatformIdentityAgentsPage", () => {
         status: "active",
         lifecycleStage: "production",
         humanSupervisorId: "HR-100",
+        sensitivity: "internal",
+        hitlTierDefault: 2,
+        executionConfig: null,
+        governanceProfile: null,
+        skills: [],
+        toolGrants: [],
       },
       {
         id: "agent-db-2",
@@ -32,6 +44,12 @@ describe("PlatformIdentityAgentsPage", () => {
         status: "active",
         lifecycleStage: "production",
         humanSupervisorId: "HR-300",
+        sensitivity: "internal",
+        hitlTierDefault: 2,
+        executionConfig: null,
+        governanceProfile: null,
+        skills: [],
+        toolGrants: [],
       },
     ] as never);
     vi.mocked(prisma.principalAlias.findMany).mockResolvedValue([
@@ -52,6 +70,8 @@ describe("PlatformIdentityAgentsPage", () => {
         createdAt: new Date("2026-04-23T00:00:00Z"),
       },
     ] as never);
+    vi.mocked(prisma.agentModelConfig.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.userFact.findMany).mockResolvedValue([] as never);
 
     const { default: PlatformIdentityAgentsPage } = await import("./page");
     const html = renderToStaticMarkup(await PlatformIdentityAgentsPage());

--- a/apps/web/lib/integrate/build-verification-e2e.test.ts
+++ b/apps/web/lib/integrate/build-verification-e2e.test.ts
@@ -108,16 +108,18 @@ describe("coworker-driven UX verification — gate behavior", () => {
 
 describe("coworker-driven UX verification — handler does not touch designReview", () => {
   it("the handler's persistence shape only writes uxTestResults + uxVerificationStatus", async () => {
-    // The Inngest handler uses prisma.featureBuild.update with the fields
-    // it writes explicitly listed. We assert the SHAPE of that write to
-    // lock in the intent rather than running the full handler.
+    // The Inngest handler persists UX evidence through artifact provenance
+    // and writes only the status directly on the build row. Assert the shape
+    // to lock in ownership without running the full handler.
     // Path is relative to vitest cwd (apps/web).
     const source = await import("fs/promises").then((fs) =>
       fs.readFile(new URL("../queue/functions/build-review-verification.ts", import.meta.url), "utf-8"),
     );
 
-    // Must update both of our fields
-    expect(source).toMatch(/uxTestResults:\s*steps/);
+    // Must persist UX results and update the status.
+    expect(source).toMatch(/saveBuildArtifactRevisionWithDb\(prisma,\s*{/);
+    expect(source).toMatch(/field:\s*"uxTestResults"/);
+    expect(source).toMatch(/value:\s*steps/);
     expect(source).toMatch(/uxVerificationStatus:\s*finalStatus/);
 
     // Must NOT write to designReview (the reviewer pipeline owns that

--- a/apps/web/lib/mcp-tools-save-build-evidence.test.ts
+++ b/apps/web/lib/mcp-tools-save-build-evidence.test.ts
@@ -13,6 +13,21 @@ const mockPrisma = {
 
 const mockAdvanceBuildPhase = vi.fn();
 const mockEmit = vi.fn();
+const mockSaveBuildArtifactRevision = vi.fn(async (args: { buildId: string; field: string; value: unknown }) => {
+  await mockPrisma.featureBuild.update({
+    where: { buildId: args.buildId },
+    data: { [args.field]: args.value },
+  });
+
+  return {
+    revisionId: "BAR-1",
+    revisionNumber: 1,
+    status: "accepted",
+    warnings: [],
+    errors: [],
+    receiptIds: [],
+  };
+});
 
 vi.mock("@dpf/db", () => ({
   prisma: mockPrisma,
@@ -26,6 +41,10 @@ vi.mock("@/lib/agent-event-bus", () => ({
   agentEventBus: {
     emit: mockEmit,
   },
+}));
+
+vi.mock("@/lib/build/build-artifact-provenance", () => ({
+  saveBuildArtifactRevision: mockSaveBuildArtifactRevision,
 }));
 
 describe("saveBuildEvidence", () => {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -223,6 +223,23 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "retire_backlog_item",
+    description: "Retire a backlog item as duplicate, deferred, or discarded after review. Use this for governed cleanup of non-buildable or superseded items without requiring backlog triage authority.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "The item ID to retire (e.g. BI-E4A86393)" },
+        outcome: { type: "string", enum: ["duplicate", "defer", "discard"], description: "The retirement decision" },
+        rationale: { type: "string", description: "Short prose rationale for retiring the item" },
+        duplicateOfId: { type: "string", description: "Canonical item ID; required when outcome=duplicate" },
+        reason: { type: "string", description: "Optional reason text for defer/discard outcomes" },
+      },
+      required: ["itemId", "outcome", "rationale"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "promote_to_build_studio",
     description: "Promote a triaged backlog item (status=open, triageOutcome=build) to a FeatureBuild in Build Studio. Runs the Definition of Ready capacity check under an advisory-lock transaction. Authority-gated via the build_promote grant category.",
     inputSchema: {
@@ -871,7 +888,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         field: { type: "string", enum: ["designDoc", "designReview", "buildPlan", "planReview", "taskResults", "verificationOut", "acceptanceMet"], description: "Evidence field to update" },
         value: { type: "object", description: "JSON value to store" },
       },
-      required: ["field", "value"],
+      required: ["field"],
     },
     requiredCapability: "view_platform",
     executionMode: "immediate",
@@ -2616,6 +2633,115 @@ export async function executeTool(
         entityId: itemId,
         message: `Triaged ${itemId} as ${outcome}`,
       };
+    }
+
+    case "retire_backlog_item": {
+      const itemId = String(params["itemId"] ?? "");
+      const outcome = String(params["outcome"] ?? "");
+      const rationale = String(params["rationale"] ?? "").trim();
+      const reason = typeof params["reason"] === "string" ? params["reason"].trim() : "";
+      const duplicateOfId = typeof params["duplicateOfId"] === "string" ? params["duplicateOfId"].trim() : "";
+      const validOutcomes = new Set(["duplicate", "defer", "discard"]);
+
+      if (!itemId) {
+        return { success: false, error: "missing_itemId", message: "itemId is required" };
+      }
+      if (!validOutcomes.has(outcome)) {
+        return { success: false, error: "invalid_outcome", message: "outcome must be duplicate, defer, or discard" };
+      }
+      if (!rationale) {
+        return { success: false, error: "missing_rationale", message: "rationale is required" };
+      }
+      if (outcome === "duplicate" && !duplicateOfId) {
+        return { success: false, error: "missing_duplicateOfId", message: "duplicateOfId is required for duplicate retirement" };
+      }
+
+      const result = await prisma.$transaction(async (tx) => {
+        const item = await tx.backlogItem.findUnique({ where: { itemId } });
+        if (!item) {
+          return { success: false, error: "not_found", message: `Item ${itemId} not found` } satisfies ToolResult;
+        }
+        if ("activeBuildId" in item && item.activeBuildId) {
+          return {
+            success: false,
+            error: "active_build_exists",
+            message: `Item ${itemId} is attached to an active build and cannot be retired`,
+          } satisfies ToolResult;
+        }
+
+        let canonicalRowId: string | null = null;
+        if (outcome === "duplicate") {
+          const canonical = await tx.backlogItem.findUnique({ where: { itemId: duplicateOfId } });
+          if (!canonical) {
+            return {
+              success: false,
+              error: "duplicate_not_found",
+              message: `Canonical item ${duplicateOfId} not found`,
+            } satisfies ToolResult;
+          }
+          canonicalRowId = canonical.id;
+        }
+
+        const updated = await tx.backlogItem.update({
+          where: { id: item.id },
+          data: {
+            status: "deferred",
+            triageOutcome: outcome,
+            duplicateOfId: canonicalRowId,
+            resolution: rationale,
+            abandonReason: reason || rationale,
+            completedAt: new Date(),
+          },
+        });
+
+        await tx.backlogItemActivity.create({
+          data: {
+            backlogItemId: item.id,
+            kind: "status_change",
+            recordedById: userId,
+            recordedByAgentId: context?.agentId ?? null,
+            summary: `Retired ${itemId} as ${outcome}`,
+            payload: {
+              from: item.status,
+              to: "deferred",
+              outcome,
+              rationale,
+              reason: reason || null,
+              duplicateOfId: outcome === "duplicate" ? duplicateOfId : null,
+            },
+          },
+        });
+
+        if (item.epicId) {
+          const remainingOpenItems = await tx.backlogItem.count({
+            where: {
+              epicId: item.epicId,
+              status: { in: ["open", "in-progress"] },
+              id: { not: item.id },
+            },
+          });
+          if (remainingOpenItems === 0) {
+            await tx.epic.update({
+              where: { id: item.epicId },
+              data: { status: "done" },
+            });
+          }
+        }
+
+        return {
+          success: true,
+          entityId: updated.itemId,
+          message: `Retired ${itemId} as ${outcome}`,
+          data: {
+            itemId: updated.itemId,
+            status: "deferred",
+            outcome,
+            duplicateOfId: outcome === "duplicate" ? duplicateOfId : null,
+          },
+        } satisfies ToolResult;
+      });
+
+      return result;
     }
 
     case "size_backlog_item": {


### PR DESCRIPTION
## Summary
- restore the governed retire_backlog_item MCP contract and handler so backlog cleanup tests no longer hit Unknown tool
- update Build Studio evidence tests for artifact provenance persistence and optional top-level evidence payloads
- refresh the agent identity page test fixture for AIDoc/model/memory query expectations

## Verification
- PASS: pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts lib/mcp-tools-save-build-evidence.test.ts lib/integrate/build-verification-e2e.test.ts app/'(shell)'/platform/identity/agents/page.test.tsx
- BLOCKED LOCALLY: pnpm --filter web typecheck (fresh worktree is missing packages/db/generated/client/client after Prisma generate panicked during pnpm install; also reports existing unrelated implicit-any errors)
- BLOCKED LOCALLY: pnpm --filter web exec vitest run (same missing generated Prisma client import across DB-backed suites)