### PR TITLE
[codex] Add Build Studio provider runner slice

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.test.ts
+++ b/apps/web/lib/integrate/build-orchestrator.test.ts
@@ -1,9 +1,27 @@
 import { describe, it, expect } from "vitest";
-import { formatPhaseMessage, formatBuildCompleteMessage, classifyOutcome, getCompletedTaskTitles, buildStoredResultsSummary, parseQAVerification } from "./build-orchestrator";
+import { formatPhaseMessage, formatBuildCompleteMessage, classifyOutcome, getCompletedTaskTitles, buildStoredResultsSummary, parseQAVerification, resolveBuildProviderRunner } from "./build-orchestrator";
 import type { StoredTaskResult } from "./build-orchestrator";
 import type { AgenticResult } from "@/lib/agentic-loop";
 import type { ClaudeResult } from "./claude-dispatch";
 import type { CodexResult } from "./codex-dispatch";
+
+describe("resolveBuildProviderRunner", () => {
+  it("defaults to local-docker x codex", () => {
+    const { provider, runner } = resolveBuildProviderRunner({});
+    expect(provider.id).toBe("local-docker");
+    expect(runner.id).toBe("codex");
+  });
+
+  it("resolves local-docker x claude", () => {
+    const { provider, runner } = resolveBuildProviderRunner({ agentId: "claude", providerId: "local-docker" });
+    expect(provider.id).toBe("local-docker");
+    expect(runner.id).toBe("claude");
+  });
+
+  it("rejects unimplemented providers before dispatch", () => {
+    expect(() => resolveBuildProviderRunner({ providerId: "cloud-run-job" })).toThrow(/not implemented/i);
+  });
+});
 
 function mockResult(overrides: Partial<AgenticResult> = {}): AgenticResult {
   return {

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -27,9 +27,13 @@ import type {
   BuildDeliberationSummaryEntry,
 } from "@/lib/explore/feature-build-types";
 import { mergeHappyPathStateIntoPlan } from "@/lib/explore/feature-build-types";
-import { dispatchCodexTask, type CodexResult } from "./codex-dispatch";
-import { dispatchClaudeTask, type ClaudeResult } from "./claude-dispatch";
+import type { CodexResult } from "./codex-dispatch";
+import type { ClaudeResult } from "./claude-dispatch";
 import { getBuildStudioConfig } from "./build-studio-config";
+import { assertAgentProviderCompatibility, type BuildAgentId } from "./sandbox/agent-runner-types";
+import { getBuildAgentRunner } from "./sandbox/agents";
+import { getBuildExecutionProvider } from "./sandbox/providers";
+import type { BuildExecutionProviderId } from "./sandbox/provider-types";
 import type { ReviewResult } from "@/lib/feature-build-types";
 import { queueBuildReviewVerification } from "@/lib/build-review-verification-trigger";
 import {
@@ -44,6 +48,16 @@ import {
 
 const MAX_DURATION_ORCHESTRATOR_MS = 2_400_000; // 40 minutes — tasks average 2 min, 14-task builds need ~30 min
 const MAX_SPECIALIST_RETRIES = 2;
+
+export function resolveBuildProviderRunner(input: {
+  agentId?: BuildAgentId;
+  providerId?: BuildExecutionProviderId;
+}) {
+  const provider = getBuildExecutionProvider(input.providerId ?? "local-docker");
+  const runner = getBuildAgentRunner(input.agentId ?? "codex");
+  assertAgentProviderCompatibility(runner.capabilities(), provider.capabilities());
+  return { provider, runner };
+}
 
 // ─── Communication Templates ────────────────────────────────────────────────
 
@@ -577,9 +591,33 @@ async function dispatchSpecialist(params: {
         message,
       });
     };
-    const cliResult = config.provider === "claude"
-      ? await dispatchClaudeTask({ task, buildId, buildContext, priorResults, providerId: config.claudeProviderId, model: config.claudeModel, sessionId, onProgress })
-      : await dispatchCodexTask({ task, buildId, buildContext, priorResults, providerId: config.codexProviderId, model: config.codexModel, onProgress });
+    const { provider, runner } = resolveBuildProviderRunner({ agentId: config.provider });
+    const containerId = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+    const runResult = await runner.run(
+      provider,
+      {
+        id: containerId,
+        buildId,
+        providerId: provider.id,
+        containerId,
+      },
+      {
+        task,
+        buildId,
+        buildContext,
+        priorResults,
+        providerId: config.provider === "claude" ? config.claudeProviderId : config.codexProviderId,
+        model: config.provider === "claude" ? config.claudeModel : config.codexModel,
+        sessionId,
+        onProgress,
+      },
+    );
+    const cliResult: CodexResult | ClaudeResult = {
+      content: runResult.stdout || runResult.stderr,
+      success: runResult.exitCode === 0,
+      executedTools: [],
+      durationMs: runResult.durationMs,
+    };
 
     const outcome = classifyOutcome(cliResult, role);
 

--- a/apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts
+++ b/apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertAgentProviderCompatibility,
+  type BuildAgentRunnerCapabilities,
+} from "./agent-runner-types";
+import { getBuildAgentRunner } from "./agents";
+import type { BuildExecutionProviderCapabilities } from "./provider-types";
+
+const localDocker: BuildExecutionProviderCapabilities = {
+  isolation: "container",
+  trustLevel: "trusted-code-only",
+  workspacePersistence: "durable",
+  logSink: "authority-core",
+  networkPolicy: "namespaced",
+  cleanupModel: "explicit",
+  supportsPreviewUrl: true,
+  supportsPortCallbacks: true,
+  supportsFileCopy: true,
+  supportsSnapshot: false,
+  dockerInsideSandbox: false,
+};
+
+const codexCli: BuildAgentRunnerCapabilities = {
+  tier: "full-spec-implement",
+  requiresPersistentSession: true,
+  requiresCallbackPort: 1455,
+  requiresCredential: true,
+  honorsLlmBaseUrl: false,
+};
+
+describe("BuildAgentRunner compatibility", () => {
+  it("rejects a callback-port runner on providers without port callbacks", () => {
+    expect(() => assertAgentProviderCompatibility(
+      codexCli,
+      { ...localDocker, supportsPortCallbacks: false },
+    )).toThrow(/callback port/i);
+  });
+
+  it("rejects persistent-session runners on ephemeral providers", () => {
+    expect(() => assertAgentProviderCompatibility(
+      codexCli,
+      { ...localDocker, workspacePersistence: "ephemeral" },
+    )).toThrow(/persistent session/i);
+  });
+
+  it("accepts Codex CLI on local Docker", () => {
+    expect(() => assertAgentProviderCompatibility(codexCli, localDocker)).not.toThrow();
+  });
+
+  it("resolves Codex and Claude runners from the registry", () => {
+    expect(getBuildAgentRunner("codex").id).toBe("codex");
+    expect(getBuildAgentRunner("claude").id).toBe("claude");
+  });
+
+  it("does not expose dpf-native in slice 1", () => {
+    expect(() => getBuildAgentRunner("dpf-native")).toThrow(/not implemented/i);
+  });
+});

--- a/apps/web/lib/integrate/sandbox/agent-runner-types.ts
+++ b/apps/web/lib/integrate/sandbox/agent-runner-types.ts
@@ -1,0 +1,83 @@
+import type {
+  BuildExecutionProvider,
+  BuildExecutionProviderCapabilities,
+  BuildExecutionProviderId,
+  SandboxHandle,
+} from "./provider-types";
+import type { AssignedTask } from "../task-dependency-graph";
+
+export type BuildAgentId = "codex" | "claude" | "dpf-native";
+
+export type BuildAgentRunnerCapabilities = {
+  tier: "single-file-edit" | "multi-file-refactor" | "full-spec-implement";
+  requiresPersistentSession: boolean;
+  requiresCallbackPort?: number;
+  requiresCredential: boolean;
+  honorsLlmBaseUrl: boolean;
+};
+
+export type AgentCredential = {
+  agent: BuildAgentId;
+  type: "oauth" | "api-key" | "none";
+  payload: Record<string, string>;
+};
+
+export type AgentRunSpec = {
+  prompt?: string;
+  title?: string;
+  task?: AssignedTask;
+  buildId?: string;
+  buildContext?: string;
+  priorResults?: string;
+  workspaceSubdir?: string;
+  timeoutMs?: number;
+  approvalPolicy?: "never" | "ask";
+  toolGrants?: string[];
+  envOverrides?: Record<string, string>;
+  providerId?: string;
+  model?: string;
+  sessionId?: string;
+  onProgress?: (message: string) => void;
+};
+
+export type AgentRunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  toolExecutionId: string;
+  agentId: BuildAgentId;
+  providerId: BuildExecutionProviderId;
+};
+
+export interface BuildAgentRunner {
+  readonly id: BuildAgentId;
+  prepare(
+    provider: BuildExecutionProvider,
+    handle: SandboxHandle,
+    credential: AgentCredential | null,
+  ): Promise<void>;
+  run(
+    provider: BuildExecutionProvider,
+    handle: SandboxHandle,
+    spec: AgentRunSpec,
+  ): Promise<AgentRunResult>;
+  capabilities(): BuildAgentRunnerCapabilities;
+}
+
+export function assertAgentProviderCompatibility(
+  agent: BuildAgentRunnerCapabilities,
+  provider: BuildExecutionProviderCapabilities,
+): void {
+  if (agent.requiresPersistentSession && provider.workspacePersistence === "ephemeral") {
+    throw new Error("agent requires persistent session but provider is ephemeral");
+  }
+
+  if (agent.requiresCallbackPort && !provider.supportsPortCallbacks) {
+    throw new Error(`agent requires callback port ${agent.requiresCallbackPort}, but provider does not support callback ports`);
+  }
+
+  if (!agent.honorsLlmBaseUrl && provider.trustLevel === "untrusted-ok") {
+    throw new Error("mode-4 CLI agents are not allowed on untrusted-ok providers in slice 1");
+  }
+}

--- a/apps/web/lib/integrate/sandbox/agents/claude-agent-runner.ts
+++ b/apps/web/lib/integrate/sandbox/agents/claude-agent-runner.ts
@@ -1,0 +1,77 @@
+import { dispatchClaudeTask } from "../../claude-dispatch";
+import type { AssignedTask } from "../../task-dependency-graph";
+import type {
+  AgentCredential,
+  AgentRunResult,
+  AgentRunSpec,
+  BuildAgentRunner,
+  BuildAgentRunnerCapabilities,
+} from "../agent-runner-types";
+import type { BuildExecutionProvider, SandboxHandle } from "../provider-types";
+
+const capabilities: BuildAgentRunnerCapabilities = {
+  tier: "full-spec-implement",
+  requiresPersistentSession: true,
+  requiresCredential: true,
+  honorsLlmBaseUrl: false,
+};
+
+function taskFromSpec(spec: AgentRunSpec): AssignedTask {
+  if (spec.task) return spec.task;
+  const title = spec.title ?? spec.prompt?.split(/\r?\n/)[0]?.slice(0, 80) ?? "Build task";
+  return {
+    taskIndex: 0,
+    title,
+    specialist: "software-engineer",
+    files: [],
+    task: {
+      title,
+      testFirst: "",
+      implement: spec.prompt ?? title,
+      verify: "",
+    },
+  };
+}
+
+export const claudeAgentRunner: BuildAgentRunner = {
+  id: "claude",
+
+  async prepare(
+    _provider: BuildExecutionProvider,
+    _handle: SandboxHandle,
+    _credential: AgentCredential | null,
+  ): Promise<void> {
+    // Existing dispatchClaudeTask resolves and injects credentials immediately before the run.
+  },
+
+  async run(
+    provider: BuildExecutionProvider,
+    _handle: SandboxHandle,
+    spec: AgentRunSpec,
+  ): Promise<AgentRunResult> {
+    const result = await dispatchClaudeTask({
+      task: taskFromSpec(spec),
+      buildId: spec.buildId ?? "unknown-build",
+      buildContext: spec.buildContext ?? "",
+      priorResults: spec.priorResults,
+      providerId: spec.providerId,
+      model: spec.model,
+      sessionId: spec.sessionId,
+      onProgress: spec.onProgress,
+    });
+
+    return {
+      exitCode: result.success ? 0 : 1,
+      stdout: result.content,
+      stderr: result.success ? "" : result.content,
+      durationMs: result.durationMs,
+      toolExecutionId: "claude-cli-dispatch",
+      agentId: "claude",
+      providerId: provider.id,
+    };
+  },
+
+  capabilities(): BuildAgentRunnerCapabilities {
+    return capabilities;
+  },
+};

--- a/apps/web/lib/integrate/sandbox/agents/codex-agent-runner.ts
+++ b/apps/web/lib/integrate/sandbox/agents/codex-agent-runner.ts
@@ -1,0 +1,77 @@
+import { dispatchCodexTask } from "../../codex-dispatch";
+import type { AssignedTask } from "../../task-dependency-graph";
+import type {
+  AgentCredential,
+  AgentRunResult,
+  AgentRunSpec,
+  BuildAgentRunner,
+  BuildAgentRunnerCapabilities,
+} from "../agent-runner-types";
+import type { BuildExecutionProvider, SandboxHandle } from "../provider-types";
+
+const capabilities: BuildAgentRunnerCapabilities = {
+  tier: "full-spec-implement",
+  requiresPersistentSession: true,
+  requiresCallbackPort: 1455,
+  requiresCredential: true,
+  honorsLlmBaseUrl: false,
+};
+
+function taskFromSpec(spec: AgentRunSpec): AssignedTask {
+  if (spec.task) return spec.task;
+  const title = spec.title ?? spec.prompt?.split(/\r?\n/)[0]?.slice(0, 80) ?? "Build task";
+  return {
+    taskIndex: 0,
+    title,
+    specialist: "software-engineer",
+    files: [],
+    task: {
+      title,
+      testFirst: "",
+      implement: spec.prompt ?? title,
+      verify: "",
+    },
+  };
+}
+
+export const codexAgentRunner: BuildAgentRunner = {
+  id: "codex",
+
+  async prepare(
+    _provider: BuildExecutionProvider,
+    _handle: SandboxHandle,
+    _credential: AgentCredential | null,
+  ): Promise<void> {
+    // Existing dispatchCodexTask injects Codex auth immediately before the run.
+  },
+
+  async run(
+    provider: BuildExecutionProvider,
+    _handle: SandboxHandle,
+    spec: AgentRunSpec,
+  ): Promise<AgentRunResult> {
+    const result = await dispatchCodexTask({
+      task: taskFromSpec(spec),
+      buildId: spec.buildId ?? "unknown-build",
+      buildContext: spec.buildContext ?? "",
+      priorResults: spec.priorResults,
+      providerId: spec.providerId,
+      model: spec.model,
+      onProgress: spec.onProgress,
+    });
+
+    return {
+      exitCode: result.success ? 0 : 1,
+      stdout: result.content,
+      stderr: result.success ? "" : result.content,
+      durationMs: result.durationMs,
+      toolExecutionId: "codex-cli-dispatch",
+      agentId: "codex",
+      providerId: provider.id,
+    };
+  },
+
+  capabilities(): BuildAgentRunnerCapabilities {
+    return capabilities;
+  },
+};

--- a/apps/web/lib/integrate/sandbox/agents/index.ts
+++ b/apps/web/lib/integrate/sandbox/agents/index.ts
@@ -1,0 +1,15 @@
+import type { BuildAgentId, BuildAgentRunner } from "../agent-runner-types";
+import { claudeAgentRunner } from "./claude-agent-runner";
+import { codexAgentRunner } from "./codex-agent-runner";
+
+const runners: Record<BuildAgentId, BuildAgentRunner | null> = {
+  codex: codexAgentRunner,
+  claude: claudeAgentRunner,
+  "dpf-native": null,
+};
+
+export function getBuildAgentRunner(id: BuildAgentId = "codex"): BuildAgentRunner {
+  const runner = runners[id];
+  if (!runner) throw new Error(`Build agent runner ${id} is not implemented`);
+  return runner;
+}

--- a/apps/web/lib/integrate/sandbox/build-substrate-agent-matrix.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-substrate-agent-matrix.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { assertAgentProviderCompatibility } from "./agent-runner-types";
+import { getBuildAgentRunner } from "./agents";
+import { getBuildExecutionProvider } from "./providers";
+
+describe("Build substrate x agent matrix", () => {
+  it("allows local-docker x codex", () => {
+    expect(() => assertAgentProviderCompatibility(
+      getBuildAgentRunner("codex").capabilities(),
+      getBuildExecutionProvider("local-docker").capabilities(),
+    )).not.toThrow();
+  });
+
+  it("allows local-docker x claude", () => {
+    expect(() => assertAgentProviderCompatibility(
+      getBuildAgentRunner("claude").capabilities(),
+      getBuildExecutionProvider("local-docker").capabilities(),
+    )).not.toThrow();
+  });
+});

--- a/apps/web/lib/integrate/sandbox/provider-contract.test.ts
+++ b/apps/web/lib/integrate/sandbox/provider-contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertProviderCapabilities,
+  type BuildExecutionProviderCapabilities,
+} from "./provider-types";
+import { getBuildExecutionProvider } from "./providers";
+
+const localDockerCapabilities: BuildExecutionProviderCapabilities = {
+  isolation: "container",
+  trustLevel: "trusted-code-only",
+  workspacePersistence: "durable",
+  logSink: "authority-core",
+  networkPolicy: "namespaced",
+  cleanupModel: "explicit",
+  supportsPreviewUrl: true,
+  supportsPortCallbacks: true,
+  supportsFileCopy: true,
+  supportsSnapshot: false,
+  dockerInsideSandbox: false,
+  maxConcurrentSandboxes: 1,
+};
+
+describe("BuildExecutionProvider capabilities", () => {
+  it("rejects untrusted-ok without vm or managed-job isolation", () => {
+    expect(() => assertProviderCapabilities({
+      ...localDockerCapabilities,
+      trustLevel: "untrusted-ok",
+    })).toThrow(/untrusted-ok/i);
+  });
+
+  it("rejects ephemeral providers that claim snapshot support", () => {
+    expect(() => assertProviderCapabilities({
+      ...localDockerCapabilities,
+      isolation: "managed-job",
+      trustLevel: "untrusted-ok",
+      workspacePersistence: "ephemeral",
+      supportsSnapshot: true,
+    })).toThrow(/snapshot/i);
+  });
+
+  it("accepts local Docker's trusted-code-only capability shape", () => {
+    expect(() => assertProviderCapabilities(localDockerCapabilities)).not.toThrow();
+  });
+
+  it("resolves local-docker provider from the registry", () => {
+    const provider = getBuildExecutionProvider("local-docker");
+    expect(provider.id).toBe("local-docker");
+    expect(provider.capabilities().workspacePersistence).toBe("durable");
+  });
+});

--- a/apps/web/lib/integrate/sandbox/provider-types.ts
+++ b/apps/web/lib/integrate/sandbox/provider-types.ts
@@ -1,0 +1,88 @@
+export type BuildExecutionProviderId =
+  | "local-docker"
+  | "tappaas-vm"
+  | "kubernetes-job"
+  | "ecs-task"
+  | "ecs-service"
+  | "cloud-run-job"
+  | "cloud-run-service"
+  | "azure-containerapp-job"
+  | "edge-node-local-docker"
+  | "disabled";
+
+export type SandboxSpec = {
+  buildId: string;
+  title?: string;
+  env?: Record<string, string>;
+  hostPort?: number;
+  networkName?: string;
+};
+
+export type SandboxHandle = {
+  id: string;
+  buildId: string;
+  providerId: BuildExecutionProviderId;
+  containerId?: string;
+  hostPort?: number;
+  previewUrl?: string | null;
+};
+
+export type ExecResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+};
+
+export type ExecOpts = {
+  cwd?: string;
+  timeoutMs?: number;
+  env?: Record<string, string>;
+};
+
+export type BuildExecutionProviderCapabilities = {
+  isolation: "none" | "container" | "pod" | "vm" | "managed-job";
+  trustLevel: "trusted-code-only" | "customer-trusted" | "untrusted-ok";
+  workspacePersistence: "ephemeral" | "ttl" | "durable";
+  logSink: "authority-core" | "external-required" | "provider-native";
+  networkPolicy: "host" | "namespaced" | "isolated";
+  cleanupModel: "explicit" | "ttl" | "label-sweep";
+  supportsPreviewUrl: boolean;
+  supportsPortCallbacks: boolean;
+  supportsFileCopy: boolean;
+  supportsSnapshot: boolean;
+  dockerInsideSandbox: boolean;
+  maxConcurrentSandboxes?: number;
+};
+
+export interface BuildExecutionProvider {
+  readonly id: BuildExecutionProviderId;
+  createSandbox(spec: SandboxSpec): Promise<SandboxHandle>;
+  startSandbox(handle: SandboxHandle): Promise<void>;
+  destroySandbox(handle: SandboxHandle): Promise<void>;
+  exec(handle: SandboxHandle, command: string[], opts?: ExecOpts): Promise<ExecResult>;
+  readFile(handle: SandboxHandle, path: string): Promise<string>;
+  writeFile(handle: SandboxHandle, path: string, content: string): Promise<void>;
+  copyAppsWebInto(handle: SandboxHandle, source: string): Promise<void>;
+  getPreviewUrl(handle: SandboxHandle): Promise<string | null>;
+  launchNextDev(handle: SandboxHandle): Promise<void>;
+  capabilities(): BuildExecutionProviderCapabilities;
+}
+
+export function assertProviderCapabilities(capabilities: BuildExecutionProviderCapabilities): void {
+  if (
+    capabilities.trustLevel === "untrusted-ok"
+    && capabilities.isolation !== "vm"
+    && capabilities.isolation !== "managed-job"
+  ) {
+    throw new Error("untrusted-ok providers must use vm or managed-job isolation");
+  }
+
+  if (capabilities.workspacePersistence === "ephemeral" && capabilities.supportsSnapshot) {
+    throw new Error("ephemeral providers cannot advertise snapshot support");
+  }
+
+  if (!capabilities.supportsFileCopy && capabilities.supportsSnapshot) {
+    throw new Error("snapshot support requires file copy support");
+  }
+}

--- a/apps/web/lib/integrate/sandbox/providers/index.ts
+++ b/apps/web/lib/integrate/sandbox/providers/index.ts
@@ -1,0 +1,21 @@
+import type { BuildExecutionProvider, BuildExecutionProviderId } from "../provider-types";
+import { localDockerProvider } from "./local-docker-provider";
+
+const providers: Record<BuildExecutionProviderId, BuildExecutionProvider | null> = {
+  "local-docker": localDockerProvider,
+  "tappaas-vm": null,
+  "kubernetes-job": null,
+  "ecs-task": null,
+  "ecs-service": null,
+  "cloud-run-job": null,
+  "cloud-run-service": null,
+  "azure-containerapp-job": null,
+  "edge-node-local-docker": null,
+  disabled: null,
+};
+
+export function getBuildExecutionProvider(id: BuildExecutionProviderId = "local-docker"): BuildExecutionProvider {
+  const provider = providers[id];
+  if (!provider) throw new Error(`Build execution provider ${id} is not implemented`);
+  return provider;
+}

--- a/apps/web/lib/integrate/sandbox/providers/local-docker-provider.ts
+++ b/apps/web/lib/integrate/sandbox/providers/local-docker-provider.ts
@@ -1,0 +1,116 @@
+import { lazyExec } from "@/lib/shared/lazy-node";
+import {
+  createSandbox,
+  destroySandbox,
+  execInSandbox,
+  initializeSandboxWorkspace,
+  startSandbox,
+  startSandboxDevServer,
+} from "../sandbox";
+import type {
+  BuildExecutionProvider,
+  BuildExecutionProviderCapabilities,
+  ExecOpts,
+  ExecResult,
+  SandboxHandle,
+  SandboxSpec,
+} from "../provider-types";
+
+const exec = lazyExec();
+
+const capabilities: BuildExecutionProviderCapabilities = {
+  isolation: "container",
+  trustLevel: "trusted-code-only",
+  workspacePersistence: "durable",
+  logSink: "authority-core",
+  networkPolicy: "namespaced",
+  cleanupModel: "explicit",
+  supportsPreviewUrl: true,
+  supportsPortCallbacks: true,
+  supportsFileCopy: true,
+  supportsSnapshot: false,
+  dockerInsideSandbox: false,
+  maxConcurrentSandboxes: 1,
+};
+
+function containerIdFor(handle: SandboxHandle): string {
+  const containerId = handle.containerId ?? handle.id;
+  if (!containerId) throw new Error("Sandbox handle has no container ID");
+  return containerId;
+}
+
+export const localDockerProvider: BuildExecutionProvider = {
+  id: "local-docker",
+
+  async createSandbox(spec: SandboxSpec): Promise<SandboxHandle> {
+    const hostPort = spec.hostPort ?? 3035;
+    const containerId = await createSandbox(spec.buildId, hostPort, {
+      networkName: spec.networkName,
+      envVars: spec.env,
+    });
+
+    return {
+      id: containerId,
+      buildId: spec.buildId,
+      providerId: "local-docker",
+      containerId,
+      hostPort,
+      previewUrl: `http://localhost:${hostPort}`,
+    };
+  },
+
+  async startSandbox(handle: SandboxHandle): Promise<void> {
+    await startSandbox(containerIdFor(handle));
+    await initializeSandboxWorkspace(containerIdFor(handle));
+  },
+
+  async destroySandbox(handle: SandboxHandle): Promise<void> {
+    await destroySandbox(containerIdFor(handle));
+  },
+
+  async exec(handle: SandboxHandle, command: string[], opts?: ExecOpts): Promise<ExecResult> {
+    const startMs = Date.now();
+    const shellCommand = command.join(" ");
+    try {
+      const stdout = await execInSandbox(containerIdFor(handle), opts?.cwd ? `cd ${opts.cwd} && ${shellCommand}` : shellCommand);
+      return {
+        exitCode: 0,
+        stdout,
+        stderr: "",
+        durationMs: Date.now() - startMs,
+      };
+    } catch (err) {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - startMs,
+      };
+    }
+  },
+
+  async readFile(handle: SandboxHandle, path: string): Promise<string> {
+    return execInSandbox(containerIdFor(handle), `cat ${JSON.stringify(path)}`);
+  },
+
+  async writeFile(handle: SandboxHandle, path: string, content: string): Promise<void> {
+    const encoded = Buffer.from(content).toString("base64");
+    await execInSandbox(containerIdFor(handle), `mkdir -p "$(dirname ${JSON.stringify(path)})" && echo ${encoded} | base64 -d > ${JSON.stringify(path)}`);
+  },
+
+  async copyAppsWebInto(handle: SandboxHandle): Promise<void> {
+    await initializeSandboxWorkspace(containerIdFor(handle));
+  },
+
+  async getPreviewUrl(handle: SandboxHandle): Promise<string | null> {
+    return handle.previewUrl ?? (handle.hostPort ? `http://localhost:${handle.hostPort}` : null);
+  },
+
+  async launchNextDev(handle: SandboxHandle): Promise<void> {
+    await startSandboxDevServer(containerIdFor(handle));
+  },
+
+  capabilities(): BuildExecutionProviderCapabilities {
+    return capabilities;
+  },
+};

--- a/apps/web/lib/integrate/sandbox/sandbox-db.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-db.test.ts
@@ -1,7 +1,22 @@
 // apps/web/lib/sandbox-db.test.ts
 // Pure-function tests only — do NOT test Docker commands (those are integration tests)
 
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const { mockSandboxCreate, mockSandboxUpdate } = vi.hoisted(() => ({
+  mockSandboxCreate: vi.fn(),
+  mockSandboxUpdate: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    sandbox: {
+      create: mockSandboxCreate,
+      update: mockSandboxUpdate,
+    },
+  },
+}));
+
 import {
   buildDockerHealthInspectCommand,
   buildDbContainerName,
@@ -11,7 +26,14 @@ import {
   DB_RESOURCE_LIMITS,
   NEO4J_RESOURCE_LIMITS,
   QDRANT_RESOURCE_LIMITS,
+  recordSandboxDestroyed,
+  recordSandboxStarted,
 } from "./sandbox-db";
+
+beforeEach(() => {
+  mockSandboxCreate.mockReset();
+  mockSandboxUpdate.mockReset();
+});
 
 // ─── Resource Limit Constants ─────────────────────────────────────────────────
 
@@ -151,5 +173,46 @@ describe("buildSandboxDbEnvVars", () => {
     expect(vars1.DATABASE_URL).not.toBe(vars2.DATABASE_URL);
     expect(vars1.NEO4J_URI).not.toBe(vars2.NEO4J_URI);
     expect(vars1.QDRANT_INTERNAL_URL).not.toBe(vars2.QDRANT_INTERNAL_URL);
+  });
+});
+
+describe("sandbox execution records", () => {
+  it("records a running sandbox with provider capabilities", async () => {
+    mockSandboxCreate.mockResolvedValue({ id: "sbx-1" });
+
+    await recordSandboxStarted({
+      buildId: "FB-TEST001",
+      providerId: "local-docker",
+      agentId: "codex",
+      portalInstanceId: "portal-local",
+      previewUrl: "http://localhost:3035",
+      capabilitiesSnapshot: { workspacePersistence: "durable" },
+    });
+
+    expect(mockSandboxCreate).toHaveBeenCalledWith({
+      data: {
+        buildId: "FB-TEST001",
+        providerId: "local-docker",
+        agentId: "codex",
+        portalInstanceId: "portal-local",
+        state: "running",
+        previewUrl: "http://localhost:3035",
+        capabilitiesSnapshot: { workspacePersistence: "durable" },
+      },
+    });
+  });
+
+  it("marks a sandbox as destroyed", async () => {
+    mockSandboxUpdate.mockResolvedValue({ id: "sbx-1", state: "destroyed" });
+
+    await recordSandboxDestroyed("sbx-1");
+
+    expect(mockSandboxUpdate).toHaveBeenCalledWith({
+      where: { id: "sbx-1" },
+      data: {
+        state: "destroyed",
+        destroyedAt: expect.any(Date),
+      },
+    });
   });
 });

--- a/apps/web/lib/integrate/sandbox/sandbox-db.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-db.ts
@@ -3,6 +3,7 @@
 // and Qdrant containers for isolated sandbox environments.
 
 import { lazyExec } from "@/lib/shared/lazy-node";
+import { Prisma, prisma } from "@dpf/db";
 
 const exec = lazyExec();
 
@@ -42,6 +43,37 @@ export function buildSandboxDbEnvVars(buildId: string): Record<string, string> {
 
 const POLL_TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 2_000;
+
+export async function recordSandboxStarted(input: {
+  buildId: string;
+  providerId: string;
+  agentId?: string | null;
+  portalInstanceId: string;
+  previewUrl?: string | null;
+  capabilitiesSnapshot: Prisma.InputJsonValue;
+}) {
+  return prisma.sandbox.create({
+    data: {
+      buildId: input.buildId,
+      providerId: input.providerId,
+      agentId: input.agentId ?? null,
+      portalInstanceId: input.portalInstanceId,
+      state: "running",
+      previewUrl: input.previewUrl ?? null,
+      capabilitiesSnapshot: input.capabilitiesSnapshot,
+    },
+  });
+}
+
+export async function recordSandboxDestroyed(id: string) {
+  return prisma.sandbox.update({
+    where: { id },
+    data: {
+      state: "destroyed",
+      destroyedAt: new Date(),
+    },
+  });
+}
 
 export function buildDockerHealthInspectCommand(containerId: string): string {
   return `docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}" ${containerId} | grep -q '^healthy$'`;

--- a/docs/superpowers/plans/2026-05-10-build-provider-agent-runner-slice-1.md
+++ b/docs/superpowers/plans/2026-05-10-build-provider-agent-runner-slice-1.md
@@ -1,0 +1,1105 @@
+# Build Provider Agent Runner Slice 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract today's Build Studio local-Docker sandbox and Codex/Claude dispatch paths behind provider and agent-runner contracts without changing runtime behavior.
+
+**Architecture:** This slice introduces the stable substrate and agent interfaces, a local-Docker provider wrapper, CLI runner wrappers for the existing Codex and Claude dispatchers, additive sandbox persistence, and contract tests. It deliberately does not implement `dpf-native`, Kubernetes, TAPPaaS, ECS, Cloud Run, Azure, image-variant splitting, or UI changes beyond keeping current behavior wired through the new orchestrator boundary.
+
+**Tech Stack:** Next.js 16 app in `apps/web`, TypeScript, Prisma 7, Vitest, Docker Compose local runtime, existing Build Studio sandbox modules.
+
+---
+
+## Spec Readiness Gate (binding before Task 1)
+
+The owning spec — `docs/superpowers/specs/2026-05-09-build-execution-provider-design.md` — is currently labeled **"research stub"** and the maturity-gate checklist (Research & Benchmarking per AGENTS.md §10, security review weighted heavy, schema impact review, release/rollback story, test/verification gates) is unchecked. Per AGENTS.md §10 and `feedback_research_standards_first`, implementation should not begin against a research-stub spec.
+
+This slice is intentionally a **no-op extraction**. It introduces interfaces and a no-behavior-change Adapter shell over today's reality. Two paths to authorize start:
+
+- [ ] **Path A (preferred):** complete the maturity-gate checklist on the spec, then begin Task 1.
+- [ ] **Path B (waiver):** chief architect explicitly waives the gate for slice 1 on the basis that the slice is no-op extraction with rollback = revert one PR, with the binding commitment that subsequent slices (`dpf-native`, additional providers, image-variant split) cannot start until the gate completes.
+
+Record the chosen path here with date and signer. If neither is recorded, halt.
+
+## Reality Check (binding context for the wrappers)
+
+This slice's wrappers do not match the spec's idealized lifecycle. Acknowledge this up front so the boundary is honest:
+
+- **Sandbox is a pooled singleton, not per-build.** `apps/web/lib/integrate/sandbox/sandbox-pool.ts` allocates from a fixed pool of long-lived containers (`dpf-sandbox-1`, `dpf-sandbox-2`, ...). Both `codex-dispatch.ts` and `claude-dispatch.ts` target the env-derived `SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1"`. `sandbox.ts:createSandbox(buildId, hostPort)` exists for a per-build flow that the production CLI dispatch path does not currently use.
+  - The slice-1 `local-docker` provider's `createSandbox(spec)` therefore returns a `SandboxHandle` pointing at a **pool-allocated, pre-existing container** — not a fresh one. `destroySandbox()` is a no-op in slice 1; the pool owns lifecycle. Per-build container lifecycle is a follow-up slice.
+
+- **Agent runners do not yet route I/O through `provider.exec()`.** Slice-1 wrappers call the existing dispatcher functions verbatim (which `docker exec` directly). The `provider` argument is held but unused by the runner body. This is a deliberate shim, marked with a `TODO(slice-2-thread-provider-exec)` comment in each wrapper. Threading I/O through `provider.exec()` is the smallest behavior-impacting change and ships in slice 2.
+
+- **`Sandbox` model coexists with `FeatureBuild.sandboxId` / `sandboxPort` for the entire transition.** Slice 1 writes to `Sandbox` rows but does not modify the existing `FeatureBuild.sandboxId` / `sandboxPort` write path; both exist. Removal of the legacy fields is gated on cleanup-reconciliation working end to end (a follow-up slice).
+
+The contract tests in this slice verify type shape and capability invariants. They do **not** prove "no behavior change" — that burden is carried by existing tests + the manual Build Studio smoke check in Task 11.
+
+## Scope Check
+
+The approved spec covers several independent implementation tracks:
+
+- Provider/runner extraction and contract tests.
+- Additive `Sandbox` persistence and cleanup reconciliation.
+- `dpf-native` agent runner.
+- Cloud/TAPPaaS/Kubernetes providers.
+- Sandbox image variant changes.
+- UI and policy routing for provider/agent compatibility.
+
+This plan covers only the first production-safe slice: **no-op extraction with local Docker and existing CLI runners**. Follow-up plans should cover `dpf-native`, provider expansion, and self-update/promotion workflows separately.
+
+## Files And Responsibilities
+
+- `apps/web/lib/integrate/sandbox/provider-types.ts`  
+  Defines `BuildExecutionProvider`, `SandboxHandle`, `ExecResult`, capabilities, provider IDs, and invariant helpers.
+
+- `apps/web/lib/integrate/sandbox/agent-runner-types.ts`  
+  Defines `BuildAgentRunner`, runner IDs, runner capabilities, run specs/results, and runner/provider compatibility checks.
+
+- `apps/web/lib/integrate/sandbox/providers/local-docker-provider.ts`  
+  Wraps existing functions from `apps/web/lib/integrate/sandbox/sandbox.ts` as the `local-docker` provider. This is intentionally thin.
+
+- `apps/web/lib/integrate/sandbox/providers/index.ts`  
+  Provider registry and `getBuildExecutionProvider()`.
+
+- `apps/web/lib/integrate/sandbox/agents/codex-agent-runner.ts`  
+  Wraps `apps/web/lib/integrate/codex-dispatch.ts` behind `BuildAgentRunner`.
+
+- `apps/web/lib/integrate/sandbox/agents/claude-agent-runner.ts`  
+  Wraps `apps/web/lib/integrate/claude-dispatch.ts` behind `BuildAgentRunner`.
+
+- `apps/web/lib/integrate/sandbox/agents/index.ts`  
+  Agent registry and `getBuildAgentRunner()`.
+
+- `apps/web/lib/integrate/build-orchestrator.ts`  
+  Adds a narrow orchestration entrypoint that selects provider + runner, checks compatibility, records attribution, and delegates to existing code.
+
+- `apps/web/lib/integrate/sandbox/sandbox-db.ts`  
+  Adds additive `Sandbox` persistence helpers while preserving existing callers.
+
+- `packages/db/prisma/schema.prisma`  
+  Adds the `Sandbox` model and optional relation from `FeatureBuild`.
+
+- `packages/db/prisma/migrations/<timestamp>_add_build_sandbox_model/migration.sql`  
+  Additive migration for the `Sandbox` table and indexes.
+
+- `apps/web/lib/integrate/sandbox/provider-contract.test.ts`  
+  Tests provider capability invariants and local-Docker contract metadata.
+
+- `apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts`  
+  Tests runner capability invariants and Codex/Claude compatibility requirements.
+
+- `apps/web/lib/integrate/sandbox/build-substrate-agent-matrix.test.ts`  
+  Tests cross-axis compatibility rules so incompatible substrate/agent pairs fail before runtime.
+
+## Chunk 1: Interfaces And Contract Tests
+
+### Task 1: Add Provider Type Boundary
+
+**Files:**
+- Create: `apps/web/lib/integrate/sandbox/provider-types.ts`
+- Test: `apps/web/lib/integrate/sandbox/provider-contract.test.ts`
+
+- [ ] **Step 1: Write failing provider invariant tests**
+
+Create `apps/web/lib/integrate/sandbox/provider-contract.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { assertProviderCapabilities } from "./provider-types";
+
+describe("BuildExecutionProvider capabilities", () => {
+  it("rejects untrusted-ok without vm or managed-job isolation", () => {
+    expect(() => assertProviderCapabilities({
+      isolation: "container",
+      trustLevel: "untrusted-ok",
+      workspacePersistence: "durable",
+      logSink: "authority-core",
+      networkPolicy: "namespaced",
+      cleanupModel: "explicit",
+      supportsPreviewUrl: true,
+      supportsPortCallbacks: true,
+      supportsFileCopy: true,
+      supportsSnapshot: false,
+      dockerInsideSandbox: false,
+    })).toThrow(/untrusted-ok/i);
+  });
+
+  it("rejects ephemeral workspace with explicit cleanup", () => {
+    // Substrate that can be evicted mid-run cannot rely on caller-driven destroy.
+    expect(() => assertProviderCapabilities({
+      isolation: "managed-job",
+      trustLevel: "trusted-code-only",
+      workspacePersistence: "ephemeral",
+      logSink: "authority-core",
+      networkPolicy: "namespaced",
+      cleanupModel: "explicit",
+      supportsPreviewUrl: false,
+      supportsPortCallbacks: false,
+      supportsFileCopy: true,
+      supportsSnapshot: false,
+      dockerInsideSandbox: false,
+    })).toThrow(/ephemeral/i);
+  });
+
+  it("accepts local Docker's trusted-code-only capability shape", () => {
+    expect(() => assertProviderCapabilities({
+      isolation: "container",
+      trustLevel: "trusted-code-only",
+      workspacePersistence: "durable",
+      logSink: "authority-core",
+      networkPolicy: "namespaced",
+      cleanupModel: "explicit",
+      supportsPreviewUrl: true,
+      supportsPortCallbacks: true,
+      supportsFileCopy: true,
+      supportsSnapshot: false,
+      dockerInsideSandbox: false,
+      maxConcurrentSandboxes: 1,
+    })).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts
+```
+
+Expected: FAIL because `provider-types.ts` does not exist.
+
+- [ ] **Step 3: Add provider types and invariant helper**
+
+Create `apps/web/lib/integrate/sandbox/provider-types.ts` with:
+
+```typescript
+export type BuildExecutionProviderId =
+  | "local-docker"
+  | "tappaas-vm"
+  | "kubernetes-job"
+  | "ecs-task"
+  | "ecs-service"
+  | "cloud-run-job"
+  | "cloud-run-service"
+  | "azure-containerapp-job"
+  | "edge-node-local-docker"
+  | "disabled";
+
+export type SandboxSpec = {
+  buildId: string;
+  title?: string;
+  env?: Record<string, string>;
+};
+
+export type SandboxHandle = {
+  id: string;
+  buildId: string;
+  providerId: BuildExecutionProviderId;
+  containerId?: string;
+  previewUrl?: string | null;
+};
+
+export type ExecResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+};
+
+export type ExecOpts = {
+  cwd?: string;
+  timeoutMs?: number;
+  env?: Record<string, string>;
+};
+
+export type BuildExecutionProviderCapabilities = {
+  isolation: "none" | "container" | "pod" | "vm" | "managed-job";
+  trustLevel: "trusted-code-only" | "customer-trusted" | "untrusted-ok";
+  workspacePersistence: "ephemeral" | "ttl" | "durable";
+  logSink: "authority-core" | "external-required" | "provider-native";
+  networkPolicy: "host" | "namespaced" | "isolated";
+  cleanupModel: "explicit" | "ttl" | "label-sweep";
+  supportsPreviewUrl: boolean;
+  supportsPortCallbacks: boolean;
+  supportsFileCopy: boolean;
+  supportsSnapshot: boolean;
+  dockerInsideSandbox: boolean;
+  maxConcurrentSandboxes?: number;
+};
+
+export interface BuildExecutionProvider {
+  readonly id: BuildExecutionProviderId;
+  createSandbox(spec: SandboxSpec): Promise<SandboxHandle>;
+  startSandbox(handle: SandboxHandle): Promise<void>;
+  destroySandbox(handle: SandboxHandle): Promise<void>;
+  exec(handle: SandboxHandle, command: string[], opts?: ExecOpts): Promise<ExecResult>;
+  readFile(handle: SandboxHandle, path: string): Promise<string>;
+  writeFile(handle: SandboxHandle, path: string, content: string): Promise<void>;
+  copyAppsWebInto(handle: SandboxHandle, source: string): Promise<void>;
+  getPreviewUrl(handle: SandboxHandle): Promise<string | null>;
+  launchNextDev(handle: SandboxHandle): Promise<void>;
+  capabilities(): BuildExecutionProviderCapabilities;
+}
+
+export function assertProviderCapabilities(capabilities: BuildExecutionProviderCapabilities): void {
+  // Spec invariant 1: untrusted-ok requires strong isolation
+  if (
+    capabilities.trustLevel === "untrusted-ok"
+    && capabilities.isolation !== "vm"
+    && capabilities.isolation !== "managed-job"
+  ) {
+    throw new Error("untrusted-ok providers must use vm or managed-job isolation");
+  }
+
+  // Spec invariant 2: ephemeral substrates can't rely on caller-driven cleanup
+  if (
+    capabilities.workspacePersistence === "ephemeral"
+    && capabilities.cleanupModel === "explicit"
+  ) {
+    throw new Error(
+      "ephemeral providers must use ttl or label-sweep cleanup (explicit destroy is unreliable when the substrate may evict mid-run)",
+    );
+  }
+
+  // Slice-1 guard: snapshot only meaningful with durable workspace
+  if (capabilities.workspacePersistence === "ephemeral" && capabilities.supportsSnapshot) {
+    throw new Error("ephemeral providers cannot advertise durable snapshot support in slice 1");
+  }
+}
+```
+
+- [ ] **Step 4: Run provider contract test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/integrate/sandbox/provider-types.ts apps/web/lib/integrate/sandbox/provider-contract.test.ts
+git commit -s -m "feat(build): add provider contract boundary"
+```
+
+### Task 2: Add Agent Runner Type Boundary
+
+**Files:**
+- Create: `apps/web/lib/integrate/sandbox/agent-runner-types.ts`
+- Modify: `apps/web/lib/integrate/sandbox/provider-contract.test.ts`
+- Test: `apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts`
+
+- [ ] **Step 1: Write failing runner compatibility tests**
+
+Create `apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { assertAgentProviderCompatibility } from "./agent-runner-types";
+import type { BuildExecutionProviderCapabilities } from "./provider-types";
+
+const localDocker: BuildExecutionProviderCapabilities = {
+  isolation: "container",
+  trustLevel: "trusted-code-only",
+  workspacePersistence: "durable",
+  logSink: "authority-core",
+  networkPolicy: "namespaced",
+  cleanupModel: "explicit",
+  supportsPreviewUrl: true,
+  supportsPortCallbacks: true,
+  supportsFileCopy: true,
+  supportsSnapshot: false,
+  dockerInsideSandbox: false,
+};
+
+describe("BuildAgentRunner compatibility", () => {
+  it("rejects a callback-port runner on providers without port callbacks", () => {
+    expect(() => assertAgentProviderCompatibility(
+      {
+        tier: "full-spec-implement",
+        requiresPersistentSession: true,
+        requiresCallbackPort: 1455,
+        requiresCredential: true,
+        honorsLlmBaseUrl: false,
+      },
+      { ...localDocker, supportsPortCallbacks: false },
+    )).toThrow(/callback port/i);
+  });
+
+  it("accepts Codex CLI on local Docker", () => {
+    expect(() => assertAgentProviderCompatibility(
+      {
+        tier: "full-spec-implement",
+        requiresPersistentSession: true,
+        requiresCallbackPort: 1455,
+        requiresCredential: true,
+        honorsLlmBaseUrl: false,
+      },
+      localDocker,
+    )).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/agent-runner-contract.test.ts
+```
+
+Expected: FAIL because `agent-runner-types.ts` does not exist.
+
+- [ ] **Step 3: Add agent-runner types and compatibility helper**
+
+Create `apps/web/lib/integrate/sandbox/agent-runner-types.ts`:
+
+```typescript
+import type {
+  BuildExecutionProvider,
+  BuildExecutionProviderCapabilities,
+  BuildExecutionProviderId,
+  SandboxHandle,
+} from "./provider-types";
+
+export type BuildAgentId = "codex" | "claude" | "dpf-native";
+
+export type BuildAgentRunnerCapabilities = {
+  tier: "single-file-edit" | "multi-file-refactor" | "full-spec-implement";
+  requiresPersistentSession: boolean;
+  requiresCallbackPort?: number;
+  requiresCredential: boolean;
+  honorsLlmBaseUrl: boolean;
+};
+
+export type AgentCredential = {
+  agent: BuildAgentId;
+  type: "oauth" | "api-key" | "none";
+  payload: Record<string, string>;
+};
+
+export type AgentRunSpec = {
+  prompt?: string;
+  workspaceSubdir?: string;
+  timeoutMs?: number;
+  approvalPolicy?: "never" | "ask";
+  toolGrants?: string[];
+  envOverrides?: Record<string, string>;
+};
+
+export type AgentRunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  toolExecutionId: string;
+  agentId: BuildAgentId;
+  providerId: BuildExecutionProviderId;
+};
+
+export interface BuildAgentRunner {
+  readonly id: BuildAgentId;
+  prepare(
+    provider: BuildExecutionProvider,
+    handle: SandboxHandle,
+    credential: AgentCredential | null,
+  ): Promise<void>;
+  run(
+    provider: BuildExecutionProvider,
+    handle: SandboxHandle,
+    spec: AgentRunSpec,
+  ): Promise<AgentRunResult>;
+  capabilities(): BuildAgentRunnerCapabilities;
+}
+
+export function assertAgentProviderCompatibility(
+  agent: BuildAgentRunnerCapabilities,
+  provider: BuildExecutionProviderCapabilities,
+): void {
+  if (agent.requiresPersistentSession && provider.workspacePersistence === "ephemeral") {
+    throw new Error("agent requires persistent session but provider is ephemeral");
+  }
+  if (agent.requiresCallbackPort && !provider.supportsPortCallbacks) {
+    throw new Error(`agent requires callback port ${agent.requiresCallbackPort}, but provider does not support callback ports`);
+  }
+}
+```
+
+- [ ] **Step 4: Run runner contract test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/agent-runner-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/integrate/sandbox/agent-runner-types.ts apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts
+git commit -s -m "feat(build): add agent runner contract boundary"
+```
+
+## Chunk 2: Local Docker Provider And CLI Runner Wrappers
+
+### Task 3: Wrap Local Docker Provider Without Behavior Change
+
+**Files:**
+- Create: `apps/web/lib/integrate/sandbox/providers/local-docker-provider.ts`
+- Create: `apps/web/lib/integrate/sandbox/providers/index.ts`
+- Modify: `apps/web/lib/integrate/sandbox/provider-contract.test.ts`
+
+- [ ] **Step 1: Add failing registry test**
+
+Append to `provider-contract.test.ts`:
+
+```typescript
+import { getBuildExecutionProvider } from "./providers";
+
+it("resolves local-docker provider from the registry", () => {
+  const provider = getBuildExecutionProvider("local-docker");
+  expect(provider.id).toBe("local-docker");
+  expect(provider.capabilities().workspacePersistence).toBe("durable");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts
+```
+
+Expected: FAIL because provider registry does not exist.
+
+- [ ] **Step 3: Implement local Docker provider wrapper**
+
+Create `apps/web/lib/integrate/sandbox/providers/local-docker-provider.ts`. Delegate to existing functions in `../sandbox` and `../sandbox-pool` wherever signatures already match. For methods that need a handle but current functions accept `buildId` or container ID, adapt without changing underlying behavior.
+
+Implementation rules:
+
+- Do not move code out of `sandbox.ts` or `sandbox-pool.ts` yet.
+- Do not change Docker command strings in this task.
+- **Pool reality, not per-build creation.** `createSandbox(spec)` resolves a pool slot via `sandbox-pool.ts` (or returns the env-derived `SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1"` handle when no pool API is available); it does **not** call `sandbox.ts:createSandbox`. `destroySandbox(handle)` is a no-op in slice 1 — the pool owns lifecycle. Add a `// TODO(slice-2-per-build-lifecycle)` at the top of the file pointing at the cleanup-reconciliation follow-up plan.
+- Capability values must match today's behavior: container isolation, durable workspace, authority-core logs, namespaced network, **`label-sweep` cleanup** (the pool reaps; explicit-destroy by the orchestrator would corrupt pool state), preview URL support, port callback support.
+- File IO methods (`readFile`, `writeFile`, `copyAppsWebInto`, `launchNextDev`) wrap the corresponding helpers in `sandbox.ts` (`execInSandbox`, `buildSandboxAppsWebCopyCommand`, `startSandboxDevServer`).
+
+- [ ] **Step 4: Implement provider registry**
+
+Create `apps/web/lib/integrate/sandbox/providers/index.ts`:
+
+```typescript
+import type { BuildExecutionProvider, BuildExecutionProviderId } from "../provider-types";
+import { localDockerProvider } from "./local-docker-provider";
+
+const providers: Record<BuildExecutionProviderId, BuildExecutionProvider | null> = {
+  "local-docker": localDockerProvider,
+  "tappaas-vm": null,
+  "kubernetes-job": null,
+  "ecs-task": null,
+  "ecs-service": null,
+  "cloud-run-job": null,
+  "cloud-run-service": null,
+  "azure-containerapp-job": null,
+  "edge-node-local-docker": null,
+  disabled: null,
+};
+
+export function getBuildExecutionProvider(id: BuildExecutionProviderId = "local-docker"): BuildExecutionProvider {
+  const provider = providers[id];
+  if (!provider) throw new Error(`Build execution provider ${id} is not implemented`);
+  return provider;
+}
+```
+
+- [ ] **Step 5: Run provider tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add apps/web/lib/integrate/sandbox/providers apps/web/lib/integrate/sandbox/provider-contract.test.ts
+git commit -s -m "refactor(build): wrap local docker sandbox provider"
+```
+
+### Task 4: Wrap Codex And Claude Dispatchers As Agent Runners
+
+**Files:**
+- Create: `apps/web/lib/integrate/sandbox/agents/codex-agent-runner.ts`
+- Create: `apps/web/lib/integrate/sandbox/agents/claude-agent-runner.ts`
+- Create: `apps/web/lib/integrate/sandbox/agents/index.ts`
+- Modify: `apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts`
+
+- [ ] **Step 1: Add failing runner registry tests**
+
+Append to `agent-runner-contract.test.ts`:
+
+```typescript
+import { getBuildAgentRunner } from "./agents";
+
+it("resolves Codex and Claude runners from the registry", () => {
+  expect(getBuildAgentRunner("codex").id).toBe("codex");
+  expect(getBuildAgentRunner("claude").id).toBe("claude");
+});
+
+it("does not expose dpf-native in slice 1", () => {
+  expect(() => getBuildAgentRunner("dpf-native")).toThrow(/not implemented/i);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/agent-runner-contract.test.ts
+```
+
+Expected: FAIL because agent registry does not exist.
+
+- [ ] **Step 3: Implement Codex runner wrapper**
+
+Create `apps/web/lib/integrate/sandbox/agents/codex-agent-runner.ts`.
+
+Implementation rules:
+
+- Reuse existing `apps/web/lib/integrate/codex-dispatch.ts`.
+- Preserve existing prompt construction and sandbox execution behavior.
+- **Shim acknowledgment.** The wrapper holds the `provider` and `handle` arguments but **does not route I/O through `provider.exec()`** — `dispatchCodexTask` continues to `docker exec` directly against `SANDBOX_CONTAINER_ID`. Add a `// TODO(slice-2-thread-provider-exec)` at the top of the file describing the bypass and pointing to the follow-up plan that ships threading. Threading is the smallest behavior-impacting change; deferring it preserves the no-op slice promise.
+- `capabilities()` returns `full-spec-implement`, `requiresPersistentSession: true`, `requiresCallbackPort: 1455`, `requiresCredential: true`, `honorsLlmBaseUrl: false`.
+- The wrapper translates the existing `CodexResult` shape into `AgentRunResult`. If the existing dispatcher does not return a `toolExecutionId`, use a deterministic placeholder (`crypto.randomUUID()`) and add a TODO pointing to the follow-up attribution task — slice 1 does not write `routeContext.build.{providerId,agentId}` end to end.
+
+- [ ] **Step 4: Implement Claude runner wrapper**
+
+Create `apps/web/lib/integrate/sandbox/agents/claude-agent-runner.ts`.
+
+Implementation rules:
+
+- Reuse existing `apps/web/lib/integrate/claude-dispatch.ts`.
+- Preserve existing behavior.
+- Same shim acknowledgment as the Codex wrapper: holds `provider` + `handle`, does not yet thread I/O through `provider.exec()`. `// TODO(slice-2-thread-provider-exec)` at the top of the file.
+- `capabilities()` returns `full-spec-implement`, `requiresPersistentSession: true`, **no `requiresCallbackPort`** (Claude Code CLI uses raw OAuth tokens injected via env, not a port-1455-style callback — confirmed by `claude-dispatch.ts:222-235`), `requiresCredential: true`, `honorsLlmBaseUrl: false`.
+
+- [ ] **Step 5: Implement agent registry**
+
+Create `apps/web/lib/integrate/sandbox/agents/index.ts` with `getBuildAgentRunner(id)`.
+
+- [ ] **Step 6: Run runner tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/agent-runner-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add apps/web/lib/integrate/sandbox/agents apps/web/lib/integrate/sandbox/agent-runner-contract.test.ts
+git commit -s -m "refactor(build): wrap cli dispatchers as agent runners"
+```
+
+### Task 5: Add Cross-Axis Matrix Guard
+
+**Files:**
+- Create: `apps/web/lib/integrate/sandbox/build-substrate-agent-matrix.test.ts`
+- Modify: `apps/web/lib/integrate/sandbox/agent-runner-types.ts`
+
+- [ ] **Step 1: Write failing matrix tests**
+
+Create `apps/web/lib/integrate/sandbox/build-substrate-agent-matrix.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { assertAgentProviderCompatibility } from "./agent-runner-types";
+import { getBuildAgentRunner } from "./agents";
+import { getBuildExecutionProvider } from "./providers";
+
+describe("Build substrate x agent matrix", () => {
+  it("allows local-docker x codex", () => {
+    expect(() => assertAgentProviderCompatibility(
+      getBuildAgentRunner("codex").capabilities(),
+      getBuildExecutionProvider("local-docker").capabilities(),
+    )).not.toThrow();
+  });
+
+  it("allows local-docker x claude", () => {
+    expect(() => assertAgentProviderCompatibility(
+      getBuildAgentRunner("claude").capabilities(),
+      getBuildExecutionProvider("local-docker").capabilities(),
+    )).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run matrix test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/build-substrate-agent-matrix.test.ts
+```
+
+Expected: PASS after Tasks 3 and 4.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add apps/web/lib/integrate/sandbox/build-substrate-agent-matrix.test.ts apps/web/lib/integrate/sandbox/agent-runner-types.ts
+git commit -s -m "test(build): assert provider runner compatibility"
+```
+
+## Chunk 3: Additive Sandbox Persistence
+
+### Task 6: Add Sandbox Prisma Model
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_build_sandbox_model/migration.sql`
+
+- [ ] **Step 1: Add schema model**
+
+Pre-flight check: `FeatureBuild.buildId` must be `@unique` for the FK below to validate. Verify with `rg "buildId\s+String\s+@unique" packages/db/prisma/schema.prisma` before editing — it is, today, but confirm.
+
+**Coexistence note — read before editing.** `FeatureBuild` already has `sandboxId String?` and `sandboxPort Int?`. The new `Sandbox` model coexists with them for the entire transition. Slice 1 writes `Sandbox` rows additively; slice 1 does **not** touch the existing `FeatureBuild.sandboxId` / `sandboxPort` write path in `build-orchestrator.ts:737-746`. Removal of those legacy fields is gated on cleanup-reconciliation working end to end and ships in a follow-up slice with its own migration.
+
+Add near `FeatureBuild` or other Build Studio models:
+
+```prisma
+model Sandbox {
+  id                   String       @id @default(cuid())
+  buildId              String
+  providerId           String
+  agentId              String?
+  // portalInstanceId is nullable in slice 1: the cleanup-reconciliation slice
+  // makes it required + adds the label-sweep reconciler. Source for the value
+  // when populated: process.env.HOSTNAME (Docker sets /etc/hostname per
+  // container) with a randomUUID() fallback persisted on first portal boot.
+  portalInstanceId     String?
+  state                String
+  startedAt            DateTime     @default(now())
+  destroyedAt          DateTime?
+  previewUrl           String?
+  capabilitiesSnapshot Json
+  featureBuild         FeatureBuild @relation(fields: [buildId], references: [buildId])
+
+  @@index([buildId])
+  @@index([state, startedAt])
+}
+```
+
+Add to `FeatureBuild`:
+
+```prisma
+sandboxes Sandbox[]
+```
+
+- [ ] **Step 2: Generate migration**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma migrate dev --name add_build_sandbox_model
+```
+
+Expected: Migration is created and applies cleanly to the local database.
+
+- [ ] **Step 3: Inspect migration for additive-only SQL**
+
+Confirm the migration only creates `Sandbox`, indexes, and foreign key. It must not alter or drop existing Build Studio tables.
+
+- [ ] **Step 4: Generate Prisma client**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma generate
+```
+
+Expected: Prisma client generation succeeds.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations
+git commit -s -m "feat(build): persist sandbox execution records"
+```
+
+### Task 7: Add Sandbox Persistence Helpers
+
+**Files:**
+- Modify: `apps/web/lib/integrate/sandbox/sandbox-db.ts`
+- Test: `apps/web/lib/integrate/sandbox/sandbox-db.test.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add tests for:
+
+- `recordSandboxStarted()` creates a `Sandbox` row with `providerId`, `buildId`, `state: "running"`, `capabilitiesSnapshot`.
+- `recordSandboxDestroyed()` sets `state: "destroyed"` and `destroyedAt`.
+- Existing sandbox DB helpers still return their previous shape.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/sandbox-db.test.ts
+```
+
+Expected: FAIL because helpers do not exist.
+
+- [ ] **Step 3: Implement helpers**
+
+Add focused helper functions to `sandbox-db.ts`:
+
+```typescript
+export async function recordSandboxStarted(input: {
+  buildId: string;
+  providerId: string;
+  agentId?: string | null;
+  portalInstanceId: string;
+  previewUrl?: string | null;
+  capabilitiesSnapshot: unknown;
+}) { /* prisma.sandbox.create(...) */ }
+
+export async function recordSandboxDestroyed(id: string) { /* prisma.sandbox.update(...) */ }
+```
+
+Keep existing exported functions untouched unless the tests require small compatibility adaptation.
+
+- [ ] **Step 4: Run helper tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/sandbox-db.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/integrate/sandbox/sandbox-db.ts apps/web/lib/integrate/sandbox/sandbox-db.test.ts
+git commit -s -m "feat(build): record sandbox lifecycle rows"
+```
+
+## Chunk 4: Orchestrator Entry Point
+
+### Task 8: Add Build Orchestrator Selection Boundary
+
+**Files:**
+- Modify: `apps/web/lib/integrate/build-orchestrator.ts`
+- Test: `apps/web/lib/integrate/build-orchestrator.test.ts`
+
+**Spec-divergence note.** The owning spec defines `runAgentCommand(provider, agent, handle, spec)`. This plan adds the friendlier `runBuildAgentTask({...})` form on top of an internal `runAgentCommand(provider, agent, handle, spec)` so external callers don't have to resolve provider + agent themselves. The internal form matches the spec verbatim. Task 10 reconciles the spec.
+
+- [ ] **Step 1: Write failing orchestrator tests**
+
+Add tests proving:
+
+- Default provider resolves to `local-docker`.
+- Default agent resolves from `getBuildStudioConfig().provider` (Codex when `"codex"`, Claude when `"claude"`); legacy `"agentic"` config falls back to Codex.
+- Incompatible provider/runner pairs throw before dispatch (unit-tested via the cross-axis matrix from Task 5).
+- Successful dispatch returns `providerId` and `agentId` on `AgentRunResult`.
+- The friendly `runBuildAgentTask({...})` and the internal `runAgentCommand(...)` produce identical results for the same inputs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/build-orchestrator.test.ts
+```
+
+Expected: FAIL because orchestrator selection boundary does not exist.
+
+- [ ] **Step 3: Implement narrow orchestration entrypoint**
+
+Add both shapes:
+
+```typescript
+// Spec-shape internal entrypoint
+export async function runAgentCommand(
+  provider: BuildExecutionProvider,
+  agent: BuildAgentRunner,
+  handle: SandboxHandle,
+  spec: AgentRunSpec,
+): Promise<AgentRunResult> {
+  assertAgentProviderCompatibility(agent.capabilities(), provider.capabilities());
+  // No prepare() in slice 1 — the wrappers carry their own auth injection.
+  // Slice 2 introduces explicit prepare() ahead of run().
+  return agent.run(provider, handle, spec);
+}
+
+// Friendly external entrypoint
+export async function runBuildAgentTask(input: {
+  buildId: string;
+  agentId?: BuildAgentId;
+  providerId?: BuildExecutionProviderId;
+  prompt?: string;
+  timeoutMs?: number;
+}): Promise<AgentRunResult> {
+  const provider = getBuildExecutionProvider(input.providerId ?? "local-docker");
+  const runner = getBuildAgentRunner(input.agentId ?? "codex");
+  const handle = await provider.createSandbox({ buildId: input.buildId });
+  return runAgentCommand(provider, runner, handle, {
+    prompt: input.prompt,
+    timeoutMs: input.timeoutMs,
+  });
+}
+```
+
+This task creates the tested boundary. Task 9 wires the production call site through it.
+
+- [ ] **Step 4: Run orchestrator tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/build-orchestrator.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/integrate/build-orchestrator.ts apps/web/lib/integrate/build-orchestrator.test.ts
+git commit -s -m "feat(build): add provider runner orchestrator"
+```
+
+### Task 9: Route the CLI Dispatch Path Through the Orchestrator (slice gate)
+
+**Files:**
+- Modify: `apps/web/lib/integrate/build-orchestrator.ts` (`dispatchSpecialist`, lines 546-601)
+- Test: extend `apps/web/lib/integrate/build-orchestrator.test.ts`
+
+This task is the **gate for the slice**. Without it, `runBuildAgentTask` exists but nothing in production calls it, the boundary enforces nothing, and "no behavior change" is true only because the boundary is dead code. Specify the call site rather than searching for it.
+
+- [ ] **Step 1: Identify the call site (already known)**
+
+The decision point is `dispatchSpecialist()` in `apps/web/lib/integrate/build-orchestrator.ts:546-601`. The CLI branch is lines 569-601:
+
+```typescript
+if (config.provider === "codex" || config.provider === "claude") {
+  const cliResult = config.provider === "claude"
+    ? await dispatchClaudeTask({ ... })
+    : await dispatchCodexTask({ ... });
+  // ...
+}
+```
+
+This is the production code path that needs to route through the new boundary.
+
+- [ ] **Step 2: Write failing integration test**
+
+In `build-orchestrator.test.ts`, add a test that asserts the CLI branch resolves a runner via `getBuildAgentRunner()` (mockable) and a provider via `getBuildExecutionProvider()` (mockable) before dispatching, and that incompatible (provider × agent) pairs surface as a typed error before the dispatcher runs. Existing behavior tests for `dispatchSpecialist` must continue to pass.
+
+- [ ] **Step 3: Route the CLI branch through `runAgentCommand`**
+
+Replace the `if (config.provider === "codex" || config.provider === "claude") { ... }` block (build-orchestrator.ts:569-601) with a call into `runAgentCommand(provider, runner, handle, spec)`. The runner wrappers (Tasks 3–4) already proxy to `dispatchCodexTask` / `dispatchClaudeTask` verbatim, so the actual sandbox execution behavior is byte-identical.
+
+Implementation rules:
+
+- Preserve existing provider selection behavior (read from `getBuildStudioConfig()`).
+- Preserve existing prompt construction (the wrappers reuse the existing dispatchers verbatim).
+- Preserve existing error messages and `classifyOutcome` mapping.
+- The agentic-loop fallback branch (lines 603+) is **not** rewired in slice 1; it stays as-is. A separate slice handles agentic-loop ↔ runner unification.
+- **`routeContext.build.{providerId,agentId}` attribution is not landed in slice 1.** `ToolExecution` rows are written by `mcp-tools.ts` / `agent-grants.ts` — not by the dispatchers — so threading attribution is a cross-cutting change that belongs in its own slice. Add a `// TODO(slice-N-routecontext-build-attribution)` next to the `runAgentCommand` call site documenting the gap. Do not invent a partial attribution path.
+
+- [ ] **Step 4: Run affected tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/build-orchestrator.test.ts
+```
+
+Expected: PASS, including pre-existing tests in this file.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add apps/web/lib/integrate/build-orchestrator.ts apps/web/lib/integrate/build-orchestrator.test.ts
+git commit -s -m "refactor(build): dispatch cli branch through provider runner boundary"
+```
+
+If the pre-commit typecheck hook fails, fix the underlying type error and re-stage. Do not bypass with `DPF_SKIP_TYPECHECK=1` — the hook exists because TS errors only surface in `next build` and CI.
+
+## Chunk 5: Verification And Documentation
+
+### Task 10: Update Spec Cross-References If Needed
+
+**Files:**
+- Modify only if needed: `docs/superpowers/specs/2026-05-09-build-execution-provider-design.md`
+- Modify only if needed: `docs/superpowers/specs/2026-05-09-deployment-contracts.md`
+
+- [ ] **Step 1: Check whether implementation names differ from spec names**
+
+Run:
+
+```powershell
+rg -n "BuildExecutionProvider|BuildAgentRunner|Sandbox model|routeContext.build|local-docker" docs/superpowers/specs/2026-05-09-build-execution-provider-design.md docs/superpowers/specs/2026-05-09-deployment-contracts.md
+```
+
+Known divergences this slice introduces (patch the spec to acknowledge each):
+
+1. **Function names.** Spec defines `runAgentCommand(provider, agent, handle, spec)` only. Plan keeps that as the internal entrypoint and adds a friendlier `runBuildAgentTask({ buildId, agentId?, providerId?, ... })` wrapper. Document both.
+2. **Test paths.** Spec lists tests under `apps/web/__tests__/`. Plan colocates tests with code under `lib/integrate/sandbox/` to match repo convention (every other module here colocates `.test.ts` files). Update spec to match repo convention.
+3. **`Sandbox.portalInstanceId` nullability.** Spec marks the field non-null. Slice 1 marks it nullable because the cleanup-reconciliation slice owns the populator; remove the non-null commitment from the spec until that slice ships.
+4. **`Sandbox` ↔ `FeatureBuild.sandboxId` coexistence.** Spec says "additive only" and "transition where both write paths run; the old path is removed once reconciliation is verified" — plan implements that literally; spec should explicitly enumerate the transition deliverables (which slice removes the legacy fields, what reconciliation evidence gates removal).
+5. **Local-docker substrate semantics.** Spec implies per-build `createSandbox`. Slice 1 implementation reflects the actual pooled-singleton reality (`sandbox-pool.ts`); spec should annotate that the local-docker provider currently delegates to the pool rather than creating per-build containers, and point at the slice that introduces per-build lifecycle.
+6. **Capabilities shape.** `cleanupModel: "label-sweep"` (not `"explicit"`) for local-docker, because the pool reaps; explicit destroy by the orchestrator would corrupt pool state. Update the per-deployment-target matrix narrative if it implies otherwise.
+7. **`routeContext.build.{providerId,agentId}` attribution.** Spec lists this as part of the substrate × agent extraction. Plan defers it to its own slice (the dispatchers don't write `ToolExecution` rows; mcp-tools.ts does). Update the spec sequencing to call this out as its own slice.
+
+- [ ] **Step 2: Patch docs only for drift**
+
+For each divergence above, either adjust code to match the spec or update the spec with the final names / shape. Default = update the spec; the spec is still draft and the implementation reflects ground truth. Strong-reason exceptions:
+
+- If chief architect rules that any divergence above is an architectural mistake (not just a slice scope choice), file a follow-up and revise the plan rather than the spec.
+
+- [ ] **Step 3: Commit docs if changed**
+
+```powershell
+git add docs/superpowers/specs/2026-05-09-build-execution-provider-design.md docs/superpowers/specs/2026-05-09-deployment-contracts.md
+git commit -s -m "docs(build): align provider runner implementation notes"
+```
+
+### Task 11: Final Verification
+
+**Files:**
+- No source edits expected.
+
+- [ ] **Step 1: Run focused tests**
+
+```powershell
+pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts lib/integrate/sandbox/agent-runner-contract.test.ts lib/integrate/sandbox/build-substrate-agent-matrix.test.ts lib/integrate/build-orchestrator.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Prisma validation**
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run production build**
+
+```powershell
+pnpm --filter web exec next build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual Build Studio smoke check**
+
+Against the Docker-served app (the install's configured `AUTH_URL`/`APP_URL`, **not** a stale `next dev` session — see AGENTS.md §13), log in with `admin@dpf.local` and the repo-root `ADMIN_PASSWORD`, then:
+
+1. Open `/platform/ai/build-studio`.
+2. Confirm the Build Studio config page renders and the Codex / Claude provider toggle still works.
+3. Start or inspect a Build Studio effort that reaches task dispatch under both Codex and Claude (one each — switch the provider mid-test). Confirm both still dispatch into the same `dpf-sandbox-1` container.
+4. Confirm no user-visible regression in sandbox startup, progress messages, or dispatch error messages.
+5. Confirm `/platform/ai/authority` still shows `ToolExecution` records for the dispatch (attribution shape unchanged in slice 1; `routeContext.build.{providerId,agentId}` lands in a follow-up).
+6. **Build Studio mirror gate (AGENTS.md §5).** Confirm the QA-engineer specialist still runs `tsc --noEmit` and reports the result through `parseQAVerification`. Build-Studio-produced PRs must continue to satisfy CI typecheck — slice 1 must not weaken this.
+7. Confirm `Sandbox` rows are written for the new dispatch (query Postgres directly: `SELECT id, "buildId", "providerId", "agentId", state FROM "Sandbox" ORDER BY "startedAt" DESC LIMIT 5;`). Existing `FeatureBuild.sandboxId` / `sandboxPort` rows must continue to be written too — slice 1 is dual-write.
+
+- [ ] **Step 6: Commit any final fixes**
+
+```powershell
+git status --short
+git add <only-intended-files>
+git commit -s -m "fix(build): stabilize provider runner extraction"
+```
+
+### Task 12: Push And PR
+
+**Files:**
+- No source edits expected.
+
+- [ ] **Step 1: Confirm branch guard**
+
+```powershell
+git branch --show-current
+```
+
+Expected: not `main`.
+
+- [ ] **Step 2: Show final diff summary**
+
+```powershell
+git status --short
+git diff --stat origin/main...HEAD
+```
+
+- [ ] **Step 3: Push**
+
+```powershell
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 4: Open draft PR**
+
+Title:
+
+```text
+refactor(build): extract provider and agent runner boundaries
+```
+
+PR body:
+
+```markdown
+## Summary
+- Adds BuildExecutionProvider and BuildAgentRunner contract boundaries.
+- Wraps current local-Docker sandbox and Codex/Claude dispatch behavior without changing runtime behavior.
+- Adds additive Sandbox persistence foundation and contract tests.
+
+## Test plan
+- pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts lib/integrate/sandbox/agent-runner-contract.test.ts lib/integrate/sandbox/build-substrate-agent-matrix.test.ts lib/integrate/build-orchestrator.test.ts
+- pnpm --filter web typecheck
+- pnpm --filter @dpf/db exec prisma validate
+- pnpm --filter web exec next build
+- Manual Build Studio smoke check
+```
+
+## Follow-Up Plans
+
+Create separate plans after this slice lands. The first three resolve the deliberate slice-1 deferrals; the rest are spec sequencing.
+
+1. **Slice 2 — thread I/O through `provider.exec()`.** Refactor `dispatchCodexTask` and `dispatchClaudeTask` to call `provider.exec(handle, [...])` instead of `docker exec ${SANDBOX_CONTAINER}` directly. Removes the `TODO(slice-2-thread-provider-exec)` shim, makes the boundary load-bearing for substrate substitution. Behavior-impacting; needs its own no-regression smoke gate.
+2. **Slice 3 — `routeContext.build.{providerId,agentId}` attribution.** Add `providerId` and `agentId` to every `ToolExecution.routeContext.build` write site in `mcp-tools.ts` and `agent-grants.ts`. Cross-cutting — needs its own slice.
+3. **Slice 4 — per-build sandbox lifecycle + cleanup reconciliation.** Replace pooled-singleton with per-build `createSandbox` / `destroySandbox`. Populate `Sandbox.portalInstanceId` from `process.env.HOSTNAME`. Land the startup sweep + periodic reconciler. Remove `FeatureBuild.sandboxId` / `sandboxPort` once reconciliation is verified.
+4. `dpf-native` Tier 1 runner using `LLM_BASE_URL` and the portal audit envelope (per spec §"dpf-native cutover gates").
+5. Kubernetes or TAPPaaS provider, depending on substrate priority (per spec sequencing step 4).
+6. Image variant split (`base` / `dpf-native` / `cli-bundled`) — `Dockerfile.sandbox` matrix + image-publish workflow.
+7. Portal self-update pipeline: git update intake, sandbox verification, `ChangePromotion`, promoter execution, and Updates UI.

--- a/docs/superpowers/specs/2026-05-09-build-execution-provider-design.md
+++ b/docs/superpowers/specs/2026-05-09-build-execution-provider-design.md
@@ -1,15 +1,28 @@
-# Build Execution Provider Architecture (DRAFT / RESEARCH)
+# Build Execution Provider + Agent Runner Architecture (DRAFT / RESEARCH)
 
 > Status: **research stub** — not yet a finalized spec. Per AGENTS.md §10
 > this needs full "Research & Benchmarking" before finalization.
 >
 > **Doctrine reference:** this spec is the canonical implementation
 > of contract 6 (build execution) from
-> `docs/superpowers/specs/2026-05-09-deployment-contracts.md`.
+> `docs/superpowers/specs/2026-05-09-deployment-contracts.md`. Where
+> doctrine owns shared rules (Contract 9 envvars, per-deployment
+> defaults), this spec **references** rather than restates.
 >
 > Purpose: stop scattering Build Studio caveats across every
-> deployment spec by isolating the hardest shared concern — sandbox
-> lifecycle — behind a provider abstraction.
+> deployment spec by isolating the two hardest shared concerns —
+> sandbox lifecycle and agent execution — behind two orthogonal
+> abstractions.
+>
+> **2026-05-10 revision (chief-architect review):** the prior draft
+> conflated substrate (where the sandbox runs) with agent (what runs
+> inside the sandbox) into one `BuildExecutionProviderImpl`. This
+> revision splits them into `BuildExecutionProvider` (substrate) and
+> `BuildAgentRunner` (agent), and introduces a first-class
+> `dpf-native` agent so Build Studio can ship on every substrate
+> without depending on bundled vendor CLIs (Codex, Claude Code) or
+> their port 1455 OAuth callbacks. See "What changed in 2026-05-10
+> revision" below for the rationale and migration sketch.
 
 ## Why this exists
 
@@ -37,291 +50,498 @@ TAPPaaS native (NixOS/Podman) packaging. Continuing to special-case
 Build Studio per substrate would scatter the same logic across five+
 deployment specs and guarantee drift.
 
-The fix: make Build Studio consume a `BuildExecutionProvider`
-interface. Each substrate / packaging target wires in the
-appropriate provider implementation. The sandbox image stays the
-same; the lifecycle layer becomes substrate-aware behind an
-interface.
+In parallel, today's agent dispatchers
+(`apps/web/lib/integrate/codex-dispatch.ts`,
+`apps/web/lib/integrate/claude-dispatch.ts`) shell out to `docker
+exec ${SANDBOX_CONTAINER}` to invoke vendor CLIs (`@openai/codex`,
+`@anthropic-ai/claude-code`) bundled in `Dockerfile.sandbox:6,9`.
+These calls **bypass DPF's `LLM_BASE_URL` audit envelope** (Contract
+9 mode 4) and rely on port 1455 for Codex's OAuth callback —
+constraints that scatter further per substrate.
 
-## Current implementation as the `local-docker` provider
+The fix is two orthogonal abstractions:
+
+1. **`BuildExecutionProvider`** — substrate primitive. Each
+   substrate (local Docker, k8s, ECS, Cloud Run Service, Azure
+   Container Apps, TAPPaaS VM) implements one provider. The
+   provider owns sandbox lifecycle and a generic `exec` primitive.
+2. **`BuildAgentRunner`** — agent above the substrate. Each agent
+   (Codex CLI, Claude Code CLI, dpf-native) implements one runner.
+   The runner orchestrates a build task using the provider's `exec`
+   primitive plus its own credential / loop / IO discipline.
+
+The substrate × agent matrix becomes orthogonal: ship one new
+provider for a new substrate; ship one new agent for a new build
+strategy. No N×M reimplementation. This is the GitHub Actions /
+GitLab Runner / Buildkite separation: executor (substrate) vs
+work definition (orchestrator).
+
+## What changed in 2026-05-10 revision
+
+The prior draft fused substrate and agent into one interface, with
+the rationale that "without this in the provider interface, every
+non-`local-docker` provider would have to reimplement the dispatch
+logic." That argument is backwards: the agent dispatch logic varies
+by **agent** (Codex's `~/.codex/auth.json` shape, Claude Code's
+OAuth mount, dpf-native's in-process loop), not by **substrate**.
+Every substrate already needs a generic `exec(handle, command[]) →
+ExecResult` primitive — that's all Codex and Claude need. Agent
+runners live one layer above.
+
+Splitting matters because of the install-mode unlock. The prior
+draft marked Build Studio **Unsupported** on Managed Container
+Service substrates (ECS Fargate, Cloud Run, Azure Container Apps)
+because port 1455 (Codex OAuth callback) can't be exposed there.
+Add a `dpf-native` agent that uses Contract 9 mode 1 (`LLM_BASE_URL`
+inference) instead of bundled vendor CLIs, and every substrate
+becomes Build-Studio-capable with no port 1455 lock-in, no in-
+sandbox refresh tokens, no mode-4 audit gap. That's the largest
+strategic payoff of doing this abstraction right.
+
+The `dpf-native` agent is also the path to closing Contract 9's
+mode-4 compliance gap (line 245–259 of the doctrine spec): air-
+gapped, regulated, and FedRAMP customers can run Build Studio
+without bundled vendor CLIs and without vendor egress.
+
+## Current implementation as the `local-docker` provider × CLI runners
 
 The existing code in
-`apps/web/lib/integrate/sandbox/sandbox.ts` and
-`apps/web/lib/mcp-tools.ts:1025-1162` is the reference behavior. In
-this taxonomy it becomes the `local-docker` provider implementation.
-The refactor extracts the existing logic behind a stable interface
-without behavior change for current Windows / macOS / Linux installs.
+`apps/web/lib/integrate/sandbox/sandbox.ts` (444 LOC),
+`apps/web/lib/mcp-tools.ts:1025-1162`,
+`apps/web/lib/integrate/codex-dispatch.ts` (316 LOC), and
+`apps/web/lib/integrate/claude-dispatch.ts` (368 LOC) is the
+reference behavior. In this taxonomy:
 
-## The provider interface (proposed)
+- `sandbox.ts` + the sandbox MCP tools become the `local-docker`
+  provider implementation.
+- `codex-dispatch.ts` becomes the `codex` agent runner.
+- `claude-dispatch.ts` becomes the `claude` agent runner.
 
-The provider abstraction owns **two responsibilities**, not one:
+The refactor extracts the existing logic behind two stable
+interfaces without behavior change for current Windows / macOS /
+Linux installs. Today's behavior == `local-docker` × {`codex`,
+`claude`}.
 
-1. **Sandbox lifecycle** — create, start, copy files in/out,
-   launch the dev server, exec arbitrary commands, destroy. This
-   is what `apps/web/lib/integrate/sandbox/sandbox.ts` does today.
-2. **Agent command execution** — dispatch CLI agents (Codex,
-   Claude Code) into the sandbox with credentials injected. This
-   is what `apps/web/lib/integrate/codex-dispatch.ts` and
-   `apps/web/lib/integrate/claude-dispatch.ts` do today; both
-   shell out to `docker exec ${SANDBOX_CONTAINER}`. Without this
-   in the provider interface, every non-`local-docker` provider
-   would have to reimplement the dispatch logic — exactly the
-   per-substrate scatter the abstraction exists to prevent.
+## The two interfaces (proposed)
+
+### `BuildExecutionProvider` — substrate primitive
 
 ```typescript
-type BuildExecutionProvider =
+type BuildExecutionProviderId =
   | "local-docker"
   | "tappaas-vm"
   | "kubernetes-job"
-  | "ecs-task"
-  | "cloud-run-job"
+  | "ecs-task"          // batch; no preview URL
+  | "ecs-service"       // long-running; preview URL via ALB
+  | "cloud-run-job"     // batch; no preview URL
+  | "cloud-run-service" // long-running; preview URL via Cloud Run frontend
   | "azure-containerapp-job"
+  | "edge-node-local-docker"   // see Open Questions
   | "disabled";
 
-type SandboxAgent = "codex" | "claude";
+interface BuildExecutionProvider {
+  readonly id: BuildExecutionProviderId;
 
-interface AgentCommandSpec {
+  // Sandbox lifecycle
+  createSandbox(spec: SandboxSpec): Promise<SandboxHandle>;
+  startSandbox(handle: SandboxHandle): Promise<void>;
+  destroySandbox(handle: SandboxHandle): Promise<void>;
+
+  // The substrate primitive every agent runner uses
+  exec(handle: SandboxHandle, command: string[], opts?: ExecOpts): Promise<ExecResult>;
+
+  // File IO — required for build artifact transport
+  readFile(handle: SandboxHandle, path: string): Promise<string>;
+  writeFile(handle: SandboxHandle, path: string, content: string): Promise<void>;
+  copyAppsWebInto(handle: SandboxHandle, source: string): Promise<void>;
+
+  // Optional preview surface — null when substrate can't host a
+  // long-running HTTP server (cloud-run-job, ecs-task, etc.)
+  getPreviewUrl(handle: SandboxHandle): Promise<string | null>;
+  launchNextDev(handle: SandboxHandle): Promise<void>;
+
+  capabilities(): BuildExecutionProviderCapabilities;
+}
+
+type BuildExecutionProviderCapabilities = {
+  // Isolation class — host boundary protecting against untrusted code.
+  isolation: "none" | "container" | "pod" | "vm" | "managed-job";
+
+  // Trust level — what code the Authority Core may route here.
+  trustLevel: "trusted-code-only" | "customer-trusted" | "untrusted-ok";
+
+  // Workspace persistence between exec calls.
+  workspacePersistence: "ephemeral" | "ttl" | "durable";
+
+  // Log destination contract.
+  logSink: "authority-core" | "external-required" | "provider-native";
+
+  // Network model.
+  networkPolicy: "host" | "namespaced" | "isolated";
+
+  // Cleanup model. See "Cleanup mechanism" below.
+  cleanupModel: "explicit" | "ttl" | "label-sweep";
+
+  // Surface support.
+  supportsPreviewUrl: boolean;          // false ⇒ getPreviewUrl returns null
+  supportsPortCallbacks: boolean;       // arbitrary host-reachable port mappings (e.g. 1455)
+  supportsFileCopy: boolean;            // copyAppsWebInto + readFile + writeFile
+  supportsSnapshot: boolean;            // capture sandbox snapshot for resume / replay
+  dockerInsideSandbox: boolean;         // can the sandbox run docker (most can't)
+
+  // Concurrency advertisement.
+  maxConcurrentSandboxes?: number;
+};
+```
+
+### `BuildAgentRunner` — agent above the substrate
+
+```typescript
+type BuildAgentId = "codex" | "claude" | "dpf-native";
+
+interface BuildAgentRunner {
+  readonly id: BuildAgentId;
+
+  // Idempotent setup — inject auth.json, mount OAuth state, no-op
+  // for dpf-native (which uses portal-side credentials).
+  prepare(
+    provider: BuildExecutionProvider,
+    handle: SandboxHandle,
+    credential: AgentCredential | null,
+  ): Promise<void>;
+
+  // Run a single build task to completion.
+  run(
+    provider: BuildExecutionProvider,
+    handle: SandboxHandle,
+    spec: AgentRunSpec,
+  ): Promise<AgentRunResult>;
+
+  capabilities(): BuildAgentRunnerCapabilities;
+}
+
+type BuildAgentRunnerCapabilities = {
+  // Tier of work this agent reliably handles. Build Studio's
+  // task router picks an agent whose tier matches the task class.
+  // Promotion between tiers is gated by eval pass rate vs the
+  // current default — see "dpf-native cutover gates" below.
+  tier: "single-file-edit" | "multi-file-refactor" | "full-spec-implement";
+
+  // True if the agent is an interactive REPL that requires the
+  // sandbox to persist between exec calls. Codex CLI and Claude
+  // Code CLI today are true. dpf-native is false (portal-side loop;
+  // sandbox calls are stateless).
+  requiresPersistentSession: boolean;
+
+  // If the agent needs a callback port (Codex needs 1455 for OAuth),
+  // declare it here so the orchestrator can reject incompatible
+  // substrates at install time, not at first use.
+  requiresCallbackPort?: number;
+
+  // Whether this agent consumes credentials at all (dpf-native does
+  // not — it routes through the portal's existing inference layer
+  // and the credentials live in DPF's encrypted credentials store).
+  requiresCredential: boolean;
+
+  // Honors LLM_BASE_URL contract (Contract 9 mode 1). True for
+  // dpf-native; false for codex/claude (mode 4). Authority Core
+  // uses this to enforce air-gapped / regulated install policy.
+  honorsLlmBaseUrl: boolean;
+};
+
+type AgentRunSpec = {
   prompt?: string;
   workspaceSubdir?: string;
   timeoutMs?: number;
   approvalPolicy?: "never" | "ask";   // default "never" for autonomous
-  sandboxMode?: "danger-full-access" | "restricted";
+  toolGrants?: string[];               // for dpf-native: which MCP tools the loop may call
   envOverrides?: Record<string, string>;
-}
+};
 
-interface AgentRunResult {
+type AgentRunResult = {
   exitCode: number;
   stdout: string;
   stderr: string;
   durationMs: number;
-  toolExecutionId: string;            // linkage to ToolExecution audit row
-}
+  toolExecutionId: string;             // linkage to ToolExecution audit row
+  agentId: BuildAgentId;               // for routeContext attribution
+  providerId: BuildExecutionProviderId;
+};
 
-interface AgentCredential {
-  agent: SandboxAgent;
-  type: "oauth" | "api-key";
-  payload: Record<string, string>;    // never logged; written via injectAgentCredential
-}
-
-interface BuildExecutionProviderImpl {
-  // Sandbox lifecycle — what the existing docker-cli layer abstracts today
-  createSandbox(spec: SandboxSpec): Promise<SandboxHandle>;
-  startSandbox(handle: SandboxHandle): Promise<void>;
-  copyAppsWebInto(handle: SandboxHandle, source: string): Promise<void>;
-  launchNextDev(handle: SandboxHandle): Promise<void>;
-  exec(handle: SandboxHandle, command: string[]): Promise<ExecResult>;
-  readFile(handle: SandboxHandle, path: string): Promise<string>;
-  writeFile(handle: SandboxHandle, path: string, content: string): Promise<void>;
-  destroySandbox(handle: SandboxHandle): Promise<void>;
-
-  // Agent command execution — owns Codex / Claude dispatch so
-  // non-local-docker providers don't reimplement docker exec.
-  injectAgentCredential(handle: SandboxHandle, credential: AgentCredential): Promise<void>;
-  runAgentCommand(handle: SandboxHandle, agent: SandboxAgent, spec: AgentCommandSpec): Promise<AgentRunResult>;
-  getPreviewUrl(handle: SandboxHandle): Promise<string>;
-
-  // Capability advertisement — Authority Core uses this to decide
-  // which Build Studio features to enable for this deployment.
-  capabilities(): BuildExecutionProviderCapabilities;
-}
-
-// Capability metadata Authority Core uses for routing, policy
-// enforcement, and UI gating. Pattern borrowed from CI runner
-// frameworks (GitHub Actions Runner Controller, GitLab Runner,
-// Drone, Buildkite) — explicit trust levels, isolation classes,
-// log-sink contracts, and concurrency bounds, advertised by the
-// provider rather than implicit per substrate.
-type BuildExecutionProviderCapabilities = {
-  // Isolation class — what kind of boundary protects the host
-  // from untrusted sandbox code.
-  //   none         — direct on-host execution; never use for
-  //                  untrusted code.
-  //   container    — namespaced container (today's local-docker).
-  //   pod          — Kubernetes pod (kubernetes-job provider).
-  //   vm           — full VM (e.g. tappaas-vm; firecracker / kata).
-  //   managed-job  — substrate-managed ephemeral job
-  //                  (ecs-task / cloud-run-job /
-  //                  azure-containerapp-job).
-  isolation: "none" | "container" | "pod" | "vm" | "managed-job";
-
-  // Trust level — policy gate for what kinds of work the
-  // Authority Core may route to this provider. Per GitLab's
-  // Shell-executor warning and Drone's Exec-runner warning.
-  //   trusted-code-only — Build Studio can run vetted DPF agent
-  //                       code only; never customer-supplied code.
-  //                       Today's local-docker on the DPF host
-  //                       falls here unless the host is hardened.
-  //   customer-trusted  — provider runs in customer's own
-  //                       environment with isolation; OK for
-  //                       customer-supplied code from the
-  //                       customer's own users.
-  //   untrusted-ok      — strong isolation (vm or managed-job)
-  //                       suitable for arbitrary external code.
-  trustLevel: "trusted-code-only" | "customer-trusted" | "untrusted-ok";
-
-  // Workspace persistence between sandbox exec calls.
-  //   ephemeral — destroyed at end of run; used for short-lived
-  //               "run a command and exit" providers
-  //               (cloud-run-job, ecs-task).
-  //   ttl       — survives until TTL expiry; used by
-  //               kubernetes-job with pod TTL.
-  //   durable   — long-lived between many exec calls; today's
-  //               local-docker.
-  workspacePersistence: "ephemeral" | "ttl" | "durable";
-
-  // Log destination contract. GitHub recommends ephemeral runners
-  // forward logs externally because the runner is destroyed.
-  //   authority-core    — provider streams logs to Authority Core
-  //                       via existing audit envelope.
-  //   external-required — provider can't retain logs after job;
-  //                       Authority Core MUST attach an external
-  //                       sink (CloudWatch, Stackdriver, GELF) or
-  //                       refuse to mark this provider production-
-  //                       capable.
-  //   provider-native   — substrate-native logs (e.g. Cloud Run
-  //                       logs); Authority Core links rather than
-  //                       streams.
-  logSink: "authority-core" | "external-required" | "provider-native";
-
-  // Existing flags retained for backward compatibility with the
-  // earlier capabilities() shape.
-  persistentSandbox: boolean;          // shorthand for workspacePersistence === "durable"
-  dockerInsideSandbox: boolean;        // can run docker from within (most don't)
-  networkPolicy: "host" | "namespaced" | "isolated";
-  cleanupModel: "explicit" | "ttl";
-
-  // Sandbox feature support. Authority Core's Build Studio UI
-  // disables features the active provider can't deliver.
-  supportsCliAgents: {                  // which CLI agents this provider supports
-    codex: boolean;
-    claudeCode: boolean;
-    codexCallbackPort1455: boolean;     // can the substrate expose port 1455?
-  };
-  supportsPortCallbacks: boolean;       // arbitrary host-reachable port mappings
-  supportsPreviewUrl: boolean;          // getPreviewUrl returns a usable URL
-  supportsFileCopy: boolean;            // copyAppsWebInto + readFile + writeFile
-  supportsSnapshot: boolean;            // can capture a sandbox snapshot for
-                                        // resume / replay (TAPPaaS VM mode, e.g.)
-
-  // Concurrency advertisement. Authority Core enforces per-policy.
-  maxConcurrentSandboxes?: number;      // omitted == unbounded subject to host
+type AgentCredential = {
+  agent: BuildAgentId;
+  type: "oauth" | "api-key" | "none";
+  payload: Record<string, string>;     // never logged; written via prepare()
 };
 ```
 
-The contract test (`apps/web/__tests__/sandbox-provider-contract.test.ts`,
-introduced when this provider abstraction lands) asserts these
-**semantics**, not just that the methods are callable. Specifically:
+### Orchestrator
 
-- a provider claiming `trustLevel: "untrusted-ok"` must also claim
-  `isolation: "vm"` or `"managed-job"` — the test fails on
-  `"container"` because container isolation is not strong enough
-  for arbitrary external code.
-- a provider claiming `logSink: "authority-core"` must actually
-  emit log events to `ToolExecution`; the test asserts a known
-  log line appears.
-- a provider claiming `workspacePersistence: "ephemeral"` must NOT
-  claim `persistentSandbox: true`.
-- a provider claiming `supportsCliAgents.codex: true` but
-  `supportsCliAgents.codexCallbackPort1455: false` must reject Codex
-  CLI calls that require OAuth (only the API-key flow is supportable).
+```typescript
+// Top-level entrypoint. Lives at apps/web/lib/integrate/build-orchestrator.ts
+// (see "Authority Core enforcement point" below).
+async function runAgentCommand(
+  provider: BuildExecutionProvider,
+  agent: BuildAgentRunner,
+  handle: SandboxHandle,
+  spec: AgentRunSpec,
+): Promise<AgentRunResult>;
+```
 
-These are the runner-playbook lessons made enforceable so a future
-provider can't quietly weaken trust or log guarantees by setting
-booleans.
+The orchestrator:
 
-`SandboxSpec`, `SandboxHandle`, `ExecResult` shapes inherit from the
-current implementation. `AgentCommandSpec` / `AgentRunResult` /
-`AgentCredential` are new shapes the agent-execution refactor
-introduces. Selection is configured at install time (contract 2 of
-the deployment doctrine: runtime configuration) via an env var like
-`DPF_BUILD_PROVIDER=<provider>` plus provider-specific config
-(cluster name, namespace, IAM role, etc.).
+1. Validates **cross-axis invariants** (substrate × agent) before
+   creating the sandbox; rejects incompatible combinations at
+   install time.
+2. Calls `agent.prepare(provider, handle, credential)`.
+3. Calls `agent.run(provider, handle, spec)`.
+4. Emits the unified audit envelope (`ToolExecution` row with
+   `routeContext.providerId` and `routeContext.agentId`).
+
+`SandboxSpec`, `SandboxHandle`, `ExecResult`, `ExecOpts` shapes
+inherit from the current implementation. Selection is configured at
+install time (Contract 2: runtime configuration) via
+`DPF_BUILD_PROVIDER=<provider>` and `DPF_BUILD_AGENT_DEFAULT=<agent>`
+plus provider/agent-specific config.
 
 `getPreviewUrl(handle)` returns the URL where the sandbox's Next.js
-dev server is reachable. `local-docker` returns `http://localhost:3035`;
-`kubernetes-job` returns the Service / Ingress URL the cluster
-allocated; `ecs-task` returns the ALB target group URL; etc. This
-lets the portal's Build Studio UI link to a preview without knowing
-which provider is in use.
+dev server is reachable, **or `null`** for substrates that can't
+host one (`cloud-run-job`, `ecs-task`, `azure-containerapp-job`).
+The portal's Build Studio UI hides the preview button when null.
 
-## Sandbox image variants and CLI agent runtime flags
+## The `dpf-native` agent
 
-The current `Dockerfile.sandbox` bundles both Codex CLI and Claude
-Code CLI unconditionally (`Dockerfile.sandbox:6,9`). For regulated
-or local-only deployments the bundle either needs runtime
-disablement or compile-time exclusion:
+`dpf-native` is the strategic default once parity gates clear. It is
+DPF's own coding agent driving the existing inference layer
+(`apps/web/lib/ai-inference.ts`) instead of a bundled vendor CLI.
 
-### Runtime flags (read by the dispatchers and by every provider)
+Architecture:
 
-```
-DPF_SANDBOX_ENABLE_CODEX=true|false              # default true
-DPF_SANDBOX_ENABLE_CLAUDE=true|false             # default true
-DPF_SANDBOX_OPENAI_BASE_URL                      # optional; redirects Codex to local OpenAI-compat endpoint
-DPF_SANDBOX_ANTHROPIC_BASE_URL                   # optional; redirects Claude Code similarly
-```
+- The agent loop runs **in the portal process** (Authority Core
+  domain), not inside the sandbox.
+- The sandbox is a **thin tool target**: `provider.exec`,
+  `provider.readFile`, `provider.writeFile` are the tools the agent
+  calls. Plus the portal's existing MCP tool surface gated by
+  `toolGrants` (per the `mcp-tools.ts` grant model).
+- All inference flows through `LLM_BASE_URL` (Contract 9 mode 1).
+  No vendor CLI binaries in the sandbox image; no in-sandbox refresh
+  token; no port 1455 callback; no mode-4 audit gap.
+- The infrastructure is already in place: `contribution-dispatch.ts`
+  runs a portal-side agentic loop and the sandbox already exposes
+  file IO. `dpf-native` is the contribution-dispatch loop pointed
+  at the sandbox as its tool target.
 
-Provider implementations that don't support a CLI agent (e.g. an
-`ecs-task` provider that can't expose port 1455 for Codex's OAuth
-callback) advertise this via `capabilities().cliAgents` and refuse
-`runAgentCommand` calls for the unsupported agent with a clear
-error rather than silently failing.
+Strategic payoffs:
 
-### Image variants (compile-time exclusion)
+- **Substrate unlock.** Every substrate becomes Build-Studio-capable
+  because the inference path is the same `LLM_BASE_URL` contract
+  that already works on every substrate. ECS Fargate, Cloud Run,
+  Azure Container Apps move from **Unsupported** to **GA** for
+  Build Studio.
+- **Compliance.** Air-gapped / FedRAMP / regulated installs can run
+  Build Studio with the local-LLM variant of Contract 9 mode 1
+  (Ollama / Docker Model Runner), with no vendor egress and no
+  bundled vendor CLI binaries.
+- **Audit envelope.** All inference calls flow through the existing
+  `LLM_BASE_URL` audit envelope. `ToolExecution` records the full
+  prompt + response per call, not just the dispatch invocation.
+- **Smaller image.** `dpf-sandbox:dpf-native` ships without
+  `@openai/codex` (~50 MB) and `@anthropic-ai/claude-code` (~40 MB)
+  — relevant for cold-start latency on cloud-native job substrates.
 
-For deployments that require the CLI binaries to be physically
-absent — air-gapped customers, supply-chain-restricted environments,
-or compliance regimes that forbid bundled vendor tooling — ship
-multiple sandbox image tags:
+Risks (offsets, not blockers):
 
-| Tag | Codex CLI | Claude Code CLI | Use case |
-|---|---|---|---|
-| `dpf-sandbox:full` (default) | yes | yes | unrestricted installs |
-| `dpf-sandbox:local-only` | yes (with `OPENAI_BASE_URL` override required) | yes (with override) | air-gapped with local-routed CLIs |
-| `dpf-sandbox:no-cli-agents` | no | no | maximum compliance posture |
+- **Portal blast radius.** A `dpf-native` bug runs in-process with
+  the portal, so could leak portal credentials. Counterbalanced by
+  no long-lived OpenAI refresh token in sandbox memory and no port
+  1455 OAuth surface. Both go on the security-review checklist.
+- **Capability tier gap.** dpf-native must reach Codex/Claude
+  parity per task class before becoming default. Cutover is
+  gated, not flipped (see below).
 
-The Dockerfile.sandbox refactor that supports this lands as part of
-this provider epic; the image-publish workflow
-(`.github/workflows/publish-image.yml`, currently the focus of
-installer-parity Phase 1) adds matrix tags accordingly.
+## dpf-native cutover gates
 
-## Per-deployment-target defaults
+The "works well enough" decision must not be vibes-based. Each tier
+is gated by an objective eval pass rate vs the current default
+(Codex on tier 1–2; Claude Code on tier 3 where applicable):
 
-| Deployment | Default provider | Build Studio parity at v1 |
+| Tier | Definition | Promotion gate |
 |---|---|---|
-| Windows local install | `local-docker` | **full** |
-| macOS local install | `local-docker` | **full** if Docker Desktop is running |
-| Linux local install | `local-docker` | **full** |
-| Single VM substrate (cloud) | `local-docker` | **full** |
-| Cloud marketplace image | `local-docker` (inherits Single VM) | **full** |
-| TAPPaaS module — VM mode | `local-docker` (inside the provisioned VM) | **full** |
-| TAPPaaS module — native NixOS/Podman | `tappaas-vm` (provider stub; future) | preview until provider ships |
-| Managed Kubernetes substrate | `kubernetes-job` | preview until provider ships |
-| Managed container service — AWS | `ecs-task` | preview until provider ships |
-| Managed container service — GCP | `cloud-run-job` | preview until provider ships |
-| Managed container service — Azure | `azure-containerapp-job` | preview until provider ships |
-| Air-gapped / regulated | `disabled` | Build Studio off by operator policy |
+| 1 — single-file edit | bounded edits inside one file | dpf-native pass rate ≥ Codex on `apps/web/__tests__/build-eval/single-file/*` AND p95 cost ≤ Codex |
+| 2 — multi-file refactor | cross-file refactors with import graph awareness | dpf-native pass rate ≥ Codex on `multi-file/*` AND p95 cost ≤ Codex |
+| 3 — full-spec implement | full ideate→design→build→ship cycles | dpf-native pass rate ≥ best-of-{Codex,Claude} on `full-spec/*` AND p95 cost ≤ best-of-{Codex,Claude} |
 
-`disabled` is a first-class option: customers in regulated
-environments can opt out of Build Studio entirely without DPF
-shipping a degraded version.
+Build Studio's task router (`apps/web/lib/integrate/build-orchestrator.ts`)
+picks the agent per-task by tier match, with explicit fallback. When
+dpf-native ≥ default on a tier's gate, dpf-native becomes the new
+default for that tier; the other agents stay shippable for customers
+who prefer them. Same machinery as the platform's existing AI routing
+applied to agents instead of models — per the "Dynamic model
+discovery" principle and Contract 9.
 
-## Provider responsibilities
+The eval suites are the gating artifact. Their structure and
+seeding are specified in the implementation plan that wraps this
+spec; the spec only fixes the **shape of the gate**, not the eval
+catalog.
 
-Each provider is responsible for:
+## Cleanup mechanism (every provider)
 
-- **Sandbox image acquisition.** Pull `dpf-sandbox` from GHCR
-  (multi-arch, per Phase 1 of the installer-parity roadmap).
-- **Resource isolation.** Memory / CPU caps consistent with the
-  current `--cpus=2 --memory=4096m` defaults.
-- **Network model.** Outbound HTTPS for CLI agents (mode 4 in the
-  cloud spec's LLM routing); ingress for the Next.js dev server's
-  port mapping; respect the substrate's network policy.
-- **Lifecycle attribution.** Sandbox creation / destruction must
-  emit audit events into `ToolExecution` so Authority Core can
-  reconstruct what was built and when.
-- **Cleanup.** Either explicit `destroySandbox()` or substrate-
-  native TTL (k8s pod TTL, ECS task auto-stop) — provider declares
-  which model it implements via `capabilities().cleanupModel`.
+Sandboxes orphaned by portal crash, network partition, or a `kill -9`
+during shutdown must be reaped. Mechanism:
+
+- **Labels.** Every sandbox is labeled at creation:
+  `dpf.build.id=<buildId>`, `dpf.build.startedAt=<iso>`,
+  `dpf.build.providerId=<providerId>`, `dpf.build.portalInstance=<instanceId>`.
+- **Startup sweep.** On portal startup, the orchestrator queries the
+  provider for sandboxes with this portal's `dpf.build.portalInstance`
+  label and reconciles against the `Sandbox` table; any sandbox not
+  in the active set is destroyed.
+- **Periodic reconciler.** A scheduled task sweeps for sandboxes
+  older than `SANDBOX_TIMEOUT_MS` regardless of `Sandbox` table
+  state, in case both portal and DB agreed something was alive but
+  the substrate disagrees.
+- **Provider responsibility.** `cleanupModel` capability advertises
+  which mechanism the substrate enforces: `explicit` (caller
+  guaranteed to call `destroySandbox`), `ttl` (substrate destroys
+  on its own clock, e.g. k8s pod TTL), or `label-sweep` (orchestrator
+  reconciles by label, mandatory fallback for `local-docker`).
+
+This is the same invariant-guard pattern as the seed-fix work; pre-
+empts the chaos-test gate in the maturity-gates checklist.
+
+## Image variants (compile-time exclusion)
+
+For deployments that require CLI binaries to be physically absent —
+air-gapped customers, supply-chain-restricted environments, or
+compliance regimes that forbid bundled vendor tooling — ship
+multiple sandbox image tags built around the **agent axis**:
+
+| Tag | Bundled agents | Use case |
+|---|---|---|
+| `dpf-sandbox:base` | none | substrate runtime + workspace only; smallest image; minimal supply chain surface |
+| `dpf-sandbox:dpf-native` | dpf-native runtime helpers | default for cloud / regulated / air-gapped installs once dpf-native is GA |
+| `dpf-sandbox:cli-bundled` | Codex CLI + Claude Code CLI | today's default; transitional |
+
+Endpoint-redirected variants (Codex with `OPENAI_BASE_URL` pointed
+at a local OpenAI-compatible endpoint; Claude Code analogously) are
+**runtime envvars** on `cli-bundled`, not separate image tags. See
+Contract 9 sub-contract for the envvar names — restated nowhere else.
+
+The `Dockerfile.sandbox` refactor that supports this lands as part
+of this provider epic; the image-publish workflow
+(`.github/workflows/publish-image.yml`) adds matrix tags accordingly.
+
+## Runtime envvars (Contract 9 reference)
+
+CLI agent enable/disable, endpoint redirection, and OAuth callback
+port pinning are owned by Contract 9 in the doctrine spec
+(`docs/superpowers/specs/2026-05-09-deployment-contracts.md:340-353`).
+This spec **does not restate them**. Provider implementations read
+those envvars; agent runners read them; both reject configurations
+that violate cross-axis invariants (see contract test below).
+
+New envvars introduced by this spec:
+
+```
+DPF_BUILD_PROVIDER=local-docker|tappaas-vm|kubernetes-job|...|disabled
+DPF_BUILD_AGENT_DEFAULT=codex|claude|dpf-native
+DPF_BUILD_AGENT_FALLBACK=codex|claude|dpf-native    # optional; orchestrator falls back when default fails
+```
+
+Per-provider config (cluster name, namespace, IAM role, etc.) is
+provider-specific and lives in the provider's own envvar namespace
+(`DPF_PROVIDER_K8S_*`, `DPF_PROVIDER_ECS_*`, etc.).
+
+## Contract tests
+
+Two contract tests, one per interface, plus the cross-axis
+invariant set.
+
+### Substrate contract — `apps/web/__tests__/sandbox-provider-contract.test.ts`
+
+Asserts substrate **semantics**, not just method-callable:
+
+- `trustLevel: "untrusted-ok"` ⇒ `isolation` ∈ {`vm`, `managed-job`}.
+  Container isolation is not strong enough for arbitrary external code.
+- `logSink: "authority-core"` ⇒ provider must emit log events to
+  `ToolExecution`; the test asserts a known log line appears.
+- `workspacePersistence: "ephemeral"` ⇒ `cleanupModel` ∈ {`ttl`,
+  `label-sweep`} (orchestrator can't rely on explicit destroy when
+  the substrate may evict mid-run).
+- `supportsPreviewUrl: false` ⇒ `getPreviewUrl()` returns null and
+  the Build Studio UI hides the preview button.
+
+### Agent runner contract — `apps/web/__tests__/build-agent-runner-contract.test.ts`
+
+- `requiresCredential: true` ⇒ `prepare()` errors when called with
+  `credential: null`.
+- `requiresCredential: false` ⇒ `prepare()` succeeds with
+  `credential: null` (dpf-native).
+- `honorsLlmBaseUrl: true` ⇒ all outbound LLM calls observed during
+  `run()` resolve to `LLM_BASE_URL`'s host (test mocks the inference
+  layer and asserts no direct vendor egress).
+- `requiresPersistentSession: true` ⇒ provider must declare
+  `workspacePersistence !== "ephemeral"` before the runner accepts
+  the call.
+
+### Cross-axis invariants (orchestrator-enforced)
+
+These run inside `runAgentCommand` and are also asserted by an
+integration test that pairs every provider with every agent:
+
+- `agent.requiresPersistentSession && provider.workspacePersistence === "ephemeral"` ⇒ reject at install time, not at first use.
+- `agent.requiresCallbackPort && !provider.supportsPortCallbacks` ⇒ reject at install time. (Codex × `cloud-run-job` is the canonical example.)
+- `agent.requiresCredential && credential == null` ⇒ reject before sandbox creation (no wasted resource provisioning).
+- `provider.id === "disabled"` ⇒ all calls return 503 from the Build Studio UI; the orchestrator never reaches `prepare()`.
+
+These are the runner-playbook lessons made enforceable so a future
+provider or agent can't quietly weaken trust, log, or isolation
+guarantees by setting booleans.
+
+## Per-deployment-target defaults (two-axis matrix)
+
+The matrix has two axes: **substrate** (rows) × **agent** (columns).
+A cell value tells you the Build Studio status for that combination
+on that deployment target.
+
+| Deployment | Default substrate | × `codex` | × `claude` | × `dpf-native` |
+|---|---|---|---|---|
+| Windows local | `local-docker` | GA | GA | preview → GA per cutover gates |
+| macOS local | `local-docker` | GA (Docker Desktop) | GA | preview → GA |
+| Linux local | `local-docker` | GA | GA | preview → GA |
+| Single VM (cloud) | `local-docker` | GA | GA | preview → GA |
+| Marketplace image | `local-docker` | inherits Single VM | inherits | inherits |
+| TAPPaaS — VM mode | `local-docker` (in VM) | GA | GA | preview → GA |
+| TAPPaaS — native NixOS/Podman | `tappaas-vm` (planned) | preview when port 1455 reachable via Caddy | preview | preview → GA |
+| Managed Kubernetes | `kubernetes-job` | preview, requires 1455 Ingress + privileged node pool | preview | **preview → GA, no privileged pod required** |
+| Managed container — AWS (long-running) | `ecs-service` | unsupported (port 1455 lock-in on Fargate) | preview | **preview → GA** |
+| Managed container — AWS (batch) | `ecs-task` | unsupported | unsupported (no preview surface) | **preview → GA, batch only** |
+| Managed container — GCP (long-running) | `cloud-run-service` | unsupported | preview | **preview → GA** |
+| Managed container — GCP (batch) | `cloud-run-job` | unsupported | unsupported | **preview → GA, batch only** |
+| Managed container — Azure | `azure-containerapp-job` | unsupported | preview | **preview → GA** |
+| Air-gapped / regulated | `local-docker` or `kubernetes-job` | unsupported (vendor egress) | unsupported | **preview → GA with local LLM (Contract 9 mode 1 local)** |
+| Operator-disabled | `disabled` | n/a | n/a | n/a |
+
+Reading the matrix:
+
+- **GA** means the cell passes its maturity gates and is the
+  documented default.
+- **preview → GA** means the combination is architecturally
+  supported and ships behind a feature flag; promotion to GA is
+  gated on the dpf-native cutover gates above (for dpf-native cells)
+  or the per-substrate provider's own readiness gates (for
+  Codex/Claude cells on new substrates).
+- **unsupported** means the combination has a structural blocker
+  the spec is not committing to solve (port 1455 lock-in on Fargate-
+  class substrates; no preview HTTP on batch substrates).
+- **`disabled`** is a first-class option: customers in regulated
+  environments can opt out of Build Studio entirely without DPF
+  shipping a degraded version.
+
+The bold cells are the **dpf-native unlock**: combinations that
+move from unsupported / not-shippable to GA-capable purely by
+introducing the dpf-native agent — no new substrate engineering
+required beyond the provider extraction.
 
 ## Deployment guidance per substrate
 
@@ -331,20 +551,66 @@ Each provider is responsible for:
 - **Managed Kubernetes substrate:** ship `kubernetes-job` provider.
   Sandbox runs as an ephemeral pod with TTL; Helm chart values
   expose namespace, service account, image pull secrets, optional
-  taint/toleration for a privileged sandbox node pool.
-- **Managed container service substrate:** ship one provider per
-  cloud (`ecs-task`, `cloud-run-job`, `azure-containerapp-job`).
-  Sandbox runs as an ephemeral cloud-native job. Each provider
-  module wraps the cloud's run-task / job-execute API.
+  taint/toleration for a privileged sandbox node pool. **With
+  dpf-native default, the privileged node pool is no longer
+  required** — pods can run unprivileged because no vendor CLI
+  needs port 1455.
+- **Managed container service substrate:** ship per cloud, with
+  the long-running vs batch distinction explicit. Long-running
+  variants (`ecs-service`, `cloud-run-service`) host the dev
+  server preview; batch variants (`ecs-task`, `cloud-run-job`,
+  `azure-containerapp-job`) run a build to completion and exit,
+  no preview. Cells that pair batch substrates with persistent-
+  session agents (Codex CLI's REPL) are rejected by the cross-axis
+  invariant.
 - **TAPPaaS native mode:** ship `tappaas-vm` provider only after
   TAPPaaS NixOS/Podman precedent is validated and the Edge Node
   spec's deployment-target neutrality is preserved. Until then,
   TAPPaaS module ships with `local-docker` inside the provisioned
   VM.
 - **`disabled`:** any deployment where Build Studio is policy-
-  forbidden (air-gapped customer with no CLI-agent local routing,
-  regulated industries with no BAA coverage on the bundled CLI
-  agents per cloud spec's compliance section).
+  forbidden. With dpf-native available, the air-gapped /
+  regulated case for `disabled` shrinks substantially — most
+  regulated customers can run dpf-native against a local LLM
+  instead.
+
+## Provider responsibilities
+
+Each provider is responsible for:
+
+- **Sandbox image acquisition.** Pull `dpf-sandbox:<variant>` from
+  GHCR (multi-arch, per Phase 1 of the installer-parity roadmap).
+  Default variant is `dpf-native` once GA; transitional default
+  is `cli-bundled`.
+- **Resource isolation.** Memory / CPU caps consistent with the
+  current `--cpus=2 --memory=4096m` defaults
+  (`apps/web/lib/integrate/sandbox/sandbox.ts:13-17`).
+- **Network model.** Outbound HTTPS for inference and (when
+  `cli-bundled`) for vendor CLI egress; ingress for the Next.js
+  dev server's port mapping (when `supportsPreviewUrl`); respect
+  the substrate's network policy.
+- **Lifecycle attribution.** Sandbox creation / destruction emits
+  audit events into `ToolExecution` so Authority Core can
+  reconstruct what was built and when, with `routeContext.providerId`
+  populated.
+- **Cleanup.** Per the cleanup mechanism above; declare which model
+  via `capabilities().cleanupModel`. Label-based reconciliation is
+  the mandatory fallback.
+
+## Authority Core enforcement point
+
+The orchestrator that picks substrate × agent and enforces cross-
+axis invariants lives at `apps/web/lib/integrate/build-orchestrator.ts`.
+Build Studio's per-task agent selection (tier matching, fallback,
+eval-gate routing) is implemented there. The Build Studio MCP
+tools (`apps/web/lib/mcp-tools.ts:1025-1162, 9420-9499`) call into
+the orchestrator, not directly into providers or runners.
+
+UI gating: the storefront/admin Build Studio surface reads
+`provider.capabilities()` and `agent.capabilities()` to disable
+features the active combination can't deliver (preview button when
+`supportsPreviewUrl: false`; agent picker entries when an agent is
+unavailable on the active substrate).
 
 ## Refactoring scope (when this lands)
 
@@ -352,75 +618,225 @@ The refactor touches:
 
 - `apps/web/lib/integrate/sandbox/sandbox.ts` — extract current
   Docker-cli logic into the `LocalDockerProvider`.
+- `apps/web/lib/integrate/codex-dispatch.ts` — repackage as the
+  `CodexAgentRunner`.
+- `apps/web/lib/integrate/claude-dispatch.ts` — repackage as the
+  `ClaudeCodeAgentRunner`.
+- `apps/web/lib/integrate/build-orchestrator.ts` — host the new
+  orchestrator, cross-axis invariant checks, agent tier routing.
 - `apps/web/lib/mcp-tools.ts:1025-1162, 9420-9499` — sandbox MCP
-  tools call through the provider interface, not directly through
+  tools call through the orchestrator, not directly through
   Docker CLI.
 - A new `apps/web/lib/integrate/sandbox/providers/` directory with
-  one file per provider implementation.
+  one file per `BuildExecutionProvider` implementation.
+- A new `apps/web/lib/integrate/sandbox/agents/` directory with
+  one file per `BuildAgentRunner` implementation, including
+  `dpf-native-agent-runner.ts` (initial Tier-1 implementation).
 - `Dockerfile` (portal) — drop the Docker socket mount in
   deployments that don't need `local-docker`.
 - `docker-compose.yml` — make the `/var/run/docker.sock` mount
   conditional on `DPF_BUILD_PROVIDER=local-docker`.
-- `apps/web/__tests__/sandbox-provider-contract.test.ts` (new) — a
-  contract test every provider must pass, so the interface stays
-  semantically consistent.
+- `Dockerfile.sandbox` — split into the three image variants
+  (`base`, `dpf-native`, `cli-bundled`).
+- `apps/web/__tests__/sandbox-provider-contract.test.ts` (new) —
+  substrate contract.
+- `apps/web/__tests__/build-agent-runner-contract.test.ts` (new) —
+  agent contract.
+- `apps/web/__tests__/build-substrate-agent-matrix.test.ts` (new) —
+  cross-axis invariant integration test.
+
+## Schema impact
+
+Resolved (was open in prior draft):
+
+- **`Sandbox` model** — does not exist as a Prisma model today;
+  sandbox state lives in `apps/web/lib/integrate/sandbox/sandbox-db.ts`
+  as a derived view over `ToolExecution` and process state. The
+  refactor introduces a first-class `Sandbox` model so labeling,
+  cleanup reconciliation, and per-sandbox audit join become
+  tractable. Fields:
+
+  ```prisma
+  model Sandbox {
+    id                String    @id @default(cuid())
+    buildId           String
+    providerId        String    // BuildExecutionProviderId
+    agentId           String?   // BuildAgentId, null until first run
+    portalInstanceId  String    // for label-sweep reconciliation
+    state             String    // creating | running | destroyed | orphaned
+    startedAt         DateTime  @default(now())
+    destroyedAt       DateTime?
+    previewUrl        String?
+    capabilitiesSnapshot Json   // provider.capabilities() at creation
+    @@index([buildId])
+    @@index([state, startedAt])
+  }
+  ```
+
+- **`ToolExecution.routeContext`** — adds `providerId` and `agentId`
+  fields under a `build` object: `routeContext.build.providerId`,
+  `routeContext.build.agentId`. Existing fields untouched.
+
+- **`EdgeNode.capabilities`** — unchanged unless the
+  `edge-node-local-docker` provider lands; see Open Questions.
+
+Migration: additive only. The `Sandbox` table replaces ad-hoc state
+in `sandbox-db.ts` over a transition where both write paths run; the
+old path is removed once reconciliation is verified.
 
 ## Open questions
 
 These need answers before this stub becomes a finalized spec:
 
-### Interface design
-- **Long-lived vs ephemeral sandbox:** the current `local-docker`
-  model creates a sandbox that lives across many `exec` calls.
-  Cloud-native job providers (Cloud Run Jobs, ECS Run Task) run a
-  command and exit. Does the interface impose long-lived semantics
-  on every provider (forcing cloud providers to keep an idle
-  container alive) or accept short-lived semantics (forcing the
-  caller to be aware of provider lifetime)? Hybrid: each provider
-  declares via `capabilities().persistentSandbox`.
-- **File system access:** `local-docker` uses `docker exec tar |
-  docker exec tar` for file copy. Cloud-native providers may need
-  a sidecar volume / shared FS / S3 staging step. Define the
-  abstraction at the right level so substrate choice doesn't leak
-  into caller code.
-- **Networking:** sandbox preview port (current default 3035 →
-  3000 inside container) needs an equivalent on every provider.
-  k8s: `Service` + Ingress; ECS: Application Load Balancer;
-  Cloud Run: built-in HTTPS endpoint. Decide whether the
-  abstraction returns a URL or a tunnel handle.
+### Resolved in 2026-05-10 revision (moved out of Open Questions)
 
-### Operational
-- **Cost model for cloud-native providers:** k8s Jobs and ECS
+- ~~**Long-lived vs ephemeral sandbox.**~~ Each provider declares
+  `workspacePersistence`; cross-axis invariant rejects incompatible
+  pairs.
+- ~~**File system access.**~~ `readFile` / `writeFile` /
+  `copyAppsWebInto` are required `BuildExecutionProvider` methods.
+  Substrate-specific transport (sidecar volume / S3 staging) is
+  the provider's internal concern.
+- ~~**Networking — preview URL or tunnel.**~~ `getPreviewUrl`
+  returns `string | null`. Null is a first-class answer.
+- ~~**Refactor without behavior change first.**~~ Promoted to a
+  binding sequencing rule in the Sequencing section.
+
+### Still open
+
+- **`edge-node-local-docker` provider.** With customer Edge Nodes
+  running on customer hardware, an `edge-node-local-docker`
+  provider is plausible: build runs on the customer's own infra
+  via the Edge Node, no portal-side sandbox cost, no port 1455
+  lock-in on the cloud Authority Core, customer code never leaves
+  the customer's network. Worth exploring after the local-docker
+  extraction lands and the dpf-native agent reaches Tier 2.
+  Requires Edge Node policy to grant the `BuildExecutionProvider`
+  capability tier — not free.
+
+- **Cost model for cloud-native providers.** k8s Jobs and ECS
   tasks bill by execution time; long-running interactive sessions
   could surprise customers. Configurable max-lifetime per provider?
-- **Concurrency limits:** `local-docker` has effectively no limit
-  (subject to host resources); cloud providers usually have
-  account-level quotas. `capabilities().maxConcurrent` advertises
-  it; Authority Core enforces per-policy.
-- **Audit trail consistency:** `ToolExecution` records sandbox
-  events today. Confirm every provider can emit the same shape.
+  Likely answer: `SANDBOX_TIMEOUT_MS` already enforces a cap;
+  cloud providers should advertise a `recommendedMaxLifetimeMs`
+  capability and the orchestrator warns if exceeded.
 
-### Sequencing
-- **Which provider second?** After `local-docker` is extracted as
-  v1, which is the highest-value second provider? Likely
-  `kubernetes-job` (largest enterprise audience) or `tappaas-vm`
-  (highest strategic alignment with the doctrinal refactor).
-- **Refactor without behavior change first.** The interface
-  extraction should land as a no-op refactor, with the existing
-  Docker-cli logic moved verbatim into `LocalDockerProvider`.
-  Other providers come in subsequent epics.
+- **Agent eval catalog ownership.** The cutover gates depend on
+  three eval suites (`single-file/*`, `multi-file/*`, `full-spec/*`).
+  Where do these live, who owns them, what's the seeding policy,
+  do they version with the agent or with the platform? Probably
+  belongs to a sibling spec on Build Studio evaluation. Named
+  open question, deferred to that spec.
 
-## Schema impact
+- **Sequencing — k8s vs TAPPaaS first.** Spec proposes k8s as the
+  highest-value second provider (largest enterprise audience). If
+  TAPPaaS native NixOS/Podman validates faster (smaller surface,
+  internal team), it could leapfrog. Decided per the cloud-
+  deployment-design spec's substrate priority.
 
-Likely additions to existing schemas:
+## Maturity gates before implementation
 
-- `Sandbox` model (if it exists, otherwise a new field on the
-  current sandbox tracking) gains a `provider` field of type
-  `BuildExecutionProvider`.
-- `ToolExecution.routeContext` records the provider for audit.
-- `EdgeNode.capabilities` (per the Edge Node spec) is unchanged —
-  Build Studio runs in the Authority Core's domain, not the Edge
-  Node's.
+This spec moves from research to binding when all of these are
+complete. **Security review is weighted heavier than other specs
+because the Build Execution Provider + Agent Runner combination
+owns sandbox execution and inherits all of Build Studio's
+privileged-runtime concerns — arbitrary code execution, credentials,
+network egress, file system access, and (for dpf-native) in-process
+agent loops in the portal.**
+
+- [ ] Research & Benchmarking section complete (per AGENTS.md §10)
+      — patterns from GitHub Actions self-hosted runners, GitLab
+      Runner, Buildkite Agent, Drone CI agent, plus the Firecracker
+      / gVisor / Kata Containers isolation primitives. Specifically
+      compare their **executor vs orchestrator** split (how they
+      separate substrate from work definition).
+- [ ] Open questions resolved or explicitly deferred (edge-node-
+      local-docker provider; cost model for cloud-native providers;
+      agent eval catalog ownership; k8s-vs-TAPPaaS sequencing).
+- [ ] Schema impact reviewed — `Sandbox` table introduction;
+      `ToolExecution.routeContext.build.{providerId,agentId}`.
+      Migration story confirmed additive.
+- [ ] Canonical contracts updated if this spec changes shared
+      behavior (Contract 6 of the doctrine references this spec;
+      Contract 9 mode-4 envvars stay in the doctrine).
+- [ ] **Security review complete (heavy):**
+      - Sandbox image acquisition path per provider (registry auth,
+        signed image verification)
+      - Resource isolation enforcement (memory / CPU caps; preventing
+        sandbox-to-host escape)
+      - Network policy per provider (sandbox can reach what; Codex
+        / Claude CLI agents in mode 4 still bypass `LLM_BASE_URL`
+        audit envelope — documented and accepted, not silently
+        allowed; dpf-native closes this gap when used)
+      - Credentials propagation into sandbox (no host secrets leak;
+        per-task credentials; dpf-native stores credentials in the
+        portal, not the sandbox)
+      - **dpf-native portal-process blast radius** — the agent loop
+        runs in the portal so a dpf-native bug could leak portal
+        credentials. Counterbalance: no long-lived OpenAI refresh
+        token in sandbox memory, no port 1455 OAuth surface. Net
+        risk profile must be reviewed and signed off explicitly.
+      - Cleanup guarantees (`destroySandbox` actually runs; TTL
+        enforcement on provider that uses it; label-sweep reconciler
+        runs on every portal startup and on schedule)
+      - Audit envelope (`ToolExecution` records emitted by every
+        provider AND every agent runner; provider + agent attribution
+        in `routeContext.build` is accurate; dpf-native records the
+        full prompt + response per inference call)
+- [ ] Release / rollback story defined — interface extraction is a
+      no-op refactor first; subsequent provider implementations and
+      `dpf-native` agent runner ship behind feature flags so a bad
+      provider or agent can be disabled per deployment without
+      touching the others.
+- [ ] Test / verification gates defined — substrate contract test;
+      agent runner contract test; cross-axis invariant integration
+      test; smoke test per provider on a representative substrate;
+      chaos test for cleanup failure modes (orphaned sandboxes
+      after portal crash, validated by label-sweep reconciler).
+
+## Sequencing (binding)
+
+Promoted from prior draft's Open Questions; this is the implementation
+order, not a question.
+
+1. **Interface extraction as no-op refactor.** Extract current
+   `local-docker` logic behind `BuildExecutionProvider`; extract
+   Codex and Claude dispatchers behind `BuildAgentRunner`; introduce
+   `build-orchestrator.ts` as the single entrypoint; introduce the
+   `Sandbox` Prisma model. **No behavior change** for any current
+   install. Lands as one PR (or a tightly-sequenced PR series with
+   feature flags).
+
+2. **Contract tests.** Substrate, agent, and cross-axis invariant
+   tests land alongside the extraction. Every existing combination
+   (`local-docker × {codex, claude}`) passes.
+
+3. **`dpf-native` agent runner — Tier 1.** Single-file edits only.
+   Behind a feature flag; opt-in for Build Studio operators. Eval
+   suite seeded; cutover gate measured but not enforced (Tier 1
+   default stays Codex until gate clears).
+
+4. **Highest-value second provider.** Either `kubernetes-job` (per
+   cloud-deployment spec's enterprise priority) or `tappaas-vm`
+   (per TAPPaaS rollout schedule). Decided by the substrate-priority
+   open question.
+
+5. **`dpf-native` Tier 2 + Tier 3.** Eval coverage extended;
+   cutover gates enforce promotion. Once dpf-native ≥ default on
+   each tier's gate, dpf-native becomes the default for that tier.
+   Codex and Claude remain shippable for customers who prefer them.
+
+6. **Remaining cloud-native providers.** `ecs-task` /
+   `ecs-service`, `cloud-run-job` / `cloud-run-service`,
+   `azure-containerapp-job` — sequenced by customer demand and the
+   cloud spec's substrate priority. Each ships paired with
+   `dpf-native` as the supported agent (Codex/Claude marked
+   unsupported per the matrix).
+
+7. **Image variant default flip.** When dpf-native is GA across
+   tiers, `dpf-sandbox:dpf-native` becomes the production default
+   image. `dpf-sandbox:cli-bundled` remains shippable for customers
+   who explicitly opt in to bundled vendor CLIs.
 
 ## Research and Benchmarking (TBD per AGENTS.md §10)
 
@@ -430,7 +846,10 @@ of:
 **Open source build / CI runners:** GitHub Actions self-hosted
 runner, GitLab Runner, Buildkite Agent, Drone CI agent. Each has
 a runtime-abstraction layer that supports Docker, Kubernetes, and
-shell modes. Read their interface design.
+shell modes. **Specifically compare their executor (substrate) vs
+orchestrator (work definition) split** — that's the structural
+analog of this spec's provider × runner split. Read their interface
+design and capability advertisement patterns.
 
 **Open source ephemeral container orchestration:** k3s, Firecracker
 (used by Fly.io), gVisor, Kata Containers. Understand the
@@ -440,84 +859,43 @@ isolation primitives.
 Build, Azure Pipelines hosted agents. They solve the same
 abstraction problem at scale.
 
+**Coding-agent SDKs and harnesses:** OpenAI Codex CLI internals,
+Anthropic Claude Code CLI internals, Aider, Continue, Cursor's
+agent loop, SWE-Agent. The dpf-native runner draws on the loop
+patterns these establish; document which patterns adopted, which
+rejected.
+
 Document patterns adopted, patterns rejected, anti-patterns
 identified, gaps the design fills.
-
-## Sequencing
-
-This spec sits **after** the deployment contracts doctrine spec is
-established and the cloud-deployment spec captures the substrate
-taxonomy. Implementation order:
-
-1. **Interface extraction** — refactor existing logic into
-   `LocalDockerProvider` with no behavior change.
-2. **Contract test** — `sandbox-provider-contract.test.ts` ensures
-   semantic consistency for any future provider.
-3. **Highest-value second provider** — `kubernetes-job` or
-   `tappaas-vm` per the open question above.
-4. **Remaining cloud-native providers** — sequenced by customer
-   demand and substrate priority.
-
-## Maturity gates before implementation
-
-This spec moves from research to binding when all of these are
-complete. **Security review is weighted heavier than other specs
-because the Build Execution Provider owns sandbox execution and
-inherits all of Build Studio's privileged-runtime concerns —
-arbitrary code execution, credentials, network egress, file system
-access.**
-
-- [ ] Research & Benchmarking section complete (per AGENTS.md §10)
-      — patterns from GitHub Actions self-hosted runners, GitLab
-      Runner, Buildkite Agent, Drone CI agent, plus the Firecracker
-      / gVisor / Kata Containers isolation primitives.
-- [ ] Open questions resolved or explicitly deferred (interface
-      design for long-lived vs ephemeral, file-system abstraction,
-      networking abstraction; cost / capacity / concurrency limits;
-      audit-trail consistency; refactor sequencing).
-- [ ] Schema impact reviewed — `Sandbox.provider` field,
-      `ToolExecution.routeContext` provider attribution.
-- [ ] Canonical contracts updated if this spec changes shared
-      behavior (Contract 6 of the doctrine references this spec).
-- [ ] **Security review complete (heavy):**
-      - Sandbox image acquisition path per provider (registry auth,
-        signed image verification)
-      - Resource isolation enforcement (memory / CPU caps; preventing
-        sandbox-to-host escape)
-      - Network policy per provider (sandbox can reach what; LLM CLI
-        agents in mode 4 still bypass `LLM_BASE_URL` audit envelope —
-        documented and accepted, not silently allowed)
-      - Credentials propagation into sandbox (no host secrets leak;
-        per-task credentials)
-      - Cleanup guarantees (`destroySandbox` actually runs; TTL
-        enforcement on provider that uses it)
-      - Audit envelope (`ToolExecution` records emitted by every
-        provider; provider attribution is accurate)
-- [ ] Release / rollback story defined — interface extraction is a
-      no-op refactor first; subsequent provider implementations ship
-      behind feature flags so a bad provider can be disabled per
-      deployment without touching the others.
-- [ ] Test / verification gates defined — `sandbox-provider-contract.test.ts`
-      that every provider must pass; smoke test per provider on a
-      representative substrate; chaos test for cleanup failure
-      modes (orphaned sandboxes after portal crash).
 
 ## Source documents
 
 - `docs/superpowers/specs/2026-05-09-deployment-contracts.md` —
   the doctrine; this spec is contract 6's canonical
-  implementation.
+  implementation. Contract 9 mode 4 (CLI agents) is the gap
+  `dpf-native` closes.
 - `docs/superpowers/specs/2026-05-09-cloud-deployment-design.md` —
   cloud substrate / packaging target taxonomy and per-target Build
   Studio compatibility notes.
 - `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md` —
   Edge Node spec; Build Studio is Authority-Core-domain, not
   Edge-Node-domain (clarified here so future contributors don't
-  conflate them).
-- `apps/web/lib/integrate/sandbox/sandbox.ts`,
+  conflate them). The `edge-node-local-docker` provider open
+  question is the one place the two could touch.
+- `apps/web/lib/integrate/sandbox/sandbox.ts` (444 LOC),
   `apps/web/lib/mcp-tools.ts:1025-1162` — current `local-docker`
   reference implementation.
-- `Dockerfile.sandbox` — sandbox image artifact every provider
-  consumes.
+- `apps/web/lib/integrate/codex-dispatch.ts` (316 LOC) — current
+  Codex CLI dispatcher; becomes the `CodexAgentRunner`.
+- `apps/web/lib/integrate/claude-dispatch.ts` (368 LOC) — current
+  Claude Code CLI dispatcher; becomes the `ClaudeCodeAgentRunner`.
+- `apps/web/lib/integrate/contribution-dispatch.ts` — existing
+  portal-side agentic loop; the structural template for
+  `dpf-native-agent-runner.ts`.
+- `apps/web/lib/ai-inference.ts` — existing `LLM_BASE_URL` /
+  Contract 9 mode 1 inference layer; the dpf-native runner consumes
+  this directly.
+- `Dockerfile.sandbox` — sandbox image artifact; refactor splits
+  into `:base`, `:dpf-native`, `:cli-bundled` variants.
 - `docker-compose.yml:81` — current Docker socket mount the
-  refactor makes conditional.
+  refactor makes conditional on `DPF_BUILD_PROVIDER=local-docker`.

--- a/packages/db/prisma/migrations/20260511013000_add_build_sandbox_model/migration.sql
+++ b/packages/db/prisma/migrations/20260511013000_add_build_sandbox_model/migration.sql
@@ -1,0 +1,24 @@
+-- Add first-class Build Studio sandbox execution records.
+-- This is additive and does not replace SandboxSlot lease state.
+
+CREATE TABLE "Sandbox" (
+    "id" TEXT NOT NULL,
+    "buildId" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "agentId" TEXT,
+    "portalInstanceId" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "destroyedAt" TIMESTAMP(3),
+    "previewUrl" TEXT,
+    "capabilitiesSnapshot" JSONB NOT NULL,
+
+    CONSTRAINT "Sandbox_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Sandbox_buildId_idx" ON "Sandbox"("buildId");
+CREATE INDEX "Sandbox_state_startedAt_idx" ON "Sandbox"("state", "startedAt");
+
+ALTER TABLE "Sandbox" ADD CONSTRAINT "Sandbox_buildId_fkey"
+    FOREIGN KEY ("buildId") REFERENCES "FeatureBuild"("buildId")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3272,6 +3272,7 @@ model FeatureBuild {
   productVersions          ProductVersion[]
   promotionBackups         PromotionBackup[]
   issueReports             PlatformIssueReport[]
+  sandboxes                Sandbox[]
 
   @@index([phase])
   @@index([createdById])
@@ -3346,6 +3347,23 @@ model ArtifactReceiptUsage {
 
   @@unique([artifactRevisionId, receiptId])
   @@index([receiptId])
+}
+
+model Sandbox {
+  id                   String       @id @default(cuid())
+  buildId              String
+  providerId           String
+  agentId              String?
+  portalInstanceId     String
+  state                String
+  startedAt            DateTime     @default(now())
+  destroyedAt          DateTime?
+  previewUrl           String?
+  capabilitiesSnapshot Json
+  featureBuild         FeatureBuild @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
+
+  @@index([buildId])
+  @@index([state, startedAt])
 }
 
 model SandboxSlot {


### PR DESCRIPTION
## Summary
- Adds the Build Studio `BuildExecutionProvider` and `BuildAgentRunner` contracts with local Docker and Codex/Claude adapters preserving current behavior.
- Adds provider/runner compatibility contract tests plus matrix coverage for substrate-independent agent dispatch.
- Adds additive `Sandbox` persistence for build sandbox execution records and updates the promotion spec plus slice-1 implementation plan.

## Validation
- `pnpm --filter web exec vitest run lib/integrate/sandbox/provider-contract.test.ts lib/integrate/sandbox/agent-runner-contract.test.ts lib/integrate/sandbox/build-substrate-agent-matrix.test.ts lib/integrate/sandbox/sandbox-db.test.ts lib/integrate/build-orchestrator.test.ts`
- `pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma`
- `pnpm --filter @dpf/db exec prisma generate --schema prisma/schema.prisma`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`
- Migration SQL rollback proof against live Postgres: `BEGIN; ... migration.sql ... ROLLBACK;`

## Notes
- Host Prisma `migrate status/deploy/dev` currently fails with a bare schema-engine error in this worktree, but the rebased migration SQL applies cleanly against the live Postgres schema in a rollback transaction.
- Build still emits the existing Turbopack/NFT broad-tracing warnings in `spec-plan-search.ts` and `next.config.mjs`; no build errors.