### PR TITLE
feat: add coworker self-assessment persistence foundation

### DIFF
--- a/apps/web/lib/coworker-self-assessment/assessment-service.test.ts
+++ b/apps/web/lib/coworker-self-assessment/assessment-service.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  linkNeedToBacklogItem,
+  listCoworkerCapabilityNeeds,
+  resolveCapabilityNeed,
+  submitCoworkerSelfAssessment,
+} from "./assessment-service";
+
+const createdAt = new Date("2026-05-10T05:30:00.000Z");
+
+function makeDeps() {
+  return {
+    now: () => createdAt,
+    createId: vi
+      .fn()
+      .mockReturnValueOnce("CWSA-000001")
+      .mockReturnValueOnce("CWN-000001")
+      .mockReturnValueOnce("CWN-000002"),
+    db: {
+      createAssessment: vi.fn(async (data) => ({ ...data, id: "assessment-row-1" })),
+      createNeed: vi.fn(async (data) => ({ ...data, id: `need-row-${data.needId}` })),
+      listNeeds: vi.fn(async () => []),
+      updateNeed: vi.fn(async (needId, data) => ({ needId, ...data })),
+    },
+  };
+}
+
+describe("submitCoworkerSelfAssessment", () => {
+  it("persists an assessment and normalized needs with coworker attribution", async () => {
+    const deps = makeDeps();
+
+    const result = await submitCoworkerSelfAssessment(
+      {
+        agentId: "marketing-strategist",
+        trigger: "user-request",
+        routeContext: "/customer/marketing",
+        verdict: "gaps",
+        confidence: "medium",
+        missionSummary: "Turn offers into trustworthy market-facing proof.",
+        capabilitySummary: "Can advise and draft, but needs governed publishing tools.",
+        rawPayload: { source: "conversation" },
+        needs: [
+          {
+            kind: "tool",
+            severity: "important",
+            need: "Create publish-ready proof assets in the marketing workspace.",
+            blocks: "The role cannot turn approved recommendations into durable assets.",
+            evidenceJson: { asked: "do you have tools to do this?" },
+            readinessJson: { matchingTools: [] },
+          },
+          {
+            kind: "ui_surface",
+            severity: "minor",
+            need: "Show accepted marketing needs in the coworker panel.",
+            blocks: "The role cannot see whether a submitted need is already planned.",
+          },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.assessmentId).toBe("CWSA-000001");
+    expect(result.needIds).toEqual(["CWN-000001", "CWN-000002"]);
+    expect(deps.db.createAssessment).toHaveBeenCalledWith({
+      assessmentId: "CWSA-000001",
+      agentId: "marketing-strategist",
+      trigger: "user-request",
+      routeContext: "/customer/marketing",
+      verdict: "gaps",
+      confidence: "medium",
+      missionSummary: "Turn offers into trustworthy market-facing proof.",
+      capabilitySummary: "Can advise and draft, but needs governed publishing tools.",
+      rawPayload: { source: "conversation" },
+      createdAt,
+    });
+    expect(deps.db.createNeed).toHaveBeenNthCalledWith(1, {
+      needId: "CWN-000001",
+      assessmentId: "CWSA-000001",
+      agentId: "marketing-strategist",
+      kind: "tool",
+      severity: "important",
+      status: "submitted",
+      need: "Create publish-ready proof assets in the marketing workspace.",
+      blocks: "The role cannot turn approved recommendations into durable assets.",
+      evidenceJson: { asked: "do you have tools to do this?" },
+      readinessJson: { matchingTools: [] },
+      createdAt,
+    });
+    expect(deps.db.createNeed).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        needId: "CWN-000002",
+        assessmentId: "CWSA-000001",
+        agentId: "marketing-strategist",
+        status: "submitted",
+      }),
+    );
+  });
+});
+
+describe("listCoworkerCapabilityNeeds", () => {
+  it("passes review filters through to persistence", async () => {
+    const deps = makeDeps();
+    deps.db.listNeeds.mockResolvedValueOnce([
+      { needId: "CWN-000001", agentId: "marketing-strategist", status: "submitted" },
+    ] as never);
+
+    const result = await listCoworkerCapabilityNeeds(
+      { agentId: "marketing-strategist", status: "submitted", kind: "tool" },
+      deps,
+    );
+
+    expect(deps.db.listNeeds).toHaveBeenCalledWith({
+      agentId: "marketing-strategist",
+      status: "submitted",
+      kind: "tool",
+    });
+    expect(result).toEqual([
+      { needId: "CWN-000001", agentId: "marketing-strategist", status: "submitted" },
+    ]);
+  });
+});
+
+describe("linkNeedToBacklogItem", () => {
+  it("marks a need as backlog-filed and stores the linked backlog item", async () => {
+    const deps = makeDeps();
+
+    await linkNeedToBacklogItem("CWN-000001", "BI-56469E47", deps);
+
+    expect(deps.db.updateNeed).toHaveBeenCalledWith("CWN-000001", {
+      linkedBacklogItemId: "BI-56469E47",
+      status: "backlog-filed",
+    });
+  });
+});
+
+describe("resolveCapabilityNeed", () => {
+  it("records duplicate decisions with the canonical need", async () => {
+    const deps = makeDeps();
+
+    await resolveCapabilityNeed(
+      "CWN-000002",
+      { status: "duplicate", duplicateOfId: "CWN-000001", reviewerNote: "Same publishing gap." },
+      deps,
+    );
+
+    expect(deps.db.updateNeed).toHaveBeenCalledWith("CWN-000002", {
+      status: "duplicate",
+      duplicateOfId: "CWN-000001",
+      reviewerNote: "Same publishing gap.",
+    });
+  });
+});

--- a/apps/web/lib/coworker-self-assessment/assessment-service.ts
+++ b/apps/web/lib/coworker-self-assessment/assessment-service.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@dpf/db";
+import type { Prisma } from "@dpf/db";
+import type {
+  CoworkerCapabilityNeedInput,
+  CoworkerNeedFilters,
+  JsonObject,
+  ResolveCoworkerCapabilityNeedInput,
+  SubmitCoworkerSelfAssessmentInput,
+} from "./types";
+
+type AssessmentCreateData = {
+  assessmentId: string;
+  agentId: string;
+  trigger: string;
+  routeContext?: string | null;
+  verdict: string;
+  confidence: string;
+  missionSummary?: string | null;
+  capabilitySummary?: string | null;
+  rawPayload: JsonObject;
+  createdAt: Date;
+};
+
+type NeedCreateData = {
+  needId: string;
+  assessmentId: string;
+  agentId: string;
+  kind: string;
+  severity: string;
+  status: string;
+  need: string;
+  blocks: string;
+  evidenceJson: JsonObject;
+  readinessJson: JsonObject;
+  createdAt: Date;
+};
+
+type NeedUpdateData = {
+  status?: string;
+  linkedBacklogItemId?: string;
+  duplicateOfId?: string;
+  reviewerNote?: string;
+};
+
+type CoworkerSelfAssessmentDb = {
+  createAssessment(data: AssessmentCreateData): Promise<unknown>;
+  createNeed(data: NeedCreateData): Promise<unknown>;
+  listNeeds(filters: CoworkerNeedFilters): Promise<unknown[]>;
+  updateNeed(needId: string, data: NeedUpdateData): Promise<unknown>;
+};
+
+export type CoworkerSelfAssessmentDeps = {
+  now: () => Date;
+  createId: (prefix: "CWSA" | "CWN") => string;
+  db: CoworkerSelfAssessmentDb;
+};
+
+function defaultCreateId(prefix: "CWSA" | "CWN") {
+  return `${prefix}-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function defined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+function defaultDb(): CoworkerSelfAssessmentDb {
+  return {
+    createAssessment: (data) =>
+      prisma.coworkerSelfAssessment.create({
+        data: {
+          ...data,
+          rawPayload: data.rawPayload as Prisma.InputJsonValue,
+        },
+      }),
+    createNeed: (data) =>
+      prisma.coworkerCapabilityNeed.create({
+        data: {
+          ...data,
+          evidenceJson: data.evidenceJson as Prisma.InputJsonValue,
+          readinessJson: data.readinessJson as Prisma.InputJsonValue,
+        },
+      }),
+    listNeeds: (filters) =>
+      prisma.coworkerCapabilityNeed.findMany({
+        where: defined({
+          agentId: filters.agentId,
+          status: filters.status,
+          kind: filters.kind,
+          severity: filters.severity,
+        }),
+        orderBy: [{ severity: "asc" }, { createdAt: "desc" }],
+      }),
+    updateNeed: (needId, data) =>
+      prisma.coworkerCapabilityNeed.update({
+        where: { needId },
+        data,
+      }),
+  };
+}
+
+function depsOrDefault(deps?: Partial<CoworkerSelfAssessmentDeps>): CoworkerSelfAssessmentDeps {
+  return {
+    now: deps?.now ?? (() => new Date()),
+    createId: deps?.createId ?? defaultCreateId,
+    db: deps?.db ?? defaultDb(),
+  };
+}
+
+function normalizeNeed(
+  input: CoworkerCapabilityNeedInput,
+  assessmentId: string,
+  agentId: string,
+  needId: string,
+  createdAt: Date,
+): NeedCreateData {
+  return {
+    needId,
+    assessmentId,
+    agentId,
+    kind: input.kind,
+    severity: input.severity,
+    status: "submitted",
+    need: input.need.trim(),
+    blocks: input.blocks.trim(),
+    evidenceJson: input.evidenceJson ?? {},
+    readinessJson: input.readinessJson ?? {},
+    createdAt,
+  };
+}
+
+export async function submitCoworkerSelfAssessment(
+  input: SubmitCoworkerSelfAssessmentInput,
+  deps?: Partial<CoworkerSelfAssessmentDeps>,
+): Promise<{ assessmentId: string; needIds: string[] }> {
+  const resolved = depsOrDefault(deps);
+  const createdAt = resolved.now();
+  const assessmentId = resolved.createId("CWSA");
+
+  await resolved.db.createAssessment({
+    assessmentId,
+    agentId: input.agentId,
+    trigger: input.trigger,
+    routeContext: input.routeContext,
+    verdict: input.verdict,
+    confidence: input.confidence,
+    missionSummary: input.missionSummary,
+    capabilitySummary: input.capabilitySummary,
+    rawPayload: input.rawPayload ?? {},
+    createdAt,
+  });
+
+  const needIds: string[] = [];
+  for (const need of input.needs) {
+    const needId = resolved.createId("CWN");
+    needIds.push(needId);
+    await resolved.db.createNeed(
+      normalizeNeed(need, assessmentId, input.agentId, needId, createdAt),
+    );
+  }
+
+  return { assessmentId, needIds };
+}
+
+export async function listCoworkerCapabilityNeeds(
+  filters: CoworkerNeedFilters = {},
+  deps?: Partial<CoworkerSelfAssessmentDeps>,
+) {
+  return depsOrDefault(deps).db.listNeeds(filters);
+}
+
+export async function linkNeedToBacklogItem(
+  needId: string,
+  backlogItemId: string,
+  deps?: Partial<CoworkerSelfAssessmentDeps>,
+) {
+  return depsOrDefault(deps).db.updateNeed(needId, {
+    linkedBacklogItemId: backlogItemId,
+    status: "backlog-filed",
+  });
+}
+
+export async function resolveCapabilityNeed(
+  needId: string,
+  decision: ResolveCoworkerCapabilityNeedInput,
+  deps?: Partial<CoworkerSelfAssessmentDeps>,
+) {
+  return depsOrDefault(deps).db.updateNeed(needId, defined({
+    status: decision.status,
+    duplicateOfId: decision.duplicateOfId,
+    reviewerNote: decision.reviewerNote,
+  }));
+}

--- a/apps/web/lib/coworker-self-assessment/types.ts
+++ b/apps/web/lib/coworker-self-assessment/types.ts
@@ -1,0 +1,74 @@
+export const COWORKER_ASSESSMENT_VERDICTS = ["adequate", "gaps", "blocked"] as const;
+export type CoworkerAssessmentVerdict = (typeof COWORKER_ASSESSMENT_VERDICTS)[number];
+
+export const COWORKER_ASSESSMENT_CONFIDENCE = ["high", "medium", "low"] as const;
+export type CoworkerAssessmentConfidence = (typeof COWORKER_ASSESSMENT_CONFIDENCE)[number];
+
+export const COWORKER_CAPABILITY_NEED_KINDS = [
+  "tool",
+  "skill",
+  "grant",
+  "model",
+  "memory",
+  "data",
+  "ui_surface",
+  "boundary",
+] as const;
+export type CoworkerCapabilityNeedKind = (typeof COWORKER_CAPABILITY_NEED_KINDS)[number];
+
+export const COWORKER_CAPABILITY_NEED_SEVERITIES = [
+  "blocker",
+  "important",
+  "minor",
+] as const;
+export type CoworkerCapabilityNeedSeverity =
+  (typeof COWORKER_CAPABILITY_NEED_SEVERITIES)[number];
+
+export const COWORKER_CAPABILITY_NEED_STATUSES = [
+  "submitted",
+  "reviewing",
+  "accepted",
+  "deferred",
+  "duplicate",
+  "discarded",
+  "backlog-filed",
+  "resolved",
+] as const;
+export type CoworkerCapabilityNeedStatus =
+  (typeof COWORKER_CAPABILITY_NEED_STATUSES)[number];
+
+export type JsonObject = Record<string, unknown>;
+
+export type CoworkerCapabilityNeedInput = {
+  kind: CoworkerCapabilityNeedKind;
+  severity: CoworkerCapabilityNeedSeverity;
+  need: string;
+  blocks: string;
+  evidenceJson?: JsonObject;
+  readinessJson?: JsonObject;
+};
+
+export type SubmitCoworkerSelfAssessmentInput = {
+  agentId: string;
+  trigger: string;
+  routeContext?: string | null;
+  verdict: CoworkerAssessmentVerdict;
+  confidence: CoworkerAssessmentConfidence;
+  missionSummary?: string | null;
+  capabilitySummary?: string | null;
+  rawPayload?: JsonObject;
+  needs: CoworkerCapabilityNeedInput[];
+};
+
+export type CoworkerNeedFilters = {
+  agentId?: string;
+  status?: CoworkerCapabilityNeedStatus;
+  kind?: CoworkerCapabilityNeedKind;
+  severity?: CoworkerCapabilityNeedSeverity;
+};
+
+export type ResolveCoworkerCapabilityNeedInput = {
+  status: Exclude<CoworkerCapabilityNeedStatus, "backlog-filed">;
+  duplicateOfId?: string;
+  reviewerNote?: string;
+};

--- a/packages/db/prisma/migrations/20260510004402_coworker_self_assessment/migration.sql
+++ b/packages/db/prisma/migrations/20260510004402_coworker_self_assessment/migration.sql
@@ -1,0 +1,84 @@
+-- CreateTable
+CREATE TABLE "CoworkerSelfAssessment" (
+    "id" TEXT NOT NULL,
+    "assessmentId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "trigger" TEXT NOT NULL,
+    "routeContext" TEXT,
+    "verdict" TEXT NOT NULL,
+    "confidence" TEXT NOT NULL,
+    "missionSummary" TEXT,
+    "capabilitySummary" TEXT,
+    "rawPayload" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "supersededAt" TIMESTAMP(3),
+
+    CONSTRAINT "CoworkerSelfAssessment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CoworkerCapabilityNeed" (
+    "id" TEXT NOT NULL,
+    "needId" TEXT NOT NULL,
+    "assessmentId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "severity" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'submitted',
+    "need" TEXT NOT NULL,
+    "blocks" TEXT NOT NULL,
+    "evidenceJson" JSONB NOT NULL DEFAULT '{}',
+    "readinessJson" JSONB NOT NULL DEFAULT '{}',
+    "linkedBacklogItemId" TEXT,
+    "duplicateOfId" TEXT,
+    "reviewerNote" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CoworkerCapabilityNeed_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CoworkerSelfAssessment_assessmentId_key" ON "CoworkerSelfAssessment"("assessmentId");
+
+-- CreateIndex
+CREATE INDEX "CoworkerSelfAssessment_agentId_createdAt_idx" ON "CoworkerSelfAssessment"("agentId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CoworkerSelfAssessment_verdict_createdAt_idx" ON "CoworkerSelfAssessment"("verdict", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CoworkerSelfAssessment_trigger_createdAt_idx" ON "CoworkerSelfAssessment"("trigger", "createdAt" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CoworkerCapabilityNeed_needId_key" ON "CoworkerCapabilityNeed"("needId");
+
+-- CreateIndex
+CREATE INDEX "CoworkerCapabilityNeed_agentId_status_idx" ON "CoworkerCapabilityNeed"("agentId", "status");
+
+-- CreateIndex
+CREATE INDEX "CoworkerCapabilityNeed_status_severity_idx" ON "CoworkerCapabilityNeed"("status", "severity");
+
+-- CreateIndex
+CREATE INDEX "CoworkerCapabilityNeed_kind_status_idx" ON "CoworkerCapabilityNeed"("kind", "status");
+
+-- CreateIndex
+CREATE INDEX "CoworkerCapabilityNeed_linkedBacklogItemId_idx" ON "CoworkerCapabilityNeed"("linkedBacklogItemId");
+
+-- CreateIndex
+CREATE INDEX "CoworkerCapabilityNeed_assessmentId_idx" ON "CoworkerCapabilityNeed"("assessmentId");
+
+-- AddForeignKey
+ALTER TABLE "CoworkerSelfAssessment" ADD CONSTRAINT "CoworkerSelfAssessment_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("agentId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoworkerCapabilityNeed" ADD CONSTRAINT "CoworkerCapabilityNeed_assessmentId_fkey" FOREIGN KEY ("assessmentId") REFERENCES "CoworkerSelfAssessment"("assessmentId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoworkerCapabilityNeed" ADD CONSTRAINT "CoworkerCapabilityNeed_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("agentId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoworkerCapabilityNeed" ADD CONSTRAINT "CoworkerCapabilityNeed_linkedBacklogItemId_fkey" FOREIGN KEY ("linkedBacklogItemId") REFERENCES "BacklogItem"("itemId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoworkerCapabilityNeed" ADD CONSTRAINT "CoworkerCapabilityNeed_duplicateOfId_fkey" FOREIGN KEY ("duplicateOfId") REFERENCES "CoworkerCapabilityNeed"("needId") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -908,6 +908,7 @@ model BacklogItem {
   submittedBy           User?                 @relation("BacklogSubmissions", fields: [submittedById], references: [id])
   taxonomyNode          TaxonomyNode?         @relation(fields: [taxonomyNodeId], references: [id])
   activities            BacklogItemActivity[]
+  coworkerNeeds         CoworkerCapabilityNeed[] @relation("BacklogItemCoworkerCapabilityNeeds")
 }
 
 // Per-item timeline. Cross-cutting tool audit lives in ToolExecution; this is
@@ -1465,6 +1466,8 @@ model Agent {
   executionConfig      AgentExecutionConfig?
   skills               AgentSkillAssignment[]
   toolGrants           AgentToolGrant[]
+  coworkerAssessments  CoworkerSelfAssessment[]    @relation("CoworkerSelfAssessmentAgent")
+  coworkerNeeds        CoworkerCapabilityNeed[]    @relation("CoworkerCapabilityNeedAgent")
   performanceProfiles  AgentPerformance[]
   degradationMappings  FeatureDegradationMapping[]
   promptContext        AgentPromptContext?
@@ -1602,6 +1605,57 @@ model AgentToolGrant {
 
   @@unique([agentId, grantKey])
   @@index([grantKey])
+}
+
+model CoworkerSelfAssessment {
+  id                String                   @id @default(cuid())
+  assessmentId      String                   @unique
+  agentId           String
+  trigger           String
+  routeContext      String?
+  verdict           String
+  confidence        String
+  missionSummary    String?
+  capabilitySummary String?
+  rawPayload        Json                     @default("{}")
+  createdAt         DateTime                 @default(now())
+  supersededAt      DateTime?
+  agent             Agent                    @relation("CoworkerSelfAssessmentAgent", fields: [agentId], references: [agentId], onDelete: Cascade)
+  needs             CoworkerCapabilityNeed[]
+
+  @@index([agentId, createdAt(sort: Desc)])
+  @@index([verdict, createdAt(sort: Desc)])
+  @@index([trigger, createdAt(sort: Desc)])
+}
+
+model CoworkerCapabilityNeed {
+  id                  String                   @id @default(cuid())
+  needId              String                   @unique
+  assessmentId        String
+  agentId             String
+  kind                String
+  severity            String
+  status              String                   @default("submitted")
+  need                String
+  blocks              String
+  evidenceJson        Json                     @default("{}")
+  readinessJson       Json                     @default("{}")
+  linkedBacklogItemId String?
+  duplicateOfId       String?
+  reviewerNote        String?
+  createdAt           DateTime                 @default(now())
+  updatedAt           DateTime                 @updatedAt
+  assessment          CoworkerSelfAssessment   @relation(fields: [assessmentId], references: [assessmentId], onDelete: Cascade)
+  agent               Agent                    @relation("CoworkerCapabilityNeedAgent", fields: [agentId], references: [agentId], onDelete: Cascade)
+  linkedBacklogItem   BacklogItem?             @relation("BacklogItemCoworkerCapabilityNeeds", fields: [linkedBacklogItemId], references: [itemId])
+  duplicateOf         CoworkerCapabilityNeed?  @relation("CoworkerCapabilityNeedDuplicates", fields: [duplicateOfId], references: [needId])
+  duplicates          CoworkerCapabilityNeed[] @relation("CoworkerCapabilityNeedDuplicates")
+
+  @@index([agentId, status])
+  @@index([status, severity])
+  @@index([kind, status])
+  @@index([linkedBacklogItemId])
+  @@index([assessmentId])
 }
 
 model AuthorityBinding {


### PR DESCRIPTION
## Summary
- Add `CoworkerSelfAssessment` and `CoworkerCapabilityNeed` models with agent/backlog linkage.
- Add generated migration for the assessment/need persistence foundation.
- Add `coworker-self-assessment` service APIs for submit, list, resolve, and backlog-link operations.
- Add focused TDD coverage for the service behavior.

Backlog: `BI-56469E47`

## Verification
- `pnpm --filter web exec vitest run lib/coworker-self-assessment/assessment-service.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter web build`

Note: `prisma migrate dev --name coworker_self_assessment` could not run from the host because the local env points `DATABASE_URL` at Docker-network host `postgres:5432`; migration SQL was generated with `prisma migrate diff` from the pre-change schema to the edited schema instead.