### PR TITLE
feat(chunk-7-partial): portfolio completeness scoring + strip

### DIFF
--- a/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx
@@ -5,7 +5,12 @@ import { getFullPortfolioTree, getAgentCounts, getPortfolioBudgets, getPortfolio
 import { resolveNodeFromSlug, getSubtreeIds, buildBreadcrumbs, computeHealth } from "@/lib/portfolio";
 import { PortfolioOverview } from "@/components/portfolio/PortfolioOverview";
 import { PortfolioNodeDetail } from "@/components/portfolio/PortfolioNodeDetail";
+import { CompletenessStrip } from "@/components/portfolio/CompletenessStrip";
 import { getFullGraphData } from "@/lib/actions/graph";
+import {
+  computePortfolioCompleteness,
+  type PortfolioCompletenessDb,
+} from "@/lib/portfolio/completeness";
 
 type Props = {
   params: Promise<{ slug?: string[] }>;
@@ -23,6 +28,8 @@ export default async function PortfolioPage({ params }: Props) {
   ]);
 
   // Overview: /portfolio
+  // No single resolved root portfolio at this level -- the overview spans all
+  // four portfolio roots. Per Task 7.2 spec, omit the strip silently.
   if (slugs.length === 0) {
     return <PortfolioOverview roots={roots} agentCounts={agentCounts} budgets={budgets} summary={summary} />;
   }
@@ -51,18 +58,37 @@ export default async function PortfolioPage({ params }: Props) {
   const ownerRole = ownerRoles[rootSlug] ?? null;
   const healthStr = computeHealth(node.activeCount, node.totalCount);
 
+  // Task 7.2: completeness strip above the existing detail. The portfolioId
+  // comes from the resolved root (slugs[0]) -- inner nodes inherit their root
+  // portfolio's completeness scope. Omit silently when the root has no
+  // portfolioId attached (taxonomy-only branch with no Portfolio peer).
+  // PrismaClient is a structural superset of PortfolioCompletenessDb (the
+  // helper's narrow injectable shape); cast via `unknown` matches the same
+  // pattern used in promotion-audit/page.tsx.
+  const rootNode = roots.find((r) => r.nodeId === rootSlug);
+  const rootPortfolioId = rootNode?.portfolioId ?? null;
+  const completenessScores = rootPortfolioId
+    ? await computePortfolioCompleteness(
+        rootPortfolioId,
+        prisma as unknown as PortfolioCompletenessDb,
+      )
+    : null;
+
   return (
-    <PortfolioNodeDetail
-      node={node}
-      subNodes={node.children}
-      products={products}
-      breadcrumbs={breadcrumbs}
-      agentCount={agentCount}
-      health={healthStr}
-      investment={investment}
-      ownerRole={ownerRole}
-      graphData={graphData}
-      taxonomyNodeId={node.nodeId}
-    />
+    <div>
+      {completenessScores ? <CompletenessStrip scores={completenessScores} /> : null}
+      <PortfolioNodeDetail
+        node={node}
+        subNodes={node.children}
+        products={products}
+        breadcrumbs={breadcrumbs}
+        agentCount={agentCount}
+        health={healthStr}
+        investment={investment}
+        ownerRole={ownerRole}
+        graphData={graphData}
+        taxonomyNodeId={node.nodeId}
+      />
+    </div>
   );
 }

--- a/apps/web/components/portfolio/CompletenessStrip.test.tsx
+++ b/apps/web/components/portfolio/CompletenessStrip.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CompletenessStrip } from "./CompletenessStrip";
+import type { PortfolioCompletenessScores } from "@/lib/portfolio/completeness";
+
+function strip(overrides: Partial<PortfolioCompletenessScores> = {}): PortfolioCompletenessScores {
+  return {
+    requiredFieldsScore: 87,
+    enrichmentScore: 64,
+    openIssuesByType: { type_not_promotable: 5, incomplete_detail: 3 },
+    productCount: 100,
+    ...overrides,
+  };
+}
+
+describe("CompletenessStrip", () => {
+  it("renders three score figures + product count", () => {
+    const html = renderToStaticMarkup(<CompletenessStrip scores={strip()} />);
+    expect(html).toContain("87");
+    expect(html).toContain("64");
+    expect(html).toContain("8"); // 5 + 3 = 8 open issues
+    expect(html).toContain("100 products tracked");
+  });
+
+  it("shows em-dash and tooltip when requiredFieldsScore is null", () => {
+    const html = renderToStaticMarkup(
+      <CompletenessStrip scores={strip({ requiredFieldsScore: null })} />,
+    );
+    // Should NOT show "null"; should show "—".
+    expect(html).not.toMatch(/>null</);
+    expect(html).toMatch(/>\s*—\s*</);
+    expect(html).toContain("required fields configured");
+  });
+
+  it("shows em-dash and tooltip when enrichmentScore is null", () => {
+    const html = renderToStaticMarkup(
+      <CompletenessStrip scores={strip({ enrichmentScore: null })} />,
+    );
+    expect(html).toContain("Enrichment status not yet tracked");
+  });
+
+  it("shows zero when openIssuesByType is empty", () => {
+    const html = renderToStaticMarkup(
+      <CompletenessStrip scores={strip({ openIssuesByType: {} })} />,
+    );
+    expect(html).toContain(">0<");
+  });
+
+  it("breaks down open issues by type (top 3)", () => {
+    const html = renderToStaticMarkup(
+      <CompletenessStrip
+        scores={strip({
+          openIssuesByType: {
+            type_not_promotable: 50,
+            incomplete_detail: 25,
+            no_taxonomy: 10,
+            no_portfolio_root: 2,
+            low_confidence_promotion: 1,
+          },
+        })}
+      />,
+    );
+    // Top 3 by count: type_not_promotable (50), incomplete_detail (25), no_taxonomy (10).
+    expect(html).toContain("50 type_not_promotable");
+    expect(html).toContain("25 incomplete_detail");
+    expect(html).toContain("10 no_taxonomy");
+    // 2 more types beyond the top 3.
+    expect(html).toMatch(/\+\s*2\s*more/);
+  });
+
+  it("uses only theme tokens — no hardcoded colors", () => {
+    const html = renderToStaticMarkup(<CompletenessStrip scores={strip()} />);
+    expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-|#[0-9a-fA-F]{3,6}/);
+  });
+});

--- a/apps/web/components/portfolio/CompletenessStrip.tsx
+++ b/apps/web/components/portfolio/CompletenessStrip.tsx
@@ -1,0 +1,131 @@
+// apps/web/components/portfolio/CompletenessStrip.tsx
+//
+// Portfolio completeness strip (Task 7.2 of the discovery -> portfolio gap
+// closure plan). Renders three orthogonal figures from
+// `computePortfolioCompleteness` (Task 7.1) above the existing portfolio
+// tree:
+//
+//   1. Required fields % — % of products whose taxonomy node's
+//      `governance.requiredFields` are all populated. Degrades to em-dash
+//      with tooltip when no node has required fields configured (Chunk 7
+//      Task 7.3 not yet shipped).
+//   2. Enrichment % — % of products with `enrichmentStatus === "enriched"`.
+//      Degrades to em-dash with tooltip when the schema column doesn't
+//      exist yet (Chunk 4 Task 4.1 not yet shipped).
+//   3. Open issues — SUM of `openIssuesByType` values, with a top-3
+//      breakdown line; "+N more" suffix when more than 3 issue types.
+//
+// `productCount` is rendered as a small muted "X products tracked" line on
+// the right.
+//
+// Theme-aware: only var(--dpf-*) tokens per AGENTS.md §12.
+
+import type { ReactElement } from "react";
+import type { PortfolioCompletenessScores } from "@/lib/portfolio/completeness";
+
+type Props = { scores: PortfolioCompletenessScores };
+
+const TOOLTIP_REQUIRED_FIELDS_NULL =
+  "No taxonomy node has required fields configured yet (set via Chunk 7 Task 7.3 once it ships)";
+
+const TOOLTIP_ENRICHMENT_NULL =
+  "Enrichment status not yet tracked (Chunk 4 Task 4.1 schema pending)";
+
+export function CompletenessStrip({ scores }: Props): ReactElement {
+  const { requiredFieldsScore, enrichmentScore, openIssuesByType, productCount } =
+    scores;
+
+  const totalOpenIssues = Object.values(openIssuesByType).reduce(
+    (sum, n) => sum + n,
+    0,
+  );
+
+  const sortedIssueTypes = Object.entries(openIssuesByType).sort(
+    ([, a], [, b]) => b - a,
+  );
+  const topIssueTypes = sortedIssueTypes.slice(0, 3);
+  const moreIssueTypes = Math.max(0, sortedIssueTypes.length - 3);
+
+  return (
+    <section
+      aria-label="Portfolio completeness"
+      className="flex flex-wrap items-start justify-between gap-6 px-5 py-4 mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+    >
+      <div className="flex flex-wrap gap-8">
+        <ScoreFigure
+          label="Required fields"
+          score={requiredFieldsScore}
+          tooltip={TOOLTIP_REQUIRED_FIELDS_NULL}
+        />
+        <ScoreFigure
+          label="Enrichment"
+          score={enrichmentScore}
+          tooltip={TOOLTIP_ENRICHMENT_NULL}
+        />
+        <div>
+          <div className="text-[var(--dpf-muted)] text-xs uppercase tracking-wide font-medium">
+            Open issues
+          </div>
+          <div className="mt-1 text-3xl font-bold tabular-nums text-[var(--dpf-text)]">
+            {totalOpenIssues}
+          </div>
+          {topIssueTypes.length > 0 ? (
+            <div className="mt-1 text-[var(--dpf-muted)] text-xs">
+              {topIssueTypes.map(([type, count], idx) => (
+                <span key={type}>
+                  {idx > 0 ? " · " : null}
+                  {count} {type}
+                </span>
+              ))}
+              {moreIssueTypes > 0 ? (
+                <span className="ml-1">+ {moreIssueTypes} more</span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="text-[var(--dpf-muted)] text-xs tabular-nums self-center">
+        {productCount} products tracked
+      </div>
+    </section>
+  );
+}
+
+function ScoreFigure({
+  label,
+  score,
+  tooltip,
+}: {
+  label: string;
+  score: number | null;
+  tooltip: string;
+}): ReactElement {
+  if (score === null) {
+    return (
+      <div>
+        <div className="text-[var(--dpf-muted)] text-xs uppercase tracking-wide font-medium">
+          {label}
+        </div>
+        <div
+          className="mt-1 text-3xl font-bold tabular-nums text-[var(--dpf-muted)] cursor-help"
+          title={tooltip}
+          aria-label={tooltip}
+        >
+          {"—"}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="text-[var(--dpf-muted)] text-xs uppercase tracking-wide font-medium">
+        {label}
+      </div>
+      <div className="mt-1 text-3xl font-bold tabular-nums text-[var(--dpf-text)]">
+        {Math.round(score)}
+        <span className="text-base font-medium text-[var(--dpf-muted)] ml-0.5">%</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/portfolio/completeness.test.ts
+++ b/apps/web/lib/portfolio/completeness.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import { computePortfolioCompleteness } from "./completeness";
+
+describe("computePortfolioCompleteness", () => {
+  function mockDb() {
+    const findMany = vi.fn();
+    const groupBy = vi.fn();
+    return {
+      db: {
+        digitalProduct: { findMany },
+        portfolioQualityIssue: { groupBy },
+      },
+      findMany,
+      groupBy,
+    };
+  }
+
+  it("returns null scores + zero count when portfolio has no products", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    expect(result.requiredFieldsScore).toBeNull();
+    expect(result.enrichmentScore).toBeNull();
+    expect(result.openIssuesByType).toEqual({});
+    expect(result.productCount).toBe(0);
+  });
+
+  it("returns null required-fields score when no node defines requiredFields", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([
+      {
+        id: "dp_1",
+        manufacturer: "Acme",
+        taxonomyNode: { governance: null },
+        observationConfig: null,
+      },
+      {
+        id: "dp_2",
+        manufacturer: null,
+        taxonomyNode: { governance: { promotion: { mode: "auto" } } }, // no requiredFields
+        observationConfig: null,
+      },
+    ]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    expect(result.requiredFieldsScore).toBeNull();
+    expect(result.productCount).toBe(2);
+  });
+
+  it("computes required-fields score across products with requiredFields", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([
+      // Complete: both required fields populated.
+      {
+        id: "dp_1",
+        manufacturer: "Acme",
+        observedVersion: "1.0",
+        taxonomyNode: { governance: { requiredFields: ["manufacturer", "observedVersion"] } },
+        observationConfig: null,
+      },
+      // Incomplete: missing observedVersion.
+      {
+        id: "dp_2",
+        manufacturer: "Acme",
+        observedVersion: null,
+        taxonomyNode: { governance: { requiredFields: ["manufacturer", "observedVersion"] } },
+        observationConfig: null,
+      },
+      // Not gated: no requiredFields.
+      {
+        id: "dp_3",
+        manufacturer: null,
+        taxonomyNode: { governance: { promotion: { mode: "auto" } } },
+        observationConfig: null,
+      },
+    ]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    // 1 of 2 gated products is complete = 50%
+    expect(result.requiredFieldsScore).toBe(50);
+    expect(result.productCount).toBe(3);
+  });
+
+  it("supports dot-paths in requiredFields (e.g. observationConfig.classifyAs)", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([
+      {
+        id: "dp_1",
+        observationConfig: { classifyAs: "infrastructure_endpoint" },
+        taxonomyNode: { governance: { requiredFields: ["observationConfig.classifyAs"] } },
+      },
+      {
+        id: "dp_2",
+        observationConfig: null,
+        taxonomyNode: { governance: { requiredFields: ["observationConfig.classifyAs"] } },
+      },
+    ]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    expect(result.requiredFieldsScore).toBe(50);
+  });
+
+  it("treats malformed requiredFields shape as empty (defensive)", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([
+      {
+        id: "dp_1",
+        manufacturer: null,
+        taxonomyNode: { governance: { requiredFields: "not-an-array" } },
+        observationConfig: null,
+      },
+    ]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    expect(result.requiredFieldsScore).toBeNull();
+  });
+
+  it("returns null enrichmentScore when no product has the field", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([
+      // No enrichmentStatus column populated (Chunk 4 hasn't shipped on this install)
+      { id: "dp_1", taxonomyNode: { governance: null }, observationConfig: null },
+      { id: "dp_2", taxonomyNode: { governance: null }, observationConfig: null },
+    ]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    expect(result.enrichmentScore).toBeNull();
+  });
+
+  it("computes enrichmentScore across products that DO have the field set", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([
+      { id: "dp_1", enrichmentStatus: "enriched", taxonomyNode: { governance: null }, observationConfig: null },
+      { id: "dp_2", enrichmentStatus: "pending", taxonomyNode: { governance: null }, observationConfig: null },
+      { id: "dp_3", enrichmentStatus: "partial", taxonomyNode: { governance: null }, observationConfig: null },
+      { id: "dp_4", enrichmentStatus: "enriched", taxonomyNode: { governance: null }, observationConfig: null },
+    ]);
+    groupBy.mockResolvedValue([]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    // 2 of 4 enriched = 50%
+    expect(result.enrichmentScore).toBe(50);
+  });
+
+  it("collects openIssuesByType from groupBy", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([]);
+    groupBy.mockResolvedValue([
+      { issueType: "type_not_promotable", _count: { _all: 5 } },
+      { issueType: "incomplete_detail", _count: { _all: 3 } },
+    ]);
+
+    const result = await computePortfolioCompleteness("p_1", db as never);
+    expect(result.openIssuesByType).toEqual({
+      type_not_promotable: 5,
+      incomplete_detail: 3,
+    });
+  });
+
+  it("groupBy is filtered to status:'open' and the requested portfolioId", async () => {
+    const { db, findMany, groupBy } = mockDb();
+    findMany.mockResolvedValue([]);
+    groupBy.mockResolvedValue([]);
+
+    await computePortfolioCompleteness("p_42", db as never);
+
+    expect(groupBy).toHaveBeenCalledTimes(1);
+    const args = groupBy.mock.calls[0][0];
+    expect(args.where).toEqual({ portfolioId: "p_42", status: "open" });
+    expect(args.by).toEqual(["issueType"]);
+  });
+});

--- a/apps/web/lib/portfolio/completeness.ts
+++ b/apps/web/lib/portfolio/completeness.ts
@@ -1,0 +1,183 @@
+/**
+ * Portfolio completeness scoring (Task 7.1 of the discovery -> portfolio
+ * gap closure plan).
+ *
+ * Pure helper over an injected db handle. Returns three orthogonal numbers
+ * powering the Portfolio Analyst's daily review (Task 7.5) and the
+ * `CompletenessStrip` UI (Task 7.2):
+ *
+ *   1. requiredFieldsScore — % of products whose containing taxonomy node's
+ *      `governance.requiredFields` are all populated. Null until at least
+ *      one node has a non-empty required-fields list. Begins to vary once
+ *      Task 7.3's `set_node_required_fields` lands.
+ *   2. enrichmentScore — % of products with `enrichmentStatus === "enriched"`.
+ *      Null until Chunk 4 Task 4.1 adds the column. Begins to vary the moment
+ *      products start carrying the field.
+ *   3. openIssuesByType — counts of open `PortfolioQualityIssue` rows scoped
+ *      to the portfolio, keyed by `issueType`.
+ *
+ * Defensive against malformed `governance` JSON: any non-`string[]`
+ * `requiredFields` value is treated as if there were no required fields.
+ */
+
+export interface PortfolioCompletenessScores {
+  /** % (0–100) of products in the portfolio with all required fields populated. Null when no product has a non-empty required-fields list. */
+  requiredFieldsScore: number | null;
+  /** % (0–100) of products with enrichmentStatus === "enriched". Null when the schema column does not exist or no products are present. */
+  enrichmentScore: number | null;
+  /** Open PortfolioQualityIssue counts keyed by issueType. */
+  openIssuesByType: Record<string, number>;
+  /** Total products counted (denominator). */
+  productCount: number;
+}
+
+export interface PortfolioCompletenessDb {
+  digitalProduct: {
+    findMany(args: {
+      where: { portfolioId: string };
+      select: Record<string, unknown>;
+    }): Promise<
+      Array<
+        {
+          id: string;
+          taxonomyNode: { governance: unknown } | null;
+          observationConfig: unknown;
+          // Forward-compat: when Chunk 4 lands, callers can include enrichmentStatus
+          enrichmentStatus?: string | null;
+          // Required-field source values — passed through observationConfig + raw entity attributes
+          // (we'll inspect these JSON-ishly per node's requiredFields list).
+          // For now the test harness mocks them.
+        } & Record<string, unknown>
+      >
+    >;
+  };
+  portfolioQualityIssue: {
+    groupBy(args: {
+      where: { portfolioId: string; status: string };
+      by: ["issueType"];
+      _count: { _all: true };
+    }): Promise<Array<{ issueType: string; _count: { _all: number } }>>;
+  };
+}
+
+/**
+ * Pull the `requiredFields` list off a node's governance JSON, defending
+ * against missing / malformed shapes. Anything that isn't an array of
+ * strings collapses to an empty list.
+ */
+function readRequiredFields(governance: unknown): string[] {
+  if (!governance || typeof governance !== "object") {
+    return [];
+  }
+  const candidate = (governance as Record<string, unknown>).requiredFields;
+  if (!Array.isArray(candidate)) {
+    return [];
+  }
+  return candidate.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Walk a dot-separated path through a product record. Returns `undefined`
+ * when any segment misses, when an intermediate value isn't an object, or
+ * when the leaf is null/undefined/empty-string.
+ */
+function readPath(source: Record<string, unknown>, path: string): unknown {
+  const segments = path.split(".");
+  let cursor: unknown = source;
+  for (const segment of segments) {
+    if (cursor === null || cursor === undefined) {
+      return undefined;
+    }
+    if (typeof cursor !== "object") {
+      return undefined;
+    }
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+}
+
+/**
+ * A required-field value counts as "populated" iff it is neither nullish
+ * nor an empty string. Empty arrays/objects are treated as populated since
+ * they're explicit caller-supplied shapes; the spec's notion of completeness
+ * is about presence, not depth.
+ */
+function isPopulated(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === "string" && value.length === 0) {
+    return false;
+  }
+  return true;
+}
+
+export async function computePortfolioCompleteness(
+  portfolioId: string,
+  db: PortfolioCompletenessDb,
+): Promise<PortfolioCompletenessScores> {
+  const [products, issueGroups] = await Promise.all([
+    db.digitalProduct.findMany({
+      where: { portfolioId },
+      select: {
+        id: true,
+        manufacturer: true,
+        observedVersion: true,
+        observationConfig: true,
+        enrichmentStatus: true,
+        taxonomyNode: { select: { governance: true } },
+      },
+    }),
+    db.portfolioQualityIssue.groupBy({
+      where: { portfolioId, status: "open" },
+      by: ["issueType"],
+      _count: { _all: true },
+    }),
+  ]);
+
+  const productCount = products.length;
+
+  // Required-fields score — only products whose taxonomy node defines a
+  // non-empty `governance.requiredFields` count toward the denominator.
+  let gatedProductCount = 0;
+  let completeGatedProductCount = 0;
+  for (const product of products) {
+    const required = readRequiredFields(product.taxonomyNode?.governance);
+    if (required.length === 0) continue;
+    gatedProductCount += 1;
+    const allPopulated = required.every((path) => isPopulated(readPath(product, path)));
+    if (allPopulated) {
+      completeGatedProductCount += 1;
+    }
+  }
+  const requiredFieldsScore =
+    gatedProductCount === 0 ? null : (completeGatedProductCount / gatedProductCount) * 100;
+
+  // Enrichment score — null when the column is absent on every row OR when
+  // there are no products at all. Otherwise % of products marked "enriched".
+  let anyHasEnrichmentField = false;
+  let enrichedCount = 0;
+  for (const product of products) {
+    if (Object.prototype.hasOwnProperty.call(product, "enrichmentStatus")) {
+      anyHasEnrichmentField = true;
+      if (product.enrichmentStatus === "enriched") {
+        enrichedCount += 1;
+      }
+    }
+  }
+  const enrichmentScore =
+    productCount === 0 || !anyHasEnrichmentField ? null : (enrichedCount / productCount) * 100;
+
+  // Open issue counts keyed by issueType.
+  const openIssuesByType: Record<string, number> = {};
+  for (const group of issueGroups) {
+    openIssuesByType[group.issueType] = group._count._all;
+  }
+
+  return {
+    requiredFieldsScore,
+    enrichmentScore,
+    openIssuesByType,
+    productCount,
+  };
+}

--- a/docs/superpowers/specs/2026-04-30-discovery-portfolio-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-04-30-discovery-portfolio-gap-closure-design.md
@@ -489,6 +489,37 @@ Display + alias only; the durable `agent_id` `AGT-WS-INVENTORY` is preserved. Bo
 - `packages/db/data/agent_registry.json` `capability_domain` copy for `AGT-WS-INVENTORY` still describes the role in product-management language; refresh in a future sweep.
 - A loader-level aliasing pass in `seed-prompt-templates.ts` could let `estate-specialist.prompt.md` redirect to `inventory-specialist.prompt.md` instead of duplicating content.
 
+### Chunk 7 — Portfolio Analyst Governance Loop (PARTIAL — Tasks 7.1 + 7.2 only, landed 2026-04-30)
+
+Ships the *measurement* surface of the governance loop today. The remaining tasks (MCP tools, skill, scheduled review) are gated on Open Questions #4 (required-field gates default) and on Chunk 4's enrichment schema landing — they will land in a follow-up PR.
+
+| Task | Files | Tests | Status |
+| - | - | - | - |
+| 7.1 Completeness scoring (pure helper) | `apps/web/lib/portfolio/completeness.ts` + test | 9/9 | ✅ |
+| 7.2 CompletenessStrip component | `apps/web/components/portfolio/CompletenessStrip.tsx` + test; wired into `apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx` | 6/6 | ✅ |
+| 7.3 Portfolio Analyst MCP tools (`approve_taxonomy_gap_proposal`, `set_node_required_fields`, `request_re_enrichment`) | — | — | ⏸ DEFERRED |
+| 7.4 `portfolio-completeness-review` skill | — | — | ⏸ DEFERRED |
+| 7.5 Daily review queue function | — | — | ⏸ DEFERRED |
+
+**Build gate (Task 7.6 partial):** `pnpm --filter @dpf/db exec vitest run` → 315 pass / 54 files. `pnpm --filter web exec vitest run` → 4539 pass / 14 skipped / 13 todo / 568 files. `cd apps/web && npx next build` → exit 0 (after one transient post-build segfault on Node v24 + Turbopack — retry was clean).
+
+**Forward compatibility.** Both `requiredFieldsScore` and `enrichmentScore` return `null` until their underlying data sources land:
+
+- `requiredFieldsScore` returns null until any `TaxonomyNode.governance.requiredFields` is non-empty. Task 7.3's `set_node_required_fields` MCP tool will start populating this. Until then the strip shows an em-dash with a tooltip explaining why.
+- `enrichmentScore` returns null until `DigitalProduct.enrichmentStatus` exists on the schema. Chunk 4 Task 4.1 adds the column; the helper checks for the field's presence via `hasOwnProperty` so it flips to a real percentage automatically when Chunk 4 ships.
+
+**Why 7.3–7.5 deferred.** Each has a hard dependency that hasn't been resolved:
+
+- 7.3 `set_node_required_fields` requires Open Question #4 (default policy: strict-everywhere vs opt-in per node). `request_re_enrichment` enqueues a Chunk 4 queue function that doesn't exist yet.
+- 7.4 + 7.5 build on top of 7.3's tool surface and on the Coworker Operator Pattern's `PortfolioReview` work-product table, which is not yet in the schema.
+
+**Next steps for the governance loop slice:**
+
+1. Resolve Open Question #4 (whose answer determines the default `requiredFields` seed pattern).
+2. Land Chunk 4 Task 4.1 (`DigitalProduct.enrichmentStatus` column) — at which point `enrichmentScore` lights up automatically.
+3. Land Chunk 4 Task 4.4 (`enrich-digital-product` queue function) — at which point `request_re_enrichment` becomes implementable.
+4. Then ship Tasks 7.3–7.5 in a single follow-up PR.
+
 ---
 
 ## 14. References


### PR DESCRIPTION
## Summary

Lands the *measurement* surface of the Portfolio Analyst governance loop (Chunk 7 of the [Discovery → Portfolio Gap Closure plan](docs/superpowers/plans/2026-04-30-discovery-portfolio-gap-closure-plan.md)). Tasks 7.1 + 7.2 ship now; Tasks 7.3–7.5 are deferred — gated on Open Question #4 and on Chunk 4's enrichment schema landing.

## What landed

| Task | Files | Tests |
| - | - | - |
| 7.1 Completeness scoring (pure helper) | `apps/web/lib/portfolio/completeness.ts` + test | 9/9 |
| 7.2 CompletenessStrip component | `apps/web/components/portfolio/CompletenessStrip.tsx` + test; wired into `apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx` | 6/6 |

## Build gate

- `pnpm --filter @dpf/db exec vitest run` → **315 pass / 54 files**
- `pnpm --filter web exec vitest run` → **4539 pass / 14 skipped / 13 todo / 568 files**
- `cd apps/web && npx next build` → **exit 0** (after one transient post-build segfault on Node v24 + Turbopack; retry was clean)

## Forward compatibility

Both scores return `null` today and degrade gracefully in the UI (em-dash + explanatory tooltip):

- **`requiredFieldsScore`** — returns null until any `TaxonomyNode.governance.requiredFields` is non-empty. Task 7.3's deferred `set_node_required_fields` MCP tool starts populating these.
- **`enrichmentScore`** — returns null until `DigitalProduct.enrichmentStatus` exists on the schema. Chunk 4 Task 4.1 adds the column; the helper detects field presence via `hasOwnProperty` so it flips to a real percentage automatically when Chunk 4 ships.

`openIssuesByType` and `productCount` are live today — they read existing `PortfolioQualityIssue` and `DigitalProduct` rows via `groupBy` and `findMany`.

## Why 7.3–7.5 deferred

- **7.3 (MCP tools)** — `set_node_required_fields` requires Open Question #4 decision (strict-everywhere vs opt-in per node). `request_re_enrichment` enqueues a Chunk 4 queue function that doesn't exist yet.
- **7.4 (skill)** + **7.5 (daily queue)** — build on top of 7.3's tool surface and on the Coworker Operator Pattern's `PortfolioReview` work-product table, which is not yet in the schema.

A follow-up PR will land 7.3–7.5 once Open Question #4 is decided and Chunk 4 Tasks 4.1 + 4.4 are in.

## Notable design decisions

- **Pure helper + injected DB.** `computePortfolioCompleteness` follows the same pattern as `getPromotionAudit` (Chunk 2 Task 2.3). 8 of 9 tests run against a vi-mocked DB; one verifies the `groupBy` query shape.
- **Theme-aware throughout.** Strip uses only `var(--dpf-*)` tokens. Test asserts no hardcoded colors leak into the rendered HTML.
- **Top-3 issue-type breakdown.** When more than 3 types of open issues exist, the strip shows the three largest by count + a `+N more` suffix. Avoids overwhelming the strip's narrow horizontal layout.

## Test plan

- [x] All 15 new tests pass
- [x] Full vitest suites green (no regressions)
- [x] `next build` exit 0
- [ ] Manual UX: log into `/portfolio/foundational`, confirm the strip renders with `productCount: 100, openIssues: <count>` and em-dashes for the two null scores. Owed once this PR merges and the install is re-deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)