### PR TITLE
feat(chunk-1): discovery-portfolio gap closure refactoring foundation

### DIFF
--- a/apps/web/lib/coworker-identity.test.ts
+++ b/apps/web/lib/coworker-identity.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  resolveCoworkerIdentity,
+  getCanonicalAgentId,
+  type CoworkerRegistry,
+} from "./coworker-identity";
+
+const fixtureRegistry: CoworkerRegistry = {
+  agents: [
+    {
+      agentId: "AGT-WS-INVENTORY",
+      agentName: "inventory-specialist",
+      displayName: "Digital Product Estate Specialist",
+      aliases: ["estate-specialist"],
+    },
+    {
+      agentId: "AGT-WS-PORTFOLIO",
+      agentName: "portfolio-advisor",
+      displayName: "Portfolio Analyst",
+    },
+    {
+      agentId: "AGT-ORCH-200",
+      agentName: "explore-orchestrator",
+    },
+  ],
+};
+
+describe("resolveCoworkerIdentity (fixture registry)", () => {
+  it("resolves by agent_id", () => {
+    const result = resolveCoworkerIdentity("AGT-WS-INVENTORY", fixtureRegistry);
+    expect(result?.agentId).toBe("AGT-WS-INVENTORY");
+    expect(result?.displayName).toBe("Digital Product Estate Specialist");
+  });
+
+  it("resolves by agent_name (the persona slug)", () => {
+    const result = resolveCoworkerIdentity("inventory-specialist", fixtureRegistry);
+    expect(result?.agentId).toBe("AGT-WS-INVENTORY");
+  });
+
+  it("resolves by alias", () => {
+    const result = resolveCoworkerIdentity("estate-specialist", fixtureRegistry);
+    expect(result?.agentId).toBe("AGT-WS-INVENTORY");
+    expect(result?.displayName).toBe("Digital Product Estate Specialist");
+  });
+
+  it("agent_name and alias matches are case-insensitive", () => {
+    expect(resolveCoworkerIdentity("Inventory-Specialist", fixtureRegistry)?.agentId).toBe(
+      "AGT-WS-INVENTORY",
+    );
+    expect(resolveCoworkerIdentity("ESTATE-SPECIALIST", fixtureRegistry)?.agentId).toBe(
+      "AGT-WS-INVENTORY",
+    );
+  });
+
+  it("agent_id matching is case-sensitive (registry IDs are canonical uppercase)", () => {
+    expect(resolveCoworkerIdentity("agt-ws-inventory", fixtureRegistry)).toBeNull();
+  });
+
+  it("returns null for unknown input", () => {
+    expect(resolveCoworkerIdentity("nonsense", fixtureRegistry)).toBeNull();
+    expect(resolveCoworkerIdentity("", fixtureRegistry)).toBeNull();
+  });
+
+  it("agents with no displayName resolve cleanly (displayName remains undefined)", () => {
+    const result = resolveCoworkerIdentity("explore-orchestrator", fixtureRegistry);
+    expect(result?.agentId).toBe("AGT-ORCH-200");
+    expect(result?.displayName).toBeUndefined();
+    expect(result?.aliases).toBeUndefined();
+  });
+});
+
+describe("getCanonicalAgentId", () => {
+  it("returns the canonical agent_id from a persona slug", () => {
+    expect(getCanonicalAgentId("inventory-specialist", fixtureRegistry)).toBe(
+      "AGT-WS-INVENTORY",
+    );
+  });
+
+  it("returns the canonical agent_id from an alias", () => {
+    expect(getCanonicalAgentId("estate-specialist", fixtureRegistry)).toBe(
+      "AGT-WS-INVENTORY",
+    );
+  });
+
+  it("returns null for unknown input", () => {
+    expect(getCanonicalAgentId("nope", fixtureRegistry)).toBeNull();
+  });
+});
+
+describe("resolveCoworkerIdentity (default registry source)", () => {
+  it("loads packages/db/data/agent_registry.json when no registry is passed", () => {
+    // The real registry has AGT-WS-INVENTORY but does not yet carry the
+    // estate-specialist alias or displayName (those land in Chunk 6 Task 6.1).
+    // Resolving by agent_id should still work today via the default loader.
+    const result = resolveCoworkerIdentity("AGT-WS-INVENTORY");
+    expect(result?.agentId).toBe("AGT-WS-INVENTORY");
+    expect(result?.agentName).toBe("inventory-specialist");
+  });
+});

--- a/apps/web/lib/coworker-identity.test.ts
+++ b/apps/web/lib/coworker-identity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   resolveCoworkerIdentity,
   getCanonicalAgentId,
@@ -84,6 +84,37 @@ describe("getCanonicalAgentId", () => {
 
   it("returns null for unknown input", () => {
     expect(getCanonicalAgentId("nope", fixtureRegistry)).toBeNull();
+  });
+});
+
+describe("resolveCoworkerIdentity edge cases", () => {
+  it("agents with empty aliases array do not break the alias loop", () => {
+    const reg: CoworkerRegistry = {
+      agents: [
+        {
+          agentId: "AGT-EDGE-1",
+          agentName: "edge-one",
+          aliases: [],
+        },
+      ],
+    };
+    expect(resolveCoworkerIdentity("AGT-EDGE-1", reg)?.agentId).toBe("AGT-EDGE-1");
+    expect(resolveCoworkerIdentity("edge-one", reg)?.agentId).toBe("AGT-EDGE-1");
+    expect(resolveCoworkerIdentity("not-a-real-alias", reg)).toBeNull();
+  });
+
+  it("agent_id wins over an alias on a different agent that happens to match", () => {
+    // Edge case: agent B has an alias that collides with agent A's agent_id.
+    // The agent_id pass runs first, so agent A wins for that lookup.
+    const reg: CoworkerRegistry = {
+      agents: [
+        { agentId: "AGT-A", agentName: "agent-a" },
+        { agentId: "AGT-B", agentName: "agent-b", aliases: ["AGT-A"] },
+      ],
+    };
+    const result = resolveCoworkerIdentity("AGT-A", reg);
+    expect(result?.agentId).toBe("AGT-A");
+    expect(result?.agentName).toBe("agent-a");
   });
 });
 

--- a/apps/web/lib/coworker-identity.ts
+++ b/apps/web/lib/coworker-identity.ts
@@ -1,0 +1,105 @@
+/**
+ * Coworker identity alias resolver.
+ *
+ * Looks up a coworker by its durable `agent_id` (e.g. `AGT-WS-INVENTORY`),
+ * its persona/agent_name slug (e.g. `inventory-specialist`), or any alias
+ * declared in the registry (e.g. a future `estate-specialist`). Backed by
+ * `packages/db/data/agent_registry.json`. The fixture-injection path lets
+ * Chunks 4-5 (enrichment & classification) wire through alias support before
+ * Chunk 6 Task 6.1 patches the actual registry with `displayName` + `aliases`.
+ *
+ * Task 1.4 of plan: docs/superpowers/plans/2026-04-30-discovery-portfolio-gap-closure-plan.md
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export interface CoworkerIdentity {
+  agentId: string;
+  agentName: string;
+  displayName?: string;
+  aliases?: string[];
+  // Other fields exist on the JSON (tier, value_stream, etc.) but the resolver
+  // only surfaces the identity-relevant ones. Callers needing more pull from
+  // the source themselves.
+}
+
+export interface CoworkerRegistry {
+  agents: CoworkerIdentity[];
+}
+
+interface RawAgent {
+  agent_id: string;
+  agent_name: string;
+  displayName?: string;
+  aliases?: string[];
+  // Other fields ignored.
+}
+
+interface RawRegistry {
+  agents: RawAgent[];
+}
+
+let cachedRegistry: CoworkerRegistry | null = null;
+
+function findRepoRoot(): string {
+  let dir = process.cwd();
+  while (dir !== resolve(dir, "..")) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+    dir = resolve(dir, "..");
+  }
+  return process.cwd();
+}
+
+function loadDefaultRegistry(): CoworkerRegistry {
+  if (cachedRegistry) return cachedRegistry;
+  const root = findRepoRoot();
+  const path = join(root, "packages/db/data/agent_registry.json");
+  const raw = JSON.parse(readFileSync(path, "utf8")) as RawRegistry;
+  const agents: CoworkerIdentity[] = raw.agents.map((a) => {
+    const identity: CoworkerIdentity = {
+      agentId: a.agent_id,
+      agentName: a.agent_name,
+    };
+    if (a.displayName !== undefined) identity.displayName = a.displayName;
+    if (a.aliases !== undefined) identity.aliases = a.aliases;
+    return identity;
+  });
+  cachedRegistry = { agents };
+  return cachedRegistry;
+}
+
+export function resolveCoworkerIdentity(
+  input: string,
+  registry?: CoworkerRegistry,
+): CoworkerIdentity | null {
+  if (!input) return null;
+  const reg = registry ?? loadDefaultRegistry();
+
+  // 1. Exact, case-sensitive match on agent_id.
+  for (const agent of reg.agents) {
+    if (agent.agentId === input) return agent;
+  }
+
+  // 2. Case-insensitive match on agent_name.
+  const lowered = input.toLowerCase();
+  for (const agent of reg.agents) {
+    if (agent.agentName.toLowerCase() === lowered) return agent;
+  }
+
+  // 3. Case-insensitive match against any alias.
+  for (const agent of reg.agents) {
+    if (!agent.aliases) continue;
+    for (const alias of agent.aliases) {
+      if (alias.toLowerCase() === lowered) return agent;
+    }
+  }
+
+  return null;
+}
+
+export function getCanonicalAgentId(
+  alias: string,
+  registry?: CoworkerRegistry,
+): string | null {
+  return resolveCoworkerIdentity(alias, registry)?.agentId ?? null;
+}

--- a/docs/superpowers/specs/2026-04-30-discovery-portfolio-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-04-30-discovery-portfolio-gap-closure-design.md
@@ -391,7 +391,34 @@ Order matters because Slice 1 widens the promotion gate before enrichment exists
 
 ---
 
-## 13. References
+## 13. Implementation Status
+
+### Chunk 1 — Refactoring Foundation (landed 2026-04-30)
+
+Pure helpers shipping zero production behavior change. All four foundation modules unit-tested; full @dpf/db + apps/web vitest suites green; production `next build` exit 0.
+
+| Task | Commits | Tests |
+| - | - | - |
+| 1.1 Promotion policy resolver | `cea88828`, `5e889ab0` (spec fix), `0b438144` (polish) | 7/7 |
+| 1.2 Shared quality-issue writer | `a631d8af`, `e1ed27e8` (polish) | 13/13 |
+| 1.3 Fingerprint-rule adapter | `0e0fcaad`, `203d0dbc` (polish) | 9/9 |
+| 1.4 Coworker identity alias resolver | `f67080c4`, `799047f6` (polish) | 13/13 |
+
+**Build gate (Task 1.5):** `pnpm --filter @dpf/db exec vitest run` → 299 pass / 52 files. `pnpm --filter web exec vitest run` → 4389 pass / 14 skipped / 13 todo / 541 files. `cd apps/web && npx next build` → exit 0. 102 pre-existing Turbopack NFT-tracing warnings in `next.config.mjs` predate this chunk; tracked separately.
+
+**Deviations from plan.** Task 1.1 originally included `already_linked` as a `PromotionSkipReason`; spec compliance reviewer caught that the spec's resolution order delegates that gate to the caller (Task 2.1's Prisma query). Removed in `5e889ab0`. Task 1.4 implementer used a `findRepoRoot()` walk-up (looks for `pnpm-workspace.yaml`) rather than `process.cwd()` for cross-context portability — matches the existing pattern in `apps/web/scripts/internal/build-grant-catalog.ts`. No other deviations.
+
+**Open questions still pending (gating later chunks):**
+- #2 Model cost guardrail (gates Chunk 4 Task 4.3 description-enricher).
+- #3 Signature seed scope (gates Chunk 4 Task 4.3 fingerprint-enricher).
+- #4 Required-field gates default (gates Chunk 7 Task 7.3).
+- #5 Freshness thresholds (gates Chunk 4 Task 4.6).
+
+**Pre-flight blocker for Chunks 4–5.** `DiscoveryFingerprintCatalogVersion` table is empty (0 rows) on the bootstrap install. The fingerprint adapter (Task 1.3) is already shippable — it just returns `null` for empty input — but Chunks 4–5 depend on rules existing in the catalog. Either the upstream fingerprint contribution slice needs to ship its seed, or this plan needs to bootstrap a small initial catalog before Chunk 4.
+
+---
+
+## 14. References
 
 - [2026-03-13 Bootstrap Infrastructure Discovery and Portfolio Quality Foundation](./2026-03-13-bootstrap-infrastructure-discovery-and-portfolio-quality-foundation-design.md)
 - [2026-04-30 AI Coworker Operator Pattern](./2026-04-30-ai-coworker-operator-pattern.md)

--- a/packages/db/src/discovery-fingerprint-adapter.test.ts
+++ b/packages/db/src/discovery-fingerprint-adapter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { matchInventoryEntity, type AdapterRule } from "./discovery-fingerprint-adapter";
+
+const baseRule: AdapterRule = {
+  id: "r_1",
+  ruleKey: "rule.foundational.postgres",
+  status: "active",
+  matchExpression: {
+    all: [{ type: "contains", path: "image", value: "postgres" }],
+  },
+  requiredEvidenceFamilies: ["container_image"],
+  taxonomyNodeId: "tn_db",
+  identityConfidence: 0.9,
+  taxonomyConfidence: 0.85,
+  resolvedIdentity: {
+    manufacturer: "PostgreSQL Global Development Group",
+    productModel: "PostgreSQL",
+    technicalClass: "relational_database",
+    iconKey: "postgres",
+  },
+};
+
+const obsPostgres = {
+  evidenceFamilies: ["container_image"],
+  normalizedEvidence: { image: "postgres:16-alpine" },
+};
+
+describe("matchInventoryEntity", () => {
+  it("returns null when no rules match", () => {
+    const noMatchRule: AdapterRule = {
+      ...baseRule,
+      matchExpression: { all: [{ type: "exact", path: "image", value: "redis" }] },
+    };
+    expect(matchInventoryEntity(obsPostgres, { rules: [noMatchRule] })).toBeNull();
+  });
+
+  it("returns the matched rule's identity + taxonomy", () => {
+    const result = matchInventoryEntity(obsPostgres, { rules: [baseRule] });
+    expect(result).not.toBeNull();
+    expect(result!.ruleId).toBe("r_1");
+    expect(result!.ruleKey).toBe("rule.foundational.postgres");
+    expect(result!.taxonomyNodeId).toBe("tn_db");
+    expect(result!.manufacturer).toBe("PostgreSQL Global Development Group");
+    expect(result!.productModel).toBe("PostgreSQL");
+    expect(result!.technicalClass).toBe("relational_database");
+    expect(result!.iconKey).toBe("postgres");
+    expect(result!.combinedConfidence).toBeCloseTo(1.75);
+  });
+
+  it("returns the highest-combined-confidence match when multiple match", () => {
+    const lowConfRule: AdapterRule = {
+      ...baseRule,
+      id: "r_low",
+      ruleKey: "rule.generic.db",
+      identityConfidence: 0.5,
+      taxonomyConfidence: 0.5,
+      taxonomyNodeId: "tn_generic_db",
+      resolvedIdentity: { technicalClass: "database" },
+    };
+    const result = matchInventoryEntity(obsPostgres, { rules: [lowConfRule, baseRule] });
+    expect(result!.ruleId).toBe("r_1");
+    expect(result!.taxonomyNodeId).toBe("tn_db");
+  });
+
+  it("ignores rules whose status is not 'active'", () => {
+    const draftRule: AdapterRule = { ...baseRule, status: "draft" };
+    const deprecatedRule: AdapterRule = { ...baseRule, id: "r_dep", status: "deprecated" };
+    expect(matchInventoryEntity(obsPostgres, { rules: [draftRule, deprecatedRule] })).toBeNull();
+  });
+
+  it("respects requiredEvidenceFamilies — rule whose required family is absent does not match", () => {
+    const ruleNeedsBanner: AdapterRule = {
+      ...baseRule,
+      requiredEvidenceFamilies: ["banner_grab"],
+    };
+    // observation only has "container_image", not "banner_grab"
+    expect(matchInventoryEntity(obsPostgres, { rules: [ruleNeedsBanner] })).toBeNull();
+  });
+
+  it("returns null when rules list is empty", () => {
+    expect(matchInventoryEntity(obsPostgres, { rules: [] })).toBeNull();
+  });
+
+  it("populates only the resolvedIdentity fields that are present", () => {
+    const partialRule: AdapterRule = {
+      ...baseRule,
+      resolvedIdentity: { manufacturer: "Acme" },
+    };
+    const result = matchInventoryEntity(obsPostgres, { rules: [partialRule] });
+    expect(result!.manufacturer).toBe("Acme");
+    expect(result!.productModel).toBeUndefined();
+    expect(result!.technicalClass).toBeUndefined();
+    expect(result!.iconKey).toBeUndefined();
+  });
+});

--- a/packages/db/src/discovery-fingerprint-adapter.test.ts
+++ b/packages/db/src/discovery-fingerprint-adapter.test.ts
@@ -92,4 +92,43 @@ describe("matchInventoryEntity", () => {
     expect(result!.technicalClass).toBeUndefined();
     expect(result!.iconKey).toBeUndefined();
   });
+
+  it("breaks ties by preferring the earlier rule in the input list", () => {
+    const firstRule: AdapterRule = {
+      ...baseRule,
+      id: "r_first",
+      ruleKey: "rule.first",
+      identityConfidence: 0.5,
+      taxonomyConfidence: 0.5,
+    };
+    const secondRule: AdapterRule = {
+      ...baseRule,
+      id: "r_second",
+      ruleKey: "rule.second",
+      identityConfidence: 0.5,
+      taxonomyConfidence: 0.5,
+    };
+    // Both match obsPostgres; both have combinedConfidence = 1.0. First wins.
+    const result = matchInventoryEntity(obsPostgres, { rules: [firstRule, secondRule] });
+    expect(result!.ruleId).toBe("r_first");
+    // Reversing the order flips the winner — confirms tiebreak is positional.
+    const reversed = matchInventoryEntity(obsPostgres, { rules: [secondRule, firstRule] });
+    expect(reversed!.ruleId).toBe("r_second");
+  });
+
+  it("returns a match with taxonomyNodeId: null for identity-only rules (taxonomy gap)", () => {
+    const identityOnlyRule: AdapterRule = {
+      ...baseRule,
+      id: "r_identity_only",
+      ruleKey: "rule.identity_only",
+      taxonomyNodeId: null,
+      taxonomyConfidence: 0,
+    };
+    const result = matchInventoryEntity(obsPostgres, { rules: [identityOnlyRule] });
+    expect(result).not.toBeNull();
+    expect(result!.taxonomyNodeId).toBeNull();
+    expect(result!.manufacturer).toBe("PostgreSQL Global Development Group");
+    // Combined confidence still derived from sum, just with taxonomy=0.
+    expect(result!.combinedConfidence).toBeCloseTo(0.9);
+  });
 });

--- a/packages/db/src/discovery-fingerprint-adapter.ts
+++ b/packages/db/src/discovery-fingerprint-adapter.ts
@@ -4,11 +4,27 @@ import {
   type FingerprintRuleObservation,
 } from "./discovery-fingerprint-rules";
 
-/** Tightened view of `DiscoveryFingerprintRule` for adapter consumption. */
+/**
+ * Status values the adapter honors. Only `"active"` rules participate in
+ * matching; `"draft"` and `"deprecated"` are filtered out. Open to extension
+ * via the `(string & {})` escape hatch for future statuses (e.g. `"archived"`)
+ * without losing autocomplete on the known set.
+ */
+export type AdapterRuleStatus = "draft" | "active" | "deprecated" | (string & {});
+
+/**
+ * Tightened view of `DiscoveryFingerprintRule` for adapter consumption.
+ *
+ * Intentionally narrow: the adapter only needs the fields required to
+ * evaluate the rule and project a match into classification + enrichment
+ * hints. Rule fields not used here (`excludedSignals`, `scope`,
+ * `catalogVersionId`, etc.) are deliberately omitted — they belong to the
+ * underlying rules engine, not this projection.
+ */
 export interface AdapterRule {
   id: string;
   ruleKey: string;
-  status: string; // "draft" | "active" | "deprecated" — only "active" is honored
+  status: AdapterRuleStatus;
   matchExpression: FingerprintMatchExpression;
   requiredEvidenceFamilies: string[];
   taxonomyNodeId: string | null;
@@ -28,6 +44,12 @@ export interface AdapterMatch {
   taxonomyNodeId: string | null;
   identityConfidence: number;
   taxonomyConfidence: number;
+  /**
+   * `identityConfidence + taxonomyConfidence` (sum, NOT average). Carried in
+   * the result for ranking across adapters / candidate sets. Callers comparing
+   * scores from multiple sources should use this consistently or normalize
+   * before combining.
+   */
   combinedConfidence: number;
   manufacturer?: string;
   productModel?: string;

--- a/packages/db/src/discovery-fingerprint-adapter.ts
+++ b/packages/db/src/discovery-fingerprint-adapter.ts
@@ -1,0 +1,97 @@
+import {
+  evaluateFingerprintRule,
+  type FingerprintMatchExpression,
+  type FingerprintRuleObservation,
+} from "./discovery-fingerprint-rules";
+
+/** Tightened view of `DiscoveryFingerprintRule` for adapter consumption. */
+export interface AdapterRule {
+  id: string;
+  ruleKey: string;
+  status: string; // "draft" | "active" | "deprecated" — only "active" is honored
+  matchExpression: FingerprintMatchExpression;
+  requiredEvidenceFamilies: string[];
+  taxonomyNodeId: string | null;
+  identityConfidence: number;
+  taxonomyConfidence: number;
+  resolvedIdentity: {
+    manufacturer?: string;
+    productModel?: string;
+    technicalClass?: string;
+    iconKey?: string;
+  };
+}
+
+export interface AdapterMatch {
+  ruleId: string;
+  ruleKey: string;
+  taxonomyNodeId: string | null;
+  identityConfidence: number;
+  taxonomyConfidence: number;
+  combinedConfidence: number;
+  manufacturer?: string;
+  productModel?: string;
+  technicalClass?: string;
+  iconKey?: string;
+}
+
+/**
+ * Interpretation layer over `evaluateFingerprintRule`.
+ *
+ * 1. Filters rules to `status === "active"`.
+ * 2. Evaluates each remaining rule against the observation.
+ * 3. Of the rules that match, returns the one with the highest combined
+ *    confidence (`identityConfidence + taxonomyConfidence`). Stable tiebreak:
+ *    earliest rule in the original list wins.
+ * 4. Projects the rule's `resolvedIdentity` JSON + taxonomy fields into a
+ *    flat `AdapterMatch`, omitting absent identity fields entirely.
+ *
+ * Web/API code MUST call this adapter rather than evaluating rules directly.
+ */
+export function matchInventoryEntity(
+  observation: FingerprintRuleObservation,
+  context: { rules: AdapterRule[] },
+): AdapterMatch | null {
+  const activeRules = context.rules.filter((rule) => rule.status === "active");
+  if (activeRules.length === 0) {
+    return null;
+  }
+
+  let best: { rule: AdapterRule; combinedConfidence: number } | null = null;
+
+  for (const rule of activeRules) {
+    const evaluation = evaluateFingerprintRule(
+      {
+        ruleKey: rule.ruleKey,
+        requiredEvidenceFamilies: rule.requiredEvidenceFamilies,
+        matchExpression: rule.matchExpression,
+      },
+      observation,
+    );
+
+    if (!evaluation.matched) {
+      continue;
+    }
+
+    const combinedConfidence = rule.identityConfidence + rule.taxonomyConfidence;
+
+    if (best === null || combinedConfidence > best.combinedConfidence) {
+      best = { rule, combinedConfidence };
+    }
+  }
+
+  if (best === null) {
+    return null;
+  }
+
+  const { rule, combinedConfidence } = best;
+  return {
+    ruleId: rule.id,
+    ruleKey: rule.ruleKey,
+    taxonomyNodeId: rule.taxonomyNodeId,
+    identityConfidence: rule.identityConfidence,
+    taxonomyConfidence: rule.taxonomyConfidence,
+    combinedConfidence,
+    ...rule.resolvedIdentity,
+  };
+}

--- a/packages/db/src/discovery-promotion-policy.test.ts
+++ b/packages/db/src/discovery-promotion-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolvePromotionDecision, LEGACY_PROMOTABLE_TYPES } from "./discovery-promotion-policy";
+
+describe("resolvePromotionDecision", () => {
+  const baseEntity = {
+    entityType: "host",
+    attributionStatus: "attributed" as const,
+    attributionConfidence: 0.95,
+    digitalProductId: null,
+    taxonomyNodeId: "tn_1",
+  };
+  const taxonomyNode = { id: "tn_1", nodeId: "foundational/compute/servers", governance: null };
+  const portfolio = { id: "p_1", slug: "foundational" };
+
+  it("approves when policy is auto and all gates pass", () => {
+    const node = { ...taxonomyNode, governance: { promotion: { mode: "auto" } } };
+    expect(resolvePromotionDecision(baseEntity, node, portfolio)).toEqual({
+      decision: "promote",
+      classifyAs: undefined,
+      evidence: { source: "node-policy" },
+    });
+  });
+
+  it("falls back to legacy PROMOTABLE_TYPES when governance.promotion is missing", () => {
+    expect(resolvePromotionDecision(baseEntity, taxonomyNode, portfolio).decision).toBe("promote");
+    const ne = { ...baseEntity, entityType: "network_client" };
+    const skip = resolvePromotionDecision(ne, taxonomyNode, portfolio);
+    expect(skip.decision).toBe("skip");
+    expect(skip.reason).toBe("type_not_promotable");
+  });
+
+  it("skips with reason 'low_confidence_promotion' below threshold", () => {
+    const e = { ...baseEntity, attributionConfidence: 0.5 };
+    expect(resolvePromotionDecision(e, taxonomyNode, portfolio).reason).toBe("low_confidence_promotion");
+  });
+
+  it("skips with reason 'no_taxonomy' when taxonomyNode is null", () => {
+    const e = { ...baseEntity, taxonomyNodeId: null };
+    expect(resolvePromotionDecision(e, null, portfolio).reason).toBe("no_taxonomy");
+  });
+
+  it("skips with reason 'no_portfolio_root' when portfolio not found", () => {
+    expect(resolvePromotionDecision(baseEntity, taxonomyNode, null).reason).toBe("no_portfolio_root");
+  });
+
+  it("emits classifyAs from policy when provided", () => {
+    const node = { ...taxonomyNode, governance: { promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" } } };
+    const e = { ...baseEntity, entityType: "network_client" };
+    expect(resolvePromotionDecision(e, node, portfolio).classifyAs).toBe("infrastructure_endpoint");
+  });
+});
+
+describe("LEGACY_PROMOTABLE_TYPES", () => {
+  it("matches the historical list exactly", () => {
+    expect(LEGACY_PROMOTABLE_TYPES).toEqual([
+      "host","runtime","container","database","monitoring_service","ai_service",
+      "application","subnet","gateway","network_interface","docker_host","router",
+    ]);
+  });
+});

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure promotion policy resolver for the Discovery -> Portfolio handoff.
+ *
+ * Given a discovered entity, its taxonomy node (if any), and the portfolio
+ * root we plan to attach under, decide whether to promote into the digital
+ * product portfolio or skip with a structured reason.
+ *
+ * No DB calls, no I/O — callers fetch the inputs and persist the outcome.
+ */
+
+export const LEGACY_PROMOTABLE_TYPES: readonly string[] = [
+  "host",
+  "runtime",
+  "container",
+  "database",
+  "monitoring_service",
+  "ai_service",
+  "application",
+  "subnet",
+  "gateway",
+  "network_interface",
+  "docker_host",
+  "router",
+];
+
+export const AUTO_PROMOTE_THRESHOLD = 0.9;
+
+export type PromotionSkipReason =
+  | "no_taxonomy"
+  | "low_confidence_promotion"
+  | "no_portfolio_root"
+  | "type_not_promotable"
+  | "already_linked";
+
+export type PromotionDecision =
+  | { decision: "promote"; classifyAs?: string; reason?: undefined; evidence: object }
+  | { decision: "skip"; classifyAs?: undefined; reason: PromotionSkipReason; evidence: object };
+
+/**
+ * Loose input shapes — callers may pass richer Prisma rows; only these
+ * fields are read.
+ */
+export interface PromotionEntityInput {
+  entityType: string;
+  attributionStatus?: string;
+  attributionConfidence: number;
+  digitalProductId: string | null;
+  taxonomyNodeId: string | null;
+}
+
+export interface PromotionTaxonomyNodeInput {
+  id: string;
+  nodeId: string;
+  governance:
+    | {
+        promotion?: {
+          mode?: string;
+          classifyAs?: string;
+        } | null;
+      }
+    | null;
+}
+
+export interface PromotionPortfolioInput {
+  id: string;
+  slug: string;
+}
+
+export function resolvePromotionDecision(
+  entity: PromotionEntityInput,
+  taxonomyNode: PromotionTaxonomyNodeInput | null,
+  portfolio: PromotionPortfolioInput | null,
+): PromotionDecision {
+  // Gate 1: must have a taxonomy node to attach against.
+  if (taxonomyNode === null) {
+    return {
+      decision: "skip",
+      reason: "no_taxonomy",
+      evidence: { source: "gate", gate: "no_taxonomy" },
+    };
+  }
+
+  // Gate 2: confidence must clear the auto-promote bar.
+  if (entity.attributionConfidence < AUTO_PROMOTE_THRESHOLD) {
+    return {
+      decision: "skip",
+      reason: "low_confidence_promotion",
+      evidence: {
+        source: "gate",
+        gate: "low_confidence_promotion",
+        threshold: AUTO_PROMOTE_THRESHOLD,
+        observed: entity.attributionConfidence,
+      },
+    };
+  }
+
+  // Gate 3: portfolio root must exist.
+  if (portfolio === null) {
+    return {
+      decision: "skip",
+      reason: "no_portfolio_root",
+      evidence: { source: "gate", gate: "no_portfolio_root" },
+    };
+  }
+
+  // Gate 4: don't double-link entities that already point at a digital product.
+  if (entity.digitalProductId !== null) {
+    return {
+      decision: "skip",
+      reason: "already_linked",
+      evidence: {
+        source: "gate",
+        gate: "already_linked",
+        digitalProductId: entity.digitalProductId,
+      },
+    };
+  }
+
+  // Policy lookup: governance.promotion on the taxonomy node wins.
+  const promotionPolicy = taxonomyNode.governance?.promotion ?? null;
+
+  if (promotionPolicy && promotionPolicy.mode === "auto") {
+    return {
+      decision: "promote",
+      classifyAs: promotionPolicy.classifyAs,
+      evidence: { source: "node-policy" },
+    };
+  }
+
+  // Legacy fallback: type-based allowlist preserves historical behavior.
+  if (promotionPolicy === null) {
+    if (LEGACY_PROMOTABLE_TYPES.includes(entity.entityType)) {
+      return {
+        decision: "promote",
+        evidence: { source: "legacy-list" },
+      };
+    }
+    return {
+      decision: "skip",
+      reason: "type_not_promotable",
+      evidence: {
+        source: "legacy-list",
+        entityType: entity.entityType,
+      },
+    };
+  }
+
+  // Policy present but not auto (e.g. "manual"): treat as not promotable.
+  return {
+    decision: "skip",
+    reason: "type_not_promotable",
+    evidence: {
+      source: "node-policy",
+      mode: promotionPolicy.mode ?? null,
+    },
+  };
+}

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -31,9 +31,18 @@ export type PromotionSkipReason =
   | "no_portfolio_root"
   | "type_not_promotable";
 
+/**
+ * Evidence is a small, JSON-serializable bag of decision context. The set
+ * of keys varies by `source`; downstream consumers (e.g. Task 1.2's quality
+ * issue writer, Task 2.1's promotion runner) read `source` first, then the
+ * source-specific fields. Values are restricted to JSON primitives so the
+ * envelope can be stored directly in `PortfolioQualityIssue.details`.
+ */
+export type PromotionEvidence = Record<string, string | number | null>;
+
 export type PromotionDecision =
-  | { decision: "promote"; classifyAs?: string; reason?: undefined; evidence: object }
-  | { decision: "skip"; classifyAs?: undefined; reason: PromotionSkipReason; evidence: object };
+  | { decision: "promote"; classifyAs?: string; reason?: undefined; evidence: PromotionEvidence }
+  | { decision: "skip"; classifyAs?: undefined; reason: PromotionSkipReason; evidence: PromotionEvidence };
 
 /**
  * Loose input shapes — callers may pass richer Prisma rows; only these
@@ -53,7 +62,10 @@ export interface PromotionTaxonomyNodeInput {
   governance:
     | {
         promotion?: {
-          mode?: string;
+          // "auto" is the only mode the resolver acts on today; other values
+          // (e.g. a future "manual") fall through to the type_not_promotable
+          // skip path. Open to extension via the (string & {}) escape hatch.
+          mode?: "auto" | (string & {});
           classifyAs?: string;
         } | null;
       }

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -29,8 +29,7 @@ export type PromotionSkipReason =
   | "no_taxonomy"
   | "low_confidence_promotion"
   | "no_portfolio_root"
-  | "type_not_promotable"
-  | "already_linked";
+  | "type_not_promotable";
 
 export type PromotionDecision =
   | { decision: "promote"; classifyAs?: string; reason?: undefined; evidence: object }
@@ -103,18 +102,10 @@ export function resolvePromotionDecision(
     };
   }
 
-  // Gate 4: don't double-link entities that already point at a digital product.
-  if (entity.digitalProductId !== null) {
-    return {
-      decision: "skip",
-      reason: "already_linked",
-      evidence: {
-        source: "gate",
-        gate: "already_linked",
-        digitalProductId: entity.digitalProductId,
-      },
-    };
-  }
+  // Note: the caller is responsible for filtering out entities that already
+  // point at a digital product (Task 2.1's promoteInventoryEntities filters
+  // digitalProductId: null at the Prisma query level). The resolver does not
+  // gate on digitalProductId — keeping it pure over (entity, node, portfolio).
 
   // Policy lookup: governance.promotion on the taxonomy node wins.
   const promotionPolicy = taxonomyNode.governance?.promotion ?? null;

--- a/packages/db/src/portfolio-quality-issue-writer.test.ts
+++ b/packages/db/src/portfolio-quality-issue-writer.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  openOrUpdateQualityIssue,
+  computeIssueKey,
+  QUALITY_ISSUE_TYPES,
+} from "./portfolio-quality-issue-writer";
+
+describe("computeIssueKey", () => {
+  it("uses inventoryEntityId as the highest-priority scope key", () => {
+    expect(
+      computeIssueKey("type_not_promotable", {
+        inventoryEntityId: "ent_1",
+        portfolioId: "p_1",
+      }),
+    ).toBe("type_not_promotable:inventoryEntityId:ent_1");
+  });
+
+  it("falls back through priority order", () => {
+    expect(computeIssueKey("incomplete_detail", { digitalProductId: "dp_1" })).toBe(
+      "incomplete_detail:digitalProductId:dp_1",
+    );
+    expect(computeIssueKey("taxonomy_gap_proposal", { taxonomyNodeId: "tn_1" })).toBe(
+      "taxonomy_gap_proposal:taxonomyNodeId:tn_1",
+    );
+  });
+
+  it("throws when scope is empty", () => {
+    expect(() => computeIssueKey("type_not_promotable", {})).toThrow(/scope/);
+  });
+});
+
+describe("openOrUpdateQualityIssue", () => {
+  function mockDb() {
+    const upsert = vi.fn().mockResolvedValue({ id: "qi_1", issueKey: "k", status: "open" });
+    return { db: { portfolioQualityIssue: { upsert } }, upsert };
+  }
+
+  it("rejects unknown issueType before touching the db", async () => {
+    const { db, upsert } = mockDb();
+    await expect(
+      openOrUpdateQualityIssue({
+        db: db as never,
+        // @ts-expect-error invalid type on purpose
+        issueType: "nope",
+        scope: { inventoryEntityId: "e" },
+        summary: "x",
+      }),
+    ).rejects.toThrow(/unknown issue type/);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("opens a new issue with sensible defaults", async () => {
+    const { db, upsert } = mockDb();
+    await openOrUpdateQualityIssue({
+      db: db as never,
+      issueType: "type_not_promotable",
+      scope: { inventoryEntityId: "ent_1" },
+      summary: "skipped",
+    });
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const args = upsert.mock.calls[0][0];
+    expect(args.where).toEqual({ issueKey: "type_not_promotable:inventoryEntityId:ent_1" });
+    expect(args.create.status).toBe("open");
+    expect(args.create.severity).toBe("warn"); // default
+    expect(args.create.inventoryEntityId).toBe("ent_1");
+    expect(args.update.status).toBeUndefined(); // update path does NOT flip status when re-detecting
+  });
+
+  it("update path refreshes lastDetectedAt and may overwrite severity/summary", async () => {
+    const { db, upsert } = mockDb();
+    await openOrUpdateQualityIssue({
+      db: db as never,
+      issueType: "incomplete_detail",
+      scope: { digitalProductId: "dp_1" },
+      severity: "error",
+      summary: "missing manufacturer",
+    });
+    const args = upsert.mock.calls[0][0];
+    expect(args.update.lastDetectedAt).toBeInstanceOf(Date);
+    expect(args.update.severity).toBe("error");
+    expect(args.update.summary).toBe("missing manufacturer");
+  });
+
+  it("status='resolve' sets resolvedAt and flips status on update", async () => {
+    const { db, upsert } = mockDb();
+    await openOrUpdateQualityIssue({
+      db: db as never,
+      issueType: "type_not_promotable",
+      scope: { inventoryEntityId: "ent_1" },
+      summary: "no longer skipped",
+      status: "resolve",
+    });
+    const args = upsert.mock.calls[0][0];
+    expect(args.create.status).toBe("resolved");
+    expect(args.create.resolvedAt).toBeInstanceOf(Date);
+    expect(args.update.status).toBe("resolved");
+    expect(args.update.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  it("QUALITY_ISSUE_TYPES contains the canonical seven values", () => {
+    expect(QUALITY_ISSUE_TYPES).toEqual([
+      "type_not_promotable",
+      "no_taxonomy",
+      "no_portfolio_root",
+      "low_confidence_promotion",
+      "taxonomy_gap_proposal",
+      "incomplete_detail",
+      "enrichment_failed",
+    ]);
+  });
+});

--- a/packages/db/src/portfolio-quality-issue-writer.test.ts
+++ b/packages/db/src/portfolio-quality-issue-writer.test.ts
@@ -24,6 +24,18 @@ describe("computeIssueKey", () => {
     );
   });
 
+  it("falls back to portfolioId when narrower keys are absent", () => {
+    expect(computeIssueKey("no_portfolio_root", { portfolioId: "p_1" })).toBe(
+      "no_portfolio_root:portfolioId:p_1",
+    );
+  });
+
+  it("falls back to inventoryRelationshipId as the lowest priority", () => {
+    expect(
+      computeIssueKey("incomplete_detail", { inventoryRelationshipId: "rel_1" }),
+    ).toBe("incomplete_detail:inventoryRelationshipId:rel_1");
+  });
+
   it("throws when scope is empty", () => {
     expect(() => computeIssueKey("type_not_promotable", {})).toThrow(/scope/);
   });
@@ -95,6 +107,54 @@ describe("openOrUpdateQualityIssue", () => {
     expect(args.create.resolvedAt).toBeInstanceOf(Date);
     expect(args.update.status).toBe("resolved");
     expect(args.update.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  it("populates every passed scope FK on create so the row carries the breadcrumb", async () => {
+    const { db, upsert } = mockDb();
+    await openOrUpdateQualityIssue({
+      db: db as never,
+      issueType: "incomplete_detail",
+      scope: {
+        inventoryEntityId: "ent_1",
+        digitalProductId: "dp_1",
+        taxonomyNodeId: "tn_1",
+        portfolioId: "p_1",
+      },
+      summary: "missing manufacturer",
+    });
+    const args = upsert.mock.calls[0][0];
+    expect(args.create.inventoryEntityId).toBe("ent_1");
+    expect(args.create.digitalProductId).toBe("dp_1");
+    expect(args.create.taxonomyNodeId).toBe("tn_1");
+    expect(args.create.portfolioId).toBe("p_1");
+    expect(args.create.inventoryRelationshipId).toBe(null);
+  });
+
+  it("omits details from update payload when caller does not pass it", async () => {
+    const { db, upsert } = mockDb();
+    await openOrUpdateQualityIssue({
+      db: db as never,
+      issueType: "type_not_promotable",
+      scope: { inventoryEntityId: "ent_1" },
+      summary: "no details this time",
+    });
+    const args = upsert.mock.calls[0][0];
+    expect("details" in args.update).toBe(false);
+    expect("details" in args.create).toBe(false);
+  });
+
+  it("includes details on both create and update payloads when passed", async () => {
+    const { db, upsert } = mockDb();
+    await openOrUpdateQualityIssue({
+      db: db as never,
+      issueType: "type_not_promotable",
+      scope: { inventoryEntityId: "ent_1" },
+      summary: "with context",
+      details: { entityType: "network_client", source: "legacy-list" },
+    });
+    const args = upsert.mock.calls[0][0];
+    expect(args.create.details).toEqual({ entityType: "network_client", source: "legacy-list" });
+    expect(args.update.details).toEqual({ entityType: "network_client", source: "legacy-list" });
   });
 
   it("QUALITY_ISSUE_TYPES contains the canonical seven values", () => {

--- a/packages/db/src/portfolio-quality-issue-writer.ts
+++ b/packages/db/src/portfolio-quality-issue-writer.ts
@@ -1,0 +1,177 @@
+/**
+ * Shared writer for `PortfolioQualityIssue` rows.
+ *
+ * Several Discovery -> Portfolio surfaces (promotion runner, classifier,
+ * enricher, freshness aging, completeness gates) all need to record the same
+ * shape of quality issue against an inventory entity, taxonomy node, portfolio,
+ * digital product, or relationship. Without a single writer each surface
+ * invents its own `issueKey`, severity defaults, and resolve semantics.
+ *
+ * This module owns:
+ *   - the canonical `QualityIssueType` union (the seven kinds we recognize),
+ *   - `computeIssueKey` — deterministic key based on issueType + primary scope,
+ *   - `openOrUpdateQualityIssue` — the upsert that opens/refreshes/resolves.
+ *
+ * The DB shape is intentionally loose (`QualityIssueDb`) so callers can pass
+ * the real Prisma client OR a narrow handle in tests without dragging the
+ * full generated client type into this file.
+ */
+
+export const QUALITY_ISSUE_TYPES = [
+  "type_not_promotable",
+  "no_taxonomy",
+  "no_portfolio_root",
+  "low_confidence_promotion",
+  "taxonomy_gap_proposal",
+  "incomplete_detail",
+  "enrichment_failed",
+] as const;
+export type QualityIssueType = (typeof QUALITY_ISSUE_TYPES)[number];
+
+export type QualityIssueSeverity = "info" | "warn" | "error";
+
+export interface QualityIssueScope {
+  inventoryEntityId?: string;
+  inventoryRelationshipId?: string;
+  portfolioId?: string;
+  taxonomyNodeId?: string;
+  digitalProductId?: string;
+}
+
+export interface OpenOrUpdateQualityIssueArgs {
+  db: QualityIssueDb;
+  issueType: QualityIssueType;
+  scope: QualityIssueScope;
+  severity?: QualityIssueSeverity;
+  summary: string;
+  details?: Record<string, unknown>;
+  /** "open" (default) re-detects/refreshes; "resolve" flips status to resolved. */
+  status?: "open" | "resolve";
+}
+
+export interface QualityIssueDb {
+  portfolioQualityIssue: {
+    upsert(args: {
+      where: { issueKey: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+      select: { id: true; issueKey: true; status: true };
+    }): Promise<{ id: string; issueKey: string; status: string }>;
+  };
+}
+
+/**
+ * Priority order for selecting the "primary scope" key. The first non-empty
+ * field wins. Order is deliberately narrowest-first: an inventoryEntityId
+ * pins the issue to a specific discovered row, while portfolioId is broad.
+ */
+const SCOPE_PRIORITY: ReadonlyArray<keyof QualityIssueScope> = [
+  "inventoryEntityId",
+  "digitalProductId",
+  "taxonomyNodeId",
+  "portfolioId",
+  "inventoryRelationshipId",
+];
+
+function pickPrimaryScope(scope: QualityIssueScope): {
+  key: keyof QualityIssueScope;
+  id: string;
+} {
+  for (const key of SCOPE_PRIORITY) {
+    const id = scope[key];
+    if (typeof id === "string" && id.length > 0) {
+      return { key, id };
+    }
+  }
+  throw new Error("scope must include at least one FK");
+}
+
+export function computeIssueKey(
+  issueType: QualityIssueType,
+  scope: QualityIssueScope,
+): string {
+  const { key, id } = pickPrimaryScope(scope);
+  return `${issueType}:${key}:${id}`;
+}
+
+function isKnownIssueType(value: string): value is QualityIssueType {
+  return (QUALITY_ISSUE_TYPES as readonly string[]).includes(value);
+}
+
+export async function openOrUpdateQualityIssue(
+  args: OpenOrUpdateQualityIssueArgs,
+): Promise<{ id: string; issueKey: string; status: string }> {
+  const {
+    db,
+    issueType,
+    scope,
+    severity = "warn",
+    summary,
+    details,
+    status = "open",
+  } = args;
+
+  // Validate issueType BEFORE any DB call so unknown values can't leak rows.
+  if (!isKnownIssueType(issueType)) {
+    throw new Error(`unknown issue type: ${String(issueType)}`);
+  }
+
+  // computeIssueKey also validates that scope has at least one FK.
+  const issueKey = computeIssueKey(issueType, scope);
+  const now = new Date();
+
+  // Build the create payload. Always populate every scope FK that was passed
+  // so the row carries the full breadcrumb (a promotion-skip on an entity may
+  // also know its portfolio + taxonomy node).
+  const createBase: Record<string, unknown> = {
+    issueKey,
+    issueType,
+    severity,
+    summary,
+    firstDetectedAt: now,
+    lastDetectedAt: now,
+    inventoryEntityId: scope.inventoryEntityId ?? null,
+    inventoryRelationshipId: scope.inventoryRelationshipId ?? null,
+    portfolioId: scope.portfolioId ?? null,
+    taxonomyNodeId: scope.taxonomyNodeId ?? null,
+    digitalProductId: scope.digitalProductId ?? null,
+  };
+  if (details !== undefined) {
+    createBase.details = details;
+  }
+
+  // Update path: latest detection wins for severity/summary/details and we
+  // always refresh `lastDetectedAt`. We never roll back firstDetectedAt or
+  // change scope FKs on update — those are immutable for a given issueKey.
+  const updateBase: Record<string, unknown> = {
+    lastDetectedAt: now,
+    severity,
+    summary,
+  };
+  if (details !== undefined) {
+    updateBase.details = details;
+  }
+
+  if (status === "resolve") {
+    // Resolve path: row may not exist yet (rare — e.g. the surface that
+    // would have created it ran while the issue was already gone). Either
+    // way the persisted state is the same: status=resolved, resolvedAt=now.
+    createBase.status = "resolved";
+    createBase.resolvedAt = now;
+    updateBase.status = "resolved";
+    updateBase.resolvedAt = now;
+  } else {
+    // Open path: create as open; on update do NOT flip status. Re-detecting
+    // an already-resolved issue should not silently re-open it — that's a
+    // policy decision callers should make explicitly via status:"open" only
+    // for fresh detections, not from a resolve loop.
+    createBase.status = "open";
+  }
+
+  return db.portfolioQualityIssue.upsert({
+    where: { issueKey },
+    create: createBase,
+    update: updateBase,
+    select: { id: true, issueKey: true, status: true },
+  });
+}

--- a/packages/db/src/portfolio-quality-issue-writer.ts
+++ b/packages/db/src/portfolio-quality-issue-writer.ts
@@ -98,6 +98,28 @@ function isKnownIssueType(value: string): value is QualityIssueType {
   return (QUALITY_ISSUE_TYPES as readonly string[]).includes(value);
 }
 
+/**
+ * Upsert a `PortfolioQualityIssue` keyed deterministically by
+ * `(issueType, primary scope FK)`.
+ *
+ * Behavior by `status` arg:
+ * - `"open"` (default) — create as `status:"open"` if new; if a row already
+ *   exists, refresh `lastDetectedAt` plus latest `severity`/`summary`/`details`
+ *   but **do NOT change `status`**. This means re-detecting an issue against
+ *   a row already marked `resolved` will refresh the detection timestamp /
+ *   summary while leaving the row resolved. Callers that want to re-open a
+ *   resolved row must do so explicitly (e.g. via direct DB update); this
+ *   writer never silently reverses a resolve.
+ * - `"resolve"` — set `status:"resolved"` + `resolvedAt:now` on both create
+ *   and update paths. Idempotent: resolving an already-resolved row just
+ *   refreshes `resolvedAt`.
+ *
+ * `firstDetectedAt` and the scope FK columns are written on `create` only;
+ * the update payload never touches them.
+ *
+ * Validates `issueType` against `QUALITY_ISSUE_TYPES` BEFORE touching the DB.
+ * Validates that `scope` contains at least one FK BEFORE the upsert.
+ */
 export async function openOrUpdateQualityIssue(
   args: OpenOrUpdateQualityIssueArgs,
 ): Promise<{ id: string; issueKey: string; status: string }> {


### PR DESCRIPTION
## Summary

Lands Chunk 1 of the [Discovery → Portfolio Gap Closure plan](docs/superpowers/plans/2026-04-30-discovery-portfolio-gap-closure-plan.md): four pure helpers that the remaining chunks depend on. **Zero production behavior change** — these are foundation modules; nothing wires them into runtime paths yet.

## What landed

| Task | File | Tests |
| - | - | - |
| 1.1 Promotion policy resolver | `packages/db/src/discovery-promotion-policy.ts` | 7 |
| 1.2 Shared quality-issue writer | `packages/db/src/portfolio-quality-issue-writer.ts` | 13 |
| 1.3 Fingerprint-rule adapter | `packages/db/src/discovery-fingerprint-adapter.ts` | 9 |
| 1.4 Coworker identity alias resolver | `apps/web/lib/coworker-identity.ts` | 13 |

42 unit tests for ~340 LOC of helpers. Each task TDD-developed with spec compliance + code quality reviews; should-fix advisories applied inline before merge.

## Build gate

- `pnpm --filter @dpf/db exec vitest run` → **299 pass / 52 files**
- `pnpm --filter web exec vitest run` → **4389 pass / 14 skipped / 13 todo / 541 files**
- `cd apps/web && npx next build` → **exit 0** (102 pre-existing Turbopack NFT warnings unrelated to this chunk)

## Notable design decisions

- **`PromotionSkipReason` does NOT include `already_linked`** — that gate belongs to Task 2.1's caller (Prisma query already filters `digitalProductId: null`). Spec compliance fix in `5e889ab0`.
- **`AGT-WS-INVENTORY` agent_id preserved** — coworker identity resolver supports the future `estate-specialist` alias via fixture-injected registry, with the actual `agent_registry.json` patch deferred to Chunk 6 Task 6.1.
- **Fingerprint adapter delegates to `evaluateFingerprintRule`** rather than duplicating match logic — web/API code in Chunks 4-5 must use the adapter, never the rules engine directly.
- **`openOrUpdateQualityIssue` does NOT silently re-open resolved rows** when re-detected — callers must explicitly re-open if that's the desired semantic.

## Test plan

- [x] All 42 new unit tests pass
- [x] Full vitest suite green across both workspaces
- [x] `next build` exits 0
- [x] Spec compliance + code quality reviews applied to each task
- [x] Final cross-cutting review across all four helpers (APPROVED FOR PR)
- [x] Implementation Status section appended to spec with deviations noted

## Follow-ups for Chunk 2

- Map `PromotionSkipReason` → `QualityIssueType` via a typed lookup table (the identical naming is by design but the compiler should enforce it).
- Avoid casting `decision.evidence` at the call site — if needed, upgrade `PromotionEvidence` to `Record<string, unknown>` and add a shared `EvidenceSource` literal type.
- Consider adding `packages/db/src/index.ts` barrel exports when wiring the helpers into `promoteInventoryEntities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)