### PR TITLE
test(codebase-tools): POSIX path portability regression coverage (Phase 10c)

### DIFF
--- a/apps/web/lib/integrate/codebase-tools.test.ts
+++ b/apps/web/lib/integrate/codebase-tools.test.ts
@@ -61,3 +61,60 @@ describe("resolveSafePath", () => {
     expect(result.ok).toBe(false);
   });
 });
+
+// Per the installer-parity roadmap Phase 10c: the path-security
+// guards above were originally written for the Windows installer
+// (D:\DPF\...). When the macOS + Linux installers shipped, we needed
+// to confirm POSIX paths flow through the same guards correctly:
+//
+//   - Relative POSIX paths (apps/web/...) stay allowed.
+//   - POSIX absolute paths (/var/run/..., /Users/..., /Applications/...)
+//     stay blocked — they are not browseable through this API surface.
+//   - The Windows-drive regex (^[A-Za-z]:) does not false-positive on
+//     POSIX paths that happen to contain a colon mid-path.
+describe("isPathAllowed — POSIX portability", () => {
+  it("allows typical relative POSIX paths used on macOS / Linux installs", () => {
+    expect(isPathAllowed("apps/web/lib/mcp-tools.ts")).toBe(true);
+    expect(isPathAllowed("packages/db/src/discovery-collectors/host.ts")).toBe(true);
+    expect(isPathAllowed("scripts/installer/lib/preflight.sh")).toBe(true);
+    expect(isPathAllowed("docs/install/macos.md")).toBe(true);
+    expect(isPathAllowed("docs/install/linux.md")).toBe(true);
+  });
+
+  it("blocks all POSIX absolute path variants", () => {
+    // Generic Unix
+    expect(isPathAllowed("/etc/passwd")).toBe(false);
+    expect(isPathAllowed("/var/run/docker.sock")).toBe(false);
+    expect(isPathAllowed("/tmp/anything")).toBe(false);
+
+    // macOS-specific
+    expect(isPathAllowed("/Applications/Docker.app/Contents/Info.plist")).toBe(false);
+    expect(isPathAllowed("/Users/foo/dpf/install-dpf.sh")).toBe(false);
+    expect(isPathAllowed("/Library/LaunchAgents/local.dpf-autostart.plist")).toBe(false);
+
+    // Linux-specific
+    expect(isPathAllowed("/home/user/dpf/install-dpf.sh")).toBe(false);
+    expect(isPathAllowed("/opt/dpf/docker-compose.yml")).toBe(false);
+    expect(isPathAllowed("/root/.dpf/install-state.json")).toBe(false);
+  });
+
+  it("Windows-drive regex does not false-positive on POSIX paths with a colon", () => {
+    // The ^[A-Za-z]: regex must anchor at start. Paths with a colon
+    // mid-string are unusual on POSIX but legal, and must not be
+    // mistaken for D:\ Windows paths.
+    expect(isPathAllowed("apps/web/some:thing.ts")).toBe(true);
+    expect(isPathAllowed("docs/architecture/note: a draft.md")).toBe(true);
+  });
+
+  it("normalizes backslash separators before pattern matching", () => {
+    // Operators on POSIX hosts occasionally paste Windows-formatted
+    // input (\) into the portal. Path security must catch the same
+    // sensitive-file patterns after the unified-slash normalization
+    // step (line 53 in codebase-tools.ts), regardless of which
+    // separator the caller used.
+    expect(isPathAllowed("apps\\web\\.env.local")).toBe(false); // .env. pattern
+    expect(isPathAllowed("certs\\server.key")).toBe(false);     // .key$ pattern
+    expect(isPathAllowed("secrets\\admin.json")).toBe(false);   // ^secrets pattern
+    expect(isPathAllowed(".git\\config")).toBe(false);          // ^.git/ pattern
+  });
+});


### PR DESCRIPTION
The path-security guards in `apps/web/lib/integrate/codebase-tools.ts`
were originally written for the Windows installer (`D:\DPF\...`). When
the macOS + Linux installers shipped, we needed to confirm the same
guards flow correctly under POSIX conventions. This adds a focused
regression suite so future edits to `isPathAllowed` /
`isPathAllowedSync` can't silently regress macOS / Linux behavior.

## What it asserts

Four new tests in a `POSIX portability` describe block:

| # | Test | Why |
|---|------|-----|
| 1 | Typical relative POSIX paths (`apps/web/...`, `packages/db/...`, `scripts/installer/...`, `docs/install/...`) are allowed | Locks in the day-to-day behavior the portal relies on |
| 2 | POSIX absolute paths are uniformly blocked — generic Unix (`/etc`, `/var`, `/tmp`), macOS-specific (`/Applications`, `/Users`, `/Library`), Linux-specific (`/home`, `/opt`, `/root/.dpf`) | The previous coverage only had `/etc/passwd` — easy to read as "the function only blocks /etc"; the new variants make the intent clear |
| 3 | The Windows-drive regex `^[A-Za-z]:` does not false-positive on POSIX paths that happen to contain a colon mid-path | The regex is anchored at start, but the test pins that invariant against future edits |
| 4 | The unified-slash normalization step correctly applies `BLOCKED_PATTERNS` to backslash-separated input | Covers operators on POSIX hosts who paste Windows-formatted paths into the portal |

## Verification

```
pnpm exec vitest run lib/integrate/codebase-tools.test.ts
  14 tests, all pass
```

## Out-of-scope finding (separate PR worth filing)

While writing test #4, I noticed the `secrets` / `credentials` patterns
in `BLOCKED_PATTERNS` are anchored at start-of-path only:

```js
/^credentials/i,
/^secrets/i,
```

So a nested `config/secrets/admin.json` slips through the guard, even
though the operator's intent is clearly to block any path component
named `secrets`. This PR only asserts the **top-level** case
(`secrets/admin.json`), which is reliably blocked.

Tightening the patterns to something like `(?:^|[\\/])secrets[\\/]`
would close the gap, but that is a security-tightening change —
it should land as its own PR with explicit framing and a check
against the existing call sites in case any legitimate paths get
caught (`apps/web/secrets-management/...` would be a false positive).

## Roadmap

`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` —
Phase 10c. Remaining in Phase 10:

- **10d**: `scripts/installer/lib/diagnostics.sh` — extended preflight
  bundle (compose render dry-run + docker context dump + port-listen
  inventory) wired into `install-dpf.sh doctor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_