### PR TITLE
feat(wiki): EP-WIKI-001 Phase 4b2a — admin lint findings page

### DIFF
--- a/apps/web/app/(shell)/admin/wiki/lint/page.tsx
+++ b/apps/web/app/(shell)/admin/wiki/lint/page.tsx
@@ -1,0 +1,227 @@
+// EP-WIKI-001 Phase 4b2: admin lint findings page.
+// Server component. Read-only listing of WikiLintFinding rows produced
+// by the Phase 4b1 daily scheduled job (apps/web/lib/queue/functions/wiki-lint.ts).
+
+import { prisma } from "@dpf/db";
+import Link from "next/link";
+
+import {
+  LintFindingCard,
+  type LintFindingRow,
+} from "@/components/wiki/LintFindingCard";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Wiki Lint · Admin",
+};
+
+const STATUS_TABS: Array<{ value: string; label: string }> = [
+  { value: "open", label: "Open" },
+  { value: "resolved", label: "Resolved" },
+  { value: "ignored", label: "Ignored" },
+  { value: "all", label: "All" },
+];
+
+const SEVERITY_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "", label: "All severities" },
+  { value: "error", label: "Error" },
+  { value: "warn", label: "Warn" },
+  { value: "info", label: "Info" },
+];
+
+const SCOPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "", label: "All scopes" },
+  { value: "kernel", label: "Kernel" },
+  { value: "overlay", label: "Overlay" },
+];
+
+type SearchParams = Promise<{
+  status?: string;
+  severity?: string;
+  scope?: string;
+  kind?: string;
+}>;
+
+export default async function AdminWikiLintPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const sp = await searchParams;
+  const statusFilter = sp.status ?? "open";
+  const severityFilter = sp.severity ?? "";
+  const scopeFilter = sp.scope ?? "";
+  const kindFilter = sp.kind ?? "";
+
+  const where: Record<string, unknown> = {};
+  if (statusFilter !== "all") where.status = statusFilter;
+  if (severityFilter) where.severity = severityFilter;
+  if (scopeFilter === "kernel") where.organizationId = null;
+  else if (scopeFilter === "overlay") where.organizationId = { not: null };
+  if (kindFilter) where.findingKind = kindFilter;
+
+  const findings = (await prisma.wikiLintFinding.findMany({
+    where,
+    orderBy: [{ severity: "desc" }, { createdAt: "desc" }],
+    take: 200,
+    include: {
+      // No relation on WikiLintFinding to WikiPage in the schema (it's a
+      // loose pageId reference), so fetch pages separately and join in memory.
+    },
+  })) as Array<{
+    id: string;
+    organizationId: string | null;
+    pageId: string;
+    findingKind: string;
+    severity: string;
+    status: string;
+    detail: unknown;
+    resolvedAt: Date | null;
+    createdAt: Date;
+  }>;
+
+  const pageIds = Array.from(new Set(findings.map((f) => f.pageId)));
+  const pages =
+    pageIds.length > 0
+      ? await prisma.wikiPage.findMany({
+          where: { id: { in: pageIds } },
+          select: { id: true, slug: true, title: true, pageKind: true, isKernel: true },
+        })
+      : [];
+  const pageById = new Map(pages.map((p) => [p.id, p]));
+
+  const rows: LintFindingRow[] = findings.map((f) => ({
+    ...f,
+    page: pageById.get(f.pageId) ?? null,
+  }));
+
+  const counts = {
+    open: rows.filter((r) => r.status === "open").length,
+    resolved: rows.filter((r) => r.status === "resolved").length,
+    ignored: rows.filter((r) => r.status === "ignored").length,
+    error: rows.filter((r) => r.severity === "error").length,
+    warn: rows.filter((r) => r.severity === "warn").length,
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto py-6 px-4">
+      <header className="mb-6">
+        <h1 className="text-xl font-semibold text-[var(--dpf-text)]">Wiki Lint</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          Findings produced by the daily scheduled job. {counts.error} errors,{" "}
+          {counts.warn} warns, {counts.open} open.
+        </p>
+      </header>
+
+      <FilterBar
+        statusFilter={statusFilter}
+        severityFilter={severityFilter}
+        scopeFilter={scopeFilter}
+        kindFilter={kindFilter}
+      />
+
+      {rows.length === 0 ? (
+        <p className="mt-6 text-sm text-[var(--dpf-muted)] italic">
+          No findings match the current filters. The daily lint job has either
+          not run yet, the kernel + overlay are clean, or your filter excluded
+          everything.
+        </p>
+      ) : (
+        <div className="mt-6 space-y-px border border-[var(--dpf-border)] rounded overflow-hidden">
+          {rows.map((r) => (
+            <LintFindingCard key={r.id} finding={r} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Filter Bar ─────────────────────────────────────────────────────────────
+
+function FilterBar({
+  statusFilter,
+  severityFilter,
+  scopeFilter,
+  kindFilter,
+}: {
+  statusFilter: string;
+  severityFilter: string;
+  scopeFilter: string;
+  kindFilter: string;
+}) {
+  function hrefWith(overrides: Record<string, string | undefined>): string {
+    const params = new URLSearchParams();
+    const current: Record<string, string> = {
+      status: statusFilter,
+      severity: severityFilter,
+      scope: scopeFilter,
+      kind: kindFilter,
+    };
+    for (const [k, v] of Object.entries({ ...current, ...overrides })) {
+      if (v) params.set(k, v);
+    }
+    const qs = params.toString();
+    return qs ? `/admin/wiki/lint?${qs}` : "/admin/wiki/lint";
+  }
+
+  return (
+    <div className="flex flex-wrap gap-3 items-center text-xs">
+      <div className="flex gap-1">
+        {STATUS_TABS.map((tab) => {
+          const active = tab.value === statusFilter;
+          return (
+            <Link
+              key={tab.value}
+              href={hrefWith({ status: tab.value })}
+              className={`px-2 py-1 rounded border ${
+                active
+                  ? "bg-[var(--dpf-surface-2)] border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                  : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
+              }`}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+      <div className="flex gap-1">
+        {SEVERITY_OPTIONS.map((opt) => {
+          const active = opt.value === severityFilter;
+          return (
+            <Link
+              key={opt.value || "all"}
+              href={hrefWith({ severity: opt.value || undefined })}
+              className={`px-2 py-1 rounded border ${
+                active
+                  ? "bg-[var(--dpf-surface-2)] border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                  : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+      <div className="flex gap-1">
+        {SCOPE_OPTIONS.map((opt) => {
+          const active = opt.value === scopeFilter;
+          return (
+            <Link
+              key={opt.value || "all"}
+              href={hrefWith({ scope: opt.value || undefined })}
+              className={`px-2 py-1 rounded border ${
+                active
+                  ? "bg-[var(--dpf-surface-2)] border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                  : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/wiki/LintFindingCard.tsx
+++ b/apps/web/components/wiki/LintFindingCard.tsx
@@ -1,0 +1,148 @@
+// EP-WIKI-001 Phase 4b2: card display for a single WikiLintFinding row.
+// Server component. Mounted by the /admin/wiki/lint page.
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+export type LintFindingRow = {
+  id: string;
+  organizationId: string | null;
+  pageId: string;
+  findingKind: string;
+  severity: string;
+  status: string;
+  detail: unknown;
+  resolvedAt: Date | null;
+  createdAt: Date;
+  page: {
+    slug: string;
+    title: string;
+    pageKind: string;
+    isKernel: boolean;
+  } | null;
+};
+
+// ─── Visual encoding ────────────────────────────────────────────────────────
+
+const SEVERITY_STYLES: Record<string, string> = {
+  error: "border-l-2 border-[var(--dpf-accent)]",
+  warn: "border-l-2 border-[var(--dpf-border)]",
+  info: "border-l-2 border-transparent",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  open: "Open",
+  resolved: "Resolved",
+  ignored: "Ignored",
+};
+
+const KIND_DESCRIPTIONS: Record<string, string> = {
+  contradiction: "Two pages contain claims an LLM detector judged incompatible.",
+  stale: "Oldest cited source is past the staleness threshold.",
+  orphan: "Page is published with no inbound links and/or no source citations.",
+  "missing-xref": "An entity mention in prose is not wrapped in [[link]].",
+  "dangling-xref": "An [[link]] target does not exist (blocks publish).",
+  "kernel-drift": "Org overlay derived from an older kernel version than current.",
+  "stance-extraction-needed":
+    "Summary page has no extracted stance or heuristic link.",
+};
+
+function formatDetail(detail: unknown): string | null {
+  if (!detail || typeof detail !== "object") return null;
+  const obj = detail as Record<string, unknown>;
+  // Surface a few commonly useful fields. Detail keys are documented per
+  // detector in apps/web/lib/wiki/lint-detectors.ts.
+  const parts: string[] = [];
+  if (typeof obj.reason === "string") parts.push(`reason: ${obj.reason}`);
+  if (Array.isArray(obj.danglingTargets)) {
+    parts.push(`targets: ${(obj.danglingTargets as string[]).join(", ")}`);
+  }
+  if (typeof obj.ageDays === "number") parts.push(`${obj.ageDays}d old`);
+  if (
+    typeof obj.derivedFromKernelVersion === "string" &&
+    typeof obj.currentKernelVersion === "string"
+  ) {
+    parts.push(
+      `v${obj.derivedFromKernelVersion} → v${obj.currentKernelVersion}`,
+    );
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+type Props = {
+  finding: LintFindingRow;
+};
+
+export function LintFindingCard({ finding }: Props): ReactNode {
+  const sevClass = SEVERITY_STYLES[finding.severity] ?? SEVERITY_STYLES.info;
+  const pageHref = finding.page ? `/wiki/${finding.page.slug}` : null;
+  const detailLine = formatDetail(finding.detail);
+
+  return (
+    <article
+      className={`px-3 py-2 bg-[var(--dpf-surface-1)] ${sevClass}`}
+    >
+      <header className="flex items-center gap-2 flex-wrap text-xs">
+        <span className="font-semibold uppercase tracking-wide text-[var(--dpf-text)]">
+          {finding.findingKind}
+        </span>
+        <span className="px-1.5 py-0.5 rounded uppercase tracking-wide text-[10px] border border-[var(--dpf-border)] text-[var(--dpf-muted)]">
+          {finding.severity}
+        </span>
+        <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+          {STATUS_LABELS[finding.status] ?? finding.status}
+        </span>
+        {finding.organizationId === null ? (
+          <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+            kernel
+          </span>
+        ) : (
+          <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+            overlay · {finding.organizationId}
+          </span>
+        )}
+        <span className="ml-auto text-[10px] text-[var(--dpf-muted)]">
+          {finding.createdAt.toISOString().slice(0, 10)}
+        </span>
+      </header>
+
+      <div className="mt-1 text-sm text-[var(--dpf-text)]">
+        {finding.page ? (
+          pageHref ? (
+            <Link href={pageHref} className="hover:underline text-[var(--dpf-accent)]">
+              {finding.page.title}{" "}
+              <span className="text-[var(--dpf-muted)] font-mono text-xs">
+                {finding.page.slug}
+              </span>
+            </Link>
+          ) : (
+            <>
+              {finding.page.title}{" "}
+              <span className="text-[var(--dpf-muted)] font-mono text-xs">
+                {finding.page.slug}
+              </span>
+            </>
+          )
+        ) : (
+          <span className="text-[var(--dpf-muted)] italic">
+            page {finding.pageId} (deleted)
+          </span>
+        )}
+      </div>
+
+      <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+        {KIND_DESCRIPTIONS[finding.findingKind] ?? finding.findingKind}
+      </p>
+
+      {detailLine && (
+        <p className="mt-1 text-xs text-[var(--dpf-muted)] font-mono">
+          {detailLine}
+        </p>
+      )}
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 4b2a — read-only `/admin/wiki/lint` page that surfaces `WikiLintFinding` rows produced by the Phase 4b1 daily scheduled job. First UI surface for the lint pipeline.

## What&#39;s in this PR

### `apps/web/components/wiki/LintFindingCard.tsx`

Per-finding card:
- Header: kind + severity + status + scope (kernel / overlay + org id) + date
- Body: affected page title/slug, linked to `/wiki/<slug>` (graceful 404 if Phase 6a viewer #443 hasn&#39;t merged yet)
- Description line per `findingKind` (human-readable explanation)
- Detail line parsed from the JSON `detail` field — surfaces `reason`, `danglingTargets`, `ageDays`, kernel-version transition, whichever fields the detector emits

### `apps/web/app/(shell)/admin/wiki/lint/page.tsx`

Server component with URL-param filters:
- `?status=` — `open` (default), `resolved`, `ignored`, `all`
- `?severity=` — `error`, `warn`, `info`, or all
- `?scope=` — `kernel`, `overlay`, or all
- `?kind=` — single `findingKind`

Counts shown in the header. 200-row cap; ordered by severity desc, then `createdAt` desc. `WikiPage` is joined in memory (no Prisma relation on `WikiLintFinding`; `pageId` is a loose reference).

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` | ✓ |
| `pnpm --filter web typecheck` | ✓ |

## Test plan

- [ ] Visit `/admin/wiki/lint` in a running dev server — empty state message appears when no findings exist
- [ ] After the daily scheduled job runs (or a manual `runWikiLint` call), findings show up grouped by severity, scoped to kernel/overlay
- [ ] Filter tabs change the URL params and refilter the list correctly
- [ ] Clicking a finding navigates to `/wiki/<slug>` (lands on Phase 6a viewer when #443 merges)
- [ ] Theme tokens render correctly in light/dark/custom-branding modes per AGENTS.md §12

## Out of scope

- **Phase 4b2b**: `wiki_lint` MCP tool registration (on-demand trigger) + agent grant.
- **Phase 4b2c**: Resolve / ignore buttons — would need a server action. Defer until manual overrides are actually needed; the orchestrator auto-resolves disappearing findings.
- **Phase 4b3**: `detectContradictions` (Qdrant cosine + LLM judge) and `detectMissingXrefs` (entity NER) detectors.
- AdminTabNav integration if/when `/admin/wiki/` becomes a multi-page section.

## Dependencies

Depends only on merged work: PR #436 (Phase 4b1 lint runtime), PR #419 (lint detectors), PR #408 (`WikiLintFinding` model). Page links to `/wiki/<slug>` from PR #443 (in flight) — links 404 gracefully until that lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_