### PR TITLE
Add WhatsApp Business native readiness integration

### DIFF
--- a/apps/web/app/(shell)/platform/tools/integrations/page.test.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/page.test.tsx
@@ -24,4 +24,15 @@ describe("EnterpriseIntegrationsPage", () => {
     expect(html).toContain("Facebook Pages");
     expect(html).toContain("/platform/tools/integrations/facebook-pages");
   });
+
+  it("surfaces WhatsApp Business on the native integrations landing page", async () => {
+    mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(1);
+
+    const { default: EnterpriseIntegrationsPage } = await import("./page");
+    const html = renderToStaticMarkup(await EnterpriseIntegrationsPage());
+
+    expect(html).toContain("WhatsApp Business");
+    expect(html).toContain("Localized Messaging");
+    expect(html).toContain("/platform/tools/integrations/whatsapp-business");
+  });
 });

--- a/apps/web/app/(shell)/platform/tools/integrations/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/page.tsx
@@ -140,6 +140,16 @@ export default async function EnterpriseIntegrationsPage() {
           ]}
         />
         <PlatformSummaryCard
+          title="WhatsApp Business"
+          description="Localized messaging readiness anchor for phone quality, approved templates, and language coverage on the enterprise substrate."
+          href="/platform/tools/integrations/whatsapp-business"
+          accent="var(--dpf-success)"
+          metrics={[
+            { label: "Category", value: "Localized Messaging" },
+            { label: "Model", value: "Native" },
+          ]}
+        />
+        <PlatformSummaryCard
           title="Mailchimp Marketing"
           description="Email marketing anchor for audiences, recent campaigns, and approved customer outreach context on the enterprise substrate."
           href="/platform/tools/integrations/mailchimp"

--- a/apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.test.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const { mockFindUnique, mockLoadPreview, mockAuth, mockCan } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockLoadPreview: vi.fn(),
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    integrationCredential: {
+      findUnique: mockFindUnique,
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((target: string) => {
+    throw new Error(`redirect:${target}`);
+  }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: mockCan,
+}));
+
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  decryptJson: vi.fn((value: string) => JSON.parse(value)),
+}));
+
+vi.mock("@/lib/integrate/whatsapp-business/preview", () => ({
+  loadWhatsAppBusinessPreview: mockLoadPreview,
+}));
+
+vi.mock("@/components/integrations/WhatsAppBusinessConnectPanel", () => ({
+  WhatsAppBusinessConnectPanel: ({
+    initialState,
+  }: {
+    initialState: {
+      status: string;
+      wabaId: string | null;
+      phoneNumberId: string | null;
+      displayPhoneNumber: string | null;
+    };
+  }) => (
+    <div
+      data-component="whatsapp-business-connect-panel"
+      data-status={initialState.status}
+      data-waba-id={initialState.wabaId ?? ""}
+      data-phone-number-id={initialState.phoneNumberId ?? ""}
+      data-display-phone-number={initialState.displayPhoneNumber ?? ""}
+    />
+  ),
+}));
+
+describe("WhatsAppBusinessPage", () => {
+  it("renders phone readiness and localized template preview", async () => {
+    mockAuth.mockResolvedValue({
+      user: { platformRole: "superadmin", isSuperuser: true },
+    });
+    mockCan.mockReturnValue(true);
+    mockFindUnique.mockResolvedValue({
+      integrationId: "whatsapp-business",
+      status: "connected",
+      lastErrorMsg: null,
+      lastTestedAt: new Date("2026-05-01T11:00:00.000Z"),
+      fieldsEnc: JSON.stringify({
+        wabaId: "waba-123",
+        phoneNumberId: "phone-456",
+        displayPhoneNumber: "+1 512-555-0100",
+      }),
+    });
+    mockLoadPreview.mockResolvedValue({
+      state: "available",
+      preview: {
+        phoneNumber: {
+          id: "phone-456",
+          displayPhoneNumber: "+1 512-555-0100",
+          verifiedName: "Acme Austin",
+          qualityRating: "GREEN",
+          codeVerificationStatus: "VERIFIED",
+          platformType: "CLOUD_API",
+        },
+        templates: [
+          {
+            id: "template-1",
+            name: "appointment_reminder",
+            language: "en_US",
+            status: "APPROVED",
+            category: "UTILITY",
+            bodyText: "Reminder for {{1}}",
+          },
+        ],
+        localeSummary: [{ language: "en_US", approved: 1, pending: 0, rejected: 0 }],
+        loadedAt: "2026-05-01T11:45:00.000Z",
+      },
+    });
+
+    const { default: WhatsAppBusinessPage } = await import("./page");
+    const html = renderToStaticMarkup(await WhatsAppBusinessPage());
+
+    expect(mockLoadPreview).toHaveBeenCalledTimes(1);
+    expect(html).toContain('data-component="whatsapp-business-connect-panel"');
+    expect(html).toContain("Live WhatsApp readiness");
+    expect(html).toContain("+1 512-555-0100");
+    expect(html).toContain("appointment_reminder");
+    expect(html).toContain("en_US");
+  });
+});

--- a/apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.tsx
@@ -1,0 +1,318 @@
+import { redirect } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { decryptJson } from "@/lib/govern/credential-crypto";
+import { loadWhatsAppBusinessPreview } from "@/lib/integrate/whatsapp-business/preview";
+import {
+  WhatsAppBusinessConnectPanel,
+  type WhatsAppBusinessConnectionState,
+} from "@/components/integrations/WhatsAppBusinessConnectPanel";
+
+export default async function WhatsAppBusinessPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  if (
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    redirect("/platform/tools");
+  }
+
+  const record = await prisma.integrationCredential.findUnique({
+    where: { integrationId: "whatsapp-business" },
+  });
+
+  const baseState = toConnectionState(record);
+  const preview = baseState.status === "connected" ? await loadWhatsAppBusinessPreview() : null;
+  const initialState = applyPreviewToConnectionState(baseState, preview);
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
+          <a href="/platform/tools" className="hover:underline">
+            Tools
+          </a>
+          <span>/</span>
+          <span>Native Integrations</span>
+          <span>/</span>
+          <span>WhatsApp Business</span>
+        </div>
+        <h1 className="mt-1 text-2xl font-bold text-[var(--dpf-text)]">WhatsApp Business</h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Customer-configured localized messaging readiness for WhatsApp Business. DPF stores
+          the Meta token encrypted in this install and performs read-first phone and template
+          probes before any outbound message, automation, or webhook subscription workflows are added.
+        </p>
+      </div>
+
+      <WhatsAppBusinessConnectPanel initialState={initialState} />
+      <WhatsAppBusinessPreviewSection preview={preview} />
+
+      <aside className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm">
+        <h2 className="font-semibold text-[var(--dpf-text)]">What this integration enables</h2>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-[var(--dpf-muted)]">
+          <li>Verifies the local WhatsApp Business phone number and Cloud API readiness posture.</li>
+          <li>Surfaces approved, pending, and rejected message templates by language and category.</li>
+          <li>Helps operators spot missing localized templates before customer outreach is designed.</li>
+          <li>Keeps outbound messaging and webhook changes out of scope until governance is explicit.</li>
+        </ul>
+      </aside>
+    </div>
+  );
+}
+
+type IntegrationCredentialRow = Awaited<
+  ReturnType<typeof prisma.integrationCredential.findUnique>
+>;
+
+function toConnectionState(record: IntegrationCredentialRow): WhatsAppBusinessConnectionState {
+  if (!record) {
+    return {
+      status: "unconfigured",
+      wabaId: null,
+      phoneNumberId: null,
+      displayPhoneNumber: null,
+      lastErrorMsg: null,
+      lastTestedAt: null,
+    };
+  }
+
+  const decoded = decryptJson<{
+    wabaId?: string;
+    phoneNumberId?: string;
+    displayPhoneNumber?: string;
+  }>(record.fieldsEnc);
+
+  return {
+    status:
+      record.status === "connected" || record.status === "error"
+        ? record.status
+        : "unconfigured",
+    wabaId: typeof decoded?.wabaId === "string" ? decoded.wabaId : null,
+    phoneNumberId:
+      typeof decoded?.phoneNumberId === "string" ? decoded.phoneNumberId : null,
+    displayPhoneNumber:
+      typeof decoded?.displayPhoneNumber === "string" ? decoded.displayPhoneNumber : null,
+    lastErrorMsg: record.lastErrorMsg,
+    lastTestedAt: record.lastTestedAt ? record.lastTestedAt.toISOString() : null,
+  };
+}
+
+function applyPreviewToConnectionState(
+  state: WhatsAppBusinessConnectionState,
+  preview: Awaited<ReturnType<typeof loadWhatsAppBusinessPreview>> | null,
+): WhatsAppBusinessConnectionState {
+  if (!preview) return state;
+
+  if (preview.state === "available") {
+    return {
+      ...state,
+      status: "connected",
+      phoneNumberId: preview.preview.phoneNumber.id,
+      displayPhoneNumber: preview.preview.phoneNumber.displayPhoneNumber,
+      lastErrorMsg: null,
+      lastTestedAt: preview.preview.loadedAt,
+    };
+  }
+
+  if (preview.state === "error") {
+    return {
+      ...state,
+      status: "error",
+      lastErrorMsg: preview.error,
+    };
+  }
+
+  return state;
+}
+
+function WhatsAppBusinessPreviewSection({
+  preview,
+}: {
+  preview: Awaited<ReturnType<typeof loadWhatsAppBusinessPreview>> | null;
+}) {
+  if (!preview) return null;
+
+  if (preview.state === "error") {
+    return (
+      <section className="rounded-lg border border-[var(--dpf-error)]/40 bg-[color-mix(in_srgb,var(--dpf-error)_10%,transparent)] p-4 text-sm">
+        <h2 className="font-semibold text-[var(--dpf-text)]">Preview unavailable</h2>
+        <p className="mt-1 text-[var(--dpf-muted)]">
+          DPF could not refresh the WhatsApp Business readiness preview.
+        </p>
+        <p className="mt-2 font-medium text-[var(--dpf-error)]">{preview.error}</p>
+      </section>
+    );
+  }
+
+  if (preview.state === "unavailable") {
+    return (
+      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm">
+        <h2 className="font-semibold text-[var(--dpf-text)]">Preview unavailable</h2>
+        <p className="mt-1 text-[var(--dpf-muted)]">
+          Connect WhatsApp Business credentials to load phone, quality, and template readiness.
+        </p>
+      </section>
+    );
+  }
+
+  const { preview: previewData } = preview;
+
+  return (
+    <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h2 className="font-semibold text-[var(--dpf-text)]">Live WhatsApp readiness</h2>
+          <p className="mt-1 text-[var(--dpf-muted)]">
+            Read-first phone readiness, quality signal, and localized template context from Meta.
+          </p>
+        </div>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          Loaded {formatDateTime(previewData.loadedAt)}
+        </p>
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-3">
+        <PreviewCard title="Phone readiness" fallback="No phone readiness returned.">
+          <PreviewRow label="Phone" value={previewData.phoneNumber.displayPhoneNumber} />
+          <PreviewRow label="Phone ID" value={previewData.phoneNumber.id} />
+          <PreviewRow label="Verified name" value={previewData.phoneNumber.verifiedName} />
+          <PreviewRow label="Quality" value={previewData.phoneNumber.qualityRating} />
+          <PreviewRow label="Verification" value={previewData.phoneNumber.codeVerificationStatus} />
+          <PreviewRow label="Platform" value={previewData.phoneNumber.platformType} />
+        </PreviewCard>
+        <PreviewCard title="Localized templates" fallback="No message templates returned yet.">
+          <LocaleSummaryList items={previewData.localeSummary} />
+        </PreviewCard>
+        <PreviewCard title="Recent templates" fallback="No template details returned yet.">
+          <TemplateList items={previewData.templates.slice(0, 5)} />
+        </PreviewCard>
+      </div>
+    </section>
+  );
+}
+
+function PreviewCard({
+  title,
+  fallback,
+  children,
+}: {
+  title: string;
+  fallback: string;
+  children: React.ReactNode;
+}) {
+  const content = Array.isArray(children) ? children.filter(Boolean) : children;
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+      <h3 className="font-medium text-[var(--dpf-text)]">{title}</h3>
+      <div className="mt-3">
+        {hasContent(content) ? content : <p className="text-[var(--dpf-muted)]">{fallback}</p>}
+      </div>
+    </div>
+  );
+}
+
+function PreviewRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) {
+  if (!value) return null;
+
+  return (
+    <div className="space-y-1">
+      <p className="text-xs uppercase tracking-[0.16em] text-[var(--dpf-muted)]">{label}</p>
+      <p className="font-medium text-[var(--dpf-text)]">{value}</p>
+    </div>
+  );
+}
+
+function LocaleSummaryList({
+  items,
+}: {
+  items: Array<{ language: string; approved: number; pending: number; rejected: number }>;
+}) {
+  if (!items.length) return null;
+
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <li key={item.language} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+          <p className="font-medium text-[var(--dpf-text)]">{item.language}</p>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            {item.approved} approved / {item.pending} pending / {item.rejected} rejected
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function TemplateList({
+  items,
+}: {
+  items: Array<{
+    id: string;
+    name: string;
+    language: string | null;
+    status: string | null;
+    category: string | null;
+    bodyText?: string | null;
+  }>;
+}) {
+  if (!items.length) return null;
+
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <li key={item.id} className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-medium text-[var(--dpf-text)]">{item.name}</p>
+            {item.status && <StatusPill>{item.status}</StatusPill>}
+          </div>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            {[item.language, item.category].filter(Boolean).join(" / ")}
+          </p>
+          {item.bodyText && (
+            <p className="mt-2 text-xs text-[var(--dpf-muted)]">{item.bodyText}</p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function StatusPill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+      {children}
+    </span>
+  );
+}
+
+function hasContent(content: React.ReactNode): boolean {
+  if (Array.isArray(content)) return content.length > 0;
+  return Boolean(content);
+}
+
+function formatDateTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/apps/web/app/api/integrations/whatsapp-business/connect/route.test.ts
+++ b/apps/web/app/api/integrations/whatsapp-business/connect/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockCan, mockConnectWhatsAppBusiness } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+  mockConnectWhatsAppBusiness: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: mockCan,
+}));
+
+vi.mock("@/lib/integrate/whatsapp-business/connect-action", () => ({
+  connectWhatsAppBusiness: mockConnectWhatsAppBusiness,
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/integrations/whatsapp-business/connect", () => {
+  beforeEach(() => {
+    mockAuth.mockReset();
+    mockCan.mockReset();
+    mockConnectWhatsAppBusiness.mockReset();
+  });
+
+  it("returns unauthorized without a session", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const response = await POST(new Request("http://localhost", { method: "POST", body: "{}" }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("connects WhatsApp Business credentials for authorized operators", async () => {
+    mockAuth.mockResolvedValue({ user: { platformRole: "superadmin", isSuperuser: true } });
+    mockCan.mockReturnValue(true);
+    mockConnectWhatsAppBusiness.mockResolvedValue({
+      ok: true,
+      status: "connected",
+      wabaId: "waba-123",
+      phoneNumberId: "phone-456",
+      displayPhoneNumber: "+1 512-555-0100",
+      lastTestedAt: "2026-05-01T12:00:00.000Z",
+    });
+
+    const response = await POST(
+      new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({
+          accessToken: "meta-token",
+          wabaId: "waba-123",
+          phoneNumberId: "phone-456",
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      status: "connected",
+      phoneNumberId: "phone-456",
+      displayPhoneNumber: "+1 512-555-0100",
+    });
+  });
+});

--- a/apps/web/app/api/integrations/whatsapp-business/connect/route.ts
+++ b/apps/web/app/api/integrations/whatsapp-business/connect/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { connectWhatsAppBusiness } from "@/lib/integrate/whatsapp-business/connect-action";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await connectWhatsAppBusiness(body);
+
+  if (result.ok) {
+    return NextResponse.json(
+      {
+        status: result.status,
+        wabaId: result.wabaId,
+        phoneNumberId: result.phoneNumberId,
+        displayPhoneNumber: result.displayPhoneNumber,
+        lastTestedAt: result.lastTestedAt,
+      },
+      { status: 200 },
+    );
+  }
+
+  return NextResponse.json(
+    { error: result.error, status: result.status },
+    { status: result.statusCode },
+  );
+}

--- a/apps/web/components/integrations/WhatsAppBusinessConnectPanel.tsx
+++ b/apps/web/components/integrations/WhatsAppBusinessConnectPanel.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export interface WhatsAppBusinessConnectionState {
+  status: "unconfigured" | "connected" | "error";
+  wabaId: string | null;
+  phoneNumberId: string | null;
+  displayPhoneNumber: string | null;
+  lastErrorMsg: string | null;
+  lastTestedAt: string | null;
+}
+
+interface Props {
+  initialState: WhatsAppBusinessConnectionState;
+}
+
+const statusToneClasses = {
+  connected:
+    "border-[var(--dpf-success)]/30 bg-[color-mix(in_srgb,var(--dpf-success)_12%,transparent)] text-[var(--dpf-success)]",
+  error:
+    "border-[var(--dpf-error)]/30 bg-[color-mix(in_srgb,var(--dpf-error)_12%,transparent)] text-[var(--dpf-error)]",
+  unconfigured: "border-[var(--dpf-border)] text-[var(--dpf-muted)]",
+} satisfies Record<WhatsAppBusinessConnectionState["status"], string>;
+
+const errorMessageClasses =
+  "rounded border border-[var(--dpf-error)]/30 bg-[color-mix(in_srgb,var(--dpf-error)_12%,transparent)] p-3 text-sm text-[var(--dpf-error)]";
+
+export function WhatsAppBusinessConnectPanel({ initialState }: Props) {
+  const router = useRouter();
+  const [accessToken, setAccessToken] = useState("");
+  const [wabaId, setWabaId] = useState(initialState.wabaId ?? "");
+  const [phoneNumberId, setPhoneNumberId] = useState(initialState.phoneNumberId ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFormError(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch("/api/integrations/whatsapp-business/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          accessToken,
+          wabaId,
+          phoneNumberId,
+        }),
+      });
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setFormError(
+          typeof payload.error === "string"
+            ? payload.error
+            : `Connect failed with status ${res.status}`,
+        );
+        router.refresh();
+        return;
+      }
+
+      setAccessToken("");
+      router.refresh();
+    } catch {
+      setFormError("Unable to reach the server. Check your network and try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-[var(--dpf-text)]">WhatsApp Business</h2>
+          <p className="text-sm text-[var(--dpf-muted)]">
+            Connect a customer-supplied Meta token so DPF can verify WhatsApp Business
+            phone readiness and approved localized templates before any outbound messaging is added.
+          </p>
+        </div>
+        <StatusBadge status={initialState.status} />
+      </header>
+
+      {initialState.status === "connected" && (
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm text-[var(--dpf-text)]">
+          Connected
+          {initialState.displayPhoneNumber
+            ? ` to ${initialState.displayPhoneNumber}`
+            : initialState.phoneNumberId
+              ? ` to ${initialState.phoneNumberId}`
+              : ""}
+          .
+          {initialState.lastTestedAt && (
+            <span className="ml-2 text-[var(--dpf-muted)]">
+              Last verified {formatDateTime(initialState.lastTestedAt)}.
+            </span>
+          )}
+        </div>
+      )}
+
+      {initialState.status === "error" && initialState.lastErrorMsg && (
+        <div role="alert" className={errorMessageClasses}>
+          Last connect attempt failed: {initialState.lastErrorMsg}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormField
+          label="Access Token"
+          hint="Use a customer-managed Meta system-user token with WhatsApp Business management read access. DPF stores it encrypted in this install."
+        >
+          <textarea
+            value={accessToken}
+            onChange={(event) => setAccessToken(event.target.value)}
+            required
+            rows={4}
+            className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-xs text-[var(--dpf-text)]"
+          />
+        </FormField>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            label="WABA ID"
+            hint="WhatsApp Business Account ID that owns the templates and phone numbers."
+          >
+            <input
+              type="text"
+              value={wabaId}
+              onChange={(event) => setWabaId(event.target.value)}
+              required
+              autoComplete="off"
+              className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-sm text-[var(--dpf-text)]"
+            />
+          </FormField>
+
+          <FormField
+            label="Phone Number ID"
+            hint="Meta phone number ID used for this local WhatsApp channel."
+          >
+            <input
+              type="text"
+              value={phoneNumberId}
+              onChange={(event) => setPhoneNumberId(event.target.value)}
+              required
+              autoComplete="off"
+              className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 font-mono text-sm text-[var(--dpf-text)]"
+            />
+          </FormField>
+        </div>
+
+        {formError && (
+          <div role="alert" className={errorMessageClasses}>
+            {formError}
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded bg-[var(--dpf-accent)] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {submitting
+              ? "Connecting..."
+              : initialState.status === "connected"
+                ? "Replace credentials"
+                : "Connect"}
+          </button>
+          <a
+            href="https://developers.facebook.com/docs/whatsapp/cloud-api/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm text-[var(--dpf-muted)] underline"
+          >
+            Meta WhatsApp docs
+          </a>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+}: {
+  status: WhatsAppBusinessConnectionState["status"];
+}) {
+  if (status === "connected") {
+    return (
+      <span className={`rounded-full border px-2 py-1 text-xs font-medium ${statusToneClasses.connected}`}>
+        Connected
+      </span>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <span className={`rounded-full border px-2 py-1 text-xs font-medium ${statusToneClasses.error}`}>
+        Error
+      </span>
+    );
+  }
+
+  return (
+    <span className={`rounded-full border px-2 py-1 text-xs font-medium ${statusToneClasses.unconfigured}`}>
+      Not connected
+    </span>
+  );
+}
+
+function FormField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-sm font-medium text-[var(--dpf-text)]">{label}</span>
+      {children}
+      {hint && <span className="block text-xs text-[var(--dpf-muted)]">{hint}</span>}
+    </label>
+  );
+}
+
+function formatDateTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/apps/web/lib/integrate/whatsapp-business/client.test.ts
+++ b/apps/web/lib/integrate/whatsapp-business/client.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MockAgent } from "undici";
+
+import {
+  probeWhatsAppBusiness,
+  resolveWhatsAppGraphApiBaseUrl,
+  WhatsAppBusinessApiError,
+} from "./client";
+
+describe("resolveWhatsAppGraphApiBaseUrl", () => {
+  const original = process.env.FACEBOOK_GRAPH_API_BASE_URL;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.FACEBOOK_GRAPH_API_BASE_URL;
+    } else {
+      process.env.FACEBOOK_GRAPH_API_BASE_URL = original;
+    }
+  });
+
+  it("defaults to the public Graph API host", () => {
+    delete process.env.FACEBOOK_GRAPH_API_BASE_URL;
+    expect(resolveWhatsAppGraphApiBaseUrl()).toBe("https://graph.facebook.com");
+  });
+
+  it("honors the shared Meta Graph base URL override", () => {
+    process.env.FACEBOOK_GRAPH_API_BASE_URL = "http://integration-test-harness:8700";
+    expect(resolveWhatsAppGraphApiBaseUrl()).toBe("http://integration-test-harness:8700");
+  });
+});
+
+describe("probeWhatsAppBusiness", () => {
+  let mockAgent: MockAgent;
+
+  beforeEach(() => {
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+  });
+
+  afterEach(async () => {
+    await mockAgent.close();
+  });
+
+  it("returns phone readiness and localized template catalog", async () => {
+    const pool = mockAgent.get("https://graph.facebook.com");
+    pool
+      .intercept({
+        path: (value) =>
+          value.startsWith("/v21.0/waba-123/phone_numbers?") &&
+          value.includes("fields=id%2Cdisplay_phone_number%2Cverified_name%2Cquality_rating%2Ccode_verification_status%2Cplatform_type"),
+        method: "GET",
+      })
+      .reply(200, {
+        data: [
+          {
+            id: "phone-456",
+            display_phone_number: "+1 512-555-0100",
+            verified_name: "Acme Austin",
+            quality_rating: "GREEN",
+            code_verification_status: "VERIFIED",
+            platform_type: "CLOUD_API",
+          },
+        ],
+      });
+    pool
+      .intercept({
+        path: (value) =>
+          value.startsWith("/v21.0/waba-123/message_templates?") &&
+          value.includes("fields=id%2Cname%2Clanguage%2Cstatus%2Ccategory%2Ccomponents"),
+        method: "GET",
+      })
+      .reply(200, {
+        data: [
+          {
+            id: "template-1",
+            name: "appointment_reminder",
+            language: "en_US",
+            status: "APPROVED",
+            category: "UTILITY",
+            components: [{ type: "BODY", text: "Reminder for {{1}}" }],
+          },
+          {
+            id: "template-2",
+            name: "promo_es",
+            language: "es_MX",
+            status: "PENDING",
+            category: "MARKETING",
+            components: [{ type: "BODY", text: "Oferta local {{1}}" }],
+          },
+        ],
+      });
+
+    const result = await probeWhatsAppBusiness({
+      accessToken: "meta-token",
+      wabaId: "waba-123",
+      phoneNumberId: "phone-456",
+      dispatcher: mockAgent,
+    });
+
+    expect(result.phoneNumber.displayPhoneNumber).toBe("+1 512-555-0100");
+    expect(result.phoneNumber.qualityRating).toBe("GREEN");
+    expect(result.templates).toHaveLength(2);
+    expect(result.templates[0]).toMatchObject({
+      name: "appointment_reminder",
+      language: "en_US",
+      status: "APPROVED",
+    });
+    expect(result.localeSummary).toEqual([
+      { language: "en_US", approved: 1, pending: 0, rejected: 0 },
+      { language: "es_MX", approved: 0, pending: 1, rejected: 0 },
+    ]);
+  });
+
+  it("throws a redacted error when Meta rejects the token", async () => {
+    mockAgent
+      .get("https://graph.facebook.com")
+      .intercept({
+        path: (value) => value.startsWith("/v21.0/waba-123/phone_numbers?"),
+        method: "GET",
+      })
+      .reply(403, {
+        error: { message: "Token includes super-secret-meta-token" },
+      });
+
+    await expect(
+      probeWhatsAppBusiness({
+        accessToken: "super-secret-meta-token",
+        wabaId: "waba-123",
+        phoneNumberId: "phone-456",
+        dispatcher: mockAgent,
+      }),
+    ).rejects.toThrow(WhatsAppBusinessApiError);
+
+    await expect(
+      probeWhatsAppBusiness({
+        accessToken: "super-secret-meta-token",
+        wabaId: "waba-123",
+        phoneNumberId: "phone-456",
+        dispatcher: mockAgent,
+      }),
+    ).rejects.not.toThrow(/super-secret-meta-token/);
+  });
+});

--- a/apps/web/lib/integrate/whatsapp-business/client.ts
+++ b/apps/web/lib/integrate/whatsapp-business/client.ts
@@ -1,0 +1,194 @@
+import type { Dispatcher } from "undici";
+import {
+  requestFacebookGraphJson,
+  resolveFacebookGraphApiBaseUrl,
+} from "../facebook/shared-client";
+
+export interface WhatsAppBusinessPhoneNumber {
+  id: string;
+  displayPhoneNumber: string | null;
+  verifiedName: string | null;
+  qualityRating: string | null;
+  codeVerificationStatus: string | null;
+  platformType: string | null;
+}
+
+export interface WhatsAppBusinessTemplate {
+  id: string;
+  name: string;
+  language: string | null;
+  status: string | null;
+  category: string | null;
+  bodyText: string | null;
+}
+
+export interface WhatsAppBusinessLocaleSummary {
+  language: string;
+  approved: number;
+  pending: number;
+  rejected: number;
+}
+
+export interface WhatsAppBusinessProbeResult {
+  phoneNumber: WhatsAppBusinessPhoneNumber;
+  templates: WhatsAppBusinessTemplate[];
+  localeSummary: WhatsAppBusinessLocaleSummary[];
+}
+
+interface WhatsAppBusinessRequestParams {
+  accessToken: string;
+  wabaId: string;
+  phoneNumberId: string;
+  dispatcher?: Dispatcher;
+}
+
+export class WhatsAppBusinessApiError extends Error {
+  readonly statusCode: number | undefined;
+
+  constructor(message: string, opts?: { statusCode?: number }) {
+    super(message);
+    this.name = "WhatsAppBusinessApiError";
+    this.statusCode = opts?.statusCode;
+  }
+}
+
+export const resolveWhatsAppGraphApiBaseUrl = resolveFacebookGraphApiBaseUrl;
+
+export async function probeWhatsAppBusiness(
+  params: WhatsAppBusinessRequestParams,
+): Promise<WhatsAppBusinessProbeResult> {
+  const [phoneNumber, templates] = await Promise.all([
+    getPhoneNumberReadiness(params),
+    listMessageTemplates(params),
+  ]);
+
+  return {
+    phoneNumber,
+    templates,
+    localeSummary: summarizeLocales(templates),
+  };
+}
+
+async function getPhoneNumberReadiness(
+  params: WhatsAppBusinessRequestParams,
+): Promise<WhatsAppBusinessPhoneNumber> {
+  const payload = await requestFacebookGraphJson<{
+    data?: Array<{
+      id?: string;
+      display_phone_number?: string;
+      verified_name?: string;
+      quality_rating?: string;
+      code_verification_status?: string;
+      platform_type?: string;
+    }>;
+  }, WhatsAppBusinessApiError>({
+    path: `v21.0/${encodeURIComponent(params.wabaId)}/phone_numbers`,
+    searchParams: new URLSearchParams({
+      fields: "id,display_phone_number,verified_name,quality_rating,code_verification_status,platform_type",
+      access_token: params.accessToken,
+    }),
+    dispatcher: params.dispatcher,
+    surfaceLabel: "WhatsApp Business",
+    invalidAccessMessage: "invalid WhatsApp Business access",
+    createError: (message, opts) => new WhatsAppBusinessApiError(message, opts),
+  });
+
+  const phoneNumbers = Array.isArray(payload.data) ? payload.data : [];
+  const match = phoneNumbers.find((phone) => phone.id === params.phoneNumberId);
+  if (!match) {
+    throw new WhatsAppBusinessApiError(
+      "WhatsApp Business phone number ID was not found on the supplied WABA",
+    );
+  }
+
+  return {
+    id: params.phoneNumberId,
+    displayPhoneNumber:
+      typeof match.display_phone_number === "string" ? match.display_phone_number : null,
+    verifiedName: typeof match.verified_name === "string" ? match.verified_name : null,
+    qualityRating: typeof match.quality_rating === "string" ? match.quality_rating : null,
+    codeVerificationStatus:
+      typeof match.code_verification_status === "string" ? match.code_verification_status : null,
+    platformType: typeof match.platform_type === "string" ? match.platform_type : null,
+  };
+}
+
+async function listMessageTemplates(
+  params: WhatsAppBusinessRequestParams,
+): Promise<WhatsAppBusinessTemplate[]> {
+  const payload = await requestFacebookGraphJson<{
+    data?: Array<{
+      id?: string;
+      name?: string;
+      language?: string;
+      status?: string;
+      category?: string;
+      components?: Array<{
+        type?: string;
+        text?: string;
+      }>;
+    }>;
+  }, WhatsAppBusinessApiError>({
+    path: `v21.0/${encodeURIComponent(params.wabaId)}/message_templates`,
+    searchParams: new URLSearchParams({
+      fields: "id,name,language,status,category,components",
+      access_token: params.accessToken,
+      limit: "25",
+    }),
+    dispatcher: params.dispatcher,
+    surfaceLabel: "WhatsApp Business",
+    invalidAccessMessage: "invalid WhatsApp Business access",
+    createError: (message, opts) => new WhatsAppBusinessApiError(message, opts),
+  });
+
+  return Array.isArray(payload.data)
+    ? payload.data
+        .filter(
+          (template): template is NonNullable<typeof template> & { id: string; name: string } =>
+            typeof template?.id === "string" && typeof template.name === "string",
+        )
+        .map((template) => ({
+          id: template.id,
+          name: template.name,
+          language: typeof template.language === "string" ? template.language : null,
+          status: typeof template.status === "string" ? template.status : null,
+          category: typeof template.category === "string" ? template.category : null,
+          bodyText: findBodyText(template.components),
+        }))
+    : [];
+}
+
+function findBodyText(
+  components: Array<{ type?: string; text?: string }> | undefined,
+): string | null {
+  const body = components?.find((component) => component.type === "BODY");
+  return typeof body?.text === "string" ? body.text : null;
+}
+
+function summarizeLocales(
+  templates: WhatsAppBusinessTemplate[],
+): WhatsAppBusinessLocaleSummary[] {
+  const byLanguage = new Map<string, WhatsAppBusinessLocaleSummary>();
+
+  for (const template of templates) {
+    const language = template.language ?? "unknown";
+    const summary =
+      byLanguage.get(language) ??
+      {
+        language,
+        approved: 0,
+        pending: 0,
+        rejected: 0,
+      };
+
+    if (template.status === "APPROVED") summary.approved += 1;
+    if (template.status === "PENDING") summary.pending += 1;
+    if (template.status === "REJECTED") summary.rejected += 1;
+
+    byLanguage.set(language, summary);
+  }
+
+  return Array.from(byLanguage.values()).sort((left, right) =>
+    left.language.localeCompare(right.language),
+  );
+}

--- a/apps/web/lib/integrate/whatsapp-business/connect-action.test.ts
+++ b/apps/web/lib/integrate/whatsapp-business/connect-action.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUpsert, mockProbeWhatsAppBusiness } = vi.hoisted(() => ({
+  mockUpsert: vi.fn(),
+  mockProbeWhatsAppBusiness: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    integrationCredential: {
+      upsert: mockUpsert,
+    },
+  },
+}));
+
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  encryptJson: vi.fn((value: unknown) => JSON.stringify(value)),
+}));
+
+vi.mock("./client", () => ({
+  WhatsAppBusinessApiError: class WhatsAppBusinessApiError extends Error {},
+  probeWhatsAppBusiness: mockProbeWhatsAppBusiness,
+}));
+
+import { connectWhatsAppBusiness } from "./connect-action";
+
+describe("connectWhatsAppBusiness", () => {
+  beforeEach(() => {
+    mockUpsert.mockReset();
+    mockProbeWhatsAppBusiness.mockReset();
+    mockUpsert.mockResolvedValue({});
+  });
+
+  it("persists encrypted credentials and returns phone summary on success", async () => {
+    mockProbeWhatsAppBusiness.mockResolvedValue({
+      phoneNumber: {
+        id: "phone-456",
+        displayPhoneNumber: "+1 512-555-0100",
+        verifiedName: "Acme Austin",
+        qualityRating: "GREEN",
+        codeVerificationStatus: "VERIFIED",
+        platformType: "CLOUD_API",
+      },
+      templates: [],
+      localeSummary: [],
+    });
+
+    const result = await connectWhatsAppBusiness({
+      accessToken: "meta-token",
+      wabaId: "waba-123",
+      phoneNumberId: "phone-456",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({
+      status: "connected",
+      wabaId: "waba-123",
+      phoneNumberId: "phone-456",
+      displayPhoneNumber: "+1 512-555-0100",
+    });
+    const call = mockUpsert.mock.calls[0][0];
+    expect(call.where.integrationId).toBe("whatsapp-business");
+    expect(call.create.provider).toBe("facebook");
+    expect(call.create.status).toBe("connected");
+  });
+
+  it("stores error state when probing fails", async () => {
+    mockProbeWhatsAppBusiness.mockRejectedValue(new Error("invalid WhatsApp Business access"));
+
+    const result = await connectWhatsAppBusiness({
+      accessToken: "meta-token",
+      wabaId: "waba-123",
+      phoneNumberId: "phone-456",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "error",
+      error: "invalid WhatsApp Business access",
+      statusCode: 400,
+    });
+    expect(mockUpsert.mock.calls[0][0].create.status).toBe("error");
+  });
+
+  it("rejects invalid input before persistence", async () => {
+    const result = await connectWhatsAppBusiness({
+      accessToken: "",
+      wabaId: "",
+      phoneNumberId: "",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({
+      status: "error",
+      statusCode: 400,
+    });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/integrate/whatsapp-business/connect-action.ts
+++ b/apps/web/lib/integrate/whatsapp-business/connect-action.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import { prisma } from "@dpf/db";
+import { encryptJson } from "@/lib/govern/credential-crypto";
+import { probeWhatsAppBusiness, WhatsAppBusinessApiError } from "./client";
+import type { Dispatcher } from "undici";
+
+export const WhatsAppBusinessConnectInputSchema = z.object({
+  accessToken: z.string().trim().min(1, "access token required").max(4096),
+  wabaId: z.string().trim().min(1, "WABA ID required").max(256),
+  phoneNumberId: z.string().trim().min(1, "phone number ID required").max(256),
+});
+
+export type WhatsAppBusinessConnectInput = z.infer<
+  typeof WhatsAppBusinessConnectInputSchema
+>;
+
+export type WhatsAppBusinessConnectResult =
+  | {
+      ok: true;
+      status: "connected";
+      wabaId: string;
+      phoneNumberId: string;
+      displayPhoneNumber: string | null;
+      lastTestedAt: string;
+    }
+  | {
+      ok: false;
+      status: "error";
+      error: string;
+      statusCode: number;
+    };
+
+interface ConnectActionDeps {
+  dispatcher?: Dispatcher;
+}
+
+const INTEGRATION_ID = "whatsapp-business";
+const PROVIDER = "facebook";
+
+export async function connectWhatsAppBusiness(
+  rawInput: unknown,
+  deps: ConnectActionDeps = {},
+): Promise<WhatsAppBusinessConnectResult> {
+  const parseResult = WhatsAppBusinessConnectInputSchema.safeParse(rawInput);
+  if (!parseResult.success) {
+    const firstIssue = parseResult.error.issues[0];
+    return {
+      ok: false,
+      status: "error",
+      error: firstIssue?.message ?? "invalid input",
+      statusCode: 400,
+    };
+  }
+
+  const input = parseResult.data;
+
+  try {
+    const probe = await probeWhatsAppBusiness({
+      accessToken: input.accessToken,
+      wabaId: input.wabaId,
+      phoneNumberId: input.phoneNumberId,
+      dispatcher: deps.dispatcher,
+    });
+    const now = new Date();
+
+    await prisma.integrationCredential.upsert({
+      where: { integrationId: INTEGRATION_ID },
+      create: {
+        integrationId: INTEGRATION_ID,
+        provider: PROVIDER,
+        status: "connected",
+        fieldsEnc: encryptJson({
+          accessToken: input.accessToken,
+          wabaId: input.wabaId,
+          phoneNumberId: input.phoneNumberId,
+          displayPhoneNumber: probe.phoneNumber.displayPhoneNumber,
+          verifiedName: probe.phoneNumber.verifiedName,
+        }),
+        tokenCacheEnc: null,
+        lastTestedAt: now,
+      },
+      update: {
+        status: "connected",
+        fieldsEnc: encryptJson({
+          accessToken: input.accessToken,
+          wabaId: input.wabaId,
+          phoneNumberId: input.phoneNumberId,
+          displayPhoneNumber: probe.phoneNumber.displayPhoneNumber,
+          verifiedName: probe.phoneNumber.verifiedName,
+        }),
+        tokenCacheEnc: null,
+        lastTestedAt: now,
+        lastErrorAt: null,
+        lastErrorMsg: null,
+      },
+    });
+
+    return {
+      ok: true,
+      status: "connected",
+      wabaId: input.wabaId,
+      phoneNumberId: input.phoneNumberId,
+      displayPhoneNumber: probe.phoneNumber.displayPhoneNumber,
+      lastTestedAt: now.toISOString(),
+    };
+  } catch (error) {
+    const message =
+      error instanceof WhatsAppBusinessApiError || error instanceof Error
+        ? error.message
+        : "unexpected error during WhatsApp Business connect";
+
+    await prisma.integrationCredential.upsert({
+      where: { integrationId: INTEGRATION_ID },
+      create: {
+        integrationId: INTEGRATION_ID,
+        provider: PROVIDER,
+        status: "error",
+        fieldsEnc: encryptJson({
+          accessToken: input.accessToken,
+          wabaId: input.wabaId,
+          phoneNumberId: input.phoneNumberId,
+        }),
+        tokenCacheEnc: null,
+        lastErrorAt: new Date(),
+        lastErrorMsg: message,
+      },
+      update: {
+        status: "error",
+        lastErrorAt: new Date(),
+        lastErrorMsg: message,
+      },
+    });
+
+    return {
+      ok: false,
+      status: "error",
+      error: message,
+      statusCode: 400,
+    };
+  }
+}

--- a/apps/web/lib/integrate/whatsapp-business/preview.test.ts
+++ b/apps/web/lib/integrate/whatsapp-business/preview.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFindUnique, mockUpdate, mockProbeWhatsAppBusiness } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockProbeWhatsAppBusiness: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    integrationCredential: {
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+    },
+  },
+}));
+
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  decryptJson: vi.fn((value: string) => JSON.parse(value)),
+}));
+
+vi.mock("./client", () => ({
+  probeWhatsAppBusiness: mockProbeWhatsAppBusiness,
+}));
+
+import { loadWhatsAppBusinessPreview } from "./preview";
+
+describe("loadWhatsAppBusinessPreview", () => {
+  beforeEach(() => {
+    mockFindUnique.mockReset();
+    mockUpdate.mockReset();
+    mockProbeWhatsAppBusiness.mockReset();
+    mockUpdate.mockResolvedValue({});
+  });
+
+  it("returns unavailable when no credential exists", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    await expect(loadWhatsAppBusinessPreview()).resolves.toEqual({ state: "unavailable" });
+  });
+
+  it("refreshes preview data and updates credential state", async () => {
+    mockFindUnique.mockResolvedValue({
+      integrationId: "whatsapp-business",
+      fieldsEnc: JSON.stringify({
+        accessToken: "meta-token",
+        wabaId: "waba-123",
+        phoneNumberId: "phone-456",
+      }),
+    });
+    mockProbeWhatsAppBusiness.mockResolvedValue({
+      phoneNumber: {
+        id: "phone-456",
+        displayPhoneNumber: "+1 512-555-0100",
+        verifiedName: "Acme Austin",
+        qualityRating: "GREEN",
+        codeVerificationStatus: "VERIFIED",
+        platformType: "CLOUD_API",
+      },
+      templates: [{ id: "template-1", name: "appointment_reminder", language: "en_US", status: "APPROVED" }],
+      localeSummary: [{ language: "en_US", approved: 1, pending: 0, rejected: 0 }],
+    });
+
+    const result = await loadWhatsAppBusinessPreview();
+
+    expect(result.state).toBe("available");
+    if (result.state !== "available") throw new Error("expected available preview");
+    expect(result.preview.phoneNumber.id).toBe("phone-456");
+    expect(result.preview.localeSummary[0]?.language).toBe("en_US");
+    expect(mockUpdate.mock.calls[0][0].data.status).toBe("connected");
+  });
+});

--- a/apps/web/lib/integrate/whatsapp-business/preview.ts
+++ b/apps/web/lib/integrate/whatsapp-business/preview.ts
@@ -1,0 +1,108 @@
+import { prisma } from "@dpf/db";
+import { decryptJson } from "@/lib/govern/credential-crypto";
+import {
+  probeWhatsAppBusiness as defaultProbeWhatsAppBusiness,
+  type WhatsAppBusinessProbeResult,
+} from "./client";
+
+const INTEGRATION_ID = "whatsapp-business";
+
+interface StoredWhatsAppBusinessFields {
+  accessToken?: string;
+  wabaId?: string;
+  phoneNumberId?: string;
+  displayPhoneNumber?: string;
+  verifiedName?: string;
+}
+
+interface WhatsAppBusinessPreviewDeps {
+  probeWhatsAppBusiness?: (args: {
+    accessToken: string;
+    wabaId: string;
+    phoneNumberId: string;
+  }) => Promise<WhatsAppBusinessProbeResult>;
+}
+
+export type WhatsAppBusinessPreviewResult =
+  | {
+      state: "available";
+      preview: WhatsAppBusinessProbeResult & { loadedAt: string };
+    }
+  | { state: "unavailable" }
+  | { state: "error"; error: string };
+
+export async function loadWhatsAppBusinessPreview(
+  deps: WhatsAppBusinessPreviewDeps = {},
+): Promise<WhatsAppBusinessPreviewResult> {
+  const record = await prisma.integrationCredential.findUnique({
+    where: { integrationId: INTEGRATION_ID },
+  });
+
+  if (!record?.fieldsEnc) {
+    return { state: "unavailable" };
+  }
+
+  const fields = decryptJson<StoredWhatsAppBusinessFields>(record.fieldsEnc);
+  if (!isConfigured(fields)) {
+    return { state: "unavailable" };
+  }
+
+  const probeWhatsAppBusiness = deps.probeWhatsAppBusiness ?? defaultProbeWhatsAppBusiness;
+
+  try {
+    const preview = await probeWhatsAppBusiness({
+      accessToken: fields.accessToken,
+      wabaId: fields.wabaId,
+      phoneNumberId: fields.phoneNumberId,
+    });
+
+    const now = new Date();
+    await prisma.integrationCredential.update({
+      where: { integrationId: INTEGRATION_ID },
+      data: {
+        status: "connected",
+        lastTestedAt: now,
+        lastErrorAt: null,
+        lastErrorMsg: null,
+      },
+    });
+
+    return {
+      state: "available",
+      preview: {
+        ...preview,
+        loadedAt: now.toISOString(),
+      },
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "WhatsApp Business preview failed";
+    const now = new Date();
+    await prisma.integrationCredential.update({
+      where: { integrationId: INTEGRATION_ID },
+      data: {
+        status: "error",
+        lastErrorAt: now,
+        lastErrorMsg: message,
+      },
+    });
+
+    return {
+      state: "error",
+      error: message,
+    };
+  }
+}
+
+function isConfigured(fields: StoredWhatsAppBusinessFields | null): fields is {
+  accessToken: string;
+  wabaId: string;
+  phoneNumberId: string;
+} {
+  return Boolean(
+    fields &&
+      typeof fields.accessToken === "string" &&
+      typeof fields.wabaId === "string" &&
+      typeof fields.phoneNumberId === "string",
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a WhatsApp Business native integration under Platform Hub -> Tools & Services -> Native Integrations.
- Stores customer-supplied Meta access token, WABA ID, and phone-number ID through the existing encrypted IntegrationCredential path.
- Adds read-first probes for WhatsApp phone readiness and localized message templates, plus a preview UI focused on phone quality, verification, template status, and language coverage.
- Keeps outbound messaging and webhook subscription changes out of scope.

## Validation
- pnpm --filter web exec vitest run "lib/integrate/whatsapp-business/client.test.ts" "lib/integrate/whatsapp-business/connect-action.test.ts" "lib/integrate/whatsapp-business/preview.test.ts" "app/api/integrations/whatsapp-business/connect/route.test.ts" "app/(shell)/platform/tools/integrations/whatsapp-business/page.test.tsx" "app/(shell)/platform/tools/integrations/page.test.tsx"
- pnpm --filter web typecheck
- pnpm exec next build
- docker compose --env-file D:\DPF\.env build --no-cache portal portal-init sandbox
- docker compose --env-file D:\DPF\.env up -d portal-init sandbox portal
- Browser QA: /platform/tools/integrations shows WhatsApp Business; /platform/tools/integrations/whatsapp-business renders Access Token, WABA ID, Phone Number ID, and read-first copy.

## Notes
- Next/Turbopack still emits the existing broad trace warnings around spec-plan-search and next.config.mjs import tracing; build exits 0.