### PR TITLE
Project Operations Map evidence sources

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -5,6 +5,9 @@ vi.mock("@dpf/db", () => ({
     storefrontConfig: { findFirst: vi.fn() },
     agent: { findMany: vi.fn() },
     toolExecution: { findMany: vi.fn() },
+    toolExecutionReceipt: { findMany: vi.fn() },
+    backlogItemActivity: { findMany: vi.fn() },
+    externalEvidenceRecord: { findMany: vi.fn() },
   },
 }));
 
@@ -55,6 +58,9 @@ describe("AI operations map page", () => {
         summary: "Write blocked by policy",
       },
     ] as never);
+    vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
 
     const { default: OperationsMapPage } = await import("./page");
     const element = await OperationsMapPage();
@@ -67,5 +73,6 @@ describe("AI operations map page", () => {
     expect(props.projections.map((projection: { summary: string }) => projection.summary)).toContain("Write blocked by policy");
     expect(props.projections[0].links.authorityHref).toBe("/platform/audit/ledger?toolExecutionId=tool-1");
     expect(props.projections[0].links.coworkerHref).toBe("/platform/ai/agent/build-specialist");
+    expect(props.recentWindowLabel).toBe("Last 40 records per evidence source");
   });
 });

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -28,6 +28,13 @@ const SEVERITY_CLASS: Record<OperationsMapProjection["severity"], string> = {
   critical: "border-[var(--dpf-error)] bg-[color-mix(in_srgb,var(--dpf-error)_10%,var(--dpf-surface-1))] text-[var(--dpf-text)]",
 };
 
+const SOURCE_LABEL: Record<OperationsMapProjection["source"], string> = {
+  "tool-execution": "Tool execution",
+  "tool-receipt": "Receipt",
+  "evidence-backlog": "Backlog evidence",
+  "evidence-external": "External evidence",
+};
+
 export function AiOperationsMap({ template, agents, projections, recentWindowLabel }: Props) {
   const [selected, setSelected] = useState<SelectedItem>({ kind: "station", id: template.stations[0]?.id ?? "" });
   const counts = useMemo(() => summarizeProjectionCounts(projections), [projections]);
@@ -51,7 +58,7 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
           </p>
           <h1 className="mt-1 text-2xl font-bold text-[var(--dpf-text)]">AI Operations Map</h1>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
-            {template.label} projects coworker work onto the business flow using existing tool execution and coworker records.
+            {template.label} projects coworker work onto the business flow using existing execution, receipt, and evidence records.
           </p>
         </div>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -74,7 +81,7 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
                 <p className="text-xs text-[var(--dpf-muted)]">{recentWindowLabel}</p>
               </div>
               <span className="rounded border border-[var(--dpf-border)] px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
-                Read-only V1
+                Read-only V2
               </span>
             </div>
           </div>
@@ -234,7 +241,7 @@ function StationInspector({
             {projection.summary}
           </button>
         )) : (
-          <p className="text-xs text-[var(--dpf-muted)]">No recent tool execution projected here.</p>
+          <p className="text-xs text-[var(--dpf-muted)]">No recent activity projected here.</p>
         )}
       </InspectorList>
     </div>
@@ -265,24 +272,34 @@ function AgentInspector({ agent }: { agent: StationedOperationsMapAgent }) {
 }
 
 function ProjectionInspector({ projection }: { projection: OperationsMapProjection }) {
+  const linkItems = [
+    projection.links.authorityHref ? { href: projection.links.authorityHref, label: "Open audit row" } : null,
+    projection.links.historyHref ? { href: projection.links.historyHref, label: "Open history" } : null,
+    projection.links.backlogHref ? { href: projection.links.backlogHref, label: "Open backlog item" } : null,
+    projection.links.coworkerHref ? { href: projection.links.coworkerHref, label: "Open coworker" } : null,
+  ].filter((item): item is { href: string; label: string } => item !== null);
+
   return (
     <div className="mt-4 space-y-4">
       <div>
-        <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Tool execution</p>
+        <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+          {SOURCE_LABEL[projection.source]}
+        </p>
         <h3 className="mt-1 text-base font-semibold text-[var(--dpf-text)]">{projection.label}</h3>
         <p className="mt-2 text-sm leading-6 text-[var(--dpf-muted)]">{projection.summary}</p>
       </div>
       <dl className="grid grid-cols-2 gap-2 text-xs">
+        <InspectorFact label="Source" value={SOURCE_LABEL[projection.source]} />
         <InspectorFact label="Severity" value={projection.severity} />
-        <InspectorFact label="Thread" value={projection.refs.threadId} />
+        {projection.refs.threadId ? <InspectorFact label="Thread" value={projection.refs.threadId} /> : null}
+        {projection.refs.backlogItemId ? <InspectorFact label="Backlog item" value={projection.refs.backlogItemId} /> : null}
       </dl>
       <div className="flex flex-wrap gap-2">
-        <Link href={projection.links.authorityHref} className="text-sm text-[var(--dpf-accent)] hover:underline">
-          Open audit row
-        </Link>
-        <Link href={projection.links.coworkerHref} className="text-sm text-[var(--dpf-accent)] hover:underline">
-          Open coworker
-        </Link>
+        {linkItems.map((item) => (
+          <Link key={item.href} href={item.href} className="text-sm text-[var(--dpf-accent)] hover:underline">
+            {item.label}
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -11,6 +11,15 @@ vi.mock("@dpf/db", () => ({
     toolExecution: {
       findMany: vi.fn(),
     },
+    toolExecutionReceipt: {
+      findMany: vi.fn(),
+    },
+    backlogItemActivity: {
+      findMany: vi.fn(),
+    },
+    externalEvidenceRecord: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -30,13 +39,16 @@ describe("loadOperationsMapData", () => {
     } as never);
     vi.mocked(prisma.agent.findMany).mockResolvedValue([makeAgentRow()] as never);
     vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([makeToolExecutionRow()] as never);
+    vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
 
     const data = await loadOperationsMapData();
 
     expect(data.template.id).toBe("managed-service-provider");
     expect(data.agents[0].stationId).toBe("service-operations");
     expect(data.projections[0].location.stationId).toBe("service-operations");
-    expect(data.recentWindowLabel).toBe("Last 40 tool executions");
+    expect(data.recentWindowLabel).toBe("Last 40 records per evidence source");
     expect(prisma.storefrontConfig.findFirst).toHaveBeenCalledWith({
       include: {
         archetype: {
@@ -53,12 +65,94 @@ describe("loadOperationsMapData", () => {
     vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.agent.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
 
     const data = await loadOperationsMapData();
 
     expect(data.template.id).toBe("generic-value-chain");
     expect(data.agents).toEqual([]);
     expect(data.projections).toEqual([]);
+  });
+
+  it("loads and chronologically merges receipts, backlog evidence, and external evidence", async () => {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.agent.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([makeToolExecutionRow()] as never);
+    vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([makeReceiptRow()] as never);
+    vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([makeBacklogEvidenceRow()] as never);
+    vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([makeExternalEvidenceRow()] as never);
+
+    const data = await loadOperationsMapData();
+
+    expect(data.projections.map((projection) => projection.source)).toEqual([
+      "evidence-external",
+      "evidence-backlog",
+      "tool-receipt",
+      "tool-execution",
+    ]);
+    expect(prisma.toolExecutionReceipt.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+      take: 40,
+      select: {
+        id: true,
+        toolExecutionId: true,
+        buildId: true,
+        receiptKind: true,
+        receiptStatus: true,
+        executionStatus: true,
+        expiresAt: true,
+        createdAt: true,
+        toolExecution: {
+          select: {
+            id: true,
+            threadId: true,
+            agentId: true,
+            userId: true,
+            toolName: true,
+            success: true,
+            executionMode: true,
+            routeContext: true,
+            durationMs: true,
+            createdAt: true,
+            auditClass: true,
+            capabilityId: true,
+            summary: true,
+          },
+        },
+      },
+    });
+    expect(prisma.backlogItemActivity.findMany).toHaveBeenCalledWith({
+      where: { kind: "evidence" },
+      orderBy: { recordedAt: "desc" },
+      take: 40,
+      select: {
+        id: true,
+        backlogItemId: true,
+        kind: true,
+        summary: true,
+        payload: true,
+        recordedAt: true,
+        recordedById: true,
+        recordedByAgentId: true,
+        toolExecutionId: true,
+      },
+    });
+    expect(prisma.externalEvidenceRecord.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+      take: 40,
+      select: {
+        id: true,
+        actorUserId: true,
+        routeContext: true,
+        operationType: true,
+        target: true,
+        provider: true,
+        resultSummary: true,
+        createdAt: true,
+      },
+    });
   });
 });
 
@@ -95,5 +189,46 @@ function makeToolExecutionRow() {
     auditClass: "journal",
     capabilityId: "platform:diagnose_customer_estate",
     summary: "Checked service health",
+  };
+}
+
+function makeReceiptRow() {
+  return {
+    id: "receipt-1",
+    toolExecutionId: "tool-1",
+    buildId: "build-1",
+    receiptKind: "sandbox-output",
+    receiptStatus: "valid",
+    executionStatus: "completed",
+    expiresAt: new Date("2026-05-11T12:00:00.000Z"),
+    createdAt: new Date("2026-05-10T12:01:00.000Z"),
+    toolExecution: makeToolExecutionRow(),
+  };
+}
+
+function makeBacklogEvidenceRow() {
+  return {
+    id: "activity-1",
+    backlogItemId: "BI-123",
+    kind: "evidence",
+    summary: "UX verification completed",
+    payload: {},
+    recordedAt: new Date("2026-05-10T12:02:00.000Z"),
+    recordedById: "user-1",
+    recordedByAgentId: "support-specialist",
+    toolExecutionId: "tool-1",
+  };
+}
+
+function makeExternalEvidenceRow() {
+  return {
+    id: "external-1",
+    actorUserId: "user-1",
+    routeContext: "release",
+    operationType: "ci-check",
+    target: "pull-request",
+    provider: "github",
+    resultSummary: "CI checks passed",
+    createdAt: new Date("2026-05-10T12:03:00.000Z"),
   };
 }

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -1,11 +1,20 @@
 import { prisma } from "@dpf/db";
 import { getMapTemplate } from "./templates";
-import { projectAgentsToStations, projectToolExecution } from "./project-events";
+import {
+  projectAgentsToStations,
+  projectBacklogEvidence,
+  projectExternalEvidence,
+  projectToolExecution,
+  projectToolExecutionReceipt,
+} from "./project-events";
 import type {
   OperationsMapAgent,
+  OperationsMapBacklogEvidence,
+  OperationsMapExternalEvidence,
   OperationsMapProjection,
   OperationsMapTemplate,
   OperationsMapToolExecution,
+  OperationsMapToolExecutionReceipt,
   StationedOperationsMapAgent,
 } from "./types";
 
@@ -19,7 +28,7 @@ export type OperationsMapData = {
 };
 
 export async function loadOperationsMapData(): Promise<OperationsMapData> {
-  const [storefrontConfig, agents, toolExecutions] = await Promise.all([
+  const [storefrontConfig, agents, toolExecutions, toolReceipts, backlogEvidence, externalEvidence] = await Promise.all([
     prisma.storefrontConfig.findFirst({
       include: {
         archetype: {
@@ -73,6 +82,67 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
         summary: true,
       },
     }),
+    prisma.toolExecutionReceipt.findMany({
+      orderBy: { createdAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        toolExecutionId: true,
+        buildId: true,
+        receiptKind: true,
+        receiptStatus: true,
+        executionStatus: true,
+        expiresAt: true,
+        createdAt: true,
+        toolExecution: {
+          select: {
+            id: true,
+            threadId: true,
+            agentId: true,
+            userId: true,
+            toolName: true,
+            success: true,
+            executionMode: true,
+            routeContext: true,
+            durationMs: true,
+            createdAt: true,
+            auditClass: true,
+            capabilityId: true,
+            summary: true,
+          },
+        },
+      },
+    }),
+    prisma.backlogItemActivity.findMany({
+      where: { kind: "evidence" },
+      orderBy: { recordedAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        backlogItemId: true,
+        kind: true,
+        summary: true,
+        payload: true,
+        recordedAt: true,
+        recordedById: true,
+        recordedByAgentId: true,
+        toolExecutionId: true,
+      },
+    }),
+    prisma.externalEvidenceRecord.findMany({
+      orderBy: { createdAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        actorUserId: true,
+        routeContext: true,
+        operationType: true,
+        target: true,
+        provider: true,
+        resultSummary: true,
+        createdAt: true,
+      },
+    }),
   ]);
 
   const template = getMapTemplate({
@@ -99,11 +169,18 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     },
   }));
 
+  const projections = [
+    ...toolExecutions.map((row) => projectToolExecution(row as OperationsMapToolExecution, template)),
+    ...toolReceipts.map((row) => projectToolExecutionReceipt(row as OperationsMapToolExecutionReceipt, template)),
+    ...backlogEvidence.map((row) => projectBacklogEvidence(row as OperationsMapBacklogEvidence, template)),
+    ...externalEvidence.map((row) => projectExternalEvidence(row as OperationsMapExternalEvidence, template)),
+  ].sort((left, right) => Date.parse(right.occurredAt) - Date.parse(left.occurredAt));
+
   return {
     template,
     agents: projectAgentsToStations(mapAgents, template),
-    projections: toolExecutions.map((row) => projectToolExecution(row as OperationsMapToolExecution, template)),
-    recentWindowLabel: `Last ${RECENT_TOOL_LIMIT} tool executions`,
+    projections,
+    recentWindowLabel: `Last ${RECENT_TOOL_LIMIT} records per evidence source`,
   };
 }
 

--- a/apps/web/lib/ai-operations-map/project-events.test.ts
+++ b/apps/web/lib/ai-operations-map/project-events.test.ts
@@ -9,10 +9,19 @@ import {
 } from "./templates";
 import {
   deriveProjectionSeverityFromTaskState,
+  projectBacklogEvidence,
+  projectExternalEvidence,
   projectAgentsToStations,
+  projectToolExecutionReceipt,
   projectToolExecution,
 } from "./project-events";
-import type { OperationsMapAgent, OperationsMapToolExecution } from "./types";
+import type {
+  OperationsMapAgent,
+  OperationsMapBacklogEvidence,
+  OperationsMapExternalEvidence,
+  OperationsMapToolExecution,
+  OperationsMapToolExecutionReceipt,
+} from "./types";
 
 describe("AI operations map projection", () => {
   it("ships a valid software-platform template with stable stations", () => {
@@ -109,6 +118,69 @@ describe("AI operations map projection", () => {
     expect(projection.links.authorityHref).toBe("/platform/audit/ledger?toolExecutionId=tool-1");
     expect(projection.links.coworkerHref).toBe("/platform/ai/agent/build-specialist");
   });
+
+  it("projects invalid tool receipts as warning evidence linked to the originating execution", () => {
+    const projection = projectToolExecutionReceipt(
+      makeToolExecutionReceipt({
+        id: "receipt-1",
+        receiptKind: "sandbox-output",
+        receiptStatus: "expired",
+        executionStatus: "completed",
+        toolExecution: makeToolExecution({
+          id: "tool-2",
+          agentId: "build-specialist",
+          toolName: "write_sandbox_file",
+          routeContext: "build",
+        }),
+      }),
+    );
+
+    expect(projection.id).toBe("receipt:receipt-1");
+    expect(projection.source).toBe("tool-receipt");
+    expect(projection.location.stationId).toBe("build");
+    expect(projection.severity).toBe("warning");
+    expect(projection.refs.toolReceiptId).toBe("receipt-1");
+    expect(projection.refs.toolExecutionId).toBe("tool-2");
+    expect(projection.links.authorityHref).toBe("/platform/audit/ledger?toolExecutionId=tool-2");
+  });
+
+  it("projects backlog evidence to the verification station with backlog references", () => {
+    const projection = projectBacklogEvidence(
+      makeBacklogEvidence({
+        id: "activity-1",
+        backlogItemId: "BI-123",
+        summary: "UX verification completed",
+        toolExecutionId: "tool-3",
+      }),
+    );
+
+    expect(projection.id).toBe("backlog-evidence:activity-1");
+    expect(projection.source).toBe("evidence-backlog");
+    expect(projection.location.stationId).toBe("verify");
+    expect(projection.severity).toBe("normal");
+    expect(projection.refs.backlogItemId).toBe("BI-123");
+    expect(projection.refs.toolExecutionId).toBe("tool-3");
+    expect(projection.links.backlogHref).toBe("/platform/backlog?itemId=BI-123");
+  });
+
+  it("projects external evidence through route context and history links", () => {
+    const projection = projectExternalEvidence(
+      makeExternalEvidence({
+        id: "external-1",
+        provider: "github",
+        operationType: "ci-check",
+        routeContext: "release",
+        resultSummary: "CI checks passed",
+      }),
+    );
+
+    expect(projection.id).toBe("external-evidence:external-1");
+    expect(projection.source).toBe("evidence-external");
+    expect(projection.location.stationId).toBe("release");
+    expect(projection.label).toBe("github ci-check");
+    expect(projection.refs.externalEvidenceRecordId).toBe("external-1");
+    expect(projection.links.historyHref).toBe("/platform/ai/history?externalEvidenceRecordId=external-1");
+  });
 });
 
 function makeAgent(overrides: Partial<OperationsMapAgent> = {}): OperationsMapAgent {
@@ -147,6 +219,52 @@ function makeToolExecution(
     auditClass: "journal",
     capabilityId: "platform:search_project_files",
     summary: null,
+    ...overrides,
+  };
+}
+
+function makeToolExecutionReceipt(
+  overrides: Partial<OperationsMapToolExecutionReceipt> = {},
+): OperationsMapToolExecutionReceipt {
+  return {
+    id: "receipt-1",
+    toolExecutionId: "tool-1",
+    buildId: null,
+    receiptKind: "tool-output",
+    receiptStatus: "valid",
+    executionStatus: "completed",
+    expiresAt: new Date("2026-05-11T12:00:00.000Z"),
+    createdAt: new Date("2026-05-10T12:01:00.000Z"),
+    toolExecution: makeToolExecution(),
+    ...overrides,
+  };
+}
+
+function makeBacklogEvidence(overrides: Partial<OperationsMapBacklogEvidence> = {}): OperationsMapBacklogEvidence {
+  return {
+    id: "activity-1",
+    backlogItemId: "BI-1",
+    kind: "evidence",
+    summary: "Evidence recorded",
+    payload: {},
+    recordedAt: new Date("2026-05-10T12:02:00.000Z"),
+    recordedById: "user-1",
+    recordedByAgentId: "agent-1",
+    toolExecutionId: null,
+    ...overrides,
+  };
+}
+
+function makeExternalEvidence(overrides: Partial<OperationsMapExternalEvidence> = {}): OperationsMapExternalEvidence {
+  return {
+    id: "external-1",
+    actorUserId: "user-1",
+    routeContext: "governance",
+    operationType: "audit-sync",
+    target: "external-system",
+    provider: "external",
+    resultSummary: "Evidence synced",
+    createdAt: new Date("2026-05-10T12:03:00.000Z"),
     ...overrides,
   };
 }

--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -3,10 +3,13 @@ import type { TaskState } from "@/lib/tak/task-states";
 import { SOFTWARE_PLATFORM_MAP_TEMPLATE } from "./templates";
 import type {
   OperationsMapAgent,
+  OperationsMapBacklogEvidence,
+  OperationsMapExternalEvidence,
   OperationsMapProjection,
   OperationsMapSeverity,
   OperationsMapTemplate,
   OperationsMapToolExecution,
+  OperationsMapToolExecutionReceipt,
   StationedOperationsMapAgent,
 } from "./types";
 
@@ -38,7 +41,7 @@ const AGENT_ID_TO_STATION_HINTS: Array<{ pattern: RegExp; stationId: string }> =
   { pattern: /backlog|portfolio|triage|evaluate/i, stationId: "evaluate" },
   { pattern: /architect|design|ux|plan|integrate/i, stationId: "integrate" },
   { pattern: /build|code|developer|specialist/i, stationId: "build" },
-  { pattern: /review|verify|qa|test/i, stationId: "verify" },
+  { pattern: /review|verify|verification|qa|test/i, stationId: "verify" },
   { pattern: /deploy|environment/i, stationId: "deploy" },
   { pattern: /release|deploy|ship/i, stationId: "release" },
   { pattern: /consume|customer|experience/i, stationId: "consume" },
@@ -56,7 +59,7 @@ const ROUTE_CONTEXT_TO_STATION: Array<{ pattern: RegExp; stationId: string }> = 
   { pattern: /backlog|portfolio|triage|evaluate/i, stationId: "evaluate" },
   { pattern: /design|plan|architect|integrate/i, stationId: "integrate" },
   { pattern: /build|sandbox|code/i, stationId: "build" },
-  { pattern: /verify|review|test|qa/i, stationId: "verify" },
+  { pattern: /verify|verification|review|test|qa/i, stationId: "verify" },
   { pattern: /deploy|environment/i, stationId: "deploy" },
   { pattern: /release|deploy|ship/i, stationId: "release" },
   { pattern: /consume|customer|experience/i, stationId: "consume" },
@@ -95,6 +98,14 @@ export function deriveProjectionSeverityFromToolExecution(
 ): OperationsMapSeverity {
   if (row.success) return "normal";
   return row.auditClass === "ledger" ? "critical" : "warning";
+}
+
+export function deriveProjectionSeverityFromToolReceipt(
+  row: Pick<OperationsMapToolExecutionReceipt, "receiptStatus" | "executionStatus">,
+): OperationsMapSeverity {
+  if (row.receiptStatus !== "valid") return "warning";
+  if (/fail|error|denied|rejected/i.test(row.executionStatus)) return "warning";
+  return "normal";
 }
 
 export function projectAgentsToStations(
@@ -145,6 +156,109 @@ export function projectToolExecution(
   };
 }
 
+export function projectToolExecutionReceipt(
+  row: OperationsMapToolExecutionReceipt,
+  template: OperationsMapTemplate = SOFTWARE_PLATFORM_MAP_TEMPLATE,
+): OperationsMapProjection {
+  const stationId = row.toolExecution
+    ? resolveToolExecutionStationId(row.toolExecution, template)
+    : resolveFallbackStationId(template);
+  const label = `${row.receiptKind} receipt`;
+  const toolExecutionId = row.toolExecution?.id ?? row.toolExecutionId;
+
+  return {
+    id: `receipt:${row.id}`,
+    occurredAt: row.createdAt.toISOString(),
+    actorAgentId: row.toolExecution?.agentId ?? null,
+    source: "tool-receipt",
+    location: {
+      lineId: resolveLineId(stationId, template),
+      stationId,
+    },
+    severity: deriveProjectionSeverityFromToolReceipt(row),
+    label,
+    summary: `${label} ${row.receiptStatus} for ${row.toolExecution?.toolName ?? row.toolExecutionId}`,
+    refs: {
+      threadId: row.toolExecution?.threadId ?? null,
+      toolExecutionId,
+      toolReceiptId: row.id,
+      buildId: row.buildId,
+      capabilityId: row.toolExecution?.capabilityId ?? null,
+    },
+    links: {
+      authorityHref: row.toolExecution
+        ? `/platform/audit/ledger?toolExecutionId=${encodeURIComponent(toolExecutionId)}`
+        : undefined,
+      coworkerHref: row.toolExecution
+        ? `/platform/ai/agent/${encodeURIComponent(row.toolExecution.agentId)}`
+        : undefined,
+      historyHref: `/platform/ai/history?toolReceiptId=${encodeURIComponent(row.id)}`,
+    },
+  };
+}
+
+export function projectBacklogEvidence(
+  row: OperationsMapBacklogEvidence,
+  template: OperationsMapTemplate = SOFTWARE_PLATFORM_MAP_TEMPLATE,
+): OperationsMapProjection {
+  const stationId = resolveEvidenceStationId(row.summary, template);
+
+  return {
+    id: `backlog-evidence:${row.id}`,
+    occurredAt: row.recordedAt.toISOString(),
+    actorAgentId: row.recordedByAgentId,
+    source: "evidence-backlog",
+    location: {
+      lineId: resolveLineId(stationId, template),
+      stationId,
+    },
+    severity: "normal",
+    label: "Backlog evidence",
+    summary: row.summary,
+    refs: {
+      backlogItemActivityId: row.id,
+      backlogItemId: row.backlogItemId,
+      toolExecutionId: row.toolExecutionId,
+    },
+    links: {
+      backlogHref: `/platform/backlog?itemId=${encodeURIComponent(row.backlogItemId)}`,
+      authorityHref: row.toolExecutionId
+        ? `/platform/audit/ledger?toolExecutionId=${encodeURIComponent(row.toolExecutionId)}`
+        : undefined,
+      coworkerHref: row.recordedByAgentId
+        ? `/platform/ai/agent/${encodeURIComponent(row.recordedByAgentId)}`
+        : undefined,
+    },
+  };
+}
+
+export function projectExternalEvidence(
+  row: OperationsMapExternalEvidence,
+  template: OperationsMapTemplate = SOFTWARE_PLATFORM_MAP_TEMPLATE,
+): OperationsMapProjection {
+  const stationId = resolveRouteStationId(row.routeContext, template) ?? resolveEvidenceStationId(row.resultSummary, template);
+
+  return {
+    id: `external-evidence:${row.id}`,
+    occurredAt: row.createdAt.toISOString(),
+    actorAgentId: null,
+    source: "evidence-external",
+    location: {
+      lineId: resolveLineId(stationId, template),
+      stationId,
+    },
+    severity: "normal",
+    label: `${row.provider} ${row.operationType}`,
+    summary: row.resultSummary,
+    refs: {
+      externalEvidenceRecordId: row.id,
+    },
+    links: {
+      historyHref: `/platform/ai/history?externalEvidenceRecordId=${encodeURIComponent(row.id)}`,
+    },
+  };
+}
+
 export function summarizeProjectionCounts(projections: OperationsMapProjection[]) {
   return projections.reduce(
     (counts, projection) => ({
@@ -172,14 +286,8 @@ function resolveAgentStationId(agent: OperationsMapAgent, template: OperationsMa
 }
 
 function resolveToolExecutionStationId(row: OperationsMapToolExecution, template: OperationsMapTemplate): string {
-  const routeContext = row.routeContext;
-  const routeDirect = routeContext ? resolveDirectTemplateStationId(routeContext, template) : null;
-  if (routeDirect) return routeDirect;
-
-  const routeHint = routeContext
-    ? ROUTE_CONTEXT_TO_STATION.find((hint) => hint.pattern.test(routeContext))?.stationId
-    : null;
-  if (routeHint && template.stations.some((station) => station.id === routeHint)) return routeHint;
+  const routeStationId = row.routeContext ? resolveRouteStationId(row.routeContext, template) : null;
+  if (routeStationId) return routeStationId;
 
   const agentDirect = resolveDirectTemplateStationId(row.agentId, template);
   if (agentDirect) return agentDirect;
@@ -188,6 +296,20 @@ function resolveToolExecutionStationId(row: OperationsMapToolExecution, template
   if (agentHint && template.stations.some((station) => station.id === agentHint)) return agentHint;
 
   return resolveFallbackStationId(template);
+}
+
+function resolveEvidenceStationId(value: string, template: OperationsMapTemplate): string {
+  return resolveRouteStationId(value, template) ?? resolveFallbackStationId(template);
+}
+
+function resolveRouteStationId(value: string, template: OperationsMapTemplate): string | null {
+  const routeDirect = resolveDirectTemplateStationId(value, template);
+  if (routeDirect) return routeDirect;
+
+  const routeHint = ROUTE_CONTEXT_TO_STATION.find((hint) => hint.pattern.test(value))?.stationId;
+  if (routeHint && template.stations.some((station) => station.id === routeHint)) return routeHint;
+
+  return null;
 }
 
 function resolveValueStreamStationId(valueStream: string, template: OperationsMapTemplate): string | null {

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -64,11 +64,52 @@ export type OperationsMapToolExecution = {
   summary: string | null;
 };
 
+export type OperationsMapToolExecutionReceipt = {
+  id: string;
+  toolExecutionId: string;
+  buildId: string | null;
+  receiptKind: string;
+  receiptStatus: string;
+  executionStatus: string;
+  expiresAt: Date;
+  createdAt: Date;
+  toolExecution: OperationsMapToolExecution | null;
+};
+
+export type OperationsMapBacklogEvidence = {
+  id: string;
+  backlogItemId: string;
+  kind: string;
+  summary: string;
+  payload: unknown;
+  recordedAt: Date;
+  recordedById: string | null;
+  recordedByAgentId: string | null;
+  toolExecutionId: string | null;
+};
+
+export type OperationsMapExternalEvidence = {
+  id: string;
+  actorUserId: string;
+  routeContext: string;
+  operationType: string;
+  target: string;
+  provider: string;
+  resultSummary: string;
+  createdAt: Date;
+};
+
+export type OperationsMapProjectionSource =
+  | "tool-execution"
+  | "tool-receipt"
+  | "evidence-backlog"
+  | "evidence-external";
+
 export type OperationsMapProjection = {
   id: string;
   occurredAt: string;
-  actorAgentId: string;
-  source: "tool-execution";
+  actorAgentId: string | null;
+  source: OperationsMapProjectionSource;
   location: {
     lineId: string;
     stationId: string;
@@ -77,13 +118,20 @@ export type OperationsMapProjection = {
   summary: string;
   label: string;
   refs: {
-    threadId: string;
-    toolExecutionId: string;
-    capabilityId: string | null;
+    threadId?: string | null;
+    toolExecutionId?: string | null;
+    toolReceiptId?: string | null;
+    backlogItemActivityId?: string | null;
+    backlogItemId?: string | null;
+    externalEvidenceRecordId?: string | null;
+    buildId?: string | null;
+    capabilityId?: string | null;
   };
   links: {
-    authorityHref: string;
-    coworkerHref: string;
+    authorityHref?: string;
+    coworkerHref?: string;
+    historyHref?: string;
+    backlogHref?: string;
   };
 };
 


### PR DESCRIPTION
## Summary
- extend AI Operations Map projections beyond ToolExecution to ToolExecutionReceipt, BacklogItemActivity evidence, and ExternalEvidenceRecord rows
- preserve source-specific refs and links for audit, history, backlog, and coworker navigation
- update the map inspector copy and link rendering for the V2 evidence-source model

## Verification
- pnpm --filter web exec vitest run lib/ai-operations-map
- pnpm --filter web typecheck
- pnpm --filter web exec next build
- UX: logged in locally on http://127.0.0.1:4011 and verified /platform/ai/operations-map renders Read-only V2, evidence-source copy, inspector, 12 stations, and activity cards

Note: production build still emits existing Turbopack NFT tracing warnings from spec-plan-search.ts / next.config.mjs; no build errors.