### PR TITLE
test(ai): route functional failures into backlog evidence

### DIFF
--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPrisma = {
   backlogItem: {
+    create: vi.fn(),
+    findFirst: vi.fn(),
     findUnique: vi.fn(),
     update: vi.fn(),
     count: vi.fn(),
@@ -329,5 +331,128 @@ describe("backlog MCP tool execution", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("missing_duplicateOfId");
     expect(mockPrisma.backlogItem.update).not.toHaveBeenCalled();
+  });
+
+  it("record_functional_failure_evidence creates a governed backlog item for the first fingerprint", async () => {
+    mockPrisma.backlogItem.findFirst.mockResolvedValue(null);
+    mockPrisma.backlogItem.create.mockResolvedValue({
+      id: "functional-failure-row-1",
+      itemId: "BI-FUNC1",
+    });
+    mockPrisma.backlogItemActivity.create.mockResolvedValue({
+      id: "activity-1",
+      recordedAt: new Date("2026-05-11T12:00:00.000Z"),
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "record_functional_failure_evidence",
+      {
+        testId: "BUILD-AI-ROUTING-01",
+        suite: "build-studio",
+        route: "/build",
+        expected: "build-specialist coworker visible",
+        actual: "Software Engineer panel missing",
+        screenshotPath: "test-results/build/screenshot.png",
+        tracePath: null,
+        userRole: "admin",
+        agentId: "build-specialist",
+        routeContext: "/build",
+        reproCommand: "pnpm exec playwright test --project=build-studio",
+        createdAt: "2026-05-11T12:00:00.000Z",
+        likelyOwnerArea: "build-studio",
+      },
+      "user-1",
+      { agentId: "platform-engineer" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(expect.objectContaining({ itemId: "BI-FUNC1", action: "created" }));
+    expect(mockPrisma.backlogItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: "[BUILD-AI-ROUTING-01] /build functional smoke failure",
+          source: "functional-test-failure",
+          status: "triaging",
+          agentId: "platform-engineer",
+          body: expect.stringContaining("failureFingerprint:"),
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "functional-failure-row-1",
+          kind: "evidence",
+          recordedById: "user-1",
+          recordedByAgentId: "platform-engineer",
+          payload: expect.objectContaining({
+            evidenceKind: "test_fail",
+            testId: "BUILD-AI-ROUTING-01",
+            route: "/build",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("record_functional_failure_evidence dedupes repeated failures into the existing item", async () => {
+    mockPrisma.backlogItem.findFirst.mockResolvedValue({
+      id: "existing-row-1",
+      itemId: "BI-EXISTING",
+      occurrenceCount: 2,
+    });
+    mockPrisma.backlogItem.update.mockResolvedValue({
+      id: "existing-row-1",
+      itemId: "BI-EXISTING",
+      occurrenceCount: 3,
+    });
+    mockPrisma.backlogItemActivity.create.mockResolvedValue({
+      id: "activity-2",
+      recordedAt: new Date("2026-05-11T12:05:00.000Z"),
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "record_functional_failure_evidence",
+      {
+        testId: "OPS-AI-ROUTING-01",
+        suite: "ops-backlog",
+        route: "/ops",
+        expected: "ops-coordinator coworker visible",
+        actual: "Scrum Master panel missing",
+        screenshotPath: null,
+        tracePath: null,
+        userRole: "admin",
+        agentId: "ops-coordinator",
+        routeContext: "/ops",
+        reproCommand: "pnpm exec playwright test --project=ops-backlog",
+        createdAt: "2026-05-11T12:05:00.000Z",
+        likelyOwnerArea: "ops-backlog",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(expect.objectContaining({ itemId: "BI-EXISTING", action: "updated" }));
+    expect(mockPrisma.backlogItem.create).not.toHaveBeenCalled();
+    expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "existing-row-1" },
+        data: expect.objectContaining({
+          occurrenceCount: { increment: 1 },
+          lastSeenAt: expect.any(Date),
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "existing-row-1",
+          kind: "evidence",
+          summary: expect.stringContaining("OPS-AI-ROUTING-01 failed again"),
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -503,6 +503,44 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "record_functional_failure_evidence",
+    description: "Create or update a deduped backlog item from Playwright FunctionalFailureEvidence. Uses a deterministic testId+route+actual fingerprint and records an evidence activity; the cross-cutting audit lives in ToolExecution. Side-effecting.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        testId: { type: "string", description: "Stable automated test id" },
+        suite: { type: "string", description: "Playwright suite or project" },
+        route: { type: "string", description: "Application route under test" },
+        expected: { type: "string", description: "Expected behavior" },
+        actual: { type: "string", description: "Observed failure" },
+        screenshotPath: { type: "string", description: "Local screenshot path when available" },
+        tracePath: { type: "string", description: "Local trace path when available" },
+        userRole: { type: "string", description: "User role used by the test" },
+        agentId: { type: "string", description: "Expected or active coworker id" },
+        routeContext: { type: "string", description: "Route context used by the test" },
+        reproCommand: { type: "string", description: "Command to reproduce the failure" },
+        createdAt: { type: "string", description: "Evidence timestamp" },
+        likelyOwnerArea: { type: "string", description: "Likely owning product area" },
+        buildId: { type: "string", description: "Optional Build Studio id" },
+        backlogItemId: { type: "string", description: "Optional explicit backlog item to attach to" },
+      },
+      required: [
+        "testId",
+        "suite",
+        "route",
+        "expected",
+        "actual",
+        "userRole",
+        "routeContext",
+        "reproCommand",
+        "createdAt",
+        "likelyOwnerArea",
+      ],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "get_next_recommended_work",
     description: "Return a short ranked list of backlog items the caller could pick up next. Ranks by spec/plan presence, triage outcome, effort size, priority, and active-build state. Read-only.",
     inputSchema: {
@@ -2844,6 +2882,12 @@ function parseCapabilityNeeds(rawNeeds: unknown): CoworkerCapabilityNeedInput[] 
     .filter((need) => need.need.length > 0 && need.blocks.length > 0);
 }
 
+function redactFunctionalFailureText(text: string): string {
+  return text
+    .replace(/\bdpfmcp_[A-Za-z0-9_-]+/g, "[redacted-token]")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/g, "[redacted-token]");
+}
+
 export async function executeTool(
   toolName: string,
   rawParams: Record<string, unknown>,
@@ -3769,6 +3813,158 @@ export async function executeTool(
         entityId: activity.id,
         message: `Recorded ${kindRaw} evidence for ${itemIdRaw}`,
         data: { activityId: activity.id, recordedAt: activity.recordedAt.toISOString() },
+      };
+    }
+
+    case "record_functional_failure_evidence": {
+      const required = [
+        "testId",
+        "suite",
+        "route",
+        "expected",
+        "actual",
+        "userRole",
+        "routeContext",
+        "reproCommand",
+        "createdAt",
+        "likelyOwnerArea",
+      ];
+      const missing = required.filter((key) => typeof params[key] !== "string" || !String(params[key]).trim());
+      if (missing.length > 0) {
+        return {
+          success: false,
+          error: "missing_required",
+          message: `Missing required functional failure evidence field(s): ${missing.join(", ")}`,
+        };
+      }
+
+      const testId = String(params["testId"]).trim();
+      const suite = String(params["suite"]).trim();
+      const route = String(params["route"]).trim();
+      const expected = redactFunctionalFailureText(String(params["expected"]));
+      const actual = redactFunctionalFailureText(String(params["actual"]));
+      const userRole = String(params["userRole"]).trim();
+      const routeContext = String(params["routeContext"]).trim();
+      const reproCommand = String(params["reproCommand"]).trim();
+      const createdAt = String(params["createdAt"]).trim();
+      const likelyOwnerArea = String(params["likelyOwnerArea"]).trim();
+      const agentId = typeof params["agentId"] === "string" ? params["agentId"].trim() || null : null;
+      const screenshotPath =
+        typeof params["screenshotPath"] === "string" ? params["screenshotPath"].trim() || null : null;
+      const tracePath = typeof params["tracePath"] === "string" ? params["tracePath"].trim() || null : null;
+      const buildId = typeof params["buildId"] === "string" ? params["buildId"].trim() || null : null;
+      const explicitItemId =
+        typeof params["backlogItemId"] === "string" ? params["backlogItemId"].trim() || null : null;
+
+      const normalizedActual = actual.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 1200);
+      const failureFingerprint = crypto
+        .createHash("sha256")
+        .update(`${testId}|${route}|${normalizedActual}`)
+        .digest("hex")
+        .slice(0, 16);
+
+      const evidencePayload = {
+        evidenceKind: "test_fail",
+        source: "functional-test-failure",
+        failureFingerprint,
+        testId,
+        suite,
+        route,
+        expected,
+        actual,
+        screenshotPath,
+        tracePath,
+        userRole,
+        agentId,
+        routeContext,
+        reproCommand,
+        createdAt,
+        likelyOwnerArea,
+        buildId,
+      };
+      const summary = `${testId} failed${route ? ` on ${route}` : ""}: ${actual.slice(0, 120)}`;
+
+      let item = explicitItemId
+        ? await prisma.backlogItem.findUnique({
+            where: { itemId: explicitItemId },
+            select: { id: true, itemId: true, occurrenceCount: true },
+          })
+        : null;
+
+      if (!item) {
+        item = await prisma.backlogItem.findFirst({
+          where: {
+            source: "functional-test-failure",
+            status: { notIn: ["done", "deferred"] },
+            body: { contains: `failureFingerprint: ${failureFingerprint}` },
+          },
+          select: { id: true, itemId: true, occurrenceCount: true },
+        });
+      }
+
+      let action: "created" | "updated";
+      if (!item) {
+        item = await prisma.backlogItem.create({
+          data: {
+            itemId: `BI-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+            title: `[${testId}] ${route} functional smoke failure`,
+            type: "product",
+            status: "triaging",
+            source: "functional-test-failure",
+            submittedById: userId,
+            agentId: context?.agentId ?? agentId ?? null,
+            lastSeenAt: new Date(createdAt),
+            body: [
+              `failureFingerprint: ${failureFingerprint}`,
+              `ownerArea: ${likelyOwnerArea}`,
+              `route: ${route}`,
+              `suite: ${suite}`,
+              `expected: ${expected}`,
+              `actual: ${actual}`,
+              `repro: ${reproCommand}`,
+            ].join("\n"),
+          },
+          select: { id: true, itemId: true, occurrenceCount: true },
+        });
+        action = "created";
+      } else {
+        item = await prisma.backlogItem.update({
+          where: { id: item.id },
+          data: {
+            occurrenceCount: { increment: 1 },
+            lastSeenAt: new Date(createdAt),
+          },
+          select: { id: true, itemId: true, occurrenceCount: true },
+        });
+        action = "updated";
+      }
+
+      const activity = await prisma.backlogItemActivity.create({
+        data: {
+          backlogItemId: item.id,
+          kind: "evidence",
+          summary: action === "created" ? summary.slice(0, 240) : `${testId} failed again on ${route}`.slice(0, 240),
+          payload: evidencePayload,
+          recordedById: userId,
+          recordedByAgentId: context?.agentId ?? agentId ?? null,
+        },
+      });
+
+      return {
+        success: true,
+        entityId: item.itemId,
+        message:
+          action === "created"
+            ? `Created ${item.itemId} for ${testId} functional failure`
+            : `Updated ${item.itemId} with repeated ${testId} functional failure`,
+        data: {
+          action,
+          itemId: item.itemId,
+          activityId: activity.id,
+          failureFingerprint,
+          occurrenceCount: item.occurrenceCount,
+          recordedAt: activity.recordedAt.toISOString(),
+        },
       };
     }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -24,6 +24,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   link_backlog_item_to_epic: ["backlog_write"],
   search_specs_and_plans: ["spec_plan_read", "backlog_read"],
   record_execution_evidence: ["backlog_write"],
+  record_functional_failure_evidence: ["backlog_write"],
   get_next_recommended_work: ["backlog_read"],
 
   // Backlog triage and Build Studio promotion (spec 2026-04-21)

--- a/docs/superpowers/plans/2026-05-11-ai-routing-ux-verification-test-architecture.md
+++ b/docs/superpowers/plans/2026-05-11-ai-routing-ux-verification-test-architecture.md
@@ -20,7 +20,7 @@
 - Tasks 4-5 implemented as reusable Playwright fixtures plus three route-family smoke projects for `/build`, `/platform/tools/discovery`, and `/ops`.
 - Task 6 implemented by linking the manual QA plan to `apps/web/lib/testing/route-contracts.ts`.
 - Task 7 verification completed for focused Vitest, web typecheck, targeted Playwright route smokes, and `pnpm --filter web build`.
-- Task 8 remains a follow-up slice for governed backlog integration of functional failure evidence.
+- Task 8 implemented in stacked branch `chore/ai-routing-evidence-backlog-loop`: functional failure evidence now has a governed MCP tool path that dedupes repeated failures by fingerprint, creates or updates a backlog item, and appends evidence activity without Playwright using direct DB access.
 
 ---
 

--- a/e2e/fixtures/evidence.ts
+++ b/e2e/fixtures/evidence.ts
@@ -1,9 +1,10 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { readFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { TestInfo } from "@playwright/test";
 import {
   buildFunctionalFailureEvidence,
   redactEvidence,
+  type FunctionalFailureEvidence,
   type FunctionalFailureEvidenceInput,
 } from "../../apps/web/lib/testing/functional-evidence";
 
@@ -22,5 +23,64 @@ export async function attachFunctionalFailureEvidence(
     path: outputPath,
   });
 
+  if (process.env.DPF_RECORD_FUNCTIONAL_FAILURES === "1") {
+    await publishFunctionalFailureEvidence(evidence);
+  }
+
   return evidence;
+}
+
+async function publishFunctionalFailureEvidence(evidence: FunctionalFailureEvidence) {
+  const config = await readMcpConfig();
+  if (!config) {
+    throw new Error("DPF_RECORD_FUNCTIONAL_FAILURES=1 but no DPF MCP config was found");
+  }
+
+  const response = await fetch(config.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: config.authorization,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: `functional-failure-${evidence.testId}`,
+      method: "tools/call",
+      params: {
+        name: "record_functional_failure_evidence",
+        arguments: evidence,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Functional evidence MCP publish failed with HTTP ${response.status}`);
+  }
+
+  const payload = await response.json() as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+  if (payload.result?.isError) {
+    throw new Error(payload.result.content?.[0]?.text ?? "Functional evidence MCP publish failed");
+  }
+}
+
+async function readMcpConfig(): Promise<{ url: string; authorization: string } | null> {
+  const explicitUrl = process.env.DPF_MCP_URL;
+  const explicitToken = process.env.DPF_MCP_TOKEN;
+  if (explicitUrl && explicitToken) {
+    return {
+      url: explicitUrl,
+      authorization: explicitToken.startsWith("Bearer ") ? explicitToken : `Bearer ${explicitToken}`,
+    };
+  }
+
+  const raw = await readFile(".mcp.json", "utf8").catch(() => null);
+  if (!raw) return null;
+
+  const parsed = JSON.parse(raw) as {
+    mcpServers?: { dpf?: { url?: string; headers?: { Authorization?: string } } };
+  };
+  const server = parsed.mcpServers?.dpf;
+  if (!server?.url || !server.headers?.Authorization) return null;
+
+  return { url: server.url, authorization: server.headers.Authorization };
 }


### PR DESCRIPTION
## Summary
- Adds `record_functional_failure_evidence` to the governed MCP tool surface.
- Dedupes Playwright functional failures by `testId + route + normalized actual` fingerprint.
- Creates the first backlog item and records an evidence activity; repeated failures update occurrence count and append evidence.
- Wires the Playwright evidence fixture to optionally publish through `/api/mcp/v1` when `DPF_RECORD_FUNCTIONAL_FAILURES=1` is set.
- Updates the AI routing verification plan to mark Task 8 implemented.

## Verification
- `pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts lib/mcp-tools.test.ts app/api/mcp/v1/route.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`

## Notes
- PR #450 has merged, so this branch is rebased onto current `main`.
- No direct DB fallback was added to Playwright. Publishing goes through JSON-RPC MCP with an MCP bearer token from `.mcp.json` or `DPF_MCP_URL` + `DPF_MCP_TOKEN`.
- A live `tools/list` check against the previously running portal did not show the new tool because that runtime had not been rebuilt from this branch yet; local tests and production build cover this branch.