### PR TITLE
feat(installer): port-conflict preflight (Phase 10a)

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -200,8 +200,12 @@ Run `bash install-dpf.sh doctor` to capture a diagnostic bundle at
 `docker compose -f docker-compose.yml -f docker-compose.linux.yml logs portal --tail 100`.
 
 **Port 3000 already in use.**
-Stop whatever is binding it (`sudo lsof -i :3000`) before re-running.
-Phase 10 of the installer roadmap adds upfront port-conflict detection.
+The installer's port preflight refuses to proceed if port 3000 is
+bound by a non-DPF process, naming the holder and exit code 64.
+Stop the conflicting process (`sudo lsof -nP -iTCP:3000 -sTCP:LISTEN`)
+or set `DPF_PORTAL_PORT` to an unused port before re-running. Force
+through with `DPF_PORT_CONFLICTS_IGNORE=1` if you know the holder
+won't actually conflict at compose-up time.
 
 **Ollama model pull stalls.**
 Watch the pull progress:

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -51,7 +51,7 @@ LIB_DIR="$REPO_ROOT/scripts/installer/lib"
 . "$LIB_DIR/autostart.sh"
 
 # Installer version (semver-ish; bump per release).
-DPF_INSTALLER_VERSION="2026.05.10-phase7c"
+DPF_INSTALLER_VERSION="2026.05.11-phase10a"
 
 # ── CLI handling ────────────────────────────────────────────────────────────
 
@@ -141,10 +141,17 @@ echo "  Platform: $DPF_PLATFORM ($DPF_ARCH)"
 echo "  Mode: $DPF_MODE$(if [ "$DPF_DRY_RUN" = "1" ]; then echo "  [dry-run]"; fi)"
 echo ""
 
-# 1. Preflight: unsupported-host detection.
+# 1. Preflight: unsupported-host detection + port conflicts.
 step "Preflight: host compatibility"
 dpf_preflight_unsupported_host
 ok "Host compatibility check passed"
+
+rc=0
+dpf_preflight_port_conflicts || rc=$?
+if [ "$rc" -ne 0 ]; then
+  exit "$rc"
+fi
+ok "Port preflight passed (portal: ${DPF_PORTAL_PORT:-3000})"
 
 # 2. Bring install-state.json into existence (or validate existing).
 step "Install state"

--- a/scripts/installer/lib/preflight.sh
+++ b/scripts/installer/lib/preflight.sh
@@ -126,3 +126,86 @@ dpf_preflight_unsupported_host() {
 
   return 0
 }
+
+# ── Port-conflict preflight ────────────────────────────────────────────────
+# Catches the most common fresh-host install failure: port 3000 is
+# already taken by some local dev process (Next.js, Grafana, Hubot,
+# etc.). Detected at preflight rather than letting `docker compose up`
+# bomb out with an opaque "address already in use" message later.
+#
+# Only the portal port (3000 by default) is gated; the rest of the
+# stack's host ports are too noisy for a hard refusal (operators
+# routinely run other DBs / monitoring tools on overlapping ports
+# without it actually conflicting with DPF's docker-proxy binds).
+
+# Detect whether $1 is bound LISTEN by some local process.
+# Returns 0 if bound, 1 if free, 2 if no detection tool is available.
+_dpf_port_in_use() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  elif command -v ss >/dev/null 2>&1; then
+    ss -ltn 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${port}$"
+    return $?
+  elif command -v netstat >/dev/null 2>&1; then
+    netstat -anP tcp 2>/dev/null | grep -qE "[.:]${port}[[:space:]]+.*LISTEN" \
+      || netstat -an 2>/dev/null | grep -qE "[.:]${port}[[:space:]]+.*LISTEN"
+    return $?
+  fi
+  return 2  # no detection tool
+}
+
+# Best-effort: return the command name holding $1.
+_dpf_port_holder() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN -F c 2>/dev/null \
+      | awk -F'^c' '/^c/ {print $2; exit}'
+    return 0
+  fi
+  echo "unknown"
+}
+
+# Public: refuse to proceed if the portal port is bound by a non-DPF
+# process. Override with DPF_PORT_CONFLICTS_IGNORE=1.
+# Args: $1 = portal port (default 3000)
+dpf_preflight_port_conflicts() {
+  local primary_port="${1:-${DPF_PORTAL_PORT:-3000}}"
+
+  local rc=0
+  _dpf_port_in_use "$primary_port" || rc=$?
+  case "$rc" in
+    1) return 0 ;;   # port free
+    2)               # no detection tool — best effort, allow
+       info "No lsof/ss/netstat available; skipping port-conflict preflight."
+       return 0 ;;
+    0) : ;;          # port in use — investigate
+  esac
+
+  # In use. Is it our existing stack? If `docker compose -p dpf ps -q`
+  # has output, treat as ours (operator is re-running install over a
+  # working stack, which is supported and idempotent).
+  if command -v docker >/dev/null 2>&1; then
+    if docker compose -p dpf ps -q 2>/dev/null | grep -q .; then
+      info "Port ${primary_port} is bound, but an existing DPF stack is running — re-install will reuse it."
+      return 0
+    fi
+  fi
+
+  local holder; holder="$(_dpf_port_holder "$primary_port" 2>/dev/null || true)"
+  [ -z "$holder" ] && holder="unknown"
+
+  if [ "${DPF_PORT_CONFLICTS_IGNORE:-0}" = "1" ]; then
+    warn "Port ${primary_port} is bound by '${holder}', but DPF_PORT_CONFLICTS_IGNORE=1 — proceeding (compose up may still fail)."
+    return 0
+  fi
+
+  printf '\n%bPort conflict detected.%b\n' "${DPF_RED:-}" "${DPF_NC:-}" >&2
+  printf '  %bReason:%b Port %s is bound by ''%s'' (no DPF stack running).\n' \
+    "${DPF_YELLOW:-}" "${DPF_NC:-}" "$primary_port" "$holder" >&2
+  printf '  %bNext:%b   Stop that process, or set DPF_PORTAL_PORT to an unused port before re-running.\n' \
+    "${DPF_YELLOW:-}" "${DPF_NC:-}" >&2
+  printf '\n  Override (advanced): DPF_PORT_CONFLICTS_IGNORE=1 bash %s\n\n' "$0" >&2
+  return 64
+}


### PR DESCRIPTION
Catches the most common fresh-host install failure: **port 3000 is
already bound by a local dev process** (Next.js, Grafana, hubot, etc.).
Refused at preflight with a clear "Reason / Next" message rather than
letting `docker compose up` bomb out later with an opaque "address
already in use" error.

## New: `dpf_preflight_port_conflicts`

In `scripts/installer/lib/preflight.sh`:

- Detects whether the portal port (`3000`, override via
  `DPF_PORTAL_PORT`) is `LISTEN` by some local process, with
  `lsof` → `ss` → `netstat` fallback. Silently skips if no detection
  tool is available.
- If the port is bound **but** `docker compose -p dpf ps -q` shows our
  stack is running, treat as ours and continue (re-install is
  idempotent over a working stack).
- Otherwise refuse with **exit code 64** (matches the existing
  unsupported-host refusal contract). Names the holder process via
  `lsof -F c` when available.
- Override: `DPF_PORT_CONFLICTS_IGNORE=1` to proceed anyway. Warns
  and continues — useful when the operator knows the holder won't
  conflict at compose-up time.

Wired into `install-dpf.sh` step 1 (preflight), before the rest of
the flow, so we fail fast without touching the state file, docker,
or `.env`.

## Why only the portal port

Only port 3000 (the one operators actually visit) is gated. The rest
of the stack's host ports — 5433, 7475, 6334, 11434, 8080, 9090,
9100, 9187, etc. — are **too noisy** for a hard refusal. Operators
routinely run other Postgres / Neo4j / monitoring tools on
overlapping ports without it actually conflicting with DPF's
docker-proxy binds. Failing on those would create more false
positives than real catches.

If we need finer-grained detection later (e.g. "is **5433** bound by
a non-docker-proxy process?"), it can be added as `--check-ports
extended` without touching the default contract.

## Smoke

```
port 3000 free                                       exit 0  "Port preflight passed"
port 3000 bound by nc, no DPF stack running          exit 64 "bound by 'nc'"
port 3000 bound + DPF_PORT_CONFLICTS_IGNORE=1        exit 0  warns and proceeds
port 3000 bound + docker compose -p dpf ps has rows  exit 0  treated as ours
```

## Drive-by

`docs/install/linux.md` previously said "Phase 10 of the installer
roadmap adds upfront port-conflict detection" — flipped to past
tense, documenting the holder-naming and override knobs.

## Version

Installer version bumped to `2026.05.11-phase10a`.

## Roadmap

`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` —
Phase 10a. Remaining in Phase 10:

- **10b**: discovery-collectors macOS branch
  (`packages/db/src/discovery-collectors/host.ts` + `docker.ts`).
- **10c**: `codebase-tools.ts` POSIX-path unit test.
- **10d**: `scripts/installer/lib/diagnostics.sh` extended preflight
  bundle (compose render dry-run + docker context dump for
  `install-dpf.sh doctor`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_