### PR TITLE
Add operations map quick views

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -9,6 +9,9 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("Showing {filteredProjections.length} of {projections.length} activities");
     expect(source).toContain("SOURCE_OPTIONS");
     expect(source).toContain("SEVERITY_OPTIONS");
+    expect(source).toContain("Quick views");
+    expect(source).toContain("OPERATIONS_MAP_QUICK_VIEWS");
+    expect(source).toContain("applyQuickView");
     expect(source).toContain("toggleSourceFilter");
     expect(source).toContain("toggleSeverityFilter");
   });

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -5,11 +5,17 @@ import Link from "next/link";
 import type {
   OperationsMapProjection,
   OperationsMapProjectionSource,
+  OperationsMapQuickViewId,
   OperationsMapSeverity,
   OperationsMapTemplate,
   StationedOperationsMapAgent,
 } from "@/lib/ai-operations-map/types";
-import { filterOperationsMapProjections, summarizeProjectionCounts } from "@/lib/ai-operations-map/project-events";
+import {
+  filterOperationsMapProjections,
+  getOperationsMapQuickViewFilters,
+  OPERATIONS_MAP_QUICK_VIEWS,
+  summarizeProjectionCounts,
+} from "@/lib/ai-operations-map/project-events";
 
 type SelectedItem =
   | { kind: "station"; id: string }
@@ -45,11 +51,20 @@ const SOURCE_OPTIONS: OperationsMapProjectionSource[] = [
 ];
 
 const SEVERITY_OPTIONS: OperationsMapSeverity[] = ["normal", "attention", "warning", "critical"];
+const DEFAULT_QUICK_VIEW_ID: OperationsMapQuickViewId = "all";
+const DEFAULT_QUICK_VIEW_FILTERS = getOperationsMapQuickViewFilters(DEFAULT_QUICK_VIEW_ID);
 
 export function AiOperationsMap({ template, agents, projections, recentWindowLabel }: Props) {
   const [selected, setSelected] = useState<SelectedItem>({ kind: "station", id: template.stations[0]?.id ?? "" });
-  const [sourceFilters, setSourceFilters] = useState<OperationsMapProjectionSource[]>(SOURCE_OPTIONS);
-  const [severityFilters, setSeverityFilters] = useState<OperationsMapSeverity[]>(SEVERITY_OPTIONS);
+  const [activeQuickViewId, setActiveQuickViewId] = useState<OperationsMapQuickViewId | "custom">(
+    DEFAULT_QUICK_VIEW_ID,
+  );
+  const [sourceFilters, setSourceFilters] = useState<OperationsMapProjectionSource[]>(
+    DEFAULT_QUICK_VIEW_FILTERS.sources,
+  );
+  const [severityFilters, setSeverityFilters] = useState<OperationsMapSeverity[]>(
+    DEFAULT_QUICK_VIEW_FILTERS.severities,
+  );
   const filteredProjections = useMemo(
     () => filterOperationsMapProjections(projections, { sources: sourceFilters, severities: severityFilters }),
     [projections, sourceFilters, severityFilters],
@@ -65,10 +80,18 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
   const selectedProjection = selected.kind === "projection"
     ? filteredProjections.find((projection) => projection.id === selected.id) ?? null
     : null;
+  const applyQuickView = (viewId: OperationsMapQuickViewId) => {
+    const filters = getOperationsMapQuickViewFilters(viewId);
+    setActiveQuickViewId(viewId);
+    setSourceFilters(filters.sources);
+    setSeverityFilters(filters.severities);
+  };
   const toggleSourceFilter = (source: OperationsMapProjectionSource) => {
+    setActiveQuickViewId("custom");
     setSourceFilters((current) => toggleFilterOption(current, source, SOURCE_OPTIONS));
   };
   const toggleSeverityFilter = (severity: OperationsMapSeverity) => {
+    setActiveQuickViewId("custom");
     setSeverityFilters((current) => toggleFilterOption(current, severity, SEVERITY_OPTIONS));
   };
 
@@ -103,7 +126,23 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
               Showing {filteredProjections.length} of {projections.length} activities
             </p>
           </div>
-          <div className="grid gap-3 lg:grid-cols-2">
+          <div className="grid gap-3 lg:grid-cols-3">
+            <FilterGroup label="Quick views">
+              {OPERATIONS_MAP_QUICK_VIEWS.map((view) => (
+                <FilterButton
+                  key={view.id}
+                  active={activeQuickViewId === view.id}
+                  label={view.label}
+                  title={view.description}
+                  onClick={() => applyQuickView(view.id)}
+                />
+              ))}
+              {activeQuickViewId === "custom" ? (
+                <span className="inline-flex min-h-8 items-center rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-xs text-[var(--dpf-muted)]">
+                  Custom
+                </span>
+              ) : null}
+            </FilterGroup>
             <FilterGroup label="Sources">
               {SOURCE_OPTIONS.map((source) => (
                 <FilterButton
@@ -252,16 +291,19 @@ function FilterGroup({ label, children }: { label: string; children: React.React
 function FilterButton({
   active,
   label,
+  title,
   onClick,
 }: {
   active: boolean;
   label: string;
+  title?: string;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
       aria-pressed={active}
+      title={title}
       onClick={onClick}
       className={[
         "min-h-8 rounded border px-2.5 py-1 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]",

--- a/apps/web/lib/ai-operations-map/project-events.test.ts
+++ b/apps/web/lib/ai-operations-map/project-events.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   deriveProjectionSeverityFromTaskState,
   filterOperationsMapProjections,
+  getOperationsMapQuickViewFilters,
+  OPERATIONS_MAP_QUICK_VIEWS,
   projectBacklogEvidence,
   projectExternalEvidence,
   projectAgentsToStations,
@@ -216,6 +218,32 @@ describe("AI operations map projection", () => {
 
     expect(filterOperationsMapProjections(projections, { sources: [], severities: ["normal"] })).toEqual([]);
     expect(filterOperationsMapProjections(projections, { sources: ["tool-execution"], severities: [] })).toEqual([]);
+  });
+
+  it("defines quick views for common operations-map management modes", () => {
+    expect(OPERATIONS_MAP_QUICK_VIEWS.map((view) => [view.id, view.label])).toEqual([
+      ["all", "All activity"],
+      ["exceptions", "Exceptions"],
+      ["evidence", "Evidence only"],
+      ["tool-runs", "Tool runs"],
+    ]);
+
+    expect(getOperationsMapQuickViewFilters("all")).toEqual({
+      sources: ["tool-execution", "tool-receipt", "evidence-backlog", "evidence-external"],
+      severities: ["normal", "attention", "warning", "critical"],
+    });
+    expect(getOperationsMapQuickViewFilters("exceptions")).toEqual({
+      sources: ["tool-execution", "tool-receipt", "evidence-backlog", "evidence-external"],
+      severities: ["attention", "warning", "critical"],
+    });
+    expect(getOperationsMapQuickViewFilters("evidence")).toEqual({
+      sources: ["tool-receipt", "evidence-backlog", "evidence-external"],
+      severities: ["normal", "attention", "warning", "critical"],
+    });
+    expect(getOperationsMapQuickViewFilters("tool-runs")).toEqual({
+      sources: ["tool-execution"],
+      severities: ["normal", "attention", "warning", "critical"],
+    });
   });
 });
 

--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -7,6 +7,9 @@ import type {
   OperationsMapExternalEvidence,
   OperationsMapProjection,
   OperationsMapProjectionFilters,
+  OperationsMapProjectionSource,
+  OperationsMapQuickView,
+  OperationsMapQuickViewId,
   OperationsMapSeverity,
   OperationsMapTemplate,
   OperationsMapToolExecution,
@@ -72,6 +75,63 @@ const ROUTE_CONTEXT_TO_STATION: Array<{ pattern: RegExp; stationId: string }> = 
   { pattern: /billing|charge|invoice/i, stationId: "billing-readiness" },
   { pattern: /lifecycle|renewal|review/i, stationId: "lifecycle-review" },
 ];
+
+const ALL_PROJECTION_SOURCES: OperationsMapProjectionSource[] = [
+  "tool-execution",
+  "tool-receipt",
+  "evidence-backlog",
+  "evidence-external",
+];
+
+const ALL_PROJECTION_SEVERITIES: OperationsMapSeverity[] = ["normal", "attention", "warning", "critical"];
+
+export const OPERATIONS_MAP_QUICK_VIEWS = [
+  {
+    id: "all",
+    label: "All activity",
+    description: "Show every projected activity source and severity.",
+    filters: {
+      sources: ALL_PROJECTION_SOURCES,
+      severities: ALL_PROJECTION_SEVERITIES,
+    },
+  },
+  {
+    id: "exceptions",
+    label: "Exceptions",
+    description: "Show activity that needs attention, warning, or critical review.",
+    filters: {
+      sources: ALL_PROJECTION_SOURCES,
+      severities: ["attention", "warning", "critical"],
+    },
+  },
+  {
+    id: "evidence",
+    label: "Evidence only",
+    description: "Show receipts, backlog evidence, and external evidence records.",
+    filters: {
+      sources: ["tool-receipt", "evidence-backlog", "evidence-external"],
+      severities: ALL_PROJECTION_SEVERITIES,
+    },
+  },
+  {
+    id: "tool-runs",
+    label: "Tool runs",
+    description: "Show raw tool execution events only.",
+    filters: {
+      sources: ["tool-execution"],
+      severities: ALL_PROJECTION_SEVERITIES,
+    },
+  },
+] satisfies OperationsMapQuickView[];
+
+export function getOperationsMapQuickViewFilters(viewId: OperationsMapQuickViewId): OperationsMapProjectionFilters {
+  const view = OPERATIONS_MAP_QUICK_VIEWS.find((candidate) => candidate.id === viewId) ?? OPERATIONS_MAP_QUICK_VIEWS[0];
+
+  return {
+    sources: [...view.filters.sources],
+    severities: [...view.filters.severities],
+  };
+}
 
 export function deriveProjectionSeverityFromTaskState(state: TaskState): OperationsMapSeverity {
   switch (state) {

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -140,6 +140,15 @@ export type OperationsMapProjectionFilters = {
   severities: OperationsMapSeverity[];
 };
 
+export type OperationsMapQuickViewId = "all" | "exceptions" | "evidence" | "tool-runs";
+
+export type OperationsMapQuickView = {
+  id: OperationsMapQuickViewId;
+  label: string;
+  description: string;
+  filters: OperationsMapProjectionFilters;
+};
+
 export type OperationsMapTemplateSelector = {
   archetypeId?: string | null;
   activationProfileType?: string | null;


### PR DESCRIPTION
## Summary
- Add shared operations-map quick-view presets for all activity, exceptions, evidence, and tool runs
- Wire the AI Operations Map controls to apply presets and show custom manual filter state
- Cover the quick-view contract in projection and component tests

## Verification
- pnpm --filter web exec vitest run lib/ai-operations-map/project-events.test.ts components/platform/AiOperationsMap.test.tsx
- pnpm --filter web exec vitest run lib/ai-operations-map 'app/(shell)/platform/ai/operations-map/page.test.tsx' components/platform/AiOperationsMap.test.tsx
- pnpm --filter @dpf/db exec prisma generate
- pnpm --filter web typecheck
- pnpm --filter web exec next build