### PR TITLE
Build Studio v2 persistent business brief editor

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -38,6 +38,7 @@ export default async function BuildPage({ searchParams }: PageProps) {
       orderBy: { updatedAt: "desc" },
       select: {
         briefId: true,
+        status: true,
         intakeSource: true,
         capabilityPackId: true,
         featureBuildId: true,

--- a/apps/web/components/build-studio/BuildStudioV2.test.tsx
+++ b/apps/web/components/build-studio/BuildStudioV2.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import "./test-setup";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { BuildStudioV2 } from "./BuildStudioV2";
 import { DEMO_BUSINESS_BRIEF } from "@/lib/build-studio-demo";
+
+vi.mock("@/lib/actions/build", () => ({
+  updateBusinessBuildBrief: vi.fn(),
+}));
 
 describe("BuildStudioV2", () => {
   it("renders the header, step tracker, conversation pane, and artifact pane", () => {

--- a/apps/web/components/build-studio/BusinessBriefPanel.test.tsx
+++ b/apps/web/components/build-studio/BusinessBriefPanel.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import "./test-setup";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { BusinessBriefPanel } from "./BusinessBriefPanel";
 import { DEMO_BUSINESS_BRIEF } from "@/lib/build-studio-demo";
+
+vi.mock("@/lib/actions/build", () => ({
+  updateBusinessBuildBrief: vi.fn(),
+}));
 
 describe("BusinessBriefPanel", () => {
   it("renders the business outcome before technical interpretation", () => {
@@ -33,5 +37,25 @@ describe("BusinessBriefPanel", () => {
 
     expect(screen.getByText(/needs clarification/i)).toBeInTheDocument();
     expect(screen.getByText("What example should this follow?")).toBeInTheDocument();
+  });
+
+  it("offers a business-language editor for persisted briefs", () => {
+    render(
+      <BusinessBriefPanel
+        brief={{
+          ...DEMO_BUSINESS_BRIEF,
+          briefId: "BBB-FB-123",
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /edit brief/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/business outcome/i)).toHaveValue(DEMO_BUSINESS_BRIEF.businessOutcome);
+    expect(screen.getByLabelText(/affected people/i)).toHaveValue(DEMO_BUSINESS_BRIEF.affectedPeople.join("\n"));
+    expect(screen.getByLabelText(/source evidence/i)).toHaveValue(
+      DEMO_BUSINESS_BRIEF.sourceEvidence.map((evidence) => evidence.summary).join("\n"),
+    );
+    expect(screen.getByRole("button", { name: /save brief/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /accept brief/i })).toBeInTheDocument();
   });
 });

--- a/apps/web/components/build-studio/BusinessBriefPanel.tsx
+++ b/apps/web/components/build-studio/BusinessBriefPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
-import { AlertCircle, CheckCircle2, FileText, Target, Users } from "lucide-react";
+import { AlertCircle, CheckCircle2, FileText, Pencil, Save, Target, Users } from "lucide-react";
 import type { ReactNode } from "react";
+import { useState, useTransition } from "react";
+import { updateBusinessBuildBrief } from "@/lib/actions/build";
 import type { BusinessBuildBrief } from "@/lib/build/business-build-brief";
 
 interface Props {
@@ -36,8 +38,74 @@ function Empty({ children }: { children: ReactNode }) {
   return <p className="m-0 text-[13px] text-[var(--dpf-muted)]">{children}</p>;
 }
 
+function textFromList(values: string[]): string {
+  return values.join("\n");
+}
+
+function textFromEvidence(brief: BusinessBuildBrief): string {
+  return brief.sourceEvidence.map((evidence) => evidence.summary).join("\n");
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  rows = 3,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  rows?: number;
+}) {
+  return (
+    <label className="grid gap-1.5 text-[13px] font-semibold text-[var(--dpf-text)]">
+      {label}
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rows={rows}
+        className="min-h-20 resize-y rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[13px] font-normal leading-5 text-[var(--dpf-text)] outline-none transition-colors focus:border-[var(--dpf-accent)]"
+      />
+    </label>
+  );
+}
+
 export function BusinessBriefPanel({ brief }: Props) {
   const needsClarification = brief.openQuestions.length > 0;
+  const [isEditing, setIsEditing] = useState(Boolean(brief.briefId));
+  const [isPending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [businessOutcome, setBusinessOutcome] = useState(brief.businessOutcome);
+  const [affectedPeopleText, setAffectedPeopleText] = useState(textFromList(brief.affectedPeople));
+  const [affectedWorkflow, setAffectedWorkflow] = useState(brief.affectedWorkflow ?? "");
+  const [sourceEvidenceText, setSourceEvidenceText] = useState(textFromEvidence(brief));
+  const [successSignalsText, setSuccessSignalsText] = useState(textFromList(brief.successSignals));
+  const [constraintsText, setConstraintsText] = useState(textFromList(brief.constraints));
+  const [openQuestionsText, setOpenQuestionsText] = useState(textFromList(brief.openQuestions));
+
+  function saveBrief(accept: boolean) {
+    const briefId = brief.briefId;
+    if (!briefId) return;
+    setMessage(null);
+    startTransition(async () => {
+      try {
+        await updateBusinessBuildBrief({
+          briefId,
+          businessOutcome,
+          affectedPeopleText,
+          affectedWorkflow,
+          sourceEvidenceText,
+          successSignalsText,
+          constraintsText,
+          openQuestionsText,
+          accept,
+        });
+        setMessage(accept ? "Brief accepted." : "Brief saved.");
+      } catch (error) {
+        setMessage(error instanceof Error ? error.message : "The brief could not be saved.");
+      }
+    });
+  }
 
   return (
     <div className="h-full overflow-auto bg-[var(--dpf-bg)] text-[var(--dpf-text)]">
@@ -63,7 +131,58 @@ export function BusinessBriefPanel({ brief }: Props) {
         <h2 className="m-0 text-[17px] font-bold tracking-normal text-[var(--dpf-text)]">
           {brief.title}
         </h2>
+        {brief.briefId && (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsEditing((value) => !value)}
+              className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-[12px] font-semibold text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)]"
+            >
+              <Pencil size={13} />
+              Edit brief
+            </button>
+            {message && (
+              <span className="text-[12px] font-medium text-[var(--dpf-muted)]">
+                {message}
+              </span>
+            )}
+          </div>
+        )}
       </header>
+
+      {brief.briefId && isEditing && (
+        <Section title="Edit business brief">
+          <div className="grid gap-3">
+            <Field label="Business outcome" value={businessOutcome} onChange={setBusinessOutcome} rows={4} />
+            <Field label="Affected people" value={affectedPeopleText} onChange={setAffectedPeopleText} />
+            <Field label="Affected workflow" value={affectedWorkflow} onChange={setAffectedWorkflow} rows={2} />
+            <Field label="Source evidence" value={sourceEvidenceText} onChange={setSourceEvidenceText} />
+            <Field label="Success signals" value={successSignalsText} onChange={setSuccessSignalsText} />
+            <Field label="Constraints" value={constraintsText} onChange={setConstraintsText} />
+            <Field label="Open questions" value={openQuestionsText} onChange={setOpenQuestionsText} />
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={isPending}
+                onClick={() => saveBrief(false)}
+                className="inline-flex min-h-9 items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-[13px] font-semibold text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <Save size={14} />
+                Save brief
+              </button>
+              <button
+                type="button"
+                disabled={isPending}
+                onClick={() => saveBrief(true)}
+                className="inline-flex min-h-9 items-center gap-1.5 rounded-md bg-[var(--dpf-accent)] px-3 text-[13px] font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <CheckCircle2 size={14} />
+                Accept brief
+              </button>
+            </div>
+          </div>
+        </Section>
+      )}
 
       <Section title="Business outcome">
         <p className="m-0 max-w-3xl text-[14px] leading-6 text-[var(--dpf-text)]">

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -11,6 +11,7 @@ const { mockAuth, mockPrisma } = vi.hoisted(() => ({
     businessBuildBrief: {
       findUnique: vi.fn(),
       upsert: vi.fn(),
+      update: vi.fn(),
     },
     organization: {
       findFirst: vi.fn(),
@@ -67,7 +68,12 @@ vi.mock("@/lib/integrate/sandbox/sandbox", () => ({
   listReleasableSandboxFiles: mockListReleasableSandboxFiles,
 }));
 
-import { approveBuildStart, advanceBuildPhase, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateFeatureBrief } from "./build";
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { revalidatePath } from "next/cache";
+import { approveBuildStart, advanceBuildPhase, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief, updateFeatureBrief } from "./build";
 
 describe("governed build start approvals", () => {
   beforeEach(() => {
@@ -83,6 +89,7 @@ describe("governed build start approvals", () => {
     mockPrisma.$transaction.mockImplementation(async (callback) => callback(mockPrisma));
     mockPrisma.businessBuildBrief.findUnique.mockResolvedValue({ status: "accepted" });
     mockPrisma.businessBuildBrief.upsert.mockResolvedValue({});
+    mockPrisma.businessBuildBrief.update.mockResolvedValue({});
     mockPrisma.organization.findFirst.mockResolvedValue({ id: "org-1" });
     mockIsSandboxAvailable.mockResolvedValue(false);
     mockStartBuildBranch.mockResolvedValue(undefined);
@@ -145,6 +152,63 @@ describe("governed build start approvals", () => {
         }),
       }),
     );
+  });
+
+  it("updateBusinessBuildBrief persists business edits and accepts a complete brief", async () => {
+    mockPrisma.businessBuildBrief.findUnique.mockResolvedValue({
+      id: "business-brief-row-1",
+      briefId: "BBB-FB-123",
+      featureBuildId: "feature-build-row-1",
+      submittedByUserId: "user-1",
+      status: "awaiting_clarification",
+    });
+
+    await updateBusinessBuildBrief({
+      briefId: "BBB-FB-123",
+      businessOutcome: "Reduce missed support escalations before the morning standup.",
+      affectedPeopleText: "Support manager\nCustomer success lead",
+      affectedWorkflow: "Customer escalation review",
+      sourceEvidenceText: "Existing Zendesk escalation report\nMorning standup SOP",
+      successSignalsText: "Managers see unresolved escalations by site\nEvery escalation has an owner",
+      constraintsText: "Do not expose customer data across accounts",
+      openQuestionsText: "",
+      accept: true,
+    });
+
+    expect(mockPrisma.businessBuildBrief.update).toHaveBeenCalledWith({
+      where: { briefId: "BBB-FB-123" },
+      data: expect.objectContaining({
+        status: "accepted",
+        acceptedByUserId: "user-1",
+        acceptedAt: expect.any(Date),
+        businessOutcome: "Reduce missed support escalations before the morning standup.",
+        affectedWorkflow: "Customer escalation review",
+        affectedPeople: [
+          { kind: "persona", label: "Support manager" },
+          { kind: "persona", label: "Customer success lead" },
+        ],
+        sourceEvidence: [
+          expect.objectContaining({
+            kind: "artifact",
+            label: "Existing Zendesk escalation report",
+            summary: "Existing Zendesk escalation report",
+          }),
+          expect.objectContaining({
+            kind: "artifact",
+            label: "Morning standup SOP",
+            summary: "Morning standup SOP",
+          }),
+        ],
+        successSignals: [
+          "Managers see unresolved escalations by site",
+          "Every escalation has an owner",
+        ],
+        constraints: ["Do not expose customer data across accounts"],
+        openQuestions: [],
+        confidence: "high",
+      }),
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/build");
   });
 
   it("advanceBuildPhase blocks ideate to plan until the business brief is accepted", async () => {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -3,6 +3,7 @@
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { prisma, type Prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
 import {
   validateFeatureBrief,
   canTransitionPhase,
@@ -20,7 +21,10 @@ import {
 import { buildDesignReviewPrompt, buildPlanReviewPrompt, parseReviewResponse } from "@/lib/build-reviewers";
 import { queueBuildReviewVerification } from "@/lib/build-review-verification-trigger";
 import { saveBuildArtifactRevision, type BuildArtifactField } from "@/lib/build/build-artifact-provenance";
-import { legacyFeatureBuildBriefToBusinessBuildBriefInput } from "@/lib/build/business-build-brief";
+import {
+  businessBuildBriefEditToPersistence,
+  legacyFeatureBuildBriefToBusinessBuildBriefInput,
+} from "@/lib/build/business-build-brief";
 import { routeAndCall } from "@/lib/routed-inference";
 import * as crypto from "crypto";
 import { listReleasableSandboxFiles } from "@/lib/integrate/sandbox/sandbox";
@@ -202,6 +206,75 @@ export async function updateFeatureBrief(
       },
     });
   });
+}
+
+export async function updateBusinessBuildBrief(input: {
+  briefId: string;
+  businessOutcome: string;
+  affectedPeopleText: string;
+  affectedWorkflow?: string | null;
+  sourceEvidenceText: string;
+  successSignalsText: string;
+  constraintsText: string;
+  openQuestionsText: string;
+  accept?: boolean;
+}): Promise<void> {
+  const userId = await requireBuildAccess();
+
+  const persistence = businessBuildBriefEditToPersistence(input);
+  const briefId = input.briefId.trim();
+
+  const existing = await prisma.businessBuildBrief.findUnique({
+    where: { briefId },
+    select: {
+      briefId: true,
+      featureBuildId: true,
+      submittedByUserId: true,
+      status: true,
+    },
+  });
+  if (!existing) throw new Error("Business build brief not found");
+  if (existing.submittedByUserId && existing.submittedByUserId !== userId) {
+    throw new Error("Forbidden");
+  }
+
+  const acceptedFields = persistence.accepted
+    ? { acceptedByUserId: userId, acceptedAt: new Date() }
+    : { acceptedByUserId: null, acceptedAt: null };
+
+  await prisma.$transaction(async (tx) => {
+    await tx.businessBuildBrief.update({
+      where: { briefId },
+      data: {
+        status: persistence.status,
+        businessOutcome: persistence.businessOutcome,
+        affectedPeople: persistence.affectedPeople as unknown as Prisma.InputJsonValue,
+        affectedWorkflow: persistence.affectedWorkflow,
+        sourceEvidence: persistence.sourceEvidence as unknown as Prisma.InputJsonValue,
+        successSignals: persistence.successSignals,
+        constraints: persistence.constraints,
+        businessInterpretation: persistence.businessInterpretation,
+        technicalInterpretation: persistence.technicalInterpretation as unknown as Prisma.InputJsonValue,
+        riskProfile: persistence.riskProfile as unknown as Prisma.InputJsonValue,
+        openQuestions: persistence.openQuestions,
+        confidence: persistence.confidence,
+        confidenceRationale: persistence.confidenceRationale,
+        submittedByUserId: userId,
+        ...acceptedFields,
+      },
+    });
+
+    if (existing.featureBuildId) {
+      await tx.featureBuild.update({
+        where: { id: existing.featureBuildId },
+        data: {
+          brief: persistence.legacyFeatureBrief as unknown as Prisma.InputJsonValue,
+        },
+      });
+    }
+  });
+
+  revalidatePath("/build");
 }
 
 // ─── Advance Phase ───────────────────────────────────────────────────────────

--- a/apps/web/lib/build/business-build-brief.test.ts
+++ b/apps/web/lib/build/business-build-brief.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildBusinessBuildBrief,
+  businessBuildBriefEditToPersistence,
   businessBuildBriefFromRecord,
   canTransitionBusinessBriefStatus,
   getCapabilityPackIdForBrief,
@@ -296,5 +297,41 @@ describe("businessBuildBriefFromRecord", () => {
     expect(brief.capabilityPackId).toBe("build_studio_self_development");
     expect(brief.capabilityPack).toBe("Build Studio / Self-Development");
     expect(brief.confidence).toBe("low");
+  });
+});
+
+describe("businessBuildBriefEditToPersistence", () => {
+  it("normalizes business editor text into persistence fields and legacy gate JSON", () => {
+    const persistence = businessBuildBriefEditToPersistence({
+      briefId: "BBB-FB-123",
+      businessOutcome: "Reduce missed support escalations before standup.",
+      affectedPeopleText: "Support manager\nCustomer success lead",
+      affectedWorkflow: "Customer escalation review",
+      sourceEvidenceText: "Zendesk escalation report\nMorning standup SOP",
+      successSignalsText: "Managers see unresolved escalations by site",
+      constraintsText: "Do not expose customer data across accounts",
+      openQuestionsText: "",
+      accept: true,
+    });
+
+    expect(persistence.status).toBe("accepted");
+    expect(persistence.accepted).toBe(true);
+    expect(persistence.affectedPeople).toEqual([
+      { kind: "persona", label: "Support manager" },
+      { kind: "persona", label: "Customer success lead" },
+    ]);
+    expect(persistence.sourceEvidence).toEqual([
+      expect.objectContaining({ kind: "artifact", summary: "Zendesk escalation report" }),
+      expect.objectContaining({ kind: "artifact", summary: "Morning standup SOP" }),
+    ]);
+    expect(persistence.legacyFeatureBrief).toEqual(
+      expect.objectContaining({
+        title: "BBB-FB-123",
+        description: "Reduce missed support escalations before standup.",
+        portfolioContext: "Customer escalation review",
+        targetRoles: ["Support manager", "Customer success lead"],
+        acceptanceCriteria: ["Managers see unresolved escalations by site"],
+      }),
+    );
   });
 });

--- a/apps/web/lib/build/business-build-brief.ts
+++ b/apps/web/lib/build/business-build-brief.ts
@@ -55,7 +55,9 @@ export type BusinessBriefEvidence = {
 };
 
 export type BusinessBuildBrief = {
+  briefId?: string;
   title: string;
+  status?: BusinessBriefStatus;
   intakeSource: BusinessBuildBriefSource;
   businessOutcome: string;
   affectedPeople: string[];
@@ -134,6 +136,8 @@ export type BusinessBuildBriefPersistenceInput = {
 };
 
 export type BusinessBuildBriefRecordInput = {
+  briefId?: string;
+  status?: BusinessBriefStatus;
   intakeSource: BusinessBuildBriefSource;
   capabilityPackId: string | null;
   businessOutcome: string;
@@ -147,6 +151,36 @@ export type BusinessBuildBriefRecordInput = {
   riskProfile: unknown;
   openQuestions: string[];
   confidence: BusinessBriefConfidence | null;
+};
+
+export type BusinessBuildBriefEditInput = {
+  briefId: string;
+  businessOutcome: string;
+  affectedPeopleText: string;
+  affectedWorkflow?: string | null;
+  sourceEvidenceText: string;
+  successSignalsText: string;
+  constraintsText: string;
+  openQuestionsText: string;
+  accept?: boolean;
+};
+
+export type BusinessBuildBriefEditPersistence = {
+  status: BusinessBriefStatus;
+  accepted: boolean;
+  businessOutcome: string;
+  affectedPeople: Array<{ kind: "persona"; label: string }>;
+  affectedWorkflow: string | null;
+  sourceEvidence: BusinessBriefEvidence[];
+  successSignals: string[];
+  constraints: string[];
+  businessInterpretation: string;
+  technicalInterpretation: BusinessBuildBrief["technicalInterpretation"];
+  riskProfile: BusinessBuildBrief["riskProfile"];
+  openQuestions: string[];
+  confidence: BusinessBriefConfidence;
+  confidenceRationale: string;
+  legacyFeatureBrief: FeatureBrief;
 };
 
 const CAPABILITY_PACKS: Array<{
@@ -195,6 +229,13 @@ function cleanList(values: string[] | null | undefined): string[] {
   return (values ?? []).map((value) => value.trim()).filter(Boolean);
 }
 
+function textLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 function includesAny(text: string, keywords: string[]): boolean {
   return keywords.some((keyword) => text.includes(keyword));
 }
@@ -219,6 +260,14 @@ function evidenceFromInputs(inputs: string[]): BusinessBriefEvidence[] {
     label: "Provided references",
     summary: inputs.join("; "),
   }];
+}
+
+function evidenceFromText(value: string): BusinessBriefEvidence[] {
+  return textLines(value).map((line) => ({
+    kind: "artifact",
+    label: line.length > 80 ? `${line.slice(0, 77)}...` : line,
+    summary: line,
+  }));
 }
 
 function riskLevel(featureBrief: FeatureBrief, constraints: string[]): BusinessBuildBrief["riskProfile"] {
@@ -263,6 +312,12 @@ function openQuestionsFor(
 }
 
 function confidenceFor(openQuestions: string[]): BusinessBriefConfidence {
+  if (openQuestions.length === 0) return "high";
+  if (openQuestions.length <= 3) return "medium";
+  return "low";
+}
+
+function confidenceForBusinessEdit(openQuestions: string[]): BusinessBriefConfidence {
   if (openQuestions.length === 0) return "high";
   if (openQuestions.length <= 3) return "medium";
   return "low";
@@ -476,7 +531,9 @@ export function businessBuildBriefFromRecord(input: {
   const capabilityPackId = capabilityPackIdFromRecord(input.row.capabilityPackId);
   const capabilityPack = capabilityPackLabel(input.row.capabilityPackId);
   return {
+    ...(input.row.briefId ? { briefId: input.row.briefId } : {}),
     title: input.title,
+    ...(input.row.status ? { status: input.row.status } : {}),
     intakeSource: input.row.intakeSource,
     businessOutcome: input.row.businessOutcome,
     affectedPeople: affectedPeopleFromRecord(input.row.affectedPeople),
@@ -491,6 +548,76 @@ export function businessBuildBriefFromRecord(input: {
     technicalInterpretation: technicalInterpretationFromRecord(input.row.technicalInterpretation),
     openQuestions: input.row.openQuestions,
     confidence: input.row.confidence ?? "low",
+  };
+}
+
+export function businessBuildBriefEditToPersistence(
+  input: BusinessBuildBriefEditInput,
+): BusinessBuildBriefEditPersistence {
+  const briefId = input.briefId.trim();
+  if (!briefId) throw new Error("Brief id is required");
+
+  const businessOutcome = input.businessOutcome.trim();
+  if (!businessOutcome) throw new Error("Business outcome is required");
+
+  const affectedPeople = textLines(input.affectedPeopleText);
+  const sourceEvidence = evidenceFromText(input.sourceEvidenceText);
+  const successSignals = textLines(input.successSignalsText);
+  const constraints = textLines(input.constraintsText);
+  const openQuestions = textLines(input.openQuestionsText);
+
+  if (affectedPeople.length === 0) openQuestions.push("Who is affected by this business change?");
+  if (sourceEvidence.length === 0) {
+    openQuestions.push("What evidence, example, or artifact should DPF use as the reference?");
+  }
+  if (successSignals.length === 0) openQuestions.push("What business signal proves this worked?");
+
+  const confidence = confidenceForBusinessEdit(openQuestions);
+  const accepted = input.accept === true && confidence !== "low" && openQuestions.length === 0;
+  const affectedWorkflow = input.affectedWorkflow?.trim() || null;
+  const likelyWorkflowImpact = [
+    affectedWorkflow,
+    ...affectedPeople,
+  ].filter((value): value is string => Boolean(value));
+  const technicalInterpretation = {
+    dataNeeds: null,
+    likelyWorkflowImpact,
+    verificationFocus: successSignals,
+  };
+  const riskProfile: BusinessBuildBrief["riskProfile"] = {
+    customerFacing: false,
+    complianceSensitive: constraints.some((constraint) => /audit|compliance|privacy|regulated/i.test(constraint)),
+    revenueImpacting: constraints.some((constraint) => /revenue|billing|payment|invoice/i.test(constraint)),
+    operationalRisk: true,
+    level: constraints.length > 0 ? "medium" : "low",
+  };
+
+  return {
+    status: accepted ? "accepted" : "awaiting_clarification",
+    accepted,
+    businessOutcome,
+    affectedPeople: affectedPeople.map((label) => ({ kind: "persona", label })),
+    affectedWorkflow,
+    sourceEvidence,
+    successSignals,
+    constraints,
+    businessInterpretation: businessOutcome,
+    technicalInterpretation,
+    riskProfile,
+    openQuestions,
+    confidence,
+    confidenceRationale: openQuestions.length === 0
+      ? "The brief has a business outcome, affected people, evidence, and success signals."
+      : `The brief still needs clarification: ${openQuestions.join(" ")}`,
+    legacyFeatureBrief: {
+      title: briefId,
+      description: businessOutcome,
+      portfolioContext: affectedWorkflow ?? "",
+      targetRoles: affectedPeople,
+      inputs: sourceEvidence.map((evidence) => evidence.summary),
+      dataNeeds: technicalInterpretation.dataNeeds ?? "",
+      acceptanceCriteria: successSignals,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a business-language editor to the persisted Build Studio v2 Brief tab so non-developers can refine outcomes, affected people, workflow context, evidence, success signals, constraints, and open questions.
- Add a governed server action for `BusinessBuildBrief` edits, including acceptance rules and linked `FeatureBuild.brief` legacy JSON sync for existing gates.
- Extract the editor text normalization into the Build Studio domain module with unit coverage.

## Verification
- Red-first tests covered the missing server action and missing editor controls before implementation.
- `pnpm --filter web exec vitest run lib/build/business-build-brief.test.ts components/build-studio/BuildStudioV2.test.tsx components/build-studio/BusinessBriefPanel.test.tsx components/build-studio/ArtifactTabs.test.tsx lib/actions/build-governed.test.ts`
- `git diff --check` (CRLF warnings only)
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `docker compose --env-file D:\DPF\.env build --no-cache portal`
- `docker compose --env-file D:\DPF\.env up -d portal`
- Playwright smoke against Docker portal: logged in, opened `/build?v=2`, verified the brief editor rendered for a temporary persisted brief fixture, saved an edited business outcome, confirmed `Brief saved.` on screen, checked the persisted DB update, then removed the fixture.

## Notes
- Existing Turbopack tracing warnings around broad `spec-plan-search.ts` / `next.config.mjs` context remain warnings only; production build completed successfully.