### PR TITLE
feat(wiki): EP-WIKI-001 Phase 4b2b — wiki_lint MCP tool

### DIFF
--- a/apps/web/lib/mcp-tools-wiki-lint.test.ts
+++ b/apps/web/lib/mcp-tools-wiki-lint.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    organization: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+const runWikiLint = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+  QDRANT_COLLECTIONS: { WIKI_PAGES: "wiki-pages" },
+}));
+
+vi.mock("@/lib/wiki/lint", () => ({
+  runWikiLint: (...args: unknown[]) => runWikiLint(...args),
+}));
+
+import { executeTool } from "./mcp-tools";
+
+afterEach(() => {
+  mockPrisma.organization.findFirst.mockReset();
+  runWikiLint.mockReset();
+});
+
+describe("wiki_lint MCP tool", () => {
+  function lintRow(overrides: Partial<{
+    organizationId: string | null;
+    scannedPageCount: number;
+    findingsOpened: number;
+    findingsKept: number;
+    findingsResolved: number;
+  }> = {}) {
+    return {
+      organizationId: null,
+      scannedPageCount: 0,
+      findingsOpened: 0,
+      findingsKept: 0,
+      findingsResolved: 0,
+      ...overrides,
+    };
+  }
+
+  it("default scope 'all' lints kernel then current org", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_acme" });
+    runWikiLint.mockResolvedValueOnce(lintRow({ scannedPageCount: 3, findingsOpened: 1 }));
+    runWikiLint.mockResolvedValueOnce(lintRow({ organizationId: "org_acme", scannedPageCount: 5 }));
+
+    const res = await executeTool("wiki_lint", {}, "user_test");
+
+    expect(res.success).toBe(true);
+    expect(runWikiLint).toHaveBeenCalledTimes(2);
+    expect(runWikiLint.mock.calls[0][0]).toMatchObject({ organizationId: null });
+    expect(runWikiLint.mock.calls[1][0]).toMatchObject({ organizationId: "org_acme" });
+  });
+
+  it("scope=kernel skips the org pass even when org exists", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_acme" });
+    runWikiLint.mockResolvedValueOnce(lintRow());
+
+    await executeTool("wiki_lint", { scope: "kernel" }, "user_test");
+
+    expect(runWikiLint).toHaveBeenCalledTimes(1);
+    expect(runWikiLint.mock.calls[0][0]).toMatchObject({ organizationId: null });
+  });
+
+  it("scope=org skips the kernel pass and uses the org id", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_acme" });
+    runWikiLint.mockResolvedValueOnce(lintRow({ organizationId: "org_acme" }));
+
+    await executeTool("wiki_lint", { scope: "org" }, "user_test");
+
+    expect(runWikiLint).toHaveBeenCalledTimes(1);
+    expect(runWikiLint.mock.calls[0][0]).toMatchObject({ organizationId: "org_acme" });
+  });
+
+  it("scope=org with no organisation row reports no work done", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce(null);
+
+    const res = await executeTool("wiki_lint", { scope: "org" }, "user_test");
+
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("No scope linted");
+    expect(runWikiLint).not.toHaveBeenCalled();
+  });
+
+  it("formats one summary line per run with scope tag and finding deltas", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValueOnce({ id: "org_acme" });
+    runWikiLint.mockResolvedValueOnce(
+      lintRow({ scannedPageCount: 12, findingsOpened: 2, findingsKept: 3, findingsResolved: 1 }),
+    );
+    runWikiLint.mockResolvedValueOnce(
+      lintRow({ organizationId: "org_acme", scannedPageCount: 4, findingsOpened: 0, findingsKept: 1, findingsResolved: 5 }),
+    );
+
+    const res = await executeTool("wiki_lint", {}, "user_test");
+
+    const lines = (res.message ?? "").split("\n");
+    expect(lines[0]).toBe("kernel: scanned=12 opened=2 kept=3 resolved=1");
+    expect(lines[1]).toBe("org org_acme: scanned=4 opened=0 kept=1 resolved=5");
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1987,6 +1987,24 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: false,
   },
+  // ─── EP-WIKI-001 Phase 4b2b: Wiki Lint trigger ─────────────────────────────
+  {
+    name: "wiki_lint",
+    description: "Run wiki lint detectors on-demand for the kernel and/or current organisation's overlay. Same orchestrator as the daily scheduled job. Use when the user asks to refresh findings or wants a quick health check. Returns scanned-page counts and finding deltas (opened / kept / resolved).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        scope: {
+          type: "string",
+          enum: ["kernel", "org", "all"],
+          description: "Which scope to lint. 'kernel' lints kernel rows only; 'org' lints the current org's overlay; 'all' (default) lints both.",
+        },
+      },
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+  },
   // ─── Knowledge Search ──────────────────────────────────────────────────────
   {
     name: "search_knowledge",
@@ -8398,6 +8416,67 @@ export async function executeTool(
         )
         .join("\n");
       return { success: true, message: summary, data: { results } };
+    }
+
+    case "wiki_lint": {
+      const { runWikiLint } = await import("@/lib/wiki/lint");
+      const { prisma } = await import("@dpf/db");
+      const scopeArg = typeof params["scope"] === "string" ? params["scope"] : "all";
+
+      // Mirrors queue/functions/wiki-lint.ts: read manifest.json directly
+      // rather than pulling in the seed module.
+      const kernelVersion = await (async () => {
+        try {
+          const fs = await import("fs/promises");
+          const path = await import("path");
+          const manifestPath = path.join(process.cwd(), "docs", "founder-kernel", "manifest.json");
+          const raw = await fs.readFile(manifestPath, "utf8");
+          return (JSON.parse(raw) as { kernelVersion?: string }).kernelVersion ?? "0.0.0";
+        } catch {
+          return "0.0.0";
+        }
+      })();
+
+      const org = await prisma.organization
+        .findFirst({ select: { id: true } })
+        .catch(() => null);
+
+      const runs: Array<Awaited<ReturnType<typeof runWikiLint>>> = [];
+      if (scopeArg === "kernel" || scopeArg === "all") {
+        runs.push(
+          await runWikiLint({
+            organizationId: null,
+            prisma: prisma as never,
+            currentKernelVersion: kernelVersion,
+          }),
+        );
+      }
+      if ((scopeArg === "org" || scopeArg === "all") && org) {
+        runs.push(
+          await runWikiLint({
+            organizationId: org.id,
+            prisma: prisma as never,
+            currentKernelVersion: kernelVersion,
+          }),
+        );
+      }
+
+      if (runs.length === 0) {
+        return {
+          success: true,
+          message: "No scope linted (no organisation found and scope was 'org').",
+          data: { runs: [] },
+        };
+      }
+
+      const summary = runs
+        .map((r) => {
+          const tag = r.organizationId === null ? "kernel" : `org ${r.organizationId}`;
+          return `${tag}: scanned=${r.scannedPageCount} opened=${r.findingsOpened} kept=${r.findingsKept} resolved=${r.findingsResolved}`;
+        })
+        .join("\n");
+
+      return { success: true, message: summary, data: { runs } };
     }
 
     case "search_knowledge": {

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -66,6 +66,8 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
 
   // EP-WIKI-001 Phase 3b2: Founder kernel + per-org overlay wiki
   wiki_query: ["registry_read"],
+  // EP-WIKI-001 Phase 4b2b: on-demand wiki lint trigger
+  wiki_lint: ["registry_read"],
 
   // Build / Sandbox
   launch_sandbox: ["sandbox_execute"],


### PR DESCRIPTION
## Summary

EP-WIKI-001 Phase 4b2b — `wiki_lint` MCP tool. Lets agents trigger the lint orchestrator on-demand (same path as the daily Inngest job from PR #436). Useful when the user asks for a refresh, after a kernel content change, or for a quick health check.

## What changed

### `apps/web/lib/mcp-tools.ts`

- **Tool def**: `wiki_lint`, immediate, `requiredCapability: null`, `sideEffect: false`. Optional `scope` input: `kernel` / `org` / `all` (default `all`).
- **Executor**: loads `currentKernelVersion` from `docs/founder-kernel/manifest.json` (same pattern as `queue/functions/wiki-lint.ts` to avoid pulling the seed module), resolves the platform organization, calls `runWikiLint` once or twice depending on scope. Returns a one-line-per-run summary with `scanned` / `opened` / `kept` / `resolved` counts.

### `apps/web/lib/tak/agent-grants.ts`

- `wiki_lint: ["registry_read"]` per spec §8. The orchestrator&#39;s writes to `WikiLintFinding` are system housekeeping (idempotent, re-running produces the same result); not user-visible state changes that would warrant `registry_write`.

### `apps/web/lib/mcp-tools-wiki-lint.test.ts` (5 vitest cases)

| Case | Asserts |
|------|---------|
| Default scope `all` | kernel pass + org pass |
| `scope=kernel` | kernel pass only; org skipped even when org exists |
| `scope=org` | org pass only; kernel skipped |
| `scope=org`, no Organization | &#34;No scope linted&#34; message; orchestrator not called |
| Summary format | Scope tag + finding deltas per run |

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` | ✓ (Sandbox + gitPromotionCandidate models from main needed regen) |
| `pnpm --filter web typecheck` | ✓ |
| `pnpm --filter web test --run mcp-tools-wiki-lint.test.ts` | ✓ 5/5 |

## Dependencies

Depends only on merged work: PR #436 (lint runtime), PR #408 (schema). Independent of in-flight PR #460 (wiki_query route-context waterfall).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_