### PR TITLE
feat: add governed tool lifecycle hooks

### DIFF
--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -42,6 +42,10 @@ vi.mock("@/lib/mcp-tools", () => ({
   PLATFORM_TOOLS: [],
 }));
 
+vi.mock("@/lib/mcp-governed-execute", () => ({
+  governedExecuteTool: vi.fn(),
+}));
+
 vi.mock("@/lib/feature-flags", () => ({
   isUnifiedCoworkerEnabled: vi.fn().mockResolvedValue(false),
 }));
@@ -145,6 +149,7 @@ import { auth } from "@/lib/auth";
 import { resolveAgentForRouteWithPrompts } from "@/lib/tak/agent-routing-server";
 import { routeAndCall } from "@/lib/routed-inference";
 import { executeTool, getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
+import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { prisma } from "@dpf/db";
 import { sendMessage } from "./agent-coworker";
 
@@ -154,6 +159,7 @@ const mockRouteAndCall = routeAndCall as ReturnType<typeof vi.fn>;
 const mockGetAvailableTools = getAvailableTools as ReturnType<typeof vi.fn>;
 const mockToolsToOpenAIFormat = toolsToOpenAIFormat as ReturnType<typeof vi.fn>;
 const mockExecuteTool = executeTool as ReturnType<typeof vi.fn>;
+const mockGovernedExecuteTool = governedExecuteTool as ReturnType<typeof vi.fn>;
 const mockPrisma = prisma as any;
 
 describe("agent coworker external access", () => {
@@ -191,6 +197,17 @@ describe("agent coworker external access", () => {
     });
     mockPrisma.agentModelConfig.findUnique.mockResolvedValue(null);
     mockPrisma.toolExecution.create.mockResolvedValue({});
+    mockGovernedExecuteTool.mockImplementation(async () => {
+      return {
+        success: true,
+        message: "Derived branding suggestions for Jack Jack's Pack.",
+        data: {
+          companyName: "Jack Jack's Pack",
+          logoUrl: "https://jackjackspack.org/logo.svg",
+          paletteAccent: "#4f46e5",
+        },
+      };
+    });
     mockPrisma.agentMessage.create
       .mockResolvedValueOnce({
         id: "user-msg-1",
@@ -321,11 +338,14 @@ describe("agent coworker external access", () => {
       },
     });
 
-    expect(mockExecuteTool).toHaveBeenCalledWith(
-      "analyze_public_website_branding",
-      { url: "https://jackjackspack.org" },
-      "user-1",
-      expect.objectContaining({ routeContext: "/admin" }),
+    expect(mockGovernedExecuteTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "analyze_public_website_branding",
+        rawParams: { url: "https://jackjackspack.org" },
+        userId: "user-1",
+        source: "agentic-loop",
+        context: expect.objectContaining({ routeContext: "/admin" }),
+      }),
     );
     expect(result).not.toHaveProperty("error");
     if (!("error" in result)) {

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _setGovernanceForTests,
   governedExecuteTool,
+  registerToolLifecycleHook,
 } from "./mcp-governed-execute";
 import type { ToolResult } from "./mcp-tools";
 
@@ -64,6 +65,107 @@ afterEach(() => {
 });
 
 describe("governedExecuteTool — happy path", () => {
+  it("supports registering and unregistering lifecycle hooks", async () => {
+    const calls: string[] = [];
+    const unregister = registerToolLifecycleHook({
+      id: "registered-test-hook",
+      onPreToolUse: async (event) => {
+        calls.push(event.toolName);
+      },
+    });
+
+    await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+
+    unregister();
+
+    await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+
+    expect(calls).toEqual(["query_backlog"]);
+  });
+
+  it("runs lifecycle hooks around successful tool execution", async () => {
+    const calls: string[] = [];
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_read"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      lifecycleHooks: [
+        {
+          id: "test-hook",
+          onPreToolUse: async (event) => {
+            calls.push(`pre:${event.toolName}:${event.source}`);
+          },
+          onPostToolUse: async (event) => {
+            calls.push(`post:${event.toolName}:${event.result.success}`);
+          },
+        },
+      ],
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: { status: "open" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-100", threadId: "thread-1" },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls).toEqual([
+      "pre:query_backlog:agentic-loop",
+      "post:query_backlog:true",
+    ]);
+  });
+
+  it("lets a pre-tool hook deny execution before executeTool is invoked", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["sandbox_execute"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      lifecycleHooks: [
+        {
+          id: "block-dangerous-command",
+          onPreToolUse: async () => ({
+            decision: "deny",
+            reason: "Sandbox command requires review",
+          }),
+        },
+      ],
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "run_sandbox_command",
+      rawParams: { command: "pnpm build" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-300", threadId: "thread-1" },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("hook_denied");
+    expect(result.message).toContain("Sandbox command requires review");
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.success).toBe(false);
+    expect(auditRows[0]?.toolName).toBe("run_sandbox_command");
+  });
+
   it("invokes executeTool, audits with the correct executionMode, and returns the result", async () => {
     const result = await governedExecuteTool({
       toolName: "query_backlog",

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -44,7 +44,8 @@ export type GovernedExecuteArgs = {
 export type GovernedExecuteRejection =
   | "unknown_tool"
   | "forbidden_capability"
-  | "forbidden_grant";
+  | "forbidden_grant"
+  | "hook_denied";
 
 export type GovernedExecuteResult = ToolResult & {
   governance?: {
@@ -53,6 +54,37 @@ export type GovernedExecuteResult = ToolResult & {
   };
 };
 
+type ToolLifecycleEvent = {
+  toolName: string;
+  rawParams: Record<string, unknown>;
+  userId: string;
+  userContext: UserContext;
+  context?: GovernedExecuteContext;
+  source: GovernedExecuteSource;
+};
+
+type ToolLifecyclePostEvent = ToolLifecycleEvent & {
+  result: ToolResult;
+  durationMs: number;
+};
+
+type ToolLifecycleDecision =
+  | { decision: "allow"; reason?: string }
+  | { decision: "deny"; reason: string };
+
+export type ToolLifecycleHook = {
+  id: string;
+  onPreToolUse?: (event: ToolLifecycleEvent) => Promise<ToolLifecycleDecision | void> | ToolLifecycleDecision | void;
+  onPostToolUse?: (event: ToolLifecyclePostEvent) => Promise<void> | void;
+};
+
+export function registerToolLifecycleHook(hook: ToolLifecycleHook): () => void {
+  _lifecycleHooks = [..._lifecycleHooks.filter((existing) => existing.id !== hook.id), hook];
+  return () => {
+    _lifecycleHooks = _lifecycleHooks.filter((existing) => existing.id !== hook.id);
+  };
+}
+
 // Test seam — production uses the imported real grant resolver. Tests can
 // override these without mocking the import system.
 export type GrantResolver = (agentId: string) => Promise<string[]>;
@@ -60,6 +92,7 @@ export type GrantPredicate = (toolName: string, grants: string[]) => boolean;
 
 let _resolveAgentGrants: GrantResolver | null = null;
 let _isAllowedByGrants: GrantPredicate | null = null;
+let _lifecycleHooks: ToolLifecycleHook[] = [];
 
 export function _setGovernanceForTests(overrides: {
   resolveAgentGrants?: GrantResolver | null;
@@ -72,12 +105,14 @@ export function _setGovernanceForTests(overrides: {
   ) => Promise<ToolResult>) | null;
   toolExecutionCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
   toolExecutionReceiptCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
+  lifecycleHooks?: ToolLifecycleHook[] | null;
 }): void {
   _resolveAgentGrants = overrides.resolveAgentGrants ?? null;
   _isAllowedByGrants = overrides.isAllowedByGrants ?? null;
   _executeToolOverride = overrides.executeTool ?? null;
   _toolExecutionCreateOverride = overrides.toolExecutionCreate ?? null;
   _toolExecutionReceiptCreateOverride = overrides.toolExecutionReceiptCreate ?? null;
+  _lifecycleHooks = overrides.lifecycleHooks ?? [];
 }
 
 let _executeToolOverride:
@@ -269,6 +304,29 @@ function rejectionResult(
   };
 }
 
+async function runPreToolHooks(event: ToolLifecycleEvent): Promise<GovernedExecuteResult | null> {
+  for (const hook of _lifecycleHooks) {
+    const decision = await hook.onPreToolUse?.(event);
+    if (decision?.decision === "deny") {
+      return rejectionResult(event.toolName, "hook_denied", decision.reason);
+    }
+  }
+  return null;
+}
+
+async function runPostToolHooks(event: ToolLifecyclePostEvent): Promise<void> {
+  for (const hook of _lifecycleHooks) {
+    try {
+      await hook.onPostToolUse?.(event);
+    } catch (err) {
+      console.error(
+        `[governed-execute] post-tool hook failed hook=${hook.id} tool=${event.toolName}:`,
+        err,
+      );
+    }
+  }
+}
+
 export async function governedExecuteTool(
   args: GovernedExecuteArgs,
 ): Promise<GovernedExecuteResult> {
@@ -328,6 +386,27 @@ export async function governedExecuteTool(
     }
   }
 
+  const hookRejection = await runPreToolHooks({
+    toolName: args.toolName,
+    rawParams: args.rawParams,
+    userId: args.userId,
+    userContext: args.userContext,
+    context: args.context,
+    source: args.source,
+  });
+  if (hookRejection) {
+    await writeAudit({
+      toolName: args.toolName,
+      rawParams: args.rawParams,
+      result: hookRejection,
+      userId: args.userId,
+      source: args.source,
+      context: args.context,
+      durationMs: 0,
+    });
+    return hookRejection;
+  }
+
   const t0 = Date.now();
   let result: ToolResult;
   try {
@@ -346,6 +425,17 @@ export async function governedExecuteTool(
     };
   }
   const durationMs = Date.now() - t0;
+
+  await runPostToolHooks({
+    toolName: args.toolName,
+    rawParams: args.rawParams,
+    userId: args.userId,
+    userContext: args.userContext,
+    context: args.context,
+    source: args.source,
+    result,
+    durationMs,
+  });
 
   const auditRow = await writeAudit({
     toolName: args.toolName,

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -19,6 +19,9 @@ vi.mock("@dpf/db", () => ({
     toolExecution: {
       create: vi.fn(),
     },
+    user: {
+      findUnique: vi.fn(),
+    },
   },
 }));
 vi.mock("@/lib/routed-inference", () => ({
@@ -28,10 +31,14 @@ vi.mock("@/lib/mcp-tools", () => ({
   executeTool: vi.fn(),
   PLATFORM_TOOLS: [],
 }));
+vi.mock("@/lib/mcp-governed-execute", () => ({
+  governedExecuteTool: vi.fn(),
+}));
 
 import { runAgenticLoop } from "./agentic-loop";
 import { routeAndCall } from "@/lib/routed-inference";
 import { executeTool } from "@/lib/mcp-tools";
+import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { prisma } from "@dpf/db";
 
 // Helper to build a mock RoutedInferenceResult
@@ -254,6 +261,13 @@ describe("runAgenticLoop", () => {
     vi.resetAllMocks();
     vi.mocked(prisma.agentModelConfig.findUnique).mockResolvedValue(null as never);
     vi.mocked(prisma.toolExecution.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      isSuperuser: true,
+      groups: [{ platformRole: { roleId: "ceo" } }],
+    } as never);
+    vi.mocked(governedExecuteTool).mockImplementation(async (args: any) =>
+      executeTool(args.toolName, args.rawParams, args.userId, args.context as any) as any,
+    );
   });
   const baseParams = {
     chatHistory: [{ role: "user" as const, content: "search for agent code" }],
@@ -266,6 +280,44 @@ describe("runAgenticLoop", () => {
     agentId: "software-engineer",
     threadId: "thread-1",
   };
+
+  it("executes tools through the governed lifecycle path", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    const mockExecuteTool = vi.mocked(executeTool);
+
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Searching.",
+        toolCalls: [{ id: "toolu_01A", name: "search_project_files", arguments: { query: "agent" } }],
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "I found the relevant files and summarized the implementation path with enough detail for the next step to continue cleanly.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "The search output lists the relevant files and the likely implementation path. It gives enough context for a follow-up step and keeps the answer limited to investigation notes.",
+      }));
+
+    mockExecuteTool.mockResolvedValueOnce({
+      success: true,
+      message: "Found files",
+    });
+
+    await runAgenticLoop(baseParams);
+
+    expect(governedExecuteTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "search_project_files",
+        rawParams: { query: "agent" },
+        userId: "user-1",
+        source: "agentic-loop",
+        context: expect.objectContaining({
+          agentId: "software-engineer",
+          threadId: "thread-1",
+          routeContext: "/build",
+        }),
+      }),
+    );
+  });
 
   it("creates structured messages with tool call IDs after tool execution", async () => {
     const mockRoute = vi.mocked(routeAndCall);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -4,9 +4,9 @@
 
 import { createHash } from "crypto";
 import { routeAndCall, type RoutedInferenceResult } from "@/lib/routed-inference";
-import { executeTool, PLATFORM_TOOLS, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
+import { PLATFORM_TOOLS, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
+import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import type { ChatMessage } from "@/lib/ai-inference";
-import type { AuditClass } from "@/lib/audit-classes";
 import { prisma } from "@dpf/db";
 import { agentEventBus } from "./agent-event-bus";
 import { TIER_MINIMUM_DIMENSIONS, type QualityTier } from "../routing/quality-tiers";
@@ -15,24 +15,7 @@ import {
   DEFAULT_MINIMUM_CONTEXT_TOKENS,
 } from "@/lib/routing/agent-capability-types";
 import type { AgentMinimumCapabilities } from "@/lib/routing/agent-capability-types";
-
-// ─── Audit helpers (Phase 3) ────────────────────────────────────────────────
-
-function deriveAuditClassForTool(toolName: string): AuditClass {
-  const tool = PLATFORM_TOOLS.find((t) => t.name === toolName);
-  if (!tool) return "journal"; // unknown — conservative default
-  // Explicit override on the tool definition wins
-  if ("auditClass" in tool && tool.auditClass) return tool.auditClass as AuditClass;
-  if (tool.sideEffect) return "ledger";
-  if (tool.requiresExternalAccess) return "journal";
-  return "metrics_only";
-}
-
-function deriveCapabilityId(toolName: string): string {
-  // Platform tools: platform:toolName
-  // MCP tools (serverSlug__toolName) are dispatched via the MCP adapter, not here.
-  return `platform:${toolName}`;
-}
+import type { UserContext } from "@/lib/permissions";
 
 // Safety ceiling — NOT a behavioral limit. The loop terminates when the model
 // responds with text only (no tool calls), matching the Anthropic API pattern
@@ -353,6 +336,24 @@ export type AgenticResult = {
   proposal: { name: string; arguments: Record<string, unknown>; content: string } | null;
 };
 
+async function resolveUserContext(userId: string): Promise<UserContext> {
+  const row = await prisma.user
+    .findUnique({
+      where: { id: userId },
+      select: {
+        isSuperuser: true,
+        groups: { include: { platformRole: true }, take: 1 },
+      },
+    })
+    .catch(() => null);
+
+  return {
+    userId,
+    platformRole: row?.groups?.[0]?.platformRole?.roleId ?? null,
+    isSuperuser: row?.isSuperuser ?? false,
+  };
+}
+
 /** Generate a phase-aware nudge based on which tools have been used so far. */
 function getPhaseSpecificNudge(executedTools: Array<{ name: string }>): string {
   const usedNames = new Set(executedTools.map(t => t.name));
@@ -519,6 +520,8 @@ export async function runAgenticLoop(params: {
     agentDisplayName,
   } = params;
 
+  const userContext = await resolveUserContext(userId);
+
   // EP-INF-012: Load admin-configured model assignment for this agent.
   // DB config takes precedence over code defaults in modelRequirements.
   const agentModelConfig = await prisma.agentModelConfig.findUnique({ where: { agentId } }).catch(() => null);
@@ -595,11 +598,6 @@ export async function runAgenticLoop(params: {
   let inferenceCallCount = 0;
   let sandboxUnavailableCount = 0; // Circuit breaker: stop trying sandbox tools if unavailable
   let previousResponseId: string | undefined; // Responses API conversation chaining
-  // Phase 3: probe chatter aggregation — suppress repetitive metrics_only writes
-  const metricsOnlyBuffer = new Map<string, { count: number; firstAt: number }>();
-  const METRICS_COLLAPSE_THRESHOLD = 3;
-  const METRICS_WINDOW_MS = 60_000;
-
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
     // EP-ASYNC-COWORKER-001: Check cancellation flag at each iteration boundary
     if (agentEventBus.isCancelled(threadId)) {
@@ -1195,12 +1193,14 @@ export async function runAgenticLoop(params: {
       const toolStartMs = Date.now();
       let toolResult: ToolResult;
       try {
-        toolResult = await executeTool(
-          tc.name,
-          tc.arguments,
+        toolResult = await governedExecuteTool({
+          toolName: tc.name,
+          rawParams: tc.arguments,
           userId,
-          { routeContext, agentId, threadId },
-        );
+          userContext,
+          context: { routeContext, agentId, threadId },
+          source: "agentic-loop",
+        });
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : "Unknown error";
         console.error(`[agentic-tool] UNCAUGHT iter=${iteration} tool=${tc.name}:`, errorMsg);
@@ -1210,49 +1210,6 @@ export async function runAgenticLoop(params: {
       const durationMs = Date.now() - toolStartMs;
       const resultPreview = (toolResult.message ?? "").slice(0, 200);
       console.log(`[agentic-tool] RESULT iter=${iteration} tool=${tc.name} success=${toolResult.success} duration=${durationMs}ms msg=${resultPreview}`);
-
-      // Audit: record every tool execution (fire-and-forget, Phase 3 enriched)
-      const auditClass = deriveAuditClassForTool(tc.name);
-      const capabilityId = deriveCapabilityId(tc.name);
-      const isMetricsOnly = auditClass === "metrics_only";
-
-      // Probe chatter aggregation: suppress repetitive metrics_only rows
-      let suppressWrite = false;
-      if (isMetricsOnly) {
-        const key = `${threadId}:${tc.name}`;
-        const now = Date.now();
-        const existing = metricsOnlyBuffer.get(key);
-        if (existing && (now - existing.firstAt) < METRICS_WINDOW_MS) {
-          existing.count++;
-          if (existing.count >= METRICS_COLLAPSE_THRESHOLD) {
-            suppressWrite = true; // absorbed into buffer
-          }
-        } else {
-          metricsOnlyBuffer.set(key, { count: 1, firstAt: now });
-        }
-      }
-
-      if (!suppressWrite) {
-        prisma.toolExecution.create({
-          data: {
-            threadId: threadId ?? "",
-            agentId: agentId ?? "unknown",
-            userId,
-            toolName: tc.name,
-            parameters: isMetricsOnly ? {} : (tc.arguments as any),
-            result: isMetricsOnly ? {} : (toolResult as any),
-            success: toolResult.success,
-            executionMode: "immediate",
-            routeContext: routeContext ?? null,
-            durationMs,
-            auditClass,
-            capabilityId,
-            summary: isMetricsOnly
-              ? `${tc.name}: ${toolResult.success ? "ok" : "failed"}${durationMs ? ` (${durationMs}ms)` : ""}`
-              : null,
-          },
-        }).catch(() => {});
-      }
 
       // Sandbox circuit breaker: track consecutive unavailable responses
       if (!toolResult.success && (toolResult.error ?? toolResult.message ?? "").includes("No sandbox slots available")) {


### PR DESCRIPTION
## Summary
- Add a governed tool lifecycle hook substrate around `governedExecuteTool`.
- Support registered pre/post hooks, including audited pre-tool denial via `hook_denied`.
- Route `runAgenticLoop` tool calls through `governedExecuteTool` so agentic-loop calls share grants, audit, and lifecycle behavior instead of duplicating tool execution/audit logic.

## Verification
- `pnpm --filter web exec vitest run lib/mcp-governed-execute.test.ts lib/tak/agentic-loop.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`

## Notes
- Production build passed with the existing broad Turbopack/NFT trace warnings around `spec-plan-search.ts` / `next.config.mjs`.
- Untracked `.githooks/*` files remain local and are not part of this PR.