### PR TITLE
fix(seed): tolerate P2002 in seedCities so seedPromptTemplates runs (BI-E4E21A7F)

### DIFF
--- a/packages/db/src/seed-geographic-data.test.ts
+++ b/packages/db/src/seed-geographic-data.test.ts
@@ -1,0 +1,131 @@
+// packages/db/src/seed-geographic-data.test.ts
+//
+// Regression test for BI-E4E21A7F: seedCities used to crash on P2002 unique
+// constraint violations, which aborted the rest of the seed (notably
+// seedPromptTemplates), so fresh installs shipped with stale coworker prompts.
+//
+// The contract under test is seedCityOnce: it must tolerate both
+//   (a) findFirst-misses-but-row-exists (raised as P2002 by Prisma)
+//   (b) cold-path creates (no row exists)
+// and must NOT swallow non-P2002 errors.
+
+import { describe, it, expect } from "vitest";
+import { seedCityOnce } from "./seed-geographic-data";
+import type { PrismaClient } from "../generated/client/client";
+
+type CityFindFirst = (args: {
+  where: { regionId: string; nameNormalized: string };
+  select: { id: true };
+}) => Promise<{ id: string } | null>;
+
+type CityCreate = (args: {
+  data: { name: string; nameNormalized: string; regionId: string };
+}) => Promise<{ id: string }>;
+
+function buildPrismaStub(opts: {
+  findFirst: CityFindFirst;
+  create: CityCreate;
+}): PrismaClient {
+  return {
+    city: { findFirst: opts.findFirst, create: opts.create },
+  } as unknown as PrismaClient;
+}
+
+const cityRecord = (name: string) => ({
+  name,
+  regionCode: "CA",
+  countryCode: "US",
+});
+
+describe("seedCityOnce", () => {
+  it("creates the city when findFirst returns null and create succeeds", async () => {
+    let captured: Parameters<CityCreate>[0] | null = null;
+    const create: CityCreate = async (args) => {
+      captured = args;
+      return { id: "city-1" };
+    };
+    const prisma = buildPrismaStub({
+      findFirst: async () => null,
+      create,
+    });
+
+    const outcome = await seedCityOnce(prisma, "region-1", cityRecord("Anaheim"));
+
+    expect(outcome).toBe("created");
+    expect(captured).not.toBeNull();
+    expect(captured!.data).toMatchObject({
+      name: "Anaheim",
+      regionId: "region-1",
+    });
+  });
+
+  it("reports 'existing' without calling create when findFirst hits a row", async () => {
+    let createCalls = 0;
+    const create: CityCreate = async () => {
+      createCalls++;
+      return { id: "city-x" };
+    };
+    const prisma = buildPrismaStub({
+      findFirst: async () => ({ id: "city-existing" }),
+      create,
+    });
+
+    const outcome = await seedCityOnce(prisma, "region-1", cityRecord("Los Angeles"));
+
+    expect(outcome).toBe("existing");
+    expect(createCalls).toBe(0);
+  });
+
+  it("swallows P2002 unique-constraint violations as 'skipped_duplicate' (BI-E4E21A7F regression)", async () => {
+    // Simulates the index-disagreement scenario:
+    //   findFirst (regionId, nameNormalized) returns null
+    //   but create trips the (LOWER(name), regionId) unique index
+    let createCalls = 0;
+    const create: CityCreate = async () => {
+      createCalls++;
+      const err = Object.assign(new Error("Unique constraint failed"), {
+        code: "P2002",
+        meta: { target: ["regionId", "name"] },
+      });
+      throw err;
+    };
+    const prisma = buildPrismaStub({
+      findFirst: async () => null,
+      create,
+    });
+
+    const outcome = await seedCityOnce(prisma, "region-1", cityRecord("São Paulo"));
+
+    expect(outcome).toBe("skipped_duplicate");
+    expect(createCalls).toBe(1);
+  });
+
+  it("re-throws non-P2002 Prisma errors so genuine bugs surface", async () => {
+    const create: CityCreate = async () => {
+      const err = Object.assign(new Error("connection lost"), { code: "P1001" });
+      throw err;
+    };
+    const prisma = buildPrismaStub({
+      findFirst: async () => null,
+      create,
+    });
+
+    await expect(seedCityOnce(prisma, "region-1", cityRecord("Boston"))).rejects.toThrow(
+      /connection lost/,
+    );
+  });
+
+  it("re-throws errors that lack a code field", async () => {
+    const create: CityCreate = async () => {
+      throw new Error("unrelated failure");
+    };
+    const prisma = buildPrismaStub({
+      findFirst: async () => null,
+      create,
+    });
+
+    await expect(seedCityOnce(prisma, "region-1", cityRecord("Toronto"))).rejects.toThrow(
+      /unrelated failure/,
+    );
+  });
+});

--- a/packages/db/src/seed-geographic-data.ts
+++ b/packages/db/src/seed-geographic-data.ts
@@ -127,6 +127,56 @@ async function seedRegions(
   return { regionKeyToDbId, regionCount };
 }
 
+/**
+ * Outcome of attempting to seed a single city. Exported so seed runners and
+ * tests can reason about counts without re-deriving them.
+ */
+export type SeedCityOutcome = "created" | "existing" | "skipped_duplicate";
+
+/**
+ * Idempotently seed one city, tolerating both findFirst-doesn't-see-it
+ * (cold path, normal create) and P2002 (the row exists but our lookup index
+ * disagreed with the unique constraint).
+ *
+ * The City model has two unique constraints that can disagree:
+ *   (1) UNIQUE (LOWER("name"), regionId)                          — case-insensitive raw name
+ *   (2) UNIQUE (regionId, nameNormalized) WHERE disambiguator IS NULL — accent-folded
+ * The findFirst checks (2). Source data with near-duplicates (e.g. accented
+ * vs. unaccented variants of the same city) can pass (2) but collide on (1).
+ *
+ * Without P2002 tolerance, seedCities crashes mid-run and
+ * seedPromptTemplates never executes — which is what produced
+ * BI-E4E21A7F (fresh installs ship with stale coworker prompts).
+ */
+export async function seedCityOnce(
+  prisma: PrismaClient,
+  regionDbId: string,
+  city: CityRecord,
+): Promise<SeedCityOutcome> {
+  const found = await prisma.city.findFirst({
+    where: { regionId: regionDbId, nameNormalized: normalizeLocalityName(city.name) },
+    select: { id: true },
+  });
+
+  if (found) return "existing";
+
+  try {
+    await prisma.city.create({
+      data: {
+        name: city.name,
+        nameNormalized: normalizeLocalityName(city.name),
+        regionId: regionDbId,
+      },
+    });
+    return "created";
+  } catch (err: unknown) {
+    // Prisma P2002 = unique constraint violation. Anything else re-throws.
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "P2002") return "skipped_duplicate";
+    throw err;
+  }
+}
+
 async function seedCities(
   prisma: PrismaClient,
   regionKeyToDbId: Map<string, string>,
@@ -137,6 +187,7 @@ async function seedCities(
 
   let created = 0;
   let existing = 0;
+  let skippedDuplicate = 0;
   const BATCH_LOG_INTERVAL = 1000;
 
   for (let i = 0; i < cities.length; i++) {
@@ -144,31 +195,25 @@ async function seedCities(
     const regionDbId = regionKeyToDbId.get(`${c.countryCode}::${c.regionCode}`);
     if (!regionDbId) continue;
 
-    const found = await prisma.city.findFirst({
-      where: { regionId: regionDbId, nameNormalized: normalizeLocalityName(c.name) },
-      select: { id: true },
-    });
-
-    if (found) {
-      existing++;
-    } else {
-      await prisma.city.create({
-        data: {
-          name: c.name,
-          nameNormalized: normalizeLocalityName(c.name),
-          regionId: regionDbId,
-        },
-      });
-      created++;
-    }
+    const outcome = await seedCityOnce(prisma, regionDbId, c);
+    if (outcome === "created") created++;
+    else if (outcome === "existing") existing++;
+    else skippedDuplicate++;
 
     if ((i + 1) % BATCH_LOG_INTERVAL === 0) {
       log(`  Progress: ${i + 1}/${cities.length} cities processed...`);
     }
   }
 
-  log(`  Cities: ${created} created, ${existing} already existed. Total: ${created + existing}`);
-  return created + existing;
+  if (skippedDuplicate > 0) {
+    log(
+      `  Cities: ${created} created, ${existing} already existed, ${skippedDuplicate} skipped (P2002 duplicate). ` +
+        `Total: ${created + existing + skippedDuplicate}`,
+    );
+  } else {
+    log(`  Cities: ${created} created, ${existing} already existed. Total: ${created + existing}`);
+  }
+  return created + existing + skippedDuplicate;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `seedCities` used to crash on a P2002 unique-constraint violation, aborting the rest of `seed.ts` before `seedPromptTemplates` ran. Fresh installs silently shipped with stale coworker prompts (the original BI-E4E21A7F symptom).
- Extracted `seedCityOnce(prisma, regionDbId, city)` so the per-city upsert is unit-testable, taught it to swallow `P2002` as `"skipped_duplicate"`, and added five regression tests.
- Non-P2002 errors still re-throw; genuine bugs are not masked.

## Why P2002 fires

The `City` model has two unique constraints that can disagree:
- `UNIQUE (LOWER("name"), regionId)` — original 2026-03-17 reference-data migration.
- `UNIQUE (regionId, nameNormalized) WHERE disambiguator IS NULL` — 2026-05-01 stewardship migration.

The seeder's pre-create `findFirst` checks `(regionId, nameNormalized)`. Source-data near-duplicates (e.g. accented vs. unaccented variants — `São Paulo` vs `Sao Paulo`) can pass that lookup but still collide on the `LOWER(name)` index, raising `P2002`. The fix tolerates that case and counts skips separately so source-data drift is visible in the seed log.

## Test plan

- [x] `pnpm --filter @dpf/db test seed-geographic-data` — 5 tests pass
- [x] `pnpm --filter @dpf/db typecheck` — clean
- [ ] Validated indirectly: next fresh-install rebuild should reach `seedPromptTemplates` without manual DB UPDATEs of the 13 stale `PromptTemplate` rows that this BI required as a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)