### PR TITLE
feat(wiki): EP-WIKI-001 Phase 3b2 — wiki_query MCP tool

### DIFF
--- a/apps/web/lib/mcp-tools-wiki-query.test.ts
+++ b/apps/web/lib/mcp-tools-wiki-query.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    organization: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+const searchWikiPages = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+  QDRANT_COLLECTIONS: { WIKI_PAGES: "wiki-pages" },
+}));
+
+vi.mock("@/lib/wiki/embeddings", () => ({
+  searchWikiPages: (...args: unknown[]) => searchWikiPages(...args),
+}));
+
+import { executeTool } from "./mcp-tools";
+
+afterEach(() => {
+  mockPrisma.organization.findFirst.mockReset();
+  searchWikiPages.mockReset();
+});
+
+describe("wiki_query MCP tool", () => {
+  it("returns 'no matching pages' message when search is empty", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_a" });
+    searchWikiPages.mockResolvedValueOnce([]);
+
+    const res = await executeTool("wiki_query", { query: "what is a digital product?" }, "user_test");
+
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("No matching wiki pages found.");
+    expect(res.data).toEqual({ results: [] });
+  });
+
+  it("forwards organization id, query, pageKind, and limit to searchWikiPages", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_acme" });
+    searchWikiPages.mockResolvedValueOnce([]);
+
+    await executeTool(
+      "wiki_query",
+      {
+        query: "Mark's stance on portfolio anchoring",
+        pageKind: "stance",
+        limit: 8,
+      },
+      "user_test",
+    );
+
+    expect(searchWikiPages).toHaveBeenCalledWith({
+      query: "Mark's stance on portfolio anchoring",
+      organizationId: "org_acme",
+      pageKind: "stance",
+      limit: 8,
+    });
+  });
+
+  it("falls back to organizationId=null when no organization exists", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce(null);
+    searchWikiPages.mockResolvedValueOnce([]);
+
+    await executeTool("wiki_query", { query: "q" }, "user_test");
+
+    expect(searchWikiPages).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: null, limit: 5 }),
+    );
+  });
+
+  it("formats a summary line per result including kernel/overlay origin", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_a" });
+    searchWikiPages.mockResolvedValueOnce([
+      {
+        pageId: "wp_1",
+        slug: "entities/digital-product",
+        title: "Digital Product",
+        pageKind: "entity",
+        contentPreview: "A digital product is...",
+        isKernel: true,
+        organizationId: null,
+        kernelPageId: null,
+        score: 0.82,
+        source: "kernel",
+      },
+      {
+        pageId: "wp_2",
+        slug: "stances/portfolio-as-anchor",
+        title: "Portfolio as Anchor",
+        pageKind: "stance",
+        contentPreview: "Portfolio is the unit of...",
+        isKernel: false,
+        organizationId: "org_a",
+        kernelPageId: "wp_kernel_x",
+        score: 0.91,
+        source: "org",
+      },
+    ]);
+
+    const res = await executeTool("wiki_query", { query: "q" }, "user_test");
+
+    expect(res.success).toBe(true);
+    const lines = (res.message ?? "").split("\n");
+    expect(lines[0]).toContain("entities/digital-product (entity, kernel)");
+    expect(lines[0]).toContain("82% match");
+    expect(lines[1]).toContain("stances/portfolio-as-anchor (stance, org)");
+    expect(lines[1]).toContain("91% match");
+  });
+
+  it("survives an organization lookup failure (kernel-only fallback)", async () => {
+    mockPrisma.organization.findFirst.mockRejectedValueOnce(new Error("DB down"));
+    searchWikiPages.mockResolvedValueOnce([]);
+
+    const res = await executeTool("wiki_query", { query: "q" }, "user_test");
+
+    expect(res.success).toBe(true);
+    expect(searchWikiPages).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: null }),
+    );
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1928,6 +1928,27 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     requiredCapability: null,
     executionMode: "immediate",
   },
+  // ─── EP-WIKI-001 Phase 3b2: Wiki Query ──────────────────────────────────────
+  {
+    name: "wiki_query",
+    description: "Search the founder kernel + per-org overlay wiki for entity, stance, heuristic, decision, summary, runbook, or index pages. Use when the user asks about a DPF concept, what the founder's view is on something, or for grounded judgment on a question. Returns top-K pages with slug, kind, kernel/overlay origin, and a content preview. Prefer this over web speculation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "What to search for. Natural language; the wiki is embedded for semantic similarity." },
+        pageKind: {
+          type: "string",
+          enum: ["entity", "summary", "decision", "runbook", "index", "stance", "heuristic"],
+          description: "Optional filter to one page kind. Use 'stance' or 'heuristic' when the user wants judgment; 'entity' for definitions; 'decision' for DEC-* records.",
+        },
+        limit: { type: "number", description: "Max results (default 5)." },
+      },
+      required: ["query"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+  },
   // ─── Knowledge Search ──────────────────────────────────────────────────────
   {
     name: "search_knowledge",
@@ -8157,6 +8178,30 @@ export async function executeTool(
         entityId: feedbackId,
         message: "Feedback submitted.",
       };
+    }
+
+    case "wiki_query": {
+      const { searchWikiPages } = await import("@/lib/wiki/embeddings");
+      const { prisma } = await import("@dpf/db");
+      const org = await prisma.organization
+        .findFirst({ select: { id: true } })
+        .catch(() => null);
+      const results = await searchWikiPages({
+        query: String(params["query"] ?? ""),
+        organizationId: org?.id ?? null,
+        pageKind: typeof params["pageKind"] === "string" ? params["pageKind"] : undefined,
+        limit: typeof params["limit"] === "number" ? params["limit"] : 5,
+      });
+      if (results.length === 0) {
+        return { success: true, message: "No matching wiki pages found.", data: { results: [] } };
+      }
+      const summary = results
+        .map(
+          (r) =>
+            `${r.slug} (${r.pageKind}, ${r.source}) — ${r.title} (${Math.round(r.score * 100)}% match)`,
+        )
+        .join("\n");
+      return { success: true, message: summary, data: { results } };
     }
 
     case "search_knowledge": {

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -63,6 +63,9 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   create_knowledge_article: ["registry_write"],
   flag_stale_knowledge: ["registry_read"],
 
+  // EP-WIKI-001 Phase 3b2: Founder kernel + per-org overlay wiki
+  wiki_query: ["registry_read"],
+
   // Build / Sandbox
   launch_sandbox: ["sandbox_execute"],
   generate_code: ["sandbox_execute"],


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 3b2 — adds the `wiki_query` MCP tool. **The explicit synthesis path** that complements the passive recall wireup from PR #449. When a user asks a wiki-specific question (e.g. &#34;what&#39;s Mark&#39;s stance on portfolio anchoring?&#34;) the agent can call `wiki_query` directly and reason over the returned pages, rather than relying solely on the passive context block.

## What&#39;s in this PR

### `apps/web/lib/mcp-tools.ts`

- **New tool definition `wiki_query`** (immediate, read-only, `requiredCapability: null` since `registry_read` is platform-wide). Inputs: `query` (required), `pageKind` (optional enum of the seven kinds), `limit` (default 5).
- **Executor** that:
  1. Looks up the platform organization id (single-tenant install pattern; tolerates DB failure → `null` fallback).
  2. Calls `searchWikiPages` with the two-pass overlay-aware retrieval from PR #421.
  3. Formats results as `slug (kind, kernel|org) — title (NN% match)` lines, mirroring the `search_knowledge_base` shape.

### `apps/web/lib/tak/agent-grants.ts`

- `wiki_query: ["registry_read"]` — same capability bracket as `search_knowledge_base`.

### `apps/web/lib/mcp-tools-wiki-query.test.ts` (5 vitest cases)

| Case | Asserts |
|------|---------|
| Empty result | &#34;No matching wiki pages found.&#34; message |
| Forwards args | `organizationId`, `query`, `pageKind`, `limit` reach `searchWikiPages` |
| No organization | Falls back to `organizationId: null` |
| Summary format | Kernel/org origin + match percentage in each line |
| DB failure | `organization.findFirst` rejection → kernel-only fallback (no throw) |

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` | ✓ (Sandbox model from main needed regen) |
| `pnpm --filter web typecheck` | ✓ |
| `pnpm --filter web test --run mcp-tools-wiki-query.test.ts` | ✓ 5/5 |

## Out of scope

- **Phase 3b3** (separate PR): `route-context-map.ts` — add `wiki_query` to every route&#39;s `domainTools` array, ranked above `search_knowledge_base`. Touches every route entry; deserves its own focused PR.
- **Phase 3b3 (cont.)**: `find-knowledge.skill.md` — update the waterfall to call `wiki_query` first.
- **Phase 2c**: `wiki_propose_edit` MCP tool — depends on Phase 2b ingest pipeline.

## Dependencies

Depends only on merged work: PR #421 (`searchWikiPages`), PR #408 (`WikiPage` model). Independent of in-flight PRs #443 (page viewer) and #449 (recall wireup).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_