### PR TITLE
feat(wiki): add wiki-preamble prompt template

### DIFF
--- a/prompts/platform-identity/wiki-preamble.prompt.md
+++ b/prompts/platform-identity/wiki-preamble.prompt.md
@@ -1,0 +1,17 @@
+---
+name: wiki-preamble
+displayName: Wiki Context Preamble
+description: One-line preamble that prefixes the RELEVANT WIKI CONTEXT block in Block 5. Tells the agent how to use the founder-kernel/per-org wiki excerpts that follow.
+category: platform-identity
+version: 1
+
+composesFrom: []
+contentFormat: markdown
+variables: []
+
+valueStream: ""
+stage: ""
+sensitivity: internal
+---
+
+This platform maintains a structured wiki — a founder kernel ships in the repo and each customer organisation overlays it. When the wiki excerpts below are relevant to the user's question, prefer them to generic web knowledge and cite the page slug when you do. The wiki is judgment, not speculation.


### PR DESCRIPTION
## Summary

Tiny content-only PR. Adds `prompts/platform-identity/wiki-preamble.prompt.md` — the DB-overridable preamble called out in spec §7 that tells the agent how to use the `RELEVANT WIKI CONTEXT` block injected into Block 5 of the system prompt.

Closes a documented loose end from [PR #432](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/432) (Phase 3a).

## What changed

`prompts/platform-identity/wiki-preamble.prompt.md` (+17 lines):

- Frontmatter follows the established `platform-identity` convention (`act-mode.prompt.md` / `advise-mode.prompt.md` / `identity-block.prompt.md`).
- Body is one sentence per spec §7: tells the agent to prefer wiki excerpts to generic web knowledge and to cite the page slug when it does.

## How it gets loaded

No code change required. The existing `discoverPromptFiles()` in `packages/db/src/seed-prompt-templates.ts` scans `prompts/<category>/<slug>.prompt.md` automatically, so this template seeds into the `PromptTemplate` table on the next `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts` run.

The prompt-assembler caller will prepend this preamble to the formatted wiki block when it lands (**Phase 3b** — wiring `recallWikiContext` into `agent-coworker.sendMessage`). For now the template just lives in the repo, ready to be loaded by `loadPrompts(["platform-identity/wiki-preamble"])`.

## Build gate

No code changes; nothing to test. The file is markdown content. Verified the frontmatter shape matches the other `platform-identity/*.prompt.md` siblings.

## Independent of in-flight work

Doesn&#39;t depend on any in-flight PR (#432, #434, #436). The template can ship and seed independently; it&#39;s referenced by Phase 3b when that PR lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_