### PR TITLE
feat(coworkers): build-specialist operator contract — Slice 1 enforcement

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1016,6 +1016,16 @@ export async function sendMessage(input: {
     // EP-INF-009b: The loop handles V2 routing internally via routeAndCall().
     const { runAgenticLoop } = await import("@/lib/agentic-loop");
     const { agentEventBus } = await import("@/lib/agent-event-bus");
+
+    // Build Specialist Operator Contract platform guards (clauses 2.2/2.4/2.6)
+    // need to know the active FeatureBuild's phase + id for attribution.
+    // findFirst returns null on non-build threads; the guards no-op when
+    // buildPhase is null/non-build.
+    const activeBuild = await prisma.featureBuild.findFirst({
+      where: { threadId: input.threadId },
+      select: { id: true, phase: true },
+    }).catch(() => null);
+
     const agenticResult = await runAgenticLoop({
       chatHistory,
       systemPrompt: populatedPrompt,
@@ -1028,6 +1038,8 @@ export async function sendMessage(input: {
       threadId: input.threadId,
       taskType: taskTypeId,
       agentDisplayName: agent.agentName,
+      buildPhase: activeBuild?.phase ?? null,
+      featureBuildId: activeBuild?.id ?? null,
       ...(Object.keys(modelReqs).length > 0 ? { modelRequirements: modelReqs } : {}),
       onProgress: (event) => agentEventBus.emit(input.threadId, event),
     });

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -6,6 +6,9 @@ import {
   detectFabrication,
   buildRepeatedQuestionNudge,
   buildRepeatedToolStopMessage,
+  detectToolRefusedDespiteAvailability,
+  phaseRequiresToolCall,
+  detectUnsavedEvidence,
 } from "./agentic-loop";
 
 vi.mock("@dpf/db", () => ({
@@ -880,5 +883,107 @@ describe("runAgenticLoop", () => {
     const thirdCallMessages = mockRoute.mock.calls[2]?.[0] ?? [];
     const lastUserMessage = [...thirdCallMessages].reverse().find((m: any) => m.role === "user");
     expect(lastUserMessage?.content).toContain("Do not pause after a failed read");
+  });
+});
+
+// ─── Build-specialist Operator Contract platform guards ────────────────────
+// Spec: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2.6
+
+describe("detectToolRefusedDespiteAvailability (clause 2.6)", () => {
+  const tools = [{ name: "start_ideate_research" }, { name: "saveBuildEvidence" }];
+
+  it("returns the tool name when response asserts unavailability of a delivered tool", () => {
+    const out = detectToolRefusedDespiteAvailability(
+      "Blocker: start_ideate_research is not available in the current runtime.",
+      tools,
+    );
+    expect(out).toBe("start_ideate_research");
+  });
+
+  it("returns null when response does not assert unavailability", () => {
+    const out = detectToolRefusedDespiteAvailability("I'll call start_ideate_research now.", tools);
+    expect(out).toBeNull();
+  });
+
+  it("returns null when the named tool is not in the delivered list", () => {
+    const out = detectToolRefusedDespiteAvailability(
+      "I cannot call do_something_else because it's not available.",
+      tools,
+    );
+    expect(out).toBeNull();
+  });
+
+  it("matches alternate phrasings", () => {
+    expect(
+      detectToolRefusedDespiteAvailability("saveBuildEvidence isn't enabled yet — pending grants.", tools),
+    ).toBe("saveBuildEvidence");
+  });
+
+  it("returns the unspecified sentinel for generic 'currently []' refusals", () => {
+    const out = detectToolRefusedDespiteAvailability(
+      "The tool grants are currently `[]` for this persona.",
+      tools,
+    );
+    expect(out).not.toBeNull();
+    expect(out).toContain("unspecified");
+  });
+});
+
+describe("phaseRequiresToolCall (clause 2.2)", () => {
+  it("returns true for ideate/plan/build/review", () => {
+    expect(phaseRequiresToolCall("ideate")).toBe(true);
+    expect(phaseRequiresToolCall("plan")).toBe(true);
+    expect(phaseRequiresToolCall("build")).toBe(true);
+    expect(phaseRequiresToolCall("review")).toBe(true);
+  });
+
+  it("returns false for ship/complete/null/undefined", () => {
+    expect(phaseRequiresToolCall("ship")).toBe(false);
+    expect(phaseRequiresToolCall("complete")).toBe(false);
+    expect(phaseRequiresToolCall(null)).toBe(false);
+    expect(phaseRequiresToolCall(undefined)).toBe(false);
+  });
+});
+
+describe("detectUnsavedEvidence (clause 2.4)", () => {
+  it("flags ideate response that contains a design-doc structure but no saveBuildEvidence call", () => {
+    const out = detectUnsavedEvidence(
+      "Here's the design doc:\n\n## Approach\nReplace gray classes with var(--dpf-*) tokens.",
+      [],
+      "ideate",
+    );
+    expect(out).toBe("designDoc");
+  });
+
+  it("returns null when saveBuildEvidence(designDoc) was called", () => {
+    const out = detectUnsavedEvidence(
+      "Saved the design doc.",
+      [{ name: "saveBuildEvidence", args: { field: "designDoc", value: {} } }],
+      "ideate",
+    );
+    expect(out).toBeNull();
+  });
+
+  it("flags plan response with task list but no saved buildPlan", () => {
+    const out = detectUnsavedEvidence(
+      "Here is the implementation plan with tasks: 1) ... 2) ...",
+      [],
+      "plan",
+    );
+    expect(out).toBe("buildPlan");
+  });
+
+  it("flags review response with verification verdict but no saved verificationOut", () => {
+    const out = detectUnsavedEvidence(
+      "Typecheck passed and tests passed; verification complete.",
+      [],
+      "review",
+    );
+    expect(out).toBe("verificationOut");
+  });
+
+  it("returns null when phase is not ideate/plan/review", () => {
+    expect(detectUnsavedEvidence("design doc", [], "build")).toBeNull();
+    expect(detectUnsavedEvidence("design doc", [], null)).toBeNull();
   });
 });

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -272,6 +272,69 @@ export function shouldNudge(params: {
   return false;
 }
 
+// ─── Build-specialist Operator Contract — clause 2.6 platform-side guards ────
+// Spec: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2.6
+// Hallucinating LLMs cannot be trusted to self-report; the platform detects.
+
+/**
+ * Clause 2.6 platform path: detect when the agent's text asserts a tool
+ * is unavailable AND that tool name appears in its delivered tool list.
+ * Returns the offending tool name (or `(unspecified — generic refusal)`
+ * for blanket "currently empty / pending" claims), or null.
+ */
+export function detectToolRefusedDespiteAvailability(
+  responseText: string,
+  deliveredTools: Array<{ name: string }>,
+): string | null {
+  if (!responseText) return null;
+  const refusalPattern = /(?:not (?:available|enabled|granted|callable|in (?:my )?tool list|exposed)|isn['’]t (?:available|enabled|granted|callable|in (?:my )?tool list|exposed)|is missing|currently `?\[\]`?|pending (?:follow-on |grant)|don['’]t have (?:access|the ability))(?:\s+(?:in|for|to|yet|now|here))?/i;
+  if (!refusalPattern.test(responseText)) return null;
+  for (const tool of deliveredTools) {
+    if (responseText.includes(tool.name)) return tool.name;
+  }
+  if (/currently `?\[\]`?|pending (?:follow-on |grant)/i.test(responseText)) {
+    return "(unspecified — generic refusal)";
+  }
+  return null;
+}
+
+/**
+ * Clause 2.2: phase advance is illegal without saved evidence; therefore
+ * a turn in a build phase that produces zero tool calls is a contract
+ * violation. Returns true when the phase requires a tool call before close.
+ */
+export function phaseRequiresToolCall(phase: string | null | undefined): boolean {
+  if (!phase) return false;
+  return ["ideate", "plan", "build", "review"].includes(phase);
+}
+
+/**
+ * Clause 2.4: if a turn produces specific phase-evidence content in the
+ * response text but does not call saveBuildEvidence with the matching field,
+ * the evidence is ephemeral. Returns the field name that should have been
+ * saved, or null. Conservative — only fires on clear evidence-content signals.
+ */
+export function detectUnsavedEvidence(
+  responseText: string,
+  executedTools: Array<{ name: string; args?: Record<string, unknown> }>,
+  phase: string | null | undefined,
+): string | null {
+  if (!phase) return null;
+  const phaseFieldMap: Record<string, { field: string; signal: RegExp }> = {
+    ideate: { field: "designDoc", signal: /\b(?:design\s+doc|design\s+document|approach[:\s]|here['’]s\s+the\s+design)\b/i },
+    plan: { field: "buildPlan", signal: /\b(?:build\s+plan|implementation\s+plan|tasks?[:\s]|file\s+structure)\b/i },
+    review: { field: "verificationOut", signal: /\b(?:typecheck\s+(?:passed|failed)|tests?\s+(?:passed|failed)|verification\s+(?:complete|done))\b/i },
+  };
+  const entry = phaseFieldMap[phase];
+  if (!entry) return null;
+  if (!entry.signal.test(responseText)) return null;
+  const wasSaved = executedTools.some(
+    (t) => t.name === "saveBuildEvidence" &&
+      (t.args as Record<string, unknown> | undefined)?.field === entry.field,
+  );
+  return wasSaved ? null : entry.field;
+}
+
 export type AgenticResult = {
   /** Final text response from the agent */
   content: string;
@@ -425,6 +488,19 @@ export async function runAgenticLoop(params: {
    * by name rather than becoming a generic "AI Assistant".
    */
   agentDisplayName?: string;
+  /**
+   * Optional active build phase ('ideate' | 'plan' | 'build' | 'review' | 'ship'
+   * | 'complete'). Set by /build route callers from FeatureBuild.phase. When
+   * set and equal to a phase that requires a tool call, a turn that produces
+   * zero tool calls writes a PlatformIssueReport (Build Specialist Operator
+   * Contract clause 2.6 platform path).
+   */
+  buildPhase?: string | null;
+  /**
+   * Optional active FeatureBuild.id for attribution on guard-written
+   * PlatformIssueReport rows. Caller should look this up alongside buildPhase.
+   */
+  featureBuildId?: string | null;
 }): Promise<AgenticResult> {
   const {
     chatHistory,
@@ -731,6 +807,67 @@ export async function runAgenticLoop(params: {
         `toolCalls=0 contentLen=${trimmed.length} nudges=${continuationNudges} ` +
         `executedTools=${executedTools.length} content=${JSON.stringify(trimmed.slice(0, 200))}`,
       );
+
+      // Build-specialist Operator Contract clause 2.6 — platform-side guards.
+      // Detect contract violations the LLM cannot self-report. Each guard
+      // writes a PlatformIssueReport tagged to the active build (when known).
+      // Spec: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2.6
+      const writeContractIssue = (
+        category: "tool-refused-despite-availability" | "zero-tool-call" | "unsaved-evidence",
+        title: string,
+        description: string,
+        severity: "high" | "medium" = "high",
+      ): void => {
+        prisma.platformIssueReport.create({
+          data: {
+            reportId: `coworker-process-${Date.now()}-${threadId.slice(0, 8)}-${category}`,
+            type: "runtime_error",
+            severity,
+            status: "open",
+            title: `[coworker-process] ${title}`,
+            description,
+            routeContext,
+            agentId,
+            featureBuildId: params.featureBuildId ?? null,
+            source: "agentic-loop-guard",
+          },
+        }).catch((err) => {
+          console.warn(`[agentic-loop] failed to write contract issue (${category}):`, err);
+        });
+      };
+
+      // 2.6a: tool-refused-despite-availability
+      const refusedToolName = detectToolRefusedDespiteAvailability(trimmed, tools);
+      if (refusedToolName) {
+        console.warn(`[agentic-loop] contract-violation tool-refused-despite-availability: ${refusedToolName}`);
+        writeContractIssue(
+          "tool-refused-despite-availability",
+          `tool-refused-despite-availability: ${refusedToolName}`,
+          `Agent ${agentId} on route ${routeContext} asserted that ${refusedToolName} is unavailable in iteration ${iteration}, but the tool was in the delivered tool list. Response excerpt: ${trimmed.slice(0, 500)}`,
+        );
+      }
+
+      // 2.6b: zero-tool-call on phase-required turn
+      if (executedTools.length === 0 && phaseRequiresToolCall(params.buildPhase)) {
+        console.warn(`[agentic-loop] contract-violation zero-tool-call phase=${params.buildPhase}`);
+        writeContractIssue(
+          "zero-tool-call",
+          `zero-tool-call on phase=${params.buildPhase}`,
+          `Agent ${agentId} on route ${routeContext} closed iteration ${iteration} of build phase '${params.buildPhase}' with zero tool calls. Response excerpt: ${trimmed.slice(0, 500)}`,
+        );
+      }
+
+      // 2.4: save-before-final-response — evidence in text but not persisted
+      const unsavedField = detectUnsavedEvidence(trimmed, executedTools, params.buildPhase);
+      if (unsavedField) {
+        console.warn(`[agentic-loop] contract-violation unsaved-evidence: ${unsavedField} described but not saved`);
+        writeContractIssue(
+          "unsaved-evidence",
+          `unsaved-evidence: ${unsavedField}`,
+          `Agent ${agentId} on route ${routeContext} produced ${unsavedField} content in iteration ${iteration} but did not call saveBuildEvidence({ field: "${unsavedField}", ... }). Response excerpt: ${trimmed.slice(0, 500)}`,
+          "medium",
+        );
+      }
 
       // Empty response guard: if the model returns empty content AND zero tool calls,
       // it can't handle the request (wrong tool format, model doesn't support tools, etc).

--- a/apps/web/lib/tak/build-specialist-prompt.test.ts
+++ b/apps/web/lib/tak/build-specialist-prompt.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Structural test for the build-specialist persona prompt. Asserts the
+ * Operator Contract clauses are present and the rotted future-state language
+ * has been removed. Source: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(here, "..", "..", "..", "..");
+const PROMPT_PATH = join(REPO_ROOT, "prompts", "route-persona", "build-specialist.prompt.md");
+const prompt = readFileSync(PROMPT_PATH, "utf-8");
+
+describe("build-specialist.prompt.md (Operator Contract)", () => {
+  it("has frontmatter version 4 (operator contract update)", () => {
+    expect(prompt).toMatch(/^version:\s*4$/m);
+  });
+
+  it("preserves the role-defining sections", () => {
+    expect(prompt).toMatch(/^# Role$/m);
+    expect(prompt).toMatch(/^# Accountable For$/m);
+    expect(prompt).toMatch(/^# Interfaces With$/m);
+    expect(prompt).toMatch(/^# Out Of Scope$/m);
+  });
+
+  it("removes the stale tool-grant rot language that caused tool refusal", () => {
+    expect(prompt).not.toMatch(/currently `\[\]`/);
+    expect(prompt).not.toMatch(/pending follow-on assignment/);
+    expect(prompt).not.toMatch(/once the per-agent grant/);
+    expect(prompt).not.toMatch(/will hold a curated set/);
+    expect(prompt).not.toMatch(/tools the role expects to hold once granted/i);
+  });
+
+  it("contains the # Operator Contract section", () => {
+    expect(prompt).toMatch(/^# Operator Contract$/m);
+  });
+
+  it("trusts the runtime tool list explicitly", () => {
+    expect(prompt).toMatch(/platform delivers your callable tool list/i);
+  });
+
+  it("references all nine contract clauses by intent", () => {
+    // 2.2 — phase advance illegal without saved evidence
+    expect(prompt).toMatch(/saveBuildEvidence/);
+    expect(prompt).toMatch(/phase advance is illegal/i);
+    // 2.3 — short confirmations advance
+    expect(prompt).toMatch(/\bok\b.*\byes\b.*\bproceed\b/i);
+    // 2.4 — save before final response
+    expect(prompt).toMatch(/save before final response/i);
+    // 2.5 — narrow approval gate (PR open / merge / promote / production)
+    expect(prompt).toMatch(/opening a PR/i);
+    expect(prompt).toMatch(/merging a PR/i);
+    // 2.6 — tool failure honesty
+    expect(prompt).toMatch(/never claim a tool is unavailable/i);
+    expect(prompt).toMatch(/report_quality_issue/);
+    // 2.7 — no-repeat-diagnosis
+    expect(prompt).toMatch(/no-repeat-diagnosis/i);
+    // 2.8 — clear next step
+    expect(prompt).toMatch(/clear next step/i);
+    // 2.9 — one clarification round
+    expect(prompt).toMatch(/one clarification round/i);
+  });
+});

--- a/apps/web/lib/tak/route-context-map.test.ts
+++ b/apps/web/lib/tak/route-context-map.test.ts
@@ -195,3 +195,22 @@ describe("FALLBACK_ROUTE_CONTEXT", () => {
     expect(FALLBACK_ROUTE_CONTEXT.domain).toBe("Workspace");
   });
 });
+
+describe("ROUTE_CONTEXT_MAP /build operator-contract tooling", () => {
+  // Build specialist operator contract clause 2.6 requires the build-specialist
+  // to be able to call report_quality_issue when it detects a genuine process
+  // issue. Spec: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2.6
+  it("delivers report_quality_issue so the build-specialist can log process issues", () => {
+    const buildRoute = ROUTE_CONTEXT_MAP["/build"];
+    expect(buildRoute).toBeDefined();
+    expect(buildRoute!.domainTools).toContain("report_quality_issue");
+  });
+
+  it("still delivers the core build-lifecycle tools used by the operator contract", () => {
+    const buildRoute = ROUTE_CONTEXT_MAP["/build"];
+    const required = ["saveBuildEvidence", "reviewDesignDoc", "reviewBuildPlan"];
+    for (const tool of required) {
+      expect(buildRoute!.domainTools).toContain(tool);
+    }
+  });
+});

--- a/apps/web/lib/tak/route-context-map.ts
+++ b/apps/web/lib/tak/route-context-map.ts
@@ -489,6 +489,7 @@ When generating or reviewing UI code, enforce these rules:
       "propose_decomposition",
       "register_tech_debt",
       "save_build_notes",
+      "report_quality_issue",
       // Build Studio lifecycle (EP-SELF-DEV-002)
       "saveBuildEvidence",
       "reviewDesignDoc",

--- a/docs/superpowers/audits/2026-04-30-prompt-state-leakage-baseline.json
+++ b/docs/superpowers/audits/2026-04-30-prompt-state-leakage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-05-01T01:08:52.428Z",
+  "generatedAt": "2026-05-01T02:34:36.006Z",
   "spec": "docs/superpowers/specs/2026-04-30-prompt-state-leakage-lint-design.md",
   "rulesChecked": 4,
-  "errorCount": 42,
+  "errorCount": 38,
   "warnCount": 111,
   "findings": [
     {
@@ -40,46 +40,6 @@
       "severity": "error",
       "file": "prompts/route-persona/admin-assistant.prompt.md",
       "line": 58,
-      "column": 14,
-      "match": "will hold a curated set",
-      "summary": "[PSL-001] forbidden state phrase: \"will hold a curated set\"",
-      "detail": "The phrase \"will hold a curated set\" tells the model that runtime grants are not yet available, even when the runtime delivers them. Remove this language. The runtime tool list is authoritative — describe behavior in the prompt, not state.\n\nSee docs/superpowers/specs/2026-04-30-prompt-state-leakage-lint-design.md §6 PSL-001."
-    },
-    {
-      "invariantId": "PSL-001",
-      "severity": "error",
-      "file": "prompts/route-persona/build-specialist.prompt.md",
-      "line": 64,
-      "column": 65,
-      "match": "once the per-agent grant",
-      "summary": "[PSL-001] forbidden state phrase: \"once the per-agent grant\"",
-      "detail": "The phrase \"once the per-agent grant\" tells the model that runtime grants are not yet available, even when the runtime delivers them. Remove this language. The runtime tool list is authoritative — describe behavior in the prompt, not state.\n\nSee docs/superpowers/specs/2026-04-30-prompt-state-leakage-lint-design.md §6 PSL-001."
-    },
-    {
-      "invariantId": "PSL-001",
-      "severity": "error",
-      "file": "prompts/route-persona/build-specialist.prompt.md",
-      "line": 64,
-      "column": 279,
-      "match": "pending follow-on assignment",
-      "summary": "[PSL-001] forbidden state phrase: \"pending follow-on assignment\"",
-      "detail": "The phrase \"pending follow-on assignment\" tells the model that runtime grants are not yet available, even when the runtime delivers them. Remove this language. The runtime tool list is authoritative — describe behavior in the prompt, not state.\n\nSee docs/superpowers/specs/2026-04-30-prompt-state-leakage-lint-design.md §6 PSL-001."
-    },
-    {
-      "invariantId": "PSL-001",
-      "severity": "error",
-      "file": "prompts/route-persona/build-specialist.prompt.md",
-      "line": 66,
-      "column": 1,
-      "match": "Tools the role expects to hold once granted",
-      "summary": "[PSL-001] forbidden state phrase: \"tools the role expects to hold once granted\"",
-      "detail": "The phrase \"tools the role expects to hold once granted\" tells the model that runtime grants are not yet available, even when the runtime delivers them. Remove this language. The runtime tool list is authoritative — describe behavior in the prompt, not state.\n\nSee docs/superpowers/specs/2026-04-30-prompt-state-leakage-lint-design.md §6 PSL-001."
-    },
-    {
-      "invariantId": "PSL-001",
-      "severity": "error",
-      "file": "prompts/route-persona/build-specialist.prompt.md",
-      "line": 64,
       "column": 14,
       "match": "will hold a curated set",
       "summary": "[PSL-001] forbidden state phrase: \"will hold a curated set\"",

--- a/packages/db/prisma/migrations/20260501010000_platform_issue_report_feature_build_id/migration.sql
+++ b/packages/db/prisma/migrations/20260501010000_platform_issue_report_feature_build_id/migration.sql
@@ -1,0 +1,15 @@
+-- Add featureBuildId FK to PlatformIssueReport so process-issue rows
+-- written by the build-specialist operator-contract guards can be
+-- attributed to the active FeatureBuild. Additive, nullable, low-risk.
+--
+-- Spec: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §5
+-- Plan: docs/superpowers/plans/2026-04-30-build-specialist-operator-contract-slice-1.md Task 1
+
+-- AlterTable
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "featureBuildId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "PlatformIssueReport_featureBuildId_idx" ON "PlatformIssueReport"("featureBuildId");
+
+-- AddForeignKey
+ALTER TABLE "PlatformIssueReport" ADD CONSTRAINT "PlatformIssueReport_featureBuildId_fkey" FOREIGN KEY ("featureBuildId") REFERENCES "FeatureBuild"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -830,35 +830,35 @@ model ServiceOffering {
 }
 
 model TaxonomyNode {
-  id                     String                  @id @default(cuid())
-  nodeId                 String                  @unique
-  name                   String
-  portfolioId            String?
-  parentId               String?
-  status                 String                  @default("active")
-  governance             Json?
-  description            String?
-  enrichment             Json?
-  backlogItems           BacklogItem[]
-  products               DigitalProduct[]
-  eaElements             EaElement[]
-  fingerprintRules       DiscoveryFingerprintRule[]
-  inventoryEntities      InventoryEntity[]
-  portfolioQualityIssues PortfolioQualityIssue[]
-  triageSelectionDecisions DiscoveryTriageDecision[] @relation("DiscoveryTriageDecisionSelectedTaxonomy")
-  parent                 TaxonomyNode?           @relation("TaxonomyTree", fields: [parentId], references: [id])
-  children               TaxonomyNode[]          @relation("TaxonomyTree")
+  id                       String                     @id @default(cuid())
+  nodeId                   String                     @unique
+  name                     String
+  portfolioId              String?
+  parentId                 String?
+  status                   String                     @default("active")
+  governance               Json?
+  description              String?
+  enrichment               Json?
+  backlogItems             BacklogItem[]
+  products                 DigitalProduct[]
+  eaElements               EaElement[]
+  fingerprintRules         DiscoveryFingerprintRule[]
+  inventoryEntities        InventoryEntity[]
+  portfolioQualityIssues   PortfolioQualityIssue[]
+  triageSelectionDecisions DiscoveryTriageDecision[]  @relation("DiscoveryTriageDecisionSelectedTaxonomy")
+  parent                   TaxonomyNode?              @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children                 TaxonomyNode[]             @relation("TaxonomyTree")
 }
 
 model BacklogItem {
-  id                    String           @id @default(cuid())
-  itemId                String           @unique
+  id                    String                @id @default(cuid())
+  itemId                String                @unique
   title                 String
   status                String
   type                  String
   body                  String?
-  createdAt             DateTime         @default(now())
-  updatedAt             DateTime         @updatedAt
+  createdAt             DateTime              @default(now())
+  updatedAt             DateTime              @updatedAt
   priority              Int?
   digitalProductId      String?
   taxonomyNodeId        String?
@@ -867,12 +867,12 @@ model BacklogItem {
   triageOutcome         String?
   effortSize            String?
   proposedOutcome       String?
-  activeBuildId         String?          @unique
+  activeBuildId         String?               @unique
   duplicateOfId         String?
   resolution            String?
   abandonReason         String?
   stalenessDetectedAt   DateTime?
-  occurrenceCount       Int              @default(1)
+  occurrenceCount       Int                   @default(1)
   lastSeenAt            DateTime?
   submittedById         String?
   completedAt           DateTime?
@@ -885,15 +885,15 @@ model BacklogItem {
   upstreamIssueNumber   Int?
   upstreamIssueUrl      String?
   upstreamSyncedAt      DateTime?
-  accountableEmployee   EmployeeProfile? @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
-  activeBuild           FeatureBuild?    @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
-  digitalProduct        DigitalProduct?  @relation(fields: [digitalProductId], references: [id])
-  duplicateOf           BacklogItem?     @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
-  duplicates            BacklogItem[]    @relation("BacklogItemDuplicates")
-  epic                  Epic?            @relation(fields: [epicId], references: [id])
-  featureBuilds         FeatureBuild[]   @relation("BacklogItemOriginator")
-  submittedBy           User?            @relation("BacklogSubmissions", fields: [submittedById], references: [id])
-  taxonomyNode          TaxonomyNode?    @relation(fields: [taxonomyNodeId], references: [id])
+  accountableEmployee   EmployeeProfile?      @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
+  activeBuild           FeatureBuild?         @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
+  digitalProduct        DigitalProduct?       @relation(fields: [digitalProductId], references: [id])
+  duplicateOf           BacklogItem?          @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
+  duplicates            BacklogItem[]         @relation("BacklogItemDuplicates")
+  epic                  Epic?                 @relation(fields: [epicId], references: [id])
+  featureBuilds         FeatureBuild[]        @relation("BacklogItemOriginator")
+  submittedBy           User?                 @relation("BacklogSubmissions", fields: [submittedById], references: [id])
+  taxonomyNode          TaxonomyNode?         @relation(fields: [taxonomyNodeId], references: [id])
   activities            BacklogItemActivity[]
 }
 
@@ -1131,25 +1131,25 @@ model DeviceCodeSession {
 }
 
 model ModelProvider {
-  id                       String                     @id @default(cuid())
-  providerId               String                     @unique
+  id                       String                    @id @default(cuid())
+  providerId               String                    @unique
   name                     String
   families                 Json
-  status                   String                     @default("unconfigured")
-  updatedAt                DateTime                   @updatedAt
+  status                   String                    @default("unconfigured")
+  updatedAt                DateTime                  @updatedAt
   authHeader               String?
   computeWatts             Float?
   cliEngine                String? // "claude" | "codex" — which CLI dispatch engine this provider works with (null = not CLI-dispatchable)
-  costModel                String                     @default("token")
+  costModel                String                    @default("token")
   electricityRateKwh       Float?
-  enabledFamilies          Json                       @default("[]")
+  enabledFamilies          Json                      @default("[]")
   endpoint                 String?
   inputPricePerMToken      Float?
   outputPricePerMToken     Float?
-  category                 String                     @default("direct")
+  category                 String                    @default("direct")
   baseUrl                  String?
-  authMethod               String                     @default("api_key")
-  supportedAuthMethods     Json                       @default("[\"api_key\"]")
+  authMethod               String                    @default("api_key")
+  supportedAuthMethods     Json                      @default("[\"api_key\"]")
   consoleUrl               String?
   docsUrl                  String?
   billingLabel             String?
@@ -1158,40 +1158,40 @@ model ModelProvider {
   oauthClientId            String?
   oauthRedirectUri         String?
   costPerformanceNotes     String?
-  endpointType             String                     @default("llm")
+  endpointType             String                    @default("llm")
   serviceKind              String?
-  sensitivityClearance     String[]                   @default([])
-  capabilityTier           String                     @default("basic")
-  costBand                 String                     @default("free")
-  taskTags                 String[]                   @default([])
+  sensitivityClearance     String[]                  @default([])
+  capabilityTier           String                    @default("basic")
+  costBand                 String                    @default("free")
+  taskTags                 String[]                  @default([])
   mcpTransport             String?
   maxConcurrency           Int?
-  catalogVisibility        String                     @default("visible")
+  catalogVisibility        String                    @default("visible")
   catalogEntry             Json?
   avgLatencyMs             Float?
-  codegen                  Int                        @default(50)
-  contextRetention         Int                        @default(50)
-  conversational           Int                        @default(50)
-  customScores             Json                       @default("{}")
-  evalCount                Int                        @default(0)
-  instructionFollowing     Int                        @default(50)
+  codegen                  Int                       @default(50)
+  contextRetention         Int                       @default(50)
+  conversational           Int                       @default(50)
+  customScores             Json                      @default("{}")
+  evalCount                Int                       @default(0)
+  instructionFollowing     Int                       @default(50)
   lastCallAt               DateTime?
   lastEvalAt               DateTime?
   maxContextTokens         Int?
   maxOutputTokens          Int?
-  modelRestrictions        String[]                   @default([])
-  profileConfidence        String                     @default("low")
-  profileSource            String                     @default("seed")
-  reasoning                Int                        @default(50)
-  recentFailureRate        Float                      @default(0)
+  modelRestrictions        String[]                  @default([])
+  profileConfidence        String                    @default("low")
+  profileSource            String                    @default("seed")
+  reasoning                Int                       @default(50)
+  recentFailureRate        Float                     @default(0)
   retiredAt                DateTime?
   retiredReason            String?
-  structuredOutput         Int                        @default(50)
-  supportedModalities      Json                       @default("{\"input\": [\"text\"], \"output\": [\"text\"]}")
-  supportsStreaming        Boolean                    @default(true)
-  supportsStructuredOutput Boolean                    @default(false)
-  supportsToolUse          Boolean                    @default(false)
-  toolFidelity             Int                        @default(50)
+  structuredOutput         Int                       @default(50)
+  supportedModalities      Json                      @default("{\"input\": [\"text\"], \"output\": [\"text\"]}")
+  supportsStreaming        Boolean                   @default(true)
+  supportsStructuredOutput Boolean                   @default(false)
+  supportsToolUse          Boolean                   @default(false)
+  toolFidelity             Int                       @default(50)
   userFacingDescription    Json?
   authMode                 String?
   credentialOwnerMode      String?
@@ -1687,8 +1687,8 @@ model AgentPromptContext {
 }
 
 model AuthorizationDecisionLog {
-  id                  String           @id @default(cuid())
-  decisionId          String           @unique
+  id                  String            @id @default(cuid())
+  decisionId          String            @unique
   actorType           String
   actorRef            String
   humanContextRef     String?
@@ -1699,14 +1699,14 @@ model AuthorizationDecisionLog {
   objectRef           String?
   decision            String
   rationale           Json
-  createdAt           DateTime         @default(now())
+  createdAt           DateTime          @default(now())
   endpointUsed        String?
   mode                String?
   routeContext        String?
   sensitivityLevel    String?
   sensitivityOverride Boolean?
   authorityBinding    AuthorityBinding? @relation(fields: [authorityBindingId], references: [id])
-  delegationGrant     DelegationGrant? @relation(fields: [delegationGrantId], references: [id])
+  delegationGrant     DelegationGrant?  @relation(fields: [delegationGrantId], references: [id])
 
   @@index([decision])
   @@index([createdAt])
@@ -2083,31 +2083,31 @@ model Activity {
 }
 
 model Organization {
-  id                    String                  @id @default(cuid())
-  orgId                 String                  @unique
-  name                  String
-  legalName             String?
-  slug                  String                  @unique
-  industry              String?
-  website               String?
-  email                 String?
-  phone                 String?
-  address               Json?
-  logoUrl               String?
-  designSystem          Json?
-  createdAt             DateTime                @default(now())
-  updatedAt             DateTime                @updatedAt
-  brandingConfig        BrandingConfig?
-  storefrontConfig      StorefrontConfig?
-  businessContext       BusinessContext?
-  marketingStrategy     MarketingStrategy?
-  marketingReviews      MarketingReview[]
-  marketingCampaignBriefs MarketingCampaignBrief[]
-  marketingAssetTasks   MarketingAssetTask[]
-  marketingKpiCheckpoints MarketingKpiCheckpoint[]
+  id                            String                         @id @default(cuid())
+  orgId                         String                         @unique
+  name                          String
+  legalName                     String?
+  slug                          String                         @unique
+  industry                      String?
+  website                       String?
+  email                         String?
+  phone                         String?
+  address                       Json?
+  logoUrl                       String?
+  designSystem                  Json?
+  createdAt                     DateTime                       @default(now())
+  updatedAt                     DateTime                       @updatedAt
+  brandingConfig                BrandingConfig?
+  storefrontConfig              StorefrontConfig?
+  businessContext               BusinessContext?
+  marketingStrategy             MarketingStrategy?
+  marketingReviews              MarketingReview[]
+  marketingCampaignBriefs       MarketingCampaignBrief[]
+  marketingAssetTasks           MarketingAssetTask[]
+  marketingKpiCheckpoints       MarketingKpiCheckpoint[]
   marketingAutomationCandidates MarketingAutomationCandidate[]
-  taxProfile            OrganizationTaxProfile?
-  platformSetupProgress PlatformSetupProgress?  @relation("OrgSetupProgress")
+  taxProfile                    OrganizationTaxProfile?
+  platformSetupProgress         PlatformSetupProgress?         @relation("OrgSetupProgress")
 }
 
 model BusinessContext {
@@ -2322,21 +2322,21 @@ model RuntimeAdvisory {
 }
 
 model DiscoveryRun {
-  id                  String                   @id @default(cuid())
-  runKey              String                   @unique
-  sourceSlug          String
-  trigger             String                   @default("bootstrap")
-  status              String                   @default("running")
-  startedAt           DateTime                 @default(now())
-  completedAt         DateTime?
-  itemCount           Int                      @default(0)
-  relationshipCount   Int                      @default(0)
-  notes               Json?
-  discoveredItems     DiscoveredItem[]
-  discoveredRelations DiscoveredRelationship[]
+  id                      String                            @id @default(cuid())
+  runKey                  String                            @unique
+  sourceSlug              String
+  trigger                 String                            @default("bootstrap")
+  status                  String                            @default("running")
+  startedAt               DateTime                          @default(now())
+  completedAt             DateTime?
+  itemCount               Int                               @default(0)
+  relationshipCount       Int                               @default(0)
+  notes                   Json?
+  discoveredItems         DiscoveredItem[]
+  discoveredRelations     DiscoveredRelationship[]
   fingerprintObservations DiscoveryFingerprintObservation[]
-  confirmedEntities   InventoryEntity[]        @relation("InventoryEntityConfirmedRun")
-  confirmedRelations  InventoryRelationship[]  @relation("InventoryRelationshipConfirmedRun")
+  confirmedEntities       InventoryEntity[]                 @relation("InventoryEntityConfirmedRun")
+  confirmedRelations      InventoryRelationship[]           @relation("InventoryRelationshipConfirmedRun")
 }
 
 model DiscoveredItem {
@@ -2411,9 +2411,9 @@ model DiscoveryFingerprintObservation {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  inventoryEntity InventoryEntity?              @relation(fields: [inventoryEntityId], references: [id], onDelete: SetNull)
-  discoveryRun    DiscoveryRun?                 @relation(fields: [discoveryRunId], references: [id], onDelete: SetNull)
-  approvedRule    DiscoveryFingerprintRule?     @relation("ApprovedFingerprintRule", fields: [approvedRuleId], references: [id], onDelete: SetNull)
+  inventoryEntity InventoryEntity?             @relation(fields: [inventoryEntityId], references: [id], onDelete: SetNull)
+  discoveryRun    DiscoveryRun?                @relation(fields: [discoveryRunId], references: [id], onDelete: SetNull)
+  approvedRule    DiscoveryFingerprintRule?    @relation("ApprovedFingerprintRule", fields: [approvedRuleId], references: [id], onDelete: SetNull)
   reviews         DiscoveryFingerprintReview[]
 
   @@index([sourceKind])
@@ -2466,7 +2466,7 @@ model DiscoveryFingerprintRule {
 
   catalogVersion       DiscoveryFingerprintCatalogVersion? @relation(fields: [catalogVersionId], references: [id], onDelete: SetNull)
   taxonomyNode         TaxonomyNode?                       @relation(fields: [taxonomyNodeId], references: [id], onDelete: SetNull)
-  approvedObservations DiscoveryFingerprintObservation[]    @relation("ApprovedFingerprintRule")
+  approvedObservations DiscoveryFingerprintObservation[]   @relation("ApprovedFingerprintRule")
 
   @@index([status])
   @@index([scope])
@@ -2509,8 +2509,8 @@ model DiscoveredRelationship {
 }
 
 model InventoryEntity {
-  id                          String                       @id @default(cuid())
-  entityKey                   String                       @unique
+  id                          String                            @id @default(cuid())
+  entityKey                   String                            @unique
   entityType                  String
   name                        String
   technicalClass              String?
@@ -2519,14 +2519,14 @@ model InventoryEntity {
   productModel                String?
   observedVersion             String?
   normalizedVersion           String?
-  supportStatus               String                       @default("unknown")
-  status                      String                       @default("active")
-  attributionStatus           String                       @default("needs_review")
+  supportStatus               String                            @default("unknown")
+  status                      String                            @default("active")
+  attributionStatus           String                            @default("needs_review")
   confidence                  Float?
-  providerView                String                       @default("foundational")
-  properties                  Json                         @default("{}")
-  firstSeenAt                 DateTime                     @default(now())
-  lastSeenAt                  DateTime                     @default(now())
+  providerView                String                            @default("foundational")
+  properties                  Json                              @default("{}")
+  firstSeenAt                 DateTime                          @default(now())
+  lastSeenAt                  DateTime                          @default(now())
   lastConfirmedRunId          String?
   portfolioId                 String?
   taxonomyNodeId              String?
@@ -2536,20 +2536,20 @@ model InventoryEntity {
   attributionEvidence         Json?
   candidateTaxonomy           Json?
   discoveredItems             DiscoveredItem[]
-  digitalProduct              DigitalProduct?              @relation(fields: [digitalProductId], references: [id])
-  lastConfirmedRun            DiscoveryRun?                @relation("InventoryEntityConfirmedRun", fields: [lastConfirmedRunId], references: [id])
-  portfolio                   Portfolio?                   @relation(fields: [portfolioId], references: [id])
-  taxonomyNode                TaxonomyNode?                @relation(fields: [taxonomyNodeId], references: [id])
-  fromRelationships           InventoryRelationship[]      @relation("InventoryRelationshipFromEntity")
-  toRelationships             InventoryRelationship[]      @relation("InventoryRelationshipToEntity")
+  digitalProduct              DigitalProduct?                   @relation(fields: [digitalProductId], references: [id])
+  lastConfirmedRun            DiscoveryRun?                     @relation("InventoryEntityConfirmedRun", fields: [lastConfirmedRunId], references: [id])
+  portfolio                   Portfolio?                        @relation(fields: [portfolioId], references: [id])
+  taxonomyNode                TaxonomyNode?                     @relation(fields: [taxonomyNodeId], references: [id])
+  fromRelationships           InventoryRelationship[]           @relation("InventoryRelationshipFromEntity")
+  toRelationships             InventoryRelationship[]           @relation("InventoryRelationshipToEntity")
   qualityIssues               PortfolioQualityIssue[]
   triageDecisions             DiscoveryTriageDecision[]
   changeItems                 ChangeItem[]
   softwareEvidence            DiscoveredSoftwareEvidence[]
   fingerprintObservations     DiscoveryFingerprintObservation[]
-  discoveryConnectionGateways DiscoveryConnection[]        @relation("DiscoveryConnectionGateway")
+  discoveryConnectionGateways DiscoveryConnection[]             @relation("DiscoveryConnectionGateway")
   discoveredViaConnectionId   String?
-  discoveredViaConnection     DiscoveryConnection?         @relation("DiscoveredViaConnection", fields: [discoveredViaConnectionId], references: [id])
+  discoveredViaConnection     DiscoveryConnection?              @relation("DiscoveredViaConnection", fields: [discoveredViaConnectionId], references: [id])
 
   @@index([entityType])
   @@index([attributionStatus])
@@ -2582,26 +2582,26 @@ model InventoryRelationship {
 }
 
 model PortfolioQualityIssue {
-  id                      String                 @id @default(cuid())
-  issueKey                String                 @unique
+  id                      String                    @id @default(cuid())
+  issueKey                String                    @unique
   issueType               String
-  status                  String                 @default("open")
-  severity                String                 @default("warn")
+  status                  String                    @default("open")
+  severity                String                    @default("warn")
   summary                 String
   details                 Json?
-  firstDetectedAt         DateTime               @default(now())
-  lastDetectedAt          DateTime               @default(now())
+  firstDetectedAt         DateTime                  @default(now())
+  lastDetectedAt          DateTime                  @default(now())
   resolvedAt              DateTime?
   inventoryEntityId       String?
   inventoryRelationshipId String?
   portfolioId             String?
   taxonomyNodeId          String?
   digitalProductId        String?
-  digitalProduct          DigitalProduct?        @relation(fields: [digitalProductId], references: [id])
-  inventoryEntity         InventoryEntity?       @relation(fields: [inventoryEntityId], references: [id])
-  inventoryRelationship   InventoryRelationship? @relation(fields: [inventoryRelationshipId], references: [id])
-  portfolio               Portfolio?             @relation(fields: [portfolioId], references: [id])
-  taxonomyNode            TaxonomyNode?          @relation(fields: [taxonomyNodeId], references: [id])
+  digitalProduct          DigitalProduct?           @relation(fields: [digitalProductId], references: [id])
+  inventoryEntity         InventoryEntity?          @relation(fields: [inventoryEntityId], references: [id])
+  inventoryRelationship   InventoryRelationship?    @relation(fields: [inventoryRelationshipId], references: [id])
+  portfolio               Portfolio?                @relation(fields: [portfolioId], references: [id])
+  taxonomyNode            TaxonomyNode?             @relation(fields: [taxonomyNodeId], references: [id])
   triageDecisions         DiscoveryTriageDecision[]
 
   @@index([issueType])
@@ -2680,25 +2680,25 @@ model AgentMessage {
 }
 
 model UserFact {
-  id              String     @id @default(cuid())
-  userId          String
-  category        String // preference | decision | constraint | domain_context
-  key             String
-  value           String
-  confidence      Float      @default(1.0)
-  sourceRoute     String
-  sourceMessageId String?
-  sourceAgentId   String?
+  id                                String     @id @default(cuid())
+  userId                            String
+  category                          String // preference | decision | constraint | domain_context
+  key                               String
+  value                             String
+  confidence                        Float      @default(1.0)
+  sourceRoute                       String
+  sourceMessageId                   String?
+  sourceAgentId                     String?
   sourceOperatingProfileFingerprint String?
-  lastValidatedAt DateTime?
-  validatedAgainstFingerprint String?
-  supersededAt    DateTime?
-  supersededById  String?
-  createdAt       DateTime   @default(now())
-  updatedAt       DateTime   @updatedAt
-  user            User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  supersededBy    UserFact?  @relation("FactSupersession", fields: [supersededById], references: [id])
-  supersedes      UserFact[] @relation("FactSupersession")
+  lastValidatedAt                   DateTime?
+  validatedAgainstFingerprint       String?
+  supersededAt                      DateTime?
+  supersededById                    String?
+  createdAt                         DateTime   @default(now())
+  updatedAt                         DateTime   @updatedAt
+  user                              User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  supersededBy                      UserFact?  @relation("FactSupersession", fields: [supersededById], references: [id])
+  supersedes                        UserFact[] @relation("FactSupersession")
 
   @@index([userId, category, key])
   @@index([userId, supersededAt])
@@ -2782,7 +2782,7 @@ model AdminActivity {
 }
 
 model ToolExecution {
-  id            String   @id @default(cuid())
+  id            String                @id @default(cuid())
   threadId      String
   agentId       String
   userId        String
@@ -2793,7 +2793,7 @@ model ToolExecution {
   executionMode String
   routeContext  String?
   durationMs    Int?
-  createdAt     DateTime @default(now())
+  createdAt     DateTime              @default(now())
   // Phase 3: audit enrichment — nullable; backfill via backfill-capability-ids.ts
   auditClass    String?
   capabilityId  String?
@@ -2813,18 +2813,18 @@ model ToolExecution {
 }
 
 model ToolExecutionReceipt {
-  id               String   @id @default(cuid())
-  toolExecutionId  String   @unique
+  id               String                 @id @default(cuid())
+  toolExecutionId  String                 @unique
   buildId          String?
   receiptKind      String
-  receiptStatus    String   @default("valid")
+  receiptStatus    String                 @default("valid")
   inputFingerprint String
   outputDigest     Json
   executionStatus  String
   expiresAt        DateTime
-  createdAt        DateTime @default(now())
-  build            FeatureBuild? @relation(fields: [buildId], references: [buildId])
-  toolExecution    ToolExecution  @relation(fields: [toolExecutionId], references: [id], onDelete: Cascade)
+  createdAt        DateTime               @default(now())
+  build            FeatureBuild?          @relation(fields: [buildId], references: [buildId])
+  toolExecution    ToolExecution          @relation(fields: [toolExecutionId], references: [id], onDelete: Cascade)
   usages           ArtifactReceiptUsage[]
 
   @@index([buildId, createdAt(sort: Desc)])
@@ -2837,20 +2837,20 @@ model ToolExecutionReceipt {
 // at rest, scoped to a subset of the user's grants, optionally bound to a
 // specific Agent identity for grant-narrowing.
 model McpApiToken {
-  id              String    @id @default(cuid())
-  userId          String
-  agentId         String?
-  name            String
-  tokenHash       String    @unique
-  prefix          String
-  scopes          String[]  @default([])
-  capability      String    @default("read")
-  lastUsedAt      DateTime?
-  expiresAt       DateTime?
-  revokedAt       DateTime?
-  revokedReason   String?
-  createdAt       DateTime  @default(now())
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id            String    @id @default(cuid())
+  userId        String
+  agentId       String?
+  name          String
+  tokenHash     String    @unique
+  prefix        String
+  scopes        String[]  @default([])
+  capability    String    @default("read")
+  lastUsedAt    DateTime?
+  expiresAt     DateTime?
+  revokedAt     DateTime?
+  revokedReason String?
+  createdAt     DateTime  @default(now())
+  user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, revokedAt])
   @@index([tokenHash])
@@ -2901,9 +2901,9 @@ model Notification {
 
 model PlatformNotification {
   id         String    @id @default(cuid())
-  severity   String    // "info" | "warning" | "critical" | "expired"
-  category   String    // e.g. "token-expiry"
-  subjectId  String?   // e.g. CredentialEntry.providerId
+  severity   String // "info" | "warning" | "critical" | "expired"
+  category   String // e.g. "token-expiry"
+  subjectId  String? // e.g. CredentialEntry.providerId
   message    String    @db.Text
   createdAt  DateTime  @default(now())
   resolvedAt DateTime?
@@ -2947,11 +2947,11 @@ model DynamicView {
 }
 
 model PlatformIssueReport {
-  id                  String    @id @default(cuid())
-  reportId            String    @unique
+  id                  String        @id @default(cuid())
+  reportId            String        @unique
   type                String
-  severity            String    @default("medium")
-  status              String    @default("open")
+  severity            String        @default("medium")
+  status              String        @default("open")
   title               String
   description         String?
   routeContext        String?
@@ -2961,13 +2961,17 @@ model PlatformIssueReport {
   digitalProductId    String?
   portfolioId         String?
   agentId             String?
-  source              String    @default("manual")
-  createdAt           DateTime  @default(now())
-  updatedAt           DateTime  @updatedAt
+  featureBuildId      String?
+  source              String        @default("manual")
+  createdAt           DateTime      @default(now())
+  updatedAt           DateTime      @updatedAt
   upstreamIssueNumber Int?
   upstreamIssueUrl    String?
   upstreamSyncedAt    DateTime?
-  reportedBy          User?     @relation(fields: [reportedById], references: [id])
+  reportedBy          User?         @relation(fields: [reportedById], references: [id])
+  featureBuild        FeatureBuild? @relation(fields: [featureBuildId], references: [id], onDelete: SetNull)
+
+  @@index([featureBuildId])
 }
 
 model ExternalEvidenceRecord {
@@ -2988,62 +2992,63 @@ model ExternalEvidenceRecord {
 }
 
 model FeatureBuild {
-  id                    String            @id @default(cuid())
-  buildId               String            @unique
-  title                 String
-  description           String?
-  portfolioId           String?
+  id                       String                  @id @default(cuid())
+  buildId                  String                  @unique
+  title                    String
+  description              String?
+  portfolioId              String?
   originatingBacklogItemId String?
-  brief                 Json?
-  plan                  Json?
-  phase                 String            @default("ideate")
-  sandboxId             String?
-  sandboxPort           Int?
-  buildBranch           String? // git branch in sandbox: "build/<buildId>"
-  diffSummary           String?
-  diffPatch             String?
-  codingProvider        String?
-  threadId              String?
-  createdById           String
-  createdAt             DateTime          @default(now())
-  updatedAt             DateTime          @updatedAt
-  digitalProductId      String?
-  designDoc             Json?
-  designReview          Json?
-  buildPlan             Json?
-  planReview            Json?
-  taskResults           Json?
-  taskResultsVersion    Int               @default(0)
-  verificationOut       Json?
-  acceptanceMet         Json?
-  scoutFindings         Json?
-  accountableEmployeeId String?
-  claimedByAgentId      String?
-  claimedAt             DateTime?
-  claimStatus           String?
-  gitCommitHashes       String[]          @default([])
-  uxTestResults         Json?
-  uxVerificationStatus  String? // null | "running" | "complete" | "failed" | "skipped"
-  deliberationSummary   Json? // compact BuildDeliberationSummary (see apps/web/lib/feature-build-types.ts)
-  buildExecState        Json?
-  taxonomyAttribution   Json?
-  releaseBundleId       String?
-  calendarEventId       String?
-  abandonedAt           DateTime?
-  abandonReason         String?
-  draftApprovedAt       DateTime?
-  activities            BuildActivity[]
-  artifactRevisions     BuildArtifactRevision[]
-  phaseHandoffs         PhaseHandoff[]
-  toolExecutionReceipts ToolExecutionReceipt[]
-  activeForBacklogItem  BacklogItem?      @relation("BacklogItemActiveBuild")
-  accountableEmployee   EmployeeProfile?  @relation("BuildAccountable", fields: [accountableEmployeeId], references: [id])
-  createdBy             User              @relation(fields: [createdById], references: [id])
-  digitalProduct        DigitalProduct?   @relation(fields: [digitalProductId], references: [id])
-  originator            BacklogItem?      @relation("BacklogItemOriginator", fields: [originatingBacklogItemId], references: [id])
-  releaseBundle         ReleaseBundle?    @relation(fields: [releaseBundleId], references: [id])
-  productVersions       ProductVersion[]
-  promotionBackups      PromotionBackup[]
+  brief                    Json?
+  plan                     Json?
+  phase                    String                  @default("ideate")
+  sandboxId                String?
+  sandboxPort              Int?
+  buildBranch              String? // git branch in sandbox: "build/<buildId>"
+  diffSummary              String?
+  diffPatch                String?
+  codingProvider           String?
+  threadId                 String?
+  createdById              String
+  createdAt                DateTime                @default(now())
+  updatedAt                DateTime                @updatedAt
+  digitalProductId         String?
+  designDoc                Json?
+  designReview             Json?
+  buildPlan                Json?
+  planReview               Json?
+  taskResults              Json?
+  taskResultsVersion       Int                     @default(0)
+  verificationOut          Json?
+  acceptanceMet            Json?
+  scoutFindings            Json?
+  accountableEmployeeId    String?
+  claimedByAgentId         String?
+  claimedAt                DateTime?
+  claimStatus              String?
+  gitCommitHashes          String[]                @default([])
+  uxTestResults            Json?
+  uxVerificationStatus     String? // null | "running" | "complete" | "failed" | "skipped"
+  deliberationSummary      Json? // compact BuildDeliberationSummary (see apps/web/lib/feature-build-types.ts)
+  buildExecState           Json?
+  taxonomyAttribution      Json?
+  releaseBundleId          String?
+  calendarEventId          String?
+  abandonedAt              DateTime?
+  abandonReason            String?
+  draftApprovedAt          DateTime?
+  activities               BuildActivity[]
+  artifactRevisions        BuildArtifactRevision[]
+  phaseHandoffs            PhaseHandoff[]
+  toolExecutionReceipts    ToolExecutionReceipt[]
+  activeForBacklogItem     BacklogItem?            @relation("BacklogItemActiveBuild")
+  accountableEmployee      EmployeeProfile?        @relation("BuildAccountable", fields: [accountableEmployeeId], references: [id])
+  createdBy                User                    @relation(fields: [createdById], references: [id])
+  digitalProduct           DigitalProduct?         @relation(fields: [digitalProductId], references: [id])
+  originator               BacklogItem?            @relation("BacklogItemOriginator", fields: [originatingBacklogItemId], references: [id])
+  releaseBundle            ReleaseBundle?          @relation(fields: [releaseBundleId], references: [id])
+  productVersions          ProductVersion[]
+  promotionBackups         PromotionBackup[]
+  issueReports             PlatformIssueReport[]
 
   @@index([phase])
   @@index([createdById])
@@ -3053,7 +3058,7 @@ model FeatureBuild {
 }
 
 model BuildArtifactRevision {
-  id             String   @id @default(cuid())
+  id             String                 @id @default(cuid())
   buildId        String
   field          String
   revisionNumber Int
@@ -3062,10 +3067,10 @@ model BuildArtifactRevision {
   savedByUserId  String
   savedByAgentId String?
   threadId       String?
-  status         String   @default("accepted")
-  legacyEvidence Boolean  @default(false)
-  createdAt      DateTime @default(now())
-  build          FeatureBuild @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
+  status         String                 @default("accepted")
+  legacyEvidence Boolean                @default(false)
+  createdAt      DateTime               @default(now())
+  build          FeatureBuild           @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
   receiptUsages  ArtifactReceiptUsage[]
 
   @@unique([buildId, field, revisionNumber])
@@ -3073,11 +3078,11 @@ model BuildArtifactRevision {
 }
 
 model ArtifactReceiptUsage {
-  id                 String   @id @default(cuid())
+  id                 String                @id @default(cuid())
   artifactRevisionId String
   receiptId          String
   role               String?
-  createdAt          DateTime @default(now())
+  createdAt          DateTime              @default(now())
   artifactRevision   BuildArtifactRevision @relation(fields: [artifactRevisionId], references: [id], onDelete: Cascade)
   receipt            ToolExecutionReceipt  @relation(fields: [receiptId], references: [id], onDelete: Cascade)
 
@@ -3340,34 +3345,34 @@ model PlatformConfig {
 }
 
 model PlatformDevConfig {
-  id                   String    @id @default("singleton")
-  contributionMode     String    @default("selective")
+  id                     String    @id @default("singleton")
+  contributionMode       String    @default("selective")
   // Values: "fork_only" | "selective" | "contribute_all"
-  gitRemoteUrl         String? // Reserved for future git push capability
-  updatePending        Boolean   @default(false)
-  pendingVersion       String?
-  configuredAt         DateTime  @default(now())
-  configuredById       String?
-  configuredBy         User?     @relation("PlatformDevConfiguredBy", fields: [configuredById], references: [id])
-  dcoAcceptedAt        DateTime?
-  dcoAcceptedById      String?
-  dcoAcceptedBy        User?     @relation("PlatformDevDcoAcceptedBy", fields: [dcoAcceptedById], references: [id])
-  upstreamRemoteUrl    String?
+  gitRemoteUrl           String? // Reserved for future git push capability
+  updatePending          Boolean   @default(false)
+  pendingVersion         String?
+  configuredAt           DateTime  @default(now())
+  configuredById         String?
+  configuredBy           User?     @relation("PlatformDevConfiguredBy", fields: [configuredById], references: [id])
+  dcoAcceptedAt          DateTime?
+  dcoAcceptedById        String?
+  dcoAcceptedBy          User?     @relation("PlatformDevDcoAcceptedBy", fields: [dcoAcceptedById], references: [id])
+  upstreamRemoteUrl      String?
   // Client identity — generated once at install, never changes.
   // Used as the git author for all agent commits so contributions are
   // indistinguishable by name but unique and traceable by email hash.
-  clientId             String? // UUID, generated at first seed
-  gitAgentEmail        String? // agent-<sha256(clientId)[:16]>@hive.dpf
+  clientId               String? // UUID, generated at first seed
+  gitAgentEmail          String? // agent-<sha256(clientId)[:16]>@hive.dpf
   // Which push model to use when contributionMode is selective | contribute_all.
   // null = unconfigured; explicit value required before contribute_to_hive runs.
   // "maintainer-direct" — push directly to upstream (legacy path, requires upstream write)
   // "fork-pr"          — push to contributor-owned fork, open cross-repo PR (public-repo default)
-  contributionModel    String?
-  contributorForkOwner String?
-  contributorForkRepo  String?
-  forkVerifiedAt       DateTime?
-  backlogTeeUpDailyCap Int       @default(3)
-  governedBacklogEnabled Boolean @default(false)
+  contributionModel      String?
+  contributorForkOwner   String?
+  contributorForkRepo    String?
+  forkVerifiedAt         DateTime?
+  backlogTeeUpDailyCap   Int       @default(3)
+  governedBacklogEnabled Boolean   @default(false)
 }
 
 model EaNotation {
@@ -4771,12 +4776,12 @@ model MarketingStrategy {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  organization Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  storefront   StorefrontConfig? @relation(fields: [storefrontId], references: [id], onDelete: SetNull)
-  reviews      MarketingReview[]
-  campaignBriefs MarketingCampaignBrief[]
-  assetTasks   MarketingAssetTask[]
-  kpiCheckpoints MarketingKpiCheckpoint[]
+  organization         Organization                   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  storefront           StorefrontConfig?              @relation(fields: [storefrontId], references: [id], onDelete: SetNull)
+  reviews              MarketingReview[]
+  campaignBriefs       MarketingCampaignBrief[]
+  assetTasks           MarketingAssetTask[]
+  kpiCheckpoints       MarketingKpiCheckpoint[]
   automationCandidates MarketingAutomationCandidate[]
 
   @@index([status])
@@ -5324,31 +5329,31 @@ model Supplier {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
-  bills          Bill[]
-  purchaseOrders PurchaseOrder[]
+  bills              Bill[]
+  purchaseOrders     PurchaseOrder[]
   aiProviderProfiles AiProviderFinanceProfile[]
-  supplierContracts SupplierContract[]
-  financeWorkItems  FinanceWorkItem[]
+  supplierContracts  SupplierContract[]
+  financeWorkItems   FinanceWorkItem[]
 
   @@index([status])
 }
 
 model AiProviderFinanceProfile {
-  id                     String   @id @default(cuid())
-  providerId             String   @unique
+  id                     String    @id @default(cuid())
+  providerId             String    @unique
   supplierId             String?
-  status                 String   @default("seeded")
-  reconciliationStrategy String   @default("provider_portal")
-  valuationMethod        String   @default("commitment_first")
-  planCurrency           String   @default("USD")
+  status                 String    @default("seeded")
+  reconciliationStrategy String    @default("provider_portal")
+  valuationMethod        String    @default("commitment_first")
+  planCurrency           String    @default("USD")
   monthlyBudget          Decimal?
   billingUrl             String?
   usageUrl               String?
   notes                  String?
   lastEvaluatedAt        DateTime?
   lastSnapshotAt         DateTime?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
 
   provider          ModelProvider      @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
   supplier          Supplier?          @relation(fields: [supplierId], references: [id], onDelete: SetNull)
@@ -5360,19 +5365,19 @@ model AiProviderFinanceProfile {
 }
 
 model SupplierContract {
-  id                     String   @id @default(cuid())
-  contractId             String   @unique
+  id                     String    @id @default(cuid())
+  contractId             String    @unique
   profileId              String
   supplierId             String
   accountableEmployeeId  String?
-  status                 String   @default("draft")
-  contractType           String   @default("subscription")
-  billingCadence         String   @default("monthly")
-  currency               String   @default("USD")
+  status                 String    @default("draft")
+  contractType           String    @default("subscription")
+  billingCadence         String    @default("monthly")
+  currency               String    @default("USD")
   monthlyCommittedAmount Decimal?
   budgetAmount           Decimal?
-  budgetWindow           String   @default("monthly")
-  allowsOverage          Boolean  @default(false)
+  budgetWindow           String    @default("monthly")
+  allowsOverage          Boolean   @default(false)
   usageUnit              String?
   billingUrl             String?
   usageUrl               String?
@@ -5380,8 +5385,8 @@ model SupplierContract {
   startDate              DateTime?
   endDate                DateTime?
   notes                  String?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
 
   profile             AiProviderFinanceProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
   supplier            Supplier                 @relation(fields: [supplierId], references: [id], onDelete: Cascade)
@@ -5414,21 +5419,21 @@ model ContractAllowance {
 }
 
 model ContractUsageSnapshot {
-  id                      String   @id @default(cuid())
-  contractId              String
-  snapshotDate            DateTime
-  sourceType              String   @default("internal_observed")
-  confidence              String   @default("medium")
-  consumedQuantity        Decimal  @default(0)
-  includedQuantity        Decimal?
-  remainingQuantity       Decimal?
-  utilizationPct          Float?
+  id                        String   @id @default(cuid())
+  contractId                String
+  snapshotDate              DateTime
+  sourceType                String   @default("internal_observed")
+  confidence                String   @default("medium")
+  consumedQuantity          Decimal  @default(0)
+  includedQuantity          Decimal?
+  remainingQuantity         Decimal?
+  utilizationPct            Float?
   projectedMonthEndQuantity Decimal?
-  projectedUnusedValue    Decimal?
-  projectedOverageCost    Decimal?
-  metadata                Json?
-  createdAt               DateTime @default(now())
-  updatedAt               DateTime @updatedAt
+  projectedUnusedValue      Decimal?
+  projectedOverageCost      Decimal?
+  metadata                  Json?
+  createdAt                 DateTime @default(now())
+  updatedAt                 DateTime @updatedAt
 
   contract SupplierContract @relation(fields: [contractId], references: [id], onDelete: Cascade)
 
@@ -5437,22 +5442,22 @@ model ContractUsageSnapshot {
 }
 
 model FinanceWorkItem {
-  id              String   @id @default(cuid())
-  workItemId      String   @unique
+  id              String    @id @default(cuid())
+  workItemId      String    @unique
   profileId       String?
   contractId      String?
   supplierId      String?
   ownerEmployeeId String?
   type            String
-  status          String   @default("open")
-  severity        String   @default("medium")
+  status          String    @default("open")
+  severity        String    @default("medium")
   title           String
   description     String?
   dueAt           DateTime?
   resolvedAt      DateTime?
   metadata        Json?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   profile       AiProviderFinanceProfile? @relation(fields: [profileId], references: [id], onDelete: SetNull)
   contract      SupplierContract?         @relation(fields: [contractId], references: [id], onDelete: SetNull)

--- a/prompts/route-persona/build-specialist.prompt.md
+++ b/prompts/route-persona/build-specialist.prompt.md
@@ -3,7 +3,7 @@ name: build-specialist
 displayName: Software Engineer
 description: User-facing build coworker. Five phases — Ideate > Plan > Build > Review > Ship. Distinct from AGT-BUILD-* sub-agents.
 category: route-persona
-version: 3
+version: 4
 
 agent_id: AGT-WS-BUILD
 reports_to: HR-200
@@ -59,22 +59,58 @@ You are distinct from the four AGT-BUILD-* sub-agents (Data Architect, Software 
 - **Strategic product decisions**: what features to build, in what order, against what budget — those are AGT-WS-PORTFOLIO and AGT-ORCH-200 work.
 - **Authoring schema, code, or UI directly**: that is the AGT-BUILD-* sub-agents' job. You direct and review; they author.
 
-# Tools Available
+# Operator Contract
 
-This persona will hold a curated set of build-route tool grants once the per-agent grant PR ships. The runtime grants come from the registry's `tool_grants` array at [packages/db/data/agent_registry.json](../../../packages/db/data/agent_registry.json) — currently `[]` (empty), pending follow-on assignment per the [2026-04-28 sequencing plan](../../../docs/superpowers/plans/2026-04-28-coworker-and-routing-sequencing-plan.md).
+The platform delivers your callable tool list each turn. Trust it. If a tool name appears in the list, you can call it — never refuse based on prompt-time beliefs about what you should or should not have. The registry source is [packages/db/data/agent_registry.json](../../../packages/db/data/agent_registry.json); the runtime intersects that with user capabilities and delivers the actual list.
 
-Tools the role expects to hold once granted: `backlog_read`, `backlog_write`, `build_promote`, `sandbox_execute` (delegated through to AGT-BUILD-* sub-agents), `spec_plan_read`.
+## 1. Domain perspective
 
-# Operating Rules
+Features as code, schemas, components, and tests across the five build phases: Ideate > Plan > Build > Review > Ship. The current build's `phase` and saved evidence are page state — reference them, do not re-derive.
 
-Lead the user through the phases. Always end with a clear next step — the phase to move to, or the action you are about to take. Never finish a turn with the user uncertain about what comes next.
+## 2. Concrete work product — phase advance is illegal without it
 
-Never ask the same clarifying question twice. If the user has answered, proceed with what they said. One clarification round maximum, then act. Repeated clarification feels like stalling.
+| Phase | Required field on `FeatureBuild` | Saved by |
+| ----- | -------------------------------- | -------- |
+| Ideate → Plan | `designDoc` | `saveBuildEvidence({ field: "designDoc", value })` |
+| Plan → Build | `buildPlan` | `saveBuildEvidence({ field: "buildPlan", value })` |
+| Build → Review | `taskResults` | sub-agent dispatch via orchestrator |
+| Review → Ship | `verificationOut`, `acceptanceMet` | `saveBuildEvidence` for each |
+| Ship → Complete | release-gate decision | AGT-ORCH-300 (out of scope for this coworker) |
 
-The user sees the Build Studio with conversation panel, feature brief/preview, and phase indicator. Reference what is on the page; do not describe it.
+A turn that the user sees as "done with this phase" without the corresponding field saved is a contract violation, not a polite stopping point.
 
-When the user is in **Ideate** — surface options, name tradeoffs, narrow.
-When in **Plan** — decompose, define done, estimate complexity.
+## 3. Short confirmations advance
+
+`ok`, `yes`, `proceed`, `next`, `continue`, `go` advance the active phase using the most recent saved evidence. They do not restart research. If `designDoc` was saved last turn and the user says `ok`, the next turn calls `reviewDesignDoc` — not `start_ideate_research` again.
+
+## 4. Save before final response
+
+If the turn produces a designDoc, plan, task-result interpretation, verification reading, or acceptance call, `saveBuildEvidence` for the corresponding field is invoked before the closing chat message. The chat message references what was saved; it does not narrate the work as ephemeral.
+
+## 5. Approval gate — narrow
+
+Only these four external, main-affecting actions require explicit approval: opening a PR (sandbox → portal repo), merging a PR, promoting a build to release-gate decision, mutating production portal state. Approval today is UI-driven — surface the action in chat, the user clicks the existing button on `FeatureBuild`. Internal sandbox/build/FeatureBuild work auto-proceeds per the existing build-phase rule "Do not pause for routine go-ahead requests during planned build work" — that rule is unaltered by this contract.
+
+## 6. Tool failure honesty
+
+Never claim a tool is unavailable when it appears in your delivered tool list. Never fabricate success. Never silently skip a phase-required action. For genuine, agent-detected issues, call `report_quality_issue` with `type=runtime_error` and a `[coworker-process]`-prefixed title. Platform-side guards detect zero-tool-call iterations and tool-refused-despite-availability claims and write `PlatformIssueReport` rows automatically — your obligation is honesty, not self-reporting your own hallucinations.
+
+## 7. No-repeat-diagnosis
+
+If the prior turn's saved evidence already covers the user's current message, advance rather than re-running the same diagnostic. "We already saved the design doc; advancing to plan" beats "let me look at the page again."
+
+## 8. Always end with a clear next step
+
+Every turn ends with the user knowing exactly what comes next: the phase to move to, the action you are about to take, or the input you need from the user. Never finish a turn with the user uncertain.
+
+## 9. One clarification round maximum
+
+If a clarifying question is needed, ask once, then act on whatever the user answered. If the user has already answered, do not re-ask. Repeated clarification feels like stalling.
+
+# Per-phase judgment
+
+When the user is in **Ideate** — surface options, name tradeoffs, narrow. Save designDoc before advancing.
+When in **Plan** — decompose, define done, estimate complexity. Save buildPlan, run reviewBuildPlan.
 When in **Build** — direct AGT-BUILD-DA / -SE / -FE; read their output.
-When in **Review** — direct AGT-BUILD-QA; surface the verdict.
+When in **Review** — direct AGT-BUILD-QA; surface the verdict; save verificationOut and acceptanceMet.
 When in **Ship** — confirm acceptance criteria met, hand the build artifact to AGT-ORCH-300 for release-gate decision.


### PR DESCRIPTION
## Summary

Implements [Slice 1](docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md#slice-1--contract-enforcement) of the Build Specialist Operator Contract per the merged plan. Wave 2 of the AI Coworker Operator Pattern — wave 1 (Marketing Strategist) already on main.

This is the behavioral fix for the BI-E9CD1B92 lifecycle test failure on 2026-04-30, where the build-specialist coworker quoted near-verbatim "currently `[]` (empty), pending follow-on assignment" from its own prompt and refused to call its 21 delivered tools across three iterations.

## Changes

- **Prompt rewrite** ([`prompts/route-persona/build-specialist.prompt.md`](prompts/route-persona/build-specialist.prompt.md)): replaces stale `# Tools Available` + `# Operating Rules` with unified `# Operator Contract` (clauses 2.1–2.9). Frontmatter version 3 → 4. Preserves Role / Accountable For / Interfaces With / Out Of Scope.
- **Tool delivery** ([`apps/web/lib/tak/route-context-map.ts`](apps/web/lib/tak/route-context-map.ts)): adds `report_quality_issue` to `/build` domainTools so clause 2.6 has a callable surface.
- **Platform-side guards** ([`apps/web/lib/tak/agentic-loop.ts`](apps/web/lib/tak/agentic-loop.ts)): three new exports wired into the no-tool-calls branch — `detectToolRefusedDespiteAvailability`, `phaseRequiresToolCall` (with zero-tool-call enforcement), `detectUnsavedEvidence`. Each writes a `PlatformIssueReport` tagged with the active build for Slice 2 UI attribution. New optional `buildPhase` + `featureBuildId` params on `runAgenticLoop`; `agent-coworker.ts` call site looks up the active FeatureBuild by threadId.
- **Schema migration** (`20260501010000_platform_issue_report_feature_build_id`): additive nullable `featureBuildId` FK + index on `PlatformIssueReport`.
- **Lint baseline shrink**: prompt rewrite resolves 4 PSL findings on the build-specialist file. Baseline regenerated (38 errors / 111 warns now, was 42 / 111). Shrink-only guard from PR #362 verifies the baseline only shrinks vs main.

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web exec vitest run lib/tak/` — 293/293 pass (12 new cases for the three guards + structural prompt assertion test)
- [x] `pnpm --filter web build` — clean
- [x] Migration applies cleanly (additive nullable column + FK + index)
- [ ] Acceptance demo (BI-E9CD1B92 lifecycle re-run end-to-end via Build Studio UI) — deferred; requires running portal + sandbox + live LLM and is best done by the maintainer post-merge

## Out of scope (future slices)

- Slice 2 (Build Studio UI visibility — process-issues badge/panel, saved-vs-unsaved evidence state, no-work-saved warning) — separate plan to follow.
- Slice 3 (build skill playbooks — `skills/build/*.skill.md`) — separate plan to follow.
- Sub-agent personas (`AGT-BUILD-DA/SE/FE/QA`) — wave 3.
- `report_quality_issue` enum widening + tool-callable approval surface — wave 3 follow-ups noted in spec §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)