### PR TITLE
fix(build-studio): show all org builds in cockpit list, not just current-user

### DIFF
--- a/apps/web/lib/actions/build-read.ts
+++ b/apps/web/lib/actions/build-read.ts
@@ -32,7 +32,14 @@ export async function getFeatureBuild(buildId: string): Promise<FeatureBuildRow 
     },
   });
 
-  if (!build || build.createdById !== session.user.id) return null;
+  // Authorization: require an authenticated session, not specific ownership.
+  // Build Studio is internal-cockpit-only and DPF is single-org-per-install,
+  // so any authenticated user on this install can view any build in the org.
+  // The previous ownership check hid builds promoted via MCP under a different
+  // identity from the portal-logged-in user (BI-AA03296D). The list query
+  // in apps/web/lib/feature-build-data.ts:getFeatureBuilds was relaxed in the
+  // same PR for the same reason.
+  if (!build) return null;
 
   return {
     ...build,

--- a/apps/web/lib/explore/feature-build-data.ts
+++ b/apps/web/lib/explore/feature-build-data.ts
@@ -7,8 +7,20 @@ import type { BuildContext } from "@/lib/build-agent-prompts";
 import type { AttachmentInfo } from "@/lib/agent-coworker-types";
 
 export const getFeatureBuilds = cache(async (userId: string): Promise<FeatureBuildRow[]> => {
+  // Build Studio is internal-cockpit-only and DPF is single-org-per-install
+  // (per project memory `single_org_per_install`). All authenticated users on
+  // this install belong to the same Org and have full visibility into Org-
+  // scoped build work. Filtering by createdById hid builds promoted via MCP
+  // under a different identity from the portal-logged-in user (BI-AA03296D),
+  // which broke the natural cross-identity workflow of MCP-driven promotion +
+  // portal-driven supervision. The userId param is retained for backwards
+  // compatibility (and so cache keys remain user-scoped) but no longer used
+  // as a filter. The per-build authorization check in
+  // apps/web/lib/actions/build-read.ts:getFeatureBuild was relaxed in the same
+  // PR for the same reason.
+  void userId;
   const rows = await prisma.featureBuild.findMany({
-    where: { createdById: userId, phase: { not: "failed" } },
+    where: { phase: { not: "failed" } },
     orderBy: { updatedAt: "desc" },
     select: {
       id: true,


### PR DESCRIPTION
## Summary

Closes [BI-AA03296D](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues). Build Studio's cockpit list at \`/build\` filtered by \`FeatureBuild.createdById = session.user.id\`, hiding builds promoted via MCP under a different identity from the portal-logged-in user. Surfaced 2026-04-30 during the BI-E9CD1B92 lifecycle test — the build was created via MCP under \`markdbodman@gmail.com\` but the portal session was \`admin@dpf.local\`, so the build was invisible.

DPF is single-org-per-install (project memory \`single_org_per_install\`); all authenticated users on this install belong to the same Org and have full visibility into Org-scoped build work. The previous filter was the wrong shape for an internal cockpit.

## Changes

| File | Change |
|---|---|
| \`apps/web/lib/feature-build-data.ts\` | \`getFeatureBuilds\` — drop \`createdById\` from WHERE; \`userId\` param retained for cache key only |
| \`apps/web/lib/actions/build-read.ts\` | \`getFeatureBuild\` — drop ownership check; require authenticated session only |

\`agent-coworker.ts\` retains its \`createdById\` filters in 5+ places — those are \"find THIS user's latest active build\" lookups for sendMessage routing, not visibility checks. Correct behavior, not a regression.

## Test plan

- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter web exec vitest run lib/explore/ lib/actions/build-read\` — 73/73 pass
- [ ] Post-merge: a build promoted via MCP under one user identity should be visible/openable from a portal session under a different user

## Related

- BI-E9CD1B92 / FB-2A2C2AC5 (the original lifecycle test where this was surfaced)
- BI-0B3EAAC8 (intake-anchors gate auto-derive — separate fix in PR #375)

🤖 Generated with [Claude Code](https://claude.com/claude-code)