### PR TITLE
Build Studio v2 real business brief data

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { getFeatureBuilds } from "@/lib/feature-build-data";
 import { getPortfoliosForSelect } from "@/lib/backlog-data";
+import { businessBuildBriefFromRecord } from "@/lib/build/business-build-brief";
 import { BuildStudio } from "@/components/build/BuildStudio";
 import { BuildStudioV2 } from "@/components/build-studio/BuildStudioV2";
 import Link from "next/link";
@@ -29,7 +30,46 @@ function getProjectBranch(): string | null {
 export default async function BuildPage({ searchParams }: PageProps) {
   const { v } = await searchParams;
   if (v === "2") {
-    return <BuildStudioV2 />;
+    const session = await auth();
+    if (!session?.user?.id) return <BuildStudioV2 />;
+
+    const businessBriefRow = await prisma.businessBuildBrief.findFirst({
+      where: { submittedByUserId: session.user.id },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        briefId: true,
+        intakeSource: true,
+        capabilityPackId: true,
+        featureBuildId: true,
+        businessOutcome: true,
+        affectedPeople: true,
+        affectedWorkflow: true,
+        sourceEvidence: true,
+        successSignals: true,
+        constraints: true,
+        businessInterpretation: true,
+        technicalInterpretation: true,
+        riskProfile: true,
+        openQuestions: true,
+        confidence: true,
+      },
+    });
+
+    const featureBuild = businessBriefRow?.featureBuildId
+      ? await prisma.featureBuild.findUnique({
+        where: { id: businessBriefRow.featureBuildId },
+        select: { title: true },
+      })
+      : null;
+
+    const businessBrief = businessBriefRow
+      ? businessBuildBriefFromRecord({
+        title: featureBuild?.title ?? businessBriefRow.briefId,
+        row: businessBriefRow,
+      })
+      : undefined;
+
+    return <BuildStudioV2 businessBrief={businessBrief} />;
   }
 
   const session = await auth();

--- a/apps/web/components/build-studio/BuildStudioV2.test.tsx
+++ b/apps/web/components/build-studio/BuildStudioV2.test.tsx
@@ -3,6 +3,7 @@ import "./test-setup";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { BuildStudioV2 } from "./BuildStudioV2";
+import { DEMO_BUSINESS_BRIEF } from "@/lib/build-studio-demo";
 
 describe("BuildStudioV2", () => {
   it("renders the header, step tracker, conversation pane, and artifact pane", () => {
@@ -21,5 +22,21 @@ describe("BuildStudioV2", () => {
     fireEvent.click(btn);
     expect(await screen.findByText(/coming in slice 3/i)).toBeInTheDocument();
     expect(screen.queryByText(/sandbox.dpf.local/)).not.toBeInTheDocument();
+  });
+
+  it("renders a supplied business brief instead of the demo brief", () => {
+    render(
+      <BuildStudioV2
+        businessBrief={{
+          ...DEMO_BUSINESS_BRIEF,
+          title: "Real persisted business brief",
+          businessOutcome: "Show the actual accepted brief from the build record.",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Real persisted business brief")).toBeInTheDocument();
+    expect(screen.getByText("Show the actual accepted brief from the build record.")).toBeInTheDocument();
+    expect(screen.queryByText(DEMO_BUSINESS_BRIEF.businessOutcome)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/build-studio/BuildStudioV2.tsx
+++ b/apps/web/components/build-studio/BuildStudioV2.tsx
@@ -7,13 +7,20 @@ import {
   DEMO_PENDING_APPROVALS,
   DEMO_STEPS,
 } from "@/lib/build-studio-demo";
+import type { BusinessBuildBrief } from "@/lib/build/business-build-brief";
 import type { ArtifactView } from "./types";
 import { HeaderBar } from "./HeaderBar";
 import { StepTracker } from "./StepTracker";
 import { ConversationPane } from "./ConversationPane";
 import { ArtifactPane } from "./ArtifactPane";
 
-export function BuildStudioV2() {
+type BuildStudioV2Props = {
+  businessBrief?: BusinessBuildBrief;
+};
+
+export function BuildStudioV2({
+  businessBrief = DEMO_BUSINESS_BRIEF,
+}: BuildStudioV2Props = {}) {
   const [theme, setTheme] = useState<"light" | "dark">("dark");
   const [view, setView] = useState<ArtifactView>("brief");
 
@@ -57,7 +64,7 @@ export function BuildStudioV2() {
           view={view}
           onViewChange={setView}
           sandboxUrl="sandbox.dpf.local/settings/api-keys"
-          businessBrief={DEMO_BUSINESS_BRIEF}
+          businessBrief={businessBrief}
         />
       </div>
     </div>

--- a/apps/web/lib/build/business-build-brief.test.ts
+++ b/apps/web/lib/build/business-build-brief.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildBusinessBuildBrief,
+  businessBuildBriefFromRecord,
   canTransitionBusinessBriefStatus,
   getCapabilityPackIdForBrief,
   getCapabilityPackForBrief,
@@ -226,5 +227,74 @@ describe("legacyFeatureBuildBriefToBusinessBuildBriefInput", () => {
       title: "Bad request",
       brief: { title: "Missing description" },
     })).toThrow(/description/i);
+  });
+});
+
+describe("businessBuildBriefFromRecord", () => {
+  it("maps a persisted BusinessBuildBrief row into the Build Studio brief panel shape", () => {
+    const brief = businessBuildBriefFromRecord({
+      title: "Improve Build Studio intake",
+      row: {
+        intakeSource: "user_conversation",
+        capabilityPackId: "build_studio_self_development",
+        businessOutcome: "Help non-developers describe business outcomes.",
+        affectedPeople: [
+          { kind: "persona", label: "Operations lead" },
+          { kind: "principal", principalId: "principal-1", label: "Platform owner" },
+        ],
+        affectedWorkflow: "Build Studio",
+        sourceEvidence: [
+          { kind: "artifact", label: "Reviewed plan", summary: "Plan called for a business-readable brief." },
+        ],
+        successSignals: ["A non-developer can approve the brief."],
+        constraints: ["Do not expose schema details first."],
+        businessInterpretation: "Build Studio should explain the business change first.",
+        technicalInterpretation: {
+          dataNeeds: "Brief status and evidence",
+          likelyWorkflowImpact: ["Build Studio"],
+          verificationFocus: ["Brief approval gate"],
+        },
+        riskProfile: {
+          customerFacing: false,
+          complianceSensitive: false,
+          revenueImpacting: false,
+          operationalRisk: true,
+          level: "medium",
+        },
+        openQuestions: [],
+        confidence: "high",
+      },
+    });
+
+    expect(brief.title).toBe("Improve Build Studio intake");
+    expect(brief.capabilityPack).toBe("Build Studio / Self-Development");
+    expect(brief.affectedPeople).toEqual(["Operations lead", "Platform owner"]);
+    expect(brief.sourceEvidence).toHaveLength(1);
+    expect(brief.technicalInterpretation.verificationFocus).toEqual(["Brief approval gate"]);
+  });
+
+  it("falls back to the self-development capability pack for unknown stored values", () => {
+    const brief = businessBuildBriefFromRecord({
+      title: "Unknown capability",
+      row: {
+        intakeSource: "user_conversation",
+        capabilityPackId: "custom_pack_that_does_not_exist",
+        businessOutcome: "Keep persisted brief rendering even if a stale pack id is present.",
+        affectedPeople: [],
+        affectedWorkflow: null,
+        sourceEvidence: [],
+        successSignals: [],
+        constraints: [],
+        businessInterpretation: null,
+        technicalInterpretation: {},
+        riskProfile: {},
+        openQuestions: [],
+        confidence: null,
+      },
+    });
+
+    expect(brief.capabilityPackId).toBe("build_studio_self_development");
+    expect(brief.capabilityPack).toBe("Build Studio / Self-Development");
+    expect(brief.confidence).toBe("low");
   });
 });

--- a/apps/web/lib/build/business-build-brief.ts
+++ b/apps/web/lib/build/business-build-brief.ts
@@ -133,6 +133,22 @@ export type BusinessBuildBriefPersistenceInput = {
   submittedByUserId: string | null;
 };
 
+export type BusinessBuildBriefRecordInput = {
+  intakeSource: BusinessBuildBriefSource;
+  capabilityPackId: string | null;
+  businessOutcome: string;
+  affectedPeople: unknown;
+  affectedWorkflow: string | null;
+  sourceEvidence: unknown;
+  successSignals: string[];
+  constraints: string[];
+  businessInterpretation: string | null;
+  technicalInterpretation: unknown;
+  riskProfile: unknown;
+  openQuestions: string[];
+  confidence: BusinessBriefConfidence | null;
+};
+
 const CAPABILITY_PACKS: Array<{
   id: CapabilityPackId;
   label: CapabilityPack;
@@ -267,6 +283,86 @@ function stringArrayField(record: Record<string, unknown>, key: string): string[
   return value.map((entry) => typeof entry === "string" ? entry.trim() : "").filter(Boolean);
 }
 
+function capabilityPackLabel(id: string | null | undefined): CapabilityPack {
+  const normalizedId = capabilityPackIdFromRecord(id);
+  return CAPABILITY_PACKS.find((pack) => pack.id === normalizedId)?.label
+    ?? "Build Studio / Self-Development";
+}
+
+function capabilityPackIdFromRecord(id: string | null | undefined): CapabilityPackId {
+  return CAPABILITY_PACKS.some((pack) => pack.id === id)
+    ? id as CapabilityPackId
+    : "build_studio_self_development";
+}
+
+function affectedPeopleFromRecord(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => {
+      if (typeof entry === "string") return entry.trim();
+      if (!isRecord(entry)) return "";
+      const label = stringField(entry, "label");
+      if (label) return label;
+      return stringField(entry, "principalId");
+    })
+    .filter(Boolean);
+}
+
+function evidenceFromRecord(value: unknown): BusinessBriefEvidence[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    const label = stringField(entry, "label") || stringField(entry, "kind") || "Evidence";
+    const summary = stringField(entry, "summary") || stringField(entry, "note") || label;
+    const kind = stringField(entry, "kind");
+    const href = stringField(entry, "href") || stringField(entry, "url");
+    return [{
+      kind: (
+        kind === "existing_example" ||
+        kind === "conversation" ||
+        kind === "coworker" ||
+        kind === "market_signal"
+      ) ? kind : "artifact",
+      label,
+      summary,
+      ...(href ? { url: href } : {}),
+    } satisfies BusinessBriefEvidence];
+  });
+}
+
+function technicalInterpretationFromRecord(
+  value: unknown,
+): BusinessBuildBrief["technicalInterpretation"] {
+  if (!isRecord(value)) {
+    return { dataNeeds: null, likelyWorkflowImpact: [], verificationFocus: [] };
+  }
+  return {
+    dataNeeds: stringField(value, "dataNeeds") || null,
+    likelyWorkflowImpact: stringArrayField(value, "likelyWorkflowImpact"),
+    verificationFocus: stringArrayField(value, "verificationFocus"),
+  };
+}
+
+function riskProfileFromRecord(value: unknown): BusinessBuildBrief["riskProfile"] {
+  if (!isRecord(value)) {
+    return {
+      customerFacing: false,
+      complianceSensitive: false,
+      revenueImpacting: false,
+      operationalRisk: false,
+      level: "low",
+    };
+  }
+  const level = stringField(value, "level");
+  return {
+    customerFacing: value.customerFacing === true,
+    complianceSensitive: value.complianceSensitive === true,
+    revenueImpacting: value.revenueImpacting === true,
+    operationalRisk: value.operationalRisk === true,
+    level: level === "high" || level === "medium" ? level : "low",
+  };
+}
+
 function coerceLegacyFeatureBrief(value: unknown, fallbackTitle: string): FeatureBrief {
   if (!isRecord(value)) {
     throw new Error("Legacy feature brief must be an object before it can be backfilled.");
@@ -370,6 +466,31 @@ export function buildBusinessBuildBrief(input: BuildBusinessBuildBriefInput): Bu
     },
     openQuestions,
     confidence: confidenceFor(openQuestions),
+  };
+}
+
+export function businessBuildBriefFromRecord(input: {
+  title: string;
+  row: BusinessBuildBriefRecordInput;
+}): BusinessBuildBrief {
+  const capabilityPackId = capabilityPackIdFromRecord(input.row.capabilityPackId);
+  const capabilityPack = capabilityPackLabel(input.row.capabilityPackId);
+  return {
+    title: input.title,
+    intakeSource: input.row.intakeSource,
+    businessOutcome: input.row.businessOutcome,
+    affectedPeople: affectedPeopleFromRecord(input.row.affectedPeople),
+    affectedWorkflow: input.row.affectedWorkflow,
+    sourceEvidence: evidenceFromRecord(input.row.sourceEvidence),
+    successSignals: input.row.successSignals,
+    constraints: input.row.constraints,
+    businessInterpretation: input.row.businessInterpretation ?? input.row.businessOutcome,
+    capabilityPackId,
+    capabilityPack,
+    riskProfile: riskProfileFromRecord(input.row.riskProfile),
+    technicalInterpretation: technicalInterpretationFromRecord(input.row.technicalInterpretation),
+    openQuestions: input.row.openQuestions,
+    confidence: input.row.confidence ?? "low",
   };
 }
 


### PR DESCRIPTION
## Summary
- load the latest persisted `BusinessBuildBrief` for `/build?v=2` when the signed-in user has one
- pass real brief data into `BuildStudioV2` while preserving the demo fallback for unauthenticated/no-data states
- add a mapper from persisted brief rows into the business-first artifact panel model, including stale capability-pack fallback handling

## Verification
- `pnpm --filter web exec vitest run lib/build/business-build-brief.test.ts components/build-studio/BuildStudioV2.test.tsx components/build-studio/BusinessBriefPanel.test.tsx components/build-studio/ArtifactTabs.test.tsx`
- `git diff --check`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`

## UX smoke
- Component-level jsdom coverage verifies the v2 brief panel renders a supplied persisted brief instead of demo content.
- Docker-served `/build?v=2` smoke could not be run from this isolated worktree because `.env` is absent here and `docker compose ps` fails interpolation for `AUTH_SECRET`.