### PR TITLE
feat(wiki): EP-WIKI-001 Phase 3a — passive recall + prompt-assembler hook

### DIFF
--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -225,4 +225,36 @@ describe("assembleSystemPrompt", () => {
     expect(prompt).toContain("unconfigured");
     expect(prompt).toContain("ungranted");
   });
+
+  // ─── EP-WIKI-001 §7: wikiContext injection in Block 5 ─────────────────────
+
+  it("omits the wiki block when wikiContext is null or undefined", async () => {
+    const prompt = await assembleSystemPrompt(fullInput);
+    expect(prompt).not.toContain("RELEVANT WIKI CONTEXT");
+  });
+
+  it("renders wikiContext inside Block 5, after domainContext and before domain tools", async () => {
+    const wikiBlock =
+      "RELEVANT WIKI CONTEXT:\n- entities/digital-product (entity, kernel) — A digital product is...";
+    const prompt = await assembleSystemPrompt({ ...fullInput, wikiContext: wikiBlock });
+
+    const domainIdx = indexOf(prompt, "portfolio tree");
+    const wikiIdx = indexOf(prompt, "RELEVANT WIKI CONTEXT");
+    const toolsIdx = indexOf(prompt, "Available domain tools");
+
+    expect(domainIdx).toBeGreaterThanOrEqual(0);
+    expect(wikiIdx).toBeGreaterThanOrEqual(0);
+    expect(toolsIdx).toBeGreaterThanOrEqual(0);
+    expect(domainIdx).toBeLessThan(wikiIdx);
+    expect(wikiIdx).toBeLessThan(toolsIdx);
+  });
+
+  it("places wikiContext on the dynamic side of the cache boundary", async () => {
+    const wikiBlock = "RELEVANT WIKI CONTEXT:\n- stances/x (stance, kernel) — body";
+    const prompt = await assembleSystemPrompt({ ...minimalInput, wikiContext: wikiBlock });
+    const boundaryIdx = indexOf(prompt, "DYNAMIC_BOUNDARY");
+    const wikiIdx = indexOf(prompt, "RELEVANT WIKI CONTEXT");
+    expect(boundaryIdx).toBeGreaterThanOrEqual(0);
+    expect(boundaryIdx).toBeLessThan(wikiIdx);
+  });
 });

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -15,6 +15,13 @@ export type PromptInput = {
   domainTools: string[];
   routeData: string | null;
   attachmentContext: string | null;
+  /**
+   * EP-WIKI-001 §7: passive wiki context injected into Block 5
+   * below `domainContext` and above `Available domain tools`.
+   * Caller produces this via `recallWikiContext()` (apps/web/lib/wiki/recall.ts).
+   * Pass `null` to omit the wiki block entirely.
+   */
+  wikiContext?: string | null;
 };
 
 // ─── Block 1: Identity (static) ─────────────────────────────────────────────
@@ -117,8 +124,11 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
     `This page is classified ${level}. Only endpoints cleared for ${level} are handling requests. Do not include classified data in sub-tasks routed to lower-clearance endpoints.`
   );
 
-  // Block 5: Domain context
+  // Block 5: Domain context (+ wiki context per EP-WIKI-001 §7)
   let domainBlock = input.domainContext;
+  if (input.wikiContext) {
+    domainBlock += `\n\n${input.wikiContext}`;
+  }
   if (input.domainTools.length > 0) {
     domainBlock += `\nAvailable domain tools: ${input.domainTools.join(", ")}`;
   }

--- a/apps/web/lib/wiki/recall.test.ts
+++ b/apps/web/lib/wiki/recall.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const searchWikiPages = vi.fn();
+
+vi.mock("./embeddings", () => ({
+  searchWikiPages: (...args: unknown[]) => searchWikiPages(...args),
+}));
+
+import { formatWikiContext, recallWikiContext } from "./recall";
+
+afterEach(() => {
+  searchWikiPages.mockReset();
+});
+
+describe("formatWikiContext", () => {
+  it("returns null when there are no results", () => {
+    expect(formatWikiContext([])).toBeNull();
+  });
+
+  it("formats a kernel result with origin=kernel", () => {
+    const out = formatWikiContext([
+      {
+        pageId: "wp_kernel_1",
+        slug: "entities/digital-product",
+        title: "Digital Product",
+        pageKind: "entity",
+        contentPreview: "A digital product is a software-defined service...",
+        isKernel: true,
+        organizationId: null,
+        kernelPageId: null,
+        score: 0.82,
+        source: "kernel",
+      },
+    ]);
+    expect(out).toContain("RELEVANT WIKI CONTEXT:");
+    expect(out).toContain(
+      "- entities/digital-product (entity, kernel) — A digital product is a software-defined service...",
+    );
+  });
+
+  it("formats an overlay result with origin=overlay", () => {
+    const out = formatWikiContext([
+      {
+        pageId: "wp_overlay_1",
+        slug: "entities/digital-product",
+        title: "Digital Product (Acme)",
+        pageKind: "entity",
+        contentPreview: "Acme treats a digital product as...",
+        isKernel: false,
+        organizationId: "org_acme",
+        kernelPageId: "wp_kernel_dp",
+        score: 0.9,
+        source: "org",
+      },
+    ]);
+    expect(out).toContain("(entity, overlay)");
+  });
+
+  it("collapses whitespace and truncates preview to 240 chars", () => {
+    const longPreview = "x".repeat(500);
+    const out = formatWikiContext([
+      {
+        pageId: "wp1",
+        slug: "summaries/long",
+        title: "Long",
+        pageKind: "summary",
+        contentPreview: `Multi\n\n  line\tpreview   ${longPreview}`,
+        isKernel: true,
+        organizationId: null,
+        kernelPageId: null,
+        score: 0.7,
+        source: "kernel",
+      },
+    ]);
+    // The dashed preview after "— " should be <= 240 chars
+    const previewPart = out!.split("— ")[1] ?? "";
+    expect(previewPart.length).toBeLessThanOrEqual(240);
+    // No double-space or newline survived
+    expect(previewPart).not.toMatch(/\s{2,}/);
+    expect(previewPart).not.toContain("\n");
+  });
+
+  it("joins multiple results with newlines", () => {
+    const out = formatWikiContext([
+      {
+        pageId: "a",
+        slug: "entities/a",
+        title: "A",
+        pageKind: "entity",
+        contentPreview: "alpha",
+        isKernel: true,
+        organizationId: null,
+        kernelPageId: null,
+        score: 0.9,
+        source: "kernel",
+      },
+      {
+        pageId: "b",
+        slug: "stances/b",
+        title: "B",
+        pageKind: "stance",
+        contentPreview: "beta",
+        isKernel: true,
+        organizationId: null,
+        kernelPageId: null,
+        score: 0.8,
+        source: "kernel",
+      },
+    ]);
+    const lines = out!.split("\n");
+    expect(lines[0]).toBe("RELEVANT WIKI CONTEXT:");
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain("entities/a");
+    expect(lines[2]).toContain("stances/b");
+  });
+});
+
+describe("recallWikiContext", () => {
+  it("forwards query + organizationId to searchWikiPages with default limit 4", async () => {
+    searchWikiPages.mockResolvedValueOnce([]);
+    await recallWikiContext({ query: "portfolio anchoring", organizationId: "org_a" });
+    expect(searchWikiPages).toHaveBeenCalledWith({
+      query: "portfolio anchoring",
+      organizationId: "org_a",
+      limit: 4,
+      scoreThreshold: undefined,
+    });
+  });
+
+  it("returns null when search returns no results", async () => {
+    searchWikiPages.mockResolvedValueOnce([]);
+    const out = await recallWikiContext({ query: "q", organizationId: null });
+    expect(out).toBeNull();
+  });
+
+  it("returns the formatted block when search returns results", async () => {
+    searchWikiPages.mockResolvedValueOnce([
+      {
+        pageId: "wp1",
+        slug: "entities/x",
+        title: "X",
+        pageKind: "entity",
+        contentPreview: "An X is a Y.",
+        isKernel: true,
+        organizationId: null,
+        kernelPageId: null,
+        score: 0.8,
+        source: "kernel",
+      },
+    ]);
+    const out = await recallWikiContext({ query: "what is X?", organizationId: null });
+    expect(out).toContain("RELEVANT WIKI CONTEXT:");
+    expect(out).toContain("entities/x");
+  });
+
+  it("returns null silently when searchWikiPages throws", async () => {
+    searchWikiPages.mockRejectedValueOnce(new Error("Qdrant down"));
+    const out = await recallWikiContext({ query: "q", organizationId: null });
+    expect(out).toBeNull();
+  });
+
+  it("respects an explicit limit override", async () => {
+    searchWikiPages.mockResolvedValueOnce([]);
+    await recallWikiContext({ query: "q", organizationId: null, limit: 10 });
+    expect(searchWikiPages).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10 }),
+    );
+  });
+});

--- a/apps/web/lib/wiki/recall.ts
+++ b/apps/web/lib/wiki/recall.ts
@@ -1,0 +1,86 @@
+// EP-WIKI-001 Phase 3a: passive wiki context recall.
+// Spec: docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md §3.6 + §7
+// Plan: docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md (Phase 3)
+//
+// `recallWikiContext()` runs at message-assembly time alongside
+// `recallRelevantContext()` (semantic memory). Its output is injected
+// into Block 5 of the system prompt (Domain context), below the
+// dynamic boundary marker. This is the "passive context injection"
+// path described in spec §3.6 — the agent gets grounded answers
+// without the user having to invoke a tool.
+//
+// The MCP tool surface (`wiki_query`, `wiki_propose_edit`) lands in
+// Phase 3b; this PR is the passive path only.
+
+import { searchWikiPages, type WikiSearchResult } from "./embeddings";
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+export type RecallWikiContextInput = {
+  /** The user's message or query, embedded against the wiki-pages collection. */
+  query: string;
+  /** Tenant context. Pass `null` for kernel-only retrieval (admin / public surfaces). */
+  organizationId: string | null;
+  /** Optional route hint surfaced as context to the model. Free-form. */
+  routeContext?: string | null;
+  /** Total results to retrieve across the two-pass search. Default 4. */
+  limit?: number;
+  /** Cosine score threshold per pass. Default 0.55 (matches `searchWikiPages`). */
+  scoreThreshold?: number;
+};
+
+// ─── Pure formatter ─────────────────────────────────────────────────────────
+
+/**
+ * Render search results as a prompt context block. Pure — no I/O.
+ *
+ * Returns `null` when there are no results, so callers can skip the
+ * Block 5 insertion entirely instead of adding an empty header.
+ *
+ * Each line is `- <slug> (<pageKind>, kernel|overlay) — <preview>`.
+ * The preview is the first 240 chars of the page's stored
+ * contentPreview, normalised to a single line.
+ */
+export function formatWikiContext(results: WikiSearchResult[]): string | null {
+  if (results.length === 0) return null;
+
+  const lines = results.map((r) => {
+    const origin = r.source === "kernel" ? "kernel" : "overlay";
+    const preview = (r.contentPreview ?? "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 240);
+    return `- ${r.slug} (${r.pageKind}, ${origin}) — ${preview}`;
+  });
+
+  return `RELEVANT WIKI CONTEXT:\n${lines.join("\n")}`;
+}
+
+// ─── Orchestrator ───────────────────────────────────────────────────────────
+
+/**
+ * Embed the query, run the overlay-aware two-pass search, and format
+ * the result as a prompt context block.
+ *
+ * Silent-degradation contract: returns `null` on embedding failure or
+ * empty result, so the caller can drop the wiki block from Block 5
+ * without affecting the rest of the prompt. Matches the
+ * `recallRelevantContext` pattern used by EP-MEMORY-001.
+ */
+export async function recallWikiContext(
+  input: RecallWikiContextInput,
+): Promise<string | null> {
+  try {
+    const results = await searchWikiPages({
+      query: input.query,
+      organizationId: input.organizationId,
+      limit: input.limit ?? 4,
+      scoreThreshold: input.scoreThreshold,
+    });
+    return formatWikiContext(results);
+  } catch (err) {
+    // Wiki retrieval is best-effort; never throw into the prompt pipeline.
+    console.warn("[recallWikiContext] failed:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 3a — wires the wiki retrieval path into agent system prompts. After this PR, when an agent receives a message, the prompt assembler can pull a `wikiContext` string (produced via `recallWikiContext()` → `searchWikiPages()` from PR #421) and render it in Block 5 below `domainContext` and above the domain-tools line.

This is the **passive context injection** path from spec §3.6 + §7 — the agent gets grounded wiki answers without the user invoking a tool. The MCP tool surface (`wiki_query`, `wiki_propose_edit`) and the assembler-caller wireup land in Phase 3b on a separate branch.

## What&#39;s in this PR

### `apps/web/lib/wiki/recall.ts`

- `formatWikiContext(results)` — pure formatter. Returns `null` on empty so the caller can skip Block 5 insertion entirely. Each line: `- <slug> (<pageKind>, kernel|overlay) — <preview>`. Preview normalised (single-line, ≤240 chars).
- `recallWikiContext({ query, organizationId, limit?, scoreThreshold? })` — orchestrator. **Silent-degradation contract**: returns `null` on embedding failure or thrown error so wiki retrieval failure never breaks the prompt pipeline (matches the `recallRelevantContext` pattern from EP-MEMORY-001).

### `apps/web/lib/wiki/recall.test.ts`

11 vitest cases. `formatWikiContext`: empty, kernel, overlay, whitespace normalisation, truncation, multi-result joining. `recallWikiContext`: default limit, empty result, formatted result, silent failure on throw, explicit limit override.

### `apps/web/lib/tak/prompt-assembler.ts`

- `PromptInput` gains `wikiContext?: string | null` (optional).
- Block 5 renders `wikiContext` after `domainContext` and before `Available domain tools:`. **The wiki block lives on the dynamic side of `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`** — it changes per turn and should not be cached as part of the static prefix.

### `apps/web/lib/tak/prompt-assembler.test.ts`

3 new cases (32 actual lines of new test code):
- Wiki block omitted when `wikiContext` is null/undefined
- Wiki block renders in correct position (after `domainContext`, before domain tools)
- Wiki block on the dynamic side of the cache boundary

> **Whitespace-only diff in this file.** The diff appears to be 108 lines but `git diff --ignore-all-space` shows the only real change is the 32 lines of new tests at the bottom. The rest is line-ending normalisation that the editor applied on save. Use the `?w=1` view on GitHub or `--ignore-all-space` locally to see the substantive changes.

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` (needed after main pull — PR #423 added `BusinessBuildBrief`) | ✓ |
| `pnpm --filter web typecheck` | ✓ |
| `pnpm --filter web test --run recall.test.ts prompt-assembler.test.ts` | ✓ 30/30 (14 new on top of existing 16) |

## Test plan

- [ ] Read `recall.ts` — confirm silent-degradation contract and the format shape
- [ ] Confirm Block 5 placement: `domainContext` → `wikiContext` → `Available domain tools` line
- [ ] Confirm cache-boundary placement: wiki block on the dynamic side, not the static prefix
- [ ] After merge, the next PR (Phase 3b) will wire the assembler caller (agent-coworker `sendMessage`) to call `recallWikiContext()` and pass the result through

## Out of scope (Phase 3b, separate PR)

- Wiring `recallWikiContext()` into the assembler caller (`agent-coworker.sendMessage`)
- `wiki_query` MCP tool registration + agent grants + route-context-map entries
- `wiki_propose_edit` MCP tool (lands with Phase 2b ingest)
- `prompts/platform-identity/wiki-preamble.prompt.md` content template
- Updating the `find-knowledge` skill waterfall to call `wiki_query` first

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_