### PR TITLE
feat(contributor-setup): rewrite setup.sh; VS Code task osx/linux overrides (Phase 2)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,14 @@
       "options": {
         "cwd": "${workspaceFolder}"
       },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "pnpm --filter web dev"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "pnpm --filter web dev"]
+      },
       "problemMatcher": []
     },
     {
@@ -24,6 +32,14 @@
       ],
       "options": {
         "cwd": "${workspaceFolder}"
+      },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "pnpm --filter @dpf/db exec prisma generate && pnpm --filter web build"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "pnpm --filter @dpf/db exec prisma generate && pnpm --filter web build"]
       },
       "group": {
         "kind": "build",
@@ -42,6 +58,14 @@
       "options": {
         "cwd": "${workspaceFolder}"
       },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "pnpm --filter web exec tsc --noEmit"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "pnpm --filter web exec tsc --noEmit"]
+      },
       "problemMatcher": "$tsc"
     },
     {
@@ -50,6 +74,14 @@
       "command": "cmd",
       "args": ["/c", "pnpm test:e2e"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "pnpm test:e2e"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "pnpm test:e2e"]
+      },
       "problemMatcher": [],
       "detail": "Run Playwright against the running portal (requires docker compose up -d first)"
     },
@@ -59,6 +91,14 @@
       "command": "cmd",
       "args": ["/c", "pnpm test:e2e:demo"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "pnpm test:e2e:demo"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "pnpm test:e2e:demo"]
+      },
       "problemMatcher": [],
       "detail": "Run the sandbox-preview demo spec with the headed demo config"
     },
@@ -68,6 +108,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose up -d postgres neo4j qdrant portal-init sandbox"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose up -d postgres neo4j qdrant portal-init sandbox"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose up -d postgres neo4j qdrant portal-init sandbox"]
+      },
       "problemMatcher": [],
       "detail": "Start databases + validation services for shared-workspace development"
     },
@@ -77,6 +125,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose up -d"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose up -d"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose up -d"]
+      },
       "problemMatcher": [],
       "detail": "Start full Docker stack including portal"
     },
@@ -86,6 +142,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose down"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose down"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose down"]
+      },
       "problemMatcher": []
     },
     {
@@ -94,6 +158,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose down && docker compose up -d"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose down && docker compose up -d"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose down && docker compose up -d"]
+      },
       "problemMatcher": []
     },
     {
@@ -102,6 +174,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose logs -f --tail 50"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose logs -f --tail 50"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose logs -f --tail 50"]
+      },
       "problemMatcher": []
     },
     {
@@ -110,6 +190,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose build --no-cache portal portal-init sandbox && docker compose up -d portal-init sandbox && docker compose up -d portal"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose build --no-cache portal portal-init sandbox && docker compose up -d portal-init sandbox && docker compose up -d portal"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose build --no-cache portal portal-init sandbox && docker compose up -d portal-init sandbox && docker compose up -d portal"]
+      },
       "group": "build",
       "problemMatcher": [],
       "detail": "Rebuild portal + sandbox images from source and restart (includes migrations)"
@@ -120,6 +208,14 @@
       "command": "cmd",
       "args": ["/c", "docker compose build && docker compose up -d"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "docker compose build && docker compose up -d"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "docker compose build && docker compose up -d"]
+      },
       "group": "build",
       "problemMatcher": [],
       "detail": "Rebuild all images and restart full stack"
@@ -130,8 +226,16 @@
       "command": "powershell",
       "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${workspaceFolder}/dpf-release.ps1", "minor"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap (docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap (docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
+      },
       "problemMatcher": [],
-      "detail": "Pull latest main, bump minor version (v0.85.0 -> v0.86.0), tag and push"
+      "detail": "Pull latest main, bump minor version (v0.85.0 -> v0.86.0), tag and push (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Release Patch",
@@ -139,8 +243,16 @@
       "command": "powershell",
       "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${workspaceFolder}/dpf-release.ps1", "patch"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap. Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap. Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
+      },
       "problemMatcher": [],
-      "detail": "Pull latest main, bump patch version (v0.85.0 -> v0.85.1), tag and push"
+      "detail": "Pull latest main, bump patch version (v0.85.0 -> v0.85.1), tag and push (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Release Major",
@@ -148,8 +260,16 @@
       "command": "powershell",
       "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${workspaceFolder}/dpf-release.ps1", "major"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap. Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap. Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
+      },
       "problemMatcher": [],
-      "detail": "Pull latest main, bump major version (v0.85.0 -> v1.0.0), tag and push"
+      "detail": "Pull latest main, bump major version (v0.85.0 -> v1.0.0), tag and push (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Clean Reinstall from Git (WIPES ALL DATA)",
@@ -157,8 +277,16 @@
       "command": "powershell",
       "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${workspaceFolder}/dpf-reinstall.ps1", "-InstallDir", "${workspaceFolder}"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF reinstall script is Windows-only today. The macOS/Linux dpf-reinstall.sh is sequenced for Phase 8 of the installer-parity roadmap (docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). Until then, manually: docker compose down -v --remove-orphans && rm -rf node_modules apps/web/.next .env apps/web/.env.local && bash scripts/setup.sh' && exit 1"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "echo 'DPF reinstall script is Windows-only today. The macOS/Linux dpf-reinstall.sh is sequenced for Phase 8 of the installer-parity roadmap (docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). Until then, manually: docker compose down -v --remove-orphans && rm -rf node_modules apps/web/.next .env apps/web/.env.local && bash scripts/setup.sh' && exit 1"]
+      },
       "problemMatcher": [],
-      "detail": "DESTRUCTIVE: Checks for uncommitted changes, closes VS Code, wipes ALL Docker volumes/images/data, and deletes the project directory. Follow the README to reinstall fresh."
+      "detail": "DESTRUCTIVE: Checks for uncommitted changes, closes VS Code, wipes ALL Docker volumes/images/data, and deletes the project directory. Follow the README to reinstall fresh. (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Factory Reset (WIPES ALL DATA)",
@@ -166,6 +294,14 @@
       "command": "cmd",
       "args": ["/c", "echo WARNING: This will destroy ALL data including the database, users, OAuth tokens, sandbox workspace, and all configuration. Press Ctrl+C to cancel, or && pause && docker compose down -v --remove-orphans && docker compose build && docker compose up -d"],
       "options": { "cwd": "${workspaceFolder}" },
+      "osx": {
+        "command": "bash",
+        "args": ["-lc", "echo 'WARNING: This will destroy ALL data including the database, users, OAuth tokens, sandbox workspace, and all configuration.' && read -r -p 'Press Enter to continue or Ctrl+C to cancel: ' && docker compose down -v --remove-orphans && docker compose build && docker compose up -d"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["-lc", "echo 'WARNING: This will destroy ALL data including the database, users, OAuth tokens, sandbox workspace, and all configuration.' && read -r -p 'Press Enter to continue or Ctrl+C to cancel: ' && docker compose down -v --remove-orphans && docker compose build && docker compose up -d"]
+      },
       "problemMatcher": [],
       "detail": "DESTRUCTIVE: Stops all containers, deletes ALL volumes (database, sandbox, neo4j, qdrant, redis), rebuilds all images from source, and starts fresh. You will need to reconfigure everything: admin user, OAuth providers, branding, etc."
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,12 +39,25 @@ git config core.hooksPath .githooks
 
 ### Setup on macOS / Linux
 
-> **Status:** the canonical macOS / Linux contributor flow is being landed via Phase 2 of the [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md) (rewriting `scripts/setup.sh` and adding `osx` / `linux` overrides to `.vscode/tasks.json`). Until that ships, two paths work:
->
-> - Run `bash scripts/setup.sh` directly. The current script is stale (uses Ollama, has BSD-`sed -i` portability bugs) but boots a contributor environment well enough to start work; it will be cleanly replaced when Phase 2 lands.
-> - Use the dev container at [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) — fully cross-platform, runs the workspace inside a Linux container regardless of host OS.
->
-> The full macOS / Linux contributor experience (native installer, native VS Code task overrides, Apple-Silicon-aware hardware detection, LaunchAgent / systemd auto-start) is sequenced through the installer-parity roadmap.
+`bash scripts/setup.sh` is the canonical contributor bootstrap on macOS and Linux. It:
+
+1. Verifies prerequisites (Docker, Node 20+, pnpm) and the host platform
+2. Configures in-repo git hooks
+3. Installs pnpm workspace dependencies
+4. Generates `apps/web/.env.local` and root `.env` from examples (with portable in-place `sed` that works on both GNU and BSD `sed`, and `openssl` / `python3` secret generation)
+5. Brings up the contributor compose stack (Postgres + Neo4j + Qdrant)
+6. Waits for Postgres readiness and runs Prisma migrations + seed
+7. Verifies the agent rulebook (AGENTS.md + pointer files) is intact
+
+VS Code tasks under `.vscode/tasks.json` carry `osx` and `linux` overrides for every task that has a Windows form, so `Cmd+Shift+P → Tasks: Run Task → DPF: <X>` works on macOS and Linux out of the box. The release-script tasks (PowerShell-only today) print a clear "lands with Phase 8 of the installer-parity roadmap" message instead of failing with a missing-command error.
+
+What's intentionally NOT in `scripts/setup.sh`:
+
+- **Docker / Node / pnpm installation.** Manual prereqs per the contributor contract. Fully-automated host bootstrap is `install-dpf.sh`'s job when installer-parity Phase 6/7 lands (see the [roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md)).
+- **LLM provider configuration.** The provider contract (Doctrine [Contract 9](docs/superpowers/specs/2026-05-09-deployment-contracts.md)) is provider-aware: Docker Model Runner on macOS Docker Desktop, Ollama-in-compose on Linux native Docker (lands in Phase 3 via `docker-compose.linux.yml`), or any external endpoint via `LLM_BASE_URL`.
+- **Auto-start, hardware detection, `install-state.json`, `dpf doctor`.** Those are `install-dpf.sh` territory.
+
+If you'd rather develop entirely inside a container regardless of host OS, the [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) is fully cross-platform — open the repo in VS Code with the Dev Containers extension and choose "Reopen in Container".
 
 ## Before you start
 

--- a/scripts/installer/lib/logging.sh
+++ b/scripts/installer/lib/logging.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Shared logging helpers for DPF installer + setup scripts.
+# Source this file; do not execute directly.
+#
+# Provides: ok, warn, fail, step, info — all writing to stderr-aware stdout
+# with ANSI color when the terminal supports it (NO_COLOR honored).
+#
+# Bash 3.2 baseline (macOS default). No associative arrays, no ${var^^}.
+
+# Idempotency guard so multiple sources don't redefine.
+if [ "${DPF_LIB_LOGGING_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_LOGGING_LOADED=1
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  DPF_GREEN='\033[0;32m'
+  DPF_YELLOW='\033[1;33m'
+  DPF_RED='\033[0;31m'
+  DPF_BLUE='\033[0;34m'
+  DPF_NC='\033[0m'
+else
+  DPF_GREEN=''
+  DPF_YELLOW=''
+  DPF_RED=''
+  DPF_BLUE=''
+  DPF_NC=''
+fi
+
+ok()   { printf '%b  OK %s%b\n'   "$DPF_GREEN"  "$1" "$DPF_NC"; }
+warn() { printf '%b  !  %s%b\n'   "$DPF_YELLOW" "$1" "$DPF_NC"; }
+info() { printf '%b  -  %s%b\n'   "$DPF_BLUE"   "$1" "$DPF_NC"; }
+fail() { printf '%b  X  %s%b\n'   "$DPF_RED"    "$1" "$DPF_NC" >&2; exit 1; }
+step() { printf '\n%b-> %s%b\n'   "$DPF_YELLOW" "$1" "$DPF_NC"; }

--- a/scripts/installer/lib/platform.sh
+++ b/scripts/installer/lib/platform.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Shared platform-detection helpers for DPF installer + setup scripts.
+# Source this file; do not execute directly.
+#
+# Provides:
+#   dpf_platform        - exports DPF_PLATFORM = "darwin" | "linux" | "unsupported"
+#   dpf_arch            - exports DPF_ARCH     = "arm64" | "amd64" | "<raw>"
+#   dpf_sed_inplace     - portable sed -i wrapper that works on GNU sed
+#                          (Linux) and BSD sed (macOS) without bak files
+#                          left behind. Usage: dpf_sed_inplace 's|a|b|' file
+#
+# Bash 3.2 baseline (macOS default).
+
+if [ "${DPF_LIB_PLATFORM_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_PLATFORM_LOADED=1
+
+dpf_platform() {
+  case "$(uname -s)" in
+    Darwin)  DPF_PLATFORM="darwin" ;;
+    Linux)   DPF_PLATFORM="linux"  ;;
+    *)       DPF_PLATFORM="unsupported" ;;
+  esac
+  export DPF_PLATFORM
+}
+
+dpf_arch() {
+  case "$(uname -m)" in
+    arm64|aarch64)  DPF_ARCH="arm64" ;;
+    x86_64|amd64)   DPF_ARCH="amd64" ;;
+    *)              DPF_ARCH="$(uname -m)" ;;
+  esac
+  export DPF_ARCH
+}
+
+# Portable in-place sed.
+#   GNU sed (Linux):  sed -i 'EXPR' file
+#   BSD sed (macOS):  sed -i '' 'EXPR' file
+# We avoid leaving .bak files by always passing an empty backup suffix on BSD.
+# Caller is responsible for ensuring EXPR is properly escaped.
+dpf_sed_inplace() {
+  local expr="$1"
+  local file="$2"
+  if [ -z "$expr" ] || [ -z "$file" ]; then
+    echo "dpf_sed_inplace: requires expression and file args" >&2
+    return 1
+  fi
+  if sed --version >/dev/null 2>&1; then
+    # GNU sed
+    sed -i "$expr" "$file"
+  else
+    # BSD sed (macOS); empty backup suffix means no .bak left behind
+    sed -i '' "$expr" "$file"
+  fi
+}

--- a/scripts/installer/lib/prompts.sh
+++ b/scripts/installer/lib/prompts.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Shared interactive-prompt helpers for DPF installer + setup scripts.
+# Source this file; do not execute directly.
+#
+# Provides:
+#   dpf_yes_no              - prompt with default; sets DPF_REPLY = "yes" | "no"
+#                             Honors --headless / DPF_HEADLESS=1 (uses default).
+#   dpf_default_value       - prompt with default value; sets DPF_REPLY
+#   dpf_random_secret_hex   - emit a hex secret (openssl, falling back to
+#                             python3.secrets, falling back to a clearly
+#                             marked dev-grade secret)
+#   dpf_random_secret_b64   - emit a base64 secret (same fallback chain)
+#
+# Bash 3.2 baseline.
+
+if [ "${DPF_LIB_PROMPTS_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_PROMPTS_LOADED=1
+
+# Read a yes/no from the user with a default. Returns via DPF_REPLY.
+# Args: $1 = prompt, $2 = default ("yes" or "no")
+dpf_yes_no() {
+  local prompt="$1"
+  local default="${2:-no}"
+  if [ "${DPF_HEADLESS:-0}" = "1" ]; then
+    DPF_REPLY="$default"
+    return 0
+  fi
+  local hint
+  if [ "$default" = "yes" ]; then hint="[Y/n]"; else hint="[y/N]"; fi
+  printf '%s %s ' "$prompt" "$hint"
+  local answer
+  read -r answer
+  case "${answer:-$default}" in
+    y|Y|yes|YES) DPF_REPLY="yes" ;;
+    *)           DPF_REPLY="no"  ;;
+  esac
+}
+
+# Read a value with a default. Returns via DPF_REPLY.
+# Args: $1 = prompt, $2 = default value
+dpf_default_value() {
+  local prompt="$1"
+  local default="${2:-}"
+  if [ "${DPF_HEADLESS:-0}" = "1" ]; then
+    DPF_REPLY="$default"
+    return 0
+  fi
+  if [ -n "$default" ]; then
+    printf '%s [%s]: ' "$prompt" "$default"
+  else
+    printf '%s: ' "$prompt"
+  fi
+  local answer
+  read -r answer
+  DPF_REPLY="${answer:-$default}"
+}
+
+# Generate a random hex secret. 32 bytes = 64 hex chars by default.
+# Args: $1 = byte length (default 32)
+dpf_random_secret_hex() {
+  local bytes="${1:-32}"
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex "$bytes"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c "import secrets; print(secrets.token_hex($bytes))"
+  else
+    # Last resort; clearly marked so a grep over .env catches dev-grade secrets.
+    echo "dpf-dev-secret-$(date +%s)-NOT-FOR-PRODUCTION"
+  fi
+}
+
+# Generate a random base64 secret. 32 bytes = 44 base64 chars by default.
+# Args: $1 = byte length (default 32)
+dpf_random_secret_b64() {
+  local bytes="${1:-32}"
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 "$bytes"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes($bytes)).decode())"
+  else
+    echo "dpf-dev-secret-$(date +%s)-NOT-FOR-PRODUCTION"
+  fi
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,41 +1,83 @@
 #!/usr/bin/env bash
-# Open Digital Product Factory — first-time setup script (Mac / Linux)
-set -e
+# Open Digital Product Factory — contributor setup (macOS / Linux).
+#
+# Brings a fresh clone up to "ready to run pnpm dev / make dev" on macOS
+# or Linux. Companion to scripts/setup.ps1 (Windows). Per the deployment
+# doctrine (Contract 3: lifecycle), this is the **contributor bootstrap**
+# surface — distinct from `install-dpf.sh` (the end-user release installer
+# that lands in installer-parity Phase 6/7).
+#
+# What this script does:
+#   1. Verifies prerequisites (Docker, Node 20+, pnpm)
+#   2. Configures in-repo git hooks
+#   3. Installs pnpm workspace dependencies
+#   4. Generates apps/web/.env.local and root .env from examples (with
+#      portable in-place sed and openssl/python3 secret generation)
+#   5. Brings up the contributor compose stack (Postgres + Neo4j + Qdrant)
+#   6. Waits for Postgres readiness and runs Prisma migrations + seed
+#   7. Verifies the agent rulebook (AGENTS.md + pointer files) is intact
+#
+# What this script does NOT do:
+#   - Install Docker, Node, or pnpm. Manual prereqs (per the contributor
+#     contract); fully-automated host bootstrap is install-dpf.sh's job
+#     when Phase 6/7 lands.
+#   - Wait for Ollama. The LLM provider contract (Doctrine Contract 9 +
+#     installer-parity Phase 4) is provider-aware: Docker Model Runner
+#     by default on Mac/Windows Docker Desktop; Ollama-in-compose only
+#     on Linux native Docker once docker-compose.linux.yml lands in
+#     Phase 3. Today's compose has no `ollama` service — waiting for
+#     it would deadlock on a fresh install.
+#   - Configure auto-start, hardware detection, install-state.json, or
+#     dpf doctor — those are install-dpf.sh territory.
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+set -euo pipefail
 
-ok()   { echo -e "${GREEN}  ✓ $1${NC}"; }
-warn() { echo -e "${YELLOW}  ! $1${NC}"; }
-fail() { echo -e "${RED}  ✗ $1${NC}"; exit 1; }
-step() { echo -e "\n${YELLOW}→ $1${NC}"; }
+# Resolve the repo root from this script's location so it works regardless
+# of cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Source shared helpers.
+# shellcheck source=installer/lib/logging.sh
+. "$SCRIPT_DIR/installer/lib/logging.sh"
+# shellcheck source=installer/lib/platform.sh
+. "$SCRIPT_DIR/installer/lib/platform.sh"
+# shellcheck source=installer/lib/prompts.sh
+. "$SCRIPT_DIR/installer/lib/prompts.sh"
+
+dpf_platform
+dpf_arch
 
 echo ""
-echo "  Open Digital Product Factory — Setup"
-echo "  ====================================="
+echo "  Open Digital Product Factory - Contributor Setup"
+echo "  ================================================="
+echo "  Platform: $DPF_PLATFORM ($DPF_ARCH)"
 
 # ── Prerequisites ───────────────────────────────────────────────────────────
 
 step "Checking prerequisites"
 
-if ! command -v docker &>/dev/null; then
-  fail "Docker is not installed. Install Docker Desktop: https://www.docker.com/products/docker-desktop/"
+if [ "$DPF_PLATFORM" = "unsupported" ]; then
+  fail "Unsupported OS: $(uname -s). This script targets macOS and Linux. Use scripts/setup.ps1 on Windows."
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  fail "Docker is not installed. Install Docker Desktop (macOS) or Docker Engine (Linux)."
 fi
 ok "Docker found: $(docker --version | cut -d' ' -f3 | tr -d ',')"
 
-if ! command -v node &>/dev/null; then
-  fail "Node.js is not installed. Download from https://nodejs.org/ (v20 or newer)"
+if ! command -v node >/dev/null 2>&1; then
+  fail "Node.js is not installed. Install Node 20+ from https://nodejs.org/"
 fi
-NODE_VERSION=$(node -v | tr -d 'v' | cut -d. -f1)
-if [ "$NODE_VERSION" -lt 20 ]; then
-  fail "Node.js v20+ required. Current: $(node -v). Download from https://nodejs.org/"
+NODE_MAJOR="$(node -v | tr -d 'v' | cut -d. -f1)"
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  fail "Node.js v20+ required. Current: $(node -v). Install from https://nodejs.org/"
 fi
 ok "Node.js found: $(node -v)"
 
-if ! command -v pnpm &>/dev/null; then
-  warn "pnpm not found. Installing..."
+if ! command -v pnpm >/dev/null 2>&1; then
+  warn "pnpm not found. Installing via npm..."
   npm install -g pnpm
 fi
 ok "pnpm found: $(pnpm -v)"
@@ -46,79 +88,63 @@ step "Configuring in-repo git hooks (.githooks/)"
 if git config core.hooksPath .githooks; then
   ok "Git hooks path set to .githooks (Prisma migration guard enabled)"
 else
-  warn "Could not set core.hooksPath. Run 'git config core.hooksPath .githooks' manually from the repo root."
+  warn "Could not set core.hooksPath. Run 'git config core.hooksPath .githooks' manually."
 fi
 
 # ── Dependencies ─────────────────────────────────────────────────────────────
 
-step "Installing dependencies"
+step "Installing pnpm workspace dependencies"
 pnpm install
 ok "Dependencies installed"
 
 # ── Environment ───────────────────────────────────────────────────────────────
 
-step "Setting up environment"
+step "Generating environment files"
 
 if [ ! -f apps/web/.env.local ]; then
   cp .env.example apps/web/.env.local
-  # Generate AUTH_SECRET
-  AUTH_SECRET=$(openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))" 2>/dev/null || echo "change-me-$(date +%s)")
-  sed -i "s|<generate with: openssl rand -base64 32>|$AUTH_SECRET|" apps/web/.env.local
-  # Generate CREDENTIAL_ENCRYPTION_KEY
-  ENC_KEY=$(openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))" 2>/dev/null || echo "change-me-$(date +%s)")
-  sed -i "s|<generate with: openssl rand -hex 32>|$ENC_KEY|" apps/web/.env.local
-  # Enable Docker internal URL for Ollama
-  echo "OLLAMA_INTERNAL_URL=http://ollama:11434" >> apps/web/.env.local
+  AUTH_SECRET_VAL="$(dpf_random_secret_hex 32)"
+  ENC_KEY_VAL="$(dpf_random_secret_hex 32)"
+  dpf_sed_inplace "s|<generate with: openssl rand -base64 32>|$AUTH_SECRET_VAL|" apps/web/.env.local
+  dpf_sed_inplace "s|<generate with: openssl rand -hex 32>|$ENC_KEY_VAL|" apps/web/.env.local
   ok "Created apps/web/.env.local with generated secrets"
 else
   ok "apps/web/.env.local already exists -- skipping"
 fi
 
-# Ensure root .env has real secrets for Docker Compose
 if [ ! -f .env ]; then
   cp .env.docker.example .env
-  AUTH_SECRET=$(openssl rand -base64 32 2>/dev/null || python3 -c "import secrets,base64; print(base64.b64encode(secrets.token_bytes(32)).decode())" 2>/dev/null)
-  ENC_KEY=$(openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))" 2>/dev/null)
-  sed -i "s|<generate with: openssl rand -base64 32>|$AUTH_SECRET|" .env
-  sed -i "s|<generate with: openssl rand -hex 32>|$ENC_KEY|" .env
+  AUTH_SECRET_VAL="$(dpf_random_secret_b64 32)"
+  ENC_KEY_VAL="$(dpf_random_secret_hex 32)"
+  ADMIN_PW_VAL="$(dpf_random_secret_hex 16)"
+  dpf_sed_inplace "s|<generate with: openssl rand -base64 32>|$AUTH_SECRET_VAL|" .env
+  dpf_sed_inplace "s|<generate with: openssl rand -hex 32>|$ENC_KEY_VAL|" .env
+  dpf_sed_inplace "s|<set a strong password>|$ADMIN_PW_VAL|" .env
+  # Default the host-install path to the repo root so docker-compose
+  # bind-mounts resolve. Operator can override post-setup.
+  dpf_sed_inplace "s|<set to absolute path of this directory on the host>|$REPO_ROOT|" .env
   ok "Created root .env with generated secrets"
-fi
-
-# ── Databases ─────────────────────────────────────────────────────────────────
-
-step "Starting services (PostgreSQL + Neo4j + Ollama)"
-docker compose up -d
-
-echo "  Building promoter image (for autonomous deployments)..."
-if docker compose --profile promote build promoter >/dev/null 2>&1; then
-  ok "Promoter image built"
 else
-  warn "Promoter image build failed (non-fatal -- can be built later)"
+  ok "root .env already exists -- skipping"
 fi
 
-echo "  Waiting for PostgreSQL to be ready..."
+# ── Compose services ─────────────────────────────────────────────────────────
+
+step "Starting contributor compose stack (Postgres + Neo4j + Qdrant)"
+docker compose up -d postgres neo4j qdrant
+
+echo "  Waiting for Postgres to be ready..."
 RETRIES=30
 until docker compose exec -T postgres pg_isready -U dpf -q 2>/dev/null; do
   RETRIES=$((RETRIES - 1))
-  if [ $RETRIES -eq 0 ]; then
-    fail "PostgreSQL did not start in time. Check: docker compose logs postgres"
+  if [ "$RETRIES" -le 0 ]; then
+    fail "Postgres did not become ready in time. Check: docker compose logs postgres"
   fi
   sleep 2
 done
-ok "PostgreSQL is ready"
+ok "Postgres is ready"
 
-echo "  Waiting for Ollama... (first run may take a few minutes to download default model)"
-RETRIES=90
-until docker compose exec -T ollama curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; do
-  RETRIES=$((RETRIES - 1))
-  if [ $RETRIES -eq 0 ]; then
-    fail "Ollama did not start in time. Check: docker compose logs ollama"
-  fi
-  sleep 2
-done
-ok "Ollama is ready"
-
-# ── Database Setup ────────────────────────────────────────────────────────────
+# ── Database migrations and seed ─────────────────────────────────────────────
 
 step "Running database migrations"
 pnpm db:migrate
@@ -129,8 +155,9 @@ pnpm db:seed
 ok "Database seeded with roles, agents, and default admin user"
 
 # ── Agent rulebook conformance ───────────────────────────────────────────────
-# Every install must ship the canonical AGENTS.md plus pointer files for each
-# supported AI tool. Fail the install if any are missing or have drifted.
+# Per AGENTS.md: every install must ship the canonical AGENTS.md plus pointer
+# files for each supported AI tool. Fail the install if any are missing or
+# have drifted.
 
 step "Verifying agent rulebook"
 
@@ -139,35 +166,37 @@ if [ ! -f AGENTS.md ]; then
 fi
 ok "Canonical rulebook: AGENTS.md"
 
-POINTERS=(
-  "CLAUDE.md"
-  ".cursor/rules/000-load-agents.mdc"
-  ".clinerules/000-load-agents.md"
-  ".github/copilot-instructions.md"
-  "CONVENTIONS.md"
-  ".continue/rules/000-load-agents.md"
-)
-for p in "${POINTERS[@]}"; do
+POINTERS="CLAUDE.md .cursor/rules/000-load-agents.mdc .clinerules/000-load-agents.md .github/copilot-instructions.md CONVENTIONS.md .continue/rules/000-load-agents.md"
+POINTER_COUNT=0
+for p in $POINTERS; do
   if [ ! -f "$p" ]; then
     fail "Pointer file missing: $p. Re-clone or restore from main."
   fi
   if ! grep -q "AGENTS.md" "$p"; then
     fail "Pointer file does not reference AGENTS.md: $p. Drift detected."
   fi
+  POINTER_COUNT=$((POINTER_COUNT + 1))
 done
-ok "Pointer files intact: ${#POINTERS[@]} tools wired to AGENTS.md"
+ok "Pointer files intact: $POINTER_COUNT tools wired to AGENTS.md"
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 
 echo ""
-echo -e "${GREEN}  Setup complete!${NC}"
+printf '%b  Setup complete!%b\n' "$DPF_GREEN" "$DPF_NC"
 echo ""
 echo "  Start the app:  pnpm dev   (or: make dev)"
 echo "  Open:           http://localhost:3000"
 echo ""
 echo "  Default login:"
 echo "    Email:    admin@dpf.local"
-echo "    Password: changeme123"
+echo "    Password: see ADMIN_PASSWORD in .env (generated above)"
 echo ""
-echo "  Change the password before any non-local deployment."
+echo "  LLM provider note:"
+echo "    The LLM provider contract (Doctrine Contract 9) is provider-aware."
+echo "    On macOS Docker Desktop:  Docker Model Runner (built-in, 4.40+)"
+echo "    On Linux native Docker:   Ollama in compose (lands in Phase 3)"
+echo "    On any host:              point LLM_BASE_URL at an external endpoint"
+echo "    See docs/superpowers/specs/2026-05-09-deployment-contracts.md"
+echo ""
+echo "  Change the admin password before any non-local deployment."
 echo ""


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the Mac/Linux installer-parity roadmap. Delivers the contributor-setup contract per the deployment doctrine (Contract 3: lifecycle, contributor surface).

Six files, +443 / -90 lines.

### Changes

**`scripts/setup.sh`** — full rewrite
- Sources shared helpers from the new `scripts/installer/lib/` directory.
- **Fixes BSD vs GNU `sed -i` portability** via `dpf_sed_inplace`. Previous version used `sed -i "EXPR"` which is GNU-only; `setup.sh` now works identically on macOS BSD `sed` and Linux GNU `sed`.
- **Drops the dead Ollama wait** (lines 110-119 in the previous version) — the base compose has no `ollama` service, so the wait deadlocked on a fresh install. The LLM provider contract (Doctrine Contract 9) is provider-aware; Ollama-in-compose lands in Phase 3 via `docker-compose.linux.yml`.
- Drops the `OLLAMA_INTERNAL_URL` write that pointed at a non-existent service.
- Brings up only the contributor compose subset (`postgres + neo4j + qdrant`) rather than the full stack — faster, fewer surprises.
- Detects unsupported OS up-front via the new platform helper.
- Generates `ADMIN_PASSWORD` (was previously left as `<set a strong password>`).
- Defaults `DPF_HOST_INSTALL_PATH` to the repo root so docker-compose bind-mounts resolve out of the box.
- `set -euo pipefail` (was just `set -e`); resolves repo root from the script's location so cwd doesn't matter.

**`scripts/installer/lib/{logging,platform,prompts}.sh`** (new)
- Shared helpers used by `setup.sh` today and by `install-dpf.sh` when installer-parity Phase 6 lands.
- `logging.sh` — `ok` / `warn` / `info` / `fail` / `step` with `NO_COLOR`-aware ANSI; bash 3.2 baseline (no associative arrays, no `${var^^}`).
- `platform.sh` — `dpf_platform` (DPF_PLATFORM = `darwin|linux|unsupported`), `dpf_arch` (DPF_ARCH = `arm64|amd64|<raw>`), `dpf_sed_inplace`.
- `prompts.sh` — `dpf_yes_no` (with default + `DPF_HEADLESS=1` honor), `dpf_default_value`, `dpf_random_secret_hex`, `dpf_random_secret_b64` (`openssl` → `python3.secrets` → dev-grade fallback chain).
- Idempotency guards on each so repeated sourcing is harmless.

**`.vscode/tasks.json`** — `osx` + `linux` overrides for all 17 tasks
- Each task that uses `cmd /c X` now has `osx` and `linux` blocks running `bash -lc X` with the same payload.
- The 4 PowerShell tasks (Release Minor/Patch/Major, Clean Reinstall) get `osx` / `linux` overrides that print a clear *"lands with Phase 8 of the installer-parity roadmap"* message and exit 1 — explicit deferred-feature signal instead of a confusing missing-command error.
- Top-level `command`/`args` preserved verbatim so Windows behavior is unchanged.
- Factory Reset task adapted for bash (`read -r -p` instead of `pause`).

**`CONTRIBUTING.md`** — fills in the macOS/Linux setup section
- Replaces the *"Status: stub pending Phase 2"* placeholder added in #400 with the actual setup flow.
- Documents the 7-step `setup.sh` flow, the VS Code task overrides, and the three things deliberately NOT in `setup.sh` (Docker/Node/pnpm install; LLM provider config; install-dpf.sh-territory features).

## Test plan

Verified locally before push:

- [x] `bash -n` parses `scripts/setup.sh` and all three lib helpers cleanly
- [x] `python3 json.load` on `.vscode/tasks.json` passes
- [x] **Smoke test of helpers end-to-end** on a Linux runner: logging colors render with correct prefixes; `dpf_platform` reports `linux/amd64`; `dpf_sed_inplace` works without leaving `.bak` files; secret generators produce correct lengths (64 hex / 44 base64); headless prompts honor defaults
- [x] DCO sign-off on commit
- [x] Diff is additive on `.vscode/tasks.json` — Windows behavior preserved verbatim

To verify in CI / on a fresh host:

- [ ] `Production Build` and `Typecheck` pass — required gating checks per CONTRIBUTING.md
- [ ] `Unit Tests` may report the same pre-existing pre-#395/#397/#398-dependabot-bumps failure as on `main` and recent doc-only PRs (informational per CONTRIBUTING.md, unrelated to this PR)
- [ ] Manual macOS smoke (Apple Silicon): clone fresh repo → `bash scripts/setup.sh` succeeds end-to-end → `make dev` runs → http://localhost:3000 reachable
- [ ] Manual Linux smoke (Ubuntu 22.04): same flow
- [ ] VS Code task verification: open repo on macOS → `Cmd+Shift+P → Tasks: Run Task → DPF: Type Check` → runs successfully via bash; same for `DPF: Production Build`, `DPF: Start Production Runtime`

## What this PR does NOT do

- Does **not** modify `install-dpf.ps1` or any Windows installer surface.
- Does **not** add `docker-compose.{macos,linux}.yml` — that's Phase 3.
- Does **not** add platform-aware LLM provider routing in compose — that's Phase 4.
- Does **not** touch hardware detection, `install-state.json`, or `dpf doctor` — those are `install-dpf.sh` territory in Phase 6/7.
- Does **not** ship `dpf-release.sh` or `dpf-reinstall.sh` — those are Phase 8. The VS Code task overrides for those four tasks emit clear deferred-feature messages instead.

## What this PR enables

- **Phase 3** can layer compose overlays on top of a contributor environment that actually works on macOS / Linux.
- **Phase 6** (the `install-dpf.sh` skeleton) inherits the shared `installer/lib/` helpers verbatim — no duplication.
- **macOS + Linux contributors** can clone, run `bash scripts/setup.sh`, and start work without hitting the BSD-`sed` portability bug or the dead `ollama` wait.
- **VS Code on macOS / Linux** runs every task that has a runnable equivalent, with explicit deferred-feature messages for tasks that don't yet.

Refs:
- `docs/superpowers/specs/2026-05-09-deployment-contracts.md` — Contract 3 (lifecycle), Contract 9 (LLM/agent-provider routing)
- `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 2
- #400 — deployment architecture foundation (merged)
- #401 — Phase 1 multi-arch GHCR publish (merged)

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_