### PR TITLE
feat(wiki): add Wiki entry to the Knowledge shell nav section

### DIFF
--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -294,6 +294,14 @@ const SHELL_ITEMS: ShellNavItem[] = [
     capabilityKey: null,
   },
   {
+    key: "wiki",
+    label: "Wiki",
+    href: "/wiki",
+    description: "Founder kernel and per-org overlay — stances, heuristics, decisions.",
+    sectionKey: "knowledge",
+    capabilityKey: null,
+  },
+  {
     key: "docs",
     label: "Docs",
     href: "/docs",


### PR DESCRIPTION
## Summary

Tiny nav-discovery PR. Adds a **"Wiki"** item to the **Knowledge** section of the shell nav so the `/wiki` route (Phase 6a viewer, PR #443) is reachable without typing the URL.

8-line change in one file.

## What changed

`apps/web/lib/govern/permissions.ts` (+8 lines):
- New `SHELL_NAV_TILE_BLUEPRINTS` entry between `Knowledge` and `Docs`:
  ```ts
  {
    key: "wiki",
    label: "Wiki",
    href: "/wiki",
    description: "Founder kernel and per-org overlay — stances, heuristics, decisions.",
    sectionKey: "knowledge",
    capabilityKey: null,
  }
  ```
- `capabilityKey: null` matches the sibling `Knowledge` / `Docs` entries (the wiki view is read-only and platform-wide).

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter web typecheck` | ✓ |
| `pnpm --filter web test --run permissions` | ✓ 28/28 across 2 files |

## Test plan

- [ ] Open the shell, expand the Knowledge section, confirm "Wiki" appears between "Knowledge" and "Docs"
- [ ] Click it → lands on `/wiki`
- [ ] If PR #443 hasn&#39;t merged yet: link 404s gracefully (acceptable; #443 should land soon)

## Dependencies

Independent of all in-flight wiki PRs. The link 404s gracefully until PR #443 (Phase 6a viewer) merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_