### PR TITLE
Add town/city stewardship for work locations

### DIFF
--- a/apps/web/components/admin/WorkLocationPanel.tsx
+++ b/apps/web/components/admin/WorkLocationPanel.tsx
@@ -140,7 +140,7 @@ export function WorkLocationPanel({ workLocations }: Props) {
 
   function handleLink(locationId: string) {
     if (!city) {
-      setError("Please select a locality.");
+      setError("Please select a town / city.");
       return;
     }
     if (!addressLine1.trim()) {

--- a/apps/web/components/employee/AddressSection.tsx
+++ b/apps/web/components/employee/AddressSection.tsx
@@ -106,7 +106,7 @@ export default function AddressSection({
 
   function handleSave() {
     if (!city) {
-      setError("Please select a locality.");
+      setError("Please select a town / city.");
       return;
     }
     if (!addressLine1.trim()) {

--- a/apps/web/components/location/LocationCascadePicker.test.tsx
+++ b/apps/web/components/location/LocationCascadePicker.test.tsx
@@ -102,16 +102,17 @@ describe("LocationCascadePicker", () => {
 
     expect(html).toMatch(/<label[^>]*for="location-country"[^>]*>Country<\/label>/);
     expect(html).toMatch(/<label[^>]*for="location-region"[^>]*>Region<\/label>/);
-    expect(html).toMatch(/<label[^>]*for="location-locality"[^>]*>Locality<\/label>/);
+    expect(html).toMatch(/<label[^>]*for="location-locality"[^>]*>Town \/ City<\/label>/);
+    expect(html).not.toContain(">Locality</label>");
     expect(html).toMatch(/role="combobox"/);
   });
 
-  it("offers an Add-new affordance for region when a country is selected and onCreateRegion is provided", () => {
+  it("uses request language for missing towns and cities instead of arbitrary active creation", () => {
     const html = renderToStaticMarkup(
       <LocationCascadePicker
         value={{
           country: { id: "country-us", label: "United States (US)" },
-          region: null,
+          region: { id: "region-tx", label: "Texas (TX)" },
           locality: null,
         }}
         onChange={vi.fn()}
@@ -123,11 +124,9 @@ describe("LocationCascadePicker", () => {
       />,
     );
 
-    // ReferenceTypeahead exposes the add-new affordance through the placeholder
-    // copy + onAddNew wiring; the dropdown itself only renders after async
-    // search results, which static markup cannot trigger. Asserting on the
-    // search-input contracts is enough to prove the wiring exists.
     expect(html).toContain('placeholder="Search regions..."');
-    expect(html).toContain('placeholder="Search towns, cities, or localities..."');
+    expect(html).toContain('placeholder="Search towns or cities..."');
+    expect(html).toContain('data-add-new-label="Request missing town / city"');
+    expect(html).not.toContain("Add new locality");
   });
 });

--- a/apps/web/components/location/LocationCascadePicker.tsx
+++ b/apps/web/components/location/LocationCascadePicker.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState, useTransition } from "react";
 import { ReferenceTypeahead } from "@/components/ui/ReferenceTypeahead";
 import type { CreateRefResult } from "@/lib/actions/reference-data";
 
-export type RefItem = { id: string; label: string };
+export type RefItem = { id: string; label: string; status?: string };
 
 export type LocationSelection = {
   country: RefItem | null;
@@ -12,7 +12,7 @@ export type LocationSelection = {
   locality: RefItem | null;
 };
 
-type Suggestion = { id: string; name: string; code?: string | null };
+type Suggestion = { id: string; name: string; code?: string | null; status?: string };
 
 type Props = {
   value: LocationSelection;
@@ -98,7 +98,11 @@ export function LocationCascadePicker({
       startTransition(async () => {
         const result = await onCreateLocality(name, value.region!.id);
         if (result.ok && result.created) {
-          setLocality({ id: result.created.id, label: result.created.name });
+          setLocality({
+            id: result.created.id,
+            label: result.created.name,
+            status: result.created.status,
+          });
         } else {
           setMessage(result.message);
           setSuggestions(result.suggestions ?? []);
@@ -173,18 +177,21 @@ export function LocationCascadePicker({
       </div>
 
       <div>
-        <label htmlFor="location-locality" className={labelCls}>Locality</label>
+        <label htmlFor="location-locality" className={labelCls}>Town / City</label>
         <ReferenceTypeahead
           inputId="location-locality"
-          placeholder="Search towns, cities, or localities..."
+          placeholder="Search towns or cities..."
           onSearch={(query) => (value.region ? searchLocalities(value.region.id, query) : Promise.resolve([]))}
           onSelect={setLocality}
           onAddNew={value.region && onCreateLocality ? createLocality : undefined}
-          addNewLabel="Add new locality"
+          addNewLabel="Request missing town / city"
           value={value.locality}
           disabled={!value.region || isPending}
         />
         {!value.region && <p className={helpCls}>Select a region first.</p>}
+        {value.locality?.status === "needs-review" && (
+          <p className={helpCls}>Pending verification by a reference-data steward.</p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/components/ui/ReferenceTypeahead.tsx
+++ b/apps/web/components/ui/ReferenceTypeahead.tsx
@@ -190,6 +190,7 @@ export function ReferenceTypeahead({
         disabled={disabled}
         value={query}
         placeholder={placeholder}
+        data-add-new-label={addNewLabel}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
         onFocus={() => {

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@dpf/db";
+import { normalizeLocalityName } from "@dpf/db/location-normalize";
 import crypto from "crypto";
 import { STAGE_DEFAULT_PROBABILITY } from "@dpf/validators";
 import { revalidatePath } from "next/cache";
@@ -167,10 +168,7 @@ export async function createCustomerSite(input: {
       where: {
         regionId: region.id,
         status: "active",
-        name: {
-          equals: validatedAddress.city,
-          mode: "insensitive",
-        },
+        nameNormalized: normalizeLocalityName(validatedAddress.city),
       },
       select: { id: true },
     });
@@ -180,6 +178,9 @@ export async function createCustomerSite(input: {
         data: {
           regionId: region.id,
           name: validatedAddress.city,
+          nameNormalized: normalizeLocalityName(validatedAddress.city),
+          source: "validated-address",
+          sourceProvider: validatedAddress.validationSource,
           status: "active",
         },
         select: { id: true },

--- a/apps/web/lib/actions/reference-data-admin.test.ts
+++ b/apps/web/lib/actions/reference-data-admin.test.ts
@@ -245,7 +245,7 @@ describe("updateCity", () => {
     expect(result.ok).toBe(true);
     expect(prisma.city.update).toHaveBeenCalledWith({
       where: { id: "ci1" },
-      data: { name: "Sydney" },
+      data: { name: "Sydney", nameNormalized: "sydney" },
     });
   });
 

--- a/apps/web/lib/actions/reference-data-admin.ts
+++ b/apps/web/lib/actions/reference-data-admin.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@dpf/db";
+import { normalizeLocalityName } from "@dpf/db/location-normalize";
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
@@ -113,7 +114,10 @@ export async function updateCity(
     const city = await prisma.city.findUnique({ where: { id }, select: { id: true } });
     if (!city) return { ok: false, message: "City not found." };
 
-    await prisma.city.update({ where: { id }, data: { name: trimmed } });
+    await prisma.city.update({
+      where: { id },
+      data: { name: trimmed, nameNormalized: normalizeLocalityName(trimmed) },
+    });
   }
 
   revalidateAdminPaths();

--- a/apps/web/lib/actions/reference-data.test.ts
+++ b/apps/web/lib/actions/reference-data.test.ts
@@ -116,10 +116,10 @@ describe("searchCities", () => {
     expect(prisma.city.findMany).toHaveBeenCalledWith({
       where: {
         regionId: "region-1",
-        status: "active",
+        status: { in: ["active", "needs-review"] },
         name: { contains: "syd", mode: "insensitive" },
       },
-      select: { id: true, name: true },
+      select: { id: true, name: true, status: true },
       orderBy: { name: "asc" },
       take: 20,
     });
@@ -204,19 +204,24 @@ describe("createCity", () => {
     vi.mocked(prisma.city.create).mockResolvedValue({
       id: "ci-new",
       name: "Hobart",
+      status: "needs-review",
     } as never);
 
     const result = await createCity("region-1", "Hobart");
 
     expect(result.ok).toBe(true);
-    expect(result.created).toEqual({ id: "ci-new", name: "Hobart" });
+    expect(result.created).toEqual({ id: "ci-new", name: "Hobart", status: "needs-review" });
     expect(prisma.city.create).toHaveBeenCalledWith({
       data: {
         name: "Hobart",
+        nameNormalized: "hobart",
         regionId: "region-1",
-        status: "active",
+        status: "needs-review",
+        localityType: "town",
+        source: "user",
+        addedByUserId: "test-user-1",
       },
-      select: { id: true, name: true },
+      select: { id: true, name: true, status: true },
     });
     expect(revalidatePath).toHaveBeenCalledWith("/employee");
     expect(revalidatePath).toHaveBeenCalledWith("/admin/reference-data");

--- a/apps/web/lib/actions/reference-data.ts
+++ b/apps/web/lib/actions/reference-data.ts
@@ -11,15 +11,16 @@ import {
   searchRegionsForLocation,
 } from "@/lib/location-resolution/service";
 
-async function requireAuth(): Promise<void> {
+async function requireAuth(): Promise<string> {
   const session = await auth();
   if (!session?.user?.id) throw new Error("Not authenticated");
+  return session.user.id;
 }
 
 export type CreateRefResult = {
   ok: boolean;
   message: string;
-  created?: { id: string; name: string; code?: string | null };
+  created?: { id: string; name: string; code?: string | null; status?: string };
   suggestions?: { id: string; name: string; code?: string | null }[];
 };
 
@@ -97,8 +98,8 @@ export async function createCity(
   regionId: string,
   name: string,
 ): Promise<CreateRefResult> {
-  await requireAuth();
-  const result = await createLocality({ regionId, name });
+  const userId = await requireAuth();
+  const result = await createLocality({ regionId, name, addedByUserId: userId });
   revalidatePath("/employee");
   revalidatePath("/admin/reference-data");
   return result;
@@ -140,8 +141,8 @@ export async function forceCreateCity(
   regionId: string,
   name: string,
 ): Promise<CreateRefResult> {
-  await requireAuth();
-  const result = await forceCreateLocality({ regionId, name });
+  const userId = await requireAuth();
+  const result = await forceCreateLocality({ regionId, name, addedByUserId: userId });
   revalidatePath("/employee");
   revalidatePath("/admin/reference-data");
   return result;

--- a/apps/web/lib/location-resolution/normalize.ts
+++ b/apps/web/lib/location-resolution/normalize.ts
@@ -1,13 +1,4 @@
-export function normalizeLocalityName(value: string): string {
-  return value
-    .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
-    .normalize("NFC")
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, " ");
-}
-
-export function namesAreExactNormalizedMatch(left: string, right: string): boolean {
-  return normalizeLocalityName(left) === normalizeLocalityName(right);
-}
+export {
+  namesAreExactNormalizedMatch,
+  normalizeLocalityName,
+} from "@dpf/db/location-normalize";

--- a/apps/web/lib/location-resolution/service.test.ts
+++ b/apps/web/lib/location-resolution/service.test.ts
@@ -93,10 +93,10 @@ describe("searchLocalities", () => {
     expect(prisma.city.findMany).toHaveBeenCalledWith({
       where: {
         regionId: "region-tx",
-        status: "active",
+        status: { in: ["active", "needs-review"] },
         name: { contains: "thor", mode: "insensitive" },
       },
-      select: { id: true, name: true },
+      select: { id: true, name: true, status: true },
       orderBy: { name: "asc" },
       take: 20,
     });
@@ -130,22 +130,34 @@ describe("createLocality", () => {
 
   it("creates locality with current City table shape when no duplicate exists", async () => {
     vi.mocked(prisma.city.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.city.create).mockResolvedValue({ id: "city-new", name: "Thorndale" } as never);
+    vi.mocked(prisma.city.create).mockResolvedValue({
+      id: "city-new",
+      name: "Thorndale",
+      status: "needs-review",
+    } as never);
 
-    const result = await createLocality({ regionId: "region-tx", name: " Thorndale " });
+    const result = await createLocality({
+      regionId: "region-tx",
+      name: " Thorndale ",
+      addedByUserId: "user-1",
+    });
 
     expect(result).toEqual({
       ok: true,
-      message: 'Locality "Thorndale" created.',
-      created: { id: "city-new", name: "Thorndale" },
+      message: 'Town / city "Thorndale" was added for review.',
+      created: { id: "city-new", name: "Thorndale", status: "needs-review" },
     });
     expect(prisma.city.create).toHaveBeenCalledWith({
       data: {
         name: "Thorndale",
+        nameNormalized: "thorndale",
         regionId: "region-tx",
-        status: "active",
+        status: "needs-review",
+        localityType: "town",
+        source: "user",
+        addedByUserId: "user-1",
       },
-      select: { id: true, name: true },
+      select: { id: true, name: true, status: true },
     });
   });
 
@@ -168,10 +180,13 @@ describe("forceCreateLocality", () => {
     expect(prisma.city.create).toHaveBeenCalledWith({
       data: {
         name: "Springfield",
+        nameNormalized: "springfield",
         regionId: "region-1",
         status: "active",
+        localityType: "town",
+        source: "user",
       },
-      select: { id: true, name: true },
+      select: { id: true, name: true, status: true },
     });
   });
 });

--- a/apps/web/lib/location-resolution/service.ts
+++ b/apps/web/lib/location-resolution/service.ts
@@ -1,17 +1,28 @@
 import { prisma } from "@dpf/db";
 import { normalizeLocalityName } from "./normalize";
+import {
+  DEFAULT_LOCALITY_SOURCE,
+  DEFAULT_LOCALITY_TYPE,
+  LOCALITY_STATUSES,
+  type LocalityStatus,
+} from "./locality-enums";
 
 export type LocationRefResult = {
   ok: boolean;
   message: string;
-  created?: { id: string; name: string; code?: string | null };
+  created?: { id: string; name: string; code?: string | null; status?: LocalityStatus };
   suggestions?: { id: string; name: string; code?: string | null }[];
 };
 
 export type CreateLocalityInput = {
   regionId: string;
   name: string;
+  addedByUserId?: string | null;
 };
+
+function toLocalityStatus(status: string): LocalityStatus | undefined {
+  return LOCALITY_STATUSES.includes(status as LocalityStatus) ? (status as LocalityStatus) : undefined;
+}
 
 export async function searchCountriesForLocation(query: string) {
   const trimmed = query.trim();
@@ -58,10 +69,10 @@ export async function searchLocalities(regionId: string, query: string) {
   return prisma.city.findMany({
     where: {
       regionId,
-      status: "active",
+      status: { in: ["active", "needs-review"] },
       name: { contains: trimmed, mode: "insensitive" },
     },
-    select: { id: true, name: true },
+    select: { id: true, name: true, status: true },
     orderBy: { name: "asc" },
     take: 20,
   });
@@ -89,7 +100,7 @@ export async function suggestDuplicateLocalities(regionId: string, name: string)
 export async function createLocality(input: CreateLocalityInput): Promise<LocationRefResult> {
   const trimmedName = input.name.trim();
   if (!trimmedName) {
-    return { ok: false, message: "Locality name is required." };
+    return { ok: false, message: "Town / city name is required." };
   }
 
   const suggestions = await suggestDuplicateLocalities(input.regionId, trimmedName);
@@ -104,29 +115,45 @@ export async function createLocality(input: CreateLocalityInput): Promise<Locati
   const created = await prisma.city.create({
     data: {
       name: trimmedName,
+      nameNormalized: normalizeLocalityName(trimmedName),
       regionId: input.regionId,
-      status: "active",
+      status: "needs-review",
+      localityType: DEFAULT_LOCALITY_TYPE,
+      source: DEFAULT_LOCALITY_SOURCE,
+      ...(input.addedByUserId ? { addedByUserId: input.addedByUserId } : {}),
     },
-    select: { id: true, name: true },
+    select: { id: true, name: true, status: true },
   });
 
-  return { ok: true, message: `Locality "${created.name}" created.`, created };
+  return {
+    ok: true,
+    message: `Town / city "${created.name}" was added for review.`,
+    created: { ...created, status: toLocalityStatus(created.status) },
+  };
 }
 
 export async function forceCreateLocality(input: CreateLocalityInput): Promise<LocationRefResult> {
   const trimmedName = input.name.trim();
   if (!trimmedName) {
-    return { ok: false, message: "Locality name is required." };
+    return { ok: false, message: "Town / city name is required." };
   }
 
   const created = await prisma.city.create({
     data: {
       name: trimmedName,
+      nameNormalized: normalizeLocalityName(trimmedName),
       regionId: input.regionId,
       status: "active",
+      localityType: DEFAULT_LOCALITY_TYPE,
+      source: DEFAULT_LOCALITY_SOURCE,
+      ...(input.addedByUserId ? { addedByUserId: input.addedByUserId } : {}),
     },
-    select: { id: true, name: true },
+    select: { id: true, name: true, status: true },
   });
 
-  return { ok: true, message: `Locality "${created.name}" created.`, created };
+  return {
+    ok: true,
+    message: `Town / city "${created.name}" created.`,
+    created: { ...created, status: toLocalityStatus(created.status) },
+  };
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
     "./discovery-triage": "./src/discovery-triage.ts",
     "./discovery-triage-enums": "./src/discovery-triage-enums.ts",
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",
+    "./location-normalize": "./src/location-normalize.ts",
     "./seed-deliberation": "./src/seed-deliberation.ts"
   },
   "scripts": {

--- a/packages/db/prisma/migrations/20260501010000_location_town_city_stewardship/migration.sql
+++ b/packages/db/prisma/migrations/20260501010000_location_town_city_stewardship/migration.sql
@@ -1,0 +1,34 @@
+-- Add stewardship metadata so user-created towns/cities are not silently
+-- promoted into canonical active reference data.
+ALTER TABLE "City"
+  ADD COLUMN "nameNormalized" TEXT NOT NULL DEFAULT '',
+  ADD COLUMN "localityType" TEXT NOT NULL DEFAULT 'city',
+  ADD COLUMN "source" TEXT NOT NULL DEFAULT 'seed',
+  ADD COLUMN "sourceProvider" TEXT,
+  ADD COLUMN "sourceRef" TEXT,
+  ADD COLUMN "confidence" DECIMAL(5,4),
+  ADD COLUMN "disambiguator" TEXT,
+  ADD COLUMN "addedByUserId" TEXT;
+
+UPDATE "City"
+SET "nameNormalized" = lower(regexp_replace(trim("name"), '\s+', ' ', 'g'))
+WHERE "nameNormalized" = '';
+
+ALTER TABLE "City"
+  ADD CONSTRAINT "City_addedByUserId_fkey"
+  FOREIGN KEY ("addedByUserId") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "City_regionId_nameNormalized_idx" ON "City"("regionId", "nameNormalized");
+CREATE INDEX "City_source_idx" ON "City"("source");
+CREATE INDEX "City_addedByUserId_idx" ON "City"("addedByUserId");
+
+-- Common case: same normalized name cannot appear twice in a region unless a
+-- steward explicitly disambiguates the records.
+CREATE UNIQUE INDEX "City_regionId_nameNormalized_unique_pending"
+  ON "City"("regionId", "nameNormalized")
+  WHERE "disambiguator" IS NULL;
+
+CREATE UNIQUE INDEX "City_regionId_nameNormalized_disambiguator_unique"
+  ON "City"("regionId", "nameNormalized", "disambiguator")
+  WHERE "disambiguator" IS NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   adminActivities              AdminActivity[]
   userFacts                    UserFact[]
   scheduledAgentTasks          ScheduledAgentTask[]          @relation("ScheduledAgentTaskOwner")
+  addedLocalities              City[]                        @relation("CityAddedByUser")
 }
 
 model UserGroup {
@@ -396,18 +397,30 @@ model Region {
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model City {
-  id        String    @id @default(cuid())
-  name      String
-  regionId  String
-  status    String    @default("active")
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
-  addresses Address[]
-  region    Region    @relation(fields: [regionId], references: [id])
+  id              String    @id @default(cuid())
+  name            String
+  nameNormalized  String    @default("")
+  regionId        String
+  localityType    String    @default("city")
+  source          String    @default("seed")
+  sourceProvider  String?
+  sourceRef       String?
+  confidence      Decimal?  @db.Decimal(5, 4)
+  disambiguator   String?
+  addedByUserId   String?
+  status          String    @default("active")
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  addedByUser     User?     @relation("CityAddedByUser", fields: [addedByUserId], references: [id])
+  addresses       Address[]
+  region          Region    @relation(fields: [regionId], references: [id])
 
   @@index([regionId, name])
   @@index([regionId])
+  @@index([regionId, nameNormalized])
   @@index([status])
+  @@index([source])
+  @@index([addedByUserId])
 }
 
 model Address {

--- a/packages/db/src/location-normalize.ts
+++ b/packages/db/src/location-normalize.ts
@@ -1,0 +1,13 @@
+export function normalizeLocalityName(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .normalize("NFC")
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function namesAreExactNormalizedMatch(left: string, right: string): boolean {
+  return normalizeLocalityName(left) === normalizeLocalityName(right);
+}

--- a/packages/db/src/seed-geographic-data.ts
+++ b/packages/db/src/seed-geographic-data.ts
@@ -9,6 +9,7 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import type { PrismaClient } from "../generated/client/client";
+import { normalizeLocalityName } from "./location-normalize";
 
 // ---------------------------------------------------------------------------
 // Data types matching the JSON file schemas
@@ -144,7 +145,7 @@ async function seedCities(
     if (!regionDbId) continue;
 
     const found = await prisma.city.findFirst({
-      where: { regionId: regionDbId, name: c.name },
+      where: { regionId: regionDbId, nameNormalized: normalizeLocalityName(c.name) },
       select: { id: true },
     });
 
@@ -154,6 +155,7 @@ async function seedCities(
       await prisma.city.create({
         data: {
           name: c.name,
+          nameNormalized: normalizeLocalityName(c.name),
           regionId: regionDbId,
         },
       });


### PR DESCRIPTION
## Summary
- add stewardship metadata for user-requested towns/cities so made-up localities are held as needs-review instead of silently becoming canonical active reference data
- update the work-location location picker copy from Locality to Town / City and change missing-place creation to a request flow
- add tests for scoped town/city creation, pending status propagation, and reference-data actions

## Verification
- pnpm --filter web exec vitest run lib/location-resolution/service.test.ts components/location/LocationCascadePicker.test.tsx lib/actions/reference-data.test.ts
- pnpm --filter @dpf/db exec prisma generate
- pnpm --filter web typecheck
- pnpm --filter @dpf/db exec prisma migrate deploy
- pnpm --filter web build
- docker compose --env-file D:\DPF\.env build portal portal-init
- docker compose --env-file D:\DPF\.env up -d portal-init portal
- Playwright live UX check against http://192.168.0.200:3000/admin/reference-data confirmed Town / City label, scoped country/region selection, and fake-town option renders as Request missing town / city