### PR TITLE
fix: show persisted tax run confirmation details

### DIFF
--- a/apps/web/components/finance/TaxExecutionPanel.test.tsx
+++ b/apps/web/components/finance/TaxExecutionPanel.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/actions/tax-remittance", () => ({
+  prepareTaxRemittanceRun: vi.fn(),
+  updateTaxRemittanceRunStatus: vi.fn(),
+}));
+
+import { TaxExecutionPanel } from "@/components/finance/TaxExecutionPanel";
+
+describe("TaxExecutionPanel", () => {
+  it("shows the latest submitted confirmation reference in the outcome summary", () => {
+    const html = renderToStaticMarkup(
+      <TaxExecutionPanel
+        filingOwner="dpf_coworker"
+        handoffMode="dpf_readiness_only"
+        periods={[
+          {
+            id: "period-1",
+            periodId: "2026-Q2-AL",
+            status: "ready",
+            dueDate: "2026-05-20T00:00:00.000Z",
+            registration: {
+              jurisdictionReference: {
+                authorityName: "Alabama Department of Revenue",
+              },
+            },
+            remittanceRuns: [
+              {
+                id: "run-1",
+                runId: "TAX-RUN-AL-1",
+                status: "submitted",
+                executionMode: "scheduled_coworker",
+                scheduledFor: "2026-05-12T15:00:00.000Z",
+                submittedAt: "2026-05-12T16:30:00.000Z",
+                confirmationRef: "UX-SUB-001",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Submitted");
+    expect(html).toContain("UX-SUB-001");
+  });
+});

--- a/apps/web/components/finance/TaxExecutionPanel.tsx
+++ b/apps/web/components/finance/TaxExecutionPanel.tsx
@@ -58,6 +58,56 @@ function formatDateTime(value: Date | string | null | undefined) {
   });
 }
 
+function formatRunStatus(status: string) {
+  return status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function buildRunOutcomeSummary(run: RunRecord) {
+  const summary: Array<{ label: string; value: string }> = [
+    { label: "Current status", value: formatRunStatus(run.status) },
+  ];
+
+  if (run.submittedAt) {
+    summary.push({
+      label: "Submitted",
+      value: formatDateTime(run.submittedAt),
+    });
+  }
+
+  if (run.paidAt) {
+    summary.push({
+      label: "Paid",
+      value: formatDateTime(run.paidAt),
+    });
+  }
+
+  if (run.confirmationRef) {
+    summary.push({
+      label: "Confirmation",
+      value: run.confirmationRef,
+    });
+  }
+
+  if (run.failureCode) {
+    summary.push({
+      label: "Failure code",
+      value: run.failureCode,
+    });
+  }
+
+  if (run.failureDetails) {
+    summary.push({
+      label: "Failure detail",
+      value: run.failureDetails,
+    });
+  }
+
+  return summary;
+}
+
 export function TaxExecutionPanel({ periods, filingOwner, handoffMode }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -202,6 +252,7 @@ export function TaxExecutionPanel({ periods, filingOwner, handoffMode }: Props) 
           periods.map((period) => {
             const latestRun = period.remittanceRuns?.[0] ?? null;
             const createForm = createForms[period.id] ?? createDefaults[period.id]!;
+            const outcomeSummary = latestRun ? buildRunOutcomeSummary(latestRun) : [];
             const statusForm = latestRun
               ? (statusForms[latestRun.id] ?? {
                   runId: latestRun.id,
@@ -291,10 +342,31 @@ export function TaxExecutionPanel({ periods, filingOwner, handoffMode }: Props) 
                     <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Latest outcome</p>
                     {latestRun && statusForm ? (
                       <div className="mt-3 space-y-3">
-                        <p className="text-xs text-[var(--dpf-muted)]">
-                          Scheduled {formatDateTime(latestRun.scheduledFor)}
-                          {latestRun.failureDetails ? ` · ${latestRun.failureDetails}` : ""}
-                        </p>
+                        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] p-3">
+                          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                            Persisted outcome
+                          </p>
+                          <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+                            <div>
+                              <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                                Scheduled
+                              </dt>
+                              <dd className="mt-1 text-sm text-[var(--dpf-text)]">
+                                {formatDateTime(latestRun.scheduledFor)}
+                              </dd>
+                            </div>
+                            {outcomeSummary.map((item) => (
+                              <div key={`${latestRun.id}-${item.label}`}>
+                                <dt className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                                  {item.label}
+                                </dt>
+                                <dd className="mt-1 text-sm text-[var(--dpf-text)]">
+                                  {item.value}
+                                </dd>
+                              </div>
+                            ))}
+                          </dl>
+                        </div>
 
                         <label className="block text-xs text-[var(--dpf-muted)]">
                           Confirmation reference


### PR DESCRIPTION
## Summary
- surface a persisted latest-outcome summary in the tax execution panel
- show submitted, paid, confirmation, and failure details as read-only operational state
- add a regression test covering submitted confirmation visibility

## Verification
- pnpm --filter web exec vitest run components/finance/TaxExecutionPanel.test.tsx lib/actions/tax-remittance.test.ts
- pnpm --filter web typecheck
- pnpm --filter web exec next build
- docker compose --env-file D:\\DPF\\.env -f D:\\DPF\\.worktrees\\tax-remittance-execution\\docker-compose.yml build --no-cache portal portal-init sandbox
- docker compose --env-file D:\\DPF\\.env -f D:\\DPF\\.worktrees\\tax-remittance-execution\\docker-compose.yml up -d portal-init sandbox && docker compose --env-file D:\\DPF\\.env -f D:\\DPF\\.worktrees\\tax-remittance-execution\\docker-compose.yml up -d portal
- Browser QA on http://192.168.0.200:3000/finance/settings/tax confirming Persisted outcome, Submitted, Confirmation, UX-SUB-001, and no Coworker Guidance block