### PR TITLE
feat(wiki): wire embeddings.jsonl sidecar into seedWikiKernel → Qdrant

### DIFF
--- a/packages/db/src/seed-wiki-kernel.test.ts
+++ b/packages/db/src/seed-wiki-kernel.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildKernelQdrantPoints,
   deriveSlug,
   extractWikilinks,
   parseFrontmatter,
+  type SeedablePage,
   type WikiPageFrontmatter,
 } from "./seed-wiki-kernel";
 
@@ -122,5 +124,90 @@ describe("seed-wiki-kernel: deriveSlug", () => {
     const base = "/repo/wiki";
     const path = "/repo/wiki/index.md";
     expect(deriveSlug(path, base)).toBe("index");
+  });
+});
+
+describe("seed-wiki-kernel: buildKernelQdrantPoints", () => {
+  const now = new Date("2026-05-10T00:00:00Z");
+
+  const pages: SeedablePage[] = [
+    {
+      id: "wp_kernel_1",
+      slug: "entities/digital-product",
+      title: "Digital Product",
+      body: "A digital product is...",
+      pageKind: "entity",
+      status: "published",
+    },
+    {
+      id: "wp_kernel_2",
+      slug: "stances/portfolio-as-anchor",
+      title: "Portfolio as the Anchor",
+      body: "The portfolio is the unit of...",
+      pageKind: "stance",
+      status: "published",
+    },
+  ];
+
+  it("builds a point per sidecar record that matches a page", () => {
+    const points = buildKernelQdrantPoints(
+      pages,
+      [
+        { slug: "entities/digital-product", vector: [0.1, 0.2, 0.3], model: "ai/nomic-embed-text-v1.5" },
+        { slug: "stances/portfolio-as-anchor", vector: [0.4, 0.5, 0.6], model: "ai/nomic-embed-text-v1.5" },
+      ],
+      "0.1.0",
+      now,
+    );
+    expect(points).toHaveLength(2);
+    expect(points[0]).toMatchObject({
+      id: "wiki-page-wp_kernel_1",
+      vector: [0.1, 0.2, 0.3],
+      payload: {
+        entityType: "wiki-page",
+        entityId: "wp_kernel_1",
+        slug: "entities/digital-product",
+        title: "Digital Product",
+        pageKind: "entity",
+        status: "published",
+        isKernel: true,
+        organizationId: null,
+        kernelVersion: "0.1.0",
+        kernelPageId: null,
+        timestamp: "2026-05-10T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("skips sidecar records with no matching page", () => {
+    const points = buildKernelQdrantPoints(
+      pages,
+      [
+        { slug: "entities/digital-product", vector: [0.1], model: "m" },
+        { slug: "entities/orphan", vector: [0.2], model: "m" },
+      ],
+      "0.1.0",
+      now,
+    );
+    expect(points).toHaveLength(1);
+    expect(points[0].payload.entityId).toBe("wp_kernel_1");
+  });
+
+  it("returns empty array for empty sidecar", () => {
+    expect(buildKernelQdrantPoints(pages, [], "0.1.0", now)).toEqual([]);
+  });
+
+  it("truncates contentPreview to 500 chars", () => {
+    const longBody = "x".repeat(2000);
+    const longPages: SeedablePage[] = [
+      { id: "wp_long", slug: "entities/long", title: "L", body: longBody, pageKind: "entity", status: "published" },
+    ];
+    const points = buildKernelQdrantPoints(
+      longPages,
+      [{ slug: "entities/long", vector: [0], model: "m" }],
+      "0.1.0",
+      now,
+    );
+    expect((points[0].payload.contentPreview as string).length).toBe(500);
   });
 });

--- a/packages/db/src/seed-wiki-kernel.ts
+++ b/packages/db/src/seed-wiki-kernel.ts
@@ -15,6 +15,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import type { PrismaClient } from "../generated/client/client";
+import { QDRANT_COLLECTIONS, upsertVectors, type VectorPoint } from "./qdrant";
 import {
   appendRevision,
   attachSource,
@@ -253,24 +254,46 @@ async function seedWikiPages(
   prisma: PrismaClient,
   kernelVersion: string,
   sourceSlugToId: Map<string, string>,
-): Promise<{ count: number; slugToId: Map<string, string>; orphanLinks: Array<{ from: string; to: string }> }> {
+): Promise<{
+  count: number;
+  slugToId: Map<string, string>;
+  orphanLinks: Array<{ from: string; to: string }>;
+  /** Per-page metadata needed to build Qdrant payloads in `seedWikiQdrant`. */
+  pages: Array<{
+    id: string;
+    slug: string;
+    title: string;
+    body: string;
+    pageKind: string;
+    status: string;
+  }>;
+}> {
   const wikiDir = join(KERNEL_DIR, "wiki");
   const files = walkMarkdownFiles(wikiDir);
   const slugToId = new Map<string, string>();
   const bodies = new Map<string, string>();
+  const pages: Array<{
+    id: string;
+    slug: string;
+    title: string;
+    body: string;
+    pageKind: string;
+    status: string;
+  }> = [];
 
   // Pass 1: upsert pages and append revisions.
   for (const file of files) {
     const raw = readFileSync(file, "utf8");
     const { frontmatter, body } = parseFrontmatter<WikiPageFrontmatter>(raw);
     const slug = frontmatter.slug ?? deriveSlug(file, wikiDir);
+    const status = frontmatter.status ?? "published";
 
     const upserted = (await upsertWikiPage(prisma, {
       slug,
       title: frontmatter.title,
       body,
       pageKind: frontmatter.pageKind,
-      status: frontmatter.status ?? "published",
+      status,
       isKernel: true,
       kernelVersion,
       abstract: frontmatter.abstract ?? null,
@@ -278,6 +301,14 @@ async function seedWikiPages(
 
     slugToId.set(slug, upserted.id);
     bodies.set(slug, body);
+    pages.push({
+      id: upserted.id,
+      slug,
+      title: frontmatter.title,
+      body,
+      pageKind: frontmatter.pageKind,
+      status,
+    });
 
     // Append a revision tagged kernel-merge if the body changed since
     // the last revision; otherwise no-op.
@@ -323,7 +354,119 @@ async function seedWikiPages(
     }
   }
 
-  return { count: files.length, slugToId, orphanLinks };
+  return { count: files.length, slugToId, orphanLinks, pages };
+}
+
+// ─── Seed: Qdrant points from the precomputed embeddings sidecar ────────────
+
+/**
+ * Read `docs/founder-kernel/embeddings.jsonl` (if present) and upsert
+ * the corresponding points into the `wiki-pages` Qdrant collection.
+ *
+ * Per EP-WIKI-001 §5: installs whose configured embedding model matches
+ * the manifest skip live embedding entirely — the sidecar is the
+ * canonical path. Live embedding for the kernel happens via Phase 2b
+ * ingest only when the sidecar is missing or stale (handled elsewhere).
+ *
+ * Payload shape mirrors `apps/web/lib/wiki/embeddings.ts:storeWikiPage`
+ * so `searchWikiPages` finds the seeded points without surprises.
+ *
+ * Silent-degradation: if Qdrant is unreachable or the upsert throws,
+ * the seed completes successfully (Postgres rows are still there) but
+ * `qdrantPointsSeeded` is `0` and a warning is logged. Wiki retrieval
+ * will degrade gracefully until Qdrant is back.
+ */
+export type SeedablePage = {
+  id: string;
+  slug: string;
+  title: string;
+  body: string;
+  pageKind: string;
+  status: string;
+};
+
+/**
+ * Build Qdrant `VectorPoint` objects from kernel pages + sidecar records.
+ * Pure — no I/O. Exported for testing; production code goes through
+ * `seedWikiQdrant`.
+ *
+ * Payload shape mirrors `apps/web/lib/wiki/embeddings.ts:storeWikiPage`
+ * so `searchWikiPages` finds the seeded points without surprises. Slugs
+ * in the sidecar with no matching page are skipped (warning logged).
+ */
+export function buildKernelQdrantPoints(
+  pages: SeedablePage[],
+  records: EmbeddingRecord[],
+  kernelVersion: string,
+  now: Date = new Date(),
+): VectorPoint[] {
+  const pageBySlug = new Map(pages.map((p) => [p.slug, p]));
+  const out: VectorPoint[] = [];
+  const timestamp = now.toISOString();
+  for (const rec of records) {
+    const page = pageBySlug.get(rec.slug);
+    if (!page) {
+      console.warn(`[seed-wiki-kernel] sidecar contains slug "${rec.slug}" with no matching wiki page; skipping`);
+      continue;
+    }
+    out.push({
+      id: `wiki-page-${page.id}`,
+      vector: rec.vector,
+      payload: {
+        entityType: "wiki-page",
+        entityId: page.id,
+        slug: page.slug,
+        title: page.title,
+        contentPreview: page.body.slice(0, 500),
+        pageKind: page.pageKind,
+        status: page.status,
+        isKernel: true,
+        // Kernel rows have organizationId = null.
+        organizationId: null,
+        kernelVersion,
+        kernelPageId: null,
+        timestamp,
+      },
+    });
+  }
+  return out;
+}
+
+/**
+ * Read `docs/founder-kernel/embeddings.jsonl` (if present) and upsert
+ * the corresponding points into the `wiki-pages` Qdrant collection.
+ *
+ * Per EP-WIKI-001 §5: installs whose configured embedding model matches
+ * the manifest skip live embedding entirely — the sidecar is the
+ * canonical path. Live embedding for the kernel happens via Phase 2b
+ * ingest only when the sidecar is missing or stale (handled elsewhere).
+ *
+ * Silent-degradation: if Qdrant is unreachable or the upsert throws,
+ * the seed completes successfully (Postgres rows are still there) but
+ * `qdrantPointsSeeded` is `0` and a warning is logged. Wiki retrieval
+ * will degrade gracefully until Qdrant is back.
+ */
+async function seedWikiQdrant(
+  pages: SeedablePage[],
+  kernelVersion: string,
+): Promise<{ pointsSeeded: number; sidecarPresent: boolean }> {
+  const records = readEmbeddingsSidecar();
+  if (records === null) {
+    return { pointsSeeded: 0, sidecarPresent: false };
+  }
+
+  const vectorPoints = buildKernelQdrantPoints(pages, records, kernelVersion);
+  if (vectorPoints.length === 0) {
+    return { pointsSeeded: 0, sidecarPresent: true };
+  }
+
+  try {
+    await upsertVectors(QDRANT_COLLECTIONS.WIKI_PAGES, vectorPoints);
+    return { pointsSeeded: vectorPoints.length, sidecarPresent: true };
+  } catch (err) {
+    console.warn("[seed-wiki-kernel] failed to upsert wiki points into Qdrant; pages remain in Postgres:", err);
+    return { pointsSeeded: 0, sidecarPresent: true };
+  }
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -335,6 +478,15 @@ export type SeedWikiKernelResult = {
   orphanLinks: Array<{ from: string; to: string }>;
   /** When true, kernel content directories are missing and nothing was seeded. */
   emptyKernel: boolean;
+  /**
+   * Number of points upserted into the `wiki-pages` Qdrant collection
+   * from the precomputed `docs/founder-kernel/embeddings.jsonl` sidecar.
+   * Zero when the sidecar is missing (seed completes; live embedding
+   * happens via Phase 2b ingest) or when Qdrant is unreachable.
+   */
+  qdrantPointsSeeded: number;
+  /** Whether the embeddings.jsonl sidecar exists. */
+  embeddingsSidecarPresent: boolean;
 };
 
 /**
@@ -359,11 +511,14 @@ export async function seedWikiKernel(prisma: PrismaClient): Promise<SeedWikiKern
       pageCount: 0,
       orphanLinks: [],
       emptyKernel: true,
+      qdrantPointsSeeded: 0,
+      embeddingsSidecarPresent: false,
     };
   }
 
   const sources = await seedRawSources(prisma, manifest.kernelVersion);
   const pages = await seedWikiPages(prisma, manifest.kernelVersion, sources.slugToId);
+  const qdrant = await seedWikiQdrant(pages.pages, manifest.kernelVersion);
 
   return {
     kernelVersion: manifest.kernelVersion,
@@ -371,6 +526,8 @@ export async function seedWikiKernel(prisma: PrismaClient): Promise<SeedWikiKern
     pageCount: pages.count,
     orphanLinks: pages.orphanLinks,
     emptyKernel: false,
+    qdrantPointsSeeded: qdrant.pointsSeeded,
+    embeddingsSidecarPresent: qdrant.sidecarPresent,
   };
 }
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -2045,10 +2045,13 @@ async function main(): Promise<void> {
   if (wikiSeed.emptyKernel) {
     console.log("  founder-kernel: empty (no docs/founder-kernel/wiki/ or raw-sources/ content yet)");
   } else {
+    const qdrantSummary = wikiSeed.embeddingsSidecarPresent
+      ? `qdrant=${wikiSeed.qdrantPointsSeeded}`
+      : "qdrant=no-sidecar";
     console.log(
       `  founder-kernel: kernelVersion=${wikiSeed.kernelVersion} ` +
         `pages=${wikiSeed.pageCount} sources=${wikiSeed.sourceCount} ` +
-        `orphan-links=${wikiSeed.orphanLinks.length}`,
+        `orphan-links=${wikiSeed.orphanLinks.length} ${qdrantSummary}`,
     );
   }
   await seedDeliberationPatterns(prisma);


### PR DESCRIPTION
## Summary

Closes the loose end documented in [PR #430](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/430): the seed now populates both Postgres **AND** the `wiki-pages` Qdrant collection when the `docs/founder-kernel/embeddings.jsonl` sidecar is present.

This is the install-time path described in spec §5: installs whose configured embedding model matches the manifest skip live embedding entirely; the sidecar is canonical. Live embedding for the kernel happens via Phase 2b ingest only when the sidecar is missing or stale (out of scope here).

## What changed

### `packages/db/src/seed-wiki-kernel.ts` (+163 lines)

- `seedWikiPages` now also returns per-page metadata (`id`, `slug`, `title`, `body`, `pageKind`, `status`) so the Qdrant payload builder has everything it needs without re-reading files.
- New `buildKernelQdrantPoints(pages, records, kernelVersion, now)` — **pure** helper that builds `VectorPoint[]` from the sidecar records. Payload shape mirrors `apps/web/lib/wiki/embeddings.ts:storeWikiPage` so `searchWikiPages` finds the seeded points without surprises. Skips sidecar records with no matching page (warning logged).
- New `seedWikiQdrant(pages, kernelVersion)` orchestrator — reads the sidecar via `readEmbeddingsSidecar()`, builds points via `buildKernelQdrantPoints`, upserts to the `wiki-pages` Qdrant collection. **Silent-degradation**: if Qdrant is down or the upsert throws, the seed completes successfully (Postgres rows are still there) but `qdrantPointsSeeded` is 0 and a warning is logged.
- `SeedWikiKernelResult` gains `qdrantPointsSeeded` + `embeddingsSidecarPresent` so callers can distinguish &#34;no sidecar&#34; from &#34;sidecar present but Qdrant failed.&#34;

### `packages/db/src/seed.ts` (+3 / −2)

Seed log line now surfaces the Qdrant outcome:
- `qdrant=42` when N points were seeded
- `qdrant=no-sidecar` when the sidecar is absent (the current Phase 0 state)

### `packages/db/src/seed-wiki-kernel.test.ts` (+87 lines, +4 cases → 18 total)

| Case | Asserts |
|------|---------|
| Matched records | Each sidecar record with a matching page produces a `VectorPoint` with the documented payload (`entityType: "wiki-page"`, `entityId`, `slug`, `title`, `contentPreview`, `pageKind`, `status`, `isKernel: true`, `organizationId: null`, `kernelVersion`, `kernelPageId: null`, `timestamp`) |
| Unmatched records | Sidecar records with no matching page are skipped |
| Empty sidecar | Returns empty array |
| Long body | `contentPreview` truncated to 500 chars |

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db typecheck` | ✓ |
| `pnpm typecheck` (web, db, types, validators, api-client, mobile) | ✓ |
| `pnpm --filter @dpf/db test --run seed-wiki-kernel.test.ts` | ✓ 18/18 (4 new) |

## Test plan

- [ ] Read `buildKernelQdrantPoints` — confirm the payload shape matches `storeWikiPage` in `apps/web/lib/wiki/embeddings.ts`
- [ ] Read `seedWikiQdrant` — confirm silent-degradation contract (no Qdrant → seed still completes)
- [ ] Confirm new seed log line shape (`founder-kernel: ... qdrant=N` or `... qdrant=no-sidecar`)
- [ ] After Mark drops content + runs `scripts/build-kernel-embeddings.ts`, the next `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts` should report a non-zero `qdrant=` count

## Out of scope

- **Live embedding for kernel pages when the sidecar is missing.** Needs the `apps/web/lib/inference/embedding.ts` helper; we don&#39;t want a cross-package dependency from `packages/db` to `apps/web`. Belongs in Phase 2b ingest.
- **Refreshing the sidecar after content edits.** Currently a manual rerun of `scripts/build-kernel-embeddings.ts`. Could be wired into CI later.

## Independent of in-flight work

This PR depends only on merged work: #415 (`seedWikiKernel`), #421 (Qdrant `wiki-pages` collection + `storeWikiPage` payload shape), and #430 (seed.ts wireup). Not stacked on PR #432.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_