### PR TITLE
[codex] Add git-triggered sandbox verification

### DIFF
--- a/apps/web/app/api/platform/git/updates/route.ts
+++ b/apps/web/app/api/platform/git/updates/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { handleGitHubWebhook } from "@/lib/integrate/git-promotion-intake";
+
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const eventName = request.headers.get("x-github-event") ?? "unknown";
+  const deliveryId = request.headers.get("x-github-delivery");
+  const signature = request.headers.get("x-hub-signature-256");
+  const secret = process.env.DPF_GIT_WEBHOOK_SECRET ?? process.env.GITHUB_WEBHOOK_SECRET ?? null;
+
+  if (!deliveryId) {
+    return NextResponse.json({ error: "Missing x-github-delivery header" }, { status: 400 });
+  }
+
+  if (!secret && process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Git webhook secret is not configured" }, { status: 503 });
+  }
+
+  try {
+    const candidate = await handleGitHubWebhook({
+      rawBody,
+      eventName,
+      deliveryId,
+      signature,
+      secret,
+    });
+    return NextResponse.json(candidate, { status: candidate.duplicate ? 200 : 202 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Webhook intake failed";
+    const status = message.includes("signature") ? 401 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/apps/web/lib/integrate/git-promotion-intake.test.ts
+++ b/apps/web/lib/integrate/git-promotion-intake.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFindUnique, mockCreate, mockSend } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockCreate: vi.fn(),
+  mockSend: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    gitPromotionCandidate: {
+      findUnique: mockFindUnique,
+      create: mockCreate,
+    },
+  },
+}));
+
+vi.mock("@/lib/queue/inngest-client", () => ({
+  inngest: {
+    send: mockSend,
+  },
+}));
+
+import crypto from "crypto";
+import {
+  branchFromRef,
+  evaluateGitHubPushForSandbox,
+  recordGitPromotionCandidate,
+  verifyGitHubSignature,
+} from "./git-promotion-intake";
+
+beforeEach(() => {
+  mockFindUnique.mockReset();
+  mockCreate.mockReset();
+  mockSend.mockReset();
+});
+
+function pushPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    ref: "refs/heads/main",
+    before: "abc",
+    after: "def",
+    repository: {
+      full_name: "OpenDigitalProductFactory/opendigitalproductfactory",
+      clone_url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git",
+      default_branch: "main",
+    },
+    ...overrides,
+  };
+}
+
+describe("git promotion intake", () => {
+  it("extracts branch names from Git refs", () => {
+    expect(branchFromRef("refs/heads/main")).toBe("main");
+    expect(branchFromRef("refs/tags/v1")).toBeNull();
+  });
+
+  it("verifies GitHub HMAC signatures", () => {
+    const rawBody = JSON.stringify(pushPayload());
+    const secret = "test-secret";
+    const digest = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+
+    expect(verifyGitHubSignature(rawBody, `sha256=${digest}`, secret)).toBe(true);
+    expect(verifyGitHubSignature(rawBody, "sha256=bad", secret)).toBe(false);
+  });
+
+  it("queues default-branch push events", () => {
+    expect(evaluateGitHubPushForSandbox(pushPayload())).toEqual({
+      status: "queued",
+      reason: null,
+      branch: "main",
+    });
+  });
+
+  it("ignores non-default branch pushes", () => {
+    expect(evaluateGitHubPushForSandbox(pushPayload({ ref: "refs/heads/feature/test" }))).toEqual({
+      status: "ignored",
+      reason: "Push was for feature/test, not default branch main.",
+      branch: "feature/test",
+    });
+  });
+
+  it("records and queues a new candidate", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    mockCreate.mockResolvedValue({
+      candidateId: "GPC-123",
+      status: "queued",
+      statusReason: null,
+    });
+
+    const result = await recordGitPromotionCandidate({
+      provider: "github",
+      eventName: "push",
+      deliveryId: "delivery-1",
+      payload: pushPayload(),
+    });
+
+    expect(result).toMatchObject({ candidateId: "GPC-123", queued: true, duplicate: false });
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        deliveryKey: "github:delivery-1",
+        status: "queued",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      }),
+    }));
+    expect(mockSend).toHaveBeenCalledWith({
+      name: "build/git-update.received",
+      data: { candidateId: "GPC-123" },
+    });
+  });
+
+  it("does not enqueue duplicate deliveries", async () => {
+    mockFindUnique.mockResolvedValue({
+      candidateId: "GPC-EXISTING",
+      status: "queued",
+      statusReason: null,
+    });
+
+    const result = await recordGitPromotionCandidate({
+      provider: "github",
+      eventName: "push",
+      deliveryId: "delivery-1",
+      payload: pushPayload(),
+    });
+
+    expect(result).toMatchObject({ candidateId: "GPC-EXISTING", duplicate: true, queued: false });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/integrate/git-promotion-intake.ts
+++ b/apps/web/lib/integrate/git-promotion-intake.ts
@@ -1,0 +1,200 @@
+import crypto from "crypto";
+import { prisma, type Prisma } from "@dpf/db";
+
+export type GitProvider = "github";
+
+export type GitUpdateCandidateStatus =
+  | "queued"
+  | "ignored"
+  | "sandbox-verification-running"
+  | "sandbox-verification-complete"
+  | "failed";
+
+export type GitHubPushPayload = {
+  ref?: string;
+  before?: string;
+  after?: string;
+  repository?: {
+    full_name?: string;
+    clone_url?: string;
+    default_branch?: string;
+  };
+  pusher?: {
+    name?: string;
+    email?: string;
+  };
+};
+
+export type GitPromotionCandidateInput = {
+  provider: GitProvider;
+  eventName: string;
+  deliveryId: string;
+  payload: GitHubPushPayload;
+};
+
+export type RecordedGitPromotionCandidate = {
+  candidateId: string;
+  status: GitUpdateCandidateStatus;
+  duplicate: boolean;
+  queued: boolean;
+  reason: string | null;
+};
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const left = Buffer.from(a, "hex");
+  const right = Buffer.from(b, "hex");
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
+export function verifyGitHubSignature(rawBody: string, signatureHeader: string | null, secret: string | null): boolean {
+  if (!secret) return true;
+  if (!signatureHeader?.startsWith("sha256=")) return false;
+  const received = signatureHeader.slice("sha256=".length);
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  return timingSafeEqualHex(received, expected);
+}
+
+export function parseGitHubWebhookPayload(rawBody: string): GitHubPushPayload {
+  const parsed = JSON.parse(rawBody) as GitHubPushPayload;
+  return parsed;
+}
+
+export function branchFromRef(ref: string | undefined): string | null {
+  const prefix = "refs/heads/";
+  if (!ref?.startsWith(prefix)) return null;
+  return ref.slice(prefix.length);
+}
+
+export function isDeletedRef(afterSha: string | undefined): boolean {
+  return !!afterSha && /^0+$/.test(afterSha);
+}
+
+export function evaluateGitHubPushForSandbox(payload: GitHubPushPayload): {
+  status: GitUpdateCandidateStatus;
+  reason: string | null;
+  branch: string | null;
+} {
+  const branch = branchFromRef(payload.ref);
+  if (!branch) return { status: "ignored", reason: "Only branch push events can trigger sandbox verification.", branch: null };
+
+  const defaultBranch = payload.repository?.default_branch ?? "main";
+  if (branch !== defaultBranch) {
+    return { status: "ignored", reason: `Push was for ${branch}, not default branch ${defaultBranch}.`, branch };
+  }
+
+  if (isDeletedRef(payload.after)) {
+    return { status: "ignored", reason: "Deleted refs do not trigger sandbox verification.", branch };
+  }
+
+  if (!payload.after) {
+    return { status: "ignored", reason: "Push payload did not include an after SHA.", branch };
+  }
+
+  if (!payload.repository?.full_name) {
+    return { status: "ignored", reason: "Push payload did not include a repository full_name.", branch };
+  }
+
+  if (!payload.repository?.clone_url) {
+    return { status: "ignored", reason: "Push payload did not include a repository clone_url.", branch };
+  }
+
+  return { status: "queued", reason: null, branch };
+}
+
+export function buildCandidateId(input: Pick<GitPromotionCandidateInput, "provider" | "deliveryId">): string {
+  const digest = crypto
+    .createHash("sha256")
+    .update(`${input.provider}:${input.deliveryId}`)
+    .digest("hex")
+    .slice(0, 12)
+    .toUpperCase();
+  return `GPC-${digest}`;
+}
+
+export async function recordGitPromotionCandidate(
+  input: GitPromotionCandidateInput,
+): Promise<RecordedGitPromotionCandidate> {
+  const deliveryKey = `${input.provider}:${input.deliveryId}`;
+  const existing = await prisma.gitPromotionCandidate.findUnique({
+    where: { deliveryKey },
+    select: { candidateId: true, status: true, statusReason: true },
+  });
+  if (existing) {
+    return {
+      candidateId: existing.candidateId,
+      status: existing.status as GitUpdateCandidateStatus,
+      duplicate: true,
+      queued: false,
+      reason: existing.statusReason,
+    };
+  }
+
+  const evaluation = evaluateGitHubPushForSandbox(input.payload);
+  const candidateId = buildCandidateId(input);
+  const created = await prisma.gitPromotionCandidate.create({
+    data: {
+      candidateId,
+      provider: input.provider,
+      deliveryKey,
+      eventName: input.eventName,
+      repositoryFullName: input.payload.repository?.full_name ?? "unknown",
+      repositoryCloneUrl: input.payload.repository?.clone_url ?? null,
+      ref: input.payload.ref ?? null,
+      branch: evaluation.branch,
+      beforeSha: input.payload.before ?? null,
+      afterSha: input.payload.after ?? null,
+      status: evaluation.status,
+      statusReason: evaluation.reason,
+      payload: input.payload as Prisma.InputJsonValue,
+    },
+    select: { candidateId: true, status: true, statusReason: true },
+  });
+
+  if (evaluation.status === "queued") {
+    const { inngest } = await import("@/lib/queue/inngest-client");
+    await inngest.send({
+      name: "build/git-update.received",
+      data: { candidateId: created.candidateId },
+    });
+  }
+
+  return {
+    candidateId: created.candidateId,
+    status: created.status as GitUpdateCandidateStatus,
+    duplicate: false,
+    queued: evaluation.status === "queued",
+    reason: created.statusReason,
+  };
+}
+
+export async function handleGitHubWebhook(input: {
+  rawBody: string;
+  eventName: string;
+  deliveryId: string;
+  signature: string | null;
+  secret: string | null;
+}): Promise<RecordedGitPromotionCandidate> {
+  if (!verifyGitHubSignature(input.rawBody, input.signature, input.secret)) {
+    throw new Error("Invalid GitHub webhook signature");
+  }
+
+  if (input.eventName !== "push") {
+    const payload = parseGitHubWebhookPayload(input.rawBody);
+    return recordGitPromotionCandidate({
+      provider: "github",
+      eventName: input.eventName,
+      deliveryId: input.deliveryId,
+      payload: {
+        ...payload,
+        repository: payload.repository ?? { full_name: "unknown" },
+      },
+    });
+  }
+
+  return recordGitPromotionCandidate({
+    provider: "github",
+    eventName: input.eventName,
+    deliveryId: input.deliveryId,
+    payload: parseGitHubWebhookPayload(input.rawBody),
+  });
+}

--- a/apps/web/lib/queue/functions/git-promotion-sandbox-verification.test.ts
+++ b/apps/web/lib/queue/functions/git-promotion-sandbox-verification.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildGitPromotionVerificationScript } from "./git-promotion-sandbox-verification";
+
+describe("buildGitPromotionVerificationScript", () => {
+  it("clones the repository, checks out the exact SHA, and runs the build gates", () => {
+    const script = buildGitPromotionVerificationScript({
+      repositoryCloneUrl: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git",
+      afterSha: "abc123",
+      candidateId: "GPC-123",
+    });
+
+    expect(script).toContain("git clone --depth 1");
+    expect(script).toContain("git fetch --depth 1 origin 'abc123'");
+    expect(script).toContain("git checkout --detach 'abc123'");
+    expect(script).toContain("pnpm install --frozen-lockfile");
+    expect(script).toContain("pnpm --filter web typecheck");
+    expect(script).toContain("pnpm --filter web exec next build");
+    expect(script).not.toContain("executePromotion");
+  });
+});

--- a/apps/web/lib/queue/functions/git-promotion-sandbox-verification.ts
+++ b/apps/web/lib/queue/functions/git-promotion-sandbox-verification.ts
@@ -1,0 +1,157 @@
+import { inngest } from "../inngest-client";
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+export function buildGitPromotionVerificationScript(input: {
+  repositoryCloneUrl: string;
+  afterSha: string;
+  candidateId: string;
+}): string {
+  const targetDir = `/workspace/git-promotion-${input.candidateId}`;
+  return [
+    "set -euo pipefail",
+    `rm -rf ${shellQuote(targetDir)}`,
+    `git clone --depth 1 ${shellQuote(input.repositoryCloneUrl)} ${shellQuote(targetDir)}`,
+    `cd ${shellQuote(targetDir)}`,
+    `git fetch --depth 1 origin ${shellQuote(input.afterSha)}`,
+    `git checkout --detach ${shellQuote(input.afterSha)}`,
+    "pnpm install --frozen-lockfile",
+    "pnpm --filter @dpf/db exec prisma generate --schema prisma/schema.prisma",
+    "pnpm --filter web typecheck",
+    "pnpm --filter web exec next build",
+  ].join("\n");
+}
+
+export const gitPromotionSandboxVerification = inngest.createFunction(
+  {
+    id: "build/git-promotion-sandbox-verification",
+    retries: 0,
+    concurrency: [{ limit: 1, scope: "fn" }],
+    triggers: [{ event: "build/git-update.received" }],
+  },
+  async ({ event, step }) => {
+    const { candidateId } = event.data as { candidateId: string };
+
+    const candidate = await step.run("load-candidate", async () => {
+      const { prisma } = await import("@dpf/db");
+      return prisma.gitPromotionCandidate.findUnique({
+        where: { candidateId },
+        select: {
+          candidateId: true,
+          status: true,
+          repositoryFullName: true,
+          repositoryCloneUrl: true,
+          afterSha: true,
+          branch: true,
+        },
+      });
+    });
+
+    if (!candidate) return { skipped: true, reason: "candidate not found" };
+    if (candidate.status !== "queued") {
+      return { skipped: true, reason: `candidate status is ${candidate.status}` };
+    }
+    if (!candidate.repositoryCloneUrl || !candidate.afterSha) {
+      await step.run("mark-missing-input", async () => {
+        const { prisma } = await import("@dpf/db");
+        await prisma.gitPromotionCandidate.update({
+          where: { candidateId },
+          data: {
+            status: "failed",
+            statusReason: "Missing clone URL or after SHA.",
+            verificationCompletedAt: new Date(),
+          },
+        });
+      });
+      return { failed: true, reason: "missing clone URL or after SHA" };
+    }
+
+    const repositoryCloneUrl = candidate.repositoryCloneUrl;
+    const afterSha = candidate.afterSha;
+    const { getBuildExecutionProvider } = await import("@/lib/integrate/sandbox/providers");
+    const provider = getBuildExecutionProvider("local-docker");
+
+    await step.run("mark-running", async () => {
+      const { prisma } = await import("@dpf/db");
+      await prisma.gitPromotionCandidate.update({
+        where: { candidateId },
+        data: {
+          status: "sandbox-verification-running",
+          sandboxProviderId: provider.id,
+          verificationStartedAt: new Date(),
+        },
+      });
+    });
+
+    const handle = await step.run("create-sandbox", async () => {
+      try {
+        const handle = await provider.createSandbox({
+          buildId: candidateId,
+          title: `Git update ${candidate.repositoryFullName}@${afterSha.slice(0, 12)}`,
+        });
+        await provider.startSandbox(handle);
+        const { prisma } = await import("@dpf/db");
+        await prisma.gitPromotionCandidate.update({
+          where: { candidateId },
+          data: { sandboxId: handle.id },
+        });
+        return handle;
+      } catch (err) {
+        const { prisma } = await import("@dpf/db");
+        await prisma.gitPromotionCandidate.update({
+          where: { candidateId },
+          data: {
+            status: "failed",
+            statusReason: `Sandbox provisioning failed: ${err instanceof Error ? err.message : String(err)}`,
+            verificationCompletedAt: new Date(),
+          },
+        });
+        throw err;
+      }
+    });
+
+    const verification = await step.run("run-sandbox-build", async () => {
+      const script = buildGitPromotionVerificationScript({
+        repositoryCloneUrl,
+        afterSha,
+        candidateId,
+      });
+      return provider.exec(handle, ["sh", "-lc", shellQuote(script)], {
+        timeoutMs: 30 * 60 * 1000,
+      });
+    });
+
+    const success = verification.exitCode === 0;
+    await step.run("persist-result", async () => {
+      const { prisma } = await import("@dpf/db");
+      await prisma.gitPromotionCandidate.update({
+        where: { candidateId },
+        data: {
+          status: success ? "sandbox-verification-complete" : "failed",
+          statusReason: success ? null : "Sandbox verification failed.",
+          verificationCompletedAt: new Date(),
+          verificationResult: {
+            exitCode: verification.exitCode,
+            stdout: verification.stdout.slice(-12000),
+            stderr: verification.stderr.slice(-12000),
+            durationMs: verification.durationMs,
+            repositoryFullName: candidate.repositoryFullName,
+            branch: candidate.branch,
+            afterSha: candidate.afterSha,
+          },
+        },
+      });
+    });
+
+    await step.run("destroy-sandbox", async () => {
+      await provider.destroySandbox(handle).catch(() => undefined);
+    });
+
+    return {
+      status: success ? "sandbox-verification-complete" : "failed",
+      exitCode: verification.exitCode,
+    };
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./governed-backlog-tee-up";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
 import { wikiLint } from "./wiki-lint";
+import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verification";
 
 export const allFunctions = [
   prometheusPoll,
@@ -41,4 +42,5 @@ export const allFunctions = [
   governedBacklogTeeUpRequested,
   tokenExpiryMonitor,
   wikiLint,
+  gitPromotionSandboxVerification,
 ];

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -101,3 +101,10 @@ export interface BuildBacklogTeeUpRequestedEvent {
     requestedByAgentId?: string | null;
   };
 }
+
+export interface BuildGitUpdateReceivedEvent {
+  name: "build/git-update.received";
+  data: {
+    candidateId: string;
+  };
+}

--- a/docs/superpowers/plans/2026-05-11-git-triggered-sandbox-promotion-slice-2.md
+++ b/docs/superpowers/plans/2026-05-11-git-triggered-sandbox-promotion-slice-2.md
@@ -1,0 +1,32 @@
+# Git-Triggered Sandbox Promotion — Slice 2
+
+## Goal
+
+Wire the first self-update loop without allowing unattended production mutation:
+
+GitHub push webhook -> governed candidate record -> queued sandbox rebuild -> verification evidence -> human/policy promotion later.
+
+This slice intentionally stops at sandbox verification. It does not execute `ChangePromotion`, restart production, or mutate the running portal.
+
+## Scope
+
+- Add a durable `GitPromotionCandidate` model for incoming Git update events.
+- Add a GitHub-compatible webhook endpoint at `/api/platform/git/updates`.
+- Verify `X-Hub-Signature-256` when `DPF_GIT_WEBHOOK_SECRET` or `GITHUB_WEBHOOK_SECRET` is configured.
+- Queue an Inngest job for push events on the default branch.
+- Use the `BuildExecutionProvider` seam to create/start a sandbox and run a clone/install/typecheck/build verification script against the updated SHA.
+- Persist status, sandbox identity, and verification output on the candidate.
+
+## Non-Goals
+
+- No automatic production promotion.
+- No PR merge automation.
+- No private-repo credential propagation beyond public clone URLs. Tokenized clone support belongs in the provider credential slice.
+- No UI beyond durable records and activities.
+
+## Verification
+
+- Focused Vitest tests for webhook parsing, signature verification, candidate recording, dedupe, and verification script construction.
+- Prisma schema validation and generation.
+- Web typecheck.
+- Production build.

--- a/packages/db/prisma/migrations/20260511135733_add_git_promotion_candidate/migration.sql
+++ b/packages/db/prisma/migrations/20260511135733_add_git_promotion_candidate/migration.sql
@@ -1,0 +1,30 @@
+CREATE TABLE "GitPromotionCandidate" (
+    "id" TEXT NOT NULL,
+    "candidateId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL DEFAULT 'github',
+    "deliveryKey" TEXT NOT NULL,
+    "eventName" TEXT NOT NULL,
+    "repositoryFullName" TEXT NOT NULL,
+    "repositoryCloneUrl" TEXT,
+    "ref" TEXT,
+    "branch" TEXT,
+    "beforeSha" TEXT,
+    "afterSha" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'queued',
+    "statusReason" TEXT,
+    "sandboxProviderId" TEXT,
+    "sandboxId" TEXT,
+    "verificationStartedAt" TIMESTAMP(3),
+    "verificationCompletedAt" TIMESTAMP(3),
+    "verificationResult" JSONB,
+    "payload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GitPromotionCandidate_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "GitPromotionCandidate_candidateId_key" ON "GitPromotionCandidate"("candidateId");
+CREATE UNIQUE INDEX "GitPromotionCandidate_deliveryKey_key" ON "GitPromotionCandidate"("deliveryKey");
+CREATE INDEX "GitPromotionCandidate_status_createdAt_idx" ON "GitPromotionCandidate"("status", "createdAt");
+CREATE INDEX "GitPromotionCandidate_repositoryFullName_afterSha_idx" ON "GitPromotionCandidate"("repositoryFullName", "afterSha");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3366,6 +3366,33 @@ model Sandbox {
   @@index([state, startedAt])
 }
 
+model GitPromotionCandidate {
+  id                      String    @id @default(cuid())
+  candidateId             String    @unique
+  provider                String    @default("github")
+  deliveryKey             String    @unique
+  eventName               String
+  repositoryFullName      String
+  repositoryCloneUrl      String?
+  ref                     String?
+  branch                  String?
+  beforeSha               String?
+  afterSha                String?
+  status                  String    @default("queued")
+  statusReason            String?
+  sandboxProviderId       String?
+  sandboxId               String?
+  verificationStartedAt   DateTime?
+  verificationCompletedAt DateTime?
+  verificationResult      Json?
+  payload                 Json?
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
+
+  @@index([status, createdAt])
+  @@index([repositoryFullName, afterSha])
+}
+
 model SandboxSlot {
   id          String    @id @default(cuid())
   slotIndex   Int       @unique


### PR DESCRIPTION
## Summary
- Adds a GitHub-compatible `/api/platform/git/updates` webhook endpoint with optional HMAC verification via `DPF_GIT_WEBHOOK_SECRET` or `GITHUB_WEBHOOK_SECRET`.
- Persists incoming Git update notifications as `GitPromotionCandidate` rows with dedupe by provider delivery id.
- Queues default-branch pushes into an Inngest sandbox-verification worker that uses the Build Studio provider seam to clone the updated SHA and run install, Prisma generate, typecheck, and production build inside the sandbox.
- Stops at sandbox verification evidence; no production promotion or portal restart is performed in this slice.

## Validation
- `pnpm --filter web exec vitest run lib/integrate/git-promotion-intake.test.ts lib/queue/functions/git-promotion-sandbox-verification.test.ts`
- `pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma`
- `pnpm --filter @dpf/db exec prisma generate --schema prisma/schema.prisma`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`
- Migration SQL rollback proof against live Postgres: `BEGIN; ... migration.sql ... ROLLBACK;`

## Notes
- Build still emits the existing Turbopack/NFT broad-tracing warnings around `spec-plan-search.ts` and `next.config.mjs`; no build errors.
- Private repository clone credentials are intentionally out of scope for this slice; this wires the governed event and sandbox verification path first.