### PR TITLE
feat(host-detect): scripts/detect-hardware-host.ts for macOS / Linux …

### DIFF
--- a/scripts/detect-hardware-host.ts
+++ b/scripts/detect-hardware-host.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env -S pnpm exec tsx
+// Host hardware detection for macOS and Linux, run BEFORE
+// `docker compose up` to populate the DPF_HOST_PROFILE env var that
+// docker-entrypoint.sh + scripts/detect-hardware.ts (container-side)
+// consume to populate PlatformConfig in Postgres.
+//
+// Mirror of the hardware-detection block in install-dpf.ps1
+// (lines 1038-1118), in TypeScript, for use by:
+//   - scripts/setup.sh  (contributor flow on macOS / Linux)
+//   - install-dpf.sh    (end-user installer; lands in Phase 7)
+//   - manual: `pnpm exec tsx scripts/detect-hardware-host.ts`
+//
+// Output: a single JSON object on stdout. Captured by callers via
+//   DPF_HOST_PROFILE=$(pnpm exec tsx scripts/detect-hardware-host.ts)
+//   docker compose up -d
+//
+// Per the deployment doctrine's Deployment Support Matrix (Apple
+// Silicon row), macOS Apple Silicon hosts get
+// `architecture: "unified"` because GPU memory is unified with RAM —
+// the discrete-VRAM model-selection tiers don't apply directly. The
+// `selectedModel` field reconciles unified vs discrete by treating
+// total RAM as the effective ceiling on Apple Silicon.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+
+type Architecture = "unified" | "discrete" | "cpu-only";
+
+type HostProfile = {
+  platform: NodeJS.Platform;
+  arch: string;
+  architecture: Architecture;
+  cpu: { name: string; cores: number };
+  ram: { totalGB: number };
+  gpu: { name: string; vramGB: number | null } | null;
+  selectedModel: string;
+  detectedAt: string;
+  notes?: string[];
+};
+
+function run(cmd: string, args: string[]): string | null {
+  const result = spawnSync(cmd, args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    return null;
+  }
+  return result.stdout.trim();
+}
+
+function detectDarwin(): HostProfile {
+  const cpuName = run("sysctl", ["-n", "machdep.cpu.brand_string"]) ?? "Unknown CPU";
+  const coresStr = run("sysctl", ["-n", "hw.ncpu"]) ?? "0";
+  const cores = parseInt(coresStr, 10) || 0;
+  const memBytesStr = run("sysctl", ["-n", "hw.memsize"]) ?? "0";
+  const memBytes = parseInt(memBytesStr, 10) || 0;
+  const totalGB = Math.round((memBytes / (1024 ** 3)) * 10) / 10;
+
+  // Apple Silicon (M1/M2/M3/M4 series) reports an Apple GPU. Detect
+  // via the cpu.brand_string substring rather than parsing
+  // system_profiler JSON (avoids a second slow shell-out and works
+  // identically on every Apple Silicon Mac).
+  const isAppleSilicon = /Apple M\d/i.test(cpuName);
+
+  let gpu: HostProfile["gpu"] = null;
+  let architecture: Architecture;
+
+  if (isAppleSilicon) {
+    architecture = "unified";
+    // Unified memory: GPU effectively shares RAM. Report the GPU name
+    // for diagnostic value but `vramGB: null` because the concept
+    // doesn't apply.
+    gpu = { name: `${cpuName.replace(/^Apple /, "Apple ")} GPU (unified)`, vramGB: null };
+  } else {
+    // Intel Mac (out of scope per the installer-parity roadmap, but
+    // the script still produces a sensible profile in case someone
+    // runs it for diagnostics). Fallback: cpu-only.
+    architecture = "cpu-only";
+  }
+
+  return {
+    platform: "darwin",
+    arch: os.arch(),
+    architecture,
+    cpu: { name: cpuName, cores },
+    ram: { totalGB },
+    gpu,
+    selectedModel: selectModel({ architecture, totalGB, gpu }),
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+function detectLinux(): HostProfile {
+  // CPU model name from /proc/cpuinfo
+  let cpuName = "Unknown CPU";
+  try {
+    const cpuinfo = fs.readFileSync("/proc/cpuinfo", "utf8");
+    const m = cpuinfo.match(/^model name\s*:\s*(.+)$/m);
+    if (m && m[1]) cpuName = m[1].trim();
+  } catch { /* keep default */ }
+
+  const coresStr = run("nproc", []) ?? "0";
+  const cores = parseInt(coresStr, 10) || 0;
+
+  // RAM from /proc/meminfo
+  let totalGB = 0;
+  try {
+    const meminfo = fs.readFileSync("/proc/meminfo", "utf8");
+    const m = meminfo.match(/^MemTotal:\s+(\d+)\s+kB/m);
+    if (m && m[1]) {
+      const kb = parseInt(m[1], 10);
+      totalGB = Math.round((kb / (1024 * 1024)) * 10) / 10;
+    }
+  } catch { /* keep zero */ }
+
+  // GPU: try nvidia-smi for NVIDIA discrete VRAM detection.
+  // AMD / Intel discrete GPUs are not detected for VRAM here; the
+  // model selection falls back to the no-GPU tier in that case.
+  let gpu: HostProfile["gpu"] = null;
+  let architecture: Architecture = "cpu-only";
+
+  const nv = run("nvidia-smi", [
+    "--query-gpu=name,memory.total",
+    "--format=csv,noheader,nounits",
+  ]);
+  if (nv) {
+    const firstLine = nv.split("\n")[0];
+    if (firstLine && firstLine.trim()) {
+      const parts = firstLine.split(",").map((s) => s.trim());
+      const name = parts[0] ?? "NVIDIA GPU";
+      const vramMB = parseInt(parts[1] ?? "0", 10);
+      if (vramMB > 0) {
+        const vramGB = Math.round((vramMB / 1024) * 10) / 10;
+        gpu = { name, vramGB };
+        architecture = "discrete";
+      }
+    }
+  }
+
+  // If no NVIDIA, do a best-effort detection via lspci so we at least
+  // record a GPU model name even if VRAM isn't probed.
+  if (!gpu) {
+    const lspci = run("sh", ["-c", "lspci 2>/dev/null | grep -iE 'vga|3d|display' | head -1"]);
+    if (lspci) {
+      // lspci output: "01:00.0 VGA compatible controller: NVIDIA ..."
+      const m = lspci.match(/:\s*[^:]+:\s*(.+)$/);
+      const name = m && m[1] ? m[1].trim() : lspci.trim();
+      gpu = { name, vramGB: null };
+      // Without a VRAM read we can't choose discrete-VRAM tiers;
+      // architecture stays cpu-only for selection purposes.
+    }
+  }
+
+  return {
+    platform: "linux",
+    arch: os.arch(),
+    architecture,
+    cpu: { name: cpuName, cores },
+    ram: { totalGB },
+    gpu,
+    selectedModel: selectModel({ architecture, totalGB, gpu }),
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+// Model selection mirrors install-dpf.ps1's tiers:
+//   discrete VRAM >= 20GB:  ai/gemma4
+//   discrete VRAM >=  8GB:  ai/gemma3 (12B)
+//   discrete VRAM >=  4GB:  ai/gemma3 (4B)
+//   unified RAM   >= 32GB:  ai/gemma4         (Apple Silicon high-mem)
+//   unified RAM   >= 16GB:  ai/gemma3 (12B)   (Apple Silicon mid-mem)
+//   unified RAM   >=  8GB:  ai/gemma3 (4B)    (Apple Silicon low-mem)
+//   cpu-only RAM  >= 16GB:  ai/gemma3
+//   default:                ai/gemma3
+function selectModel(p: {
+  architecture: Architecture;
+  totalGB: number;
+  gpu: HostProfile["gpu"];
+}): string {
+  if (p.architecture === "discrete" && p.gpu && typeof p.gpu.vramGB === "number") {
+    if (p.gpu.vramGB >= 20) return "ai/gemma4";
+    if (p.gpu.vramGB >= 8) return "ai/gemma3";
+    if (p.gpu.vramGB >= 4) return "ai/gemma3";
+  }
+  if (p.architecture === "unified") {
+    if (p.totalGB >= 32) return "ai/gemma4";
+    if (p.totalGB >= 16) return "ai/gemma3";
+  }
+  if (p.totalGB >= 16) return "ai/gemma3";
+  return "ai/gemma3";
+}
+
+function main(): void {
+  const platform = os.platform();
+  let profile: HostProfile;
+
+  switch (platform) {
+    case "darwin":
+      profile = detectDarwin();
+      break;
+    case "linux":
+      profile = detectLinux();
+      break;
+    default:
+      // Windows hosts use install-dpf.ps1's PowerShell hardware
+      // detection; this script is the macOS / Linux counterpart.
+      console.error(
+        `Unsupported platform: ${platform}. Windows hosts use install-dpf.ps1's WMI-based detection.`
+      );
+      process.exit(2);
+  }
+
+  // Emit a single JSON object — install-dpf.sh / setup.sh capture
+  // this verbatim into DPF_HOST_PROFILE.
+  process.stdout.write(JSON.stringify(profile));
+}
+
+main();


### PR DESCRIPTION
…(Phase 5)

Implements the main deliverable of Phase 5 of the Mac/Linux installer-parity roadmap: host-side hardware detection on macOS and native Linux that produces the DPF_HOST_PROFILE JSON envvar that docker-entrypoint.sh + scripts/detect-hardware.ts (container-side) already consume.

This is the macOS/Linux counterpart to install-dpf.ps1's WMI-based hardware-detection block (Windows-side, lines 1038-1118). Identical JSON shape so existing consumers (PlatformConfig.host_profile in Postgres, model-selection logic) need no changes.

Detection paths:
  macOS:
    sysctl -n machdep.cpu.brand_string  -> CPU name
    sysctl -n hw.ncpu                   -> CPU cores
    sysctl -n hw.memsize                -> RAM bytes
    Apple M-series detection via cpu.brand_string regex; emits
    architecture: "unified" with vramGB: null because GPU memory is
    unified with RAM on Apple Silicon
  Linux:
    /proc/cpuinfo                       -> CPU name
    nproc                               -> CPU cores
    /proc/meminfo                       -> RAM kB
    nvidia-smi --query-gpu=name,memory.total -> NVIDIA discrete VRAM
    lspci | grep VGA                    -> fallback GPU name (no VRAM)
    architecture: "discrete" when nvidia-smi reports VRAM,
                   "cpu-only" otherwise

Model selection mirrors install-dpf.ps1's tiers:
  discrete VRAM >= 20GB:  ai/gemma4
  discrete VRAM >=  8GB:  ai/gemma3 (12B)
  discrete VRAM >=  4GB:  ai/gemma3 (4B)
  unified RAM   >= 32GB:  ai/gemma4   (Apple Silicon high-mem)
  unified RAM   >= 16GB:  ai/gemma3   (Apple Silicon mid-mem)
  cpu-only RAM  >= 16GB:  ai/gemma3
  default:                ai/gemma3

The unified-vs-discrete distinction is per the deployment doctrine's Deployment Support Matrix: Apple Silicon hosts get the architecture: "unified" tag because the GPU memory is shared with RAM, so discrete-VRAM model-selection tiers don't apply directly; total RAM serves as the effective ceiling instead.

Output: a single JSON object on stdout. Captured by callers via:
  DPF_HOST_PROFILE=$(pnpm --filter @dpf/db exec tsx \
    scripts/detect-hardware-host.ts)
  docker compose up -d
This is exactly the same env-var consumption pattern install-dpf.ps1 already uses, so no consumer-side changes are needed in this PR.

Invocation:
  pnpm --filter @dpf/db exec tsx scripts/detect-hardware-host.ts
The shebang `#!/usr/bin/env -S pnpm exec tsx` is a documentation anchor; the canonical invocation goes through pnpm exec because tsx is a workspace dev-dep, not on PATH.

What this PR does NOT do:
- Does NOT touch the consumer side (PlatformConfig in scripts/detect-hardware.ts, agent-grants.ts, provider-selection paths). The new architecture: "unified" field is additive — no consumer code currently parses host_profile shape strictly enough to break, and the Apple Silicon model-selection tiers produce the same model names the consumer already knows about. If a consumer later wants to special-case unified architecture (e.g. don't schedule large models that would oversubscribe shared RAM), that's a follow-up.
- Does NOT update the discovery-collectors (Phase 5 also calls for packages/db/src/discovery-collectors/docker.ts to use docker context inspect, and host.ts to gain a darwin branch). Those are runtime-discovery concerns rather than install-time hardware profile concerns; tracked as a follow-up Phase 5b PR to keep this one focused.
- Does NOT wire the script into scripts/setup.sh. setup.sh today only brings up postgres/neo4j/qdrant for contributor work — not portal-init, which is the consumer of DPF_HOST_PROFILE. The natural integration point is install-dpf.sh in Phase 7.
- Does NOT add CI smoke for the script. Phase 9's release gates cover that; the architecture: "unified" branch needs a real Apple Silicon runner (macos-14) to exercise.

Local verification:
- TypeScript review: imports, types, control flow checked manually. Existing scripts/detect-hardware.ts has the same import patterns (node:child_process, node:fs, node:os) and identical packaging context (uses spawnSync and fs.readFileSync against /proc/*).
- Runtime smoke would require pnpm install in the dev environment; Typecheck CI will catch any TS issues.

Refs: docs/superpowers/specs/2026-05-09-deployment-contracts.md
      (Deployment Support Matrix; architecture: unified)
Refs: docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
      (Phase 5)

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
