### PR TITLE
feat(wiki): EP-WIKI-001 Phase 4b1 — lint orchestrator + scheduled job

### DIFF
--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -17,6 +17,7 @@ import {
   governedBacklogTeeUpScheduled,
 } from "./governed-backlog-tee-up";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
+import { wikiLint } from "./wiki-lint";
 
 export const allFunctions = [
   prometheusPoll,
@@ -39,4 +40,5 @@ export const allFunctions = [
   governedBacklogTeeUpScheduled,
   governedBacklogTeeUpRequested,
   tokenExpiryMonitor,
+  wikiLint,
 ];

--- a/apps/web/lib/queue/functions/wiki-lint.ts
+++ b/apps/web/lib/queue/functions/wiki-lint.ts
@@ -1,0 +1,87 @@
+// EP-WIKI-001 Phase 4b1: scheduled wiki lint job.
+// Spec: docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md §6
+// Plan: docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md (Phase 4b)
+//
+// Runs runWikiLint() for the kernel (organizationId=null) and then for
+// every active Organization. Mirrors infra-prune.ts's pattern of
+// dynamic Prisma + helper imports inside step.run so the function file
+// itself stays tree-shaken when Inngest registers schedules at build.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+
+// Daily at 03:30 UTC (matches the time spec §3.6 calls out). Two
+// retries because the orchestrator is idempotent — re-running on
+// failure is safe and surfaces transient DB hiccups.
+export const wikiLint = inngest.createFunction(
+  { id: "wiki/lint-daily", retries: 2, triggers: [cron("30 3 * * *")] },
+  async ({ step }) => {
+    const orgIds = await step.run("collect-active-orgs", async () => {
+      const { prisma } = await import("@dpf/db");
+      const orgs = await prisma.organization.findMany({
+        select: { id: true },
+      });
+      return orgs.map((o) => o.id);
+    });
+
+    const kernelResult = await step.run("lint-kernel", async () => {
+      const { prisma } = await import("@dpf/db");
+      const { runWikiLint } = await import("@/lib/wiki/lint");
+      return runWikiLint({
+        organizationId: null,
+        prisma: prisma as never,
+        currentKernelVersion: await readKernelVersion(),
+      });
+    });
+
+    const orgResults: Array<{ organizationId: string; opened: number; resolved: number; scanned: number }> = [];
+    for (const orgId of orgIds) {
+      const r = await step.run(`lint-org-${orgId}`, async () => {
+        const { prisma } = await import("@dpf/db");
+        const { runWikiLint } = await import("@/lib/wiki/lint");
+        return runWikiLint({
+          organizationId: orgId,
+          prisma: prisma as never,
+          currentKernelVersion: await readKernelVersion(),
+        });
+      });
+      orgResults.push({
+        organizationId: orgId,
+        opened: r.findingsOpened,
+        resolved: r.findingsResolved,
+        scanned: r.scannedPageCount,
+      });
+    }
+
+    return {
+      kernel: {
+        scanned: kernelResult.scannedPageCount,
+        opened: kernelResult.findingsOpened,
+        kept: kernelResult.findingsKept,
+        resolved: kernelResult.findingsResolved,
+      },
+      orgs: orgResults,
+    };
+  },
+);
+
+// ─── manifest helper ────────────────────────────────────────────────────────
+
+async function readKernelVersion(): Promise<string> {
+  const { readFile } = await import("fs/promises");
+  const { join } = await import("path");
+  // Manifest path is the same one packages/db/src/seed-wiki-kernel.ts uses.
+  // We read it directly from the repo root rather than importing the seed
+  // module (which would pull in the `fs` walker and Postgres CRUD calls).
+  const manifestPath = join(process.cwd(), "docs", "founder-kernel", "manifest.json");
+  try {
+    const raw = await readFile(manifestPath, "utf8");
+    const parsed = JSON.parse(raw) as { kernelVersion?: string };
+    return parsed.kernelVersion ?? "0.0.0";
+  } catch {
+    // If the manifest is missing (rare; ships with the repo), the kernel
+    // is effectively empty — lint will still run, but the kernel-drift
+    // detector becomes a no-op against unknown version "0.0.0".
+    return "0.0.0";
+  }
+}

--- a/apps/web/lib/wiki/lint.test.ts
+++ b/apps/web/lib/wiki/lint.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchWikiSnapshot,
+  persistFindings,
+  runWikiLint,
+  type WikiLintPrismaClient,
+} from "./lint";
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+function makePrismaMock(seed: {
+  pages?: Array<Record<string, unknown>>;
+  links?: Array<Record<string, unknown>>;
+  sources?: Array<Record<string, unknown>>;
+  rawSources?: Array<Record<string, unknown>>;
+  existingFindings?: Array<{ id: string; pageId: string; findingKind: string }>;
+}): WikiLintPrismaClient & {
+  __findingsCreated: ReturnType<typeof vi.fn>;
+  __findingsUpdated: ReturnType<typeof vi.fn>;
+  __findingsFetched: ReturnType<typeof vi.fn>;
+  __pagesFetched: ReturnType<typeof vi.fn>;
+} {
+  const created = vi.fn();
+  const updated = vi.fn();
+  const findingsFetched = vi.fn(async () => seed.existingFindings ?? []);
+  const pagesFetched = vi.fn(async () => seed.pages ?? []);
+  return {
+    wikiPage: { findMany: pagesFetched as never },
+    wikiPageLink: { findMany: vi.fn(async () => seed.links ?? []) as never },
+    wikiPageSource: { findMany: vi.fn(async () => seed.sources ?? []) as never },
+    rawSource: { findMany: vi.fn(async () => seed.rawSources ?? []) as never },
+    wikiLintFinding: {
+      findMany: findingsFetched as never,
+      create: created as never,
+      update: updated as never,
+    },
+    __findingsCreated: created,
+    __findingsUpdated: updated,
+    __findingsFetched: findingsFetched,
+    __pagesFetched: pagesFetched,
+  };
+}
+
+const dummyPage = {
+  id: "wp_1",
+  slug: "entities/lonely",
+  title: "Lonely",
+  body: "An entity with no inbound link and no source.",
+  pageKind: "entity",
+  status: "published",
+  isKernel: true,
+  kernelVersion: "0.1.0",
+  organizationId: null,
+  kernelPageId: null,
+  derivedFromKernelVersion: null,
+};
+
+// ─── fetchWikiSnapshot ───────────────────────────────────────────────────────
+
+describe("fetchWikiSnapshot", () => {
+  it("filters pages by organizationId IS NULL when linting the kernel", async () => {
+    const prisma = makePrismaMock({});
+    await fetchWikiSnapshot(prisma, null);
+    expect(prisma.__pagesFetched).toHaveBeenCalledWith({
+      where: { organizationId: null },
+    });
+  });
+
+  it("includes both org-scoped and kernel pages when linting an org", async () => {
+    const prisma = makePrismaMock({});
+    await fetchWikiSnapshot(prisma, "org_acme");
+    expect(prisma.__pagesFetched).toHaveBeenCalledWith({
+      where: { OR: [{ organizationId: "org_acme" }, { organizationId: null }] },
+    });
+  });
+
+  it("projects Prisma rows into the LintWikiPage shape", async () => {
+    const prisma = makePrismaMock({
+      pages: [
+        {
+          id: "wp_1",
+          slug: "entities/test",
+          title: "Test",
+          body: "B",
+          pageKind: "entity",
+          status: "published",
+          isKernel: true,
+          kernelVersion: "0.1.0",
+          organizationId: null,
+          kernelPageId: null,
+          derivedFromKernelVersion: null,
+        },
+      ],
+    });
+    const snap = await fetchWikiSnapshot(prisma, null);
+    expect(snap.pages).toEqual([
+      {
+        id: "wp_1",
+        slug: "entities/test",
+        title: "Test",
+        body: "B",
+        pageKind: "entity",
+        status: "published",
+        isKernel: true,
+        kernelVersion: "0.1.0",
+        organizationId: null,
+        kernelPageId: null,
+        derivedFromKernelVersion: null,
+      },
+    ]);
+  });
+
+  it("preserves Date instances on retrievedAt and nulls others", async () => {
+    const dt = new Date("2026-01-01T00:00:00Z");
+    const prisma = makePrismaMock({
+      rawSources: [
+        { id: "src_1", retrievedAt: dt },
+        { id: "src_2", retrievedAt: null },
+        { id: "src_3" }, // missing field
+      ],
+    });
+    const snap = await fetchWikiSnapshot(prisma, null);
+    expect(snap.rawSources[0]).toEqual({ id: "src_1", retrievedAt: dt });
+    expect(snap.rawSources[1]).toEqual({ id: "src_2", retrievedAt: null });
+    expect(snap.rawSources[2]).toEqual({ id: "src_3", retrievedAt: null });
+  });
+});
+
+// ─── persistFindings ─────────────────────────────────────────────────────────
+
+describe("persistFindings", () => {
+  it("creates a new row for a finding with no prior open match", async () => {
+    const prisma = makePrismaMock({ existingFindings: [] });
+    const res = await persistFindings(prisma, null, [
+      {
+        organizationId: null,
+        pageId: "wp_1",
+        findingKind: "orphan",
+        severity: "warn",
+        detail: { slug: "entities/lonely" },
+      },
+    ]);
+    expect(res).toEqual({ opened: 1, kept: 0, resolved: 0 });
+    expect(prisma.__findingsCreated).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: null,
+        pageId: "wp_1",
+        findingKind: "orphan",
+        status: "open",
+      }),
+    });
+  });
+
+  it("updates an existing open row when the same (pageId, kind) re-emits", async () => {
+    const prisma = makePrismaMock({
+      existingFindings: [{ id: "f_existing", pageId: "wp_1", findingKind: "orphan" }],
+    });
+    const res = await persistFindings(prisma, null, [
+      {
+        organizationId: null,
+        pageId: "wp_1",
+        findingKind: "orphan",
+        severity: "warn",
+        detail: { reason: "no_sources" },
+      },
+    ]);
+    expect(res).toEqual({ opened: 0, kept: 1, resolved: 0 });
+    expect(prisma.__findingsUpdated).toHaveBeenCalledWith({
+      where: { id: "f_existing" },
+      data: expect.objectContaining({
+        detail: { reason: "no_sources" },
+        severity: "warn",
+        status: "open",
+      }),
+    });
+    expect(prisma.__findingsCreated).not.toHaveBeenCalled();
+  });
+
+  it("resolves prior findings that did not re-emit this run", async () => {
+    const prisma = makePrismaMock({
+      existingFindings: [
+        { id: "f_old", pageId: "wp_other", findingKind: "stale" },
+      ],
+    });
+    const res = await persistFindings(prisma, null, []);
+    expect(res).toEqual({ opened: 0, kept: 0, resolved: 1 });
+    expect(prisma.__findingsUpdated).toHaveBeenCalledWith({
+      where: { id: "f_old" },
+      data: expect.objectContaining({
+        status: "resolved",
+        resolvedAt: expect.any(Date),
+      }),
+    });
+  });
+});
+
+// ─── runWikiLint (end-to-end with mocked prisma) ─────────────────────────────
+
+describe("runWikiLint", () => {
+  it("creates findings on a fresh fixture and reports counts", async () => {
+    const prisma = makePrismaMock({
+      pages: [dummyPage],
+      existingFindings: [],
+    });
+    const res = await runWikiLint({
+      organizationId: null,
+      prisma,
+      currentKernelVersion: "0.1.0",
+    });
+    expect(res.scannedPageCount).toBe(1);
+    expect(res.findingsOpened).toBeGreaterThan(0); // orphan + dangling-xref shouldn't both fire here, just orphan
+    expect(prisma.__findingsCreated).toHaveBeenCalled();
+  });
+
+  it("is idempotent — re-emitting the same finding keeps the prior row", async () => {
+    const prisma = makePrismaMock({
+      pages: [dummyPage],
+      existingFindings: [{ id: "f_pre", pageId: "wp_1", findingKind: "orphan" }],
+    });
+    const res = await runWikiLint({
+      organizationId: null,
+      prisma,
+      currentKernelVersion: "0.1.0",
+    });
+    expect(res.findingsOpened).toBe(0);
+    expect(res.findingsKept).toBeGreaterThan(0);
+    expect(prisma.__findingsCreated).not.toHaveBeenCalled();
+  });
+
+  it("propagates organizationId through the snapshot filter", async () => {
+    const prisma = makePrismaMock({ pages: [], existingFindings: [] });
+    await runWikiLint({
+      organizationId: "org_acme",
+      prisma,
+      currentKernelVersion: "0.1.0",
+    });
+    expect(prisma.__pagesFetched).toHaveBeenCalledWith({
+      where: { OR: [{ organizationId: "org_acme" }, { organizationId: null }] },
+    });
+    expect(prisma.__findingsFetched).toHaveBeenCalledWith({
+      where: { organizationId: "org_acme", status: "open" },
+    });
+  });
+});

--- a/apps/web/lib/wiki/lint.ts
+++ b/apps/web/lib/wiki/lint.ts
@@ -1,0 +1,261 @@
+// EP-WIKI-001 Phase 4b1: lint runtime orchestrator.
+// Spec: docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md §6
+// Plan: docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md (Phase 4b)
+//
+// Wraps the pure detectors from `lint-detectors.ts` (PR #419) with a
+// Prisma snapshot fetcher and a finding persister. Designed to be
+// called from:
+//   - the Inngest scheduled job (queue/functions/wiki-lint.ts)
+//   - the wiki_lint MCP tool (Phase 4b2)
+//   - admin endpoint for on-demand triggering (Phase 4b2)
+//
+// Phase 4b1 ships the orchestrator + scheduled job only. Phase 4b2
+// adds the admin UI + MCP tool. Phase 4b3 adds detectContradictions
+// (Qdrant cosine + LLM judge) and detectMissingXrefs (entity NER).
+
+import {
+  runDetectors,
+  type LintFinding,
+  type LintRawSource,
+  type LintWikiPage,
+  type LintWikiPageLink,
+  type LintWikiPageSource,
+} from "./lint-detectors";
+
+// ─── Input ──────────────────────────────────────────────────────────────────
+
+export type RunWikiLintInput = {
+  /** Tenant scope. `null` lints the kernel; a string lints that org's overlay rows. */
+  organizationId: string | null;
+  /** Prisma client (or a Prisma-shaped mock for tests). */
+  prisma: WikiLintPrismaClient;
+  /** Current kernel version from `docs/founder-kernel/manifest.json`. */
+  currentKernelVersion: string;
+  /** Optional override; default 180 days per spec §6. */
+  staleThresholdDays?: number;
+};
+
+export type RunWikiLintResult = {
+  organizationId: string | null;
+  scannedPageCount: number;
+  findingsOpened: number;
+  findingsKept: number;
+  findingsResolved: number;
+};
+
+// ─── Prisma surface ─────────────────────────────────────────────────────────
+
+/**
+ * Narrow view of the Prisma client that this orchestrator touches. Allows
+ * the helper to be tested with a typed mock instead of a full PrismaClient
+ * instance. Production callers pass the real `prisma` import.
+ */
+export type WikiLintPrismaClient = {
+  wikiPage: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+  };
+  wikiPageLink: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+  };
+  wikiPageSource: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+  };
+  rawSource: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+  };
+  wikiLintFinding: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+    create: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+};
+
+// ─── Snapshot fetch ─────────────────────────────────────────────────────────
+
+/**
+ * Build a typed snapshot of the wiki in the shape detectors expect.
+ *
+ * Per spec §3.3: kernel rows (organizationId IS NULL) are visible to every
+ * org overlay (kernel fallback). When linting an org, the snapshot
+ * includes both org-scoped rows AND kernel rows; when linting the kernel,
+ * only kernel rows are included.
+ */
+export async function fetchWikiSnapshot(
+  prisma: WikiLintPrismaClient,
+  organizationId: string | null,
+): Promise<{
+  pages: LintWikiPage[];
+  links: LintWikiPageLink[];
+  sources: LintWikiPageSource[];
+  rawSources: LintRawSource[];
+}> {
+  const orgFilter =
+    organizationId === null
+      ? { organizationId: null }
+      : { OR: [{ organizationId }, { organizationId: null }] };
+
+  const [pages, links, sources, rawSources] = await Promise.all([
+    prisma.wikiPage.findMany({ where: orgFilter }) as Promise<unknown[]>,
+    prisma.wikiPageLink.findMany({}) as Promise<unknown[]>,
+    prisma.wikiPageSource.findMany({}) as Promise<unknown[]>,
+    prisma.rawSource.findMany({}) as Promise<unknown[]>,
+  ]);
+
+  return {
+    pages: (pages as Array<Record<string, unknown>>).map(asLintWikiPage),
+    links: (links as Array<Record<string, unknown>>).map(asLintWikiPageLink),
+    sources: (sources as Array<Record<string, unknown>>).map(asLintWikiPageSource),
+    rawSources: (rawSources as Array<Record<string, unknown>>).map(asLintRawSource),
+  };
+}
+
+function asLintWikiPage(r: Record<string, unknown>): LintWikiPage {
+  return {
+    id: String(r["id"]),
+    slug: String(r["slug"]),
+    title: String(r["title"]),
+    body: String(r["body"]),
+    pageKind: String(r["pageKind"]),
+    status: String(r["status"]),
+    isKernel: Boolean(r["isKernel"]),
+    kernelVersion: (r["kernelVersion"] as string | null) ?? null,
+    organizationId: (r["organizationId"] as string | null) ?? null,
+    kernelPageId: (r["kernelPageId"] as string | null) ?? null,
+    derivedFromKernelVersion: (r["derivedFromKernelVersion"] as string | null) ?? null,
+  };
+}
+
+function asLintWikiPageLink(r: Record<string, unknown>): LintWikiPageLink {
+  return { fromPageId: String(r["fromPageId"]), toPageId: String(r["toPageId"]) };
+}
+
+function asLintWikiPageSource(r: Record<string, unknown>): LintWikiPageSource {
+  return { pageId: String(r["pageId"]), sourceId: String(r["sourceId"]) };
+}
+
+function asLintRawSource(r: Record<string, unknown>): LintRawSource {
+  const retrievedAt = r["retrievedAt"];
+  return {
+    id: String(r["id"]),
+    retrievedAt: retrievedAt instanceof Date ? retrievedAt : null,
+  };
+}
+
+// ─── Finding persistence ────────────────────────────────────────────────────
+
+/**
+ * Idempotent finding persistence per the spec: a re-run does not produce
+ * duplicate rows. Strategy:
+ *   1. Fetch all open findings for the scope.
+ *   2. For each new finding, if a row exists with the same
+ *      (organizationId, pageId, findingKind), update its detail/severity
+ *      in place. Otherwise insert.
+ *   3. Any open finding from the prior run that wasn't re-emitted is
+ *      marked `status: "resolved"` with the current timestamp.
+ *
+ * The `(organizationId, pageId, findingKind)` triple is the natural key
+ * — a page has at most one open finding of each kind at a time. The
+ * schema doesn't enforce uniqueness here yet; we enforce it in the
+ * orchestrator and may add a composite unique index in a later PR.
+ */
+export async function persistFindings(
+  prisma: WikiLintPrismaClient,
+  organizationId: string | null,
+  findings: LintFinding[],
+): Promise<{ opened: number; kept: number; resolved: number }> {
+  const existing = (await prisma.wikiLintFinding.findMany({
+    where: { organizationId, status: "open" },
+  })) as Array<{
+    id: string;
+    pageId: string;
+    findingKind: string;
+  }>;
+
+  const existingByKey = new Map<string, { id: string }>();
+  for (const f of existing) {
+    existingByKey.set(`${f.pageId}::${f.findingKind}`, { id: f.id });
+  }
+
+  const seenKeys = new Set<string>();
+  let opened = 0;
+  let kept = 0;
+
+  for (const f of findings) {
+    const key = `${f.pageId}::${f.findingKind}`;
+    seenKeys.add(key);
+    const prior = existingByKey.get(key);
+    if (prior) {
+      kept += 1;
+      await prisma.wikiLintFinding.update({
+        where: { id: prior.id },
+        data: {
+          detail: f.detail,
+          severity: f.severity,
+          status: "open",
+        },
+      });
+    } else {
+      opened += 1;
+      await prisma.wikiLintFinding.create({
+        data: {
+          organizationId: f.organizationId,
+          pageId: f.pageId,
+          findingKind: f.findingKind,
+          severity: f.severity,
+          status: "open",
+          detail: f.detail,
+        },
+      });
+    }
+  }
+
+  // Resolve findings that disappeared in this run.
+  const now = new Date();
+  let resolved = 0;
+  for (const f of existing) {
+    const key = `${f.pageId}::${f.findingKind}`;
+    if (!seenKeys.has(key)) {
+      resolved += 1;
+      await prisma.wikiLintFinding.update({
+        where: { id: f.id },
+        data: { status: "resolved", resolvedAt: now },
+      });
+    }
+  }
+
+  return { opened, kept, resolved };
+}
+
+// ─── Orchestrator ───────────────────────────────────────────────────────────
+
+/**
+ * One full lint pass over the wiki scope. Fetches the snapshot, runs
+ * every detector that's available in this phase, persists findings
+ * idempotently. Safe to re-run; safe to call concurrently for
+ * different `organizationId` values.
+ *
+ * Returns counts so the caller (Inngest job, MCP tool, admin button)
+ * can surface a one-line result.
+ */
+export async function runWikiLint(input: RunWikiLintInput): Promise<RunWikiLintResult> {
+  const snap = await fetchWikiSnapshot(input.prisma, input.organizationId);
+
+  const findings = runDetectors({
+    pages: snap.pages,
+    links: snap.links,
+    sources: snap.sources,
+    rawSources: snap.rawSources,
+    currentKernelVersion: input.currentKernelVersion,
+    staleThresholdDays: input.staleThresholdDays,
+  });
+
+  const persisted = await persistFindings(input.prisma, input.organizationId, findings);
+
+  return {
+    organizationId: input.organizationId,
+    scannedPageCount: snap.pages.length,
+    findingsOpened: persisted.opened,
+    findingsKept: persisted.kept,
+    findingsResolved: persisted.resolved,
+  };
+}


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 4b1 — brings the merged Phase 4a detectors (PR #419) from **dead code** to **running daily and persisting findings**. Lint findings now show up in `WikiLintFinding` rows, queryable by org/status/kind for the upcoming admin UI (Phase 4b2).

Independent of in-flight PRs #432 (Phase 3a recall) and #434 (seed→Qdrant). Depends only on merged work.

## Phase split (4b1 / 4b2 / 4b3)

- **4b1 (this PR)** — orchestrator + persistence + Inngest scheduled job
- **4b2 (next)** — admin UI at `/admin/wiki/lint` + `wiki_lint` MCP tool registration
- **4b3 (later)** — the two detectors that need external services: `detectContradictions` (Qdrant cosine + LLM judge) and `detectMissingXrefs` (entity NER)

## What&#39;s in this PR

### `apps/web/lib/wiki/lint.ts` (~250 lines)

- `fetchWikiSnapshot(prisma, organizationId)` — pulls pages, links, sources, rawSources from Prisma in the typed shapes the detectors expect. Per spec §3.3: kernel rows (`organizationId IS NULL`) are included for org-scoped runs too (kernel fallback).
- `persistFindings(prisma, organizationId, findings)` — **idempotent** by `(organizationId, pageId, findingKind)`:
  - match found → **update** detail/severity in place
  - no match → **insert** new finding with `status: "open"`
  - prior open finding not re-emitted → mark `status: "resolved"` with `resolvedAt: now()`
- `runWikiLint({ organizationId, prisma, currentKernelVersion, staleThresholdDays? })` — full pass: snapshot → detectors → persist. Returns counts (`scannedPageCount`, `findingsOpened`, `findingsKept`, `findingsResolved`).
- `WikiLintPrismaClient` — narrow type capturing just the delegate methods the orchestrator touches, so tests can pass mocks without constructing a full PrismaClient.

### `apps/web/lib/wiki/lint.test.ts` (10 vitest cases)

| Case | Asserts |
|------|---------|
| `fetchWikiSnapshot`: kernel filter | `where: { organizationId: null }` |
| `fetchWikiSnapshot`: org-with-fallback | `where: { OR: [{ organizationId }, { organizationId: null }] }` |
| `fetchWikiSnapshot`: row projection | Prisma row → `LintWikiPage` shape |
| `fetchWikiSnapshot`: retrievedAt | Date preserved; null + missing → null |
| `persistFindings`: new finding | `create` called with `status: open` |
| `persistFindings`: re-emit | `update` on prior row; no `create` |
| `persistFindings`: missing re-emit | `update` to `status: resolved` with `resolvedAt` |
| `runWikiLint`: fresh fixture | Detectors fire and findings get created |
| `runWikiLint`: idempotent | Re-run with prior open finding → `update`, no `create` |
| `runWikiLint`: org propagation | `organizationId` flows through both snapshot and finding fetch |

### `apps/web/lib/queue/functions/wiki-lint.ts`

Inngest function `wiki/lint-daily` with cron `30 3 * * *` (daily 03:30 UTC per plan). One `step.run` for kernel, then one per active `Organization`. Reads `currentKernelVersion` from `docs/founder-kernel/manifest.json` directly (no seed-module import — keeps the queue bundle lean). 2 retries because the orchestrator is idempotent.

### `apps/web/lib/queue/functions/index.ts`

Registers `wikiLint` alongside the existing functions.

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` | ✓ |
| `pnpm --filter web typecheck` | ✓ |
| `pnpm typecheck` (all six packages) | ✓ |
| `pnpm --filter web test --run lint.test.ts` | ✓ 10/10 |

## Test plan

- [ ] Read `persistFindings` — confirm the idempotency strategy (`(orgId, pageId, kind)` key, update-in-place, auto-resolve disappearing findings)
- [ ] Confirm Inngest scheduling: `wikiLint` registered in `allFunctions`, cron `30 3 * * *`
- [ ] Confirm `readKernelVersion()` graceful fallback when `manifest.json` is missing
- [ ] After merge, watch the first daily run in Inngest dashboard; confirm `WikiLintFinding` rows appear for the empty current kernel (likely zero findings since no kernel content yet)

## Out of scope

- Admin UI at `/admin/wiki/lint` and `LintFindingCard` component — **Phase 4b2**
- `wiki_lint` MCP tool registration + agent grants — **Phase 4b2**
- `detectContradictions` (Qdrant cosine + LLM judge) and `detectMissingXrefs` (entity NER) — **Phase 4b3**
- Composite unique index on `(organizationId, pageId, findingKind)` — currently enforced in application code via `persistFindings`; could move to a Prisma constraint in a follow-up if contention becomes a real issue

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_