### PR TITLE
chore(db): align inventory-specialist coworker name with Chunk 6 rename

### DIFF
--- a/apps/web/app/(shell)/platform/ai/assignments/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/assignments/page.tsx
@@ -54,7 +54,7 @@ const AGENT_NAMES: Record<string, string> = {
   "hr-specialist":        "HR Director",
   "customer-advisor":     "Customer Success Manager",
   "portfolio-advisor":    "Portfolio Analyst",
-  "inventory-specialist": "Product Manager",
+  "inventory-specialist": "Digital Product Estate Specialist",
   "ea-architect":         "Enterprise Architect",
   "ops-coordinator":      "Scrum Master",
   "onboarding-coo":       "Onboarding COO",

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -926,7 +926,7 @@ async function seedCoworkerAgents(): Promise<void> {
   // EP-AI-WORKFORCE-001: Coworker agents with canonical AGT-UI-xxx IDs and slugId aliases
   const coworkers = [
     { agentId: "portfolio-advisor", slugId: "portfolio-advisor", name: "Portfolio Analyst", tier: 1, type: "coworker", description: "Investment, risk, and portfolio health analysis", valueStream: "evaluate", sensitivity: "internal" },
-    { agentId: "inventory-specialist", slugId: "inventory-specialist", name: "Product Manager", tier: 2, type: "coworker", description: "Product lifecycle, maturity, and market fit analysis", valueStream: "explore", sensitivity: "internal" },
+    { agentId: "inventory-specialist", slugId: "inventory-specialist", name: "Digital Product Estate Specialist", tier: 2, type: "coworker", description: "Lifecycle, maturity, and attribution analysis across the discovered digital product estate", valueStream: "explore", sensitivity: "internal" },
     { agentId: "ea-architect", slugId: "ea-architect", name: "Enterprise Architect", tier: 2, type: "coworker", description: "Structural analysis, dependency tracing, and architecture governance", valueStream: "cross-cutting", sensitivity: "internal" },
     { agentId: "hr-specialist", slugId: "hr-specialist", name: "HR Director", tier: 2, type: "coworker", description: "People, roles, accountability chains, and governance compliance", valueStream: "cross-cutting", sensitivity: "confidential" },
     { agentId: "customer-advisor", slugId: "customer-advisor", name: "Customer Success Manager", tier: 2, type: "coworker", description: "Customer journey, service adoption, and satisfaction analysis", valueStream: "consume", sensitivity: "confidential" },


### PR DESCRIPTION
## Summary

Carry-over cleanup from Chunk 6 (PR #382). The Chunk 6 PR updated the `agent_registry.json` `displayName` for `AGT-WS-INVENTORY` to "Digital Product Estate Specialist" and updated the matching prompt files. Two stale "Product Manager" references remained outside the registry.

## Changes

- `packages/db/src/seed.ts:929` — hardcoded coworker entry for `inventory-specialist`: `name: "Product Manager"` → `name: "Digital Product Estate Specialist"`. Description also refreshed from generic "Product lifecycle, maturity, and market fit analysis" to the route's actual scope: "Lifecycle, maturity, and attribution analysis across the discovered digital product estate."
- `apps/web/app/(shell)/platform/ai/assignments/page.tsx:57` — `AGENT_NAMES` label map: `"Product Manager"` → `"Digital Product Estate Specialist"`

The `BusinessModelBuilder.tsx:38` reference to "Digital Product Manager (HR-200)" is intentionally left alone — it's the human supervisor role, not the AI coworker.

## Test plan

- [x] `pnpm --filter @dpf/db exec vitest run` → 315 pass / 54 files
- [x] `pnpm --filter web typecheck` clean
- [x] Pre-commit typecheck hook passed
- [x] No test asserts on the old "Product Manager" string (grep confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)