### PR TITLE
feat(contributor-setup): seed worktree MCP config from main worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Hyphens, not underscores. Adding a new value requires updating both `backlog.ts`
 - **Always push** after committing. Local-only commits are invisible to CI.
 - **Squash-and-delete on merge:** `gh pr merge <n> --squash --delete-branch`.
 - **Concurrent sessions:** one thread = one branch + one git worktree. Create with `git worktree add ../DPF-<topic> -b <prefix>/<topic>`. Never share a working tree across sessions; doing so causes index/HEAD collisions and cross-thread file sweeps.
+- **After creating a worktree, seed its MCP config:** `.mcp.json` and `.vscode/mcp.json` are gitignored (they carry your local `dpfmcp_...` bearer token), so `git worktree add` does not carry them across. Run `scripts/seed-worktree-mcp.ps1` (Windows) or `scripts/seed-worktree-mcp.sh` (macOS / Linux) from inside the new worktree to copy them from the root clone. The script is predicated on the platform being installed and an MCP token already generated at Admin > Platform Development. Restart Claude Code in the worktree afterwards so `/mcp` picks up the `dpf` connector.
 - **Keep the root clone as the merge/release worktree** — read-only for active feature work. Conventional locations: `d:\DPF` on Windows, `~/dpf` on macOS/Linux. Topic worktrees go alongside (`d:\DPF-<topic>` or `~/dpf-worktrees/<topic>`).
 - **Branch guard before commit:** if `git branch --show-current` returns `main`, abort.
 

--- a/scripts/seed-worktree-mcp.ps1
+++ b/scripts/seed-worktree-mcp.ps1
@@ -1,0 +1,92 @@
+# Open Digital Product Factory -- worktree MCP config seeder (Windows PowerShell)
+#
+# Copies .mcp.json and .vscode/mcp.json from the main worktree (root clone)
+# into a target git worktree so Claude Code's /mcp connector list and the
+# VS Code MCP client can find the dpf server.
+#
+# Predicated on platform installation: scripts/setup.ps1 must have completed
+# AND an admin must have generated an MCP token at Admin > Platform Development
+# (which writes the source files at the root clone). The two source files are
+# gitignored on purpose -- they carry a local bearer token -- so they do not
+# travel with `git worktree add`.
+#
+# Usage:
+#   .\scripts\seed-worktree-mcp.ps1                    # seed current directory
+#   .\scripts\seed-worktree-mcp.ps1 -Target <path>     # seed a specific worktree
+#   .\scripts\seed-worktree-mcp.ps1 -Force             # overwrite existing files
+
+param(
+    [string]$Target = (Get-Location).Path,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step { param($msg) Write-Host "`n-> $msg" -ForegroundColor Yellow }
+function Write-Ok   { param($msg) Write-Host "  [OK] $msg" -ForegroundColor Green }
+function Write-Skip { param($msg) Write-Host "  [SKIP] $msg" -ForegroundColor Yellow }
+function Write-Fail { param($msg) Write-Host "  [FAIL] $msg" -ForegroundColor Red; exit 1 }
+
+$Target = (Resolve-Path -LiteralPath $Target).Path
+
+Write-Step "Locating main worktree"
+
+Push-Location -LiteralPath $Target
+try {
+    $null = git rev-parse --is-inside-work-tree 2>$null
+    if ($LASTEXITCODE -ne 0) { Write-Fail "Not inside a git working tree: $Target" }
+    $mainGitDir = (git rev-parse --path-format=absolute --git-common-dir).Trim()
+} finally {
+    Pop-Location
+}
+
+if (-not $mainGitDir -or -not (Test-Path -LiteralPath $mainGitDir)) {
+    Write-Fail "Could not resolve main git directory from $Target."
+}
+
+$mainAbs = (Resolve-Path -LiteralPath ([System.IO.Path]::GetDirectoryName($mainGitDir))).Path
+Write-Ok "Main worktree:   $mainAbs"
+Write-Ok "Target worktree: $Target"
+
+if ($mainAbs -ieq $Target) {
+    Write-Ok "Target IS the main worktree -- nothing to seed."
+    exit 0
+}
+
+$pairs = @(
+    @{ Src = (Join-Path $mainAbs ".mcp.json");        Dst = (Join-Path $Target ".mcp.json") },
+    @{ Src = (Join-Path $mainAbs ".vscode\mcp.json"); Dst = (Join-Path $Target ".vscode\mcp.json") }
+)
+
+Write-Step "Copying MCP config"
+foreach ($pair in $pairs) {
+    if (-not (Test-Path -LiteralPath $pair.Src)) {
+        Write-Host ""
+        Write-Host "  [FAIL] Missing source: $($pair.Src)" -ForegroundColor Red
+        Write-Host ""
+        Write-Host "  The platform must be installed and an MCP token generated before seeding worktrees." -ForegroundColor Yellow
+        Write-Host "  Steps:" -ForegroundColor Yellow
+        Write-Host "    1. From the main worktree at $mainAbs, run scripts\setup.ps1 if you have not already." -ForegroundColor Yellow
+        Write-Host "    2. Start the platform (pnpm dev or docker compose up) and log in at http://localhost:3000 as admin@dpf.local." -ForegroundColor Yellow
+        Write-Host "    3. Open Admin > Platform Development and generate an MCP token (writes .mcp.json + .vscode\mcp.json at the root)." -ForegroundColor Yellow
+        Write-Host "    4. Re-run this script." -ForegroundColor Yellow
+        exit 1
+    }
+
+    $dstDir = [System.IO.Path]::GetDirectoryName($pair.Dst)
+    if (-not (Test-Path -LiteralPath $dstDir)) {
+        New-Item -ItemType Directory -Path $dstDir -Force | Out-Null
+    }
+
+    if ((Test-Path -LiteralPath $pair.Dst) -and -not $Force) {
+        Write-Skip "$($pair.Dst) already exists. Re-run with -Force to overwrite."
+        continue
+    }
+
+    Copy-Item -LiteralPath $pair.Src -Destination $pair.Dst -Force
+    Write-Ok "Wrote $($pair.Dst)"
+}
+
+Write-Host ""
+Write-Host "Done. Restart Claude Code (or VS Code) in the worktree to pick up the dpf connector." -ForegroundColor Green
+Write-Host ""

--- a/scripts/seed-worktree-mcp.sh
+++ b/scripts/seed-worktree-mcp.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory -- worktree MCP config seeder (POSIX shell)
+#
+# Copies .mcp.json and .vscode/mcp.json from the main worktree (root clone)
+# into a target git worktree so Claude Code's /mcp connector list and the
+# VS Code MCP client can find the dpf server.
+#
+# Predicated on platform installation: scripts/setup.sh must have completed
+# AND an admin must have generated an MCP token at Admin > Platform Development
+# (which writes the source files at the root clone). The two source files are
+# gitignored on purpose -- they carry a local bearer token -- so they do not
+# travel with `git worktree add`.
+#
+# Usage:
+#   ./scripts/seed-worktree-mcp.sh                  # seed current directory
+#   ./scripts/seed-worktree-mcp.sh <path>           # seed a specific worktree
+#   ./scripts/seed-worktree-mcp.sh --force          # overwrite existing files
+#   ./scripts/seed-worktree-mcp.sh <path> --force
+
+set -euo pipefail
+
+target=""
+force=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) force=1 ;;
+        *)
+            if [ -z "$target" ]; then
+                target="$arg"
+            else
+                printf '  [FAIL] Unexpected argument: %s\n' "$arg" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+target="${target:-$PWD}"
+
+step() { printf '\n-> %s\n' "$1"; }
+ok()   { printf '  [OK] %s\n' "$1"; }
+skip() { printf '  [SKIP] %s\n' "$1"; }
+
+if [ ! -d "$target" ]; then
+    printf '  [FAIL] Target is not a directory: %s\n' "$target" >&2
+    exit 1
+fi
+
+cd "$target"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf '  [FAIL] Not inside a git working tree: %s\n' "$target" >&2
+    exit 1
+fi
+
+target_abs="$(pwd -P)"
+main_git_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+main_abs="$(cd "$(dirname "$main_git_dir")" && pwd -P)"
+
+step "Locating main worktree"
+ok "Main worktree:   $main_abs"
+ok "Target worktree: $target_abs"
+
+if [ "$main_abs" = "$target_abs" ]; then
+    ok "Target IS the main worktree -- nothing to seed."
+    exit 0
+fi
+
+step "Copying MCP config"
+
+copy_one() {
+    local src="$1" dst="$2"
+    if [ ! -f "$src" ]; then
+        printf '\n  [FAIL] Missing source: %s\n\n' "$src" >&2
+        cat >&2 <<EOF
+  The platform must be installed and an MCP token generated before seeding worktrees.
+  Steps:
+    1. From the main worktree at $main_abs, run scripts/setup.sh if you have not already.
+    2. Start the platform (pnpm dev or docker compose up) and log in at http://localhost:3000 as admin@dpf.local.
+    3. Open Admin > Platform Development and generate an MCP token (writes .mcp.json + .vscode/mcp.json at the root).
+    4. Re-run this script.
+EOF
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$dst")"
+    if [ -f "$dst" ] && [ "$force" -ne 1 ]; then
+        skip "$dst already exists. Re-run with --force to overwrite."
+        return 0
+    fi
+    cp "$src" "$dst"
+    ok "Wrote $dst"
+}
+
+copy_one "$main_abs/.mcp.json"        "$target_abs/.mcp.json"
+copy_one "$main_abs/.vscode/mcp.json" "$target_abs/.vscode/mcp.json"
+
+printf '\nDone. Restart Claude Code (or VS Code) in the worktree to pick up the dpf connector.\n\n'


### PR DESCRIPTION
## Summary

- Claude-Code-created worktrees (and any non-trivial `git worktree add`) ship without `.mcp.json` or `.vscode/mcp.json` because both files are gitignored — they carry the local `dpfmcp_...` bearer token. Result: `/mcp` lists no `dpf` connector inside the worktree even though the platform is installed and the token works at the root clone.
- Adds `scripts/seed-worktree-mcp.{ps1,sh}` that auto-detect the main worktree via `git rev-parse --git-common-dir` and copy both files into the target worktree. Idempotent; supports `--force` / `-Force` to overwrite.
- Predicated on platform installation: the script emits a clear remediation message pointing at `scripts/setup.{ps1,sh}` and Admin > Platform Development if the source files are missing at the root clone.
- AGENTS.md §4 (Concurrent sessions) now points contributors at the script after `git worktree add`, including the Claude Code restart needed for `/mcp` to pick up the new connector.

## Test plan

- [ ] On Windows: run `.\scripts\seed-worktree-mcp.ps1` from a fresh worktree → both files appear, `/mcp` lists `dpf` after Claude Code restart.
- [ ] On Windows: re-run without `-Force` → both files report `[SKIP]`.
- [ ] On Windows: re-run with `-Force` → both files re-copied.
- [ ] On macOS / Linux: same three checks via `./scripts/seed-worktree-mcp.sh` (`--force` for overwrite).
- [ ] Run from the main worktree itself → script reports "Target IS the main worktree -- nothing to seed" and exits 0.
- [ ] Delete the source `.mcp.json` at the root → script fails with the Admin > Platform Development remediation message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)