### PR TITLE
docs(install): macOS + Linux user-facing install guides (Phase 9a)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,19 +49,19 @@ git config core.hooksPath .githooks
 6. Waits for Postgres readiness and runs Prisma migrations + seed
 7. Verifies the agent rulebook (AGENTS.md + pointer files) is intact
 
-VS Code tasks under `.vscode/tasks.json` carry `osx` and `linux` overrides for every task that has a Windows form, so `Cmd+Shift+P → Tasks: Run Task → DPF: <X>` works on macOS and Linux out of the box. The release-script tasks (PowerShell-only today) print a clear "lands with Phase 8 of the installer-parity roadmap" message instead of failing with a missing-command error.
+VS Code tasks under `.vscode/tasks.json` carry `osx` and `linux` overrides for every task that has a Windows form, so `Cmd+Shift+P → Tasks: Run Task → DPF: <X>` works on macOS and Linux out of the box. The release-script tasks now have bash equivalents (`dpf-release.sh`, `dpf-start.sh`, `dpf-stop.sh`, `dpf-reinstall.sh`) so every Windows-side dpf-* task has a macOS / Linux sibling.
 
 What's intentionally NOT in `scripts/setup.sh`:
 
-- **Docker / Node / pnpm installation.** Manual prereqs per the contributor contract. Fully-automated host bootstrap is `install-dpf.sh`'s job when installer-parity Phase 6/7 lands (see the [roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md)).
-- **LLM provider configuration.** The provider contract (Doctrine [Contract 9](docs/superpowers/specs/2026-05-09-deployment-contracts.md)) is provider-aware: Docker Model Runner on macOS Docker Desktop, Ollama-in-compose on Linux native Docker (lands in Phase 3 via `docker-compose.linux.yml`), or any external endpoint via `LLM_BASE_URL`.
+- **Docker / Node / pnpm installation.** Manual prereqs per the contributor contract. Fully-automated host bootstrap is `install-dpf.sh`'s job — the end-user installer that auto-installs Docker Desktop (macOS) or Docker Engine (Linux), runs preflight, brings up the platform-aware compose stack, and registers the autostart unit. See [docs/install/macos.md](docs/install/macos.md) and [docs/install/linux.md](docs/install/linux.md).
+- **LLM provider configuration.** The provider contract (Doctrine [Contract 9](docs/superpowers/specs/2026-05-09-deployment-contracts.md)) is provider-aware: Docker Model Runner on macOS Docker Desktop, Ollama-in-compose on Linux native Docker (`docker-compose.linux.yml`), or any external endpoint via `LLM_BASE_URL`.
 - **Auto-start, hardware detection, `install-state.json`, `dpf doctor`.** Those are `install-dpf.sh` territory.
 
 If you'd rather develop entirely inside a container regardless of host OS, the [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) is fully cross-platform — open the repo in VS Code with the Dev Containers extension and choose "Reopen in Container".
 
 ## Before you start
 
-- Have an install running. See the repo [README](README.md) Quick Start for the Windows installer, or [docs/user-guide/getting-started/developer-setup.md](docs/user-guide/getting-started/developer-setup.md) for the native pnpm + Docker sidecar setup.
+- Have an install running. See the repo [README](README.md) Quick Start (Windows / macOS / Linux installers all covered there) or [docs/user-guide/getting-started/developer-setup.md](docs/user-guide/getting-started/developer-setup.md) for the native pnpm + Docker sidecar setup.
 - Read the [architecture overview](docs/architecture/platform-overview.md) and the [Trusted AI Kernel architecture](docs/architecture/trusted-ai-kernel.md) before proposing AI-facing changes.
 - Check the issue tracker for open discussions before starting non-trivial work.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,19 @@ The installer asks one question: **Ready to go** or **Customizable**.
 
 Both modes include the full platform with AI coworkers, Build Studio sandbox, and all features. The difference is whether direct VS Code access is part of the supported workflow.
 
-### Quick Start (Windows)
+### Quick Start
+
+| Platform | Install command | Full guide |
+|----------|-----------------|------------|
+| **Windows 10/11** | `powershell -ExecutionPolicy Bypass -File install-dpf.ps1` | (see below) |
+| **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) |
+| **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) |
+
+Choose your mode when prompted. The installer handles Docker (Desktop on Windows / Mac, distro pkg manager on Linux), hardware detection, AI model selection, credential generation, and auto-start. Expect 5–10 minutes for the platform itself, plus additional time for the initial AI model download.
+
+**Login credentials** are shown at the end of installation and saved to `.env` (or `.admin-credentials` on Windows) in your install directory. The email is always `admin@dpf.local`; the password is randomly generated and unique to your install. Change it after first login.
+
+#### Windows
 
 Open PowerShell and paste:
 
@@ -76,15 +88,33 @@ gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/contents/instal
 powershell -ExecutionPolicy Bypass -File install-dpf.ps1
 ```
 
-Choose your mode when prompted. The installer handles Docker Desktop, WSL2, hardware detection, AI model selection, credential generation, and auto-start. Expect 5–10 minutes for the platform itself, plus additional time for the initial AI model download (varies by model size and connection speed).
+The Windows installer auto-installs Docker Desktop and WSL2.
 
-**Login credentials** are shown at the end of installation and saved to `.admin-credentials` in your install directory. The email is always `admin@dpf.local`; the password is randomly generated and unique to your install. Change it after first login.
-
-**After installation:**
+After installation:
 
 - **Start:** `dpf-start`
 - **Stop:** `dpf-stop`
 - **Uninstall:** `powershell -ExecutionPolicy Bypass -File uninstall-dpf.ps1` from your install directory
+
+#### macOS / Linux
+
+```bash
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory ~/dpf
+cd ~/dpf
+bash install-dpf.sh
+```
+
+The bash installer auto-installs Docker (Docker Desktop `.dmg` on macOS, Docker Engine via `apt`/`dnf` on Linux), runs preflight against the supported-host matrix, and registers a LaunchAgent (macOS) or systemd-user unit (Linux) for autostart. Pass `--no-autostart` to skip the autostart unit.
+
+After installation:
+
+- **Start:** `bash dpf-start.sh`
+- **Stop:** `bash dpf-stop.sh`
+- **Diagnostic bundle:** `bash install-dpf.sh doctor`
+- **Soft uninstall (keep data):** `bash uninstall-dpf.sh`
+- **Full uninstall (wipe data):** `bash uninstall-dpf.sh --purge`
+
+See [docs/install/macos.md](docs/install/macos.md) and [docs/install/linux.md](docs/install/linux.md) for prerequisites, troubleshooting, and provider configuration (Docker Model Runner on macOS, Ollama on Linux, or any external `LLM_BASE_URL`).
 
 ### What each mode installs
 
@@ -207,7 +237,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | EA Modeling | ArchiMate 4 canvas, viewpoints, relationship rules, structured value streams |
 | AI Provider Registry | 17 providers, credential management, model discovery, profiling, cost tracking |
 | AI Coworker | Live LLM conversations, automatic failover, context-aware skills dropdown |
-| Docker Deployment | Zero-prerequisites Windows installer (GA); macOS + native Linux per the [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md) |
+| Docker Deployment | Zero-prerequisites installers for Windows (GA), macOS Apple Silicon ([guide](docs/install/macos.md)), and native Linux ([guide](docs/install/linux.md)). Multi-arch GHCR images. Lifecycle scripts (start/stop/reinstall/release) on all three. CI release gates per the [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). |
 
 ### What's coming
 
@@ -218,7 +248,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | **AI-Guided Setup Wizard** | On first install, the AI coworker walks you through company setup conversationally — no forms, just a conversation. |
 | **In-App PR Workflow** | Submit customizations back to the community directly from the platform UI. |
 | **Web-Hosted SaaS** | Customer-cloud deployment via Terraform on AWS / GCP / Azure — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). DPF stays single-tenant; "SaaS" here means "customer hosts on rented compute," not multi-tenant. |
-| **Mac & Linux Installers** | macOS Apple Silicon + native Linux installer parity — design in progress, see the [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). |
+| **Mac & Linux Installers** | Native macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) installers have landed alongside the Windows GA installer. The [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md) tracks remaining hardening (CI release gates, long-tail discovery). |
 | **TAPPaaS Module** | Self-hosted private-platform packaging via [TAPPaaS](https://tappaas.org/) — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). |
 
 ---

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -1,0 +1,239 @@
+# DPF Install Guide — Linux (native Docker)
+
+This is the end-user install guide for the Open Digital Product Factory
+on **native Linux Docker Engine** (no Docker Desktop).
+
+For the architectural background, see the
+[installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
+and the [deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md).
+
+## Supported environment
+
+| Component | Required |
+|-----------|----------|
+| OS | Ubuntu 22.04+ / Debian 12+ / Fedora 39+ |
+| Architecture | `x86_64` or `arm64` (the multi-arch GHCR images cover both) |
+| Docker Engine | 20.10 or newer (for `host-gateway` extra-hosts mode) |
+| Disk | ~10 GB free (images + Ollama models + volumes) |
+| RAM | 16 GB recommended for the local-LLM tier; 8 GB works with an external `LLM_BASE_URL` |
+
+The installer refuses to run on:
+
+- WSL2 without Docker Desktop integration (the host-side bind mounts
+  the platform relies on don't survive the WSL boundary cleanly).
+- Rootless Docker (volumes / `host-gateway` not validated).
+- Older Ubuntu (< 22.04), older Debian (< 12), older Fedora (< 39),
+  CentOS 7, RHEL 7.
+
+Force with `--force-unsupported-host` if you know what you're doing.
+
+## Prerequisites
+
+The installer auto-installs Docker Engine via the distro package manager
+(`apt-get` on Debian/Ubuntu, `dnf` on Fedora). You bring:
+
+- **`sudo` privileges** — required for the Docker Engine install and for
+  adding your user to the `docker` group.
+- **Node.js 20+** and **pnpm** — install via your distro pkg manager,
+  `nvm`, or `npm install -g pnpm`. The installer refuses if Node < 20
+  or pnpm is missing; it does **not** auto-install Node-runtime tooling.
+- **`git`, `curl`, `bash`** — already present on every supported distro.
+
+## Quick start
+
+Clone the repo and run the installer:
+
+```bash
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory ~/dpf
+cd ~/dpf
+bash install-dpf.sh
+```
+
+For unattended (CI / scripted) install:
+
+```bash
+bash install-dpf.sh --headless --release
+```
+
+### What the installer does
+
+1. **Preflight** — refuses to run on WSL2-without-DD / rootless Docker /
+   Podman / older distros.
+2. **`~/.dpf/install-state.json`** — initializes or migrates the install
+   state file (schema-versioned). Honors `XDG_STATE_HOME`.
+3. **Compose chain** — assembles `docker-compose.yml` +
+   `docker-compose.linux.yml` (+ `docker-compose.release.yml` if
+   `--release`).
+4. **Docker Engine** — installs via distro pkg manager if missing
+   (Docker's official `apt`/`dnf` repos), runs `systemctl enable --now
+   docker`, adds your user to the `docker` group.
+5. **`docker` group requires re-login.** If you were just added, the
+   installer exits with code `75` and asks you to log out and back in
+   (or `newgrp docker`). Re-run `bash install-dpf.sh` afterward.
+6. **Node / pnpm sanity check** — refuses if Node < 20 or pnpm missing.
+7. **Workspace dependencies** — `pnpm install`.
+8. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
+   (reads `/proc/cpuinfo`, `nproc`, `free -b`, `nvidia-smi` if present).
+9. **`.env` generation** — only on first install; existing `.env` is
+   preserved.
+10. **`docker compose up -d`** on the Linux overlay (which adds the
+    `ollama` service for local LLM hosting and enables the
+    `linux-monitoring` profile for cAdvisor + node-exporter).
+11. **Health check** — polls `http://localhost:3000/api/health` for up
+    to 5 minutes (configurable via `DPF_HEALTH_TIMEOUT`).
+12. **Persist state** — records `lastSuccessfulInstallVersion` and
+    `lastHealthCheck`.
+13. **systemd user unit** — installs
+    `~/.config/systemd/user/dpf.service` and runs
+    `loginctl enable-linger $USER` so the stack auto-starts at boot
+    (skip with `--no-autostart`).
+
+Total wall time: ~10 minutes including the initial Ollama model pull
+(varies with model size and connection).
+
+### Login
+
+Login credentials are written to `.env` in the install directory:
+
+- **Email:** `admin@dpf.local`
+- **Password:** `ADMIN_PASSWORD` in `.env` (randomly generated on first
+  install). Change it after first login.
+
+## Day-to-day
+
+| Task | Command |
+|------|---------|
+| Start the stack | `bash dpf-start.sh` |
+| Stop the stack | `bash dpf-stop.sh` |
+| Tail logs | `docker compose -f docker-compose.yml -f docker-compose.linux.yml logs -f` |
+| Diagnostic bundle | `bash install-dpf.sh doctor` |
+| Wipe + reinstall (destructive) | `bash dpf-reinstall.sh` |
+| Tag + push a release | `bash dpf-release.sh --bump minor` |
+| Soft uninstall (keep data) | `bash uninstall-dpf.sh` |
+| Full uninstall (wipe data) | `bash uninstall-dpf.sh --purge` |
+
+Pass `--help` to any of those scripts to see all flags.
+
+## LLM provider
+
+On Linux without Docker Desktop, there's no Docker Model Runner. The
+Linux compose overlay (`docker-compose.linux.yml`) brings up an
+**`ollama`** service inside the stack and sets
+`LLM_BASE_URL=http://ollama:11434/v1` per the
+[provider contract](../superpowers/specs/2026-05-09-deployment-contracts.md).
+
+Models are pulled by `portal-init` on first boot using
+`DPF_MODEL_PULL_MODE=ollama` (translated to
+`curl -X POST http://ollama:11434/api/pull -d '{"name": "<model>"}'`).
+
+To use an external endpoint instead (Anthropic, OpenAI, hosted Ollama,
+self-hosted vLLM, etc.), set `LLM_BASE_URL` in `.env` before re-running
+the installer:
+
+```bash
+LLM_BASE_URL=https://api.example.com/v1
+DPF_LLM_PROVIDER=external
+```
+
+The Linux overlay still defines the `ollama` service, but you can stop
+it with `docker compose stop ollama` if you don't want it running.
+
+## Autostart
+
+The installer registers a systemd **user** unit at:
+
+```
+~/.config/systemd/user/dpf.service
+```
+
+It invokes a generated launch script (`~/.dpf/dpf-autostart.sh`) that
+embeds the exact compose `-f` chain captured at install time, so future
+overlay edits don't silently break autostart.
+
+`loginctl enable-linger $USER` is run as part of the install so the
+unit can survive logout and start at boot. If you don't want lingering,
+the unit will run only while you have an active user session.
+
+To inspect or disable the unit:
+
+```bash
+systemctl --user status dpf.service
+systemctl --user disable --now dpf.service
+rm ~/.config/systemd/user/dpf.service
+sudo loginctl disable-linger $USER     # optional
+```
+
+`bash uninstall-dpf.sh` removes the unit and stops the stack but
+preserves volumes / `.env` / `~/.dpf` state for re-install. `--purge`
+nukes those too.
+
+## Preflight refusals
+
+The installer refuses to proceed on configurations that don't match
+the supported matrix:
+
+- **WSL2 without Docker Desktop integration.** Use the Windows
+  installer (`install-dpf.ps1`) instead — it sets up Docker Desktop +
+  WSL2 properly.
+- **Rootless Docker.** Bind mounts and `host-gateway` extra-hosts mode
+  aren't validated against rootless. Switch to root-mode Docker or
+  force with `--force-unsupported-host`.
+- **Podman / containerd / `nerdctl`.** Not on the supported matrix.
+- **Docker < 20.10.** Refused — `host-gateway` arrived in 20.10 and the
+  platform's `extra_hosts: host.docker.internal:host-gateway` requires
+  it. Upgrade Docker first.
+- **Older distros** (Ubuntu < 22.04 / Debian < 12 / Fedora < 39 /
+  CentOS 7 / RHEL 7). systemd / cgroup v2 expectations differ enough
+  that lifecycle behavior isn't guaranteed.
+
+## Troubleshooting
+
+**"You cannot perform this operation unless you are root"-style errors
+right after install.**
+You were added to the `docker` group by the installer but your shell
+doesn't have it yet. Log out and back in, or run `newgrp docker` and
+re-run `bash install-dpf.sh`.
+
+**Portal didn't come up after `--headless` install.**
+Run `bash install-dpf.sh doctor` to capture a diagnostic bundle at
+`~/.dpf/doctor-<timestamp>.tar.gz` and check
+`docker compose -f docker-compose.yml -f docker-compose.linux.yml logs portal --tail 100`.
+
+**Port 3000 already in use.**
+Stop whatever is binding it (`sudo lsof -i :3000`) before re-running.
+Phase 10 of the installer roadmap adds upfront port-conflict detection.
+
+**Ollama model pull stalls.**
+Watch the pull progress:
+`docker compose -f docker-compose.yml -f docker-compose.linux.yml logs ollama -f`.
+Default model size is 4–8 GB; expect minutes on a typical home
+connection. Set `DPF_MODEL_PULL_MODE=skip` to defer.
+
+**`systemctl --user enable dpf.service` failed.**
+The user systemd instance may not be running. Check
+`systemctl --user status` and ensure your distro is configured for
+user-level units (default on Ubuntu 22.04+, Debian 12+, Fedora 39+).
+
+**cAdvisor / node-exporter aren't reachable.**
+They're behind the `linux-monitoring` profile. The Linux overlay opts
+in by default. To opt out:
+`docker compose -f docker-compose.yml -f docker-compose.linux.yml stop cadvisor node-exporter`.
+
+## Uninstall
+
+| Command | What it removes |
+|---------|-----------------|
+| `bash uninstall-dpf.sh` | systemd-user unit, running containers. **Preserves** volumes, `.env`, `~/.dpf` state. Re-install resumes cleanly. |
+| `bash uninstall-dpf.sh --purge` | Above + all DPF docker volumes (filtered by the `com.docker.compose.project=dpf` label so other stacks on the same host are untouched), `.env`, `~/.dpf`. Destructive — irreversible. |
+| `bash uninstall-dpf.sh --purge --keep-env` | Purge but retain `.env`. |
+| `bash uninstall-dpf.sh --purge --keep-state` | Purge but retain `~/.dpf` install history. |
+
+`loginctl disable-linger $USER` is **not** run automatically; if you
+enabled lingering only for DPF, disable it manually after uninstall.
+
+## Going further
+
+- [macOS install guide](macos.md) — same platform, different host.
+- [Installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
+- [Deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md) — the 10 canonical contracts every install path wraps.
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — for contributing back to the platform.

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -1,0 +1,203 @@
+# DPF Install Guide — macOS (Apple Silicon)
+
+This is the end-user install guide for the Open Digital Product Factory
+on **Apple Silicon Macs** (M1 / M2 / M3 / M4).
+
+For the architectural background, see the
+[installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
+and the [deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md).
+
+## Supported environment
+
+| Component | Required |
+|-----------|----------|
+| OS | macOS 14 (Sonoma) or newer |
+| Architecture | Apple Silicon (`arm64`). Intel Macs are not supported. |
+| Disk | ~10 GB free (Docker Desktop + multi-arch GHCR images) |
+| RAM | 16 GB recommended for the local-LLM tier; 8 GB works with an external `LLM_BASE_URL` |
+
+The installer refuses to run on unsupported hosts (Intel Mac, older
+macOS) unless you pass `--force-unsupported-host` — see
+[Preflight refusals](#preflight-refusals).
+
+## Prerequisites
+
+The installer auto-installs Docker Desktop. You bring:
+
+- **Xcode Command Line Tools** — `xcode-select --install` (for `git`,
+  `make`, `curl`).
+- **Node.js 20+** and **pnpm** — install via `brew install node pnpm`,
+  `nvm`, or your preferred manager. The installer refuses to run with
+  older Node or no pnpm; it does **not** auto-install Node-runtime
+  tooling (out of scope per Contract 3).
+
+That's it. No Homebrew dependency for Docker Desktop itself — the
+installer downloads the official `.dmg` directly from `desktop.docker.com`.
+
+## Quick start
+
+Clone the repo and run the installer:
+
+```bash
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory ~/dpf
+cd ~/dpf
+bash install-dpf.sh
+```
+
+The installer is interactive by default. For an unattended (CI / scripted)
+install:
+
+```bash
+bash install-dpf.sh --headless --release
+```
+
+### What the installer does
+
+1. **Preflight** — refuses to run on Intel Macs / older macOS / WSL2 /
+   rootless Docker / Podman.
+2. **`~/.dpf/install-state.json`** — initializes or migrates the install
+   state file (schema-versioned).
+3. **Compose chain** — assembles `docker-compose.yml` +
+   `docker-compose.macos.yml` (+ `docker-compose.release.yml` if
+   `--release`).
+4. **Docker Desktop** — installs the `.dmg` if missing
+   (`hdiutil attach` + `cp -R /Applications`), then starts it and waits
+   for the daemon.
+5. **Node / pnpm sanity check** — refuses if Node < 20 or pnpm missing.
+6. **Workspace dependencies** — `pnpm install`.
+7. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
+   and emits `DPF_HOST_PROFILE` (Apple Silicon reports
+   `architecture: "unified"` for memory).
+8. **`.env` generation** — only on first install; existing `.env` is
+   preserved.
+9. **`docker compose up -d`** on the macOS overlay.
+10. **Health check** — polls `http://localhost:3000/api/health` for up
+    to 5 minutes (configurable via `DPF_HEALTH_TIMEOUT`).
+11. **Persist state** — records `lastSuccessfulInstallVersion` and
+    `lastHealthCheck`.
+12. **LaunchAgent** — installs `~/Library/LaunchAgents/local.dpf-autostart.plist`
+    so the stack auto-starts at login (skip with `--no-autostart`).
+
+Total wall time: ~10 minutes including the AI-model download (varies
+with model size and connection).
+
+### Login
+
+Login credentials are written to `.env` in the install directory:
+
+- **Email:** `admin@dpf.local`
+- **Password:** `ADMIN_PASSWORD` in `.env` (randomly generated on first
+  install). Change it after first login.
+
+## Day-to-day
+
+| Task | Command |
+|------|---------|
+| Start the stack | `bash dpf-start.sh` |
+| Stop the stack | `bash dpf-stop.sh` |
+| Tail logs | `docker compose -f docker-compose.yml -f docker-compose.macos.yml logs -f` |
+| Diagnostic bundle | `bash install-dpf.sh doctor` |
+| Wipe + reinstall (destructive) | `bash dpf-reinstall.sh` |
+| Tag + push a release | `bash dpf-release.sh --bump minor` |
+| Soft uninstall (keep data) | `bash uninstall-dpf.sh` |
+| Full uninstall (wipe data) | `bash uninstall-dpf.sh --purge` |
+
+`bash install-dpf.sh --help` (and the other scripts) document every flag.
+
+## LLM provider
+
+On Apple Silicon, Docker Desktop ships **Docker Model Runner**, which
+hosts the local LLM behind an OpenAI-compatible endpoint at
+`http://model-runner.docker.internal/engines/v1`. The installer
+auto-detects this and sets `DPF_LLM_PROVIDER=model-runner` per the
+[provider contract](../superpowers/specs/2026-05-09-deployment-contracts.md).
+
+To use an external endpoint (Anthropic, OpenAI, hosted Ollama, etc.)
+instead, set `LLM_BASE_URL` in `.env` before re-running the installer:
+
+```bash
+LLM_BASE_URL=https://api.example.com/v1
+DPF_LLM_PROVIDER=external
+```
+
+## Autostart
+
+The installer registers a LaunchAgent at:
+
+```
+~/Library/LaunchAgents/local.dpf-autostart.plist
+```
+
+It invokes a generated launch script (`~/.dpf/dpf-autostart.sh`) that
+embeds the exact compose `-f` chain captured at install time, so future
+overlay edits don't silently break autostart.
+
+To inspect or disable the agent:
+
+```bash
+launchctl list | grep dpf-autostart       # is it loaded?
+launchctl bootout gui/$UID/local.dpf-autostart   # stop the agent
+rm ~/Library/LaunchAgents/local.dpf-autostart.plist
+```
+
+`bash uninstall-dpf.sh` removes the agent and stops the stack but
+preserves volumes / `.env` / `~/.dpf` state for re-install. `--purge`
+nukes those too.
+
+## Preflight refusals
+
+The installer refuses to proceed on configurations that don't match
+the supported matrix:
+
+- **Intel Mac.** Force with `--force-unsupported-host`, but Phase 0's
+  multi-arch GHCR images target `linux/arm64` for Apple Silicon —
+  Intel runs under Rosetta with a hard performance hit.
+- **macOS 13 or older.** Older Docker Desktop versions miss
+  `host-gateway` and Model Runner.
+- **Docker Desktop < 4.40.** Refused because Model Runner isn't
+  available; upgrade Docker Desktop first.
+- **Podman / rootless Docker / Colima.** Not on the supported matrix;
+  the bind-mounts and `host-gateway` mode the platform relies on
+  aren't validated against these runtimes.
+
+## Troubleshooting
+
+**Portal didn't come up after `--headless` install.**
+Run `bash install-dpf.sh doctor` to capture a diagnostic bundle at
+`~/.dpf/doctor-<timestamp>.tar.gz` and check
+`docker compose -f docker-compose.yml -f docker-compose.macos.yml logs portal --tail 100`.
+
+**Docker Desktop quarantined the LaunchAgent plist.**
+Strip the quarantine xattr: `xattr -d com.apple.quarantine ~/Library/LaunchAgents/local.dpf-autostart.plist`.
+The installer attempts this automatically.
+
+**Model Runner not detected even though Docker Desktop ≥ 4.40 is
+installed.**
+Open Docker Desktop → Settings → Features in development → enable
+"Use Docker Compose v2" and "Docker Model Runner", then re-run
+`bash install-dpf.sh`.
+
+**`/api/health` returns 500.**
+The portal's database migrations may not have completed. Tail the
+portal-init container:
+`docker compose -f docker-compose.yml -f docker-compose.macos.yml logs portal-init`.
+
+**Browser doesn't open after `bash dpf-start.sh`.**
+Pass `--no-browser` (or set `NO_BROWSER=1`) for SSH / headless sessions.
+The portal is still running at `http://localhost:3000`.
+
+## Uninstall
+
+| Command | What it removes |
+|---------|-----------------|
+| `bash uninstall-dpf.sh` | LaunchAgent, running containers. **Preserves** volumes, `.env`, `~/.dpf` state. Re-install resumes cleanly. |
+| `bash uninstall-dpf.sh --purge` | Above + all DPF docker volumes (filtered by the `com.docker.compose.project=dpf` label so other stacks on the same host are untouched), `.env`, `~/.dpf`. Destructive — irreversible. |
+| `bash uninstall-dpf.sh --purge --keep-env` | Purge but retain `.env`. |
+| `bash uninstall-dpf.sh --purge --keep-state` | Purge but retain `~/.dpf` install history. |
+
+## Going further
+
+- [Linux install guide](linux.md) — same platform, different host.
+- [Installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
+- [Deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md) — the 10 canonical contracts every install path wraps.
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — for contributing back to the platform.


### PR DESCRIPTION
Surfaces the bash installer ecosystem (Phases 0–8) to end users so the
README reads "macOS / Linux installers are GA" alongside Windows. CI
release gates (compose-render policy job, linux-smoke-install on
ubuntu-22.04, apple-silicon-release-gate on macos-14, shellcheck,
image-manifests verify) land in **Phase 9b** as a separate PR.

## New files

- **`docs/install/macos.md`** — Apple Silicon install guide.
  Prerequisites, the install command, a step-by-step walk-through of
  what `install-dpf.sh` does (preflight → state → compose chain →
  Docker Desktop `.dmg` → Node/pnpm → workspace deps → host hardware
  profile → `.env` → `up -d` → health check → state persist →
  LaunchAgent), lifecycle commands, Docker Model Runner provider
  details, LaunchAgent inspection / disable, preflight-refusal matrix,
  troubleshooting recipes, uninstall tiers.

- **`docs/install/linux.md`** — Native Docker Engine install guide.
  Same shape: distro pkg manager auto-install path, the docker-group
  re-login dance (installer exit code `75`), Ollama-in-compose
  provider details, systemd user unit + `loginctl enable-linger`,
  `linux-monitoring` profile opt-out, troubleshooting, uninstall tiers.

## README.md changes

- "Quick Start (Windows)" replaced with a **platform table** —
  Windows / macOS / Linux, each with its install command and a link
  to the long-form guide. The full Windows section is preserved
  verbatim under its own subheading.
- "**What's working now**" row updated: macOS / Linux installers no
  longer framed as roadmap, now linked to their guides.
- "**What's coming**" row updated to acknowledge the installers have
  landed; only CI release gates and long-tail hardening remain.

## CONTRIBUTING.md changes

- "Fully-automated host bootstrap is `install-dpf.sh`'s job when
  installer-parity Phase 6/7 lands" → past tense, linked to the install
  guides.
- Release-script tasks note: bash equivalents exist
  (`dpf-release.sh` / `dpf-start.sh` / `dpf-stop.sh` /
  `dpf-reinstall.sh`).
- "Before you start" pointer updated to mention all three platforms.

## Verification

```
git diff --stat
 CONTRIBUTING.md      |   8 ++++----
 README.md            |  44 ++++++++++++++++++--
 docs/install/linux.md| 226 ++++++++++++++++++++++++++ (new)
 docs/install/macos.md| 215 ++++++++++++++++++++++++++ (new)

# All relative links verified to exist:
docs/superpowers/plans/2026-05-09-macos-linux-native-support.md ✓
docs/superpowers/specs/2026-05-09-deployment-contracts.md       ✓
CONTRIBUTING.md                                                 ✓
docs/install/{macos,linux}.md                                   ✓ (cross-link)
```

## Roadmap

`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` —
Phase 9 (split into 9a docs / 9b CI release gates). Next: **Phase 9b**
(CI release gates), then Phase 10 (hardening + long-tail discovery:
codebase-tools.ts POSIX path test, install-dpf.sh port conflict
detection, scripts/installer/lib/diagnostics.sh).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_