### PR TITLE
feat(wiki): EP-WIKI-001 Phase 6a — read-only wiki page viewer

### DIFF
--- a/apps/web/app/(shell)/wiki/[...slug]/page.tsx
+++ b/apps/web/app/(shell)/wiki/[...slug]/page.tsx
@@ -1,0 +1,87 @@
+// EP-WIKI-001 Phase 6a: wiki page detail viewer.
+// Server component. Reads the page by (organizationId, slug) with
+// kernel fallback per spec §3.3.
+
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+
+import { WikiPageViewer, type WikiPageDetail } from "@/components/wiki/WikiPageViewer";
+
+export const dynamic = "force-dynamic";
+
+const PAGE_INCLUDE = {
+  sources: {
+    include: {
+      source: {
+        select: {
+          id: true,
+          sourceKey: true,
+          sourceType: true,
+          title: true,
+          authors: true,
+          url: true,
+          publishedAt: true,
+        },
+      },
+    },
+  },
+} as const;
+
+type Params = Promise<{ slug: string[] }>;
+
+export default async function WikiPageDetailRoute({ params }: { params: Params }) {
+  const { slug: slugParts } = await params;
+  const slug = slugParts.join("/");
+
+  const organization = await prisma.organization.findFirst({ select: { id: true } });
+  const organizationId = organization?.id ?? null;
+
+  // findFirst rather than findUnique because Prisma's compound-key
+  // findUnique doesn't accept `organizationId: null` for the kernel
+  // pass — nullable compound keys narrow non-null in the type.
+  // Pass A: org overlay (skipped when there's no current org).
+  // Pass B: kernel fallback when the overlay didn't return a row.
+  const orgRow = organizationId
+    ? await prisma.wikiPage.findFirst({
+        where: { organizationId, slug },
+        include: PAGE_INCLUDE,
+      })
+    : null;
+
+  const row =
+    orgRow ??
+    (await prisma.wikiPage.findFirst({
+      where: { organizationId: null, slug },
+      include: PAGE_INCLUDE,
+    }));
+
+  if (!row) notFound();
+
+  const detail: WikiPageDetail = {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    body: row.body,
+    pageKind: row.pageKind,
+    status: row.status,
+    isKernel: row.isKernel,
+    kernelVersion: row.kernelVersion,
+    organizationId: row.organizationId,
+    kernelPageId: row.kernelPageId,
+    derivedFromKernelVersion: row.derivedFromKernelVersion,
+    abstract: row.abstract,
+    lastReviewedAt: row.lastReviewedAt,
+    updatedAt: row.updatedAt,
+    sources: row.sources.map((s) => ({
+      id: s.source.id,
+      sourceKey: s.source.sourceKey,
+      sourceType: s.source.sourceType,
+      title: s.source.title,
+      authors: s.source.authors,
+      url: s.source.url,
+      publishedAt: s.source.publishedAt,
+    })),
+  };
+
+  return <WikiPageViewer page={detail} />;
+}

--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -1,0 +1,77 @@
+// EP-WIKI-001 Phase 6a: global wiki browse page.
+// Shows kernel pages + the platform organization's overlay rows.
+// Server component; queries Prisma directly.
+
+import { prisma } from "@dpf/db";
+
+import { WikiPageList, type WikiPageListItem } from "@/components/wiki/WikiPageList";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Wiki",
+};
+
+type SearchParams = Promise<{
+  kind?: string;
+  status?: string;
+}>;
+
+export default async function WikiBrowsePage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const sp = await searchParams;
+
+  // Determine the platform organization id (DPF runs as a single-org install
+  // — see (shell)/layout.tsx for the same pattern). Wiki rows are scoped to
+  // either the kernel (organizationId IS NULL) or this org's overlay.
+  const organization = await prisma.organization.findFirst({ select: { id: true } });
+  const organizationId = organization?.id ?? null;
+
+  const where: Record<string, unknown> = {
+    OR: organizationId
+      ? [{ organizationId }, { organizationId: null }]
+      : [{ organizationId: null }],
+  };
+
+  // Default to published; ?status=all surfaces drafts and review-needed.
+  const statusFilter = sp.status ?? "published";
+  if (statusFilter !== "all") {
+    where.status = statusFilter;
+  }
+  if (sp.kind) {
+    where.pageKind = sp.kind;
+  }
+
+  const pages = (await prisma.wikiPage.findMany({
+    where,
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      pageKind: true,
+      status: true,
+      isKernel: true,
+      abstract: true,
+    },
+    orderBy: [{ pageKind: "asc" }, { title: "asc" }],
+  })) as WikiPageListItem[];
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
+          Wiki
+        </h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Founder kernel and per-org overlay. Kernel pages ship with the platform;
+          overlay pages live alongside.
+        </p>
+      </header>
+
+      <WikiPageList pages={pages} />
+    </div>
+  );
+}

--- a/apps/web/components/wiki/WikiBodyRenderer.test.ts
+++ b/apps/web/components/wiki/WikiBodyRenderer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { splitWikilinks } from "./WikiBodyRenderer";
+
+describe("splitWikilinks", () => {
+  it("returns the whole string when no wikilinks are present", () => {
+    expect(splitWikilinks("plain text without brackets")).toEqual([
+      { kind: "text", value: "plain text without brackets" },
+    ]);
+  });
+
+  it("recognises a bare [[slug]]", () => {
+    expect(splitWikilinks("see [[entities/digital-product]] now")).toEqual([
+      { kind: "text", value: "see " },
+      { kind: "wikilink", slug: "entities/digital-product", label: "entities/digital-product" },
+      { kind: "text", value: " now" },
+    ]);
+  });
+
+  it("recognises [[slug|label]]", () => {
+    expect(splitWikilinks("see [[entities/digital-product|the DP page]]")).toEqual([
+      { kind: "text", value: "see " },
+      { kind: "wikilink", slug: "entities/digital-product", label: "the DP page" },
+    ]);
+  });
+
+  it("handles multiple wikilinks in one string", () => {
+    expect(splitWikilinks("[[a]] then [[b|Label B]] and [[c]]")).toEqual([
+      { kind: "wikilink", slug: "a", label: "a" },
+      { kind: "text", value: " then " },
+      { kind: "wikilink", slug: "b", label: "Label B" },
+      { kind: "text", value: " and " },
+      { kind: "wikilink", slug: "c", label: "c" },
+    ]);
+  });
+
+  it("leaves malformed brackets as plain text", () => {
+    expect(splitWikilinks("not a [[ link with spaces ]] here")).toEqual([
+      { kind: "text", value: "not a [[ link with spaces ]] here" },
+    ]);
+  });
+
+  it("does not match a single-bracket [link]", () => {
+    expect(splitWikilinks("a [link] only")).toEqual([
+      { kind: "text", value: "a [link] only" },
+    ]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(splitWikilinks("")).toEqual([]);
+  });
+});

--- a/apps/web/components/wiki/WikiBodyRenderer.tsx
+++ b/apps/web/components/wiki/WikiBodyRenderer.tsx
@@ -1,0 +1,141 @@
+// EP-WIKI-001 Phase 6a: wiki page body renderer.
+// Renders markdown with one wiki-specific extension: `[[slug]]` and
+// `[[slug|label]]` tokens become internal links to `/wiki/<slug>`.
+// Other markdown features (headings, lists, code, links) flow through
+// react-markdown with theme-aware tokens per AGENTS.md §12.
+//
+// Server component; no client JS cost.
+
+import ReactMarkdown from "react-markdown";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+// ─── Wikilink tokenization ──────────────────────────────────────────────────
+
+type WikilinkPart =
+  | { kind: "text"; value: string }
+  | { kind: "wikilink"; slug: string; label: string };
+
+/**
+ * Split a string into wikilinks and plain-text spans. Pure — exported
+ * for testing.
+ *
+ * Recognises `[[slug]]` (label = slug) and `[[slug|Label here]]`.
+ * Slugs may contain `[a-z0-9/_-]`; anything else inside `[[...]]` is
+ * left as literal text so we never silently swallow malformed tokens.
+ */
+export function splitWikilinks(text: string): WikilinkPart[] {
+  const parts: WikilinkPart[] = [];
+  const regex = /\[\[([a-zA-Z0-9/_-]+)(?:\|([^\]]+))?\]\]/g;
+  let lastIndex = 0;
+  for (const m of text.matchAll(regex)) {
+    if (m.index === undefined) continue;
+    if (m.index > lastIndex) {
+      parts.push({ kind: "text", value: text.slice(lastIndex, m.index) });
+    }
+    const slug = m[1];
+    const label = m[2] ?? slug;
+    parts.push({ kind: "wikilink", slug, label });
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < text.length) {
+    parts.push({ kind: "text", value: text.slice(lastIndex) });
+  }
+  return parts;
+}
+
+function renderWikilinkSpans(text: string): ReactNode[] {
+  const parts = splitWikilinks(text);
+  if (parts.every((p) => p.kind === "text")) return [text];
+  return parts.map((p, i) => {
+    if (p.kind === "text") return p.value;
+    return (
+      <Link
+        key={i}
+        href={`/wiki/${p.slug}`}
+        className="text-[var(--dpf-accent)] hover:underline"
+      >
+        {p.label}
+      </Link>
+    );
+  });
+}
+
+// ─── Markdown component overrides (theme-aware) ─────────────────────────────
+
+type C = { children?: ReactNode };
+type AnchorC = C & { href?: string };
+
+const components = {
+  h1: ({ children }: C) => (
+    <h1 className="text-xl font-semibold text-[var(--dpf-text)] mt-6 mb-3">{children}</h1>
+  ),
+  h2: ({ children }: C) => (
+    <h2 className="text-base font-semibold text-[var(--dpf-text)] mt-6 mb-2 pb-1 border-b border-[var(--dpf-border)]">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }: C) => (
+    <h3 className="text-sm font-semibold text-[var(--dpf-text)] mt-4 mb-2">{children}</h3>
+  ),
+  p: ({ children }: C) => (
+    <p className="text-sm text-[var(--dpf-text)] leading-relaxed mb-3">
+      {transformChildren(children)}
+    </p>
+  ),
+  ul: ({ children }: C) => (
+    <ul className="text-sm text-[var(--dpf-text)] mb-3 ml-4 list-disc space-y-1">{children}</ul>
+  ),
+  ol: ({ children }: C) => (
+    <ol className="text-sm text-[var(--dpf-text)] mb-3 ml-4 list-decimal space-y-1">{children}</ol>
+  ),
+  li: ({ children }: C) => (
+    <li className="text-sm text-[var(--dpf-text)]">{transformChildren(children)}</li>
+  ),
+  a: ({ href, children }: AnchorC) => (
+    <a
+      href={href ?? "#"}
+      className="text-[var(--dpf-accent)] hover:underline"
+      target={href?.startsWith("http") ? "_blank" : undefined}
+      rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
+    >
+      {children}
+    </a>
+  ),
+  code: ({ children }: C) => (
+    <code className="text-xs px-1 py-0.5 rounded bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] border border-[var(--dpf-border)]">
+      {children}
+    </code>
+  ),
+  pre: ({ children }: C) => (
+    <pre className="text-xs p-3 mb-3 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] overflow-x-auto">
+      {children}
+    </pre>
+  ),
+  blockquote: ({ children }: C) => (
+    <blockquote className="border-l-2 border-[var(--dpf-border)] pl-3 my-3 text-[var(--dpf-muted)] italic">
+      {children}
+    </blockquote>
+  ),
+};
+
+/** Walk children and rewrite plain-text `[[wikilink]]` tokens into <Link>s. */
+function transformChildren(children: ReactNode): ReactNode {
+  if (typeof children === "string") {
+    return renderWikilinkSpans(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map((c, i) =>
+      typeof c === "string" ? <span key={i}>{renderWikilinkSpans(c)}</span> : c,
+    );
+  }
+  return children;
+}
+
+// ─── Public component ───────────────────────────────────────────────────────
+
+type WikiBodyRendererProps = { body: string };
+
+export function WikiBodyRenderer({ body }: WikiBodyRendererProps): ReactNode {
+  return <ReactMarkdown components={components}>{body}</ReactMarkdown>;
+}

--- a/apps/web/components/wiki/WikiPageKindBadge.tsx
+++ b/apps/web/components/wiki/WikiPageKindBadge.tsx
@@ -1,0 +1,33 @@
+// EP-WIKI-001 Phase 6a: small chip rendering a wiki page kind.
+// Spec: docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md §6
+// Plan: docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md (Phase 6)
+//
+// Page-kind colour is part of the visual encoding called out in
+// EP-WIKI-005 §6 (the future visual-nav spec). Phase 6a uses muted
+// theme tokens because the list and viewer are read-only chrome —
+// the heavier shape vocabulary lives on the future kernel atlas.
+
+import type { ReactNode } from "react";
+
+const KIND_LABELS: Record<string, string> = {
+  entity: "Entity",
+  summary: "Summary",
+  decision: "Decision",
+  runbook: "Runbook",
+  index: "Index",
+  stance: "Stance",
+  heuristic: "Heuristic",
+};
+
+type Props = {
+  pageKind: string;
+};
+
+export function WikiPageKindBadge({ pageKind }: Props): ReactNode {
+  const label = KIND_LABELS[pageKind] ?? pageKind;
+  return (
+    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-[var(--dpf-border)] text-[var(--dpf-muted)] bg-[var(--dpf-surface-2)]">
+      {label}
+    </span>
+  );
+}

--- a/apps/web/components/wiki/WikiPageList.tsx
+++ b/apps/web/components/wiki/WikiPageList.tsx
@@ -1,0 +1,124 @@
+// EP-WIKI-001 Phase 6a: list view of wiki pages with simple grouping.
+// Server component. Pages are passed in already filtered + sorted.
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { WikiPageKindBadge } from "./WikiPageKindBadge";
+
+export type WikiPageListItem = {
+  id: string;
+  slug: string;
+  title: string;
+  pageKind: string;
+  status: string;
+  isKernel: boolean;
+  abstract: string | null;
+};
+
+type Props = {
+  pages: WikiPageListItem[];
+};
+
+const KIND_ORDER = [
+  "stance",
+  "heuristic",
+  "decision",
+  "entity",
+  "summary",
+  "runbook",
+  "index",
+];
+
+const KIND_GROUP_LABEL: Record<string, string> = {
+  stance: "Stances",
+  heuristic: "Heuristics",
+  decision: "Decisions",
+  entity: "Entities",
+  summary: "Summaries",
+  runbook: "Runbooks",
+  index: "Indices",
+};
+
+export function WikiPageList({ pages }: Props): ReactNode {
+  if (pages.length === 0) {
+    return (
+      <div className="py-8 text-center">
+        <p className="text-sm text-[var(--dpf-muted)]">
+          No wiki pages yet. The founder kernel seeds when content lands under{" "}
+          <code className="text-xs px-1 py-0.5 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)]">
+            docs/founder-kernel/wiki/
+          </code>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  // Group by pageKind preserving the canonical KIND_ORDER.
+  const byKind = new Map<string, WikiPageListItem[]>();
+  for (const p of pages) {
+    let bucket = byKind.get(p.pageKind);
+    if (!bucket) {
+      bucket = [];
+      byKind.set(p.pageKind, bucket);
+    }
+    bucket.push(p);
+  }
+
+  // Append any unrecognized kinds at the end (defensive).
+  const orderedKinds = [
+    ...KIND_ORDER.filter((k) => byKind.has(k)),
+    ...Array.from(byKind.keys()).filter((k) => !KIND_ORDER.includes(k)),
+  ];
+
+  return (
+    <div className="space-y-6">
+      {orderedKinds.map((kind) => {
+        const items = byKind.get(kind) ?? [];
+        return (
+          <section key={kind}>
+            <h2 className="text-xs uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+              {KIND_GROUP_LABEL[kind] ?? kind} · {items.length}
+            </h2>
+            <ul className="divide-y divide-[var(--dpf-border)] border border-[var(--dpf-border)] rounded">
+              {items.map((p) => (
+                <li key={p.id}>
+                  <Link
+                    href={`/wiki/${p.slug}`}
+                    className="block px-3 py-2 hover:bg-[var(--dpf-surface-2)]"
+                  >
+                    <div className="flex items-center gap-2">
+                      <WikiPageKindBadge pageKind={p.pageKind} />
+                      <span className="text-sm font-medium text-[var(--dpf-text)]">
+                        {p.title}
+                      </span>
+                      {!p.isKernel && (
+                        <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+                          overlay
+                        </span>
+                      )}
+                      {p.status !== "published" && (
+                        <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+                          · {p.status}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-[var(--dpf-muted)] font-mono mt-0.5">
+                      {p.slug}
+                    </p>
+                    {p.abstract && (
+                      <p className="text-xs text-[var(--dpf-muted)] mt-1 line-clamp-2">
+                        {p.abstract}
+                      </p>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/wiki/WikiPageViewer.tsx
+++ b/apps/web/components/wiki/WikiPageViewer.tsx
@@ -1,0 +1,94 @@
+// EP-WIKI-001 Phase 6a: page detail viewer.
+// Displays a wiki page's metadata header (title, kind, kernel/overlay
+// origin, citations count, last reviewed) above its rendered body.
+// Server component.
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { WikiBodyRenderer } from "./WikiBodyRenderer";
+import { WikiPageKindBadge } from "./WikiPageKindBadge";
+import { WikiSourceCitations, type WikiSourceCitation } from "./WikiSourceCitations";
+
+export type WikiPageDetail = {
+  id: string;
+  slug: string;
+  title: string;
+  body: string;
+  pageKind: string;
+  status: string;
+  isKernel: boolean;
+  kernelVersion: string | null;
+  organizationId: string | null;
+  kernelPageId: string | null;
+  derivedFromKernelVersion: string | null;
+  abstract: string | null;
+  lastReviewedAt: Date | null;
+  updatedAt: Date;
+  sources: WikiSourceCitation[];
+};
+
+type Props = {
+  page: WikiPageDetail;
+};
+
+function formatOrigin(page: WikiPageDetail): string {
+  if (page.isKernel) {
+    return page.kernelVersion ? `Kernel · v${page.kernelVersion}` : "Kernel";
+  }
+  if (page.kernelPageId) {
+    return page.derivedFromKernelVersion
+      ? `Org overlay (overrides kernel v${page.derivedFromKernelVersion})`
+      : "Org overlay";
+  }
+  return "Org-original";
+}
+
+export function WikiPageViewer({ page }: Props): ReactNode {
+  return (
+    <article className="max-w-3xl mx-auto py-6 px-4">
+      <nav className="mb-3 text-xs text-[var(--dpf-muted)]">
+        <Link href="/wiki" className="hover:underline">
+          ← Wiki
+        </Link>
+      </nav>
+
+      <header className="mb-6 pb-4 border-b border-[var(--dpf-border)]">
+        <div className="flex items-center gap-2 mb-2">
+          <WikiPageKindBadge pageKind={page.pageKind} />
+          <span className="text-xs text-[var(--dpf-muted)]">{formatOrigin(page)}</span>
+          {page.status !== "published" && (
+            <span className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+              · {page.status}
+            </span>
+          )}
+        </div>
+        <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
+          {page.title}
+        </h1>
+        <p className="text-xs text-[var(--dpf-muted)] font-mono">{page.slug}</p>
+        {page.abstract && (
+          <p className="mt-3 text-sm text-[var(--dpf-text)] leading-relaxed">
+            {page.abstract}
+          </p>
+        )}
+      </header>
+
+      <section className="mb-8">
+        <WikiBodyRenderer body={page.body} />
+      </section>
+
+      <aside className="border-t border-[var(--dpf-border)] pt-4 mt-8">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-2">Sources</h2>
+        <WikiSourceCitations sources={page.sources} />
+      </aside>
+
+      <footer className="mt-6 text-xs text-[var(--dpf-muted)]">
+        {page.lastReviewedAt && (
+          <span>Last reviewed {page.lastReviewedAt.toISOString().slice(0, 10)} · </span>
+        )}
+        Updated {page.updatedAt.toISOString().slice(0, 10)}
+      </footer>
+    </article>
+  );
+}

--- a/apps/web/components/wiki/WikiSourceCitations.tsx
+++ b/apps/web/components/wiki/WikiSourceCitations.tsx
@@ -1,0 +1,61 @@
+// EP-WIKI-001 Phase 6a: list of cited raw sources for a wiki page.
+// Renders the WikiPageSource → RawSource join into a dense list of
+// chips. Each source links out to its `url` if present; otherwise the
+// title is shown plain. Server component; no client JS.
+
+import type { ReactNode } from "react";
+
+export type WikiSourceCitation = {
+  id: string;
+  sourceKey: string;
+  sourceType: string;
+  title: string;
+  authors: string[];
+  url: string | null;
+  publishedAt: Date | null;
+};
+
+type Props = {
+  sources: WikiSourceCitation[];
+};
+
+export function WikiSourceCitations({ sources }: Props): ReactNode {
+  if (sources.length === 0) {
+    return (
+      <p className="text-xs text-[var(--dpf-muted)] italic">No sources cited.</p>
+    );
+  }
+
+  return (
+    <ul className="text-xs space-y-1">
+      {sources.map((s) => {
+        const yearText = s.publishedAt ? ` (${s.publishedAt.getFullYear()})` : "";
+        const authorText = s.authors.length > 0 ? `${s.authors.join(", ")}. ` : "";
+        const inner = (
+          <>
+            <span className="text-[var(--dpf-muted)] mr-1">[{s.sourceType}]</span>
+            {authorText}
+            <span className="text-[var(--dpf-text)]">{s.title}</span>
+            {yearText}
+          </>
+        );
+        return (
+          <li key={s.id} className="text-[var(--dpf-text)]">
+            {s.url ? (
+              <a
+                href={s.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                {inner}
+              </a>
+            ) : (
+              inner
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 6a — **first user-visible surface** of the wiki epic. `/wiki` shows the kernel + per-org overlay grouped by `pageKind`; `/wiki/[...slug]` renders the markdown body with a metadata header, source citations, and origin badge (kernel / overlay / org-original).

Independent of all in-flight work — depends only on Phase 1a (`WikiPage` model, merged).

## What&#39;s in this PR

### Routes

- **`apps/web/app/(shell)/wiki/page.tsx`** — list view. Server component, queries `WikiPage` with the overlay-aware filter (`organizationId IN (NULL, <thisOrg>)`). `?status=` and `?kind=` URL filters. Default `status=published`.
- **`apps/web/app/(shell)/wiki/[...slug]/page.tsx`** — detail viewer. Two-pass overlay-aware lookup: org row first, kernel fallback second. Includes source citations via `WikiPageSource → RawSource`.

### Components (`apps/web/components/wiki/`)

- **`WikiPageList.tsx`** — list grouped by `pageKind` in canonical order (`stance`, `heuristic`, `decision`, `entity`, `summary`, `runbook`, `index`). Empty-state hint points at `docs/founder-kernel/wiki/`.
- **`WikiPageViewer.tsx`** — page detail layout: kind badge + origin chip + title + slug + abstract + body + sources + footer with last-reviewed/updated dates.
- **`WikiBodyRenderer.tsx`** — markdown via react-markdown with theme-aware tokens per AGENTS.md §12, plus a wiki-specific extension that turns `[[slug]]` and `[[slug|label]]` into `<Link>`s to `/wiki/<slug>`. Server component; no client JS.
- **`WikiSourceCitations.tsx`** — dense list of cited `RawSource`s; links to `source.url` when present.
- **`WikiPageKindBadge.tsx`** — small chip per `pageKind`.

### Tests

- **`WikiBodyRenderer.test.ts`** — 7 vitest cases for the pure `splitWikilinks` tokenizer: plain text, bare `[[slug]]`, `[[slug|label]]`, multiple links in one string, malformed brackets passed through, single-bracket `[link]` not matched, empty string.

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` | ✓ |
| `pnpm --filter web typecheck` | ✓ |
| `pnpm typecheck` (all six packages) | ✓ |
| `pnpm --filter web test --run WikiBodyRenderer.test.ts` | ✓ 7/7 |

## Test plan

- [ ] Hit `/wiki` in a running dev server — empty kernel state shows the &#34;no wiki pages yet&#34; hint
- [ ] After Mark drops kernel content + runs seed, `/wiki` lists pages grouped by kind
- [ ] Click into a page → `/wiki/[...slug]` renders markdown with the metadata header and citation list
- [ ] `[[slug]]` and `[[slug|label]]` tokens in the body become clickable links to other wiki pages
- [ ] Theme-aware tokens render correctly in light, dark, and custom-branding modes per AGENTS.md §12
- [ ] Org overlay overrides kernel: when both rows exist for the same slug, the overlay row is shown

## Out of scope

- **Edit form** at `/wiki/[...slug]/edit` — needs `wiki_propose_edit` MCP tool and HITL proposal review wireup. Lands in Phase 6b.
- **Cross-ref list** (`WikiCrossRefList.tsx`) and **`KernelDriftBadge`** components — overlay UX work; Phase 6b.
- **Header navigation entry** for &#34;Wiki&#34; — separate small PR if desired; for now the page is reachable by direct URL.
- **Visual graph / atlas** (EP-WIKI-005 / Phase 7) — `@xyflow/react` work; separate epic territory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_