### PR TITLE
feat(build-studio): add Advance to Plan button on ideate phase

### DIFF
--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -119,6 +119,38 @@ describe("deriveBuildStudioWorkflowAction", () => {
     expect(action.message).toContain("before planning");
   });
 
+  it("surfaces an Advance to Plan button when ideate review has passed and intake is ready (BI-77A1973C)", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        phase: "ideate",
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    expect(action.kind).toBe("advance-phase");
+    expect(action.primaryLabel).toBe("Advance to Plan");
+    expect(action.targetPhase).toBe("plan");
+    expect(action.disabledReason).toBeNull();
+  });
+
+  it("disables Advance to Plan with the gate reason when ideate evidence is incomplete", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        phase: "ideate",
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        designDoc: null,
+        designReview: null,
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    expect(action.kind).toBe("advance-phase");
+    expect(action.targetPhase).toBe("plan");
+    expect(action.disabledReason).not.toBeNull();
+    expect(action.disabledReason).toMatch(/design document|design review/i);
+  });
+
   it("surfaces implementation when planning is ready to advance", () => {
     const action = deriveBuildStudioWorkflowAction({
       build: makeBuild({

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -183,6 +183,29 @@ export function deriveBuildStudioWorkflowAction({
     };
   }
 
+  if (build.phase === "ideate") {
+    // BI-77A1973C: previously the ideate phase fell through to review-only,
+    // hiding the advance affordance even after design review passed and the
+    // intake gate auto-derived. The agent's chat said "Ready to advance to
+    // Plan? Confirm and I'll structure the decomposition" but there was no
+    // UI button to act on it — only chat-driven confirmation. Now there's an
+    // explicit Advance to Plan button that mirrors the existing plan→build
+    // pattern below. Disabled state surfaces the gate reason from
+    // checkPhaseGate so users see exactly what's blocking (missing
+    // designDoc, designReview pending, or intake anchors not satisfied).
+    return {
+      kind: "advance-phase",
+      title: "Ready for Planning",
+      message: "Move this reviewed design into planning so the coworker can decompose the work into sandbox tasks with acceptance criteria.",
+      primaryLabel: "Advance to Plan",
+      targetPhase: "plan",
+      disabledReason: getPhaseGateReason(build, "plan"),
+      coworkerLabel: "Refine the design",
+      coworkerPrompt:
+        "Use the saved Build Studio design evidence to confirm or revise the design now. If revisions are needed, save the updated design with saveBuildEvidence field designDoc and re-run reviewDesignDoc. Otherwise tell me Advance to Plan is the next approval.",
+    };
+  }
+
   if (build.phase === "plan") {
     return {
       kind: "advance-phase",


### PR DESCRIPTION
## Summary

Closes [BI-77A1973C](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues). Slice 1 validation on 2026-05-01 surfaced that Build Studio shows _\"Design review passed, but the phase gate is holding advance\"_ messaging when ideate completes, but provides no UI button to actually advance the phase. Users had to type a chat confirmation — no equivalent button affordance.

## Root cause

\`deriveBuildStudioWorkflowAction\` in \`apps/web/components/build/build-studio-workflow-actions.ts\` handled the plan, build, review, and failed phases, but had no handler for the **ideate** phase. The ideate phase fell through to the default \`review-only\` path that just shows _\"Open coworker\"_.

## Fix

Add an ideate handler that mirrors the existing plan→build pattern — returns an \`advance-phase\` action with:

- \`primaryLabel: \"Advance to Plan\"\`
- \`targetPhase: \"plan\"\`
- \`disabledReason: getPhaseGateReason(build, \"plan\")\` (surfaces missing designDoc / designReview / intake anchors when blocked)

The button enables when \`designDoc\` is saved, \`designReview\` passes, and intake anchors are ready — the latter being satisfied automatically for triaged-BI builds by [BI-0B3EAAC8](#) / PR #375's auto-derive logic.

## Tests

Two new cases in \`build-studio-workflow-actions.test.ts\`:

1. **enabled-when-ready** — standard happy path with all evidence + intake satisfied
2. **disabled-with-gate-reason** — gate-blocked path; surfaces the gate reason as \`disabledReason\`

\`pnpm --filter web exec vitest run components/build/build-studio-workflow-actions\` — 15/15 pass.

## Related

- Spec: \`docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md\` §7 Slice 2
- BI-0B3EAAC8 / PR #375 (intake-anchors gate auto-derive — required so the button enables on triaged-BI builds)
- Validation evidence: 2026-05-01 BI-E9CD1B92 lifecycle attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)