### PR TITLE
fix(coworkers): clarify saveBuildEvidence args in prompt + tool description

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -980,14 +980,14 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   // ─── Build Studio Lifecycle Tools (EP-SELF-DEV-002) ───────────────────────
   {
     name: "saveBuildEvidence",
-    description: "Save evidence to a FeatureBuild record. Fields: designDoc, buildPlan, taskResults, verificationOut, acceptanceMet.",
+    description: "Save evidence to a FeatureBuild record. ALWAYS pass both `field` and `value` — calls with empty `{}` are rejected. Example: `{field: \"designDoc\", value: {summary: \"...\", files: [\"apps/web/...\"], approach: \"...\"}}`. Valid fields: designDoc, designReview, buildPlan, planReview, taskResults, verificationOut, acceptanceMet.",
     inputSchema: {
       type: "object",
       properties: {
-        field: { type: "string", enum: ["designDoc", "designReview", "buildPlan", "planReview", "taskResults", "verificationOut", "acceptanceMet"], description: "Evidence field to update" },
-        value: { type: "object", description: "JSON value to store" },
+        field: { type: "string", enum: ["designDoc", "designReview", "buildPlan", "planReview", "taskResults", "verificationOut", "acceptanceMet"], description: "Evidence field to update — required" },
+        value: { type: "object", description: "JSON value to store — required, do not omit. Shape varies by field; for designDoc include summary/files/approach, for buildPlan include tasks array with per-task acceptance criteria." },
       },
-      required: ["field"],
+      required: ["field", "value"],
     },
     requiredCapability: "view_platform",
     executionMode: "immediate",

--- a/prompts/route-persona/build-specialist.prompt.md
+++ b/prompts/route-persona/build-specialist.prompt.md
@@ -79,6 +79,13 @@ Features as code, schemas, components, and tests across the five build phases: I
 
 A turn that the user sees as "done with this phase" without the corresponding field saved is a contract violation, not a polite stopping point.
 
+**Always pass both `field` and `value` to `saveBuildEvidence`.** Calls with empty `{}` are rejected. Concrete shapes:
+
+- `saveBuildEvidence({ field: "designDoc", value: { summary, files, approach, risks } })`
+- `saveBuildEvidence({ field: "buildPlan", value: { tasks: [{ id, file, change, acceptanceCriterion }, ...], fileStructure } })`
+- `saveBuildEvidence({ field: "verificationOut", value: { typecheck: "pass"|"fail", tests: { passed, failed }, errors: [] } })`
+- `saveBuildEvidence({ field: "acceptanceMet", value: { acceptanceCriteria: [{ id, met: true|false, evidence }], userOverride?: "..." } })`
+
 ## 3. Short confirmations advance
 
 `ok`, `yes`, `proceed`, `next`, `continue`, `go` advance the active phase using the most recent saved evidence. They do not restart research. If `designDoc` was saved last turn and the user says `ok`, the next turn calls `reviewDesignDoc` — not `start_ideate_research` again.


### PR DESCRIPTION
## Summary

Closes [BI-255C460B](docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md). Slice 1 validation on 2026-05-01 (driving BI-E9CD1B92 through Build Studio) showed the build-specialist agent calling \`saveBuildEvidence({})\` with empty params on first attempts before self-correcting. The repetition guard caught it after 3 retries, but it burned iterations and tokens.

Root cause: prompt mentions \`saveBuildEvidence\` but doesn't show the argument shape, and the tool's description is just \"Save evidence to a FeatureBuild record\" with no example. Haiku-class models often need an inline example.

## Changes

- **\`apps/web/lib/mcp-tools.ts\`** — saveBuildEvidence description now includes a concrete example, marks both \`field\` and \`value\` as required, and gives shape hints per field. \`value\` added to \`required[]\` array of the input schema so the platform rejects empty-value calls structurally.
- **\`prompts/route-persona/build-specialist.prompt.md\`** — clause 2.2 adds four inline examples (designDoc / buildPlan / verificationOut / acceptanceMet) right after the phase-required-field table.

## Test plan

- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter web exec vitest run lib/tak/build-specialist-prompt.test.ts\` — 6/6 pass (prompt structural test still satisfied)
- [x] \`pnpm --filter web exec tsx scripts/audit-prompt-state-leakage.ts\` — baseline unchanged, no new violations
- [ ] Re-run BI-E9CD1B92 lifecycle through Build Studio after merge to verify saveBuildEvidence first-attempt success rate improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)