### PR TITLE
feat(installer): install-dpf.sh framework + preflight + state + doctor (Phase 6)

### DIFF
--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory — end-user installer (macOS / Linux).
+#
+# This is the Phase 6 *vertical slice*: framework only. Phase 7 adds
+# Docker Engine installation, autostart, and the rest of the
+# end-user-facing automation. Phase 6 ships:
+#
+#   - Preflight: unsupported-host detection (Intel Mac, WSL2-without-DD,
+#     rootless Docker, Podman, older distros, air-gapped warn).
+#   - install-state.json (~/.dpf/install-state.json) read/write/migration.
+#   - --dry-run flag: prints planned compose chain + env diffs + state
+#     file diffs without touching the host.
+#   - --headless flag: non-interactive (default for CI).
+#   - doctor subcommand: emits a diagnostic bundle for support reports.
+#
+# Companion: scripts/setup.sh is the *contributor* bootstrap (clone,
+# install deps, run the dev loop). install-dpf.sh is the *end-user*
+# installer (release images, full stack, autostart).
+#
+# Per the deployment doctrine: this implements Contracts 2 (runtime
+# config), 3 (lifecycle), 8 (secrets — via .env generation), and is
+# the macOS/Linux counterpart to install-dpf.ps1 (Windows GA).
+#
+# Bash 3.2 baseline (macOS default).
+
+set -euo pipefail
+
+# Resolve repo root from script location so cwd doesn't matter.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+LIB_DIR="$REPO_ROOT/scripts/installer/lib"
+
+# Source shared helpers from Phase 2 + Phase 3 + Phase 6.
+# shellcheck source=scripts/installer/lib/logging.sh
+. "$LIB_DIR/logging.sh"
+# shellcheck source=scripts/installer/lib/platform.sh
+. "$LIB_DIR/platform.sh"
+# shellcheck source=scripts/installer/lib/prompts.sh
+. "$LIB_DIR/prompts.sh"
+# shellcheck source=scripts/installer/lib/compose.sh
+. "$LIB_DIR/compose.sh"
+# shellcheck source=scripts/installer/lib/preflight.sh
+. "$LIB_DIR/preflight.sh"
+# shellcheck source=scripts/installer/lib/state.sh
+. "$LIB_DIR/state.sh"
+# shellcheck source=scripts/installer/lib/doctor.sh
+. "$LIB_DIR/doctor.sh"
+
+# Installer version (semver-ish; bump per release).
+DPF_INSTALLER_VERSION="2026.05.10-phase6"
+
+# ── CLI handling ────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Open Digital Product Factory — Installer
+
+Usage:
+  bash install-dpf.sh [flags] [subcommand]
+
+Subcommands:
+  (default)     Run the install flow.
+  doctor        Emit a diagnostic bundle to ~/.dpf/doctor-<timestamp>.tar.gz.
+
+Flags:
+  --dry-run     Print the planned actions without touching the host.
+                Honors --headless. Useful for CI smoke and pre-flight review.
+  --headless    Non-interactive (no prompts). Defaults are used; required
+                for CI / unattended installs.
+  --release     Use pre-built multi-arch GHCR images
+                (docker-compose.release.yml overlay). Default in Phase 7+.
+  --dev         Build images locally (default for Phase 6 framework slice
+                until release-mode integration lands).
+  --force-unsupported-host
+                Override unsupported-host preflight refusal (advanced).
+                Equivalent to DPF_FORCE_UNSUPPORTED_HOST=1.
+  -h, --help    Show this help.
+
+Status: Phase 6 (framework vertical slice). Full end-user install (Docker
+auto-install, autostart, model pulls) lands in Phase 7. Until then,
+install-dpf.sh validates preflight, persists install-state.json, and
+prints the planned compose chain. Use scripts/setup.sh for contributor
+bootstrap.
+
+Roadmap: docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
+Doctrine: docs/superpowers/specs/2026-05-09-deployment-contracts.md
+EOF
+}
+
+DPF_DRY_RUN=0
+DPF_MODE="dev"   # dev | release
+SUBCOMMAND=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)              DPF_DRY_RUN=1 ;;
+    --headless)             DPF_HEADLESS=1; export DPF_HEADLESS ;;
+    --release)              DPF_MODE="release" ;;
+    --dev)                  DPF_MODE="dev" ;;
+    --force-unsupported-host)
+                            DPF_FORCE_UNSUPPORTED_HOST=1
+                            export DPF_FORCE_UNSUPPORTED_HOST ;;
+    -h|--help)              usage; exit 0 ;;
+    doctor)                 SUBCOMMAND="doctor" ;;
+    *)
+      echo "install-dpf.sh: unknown argument: $1" >&2
+      echo "Run 'bash install-dpf.sh --help' for usage." >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+cd "$REPO_ROOT"
+
+# ── Subcommand: doctor ──────────────────────────────────────────────────────
+
+if [ "$SUBCOMMAND" = "doctor" ]; then
+  dpf_doctor_collect "$DPF_MODE"
+  exit 0
+fi
+
+# ── Main install flow (Phase 6 vertical slice) ──────────────────────────────
+
+echo ""
+echo "  Open Digital Product Factory — Installer (Phase 6 vertical slice)"
+echo "  =================================================================="
+dpf_platform
+dpf_arch
+echo "  Platform: $DPF_PLATFORM ($DPF_ARCH)"
+echo "  Mode: $DPF_MODE${DPF_DRY_RUN:+  [dry-run]}"
+echo ""
+
+# 1. Preflight: unsupported-host detection.
+step "Preflight: host compatibility"
+dpf_preflight_unsupported_host
+ok "Host compatibility check passed"
+
+# 2. Bring install-state.json into existence (or validate existing).
+step "Install state"
+# dpf_state_validate returns 0/2/3 to differentiate states; we capture
+# without tripping set -e.
+rc=0
+dpf_state_validate || rc=$?
+case "$rc" in
+  0) ok "Install state at $(dpf_state_path) is current (schema $DPF_STATE_SCHEMA_VERSION)" ;;
+  2) info "No prior install state; initializing $(dpf_state_path)"
+     dpf_state_init "$DPF_INSTALLER_VERSION" "$REPO_ROOT" ;;
+  3) warn "Install state is from an older installer; running forward migration"
+     dpf_state_migrate ;;
+  *) fail "Install state validation failed (see message above)" ;;
+esac
+
+# 3. Resolve the compose -f chain (per-platform via compose.sh).
+step "Compose chain"
+dpf_compose_files "$DPF_MODE"
+echo "  Files: ${DPF_COMPOSE_FILES[*]}"
+
+# 4. Dry-run gate.
+if [ "$DPF_DRY_RUN" = "1" ]; then
+  echo ""
+  step "Dry-run plan"
+  echo "  Would run:"
+  echo "    docker compose ${DPF_COMPOSE_FILES[*]} up -d"
+  echo ""
+  echo "  Install state file: $(dpf_state_path)"
+  echo "  Repo root:          $REPO_ROOT"
+  echo ""
+  ok "Dry-run complete; no changes made."
+  exit 0
+fi
+
+# 5. Non-dry-run: Phase 6 stops here. Phase 7 takes over from this point
+#    with Docker Engine install, env generation, compose up, model pulls,
+#    and autostart wiring.
+echo ""
+warn "Phase 6 framework vertical slice: install execution lands in Phase 7."
+echo ""
+echo "  Until Phase 7 ships, the canonical end-to-end paths are:"
+echo "    Contributors: bash scripts/setup.sh && pnpm dev"
+echo "    Operators (macOS / Linux): docker compose ${DPF_COMPOSE_FILES[*]} up -d"
+echo "    Diagnostic bundle: bash install-dpf.sh doctor"
+echo ""
+echo "  This skeleton has validated:"
+echo "    [x] Host compatibility preflight"
+echo "    [x] install-state.json schema-aware bookkeeping"
+echo "    [x] Compose -f chain assembly per platform"
+echo "    [x] --dry-run and --headless flags"
+echo "    [x] doctor subcommand"
+echo "    [ ] Dependency installation (Phase 7)"
+echo "    [ ] Env generation + secret bootstrap (Phase 7)"
+echo "    [ ] docker compose up + health-check loop (Phase 7)"
+echo "    [ ] Model pull (uses entrypoint's provider-aware logic; Phase 7)"
+echo "    [ ] LaunchAgent / systemd autostart (Phase 7)"
+echo ""
+exit 0

--- a/scripts/installer/install-state.schema.json
+++ b/scripts/installer/install-state.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://dpf.local/schemas/install-state.json",
+  "title": "DPF Install State",
+  "description": "Persisted state at ~/.dpf/install-state.json. Read by every lifecycle script (install-dpf.sh, dpf-{start,stop,reinstall,release}.sh) so they don't redetect platform reality independently. Per the deployment doctrine (Contract 2: runtime configuration; Contract 3: lifecycle).",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "installerVersion",
+    "platform",
+    "arch"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version for forward-migration. Lifecycle scripts must run dpf_state_migrate() if the file's schemaVersion is lower than the installer's expected version, or refuse to operate and direct the operator to re-run install-dpf.sh."
+    },
+    "installerVersion": {
+      "type": "string",
+      "description": "Installer version that wrote this file (semver-ish; e.g. '2026.05.10')."
+    },
+    "lastSuccessfulInstallVersion": {
+      "type": ["string", "null"],
+      "description": "Most recent installer version that completed successfully end-to-end."
+    },
+    "lastSuccessfulComposeHash": {
+      "type": ["string", "null"],
+      "description": "sha256 of the rendered docker compose config from the last successful install. Used to detect compose drift on restart."
+    },
+    "composeProjectName": {
+      "type": "string",
+      "default": "dpf",
+      "description": "Docker Compose project name. Defaults to 'dpf'."
+    },
+    "platform": {
+      "type": "string",
+      "enum": ["darwin", "linux", "win32"],
+      "description": "Host OS. win32 is informational only — the canonical Windows installer is install-dpf.ps1, which writes its own state."
+    },
+    "arch": {
+      "type": "string",
+      "enum": ["arm64", "amd64", "x86_64"],
+      "description": "Host architecture. arm64 covers Apple Silicon and Linux ARM."
+    },
+    "dockerContext": {
+      "type": ["string", "null"],
+      "description": "Active Docker context name (`docker context show`). null when DOCKER_HOST takes precedence or no context is configured."
+    },
+    "dockerEndpoint": {
+      "type": ["string", "null"],
+      "description": "Resolved Docker daemon endpoint (unix socket path or DOCKER_HOST URL)."
+    },
+    "installPath": {
+      "type": "string",
+      "description": "Absolute path to the repo root on the host. Mirrors DPF_HOST_INSTALL_PATH."
+    },
+    "stateDir": {
+      "type": "string",
+      "description": "Absolute path to the state directory (~/.dpf by default; XDG-aware on Linux when XDG_STATE_HOME is set)."
+    },
+    "composeFiles": {
+      "type": "array",
+      "description": "Ordered list of compose -f files used at install time. The compose.sh helper assembles this dynamically; persisting it enables lifecycle scripts to use the same chain.",
+      "items": { "type": "string" }
+    },
+    "imageTag": {
+      "type": ["string", "null"],
+      "description": "DPF_IMAGE_TAG used at install time. null when running in dev mode (services build locally)."
+    },
+    "llmProvider": {
+      "type": ["string", "null"],
+      "enum": ["model-runner", "ollama", "external", null],
+      "description": "Resolved DPF_LLM_PROVIDER at install time."
+    },
+    "resourceLabels": {
+      "type": "object",
+      "description": "Labels applied to all DPF-owned Docker resources for clean teardown. Default: { 'dpf': 'true' }.",
+      "additionalProperties": { "type": "string" }
+    },
+    "autostart": {
+      "type": "object",
+      "description": "Autostart configuration recorded at install time.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "kind": {
+          "type": "string",
+          "enum": ["launchagent", "systemd-user", "scheduled-task", "none"],
+          "description": "Mechanism used: launchagent (macOS), systemd-user (Linux), scheduled-task (Windows; informational), none."
+        }
+      },
+      "required": ["enabled", "kind"],
+      "additionalProperties": false
+    },
+    "lastHealthCheck": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO timestamp of the last successful /api/health check."
+    },
+    "lastBackupAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "lastDoctorBundlePath": {
+      "type": ["string", "null"],
+      "description": "Absolute path to the most recent doctor bundle, for support reports."
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/installer/lib/doctor.sh
+++ b/scripts/installer/lib/doctor.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Diagnostic bundle generator for DPF installations.
+# Source this file; do not execute directly.
+#
+# Per the installer-parity roadmap Phase 6: ship a minimum dpf doctor
+# alongside the installer skeleton so early macOS / Linux installs
+# don't write bug reports in fog.
+#
+# Bundle contents (per Doctrine maturity-gate):
+#   - Host OS + arch
+#   - Docker version + context + info
+#   - Compose -f chain (via compose.sh helper) + rendered config sha256
+#   - install-state.json (redacted)
+#   - docker compose ps
+#   - tail -200 of core service logs (portal, postgres, neo4j, qdrant)
+#   - Port-conflict scan
+#   - LLM provider reachability
+#   - Redacted env summary
+#
+# Output: tarball at $(dpf_state_dir)/doctor-<timestamp>.tar.gz plus
+# a human-readable summary on stdout.
+#
+# Bash 3.2 baseline.
+
+if [ "${DPF_LIB_DOCTOR_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_DOCTOR_LOADED=1
+
+if [ -z "${DPF_LIB_LOGGING_LOADED:-}" ]; then
+  # shellcheck source=logging.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/logging.sh"
+fi
+if [ -z "${DPF_LIB_STATE_LOADED:-}" ]; then
+  # shellcheck source=state.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/state.sh"
+fi
+if [ -z "${DPF_LIB_COMPOSE_LOADED:-}" ]; then
+  # shellcheck source=compose.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/compose.sh"
+fi
+
+# Redact common secret patterns from env / state output. Replaces values
+# of any line matching SECRET|PASSWORD|TOKEN|KEY|AUTH (case-insensitive)
+# with "***REDACTED***".
+_dpf_doctor_redact() {
+  sed -E 's/((SECRET|PASSWORD|TOKEN|KEY|AUTH)[A-Z_]*)(=|: )(.*)$/\1\3***REDACTED***/Ig'
+}
+
+# Common ports DPF binds. Used by the conflict scan.
+_DPF_DOCTOR_PORTS="3000 3001 3002 3035 5432 6333 7474 7687 8080 8500 8600 8700 9090 9100 9182 9187 11434 1455"
+
+dpf_doctor_collect() {
+  # Diagnostic gathering is best-effort. Many shell-outs (docker info
+  # without daemon, compose config without .env, lsof/ss without those
+  # tools installed) fail naturally; relax set -e for the duration so
+  # partial bundles always produce useful output instead of aborting.
+  set +e
+
+  local timestamp; timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  local state_dir; state_dir="$(dpf_state_dir)"
+  local bundle_dir; bundle_dir="$(mktemp -d)"
+  local tarball="${state_dir}/doctor-${timestamp}.tar.gz"
+
+  mkdir -p "$state_dir"
+
+  step "Collecting diagnostic bundle"
+
+  # 1. Host info
+  {
+    echo "uname -a:"
+    uname -a 2>&1
+    echo
+    echo "uname -srm:"
+    uname -srm 2>&1
+    echo
+    if [ -r /etc/os-release ]; then
+      echo "/etc/os-release:"
+      cat /etc/os-release 2>&1
+    fi
+    if [ "$(uname -s)" = "Darwin" ]; then
+      echo "sw_vers:"
+      sw_vers 2>&1 || true
+    fi
+  } > "$bundle_dir/host.txt"
+
+  # 2. Docker
+  {
+    echo "docker --version:"
+    docker --version 2>&1 || true
+    echo
+    echo "docker context show:"
+    docker context show 2>&1 || true
+    echo
+    echo "docker context inspect:"
+    docker context inspect 2>&1 || true
+    echo
+    echo "docker info:"
+    docker info 2>&1 || true
+  } > "$bundle_dir/docker.txt"
+
+  # 3. Compose chain + rendered config hash
+  {
+    if dpf_compose_files "${1:-dev}" 2>/dev/null; then
+      echo "compose chain: ${DPF_COMPOSE_FILES[*]}"
+      echo
+      echo "rendered config sha256:"
+      docker compose "${DPF_COMPOSE_FILES[@]}" config 2>/dev/null | sha256sum 2>/dev/null || echo "(unable to render — see container status)"
+    else
+      echo "(unable to assemble compose chain)"
+    fi
+  } > "$bundle_dir/compose.txt"
+
+  # 4. install-state.json (redacted)
+  if [ -f "$(dpf_state_path)" ]; then
+    _dpf_doctor_redact < "$(dpf_state_path)" > "$bundle_dir/install-state.redacted.json"
+  fi
+
+  # 5. docker compose ps
+  if dpf_compose_files "${1:-dev}" 2>/dev/null; then
+    docker compose "${DPF_COMPOSE_FILES[@]}" ps 2>&1 > "$bundle_dir/compose-ps.txt" || true
+  fi
+
+  # 6. Core service logs (last 200 lines each)
+  mkdir -p "$bundle_dir/logs"
+  for svc in portal postgres neo4j qdrant; do
+    if dpf_compose_files "${1:-dev}" 2>/dev/null; then
+      docker compose "${DPF_COMPOSE_FILES[@]}" logs --tail=200 "$svc" 2>&1 > "$bundle_dir/logs/$svc.log" || true
+    fi
+  done
+
+  # 7. Port-conflict scan
+  {
+    echo "Listening ports on common DPF binds:"
+    echo
+    for p in $_DPF_DOCTOR_PORTS; do
+      local who
+      if command -v lsof >/dev/null 2>&1; then
+        who="$(lsof -nP -iTCP:"$p" -sTCP:LISTEN 2>/dev/null | tail -n +2 | awk '{print $1, $2}' | sort -u | tr '\n' '; ')"
+      elif command -v ss >/dev/null 2>&1; then
+        who="$(ss -ltn "sport = :$p" 2>/dev/null | tail -n +2 | awk '{print $4}')"
+      fi
+      if [ -n "$who" ]; then
+        echo "  $p: $who"
+      fi
+    done
+  } > "$bundle_dir/ports.txt"
+
+  # 8. LLM provider reachability
+  {
+    local llm_url="${LLM_BASE_URL:-http://model-runner.docker.internal/v1}"
+    echo "LLM_BASE_URL: $llm_url"
+    echo "DPF_LLM_PROVIDER: ${DPF_LLM_PROVIDER:-(auto-detect)}"
+    echo
+    if curl --silent --max-time 5 --output /dev/null --write-out "GET /models -> HTTP %{http_code} (%{time_total}s)\n" "${llm_url}/models" 2>&1; then
+      :
+    else
+      echo "GET /models -> unreachable"
+    fi
+  } > "$bundle_dir/llm.txt"
+
+  # 9. Redacted env summary (snapshot of known DPF envvars)
+  {
+    echo "DPF-related environment variables (redacted):"
+    env | grep -iE '^(DPF_|LLM_|EMBEDDING_|BROWSER_USE_|GHCR_|POSTGRES_|NEO4J_|AUTH_|ADMIN_|MCP_|DOCKER_)' \
+      | _dpf_doctor_redact | sort
+  } > "$bundle_dir/env.txt"
+
+  # Bundle and stamp the install-state with the bundle path.
+  tar -czf "$tarball" -C "$bundle_dir" . 2>/dev/null
+  rm -rf "$bundle_dir"
+
+  if [ -f "$(dpf_state_path)" ]; then
+    dpf_state_write lastDoctorBundlePath "$tarball" 2>/dev/null || true
+  fi
+
+  ok "Bundle written: $tarball"
+  echo
+  echo "  Send this file to support, or attach it to a GitHub issue."
+  echo "  Secrets are redacted; review before sending to confirm."
+  echo
+  echo "$tarball"
+
+  # Restore strict mode for the caller.
+  set -e
+}

--- a/scripts/installer/lib/preflight.sh
+++ b/scripts/installer/lib/preflight.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Unsupported-host preflight detector for the DPF installer.
+# Source this file; do not execute directly.
+#
+# Per the installer-parity roadmap Phase 6: detect known-unsupported
+# host configurations during preflight and refuse to proceed with a
+# crisp Reason + Next message rather than failing opaquely later.
+#
+# Bash 3.2 baseline.
+
+if [ "${DPF_LIB_PREFLIGHT_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_PREFLIGHT_LOADED=1
+
+# Source logging if not already loaded so we can emit warn/info uniformly.
+if [ -z "${DPF_LIB_LOGGING_LOADED:-}" ]; then
+  # shellcheck source=logging.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/logging.sh"
+fi
+
+# Each refusal exits non-zero with a clear "Reason:" and "Next:" line.
+# Operators can override the unsupported decision by setting
+# DPF_FORCE_UNSUPPORTED_HOST=1; the installer logs the override and
+# proceeds at the operator's risk.
+_dpf_preflight_refuse() {
+  local reason="$1"
+  local next="$2"
+  if [ "${DPF_FORCE_UNSUPPORTED_HOST:-0}" = "1" ]; then
+    warn "Unsupported host detected, but DPF_FORCE_UNSUPPORTED_HOST=1 — proceeding."
+    info "  Reason: $reason"
+    info "  Next: $next"
+    return 0
+  fi
+  printf '\n%bUnsupported host detected.%b\n' "${DPF_RED:-}" "${DPF_NC:-}" >&2
+  printf '  %bReason:%b %s\n' "${DPF_YELLOW:-}" "${DPF_NC:-}" "$reason" >&2
+  printf '  %bNext:%b   %s\n' "${DPF_YELLOW:-}" "${DPF_NC:-}" "$next" >&2
+  printf '\n  Override (advanced): DPF_FORCE_UNSUPPORTED_HOST=1 bash %s\n\n' "$0" >&2
+  exit 64  # EX_USAGE-ish: configuration error
+}
+
+# Run all unsupported-host checks. Exits non-zero on any failure unless
+# DPF_FORCE_UNSUPPORTED_HOST=1.
+dpf_preflight_unsupported_host() {
+  local kernel; kernel="$(uname -s)"
+  local arch;   arch="$(uname -m)"
+
+  # Intel Mac — out of scope per the installer-parity roadmap.
+  if [ "$kernel" = "Darwin" ] && [ "$arch" = "x86_64" ]; then
+    _dpf_preflight_refuse \
+      "Intel Mac is out of scope for the macOS installer." \
+      "Use the Windows installer (install-dpf.ps1), or run inside a Linux VM on this host."
+  fi
+
+  # WSL2 without Docker Desktop.
+  if [ "$kernel" = "Linux" ] && uname -r 2>/dev/null | grep -qi "microsoft"; then
+    if ! docker info 2>/dev/null | grep -qi "Docker Desktop"; then
+      _dpf_preflight_refuse \
+        "WSL2 detected without Docker Desktop integration." \
+        "Install Docker Desktop for Windows and enable WSL2 integration, or run install-dpf.sh on a native Linux host."
+    fi
+  fi
+
+  # Rootless Docker — host-network and host-gateway semantics differ.
+  if command -v docker >/dev/null 2>&1; then
+    if docker info 2>/dev/null | grep -qi "rootless"; then
+      _dpf_preflight_refuse \
+        "Rootless Docker detected." \
+        "DPF requires standard Docker Engine for host-gateway and selected-profile host-network semantics. Reinstall with rootful Docker, or run on Docker Desktop."
+    fi
+
+    # Podman or containerd masquerading as docker.
+    local docker_ver; docker_ver="$(docker --version 2>/dev/null || true)"
+    case "$docker_ver" in
+      *podman*|*Podman*)
+        _dpf_preflight_refuse \
+          "Podman detected via the 'docker' command alias." \
+          "DPF currently requires standard Docker Engine. Install Docker Engine alongside Podman or remove the alias."
+        ;;
+    esac
+  fi
+
+  # Older Linux distros — warn-only with override flag, default refuse.
+  if [ "$kernel" = "Linux" ] && [ -r /etc/os-release ]; then
+    local distro_id distro_ver
+    # shellcheck disable=SC1091
+    distro_id="$(. /etc/os-release && echo "${ID:-}")"
+    distro_ver="$(. /etc/os-release && echo "${VERSION_ID:-}")"
+    case "$distro_id" in
+      ubuntu)
+        # Require Ubuntu 22.04+
+        local major; major="$(echo "$distro_ver" | cut -d. -f1)"
+        if [ -n "$major" ] && [ "$major" -lt 22 ] 2>/dev/null; then
+          _dpf_preflight_refuse \
+            "Ubuntu $distro_ver is below the supported floor (Ubuntu 22.04)." \
+            "Upgrade to Ubuntu 22.04+ or override with DPF_FORCE_UNSUPPORTED_HOST=1."
+        fi
+        ;;
+      debian)
+        local major; major="$(echo "$distro_ver" | cut -d. -f1)"
+        if [ -n "$major" ] && [ "$major" -lt 12 ] 2>/dev/null; then
+          _dpf_preflight_refuse \
+            "Debian $distro_ver is below the supported floor (Debian 12)." \
+            "Upgrade to Debian 12+ or override with DPF_FORCE_UNSUPPORTED_HOST=1."
+        fi
+        ;;
+      fedora)
+        local major; major="$(echo "$distro_ver" | cut -d. -f1)"
+        if [ -n "$major" ] && [ "$major" -lt 39 ] 2>/dev/null; then
+          _dpf_preflight_refuse \
+            "Fedora $distro_ver is below the supported floor (Fedora 39)." \
+            "Upgrade to Fedora 39+ or override with DPF_FORCE_UNSUPPORTED_HOST=1."
+        fi
+        ;;
+    esac
+  fi
+
+  # Air-gapped Linux — warn but allow proceeding.
+  if [ "$kernel" = "Linux" ]; then
+    if ! curl --silent --max-time 3 --output /dev/null https://github.com 2>/dev/null; then
+      warn "Outbound network connectivity check to https://github.com failed."
+      info "  Air-gapped or restricted-network installs aren't fully supported yet."
+      info "  Install will proceed but image pulls and provider OAuth flows may fail."
+    fi
+  fi
+
+  return 0
+}

--- a/scripts/installer/lib/state.sh
+++ b/scripts/installer/lib/state.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Install-state file management for the DPF installer.
+# Source this file; do not execute directly.
+#
+# Reads, writes, and migrates ~/.dpf/install-state.json. Schema lives at
+# scripts/installer/install-state.schema.json. Per the deployment
+# doctrine (Contract 2: runtime configuration; Contract 3: lifecycle).
+#
+# Bash 3.2 baseline.
+
+if [ "${DPF_LIB_STATE_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_STATE_LOADED=1
+
+# Source platform.sh for dpf_platform / dpf_arch.
+if [ -z "${DPF_LIB_PLATFORM_LOADED:-}" ]; then
+  # shellcheck source=platform.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/platform.sh"
+fi
+
+# Current schema version this installer expects. Bump when adding
+# required fields or breaking-changing existing field semantics.
+DPF_STATE_SCHEMA_VERSION=1
+
+# Resolve state directory honoring XDG_STATE_HOME on Linux.
+dpf_state_dir() {
+  if [ -n "${XDG_STATE_HOME:-}" ]; then
+    echo "${XDG_STATE_HOME}/dpf"
+  else
+    echo "${HOME}/.dpf"
+  fi
+}
+
+dpf_state_path() {
+  echo "$(dpf_state_dir)/install-state.json"
+}
+
+# Initialize a fresh state file at the canonical path. Idempotent —
+# returns 0 silently if file already exists.
+# Args: $1 = installerVersion, $2 = installPath
+dpf_state_init() {
+  local installer_version="${1:-unknown}"
+  local install_path="${2:-$(pwd)}"
+  local state_dir; state_dir="$(dpf_state_dir)"
+  local path; path="$(dpf_state_path)"
+
+  if [ -f "$path" ]; then
+    return 0
+  fi
+
+  mkdir -p "$state_dir"
+  dpf_platform
+  dpf_arch
+
+  # Build the initial JSON. Keep it shell-only for bash 3.2 portability;
+  # don't reach for jq here so the install can bootstrap on hosts that
+  # haven't installed jq yet.
+  cat > "$path" <<EOF
+{
+  "schemaVersion": ${DPF_STATE_SCHEMA_VERSION},
+  "installerVersion": "${installer_version}",
+  "lastSuccessfulInstallVersion": null,
+  "lastSuccessfulComposeHash": null,
+  "composeProjectName": "dpf",
+  "platform": "${DPF_PLATFORM}",
+  "arch": "${DPF_ARCH}",
+  "dockerContext": null,
+  "dockerEndpoint": null,
+  "installPath": "${install_path}",
+  "stateDir": "${state_dir}",
+  "composeFiles": [],
+  "imageTag": null,
+  "llmProvider": null,
+  "resourceLabels": { "dpf": "true" },
+  "autostart": { "enabled": false, "kind": "none" },
+  "lastHealthCheck": null,
+  "lastBackupAt": null,
+  "lastDoctorBundlePath": null
+}
+EOF
+  chmod 600 "$path"
+}
+
+# Read a top-level key from the state file. Uses jq if available,
+# falling back to python3, falling back to a grep-based read for
+# top-level scalar keys only. Emits empty string for missing keys.
+# Args: $1 = key
+dpf_state_read() {
+  local key="$1"
+  local path; path="$(dpf_state_path)"
+  if [ ! -f "$path" ]; then
+    return 0
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    jq -r --arg k "$key" '.[$k] // ""' "$path"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c "import json,sys; d=json.load(open('$path')); v=d.get('$key',''); print('' if v is None else (v if isinstance(v,str) else json.dumps(v)))"
+  else
+    # Last-resort scalar grep (string and number top-level fields).
+    grep -E "\"${key}\"\s*:" "$path" | head -1 | sed -E 's/.*:\s*"?([^",}]*)"?.*/\1/'
+  fi
+}
+
+# Write a top-level scalar (string or number) to the state file.
+# Numbers (no quotes) require value matching ^-?[0-9.]+$; everything
+# else is treated as a string and quoted. For object/array fields,
+# use jq directly via dpf_state_jq_set.
+# Args: $1 = key, $2 = value
+dpf_state_write() {
+  local key="$1"
+  local value="$2"
+  local path; path="$(dpf_state_path)"
+  if [ ! -f "$path" ]; then
+    echo "dpf_state_write: state file missing; call dpf_state_init first" >&2
+    return 1
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    local tmp; tmp="$(mktemp)"
+    if [ "$value" = "true" ] || [ "$value" = "false" ] || [ "$value" = "null" ]; then
+      jq --arg k "$key" --argjson v "$value" '.[$k] = $v' "$path" > "$tmp"
+    elif echo "$value" | grep -qE '^-?[0-9]+(\.[0-9]+)?$'; then
+      jq --arg k "$key" --argjson v "$value" '.[$k] = $v' "$path" > "$tmp"
+    else
+      jq --arg k "$key" --arg v "$value" '.[$k] = $v' "$path" > "$tmp"
+    fi
+    mv "$tmp" "$path"
+    chmod 600 "$path"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 - "$path" "$key" "$value" <<'PY'
+import json, sys
+path, key, value = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    d = json.load(f)
+# Try to coerce numerics; fall back to string.
+if value in ("true", "false"):
+    d[key] = (value == "true")
+elif value == "null":
+    d[key] = None
+else:
+    try:
+        d[key] = int(value)
+    except ValueError:
+        try:
+            d[key] = float(value)
+        except ValueError:
+            d[key] = value
+with open(path, "w") as f:
+    json.dump(d, f, indent=2)
+PY
+    chmod 600 "$path"
+  else
+    echo "dpf_state_write: needs jq or python3 to update JSON" >&2
+    return 1
+  fi
+}
+
+# Validate the state file's schema version. Returns 0 if matches the
+# installer's expected version; non-zero with a clear message if the
+# file is from a future installer version (refuse) or older version
+# (caller should run migration).
+# Args: none
+dpf_state_validate() {
+  local path; path="$(dpf_state_path)"
+  if [ ! -f "$path" ]; then
+    return 2  # No state — fresh install
+  fi
+  local file_ver; file_ver="$(dpf_state_read schemaVersion)"
+  if [ -z "$file_ver" ]; then
+    echo "dpf_state_validate: state file at $path has no schemaVersion; treating as fresh." >&2
+    return 2
+  fi
+  if [ "$file_ver" -gt "$DPF_STATE_SCHEMA_VERSION" ] 2>/dev/null; then
+    echo "dpf_state_validate: state file is from a newer installer (schema $file_ver > $DPF_STATE_SCHEMA_VERSION). Update install-dpf.sh and re-run." >&2
+    return 1
+  fi
+  if [ "$file_ver" -lt "$DPF_STATE_SCHEMA_VERSION" ] 2>/dev/null; then
+    return 3  # Older — caller should run migration
+  fi
+  return 0
+}
+
+# Forward-migrate the state file. Currently a stub since
+# DPF_STATE_SCHEMA_VERSION=1; future versions add cases here.
+# Args: none
+dpf_state_migrate() {
+  local file_ver; file_ver="$(dpf_state_read schemaVersion)"
+  echo "dpf_state_migrate: migrating state from schema $file_ver to $DPF_STATE_SCHEMA_VERSION"
+  # Future: per-version migration cases.
+  # case "$file_ver" in
+  #   1) <migrate from 1 to 2> ;;
+  # esac
+  dpf_state_write schemaVersion "$DPF_STATE_SCHEMA_VERSION"
+}


### PR DESCRIPTION
## Summary

Implements the **vertical slice of Phase 6** of the Mac/Linux installer-parity roadmap: the installer skeleton with preflight, install-state, dry-run/headless flags, and a minimum dpf doctor — ready for **Phase 7** to layer on Docker Engine install, autostart, model pulls, and the full end-user automation.

Five files, +814 lines.

### Changes

**`install-dpf.sh`** (new) — installer skeleton
- CLI: `--dry-run`, `--headless`, `--release`, `--dev`, `--force-unsupported-host`, `-h/--help`; `doctor` subcommand
- Sources Phase 2/3/6 helpers (`logging`, `platform`, `prompts`, `compose`, `preflight`, `state`, `doctor`)
- Main flow: preflight check → install-state validate/init/migrate → resolve compose chain via `compose.sh` → dry-run gate → Phase 6 framework summary (Phase 7 fills in execution)
- `doctor` subcommand short-circuits to `dpf_doctor_collect`

**`scripts/installer/lib/preflight.sh`** (new) — unsupported-host detector

Refuses with crisp `Reason:` + `Next:` messages on:
- Intel Mac (Darwin x86_64 — out of scope per roadmap)
- WSL2 without Docker Desktop integration
- Rootless Docker
- Podman/containerd masquerading as docker
- Older Linux distros (Ubuntu <22.04, Debian <12, Fedora <39)

Warns (non-fatal) on:
- Air-gapped Linux (no outbound to github.com)

`DPF_FORCE_UNSUPPORTED_HOST=1` escape hatch for advanced operators.

**`scripts/installer/lib/state.sh`** (new) — `install-state.json` management
- `DPF_STATE_SCHEMA_VERSION=1` (single source of truth for migrations)
- `dpf_state_dir()`: honors `XDG_STATE_HOME` on Linux, `~/.dpf` otherwise
- `dpf_state_init`: bootstrap-only JSON write (no jq dependency at install time)
- `dpf_state_read`/`write`: jq → python3 → grep fallback chain so the installer doesn't require jq pre-installed
- `dpf_state_validate`: returns 0/2/3 to differentiate current/missing/older-needs-migration; caller dispatches via case
- `dpf_state_migrate`: stub at v1; future versions add per-version cases
- `chmod 600` on the state file (it eventually carries refresh tokens and similar)

**`scripts/installer/lib/doctor.sh`** (new) — minimum dpf doctor

9-section diagnostic bundle written to `$(dpf_state_dir)/doctor-<timestamp>.tar.gz`:

| Section | Contents |
|---|---|
| `host.txt` | uname / sw_vers / /etc/os-release |
| `docker.txt` | docker --version, context show, context inspect, info |
| `compose.txt` | compose -f chain + rendered config sha256 |
| `install-state.redacted.json` | (if state file exists) |
| `compose-ps.txt` | docker compose ps |
| `logs/{portal,postgres,neo4j,qdrant}.log` | last 200 lines each |
| `ports.txt` | lsof/ss scan for the 18 ports DPF binds |
| `llm.txt` | LLM_BASE_URL reachability check |
| `env.txt` | DPF_*/LLM_*/POSTGRES_*/NEO4J_*/AUTH_*/MCP_*/etc. envvars (redacted: SECRET\|PASSWORD\|TOKEN\|KEY\|AUTH) |

`set -e` relaxed during collection (best-effort gathering); restored before return. Stamps `lastDoctorBundlePath` into install-state.json on success.

**`scripts/installer/install-state.schema.json`** (new) — JSON schema (Draft-07)

Captures every field from the doctrine's Contract 2/3 install-state contract: `schemaVersion`, `installerVersion`, `lastSuccessful*`, `composeProjectName`, `platform`, `arch`, `dockerContext`, `dockerEndpoint`, `installPath`, `stateDir`, `composeFiles[]`, `imageTag`, `llmProvider`, `resourceLabels`, `autostart{enabled,kind}`, `lastHealthCheck`, `lastBackupAt`, `lastDoctorBundlePath`. `additionalProperties: false` to catch typos before they land.

## Test plan

Verified locally before push:

- [x] `bash -n` on all 4 new bash files passes
- [x] `python3 json.load` on `install-state.schema.json` passes (valid JSON)
- [x] `bash install-dpf.sh --help` renders correctly
- [x] `bash install-dpf.sh --dry-run --headless` on a Linux runner: preflight passes → initializes `~/.dpf/install-state.json` with valid schema → assembles compose chain `-f docker-compose.yml -f docker-compose.linux.yml` → prints dry-run plan → exits 0
- [x] Verified `install-state.json` schema fields match: `schemaVersion=1`, `platform=linux`, `arch=amd64`, `installer=2026.05.10-phase6`
- [x] `bash install-dpf.sh doctor` produces a valid 1.5 KB tarball with all 9 expected sections (host/docker/compose/compose-ps/logs/ports/llm/env)
- [x] DCO sign-off

To verify in CI / on real platforms:

- [ ] `Production Build` and `Typecheck` pass — required gating checks per CONTRIBUTING.md
- [ ] **macOS (Apple Silicon)** smoke: `bash install-dpf.sh --dry-run --headless` succeeds; `bash install-dpf.sh doctor` produces a bundle; preflight does NOT refuse on Darwin arm64
- [ ] **macOS (Intel)** smoke: preflight refuses with the documented Reason: / Next: messages (verifies the unsupported-host gate)
- [ ] **Linux (Ubuntu 22.04)** smoke: same as macOS arm64 + preflight does NOT refuse
- [ ] **Linux (Ubuntu 20.04)** smoke: preflight refuses (older-floor)

## What this PR does NOT do

- Does **not** implement actual install execution (Docker Engine install, env generation, compose up + health-check, model pulls, autostart wiring). All that is **Phase 7**'s scope; Phase 6 ships the framework Phase 7 will plug into.
- Does **not** add `docker.sh` / `model.sh` / `paths.sh` helpers from the roadmap's Phase 6 file list. `paths.sh` is small enough to inline when needed; `docker.sh`'s checks are already in `setup.sh` and `scripts/installer/lib/compose.sh`; `model.sh` is moot because Phase 4 put the provider-aware logic directly in `docker-entrypoint.sh`. These can be added in Phase 6b if a real consumer materializes.
- Does **not** wire `doctor` or `preflight` into `setup.sh`. Contributor bootstrap stays scoped to dev-loop concerns.
- Does **not** add CI smoke for `install-dpf.sh --dry-run`. Phase 9 release gates land that as the `linux-smoke-install` CI job.

## What this PR enables

- **Phase 7** (full installer): the skeleton, preflight, state, and doctor are all in place. Phase 7 fills in the Docker auto-install, env generation, compose `up`, model pulls, and autostart between the preflight and the dry-run summary.
- **Operators on macOS / Linux**: can run `bash install-dpf.sh doctor` to produce a support bundle even before a full install lands.
- **CI**: `bash install-dpf.sh --dry-run --headless` is now a meaningful smoke test for compose-chain + state + preflight without requiring docker daemon access.
- **Lifecycle scripts** (Phase 8): `dpf-{start,stop,reinstall,release}.sh` will read `~/.dpf/install-state.json` instead of redetecting platform reality independently. Single source of truth.

Refs:
- `docs/superpowers/specs/2026-05-09-deployment-contracts.md` — Contract 2 (runtime config), Contract 3 (lifecycle)
- `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 6
- #400, #401, #402, #404, #410, #411 (all merged) — doctrine + Phases 1–5

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_