### PR TITLE
feat(installer): fill in Linux end-to-end install flow (Phase 7a)

### DIFF
--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -30,7 +30,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR"
 LIB_DIR="$REPO_ROOT/scripts/installer/lib"
 
-# Source shared helpers from Phase 2 + Phase 3 + Phase 6.
+# Source shared helpers from Phase 2 + Phase 3 + Phase 6 + Phase 7a.
 # shellcheck source=scripts/installer/lib/logging.sh
 . "$LIB_DIR/logging.sh"
 # shellcheck source=scripts/installer/lib/platform.sh
@@ -45,9 +45,11 @@ LIB_DIR="$REPO_ROOT/scripts/installer/lib"
 . "$LIB_DIR/state.sh"
 # shellcheck source=scripts/installer/lib/doctor.sh
 . "$LIB_DIR/doctor.sh"
+# shellcheck source=scripts/installer/lib/docker.sh
+. "$LIB_DIR/docker.sh"
 
 # Installer version (semver-ish; bump per release).
-DPF_INSTALLER_VERSION="2026.05.10-phase6"
+DPF_INSTALLER_VERSION="2026.05.10-phase7a"
 
 # ── CLI handling ────────────────────────────────────────────────────────────
 
@@ -170,27 +172,131 @@ if [ "$DPF_DRY_RUN" = "1" ]; then
   exit 0
 fi
 
-# 5. Non-dry-run: Phase 6 stops here. Phase 7 takes over from this point
-#    with Docker Engine install, env generation, compose up, model pulls,
-#    and autostart wiring.
+# 5. Ensure Docker is installed (Linux: distro pkg manager; macOS: see
+#    Phase 7b for the .dmg flow — until then, manual install).
+step "Docker Engine"
+dpf_docker_ensure_installed; rc=$?
+case "$rc" in
+  0) ok "Docker present and reachable"
+     dpf_state_write dockerEndpoint "$(dpf_docker_endpoint)" 2>/dev/null || true ;;
+  75) # Docker was just installed; operator must log out / newgrp
+      echo ""
+      warn "Re-run install-dpf.sh after logging out and back in (or 'newgrp docker')."
+      exit 75 ;;
+  *) fail "Docker setup failed (rc=$rc)" ;;
+esac
+
+# 6. Verify Node.js / pnpm. We don't auto-install Node — that's a
+#    user choice (nvm / brew / distro pkg) outside the installer's
+#    governance. Phase 7 stays clear of language-runtime installation.
+step "Node.js and pnpm"
+if ! command -v node >/dev/null 2>&1; then
+  fail "Node.js is not installed. Install Node 20+ via your platform's package manager (nvm, brew, apt) and re-run."
+fi
+NODE_MAJOR="$(node -v | tr -d 'v' | cut -d. -f1)"
+if [ "$NODE_MAJOR" -lt 20 ] 2>/dev/null; then
+  fail "Node.js v20+ required. Current: $(node -v). Upgrade and re-run."
+fi
+ok "Node.js $(node -v)"
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  info "pnpm not found; installing via npm..."
+  npm install -g pnpm
+fi
+ok "pnpm $(pnpm -v)"
+
+# 7. Install workspace dependencies (so scripts/detect-hardware-host.ts
+#    is runnable via the @dpf/db tsx in the steps below).
+step "Workspace dependencies"
+pnpm install
+ok "Dependencies installed"
+
+# 8. Resolve host hardware profile (Phase 5 macOS / Linux detector).
+#    Writes DPF_HOST_PROFILE for docker-entrypoint.sh to consume on
+#    portal-init.
+step "Host hardware profile"
+if DPF_HOST_PROFILE_JSON="$(pnpm --filter @dpf/db exec tsx scripts/detect-hardware-host.ts 2>/dev/null)"; then
+  export DPF_HOST_PROFILE="$DPF_HOST_PROFILE_JSON"
+  ok "Hardware profile detected (will be passed to portal-init via DPF_HOST_PROFILE)"
+else
+  warn "Host hardware detection failed (non-fatal); portal-init will skip the profile step."
+fi
+
+# 9. Generate / ensure root .env exists. Mirrors scripts/setup.sh's
+#    env-generation logic (Phase 2). If .env already exists we leave
+#    it alone — operators editing secrets shouldn't have them clobbered.
+step "Environment file"
+if [ ! -f .env ]; then
+  cp .env.docker.example .env
+  AUTH_SECRET_VAL="$(dpf_random_secret_b64 32)"
+  ENC_KEY_VAL="$(dpf_random_secret_hex 32)"
+  ADMIN_PW_VAL="$(dpf_random_secret_hex 16)"
+  dpf_sed_inplace "s|<generate with: openssl rand -base64 32>|$AUTH_SECRET_VAL|" .env
+  dpf_sed_inplace "s|<generate with: openssl rand -hex 32>|$ENC_KEY_VAL|" .env
+  dpf_sed_inplace "s|<set a strong password>|$ADMIN_PW_VAL|" .env
+  dpf_sed_inplace "s|<set to absolute path of this directory on the host>|$REPO_ROOT|" .env
+  ok ".env created with generated secrets"
+  info "  Admin password: $ADMIN_PW_VAL"
+  info "  (Stored in .env; change before any non-local deployment)"
+else
+  ok ".env already exists; preserving operator edits"
+fi
+
+# 10. Bring up the platform-aware compose stack. Per the doctrine's
+#     Contract 9: the entrypoint is provider-aware, so model pulls
+#     happen inside portal-init using whatever DPF_LLM_PROVIDER
+#     resolves to (Docker Model Runner on Docker Desktop; Ollama on
+#     Linux native Docker via docker-compose.linux.yml).
+step "Bringing up the platform"
+docker compose "${DPF_COMPOSE_FILES[@]}" up -d
+ok "docker compose up returned"
+
+# 11. Wait for /api/health (or DPF_HEALTH_TIMEOUT seconds, default 300).
+step "Health check"
+HEALTH_TIMEOUT="${DPF_HEALTH_TIMEOUT:-300}"
+HEALTH_URL="${DPF_HEALTH_URL:-http://localhost:3000/api/health}"
+elapsed=0
+interval=5
+while [ "$elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+  if curl --silent --max-time 5 --output /dev/null --fail "$HEALTH_URL" 2>/dev/null; then
+    ok "Portal is healthy at $HEALTH_URL (took ${elapsed}s)"
+    HEALTH_OK=1
+    break
+  fi
+  sleep "$interval"
+  elapsed=$((elapsed + interval))
+  if [ "$((elapsed % 30))" = "0" ]; then
+    info "  Still waiting for $HEALTH_URL ... (${elapsed}s / ${HEALTH_TIMEOUT}s)"
+  fi
+done
+
+if [ "${HEALTH_OK:-0}" != "1" ]; then
+  warn "Portal did not become healthy within ${HEALTH_TIMEOUT}s."
+  info "  Inspect: bash install-dpf.sh doctor"
+  info "  Or:      docker compose ${DPF_COMPOSE_FILES[*]} logs portal --tail 100"
+  exit 1
+fi
+
+# 12. Persist successful install state.
+dpf_state_write lastSuccessfulInstallVersion "$DPF_INSTALLER_VERSION" 2>/dev/null || true
+dpf_state_write lastHealthCheck "$(date -u +%Y-%m-%dT%H:%M:%SZ)" 2>/dev/null || true
+
+# ── Done ──────────────────────────────────────────────────────────────────────
 echo ""
-warn "Phase 6 framework vertical slice: install execution lands in Phase 7."
+printf '%b  Install complete!%b\n' "${DPF_GREEN:-}" "${DPF_NC:-}"
 echo ""
-echo "  Until Phase 7 ships, the canonical end-to-end paths are:"
-echo "    Contributors: bash scripts/setup.sh && pnpm dev"
-echo "    Operators (macOS / Linux): docker compose ${DPF_COMPOSE_FILES[*]} up -d"
-echo "    Diagnostic bundle: bash install-dpf.sh doctor"
+echo "  Portal:        $HEALTH_URL"
+echo "  Login:         admin@dpf.local"
+echo "  Password:      see ADMIN_PASSWORD in .env"
 echo ""
-echo "  This skeleton has validated:"
-echo "    [x] Host compatibility preflight"
-echo "    [x] install-state.json schema-aware bookkeeping"
-echo "    [x] Compose -f chain assembly per platform"
-echo "    [x] --dry-run and --headless flags"
-echo "    [x] doctor subcommand"
-echo "    [ ] Dependency installation (Phase 7)"
-echo "    [ ] Env generation + secret bootstrap (Phase 7)"
-echo "    [ ] docker compose up + health-check loop (Phase 7)"
-echo "    [ ] Model pull (uses entrypoint's provider-aware logic; Phase 7)"
-echo "    [ ] LaunchAgent / systemd autostart (Phase 7)"
+echo "  Lifecycle:"
+echo "    bash install-dpf.sh doctor         Generate a diagnostic bundle"
+echo "    docker compose ${DPF_COMPOSE_FILES[*]} logs -f"
+echo "    docker compose ${DPF_COMPOSE_FILES[*]} down"
+echo ""
+echo "  Autostart (LaunchAgent on macOS / systemd user unit on Linux)"
+echo "    lands with installer-parity Phase 7c."
+echo "  dpf-{start,stop,reinstall,release}.sh lifecycle scripts"
+echo "    land with installer-parity Phase 8."
 echo ""
 exit 0

--- a/scripts/installer/lib/docker.sh
+++ b/scripts/installer/lib/docker.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Docker Engine detection + install helper for the DPF installer.
+# Source this file; do not execute directly.
+#
+# Per the installer-parity roadmap Phase 7a (Linux Docker install).
+# macOS .dmg flow lands in Phase 7b. Windows is install-dpf.ps1's job.
+#
+# Bash 3.2 baseline.
+
+if [ "${DPF_LIB_DOCKER_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_DOCKER_LOADED=1
+
+if [ -z "${DPF_LIB_LOGGING_LOADED:-}" ]; then
+  # shellcheck source=logging.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/logging.sh"
+fi
+if [ -z "${DPF_LIB_PLATFORM_LOADED:-}" ]; then
+  # shellcheck source=platform.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/platform.sh"
+fi
+
+# Minimum Docker Engine version. host-gateway (used by base compose
+# extra_hosts for all services) requires 20.10+; preflight refuses
+# older.
+DPF_DOCKER_MIN_VERSION="20.10"
+
+# Return the installed Docker version (e.g. "27.3.1") or empty.
+dpf_docker_version() {
+  if ! command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+  docker --version 2>/dev/null | sed -nE 's/^Docker version ([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/p'
+}
+
+# semver-ish compare: "20.10" <= "27.3.1". POSIX-compatible.
+# Args: $1 = candidate, $2 = floor
+# Returns 0 if candidate >= floor; non-zero otherwise.
+dpf_docker_version_ge() {
+  local candidate="$1"
+  local floor="$2"
+  local cand_major cand_minor floor_major floor_minor
+  cand_major="$(echo "$candidate" | cut -d. -f1)"
+  cand_minor="$(echo "$candidate" | cut -d. -f2)"
+  floor_major="$(echo "$floor" | cut -d. -f1)"
+  floor_minor="$(echo "$floor" | cut -d. -f2)"
+  if [ "$cand_major" -gt "$floor_major" ] 2>/dev/null; then
+    return 0
+  fi
+  if [ "$cand_major" -lt "$floor_major" ] 2>/dev/null; then
+    return 1
+  fi
+  if [ "$cand_minor" -ge "$floor_minor" ] 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# Resolve the active Docker context's endpoint (unix socket path or
+# DOCKER_HOST URL). Returns empty string if no daemon configured.
+dpf_docker_endpoint() {
+  if [ -n "${DOCKER_HOST:-}" ]; then
+    echo "$DOCKER_HOST"
+    return 0
+  fi
+  if ! command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+  # Prefer `docker context inspect`; fall back to the legacy socket
+  # path. The context-inspect path is the canonical answer per the
+  # cloud-deployment spec (Phase 5 docker.ts discovery alignment).
+  docker context inspect 2>/dev/null \
+    | grep -m1 '"Host"' \
+    | sed -E 's/.*"Host"\s*:\s*"([^"]+)".*/\1/' \
+    || echo ""
+}
+
+# Linux-only: install Docker Engine via the host's distro package
+# manager. Refuses gracefully on unsupported distros; the caller
+# (install-dpf.sh) preflight already weeded out older / unsupported
+# distros, so this function trusts that gate.
+#
+# Args: none. Reads /etc/os-release.
+dpf_docker_install_linux() {
+  dpf_platform
+  if [ "$DPF_PLATFORM" != "linux" ]; then
+    fail "dpf_docker_install_linux: not on Linux"
+  fi
+
+  if [ ! -r /etc/os-release ]; then
+    fail "Cannot read /etc/os-release; can't determine Linux distro for Docker install."
+  fi
+
+  local distro_id
+  # shellcheck disable=SC1091
+  distro_id="$(. /etc/os-release && echo "${ID:-}")"
+
+  case "$distro_id" in
+    ubuntu|debian)
+      info "Installing Docker Engine via apt-get (Debian / Ubuntu)"
+      # Use the official Docker apt repo per docs.docker.com/engine/install
+      # We don't manage the keyring file directly here — distros 22.04+ /
+      # 12+ already package docker.io which is functionally equivalent for
+      # our purposes (Docker Engine 20.10+ with compose plugin available).
+      # Customers who want the upstream `docker-ce` build can install it
+      # themselves and re-run; preflight will detect the version.
+      sudo apt-get update -y
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-plugin || \
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+      ;;
+    fedora|rhel|centos)
+      info "Installing Docker Engine via dnf (Fedora / RHEL / CentOS)"
+      sudo dnf install -y docker docker-compose-plugin || sudo dnf install -y moby-engine
+      ;;
+    *)
+      fail "Unsupported Linux distro for automated Docker install: $distro_id. Install Docker Engine manually (https://docs.docker.com/engine/install/) and re-run."
+      ;;
+  esac
+
+  # Enable and start the daemon.
+  if command -v systemctl >/dev/null 2>&1; then
+    sudo systemctl enable --now docker || true
+  fi
+
+  # Add the invoking user to the docker group so non-sudo docker
+  # commands work in the subsequent session. We DO NOT call newgrp
+  # automatically (per the roadmap: "no magical newgrp dependency
+  # unless tested"). The installer reports the requirement explicitly.
+  local target_user="${SUDO_USER:-$USER}"
+  if [ -n "$target_user" ] && [ "$target_user" != "root" ]; then
+    sudo usermod -aG docker "$target_user" || true
+    warn "Added '$target_user' to the docker group."
+    info "  Log out and back in (or run 'newgrp docker') before continuing,"
+    info "  then re-run install-dpf.sh to complete the install."
+    return 75  # EX_TEMPFAIL-ish: caller should exit and ask operator to re-run
+  fi
+}
+
+# Ensure Docker is present at acceptable version. Installs on Linux
+# if missing. macOS .dmg flow is Phase 7b; preflight catches Intel
+# Mac, so this function only encounters Apple Silicon Macs that
+# either already have Docker Desktop or need the user to install it
+# manually (until Phase 7b ships).
+#
+# Args: none.
+# Returns:
+#   0   Docker present and version acceptable
+#   75  Docker just installed; operator must log out / newgrp and re-run
+#   non-zero otherwise
+dpf_docker_ensure_installed() {
+  dpf_platform
+
+  local version
+  version="$(dpf_docker_version)"
+
+  if [ -z "$version" ]; then
+    info "Docker is not installed."
+    if [ "$DPF_PLATFORM" = "linux" ]; then
+      dpf_docker_install_linux
+      return $?
+    fi
+    if [ "$DPF_PLATFORM" = "darwin" ]; then
+      fail "Docker Desktop not detected. Until installer-parity Phase 7b ships the automated .dmg install, please install Docker Desktop manually from https://www.docker.com/products/docker-desktop/ and re-run install-dpf.sh."
+    fi
+    fail "Unsupported platform for Docker install: $DPF_PLATFORM"
+  fi
+
+  if ! dpf_docker_version_ge "$version" "$DPF_DOCKER_MIN_VERSION"; then
+    fail "Docker $version is below the supported floor ($DPF_DOCKER_MIN_VERSION+; host-gateway support required). Upgrade Docker Engine and re-run install-dpf.sh."
+  fi
+
+  ok "Docker $version present"
+
+  # Verify the daemon is reachable.
+  if ! docker info >/dev/null 2>&1; then
+    fail "Docker daemon is not reachable. On macOS: open Docker Desktop and wait for it to start. On Linux: sudo systemctl start docker."
+  fi
+  ok "Docker daemon reachable"
+
+  return 0
+}


### PR DESCRIPTION
## Summary

Implements **Phase 7a** of the Mac/Linux installer-parity roadmap: the Linux end-to-end install flow that slots in between Phase 6's preflight + dry-run gate and the framework summary.

Two files, +309 lines. **macOS .dmg flow lands as Phase 7b; LaunchAgent / systemd autostart as Phase 7c; `uninstall-dpf.sh` as Phase 7d.** This PR is the Linux slice — largest user base for native install, and the substrate the Linux CI runner can exercise end-to-end in Phase 9.

### Changes

**`scripts/installer/lib/docker.sh`** (new) — Docker Engine helper
- `dpf_docker_version` / `dpf_docker_version_ge` (20.10 floor — host-gateway support)
- `dpf_docker_endpoint` — resolves via `DOCKER_HOST` → `docker context inspect` (canonical answer per cloud-deployment spec)
- `dpf_docker_install_linux` — `apt-get install docker.io docker-compose-plugin` (Debian/Ubuntu); `dnf install docker docker-compose-plugin` (Fedora/RHEL/CentOS); `systemctl enable --now docker`; `usermod -aG docker $SUDO_USER`. Returns **75 (EX_TEMPFAIL-ish)** when fresh group membership requires the operator to log out / `newgrp docker` and re-run.
- `dpf_docker_ensure_installed` — installs if missing on Linux; fails on macOS with a clear Phase-7b deferral message + Docker Desktop URL; verifies daemon reachability via `docker info`.

**`install-dpf.sh`** — fill in Phase 7a main flow

After Phase 6's preflight + state init + compose-chain assembly, the main flow now does:

| Step | Action |
|---|---|
| 5 | `dpf_docker_ensure_installed` — installs Docker on Linux if absent; persists `dockerEndpoint` into state.json |
| 6 | Node.js v20+ and pnpm presence checks (no auto-install — language runtimes are user choice) |
| 7 | `pnpm install` — workspace deps so the Phase 5 host detector can run |
| 8 | `scripts/detect-hardware-host.ts` → exports `DPF_HOST_PROFILE` (consumed by `docker-entrypoint.sh` on portal-init) |
| 9 | Env generation — mirrors `setup.sh`'s Phase 2 logic; **preserves existing `.env` if operator already edited it** |
| 10 | `docker compose ${DPF_COMPOSE_FILES[@]} up -d` — provider-aware model pulls happen INSIDE portal-init via Phase 4 entrypoint logic |
| 11 | Health check loop on `http://localhost:3000/api/health`; `DPF_HEALTH_TIMEOUT` bounds the wait (default 300s) |
| 12 | Persist `lastSuccessfulInstallVersion` + `lastHealthCheck` into install-state.json |

Installer version bumped: `2026.05.10-phase6` → `2026.05.10-phase7a`.

## Test plan

Verified locally:

- [x] `bash -n` on `install-dpf.sh` + `scripts/installer/lib/docker.sh` passes
- [x] `bash install-dpf.sh --dry-run --headless` still exits 0 (Phase 6 behavior preserved; new code lives after the dry-run gate)
- [x] DCO sign-off

To verify in CI / on real platforms:

- [ ] `Production Build` and `Typecheck` pass — required gating checks per CONTRIBUTING.md
- [ ] **Linux (Ubuntu 22.04 with Docker pre-installed)**: `bash install-dpf.sh --headless` runs through all 12 steps, brings up the stack, `/api/health` returns 200, `install-state.json` is updated with `lastSuccessfulInstallVersion`.
- [ ] **Linux (Ubuntu 22.04 without Docker)**: first run installs Docker via apt, returns 75 with the log-out-and-re-run message; second run (after `newgrp docker`) completes successfully.
- [ ] **macOS (Apple Silicon)**: `bash install-dpf.sh --headless` fails at the Docker step with the clear Phase-7b deferral message and Docker Desktop URL.
- [ ] **macOS (Apple Silicon with Docker Desktop pre-installed)**: `bash install-dpf.sh --headless` runs through (Docker detection skips install; the rest of the flow proceeds).

## What this PR does NOT do

- Does **not** implement macOS Docker Desktop install via .dmg. That's **Phase 7b**. `dpf_docker_ensure_installed` fails on macOS with a clear deferral message.
- Does **not** install Node.js or pnpm automatically. Language runtime bootstrapping is user choice (nvm / brew / distro pkg).
- Does **not** install LaunchAgent / systemd autostart units. **Phase 7c**.
- Does **not** add `dpf-{start,stop,reinstall,release}.sh` lifecycle scripts. **Phase 8**.
- Does **not** add CI smoke for the full end-to-end install. **Phase 9**.
- Does **not** use the upstream Docker CE apt repo (with its own keyring); uses the distro's `docker.io` package which is functionally equivalent (Docker Engine 20.10+ with compose plugin available on Ubuntu 22.04+ / Debian 12+ / Fedora 39+). Operators who want upstream `docker-ce` install it themselves; preflight's version check still passes.

## What this PR enables

- **Linux end-users** can now run `bash install-dpf.sh` on a fresh Ubuntu/Debian/Fedora host and reach a running portal (subject to the Phase 7a non-goals above).
- **CI Linux smoke** (Phase 9): the Linux runner can exercise `install-dpf.sh --headless` end-to-end as a release-gate check.
- **Phase 7b** (macOS .dmg) is now well-scoped: replace the macOS branch of `dpf_docker_ensure_installed` and the rest of the flow stays untouched.
- **Phase 8** (lifecycle scripts) can read the now-fully-populated `~/.dpf/install-state.json` instead of redetecting platform reality.

Refs:
- `docs/superpowers/specs/2026-05-09-deployment-contracts.md` — Contract 3 (lifecycle); Contract 9 (LLM provider routing)
- `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 7a; Phase 7b/c/d follow-ups
- #400, #401, #402, #404, #410, #411, #414 (merged) — doctrine + Phases 1–6

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_