### PR TITLE
feat(installer): supplementary doctor diagnostics (Phase 10d)

### DIFF
--- a/scripts/installer/lib/diagnostics.sh
+++ b/scripts/installer/lib/diagnostics.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Supplementary diagnostics collector for DPF installations.
+# Source this file; do not execute directly.
+#
+# Per the installer-parity roadmap Phase 10d. The core bundle in
+# doctor.sh (Phase 6) already covers host info, docker version /
+# context, compose chain + render hash, install-state, service logs,
+# port-conflict scan, LLM reachability, and redacted env. This module
+# adds the long-tail sections field experience flagged as missing:
+#
+#   - Autostart unit state (LaunchAgent on macOS, systemd-user unit
+#     on Linux) — most "stack didn't come back after reboot" reports
+#     trace back to a misconfigured or quarantined autostart unit.
+#   - Full rendered compose YAML — the existing sha256 in doctor.sh
+#     answers "did the chain change?", but the YAML itself is what
+#     an investigator needs to see to diagnose overlay-merge issues.
+#   - Disk space on key mount points — common silent failure on small
+#     VMs / runners; the platform fills /var/lib/docker quickly with
+#     5 GB of images.
+#   - DNS resolution for the four hosts the installer + image pulls
+#     depend on (github.com, ghcr.io, registry-1.docker.io,
+#     model-runner.docker.internal).
+#   - ~/.dpf perms snapshot — silent permission corruption (state
+#     file world-readable after a misconfigured chmod, etc.) is hard
+#     to debug without a perms dump.
+#
+# Bash 3.2 baseline.
+
+if [ "${DPF_LIB_DIAGNOSTICS_LOADED:-}" = "1" ]; then
+  return 0
+fi
+DPF_LIB_DIAGNOSTICS_LOADED=1
+
+if [ -z "${DPF_LIB_LOGGING_LOADED:-}" ]; then
+  # shellcheck source=logging.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/logging.sh"
+fi
+if [ -z "${DPF_LIB_STATE_LOADED:-}" ]; then
+  # shellcheck source=state.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/state.sh"
+fi
+if [ -z "${DPF_LIB_COMPOSE_LOADED:-}" ]; then
+  # shellcheck source=compose.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/compose.sh"
+fi
+if [ -z "${DPF_LIB_PLATFORM_LOADED:-}" ]; then
+  # shellcheck source=platform.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/platform.sh"
+fi
+
+# Public: write the supplementary diagnostics into $1 (existing bundle
+# directory created by doctor.sh). Best-effort throughout — every
+# section is wrapped so a failing shell-out (e.g. no systemctl on a
+# darwin box) doesn't abort the rest of the bundle. Caller is expected
+# to have already relaxed `set -e` for the duration of doctor collect.
+#
+# Args:
+#   $1 = bundle directory (already exists, owned by caller)
+#   $2 = mode hint (dev|release) for compose chain assembly
+dpf_diagnostics_collect() {
+  local bundle_dir="$1"
+  local mode="${2:-dev}"
+
+  if [ -z "$bundle_dir" ] || [ ! -d "$bundle_dir" ]; then
+    return 1
+  fi
+
+  dpf_platform
+
+  # 1. Autostart unit state.
+  {
+    echo "Platform: $DPF_PLATFORM"
+    echo
+    case "$DPF_PLATFORM" in
+      darwin)
+        local plist="$HOME/Library/LaunchAgents/local.dpf-autostart.plist"
+        echo "Expected plist: $plist"
+        if [ -f "$plist" ]; then
+          echo "  status: present"
+          echo "  perms: $(ls -l "$plist" 2>/dev/null | awk '{print $1, $3, $4}')"
+        else
+          echo "  status: missing"
+        fi
+        echo
+        echo "launchctl print gui/$UID/local.dpf-autostart:"
+        launchctl print "gui/$UID/local.dpf-autostart" 2>&1 | head -50 || true
+        echo
+        echo "xattr (quarantine check):"
+        [ -f "$plist" ] && xattr -l "$plist" 2>&1 || echo "  (plist not present)"
+        ;;
+      linux)
+        local unit="$HOME/.config/systemd/user/dpf.service"
+        echo "Expected unit: $unit"
+        if [ -f "$unit" ]; then
+          echo "  status: present"
+          echo "  perms: $(ls -l "$unit" 2>/dev/null | awk '{print $1, $3, $4}')"
+        else
+          echo "  status: missing"
+        fi
+        echo
+        if command -v systemctl >/dev/null 2>&1; then
+          echo "systemctl --user status dpf.service:"
+          systemctl --user status dpf.service 2>&1 | head -30 || true
+          echo
+          echo "systemctl --user is-enabled dpf.service:"
+          systemctl --user is-enabled dpf.service 2>&1 || true
+          echo
+          if command -v loginctl >/dev/null 2>&1; then
+            echo "loginctl show-user (linger):"
+            loginctl show-user "$(id -un)" 2>&1 | grep -i linger || true
+          fi
+        else
+          echo "(systemctl not available)"
+        fi
+        ;;
+      *)
+        echo "(autostart not implemented for platform: $DPF_PLATFORM)"
+        ;;
+    esac
+  } > "$bundle_dir/autostart.txt"
+
+  # 2. Full rendered compose YAML (caller already records sha256 in
+  #    compose.txt; this is the content the hash summarizes).
+  if dpf_compose_files "$mode" 2>/dev/null; then
+    docker compose "${DPF_COMPOSE_FILES[@]}" config > "$bundle_dir/compose-rendered.yml" 2>&1 || \
+      echo "(compose config failed — see file for stderr)" >> "$bundle_dir/compose-rendered.yml"
+  fi
+
+  # 3. Disk space on the paths the installer touches.
+  {
+    echo "Disk usage on DPF-relevant mount points:"
+    echo
+    # df -h with explicit POSIX-portable args. macOS df defaults to
+    # 512-byte blocks; -h gives human-readable on both BSD and GNU.
+    local paths="$HOME"
+    [ -d "$(dpf_state_dir)" ] && paths="$paths $(dpf_state_dir)"
+    [ -d "/var/lib/docker" ] && paths="$paths /var/lib/docker"
+    [ -d "/" ] && paths="$paths /"
+    # shellcheck disable=SC2086
+    df -h $paths 2>&1 | sort -u
+    echo
+    echo "DPF state directory size:"
+    if [ -d "$(dpf_state_dir)" ]; then
+      du -sh "$(dpf_state_dir)" 2>&1 || true
+    fi
+  } > "$bundle_dir/disk.txt"
+
+  # 4. DNS resolution + outbound reachability for the four hosts the
+  #    installer + image pulls depend on.
+  {
+    echo "Outbound reachability:"
+    echo
+    for host in github.com ghcr.io registry-1.docker.io model-runner.docker.internal; do
+      printf '  %-40s ' "$host"
+      if command -v getent >/dev/null 2>&1; then
+        getent hosts "$host" >/dev/null 2>&1 && echo -n "[DNS ok] " || echo -n "[DNS FAIL] "
+      elif command -v host >/dev/null 2>&1; then
+        host "$host" >/dev/null 2>&1 && echo -n "[DNS ok] " || echo -n "[DNS FAIL] "
+      elif command -v dscacheutil >/dev/null 2>&1; then
+        # macOS
+        dscacheutil -q host -a name "$host" 2>/dev/null | grep -q "ip_address:" && echo -n "[DNS ok] " || echo -n "[DNS FAIL] "
+      else
+        echo -n "[DNS unknown] "
+      fi
+      curl --silent --max-time 5 --output /dev/null --write-out "HTTPS %{http_code} (%{time_total}s)\n" "https://$host" 2>&1 \
+        || echo "HTTPS unreachable"
+    done
+  } > "$bundle_dir/connectivity.txt"
+
+  # 5. ~/.dpf perms snapshot. Surfaces world-readable secrets, stale
+  #    launch script perms, missing log directory, etc.
+  {
+    local state_dir; state_dir="$(dpf_state_dir)"
+    echo "State dir: $state_dir"
+    echo
+    if [ -d "$state_dir" ]; then
+      ls -la "$state_dir" 2>&1 || true
+      if [ -d "$state_dir/logs" ]; then
+        echo
+        echo "logs/:"
+        ls -la "$state_dir/logs" 2>&1 || true
+      fi
+    else
+      echo "(state dir does not exist)"
+    fi
+    echo
+    echo "Repo .env perms (if present):"
+    if [ -f .env ]; then
+      ls -l .env 2>&1 || true
+    else
+      echo "(.env not present in CWD)"
+    fi
+  } > "$bundle_dir/perms.txt"
+}

--- a/scripts/installer/lib/doctor.sh
+++ b/scripts/installer/lib/doctor.sh
@@ -39,6 +39,16 @@ if [ -z "${DPF_LIB_COMPOSE_LOADED:-}" ]; then
   # shellcheck source=compose.sh
   . "$(dirname "${BASH_SOURCE[0]}")/compose.sh"
 fi
+# Supplementary diagnostics module (Phase 10d) adds autostart unit
+# state, full rendered compose YAML, disk space, DNS reachability, and
+# state-dir perms snapshot. Optional — older installs missing the file
+# silently fall back to the Phase-6 core bundle.
+if [ -z "${DPF_LIB_DIAGNOSTICS_LOADED:-}" ]; then
+  if [ -f "$(dirname "${BASH_SOURCE[0]}")/diagnostics.sh" ]; then
+    # shellcheck source=diagnostics.sh
+    . "$(dirname "${BASH_SOURCE[0]}")/diagnostics.sh"
+  fi
+fi
 
 # Redact common secret patterns from env / state output. Replaces values
 # of any line matching SECRET|PASSWORD|TOKEN|KEY|AUTH (case-insensitive)
@@ -165,6 +175,13 @@ dpf_doctor_collect() {
     env | grep -iE '^(DPF_|LLM_|EMBEDDING_|BROWSER_USE_|GHCR_|POSTGRES_|NEO4J_|AUTH_|ADMIN_|MCP_|DOCKER_)' \
       | _dpf_doctor_redact | sort
   } > "$bundle_dir/env.txt"
+
+  # 10. Phase 10d supplementary diagnostics — autostart unit, full
+  #     rendered compose YAML, disk usage, outbound reachability, perms.
+  #     Best-effort; module is optional so older installs still work.
+  if command -v dpf_diagnostics_collect >/dev/null 2>&1; then
+    dpf_diagnostics_collect "$bundle_dir" "${1:-dev}" 2>/dev/null || true
+  fi
 
   # Bundle and stamp the install-state with the bundle path.
   tar -czf "$tarball" -C "$bundle_dir" . 2>/dev/null


### PR DESCRIPTION
The Phase 6 doctor bundle in `scripts/installer/lib/doctor.sh` already
covers host info, docker version + context, compose chain + render
hash, install-state, service logs, port-conflict scan, LLM
reachability, and redacted env. **Phase 10d** adds the long-tail
sections field experience flagged as missing.

## What it adds

New module: **`scripts/installer/lib/diagnostics.sh`**, sourced by
`doctor.sh` when present (older installs missing the file fall back
silently to the Phase-6 core bundle).

| New artifact | Contents | Why it matters |
|--------------|----------|----------------|
| **`autostart.txt`** | LaunchAgent (macOS) or systemd-user unit (Linux) presence, perms, status, enable state, linger flag. Plus `xattr` quarantine check on macOS. | Most "stack didn't come back after reboot" reports trace back to a missing / quarantined / not-enabled autostart unit. Capturing this at doctor-time avoids a round-trip with every support contact. |
| **`compose-rendered.yml`** | Full `docker compose config` output. | Existing `compose.txt` records only the sha256 — useful for "did the chain change?" but not for diagnosing overlay-merge bugs. The YAML is what an investigator needs. |
| **`disk.txt`** | `df -h` on `$HOME`, state dir, `/var/lib/docker`, `/`. Plus `du -sh` of the state dir. | Small-VM out-of-disk is a common silent failure when 5 GB of GHCR images land on a 20 GB volume. |
| **`connectivity.txt`** | DNS + HTTPS reachability for `github.com`, `ghcr.io`, `registry-1.docker.io`, `model-runner.docker.internal`. Uses `getent` / `host` / `dscacheutil` with platform-appropriate fallback. | Extends the existing air-gap warn in preflight into the doctor bundle so investigators can see whether the host can actually pull images. |
| **`perms.txt`** | `ls -la ~/.dpf`, `~/.dpf/logs/`, and `.env`. | Surfaces world-readable secrets, stale launch script perms, missing log dir — silent permission drift that's hard to spot without a snapshot. |

Hooked into `dpf_doctor_collect()` as step 10, after the existing 9
sections. Every block is best-effort wrapped — a failing shell-out on
a darwin box (no `systemctl`) or a fresh Linux runner (no docker)
doesn't abort the rest of the bundle.

## Verification

```
bash install-dpf.sh doctor
  OK Bundle written: /root/.dpf/doctor-20260511T025830Z.tar.gz

tar -tzf .../doctor-20260511T025830Z.tar.gz
  15 artifacts (was 10):
    + autostart.txt       (systemd-user unit state, linger flag)
    + compose-rendered.yml (full YAML)
    + disk.txt            (df + du)
    + connectivity.txt    (DNS + HTTPS for 4 hosts)
    + perms.txt           (state dir + .env perms)
```

Sample `connectivity.txt` output:

```
Outbound reachability:

  github.com                               [DNS ok] HTTPS 200 (0.108s)
  ghcr.io                                  [DNS ok] HTTPS 301 (0.223s)
  registry-1.docker.io                     [DNS ok] HTTPS 404 (0.445s)
  model-runner.docker.internal             [DNS FAIL] HTTPS 000 (0.001s)
```

(The Model Runner failure is expected in sandbox; on a real macOS
Docker Desktop host with Model Runner enabled, the entry resolves
through the docker daemon DNS.)

## Roadmap

`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md` —
Phase 10d. **Closes out Phase 10 and the full macOS / Linux
installer-parity roadmap** (Phases 0 – 10).

Remaining concerns outside this roadmap, tracked as follow-up:

- **codebase-tools secrets pattern**: nested `config/secrets/...`
  slips through the `^secrets/i` start-anchored regex (surfaced
  during #447). Security-tightening change worth its own PR.
- **Unit Tests regression on main**: pre-existing breakage from
  dependabot bumps; out-of-scope for this roadmap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_