### PR TITLE
feat(coworkers): autonomous coworker runtime slice 1

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -42,6 +42,7 @@ const SEVERITY_CLASS: Record<OperationsMapProjection["severity"], string> = {
 };
 
 const SOURCE_LABEL: Record<OperationsMapProjection["source"], string> = {
+  "task-run": "Task run",
   "tool-execution": "Tool execution",
   "tool-receipt": "Receipt",
   "evidence-backlog": "Backlog evidence",
@@ -49,6 +50,7 @@ const SOURCE_LABEL: Record<OperationsMapProjection["source"], string> = {
 };
 
 const SOURCE_OPTIONS: OperationsMapProjectionSource[] = [
+  "task-run",
   "tool-execution",
   "tool-receipt",
   "evidence-backlog",

--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -1,11 +1,67 @@
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
-vi.mock("@dpf/db", () => ({ prisma: {} }));
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  prisma: {
+    scheduledAgentTask: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    scheduledJob: {
+      update: vi.fn(),
+      upsert: vi.fn(),
+    },
+    agentThread: {
+      upsert: vi.fn(),
+    },
+    agentMessage: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+    taskRun: {
+      create: vi.fn(),
+      update: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    taskMessage: {
+      create: vi.fn(),
+    },
+  },
+  resolveAgentForRouteWithPrompts: vi.fn(),
+  runAgenticLoop: vi.fn(),
+  getAvailableTools: vi.fn(),
+  toolsToOpenAIFormat: vi.fn(),
+  executeTool: vi.fn(),
+}));
 
-import { describe, expect, it } from "vitest";
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("@/lib/tak/agent-routing-server", () => ({
+  resolveAgentForRouteWithPrompts: mocks.resolveAgentForRouteWithPrompts,
+}));
+vi.mock("@/lib/tak/agentic-loop", () => ({
+  runAgenticLoop: mocks.runAgenticLoop,
+}));
+vi.mock("@/lib/mcp-tools", () => ({
+  getAvailableTools: mocks.getAvailableTools,
+  toolsToOpenAIFormat: mocks.toolsToOpenAIFormat,
+  executeTool: mocks.executeTool,
+}));
 
+import {
+  executeScheduledAgentTask,
+  scheduleAgentTask,
+} from "./agent-task-scheduler";
 import { extractDiscoveryTriageSummary } from "./agent-task-scheduler-summary";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 describe("extractDiscoveryTriageSummary", () => {
   it("builds a compact status string and thread payload for executed triage runs", () => {
@@ -91,5 +147,141 @@ describe("extractDiscoveryTriageSummary", () => {
     ]);
 
     expect(summary).toBeNull();
+  });
+});
+
+function arrangeScheduledTask() {
+  mocks.prisma.scheduledAgentTask.findUnique.mockResolvedValue({
+    taskId: "discovery-taxonomy-gap-triage-daily",
+    agentId: "inventory-specialist",
+    title: "Discovery Taxonomy Gap Triage",
+    prompt: "Triage taxonomy gaps.",
+    routeContext: "/platform/tools/discovery",
+    schedule: "0 8 * * *",
+    timezone: "UTC",
+    isActive: true,
+    ownerUserId: "user-1",
+  });
+  mocks.prisma.agentThread.upsert.mockResolvedValue({ id: "thread-1" });
+  mocks.prisma.agentMessage.create.mockResolvedValue({});
+  mocks.prisma.user.findUnique.mockResolvedValue({ id: "user-1", isSuperuser: true });
+  mocks.resolveAgentForRouteWithPrompts.mockResolvedValue({
+    systemPrompt: "You are Inventory Specialist.",
+    sensitivity: "internal",
+  });
+  mocks.prisma.agentMessage.findMany.mockResolvedValue([
+    { role: "user", content: "Triage taxonomy gaps." },
+  ]);
+  mocks.getAvailableTools.mockResolvedValue([
+    {
+      name: "run_discovery_triage",
+      description: "Run triage",
+      inputSchema: {},
+      requiredCapability: null,
+      executionMode: "immediate",
+      sideEffect: false,
+    },
+  ]);
+  mocks.toolsToOpenAIFormat.mockReturnValue([]);
+  mocks.prisma.taskRun.create.mockResolvedValue({
+    id: "task-run-row-1",
+    taskRunId: "TR-SCHED-ABCDE",
+    contextId: "thread-1",
+  });
+  mocks.prisma.taskMessage.create.mockResolvedValue({});
+  mocks.prisma.taskRun.update.mockResolvedValue({});
+  mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
+  mocks.prisma.scheduledJob.update.mockResolvedValue({});
+}
+
+describe("executeScheduledAgentTask TaskRun lifecycle", () => {
+  it("creates a TaskRun before the first runAgenticLoop call and links it back to ScheduledAgentTask", async () => {
+    arrangeScheduledTask();
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "Done.",
+      executedTools: [{ name: "run_discovery_triage", args: {}, result: { success: true } }],
+    });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    expect(mocks.prisma.taskRun.create).toHaveBeenCalledOnce();
+    expect(mocks.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: "TR-SCHED-ABCDE",
+        agentId: "inventory-specialist",
+        threadId: "thread-1",
+      }),
+    );
+    expect(mocks.prisma.taskRun.create.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.runAgenticLoop.mock.invocationCallOrder[0],
+    );
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "discovery-taxonomy-gap-triage-daily" },
+        data: expect.objectContaining({
+          lastStatus: "ok",
+          taskRunId: "TR-SCHED-ABCDE",
+        }),
+      }),
+    );
+    expect(mocks.prisma.taskRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "task-run-row-1" },
+        data: expect.objectContaining({
+          status: "completed",
+          completedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it("marks the TaskRun failed and preserves the next schedule when the loop throws", async () => {
+    arrangeScheduledTask();
+    mocks.runAgenticLoop.mockRejectedValue(new Error("LLM unavailable"));
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    expect(mocks.prisma.taskRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "task-run-row-1" },
+        data: expect.objectContaining({
+          status: "failed",
+          completedAt: expect.any(Date),
+          progressPayload: { error: "LLM unavailable" },
+        }),
+      }),
+    );
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "discovery-taxonomy-gap-triage-daily" },
+        data: expect.objectContaining({
+          lastStatus: "error",
+          lastError: "LLM unavailable",
+          taskRunId: "TR-SCHED-ABCDE",
+          nextRunAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+});
+
+describe("scheduleAgentTask UTC-only timezone", () => {
+  it("rejects non-UTC timezone with an explanatory error", async () => {
+    mocks.auth.mockResolvedValue({ user: { id: "user-1" } });
+
+    const result = await scheduleAgentTask({
+      agentId: "inventory-specialist",
+      title: "Discovery Taxonomy Gap Triage",
+      prompt: "Triage taxonomy gaps.",
+      routeContext: "/platform/tools/discovery",
+      schedule: "0 8 * * *",
+      timezone: "America/Chicago",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringMatching(/Non-UTC timezones are not yet supported/),
+    });
+    expect(mocks.prisma.scheduledAgentTask.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -4,6 +4,11 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { randomUUID } from "crypto";
 import { extractDiscoveryTriageSummary } from "./agent-task-scheduler-summary";
+import {
+  createTaskRunForScheduledTask,
+  type ScheduledTaskRunRef,
+} from "@/lib/tak/scheduled-task-runs";
+import { createTaskMessage } from "@/lib/tak/task-records";
 
 // ─── Cron helpers ───────────────────────────────────────────────────────────
 
@@ -60,6 +65,13 @@ export async function scheduleAgentTask(
 ): Promise<{ success: true; taskId: string } | { success: false; error: string }> {
   const session = await auth();
   if (!session?.user?.id) return { success: false, error: "Unauthorized" };
+
+  if (input.timezone && input.timezone !== "UTC") {
+    return {
+      success: false,
+      error: "Non-UTC timezones are not yet supported. All schedules run in UTC.",
+    };
+  }
 
   const taskId = `agent-task-${randomUUID().slice(0, 8)}`;
   const now = new Date();
@@ -165,6 +177,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
   if (!task || !task.isActive) return;
 
   const now = new Date();
+  let taskRunRef: ScheduledTaskRunRef | null = null;
 
   try {
     // Get or create a dedicated thread for this scheduled task
@@ -182,6 +195,29 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         role: "user",
         content: `[Scheduled task: ${task.title}]\n\n${task.prompt}`,
         agentId: task.agentId,
+        routeContext: task.routeContext,
+      },
+    });
+
+    taskRunRef = await createTaskRunForScheduledTask({
+      taskId: task.taskId,
+      ownerUserId: task.ownerUserId,
+      agentId: task.agentId,
+      threadId: thread.id,
+      routeContext: task.routeContext,
+      title: task.title,
+      prompt: task.prompt,
+    });
+
+    await createTaskMessage({
+      taskRunId: taskRunRef.taskRunId,
+      taskRunRecordId: taskRunRef.id,
+      contextId: taskRunRef.contextId,
+      role: "user",
+      content: `[Scheduled task: ${task.title}]\n\n${task.prompt}`,
+      metadata: {
+        source: "scheduled",
+        taskId: task.taskId,
         routeContext: task.routeContext,
       },
     });
@@ -236,6 +272,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       routeContext: task.routeContext,
       agentId: task.agentId,
       threadId: thread.id,
+      taskRunId: taskRunRef.taskRunId,
     });
 
     // Persist agent response
@@ -246,6 +283,19 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         content: result.content ?? "(No response)",
         agentId: task.agentId,
         routeContext: task.routeContext,
+      },
+    });
+
+    await createTaskMessage({
+      taskRunId: taskRunRef.taskRunId,
+      taskRunRecordId: taskRunRef.id,
+      contextId: taskRunRef.contextId,
+      role: "agent",
+      content: result.content ?? "(No response)",
+      metadata: {
+        source: "scheduled",
+        taskId: task.taskId,
+        agentId: task.agentId,
       },
     });
 
@@ -272,7 +322,20 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         lastStatus: "ok",
         lastError: scheduledSummary?.compactStatus ?? null,
         lastThreadId: thread.id,
+        taskRunId: taskRunRef.taskRunId,
         nextRunAt,
+      },
+    });
+
+    await prisma.taskRun.update({
+      where: { id: taskRunRef.id },
+      data: {
+        status: "completed",
+        completedAt: new Date(),
+        progressPayload: {
+          scheduledSummary: scheduledSummary?.compactStatus ?? null,
+          executedToolCount: result.executedTools?.length ?? 0,
+        },
       },
     });
 
@@ -290,10 +353,35 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
     const errMsg = err instanceof Error ? err.message : "unknown error";
     console.error(`[agent-task-scheduler] Task ${taskId} failed:`, errMsg);
 
+    const ref = taskRunRef;
+    if (ref) {
+      await prisma.taskRun.update({
+        where: { id: ref.id },
+        data: {
+          status: "failed",
+          completedAt: new Date(),
+          progressPayload: {
+            error: errMsg,
+          },
+        },
+      }).catch((updateErr) => {
+        console.error(
+          `[agent-task-scheduler] Failed to mark TaskRun ${ref.taskRunId} failed:`,
+          updateErr,
+        );
+      });
+    }
+
     const nextRunAt = computeNextCronRun(task.schedule, now);
     await prisma.scheduledAgentTask.update({
       where: { taskId },
-      data: { lastRunAt: now, lastStatus: "error", lastError: errMsg, nextRunAt },
+      data: {
+        lastRunAt: now,
+        lastStatus: "error",
+        lastError: errMsg,
+        taskRunId: taskRunRef?.taskRunId ?? null,
+        nextRunAt,
+      },
     });
 
     await prisma.scheduledJob.update({

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -14,6 +14,9 @@ vi.mock("@dpf/db", () => ({
     toolExecutionReceipt: {
       findMany: vi.fn(),
     },
+    taskRun: {
+      findMany: vi.fn(),
+    },
     backlogItemActivity: {
       findMany: vi.fn(),
     },
@@ -38,6 +41,7 @@ describe("loadOperationsMapData", () => {
       },
     } as never);
     vi.mocked(prisma.agent.findMany).mockResolvedValue([makeAgentRow()] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([makeToolExecutionRow()] as never);
     vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
@@ -64,6 +68,7 @@ describe("loadOperationsMapData", () => {
   it("falls back to the generic value-chain map when no storefront archetype is configured", async () => {
     vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.agent.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
@@ -79,6 +84,7 @@ describe("loadOperationsMapData", () => {
   it("loads and chronologically merges receipts, backlog evidence, and external evidence", async () => {
     vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.agent.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([makeTaskRunRow()] as never);
     vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([makeToolExecutionRow()] as never);
     vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([makeReceiptRow()] as never);
     vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([makeBacklogEvidenceRow()] as never);
@@ -90,8 +96,28 @@ describe("loadOperationsMapData", () => {
       "evidence-external",
       "evidence-backlog",
       "tool-receipt",
+      "task-run",
       "tool-execution",
     ]);
+    expect(prisma.taskRun.findMany).toHaveBeenCalledWith({
+      where: {
+        archivedAt: null,
+        source: "proactive",
+      },
+      orderBy: { startedAt: "desc" },
+      take: 40,
+      select: {
+        id: true,
+        taskRunId: true,
+        status: true,
+        source: true,
+        currentAgentId: true,
+        routeContext: true,
+        title: true,
+        startedAt: true,
+        completedAt: true,
+      },
+    });
     expect(prisma.toolExecutionReceipt.findMany).toHaveBeenCalledWith({
       orderBy: { createdAt: "desc" },
       take: 40,
@@ -189,6 +215,20 @@ function makeToolExecutionRow() {
     auditClass: "journal",
     capabilityId: "platform:diagnose_customer_estate",
     summary: "Checked service health",
+  };
+}
+
+function makeTaskRunRow() {
+  return {
+    id: "tr-1",
+    taskRunId: "TR-SCHED-ABCDE",
+    status: "working",
+    source: "proactive",
+    currentAgentId: "support-specialist",
+    routeContext: "service-operations",
+    title: "Discovery Taxonomy Gap Triage",
+    startedAt: new Date("2026-05-10T12:00:30.000Z"),
+    completedAt: null,
   };
 }
 

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -4,6 +4,7 @@ import {
   projectAgentsToStations,
   projectBacklogEvidence,
   projectExternalEvidence,
+  projectTaskRun,
   projectToolExecution,
   projectToolExecutionReceipt,
 } from "./project-events";
@@ -12,6 +13,7 @@ import type {
   OperationsMapBacklogEvidence,
   OperationsMapExternalEvidence,
   OperationsMapProjection,
+  OperationsMapTaskRun,
   OperationsMapTemplate,
   OperationsMapToolExecution,
   OperationsMapToolExecutionReceipt,
@@ -28,7 +30,7 @@ export type OperationsMapData = {
 };
 
 export async function loadOperationsMapData(): Promise<OperationsMapData> {
-  const [storefrontConfig, agents, toolExecutions, toolReceipts, backlogEvidence, externalEvidence] = await Promise.all([
+  const [storefrontConfig, agents, taskRuns, toolExecutions, toolReceipts, backlogEvidence, externalEvidence] = await Promise.all([
     prisma.storefrontConfig.findFirst({
       include: {
         archetype: {
@@ -61,6 +63,25 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
             toolGrants: true,
           },
         },
+      },
+    }),
+    prisma.taskRun.findMany({
+      where: {
+        archivedAt: null,
+        source: "proactive",
+      },
+      orderBy: { startedAt: "desc" },
+      take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        taskRunId: true,
+        status: true,
+        source: true,
+        currentAgentId: true,
+        routeContext: true,
+        title: true,
+        startedAt: true,
+        completedAt: true,
       },
     }),
     prisma.toolExecution.findMany({
@@ -170,6 +191,7 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
   }));
 
   const projections = [
+    ...taskRuns.map((row) => projectTaskRun(row as OperationsMapTaskRun, template)),
     ...toolExecutions.map((row) => projectToolExecution(row as OperationsMapToolExecution, template)),
     ...toolReceipts.map((row) => projectToolExecutionReceipt(row as OperationsMapToolExecutionReceipt, template)),
     ...backlogEvidence.map((row) => projectBacklogEvidence(row as OperationsMapBacklogEvidence, template)),

--- a/apps/web/lib/ai-operations-map/project-events.test.ts
+++ b/apps/web/lib/ai-operations-map/project-events.test.ts
@@ -15,6 +15,7 @@ import {
   projectBacklogEvidence,
   projectExternalEvidence,
   projectAgentsToStations,
+  projectTaskRun,
   projectToolExecutionReceipt,
   projectToolExecution,
 } from "./project-events";
@@ -22,6 +23,7 @@ import type {
   OperationsMapAgent,
   OperationsMapBacklogEvidence,
   OperationsMapExternalEvidence,
+  OperationsMapTaskRun,
   OperationsMapToolExecution,
   OperationsMapToolExecutionReceipt,
 } from "./types";
@@ -120,6 +122,35 @@ describe("AI operations map projection", () => {
     expect(projection.summary).toContain("write_sandbox_file failed");
     expect(projection.links.authorityHref).toBe("/platform/audit/ledger?toolExecutionId=tool-1");
     expect(projection.links.coworkerHref).toBe("/platform/ai/agent/build-specialist");
+  });
+
+  it("projects a scheduled TaskRun onto the map with status severity", () => {
+    const projection = projectTaskRun(makeTaskRun({
+      id: "tr-1",
+      taskRunId: "TR-SCHED-ABCDE",
+      title: "Discovery Taxonomy Gap Triage",
+      status: "working",
+      source: "proactive",
+      currentAgentId: "inventory-specialist",
+      routeContext: "/platform/tools/discovery",
+    }));
+
+    expect(projection.id).toBe("task-run:tr-1");
+    expect(projection.source).toBe("task-run");
+    expect(projection.severity).toBe("normal");
+    expect(projection.summary).toContain("Discovery Taxonomy Gap Triage");
+    expect(projection.actorAgentId).toBe("inventory-specialist");
+    expect(projection.refs.taskRunId).toBe("TR-SCHED-ABCDE");
+  });
+
+  it("projects a failed TaskRun as critical", () => {
+    const projection = projectTaskRun(makeTaskRun({
+      id: "tr-2",
+      taskRunId: "TR-SCHED-FFFFF",
+      status: "failed",
+    }));
+
+    expect(projection.severity).toBe("critical");
   });
 
   it("projects invalid tool receipts as warning evidence linked to the originating execution", () => {
@@ -229,11 +260,11 @@ describe("AI operations map projection", () => {
     ]);
 
     expect(getOperationsMapQuickViewFilters("all")).toEqual({
-      sources: ["tool-execution", "tool-receipt", "evidence-backlog", "evidence-external"],
+      sources: ["task-run", "tool-execution", "tool-receipt", "evidence-backlog", "evidence-external"],
       severities: ["normal", "attention", "warning", "critical"],
     });
     expect(getOperationsMapQuickViewFilters("exceptions")).toEqual({
-      sources: ["tool-execution", "tool-receipt", "evidence-backlog", "evidence-external"],
+      sources: ["task-run", "tool-execution", "tool-receipt", "evidence-backlog", "evidence-external"],
       severities: ["attention", "warning", "critical"],
     });
     expect(getOperationsMapQuickViewFilters("evidence")).toEqual({
@@ -329,6 +360,21 @@ function makeExternalEvidence(overrides: Partial<OperationsMapExternalEvidence> 
     provider: "external",
     resultSummary: "Evidence synced",
     createdAt: new Date("2026-05-10T12:03:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeTaskRun(overrides: Partial<OperationsMapTaskRun> = {}): OperationsMapTaskRun {
+  return {
+    id: "tr-1",
+    taskRunId: "TR-SCHED-ABCDE",
+    status: "working",
+    source: "proactive",
+    currentAgentId: "inventory-specialist",
+    routeContext: "/platform/tools/discovery",
+    title: "Discovery Taxonomy Gap Triage",
+    startedAt: new Date("2026-05-11T08:00:00.000Z"),
+    completedAt: null,
     ...overrides,
   };
 }

--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -11,6 +11,7 @@ import type {
   OperationsMapQuickView,
   OperationsMapQuickViewId,
   OperationsMapSeverity,
+  OperationsMapTaskRun,
   OperationsMapTemplate,
   OperationsMapToolExecution,
   OperationsMapToolExecutionReceipt,
@@ -77,6 +78,7 @@ const ROUTE_CONTEXT_TO_STATION: Array<{ pattern: RegExp; stationId: string }> = 
 ];
 
 const ALL_PROJECTION_SOURCES: OperationsMapProjectionSource[] = [
+  "task-run",
   "tool-execution",
   "tool-receipt",
   "evidence-backlog",
@@ -213,6 +215,37 @@ export function projectToolExecution(
     links: {
       authorityHref: `/platform/audit/ledger?toolExecutionId=${encodeURIComponent(row.id)}`,
       coworkerHref: `/platform/ai/agent/${encodeURIComponent(row.agentId)}`,
+    },
+  };
+}
+
+export function projectTaskRun(
+  row: OperationsMapTaskRun,
+  template: OperationsMapTemplate = SOFTWARE_PLATFORM_MAP_TEMPLATE,
+): OperationsMapProjection {
+  const stationId = resolveTaskRunStationId(row, template);
+  const label = row.source === "proactive" ? "Scheduled task run" : "Task run";
+
+  return {
+    id: `task-run:${row.id}`,
+    occurredAt: row.startedAt.toISOString(),
+    actorAgentId: row.currentAgentId,
+    source: "task-run",
+    location: {
+      lineId: resolveLineId(stationId, template),
+      stationId,
+    },
+    severity: severityForTaskRunStatus(row.status),
+    label,
+    summary: `${row.title} (${row.status})`,
+    refs: {
+      taskRunId: row.taskRunId,
+    },
+    links: {
+      historyHref: `/api/internal/tasks/${encodeURIComponent(row.taskRunId)}`,
+      coworkerHref: row.currentAgentId
+        ? `/platform/ai/agent/${encodeURIComponent(row.currentAgentId)}`
+        : undefined,
     },
   };
 }
@@ -369,6 +402,26 @@ function resolveToolExecutionStationId(row: OperationsMapToolExecution, template
   if (agentHint && template.stations.some((station) => station.id === agentHint)) return agentHint;
 
   return resolveFallbackStationId(template);
+}
+
+function resolveTaskRunStationId(row: OperationsMapTaskRun, template: OperationsMapTemplate): string {
+  const routeStationId = row.routeContext ? resolveRouteStationId(row.routeContext, template) : null;
+  if (routeStationId) return routeStationId;
+
+  const agentId = row.currentAgentId ?? "";
+  const agentDirect = agentId ? resolveDirectTemplateStationId(agentId, template) : null;
+  if (agentDirect) return agentDirect;
+
+  const agentHint = AGENT_ID_TO_STATION_HINTS.find((hint) => hint.pattern.test(agentId))?.stationId;
+  if (agentHint && template.stations.some((station) => station.id === agentHint)) return agentHint;
+
+  return resolveFallbackStationId(template);
+}
+
+function severityForTaskRunStatus(status: string): OperationsMapSeverity {
+  if (status === "failed" || status === "rejected") return "critical";
+  if (status === "input-required" || status === "auth-required") return "attention";
+  return "normal";
 }
 
 function resolveEvidenceStationId(value: string, template: OperationsMapTemplate): string {

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -99,7 +99,20 @@ export type OperationsMapExternalEvidence = {
   createdAt: Date;
 };
 
+export type OperationsMapTaskRun = {
+  id: string;
+  taskRunId: string;
+  status: string;
+  source: string;
+  currentAgentId: string | null;
+  routeContext: string | null;
+  title: string;
+  startedAt: Date;
+  completedAt: Date | null;
+};
+
 export type OperationsMapProjectionSource =
+  | "task-run"
   | "tool-execution"
   | "tool-receipt"
   | "evidence-backlog"
@@ -124,6 +137,7 @@ export type OperationsMapProjection = {
     backlogItemActivityId?: string | null;
     backlogItemId?: string | null;
     externalEvidenceRecordId?: string | null;
+    taskRunId?: string | null;
     buildId?: string | null;
     capabilityId?: string | null;
   };

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -319,6 +319,44 @@ describe("runAgenticLoop", () => {
     );
   });
 
+  it("forwards taskRunId into governedExecuteTool context on every tool call", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    const mockExecuteTool = vi.mocked(executeTool);
+
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Searching.",
+        toolCalls: [{ id: "toolu_01A", name: "search_project_files", arguments: { query: "agent" } }],
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "I found the relevant files and summarized the implementation path with enough detail for the next step to continue cleanly.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "The search output lists the relevant files and the likely implementation path. It gives enough context for a follow-up step and keeps the answer limited to investigation notes.",
+      }));
+
+    mockExecuteTool.mockResolvedValueOnce({
+      success: true,
+      message: "Found files",
+    });
+
+    await runAgenticLoop({
+      ...baseParams,
+      taskRunId: "TR-SCHED-TESTRUN",
+    });
+
+    expect(governedExecuteTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          taskRunId: "TR-SCHED-TESTRUN",
+          agentId: "software-engineer",
+          threadId: "thread-1",
+          routeContext: "/build",
+        }),
+      }),
+    );
+  });
+
   it("creates structured messages with tool call IDs after tool execution", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     const mockExecuteTool = vi.mocked(executeTool);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -502,6 +502,11 @@ export async function runAgenticLoop(params: {
    * PlatformIssueReport rows. Caller should look this up alongside buildPhase.
    */
   featureBuildId?: string | null;
+  /**
+   * Parent TaskRun for this agentic loop. When set, each governed tool call
+   * records the same TaskRun id in ToolExecution audit rows.
+   */
+  taskRunId?: string | null;
 }): Promise<AgenticResult> {
   const {
     chatHistory,
@@ -518,6 +523,7 @@ export async function runAgenticLoop(params: {
     onProgress,
     requireTools,
     agentDisplayName,
+    taskRunId,
   } = params;
 
   const userContext = await resolveUserContext(userId);
@@ -1198,7 +1204,7 @@ export async function runAgenticLoop(params: {
           rawParams: tc.arguments,
           userId,
           userContext,
-          context: { routeContext, agentId, threadId },
+          context: { routeContext, agentId, threadId, taskRunId: taskRunId ?? undefined },
           source: "agentic-loop",
         });
       } catch (err) {

--- a/apps/web/lib/tak/scheduled-task-runs.test.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => {
+  const create = vi.fn();
+  return {
+    prisma: {
+      taskRun: { create },
+    },
+  };
+});
+
+describe("createTaskRunForScheduledTask", () => {
+  beforeEach(async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockReset();
+  });
+
+  it("creates a proactive TaskRun with the scheduled-task source ref", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_1",
+      taskRunId: "TR-SCHED-ABCDE",
+      contextId: "thread-1",
+    } as never);
+
+    const { createTaskRunForScheduledTask } = await import("./scheduled-task-runs");
+
+    const ref = await createTaskRunForScheduledTask({
+      taskId: "discovery-taxonomy-gap-triage-daily",
+      ownerUserId: "user-1",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      routeContext: "/platform/tools/discovery",
+      title: "Discovery Taxonomy Gap Triage",
+      prompt: "Triage taxonomy gaps from discovery.",
+    });
+
+    expect(ref).toEqual({
+      id: "tr_internal_1",
+      taskRunId: "TR-SCHED-ABCDE",
+      contextId: "thread-1",
+    });
+
+    expect(prisma.taskRun.create).toHaveBeenCalledOnce();
+    const arg = vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0];
+    expect(arg?.data).toMatchObject({
+      userId: "user-1",
+      threadId: "thread-1",
+      contextId: "thread-1",
+      initiatingAgentId: "inventory-specialist",
+      currentAgentId: "inventory-specialist",
+      routeContext: "/platform/tools/discovery",
+      title: "Discovery Taxonomy Gap Triage",
+      objective: "Triage taxonomy gaps from discovery.",
+      source: "proactive",
+      status: "working",
+      authorityScope: [],
+      a2aMetadata: {
+        trigger: "scheduled",
+        sourceRef: {
+          kind: "scheduled-task",
+          id: "discovery-taxonomy-gap-triage-daily",
+        },
+      },
+    });
+    expect(String(arg?.data?.taskRunId)).toMatch(/^TR-SCHED-/);
+  });
+});

--- a/apps/web/lib/tak/scheduled-task-runs.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "crypto";
+import { prisma } from "@dpf/db";
+
+export type ScheduledTaskRunRef = {
+  id: string;
+  taskRunId: string;
+  contextId: string | null;
+};
+
+export async function createTaskRunForScheduledTask(input: {
+  taskId: string;
+  ownerUserId: string;
+  agentId: string;
+  threadId: string;
+  routeContext: string;
+  title: string;
+  prompt: string;
+}): Promise<ScheduledTaskRunRef> {
+  const taskRunId = `TR-SCHED-${randomUUID().slice(0, 8).toUpperCase()}`;
+
+  return prisma.taskRun.create({
+    data: {
+      taskRunId,
+      userId: input.ownerUserId,
+      threadId: input.threadId,
+      contextId: input.threadId,
+      initiatingAgentId: input.agentId,
+      currentAgentId: input.agentId,
+      routeContext: input.routeContext,
+      title: input.title,
+      objective: input.prompt.slice(0, 1000),
+      source: "proactive",
+      status: "working",
+      authorityScope: [],
+      a2aMetadata: {
+        trigger: "scheduled",
+        sourceRef: {
+          kind: "scheduled-task",
+          id: input.taskId,
+        },
+      },
+    },
+    select: { id: true, taskRunId: true, contextId: true },
+  });
+}

--- a/packages/db/prisma/migrations/20260511154254_add_task_run_id_to_scheduled_and_tool_execution/migration.sql
+++ b/packages/db/prisma/migrations/20260511154254_add_task_run_id_to_scheduled_and_tool_execution/migration.sql
@@ -1,0 +1,7 @@
+-- Autonomous coworker runtime Slice 1: remember latest TaskRun for scheduled work.
+-- Additive and nullable by design; historical rows predate this model.
+-- ToolExecution.taskRunId already exists from 20260424090000_add_task_trace_to_proposals_and_audit.
+
+ALTER TABLE "ScheduledAgentTask" ADD COLUMN "taskRunId" TEXT;
+
+CREATE INDEX "ScheduledAgentTask_taskRunId_idx" ON "ScheduledAgentTask"("taskRunId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3024,6 +3024,9 @@ model ToolExecution {
   // External MCP transport (spec §13) — set when the tool call originated from
   // a Bearer-token authenticated request through /api/mcp/v1.
   apiTokenId    String?
+  // Autonomous coworker runtime Slice 1: nullable parent TaskRun link.
+  // Persisted by mcp-governed-execute.ts when context.taskRunId is provided.
+  taskRunId     String?
   receipt       ToolExecutionReceipt?
 
   @@index([agentId, createdAt])
@@ -3033,6 +3036,7 @@ model ToolExecution {
   @@index([auditClass, createdAt(sort: Desc)])
   @@index([capabilityId, createdAt(sort: Desc)])
   @@index([apiTokenId, createdAt(sort: Desc)])
+  @@index([taskRunId, createdAt(sort: Desc)])
 }
 
 model ToolExecutionReceipt {
@@ -4321,6 +4325,8 @@ model ScheduledAgentTask {
   lastStatus   String? // ok | error
   lastError    String?
   lastThreadId String?
+  // Autonomous coworker runtime Slice 1: latest TaskRun spawned by this schedule.
+  taskRunId    String?
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
@@ -4329,6 +4335,7 @@ model ScheduledAgentTask {
   @@index([agentId])
   @@index([ownerUserId])
   @@index([isActive, nextRunAt])
+  @@index([taskRunId])
 }
 
 model CalendarSync {


### PR DESCRIPTION
## Summary

- Implements Slice 1 of the autonomous coworker runtime spec: scheduled coworker runs now create a TaskRun before agent execution.
- Threads `taskRunId` through `runAgenticLoop` into governed tool execution so ToolExecution audit rows can carry the run link.
- Mirrors scheduled prompt/final response into TaskMessage, updates TaskRun success/failure state, and records latest run on ScheduledAgentTask.
- Projects proactive TaskRuns into the AI Operations Map and adds the Task run source filter label.
- Rejects non-UTC scheduled task timezones explicitly instead of silently accepting unsupported behavior.

## Schema

- Restores `ToolExecution.taskRunId` in Prisma schema to match the existing 20260424090000 migration.
- Adds nullable `ScheduledAgentTask.taskRunId` with an index.

## Verification

- `pnpm --filter web exec vitest run lib/tak/scheduled-task-runs.test.ts lib/tak/agentic-loop.test.ts lib/actions/agent-task-scheduler.test.ts lib/ai-operations-map/project-events.test.ts lib/ai-operations-map/load-map-data.test.ts`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- Fresh temporary database migration replay with `pnpm --filter @dpf/db exec prisma migrate deploy`

## Notes

The shared local dev database has unrelated drift from other local branches, so I did not reset it. Migration cleanliness was verified against a fresh temporary database and the temp DB was dropped afterward.