### PR TITLE
feat(installer): macOS Docker Desktop .dmg install (Phase 7b)

### DIFF
--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -49,7 +49,7 @@ LIB_DIR="$REPO_ROOT/scripts/installer/lib"
 . "$LIB_DIR/docker.sh"
 
 # Installer version (semver-ish; bump per release).
-DPF_INSTALLER_VERSION="2026.05.10-phase7a"
+DPF_INSTALLER_VERSION="2026.05.10-phase7b"
 
 # ── CLI handling ────────────────────────────────────────────────────────────
 

--- a/scripts/installer/lib/docker.sh
+++ b/scripts/installer/lib/docker.sh
@@ -76,7 +76,91 @@ dpf_docker_endpoint() {
     || echo ""
 }
 
-# Linux-only: install Docker Engine via the host's distro package
+# Apple Silicon Docker Desktop .dmg download URL. Hardcoded to the
+# canonical Docker Desktop endpoint; can be overridden via env var
+# for mirror / corporate-proxy setups.
+DPF_DOCKER_DESKTOP_DMG_URL="${DPF_DOCKER_DESKTOP_DMG_URL:-https://desktop.docker.com/mac/main/arm64/Docker.dmg}"
+
+# macOS-only: install Docker Desktop by downloading the .dmg directly
+# from Docker's official endpoint, mounting it via hdiutil, copying
+# Docker.app into /Applications, ejecting the volume, then launching
+# Docker.app and waiting for the daemon.
+#
+# Deliberately does NOT bootstrap Homebrew per the installer-parity
+# roadmap. Customers who want Homebrew install it themselves; this
+# function only needs Docker.app to land in /Applications.
+#
+# Args: none.
+dpf_docker_install_darwin() {
+  dpf_platform
+  if [ "$DPF_PLATFORM" != "darwin" ]; then
+    fail "dpf_docker_install_darwin: not on Darwin"
+  fi
+
+  # Apple Silicon-only per the installer-parity roadmap (preflight
+  # refuses Intel Mac). Belt-and-suspenders check.
+  if [ "$(uname -m)" != "arm64" ]; then
+    fail "dpf_docker_install_darwin: only Apple Silicon is supported; preflight should have refused Intel Mac."
+  fi
+
+  local dmg="${TMPDIR:-/tmp}/DPF-DockerDesktop-$(date +%s).dmg"
+  local mountpoint="/Volumes/Docker"
+
+  info "Downloading Docker Desktop for Apple Silicon..."
+  info "  Source: $DPF_DOCKER_DESKTOP_DMG_URL"
+  info "  Target: $dmg"
+  if ! curl -fsSL --max-time 600 -o "$dmg" "$DPF_DOCKER_DESKTOP_DMG_URL"; then
+    fail "Failed to download Docker Desktop .dmg from $DPF_DOCKER_DESKTOP_DMG_URL. Check network connectivity, or install Docker Desktop manually from https://www.docker.com/products/docker-desktop/ and re-run install-dpf.sh."
+  fi
+  ok "Downloaded Docker Desktop .dmg"
+
+  info "Mounting .dmg..."
+  if ! hdiutil attach -nobrowse -quiet "$dmg"; then
+    rm -f "$dmg"
+    fail "Failed to mount Docker Desktop .dmg. The downloaded file may be corrupt; delete $dmg and re-run."
+  fi
+
+  # Cleanup trap — eject the .dmg and remove the download even if the
+  # cp below fails.
+  _dpf_dmg_cleanup() {
+    hdiutil detach -quiet "$mountpoint" 2>/dev/null || true
+    rm -f "$dmg"
+  }
+  trap _dpf_dmg_cleanup EXIT
+
+  info "Copying Docker.app into /Applications..."
+  if ! sudo cp -R "$mountpoint/Docker.app" /Applications/; then
+    _dpf_dmg_cleanup
+    trap - EXIT
+    fail "Failed to copy Docker.app into /Applications. This often means MDM (corporate device management) restricts /Applications writes. Install Docker Desktop manually from https://www.docker.com/products/docker-desktop/ (drag Docker.app from the mounted .dmg yourself) and re-run install-dpf.sh."
+  fi
+  ok "Copied Docker.app into /Applications"
+
+  _dpf_dmg_cleanup
+  trap - EXIT
+
+  info "Launching Docker.app and waiting for daemon..."
+  open -a Docker
+
+  # Wait-for-daemon loop. Docker Desktop typically takes 30-120s to
+  # boot on a fresh install (first-run prompts not shown when --headless,
+  # but the VM still has to start).
+  local wait_seconds="${DPF_DOCKER_DESKTOP_START_TIMEOUT:-300}"
+  local elapsed=0
+  while [ "$elapsed" -lt "$wait_seconds" ]; do
+    if docker info >/dev/null 2>&1; then
+      ok "Docker daemon reachable after ${elapsed}s"
+      return 0
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+    if [ "$((elapsed % 30))" = "0" ]; then
+      info "  Still waiting for Docker Desktop daemon... (${elapsed}s / ${wait_seconds}s)"
+    fi
+  done
+
+  fail "Docker Desktop did not become reachable within ${wait_seconds}s. On first launch, Docker Desktop may show a Welcome / Privacy prompt that requires manual confirmation. Open Docker.app from /Applications, complete the first-run flow, then re-run install-dpf.sh."
+}
 # manager. Refuses gracefully on unsupported distros; the caller
 # (install-dpf.sh) preflight already weeded out older / unsupported
 # distros, so this function trusts that gate.
@@ -138,16 +222,14 @@ dpf_docker_install_linux() {
 }
 
 # Ensure Docker is present at acceptable version. Installs on Linux
-# if missing. macOS .dmg flow is Phase 7b; preflight catches Intel
-# Mac, so this function only encounters Apple Silicon Macs that
-# either already have Docker Desktop or need the user to install it
-# manually (until Phase 7b ships).
+# (apt/dnf) or macOS (Docker Desktop .dmg) if missing.
 #
 # Args: none.
 # Returns:
 #   0   Docker present and version acceptable
 #   75  Docker just installed; operator must log out / newgrp and re-run
-#   non-zero otherwise
+#       (Linux only — macOS does not require a re-login after install)
+#   non-zero otherwise (fail messages emitted)
 dpf_docker_ensure_installed() {
   dpf_platform
 
@@ -161,19 +243,55 @@ dpf_docker_ensure_installed() {
       return $?
     fi
     if [ "$DPF_PLATFORM" = "darwin" ]; then
-      fail "Docker Desktop not detected. Until installer-parity Phase 7b ships the automated .dmg install, please install Docker Desktop manually from https://www.docker.com/products/docker-desktop/ and re-run install-dpf.sh."
+      # Check /Applications/Docker.app as a sanity step before downloading
+      # the .dmg — if Docker.app is present but the CLI isn't on PATH,
+      # the operator has Docker Desktop installed but never launched it.
+      if [ -d "/Applications/Docker.app" ]; then
+        info "Docker.app found in /Applications but the daemon isn't running."
+        info "  Launching Docker.app and waiting..."
+        open -a Docker
+        local wait_seconds="${DPF_DOCKER_DESKTOP_START_TIMEOUT:-300}"
+        local elapsed=0
+        while [ "$elapsed" -lt "$wait_seconds" ]; do
+          if docker info >/dev/null 2>&1; then
+            ok "Docker daemon reachable after ${elapsed}s"
+            return 0
+          fi
+          sleep 5
+          elapsed=$((elapsed + 5))
+        done
+        fail "Docker Desktop did not become reachable within ${wait_seconds}s. Open Docker.app, complete any first-run prompts, and re-run install-dpf.sh."
+      fi
+      # No Docker.app — install via .dmg.
+      dpf_docker_install_darwin
+      return $?
     fi
     fail "Unsupported platform for Docker install: $DPF_PLATFORM"
   fi
 
   if ! dpf_docker_version_ge "$version" "$DPF_DOCKER_MIN_VERSION"; then
-    fail "Docker $version is below the supported floor ($DPF_DOCKER_MIN_VERSION+; host-gateway support required). Upgrade Docker Engine and re-run install-dpf.sh."
+    fail "Docker $version is below the supported floor ($DPF_DOCKER_MIN_VERSION+; host-gateway support required). Upgrade Docker Engine / Docker Desktop and re-run install-dpf.sh."
   fi
 
   ok "Docker $version present"
 
   # Verify the daemon is reachable.
   if ! docker info >/dev/null 2>&1; then
+    if [ "$DPF_PLATFORM" = "darwin" ] && [ -d "/Applications/Docker.app" ]; then
+      info "Docker CLI present but daemon not running. Launching Docker.app..."
+      open -a Docker
+      local wait_seconds="${DPF_DOCKER_DESKTOP_START_TIMEOUT:-300}"
+      local elapsed=0
+      while [ "$elapsed" -lt "$wait_seconds" ]; do
+        if docker info >/dev/null 2>&1; then
+          ok "Docker daemon reachable after ${elapsed}s"
+          return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      fail "Docker Desktop did not become reachable within ${wait_seconds}s."
+    fi
     fail "Docker daemon is not reachable. On macOS: open Docker Desktop and wait for it to start. On Linux: sudo systemctl start docker."
   fi
   ok "Docker daemon reachable"


### PR DESCRIPTION
## Summary

Implements **Phase 7b** of the Mac/Linux installer-parity roadmap: automated Docker Desktop install on Apple Silicon via the .dmg flow, replacing Phase 7a's deferral message with the real installer path.

One-file change (`scripts/installer/lib/docker.sh`) plus a one-line installer-version bump in `install-dpf.sh`. +127 / -9 lines.

### Changes

**`scripts/installer/lib/docker.sh`** — adds `dpf_docker_install_darwin`

The .dmg install flow:

1. **Resolve** `DPF_DOCKER_DESKTOP_DMG_URL` (default: canonical `https://desktop.docker.com/mac/main/arm64/Docker.dmg`; override-able for corporate mirrors).
2. **Download** via `curl -fsSL --max-time 600 -o $TMPDIR/DPF-DockerDesktop-<ts>.dmg`.
3. **Mount** via `hdiutil attach -nobrowse -quiet` to `/Volumes/Docker`.
4. **Copy** `sudo cp -R /Volumes/Docker/Docker.app /Applications/`. `EXIT` trap ejects + deletes the download on any failure. If `cp` fails (typically MDM-restricted `/Applications`), exits with a clear manual-install instruction.
5. **Eject** `hdiutil detach /Volumes/Docker`; `rm` the .dmg.
6. **Launch** `open -a Docker`.
7. **Wait-for-daemon** loop: poll `docker info` every 5s for up to `DPF_DOCKER_DESKTOP_START_TIMEOUT` (default 300s). Progress logs every 30s.
8. **Returns 0** when daemon is reachable. On timeout, fails with a manual-confirmation instruction (Docker Desktop's first-launch prompt may need GUI interaction).

Apple Silicon-only per the roadmap; belt-and-suspenders `uname -m` check. **Does NOT bootstrap Homebrew** (explicit non-goal per the roadmap's revision-history note).

**`scripts/installer/lib/docker.sh`** — updates `dpf_docker_ensure_installed`

Two new code paths on macOS:
1. **Docker.app present but daemon not reachable** (operator has Docker Desktop installed but never launched it) → launches via `open -a Docker` and waits.
2. **Docker CLI present but daemon not reachable** (same scenario via a different signal) → same recovery path.

Both paths reuse the same `DPF_DOCKER_DESKTOP_START_TIMEOUT` bound.

Previously the macOS branch unconditionally failed with the Phase-7b deferral message; now it dispatches to `dpf_docker_install_darwin` when Docker.app is absent.

**`install-dpf.sh`** — version bump: `2026.05.10-phase7a` → `2026.05.10-phase7b`.

## Test plan

Verified locally:

- [x] `bash -n` on `install-dpf.sh` + `scripts/installer/lib/docker.sh` passes
- [x] `bash install-dpf.sh --dry-run --headless` still exits 0 (Phase 6/7a behavior preserved; new macOS code path is dormant on Linux runner)
- [x] DCO sign-off

To verify on real Apple Silicon:

- [ ] **Apple Silicon Mac without Docker Desktop**: `bash install-dpf.sh --headless` downloads the .dmg, mounts it, copies Docker.app to /Applications, launches Docker, waits for daemon, then continues the rest of the install flow.
- [ ] **Apple Silicon Mac with Docker.app present but daemon not running**: installer detects Docker.app, launches it via `open -a Docker`, waits for daemon, then continues — no download needed.
- [ ] **Apple Silicon Mac with MDM-restricted /Applications**: installer fails the `cp` step with the clear manual-install instruction and exits non-zero.
- [ ] **Apple Silicon Mac with first-launch Docker Desktop privacy prompt**: installer fails the daemon wait loop with the manual-confirmation instruction.

## What this PR does NOT do

- Does **not** install Docker Desktop GUI first-run prompts. If Docker Desktop shows a Privacy / Welcome dialog on first launch, the installer fails the wait loop and asks the operator to confirm manually. Acceptable per the "macOS-runner caveat" in the umbrella plan's test-environment-strategy section.
- Does **not** install LaunchAgent autostart. **Phase 7c**.
- Does **not** install Homebrew, even if the operator already has it. Installer does not bootstrap a package manager (governance call per the umbrella plan's installer-parity roadmap revision history).
- Does **not** add CI smoke for the .dmg flow. GitHub `macos-14` hosted runners cannot run nested virtualization, so Docker Desktop install from .dmg cannot run in CI. Per the umbrella plan's test-environment-strategy: this is a **Tier-3** verification (real Apple Silicon hardware or paid MacStadium / MacinCloud rental).

## What this PR enables

- **Apple Silicon end-users** can now run `bash install-dpf.sh` on a fresh macOS host (with sudo, Xcode CLT for `curl`) and reach a running portal end-to-end — except for the documented Docker Desktop first-run GUI prompt (acceptable per the spec).
- **Phase 7c** (autostart) is now well-scoped: LaunchAgent plist + systemd-user unit, with `install-dpf.sh` writing them post-`up`.
- **Phase 9** (CI release gates) can include an `apple-silicon-release-gate` job on `macos-14` that exercises the `dpf_docker_ensure_installed` "Docker.app present, daemon idle" branch (since macos-14 runners ship with Docker pre-installed but the daemon isn't necessarily running at job start).

Refs:
- `docs/superpowers/specs/2026-05-09-deployment-contracts.md` — Contract 3 (lifecycle)
- `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 7b (macOS Docker Desktop .dmg install)
- `docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md` — Test environment strategy: macOS-runner nested-virt caveat
- #416 (merged) — Phase 7a Linux end-to-end flow this builds on

https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_