### PR TITLE
Build Studio brief handoff gate

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -9,6 +9,7 @@ const { mockAuth, mockPrisma } = vi.hoisted(() => ({
       create: vi.fn(),
     },
     businessBuildBrief: {
+      findUnique: vi.fn(),
       upsert: vi.fn(),
     },
     organization: {
@@ -20,6 +21,7 @@ const { mockAuth, mockPrisma } = vi.hoisted(() => ({
     buildActivity: {
       create: vi.fn(),
     },
+    $transaction: vi.fn(),
   },
 }));
 
@@ -78,6 +80,8 @@ describe("governed build start approvals", () => {
       },
     });
     mockPrisma.buildActivity.create.mockResolvedValue({});
+    mockPrisma.$transaction.mockImplementation(async (callback) => callback(mockPrisma));
+    mockPrisma.businessBuildBrief.findUnique.mockResolvedValue({ status: "accepted" });
     mockPrisma.businessBuildBrief.upsert.mockResolvedValue({});
     mockPrisma.organization.findFirst.mockResolvedValue({ id: "org-1" });
     mockIsSandboxAvailable.mockResolvedValue(false);
@@ -116,6 +120,7 @@ describe("governed build start approvals", () => {
 
     await updateFeatureBrief("FB-123", brief);
 
+    expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function));
     expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith({
       where: { buildId: "FB-123" },
       data: { brief },
@@ -140,6 +145,40 @@ describe("governed build start approvals", () => {
         }),
       }),
     );
+  });
+
+  it("advanceBuildPhase blocks ideate to plan until the business brief is accepted", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      id: "build-row-1",
+      phase: "ideate",
+      createdById: "user-1",
+      originatingBacklogItemId: null,
+      draftApprovedAt: null,
+      designDoc: null,
+      designReview: null,
+      plan: null,
+      brief: {
+        acceptanceCriteria: ["A non-developer can approve the business brief."],
+      },
+      buildPlan: null,
+      planReview: null,
+      taskResults: null,
+      verificationOut: null,
+      acceptanceMet: null,
+      uxTestResults: null,
+      uxVerificationStatus: null,
+    });
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      governedBacklogEnabled: true,
+    });
+    mockPrisma.businessBuildBrief.findUnique.mockResolvedValue({
+      status: "awaiting_clarification",
+    });
+
+    await expect(advanceBuildPhase("FB-123", "plan")).rejects.toThrow(
+      "Accept the business build brief before moving into planning.",
+    );
+    expect(mockPrisma.featureBuild.update).not.toHaveBeenCalled();
   });
 
   it("approveBuildStart stamps draftApprovedAt for governed backlog drafts", async () => {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -42,6 +42,18 @@ async function requireBuildAccess(): Promise<string> {
   return user.id!;
 }
 
+function businessBriefJsonPayload(
+  businessBrief: ReturnType<typeof legacyFeatureBuildBriefToBusinessBuildBriefInput>,
+) {
+  return {
+    affectedPeople: businessBrief.affectedPeople as unknown as Prisma.InputJsonValue,
+    sourceEvidence: businessBrief.sourceEvidence as unknown as Prisma.InputJsonValue,
+    technicalInterpretation: businessBrief.technicalInterpretation as unknown as Prisma.InputJsonValue,
+    riskProfile: businessBrief.riskProfile as unknown as Prisma.InputJsonValue,
+    hiveReadiness: businessBrief.hiveReadiness as unknown as Prisma.InputJsonValue,
+  };
+}
+
 // ─── Create Feature Build ────────────────────────────────────────────────────
 
 export async function createFeatureBuild(input: {
@@ -152,44 +164,43 @@ export async function updateFeatureBrief(
   const acceptedFields = businessBrief.status === "accepted"
     ? { acceptedByUserId: userId, acceptedAt: new Date() }
     : { acceptedByUserId: null, acceptedAt: null };
+  const jsonPayload = businessBriefJsonPayload(businessBrief);
 
-  await prisma.featureBuild.update({
-    where: { buildId },
-    data: { brief: brief as unknown as Prisma.InputJsonValue },
-  });
+  await prisma.$transaction(async (tx) => {
+    await tx.featureBuild.update({
+      where: { buildId },
+      data: { brief: brief as unknown as Prisma.InputJsonValue },
+    });
 
-  await prisma.businessBuildBrief.upsert({
-    where: { featureBuildId: build.id },
-    create: {
-      ...businessBrief,
-      affectedPeople: businessBrief.affectedPeople as unknown as Prisma.InputJsonValue,
-      sourceEvidence: businessBrief.sourceEvidence as unknown as Prisma.InputJsonValue,
-      technicalInterpretation: businessBrief.technicalInterpretation as unknown as Prisma.InputJsonValue,
-      riskProfile: businessBrief.riskProfile as unknown as Prisma.InputJsonValue,
-      hiveReadiness: businessBrief.hiveReadiness as unknown as Prisma.InputJsonValue,
-      ...acceptedFields,
-    },
-    update: {
-      status: businessBrief.status,
-      intakeSource: businessBrief.intakeSource,
-      capabilityPackId: businessBrief.capabilityPackId,
-      backlogItemId: businessBrief.backlogItemId,
-      businessOutcome: businessBrief.businessOutcome,
-      affectedPeople: businessBrief.affectedPeople as unknown as Prisma.InputJsonValue,
-      affectedWorkflow: businessBrief.affectedWorkflow,
-      sourceEvidence: businessBrief.sourceEvidence as unknown as Prisma.InputJsonValue,
-      successSignals: businessBrief.successSignals,
-      constraints: businessBrief.constraints,
-      businessInterpretation: businessBrief.businessInterpretation,
-      technicalInterpretation: businessBrief.technicalInterpretation as unknown as Prisma.InputJsonValue,
-      riskProfile: businessBrief.riskProfile as unknown as Prisma.InputJsonValue,
-      hiveReadiness: businessBrief.hiveReadiness as unknown as Prisma.InputJsonValue,
-      openQuestions: businessBrief.openQuestions,
-      confidence: businessBrief.confidence,
-      confidenceRationale: businessBrief.confidenceRationale,
-      submittedByUserId: businessBrief.submittedByUserId,
-      ...acceptedFields,
-    },
+    await tx.businessBuildBrief.upsert({
+      where: { featureBuildId: build.id },
+      create: {
+        ...businessBrief,
+        ...jsonPayload,
+        ...acceptedFields,
+      },
+      update: {
+        status: businessBrief.status,
+        intakeSource: businessBrief.intakeSource,
+        capabilityPackId: businessBrief.capabilityPackId,
+        backlogItemId: businessBrief.backlogItemId,
+        businessOutcome: businessBrief.businessOutcome,
+        affectedPeople: jsonPayload.affectedPeople,
+        affectedWorkflow: businessBrief.affectedWorkflow,
+        sourceEvidence: jsonPayload.sourceEvidence,
+        successSignals: businessBrief.successSignals,
+        constraints: businessBrief.constraints,
+        businessInterpretation: businessBrief.businessInterpretation,
+        technicalInterpretation: jsonPayload.technicalInterpretation,
+        riskProfile: jsonPayload.riskProfile,
+        hiveReadiness: jsonPayload.hiveReadiness,
+        openQuestions: businessBrief.openQuestions,
+        confidence: businessBrief.confidence,
+        confidenceRationale: businessBrief.confidenceRationale,
+        submittedByUserId: businessBrief.submittedByUserId,
+        ...acceptedFields,
+      },
+    });
   });
 }
 
@@ -251,6 +262,16 @@ export async function advanceBuildPhase(
 
   if (!canTransitionPhase(currentPhase, targetPhase)) {
     throw new Error(`Cannot transition from ${currentPhase} to ${targetPhase}`);
+  }
+
+  if (currentPhase === "ideate" && targetPhase === "plan") {
+    const businessBrief = await prisma.businessBuildBrief.findUnique({
+      where: { featureBuildId: build.id },
+      select: { status: true },
+    });
+    if (businessBrief?.status !== "accepted") {
+      throw new Error("Accept the business build brief before moving into planning.");
+    }
   }
 
   const brief = build.brief as { acceptanceCriteria?: string[] } | null;


### PR DESCRIPTION
## Summary
- make legacy FeatureBuild brief persistence and BusinessBuildBrief upsert atomic
- block ideate → plan until the linked BusinessBuildBrief is accepted
- refactor BusinessBuildBrief JSON payload mapping so create/update stay aligned

## Verification
- pnpm --filter web exec vitest run lib/actions/build-governed.test.ts lib/build/business-build-brief.test.ts components/build-studio/BusinessBriefPanel.test.tsx components/build-studio/BuildStudioV2.test.tsx components/build-studio/ArtifactTabs.test.tsx
- git diff --check
- pnpm --filter web typecheck
- pnpm --filter web build

## Notes
- Production build passes with existing Turbopack tracing warnings in backlog spec/plan search and next.config NFT tracing.