### PR TITLE
feat(entrypoint): provider-aware embedding-model setup (Phase 4)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -49,6 +49,48 @@ HIVE_CONTRIBUTION_TOKEN=
 GF_ADMIN_USER=admin
 GF_ADMIN_PASSWORD=dpf_monitor
 
+# ─── LLM provider contract (Doctrine Contract 9) ────────────────────────
+# Universal envvars consumed by the portal, sandbox, browser-use, and
+# docker-entrypoint.sh. The platform's LLM provider contract is
+# provider-aware: the same code paths work on Docker Desktop's
+# Docker Model Runner, on in-cluster Ollama, and against any external
+# OpenAI-compatible endpoint, by switching DPF_LLM_PROVIDER.
+#
+# DPF_LLM_PROVIDER:  model-runner | ollama | external
+#                    Selects which provider-specific endpoints the
+#                    entrypoint uses for embedding-model setup. If
+#                    unset, the entrypoint infers from LLM_BASE_URL
+#                    (defaults to model-runner for backwards compat).
+#
+# LLM_BASE_URL:      OpenAI-compatible base URL. Defaults differ per
+#                    substrate (Docker Desktop -> model-runner;
+#                    docker-compose.linux.yml overrides to
+#                    http://ollama:11434/v1; external endpoint sets
+#                    its own URL).
+#
+# LLM_MODEL:         Default chat-completions model (e.g. gpt-4o,
+#                    ai/gemma3, llama3.1). Provider-specific naming.
+#
+# EMBEDDING_MODEL:   Default embedding model. Provider-specific naming;
+#                    ai/nomic-embed-text-v1.5 for Docker Model Runner,
+#                    nomic-embed-text for Ollama. The entrypoint defaults
+#                    appropriately based on the active provider.
+#
+# BROWSER_USE_MODEL: Model for the browser-use service (UX verification).
+#
+# DPF_MODEL_PULL_MODE: auto | skip | verify-only
+#                    Controls embedding-model setup behavior in the
+#                    entrypoint. auto verifies and pulls if missing
+#                    (default). verify-only never pulls. skip does
+#                    nothing. external provider is forced to verify-only
+#                    regardless of this setting.
+DPF_LLM_PROVIDER=
+LLM_BASE_URL=
+LLM_MODEL=
+EMBEDDING_MODEL=
+BROWSER_USE_MODEL=gpt-4o
+DPF_MODEL_PULL_MODE=auto
+
 # ─── Release-image distribution (used by docker-compose.release.yml) ──
 # Set these when consuming pre-built multi-arch GHCR images instead of
 # building locally. See docs/superpowers/specs/2026-05-09-deployment-contracts.md

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -153,25 +153,103 @@ psql "$DATABASE_URL" -c "
 " 2>/dev/null || echo "  WARN post-init SQL had warnings (non-fatal)"
 echo "  OK Provider config set"
 
-# ─── Pull embedding model into Docker Model Runner if available ──────────
+# ─── Provider-aware embedding model setup ────────────────────────────────
+# Per the deployment doctrine (Contract 9: LLM and agent-provider routing),
+# the entrypoint must NOT call provider-specific endpoints for the wrong
+# provider. Three modes:
+#   model-runner — Docker Desktop's built-in runner; pull via
+#                   POST /models/create (Docker-Model-Runner-only endpoint)
+#   ollama       — in-cluster Ollama; pull via POST /api/pull (Ollama-only)
+#   external     — customer-managed endpoint; verify only, never pull
+#
+# DPF_LLM_PROVIDER selects the mode explicitly. If unset, we infer from
+# LLM_BASE_URL: defaults to model-runner for backwards compatibility with
+# the existing default URL; the Linux compose overlay sets
+# LLM_BASE_URL=http://ollama:11434/v1 which auto-infers ollama.
+#
+# DPF_MODEL_PULL_MODE controls behavior:
+#   auto        — verify the model exists; pull if missing (default)
+#   verify-only — verify only; never pull
+#   skip        — do nothing
 echo "[post-init] Checking embedding model..."
-# Docker Model Runner exposes an OpenAI-compatible API on the host.
-# The portal talks to it via LLM_BASE_URL. Try to pull the embedding model
-# so preflight check 10 passes on fresh install. This is best-effort —
-# Model Runner may not be available (e.g. CI or non-Docker hosts).
+
 EMB_BASE_URL="${LLM_BASE_URL:-http://model-runner.docker.internal/v1}"
-EMB_MODEL="ai/nomic-embed-text-v1.5"
-emb_already=$(wget -qO- --timeout=5 "${EMB_BASE_URL}/models" 2>/dev/null || true)
-if echo "$emb_already" | grep -q "nomic-embed-text"; then
-  echo "  OK Embedding model already available"
+PULL_MODE="${DPF_MODEL_PULL_MODE:-auto}"
+
+# Auto-detect provider from LLM_BASE_URL when DPF_LLM_PROVIDER is unset.
+PROVIDER="${DPF_LLM_PROVIDER:-}"
+if [ -z "$PROVIDER" ]; then
+  case "$EMB_BASE_URL" in
+    *model-runner*)  PROVIDER="model-runner" ;;
+    *:11434*)        PROVIDER="ollama" ;;
+    *)               PROVIDER="external" ;;
+  esac
+fi
+
+# Provider-aware default for the embedding model. Operators override
+# EMBEDDING_MODEL explicitly when they want a different model.
+EMB_MODEL="${EMBEDDING_MODEL:-}"
+if [ -z "$EMB_MODEL" ]; then
+  case "$PROVIDER" in
+    model-runner)  EMB_MODEL="ai/nomic-embed-text-v1.5" ;;
+    ollama)        EMB_MODEL="nomic-embed-text" ;;
+    *)             EMB_MODEL="ai/nomic-embed-text-v1.5" ;;
+  esac
+fi
+
+echo "  Provider: $PROVIDER  Pull mode: $PULL_MODE  Base URL: $EMB_BASE_URL"
+echo "  Embedding model: $EMB_MODEL"
+
+# Skip path: do nothing, log explicitly.
+if [ "$PULL_MODE" = "skip" ]; then
+  echo "  SKIP DPF_MODEL_PULL_MODE=skip; not verifying or pulling embedding model"
+elif [ "$PULL_MODE" = "verify-only" ] || [ "$PROVIDER" = "external" ]; then
+  # Verify path: GET /v1/models, log presence/absence, never pull.
+  emb_listing=$(wget -qO- --timeout=5 "${EMB_BASE_URL}/models" 2>/dev/null || true)
+  if [ -z "$emb_listing" ]; then
+    echo "  WARN Could not reach ${EMB_BASE_URL}/models — platform will retry on first inference."
+  elif echo "$emb_listing" | grep -q "nomic-embed"; then
+    echo "  OK Embedding model verified at $EMB_BASE_URL"
+  else
+    echo "  WARN '$EMB_MODEL' not listed at $EMB_BASE_URL — operator must pull it manually."
+  fi
 else
-  echo "  Pulling ${EMB_MODEL} via Model Runner (first run only)..."
-  # Model Runner accepts POST /models/create with {"model":"..."} to pull
-  wget -qO- --timeout=120 --post-data "{\"model\":\"${EMB_MODEL}\"}" \
-    --header="Content-Type: application/json" \
-    "${EMB_BASE_URL%/v1}/models/create" 2>/dev/null \
-    && echo "  OK Embedding model pulled" \
-    || echo "  WARN Could not auto-pull embedding model. Run: docker model pull ${EMB_MODEL}"
+  # auto + known provider: branch on provider type to use the right pull endpoint.
+  case "$PROVIDER" in
+    model-runner)
+      # Docker Model Runner: POST /models/create with {"model":"..."}
+      emb_listing=$(wget -qO- --timeout=5 "${EMB_BASE_URL}/models" 2>/dev/null || true)
+      if echo "$emb_listing" | grep -q "nomic-embed-text"; then
+        echo "  OK Embedding model already available (Docker Model Runner)"
+      else
+        echo "  Pulling ${EMB_MODEL} via Docker Model Runner (first run only)..."
+        wget -qO- --timeout=120 --post-data "{\"model\":\"${EMB_MODEL}\"}" \
+          --header="Content-Type: application/json" \
+          "${EMB_BASE_URL%/v1}/models/create" 2>/dev/null \
+          && echo "  OK Embedding model pulled" \
+          || echo "  WARN Could not auto-pull. Run: docker model pull ${EMB_MODEL}"
+      fi
+      ;;
+    ollama)
+      # Ollama: POST /api/pull with {"name":"..."}. Ollama exposes /api
+      # at the same host (not /v1), so strip the /v1 suffix.
+      OLLAMA_HOST="${EMB_BASE_URL%/v1}"
+      emb_listing=$(wget -qO- --timeout=5 "${OLLAMA_HOST}/api/tags" 2>/dev/null || true)
+      if echo "$emb_listing" | grep -q "$EMB_MODEL"; then
+        echo "  OK Embedding model '$EMB_MODEL' already available (Ollama)"
+      else
+        echo "  Pulling '${EMB_MODEL}' via Ollama (first run; can take several minutes)..."
+        wget -qO- --timeout=300 --post-data "{\"name\":\"${EMB_MODEL}\"}" \
+          --header="Content-Type: application/json" \
+          "${OLLAMA_HOST}/api/pull" 2>/dev/null \
+          && echo "  OK Embedding model pulled (Ollama)" \
+          || echo "  WARN Could not auto-pull. Run: ollama pull ${EMB_MODEL}"
+      fi
+      ;;
+    *)
+      echo "  WARN Unknown DPF_LLM_PROVIDER='$PROVIDER'; skipping embedding model setup"
+      ;;
+  esac
 fi
 
 echo "=== Init complete ==="


### PR DESCRIPTION
## Summary

Implements **Phase 4** of the Mac/Linux installer-parity roadmap. Closes the loop on **Doctrine Contract 9** (LLM and agent-provider routing) by making `docker-entrypoint.sh` provider-aware: it never calls provider-specific endpoints for the wrong provider.

Two files. POSIX-shell-compatible (the entrypoint runs in alpine with `/bin/sh`).

### Why

The previous embedding-model setup hardcoded a Docker-Model-Runner-specific `POST /models/create`. That endpoint doesn't exist on Ollama (which uses `POST /api/pull`) or external endpoints (which can't be pulled to). On Linux native Docker (where `docker-compose.linux.yml` from Phase 3 sets `LLM_BASE_URL=http://ollama:11434/v1`), the entrypoint silently failed to pull the embedding model.

### Changes

**`docker-entrypoint.sh:156-175`** — provider-aware refactor

Three modes:

| Mode | Pull endpoint | When used |
|---|---|---|
| `model-runner` | `POST {base}/models/create` (Docker-Model-Runner-only) | Docker Desktop default |
| `ollama` | `POST {base-no-/v1}/api/pull` (Ollama-only) | `docker-compose.linux.yml` default |
| `external` | `GET {base}/models` only — never pulls | Customer-managed endpoint |

`DPF_LLM_PROVIDER` selects the mode explicitly. When unset, the entrypoint **auto-infers from `LLM_BASE_URL`**:
- `*model-runner*` → `model-runner` (preserves backwards compat with the existing default URL)
- `*:11434*` → `ollama` (matches Phase 3's `docker-compose.linux.yml` Ollama service)
- else → `external`

`DPF_MODEL_PULL_MODE` controls behavior: `auto` (verify, pull if missing — default) / `verify-only` / `skip`. External provider is always verify-only regardless of this setting — we never pull to a customer endpoint we don't control.

`EMBEDDING_MODEL` defaults appropriately per provider when unset:
- `model-runner` → `ai/nomic-embed-text-v1.5`
- `ollama` → `nomic-embed-text`

**`.env.docker.example`** — full LLM provider envvar contract documented

Adds a documented section for Doctrine Contract 9's universal envvars: `DPF_LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`, `EMBEDDING_MODEL`, `BROWSER_USE_MODEL`, `DPF_MODEL_PULL_MODE`. Each documented with provider-specific naming guidance and substrate-specific defaults.

## Test plan

Verified locally before push:

- [x] `sh -n docker-entrypoint.sh` passes (POSIX-shell syntactically valid)
- [x] Provider auto-detection smoke test:

| `LLM_BASE_URL` | Detected provider |
|---|---|
| `http://model-runner.docker.internal/v1` | `model-runner` |
| `http://ollama:11434/v1` | `ollama` |
| `https://api.openai.com/v1` | `external` |
| `https://api.anthropic.com/v1` | `external` |
| `DPF_LLM_PROVIDER=external` + model-runner URL | `external` (explicit wins) |

- [x] DCO sign-off

Manual smoke runs to validate end-to-end (require running stacks):

- [ ] **Docker Desktop (macOS / Windows)**: `docker compose up -d` — entrypoint logs should report `Provider: model-runner Pull mode: auto`; embedding model pull via `/models/create` succeeds (or already-cached path is taken).
- [ ] **Linux native Docker** (with `docker-compose.linux.yml` from Phase 3): `docker compose -f docker-compose.yml -f docker-compose.linux.yml up -d` — entrypoint should auto-detect `Provider: ollama` from the overlay's `LLM_BASE_URL=http://ollama:11434/v1` and pull `nomic-embed-text` via `/api/pull` against the in-cluster ollama service.
- [ ] **External endpoint**: `LLM_BASE_URL=https://api.openai.com/v1 DPF_LLM_PROVIDER=external docker compose up -d` — entrypoint should log `Provider: external` and only verify (no pull attempt).

## What this PR does NOT do

- Does **not** add an integration test asserting "entrypoint never calls `/models/create` under `DPF_LLM_PROVIDER=ollama`." The installer-parity roadmap Phase 4 verify gate calls for one; it's a follow-up because the entrypoint runs in alpine `/bin/sh` inside the container, and the natural test harness (vitest) doesn't exercise it. A POSIX-shell test that stubs `wget` and asserts the request log is the right shape; it lands when Phase 9 (CI release gates) wires up shell-based integration testing.
- Does **not** touch `apps/web/lib/inference/ollama-url.ts` — already supports `LLM_BASE_URL` precedence correctly per the contract.
- Does **not** touch `packages/db/data/providers-registry.json` — each provider's `baseUrl` is provider-specific (e.g. `https://api.anthropic.com/v1` for Anthropic) and correctly per-provider; the registry is the source of truth for provider catalog metadata, not for runtime `LLM_BASE_URL` selection.
- Does **not** modify `docker-compose.yml`, `docker-compose.macos.yml`, or `docker-compose.linux.yml` — Phase 3 already wired the right `LLM_BASE_URL` defaults per substrate; this PR only changes how the entrypoint *consumes* them.

## What this PR enables

- **Linux native Docker installs** can now successfully pull and use embedding models out of the box (previously the entrypoint would silently fail against Ollama).
- **External LLM endpoints** are first-class: the entrypoint correctly verifies-only against customer-managed endpoints rather than failing on a write attempt.
- **Phase 5** (host hardware detection) builds on the now-stable LLM provider contract.
- **Phase 6** (`install-dpf.sh`) can rely on `DPF_LLM_PROVIDER` / `DPF_MODEL_PULL_MODE` envvars being well-defined.

Refs:
- `docs/superpowers/specs/2026-05-09-deployment-contracts.md` — Contract 9
- `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 4
- #404 (merged) — Phase 3 compose overlays this builds on

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_