### PR TITLE
feat(installer): bash lifecycle scripts (start/stop/reinstall/release) (Phase 8)

### DIFF
--- a/dpf-reinstall.sh
+++ b/dpf-reinstall.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory — clean reinstall (macOS / Linux).
+#
+# Orchestrator: nuke local runtime state, then redo install. Equivalent to:
+#
+#   bash uninstall-dpf.sh --purge && bash install-dpf.sh
+#
+# but with shared flag forwarding (--headless, --dry-run, --release, ...)
+# so operators don't have to retype the same options twice.
+#
+# Important difference from the Windows-side dpf-reinstall.ps1: this script
+# does NOT delete the cloned repo directory, and there is no Windows-only
+# bind-mount data dir to wipe (Phase 2 dropped that pattern). The "wipe
+# everything local" surface is handled cleanly by uninstall-dpf.sh --purge,
+# which uses compose-project label selection.
+#
+# Per the deployment doctrine (Contract 3 — lifecycle).
+#
+# Bash 3.2 baseline.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+LIB_DIR="$REPO_ROOT/scripts/installer/lib"
+
+# shellcheck source=scripts/installer/lib/logging.sh
+. "$LIB_DIR/logging.sh"
+# shellcheck source=scripts/installer/lib/prompts.sh
+. "$LIB_DIR/prompts.sh"
+
+usage() {
+  cat <<EOF
+Open Digital Product Factory — Reinstall
+
+Usage:
+  bash dpf-reinstall.sh [flags]
+
+This is a destructive operation. It runs:
+
+  1. bash uninstall-dpf.sh --purge          (wipes data, .env, ~/.dpf state)
+  2. bash install-dpf.sh                    (full re-install)
+
+Flags forwarded to uninstall-dpf.sh:
+  --keep-env      Preserve .env across the wipe.
+  --keep-state    Preserve ~/.dpf/install-state.json across the wipe.
+
+Flags forwarded to install-dpf.sh:
+  --release       Use pre-built GHCR images.
+  --dev           Build images locally.
+  --no-autostart  Skip LaunchAgent / systemd-user unit install.
+
+Flags applied to both:
+  --headless      Non-interactive. Required for CI.
+  --yes           Skip the destructive-confirmation prompt under --headless.
+                  Without --yes, --headless purge is refused.
+  --dry-run       Print planned actions without executing.
+  -h, --help      Show this help.
+EOF
+}
+
+DPF_KEEP_ENV=0
+DPF_KEEP_STATE=0
+DPF_MODE=""           # forwarded to install-dpf.sh
+DPF_NO_AUTOSTART=0
+DPF_HEADLESS_FLAG=""
+DPF_YES=0
+DPF_DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep-env)       DPF_KEEP_ENV=1 ;;
+    --keep-state)     DPF_KEEP_STATE=1 ;;
+    --release)        DPF_MODE="release" ;;
+    --dev)            DPF_MODE="dev" ;;
+    --no-autostart)   DPF_NO_AUTOSTART=1 ;;
+    --headless)       DPF_HEADLESS_FLAG="--headless"; DPF_HEADLESS=1; export DPF_HEADLESS ;;
+    --yes)            DPF_YES=1 ;;
+    --dry-run)        DPF_DRY_RUN=1 ;;
+    -h|--help)        usage; exit 0 ;;
+    *)
+      echo "dpf-reinstall.sh: unknown argument: $1" >&2
+      echo "Run 'bash dpf-reinstall.sh --help' for usage." >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+cd "$REPO_ROOT"
+
+echo ""
+echo "  Open Digital Product Factory — Reinstall (destructive)"
+echo "  ======================================================="
+echo ""
+warn "This will:"
+warn "  1. Stop the stack and delete all DPF docker volumes"
+[ "$DPF_KEEP_ENV"   = "1" ] || warn "  2. Delete .env (operator secrets)"
+[ "$DPF_KEEP_STATE" = "1" ] || warn "  3. Delete ~/.dpf state directory"
+warn "  4. Re-run install-dpf.sh from scratch"
+echo ""
+
+# Top-level confirmation in interactive mode. We let uninstall-dpf.sh
+# also prompt under --purge so operators get a second chance to abort
+# right before the actual delete. Under --headless we require --yes here
+# so the orchestrator and the underlying scripts agree on intent.
+if [ "${DPF_HEADLESS:-0}" = "1" ]; then
+  if [ "$DPF_YES" != "1" ]; then
+    fail "--headless reinstall requires --yes (destructive)."
+  fi
+else
+  dpf_yes_no "Proceed?" "no"
+  if [ "$DPF_REPLY" != "yes" ]; then
+    info "Aborted."
+    exit 0
+  fi
+fi
+
+# Build forwarded flag arrays.
+UNINSTALL_FLAGS=( --purge )
+[ "$DPF_KEEP_ENV"   = "1" ] && UNINSTALL_FLAGS+=( --keep-env )
+[ "$DPF_KEEP_STATE" = "1" ] && UNINSTALL_FLAGS+=( --keep-state )
+[ -n "$DPF_HEADLESS_FLAG" ] && UNINSTALL_FLAGS+=( "$DPF_HEADLESS_FLAG" )
+[ "$DPF_YES"        = "1" ] && UNINSTALL_FLAGS+=( --yes )
+[ "$DPF_DRY_RUN"    = "1" ] && UNINSTALL_FLAGS+=( --dry-run )
+
+INSTALL_FLAGS=()
+[ -n "$DPF_MODE" ]              && INSTALL_FLAGS+=( "--$DPF_MODE" )
+[ "$DPF_NO_AUTOSTART" = "1" ]   && INSTALL_FLAGS+=( --no-autostart )
+[ -n "$DPF_HEADLESS_FLAG" ]     && INSTALL_FLAGS+=( "$DPF_HEADLESS_FLAG" )
+[ "$DPF_DRY_RUN"      = "1" ]   && INSTALL_FLAGS+=( --dry-run )
+
+step "Phase 1: uninstall --purge"
+bash "$REPO_ROOT/uninstall-dpf.sh" "${UNINSTALL_FLAGS[@]}"
+
+step "Phase 2: install"
+# Use exec so install-dpf.sh's exit code becomes ours and we don't double
+# up shell stack frames during the long second half.
+if [ "${#INSTALL_FLAGS[@]}" -gt 0 ]; then
+  exec bash "$REPO_ROOT/install-dpf.sh" "${INSTALL_FLAGS[@]}"
+else
+  exec bash "$REPO_ROOT/install-dpf.sh"
+fi

--- a/dpf-release.sh
+++ b/dpf-release.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory — tag and push a production release.
+#
+# Bash port of dpf-release.ps1 (Windows GA). Pure git operations:
+#
+#   1. If on a non-main branch, stash + check out main.
+#   2. Fast-forward pull origin/main (refuses if main has diverged).
+#   3. Parse latest semver tag (vMAJOR.MINOR.PATCH); compute next per
+#      --bump (major/minor/patch; default minor).
+#   4. Confirm interactively (--yes skips, required under --headless).
+#   5. Tag + push the tag only.
+#   6. Return to the original branch and pop the stash.
+#
+# This script does NOT push commits to main. Releases are tag-only:
+# the GHCR multi-arch image build + publish is triggered by the tag
+# push, per .github/workflows/publish-image.yml.
+#
+# Bash 3.2 baseline.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+LIB_DIR="$REPO_ROOT/scripts/installer/lib"
+
+# shellcheck source=scripts/installer/lib/logging.sh
+. "$LIB_DIR/logging.sh"
+# shellcheck source=scripts/installer/lib/prompts.sh
+. "$LIB_DIR/prompts.sh"
+
+usage() {
+  cat <<EOF
+Open Digital Product Factory — Release
+
+Usage:
+  bash dpf-release.sh [--bump major|minor|patch] [flags]
+
+Flags:
+  --bump LEVEL    Version bump level (default: minor).
+                    major: v1.2.3 -> v2.0.0
+                    minor: v1.2.3 -> v1.3.0
+                    patch: v1.2.3 -> v1.2.4
+  --yes           Skip the interactive confirmation prompt.
+  --headless      Non-interactive (requires --yes).
+  --dry-run       Print what would happen; don't tag or push.
+  -h, --help      Show this help.
+
+Tag-only release: pushes a vX.Y.Z tag to origin. The publish-image
+workflow (Phase 1) builds and pushes multi-arch images on tag push.
+EOF
+}
+
+DPF_BUMP="minor"
+DPF_YES=0
+DPF_DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bump)
+      shift
+      [ $# -gt 0 ] || { echo "dpf-release.sh: --bump requires an argument" >&2; exit 64; }
+      DPF_BUMP="$1"
+      ;;
+    --yes)        DPF_YES=1 ;;
+    --headless)   DPF_HEADLESS=1; export DPF_HEADLESS ;;
+    --dry-run)    DPF_DRY_RUN=1 ;;
+    -h|--help)    usage; exit 0 ;;
+    *)
+      echo "dpf-release.sh: unknown argument: $1" >&2
+      echo "Run 'bash dpf-release.sh --help' for usage." >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+case "$DPF_BUMP" in
+  major|minor|patch) : ;;
+  *) fail "--bump must be one of: major, minor, patch (got: $DPF_BUMP)" ;;
+esac
+
+cd "$REPO_ROOT"
+
+if [ ! -d .git ]; then
+  fail "dpf-release.sh must run inside a git working tree (no .git/ here)."
+fi
+
+# ── 1. Switch to main if needed (with stash for safety) ─────────────────
+ORIG_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+STASHED=0
+
+_restore() {
+  # Idempotent restoration on success or interrupted exit. We never run
+  # this until after we've left the git working tree in a known state.
+  if [ "$ORIG_BRANCH" != "main" ]; then
+    git checkout "$ORIG_BRANCH" -q 2>/dev/null || true
+    if [ "$STASHED" = "1" ]; then
+      git stash pop -q 2>/dev/null || warn "Could not pop stash; check 'git stash list'."
+    fi
+  fi
+}
+
+if [ "$ORIG_BRANCH" != "main" ]; then
+  step "Switching from $ORIG_BRANCH to main"
+  if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    if git stash push --include-untracked -q -m "dpf-release auto-stash" 2>/dev/null; then
+      STASHED=1
+    fi
+  fi
+  if ! git checkout main -q; then
+    _restore
+    fail "Could not switch to main."
+  fi
+fi
+
+# ── 2. Fast-forward pull ─────────────────────────────────────────────────
+step "Pulling latest main from origin"
+if ! git pull origin main --ff-only; then
+  warn "Fast-forward pull failed. main may have local commits that diverge from origin."
+  info "Inspect: git log origin/main..main"
+  _restore
+  exit 1
+fi
+
+# ── 3. Compute next version ──────────────────────────────────────────────
+step "Computing next version"
+LATEST_TAG="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
+if [ -z "$LATEST_TAG" ]; then
+  warn "No semver tags found on this repo. Starting from v0.0.0."
+  MAJOR=0; MINOR=0; PATCH=0
+else
+  # Strip the leading 'v' and split on '.' into three parts.
+  TAG_NUM="${LATEST_TAG#v}"
+  MAJOR="${TAG_NUM%%.*}"
+  REST="${TAG_NUM#*.}"
+  MINOR="${REST%%.*}"
+  PATCH="${REST#*.}"
+fi
+
+case "$DPF_BUMP" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+
+NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo ""
+info "Current version: ${LATEST_TAG:-<none>}"
+ok   "New version:     $NEW_TAG ($DPF_BUMP bump)"
+echo ""
+
+# ── 4. Confirm ──────────────────────────────────────────────────────────
+if [ "$DPF_YES" != "1" ]; then
+  if [ "${DPF_HEADLESS:-0}" = "1" ]; then
+    _restore
+    fail "--headless release requires --yes."
+  fi
+  dpf_yes_no "Tag and push ${NEW_TAG}?" "no"
+  if [ "$DPF_REPLY" != "yes" ]; then
+    info "Aborted by operator."
+    _restore
+    exit 0
+  fi
+fi
+
+# ── 5. Tag + push ───────────────────────────────────────────────────────
+if [ "$DPF_DRY_RUN" = "1" ]; then
+  info "[dry-run] would run: git tag $NEW_TAG && git push origin $NEW_TAG"
+  ok "Dry-run complete; no tag created."
+  _restore
+  exit 0
+fi
+
+step "Tagging $NEW_TAG"
+if ! git tag "$NEW_TAG"; then
+  _restore
+  fail "Failed to create tag $NEW_TAG (already exists?)."
+fi
+
+step "Pushing $NEW_TAG to origin"
+if ! git push origin "$NEW_TAG"; then
+  warn "Push failed. The tag was created locally."
+  warn "Remove with: git tag -d $NEW_TAG"
+  _restore
+  exit 1
+fi
+
+echo ""
+ok "Released $NEW_TAG"
+echo ""
+info "GHCR images for $NEW_TAG will be built and pushed by the publish-image workflow."
+
+# ── 6. Restore original branch ──────────────────────────────────────────
+_restore
+if [ "$ORIG_BRANCH" != "main" ]; then
+  info "Returned to $ORIG_BRANCH"
+fi

--- a/dpf-start.sh
+++ b/dpf-start.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory — start the stack.
+#
+# Day-to-day "bring it up" sibling. Mirrors the PowerShell dpf-start.ps1
+# (Windows GA) with the same defaults: docker compose up -d on the
+# canonical chain (per-platform overlay included via compose.sh), then
+# optionally opens the portal in a browser.
+#
+# Use this when the stack is already installed (install-dpf.sh has run
+# at least once) and you just want it running again — for example after
+# a host reboot if you opted out of autostart, or after a manual stop.
+#
+# Bash 3.2 baseline (macOS default).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+LIB_DIR="$REPO_ROOT/scripts/installer/lib"
+
+# shellcheck source=scripts/installer/lib/logging.sh
+. "$LIB_DIR/logging.sh"
+# shellcheck source=scripts/installer/lib/platform.sh
+. "$LIB_DIR/platform.sh"
+# shellcheck source=scripts/installer/lib/compose.sh
+. "$LIB_DIR/compose.sh"
+# shellcheck source=scripts/installer/lib/state.sh
+. "$LIB_DIR/state.sh"
+
+usage() {
+  cat <<EOF
+Open Digital Product Factory — Start
+
+Usage:
+  bash dpf-start.sh [flags]
+
+Flags:
+  --release       Use pre-built GHCR images (docker-compose.release.yml
+                  overlay). Default if install-state.json records release
+                  mode; otherwise dev.
+  --dev           Force dev mode (build images locally).
+  --no-browser    Don't try to open the portal in a browser after start.
+  --dry-run       Print the planned compose command without running it.
+  -h, --help      Show this help.
+
+Reads ~/.dpf/install-state.json to pick the right mode if neither
+--release nor --dev is given. Falls back to dev.
+EOF
+}
+
+DPF_MODE=""
+DPF_NO_BROWSER=0
+DPF_DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release)     DPF_MODE="release" ;;
+    --dev)         DPF_MODE="dev" ;;
+    --no-browser)  DPF_NO_BROWSER=1 ;;
+    --dry-run)     DPF_DRY_RUN=1 ;;
+    -h|--help)     usage; exit 0 ;;
+    *)
+      echo "dpf-start.sh: unknown argument: $1" >&2
+      echo "Run 'bash dpf-start.sh --help' for usage." >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+cd "$REPO_ROOT"
+dpf_platform
+
+# Resolve mode from state if not explicitly chosen.
+if [ -z "$DPF_MODE" ]; then
+  if [ -f "$(dpf_state_path)" ]; then
+    case "$(dpf_state_read installerVersion 2>/dev/null || true)" in
+      *release*) DPF_MODE="release" ;;
+      *)         DPF_MODE="dev" ;;
+    esac
+  else
+    DPF_MODE="dev"
+  fi
+fi
+
+dpf_compose_files "$DPF_MODE"
+
+step "Starting Digital Product Factory ($DPF_MODE)"
+if [ "$DPF_DRY_RUN" = "1" ]; then
+  echo "  would run: docker compose ${DPF_COMPOSE_FILES[*]} up -d"
+  ok "Dry-run complete; no changes made."
+  exit 0
+fi
+
+docker compose "${DPF_COMPOSE_FILES[@]}" up -d
+ok "Stack is starting at http://localhost:3000"
+
+# Best-effort browser open. Honors NO_BROWSER for headless / SSH.
+if [ "$DPF_NO_BROWSER" != "1" ] && [ -z "${NO_BROWSER:-}" ] && [ -t 1 ]; then
+  sleep 5
+  if [ "$DPF_PLATFORM" = "darwin" ] && command -v open >/dev/null 2>&1; then
+    open "http://localhost:3000" 2>/dev/null || true
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "http://localhost:3000" 2>/dev/null || true
+  fi
+fi

--- a/dpf-stop.sh
+++ b/dpf-stop.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Open Digital Product Factory — stop the stack.
+#
+# Day-to-day "bring it down" sibling. Mirrors the PowerShell dpf-stop.ps1
+# (Windows GA): docker compose down on the canonical chain. Containers
+# are removed; named volumes are preserved (see uninstall-dpf.sh --purge
+# for the destructive variant).
+#
+# Bash 3.2 baseline (macOS default).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+LIB_DIR="$REPO_ROOT/scripts/installer/lib"
+
+# shellcheck source=scripts/installer/lib/logging.sh
+. "$LIB_DIR/logging.sh"
+# shellcheck source=scripts/installer/lib/platform.sh
+. "$LIB_DIR/platform.sh"
+# shellcheck source=scripts/installer/lib/compose.sh
+. "$LIB_DIR/compose.sh"
+# shellcheck source=scripts/installer/lib/state.sh
+. "$LIB_DIR/state.sh"
+
+usage() {
+  cat <<EOF
+Open Digital Product Factory — Stop
+
+Usage:
+  bash dpf-stop.sh [flags]
+
+Flags:
+  --release    Use release-mode compose chain (default if install-state.json
+               records release; else dev).
+  --dev        Force dev-mode chain.
+  --dry-run    Print the planned command without running it.
+  -h, --help   Show this help.
+
+Volumes are preserved. To wipe data too: bash uninstall-dpf.sh --purge
+EOF
+}
+
+DPF_MODE=""
+DPF_DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release)   DPF_MODE="release" ;;
+    --dev)       DPF_MODE="dev" ;;
+    --dry-run)   DPF_DRY_RUN=1 ;;
+    -h|--help)   usage; exit 0 ;;
+    *)
+      echo "dpf-stop.sh: unknown argument: $1" >&2
+      echo "Run 'bash dpf-stop.sh --help' for usage." >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+cd "$REPO_ROOT"
+dpf_platform
+
+if [ -z "$DPF_MODE" ]; then
+  if [ -f "$(dpf_state_path)" ]; then
+    case "$(dpf_state_read installerVersion 2>/dev/null || true)" in
+      *release*) DPF_MODE="release" ;;
+      *)         DPF_MODE="dev" ;;
+    esac
+  else
+    DPF_MODE="dev"
+  fi
+fi
+
+dpf_compose_files "$DPF_MODE"
+
+step "Stopping Digital Product Factory ($DPF_MODE)"
+if [ "$DPF_DRY_RUN" = "1" ]; then
+  echo "  would run: docker compose ${DPF_COMPOSE_FILES[*]} down --remove-orphans"
+  ok "Dry-run complete; no changes made."
+  exit 0
+fi
+
+docker compose "${DPF_COMPOSE_FILES[@]}" down --remove-orphans
+ok "Digital Product Factory stopped."

--- a/uninstall-dpf.sh
+++ b/uninstall-dpf.sh
@@ -208,13 +208,13 @@ if [ "$DPF_PURGE" = "1" ]; then
 
   if [ "$DPF_KEEP_ENV" != "1" ] && [ -f "$REPO_ROOT/.env" ]; then
     _run rm -f "$REPO_ROOT/.env"
-    info "Removed $REPO_ROOT/.env"
+    [ "$DPF_DRY_RUN" = "1" ] || info "Removed $REPO_ROOT/.env"
   fi
 
   state_dir="$(dpf_state_dir)"
   if [ "$DPF_KEEP_STATE" != "1" ] && [ -d "$state_dir" ]; then
     _run rm -rf "$state_dir"
-    info "Removed $state_dir"
+    [ "$DPF_DRY_RUN" = "1" ] || info "Removed $state_dir"
   fi
 fi
 


### PR DESCRIPTION
Four day-to-day lifecycle siblings of `install-dpf.sh` / `uninstall-dpf.sh`,
mirroring the Windows-side `dpf-{start,stop,reinstall,release}.ps1`
scripts so operator UX is consistent across platforms.

## What ships

| Script | Behavior | Mirrors |
|--------|----------|---------|
| `dpf-start.sh` | `docker compose ${chain} up -d`, optional browser open | `dpf-start.ps1` |
| `dpf-stop.sh` | `docker compose ${chain} down --remove-orphans` (volumes preserved) | `dpf-stop.ps1` |
| `dpf-reinstall.sh` | Orchestrator: `uninstall --purge` then `install`, with shared flag forwarding | `dpf-reinstall.ps1` (simplified — see below) |
| `dpf-release.sh` | Stash + ff-pull main, bump semver, tag-only push to origin | `dpf-release.ps1` |

All four:
- Source `scripts/installer/lib/{logging,platform,compose,state}.sh` so
  the compose `-f` chain matches install / uninstall exactly (base +
  `macos.yml` / `linux.yml` overlay, optional `release.yml`).
- Read `~/.dpf/install-state.json` to pick `dev` vs `release` mode if not
  explicitly overridden — so day-to-day ops match how the operator
  installed the platform.
- Honor `--dry-run` and `--headless`.

## Notable simplifications vs PowerShell

`dpf-reinstall.sh` drops Windows-only concerns from `dpf-reinstall.ps1`:

- No TEMP-relaunch (the bash script never tries to delete its own
  CWD; `uninstall-dpf.sh --purge` only touches docker resources +
  `.env` + `~/.dpf`, never the cloned repo).
- No VS Code lock detection (Linux/macOS file handles don't block
  `rm -rf` like NTFS does).
- No drive-letter `${drive}:\docker-data\dpf` sweep — Phase 2 already
  removed that bind-mount pattern. Volume cleanup is delegated to
  `uninstall-dpf.sh`'s `com.docker.compose.project=dpf` label filter,
  which is platform-agnostic and never targets foreign stacks.

`dpf-release.sh` is a near-direct port. Refactors the
`Set-StrictMode`/`$LASTEXITCODE` boilerplate into a single `_restore`
trap-style cleanup that runs on success, abort, or error so the
original branch + stash are always restored.

## Safety rails

- `dpf-reinstall.sh` refuses `--headless` without `--yes` (destructive).
- `dpf-release.sh` refuses `--headless` without `--yes` (publishes a tag).
- `--dry-run` paths print the planned compose / git commands without
  executing them.

## Drive-by

Fix `uninstall-dpf.sh` dry-run output: previously printed `Removed
~/.dpf` and `Removed .env` even under `--dry-run`. Now silent except for
the upstream `would run: rm -rf ...` line.

## Smoke

```
bash -n dpf-{start,stop,reinstall,release}.sh                  OK
bash dpf-start.sh --help                                       OK
bash dpf-start.sh --dry-run                                    OK
bash dpf-stop.sh --dry-run                                     OK
bash dpf-reinstall.sh --help                                   OK
bash dpf-reinstall.sh --dry-run --headless --yes               OK (full chain)
bash dpf-reinstall.sh --headless                               refused (exit 1)
bash dpf-release.sh --help                                     OK
bash dpf-release.sh --bump bogus                               refused (exit 1)
```

## Roadmap

`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` — Phase 8.
Next: Phase 9 (docs + CI release gates: README install sections,
`docs/install/{macos,linux}.md`, compose-render policy job, linux smoke
install on `ubuntu-22.04`, apple-silicon-release-gate on `macos-14`,
shellcheck, image-manifests verify). Then Phase 10 (hardening +
long-tail discovery).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_