### PR TITLE
feat(release): multi-arch GHCR publish + release compose overlay (Phase 1)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -48,3 +48,18 @@ HIVE_CONTRIBUTION_TOKEN=
 # Grafana credentials (monitoring stack starts automatically)
 GF_ADMIN_USER=admin
 GF_ADMIN_PASSWORD=dpf_monitor
+
+# ─── Release-image distribution (used by docker-compose.release.yml) ──
+# Set these when consuming pre-built multi-arch GHCR images instead of
+# building locally. See docs/superpowers/specs/2026-05-09-deployment-contracts.md
+# (Contract 1: release artifacts) and the installer-parity roadmap Phase 1.
+#
+# GHCR_OWNER:     the GHCR namespace publishing the images. Default
+#                 'opendigitalproductfactory' is the canonical OSS
+#                 publishing namespace. Override for forks or mirrors.
+# DPF_IMAGE_TAG:  the version tag to pull. Use a release tag (e.g.
+#                 'v0.42.0') for production; 'latest' for development
+#                 against the most recent release. Pin to an immutable
+#                 tag or digest for reproducible deploys.
+GHCR_OWNER=opendigitalproductfactory
+DPF_IMAGE_TAG=latest

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -12,6 +12,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  # Multi-arch + supply-chain attestation defaults applied to every
+  # installed-runtime image per the deployment doctrine (Contract 1)
+  # and the installer-parity roadmap Phase 1.
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build-and-push:
@@ -19,6 +23,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Required for SBOM and provenance attestations (id-token write
+      # so the OIDC-signed attestation can be uploaded with the image).
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v6
@@ -39,6 +47,16 @@ jobs:
 
       - name: Typecheck (all packages)
         run: pnpm typecheck
+
+      - name: Set up QEMU
+        # Enables cross-architecture builds (linux/arm64 from an amd64 runner).
+        # Required before docker/setup-buildx-action for multi-arch builds.
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        # buildx is required for multi-arch manifest list publishing
+        # (a single tag that resolves to amd64 or arm64 per the puller).
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -61,12 +79,23 @@ jobs:
         id: owner
         run: echo "value=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
+      # ─── Installed-runtime images ──────────────────────────────────
+      # Each step publishes a multi-arch manifest list (linux/amd64 +
+      # linux/arm64) with SBOM + provenance attestations. The service
+      # classification (installed-runtime vs developer/test-only) is
+      # documented in docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
+      # Phase 1. integration-test-harness is intentionally NOT published
+      # because it's developer/test-only.
+
       - name: Build and push portal image
         uses: docker/build-push-action@v7
         with:
           context: .
           target: runner
           push: true
+          platforms: ${{ env.PLATFORMS }}
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-portal:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-portal:latest
@@ -77,6 +106,73 @@ jobs:
           context: .
           file: Dockerfile.sandbox
           push: true
+          platforms: ${{ env.PLATFORMS }}
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-sandbox:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-sandbox:latest
+
+      - name: Build and push promoter image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.promoter
+          push: true
+          platforms: ${{ env.PLATFORMS }}
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-promoter:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-promoter:latest
+
+      - name: Build and push browser-use image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./services/browser-use
+          file: ./services/browser-use/Dockerfile
+          push: true
+          platforms: ${{ env.PLATFORMS }}
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-browser-use:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-browser-use:latest
+
+      - name: Build and push adp image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: services/adp/Dockerfile
+          push: true
+          platforms: ${{ env.PLATFORMS }}
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-adp:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/dpf-adp:latest
+
+      # ─── Manifest verification ──────────────────────────────────
+      # Per the installer-parity roadmap Phase 1 exit gate: every
+      # installed-runtime image must publish both linux/amd64 and
+      # linux/arm64 manifests. Fail the workflow if any image is
+      # single-arch.
+
+      - name: Verify multi-arch manifests
+        run: |
+          set -euo pipefail
+          OWNER="${{ steps.owner.outputs.value }}"
+          TAG="${{ steps.tag.outputs.version }}"
+          IMAGES=(dpf-portal dpf-sandbox dpf-promoter dpf-browser-use dpf-adp)
+          for image in "${IMAGES[@]}"; do
+            echo "::group::${image}:${TAG}"
+            docker buildx imagetools inspect "${{ env.REGISTRY }}/${OWNER}/${image}:${TAG}"
+            # Assert both architectures are present in the manifest list.
+            docker buildx imagetools inspect "${{ env.REGISTRY }}/${OWNER}/${image}:${TAG}" --raw \
+              | grep -q '"architecture": "amd64"' \
+              || { echo "Missing linux/amd64 in ${image}:${TAG}"; exit 1; }
+            docker buildx imagetools inspect "${{ env.REGISTRY }}/${OWNER}/${image}:${TAG}" --raw \
+              | grep -q '"architecture": "arm64"' \
+              || { echo "Missing linux/arm64 in ${image}:${TAG}"; exit 1; }
+            echo "::endgroup::"
+          done

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,0 +1,52 @@
+# Release runtime overlay — consumes pre-built multi-arch GHCR images
+# instead of building locally.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.release.yml up -d
+#
+# Per the deployment doctrine (Contract 1: release artifacts) and the
+# installer-parity roadmap Phase 1: every installed-runtime service
+# resolves to a versioned multi-arch GHCR image. The base
+# docker-compose.yml's `build:` entries are reset to null so the runtime
+# never silently builds when a release tag is meant to be pulled.
+#
+# Set GHCR_OWNER and DPF_IMAGE_TAG in .env (see .env.docker.example).
+# Default GHCR_OWNER is the canonical OSS publishing namespace; customers
+# running forks or mirrors override it.
+#
+# integration-test-harness is intentionally absent from this overlay
+# because it is classified as developer/test-only per the roadmap's
+# service classification (Phase 1) and is not published to GHCR.
+
+services:
+  portal-init:
+    # portal-init shares the portal image (Dockerfile target: runner).
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-portal:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
+  portal:
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-portal:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
+  sandbox-init:
+    # sandbox-init also shares the portal image (same Dockerfile, same
+    # target: runner) so initialization runs against the pinned portal
+    # release without duplicating images.
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-portal:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
+  sandbox:
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-sandbox:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
+  promoter:
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-promoter:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
+  browser-use:
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-browser-use:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
+  adp:
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-adp:${DPF_IMAGE_TAG:-latest}
+    build: !reset null


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the Mac/Linux installer-parity roadmap and **Contract 1 (release artifacts)** of the deployment doctrine merged in #400. Establishes the release artifact contract so future install paths (Mac/Linux installer, cloud Single VM, TAPPaaS module, marketplace image) consume **versioned multi-arch GHCR images** instead of building locally.

This is the first concrete code change against the deployment doctrine. Three files, +163 lines, no removals.

### Changes

**`.github/workflows/publish-image.yml`**
- Adds `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` before any build, enabling cross-architecture publishing from the amd64 `ubuntu-latest` runner.
- All build steps now publish multi-arch (`linux/amd64,linux/arm64`) via a shared `PLATFORMS` env var.
- All build steps add `provenance: mode=max` and `sbom: true` per Phase 1's supply-chain attestation gates. Permissions extended with `id-token: write` and `attestations: write`.
- Adds three new build steps for installed-runtime services that were not previously published: **dpf-promoter**, **dpf-browser-use**, **dpf-adp**. `integration-test-harness` intentionally not added — classified developer/test-only per the roadmap's service-classification table.
- Adds a **"Verify multi-arch manifests" step** that fails the workflow if any installed-runtime image is missing `linux/amd64` or `linux/arm64`. Implements the Phase 1 exit gate inside the publishing workflow itself.

**`docker-compose.release.yml`** (new)
- Release runtime overlay. Sets `image:` to `ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-<svc>:${DPF_IMAGE_TAG:-latest}` for every installed-runtime service: portal, portal-init, sandbox-init (all share the portal image), sandbox, promoter, browser-use, adp.
- Uses Compose's `!reset null` extension to clear each service's `build:` so the runtime never silently falls back to building when a release tag is meant to be pulled.
- `integration-test-harness` intentionally absent.

**`.env.docker.example`**
- Documents `GHCR_OWNER` (default `opendigitalproductfactory`; override for forks/mirrors) and `DPF_IMAGE_TAG` (default `latest`; pin to release tag or digest for reproducible deploys).

### Service classification (decided pre-PR per the roadmap)

| Service | Classification | Image |
|---|---|---|
| portal | installed-runtime | `dpf-portal` (already published; now multi-arch + attested) |
| portal-init | installed-runtime via portal image | `dpf-portal` |
| sandbox | installed-runtime | `dpf-sandbox` (already published; now multi-arch + attested) |
| sandbox-init | installed-runtime via portal image | `dpf-portal` |
| promoter | installed-runtime, profile-only | `dpf-promoter` (newly published) |
| browser-use | installed-runtime | `dpf-browser-use` (newly published) |
| adp | installed-runtime | `dpf-adp` (newly published) |
| integration-test-harness | developer/test-only | not published |

## Test plan

Verified locally before push:

- [x] `docker compose -f docker-compose.yml -f docker-compose.release.yml config` exits 0 with zero `build:` entries for installed-runtime services
- [x] `docker compose ... --profile promote config` correctly includes promoter with the published image
- [x] `docker compose ... --profile dev config` correctly retains `build:` entries for `dev-init` / `dev-portal` (developer/test-only, not in the release overlay)
- [x] All five published images resolve to the expected `ghcr.io/opendigitalproductfactory/dpf-{portal,sandbox,promoter,browser-use,adp}:latest` paths
- [x] DCO sign-off on commit

To verify in CI / on next release tag (this PR's manual exit gates):

- [ ] `Production Build` and `Typecheck` pass — required gating checks per CONTRIBUTING.md
- [ ] `Unit Tests` may report pre-existing failures (informational per CONTRIBUTING.md; the same set of failures appears on `main` post-#395 / #397 / #398 dependabot churn — unrelated to this PR)
- [ ] On a release tag push, the **"Verify multi-arch manifests"** step in the workflow asserts `linux/amd64` and `linux/arm64` for every published image. If any image is single-arch, the workflow fails — this is the Phase 1 exit gate enforced in CI.
- [ ] Post-publish, manually `docker buildx imagetools inspect --raw ghcr.io/opendigitalproductfactory/dpf-portal:latest` should show SBOM and provenance attestation manifests alongside the platform manifests.

## What this PR does NOT do

- Does **not** touch the Windows installer (`install-dpf.ps1`) or any runtime code.
- Does **not** change the dev-loop compose flow — `docker compose up` (without the release overlay) still builds locally as before.
- Does **not** retire any Windows-specific code or services.
- Does **not** start any of the cloud / TAPPaaS / marketplace deployment work — those are subsequent epics that consume this PR's published images.

## What this PR enables

- **Epic A Phase 6+** can ship `install-dpf.sh --headless` against the published release images.
- **Epic D** (Cloud Single VM Terraform) can pull these images on EC2/Compute Engine/Azure VM.
- **Epic E** (TAPPaaS module) can reference these images in its module's `install.sh`.
- The Mac/Linux installer stops being theoretical — its release-image dependency is now real.

Refs:
- `docs/superpowers/specs/2026-05-09-deployment-contracts.md` — Contract 1 (release artifacts)
- `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 1
- #400 — deployment architecture foundation (merged)

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_