### PR TITLE
fix(build-studio): auto-derive intake anchors for triaged-BI builds

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4640,6 +4640,59 @@ export async function executeTool(
             }
           }
 
+          // Auto-derive constrainedGoal if missing — fall back to the build
+          // title. For triaged-BI builds the title was generated from the BI
+          // body which itself was triaged, so the title IS the constrained
+          // goal for governance purposes. For ad-hoc free-text builds where
+          // the user explicitly set a goal via update_feature_brief, this
+          // path is a no-op (the goal is already populated).
+          //
+          // Closes BI-0B3EAAC8: the existing reviewDesignDoc auto-advance
+          // already auto-creates epic + backlog item but did NOT auto-derive
+          // constrainedGoal or taxonomyNodeId, so triaged-BI builds got
+          // stuck in ideate forever even when the BI body fully described
+          // the work.
+          if (!happyPathState.intake.constrainedGoal && updatedBuild.title) {
+            try {
+              const goal = updatedBuild.title.trim().slice(0, 280);
+              await updateBuildHappyPathState(userId, {
+                intake: { constrainedGoal: goal },
+              }, buildId);
+              happyPathState = {
+                ...happyPathState,
+                intake: { ...happyPathState.intake, constrainedGoal: goal },
+              };
+              logBuildActivity(buildId, "auto-intake:constrained-goal", `Auto-set constrainedGoal from build title`);
+            } catch (err) {
+              console.warn("[reviewDesignDoc] auto-set constrainedGoal failed:", err);
+            }
+          }
+
+          // Auto-derive taxonomyNodeId for triaged-BI builds. The BI's
+          // existence + triage outcome IS the categorization for governance
+          // purposes — we just need a stable, traceable anchor that
+          // satisfies isHappyPathIntakeReady. Use the originating BI id as
+          // a "triaged-bi:" prefixed anchor so downstream UI can recognize
+          // the difference between a real taxonomy node and a triaged-BI
+          // bypass. For ad-hoc builds without an originating BI, leave
+          // taxonomyNodeId null — the agent must call
+          // confirm_taxonomy_placement explicitly for those.
+          if (!happyPathState.intake.taxonomyNodeId && updatedBuild.originatingBacklogItemId) {
+            try {
+              const anchor = `triaged-bi:${updatedBuild.originatingBacklogItemId}`;
+              await updateBuildHappyPathState(userId, {
+                intake: { taxonomyNodeId: anchor },
+              }, buildId);
+              happyPathState = {
+                ...happyPathState,
+                intake: { ...happyPathState.intake, taxonomyNodeId: anchor },
+              };
+              logBuildActivity(buildId, "auto-intake:taxonomy-anchor", `Auto-set taxonomyNodeId=${anchor}`);
+            } catch (err) {
+              console.warn("[reviewDesignDoc] auto-set taxonomyNodeId failed:", err);
+            }
+          }
+
           const gate = checkPhaseGate("ideate", "plan", {
             designDoc: updatedBuild.designDoc,
             designReview: updatedBuild.designReview,


### PR DESCRIPTION
## Summary

Closes [BI-0B3EAAC8](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues). Slice 1 validation on 2026-05-01 surfaced that the ideate-to-plan phase gate held forever even after design review passed, because \`happyPathState\` was missing two intake anchors:

- \`constrainedGoal\` (set by \`update_feature_brief\`)
- \`taxonomyNodeId\` (set by \`confirm_taxonomy_placement\`)

The existing \`reviewDesignDoc\` auto-advance code (\`apps/web/lib/mcp-tools.ts:4538+\`) already auto-creates \`epicId\` and \`backlogItemId\` if missing — this extends the same pattern to the other two anchors for triaged-BI builds.

## Behavior

| Field | Source |
|---|---|
| \`epicId\` | (existing) auto-created via \`createBuildEpic\` |
| \`backlogItemId\` | (existing) auto-created from \`updatedBuild.title\` + \`description\` |
| **\`constrainedGoal\`** | **NEW** — falls back to \`updatedBuild.title\` (which the orchestrator generated from the originating BI body) |
| **\`taxonomyNodeId\`** | **NEW** — \`triaged-bi:<itemId>\` for builds with \`originatingBacklogItemId\` set; null otherwise |

For ad-hoc free-text builds (no originating BI), \`taxonomyNodeId\` stays null and the agent must still call \`confirm_taxonomy_placement\` explicitly. Governance for triaged BIs is satisfied by the BI's existing triage outcome.

## Why a sentinel and not a real taxonomy node

\`taxonomyNodeId\` is just \`String\` in the schema; it's not FK'd to a TaxonomyNode table. The auto-derived value uses a \`triaged-bi:\` prefix so downstream UI / audit can recognize the bypass vs a real explicit taxonomy placement. This avoids fabricating a fake real-taxonomy reference.

## Test plan

- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter web exec vitest run lib/integrate lib/explore/feature-build-types\` — 59/59 pass (no regression)
- [ ] Re-run BI-E9CD1B92 lifecycle through Build Studio post-merge to verify the gate now advances ideate → plan automatically

## Related

- Spec: \`docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md\`
- Validation evidence: 2026-05-01 BI-E9CD1B92 / FB-2A2C2AC5 lifecycle attempt
- BI-77A1973C (advance-phase UI button) is a separate next-slice concern; this PR fixes the gate logic, not the UI affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)