### PR TITLE
feat(chunk-3): portfolio + digital product detail page rendering

### DIFF
--- a/apps/web/app/(shell)/portfolio/products/[productId]/page.test.ts
+++ b/apps/web/app/(shell)/portfolio/products/[productId]/page.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import * as pageModule from "./page";
+
+describe("digital product page module", () => {
+  it("exports a default function (the route handler)", () => {
+    expect(typeof pageModule.default).toBe("function");
+  });
+});

--- a/apps/web/app/(shell)/portfolio/products/[productId]/page.tsx
+++ b/apps/web/app/(shell)/portfolio/products/[productId]/page.tsx
@@ -1,0 +1,120 @@
+// apps/web/app/(shell)/portfolio/products/[productId]/page.tsx
+//
+// Digital product detail route (Task 3.4 of the discovery -> portfolio gap
+// closure plan). Loads a DigitalProduct by `productId`, hydrates the
+// taxonomy ancestor chain from `taxonomyNode.nodeId`, projects everything
+// through `toDigitalProductViewModel`, then hands off to the pure
+// presentation component.
+//
+// Route placement note: the plan originally specified
+// `[[...slug]]/products/[productId]/page.tsx`, but Next.js rejects children
+// under an optional catch-all ("Optional catch-all must be the last part
+// of the URL"). Moved up one level so `products` is a sibling of the
+// optional catch-all; static segments still win route matching, so the
+// URL `/portfolio/products/<id>` resolves here and not into the catch-all.
+//
+// Forward-compatible with Chunk 4 Task 4.1: `freshness` (on InventoryEntity)
+// and `enrichmentStatus` / `lastEnrichedAt` (on DigitalProduct) are not yet
+// in the Prisma schema. The view model accepts them as optional inputs and
+// defaults them to null, so this page renders today on the existing schema
+// and will light up once Chunk 4 lands without further changes here.
+
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { toDigitalProductViewModel } from "@/lib/portfolio/digital-product-view-model";
+import { DigitalProductDetail } from "@/components/portfolio/DigitalProductDetail";
+
+type Props = {
+  params: Promise<{ productId: string }>;
+};
+
+export default async function DigitalProductPage({ params }: Props) {
+  const { productId } = await params;
+
+  const product = await prisma.digitalProduct.findUnique({
+    where: { productId },
+    select: {
+      id: true,
+      productId: true,
+      name: true,
+      description: true,
+      version: true,
+      lifecycleStage: true,
+      lifecycleStatus: true,
+      observationConfig: true,
+      portfolio: { select: { id: true, slug: true, name: true } },
+      taxonomyNode: { select: { nodeId: true, name: true } },
+      // TODO(Chunk 4 Task 4.1): add enrichmentStatus + lastEnrichedAt once schema lands.
+      inventoryEntities: {
+        select: {
+          id: true,
+          name: true,
+          entityKey: true,
+          entityType: true,
+          manufacturer: true,
+          productModel: true,
+          technicalClass: true,
+          iconKey: true,
+          observedVersion: true,
+          normalizedVersion: true,
+          attributionConfidence: true,
+          lastSeenAt: true,
+          // TODO(Chunk 4 Task 4.1): add freshness once schema lands.
+        },
+      },
+      portfolioQualityIssues: {
+        where: { status: "open" },
+        orderBy: { lastDetectedAt: "desc" },
+        take: 10,
+        select: {
+          id: true,
+          issueType: true,
+          severity: true,
+          summary: true,
+          lastDetectedAt: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!product) notFound();
+
+  const taxonomyAncestors = await buildAncestors(product.taxonomyNode?.nodeId);
+
+  const vm = toDigitalProductViewModel({
+    product,
+    taxonomyAncestors,
+    inventoryEntities: product.inventoryEntities,
+    qualityIssues: product.portfolioQualityIssues,
+    // freshness / enrichmentStatus / lastEnrichedAt -- pending Chunk 4 Task 4.1
+  });
+
+  return <DigitalProductDetail vm={vm} />;
+}
+
+/**
+ * Build the taxonomy ancestor list (root-first, leaf excluded) from the
+ * product's `taxonomyNode.nodeId` slash-delimited path. The leaf itself is
+ * the product's own node, which the view model appends after the ancestors.
+ */
+async function buildAncestors(
+  nodeId: string | null | undefined,
+): Promise<Array<{ nodeId: string; name: string }>> {
+  if (!nodeId) return [];
+  const segments = nodeId.split("/");
+  const ancestorIds: string[] = [];
+  for (let i = 1; i < segments.length; i++) {
+    ancestorIds.push(segments.slice(0, i).join("/"));
+  }
+  if (ancestorIds.length === 0) return [];
+  const nodes = await prisma.taxonomyNode.findMany({
+    where: { nodeId: { in: ancestorIds } },
+    select: { nodeId: true, name: true },
+  });
+  // Sort to match ancestorIds order (root -> deeper).
+  const byNodeId = new Map(nodes.map((n) => [n.nodeId, n]));
+  return ancestorIds
+    .map((id) => byNodeId.get(id))
+    .filter((n): n is { nodeId: string; name: string } => n !== undefined);
+}

--- a/apps/web/components/portfolio/DigitalProductDetail.test.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DigitalProductDetail } from "./DigitalProductDetail";
+import type { DigitalProductView } from "@/lib/portfolio/digital-product-view-model";
+
+const emptyVm: DigitalProductView = {
+  id: "dp_min",
+  productId: "minimal-thing",
+  name: "Minimal Thing",
+  description: null,
+  version: "0.1.0",
+  lifecycleStage: "plan",
+  lifecycleStatus: "draft",
+  observationConfig: null,
+  taxonomyLineage: [],
+  portfolio: null,
+  primaryEntity: null,
+  linkedEntityCount: 0,
+  freshness: null,
+  enrichmentStatus: null,
+  lastEnrichedAt: null,
+  openQualityIssues: [],
+};
+
+const fullVm: DigitalProductView = {
+  id: "dp_1",
+  productId: "host-postgres",
+  name: "PostgreSQL",
+  description: "Primary relational database for the platform.",
+  version: "16.0",
+  lifecycleStage: "production",
+  lifecycleStatus: "active",
+  observationConfig: { classifyAs: "infrastructure_endpoint" },
+  taxonomyLineage: [
+    { nodeId: "foundational", name: "Foundational" },
+    { nodeId: "foundational/data_and_storage_management", name: "Data and Storage Management" },
+    { nodeId: "foundational/data_and_storage_management/database", name: "Database" },
+  ],
+  portfolio: { id: "p_1", slug: "foundational", name: "Foundational" },
+  primaryEntity: {
+    id: "ent_1",
+    name: "PostgreSQL Container",
+    entityKey: "container:dpf-postgres-1",
+    entityType: "container",
+    manufacturer: "PostgreSQL Global Development Group",
+    productModel: "PostgreSQL",
+    technicalClass: "relational_database",
+    iconKey: "postgres",
+    observedVersion: "16.0",
+    normalizedVersion: "16.0.0",
+    attributionConfidence: 0.98,
+    lastSeenAt: new Date("2026-04-30T12:00:00Z"),
+  },
+  linkedEntityCount: 3,
+  freshness: "fresh",
+  enrichmentStatus: "enriched",
+  lastEnrichedAt: new Date("2026-04-29T08:00:00Z"),
+  openQualityIssues: [
+    {
+      id: "q_1",
+      issueType: "incomplete_detail",
+      severity: "warn",
+      summary: "Manufacturer field is missing on related entity",
+      lastDetectedAt: new Date("2026-04-30T11:00:00Z"),
+    },
+  ],
+};
+
+describe("DigitalProductDetail", () => {
+  describe("empty (only required fields populated)", () => {
+    it("renders the product name and version", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).toContain("Minimal Thing");
+      expect(html).toContain("0.1.0");
+    });
+
+    it("renders the productId", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).toContain("minimal-thing");
+    });
+
+    it("renders lifecycle stage and status", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).toContain("plan");
+      expect(html).toContain("draft");
+    });
+
+    it("renders 'Unknown' freshness badge when freshness is null", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).toContain("Unknown");
+    });
+
+    it("does not render description section when description is null", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).not.toMatch(/>Description</);
+    });
+
+    it("does not render quality issues section when none open", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).not.toMatch(/>Open Quality Issues</);
+    });
+
+    it("does not render linked entities section when no entities linked", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).not.toMatch(/>Linked Inventory Entities</);
+    });
+
+    it("does not render taxonomy breadcrumb when lineage is empty", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={emptyVm} />);
+      expect(html).not.toMatch(/>Taxonomy</);
+    });
+  });
+
+  describe("full (all fields populated)", () => {
+    it("renders the product name, version, and productId", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain("PostgreSQL");
+      expect(html).toContain("16.0");
+      expect(html).toContain("host-postgres");
+    });
+
+    it("renders the description in a Description section", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain(">Description<");
+      expect(html).toContain("Primary relational database for the platform.");
+    });
+
+    it("renders Identity (manufacturer, productModel, technicalClass, iconKey)", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain(">Identity<");
+      expect(html).toContain("PostgreSQL Global Development Group");
+      expect(html).toContain("relational_database");
+      expect(html).toContain("postgres");
+    });
+
+    it("renders the taxonomy lineage breadcrumb", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain(">Taxonomy<");
+      expect(html).toContain("Foundational");
+      expect(html).toContain("Data and Storage Management");
+      expect(html).toContain("Database");
+    });
+
+    it("renders Linked Inventory Entities section with primary entity and count", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain(">Linked Inventory Entities<");
+      expect(html).toContain("PostgreSQL Container");
+      expect(html).toContain("container:dpf-postgres-1");
+      // Count of others = total - 1 = 2
+      expect(html).toMatch(/2\s*(?:other|more)/i);
+    });
+
+    it("renders Open Quality Issues section with summary text", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain(">Open Quality Issues<");
+      expect(html).toContain("Manufacturer field is missing on related entity");
+    });
+
+    it("renders the Fresh freshness badge", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).toContain("Fresh");
+    });
+
+    it("does not leak raw JSON (no { or } around primaryEntity name string)", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      // No bare JSON-looking blobs (e.g. the entire stringified entity).
+      expect(html).not.toContain("entityKey:");
+      expect(html).not.toContain('"manufacturer"');
+    });
+  });
+
+  describe("theming", () => {
+    it("uses only theme tokens (no raw white/black/gray classes)", () => {
+      const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
+      expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);
+      expect(html).toContain("var(--dpf-");
+    });
+  });
+});

--- a/apps/web/components/portfolio/DigitalProductDetail.test.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.test.tsx
@@ -15,6 +15,7 @@ const emptyVm: DigitalProductView = {
   taxonomyLineage: [],
   portfolio: null,
   primaryEntity: null,
+  linkedEntities: [],
   linkedEntityCount: 0,
   freshness: null,
   enrichmentStatus: null,
@@ -51,6 +52,50 @@ const fullVm: DigitalProductView = {
     attributionConfidence: 0.98,
     lastSeenAt: new Date("2026-04-30T12:00:00Z"),
   },
+  linkedEntities: [
+    {
+      id: "ent_1",
+      name: "PostgreSQL Container",
+      entityKey: "container:dpf-postgres-1",
+      entityType: "container",
+      manufacturer: "PostgreSQL Global Development Group",
+      productModel: "PostgreSQL",
+      technicalClass: "relational_database",
+      iconKey: "postgres",
+      observedVersion: "16.0",
+      normalizedVersion: "16.0.0",
+      attributionConfidence: 0.98,
+      lastSeenAt: new Date("2026-04-30T12:00:00Z"),
+    },
+    {
+      id: "ent_2",
+      name: "Postgres Replica",
+      entityKey: "container:dpf-postgres-2",
+      entityType: "container",
+      manufacturer: null,
+      productModel: null,
+      technicalClass: null,
+      iconKey: null,
+      observedVersion: "16.0",
+      normalizedVersion: "16.0.0",
+      attributionConfidence: 0.92,
+      lastSeenAt: new Date("2026-04-30T11:00:00Z"),
+    },
+    {
+      id: "ent_3",
+      name: "Postgres Backup Job",
+      entityKey: "container:dpf-postgres-backup",
+      entityType: "container",
+      manufacturer: null,
+      productModel: null,
+      technicalClass: null,
+      iconKey: null,
+      observedVersion: null,
+      normalizedVersion: null,
+      attributionConfidence: null,
+      lastSeenAt: new Date("2026-04-29T08:00:00Z"),
+    },
+  ],
   linkedEntityCount: 3,
   freshness: "fresh",
   enrichmentStatus: "enriched",
@@ -141,13 +186,21 @@ describe("DigitalProductDetail", () => {
       expect(html).toContain("Database");
     });
 
-    it("renders Linked Inventory Entities section with primary entity and count", () => {
+    it("renders Linked Inventory Entities section with all entities, not just the primary", () => {
       const html = renderToStaticMarkup(<DigitalProductDetail vm={fullVm} />);
       expect(html).toContain(">Linked Inventory Entities<");
+      // All three entities render in the table, in order.
       expect(html).toContain("PostgreSQL Container");
       expect(html).toContain("container:dpf-postgres-1");
-      // Count of others = total - 1 = 2
-      expect(html).toMatch(/2\s*(?:other|more)/i);
+      expect(html).toContain("Postgres Replica");
+      expect(html).toContain("container:dpf-postgres-2");
+      expect(html).toContain("Postgres Backup Job");
+      expect(html).toContain("container:dpf-postgres-backup");
+      // Three <tr> rows in <tbody> (header row is in <thead>).
+      const tbodyMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/);
+      expect(tbodyMatch).not.toBeNull();
+      const trCount = (tbodyMatch![1].match(/<tr\b/g) ?? []).length;
+      expect(trCount).toBe(3);
     });
 
     it("renders Open Quality Issues section with summary text", () => {

--- a/apps/web/components/portfolio/DigitalProductDetail.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.tsx
@@ -128,9 +128,7 @@ function TaxonomySection({
 // --- Linked inventory entities -----------------------------------------
 
 function LinkedEntitiesSection({ vm }: { vm: DigitalProductView }): ReactElement | null {
-  const entity = vm.primaryEntity;
-  if (entity === null || vm.linkedEntityCount === 0) return null;
-  const others = Math.max(0, vm.linkedEntityCount - 1);
+  if (vm.linkedEntities.length === 0) return null;
 
   return (
     <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
@@ -150,33 +148,39 @@ function LinkedEntitiesSection({ vm }: { vm: DigitalProductView }): ReactElement
             </tr>
           </thead>
           <tbody>
-            <tr className="border-t border-[var(--dpf-border)]">
-              <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.name}</td>
-              <td className="py-2 pr-3 font-mono text-xs text-[var(--dpf-muted)]">
-                {entity.entityKey}
-              </td>
-              <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.entityType}</td>
-              <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.observedVersion ?? "—"}</td>
-              <td className="py-2 pr-3 text-[var(--dpf-text)]">
-                {entity.attributionConfidence === null
-                  ? "—"
-                  : entity.attributionConfidence.toFixed(2)}
-              </td>
-              <td className="py-2 pr-3 text-[var(--dpf-muted)] text-xs">
-                {entity.lastSeenAt.toISOString().slice(0, 10)}
-              </td>
-            </tr>
+            {vm.linkedEntities.map((entity) => (
+              <tr key={entity.id} className="border-t border-[var(--dpf-border)]">
+                <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.name}</td>
+                <td className="py-2 pr-3 font-mono text-xs text-[var(--dpf-muted)]">
+                  {entity.entityKey}
+                </td>
+                <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.entityType}</td>
+                <td className="py-2 pr-3 text-[var(--dpf-text)]">
+                  {entity.observedVersion ?? "—"}
+                </td>
+                <td className="py-2 pr-3 text-[var(--dpf-text)]">
+                  {entity.attributionConfidence === null
+                    ? "—"
+                    : entity.attributionConfidence.toFixed(2)}
+                </td>
+                <td className="py-2 pr-3 text-[var(--dpf-muted)] text-xs">
+                  {entity.lastSeenAt.toISOString().slice(0, 10)}
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
-      {others > 0 && (
-        <p className="mt-2 text-xs text-[var(--dpf-muted)]">
-          and {others} other{others === 1 ? "" : "s"} linked
-        </p>
-      )}
     </section>
   );
 }
+
+// TODO(Chunk 4 Task 4.3): render an Enrichment section reading
+// vm.enrichmentStatus + vm.lastEnrichedAt once the schema columns land.
+//
+// TODO(Chunk 4+): render recent ChangeItem rows once a query helper exists;
+// the spec calls for "recent change items" but ChangeItem rollups for a
+// product are out of scope for Chunk 3.
 
 // --- Open quality issues -----------------------------------------------
 

--- a/apps/web/components/portfolio/DigitalProductDetail.tsx
+++ b/apps/web/components/portfolio/DigitalProductDetail.tsx
@@ -1,0 +1,212 @@
+// apps/web/components/portfolio/DigitalProductDetail.tsx
+//
+// Renders the digital product detail view (Task 3.4 of the discovery ->
+// portfolio gap closure plan). Pure presentation -- consumes a typed
+// `DigitalProductView` produced by `toDigitalProductViewModel` so this
+// component never sees raw Prisma rows or JSON columns.
+//
+// Layout: full-width sections separated by top borders (matches the
+// PortfolioNodeDetail pattern from Task 3.3). No nested cards, no empty
+// bands -- sections that have nothing to show return null.
+
+import type { ReactElement } from "react";
+import type { DigitalProductView } from "@/lib/portfolio/digital-product-view-model";
+import { FreshnessBadge } from "./FreshnessBadge";
+
+type Props = { vm: DigitalProductView };
+
+export function DigitalProductDetail({ vm }: Props): ReactElement {
+  return (
+    <div>
+      <Header vm={vm} />
+      <DescriptionSection description={vm.description} />
+      <IdentitySection vm={vm} />
+      <TaxonomySection lineage={vm.taxonomyLineage} />
+      <LinkedEntitiesSection vm={vm} />
+      <QualityIssuesSection issues={vm.openQualityIssues} />
+    </div>
+  );
+}
+
+// --- Header ------------------------------------------------------------
+
+function Header({ vm }: { vm: DigitalProductView }): ReactElement {
+  return (
+    <div className="mb-2">
+      <div className="flex flex-wrap items-baseline gap-3 mb-2">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">{vm.name}</h1>
+        <span className="text-sm text-[var(--dpf-accent)]">v{vm.version}</span>
+        <span className="text-xs font-mono text-[var(--dpf-muted)]">{vm.productId}</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <LifecycleBadge label="Stage" value={vm.lifecycleStage} />
+        <LifecycleBadge label="Status" value={vm.lifecycleStatus} />
+        <FreshnessBadge freshness={vm.freshness} />
+      </div>
+    </div>
+  );
+}
+
+function LifecycleBadge({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <span className="inline-flex items-center gap-1 text-xs rounded-full px-2 py-0.5 bg-[var(--dpf-surface-2)]">
+      <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">{label}</span>
+      <span className="text-[var(--dpf-text)]">{value}</span>
+    </span>
+  );
+}
+
+// --- Description -------------------------------------------------------
+
+function DescriptionSection({ description }: { description: string | null }): ReactElement | null {
+  if (description === null) return null;
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">Description</h2>
+      <p className="text-sm text-[var(--dpf-text)]">{description}</p>
+    </section>
+  );
+}
+
+// --- Identity (from primary entity) ------------------------------------
+
+function IdentitySection({ vm }: { vm: DigitalProductView }): ReactElement | null {
+  const entity = vm.primaryEntity;
+  if (entity === null) return null;
+  // Only render if at least one identity field is populated.
+  const fields = [
+    { label: "Manufacturer", value: entity.manufacturer },
+    { label: "Product Model", value: entity.productModel },
+    { label: "Technical Class", value: entity.technicalClass },
+    { label: "Icon", value: entity.iconKey },
+  ].filter((f) => f.value !== null && f.value !== "");
+  if (fields.length === 0) return null;
+
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">Identity</h2>
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+        {fields.map((f) => (
+          <div key={f.label} className="flex flex-col">
+            <dt className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">
+              {f.label}
+            </dt>
+            <dd className="text-[var(--dpf-text)]">{f.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+// --- Taxonomy lineage --------------------------------------------------
+
+function TaxonomySection({
+  lineage,
+}: {
+  lineage: Array<{ nodeId: string; name: string }>;
+}): ReactElement | null {
+  if (lineage.length === 0) return null;
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">Taxonomy</h2>
+      <nav
+        aria-label="Taxonomy lineage"
+        className="flex flex-wrap items-center gap-1 text-xs text-[var(--dpf-muted)]"
+      >
+        {lineage.map((node, i) => (
+          <span key={node.nodeId} className="flex items-center gap-1">
+            {i > 0 && <span aria-hidden="true">›</span>}
+            <span className="text-[var(--dpf-text)]">{node.name}</span>
+          </span>
+        ))}
+      </nav>
+    </section>
+  );
+}
+
+// --- Linked inventory entities -----------------------------------------
+
+function LinkedEntitiesSection({ vm }: { vm: DigitalProductView }): ReactElement | null {
+  const entity = vm.primaryEntity;
+  if (entity === null || vm.linkedEntityCount === 0) return null;
+  const others = Math.max(0, vm.linkedEntityCount - 1);
+
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">
+        Linked Inventory Entities
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="text-left text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">
+              <th className="py-1 pr-3">Name</th>
+              <th className="py-1 pr-3">Key</th>
+              <th className="py-1 pr-3">Type</th>
+              <th className="py-1 pr-3">Observed Version</th>
+              <th className="py-1 pr-3">Confidence</th>
+              <th className="py-1 pr-3">Last Seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-t border-[var(--dpf-border)]">
+              <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.name}</td>
+              <td className="py-2 pr-3 font-mono text-xs text-[var(--dpf-muted)]">
+                {entity.entityKey}
+              </td>
+              <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.entityType}</td>
+              <td className="py-2 pr-3 text-[var(--dpf-text)]">{entity.observedVersion ?? "—"}</td>
+              <td className="py-2 pr-3 text-[var(--dpf-text)]">
+                {entity.attributionConfidence === null
+                  ? "—"
+                  : entity.attributionConfidence.toFixed(2)}
+              </td>
+              <td className="py-2 pr-3 text-[var(--dpf-muted)] text-xs">
+                {entity.lastSeenAt.toISOString().slice(0, 10)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {others > 0 && (
+        <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+          and {others} other{others === 1 ? "" : "s"} linked
+        </p>
+      )}
+    </section>
+  );
+}
+
+// --- Open quality issues -----------------------------------------------
+
+function QualityIssuesSection({
+  issues,
+}: {
+  issues: DigitalProductView["openQualityIssues"];
+}): ReactElement | null {
+  if (issues.length === 0) return null;
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">
+        Open Quality Issues
+      </h2>
+      <ul className="flex flex-col gap-2">
+        {issues.map((issue) => (
+          <li
+            key={issue.id}
+            className="flex flex-col sm:flex-row sm:items-baseline sm:gap-3 text-sm"
+          >
+            <span className="inline-flex items-center gap-2 text-xs">
+              <span className="uppercase tracking-wide text-[var(--dpf-muted)]">
+                {issue.severity}
+              </span>
+              <span className="font-mono text-[var(--dpf-muted)]">{issue.issueType}</span>
+            </span>
+            <span className="text-[var(--dpf-text)]">{issue.summary}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/portfolio/FreshnessBadge.test.tsx
+++ b/apps/web/components/portfolio/FreshnessBadge.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FreshnessBadge } from "./FreshnessBadge";
+
+describe("FreshnessBadge", () => {
+  it("renders 'Unknown' (muted) when freshness is null", () => {
+    const html = renderToStaticMarkup(<FreshnessBadge freshness={null} />);
+    expect(html).toContain("Unknown");
+    expect(html).toContain("text-[var(--dpf-muted)]");
+  });
+
+  it("renders 'Unknown' (muted) when freshness is undefined", () => {
+    const html = renderToStaticMarkup(<FreshnessBadge freshness={undefined} />);
+    expect(html).toContain("Unknown");
+    expect(html).toContain("text-[var(--dpf-muted)]");
+  });
+
+  it("renders 'Fresh' with accent token when fresh", () => {
+    const html = renderToStaticMarkup(<FreshnessBadge freshness="fresh" />);
+    expect(html).toContain("Fresh");
+    expect(html).toContain("text-[var(--dpf-accent)]");
+  });
+
+  it("renders 'Stale' with muted token when stale", () => {
+    const html = renderToStaticMarkup(<FreshnessBadge freshness="stale" />);
+    expect(html).toContain("Stale");
+    expect(html).toContain("text-[var(--dpf-muted)]");
+  });
+
+  it("renders 'Retired' with strikethrough + muted token when retired", () => {
+    const html = renderToStaticMarkup(<FreshnessBadge freshness="retired" />);
+    expect(html).toContain("Retired");
+    expect(html).toContain("line-through");
+    expect(html).toContain("text-[var(--dpf-muted)]");
+  });
+
+  it("uses theme tokens only (no raw white/black/gray classes)", () => {
+    const html = renderToStaticMarkup(<FreshnessBadge freshness="fresh" />);
+    expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/portfolio/FreshnessBadge.tsx
+++ b/apps/web/components/portfolio/FreshnessBadge.tsx
@@ -1,0 +1,48 @@
+// apps/web/components/portfolio/FreshnessBadge.tsx
+//
+// Small all-caps pill that surfaces an InventoryEntity's freshness state on
+// the digital product detail page (Task 3.4 of the discovery -> portfolio
+// gap closure plan).
+//
+// Forward-compatible with Chunk 4 Task 4.1: until the schema gains a
+// `freshness` column, callers pass `null` / `undefined` and the badge
+// renders an "Unknown" muted state. Once Chunk 4 lands, the same component
+// surfaces the real value with no further changes.
+
+import type { ReactElement } from "react";
+
+export type FreshnessProp = "fresh" | "stale" | "retired" | null | undefined;
+
+type Props = {
+  freshness: FreshnessProp;
+};
+
+const BASE_CLASSES =
+  "inline-block text-xs uppercase tracking-wide rounded-full px-2 py-0.5 bg-[var(--dpf-surface-2)]";
+
+export function FreshnessBadge({ freshness }: Props): ReactElement {
+  if (freshness === null || freshness === undefined) {
+    return (
+      <span className={`${BASE_CLASSES} text-[var(--dpf-muted)]`}>Unknown</span>
+    );
+  }
+
+  if (freshness === "fresh") {
+    return (
+      <span className={`${BASE_CLASSES} text-[var(--dpf-accent)]`}>Fresh</span>
+    );
+  }
+
+  if (freshness === "stale") {
+    return (
+      <span className={`${BASE_CLASSES} text-[var(--dpf-muted)]`}>Stale</span>
+    );
+  }
+
+  // "retired"
+  return (
+    <span className={`${BASE_CLASSES} line-through text-[var(--dpf-muted)]`}>
+      Retired
+    </span>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioNodeAbout.test.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeAbout.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PortfolioNodeAbout } from "./PortfolioNodeAbout";
+
+describe("PortfolioNodeAbout", () => {
+  it("returns null when about is null", () => {
+    expect(renderToStaticMarkup(<PortfolioNodeAbout about={null} />)).toBe("");
+  });
+
+  it("renders the description text in a populated state", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeAbout about="Compute servers running production workloads." />,
+    );
+    expect(html).toContain("Compute servers running production workloads.");
+    expect(html).toContain(">About<");
+  });
+
+  it("uses theme tokens (no raw white/black/gray classes)", () => {
+    const html = renderToStaticMarkup(<PortfolioNodeAbout about="Hello." />);
+    expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/portfolio/PortfolioNodeAbout.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeAbout.tsx
@@ -1,0 +1,23 @@
+// apps/web/components/portfolio/PortfolioNodeAbout.tsx
+//
+// Renders the TaxonomyNode.description as a full-width "About" band on the
+// portfolio detail page (Task 3.3 of the discovery -> portfolio gap closure
+// plan). When `about` is null the component renders nothing -- per spec
+// section 6.4 we never show an empty band.
+
+import type { ReactElement } from "react";
+
+type Props = {
+  about: string | null;
+};
+
+export function PortfolioNodeAbout({ about }: Props): ReactElement | null {
+  if (about === null) return null;
+
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-2">About</h2>
+      <p className="text-sm text-[var(--dpf-text)]">{about}</p>
+    </section>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioNodeDetail.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeDetail.tsx
@@ -5,6 +5,10 @@ import type { OwnerRoleInfo } from "@/lib/portfolio";
 import { ProductList } from "./ProductList";
 import { TopologyGraph } from "@/components/inventory/TopologyGraph";
 import type { GraphData } from "@/lib/actions/graph";
+import { toPortfolioNodeViewModel } from "@/lib/portfolio/portfolio-node-view-model";
+import { PortfolioNodeAbout } from "./PortfolioNodeAbout";
+import { PortfolioNodeGovernance } from "./PortfolioNodeGovernance";
+import { PortfolioNodeEnrichment } from "./PortfolioNodeEnrichment";
 
 type Product = { id: string; productId: string; name: string; lifecycleStatus: string };
 
@@ -34,6 +38,16 @@ export function PortfolioNodeDetail({
   taxonomyNodeId,
 }: Props) {
   const subLabel = node.parentId === null ? "Capability Domains" : "Functional Groups";
+
+  // Task 3.3: typed view model for the description / governance / enrichment
+  // JSON columns. View model handles null/empty input gracefully and the three
+  // section components return null when there's nothing to render -- so this is
+  // a no-op for nodes that have none of these fields populated.
+  const vm = toPortfolioNodeViewModel({
+    description: node.description ?? null,
+    governance: node.governance ?? null,
+    enrichment: node.enrichment ?? null,
+  });
 
   return (
     <div>
@@ -71,6 +85,12 @@ export function PortfolioNodeDetail({
         <StatBox label="Health" value={health} />
         <StatBox label="Budget" value={investment} />
       </div>
+
+      {/* About / Governance / Enrichment (Task 3.3): each renders null when its
+       *  source view-model field is empty -- no empty bands. */}
+      <PortfolioNodeAbout about={vm.about} />
+      <PortfolioNodeGovernance governance={vm.governance} />
+      <PortfolioNodeEnrichment enrichment={vm.enrichment} />
 
       {/* Sub-nodes */}
       {subNodes.length > 0 && (

--- a/apps/web/components/portfolio/PortfolioNodeDetail.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeDetail.tsx
@@ -1,7 +1,7 @@
 // apps/web/components/portfolio/PortfolioNodeDetail.tsx
 import Link from "next/link";
 import type { PortfolioTreeNode } from "@/lib/portfolio";
-import { PORTFOLIO_COLOURS, type OwnerRoleInfo } from "@/lib/portfolio";
+import type { OwnerRoleInfo } from "@/lib/portfolio";
 import { ProductList } from "./ProductList";
 import { TopologyGraph } from "@/components/inventory/TopologyGraph";
 import type { GraphData } from "@/lib/actions/graph";
@@ -21,10 +21,6 @@ type Props = {
   taxonomyNodeId?: string;
 };
 
-function getRootSlug(nodeId: string): string {
-  return nodeId.split("/")[0] ?? nodeId;
-}
-
 export function PortfolioNodeDetail({
   node,
   subNodes,
@@ -37,8 +33,6 @@ export function PortfolioNodeDetail({
   graphData,
   taxonomyNodeId,
 }: Props) {
-  const rootSlug = getRootSlug(node.nodeId);
-  const colour = PORTFOLIO_COLOURS[rootSlug] ?? "#7c8cf8";
   const subLabel = node.parentId === null ? "Capability Domains" : "Functional Groups";
 
   return (
@@ -64,18 +58,18 @@ export function PortfolioNodeDetail({
       {/* Title */}
       <div className="flex items-baseline gap-3 mb-5">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">{node.name}</h1>
-        <span className="text-sm" style={{ color: colour }}>
+        <span className="text-sm text-[var(--dpf-accent)]">
           {node.totalCount} products
         </span>
       </div>
 
       {/* Stats strip */}
       <div className="flex flex-wrap gap-3 mb-6">
-        <StatBox label="Products" value={String(node.totalCount)} colour="#e2e2f0" />
-        <StatBox label="Owner" value={ownerRole?.roleId ?? "—"} colour={colour} />
-        <StatBox label="Agents" value={String(agentCount)} colour={colour} />
-        <StatBox label="Health" value={health} colour={colour} />
-        <StatBox label="Budget" value={investment} colour={colour} />
+        <StatBox label="Products" value={String(node.totalCount)} />
+        <StatBox label="Owner" value={ownerRole?.roleId ?? "—"} />
+        <StatBox label="Agents" value={String(agentCount)} />
+        <StatBox label="Health" value={health} />
+        <StatBox label="Budget" value={investment} />
       </div>
 
       {/* Sub-nodes */}
@@ -91,12 +85,9 @@ export function PortfolioNodeDetail({
                 href={`/portfolio/${child.nodeId}`}
                 className="flex items-center justify-between p-3 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg hover:bg-[var(--dpf-surface-2)] transition-colors"
               >
-                <span className="text-sm text-[#e2e2f0]">{child.name}</span>
+                <span className="text-sm text-[var(--dpf-text)]">{child.name}</span>
                 {child.totalCount > 0 && (
-                  <span
-                    className="text-[9px] px-2 py-0.5 rounded-full"
-                    style={{ background: `${colour}20`, color: colour }}
-                  >
+                  <span className="text-[9px] px-2 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-accent)]">
                     {child.totalCount}
                   </span>
                 )}
@@ -108,7 +99,7 @@ export function PortfolioNodeDetail({
 
       {/* Products */}
       {products.length > 0 && (
-        <ProductList products={products} colour={colour} />
+        <ProductList products={products} colour="var(--dpf-accent)" />
       )}
 
       {/* Empty state */}
@@ -130,7 +121,7 @@ export function PortfolioNodeDetail({
 
       {/* People */}
       <div className="mt-8">
-        <PeoplePanel ownerRole={ownerRole} colour={colour} />
+        <PeoplePanel ownerRole={ownerRole} />
       </div>
     </div>
   );
@@ -139,12 +130,10 @@ export function PortfolioNodeDetail({
 function StatBox({
   label,
   value,
-  colour,
   dashed = false,
 }: {
   label: string;
   value: string;
-  colour: string;
   dashed?: boolean;
 }) {
   return (
@@ -153,7 +142,7 @@ function StatBox({
         dashed ? "border border-dashed border-[var(--dpf-border)] opacity-40" : "border border-[var(--dpf-border)]"
       }`}
     >
-      <p className="text-sm font-bold" style={{ color: colour }}>
+      <p className="text-sm font-bold text-[var(--dpf-accent)]">
         {value}
       </p>
       <p className="text-[9px] text-[var(--dpf-muted)] uppercase tracking-widest">
@@ -165,10 +154,8 @@ function StatBox({
 
 function PeoplePanel({
   ownerRole,
-  colour,
 }: {
   ownerRole: OwnerRoleInfo | null;
-  colour: string;
 }) {
   return (
     <div>
@@ -181,7 +168,7 @@ function PeoplePanel({
         <div className="bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg px-4 py-3">
           <div className="flex items-baseline gap-2 mb-1">
             <p className="text-sm font-semibold text-[var(--dpf-text)]">{ownerRole.name}</p>
-            <p className="text-[10px] font-mono" style={{ color: colour }}>
+            <p className="text-[10px] font-mono text-[var(--dpf-accent)]">
               {ownerRole.roleId}
             </p>
           </div>

--- a/apps/web/components/portfolio/PortfolioNodeEnrichment.test.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeEnrichment.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PortfolioNodeEnrichment } from "./PortfolioNodeEnrichment";
+import type { EnrichmentView } from "@/lib/portfolio/portfolio-node-view-model";
+
+const empty: EnrichmentView = {
+  standards: null,
+  patterns: null,
+  references: null,
+  raw: null,
+};
+
+describe("PortfolioNodeEnrichment", () => {
+  it("returns null when all fields are null", () => {
+    expect(renderToStaticMarkup(<PortfolioNodeEnrichment enrichment={empty} />)).toBe("");
+  });
+
+  it("returns null when all collections are present but empty", () => {
+    const allEmpty: EnrichmentView = {
+      standards: [],
+      patterns: [],
+      references: [],
+      raw: null,
+    };
+    expect(renderToStaticMarkup(<PortfolioNodeEnrichment enrichment={allEmpty} />)).toBe("");
+  });
+
+  it("renders standards list when present", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeEnrichment
+        enrichment={{
+          standards: ["ISO 27001", "NIST CSF"],
+          patterns: null,
+          references: null,
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).toContain(">Enrichment<");
+    expect(html).toContain(">Standards<");
+    expect(html).toContain("ISO 27001");
+    expect(html).toContain("NIST CSF");
+    expect(html).not.toContain(">Patterns<");
+    expect(html).not.toContain(">References<");
+  });
+
+  it("renders patterns list when present", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeEnrichment
+        enrichment={{
+          standards: null,
+          patterns: ["circuit-breaker", "saga"],
+          references: null,
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).toContain(">Patterns<");
+    expect(html).toContain("circuit-breaker");
+    expect(html).toContain("saga");
+  });
+
+  it("renders references as anchors with rel/target", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeEnrichment
+        enrichment={{
+          standards: null,
+          patterns: null,
+          references: [
+            { label: "ISO 27001 overview", href: "https://example.com/iso27001" },
+          ],
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).toContain(">References<");
+    expect(html).toContain("ISO 27001 overview");
+    expect(html).toContain('href="https://example.com/iso27001"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("does not render raw JSON blob in output", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeEnrichment
+        enrichment={{
+          standards: ["ISO 27001"],
+          patterns: ["saga"],
+          references: [{ label: "Doc", href: "https://example.com" }],
+          raw: { standards: ["ISO 27001"], secretKey: "should-not-leak" },
+        }}
+      />,
+    );
+    expect(html).not.toContain('"standards"');
+    expect(html).not.toContain('"patterns"');
+    expect(html).not.toContain("secretKey");
+    expect(html).not.toContain("should-not-leak");
+  });
+
+  it("uses theme tokens only", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeEnrichment
+        enrichment={{
+          standards: ["ISO 27001"],
+          patterns: null,
+          references: [{ label: "Doc", href: "https://example.com" }],
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
@@ -1,0 +1,76 @@
+// apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
+//
+// Renders the typed enrichment view-model fields (standards, patterns,
+// references) as a full-width band on the portfolio detail page. Task 3.3 of
+// the discovery -> portfolio gap closure plan.
+//
+// Per spec section 6.4: no nested cards; full-width band with theme tokens
+// only. Each subsection only renders when its source field is non-null and
+// non-empty -- we never show "0 standards" or an empty <ul>.
+
+import type { ReactElement } from "react";
+import type { EnrichmentView } from "@/lib/portfolio/portfolio-node-view-model";
+
+type Props = {
+  enrichment: EnrichmentView;
+};
+
+function hasItems<T>(arr: T[] | null): arr is T[] {
+  return arr !== null && arr.length > 0;
+}
+
+export function PortfolioNodeEnrichment({ enrichment }: Props): ReactElement | null {
+  const { standards, patterns, references } = enrichment;
+  const showStandards = hasItems(standards);
+  const showPatterns = hasItems(patterns);
+  const showReferences = hasItems(references);
+  if (!showStandards && !showPatterns && !showReferences) return null;
+
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-3">Enrichment</h2>
+
+      {showStandards && (
+        <div className="mb-4">
+          <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">Standards</p>
+          <ul className="list-disc list-inside text-sm text-[var(--dpf-text)]">
+            {standards!.map((s) => (
+              <li key={s}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {showPatterns && (
+        <div className="mb-4">
+          <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">Patterns</p>
+          <ul className="list-disc list-inside text-sm text-[var(--dpf-text)]">
+            {patterns!.map((p) => (
+              <li key={p}>{p}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {showReferences && (
+        <div>
+          <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">References</p>
+          <ul className="text-sm">
+            {references!.map((ref) => (
+              <li key={`${ref.label}|${ref.href}`}>
+                <a
+                  href={ref.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--dpf-accent)] hover:underline"
+                >
+                  {ref.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/portfolio/PortfolioNodeGovernance.test.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeGovernance.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PortfolioNodeGovernance } from "./PortfolioNodeGovernance";
+import type { GovernanceView } from "@/lib/portfolio/portfolio-node-view-model";
+
+const empty: GovernanceView = { promotion: null, requiredFields: null, raw: null };
+
+describe("PortfolioNodeGovernance", () => {
+  it("returns null when promotion and requiredFields are both null", () => {
+    expect(renderToStaticMarkup(<PortfolioNodeGovernance governance={empty} />)).toBe("");
+  });
+
+  it("renders promotion policy as labeled fields when present", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeGovernance
+        governance={{
+          promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" },
+          requiredFields: null,
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).toContain(">Governance<");
+    expect(html).toContain(">Promotion policy<");
+    expect(html).toContain("auto");
+    expect(html).toContain("infrastructure_endpoint");
+  });
+
+  it("does not render raw JSON blob in output", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeGovernance
+        governance={{
+          promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" },
+          requiredFields: ["manufacturer"],
+          raw: { promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" }, secret: "x" },
+        }}
+      />,
+    );
+    // No raw JSON: no curly braces wrapping the literal blob, no quoted keys.
+    expect(html).not.toContain('"promotion"');
+    expect(html).not.toContain('"mode"');
+    expect(html).not.toContain('"classifyAs"');
+    expect(html).not.toContain("secret");
+  });
+
+  it("renders requiredFields as a list when present", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeGovernance
+        governance={{
+          promotion: null,
+          requiredFields: ["manufacturer", "observedVersion"],
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).toContain(">Required fields<");
+    expect(html).toContain("<ul");
+    expect(html).toContain("<li");
+    expect(html).toContain("manufacturer");
+    expect(html).toContain("observedVersion");
+  });
+
+  it("uses theme tokens only", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioNodeGovernance
+        governance={{
+          promotion: { mode: "manual" },
+          requiredFields: ["manufacturer"],
+          raw: null,
+        }}
+      />,
+    );
+    expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/portfolio/PortfolioNodeGovernance.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeGovernance.tsx
@@ -1,0 +1,56 @@
+// apps/web/components/portfolio/PortfolioNodeGovernance.tsx
+//
+// Renders the typed governance view-model fields (promotion policy + required
+// fields) as a full-width band on the portfolio detail page. Task 3.3 of the
+// discovery -> portfolio gap closure plan.
+//
+// Per spec section 6.4: no nested cards; full-width band with theme tokens
+// only. We deliberately do NOT render `governance.raw` -- a JSON blob is not a
+// product surface.
+
+import type { ReactElement } from "react";
+import type { GovernanceView } from "@/lib/portfolio/portfolio-node-view-model";
+
+type Props = {
+  governance: GovernanceView;
+};
+
+export function PortfolioNodeGovernance({ governance }: Props): ReactElement | null {
+  const { promotion, requiredFields } = governance;
+  if (promotion === null && requiredFields === null) return null;
+
+  return (
+    <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-3">Governance</h2>
+
+      {promotion !== null && (
+        <div className="mb-4">
+          <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">Promotion policy</p>
+          <dl className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-[var(--dpf-text)]">
+            <div className="flex items-baseline gap-2">
+              <dt className="text-xs text-[var(--dpf-muted)]">Mode</dt>
+              <dd>{promotion.mode}</dd>
+            </div>
+            {promotion.classifyAs !== undefined && (
+              <div className="flex items-baseline gap-2">
+                <dt className="text-xs text-[var(--dpf-muted)]">Classify as</dt>
+                <dd>{promotion.classifyAs}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      )}
+
+      {requiredFields !== null && requiredFields.length > 0 && (
+        <div>
+          <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">Required fields</p>
+          <ul className="list-disc list-inside text-sm text-[var(--dpf-text)]">
+            {requiredFields.map((field) => (
+              <li key={field}>{field}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/evaluate/portfolio-data.ts
+++ b/apps/web/lib/evaluate/portfolio-data.ts
@@ -30,7 +30,17 @@ export const getFullPortfolioTree = cache(async () => {
   const [nodes, totalCounts, activeCounts] = await Promise.all([
     prisma.taxonomyNode.findMany({
       where: { status: "active" },
-      select: { id: true, nodeId: true, name: true, parentId: true, portfolioId: true },
+      select: {
+        id: true,
+        nodeId: true,
+        name: true,
+        parentId: true,
+        portfolioId: true,
+        // Detail page (Task 3.3) renders these via toPortfolioNodeViewModel.
+        description: true,
+        governance: true,
+        enrichment: true,
+      },
     }),
     prisma.digitalProduct.groupBy({
       by: ["taxonomyNodeId"],

--- a/apps/web/lib/evaluate/portfolio.ts
+++ b/apps/web/lib/evaluate/portfolio.ts
@@ -10,6 +10,12 @@ export type PortfolioTreeNode = {
   directCount: number;
   totalCount: number;
   activeCount: number;   // ← new: active products in subtree, rolled up
+  /** Optional TaxonomyNode.description -- detail page consumers populate when present. */
+  description?: string | null;
+  /** Optional TaxonomyNode.governance JSON column (Prisma `Json?`). */
+  governance?: unknown;
+  /** Optional TaxonomyNode.enrichment JSON column (Prisma `Json?`). */
+  enrichment?: unknown;
   children: PortfolioTreeNode[];
 };
 
@@ -42,6 +48,9 @@ type RawNode = {
   name: string;
   parentId: string | null;
   portfolioId: string | null | undefined;
+  description?: string | null;
+  governance?: unknown;
+  enrichment?: unknown;
 };
 
 type CountRow = {
@@ -96,6 +105,9 @@ export function buildPortfolioTree(
       directCount: countById.get(n.id) ?? 0,
       totalCount: 0,
       activeCount: 0,   // populated during DFS below
+      description: n.description ?? null,
+      governance: n.governance ?? null,
+      enrichment: n.enrichment ?? null,
       children: [],
     });
   }

--- a/apps/web/lib/portfolio/digital-product-view-model.test.ts
+++ b/apps/web/lib/portfolio/digital-product-view-model.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { toDigitalProductViewModel } from "./digital-product-view-model";
+
+const baseProduct = {
+  id: "dp_1",
+  productId: "host-postgres",
+  name: "PostgreSQL",
+  description: "Primary relational database",
+  version: "16.0",
+  lifecycleStage: "production",
+  lifecycleStatus: "active",
+  observationConfig: { classifyAs: "infrastructure_endpoint" },
+  portfolio: { id: "p_1", slug: "foundational", name: "Foundational" },
+  taxonomyNode: { nodeId: "foundational/data_and_storage_management/database", name: "Database" },
+};
+
+describe("toDigitalProductViewModel", () => {
+  it("projects basic product fields", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [
+        { nodeId: "foundational", name: "Foundational" },
+        { nodeId: "foundational/data_and_storage_management", name: "Data and Storage Management" },
+      ],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.id).toBe("dp_1");
+    expect(vm.productId).toBe("host-postgres");
+    expect(vm.name).toBe("PostgreSQL");
+    expect(vm.description).toBe("Primary relational database");
+    expect(vm.lifecycleStage).toBe("production");
+  });
+
+  it("builds taxonomy lineage root -> leaf", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [
+        { nodeId: "foundational", name: "Foundational" },
+        { nodeId: "foundational/data_and_storage_management", name: "Data and Storage Management" },
+      ],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.taxonomyLineage).toEqual([
+      { nodeId: "foundational", name: "Foundational" },
+      { nodeId: "foundational/data_and_storage_management", name: "Data and Storage Management" },
+      { nodeId: "foundational/data_and_storage_management/database", name: "Database" },
+    ]);
+  });
+
+  it("returns ancestors only when product has no taxonomyNode", () => {
+    const vm = toDigitalProductViewModel({
+      product: { ...baseProduct, taxonomyNode: null },
+      taxonomyAncestors: [{ nodeId: "foundational", name: "Foundational" }],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.taxonomyLineage).toEqual([{ nodeId: "foundational", name: "Foundational" }]);
+  });
+
+  it("surfaces observationConfig.classifyAs when present", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.observationConfig).toEqual({ classifyAs: "infrastructure_endpoint" });
+  });
+
+  it("returns null observationConfig when absent or malformed", () => {
+    const vm1 = toDigitalProductViewModel({
+      product: { ...baseProduct, observationConfig: null },
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm1.observationConfig).toBeNull();
+    const vm2 = toDigitalProductViewModel({
+      product: { ...baseProduct, observationConfig: "not-an-object" },
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm2.observationConfig).toBeNull();
+  });
+
+  it("picks primaryEntity from first inventory entity", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [
+        {
+          id: "ent_1",
+          name: "PostgreSQL Container",
+          entityKey: "container:dpf-postgres-1",
+          entityType: "container",
+          manufacturer: "PostgreSQL Global Development Group",
+          productModel: "PostgreSQL",
+          technicalClass: "relational_database",
+          iconKey: "postgres",
+          observedVersion: "16.0",
+          normalizedVersion: "16.0.0",
+          attributionConfidence: 0.98,
+          lastSeenAt: new Date("2026-04-30"),
+        },
+        {
+          id: "ent_2",
+          name: "Other",
+          entityKey: "container:other",
+          entityType: "container",
+          manufacturer: null,
+          productModel: null,
+          technicalClass: null,
+          iconKey: null,
+          observedVersion: null,
+          normalizedVersion: null,
+          attributionConfidence: null,
+          lastSeenAt: new Date(),
+        },
+      ],
+      qualityIssues: [],
+    });
+    expect(vm.primaryEntity?.id).toBe("ent_1");
+    expect(vm.primaryEntity?.manufacturer).toBe("PostgreSQL Global Development Group");
+    expect(vm.linkedEntityCount).toBe(2);
+  });
+
+  it("primaryEntity is null when no entities are linked", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.primaryEntity).toBeNull();
+    expect(vm.linkedEntityCount).toBe(0);
+  });
+
+  it("filters quality issues to status='open' and sorts desc by lastDetectedAt", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [
+        { id: "q1", issueType: "incomplete_detail", severity: "warn", summary: "old", lastDetectedAt: new Date("2026-04-01"), status: "open" },
+        { id: "q2", issueType: "incomplete_detail", severity: "warn", summary: "resolved", lastDetectedAt: new Date("2026-04-15"), status: "resolved" },
+        { id: "q3", issueType: "type_not_promotable", severity: "error", summary: "newer", lastDetectedAt: new Date("2026-04-30"), status: "open" },
+      ],
+    });
+    expect(vm.openQualityIssues).toHaveLength(2);
+    expect(vm.openQualityIssues[0].id).toBe("q3"); // newest first
+    expect(vm.openQualityIssues[1].id).toBe("q1");
+  });
+
+  it("caps openQualityIssues at 10", () => {
+    const issues = Array.from({ length: 15 }).map((_, i) => ({
+      id: `q${i}`,
+      issueType: "incomplete_detail",
+      severity: "warn",
+      summary: `issue ${i}`,
+      lastDetectedAt: new Date(2026, 3, i + 1),
+      status: "open",
+    }));
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: issues,
+    });
+    expect(vm.openQualityIssues).toHaveLength(10);
+  });
+
+  it("Chunk 4 fields default to null when not passed", () => {
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+    });
+    expect(vm.freshness).toBeNull();
+    expect(vm.enrichmentStatus).toBeNull();
+    expect(vm.lastEnrichedAt).toBeNull();
+  });
+
+  it("passes Chunk 4 fields through when provided (forward-compat)", () => {
+    const enrichedAt = new Date("2026-04-30");
+    const vm = toDigitalProductViewModel({
+      product: baseProduct,
+      taxonomyAncestors: [],
+      inventoryEntities: [],
+      qualityIssues: [],
+      freshness: "stale",
+      enrichmentStatus: "enriched",
+      lastEnrichedAt: enrichedAt,
+    });
+    expect(vm.freshness).toBe("stale");
+    expect(vm.enrichmentStatus).toBe("enriched");
+    expect(vm.lastEnrichedAt).toBe(enrichedAt);
+  });
+});

--- a/apps/web/lib/portfolio/digital-product-view-model.ts
+++ b/apps/web/lib/portfolio/digital-product-view-model.ts
@@ -34,20 +34,16 @@ export interface DigitalProductView {
   portfolio: { id: string; slug: string; name: string } | null;
 
   // Pulled from a primary linked InventoryEntity (or null when none).
-  primaryEntity: {
-    id: string;
-    name: string;
-    entityKey: string;
-    entityType: string;
-    manufacturer: string | null;
-    productModel: string | null;
-    technicalClass: string | null;
-    iconKey: string | null;
-    observedVersion: string | null;
-    normalizedVersion: string | null;
-    attributionConfidence: number | null;
-    lastSeenAt: Date;
-  } | null;
+  // Same shape as `linkedEntities[0]` — kept as a separate field for ergonomic
+  // identity-row rendering without indexing.
+  primaryEntity: LinkedEntitySummary | null;
+
+  /**
+   * Full set of linked InventoryEntity rows, in the order returned by the
+   * caller. The detail page renders these in the "Linked Inventory Entities"
+   * table; consumers who only need identity hints can read `primaryEntity`.
+   */
+  linkedEntities: LinkedEntitySummary[];
 
   linkedEntityCount: number;
 
@@ -64,6 +60,26 @@ export interface DigitalProductView {
     summary: string;
     lastDetectedAt: Date;
   }>;
+}
+
+/**
+ * Summary shape used by both `primaryEntity` and `linkedEntities`. Keep the
+ * fields aligned with what `DigitalProductDetail`'s linked-entities table
+ * renders — adding a column here means adding a column there.
+ */
+export interface LinkedEntitySummary {
+  id: string;
+  name: string;
+  entityKey: string;
+  entityType: string;
+  manufacturer: string | null;
+  productModel: string | null;
+  technicalClass: string | null;
+  iconKey: string | null;
+  observedVersion: string | null;
+  normalizedVersion: string | null;
+  attributionConfidence: number | null;
+  lastSeenAt: Date;
 }
 
 export interface ToDigitalProductViewModelInput {
@@ -138,25 +154,23 @@ function projectTaxonomyLineage(
   return lineage;
 }
 
-function projectPrimaryEntity(
+function projectLinkedEntities(
   entities: ToDigitalProductViewModelInput["inventoryEntities"],
-): DigitalProductView["primaryEntity"] {
-  const first = entities[0];
-  if (!first) return null;
-  return {
-    id: first.id,
-    name: first.name,
-    entityKey: first.entityKey,
-    entityType: first.entityType,
-    manufacturer: first.manufacturer,
-    productModel: first.productModel,
-    technicalClass: first.technicalClass,
-    iconKey: first.iconKey,
-    observedVersion: first.observedVersion,
-    normalizedVersion: first.normalizedVersion,
-    attributionConfidence: first.attributionConfidence,
-    lastSeenAt: first.lastSeenAt,
-  };
+): LinkedEntitySummary[] {
+  return entities.map((e) => ({
+    id: e.id,
+    name: e.name,
+    entityKey: e.entityKey,
+    entityType: e.entityType,
+    manufacturer: e.manufacturer,
+    productModel: e.productModel,
+    technicalClass: e.technicalClass,
+    iconKey: e.iconKey,
+    observedVersion: e.observedVersion,
+    normalizedVersion: e.normalizedVersion,
+    attributionConfidence: e.attributionConfidence,
+    lastSeenAt: e.lastSeenAt,
+  }));
 }
 
 function projectOpenQualityIssues(
@@ -194,7 +208,8 @@ export function toDigitalProductViewModel(
     observationConfig: projectObservationConfig(product.observationConfig),
     taxonomyLineage: projectTaxonomyLineage(taxonomyAncestors, product.taxonomyNode),
     portfolio: product.portfolio,
-    primaryEntity: projectPrimaryEntity(inventoryEntities),
+    primaryEntity: projectLinkedEntities(inventoryEntities)[0] ?? null,
+    linkedEntities: projectLinkedEntities(inventoryEntities),
     linkedEntityCount: inventoryEntities.length,
     freshness: input.freshness ?? null,
     enrichmentStatus: input.enrichmentStatus ?? null,

--- a/apps/web/lib/portfolio/digital-product-view-model.ts
+++ b/apps/web/lib/portfolio/digital-product-view-model.ts
@@ -1,0 +1,205 @@
+/**
+ * Digital product view model
+ *
+ * Pure mapping from a Prisma DigitalProduct + linked InventoryEntity[] +
+ * open PortfolioQualityIssue[] (and forward-compatible Chunk 4 freshness /
+ * enrichment fields) into a typed render-ready shape used by the digital
+ * product detail page (Task 3.4 of the discovery -> portfolio gap closure
+ * plan).
+ *
+ * View-model-first per Task 3.3 review: the page does the I/O, this module
+ * does only projection. No DB. No I/O. Tolerates null/undefined inputs.
+ *
+ * Chunk 4 forward compatibility: `freshness`, `enrichmentStatus`,
+ * `lastEnrichedAt` are accepted as optional inputs but never read off the
+ * Prisma row in this chunk -- they default to null. When Chunk 4 Task 4.1
+ * lands the Prisma schema fields, the page will pass them through and the
+ * view will light up without further changes here.
+ */
+
+export type FreshnessValue = "fresh" | "stale" | "retired";
+export type EnrichmentStatusValue = "pending" | "enriched" | "partial" | "failed";
+
+export interface DigitalProductView {
+  id: string;
+  productId: string;
+  name: string;
+  description: string | null;
+  version: string;
+  lifecycleStage: string;
+  lifecycleStatus: string;
+  observationConfig: { classifyAs?: string } | null;
+
+  taxonomyLineage: Array<{ nodeId: string; name: string }>; // breadcrumb root -> leaf
+  portfolio: { id: string; slug: string; name: string } | null;
+
+  // Pulled from a primary linked InventoryEntity (or null when none).
+  primaryEntity: {
+    id: string;
+    name: string;
+    entityKey: string;
+    entityType: string;
+    manufacturer: string | null;
+    productModel: string | null;
+    technicalClass: string | null;
+    iconKey: string | null;
+    observedVersion: string | null;
+    normalizedVersion: string | null;
+    attributionConfidence: number | null;
+    lastSeenAt: Date;
+  } | null;
+
+  linkedEntityCount: number;
+
+  // Chunk 4 territory -- accepted as optional inputs, never read from Prisma in this chunk.
+  freshness: FreshnessValue | null;
+  enrichmentStatus: EnrichmentStatusValue | null;
+  lastEnrichedAt: Date | null;
+
+  // Open quality issues sourced from a separate query (not embedded in DigitalProduct).
+  openQualityIssues: Array<{
+    id: string;
+    issueType: string;
+    severity: string;
+    summary: string;
+    lastDetectedAt: Date;
+  }>;
+}
+
+export interface ToDigitalProductViewModelInput {
+  product: {
+    id: string;
+    productId: string;
+    name: string;
+    description: string | null;
+    version: string;
+    lifecycleStage: string;
+    lifecycleStatus: string;
+    observationConfig: unknown;
+    portfolio: { id: string; slug: string; name: string } | null;
+    taxonomyNode: { nodeId: string; name: string } | null;
+  };
+  taxonomyAncestors: Array<{ nodeId: string; name: string }>; // root-first; may be empty
+  inventoryEntities: Array<{
+    id: string;
+    name: string;
+    entityKey: string;
+    entityType: string;
+    manufacturer: string | null;
+    productModel: string | null;
+    technicalClass: string | null;
+    iconKey: string | null;
+    observedVersion: string | null;
+    normalizedVersion: string | null;
+    attributionConfidence: number | null;
+    lastSeenAt: Date;
+  }>;
+  qualityIssues: Array<{
+    id: string;
+    issueType: string;
+    severity: string;
+    summary: string;
+    lastDetectedAt: Date;
+    status: string; // only "open" should appear in the output
+  }>;
+  // Chunk 4 future fields -- accept but don't require
+  freshness?: FreshnessValue | null;
+  enrichmentStatus?: EnrichmentStatusValue | null;
+  lastEnrichedAt?: Date | null;
+}
+
+// --- helpers -----------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function projectObservationConfig(value: unknown): { classifyAs?: string } | null {
+  if (!isPlainObject(value)) return null;
+  const out: { classifyAs?: string } = {};
+  if (typeof value.classifyAs === "string") {
+    out.classifyAs = value.classifyAs;
+  }
+  // If nothing meaningful surfaced, return null rather than {} so callers can
+  // boolean-check the presence of any known field. (Future fields go here.)
+  if (Object.keys(out).length === 0) return null;
+  return out;
+}
+
+function projectTaxonomyLineage(
+  ancestors: Array<{ nodeId: string; name: string }>,
+  leaf: { nodeId: string; name: string } | null,
+): Array<{ nodeId: string; name: string }> {
+  const lineage: Array<{ nodeId: string; name: string }> = ancestors.map((a) => ({
+    nodeId: a.nodeId,
+    name: a.name,
+  }));
+  if (leaf !== null) lineage.push({ nodeId: leaf.nodeId, name: leaf.name });
+  return lineage;
+}
+
+function projectPrimaryEntity(
+  entities: ToDigitalProductViewModelInput["inventoryEntities"],
+): DigitalProductView["primaryEntity"] {
+  const first = entities[0];
+  if (!first) return null;
+  return {
+    id: first.id,
+    name: first.name,
+    entityKey: first.entityKey,
+    entityType: first.entityType,
+    manufacturer: first.manufacturer,
+    productModel: first.productModel,
+    technicalClass: first.technicalClass,
+    iconKey: first.iconKey,
+    observedVersion: first.observedVersion,
+    normalizedVersion: first.normalizedVersion,
+    attributionConfidence: first.attributionConfidence,
+    lastSeenAt: first.lastSeenAt,
+  };
+}
+
+function projectOpenQualityIssues(
+  issues: ToDigitalProductViewModelInput["qualityIssues"],
+): DigitalProductView["openQualityIssues"] {
+  return issues
+    .filter((i) => i.status === "open")
+    .slice() // copy before sort
+    .sort((a, b) => b.lastDetectedAt.getTime() - a.lastDetectedAt.getTime())
+    .slice(0, 10)
+    .map((i) => ({
+      id: i.id,
+      issueType: i.issueType,
+      severity: i.severity,
+      summary: i.summary,
+      lastDetectedAt: i.lastDetectedAt,
+    }));
+}
+
+// --- public ------------------------------------------------------------
+
+export function toDigitalProductViewModel(
+  input: ToDigitalProductViewModelInput,
+): DigitalProductView {
+  const { product, taxonomyAncestors, inventoryEntities, qualityIssues } = input;
+
+  return {
+    id: product.id,
+    productId: product.productId,
+    name: product.name,
+    description: product.description,
+    version: product.version,
+    lifecycleStage: product.lifecycleStage,
+    lifecycleStatus: product.lifecycleStatus,
+    observationConfig: projectObservationConfig(product.observationConfig),
+    taxonomyLineage: projectTaxonomyLineage(taxonomyAncestors, product.taxonomyNode),
+    portfolio: product.portfolio,
+    primaryEntity: projectPrimaryEntity(inventoryEntities),
+    linkedEntityCount: inventoryEntities.length,
+    freshness: input.freshness ?? null,
+    enrichmentStatus: input.enrichmentStatus ?? null,
+    lastEnrichedAt: input.lastEnrichedAt ?? null,
+    openQualityIssues: projectOpenQualityIssues(qualityIssues),
+  };
+}
+

--- a/apps/web/lib/portfolio/portfolio-node-view-model.test.ts
+++ b/apps/web/lib/portfolio/portfolio-node-view-model.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { toPortfolioNodeViewModel } from "./portfolio-node-view-model";
+
+describe("toPortfolioNodeViewModel", () => {
+  describe("about", () => {
+    it("uses description verbatim", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: "Compute servers running production workloads.",
+        governance: null,
+        enrichment: null,
+      });
+      expect(vm.about).toBe("Compute servers running production workloads.");
+    });
+
+    it("treats empty string as absent", () => {
+      const vm = toPortfolioNodeViewModel({ description: "", governance: null, enrichment: null });
+      expect(vm.about).toBeNull();
+    });
+
+    it("treats null as absent", () => {
+      const vm = toPortfolioNodeViewModel({ description: null, governance: null, enrichment: null });
+      expect(vm.about).toBeNull();
+    });
+  });
+
+  describe("governance", () => {
+    it("projects promotion policy when mode is present", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: { promotion: { mode: "auto", classifyAs: "infrastructure_endpoint" } },
+        enrichment: null,
+      });
+      expect(vm.governance.promotion).toEqual({ mode: "auto", classifyAs: "infrastructure_endpoint" });
+    });
+
+    it("returns null promotion when governance has no promotion key", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: { somethingElse: 1 },
+        enrichment: null,
+      });
+      expect(vm.governance.promotion).toBeNull();
+    });
+
+    it("captures requiredFields when present as an array of strings", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: { requiredFields: ["manufacturer", "observedVersion"] },
+        enrichment: null,
+      });
+      expect(vm.governance.requiredFields).toEqual(["manufacturer", "observedVersion"]);
+    });
+
+    it("ignores requiredFields when shape is wrong", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: { requiredFields: "not-an-array" },
+        enrichment: null,
+      });
+      expect(vm.governance.requiredFields).toBeNull();
+    });
+
+    it("populates raw when governance is a non-null object", () => {
+      const gov = { promotion: { mode: "auto" }, custom: 42 };
+      const vm = toPortfolioNodeViewModel({ description: null, governance: gov, enrichment: null });
+      expect(vm.governance.raw).toEqual(gov);
+      // raw should be a clone, not the same reference
+      expect(vm.governance.raw).not.toBe(gov);
+    });
+
+    it("returns null governance views when input is null", () => {
+      const vm = toPortfolioNodeViewModel({ description: null, governance: null, enrichment: null });
+      expect(vm.governance).toEqual({ promotion: null, requiredFields: null, raw: null });
+    });
+  });
+
+  describe("enrichment", () => {
+    it("projects standards/patterns/references when shapes are correct", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: null,
+        enrichment: {
+          standards: ["ISO-27001", "SOC-2"],
+          patterns: ["leader-follower"],
+          references: [
+            { label: "RFC", href: "https://example.com" },
+            { label: "Bad", href: 123 }, // malformed; should be filtered
+          ],
+        },
+      });
+      expect(vm.enrichment.standards).toEqual(["ISO-27001", "SOC-2"]);
+      expect(vm.enrichment.patterns).toEqual(["leader-follower"]);
+      expect(vm.enrichment.references).toEqual([{ label: "RFC", href: "https://example.com" }]);
+    });
+
+    it("warns and returns null for malformed enrichment shape", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: null,
+        enrichment: { standards: "not-an-array" },
+      });
+      expect(vm.enrichment.standards).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("[view-model]"));
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("isolation", () => {
+    it("input objects are not mutated", () => {
+      const node = {
+        description: "x",
+        governance: { promotion: { mode: "auto" } },
+        enrichment: { standards: ["A"] },
+      };
+      const snapshot = JSON.stringify(node);
+      toPortfolioNodeViewModel(node);
+      expect(JSON.stringify(node)).toBe(snapshot);
+    });
+  });
+});

--- a/apps/web/lib/portfolio/portfolio-node-view-model.ts
+++ b/apps/web/lib/portfolio/portfolio-node-view-model.ts
@@ -1,0 +1,191 @@
+/**
+ * Portfolio node view model
+ *
+ * Pure mapping from a raw TaxonomyNode (description + governance JSON +
+ * enrichment JSON) into a typed render-ready shape used by the portfolio
+ * detail page (Task 3.3 of the discovery -> portfolio gap closure plan).
+ *
+ * Unknown JSON shapes log a one-line `[view-model]` warning and emit null
+ * for the offending field; valid known shapes flow through with strict
+ * types. The `raw` fields are JSON-cloned so callers cannot accidentally
+ * mutate the source object.
+ *
+ * Hand-rolled type guards (no Zod) — keeps this module dependency-free
+ * since it ships in the web app's render path.
+ */
+
+export interface PromotionView {
+  mode: "auto" | "manual" | string;
+  classifyAs?: string;
+}
+
+export interface GovernanceView {
+  promotion: PromotionView | null;
+  /** Optional governance.requiredFields per spec section 6.3. Future Chunk 7 sets this. */
+  requiredFields: string[] | null;
+  /** Entire JSON for debugging/hover display. JSON-cloned. */
+  raw: Record<string, unknown> | null;
+}
+
+export interface EnrichmentReference {
+  label: string;
+  href: string;
+}
+
+export interface EnrichmentView {
+  standards: string[] | null;
+  patterns: string[] | null;
+  references: EnrichmentReference[] | null;
+  /** Entire JSON for debugging/hover display. JSON-cloned. */
+  raw: Record<string, unknown> | null;
+}
+
+export interface PortfolioNodeViewModel {
+  /** Equal to node.description; empty strings collapse to null. */
+  about: string | null;
+  governance: GovernanceView;
+  enrichment: EnrichmentView;
+}
+
+export interface PortfolioNodeInput {
+  description: string | null;
+  governance: unknown;
+  enrichment: unknown;
+}
+
+// --- type guards -------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function cloneObject(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function warn(message: string): void {
+  console.warn(`[view-model] ${message}`);
+}
+
+// --- about -------------------------------------------------------------
+
+function projectAbout(description: string | null): string | null {
+  if (description === null) return null;
+  if (description === "") return null;
+  return description;
+}
+
+// --- governance --------------------------------------------------------
+
+function projectPromotion(governance: Record<string, unknown>): PromotionView | null {
+  if (!("promotion" in governance)) return null;
+  const promotion = governance.promotion;
+  if (!isPlainObject(promotion)) {
+    warn("governance.promotion is not an object; ignoring");
+    return null;
+  }
+  const mode = promotion.mode;
+  if (typeof mode !== "string") {
+    warn("governance.promotion.mode is not a string; ignoring");
+    return null;
+  }
+  const view: PromotionView = { mode };
+  if (typeof promotion.classifyAs === "string") {
+    view.classifyAs = promotion.classifyAs;
+  }
+  return view;
+}
+
+function projectRequiredFields(governance: Record<string, unknown>): string[] | null {
+  if (!("requiredFields" in governance)) return null;
+  const required = governance.requiredFields;
+  if (!isStringArray(required)) {
+    warn("governance.requiredFields is not a string[]; ignoring");
+    return null;
+  }
+  return [...required];
+}
+
+function projectGovernance(governance: unknown): GovernanceView {
+  if (governance === null || governance === undefined) {
+    return { promotion: null, requiredFields: null, raw: null };
+  }
+  if (!isPlainObject(governance)) {
+    warn("governance is not an object; ignoring");
+    return { promotion: null, requiredFields: null, raw: null };
+  }
+  return {
+    promotion: projectPromotion(governance),
+    requiredFields: projectRequiredFields(governance),
+    raw: cloneObject(governance),
+  };
+}
+
+// --- enrichment --------------------------------------------------------
+
+function projectStandards(enrichment: Record<string, unknown>): string[] | null {
+  if (!("standards" in enrichment)) return null;
+  const standards = enrichment.standards;
+  if (!isStringArray(standards)) {
+    warn("enrichment.standards is not a string[]; ignoring");
+    return null;
+  }
+  return [...standards];
+}
+
+function projectPatterns(enrichment: Record<string, unknown>): string[] | null {
+  if (!("patterns" in enrichment)) return null;
+  const patterns = enrichment.patterns;
+  if (!isStringArray(patterns)) {
+    warn("enrichment.patterns is not a string[]; ignoring");
+    return null;
+  }
+  return [...patterns];
+}
+
+function projectReferences(enrichment: Record<string, unknown>): EnrichmentReference[] | null {
+  if (!("references" in enrichment)) return null;
+  const references = enrichment.references;
+  if (!Array.isArray(references)) {
+    warn("enrichment.references is not an array; ignoring");
+    return null;
+  }
+  const projected: EnrichmentReference[] = [];
+  for (const entry of references) {
+    if (!isPlainObject(entry)) continue;
+    const { label, href } = entry;
+    if (typeof label !== "string" || typeof href !== "string") continue;
+    projected.push({ label, href });
+  }
+  return projected;
+}
+
+function projectEnrichment(enrichment: unknown): EnrichmentView {
+  if (enrichment === null || enrichment === undefined) {
+    return { standards: null, patterns: null, references: null, raw: null };
+  }
+  if (!isPlainObject(enrichment)) {
+    warn("enrichment is not an object; ignoring");
+    return { standards: null, patterns: null, references: null, raw: null };
+  }
+  return {
+    standards: projectStandards(enrichment),
+    patterns: projectPatterns(enrichment),
+    references: projectReferences(enrichment),
+    raw: cloneObject(enrichment),
+  };
+}
+
+// --- public ------------------------------------------------------------
+
+export function toPortfolioNodeViewModel(node: PortfolioNodeInput): PortfolioNodeViewModel {
+  return {
+    about: projectAbout(node.description),
+    governance: projectGovernance(node.governance),
+    enrichment: projectEnrichment(node.enrichment),
+  };
+}

--- a/docs/superpowers/specs/2026-04-30-discovery-portfolio-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-04-30-discovery-portfolio-gap-closure-design.md
@@ -438,6 +438,33 @@ Replaces the hardcoded `PROMOTABLE_TYPES` SQL filter with the Chunk 1 policy res
 
 **Open questions still pending (gating later chunks):** unchanged from Chunk 1 — #2 (model cost guardrail), #3 (signature seed scope), #4 (required-field gates default), #5 (freshness thresholds). All gate Chunks 4 and 7.
 
+### Chunk 3 — Detail Page Rendering (landed 2026-04-30)
+
+Renders the three `TaxonomyNode` JSON columns (`description`, `governance`, `enrichment`) that the schema already had but the detail UI was ignoring. Adds a full `DigitalProduct` detail page with a typed view-model abstraction. Theme-token cleanup of `PortfolioNodeDetail` lands as part of the chunk per spec §6.4.
+
+| Task | Files | Tests |
+| - | - | - |
+| 3.1 Portfolio node view model | `apps/web/lib/portfolio/portfolio-node-view-model.ts` + test | 12/12 |
+| 3.2 Theme-token cleanup of PortfolioNodeDetail | `PortfolioNodeDetail.tsx` (refactored — `PORTFOLIO_COLOURS` import dropped, every hardcoded color replaced with `var(--dpf-*)` tokens) | n/a (build verified) |
+| 3.3 About/Governance/Enrichment sections | 3 new components + tests; widened `PortfolioTreeNode` type + `getFullPortfolioTree` Prisma select | 15/15 |
+| 3.4 Digital product detail page | `digital-product-view-model.ts` + 3 components + page (4 files + 4 tests) | 35/35 (after multi-row table extension) |
+
+**Build gate (Task 3.5):** `pnpm --filter @dpf/db exec vitest run` → 304 pass / 53 files. `pnpm --filter web exec vitest run` → 4494 pass / 14 skipped / 13 todo / 557 files. `cd apps/web && npx next build` → exit 0.
+
+**Deviations from plan.**
+
+- **Task 3.4 route path forced to relocate** from `/portfolio/[[...slug]]/products/[productId]` to `/portfolio/products/[productId]`. Next.js refuses children under optional catch-all routes ("Optional catch-all must be the last part of the URL"). Static segments still win route matching, so the new URL resolves correctly. Documented in the page header comment.
+- **Task 3.4 deferred sections to Chunk 4.** `enrichmentStatus` / `lastEnrichedAt` / "recent change items" not rendered yet — dependent on Chunk 4 schema columns (`InventoryEntity.freshness`, `DigitalProduct.enrichmentStatus`, `DigitalProduct.lastEnrichedAt`). View model accepts them as optional inputs (forward-compatible); component carries `TODO(Chunk 4 Task 4.3)` comments at the insertion points. `FreshnessBadge` degrades to muted "Unknown" when freshness is undefined.
+- **Per-portfolio-root color differentiation removed** from `PortfolioNodeDetail` (Task 3.2). Spec §6.4 endorsed replacing `PORTFOLIO_COLOURS` with theme tokens; the four other consumers (`PortfolioTreeNode`, `PortfolioOverview`, `DiscoveryOperationsPage`, `AgentGovernanceCard`) still import the constant from `apps/web/lib/evaluate/portfolio.ts` and remain unchanged.
+- **Manual UX verification deferred.** Plan Task 3.2 calls for "light + dark + brand override" check; Task 3.3 calls for "view a foundational node with description/governance present and one without"; Task 3.4 calls for "drill into an existing promoted product, confirm all sections render". All three are owed against the running portal once this branch lands and the install is re-deployed. Theme-token grep is empty across all new TSX files; component tests assert empty-state behavior + raw-JSON-leak prevention.
+
+**Carry-overs to Chunk 4.**
+
+- Render an Enrichment section in `DigitalProductDetail` reading `vm.enrichmentStatus` + `vm.lastEnrichedAt` once the schema columns land.
+- Render recent `ChangeItem` rollups for a product (spec §6.4 calls this out; per-product query helper does not exist yet).
+- The `colour` prop on `ProductList` is now effectively dead (detail callers pass a literal token string the component ignores). Cleanup candidate.
+- `AgentGovernanceCard.tsx` still falls back to a hardcoded hex `"#555566"` — flag for the next theme-token sweep.
+
 ---
 
 ## 14. References


### PR DESCRIPTION
## Summary

Lands Chunk 3 of the [Discovery → Portfolio Gap Closure plan](docs/superpowers/plans/2026-04-30-discovery-portfolio-gap-closure-plan.md). Independent of Chunk 1 (#368, merged) and Chunk 2 (#372, in review). All four foundation modules + the new product page.

**Closes the spec §1.3 gap:** the detail UI was rendering summary stats only, ignoring three `TaxonomyNode` JSON columns (`description`, `governance`, `enrichment`) that the schema already had. Now they render. Plus a brand-new `DigitalProduct` detail page at `/portfolio/products/[productId]` with full linked-entity table.

## What landed

| Task | Files | Tests |
| - | - | - |
| 3.1 Portfolio node view model | `apps/web/lib/portfolio/portfolio-node-view-model.ts` + test | 12 |
| 3.2 Theme-token cleanup of PortfolioNodeDetail | `PortfolioNodeDetail.tsx` (refactored) | n/a |
| 3.3 About/Governance/Enrichment sections | 3 components + tests; widened `PortfolioTreeNode` + `getFullPortfolioTree` Prisma select | 15 |
| 3.4 Digital product detail page | `digital-product-view-model.ts` + 3 components + page | 35 |

## Build gate

- `pnpm --filter @dpf/db exec vitest run` → **304 pass / 53 files**
- `pnpm --filter web exec vitest run` → **4494 pass / 14 skipped / 13 todo / 557 files**
- `cd apps/web && npx next build` → **exit 0**

## Notable design decisions

- **View-model-first pattern** (introduced at Task 3.1, confirmed at Task 3.4 review): pure function does the JSON → typed shape projection. Components are pure presentation. Pages do I/O. Each layer testable independently.
- **No nested cards** per spec §6.4 — full-width bands with top-border separators throughout.
- **Forward-compatible with Chunk 4.** `freshness` / `enrichmentStatus` / `lastEnrichedAt` are accepted as optional VM inputs and degrade gracefully when unset (FreshnessBadge → "Unknown"). `TODO(Chunk 4 Task 4.3)` markers at the page Prisma select + the component insertion points.
- **Route deviation forced by Next.js.** Plan called for `/portfolio/[[...slug]]/products/[productId]`. Next.js refuses children under optional catch-all routes. Moved to `/portfolio/products/[productId]` — static segment wins route matching.
- **Per-portfolio-root color differentiation removed** from the detail view (theme tokens now). Other consumers of `PORTFOLIO_COLOURS` unchanged.

## Theme-token discipline

Greps verify zero `text-white|text-black|text-gray-*|bg-white|bg-black|bg-gray-*|border-gray-*|#xxx|style={{ color }}` across all new TSX files. Component tests pin the discipline (assertions like `expect(html).not.toContain('text-gray-')`).

## Test plan

- [x] All 62 new tests pass
- [x] Full vitest suites green
- [x] `next build` exit 0
- [x] Spec + code quality reviews on each task; should-fix advisories applied inline (linked entities full table after Task 3.4 review)
- [x] Cross-cutting view-model pattern verified at Task 3.4 review
- [ ] Manual UX (light/dark/brand override on PortfolioNodeDetail; drill into a promoted product) — owed once branch is rebased to main and install re-deployed

## Carry-overs to Chunk 4

- Render Enrichment section in `DigitalProductDetail` once schema columns land
- Render recent `ChangeItem` rollups (per-product query helper TBD)
- Remove dead `colour` prop on `ProductList`
- Sweep remaining hardcoded hex in `AgentGovernanceCard.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)