### PR TITLE
Add Operations Map activity controls

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("AiOperationsMap", () => {
+  it("renders source and severity controls for managing projected activity", () => {
+    const source = readFileSync(new URL("./AiOperationsMap.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain("View controls");
+    expect(source).toContain("Showing {filteredProjections.length} of {projections.length} activities");
+    expect(source).toContain("SOURCE_OPTIONS");
+    expect(source).toContain("SEVERITY_OPTIONS");
+    expect(source).toContain("toggleSourceFilter");
+    expect(source).toContain("toggleSeverityFilter");
+  });
+});

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -4,10 +4,12 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import type {
   OperationsMapProjection,
+  OperationsMapProjectionSource,
+  OperationsMapSeverity,
   OperationsMapTemplate,
   StationedOperationsMapAgent,
 } from "@/lib/ai-operations-map/types";
-import { summarizeProjectionCounts } from "@/lib/ai-operations-map/project-events";
+import { filterOperationsMapProjections, summarizeProjectionCounts } from "@/lib/ai-operations-map/project-events";
 
 type SelectedItem =
   | { kind: "station"; id: string }
@@ -35,9 +37,24 @@ const SOURCE_LABEL: Record<OperationsMapProjection["source"], string> = {
   "evidence-external": "External evidence",
 };
 
+const SOURCE_OPTIONS: OperationsMapProjectionSource[] = [
+  "tool-execution",
+  "tool-receipt",
+  "evidence-backlog",
+  "evidence-external",
+];
+
+const SEVERITY_OPTIONS: OperationsMapSeverity[] = ["normal", "attention", "warning", "critical"];
+
 export function AiOperationsMap({ template, agents, projections, recentWindowLabel }: Props) {
   const [selected, setSelected] = useState<SelectedItem>({ kind: "station", id: template.stations[0]?.id ?? "" });
-  const counts = useMemo(() => summarizeProjectionCounts(projections), [projections]);
+  const [sourceFilters, setSourceFilters] = useState<OperationsMapProjectionSource[]>(SOURCE_OPTIONS);
+  const [severityFilters, setSeverityFilters] = useState<OperationsMapSeverity[]>(SEVERITY_OPTIONS);
+  const filteredProjections = useMemo(
+    () => filterOperationsMapProjections(projections, { sources: sourceFilters, severities: severityFilters }),
+    [projections, sourceFilters, severityFilters],
+  );
+  const counts = useMemo(() => summarizeProjectionCounts(filteredProjections), [filteredProjections]);
 
   const selectedStation = selected.kind === "station"
     ? template.stations.find((station) => station.id === selected.id) ?? null
@@ -46,8 +63,14 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
     ? agents.find((agent) => agent.agentId === selected.id) ?? null
     : null;
   const selectedProjection = selected.kind === "projection"
-    ? projections.find((projection) => projection.id === selected.id) ?? null
+    ? filteredProjections.find((projection) => projection.id === selected.id) ?? null
     : null;
+  const toggleSourceFilter = (source: OperationsMapProjectionSource) => {
+    setSourceFilters((current) => toggleFilterOption(current, source, SOURCE_OPTIONS));
+  };
+  const toggleSeverityFilter = (severity: OperationsMapSeverity) => {
+    setSeverityFilters((current) => toggleFilterOption(current, severity, SEVERITY_OPTIONS));
+  };
 
   return (
     <div className="space-y-6">
@@ -68,6 +91,42 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
           <Metric label="Critical" value={counts.critical} />
         </div>
       </header>
+
+      <section
+        aria-label="Map view controls"
+        className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3"
+      >
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">View controls</h2>
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              Showing {filteredProjections.length} of {projections.length} activities
+            </p>
+          </div>
+          <div className="grid gap-3 lg:grid-cols-2">
+            <FilterGroup label="Sources">
+              {SOURCE_OPTIONS.map((source) => (
+                <FilterButton
+                  key={source}
+                  active={sourceFilters.includes(source)}
+                  label={SOURCE_LABEL[source]}
+                  onClick={() => toggleSourceFilter(source)}
+                />
+              ))}
+            </FilterGroup>
+            <FilterGroup label="Severity">
+              {SEVERITY_OPTIONS.map((severity) => (
+                <FilterButton
+                  key={severity}
+                  active={severityFilters.includes(severity)}
+                  label={capitalizeSeverity(severity)}
+                  onClick={() => toggleSeverityFilter(severity)}
+                />
+              ))}
+            </FilterGroup>
+          </div>
+        </div>
+      </section>
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
         <section
@@ -102,7 +161,7 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
                     const station = template.stations.find((candidate) => candidate.id === stationId);
                     if (!station) return null;
                     const stationAgents = agents.filter((agent) => agent.stationId === station.id);
-                    const stationProjections = projections.filter((projection) => projection.location.stationId === station.id);
+                    const stationProjections = filteredProjections.filter((projection) => projection.location.stationId === station.id);
                     const isSelected = selected.kind === "station" && selected.id === station.id;
 
                     return (
@@ -171,13 +230,48 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
         <aside className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4" aria-label="Map inspector">
           <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Inspector</h2>
           {selectedStation ? (
-            <StationInspector station={selectedStation} agents={agents} projections={projections} onSelect={setSelected} />
+            <StationInspector station={selectedStation} agents={agents} projections={filteredProjections} onSelect={setSelected} />
           ) : null}
           {selectedAgent ? <AgentInspector agent={selectedAgent} /> : null}
           {selectedProjection ? <ProjectionInspector projection={selectedProjection} /> : null}
         </aside>
       </div>
     </div>
+  );
+}
+
+function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">{label}</p>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  );
+}
+
+function FilterButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={[
+        "min-h-8 rounded border px-2.5 py-1 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]",
+        active
+          ? "border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)] text-[var(--dpf-text)]"
+          : "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)]",
+      ].join(" ")}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -321,4 +415,13 @@ function InspectorFact({ label, value }: { label: string; value: string }) {
       <dd className="mt-1 break-words font-medium text-[var(--dpf-text)]">{value}</dd>
     </div>
   );
+}
+
+function toggleFilterOption<T extends string>(current: T[], option: T, allOptions: T[]): T[] {
+  if (current.includes(option)) return current.filter((candidate) => candidate !== option);
+  return allOptions.filter((candidate) => candidate === option || current.includes(candidate));
+}
+
+function capitalizeSeverity(severity: OperationsMapSeverity): string {
+  return severity.charAt(0).toUpperCase() + severity.slice(1);
 }

--- a/apps/web/lib/ai-operations-map/project-events.test.ts
+++ b/apps/web/lib/ai-operations-map/project-events.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./templates";
 import {
   deriveProjectionSeverityFromTaskState,
+  filterOperationsMapProjections,
   projectBacklogEvidence,
   projectExternalEvidence,
   projectAgentsToStations,
@@ -180,6 +181,41 @@ describe("AI operations map projection", () => {
     expect(projection.label).toBe("github ci-check");
     expect(projection.refs.externalEvidenceRecordId).toBe("external-1");
     expect(projection.links.historyHref).toBe("/platform/ai/history?externalEvidenceRecordId=external-1");
+  });
+
+  it("filters projections by selected source and severity without mutating the event stream", () => {
+    const projections = [
+      projectToolExecution(makeToolExecution({ id: "tool-1", success: true })),
+      projectToolExecutionReceipt(
+        makeToolExecutionReceipt({
+          id: "receipt-1",
+          receiptStatus: "expired",
+          toolExecution: makeToolExecution({ id: "tool-2", routeContext: "build" }),
+        }),
+      ),
+      projectBacklogEvidence(makeBacklogEvidence({ id: "activity-1", summary: "UX verification completed" })),
+      projectExternalEvidence(makeExternalEvidence({ id: "external-1", routeContext: "release" })),
+    ];
+
+    const filtered = filterOperationsMapProjections(projections, {
+      sources: ["tool-receipt", "evidence-backlog"],
+      severities: ["warning", "normal"],
+    });
+
+    expect(filtered.map((projection) => projection.id)).toEqual(["receipt:receipt-1", "backlog-evidence:activity-1"]);
+    expect(projections.map((projection) => projection.id)).toEqual([
+      "tool:tool-1",
+      "receipt:receipt-1",
+      "backlog-evidence:activity-1",
+      "external-evidence:external-1",
+    ]);
+  });
+
+  it("returns no projections when a filter group has no enabled options", () => {
+    const projections = [projectToolExecution(makeToolExecution({ id: "tool-1" }))];
+
+    expect(filterOperationsMapProjections(projections, { sources: [], severities: ["normal"] })).toEqual([]);
+    expect(filterOperationsMapProjections(projections, { sources: ["tool-execution"], severities: [] })).toEqual([]);
   });
 });
 

--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -6,6 +6,7 @@ import type {
   OperationsMapBacklogEvidence,
   OperationsMapExternalEvidence,
   OperationsMapProjection,
+  OperationsMapProjectionFilters,
   OperationsMapSeverity,
   OperationsMapTemplate,
   OperationsMapToolExecution,
@@ -267,6 +268,18 @@ export function summarizeProjectionCounts(projections: OperationsMapProjection[]
     }),
     { normal: 0, attention: 0, warning: 0, critical: 0 } satisfies Record<OperationsMapSeverity, number>,
   );
+}
+
+export function filterOperationsMapProjections(
+  projections: OperationsMapProjection[],
+  filters: OperationsMapProjectionFilters,
+): OperationsMapProjection[] {
+  if (filters.sources.length === 0 || filters.severities.length === 0) return [];
+
+  const sources = new Set(filters.sources);
+  const severities = new Set(filters.severities);
+
+  return projections.filter((projection) => sources.has(projection.source) && severities.has(projection.severity));
 }
 
 function resolveAgentStationId(agent: OperationsMapAgent, template: OperationsMapTemplate): string {

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -135,6 +135,11 @@ export type OperationsMapProjection = {
   };
 };
 
+export type OperationsMapProjectionFilters = {
+  sources: OperationsMapProjectionSource[];
+  severities: OperationsMapSeverity[];
+};
+
 export type OperationsMapTemplateSelector = {
   archetypeId?: string | null;
   activationProfileType?: string | null;


### PR DESCRIPTION
## Summary
- add source and severity filter controls to the AI Operations Map
- route map counts, station activity, and inspector projection selection through filtered activity
- add a pure projection filter helper plus focused tests for source/severity filtering and the component control contract

## Verification
- pnpm --filter web exec vitest run lib/ai-operations-map 'app/(shell)/platform/ai/operations-map/page.test.tsx' components/platform/AiOperationsMap.test.tsx
- pnpm --filter web typecheck
- pnpm --filter web exec next build

## UX note
Attempted a local branch-server browser pass on http://127.0.0.1:4012. The server started, but the host-launched Next process could not complete login because the Docker Postgres service is not published to the host and timed out even when addressed by container IP. No runtime data was changed. Production build and focused UI/projection tests passed.

Production build still emits the existing Turbopack NFT tracing warnings from spec-plan-search.ts / next.config.mjs; no build errors.