### PR TITLE
feat(wiki): EP-WIKI-001 Phase 4a — pure lint detectors

### DIFF
--- a/apps/web/lib/wiki/lint-detectors.test.ts
+++ b/apps/web/lib/wiki/lint-detectors.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectDanglingXrefs,
+  detectKernelDrift,
+  detectOrphans,
+  detectStaleClaims,
+  detectStanceExtractionNeeded,
+  runDetectors,
+  type LintWikiPage,
+} from "./lint-detectors";
+
+// ─── Fixture factory ─────────────────────────────────────────────────────────
+
+function makePage(overrides: Partial<LintWikiPage> = {}): LintWikiPage {
+  return {
+    id: "wp_test",
+    slug: "entities/test",
+    title: "Test",
+    body: "Body content.",
+    pageKind: "entity",
+    status: "published",
+    isKernel: true,
+    kernelVersion: "0.1.0",
+    organizationId: null,
+    kernelPageId: null,
+    derivedFromKernelVersion: null,
+    ...overrides,
+  };
+}
+
+// ─── 1. Orphans ──────────────────────────────────────────────────────────────
+
+describe("detectOrphans", () => {
+  it("flags published page with no inbound links and no sources", () => {
+    const pages = [makePage({ id: "wp1", slug: "entities/lonely" })];
+    const findings = detectOrphans({ pages, links: [], sources: [] });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      pageId: "wp1",
+      findingKind: "orphan",
+      severity: "warn",
+      detail: {
+        slug: "entities/lonely",
+        inboundLinkCount: 0,
+        sourceCitationCount: 0,
+        reason: "no_inbound_links_and_no_sources",
+      },
+    });
+  });
+
+  it("flags page with sources but no inbound links", () => {
+    const pages = [makePage({ id: "wp1" })];
+    const findings = detectOrphans({
+      pages,
+      links: [],
+      sources: [{ pageId: "wp1", sourceId: "src_a" }],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toMatchObject({
+      reason: "no_inbound_links",
+      inboundLinkCount: 0,
+      sourceCitationCount: 1,
+    });
+  });
+
+  it("does not flag well-connected published pages", () => {
+    const pages = [makePage({ id: "wp1" })];
+    const findings = detectOrphans({
+      pages,
+      links: [{ fromPageId: "wp_other", toPageId: "wp1" }],
+      sources: [{ pageId: "wp1", sourceId: "src_a" }],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("ignores draft and archived pages", () => {
+    const pages = [
+      makePage({ id: "wp_draft", status: "draft" }),
+      makePage({ id: "wp_archived", status: "archived" }),
+    ];
+    const findings = detectOrphans({ pages, links: [], sources: [] });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("exempts index and runbook pages from inbound-link requirement", () => {
+    const pages = [
+      makePage({ id: "wp_index", pageKind: "index", slug: "index" }),
+      makePage({ id: "wp_runbook", pageKind: "runbook", slug: "runbooks/deploy" }),
+    ];
+    const findings = detectOrphans({
+      pages,
+      links: [],
+      sources: [
+        { pageId: "wp_index", sourceId: "src_a" },
+        { pageId: "wp_runbook", sourceId: "src_b" },
+      ],
+    });
+    expect(findings).toHaveLength(0);
+  });
+});
+
+// ─── 2. Dangling cross-references ────────────────────────────────────────────
+
+describe("detectDanglingXrefs", () => {
+  it("flags [[slug]] tokens whose target does not exist", () => {
+    const pages = [
+      makePage({
+        id: "wp1",
+        slug: "entities/a",
+        body: "See [[entities/b]] and [[entities/missing]].",
+      }),
+      makePage({ id: "wp2", slug: "entities/b" }),
+    ];
+    const findings = detectDanglingXrefs({ pages });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      pageId: "wp1",
+      findingKind: "dangling-xref",
+      severity: "error",
+      detail: { danglingTargets: ["entities/missing"] },
+    });
+  });
+
+  it("resolves org overlay against kernel + own org slugs (kernel fallback)", () => {
+    const pages = [
+      makePage({ id: "wp_kernel", slug: "entities/digital-product", organizationId: null }),
+      makePage({
+        id: "wp_org",
+        slug: "entities/customer-portal",
+        organizationId: "org_acme",
+        body: "Connects to [[entities/digital-product]] and [[entities/internal]].",
+      }),
+      makePage({ id: "wp_org_internal", slug: "entities/internal", organizationId: "org_acme" }),
+    ];
+    const findings = detectDanglingXrefs({ pages });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not let one org's slugs satisfy another org's references", () => {
+    const pages = [
+      makePage({ id: "wp_a", slug: "entities/private-a", organizationId: "org_a" }),
+      makePage({
+        id: "wp_b",
+        slug: "entities/x",
+        organizationId: "org_b",
+        body: "Refers to [[entities/private-a]].",
+      }),
+    ];
+    const findings = detectDanglingXrefs({ pages });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail.danglingTargets).toEqual(["entities/private-a"]);
+  });
+
+  it("returns no findings when bodies have no wikilinks", () => {
+    const pages = [makePage({ body: "Plain prose with no brackets at all." })];
+    expect(detectDanglingXrefs({ pages })).toHaveLength(0);
+  });
+});
+
+// ─── 3. Stance extraction needed ─────────────────────────────────────────────
+
+describe("detectStanceExtractionNeeded", () => {
+  it("flags published summary pages with no stance/heuristic links", () => {
+    const pages = [
+      makePage({
+        id: "wp1",
+        pageKind: "summary",
+        slug: "summaries/it4it-overview",
+        body: "Refers to [[entities/digital-product]] but no judgment extracted.",
+      }),
+    ];
+    const findings = detectStanceExtractionNeeded({ pages });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      pageId: "wp1",
+      findingKind: "stance-extraction-needed",
+      severity: "info",
+    });
+  });
+
+  it("does not flag summary pages that link to a stance", () => {
+    const pages = [
+      makePage({
+        pageKind: "summary",
+        body: "See [[stances/portfolio-as-anchor]] for the stance.",
+      }),
+    ];
+    expect(detectStanceExtractionNeeded({ pages })).toHaveLength(0);
+  });
+
+  it("does not flag summary pages that link to a heuristic", () => {
+    const pages = [
+      makePage({
+        pageKind: "summary",
+        body: "Apply [[heuristics/split-portfolio-when]] when in doubt.",
+      }),
+    ];
+    expect(detectStanceExtractionNeeded({ pages })).toHaveLength(0);
+  });
+
+  it("ignores non-summary page kinds", () => {
+    const pages = [
+      makePage({ pageKind: "entity", body: "no stance link here" }),
+      makePage({ pageKind: "decision", body: "no stance link here" }),
+      makePage({ pageKind: "runbook", body: "no stance link here" }),
+    ];
+    expect(detectStanceExtractionNeeded({ pages })).toHaveLength(0);
+  });
+
+  it("ignores draft summary pages", () => {
+    const pages = [
+      makePage({ pageKind: "summary", status: "draft", body: "no stance" }),
+    ];
+    expect(detectStanceExtractionNeeded({ pages })).toHaveLength(0);
+  });
+});
+
+// ─── 4. Stale claims ─────────────────────────────────────────────────────────
+
+describe("detectStaleClaims", () => {
+  const now = new Date("2026-05-10T00:00:00Z");
+
+  it("flags pages whose oldest source is older than threshold", () => {
+    const pages = [makePage({ id: "wp1", slug: "summaries/old" })];
+    const sources = [
+      { pageId: "wp1", sourceId: "src_old" },
+      { pageId: "wp1", sourceId: "src_recent" },
+    ];
+    const rawSources = [
+      { id: "src_old", retrievedAt: new Date("2025-01-01T00:00:00Z") },
+      { id: "src_recent", retrievedAt: new Date("2026-04-01T00:00:00Z") },
+    ];
+    const findings = detectStaleClaims({
+      pages,
+      sources,
+      rawSources,
+      staleThresholdDays: 180,
+      now,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      findingKind: "stale",
+      severity: "info",
+      detail: { thresholdDays: 180 },
+    });
+    expect(findings[0].detail.ageDays).toBeGreaterThan(180);
+  });
+
+  it("does not flag pages with all-fresh sources", () => {
+    const pages = [makePage({ id: "wp1" })];
+    const sources = [{ pageId: "wp1", sourceId: "src" }];
+    const rawSources = [
+      { id: "src", retrievedAt: new Date("2026-04-01T00:00:00Z") },
+    ];
+    expect(
+      detectStaleClaims({ pages, sources, rawSources, now }),
+    ).toHaveLength(0);
+  });
+
+  it("skips pages with no sources (handled by orphan detector)", () => {
+    const pages = [makePage({ id: "wp1" })];
+    expect(
+      detectStaleClaims({ pages, sources: [], rawSources: [], now }),
+    ).toHaveLength(0);
+  });
+
+  it("skips pages whose sources have no retrievedAt timestamp", () => {
+    const pages = [makePage({ id: "wp1" })];
+    const sources = [{ pageId: "wp1", sourceId: "src" }];
+    const rawSources = [{ id: "src", retrievedAt: null }];
+    expect(
+      detectStaleClaims({ pages, sources, rawSources, now }),
+    ).toHaveLength(0);
+  });
+
+  it("uses default threshold of 180 days when unspecified", () => {
+    const pages = [makePage({ id: "wp1" })];
+    const sources = [{ pageId: "wp1", sourceId: "src" }];
+    const rawSources = [
+      { id: "src", retrievedAt: new Date("2025-10-01T00:00:00Z") },
+    ];
+    const findings = detectStaleClaims({ pages, sources, rawSources, now });
+    expect(findings[0].detail.thresholdDays).toBe(180);
+  });
+});
+
+// ─── 5. Kernel drift ─────────────────────────────────────────────────────────
+
+describe("detectKernelDrift", () => {
+  it("flags overlays whose derivedFromKernelVersion is older than current", () => {
+    const pages = [
+      makePage({
+        id: "wp_overlay",
+        slug: "entities/digital-product",
+        organizationId: "org_acme",
+        kernelPageId: "wp_kernel",
+        derivedFromKernelVersion: "0.1.0",
+      }),
+    ];
+    const findings = detectKernelDrift({ pages, currentKernelVersion: "0.2.0" });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      pageId: "wp_overlay",
+      organizationId: "org_acme",
+      findingKind: "kernel-drift",
+      severity: "warn",
+      detail: {
+        derivedFromKernelVersion: "0.1.0",
+        currentKernelVersion: "0.2.0",
+      },
+    });
+  });
+
+  it("does not flag overlays already on the current kernel version", () => {
+    const pages = [
+      makePage({
+        kernelPageId: "wp_kernel",
+        derivedFromKernelVersion: "0.2.0",
+        organizationId: "org_acme",
+      }),
+    ];
+    expect(
+      detectKernelDrift({ pages, currentKernelVersion: "0.2.0" }),
+    ).toHaveLength(0);
+  });
+
+  it("does not flag org-original pages (no kernelPageId)", () => {
+    const pages = [
+      makePage({
+        kernelPageId: null,
+        derivedFromKernelVersion: null,
+        organizationId: "org_acme",
+      }),
+    ];
+    expect(
+      detectKernelDrift({ pages, currentKernelVersion: "0.2.0" }),
+    ).toHaveLength(0);
+  });
+
+  it("does not flag kernel pages themselves", () => {
+    const pages = [
+      makePage({
+        kernelPageId: null,
+        derivedFromKernelVersion: null,
+        organizationId: null,
+        isKernel: true,
+      }),
+    ];
+    expect(
+      detectKernelDrift({ pages, currentKernelVersion: "0.2.0" }),
+    ).toHaveLength(0);
+  });
+});
+
+// ─── Aggregator ──────────────────────────────────────────────────────────────
+
+describe("runDetectors", () => {
+  it("returns the union of all detector findings", () => {
+    const pages = [
+      // Orphan: published, no inbound, no sources
+      makePage({ id: "wp_orphan", slug: "entities/orphan" }),
+      // Dangling: cites a missing slug
+      makePage({
+        id: "wp_dangling",
+        slug: "entities/dangling-source",
+        body: "[[entities/missing]]",
+      }),
+      // Stance-extraction-needed: summary with no stance link
+      makePage({
+        id: "wp_summary",
+        pageKind: "summary",
+        slug: "summaries/no-stance",
+        body: "no stance link",
+      }),
+      // Drift: overlay one version behind
+      makePage({
+        id: "wp_overlay",
+        slug: "entities/dp",
+        organizationId: "org_acme",
+        kernelPageId: "wp_kernel",
+        derivedFromKernelVersion: "0.1.0",
+      }),
+      // Kernel referent for the overlay (so the overlay isn't also flagged dangling)
+      makePage({ id: "wp_kernel", slug: "entities/dp" }),
+    ];
+
+    const findings = runDetectors({
+      pages,
+      links: [],
+      sources: [],
+      rawSources: [],
+      currentKernelVersion: "0.2.0",
+    });
+
+    const kinds = findings.map((f) => f.findingKind).sort();
+    expect(kinds).toContain("orphan");
+    expect(kinds).toContain("dangling-xref");
+    expect(kinds).toContain("stance-extraction-needed");
+    expect(kinds).toContain("kernel-drift");
+  });
+});

--- a/apps/web/lib/wiki/lint-detectors.ts
+++ b/apps/web/lib/wiki/lint-detectors.ts
@@ -1,0 +1,379 @@
+// EP-WIKI-001 Phase 4a: pure lint detectors.
+// Spec: docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md §6
+// Plan: docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md (Phase 4a)
+//
+// These detectors are pure functions: they take typed snapshots of the
+// wiki state and return findings. Side-effecting concerns (DB read,
+// finding persistence, scheduled invocation, admin UI) live in Phase 4b
+// (`runWikiLint` orchestrator, Inngest job, /admin/wiki/lint route).
+//
+// Five of the seven §6 detectors land here. The remaining two need
+// either an LLM call (`detectContradictions`) or entity recognition
+// (`detectMissingXrefs`); they belong in Phase 4b alongside the
+// orchestrator that can supply those services.
+
+// ─── Finding shape ──────────────────────────────────────────────────────────
+
+/** Mirrors the `WikiLintFinding.findingKind` enum on the Prisma model. */
+export type LintFindingKind =
+  | "contradiction"
+  | "stale"
+  | "orphan"
+  | "missing-xref"
+  | "dangling-xref"
+  | "kernel-drift"
+  | "stance-extraction-needed";
+
+/** Mirrors the `WikiLintFinding.severity` enum. */
+export type LintSeverity = "info" | "warn" | "error";
+
+/**
+ * What a detector emits. Persisted as `WikiLintFinding` rows; the DB
+ * adds `id`, `createdAt`, `status`, `resolvedAt`. Detectors emit
+ * findings; they do not write rows.
+ */
+export type LintFinding = {
+  organizationId: string | null;
+  pageId: string;
+  findingKind: LintFindingKind;
+  severity: LintSeverity;
+  detail: Record<string, unknown>;
+};
+
+// ─── Input snapshots (narrow read-only views of the wiki) ───────────────────
+
+export type LintWikiPage = {
+  id: string;
+  slug: string;
+  title: string;
+  body: string;
+  pageKind: string;
+  status: string;
+  isKernel: boolean;
+  kernelVersion: string | null;
+  organizationId: string | null;
+  kernelPageId: string | null;
+  derivedFromKernelVersion: string | null;
+};
+
+export type LintWikiPageLink = {
+  fromPageId: string;
+  toPageId: string;
+};
+
+export type LintWikiPageSource = {
+  pageId: string;
+  sourceId: string;
+};
+
+export type LintRawSource = {
+  id: string;
+  retrievedAt: Date | null;
+};
+
+// ─── 1. Orphans ─────────────────────────────────────────────────────────────
+
+/**
+ * Published page with **no inbound `WikiPageLink`** OR with an empty
+ * `WikiPageSource[]` list.
+ *
+ * Severity: warn. Per spec §13, citation-empty pages cannot be
+ * `published` — but a published row that lost its sources via a
+ * delete-cascade would slip past the publish gate; the lint catches it.
+ *
+ * Index pages are exempt: their job is to *be* link aggregators, not
+ * to be linked-to. Same for `runbook` pages, which are entry points.
+ */
+export function detectOrphans(input: {
+  pages: LintWikiPage[];
+  links: LintWikiPageLink[];
+  sources: LintWikiPageSource[];
+}): LintFinding[] {
+  const inboundCount = new Map<string, number>();
+  for (const link of input.links) {
+    inboundCount.set(link.toPageId, (inboundCount.get(link.toPageId) ?? 0) + 1);
+  }
+
+  const sourceCount = new Map<string, number>();
+  for (const src of input.sources) {
+    sourceCount.set(src.pageId, (sourceCount.get(src.pageId) ?? 0) + 1);
+  }
+
+  const findings: LintFinding[] = [];
+  for (const page of input.pages) {
+    if (page.status !== "published") continue;
+    if (page.pageKind === "index" || page.pageKind === "runbook") continue;
+
+    const inbound = inboundCount.get(page.id) ?? 0;
+    const cites = sourceCount.get(page.id) ?? 0;
+
+    if (inbound === 0 || cites === 0) {
+      findings.push({
+        organizationId: page.organizationId,
+        pageId: page.id,
+        findingKind: "orphan",
+        severity: "warn",
+        detail: {
+          slug: page.slug,
+          inboundLinkCount: inbound,
+          sourceCitationCount: cites,
+          reason:
+            inbound === 0 && cites === 0
+              ? "no_inbound_links_and_no_sources"
+              : inbound === 0
+                ? "no_inbound_links"
+                : "no_sources",
+        },
+      });
+    }
+  }
+  return findings;
+}
+
+// ─── 2. Dangling cross-references ───────────────────────────────────────────
+
+/**
+ * `[[slug]]` token in a page body whose target page does not exist
+ * for the same scope (kernel for kernel pages; org overlay for org
+ * pages, falling back to kernel).
+ *
+ * Severity: error. Spec §13: "blocks publish if any [[...]] is dangling."
+ */
+export function detectDanglingXrefs(input: {
+  pages: LintWikiPage[];
+}): LintFinding[] {
+  // Build per-organization slug sets. Kernel slugs are visible to every
+  // org overlay (kernel fallback), so each org's resolution set is
+  // (org slugs) ∪ (kernel slugs).
+  const kernelSlugs = new Set<string>();
+  const orgSlugs = new Map<string, Set<string>>();
+
+  for (const page of input.pages) {
+    if (page.organizationId === null) {
+      kernelSlugs.add(page.slug);
+    } else {
+      let set = orgSlugs.get(page.organizationId);
+      if (!set) {
+        set = new Set<string>();
+        orgSlugs.set(page.organizationId, set);
+      }
+      set.add(page.slug);
+    }
+  }
+
+  const findings: LintFinding[] = [];
+  for (const page of input.pages) {
+    const tokens = extractWikilinks(page.body);
+    if (tokens.length === 0) continue;
+
+    const visible =
+      page.organizationId === null
+        ? kernelSlugs
+        : new Set<string>([...(orgSlugs.get(page.organizationId) ?? []), ...kernelSlugs]);
+
+    const dangling = tokens.filter((slug) => !visible.has(slug));
+    if (dangling.length === 0) continue;
+
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "dangling-xref",
+      severity: "error",
+      detail: {
+        slug: page.slug,
+        danglingTargets: dangling,
+      },
+    });
+  }
+  return findings;
+}
+
+/** Internal helper — same regex as `seed-wiki-kernel.ts:extractWikilinks`. */
+function extractWikilinks(body: string): string[] {
+  const matches = body.matchAll(/\[\[([a-zA-Z0-9/_-]+)\]\]/g);
+  const slugs = new Set<string>();
+  for (const m of matches) {
+    if (m[1]) slugs.add(m[1]);
+  }
+  return Array.from(slugs);
+}
+
+// ─── 3. Stance extraction needed ────────────────────────────────────────────
+
+/**
+ * `summary` page whose body has no `[[stances/...]]` or
+ * `[[heuristics/...]]` link extracted.
+ *
+ * Severity: info. Per spec §6: "the kernel's purpose is judgment, not
+ * summarization. Summary-only pages defeat the 'what would Mark do?'
+ * goal."
+ */
+export function detectStanceExtractionNeeded(input: {
+  pages: LintWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of input.pages) {
+    if (page.pageKind !== "summary") continue;
+    if (page.status !== "published") continue;
+
+    const tokens = extractWikilinks(page.body);
+    const hasStanceOrHeuristic = tokens.some(
+      (t) => t.startsWith("stances/") || t.startsWith("heuristics/"),
+    );
+    if (hasStanceOrHeuristic) continue;
+
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "stance-extraction-needed",
+      severity: "info",
+      detail: {
+        slug: page.slug,
+        message:
+          "Summary page does not link to any stance or heuristic. " +
+          "Consider extracting the underlying judgment as a stance or heuristic page.",
+      },
+    });
+  }
+  return findings;
+}
+
+// ─── 4. Stale claims ────────────────────────────────────────────────────────
+
+/**
+ * Page whose oldest `RawSource.retrievedAt` exceeds `staleThresholdDays`.
+ *
+ * Severity: info. Source data ages — this is a *signal* that the
+ * underlying material may have been superseded, not a publish blocker.
+ */
+export function detectStaleClaims(input: {
+  pages: LintWikiPage[];
+  sources: LintWikiPageSource[];
+  rawSources: LintRawSource[];
+  staleThresholdDays?: number;
+  now?: Date;
+}): LintFinding[] {
+  const threshold = input.staleThresholdDays ?? 180;
+  const now = input.now ?? new Date();
+  const cutoff = new Date(now.getTime() - threshold * 24 * 60 * 60 * 1000);
+
+  const rawById = new Map<string, LintRawSource>();
+  for (const r of input.rawSources) {
+    rawById.set(r.id, r);
+  }
+
+  const sourcesByPage = new Map<string, string[]>();
+  for (const ws of input.sources) {
+    let list = sourcesByPage.get(ws.pageId);
+    if (!list) {
+      list = [];
+      sourcesByPage.set(ws.pageId, list);
+    }
+    list.push(ws.sourceId);
+  }
+
+  const findings: LintFinding[] = [];
+  for (const page of input.pages) {
+    if (page.status !== "published") continue;
+    const sourceIds = sourcesByPage.get(page.id) ?? [];
+    if (sourceIds.length === 0) continue; // orphan-detector handles empty source lists
+
+    let oldest: Date | null = null;
+    for (const sid of sourceIds) {
+      const r = rawById.get(sid);
+      if (!r?.retrievedAt) continue;
+      if (oldest === null || r.retrievedAt < oldest) oldest = r.retrievedAt;
+    }
+    if (oldest === null) continue; // no retrievedAt timestamps yet
+    if (oldest > cutoff) continue; // fresh enough
+
+    const ageDays = Math.floor((now.getTime() - oldest.getTime()) / (24 * 60 * 60 * 1000));
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "stale",
+      severity: "info",
+      detail: {
+        slug: page.slug,
+        oldestSourceRetrievedAt: oldest.toISOString(),
+        ageDays,
+        thresholdDays: threshold,
+      },
+    });
+  }
+  return findings;
+}
+
+// ─── 5. Kernel drift ────────────────────────────────────────────────────────
+
+/**
+ * Org overlay whose `derivedFromKernelVersion` is older than the
+ * current `kernelVersion`.
+ *
+ * Severity: warn. Phase 4a ships the simple "version mismatch" check.
+ * Phase 4b will add the paragraph-hash diff per spec §3.3 ("kernel
+ * diff touched a paragraph the override also modifies"); until then
+ * the simple version surfaces drift candidates conservatively.
+ */
+export function detectKernelDrift(input: {
+  pages: LintWikiPage[];
+  currentKernelVersion: string;
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of input.pages) {
+    if (page.kernelPageId === null) continue; // org-original, not an override
+    if (page.derivedFromKernelVersion === null) continue;
+    if (page.derivedFromKernelVersion === input.currentKernelVersion) continue;
+
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "kernel-drift",
+      severity: "warn",
+      detail: {
+        slug: page.slug,
+        derivedFromKernelVersion: page.derivedFromKernelVersion,
+        currentKernelVersion: input.currentKernelVersion,
+      },
+    });
+  }
+  return findings;
+}
+
+// ─── Aggregator ─────────────────────────────────────────────────────────────
+
+/**
+ * Run every Phase 4a detector against a snapshot of the wiki and
+ * return the union of findings. Phase 4b's `runWikiLint()` orchestrator
+ * will call this after fetching the snapshot from Prisma.
+ */
+export function runDetectors(input: {
+  pages: LintWikiPage[];
+  links: LintWikiPageLink[];
+  sources: LintWikiPageSource[];
+  rawSources: LintRawSource[];
+  currentKernelVersion: string;
+  staleThresholdDays?: number;
+  now?: Date;
+}): LintFinding[] {
+  return [
+    ...detectOrphans({
+      pages: input.pages,
+      links: input.links,
+      sources: input.sources,
+    }),
+    ...detectDanglingXrefs({ pages: input.pages }),
+    ...detectStanceExtractionNeeded({ pages: input.pages }),
+    ...detectStaleClaims({
+      pages: input.pages,
+      sources: input.sources,
+      rawSources: input.rawSources,
+      staleThresholdDays: input.staleThresholdDays,
+      now: input.now,
+    }),
+    ...detectKernelDrift({
+      pages: input.pages,
+      currentKernelVersion: input.currentKernelVersion,
+    }),
+  ];
+}

--- a/docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md
+++ b/docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md
@@ -158,9 +158,38 @@ After Phase 5 (kernel seed content) lands and we've validated `WikiPage` in real
 
 **Branch:** `feat/wiki-lint`
 
+**Implementation note (added 2026-05-10).** Phase 4 is split into 4a (pure detectors only) and 4b (orchestrator + scheduled job + admin UI + MCP tool) so the detectors can land independently of Inngest + UI plumbing. The detectors are testable in isolation against synthetic fixtures, so they are usable from any caller (manual run, on-demand admin trigger, scheduled job) once 4b's orchestrator wires them up.
+
+### Phase 4a — Pure detectors
+
+**Branch:** `feat/wiki-lint-detectors`
+
 **Files created:**
-- `apps/web/lib/wiki/lint.ts` — `runWikiLint({ organizationId | null })`, individual checkers (`detectContradictions`, `detectStaleClaims`, `detectOrphans`, `detectMissingXrefs`, `detectDanglingXrefs`, `detectKernelDrift`, `detectStanceExtractionNeeded`).
-- `apps/web/lib/wiki/lint.test.ts`
+- `apps/web/lib/wiki/lint-detectors.ts` — five of the seven §6 detectors as pure functions (no DB, no LLM, no network):
+  - `detectOrphans` — published page with no inbound link or empty source list (warn). Index/runbook pages exempt.
+  - `detectDanglingXrefs` — `[[slug]]` token with no resolvable target in the page's visibility scope (error). Org overlays resolve against own-org slugs ∪ kernel slugs (kernel fallback).
+  - `detectStanceExtractionNeeded` — published `summary` page with no `[[stances/...]]` or `[[heuristics/...]]` link (info).
+  - `detectStaleClaims` — page whose oldest `RawSource.retrievedAt` exceeds `staleThresholdDays` (default 180) (info).
+  - `detectKernelDrift` — overlay's `derivedFromKernelVersion ≠ currentKernelVersion` (warn). Phase 4a ships the simple version-mismatch check; Phase 4b adds the paragraph-hash diff per spec §3.3.
+  - Plus a `runDetectors()` aggregator that returns the union.
+- `apps/web/lib/wiki/lint-detectors.test.ts` — vitest coverage for each detector (positive case, negative case, edge cases like draft/archived pages, kernel fallback, missing data).
+
+**Deferred to Phase 4b:**
+- `detectContradictions` — needs cosine search over `wiki-pages` Qdrant collection plus an LLM judge. Belongs alongside the orchestrator that has DB + Qdrant + LLM access.
+- `detectMissingXrefs` — needs entity recognition over the body. Belongs alongside the orchestrator (or shipped as its own follow-up if the NLP work is large).
+
+**Acceptance (Phase 4a):**
+- Each shipped detector produces findings on its fixture and emits no findings on its negative-case fixture.
+- `runDetectors()` returns the union without crosstalk.
+- `pnpm typecheck` and `pnpm --filter web test --run lint-detectors.test.ts` clean.
+
+### Phase 4b — Orchestrator + scheduled job + admin UI + MCP tool
+
+**Branch:** `feat/wiki-lint-runtime`
+
+**Files created:**
+- `apps/web/lib/wiki/lint.ts` — `runWikiLint({ organizationId | null })`: fetches wiki snapshot from Prisma, calls `runDetectors()`, plus implements `detectContradictions` (Qdrant cosine + LLM judge) and `detectMissingXrefs` (entity recognition). Persists findings as `WikiLintFinding` rows; idempotent against existing open findings (re-runs update, don't duplicate).
+- `apps/web/lib/wiki/lint.test.ts` — integration tests against a mocked Prisma client.
 - `apps/web/lib/queue/functions/wiki-lint.ts` — Inngest scheduled function (daily 03:30 local; mirror `infra-prune.ts`).
 - `apps/web/app/(shell)/admin/wiki/lint/page.tsx` — list of `WikiLintFinding` filtered by org/kernel + status.
 - `apps/web/components/wiki/LintFindingCard.tsx`
@@ -170,11 +199,11 @@ After Phase 5 (kernel seed content) lands and we've validated `WikiPage` in real
 - `apps/web/lib/mcp-tools.ts` — add `wiki_lint` (read-only on-demand trigger).
 - `apps/web/lib/tak/agent-grants.ts` — `wiki_lint: ["registry_read"]`.
 
-**Acceptance:**
-- Each detector produces a finding on its fixture: contradiction between two pages → finding; stale page → finding; orphan → finding; missing-xref → finding; dangling-xref → blocks publish; kernel-drift → finding; summary without stance → finding.
+**Acceptance (Phase 4b):**
+- Each detector (including the two added in 4b) produces a finding on its fixture.
 - Daily run completes within 5 minutes for a 1k-page wiki on a single org.
 - Findings carry `organizationId` correctly; kernel findings are visible only to platform admins.
-- Re-runs are idempotent (no duplicate findings).
+- Re-runs are idempotent (no duplicate findings — existing open findings are updated, not re-inserted).
 - `/admin/wiki/lint` renders findings with theme-aware tokens per AGENTS.md §12.
 
 ---


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 4a — **pure lint detectors**. Five of the seven §6 detectors as pure functions with no DB, LLM, network, or Inngest dependencies. Phase 4b will wire them into the runtime orchestrator and add the remaining two (`detectContradictions`, `detectMissingXrefs`) which need Qdrant cosine + LLM judge / entity recognition respectively.

Independent of [PR #415](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/415) (Phase 5 machinery) — both depend only on Phase 1a, which is on `main`.

## Phase split rationale (added 2026-05-10)

The detectors are testable in isolation and stable enough to land independently of the Inngest + UI plumbing. Splitting keeps the surface that needs careful **logic review** (the detectors) separate from the surface that needs careful **infrastructure review** (scheduled jobs, admin UI, MCP tool registration, Qdrant cosine, LLM calls).

## What&#39;s in this PR

### `apps/web/lib/wiki/lint-detectors.ts`

Five pure detectors:

| Detector | Severity | What it flags |
|----------|----------|---------------|
| `detectOrphans` | warn | published page with no inbound link or empty source list. `index` and `runbook` pages exempt. |
| `detectDanglingXrefs` | error | `[[slug]]` token with no resolvable target. Org overlays resolve against own-org slugs ∪ kernel slugs (kernel fallback per spec §3.3). |
| `detectStanceExtractionNeeded` | info | published `summary` page with no `[[stances/...]]` or `[[heuristics/...]]` link. The kernel exists for judgment, not summarization. |
| `detectStaleClaims` | info | page whose oldest `RawSource.retrievedAt` exceeds `staleThresholdDays` (default 180). |
| `detectKernelDrift` | warn | overlay&#39;s `derivedFromKernelVersion ≠ currentKernelVersion`. Phase 4a ships the simple version-mismatch check; Phase 4b adds the paragraph-hash diff per spec §3.3. |

Plus a `runDetectors()` aggregator returning the union.

### `apps/web/lib/wiki/lint-detectors.test.ts`

24 vitest cases. For each detector: positive case, negative case, edge cases (draft/archived exemption, kernel fallback, cross-org isolation, missing data handling, default thresholds, page-kind exemptions).

### Plan update

`docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md` Phase 4 section split into 4a (this PR) and 4b (orchestrator + Inngest scheduled job + admin UI + MCP tool + the two LLM/Qdrant detectors).

## Detectors deferred to Phase 4b

| Detector | Why deferred |
|----------|--------------|
| `detectContradictions` | Needs cosine search over the `wiki-pages` Qdrant collection plus an LLM judge. Belongs alongside the orchestrator that has DB + Qdrant + LLM access. |
| `detectMissingXrefs` | Needs entity recognition over the body. Belongs alongside the orchestrator (or shipped as its own follow-up if the NLP work is large). |

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter web typecheck` | ✓ |
| `pnpm --filter web test --run lint-detectors.test.ts` | ✓ 24/24 |

## Test plan

- [ ] Read `lint-detectors.ts` for each detector&#39;s logic
- [ ] Confirm the page-kind exemptions on `detectOrphans` (index, runbook) are correct
- [ ] Confirm the kernel-fallback resolution semantics on `detectDanglingXrefs`
- [ ] Confirm `detectKernelDrift`&#39;s simple version-mismatch shape is acceptable for Phase 4a; the paragraph-hash refinement lands in Phase 4b

## Out of scope (Phase 4b)

- The runtime orchestrator (`runWikiLint`) that fetches the snapshot from Prisma and persists findings.
- The Inngest scheduled function (daily run).
- The admin UI at `/admin/wiki/lint`.
- The `wiki_lint` MCP tool registration.
- The two remaining detectors that need Qdrant cosine + LLM (`detectContradictions`) and entity recognition (`detectMissingXrefs`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_