### PR TITLE
feat: select operations map by archetype

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -2,12 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
-    agent: {
-      findMany: vi.fn(),
-    },
-    toolExecution: {
-      findMany: vi.fn(),
-    },
+    storefrontConfig: { findFirst: vi.fn() },
+    agent: { findMany: vi.fn() },
+    toolExecution: { findMany: vi.fn() },
   },
 }));
 
@@ -22,7 +19,7 @@ vi.mock("next/link", () => ({
 import { prisma } from "@dpf/db";
 
 describe("AI operations map page", () => {
-  it("renders the software platform map with coworkers, tool pulses, and drill-down links", async () => {
+  it("renders the selected map with coworkers, tool pulses, and drill-down links", async () => {
     vi.mocked(prisma.agent.findMany).mockResolvedValue([
       {
         id: "agent-db-1",
@@ -63,8 +60,8 @@ describe("AI operations map page", () => {
     const element = await OperationsMapPage();
     const props = element.props;
 
-    expect(props.template.label).toBe("Software Platform Operations");
-    expect(props.template.stations.map((station: { label: string }) => station.label)).toContain("Discover");
+    expect(props.template.label).toBe("Generic Value Chain");
+    expect(props.template.stations.map((station: { label: string }) => station.label)).toContain("Demand");
     expect(props.agents.map((agent: { name: string }) => agent.name)).toContain("Build Specialist");
     expect(props.projections.map((projection: { label: string }) => projection.label)).toContain("write_sandbox_file");
     expect(props.projections.map((projection: { summary: string }) => projection.summary)).toContain("Write blocked by policy");

--- a/apps/web/app/(shell)/platform/ai/operations-map/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.tsx
@@ -1,88 +1,15 @@
-import { prisma } from "@dpf/db";
 import { AiOperationsMap } from "@/components/platform/AiOperationsMap";
-import { SOFTWARE_PLATFORM_MAP_TEMPLATE } from "@/lib/ai-operations-map/templates";
-import { projectAgentsToStations, projectToolExecution } from "@/lib/ai-operations-map/project-events";
-import type { OperationsMapAgent, OperationsMapToolExecution } from "@/lib/ai-operations-map/types";
-
-const RECENT_TOOL_LIMIT = 40;
+import { loadOperationsMapData } from "@/lib/ai-operations-map/load-map-data";
 
 export default async function OperationsMapPage() {
-  const [agents, toolExecutions] = await Promise.all([
-    prisma.agent.findMany({
-      where: { archived: false },
-      orderBy: [{ tier: "asc" }, { name: "asc" }],
-      select: {
-        id: true,
-        agentId: true,
-        slugId: true,
-        name: true,
-        tier: true,
-        type: true,
-        description: true,
-        status: true,
-        valueStream: true,
-        it4itSections: true,
-        sensitivity: true,
-        lifecycleStage: true,
-        _count: {
-          select: {
-            skills: true,
-            toolGrants: true,
-          },
-        },
-      },
-    }),
-    prisma.toolExecution.findMany({
-      orderBy: { createdAt: "desc" },
-      take: RECENT_TOOL_LIMIT,
-      select: {
-        id: true,
-        threadId: true,
-        agentId: true,
-        userId: true,
-        toolName: true,
-        success: true,
-        executionMode: true,
-        routeContext: true,
-        durationMs: true,
-        createdAt: true,
-        auditClass: true,
-        capabilityId: true,
-        summary: true,
-      },
-    }),
-  ]);
-
-  const mapAgents: OperationsMapAgent[] = agents.map((agent) => ({
-    id: agent.id,
-    agentId: agent.agentId,
-    slugId: agent.slugId,
-    name: agent.name,
-    tier: agent.tier,
-    type: agent.type,
-    description: agent.description,
-    status: agent.status,
-    valueStream: agent.valueStream,
-    it4itSections: agent.it4itSections,
-    sensitivity: agent.sensitivity,
-    lifecycleStage: agent.lifecycleStage,
-    counts: {
-      skills: agent._count.skills,
-      toolGrants: agent._count.toolGrants,
-    },
-  }));
-
-  const projectedAgents = projectAgentsToStations(mapAgents, SOFTWARE_PLATFORM_MAP_TEMPLATE);
-  const projections = toolExecutions.map((row) =>
-    projectToolExecution(row as OperationsMapToolExecution),
-  );
+  const data = await loadOperationsMapData();
 
   return (
     <AiOperationsMap
-      template={SOFTWARE_PLATFORM_MAP_TEMPLATE}
-      agents={projectedAgents}
-      projections={projections}
-      recentWindowLabel={`Last ${RECENT_TOOL_LIMIT} tool executions`}
+      template={data.template}
+      agents={data.agents}
+      projections={data.projections}
+      recentWindowLabel={data.recentWindowLabel}
     />
   );
 }

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -24,8 +24,8 @@ type Props = {
 const SEVERITY_CLASS: Record<OperationsMapProjection["severity"], string> = {
   normal: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
   attention: "border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)] text-[var(--dpf-text)]",
-  warning: "border-[var(--dpf-state-warning)] bg-[color-mix(in_srgb,var(--dpf-state-warning)_10%,var(--dpf-surface-1))] text-[var(--dpf-text)]",
-  critical: "border-[var(--dpf-state-error)] bg-[color-mix(in_srgb,var(--dpf-state-error)_10%,var(--dpf-surface-1))] text-[var(--dpf-text)]",
+  warning: "border-[var(--dpf-warning)] bg-[color-mix(in_srgb,var(--dpf-warning)_10%,var(--dpf-surface-1))] text-[var(--dpf-text)]",
+  critical: "border-[var(--dpf-error)] bg-[color-mix(in_srgb,var(--dpf-error)_10%,var(--dpf-surface-1))] text-[var(--dpf-text)]",
 };
 
 export function AiOperationsMap({ template, agents, projections, recentWindowLabel }: Props) {

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    storefrontConfig: {
+      findFirst: vi.fn(),
+    },
+    agent: {
+      findMany: vi.fn(),
+    },
+    toolExecution: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { loadOperationsMapData } from "./load-map-data";
+
+describe("loadOperationsMapData", () => {
+  it("selects the map template from StorefrontConfig archetype truth", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
+      archetype: {
+        archetypeId: "it-managed-services",
+        activationProfile: {
+          profileType: "managed-service-provider",
+          modules: ["customer-estate", "service-agreements", "billing-readiness", "service-operations"],
+        },
+      },
+    } as never);
+    vi.mocked(prisma.agent.findMany).mockResolvedValue([makeAgentRow()] as never);
+    vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([makeToolExecutionRow()] as never);
+
+    const data = await loadOperationsMapData();
+
+    expect(data.template.id).toBe("managed-service-provider");
+    expect(data.agents[0].stationId).toBe("service-operations");
+    expect(data.projections[0].location.stationId).toBe("service-operations");
+    expect(data.recentWindowLabel).toBe("Last 40 tool executions");
+    expect(prisma.storefrontConfig.findFirst).toHaveBeenCalledWith({
+      include: {
+        archetype: {
+          select: {
+            archetypeId: true,
+            activationProfile: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("falls back to the generic value-chain map when no storefront archetype is configured", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.agent.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([] as never);
+
+    const data = await loadOperationsMapData();
+
+    expect(data.template.id).toBe("generic-value-chain");
+    expect(data.agents).toEqual([]);
+    expect(data.projections).toEqual([]);
+  });
+});
+
+function makeAgentRow() {
+  return {
+    id: "agent-db-1",
+    agentId: "support-specialist",
+    slugId: "support-specialist",
+    name: "Support Specialist",
+    tier: 2,
+    type: "specialist",
+    description: "Handles service operations.",
+    status: "active",
+    valueStream: "operate",
+    it4itSections: [],
+    sensitivity: "internal",
+    lifecycleStage: "production",
+    _count: { skills: 2, toolGrants: 4 },
+  };
+}
+
+function makeToolExecutionRow() {
+  return {
+    id: "tool-1",
+    threadId: "thread-1",
+    agentId: "support-specialist",
+    userId: "user-1",
+    toolName: "diagnose_customer_estate",
+    success: true,
+    executionMode: "immediate",
+    routeContext: "service-operations",
+    durationMs: 80,
+    createdAt: new Date("2026-05-10T12:00:00.000Z"),
+    auditClass: "journal",
+    capabilityId: "platform:diagnose_customer_estate",
+    summary: "Checked service health",
+  };
+}

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -1,0 +1,114 @@
+import { prisma } from "@dpf/db";
+import { getMapTemplate } from "./templates";
+import { projectAgentsToStations, projectToolExecution } from "./project-events";
+import type {
+  OperationsMapAgent,
+  OperationsMapProjection,
+  OperationsMapTemplate,
+  OperationsMapToolExecution,
+  StationedOperationsMapAgent,
+} from "./types";
+
+export const RECENT_TOOL_LIMIT = 40;
+
+export type OperationsMapData = {
+  template: OperationsMapTemplate;
+  agents: StationedOperationsMapAgent[];
+  projections: OperationsMapProjection[];
+  recentWindowLabel: string;
+};
+
+export async function loadOperationsMapData(): Promise<OperationsMapData> {
+  const [storefrontConfig, agents, toolExecutions] = await Promise.all([
+    prisma.storefrontConfig.findFirst({
+      include: {
+        archetype: {
+          select: {
+            archetypeId: true,
+            activationProfile: true,
+          },
+        },
+      },
+    }),
+    prisma.agent.findMany({
+      where: { archived: false },
+      orderBy: [{ tier: "asc" }, { name: "asc" }],
+      select: {
+        id: true,
+        agentId: true,
+        slugId: true,
+        name: true,
+        tier: true,
+        type: true,
+        description: true,
+        status: true,
+        valueStream: true,
+        it4itSections: true,
+        sensitivity: true,
+        lifecycleStage: true,
+        _count: {
+          select: {
+            skills: true,
+            toolGrants: true,
+          },
+        },
+      },
+    }),
+    prisma.toolExecution.findMany({
+      orderBy: { createdAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        threadId: true,
+        agentId: true,
+        userId: true,
+        toolName: true,
+        success: true,
+        executionMode: true,
+        routeContext: true,
+        durationMs: true,
+        createdAt: true,
+        auditClass: true,
+        capabilityId: true,
+        summary: true,
+      },
+    }),
+  ]);
+
+  const template = getMapTemplate({
+    archetypeId: storefrontConfig?.archetype?.archetypeId ?? null,
+    activationProfileType: getActivationProfileType(storefrontConfig?.archetype?.activationProfile),
+  });
+
+  const mapAgents: OperationsMapAgent[] = agents.map((agent) => ({
+    id: agent.id,
+    agentId: agent.agentId,
+    slugId: agent.slugId,
+    name: agent.name,
+    tier: agent.tier,
+    type: agent.type,
+    description: agent.description,
+    status: agent.status,
+    valueStream: agent.valueStream,
+    it4itSections: agent.it4itSections,
+    sensitivity: agent.sensitivity,
+    lifecycleStage: agent.lifecycleStage,
+    counts: {
+      skills: agent._count.skills,
+      toolGrants: agent._count.toolGrants,
+    },
+  }));
+
+  return {
+    template,
+    agents: projectAgentsToStations(mapAgents, template),
+    projections: toolExecutions.map((row) => projectToolExecution(row as OperationsMapToolExecution, template)),
+    recentWindowLabel: `Last ${RECENT_TOOL_LIMIT} tool executions`,
+  };
+}
+
+function getActivationProfileType(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const profileType = (value as { profileType?: unknown }).profileType;
+  return typeof profileType === "string" ? profileType : null;
+}

--- a/apps/web/lib/ai-operations-map/project-events.test.ts
+++ b/apps/web/lib/ai-operations-map/project-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { AUDIT_CLASSES } from "@/lib/audit-classes";
 import { TASK_STATES } from "@/lib/tak/task-states";
 import {
+  MANAGED_SERVICE_PROVIDER_MAP_TEMPLATE,
   SOFTWARE_PLATFORM_MAP_TEMPLATE,
   getMapTemplate,
   validateMapTemplate,
@@ -17,19 +18,42 @@ describe("AI operations map projection", () => {
   it("ships a valid software-platform template with stable stations", () => {
     expect(SOFTWARE_PLATFORM_MAP_TEMPLATE.id).toBe("software-platform");
     expect(SOFTWARE_PLATFORM_MAP_TEMPLATE.stations.map((station) => station.id)).toEqual([
-      "discover",
-      "backlog",
-      "design",
+      "cross-cutting",
+      "explore",
+      "evaluate",
+      "integrate",
       "build",
       "verify",
+      "deploy",
       "release",
-      "support",
-      "improve",
+      "consume",
+      "operate",
+      "governance",
+      "unplaced",
     ]);
 
     expect(validateMapTemplate(SOFTWARE_PLATFORM_MAP_TEMPLATE)).toEqual([]);
     expect(getMapTemplate("software-platform").id).toBe("software-platform");
     expect(getMapTemplate("unknown-archetype").id).toBe("generic-value-chain");
+  });
+
+  it("selects a managed service provider template from archetype or activation profile", () => {
+    expect(MANAGED_SERVICE_PROVIDER_MAP_TEMPLATE.stations.map((station) => station.id)).toEqual([
+      "customer-intake",
+      "triage",
+      "agreements",
+      "service-operations",
+      "customer-estate",
+      "billing-readiness",
+      "lifecycle-review",
+      "improvement",
+    ]);
+
+    expect(validateMapTemplate(MANAGED_SERVICE_PROVIDER_MAP_TEMPLATE)).toEqual([]);
+    expect(getMapTemplate("it-managed-services").id).toBe("managed-service-provider");
+    expect(getMapTemplate({ archetypeId: "custom-msp", activationProfileType: "managed-service-provider" }).id).toBe(
+      "managed-service-provider",
+    );
   });
 
   it("maps every canonical task state to a projection severity", () => {
@@ -53,14 +77,16 @@ describe("AI operations map projection", () => {
       makeAgent({ agentId: "hive-scout", name: "Hive Scout", valueStream: "explore" }),
       makeAgent({ agentId: "build-specialist", name: "Build Specialist", valueStream: null }),
       makeAgent({ agentId: "release-manager", name: "Release Manager", valueStream: "release" }),
+      makeAgent({ agentId: "unknown-agent", name: "Unknown Agent", valueStream: "mystery" }),
     ];
 
     const projected = projectAgentsToStations(agents, SOFTWARE_PLATFORM_MAP_TEMPLATE);
 
     expect(projected.map((agent) => [agent.agentId, agent.stationId])).toEqual([
-      ["hive-scout", "discover"],
+      ["hive-scout", "explore"],
       ["build-specialist", "build"],
       ["release-manager", "release"],
+      ["unknown-agent", "unplaced"],
     ]);
   });
 

--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -1,5 +1,6 @@
 import type { AuditClass } from "@/lib/audit-classes";
 import type { TaskState } from "@/lib/tak/task-states";
+import { SOFTWARE_PLATFORM_MAP_TEMPLATE } from "./templates";
 import type {
   OperationsMapAgent,
   OperationsMapProjection,
@@ -10,34 +11,62 @@ import type {
 } from "./types";
 
 const VALUE_STREAM_TO_STATION: Record<string, string> = {
-  evaluate: "discover",
-  explore: "discover",
-  integrate: "build",
-  deploy: "release",
+  evaluate: "evaluate",
+  explore: "explore",
+  integrate: "integrate",
+  deploy: "deploy",
   release: "release",
-  consume: "support",
-  operate: "support",
-  "cross-cutting": "improve",
+  consume: "consume",
+  operate: "operate",
+  governance: "governance",
+  "cross-cutting": "cross-cutting",
+};
+
+const MSP_VALUE_STREAM_TO_STATION: Record<string, string> = {
+  evaluate: "customer-intake",
+  explore: "customer-intake",
+  integrate: "service-operations",
+  deploy: "service-operations",
+  release: "lifecycle-review",
+  consume: "customer-estate",
+  operate: "service-operations",
+  "cross-cutting": "improvement",
 };
 
 const AGENT_ID_TO_STATION_HINTS: Array<{ pattern: RegExp; stationId: string }> = [
-  { pattern: /scout|research|discover/i, stationId: "discover" },
-  { pattern: /backlog|portfolio|triage/i, stationId: "backlog" },
-  { pattern: /architect|design|ux|plan/i, stationId: "design" },
+  { pattern: /scout|research|discover/i, stationId: "explore" },
+  { pattern: /backlog|portfolio|triage|evaluate/i, stationId: "evaluate" },
+  { pattern: /architect|design|ux|plan|integrate/i, stationId: "integrate" },
   { pattern: /build|code|developer|specialist/i, stationId: "build" },
   { pattern: /review|verify|qa|test/i, stationId: "verify" },
+  { pattern: /deploy|environment/i, stationId: "deploy" },
   { pattern: /release|deploy|ship/i, stationId: "release" },
-  { pattern: /support|admin|ops|diagnostic/i, stationId: "support" },
+  { pattern: /consume|customer|experience/i, stationId: "consume" },
+  { pattern: /support|admin|ops|operate|diagnostic/i, stationId: "operate" },
+  { pattern: /govern|compliance|policy|authority/i, stationId: "governance" },
+  { pattern: /service|incident|help.?desk|diagnostic/i, stationId: "service-operations" },
+  { pattern: /estate|site|configuration|asset/i, stationId: "customer-estate" },
+  { pattern: /agreement|sla|entitlement/i, stationId: "agreements" },
+  { pattern: /billing|charge|invoice/i, stationId: "billing-readiness" },
+  { pattern: /lifecycle|renewal|review/i, stationId: "lifecycle-review" },
 ];
 
 const ROUTE_CONTEXT_TO_STATION: Array<{ pattern: RegExp; stationId: string }> = [
-  { pattern: /discover|research|scout/i, stationId: "discover" },
-  { pattern: /backlog|portfolio|triage/i, stationId: "backlog" },
-  { pattern: /design|plan|architect/i, stationId: "design" },
+  { pattern: /discover|research|scout|explore/i, stationId: "explore" },
+  { pattern: /backlog|portfolio|triage|evaluate/i, stationId: "evaluate" },
+  { pattern: /design|plan|architect|integrate/i, stationId: "integrate" },
   { pattern: /build|sandbox|code/i, stationId: "build" },
   { pattern: /verify|review|test|qa/i, stationId: "verify" },
+  { pattern: /deploy|environment/i, stationId: "deploy" },
   { pattern: /release|deploy|ship/i, stationId: "release" },
-  { pattern: /support|admin|ops|diagnostic/i, stationId: "support" },
+  { pattern: /consume|customer|experience/i, stationId: "consume" },
+  { pattern: /support|admin|ops|operate|diagnostic/i, stationId: "operate" },
+  { pattern: /govern|compliance|policy|authority/i, stationId: "governance" },
+  { pattern: /service-operations|incident|help.?desk|diagnostic/i, stationId: "service-operations" },
+  { pattern: /customer-estate|site|configuration|asset/i, stationId: "customer-estate" },
+  { pattern: /agreement|sla|entitlement/i, stationId: "agreements" },
+  { pattern: /billing|charge|invoice/i, stationId: "billing-readiness" },
+  { pattern: /lifecycle|renewal|review/i, stationId: "lifecycle-review" },
 ];
 
 export function deriveProjectionSeverityFromTaskState(state: TaskState): OperationsMapSeverity {
@@ -84,8 +113,11 @@ export function projectAgentsToStations(
   });
 }
 
-export function projectToolExecution(row: OperationsMapToolExecution): OperationsMapProjection {
-  const stationId = resolveToolExecutionStationId(row);
+export function projectToolExecution(
+  row: OperationsMapToolExecution,
+  template: OperationsMapTemplate = SOFTWARE_PLATFORM_MAP_TEMPLATE,
+): OperationsMapProjection {
+  const stationId = resolveToolExecutionStationId(row, template);
   const severity = deriveProjectionSeverityFromToolExecution(row);
   const outcome = row.success ? "completed" : "failed";
 
@@ -95,7 +127,7 @@ export function projectToolExecution(row: OperationsMapToolExecution): Operation
     actorAgentId: row.agentId,
     source: "tool-execution",
     location: {
-      lineId: "product-flow",
+      lineId: resolveLineId(stationId, template),
       stationId,
     },
     severity,
@@ -125,23 +157,65 @@ export function summarizeProjectionCounts(projections: OperationsMapProjection[]
 
 function resolveAgentStationId(agent: OperationsMapAgent, template: OperationsMapTemplate): string {
   const stationIds = new Set(template.stations.map((station) => station.id));
-  const byValueStream = agent.valueStream ? VALUE_STREAM_TO_STATION[agent.valueStream] : null;
+  const byValueStream = agent.valueStream ? resolveValueStreamStationId(agent.valueStream, template) : null;
   if (byValueStream && stationIds.has(byValueStream)) return byValueStream;
+  if (agent.valueStream) return resolveFallbackStationId(template);
 
   const searchable = `${agent.agentId} ${agent.slugId ?? ""} ${agent.name} ${agent.type}`;
+  const direct = resolveDirectTemplateStationId(searchable, template);
+  if (direct) return direct;
+
   const hinted = AGENT_ID_TO_STATION_HINTS.find((hint) => hint.pattern.test(searchable))?.stationId;
   if (hinted && stationIds.has(hinted)) return hinted;
 
-  return stationIds.has("improve") ? "improve" : template.stations[0].id;
+  return resolveFallbackStationId(template);
 }
 
-function resolveToolExecutionStationId(row: OperationsMapToolExecution): string {
+function resolveToolExecutionStationId(row: OperationsMapToolExecution, template: OperationsMapTemplate): string {
   const routeContext = row.routeContext;
+  const routeDirect = routeContext ? resolveDirectTemplateStationId(routeContext, template) : null;
+  if (routeDirect) return routeDirect;
+
   const routeHint = routeContext
     ? ROUTE_CONTEXT_TO_STATION.find((hint) => hint.pattern.test(routeContext))?.stationId
     : null;
-  if (routeHint) return routeHint;
+  if (routeHint && template.stations.some((station) => station.id === routeHint)) return routeHint;
+
+  const agentDirect = resolveDirectTemplateStationId(row.agentId, template);
+  if (agentDirect) return agentDirect;
 
   const agentHint = AGENT_ID_TO_STATION_HINTS.find((hint) => hint.pattern.test(row.agentId))?.stationId;
-  return agentHint ?? "improve";
+  if (agentHint && template.stations.some((station) => station.id === agentHint)) return agentHint;
+
+  return resolveFallbackStationId(template);
+}
+
+function resolveValueStreamStationId(valueStream: string, template: OperationsMapTemplate): string | null {
+  const map = template.id === "managed-service-provider" ? MSP_VALUE_STREAM_TO_STATION : VALUE_STREAM_TO_STATION;
+  return map[valueStream] ?? null;
+}
+
+function resolveDirectTemplateStationId(value: string, template: OperationsMapTemplate): string | null {
+  const normalized = normalizeStationText(value);
+  return (
+    template.stations.find((station) =>
+      [station.id, station.label, station.shortLabel].map(normalizeStationText).includes(normalized),
+    )?.id ?? null
+  );
+}
+
+function resolveLineId(stationId: string, template: OperationsMapTemplate): string {
+  return template.lines.find((line) => line.stationIds.includes(stationId))?.id ?? template.lines[0]?.id ?? "flow";
+}
+
+function resolveFallbackStationId(template: OperationsMapTemplate): string {
+  const stationIds = new Set(template.stations.map((station) => station.id));
+  for (const stationId of ["unplaced", "improve", "improvement", "operate"]) {
+    if (stationIds.has(stationId)) return stationId;
+  }
+  return template.stations[0].id;
+}
+
+function normalizeStationText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
 }

--- a/apps/web/lib/ai-operations-map/templates.ts
+++ b/apps/web/lib/ai-operations-map/templates.ts
@@ -1,4 +1,4 @@
-import type { OperationsMapTemplate } from "./types";
+import type { OperationsMapTemplate, OperationsMapTemplateSelector } from "./types";
 
 export const SOFTWARE_PLATFORM_MAP_TEMPLATE: OperationsMapTemplate = {
   id: "software-platform",
@@ -6,21 +6,27 @@ export const SOFTWARE_PLATFORM_MAP_TEMPLATE: OperationsMapTemplate = {
   archetypeCategoryIds: ["software-platform"],
   stations: [
     {
-      id: "discover",
+      id: "cross-cutting",
+      label: "Cross-Cutting",
+      shortLabel: "Cross",
+      description: "Orchestrators and operators that coordinate across multiple value streams.",
+    },
+    {
+      id: "explore",
       label: "Discover",
       shortLabel: "Discover",
       description: "Research signals, customer needs, technical opportunities, and operating risks.",
     },
     {
-      id: "backlog",
-      label: "Backlog",
-      shortLabel: "Backlog",
+      id: "evaluate",
+      label: "Backlog and Evaluation",
+      shortLabel: "Evaluate",
       description: "Convert signals into governed epics, items, priorities, and execution evidence.",
     },
     {
-      id: "design",
-      label: "Design",
-      shortLabel: "Design",
+      id: "integrate",
+      label: "Design and Integrate",
+      shortLabel: "Integrate",
       description: "Shape architecture, UX, policies, specifications, and implementation plans.",
     },
     {
@@ -36,29 +42,57 @@ export const SOFTWARE_PLATFORM_MAP_TEMPLATE: OperationsMapTemplate = {
       description: "Run tests, builds, QA, review, and acceptance checks before release.",
     },
     {
+      id: "deploy",
+      label: "Deploy",
+      shortLabel: "Deploy",
+      description: "Prepare runtime, deployment, and environment changes.",
+    },
+    {
       id: "release",
       label: "Release",
       shortLabel: "Release",
-      description: "Prepare, review, promote, and publish approved changes.",
+      description: "Review, promote, and publish approved changes.",
     },
     {
-      id: "support",
-      label: "Support",
-      shortLabel: "Support",
-      description: "Handle operational issues, customer support, diagnostics, and recovery.",
+      id: "consume",
+      label: "Customer Experience",
+      shortLabel: "Consume",
+      description: "Support customer-facing adoption, service experience, and trust work.",
     },
     {
-      id: "improve",
-      label: "Improve",
-      shortLabel: "Improve",
-      description: "Feed outcomes, incidents, and evidence back into better platform behavior.",
+      id: "operate",
+      label: "Operate and Improve",
+      shortLabel: "Operate",
+      description: "Handle operational issues, diagnostics, recovery, and improvement loops.",
+    },
+    {
+      id: "governance",
+      label: "Governance",
+      shortLabel: "Govern",
+      description: "Policy, evidence, compliance, and constitutional governance for AI coworker actions.",
+    },
+    {
+      id: "unplaced",
+      label: "Unplaced",
+      shortLabel: "Unplaced",
+      description: "Coworkers or activity whose registry value stream does not yet map to a station.",
     },
   ],
   lines: [
     {
+      id: "cross-cutting-band",
+      label: "Cross-cutting band",
+      stationIds: ["cross-cutting"],
+    },
+    {
       id: "product-flow",
       label: "Product flow",
-      stationIds: ["discover", "backlog", "design", "build", "verify", "release", "support", "improve"],
+      stationIds: ["explore", "evaluate", "integrate", "build", "verify", "deploy", "release", "consume", "operate"],
+    },
+    {
+      id: "governance-band",
+      label: "Governance band",
+      stationIds: ["governance", "unplaced"],
     },
   ],
 };
@@ -108,15 +142,98 @@ export const GENERIC_VALUE_CHAIN_TEMPLATE: OperationsMapTemplate = {
   ],
 };
 
+export const MANAGED_SERVICE_PROVIDER_MAP_TEMPLATE: OperationsMapTemplate = {
+  id: "managed-service-provider",
+  label: "Managed Service Provider Operations",
+  archetypeCategoryIds: ["it-managed-services"],
+  activationProfileTypes: ["managed-service-provider"],
+  stations: [
+    {
+      id: "customer-intake",
+      label: "Customer Intake",
+      shortLabel: "Intake",
+      description: "New customer requests, qualification, onboarding signals, and context capture.",
+    },
+    {
+      id: "triage",
+      label: "Triage",
+      shortLabel: "Triage",
+      description: "Classify service demand, urgency, ownership, and response path.",
+    },
+    {
+      id: "agreements",
+      label: "Agreement and SLA",
+      shortLabel: "SLA",
+      description: "Connect work to service agreements, entitlements, approval gates, and SLA posture.",
+    },
+    {
+      id: "service-operations",
+      label: "Service Operations",
+      shortLabel: "Ops",
+      description: "Resolve incidents, fulfill service requests, coordinate projects, and operate support workflows.",
+    },
+    {
+      id: "customer-estate",
+      label: "Customer Estate",
+      shortLabel: "Estate",
+      description: "Inspect customers, sites, configuration items, integrations, and estate separation signals.",
+    },
+    {
+      id: "billing-readiness",
+      label: "Billing Readiness",
+      shortLabel: "Billing",
+      description: "Prepare chargeable work, billing units, pass-through costs, and commercial readiness evidence.",
+    },
+    {
+      id: "lifecycle-review",
+      label: "Lifecycle Review",
+      shortLabel: "Review",
+      description: "Surface lifecycle signals, risk reviews, renewal prompts, and improvement opportunities.",
+    },
+    {
+      id: "improvement",
+      label: "Improvement",
+      shortLabel: "Improve",
+      description: "Feed service evidence, incidents, and lessons back into better customer operations.",
+    },
+  ],
+  lines: [
+    {
+      id: "service-flow",
+      label: "Service flow",
+      stationIds: [
+        "customer-intake",
+        "triage",
+        "agreements",
+        "service-operations",
+        "customer-estate",
+        "billing-readiness",
+        "lifecycle-review",
+        "improvement",
+      ],
+    },
+  ],
+};
+
 export const OPERATIONS_MAP_TEMPLATES = [
   SOFTWARE_PLATFORM_MAP_TEMPLATE,
+  MANAGED_SERVICE_PROVIDER_MAP_TEMPLATE,
   GENERIC_VALUE_CHAIN_TEMPLATE,
 ] as const;
 
-export function getMapTemplate(archetypeCategoryId: string | null | undefined): OperationsMapTemplate {
+export function getMapTemplate(
+  selector: string | OperationsMapTemplateSelector | null | undefined,
+): OperationsMapTemplate {
+  const normalized = normalizeTemplateSelector(selector);
+
   return (
     OPERATIONS_MAP_TEMPLATES.find((template) =>
-      archetypeCategoryId ? template.archetypeCategoryIds.includes(archetypeCategoryId) : false,
+      normalized.activationProfileType
+        ? template.activationProfileTypes?.includes(normalized.activationProfileType)
+        : false,
+    ) ??
+    OPERATIONS_MAP_TEMPLATES.find((template) =>
+      normalized.archetypeId ? template.archetypeCategoryIds.includes(normalized.archetypeId) : false,
     ) ?? GENERIC_VALUE_CHAIN_TEMPLATE
   );
 }
@@ -134,4 +251,11 @@ export function validateMapTemplate(template: OperationsMapTemplate): string[] {
   }
 
   return errors;
+}
+
+function normalizeTemplateSelector(
+  selector: string | OperationsMapTemplateSelector | null | undefined,
+): OperationsMapTemplateSelector {
+  if (typeof selector === "string") return { archetypeId: selector };
+  return selector ?? {};
 }

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -19,6 +19,7 @@ export type OperationsMapTemplate = {
   id: string;
   label: string;
   archetypeCategoryIds: string[];
+  activationProfileTypes?: string[];
   stations: OperationsMapStation[];
   lines: OperationsMapLine[];
 };
@@ -84,4 +85,9 @@ export type OperationsMapProjection = {
     authorityHref: string;
     coworkerHref: string;
   };
+};
+
+export type OperationsMapTemplateSelector = {
+  archetypeId?: string | null;
+  activationProfileType?: string | null;
 };

--- a/docs/superpowers/plans/2026-05-10-ai-operations-map-v1.md
+++ b/docs/superpowers/plans/2026-05-10-ai-operations-map-v1.md
@@ -19,9 +19,9 @@
 **Create:**
 
 - `apps/web/lib/ai-operations-map/types.ts` — view-layer types: `MapTemplate`, `MapLine`, `MapStation`, `MapProjection`, view DTOs (`ToolExecutionView`, `ToolExecutionReceiptView`, `BacklogItemActivityView`, `ExternalEvidenceRecordView`), `ActorRef`.
-- `apps/web/lib/ai-operations-map/templates.ts` — the software-platform template (`software-platform`) with stable line/station ids: `discover`, `backlog`, `design`, `build`, `verify`, `release`, `support`, `improve`.
-- `apps/web/lib/ai-operations-map/project-events.ts` — pure functions: `projectToolExecution`, `projectToolReceipt`, `projectBacklogActivity`, `projectExternalEvidence`, `projectAgentEvent`, `synthesizeHandoff`, `deriveSeverity`, `dedupeByToolExecution`.
-- `apps/web/lib/ai-operations-map/load-projection.ts` — server-side fetcher that takes `{ organizationId, since, viewerCapabilities }` and returns `MapProjection[]` from Prisma.
+- `apps/web/lib/ai-operations-map/templates.ts` — the software-platform template (`software-platform`) with stable IT4IT-aligned station ids: `explore`, `evaluate`, `integrate`, `build`, `verify`, `deploy`, `release`, `consume`, `operate`. Plus `governance` (support band) and `cross-cutting` (top band). These match the `value_stream` field on `packages/db/data/agent_registry.json`, so auto-placement is `agent.value_stream → station`.
+- `apps/web/lib/ai-operations-map/project-events.ts` — pure functions: `projectToolExecution`, `projectToolReceipt`, `projectBacklogActivity`, `projectExternalEvidence`, `projectAgentEvent`, `synthesizeHandoff`, `deriveSeverity`, `dedupeByToolExecution`, `placeOnStation` (uses `Agent.value_stream` + `agent_name` prefix for `build-*` placement; unknown `value_stream` lands in the "unplaced" lane).
+- `apps/web/lib/ai-operations-map/load-projection.ts` — server-side fetcher that takes `{ organizationId, since, viewerCapabilities, limit }` and returns `MapProjection[]` from Prisma. Five parallel queries (see spec §Performance Budget); enforces `since ≤ 1h` by default, `≤ 24h` for operator override, `≤ 7d` requires Auditor tier; `limit = 250` per source; adds dev-mode assertion that no cross-org rows leak.
 - `apps/web/lib/ai-operations-map/access.ts` — derives view tier (`operator | reviewer | auditor | admin`) from `EffectiveAuthContext` and applies redaction.
 - `apps/web/lib/ai-operations-map/project-events.test.ts`
 - `apps/web/lib/ai-operations-map/load-projection.test.ts`
@@ -72,18 +72,23 @@
 Per superpowers:test-driven-development — write the tests first, watch them fail for the right reason, then implement.
 
 - [ ] **`project-events.test.ts`:** assert
-  - software-platform template has the 8 stations and lines with stable ids; every line references existing stations
+  - software-platform template has stations `explore`, `evaluate`, `integrate`, `build`, `verify`, `deploy`, `release`, `consume`, `operate` plus `governance` (support band) and `cross-cutting` (top band); every line references existing stations; ids are stable
+  - `placeOnStation` maps each value in `Agent.value_stream` to the expected station id; `build-*` agents land on `build` or `verify` per agent_name prefix; unknown `value_stream` lands in the "unplaced" lane and **does not throw**
   - `deriveSeverity` is exhaustive over `TaskState` (build fails if a new state is added without a mapping)
-  - `deriveSeverity` is exhaustive over the `auditClass` values used by `mcp-governed-execute.ts` (read the union from there, don't duplicate it)
+  - `deriveSeverity` is exhaustive over the `auditClass` values used by `mcp-governed-execute.ts` (read the union from there, don't duplicate it); unknown `auditClass` produces `severity: "warning"` (fail safe)
   - `projectToolExecution` produces `severity = "critical"` for `success=false` + `auditClass ∈ {destructive, sensitive}`, `"warning"` otherwise for `success=false`, `"normal"` for `success=true`
   - `projectAgentEvent` covers `task:status`, `tool:start`, `tool:complete`, `verification:complete`, `queue:escalation`, `orchestrator:task_dispatched`, `async:failed`, `error`, `deliberation:degraded_diversity`
+  - `projectAgentEvent` **default branch**: an unknown discriminant produces a `severity: "normal"` projection with the raw event in `kind.event`, **never throws**, and logs the discriminant once per session (forward-compat invariant from spec §Forward Compatibility)
   - `dedupeByToolExecution` collapses a `tool:start` + matching `ToolExecution` row within ±2s into a single projection where `source === "tool-execution"`
   - `synthesizeHandoff` correlates `queue:escalation` + `orchestrator:task_dispatched` events by `threadId|buildId` into a single `source === "handoff"` projection
   - every projection produces working refs that resolve to a real source id (trace-integrity invariant)
 - [ ] **`load-projection.test.ts`:** with Prisma mocked, assert
-  - cross-organization rows are filtered (seed two orgs in fixtures; only the viewer's org appears)
+  - cross-organization rows are filtered (seed two orgs in fixtures; only the viewer's org appears); in dev mode (`NODE_ENV !== "production"`), a stray cross-org row **throws** so seeding bugs surface immediately
   - identity resolution: every `actor.principalId` resolves through a `PrincipalAlias` row; no `Agent.id` leaks
-  - source set matches the spec's §Sources table
+  - source set matches the spec's §Sources table (five parallel queries, no more, no fewer)
+  - `since` clamping: default 1h; viewer with only `view_platform` cannot exceed 24h; 7d requires `view_compliance`
+  - per-source `limit = 250`; the "more in this window" affordance is emitted when any source hits the limit
+  - all five source queries fire in parallel (`Promise.all`); the test asserts call ordering via mocked timers
 - [ ] **`access.test.ts`:** assert
   - viewer with only `view_platform` sees `summary`-only projections (`ToolExecution.parameters` and `result` are not in the payload)
   - viewer with `view_platform` + `view_compliance` (Auditor) sees full payload
@@ -103,13 +108,18 @@ Per superpowers:test-driven-development — write the tests first, watch them fa
 
 - [ ] **`page.test.tsx`:** with `@dpf/db` mocked and `getEffectiveAuthContext` stubbed to a `view_platform`-only user, assert the page heading renders, the software-platform stations render, the inspector is keyboard-reachable from the first station, and no `parameters` payload appears in the DOM. Then re-stub with `view_compliance` and assert the payload does appear.
 - [ ] **`AiOperationsMap.test.tsx`:** assert
-  - renders with empty projection (no events) — no errors, all stations show "Idle"
+  - renders with empty projection (no events) — no errors, all stations show "Idle", banner "No activity in the last hour"
   - renders an active tool pulse from a `source: "tool-execution"` projection
   - renders a "BLOCKED" / "DEGRADED" badge with label + shape (not color alone)
   - opens inspector on station / coworker / gate / pulse selection
   - inspector exposes the deep link to `/platform/ai/history?toolExecutionId=...` (or equivalent for receipt / evidence)
-  - keyboard: Tab moves between focusable elements in DOM order; Enter / Space activates; Esc closes inspector
+  - keyboard: Tab moves between focusable elements in DOM order; Enter / Space activates; Esc closes inspector and restores focus to the trigger
   - reduced-motion: with `matchMedia('(prefers-reduced-motion: reduce)')` true, no animation-driving classes are applied; `aria-live="polite"` region still updates with state labels
+  - **failure modes** (from spec §Failure Modes):
+    - when `loadProjection` returns `{ projections: [], sourceErrors: ["tool-receipt"] }`, the receipt-source banner renders per affected station and the rest of the map continues to render
+    - when `loadProjection` throws, the full-page error renders with the actual error message (not a generic placeholder) and a retry button
+  - **forward-compat**: a projection with an unknown `kind.event.type` renders as a quiet generic badge with the discriminant in the inspector — does **not** crash
+  - **responsive**: at 1024px viewport (jsdom override), support/cross-cutting bands collapse; at 480px the schematic is replaced by a stacked-list view
 - [ ] **`platform-nav.test.ts`:** assert the new Operations Map subnav entry exists under the AI Operations section and has `href: "/platform/ai/operations-map"`.
 - [ ] Run all three test files; confirm they fail.
 - [ ] Add the Operations Map subnav entry to `platform-nav.ts` and the tab to `AiTabNav.tsx`.
@@ -126,16 +136,20 @@ Per superpowers:test-driven-development — write the tests first, watch them fa
 - [ ] `pnpm --filter web exec vitest run lib/ai-operations-map app/(shell)/platform/ai/operations-map components/platform/AiOperationsMap` (all new tests pass).
 - [ ] `pnpm --filter web typecheck` (clean).
 - [ ] `cd apps/web && npx next build` (clean — no TS errors that only surface here).
-- [ ] **UX exercise on the running portal** (mandatory for UI work):
-  - rebuild + restart the portal containers (per Mark's "no direct sandbox writes" / docker-explicit-approval rules, **list the exact commands and wait for go-ahead** before running them)
+- [ ] **UX exercise on the running portal** (mandatory for UI work — `2026-04-25-dpf-on-dpf-production-instance-design.md` dogfooding):
+  - rebuild + restart the portal containers (per Mark's "no direct sandbox writes" / docker-explicit-approval rules, **list the exact commands and wait for go-ahead** before running them — typically `docker compose build portal portal-init && docker compose up -d` per AGENTS.md §13)
   - log in at `/login` with `admin@dpf.local`
   - navigate to `/platform/ai/operations-map`
   - verify orientation test from spec acceptance #1 (which coworkers ran in the last hour and where)
   - verify drill-down test from acceptance #2 (every pulse opens an inspector with working links)
-  - tab through the map keyboard-only; activate stations and the inspector with Enter; close with Esc
-  - toggle reduced motion in the OS and confirm pulses become static
+  - **performance:** open DevTools → Network. The route response should arrive in < 250ms P95 on the DPF-on-DPF instance with the default 1h window. Capture the trace as evidence.
+  - tab through the map keyboard-only; activate stations and the inspector with Enter; close with Esc; focus returns to trigger
+  - toggle reduced motion in the OS and confirm pulses become static and `aria-live` announcements still occur on state change
   - check both light + dark theme (existing branding pipeline)
+  - resize to ~1024px and ~480px viewports; confirm responsive collapses are clean (no horizontal scroll, no overlap)
   - confirm `parameters` payload is absent for a `view_platform`-only seed user
+  - confirm a `view_compliance` seed user (or a superuser with the role applied) sees the full payload in the inspector
+  - intentionally break one source (temporarily rename `ToolExecutionReceipt` in a local fixture or mock the loader to throw on that source) and confirm the per-station banner renders rather than the whole map blanking
 - [ ] **Lint:** run repo lint and the no-hex-colors check; zero violations.
 - [ ] **Pre-existing failures:** if vitest / typecheck / next-build reports failures **not introduced by this slice**, file them as separate backlog items with repro steps — do not paper over them, and do not block the merge on them per AGENTS.md §5 unless they are in the affected files.
 
@@ -175,7 +189,9 @@ Per superpowers:test-driven-development — write the tests first, watch them fa
 
 ## Risk Watch (cross-reference to spec §Risks)
 
-- **Parallel event grammar** — guarded by Task 2's exhaustiveness tests. If a reviewer spots a new envelope, fail review.
+- **Parallel event grammar** — guarded by Task 2's exhaustiveness tests + the forward-compat default-branch test. If a reviewer spots a new envelope, fail review.
 - **Parallel identity model** — guarded by `load-projection.test.ts` identity assertion.
 - **Token / capability drift** — guarded by the "Do NOT modify" list above and the §Non-Goals section. Any PR that touches `globals.css` or `lib/govern/permissions.ts` is out of scope for this slice.
+- **Performance regression** — guarded by the < 250ms P95 budget. If the DPF-on-DPF measurement exceeds the budget, the response is to lower `limit` or `since` defaults, NOT to add caching in V1.
+- **Failure-mode silent break** — guarded by the failure-mode component tests + the explicit dogfooding step that breaks a source on purpose.
 - **Scope creep** — if a reviewer asks for live SSE, simulation, or write actions, defer to V2 rather than expand this PR.

--- a/docs/superpowers/specs/2026-05-10-ai-coworker-visual-control-surface-design.md
+++ b/docs/superpowers/specs/2026-05-10-ai-coworker-visual-control-surface-design.md
@@ -223,28 +223,47 @@ Reference:
 
 ### AI agent observability and workflow tools
 
-Modern AI agent tooling is converging on traces, spans, tool calls, handoffs, guardrails, and workflow graphs.
+Per AGENTS.md §10, this section compares **data models**, not just feature lists, across 3 open-source leaders and 3 commercial products.
 
-OpenAI Agents tracing includes spans for agent runs, model generations, function/tool calls, guardrails, and handoffs. LangSmith observability emphasizes seeing which tools are called, what prompts are generated, and how agents make decisions. AutoGen Studio provides a low-code interface for prototyping agents, composing teams, and interacting with workflows.
+**Open-source leaders:**
 
-Pattern to adopt:
+- **OpenAI Agents SDK tracing.** Data model: `Trace` contains `Spans`; span kinds include `AgentSpan`, `GenerationSpan`, `FunctionSpan`, `HandoffSpan`, `GuardrailSpan`, `CustomSpan`. Each span has parent linkage, timestamps, input/output. Pattern adopted: **handoffs are first-class spans** — DPF's map projects handoffs from `queue:escalation` + `orchestrator:task_dispatched`, mapping to the same conceptual primitive. Pattern rejected: OpenAI's `GenerationSpan` carries the raw prompt; DPF's `ToolExecution.parameters` is redacted to `summary` for non-Auditor tiers (privacy-first projection).
+- **LangSmith (LangChain).** Data model: `Run` is the unit; runs nest in a tree; each run records `inputs`, `outputs`, `error`, `tags`, `metadata`, `parent_run_id`. Adopted: **flat audit row keyed by parent** — DPF's `ToolExecution.threadId` plays this role; the map deduplicates by `(toolExecutionId, occurredAt±2s)` rather than rebuilding a tree client-side. Rejected: storing prompt/response as the canonical audit (instead, DPF stores `ToolExecution` rows + an SSE liveness stream; `parameters` redaction is enforced at projection, not at storage).
+- **AutoGen Studio (Microsoft).** Data model: `Team` of `Agents` with shared `Workflow`; tasks have explicit `terminationCondition`. Adopted: **multi-agent teams render as a composite badge** — DPF's Build Studio `FeatureBuild` is the team, individual specialists appear in the inspector. Rejected: AutoGen's free-form "conversation" view as the primary surface; DPF emphasizes state + flow over chat transcripts.
 
-- every visible animation should be backed by a real event, trace span, tool call, policy gate, or evidence receipt
-- users should be able to drill from a map pulse into the actual execution trace
-- handoffs and approvals should be first-class visual events
-- visual management should be useful for debugging and governance, not just presentation
+**Commercial products:**
 
-Pattern to reject:
+- **Langfuse (open core + cloud).** Data model: `Trace` → `Observation` (where `Observation` is `Span | Generation | Event`); generations capture `model`, `usage`, `cost`. Adopted: **per-observation cost + latency surfaced in the inspector** — DPF can project these from `AgentEvent.done.providerInfo` + `ToolExecution.durationMs`. Anti-pattern observed: Langfuse's filters require knowledge of the schema; DPF avoids this by mapping observations onto a business-flow schematic, not a raw observation list.
+- **Helicone.** Data model: `Request` row (HTTP-level) joined to `Properties` for arbitrary metadata. Adopted: **defensive `organizationId` scoping on every read** (Helicone's multi-tenant model is instructive even for single-org DPF installs because misordered joins are the most common silent leak). Rejected: Helicone's "everything is an HTTP request" framing — DPF's `ToolExecution` already abstracts above HTTP.
+- **AgentOps (cloud).** Data model: `Session` → `Event` where `Event` discriminates `LLM | Action | Tool | Error`. Adopted: **error events are first-class on the bus** — DPF already has `AgentEvent.type === "error"` and `async:failed`; the map promotes those to `severity: "critical"`. Rejected: AgentOps' opt-in instrumentation per agent — DPF requires the governed executor to emit; instrumentation is structural, not optional.
 
-- showing hidden chain-of-thought as the management primitive
-- implying certainty or intent that the runtime did not record
-- using agent "thought bubbles" as a substitute for traceable events and evidence
+**Composite pattern adoption:**
+
+- Every visible animation is backed by a real event, trace span, tool call, policy gate, or evidence receipt.
+- Users drill from a map pulse into the actual execution trace (Langfuse-style nesting, but business-flow-anchored).
+- Handoffs and approvals are first-class visual events (OpenAI Agents pattern).
+- Visual management is useful for debugging and governance, not just presentation.
+
+**Composite pattern rejection:**
+
+- Showing hidden chain-of-thought as the management primitive (AutoGen anti-pattern).
+- Implying certainty or intent that the runtime did not record.
+- Using agent "thought bubbles" as a substitute for traceable events and evidence.
+- Raw observation lists as the primary view (Langfuse / Helicone anti-pattern for non-engineer operators).
+
+**Gaps DPF's design fills:**
+
+- None of the surveyed tools render observations onto a **business-flow schematic** keyed by archetype. They all default to time-series / list / tree views. The Operations Map's primary contribution is anchoring AI activity to the operator's mental model of the business.
+- None project from a **multi-source heterogeneous evidence ledger** (`ToolExecutionReceipt` + `BacklogItemActivity` + `ExternalEvidenceRecord`). DPF unifies these at the projection layer rather than forcing one substrate.
 
 References:
 
 - OpenAI Agents SDK tracing: https://openai.github.io/openai-agents-python/tracing/
 - LangSmith observability: https://docs.langchain.com/oss/python/langchain/observability
 - AutoGen Studio: https://microsoft.github.io/autogen/stable/user-guide/autogenstudio-user-guide/index.html
+- Langfuse data model: https://langfuse.com/docs/tracing-data-model
+- Helicone architecture: https://docs.helicone.ai/getting-started/quick-start
+- AgentOps SDK: https://docs.agentops.ai/v1/concepts/sessions
 
 ## Design Principles
 
@@ -388,28 +407,35 @@ Support bands:
 
 ### Software platform map
 
-Use for `software-platform`.
+Use for `software-platform`. Stations align to **IT4IT v3 value streams**, which is also how `packages/db/data/agent_registry.json` tags every coworker (`value_stream` field on each agent row). This makes auto-placement deterministic and avoids inventing a parallel taxonomy.
 
-Primary flow:
+Primary flow (station id → IT4IT value stream → station label):
 
-1. Discover
-2. Backlog
-3. Design
-4. Build
-5. Verify
-6. Release
-7. Support
-8. Improve
+| Station id | IT4IT value stream | Display label |
+| --- | --- | --- |
+| `explore` | `explore` | Discover |
+| `evaluate` | `evaluate` | Backlog & Evaluation |
+| `integrate` | `integrate` | Design & Integrate |
+| `build` | (DPF-internal) | Build |
+| `verify` | (DPF-internal) | Verify |
+| `deploy` | `deploy` | Deploy |
+| `release` | `release` | Release |
+| `consume` | `consume` | Customer Experience |
+| `operate` | `operate` | Operate & Improve |
 
-Expected coworker positions:
+Support band: `governance` value stream renders as a band beneath the primary flow (policy, constitutional governance, evidence chain).
 
-- Scout/research coworkers at Discover and Backlog
-- Architect/design coworkers at Design
-- Build Studio coworkers at Build and Verify
-- Release/governance coworkers at Release
-- Support/operations coworkers at Support and Improve
+Cross-cutting band: `cross-cutting` value stream renders as a band above (orchestrators, COO).
 
-This should be the first implementation target because DPF can use it on itself.
+**Auto-placement rule (resolves Open Question #3):**
+
+1. Read each `Agent.value_stream` from the registry (`packages/db/data/agent_registry.json` is the seed; live state lives in the `Agent` table — query live state per AGENTS.md §1).
+2. Map value stream → station id using the table above.
+3. Agents with `agent_name` matching `build-*` (e.g. `build-data-architect`, `build-software-engineer`, `build-frontend-engineer`, `build-qa-engineer`) land on `build` or `verify` per `2026-04-30-build-specialist-operator-contract.md`. The QA specialist defaults to `verify`; the rest default to `build`.
+4. Agents with `value_stream === "cross-cutting"` land in the cross-cutting band, not on the flow.
+5. Agents with no `value_stream` or an unrecognized value land in an "unplaced" lane below the support band with a quiet badge — the map fails open, not silently.
+
+This map should be the first implementation target because DPF can use it on itself (`2026-04-25-dpf-on-dpf-production-instance-design.md`) and the agent registry already carries the placement data.
 
 ### Managed service provider map
 
@@ -695,6 +721,77 @@ Mapping:
 
 The canonical `AgentEvent` union already covers task lifecycle, tool calls, orchestrator phases, queue escalations, verification, deliberation, brand extract, and async inference. **The map MUST NOT add a parallel discriminant in V1.** If a genuine gap appears during implementation, it lands on the canonical bus first, with a companion change in the substrate spec (`2026-04-29-coworker-execution-adapter-substrate-design.md`) — never as a parallel envelope owned by the map. Specifically, handoffs are projected from `queue:escalation` and `orchestrator:task_dispatched` / `task_complete` correlated by `threadId|buildId`; approvals are projected from `task:status === "input-required" | "auth-required"`; verification is projected from `verification:complete`.
 
+## Performance Budget
+
+A map that costs 200ms to render and 12 queries to assemble is a map nobody opens. V1 commits to the following budget; the load-projection layer enforces it.
+
+### Query plan
+
+`loadProjection({ organizationId, since, viewerCapabilities, limit })` issues exactly **five parallel queries**, one per source:
+
+1. `ToolExecution.findMany` — index `(agentId, createdAt)` already exists (`schema.prisma:3003`); add `where: { createdAt: { gte: since } }` plus `organizationId` scoping via the user/agent join. **Reuse the existing index.**
+2. `ToolExecutionReceipt.findMany` — index `(receiptKind, createdAt(sort:Desc))` exists (`schema.prisma:3028`); filter by `createdAt >= since` and `receiptStatus = "valid"`. **Reuse.**
+3. `BacklogItemActivity.findMany` where `kind = "evidence"` and `recordedAt >= since`. Existing index on `(backlogItemId, recordedAt)` covers this when scoped per item; for the global view, add `@@index([kind, recordedAt(sort:Desc)])` **only if** the query plan shows a sequential scan in `EXPLAIN ANALYZE` on a 1M-row table (verify on the DPF-on-DPF instance before adding the index — don't add speculatively).
+4. `ExternalEvidenceRecord.findMany` — index `(operationType, createdAt)` exists (`schema.prisma:3188`). **Reuse.**
+5. `Agent.findMany` — small table, scan is fine; used for `actor` resolution.
+
+The SSE `AgentEvent` stream is **not** part of this query (it's a transport, not a query); when the feature flag for live mode is on, the client opens a single SSE connection to `/api/agent/stream` and merges events into the in-memory projection.
+
+### Budget
+
+| Metric | V1 budget |
+| --- | --- |
+| Default `since` | 1 hour |
+| Max `since` | 24 hours (operator override); 7 days requires Auditor tier |
+| `limit` per source | 250 rows |
+| Total projection size | ≤ 1,250 rows pre-dedupe |
+| Server render time | < 250 ms P95 on the DPF-on-DPF instance |
+| Initial DOM nodes | < 800 |
+| First inspector open | < 50 ms (data already in memory; no follow-up fetch) |
+
+If a viewer needs more, the inspector deep-links to `/platform/ai/history` with the relevant filter pre-applied. The map is for orientation; the history page is for excavation.
+
+### Pagination behavior
+
+V1 does not paginate the map itself. Above the `limit`, the projection adds a "more in this window" affordance per station that links into `/platform/ai/history`. The map never silently truncates.
+
+## Failure Modes
+
+What the map shows when something is wrong matters as much as what it shows when everything is normal.
+
+| Condition | Render | Inspector | Telemetry |
+| --- | --- | --- | --- |
+| Zero events in window | Quiet empty state: stations rendered idle, banner "No activity in the last hour. Try widening the window." | hidden | event-bus heartbeat shown in footer |
+| One source fails (e.g. `ToolExecutionReceipt` query rejects) | Map renders from remaining sources; affected source shows a per-station banner "Receipts unavailable — try again or check `/platform/audit/journal`" | shown for other sources | error logged with `tool-trace`-style structured log |
+| All sources fail | Full-page error with the actual error from the projection layer (no generic "Something went wrong"); link to `/platform/audit/journal`; retry button | hidden | error logged + alert |
+| Viewer lacks `view_platform` | Redirect to `/welcome` (existing route guard); no map renders | n/a | n/a |
+| Cross-org row in result set | Filter at the projection layer; **also** assert in dev mode (`process.env.NODE_ENV !== "production"`) and throw if found, so seeding bugs surface immediately | n/a | error in dev; silent filter in prod |
+| Unknown `AgentEvent` discriminant | Projected with `severity: "normal"` and `summary: <discriminant>`; rendered as a quiet generic badge; **never crashes** | shown with raw event | discriminant logged once per session for follow-up |
+| Unknown `auditClass` value | Projected with `severity: "warning"` (fail safe — unknown = treat with caution); inspector flags it | shown | logged |
+
+The "fail open with a quiet banner" pattern is intentional. The map is an operator surface; a missing source should degrade visibility, not blank the screen.
+
+## Forward Compatibility
+
+`AgentEvent` is an evolving union. The map MUST handle discriminants it doesn't recognize without breaking. This is enforced two ways:
+
+1. **TypeScript exhaustiveness with default branch.** The projection function uses an exhaustiveness check (`assertNever`) but the **default case projects** rather than throws — it produces a `severity: "normal"` projection with the raw event in the inspector. The exhaustiveness check fires as a build-time test (Vitest), not as a runtime guard.
+2. **Source kind set is closed; event discriminants are open.** New `MapProjection.kind.source` values require a spec PR (they imply a new data source). New `AgentEvent` discriminants do not — they project under the default branch until the team explicitly decides how to render them.
+
+This keeps the map honest about what it knows while letting the canonical event bus evolve without coordinated PRs.
+
+## Responsive Behavior
+
+The map is a desktop-first surface; mobile is a fallback, not a primary mode.
+
+| Breakpoint | Behavior |
+| --- | --- |
+| ≥ 1280 px | Full schematic with lines, support bands, cross-cutting band; inspector docked right |
+| 768–1279 px | Schematic compresses to single primary flow; support/cross-cutting bands collapse to a togglable strip; inspector docked right or bottom |
+| < 768 px | Stacked list per station with the pulse count; selecting a station opens a full-screen inspector; the schematic is not drawn |
+
+The transition between breakpoints is CSS-driven (`@media`), not JS-driven. Reduced motion still applies at every breakpoint.
+
 ## Data Model Recommendation
 
 Do not begin with a large schema migration.
@@ -927,7 +1024,7 @@ Per repo rulebook:
 
 1. **Launch shape.** New tab at `/platform/ai/operations-map` first (recommended). Replacement of the AI overview waits until the new IA is exercised on a real install. The legacy `/platform/ai/operations` redirect is an available alias slot; V2 IA refresh may point it at the map.
 2. **Template ownership.** Code-owned through V2. Admin customization is deferred — the platform must first prove the model has settled before opening it for edit.
-3. **Auto-placement.** Which coworker roles are canonical enough today to place automatically on the software-platform map? Resolve in the V1 PR by querying the `Agent` registry on a fresh install + DPF's own production instance and listing the roles actually seeded. Anything not in that intersection lives in an "unplaced" lane until manually positioned in V2.
+3. ~~**Auto-placement.**~~ **Resolved.** `packages/db/data/agent_registry.json` already carries `value_stream` per agent (IT4IT v3 values). The software-platform map's stations align to those values; placement is `Agent.value_stream → station`. Unknown / missing values land in the "unplaced" lane. See §"Software platform map".
 4. **Projection precedence.** When the same logical event appears on both the `AgentEvent` bus and as a `ToolExecution` row (common for tool starts), which is authoritative for the pulse? **Decision:** `ToolExecution` is the audit truth; `AgentEvent` is the liveness signal. Inspector shows both; map deduplicates by `(toolExecutionId, occurredAt±2s)`. Pulses that exist only on the bus (e.g. `verification:step`) remain liveness-only and inspector-linked.
 5. **Build Studio rendering.** Single coworker badge anchored to Build, with per-task children in the inspector? Or per-phase badges across Design / Build / Verify? **Resolved for V1:** one badge per active `FeatureBuild` anchored to Build with phase shown inside the badge (`phase:change` event drives the position from Design → Build → Verify → Release). Per-task specialists appear in the inspector, not on the map, per `2026-04-30-build-specialist-operator-contract.md`.
 6. **Handoff event.** The current `AgentEvent` union has no `task:handoff`, but it has `queue:escalation`, `orchestrator:task_dispatched`, `orchestrator:task_complete`, and queue transitions. **Decision:** V1 projects handoffs from those existing discriminants correlated by `(threadId|buildId, workItemId)`. Do **not** add a `task:handoff` discriminant in V1; revisit only if correlation proves unreliable on a real install.


### PR DESCRIPTION
## Summary
- Adds a server-side Operations Map loader so the route no longer owns direct Prisma projection logic.
- Selects the map template from canonical StorefrontConfig -> StorefrontArchetype truth, including activationProfile.profileType.
- Adds the Managed Service Provider operations map template and projects service operations activity onto MSP stations.
- Moves the map severity UI to canonical --dpf-warning / --dpf-error tokens.

## Verification
- pnpm --filter web exec vitest run lib/ai-operations-map 'app/(shell)/platform/ai/operations-map/page.test.tsx'
- pnpm --filter web typecheck
- pnpm --filter web exec next build

Production build passes with existing Turbopack broad-tracing warnings around spec-plan-search.ts and next.config.mjs.

## Scope notes
- No migrations.
- No new permission keys.
- No new event discriminants.
- No new global theme tokens.