### PR TITLE
feat(wiki): EP-WIKI-001 Phase 3b1 — wire recallWikiContext into sendMessage

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -31,6 +31,7 @@ import { observeConversation } from "@/lib/process-observer-hook";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveRouteContext } from "@/lib/route-context-map";
 import { assembleSystemPrompt } from "@/lib/prompt-assembler";
+import { recallWikiContext } from "@/lib/wiki/recall";
 import { getGrantedCapabilities, getDeniedCapabilities } from "@/lib/permissions";
 import { classifyTask } from "@/lib/task-classifier";
 import { getTaskType } from "@/lib/task-types";
@@ -489,6 +490,21 @@ export async function sendMessage(input: {
     if (selectedKnowledge) finalDomainContext += "\n\n" + selectedKnowledge;
     if (selectedMemory) finalDomainContext += "\n\n" + selectedMemory;
 
+    // EP-WIKI-001 Phase 3b1: passive wiki context injection.
+    // Pulls the top-K kernel + overlay pages relevant to the user's
+    // message and renders them in Block 5 below domainContext.
+    // recallWikiContext has a silent-degradation contract (returns
+    // null on any failure) so wiki retrieval can never break the
+    // prompt pipeline.
+    const wikiOrg = await prisma.organization
+      .findFirst({ select: { id: true } })
+      .catch(() => null);
+    const wikiContext = await recallWikiContext({
+      query: input.content,
+      organizationId: wikiOrg?.id ?? null,
+      limit: 4,
+    });
+
     populatedPrompt = await assembleSystemPrompt({
       hrRole: user.platformRole ?? "none",
       grantedCapabilities: granted,
@@ -499,6 +515,7 @@ export async function sendMessage(input: {
       domainTools: [], // Already included in domain block
       routeData: selectedPageData,
       attachmentContext: selectedAttachments,
+      wikiContext,
     });
   } else {
     // ── Legacy persona-based prompt assembly ──


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 3b1 — **makes the passive wiki context injection from PR #432 actually fire**. Before this PR, `recallWikiContext()` existed but was never called; after this PR, every assembled system prompt includes the `RELEVANT WIKI CONTEXT` block in Block 5 when the wiki has relevant pages for the user&#39;s query.

17-line change.

## What changed

`apps/web/lib/actions/agent-coworker.ts` (+17 lines):

- Import `recallWikiContext` from `@/lib/wiki/recall`.
- Before `assembleSystemPrompt`: look up the platform organization id (single-tenant install pattern, same as `(shell)/layout.tsx`), then call `recallWikiContext({ query: input.content, organizationId, limit: 4 })`.
- Pass the result through as `wikiContext` on `PromptInput`. `recallWikiContext` has a **silent-degradation contract** (returns `null` on embedding failure / Qdrant down / any throw) so wiki retrieval can never break the prompt pipeline.

## Mechanics

- **Two-pass overlay-aware search** runs against the `wiki-pages` Qdrant collection: pass A = this org&#39;s overlay rows, pass B = kernel fallback excluding any `kernelPageId` that pass A masked.
- **Bounded output**: up to 4 results, each ≤300 chars after formatting (slug + kind + 240-char preview) → ~1.2 KB max added to Block 5.
- **One extra Prisma query per message** (`organization.findFirst` on PK) + one Qdrant search call (already in the recall path). Both are fast and wrapped in catch handlers; failures degrade silently.

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter web typecheck` | ✓ |
| `pnpm --filter web test --run agent-coworker` | ✓ 12/12 existing pass |

## Test plan

- [ ] Hit a coworker chat in a running dev server with the kernel empty — confirm no wiki block appears (silent degradation)
- [ ] After Mark drops kernel content + runs seed, ask the agent a kernel-relevant question and confirm the wiki block appears in the system prompt
- [ ] Confirm the org overlay path works once an overlay page exists (mask kernel page; org row shown)
- [ ] Confirm the agent grounds answers in the wiki block when present and cites slugs (the wiki-preamble template from #439 directs this)

## Out of scope

- `wiki_query` MCP tool registration + agent grants + route-context-map entries — **Phase 3b2**
- `wiki_propose_edit` MCP tool — Phase 2b ingest territory
- Caching the platform organization id across messages — the `findFirst` on PK is fast enough; revisit if profiling shows it&#39;s hot

## Dependencies

Depends only on merged work: PR #432 (`recallWikiContext` + prompt-assembler hook), PR #421 (`searchWikiPages`), PR #408 (`WikiPage` model).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_