### PR TITLE
Build Studio evidence-rich brief intake controls

### DIFF
--- a/apps/web/components/build-studio/BusinessBriefPanel.test.tsx
+++ b/apps/web/components/build-studio/BusinessBriefPanel.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 import "./test-setup";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { BusinessBriefPanel } from "./BusinessBriefPanel";
 import { DEMO_BUSINESS_BRIEF } from "@/lib/build-studio-demo";
 
+const updateBusinessBuildBrief = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/actions/build", () => ({
-  updateBusinessBuildBrief: vi.fn(),
+  updateBusinessBuildBrief,
 }));
 
 describe("BusinessBriefPanel", () => {
@@ -57,5 +59,47 @@ describe("BusinessBriefPanel", () => {
     );
     expect(screen.getByRole("button", { name: /save brief/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /accept brief/i })).toBeInTheDocument();
+  });
+
+  it("lets a non-developer mark evidence as an existing working example", async () => {
+    updateBusinessBuildBrief.mockResolvedValue(undefined);
+
+    render(
+      <BusinessBriefPanel
+        brief={{
+          ...DEMO_BUSINESS_BRIEF,
+          briefId: "BBB-FB-123",
+          intakeSource: "artifact_reference",
+          sourceEvidence: [
+            {
+              kind: "existing_example",
+              label: "Employee setup flow",
+              summary: "Employee setup flow",
+              copy: ["guided checklist"],
+              adapt: ["approval rules"],
+              avoid: ["HR-only labels"],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/reference type/i)).toHaveValue("existing_example");
+    expect(screen.getByLabelText(/copy, adapt, avoid/i)).toHaveValue(
+      "Copy: guided checklist\nAdapt: approval rules\nAvoid: HR-only labels",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save brief/i }));
+
+    await waitFor(() => {
+      expect(updateBusinessBuildBrief).toHaveBeenCalledWith(
+        expect.objectContaining({
+          briefId: "BBB-FB-123",
+          intakeSource: "existing_example",
+          evidenceKind: "existing_example",
+          copyAdaptAvoidText: "Copy: guided checklist\nAdapt: approval rules\nAvoid: HR-only labels",
+        }),
+      );
+    });
   });
 });

--- a/apps/web/components/build-studio/BusinessBriefPanel.tsx
+++ b/apps/web/components/build-studio/BusinessBriefPanel.tsx
@@ -3,7 +3,12 @@ import { AlertCircle, CheckCircle2, FileText, Pencil, Save, Target, Users } from
 import type { ReactNode } from "react";
 import { useState, useTransition } from "react";
 import { updateBusinessBuildBrief } from "@/lib/actions/build";
-import type { BusinessBuildBrief } from "@/lib/build/business-build-brief";
+import type {
+  BusinessBriefEvidence,
+  BusinessBriefEvidenceKind,
+  BusinessBuildBrief,
+  BusinessBuildBriefSource,
+} from "@/lib/build/business-build-brief";
 
 interface Props {
   brief: BusinessBuildBrief;
@@ -46,6 +51,54 @@ function textFromEvidence(brief: BusinessBuildBrief): string {
   return brief.sourceEvidence.map((evidence) => evidence.summary).join("\n");
 }
 
+function evidenceKindFromBrief(brief: BusinessBuildBrief): BusinessBriefEvidenceKind {
+  const firstKind = brief.sourceEvidence[0]?.kind;
+  if (
+    firstKind === "document" ||
+    firstKind === "screenshot" ||
+    firstKind === "spreadsheet" ||
+    firstKind === "url" ||
+    firstKind === "existing_route" ||
+    firstKind === "backlog_item" ||
+    firstKind === "feature_build" ||
+    firstKind === "email" ||
+    firstKind === "existing_example"
+  ) {
+    return firstKind;
+  }
+  if (brief.intakeSource === "existing_example") return "existing_example";
+  if (brief.intakeSource === "artifact_reference") return "document";
+  return "artifact";
+}
+
+function intakeSourceFromEvidenceKind(kind: BusinessBriefEvidenceKind): BusinessBuildBriefSource {
+  if (kind === "existing_example" || kind === "existing_route" || kind === "feature_build") {
+    return "existing_example";
+  }
+  return "artifact_reference";
+}
+
+function copyAdaptAvoidText(evidence: BusinessBriefEvidence[]): string {
+  const first = evidence.find((item) => item.kind === "existing_example");
+  if (!first) return "";
+  return [
+    ...(first.copy ?? []).map((entry) => `Copy: ${entry}`),
+    ...(first.adapt ?? []).map((entry) => `Adapt: ${entry}`),
+    ...(first.avoid ?? []).map((entry) => `Avoid: ${entry}`),
+  ].join("\n");
+}
+
+const EVIDENCE_KIND_OPTIONS: Array<{
+  value: BusinessBriefEvidenceKind;
+  label: string;
+}> = [
+  { value: "document", label: "Document or artifact" },
+  { value: "screenshot", label: "Screenshot or visual example" },
+  { value: "spreadsheet", label: "Spreadsheet or working tracker" },
+  { value: "url", label: "Public URL or vendor guide" },
+  { value: "existing_example", label: "Something that already works" },
+];
+
 function Field({
   label,
   value,
@@ -70,6 +123,37 @@ function Field({
   );
 }
 
+function SelectField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: BusinessBriefEvidenceKind;
+  onChange: (value: BusinessBriefEvidenceKind) => void;
+}) {
+  return (
+    <label className="grid gap-1.5 text-[13px] font-semibold text-[var(--dpf-text)]">
+      {label}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value as BusinessBriefEvidenceKind)}
+        className="min-h-10 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-[13px] font-normal text-[var(--dpf-text)] outline-none transition-colors focus:border-[var(--dpf-accent)]"
+      >
+        {EVIDENCE_KIND_OPTIONS.map((option) => (
+          <option
+            key={option.value}
+            className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+            value={option.value}
+          >
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
 export function BusinessBriefPanel({ brief }: Props) {
   const needsClarification = brief.openQuestions.length > 0;
   const [isEditing, setIsEditing] = useState(Boolean(brief.briefId));
@@ -79,6 +163,8 @@ export function BusinessBriefPanel({ brief }: Props) {
   const [affectedPeopleText, setAffectedPeopleText] = useState(textFromList(brief.affectedPeople));
   const [affectedWorkflow, setAffectedWorkflow] = useState(brief.affectedWorkflow ?? "");
   const [sourceEvidenceText, setSourceEvidenceText] = useState(textFromEvidence(brief));
+  const [evidenceKind, setEvidenceKind] = useState<BusinessBriefEvidenceKind>(evidenceKindFromBrief(brief));
+  const [copyAdaptAvoid, setCopyAdaptAvoid] = useState(copyAdaptAvoidText(brief.sourceEvidence));
   const [successSignalsText, setSuccessSignalsText] = useState(textFromList(brief.successSignals));
   const [constraintsText, setConstraintsText] = useState(textFromList(brief.constraints));
   const [openQuestionsText, setOpenQuestionsText] = useState(textFromList(brief.openQuestions));
@@ -91,10 +177,13 @@ export function BusinessBriefPanel({ brief }: Props) {
       try {
         await updateBusinessBuildBrief({
           briefId,
+          intakeSource: intakeSourceFromEvidenceKind(evidenceKind),
+          evidenceKind,
           businessOutcome,
           affectedPeopleText,
           affectedWorkflow,
           sourceEvidenceText,
+          copyAdaptAvoidText: copyAdaptAvoid,
           successSignalsText,
           constraintsText,
           openQuestionsText,
@@ -156,7 +245,16 @@ export function BusinessBriefPanel({ brief }: Props) {
             <Field label="Business outcome" value={businessOutcome} onChange={setBusinessOutcome} rows={4} />
             <Field label="Affected people" value={affectedPeopleText} onChange={setAffectedPeopleText} />
             <Field label="Affected workflow" value={affectedWorkflow} onChange={setAffectedWorkflow} rows={2} />
+            <SelectField label="Reference type" value={evidenceKind} onChange={setEvidenceKind} />
             <Field label="Source evidence" value={sourceEvidenceText} onChange={setSourceEvidenceText} />
+            {evidenceKind === "existing_example" && (
+              <Field
+                label="Copy, adapt, avoid"
+                value={copyAdaptAvoid}
+                onChange={setCopyAdaptAvoid}
+                rows={4}
+              />
+            )}
             <Field label="Success signals" value={successSignalsText} onChange={setSuccessSignalsText} />
             <Field label="Constraints" value={constraintsText} onChange={setConstraintsText} />
             <Field label="Open questions" value={openQuestionsText} onChange={setOpenQuestionsText} />

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -165,10 +165,13 @@ describe("governed build start approvals", () => {
 
     await updateBusinessBuildBrief({
       briefId: "BBB-FB-123",
+      intakeSource: "artifact_reference",
+      evidenceKind: "document",
       businessOutcome: "Reduce missed support escalations before the morning standup.",
       affectedPeopleText: "Support manager\nCustomer success lead",
       affectedWorkflow: "Customer escalation review",
       sourceEvidenceText: "Existing Zendesk escalation report\nMorning standup SOP",
+      copyAdaptAvoidText: "",
       successSignalsText: "Managers see unresolved escalations by site\nEvery escalation has an owner",
       constraintsText: "Do not expose customer data across accounts",
       openQuestionsText: "",
@@ -189,12 +192,12 @@ describe("governed build start approvals", () => {
         ],
         sourceEvidence: [
           expect.objectContaining({
-            kind: "artifact",
+            kind: "document",
             label: "Existing Zendesk escalation report",
             summary: "Existing Zendesk escalation report",
           }),
           expect.objectContaining({
-            kind: "artifact",
+            kind: "document",
             label: "Morning standup SOP",
             summary: "Morning standup SOP",
           }),

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -22,6 +22,8 @@ import { buildDesignReviewPrompt, buildPlanReviewPrompt, parseReviewResponse } f
 import { queueBuildReviewVerification } from "@/lib/build-review-verification-trigger";
 import { saveBuildArtifactRevision, type BuildArtifactField } from "@/lib/build/build-artifact-provenance";
 import {
+  type BusinessBriefEvidenceKind,
+  type BusinessBuildBriefSource,
   businessBuildBriefEditToPersistence,
   legacyFeatureBuildBriefToBusinessBuildBriefInput,
 } from "@/lib/build/business-build-brief";
@@ -210,10 +212,13 @@ export async function updateFeatureBrief(
 
 export async function updateBusinessBuildBrief(input: {
   briefId: string;
+  intakeSource?: BusinessBuildBriefSource;
+  evidenceKind?: BusinessBriefEvidenceKind;
   businessOutcome: string;
   affectedPeopleText: string;
   affectedWorkflow?: string | null;
   sourceEvidenceText: string;
+  copyAdaptAvoidText?: string;
   successSignalsText: string;
   constraintsText: string;
   openQuestionsText: string;
@@ -247,6 +252,7 @@ export async function updateBusinessBuildBrief(input: {
       where: { briefId },
       data: {
         status: persistence.status,
+        intakeSource: persistence.intakeSource,
         businessOutcome: persistence.businessOutcome,
         affectedPeople: persistence.affectedPeople as unknown as Prisma.InputJsonValue,
         affectedWorkflow: persistence.affectedWorkflow,

--- a/apps/web/lib/build/business-build-brief.test.ts
+++ b/apps/web/lib/build/business-build-brief.test.ts
@@ -334,4 +334,41 @@ describe("businessBuildBriefEditToPersistence", () => {
       }),
     );
   });
+
+  it("preserves artifact and existing-example intake context from business evidence controls", () => {
+    const persistence = businessBuildBriefEditToPersistence({
+      briefId: "BBB-FB-EXAMPLE",
+      intakeSource: "existing_example",
+      evidenceKind: "existing_example",
+      businessOutcome: "Make customer onboarding follow the employee setup flow.",
+      affectedPeopleText: "Customer success manager",
+      affectedWorkflow: "Customer onboarding",
+      sourceEvidenceText: "Employee setup flow",
+      copyAdaptAvoidText: "Copy: guided checklist and progress visibility\nAdapt: approvals for customer-facing handoff\nAvoid: employee-only HR language",
+      successSignalsText: "Managers can see onboarding progress without asking engineering",
+      constraintsText: "Keep customer data scoped to the right account",
+      openQuestionsText: "",
+      accept: true,
+    });
+
+    expect(persistence.status).toBe("accepted");
+    expect(persistence.intakeSource).toBe("existing_example");
+    expect(persistence.sourceEvidence).toEqual([
+      expect.objectContaining({
+        kind: "existing_example",
+        label: "Employee setup flow",
+        summary: "Employee setup flow",
+        copy: ["guided checklist and progress visibility"],
+        adapt: ["approvals for customer-facing handoff"],
+        avoid: ["employee-only HR language"],
+      }),
+    ]);
+    expect(persistence.businessInterpretation).toContain("Copy: guided checklist and progress visibility");
+    expect(persistence.legacyFeatureBrief.inputs).toEqual([
+      "Employee setup flow",
+      "Copy: guided checklist and progress visibility",
+      "Adapt: approvals for customer-facing handoff",
+      "Avoid: employee-only HR language",
+    ]);
+  });
 });

--- a/apps/web/lib/build/business-build-brief.ts
+++ b/apps/web/lib/build/business-build-brief.ts
@@ -42,6 +42,14 @@ export type BusinessBriefStatus =
 
 export type BusinessBriefEvidenceKind =
   | "artifact"
+  | "document"
+  | "screenshot"
+  | "spreadsheet"
+  | "url"
+  | "existing_route"
+  | "backlog_item"
+  | "feature_build"
+  | "email"
   | "existing_example"
   | "conversation"
   | "coworker"
@@ -52,6 +60,9 @@ export type BusinessBriefEvidence = {
   label: string;
   summary: string;
   url?: string;
+  copy?: string[];
+  adapt?: string[];
+  avoid?: string[];
 };
 
 export type BusinessBuildBrief = {
@@ -155,10 +166,13 @@ export type BusinessBuildBriefRecordInput = {
 
 export type BusinessBuildBriefEditInput = {
   briefId: string;
+  intakeSource?: BusinessBuildBriefSource;
+  evidenceKind?: BusinessBriefEvidenceKind;
   businessOutcome: string;
   affectedPeopleText: string;
   affectedWorkflow?: string | null;
   sourceEvidenceText: string;
+  copyAdaptAvoidText?: string;
   successSignalsText: string;
   constraintsText: string;
   openQuestionsText: string;
@@ -166,6 +180,7 @@ export type BusinessBuildBriefEditInput = {
 };
 
 export type BusinessBuildBriefEditPersistence = {
+  intakeSource: BusinessBuildBriefSource;
   status: BusinessBriefStatus;
   accepted: boolean;
   businessOutcome: string;
@@ -262,11 +277,88 @@ function evidenceFromInputs(inputs: string[]): BusinessBriefEvidence[] {
   }];
 }
 
-function evidenceFromText(value: string): BusinessBriefEvidence[] {
+function copyAdaptAvoidFromText(value: string | null | undefined): {
+  copy: string[];
+  adapt: string[];
+  avoid: string[];
+} {
+  const buckets = { copy: [] as string[], adapt: [] as string[], avoid: [] as string[] };
+  for (const line of textLines(value ?? "")) {
+    const match = /^(copy|adapt|avoid)\s*:\s*(.+)$/i.exec(line);
+    if (!match) continue;
+    const bucket = match[1]!.toLowerCase() as "copy" | "adapt" | "avoid";
+    buckets[bucket].push(match[2]!.trim());
+  }
+  return buckets;
+}
+
+function copyAdaptAvoidLines(value: {
+  copy: string[];
+  adapt: string[];
+  avoid: string[];
+}): string[] {
+  return [
+    ...value.copy.map((entry) => `Copy: ${entry}`),
+    ...value.adapt.map((entry) => `Adapt: ${entry}`),
+    ...value.avoid.map((entry) => `Avoid: ${entry}`),
+  ];
+}
+
+function evidenceKindForEdit(kind: BusinessBriefEvidenceKind | undefined): BusinessBriefEvidenceKind {
+  if (
+    kind === "document" ||
+    kind === "screenshot" ||
+    kind === "spreadsheet" ||
+    kind === "url" ||
+    kind === "existing_route" ||
+    kind === "backlog_item" ||
+    kind === "feature_build" ||
+    kind === "email" ||
+    kind === "existing_example" ||
+    kind === "market_signal"
+  ) {
+    return kind;
+  }
+  return "artifact";
+}
+
+function intakeSourceForEdit(
+  intakeSource: BusinessBuildBriefSource | undefined,
+  evidenceKind: BusinessBriefEvidenceKind,
+): BusinessBuildBriefSource {
+  if (
+    intakeSource === "user_conversation" ||
+    intakeSource === "artifact_reference" ||
+    intakeSource === "existing_example" ||
+    intakeSource === "coworker_proposal" ||
+    intakeSource === "innovation_radar"
+  ) {
+    return intakeSource;
+  }
+  if (evidenceKind === "existing_example" || evidenceKind === "existing_route" || evidenceKind === "feature_build") {
+    return "existing_example";
+  }
+  if (evidenceKind === "coworker") return "coworker_proposal";
+  if (evidenceKind === "market_signal") return "innovation_radar";
+  return "artifact_reference";
+}
+
+function evidenceFromText(
+  value: string,
+  kind: BusinessBriefEvidenceKind = "artifact",
+  copyAdaptAvoid?: { copy: string[]; adapt: string[]; avoid: string[] },
+): BusinessBriefEvidence[] {
   return textLines(value).map((line) => ({
-    kind: "artifact",
+    kind,
     label: line.length > 80 ? `${line.slice(0, 77)}...` : line,
     summary: line,
+    ...(kind === "existing_example" && copyAdaptAvoid
+      ? {
+        copy: copyAdaptAvoid.copy,
+        adapt: copyAdaptAvoid.adapt,
+        avoid: copyAdaptAvoid.avoid,
+      }
+      : {}),
   }));
 }
 
@@ -371,8 +463,19 @@ function evidenceFromRecord(value: unknown): BusinessBriefEvidence[] {
     const summary = stringField(entry, "summary") || stringField(entry, "note") || label;
     const kind = stringField(entry, "kind");
     const href = stringField(entry, "href") || stringField(entry, "url");
+    const copy = stringArrayField(entry, "copy");
+    const adapt = stringArrayField(entry, "adapt");
+    const avoid = stringArrayField(entry, "avoid");
     return [{
       kind: (
+        kind === "document" ||
+        kind === "screenshot" ||
+        kind === "spreadsheet" ||
+        kind === "url" ||
+        kind === "existing_route" ||
+        kind === "backlog_item" ||
+        kind === "feature_build" ||
+        kind === "email" ||
         kind === "existing_example" ||
         kind === "conversation" ||
         kind === "coworker" ||
@@ -381,6 +484,9 @@ function evidenceFromRecord(value: unknown): BusinessBriefEvidence[] {
       label,
       summary,
       ...(href ? { url: href } : {}),
+      ...(copy.length > 0 ? { copy } : {}),
+      ...(adapt.length > 0 ? { adapt } : {}),
+      ...(avoid.length > 0 ? { avoid } : {}),
     } satisfies BusinessBriefEvidence];
   });
 }
@@ -560,8 +666,12 @@ export function businessBuildBriefEditToPersistence(
   const businessOutcome = input.businessOutcome.trim();
   if (!businessOutcome) throw new Error("Business outcome is required");
 
+  const evidenceKind = evidenceKindForEdit(input.evidenceKind);
+  const intakeSource = intakeSourceForEdit(input.intakeSource, evidenceKind);
+  const copyAdaptAvoid = copyAdaptAvoidFromText(input.copyAdaptAvoidText);
+  const copyAdaptAvoidEvidence = copyAdaptAvoidLines(copyAdaptAvoid);
   const affectedPeople = textLines(input.affectedPeopleText);
-  const sourceEvidence = evidenceFromText(input.sourceEvidenceText);
+  const sourceEvidence = evidenceFromText(input.sourceEvidenceText, evidenceKind, copyAdaptAvoid);
   const successSignals = textLines(input.successSignalsText);
   const constraints = textLines(input.constraintsText);
   const openQuestions = textLines(input.openQuestionsText);
@@ -593,6 +703,7 @@ export function businessBuildBriefEditToPersistence(
   };
 
   return {
+    intakeSource,
     status: accepted ? "accepted" : "awaiting_clarification",
     accepted,
     businessOutcome,
@@ -601,7 +712,9 @@ export function businessBuildBriefEditToPersistence(
     sourceEvidence,
     successSignals,
     constraints,
-    businessInterpretation: businessOutcome,
+    businessInterpretation: copyAdaptAvoidEvidence.length > 0
+      ? `${businessOutcome}\n\n${copyAdaptAvoidEvidence.join("\n")}`
+      : businessOutcome,
     technicalInterpretation,
     riskProfile,
     openQuestions,
@@ -614,7 +727,10 @@ export function businessBuildBriefEditToPersistence(
       description: businessOutcome,
       portfolioContext: affectedWorkflow ?? "",
       targetRoles: affectedPeople,
-      inputs: sourceEvidence.map((evidence) => evidence.summary),
+      inputs: [
+        ...sourceEvidence.map((evidence) => evidence.summary),
+        ...copyAdaptAvoidEvidence,
+      ],
       dataNeeds: technicalInterpretation.dataNeeds ?? "",
       acceptanceCriteria: successSignals,
     },


### PR DESCRIPTION
## Summary
- Add business-facing reference type controls to the Build Studio v2 business brief editor for documents, screenshots, spreadsheets, URLs, and existing working examples.
- Persist the selected evidence kind and intake source through the governed `updateBusinessBuildBrief` action.
- Preserve copy/adapt/avoid guidance for existing-example intake in structured `sourceEvidence`, business interpretation text, and legacy `FeatureBuild.brief` inputs.

## Verification
- Red-first tests failed on missing intake source, typed evidence kind, and editor reference controls before implementation.
- `pnpm --filter web exec vitest run lib/build/business-build-brief.test.ts components/build-studio/BusinessBriefPanel.test.tsx lib/actions/build-governed.test.ts`
- `git diff --check` (CRLF warnings only)
- `pnpm --filter web exec vitest run lib/build/business-build-brief.test.ts components/build-studio/BuildStudioV2.test.tsx components/build-studio/BusinessBriefPanel.test.tsx components/build-studio/ArtifactTabs.test.tsx lib/actions/build-governed.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `docker compose --env-file D:\DPF\.env build --no-cache portal`
- `docker compose --env-file D:\DPF\.env up -d portal`
- Playwright smoke against Docker portal: logged in, opened `/build?v=2`, changed a temporary persisted brief to `existing_example`, saved copy/adapt/avoid guidance, confirmed `Brief saved.`, verified structured DB persistence, then removed the fixture.

## Notes
- Existing Turbopack tracing warnings around broad `spec-plan-search.ts` / `next.config.mjs` context remain warnings only; production build completed successfully.