### PR TITLE
feat(discovery): macOS branch for host + docker collectors (Phase 10b)

### DIFF
--- a/packages/db/src/discovery-collectors/docker.ts
+++ b/packages/db/src/discovery-collectors/docker.ts
@@ -1,10 +1,37 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import type { CollectorContext, CollectorOutput } from "../discovery-types";
 
+// Candidate Docker daemon socket paths, in detection order. The host's
+// platform dictates which one is real:
+//
+//   Linux                 /var/run/docker.sock
+//   macOS Docker Desktop  /var/run/docker.sock (symlink) OR ~/.docker/run/docker.sock
+//                         OR ~/Library/Containers/com.docker.docker/Data/docker.raw.sock
+//                         (depending on Docker Desktop version)
+//   Windows               \\.\pipe\docker_engine
+//
+// We list the Unix path first so a Linux + Docker Engine install picks
+// up the canonical path immediately; macOS / Windows variants follow.
+// Per the installer-parity roadmap Phase 10b.
+const HOME = os.homedir();
 const DOCKER_SOCKET_PATHS = [
   "/var/run/docker.sock",
+  // Docker Desktop 4.13+ (macOS): per-user socket under ~/.docker/run
+  path.join(HOME, ".docker", "run", "docker.sock"),
+  // Docker Desktop older builds (macOS): sandboxed container path
+  path.join(
+    HOME,
+    "Library",
+    "Containers",
+    "com.docker.docker",
+    "Data",
+    "docker.raw.sock",
+  ),
+  // Windows named pipe
   "\\\\.\\pipe\\docker_engine",
 ];
 

--- a/packages/db/src/discovery-collectors/host.ts
+++ b/packages/db/src/discovery-collectors/host.ts
@@ -58,6 +58,83 @@ async function collectInstalledSoftware(): Promise<DiscoveredSoftwareInput[]> {
     }));
   }
 
+  if (process.platform === "darwin") {
+    const software: DiscoveredSoftwareInput[] = [];
+
+    // System package receipts (.pkg installers). pkgutil ships with macOS,
+    // no third-party tooling required. Each package id is a reverse-DNS
+    // string like com.apple.pkg.MobileDeviceDevelopment.
+    const pkgutil = spawnSync("pkgutil", ["--pkgs"], { encoding: "utf8" });
+    if (pkgutil.status === 0 && pkgutil.stdout.trim()) {
+      for (const pkgId of pkgutil.stdout.split(/\r?\n/).filter(Boolean)) {
+        const info = spawnSync(
+          "pkgutil",
+          ["--pkg-info", pkgId],
+          { encoding: "utf8" },
+        );
+        let version: string | undefined;
+        let installLocation: string | undefined;
+        if (info.status === 0) {
+          for (const line of info.stdout.split(/\r?\n/)) {
+            if (line.startsWith("version: ")) version = line.slice(9).trim();
+            else if (line.startsWith("location: ")) installLocation = line.slice(10).trim();
+          }
+        }
+        software.push({
+          evidenceSource: "installed_software",
+          packageManager: "pkgutil",
+          rawPackageName: pkgId,
+          rawProductName: pkgId,
+          ...(version ? { rawVersion: version } : {}),
+          ...(installLocation ? { installLocation } : {}),
+        });
+      }
+    }
+
+    // Homebrew formulas + casks. Optional — many DPF hosts have brew, but
+    // a fresh macOS install may not. We probe with `command -v` style
+    // checks via spawnSync's exit code.
+    const brewFormula = spawnSync(
+      "brew",
+      ["list", "--formula", "--versions"],
+      { encoding: "utf8" },
+    );
+    if (brewFormula.status === 0 && brewFormula.stdout.trim()) {
+      for (const line of brewFormula.stdout.split(/\r?\n/).filter(Boolean)) {
+        const [name, ...versionParts] = line.split(/\s+/);
+        if (!name) continue;
+        software.push({
+          evidenceSource: "host_packages",
+          packageManager: "brew",
+          rawPackageName: name,
+          rawProductName: name,
+          ...(versionParts.length > 0 ? { rawVersion: versionParts.join(" ") } : {}),
+        });
+      }
+    }
+
+    const brewCask = spawnSync(
+      "brew",
+      ["list", "--cask", "--versions"],
+      { encoding: "utf8" },
+    );
+    if (brewCask.status === 0 && brewCask.stdout.trim()) {
+      for (const line of brewCask.stdout.split(/\r?\n/).filter(Boolean)) {
+        const [name, ...versionParts] = line.split(/\s+/);
+        if (!name) continue;
+        software.push({
+          evidenceSource: "installed_software",
+          packageManager: "brew-cask",
+          rawPackageName: name,
+          rawProductName: name,
+          ...(versionParts.length > 0 ? { rawVersion: versionParts.join(" ") } : {}),
+        });
+      }
+    }
+
+    return software;
+  }
+
   const dpkg = spawnSync(
     "dpkg-query",
     ["-W", "-f=${Package}\\t${Version}\\n"],


### PR DESCRIPTION
Closes the macOS gap in the bootstrap discovery pipeline so a
freshly-installed DPF on Apple Silicon doesn't produce empty
installed-software lists or `docker_unavailable` warnings just because
the host isn't Linux or Windows.

## `packages/db/src/discovery-collectors/host.ts`

Adds a `darwin` branch to `collectInstalledSoftware()` that emits:

| Source | Command | `evidenceSource` | `packageManager` | Notes |
|--------|---------|------------------|------------------|-------|
| **System receipts** | `pkgutil --pkgs` + `pkgutil --pkg-info <id>` per row | `installed_software` | `pkgutil` | Ships with macOS — no third-party dependency. Version + install location enriched per package id. |
| **Homebrew formulas** | `brew list --formula --versions` | `host_packages` | `brew` | Optional — silently emits zero entries if brew isn't installed. |
| **Homebrew casks** | `brew list --cask --versions` | `installed_software` | `brew-cask` | Optional — same fallback as formulas. |

The Windows registry branch and the Linux `dpkg → rpm` chain are
untouched; `process.platform === "darwin"` short-circuits before
falling through to them.

## `packages/db/src/discovery-collectors/docker.ts`

Extends `DOCKER_SOCKET_PATHS` with two macOS-specific fallbacks used
by Docker Desktop:

```
/var/run/docker.sock                                           ← preserved (Linux + DD symlink)
~/.docker/run/docker.sock                                      ← NEW (Docker Desktop 4.13+)
~/Library/Containers/com.docker.docker/Data/docker.raw.sock    ← NEW (older Docker Desktop)
\\.\pipe\docker_engine                                         ← preserved (Windows)
```

`/var/run/docker.sock` stays first since both Linux and the macOS
Docker Desktop symlink resolve there when present. The fallbacks
catch the cases where the symlink isn't created (newer Docker Desktop
versions, sandboxed builds).

The `DockerDeps` interface lets tests inject mocked socket paths, so
expanding the default constant doesn't disturb the fixture.

## Verification

```
pnpm --filter @dpf/db typecheck            clean
pnpm --filter @dpf/db exec vitest run discovery
  25 test files, 172 tests, all pass
```

## Roadmap

`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` —
Phase 10b. Remaining in Phase 10:

- **10c**: `apps/web/lib/integrate/codebase-tools.ts` POSIX-path test
  (assert absolute Unix paths aren't falsely blocked by the
  `^[A-Za-z]:` Windows-drive guard at lines 47-71).
- **10d**: `scripts/installer/lib/diagnostics.sh` — extended preflight
  bundle (compose render dry-run + docker context dump) wired into
  `install-dpf.sh doctor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_