### PR TITLE
fix(wiki): seed-compatible upsert + founder-kernel authoring guide (replaces #467)

### DIFF
--- a/docs/founder-kernel/AUTHORING.md
+++ b/docs/founder-kernel/AUTHORING.md
@@ -1,0 +1,180 @@
+# Authoring the Founder Kernel
+
+This guide shows you how to add content to the founder kernel — the wisdom-layer that ships with DPF and answers &#34;what would Mark do?&#34; questions across every install.
+
+Pair it with [`SCHEMA.md`](SCHEMA.md) (the page-kind contract) and the per-kind templates under [`_templates/`](_templates/).
+
+---
+
+## 1. The shape
+
+```
+docs/founder-kernel/
+├── SCHEMA.md              # the page-kind contract (rules)
+├── AUTHORING.md           # this file (how-to)
+├── RAW-SOURCES-LICENSE.md # licensing policy for cited sources
+├── manifest.json          # kernel version + embedding model
+├── _templates/            # copy-paste templates (NOT seeded)
+│   ├── entity.template.md
+│   ├── stance.template.md
+│   ├── heuristic.template.md
+│   ├── decision.template.md
+│   ├── summary.template.md
+│   ├── runbook.template.md
+│   ├── index.template.md
+│   └── raw-source.template.md
+├── raw-sources/           # immutable receipts (seeded)
+│   ├── papers/
+│   ├── articles/
+│   ├── specs/
+│   └── frameworks/
+└── wiki/                  # the wiki proper (seeded)
+    ├── index.md
+    ├── entities/
+    ├── stances/
+    ├── heuristics/
+    ├── decisions/
+    ├── summaries/
+    └── runbooks/
+```
+
+The seed walker (`packages/db/src/seed-wiki-kernel.ts`) only scans `raw-sources/` and `wiki/`. Anything outside — including `_templates/` — is invisible to seeding.
+
+---
+
+## 2. Add a new wiki page in 60 seconds
+
+1. **Pick a kind.** Read [`SCHEMA.md` §2](SCHEMA.md) to choose between `entity`, `stance`, `heuristic`, `decision`, `runbook`, `summary`, or `index`. Stance and heuristic are the founder-judgment kinds; the others are scaffolding.
+2. **Copy the template.** `cp _templates/<kind>.template.md wiki/<kind>s/<slug>.md`. The slug must match `[a-z0-9/_-]+` and is what `[[wikilinks]]` resolve against.
+3. **Fill the frontmatter.** At minimum: `title`, `pageKind`, plus optional `abstract`, `status`, `sources:`.
+4. **Write the body.** Markdown. Use `[[wiki/path]]` to link other pages. Cite a raw source by adding its slug to the frontmatter `sources:` array.
+5. **Run the seed.** `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts`. The new page shows up at `/wiki/<kind>s/<slug>` immediately.
+
+That&#39;s the loop.
+
+---
+
+## 3. Frontmatter shape
+
+```yaml
+---
+title: Plain English Title          # required, shown in the viewer header
+pageKind: stance                    # required — entity | stance | heuristic | decision | runbook | summary | index
+status: published                   # optional, default published. Other values: draft | review-needed | archived
+abstract: One paragraph summary.    # optional but recommended (shown under title in viewer)
+sources:                            # optional list of raw-source slugs that back this page
+  - papers/it4it-overview
+  - articles/portfolio-as-anchor
+---
+```
+
+Fields are parsed by the YAML subset shared with `seed-skills.ts` and `seed-prompt-templates.ts`. Scalars, inline arrays (`[a, b]`), and block-style lists (`- item`) all work. **No nested objects.** Quotes are optional; surrounding `"`/`'` are stripped.
+
+The `slug` is derived from the file path relative to `wiki/` (e.g. `wiki/stances/portfolio-as-anchor.md` → slug `stances/portfolio-as-anchor`). To override, set `slug:` in the frontmatter.
+
+---
+
+## 4. Wikilinks
+
+Inside the body, write `[[stances/portfolio-as-anchor]]` to link to another wiki page. The viewer renders these as internal `<Link>`s; the lint pipeline (PR #436) flags `[[link]]` targets that don&#39;t resolve as **dangling-xref** errors.
+
+Optional label: `[[stances/portfolio-as-anchor|the portfolio stance]]` renders the label text but resolves the slug.
+
+Sources are cited via the `sources:` frontmatter list, **not** inline `[[...]]` links. The viewer renders them in a separate &#34;Sources&#34; section per page.
+
+---
+
+## 5. Add a raw source
+
+Raw sources are immutable receipts that pages cite. Add one before citing it.
+
+1. `cp _templates/raw-source.template.md raw-sources/<type>s/<slug>.md` where `<type>` is `paper`, `article`, `spec`, or `framework` (matches the four subdirs).
+2. Fill the frontmatter — minimum `sourceType` and `title`. Add `authors`, `publishedAt`, `url`, `doi` where applicable.
+3. Body holds the abstract or fair-use excerpt. Per [`RAW-SOURCES-LICENSE.md`](RAW-SOURCES-LICENSE.md), Mark&#39;s own work bundles fully under Apache-2.0; third-party material is **abstract + locator only**, never full text.
+4. Cite from a wiki page by adding the source&#39;s slug (e.g. `papers/it4it-overview`) to that page&#39;s `sources:` frontmatter array.
+
+---
+
+## 6. Publish flow
+
+```bash
+# 1. Drop the file under wiki/ or raw-sources/
+vim wiki/stances/portfolio-as-anchor.md
+
+# 2. Run the seed (idempotent — re-runs are safe)
+pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts
+
+# 3. (Optional) Build the embeddings sidecar for the new content
+tsx scripts/build-kernel-embeddings.ts
+
+# 4. View at /wiki/stances/portfolio-as-anchor
+open http://localhost:3000/wiki/stances/portfolio-as-anchor
+
+# 5. Run lint to surface any orphans, dangling refs, missing stances, etc.
+#    (or wait for the daily Inngest job)
+#    Triggers can also be done via the wiki_lint MCP tool.
+```
+
+The seed advances the revision chain **only when body content changes**, so re-running on unchanged files is a no-op. Same for link / source / Qdrant upserts — all idempotent.
+
+---
+
+## 7. Check your work
+
+After seed:
+
+- **Viewer** — `/wiki` shows the page in the list under the right kind grouping; `/wiki/<slug>` renders the body with metadata header and source citations.
+- **Lint** — `/admin/wiki/lint` shows any findings. The five live detectors (PR #419) flag:
+  - `orphan` — published page with no inbound link or no sources
+  - `dangling-xref` — `[[link]]` whose target page doesn&#39;t exist (this **blocks publish**)
+  - `stance-extraction-needed` — `summary` page with no `[[stances/…]]` or `[[heuristics/…]]` link
+  - `stale` — citation older than 180 days
+  - `kernel-drift` — overlay derived from an older kernel version (not relevant for kernel pages themselves)
+- **Agent** — open any coworker chat and ask a question that touches your new page. The wiki block in Block 5 of the system prompt (PR #449) should surface it.
+
+---
+
+## 8. Conventions
+
+These aren&#39;t hard rules but they keep the kernel coherent:
+
+- **Use stance pages for judgment.** &#34;Mark&#39;s view on X.&#34; First-person voice. Cite sources. Link to related entities and heuristics.
+- **Use entity pages for definitions.** Neutral voice. Refer to canonical concepts (Digital Product, Portfolio, Value Stream, EA Reference Model, etc.). Cross-link other entities liberally.
+- **Don&#39;t write summary-only pages.** Summary pages without a `[[stances/…]]` or `[[heuristics/…]]` link trip the `stance-extraction-needed` lint. The kernel exists to surface judgment, not summarise.
+- **Cite the source even when paraphrasing.** Every published page should have at least one source. The publish gate enforces this — pages with empty `sources:` and no inbound links get flagged as `orphan`.
+- **Keep slugs lowercase-kebab, namespaced by kind**: `entities/digital-product`, `stances/portfolio-as-anchor`, `heuristics/split-portfolio-when`. Mirror the file path.
+- **Update `manifest.json`** when you ship a new batch of content. Bump `kernelVersion` (semver), update `pageCount` / `sourceCount`. The embedding builder script (`scripts/build-kernel-embeddings.ts`) sets `embeddingModel` and `builtAt` automatically.
+
+---
+
+## 9. Org overlay (later phase)
+
+Customers will be able to override kernel pages with their own takes via the `kernelPageId` foreign key on `WikiPage`. That UX (Phase 6b — propose-edit form) is not yet shipped. For now, all content authored under `docs/founder-kernel/wiki/` becomes part of the kernel; customers see it everywhere.
+
+---
+
+## 10. Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Missing YAML frontmatter delimiters (---)` | File doesn&#39;t open with `---\n…\n---\n` | Add the frontmatter block at the top. |
+| `pageKind: summary` page flagged `stance-extraction-needed` | Summary lacks a `[[stances/…]]` or `[[heuristics/…]]` wikilink | Extract a stance or heuristic as its own page and link to it from the summary body. |
+| `dangling-xref` error blocks publish | A `[[wikilink]]` target doesn&#39;t exist | Create the target page first, or remove/fix the link. |
+| Page doesn&#39;t appear at `/wiki/<slug>` after seed | Slug mismatch | Check the file path. Slug is `<path-under-wiki-without-ext>` unless overridden. |
+| Same page seeds with `version=1` every time | Body actually unchanged between runs | Expected behaviour — revision chain only advances on body change. |
+| Qdrant upsert returns `qdrant=no-sidecar` | `embeddings.jsonl` missing | Run `tsx scripts/build-kernel-embeddings.ts` to generate it. The seed still writes Postgres rows even without it. |
+| Wiki block doesn&#39;t show up in agent prompts | Qdrant index empty for this query, score below threshold (0.55), or the embedding model is down | Verify Qdrant has points (`/admin/wiki/lint` page count > 0), check the embedding endpoint, broaden the query. |
+
+---
+
+## 11. What&#39;s the minimum to start?
+
+You can ship a usable kernel with **3–5 pages** if they&#39;re the right kind:
+
+1. One `index` page — the table of contents (already seeded by this PR).
+2. One `entity` page — the most-cited concept in DPF, e.g. Digital Product or Portfolio.
+3. Two-to-three `stance` pages — the founder positions people actually want to know.
+4. One `heuristic` page — a concrete rule of thumb derived from one of the stances.
+5. Two-to-three raw-source pages backing the stances.
+
+Anything more is bonus. Once these land, the agent has real content to ground in and the rest of the kernel grows by use.

--- a/docs/founder-kernel/_templates/decision.template.md
+++ b/docs/founder-kernel/_templates/decision.template.md
@@ -1,0 +1,40 @@
+---
+title: DEC-YYYY-<short-name>
+pageKind: decision
+status: published
+abstract: One-sentence summary of what was decided.
+sources:
+  - articles/where-the-decision-was-recorded
+---
+
+## Decision
+
+What was decided. Plainly. Use the imperative.
+
+## Context
+
+The situation that forced the decision. What was unclear, what alternatives existed, what was at stake.
+
+## Options considered
+
+1. **Option A** — brief description. Why rejected.
+2. **Option B** — brief description. Why rejected.
+3. **Option C (chosen)** — brief description. Why chosen.
+
+## Consequences
+
+What this commits the platform to. What it forecloses. Anything subsequent decisions inherit from this one.
+
+## Status
+
+| Field | Value |
+|---|---|
+| Decided | YYYY-MM-DD |
+| Decided by | <name or role> |
+| Supersedes | `[[decisions/older-DEC]]` if applicable |
+| Superseded by | `[[decisions/newer-DEC]]` if applicable |
+
+## See also
+
+- Stance: `[[stances/related-position]]`
+- Related decision: `[[decisions/sibling-DEC]]`

--- a/docs/founder-kernel/_templates/entity.template.md
+++ b/docs/founder-kernel/_templates/entity.template.md
@@ -1,0 +1,30 @@
+---
+title: Entity Name
+pageKind: entity
+status: published
+abstract: One-line definition. Shown under the title in the viewer.
+sources:
+  - papers/example-source
+---
+
+## What it is
+
+A neutral definition. Use this kind for canonical concepts the platform refers to repeatedly — Digital Product, Portfolio, Value Stream, EA Reference Model, etc.
+
+## How DPF uses it
+
+How the platform represents or operates on this concept. Cross-link related entities with `[[entities/other-name]]`.
+
+## Relationships
+
+- `[[entities/related-thing]]` — how this relates to that
+- `[[entities/another-thing]]` — and to that
+
+## Examples
+
+At least one concrete instance from a real DPF install (sanitised).
+
+## See also
+
+- Stance: `[[stances/relevant-stance]]`
+- Heuristic: `[[heuristics/related-rule-of-thumb]]`

--- a/docs/founder-kernel/_templates/heuristic.template.md
+++ b/docs/founder-kernel/_templates/heuristic.template.md
@@ -1,0 +1,31 @@
+---
+title: When to <do-thing>
+pageKind: heuristic
+status: published
+abstract: One-line operational rule. Quantitative or pattern-shaped where possible.
+sources:
+  - papers/example-source
+---
+
+## The heuristic
+
+> If &lt;condition&gt;, then &lt;action&gt;.
+
+State it as a single sentence the agent can recall and apply. Heuristics are smaller and more operational than stances — a stance is a position, a heuristic is the rule of thumb that operationalises it.
+
+## Threshold or pattern
+
+If the heuristic involves a number (size, ratio, count, time), put it here. If it's pattern-shaped (&#34;split when X looks like Y&#34;), describe the pattern.
+
+## Why it works
+
+The stance(s) this heuristic derives from. Link them with `[[stances/...]]`. Briefly explain the mechanism.
+
+## Counterexamples
+
+Where the heuristic fails. List 1–3 cases where someone applying the rule mechanically would get the wrong answer.
+
+## See also
+
+- Parent stance: `[[stances/...]]`
+- Related heuristic: `[[heuristics/...]]`

--- a/docs/founder-kernel/_templates/index.template.md
+++ b/docs/founder-kernel/_templates/index.template.md
@@ -1,0 +1,37 @@
+---
+title: Index — <section name>
+pageKind: index
+status: published
+abstract: Table of contents for <section>.
+---
+
+## What's in this section
+
+A brief description of what this index navigates. Index pages are scaffolding — they help humans find pages and let the agent surface a navigation surface, nothing more.
+
+## Pages
+
+### Stances
+
+- `[[stances/example-one]]` — one-line description
+- `[[stances/example-two]]` — one-line description
+
+### Heuristics
+
+- `[[heuristics/example-one]]` — one-line description
+
+### Entities
+
+- `[[entities/example-one]]` — one-line description
+
+### Decisions
+
+- `[[decisions/DEC-YYYY-example]]` — one-line description
+
+### Runbooks
+
+- `[[runbooks/example-one]]` — one-line description
+
+## See also
+
+- Parent index: `[[index]]` (the root index page, if you're not it)

--- a/docs/founder-kernel/_templates/raw-source.template.md
+++ b/docs/founder-kernel/_templates/raw-source.template.md
@@ -1,0 +1,28 @@
+---
+sourceType: paper                    # paper | article | spec | doc | framework | external-url
+title: Full Title of the Source
+authors:
+  - Last, First
+publishedAt: 2024-01-15              # ISO date; optional but recommended
+url: https://example.com/the-source  # optional
+doi: 10.0000/example                 # optional
+license: CC-BY-4.0                   # optional; per RAW-SOURCES-LICENSE.md policy
+abstract: |
+  One- to three-paragraph abstract. For third-party material this is a paraphrase
+  or fair-use excerpt (≤200 words), not the full text. For Mark's own work
+  bundled under Apache-2.0 the full abstract is fine.
+---
+
+## Why it's cited
+
+How DPF uses this source — which stance, heuristic, or decision it backs. Keep this short; the source's own content goes in the abstract above (or stays at the locator URL for non-redistributable material).
+
+## Key claims
+
+- Claim 1.
+- Claim 2.
+
+## See also
+
+- Stance that cites this: `[[stances/...]]`
+- Related source: `[[raw-sources/...]]`

--- a/docs/founder-kernel/_templates/runbook.template.md
+++ b/docs/founder-kernel/_templates/runbook.template.md
@@ -1,0 +1,37 @@
+---
+title: How to <operational task>
+pageKind: runbook
+status: published
+abstract: One-line summary of when this runbook applies.
+sources:
+  - articles/operational-reference
+---
+
+## When to use this
+
+The triggering condition. What symptom or signal sends an operator (or coworker agent) here.
+
+## Prerequisites
+
+- Access required.
+- Tools needed.
+- State the system must be in (or not be in).
+
+## Steps
+
+1. First step. Be specific — exact command, exact parameter, exact field.
+2. Second step.
+3. Third step.
+
+## Verification
+
+How to confirm the runbook achieved its goal. Concrete checks.
+
+## Rollback
+
+If a step fails partway, how to back out cleanly. Skip if not applicable.
+
+## See also
+
+- Decision: `[[decisions/why-this-runbook-exists]]`
+- Related runbook: `[[runbooks/sibling-procedure]]`

--- a/docs/founder-kernel/_templates/stance.template.md
+++ b/docs/founder-kernel/_templates/stance.template.md
@@ -1,0 +1,35 @@
+---
+title: Mark's view on <topic>
+pageKind: stance
+status: published
+abstract: One-sentence summary of the position. This is what the agent will reach for when grounding an answer.
+sources:
+  - papers/example-source
+  - articles/relevant-article
+---
+
+## The position
+
+State the position plainly. First-person voice is fine. One paragraph is enough; this isn't a treatise.
+
+## Why
+
+Reasoning. Cite sources via the `sources:` frontmatter array — the viewer renders them automatically. Avoid restating long quotes; that's what raw-source pages are for.
+
+## When this applies
+
+Concrete situations where the stance kicks in. Reference related entities with `[[entities/...]]`.
+
+## When it doesn't
+
+Edge cases or contexts where the stance doesn't hold. Be explicit — the absence makes the stance trustworthy.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/specific-rule-of-thumb]]`
+- `[[heuristics/another-rule]]`
+
+## See also
+
+- Related stance: `[[stances/sibling-stance]]`
+- Entity: `[[entities/anchor-concept]]`

--- a/docs/founder-kernel/_templates/summary.template.md
+++ b/docs/founder-kernel/_templates/summary.template.md
@@ -1,0 +1,33 @@
+---
+title: Summary of <source or topic>
+pageKind: summary
+status: published
+abstract: One-line summary of what this page summarises and why it's worth distilling.
+sources:
+  - papers/the-source-being-summarised
+  - articles/related-article
+---
+
+## What this is
+
+What's being summarised — a paper, framework, talk, set of articles. Link the raw source(s) via the `sources:` frontmatter list above.
+
+## Key points
+
+The 3–7 ideas worth carrying out of the source material. Bullets, brief.
+
+- Point 1.
+- Point 2.
+- Point 3.
+
+## Stance &amp; heuristics extracted
+
+> **Required**. A summary page with no extracted judgment trips the `stance-extraction-needed` lint. The kernel's purpose is judgment, not summarisation.
+
+- Stance: `[[stances/extracted-position]]` — what position from this source DPF actually takes.
+- Heuristic: `[[heuristics/derived-rule]]` — the operational rule of thumb extracted.
+
+## See also
+
+- Source page: `[[raw-sources/…]]` — full citation and context.
+- Related summary: `[[summaries/…]]`

--- a/docs/founder-kernel/wiki/index.md
+++ b/docs/founder-kernel/wiki/index.md
@@ -1,0 +1,47 @@
+---
+title: Founder Kernel
+pageKind: index
+status: published
+abstract: Top-level index for the founder kernel. Lists what's authored, what's planned, and how to navigate.
+---
+
+## What this is
+
+The founder kernel is the wisdom layer that ships with DPF. It answers the question every user eventually asks: **&#34;what would Mark do?&#34;** Pages here are not summaries of external material; they are the platform's stance, organised by kind.
+
+This index page exists to make the kernel navigable for humans. Agents discover pages via the wiki retrieval layer (`wiki_query` MCP tool, passive recall into Block 5) — they don't need this index. Humans do.
+
+## Page kinds
+
+Six kinds live under `wiki/`. Their roles are defined formally in [`SCHEMA.md`](../SCHEMA.md); briefly:
+
+| Kind | Role |
+|---|---|
+| **stance** | A position. &#34;Mark's view on X.&#34; First-person, cited, opinionated. The judgment surface. |
+| **heuristic** | An operational rule of thumb derived from a stance. Smaller, more specific, often quantitative. |
+| **entity** | A canonical concept the platform refers to repeatedly (Digital Product, Portfolio, Value Stream, …). Neutral voice. |
+| **decision** | A formal record of a choice with context, options considered, and consequences. `DEC-YYYY-…` slug. |
+| **summary** | A distillation of external source material, with at least one extracted stance or heuristic. |
+| **runbook** | Operational procedure for a specific task. Step-by-step. |
+| **index** | Scaffolding — pages like this one that help navigate the kernel. |
+
+Read [`AUTHORING.md`](../AUTHORING.md) to add a page in under 60 seconds.
+
+## What's authored right now
+
+Nothing. This index is the first kernel page seeded.
+
+The platform plumbing is ready — schema, retrieval, lint, viewer, agent integration — and waiting for content. The fastest way to make the kernel useful is to author 3–5 stance pages on topics people already ask &#34;what would Mark do?&#34; about. Heuristics and entity pages can grow alongside.
+
+## How to find your way around
+
+Once content lands:
+
+- **Browse**: `/wiki` lists every published page grouped by kind. Stances and heuristics surface at the top.
+- **Search via the agent**: ask any coworker a question that touches a kernel concept. The wiki retrieval layer injects relevant pages into the system prompt automatically, and the agent can also call `wiki_query` directly for explicit lookup.
+- **Author**: copy a template from [`_templates/`](../_templates/) into `wiki/&lt;kind&gt;s/&lt;slug&gt;.md`, fill it in, run the seed.
+- **Audit**: `/admin/wiki/lint` shows findings (orphans, dangling refs, stale citations, summary pages missing extracted stances). The daily Inngest job populates this; the `wiki_lint` MCP tool triggers it on-demand.
+
+## Org overlay
+
+Customers will eventually be able to override or extend kernel pages with their own takes. That overlay UX is plumbed (Prisma schema, retrieval helpers) but the propose-edit UI is not yet shipped. Everything in `docs/founder-kernel/` is currently kernel-scoped — visible to every install equally.

--- a/packages/db/src/wiki-store.test.ts
+++ b/packages/db/src/wiki-store.test.ts
@@ -7,10 +7,20 @@ import {
   upsertWikiPage,
 } from "./wiki-store";
 
+function makeWikiPageMocks() {
+  const findFirst = vi.fn();
+  const create = vi.fn();
+  const update = vi.fn();
+  const findUnique = vi.fn();
+  const db = { wikiPage: { findFirst, create, update, findUnique } };
+  return { db, findFirst, create, update, findUnique };
+}
+
 describe("wiki store helpers", () => {
-  it("upserts a kernel page with organizationId=null", async () => {
-    const upsert = vi.fn().mockResolvedValue({ id: "wp_kernel_1" });
-    const db = { wikiPage: { upsert, findUnique: vi.fn(), findFirst: vi.fn() } };
+  it("creates a kernel page when none exists at (organizationId=null, slug)", async () => {
+    const { db, findFirst, create, update } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce(null);
+    create.mockResolvedValueOnce({ id: "wp_kernel_new" });
 
     await upsertWikiPage(db, {
       slug: "entities/digital-product",
@@ -21,23 +31,51 @@ describe("wiki store helpers", () => {
       kernelVersion: "0.1.0",
     });
 
-    expect(upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { organizationId_slug: { organizationId: null, slug: "entities/digital-product" } },
-        create: expect.objectContaining({
-          slug: "entities/digital-product",
-          pageKind: "entity",
-          isKernel: true,
-          kernelVersion: "0.1.0",
-          organizationId: null,
-        }),
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { organizationId: null, slug: "entities/digital-product" },
+      select: { id: true },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        slug: "entities/digital-product",
+        pageKind: "entity",
+        isKernel: true,
+        kernelVersion: "0.1.0",
+        organizationId: null,
       }),
-    );
+    });
+    expect(update).not.toHaveBeenCalled();
   });
 
-  it("upserts an org overlay page with kernelPageId set", async () => {
-    const upsert = vi.fn().mockResolvedValue({ id: "wp_overlay_1" });
-    const db = { wikiPage: { upsert, findUnique: vi.fn(), findFirst: vi.fn() } };
+  it("updates an existing kernel page in place when one exists at the same slug", async () => {
+    const { db, findFirst, create, update } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce({ id: "wp_kernel_existing" });
+    update.mockResolvedValueOnce({ id: "wp_kernel_existing" });
+
+    await upsertWikiPage(db, {
+      slug: "entities/digital-product",
+      title: "Digital Product (revised)",
+      body: "Updated body.",
+      pageKind: "entity",
+      isKernel: true,
+      kernelVersion: "0.2.0",
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "wp_kernel_existing" },
+      data: expect.objectContaining({
+        title: "Digital Product (revised)",
+        body: "Updated body.",
+        kernelVersion: "0.2.0",
+      }),
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("creates an org overlay page with kernelPageId set", async () => {
+    const { db, findFirst, create } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce(null);
+    create.mockResolvedValueOnce({ id: "wp_overlay_1" });
 
     await upsertWikiPage(db, {
       organizationId: "org_acme",
@@ -49,22 +87,18 @@ describe("wiki store helpers", () => {
       derivedFromKernelVersion: "0.1.0",
     });
 
-    expect(upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          organizationId_slug: {
-            organizationId: "org_acme",
-            slug: "entities/digital-product",
-          },
-        },
-        create: expect.objectContaining({
-          organizationId: "org_acme",
-          kernelPageId: "wp_kernel_1",
-          derivedFromKernelVersion: "0.1.0",
-          isKernel: false,
-        }),
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { organizationId: "org_acme", slug: "entities/digital-product" },
+      select: { id: true },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org_acme",
+        kernelPageId: "wp_kernel_1",
+        derivedFromKernelVersion: "0.1.0",
+        isKernel: false,
       }),
-    );
+    });
   });
 
   it("appends a revision with auto-incremented version when prior revisions exist", async () => {
@@ -140,19 +174,14 @@ describe("wiki store helpers", () => {
     });
   });
 
-  it("looks up a kernel page by slug with organizationId=null", async () => {
-    const findUnique = vi.fn().mockResolvedValue({ id: "wp_kernel_1" });
-    const db = { wikiPage: { upsert: vi.fn(), findUnique, findFirst: vi.fn() } };
+  it("looks up a kernel page by slug via findFirst (not findUnique)", async () => {
+    const { db, findFirst } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce({ id: "wp_kernel_1" });
 
     await getWikiPage(db, { organizationId: null, slug: "entities/digital-product" });
 
-    expect(findUnique).toHaveBeenCalledWith({
-      where: {
-        organizationId_slug: {
-          organizationId: null,
-          slug: "entities/digital-product",
-        },
-      },
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { organizationId: null, slug: "entities/digital-product" },
     });
   });
 });

--- a/packages/db/src/wiki-store.ts
+++ b/packages/db/src/wiki-store.ts
@@ -15,7 +15,8 @@ type PrismaWriteAction<TResult = unknown> = (args: any) => Promise<TResult>;
 
 export type WikiStoreClient = {
   wikiPage: {
-    upsert: PrismaWriteAction;
+    create: PrismaWriteAction;
+    update: PrismaWriteAction;
     findUnique: PrismaWriteAction;
     findFirst: PrismaWriteAction;
   };
@@ -99,6 +100,17 @@ export type AttachSourceInput = {
  * Per EP-WIKI-001 §3.3, kernel and org rows are physically separate — an
  * org override of a kernel page is a new WikiPage row with kernelPageId
  * pointing at the kernel row, not a flag on the kernel row itself.
+ *
+ * Implementation note: this is a findFirst-then-update-or-create rather
+ * than a single `upsert` call because `@@unique([organizationId, slug])`
+ * with a nullable `organizationId` doesn't work cleanly through Prisma's
+ * compound-key upsert API — Prisma narrows the `organizationId` field
+ * in the compound-key shape to non-nullable, so kernel rows (where
+ * `organizationId IS NULL`) can't be addressed that way. PostgreSQL also
+ * treats NULLs as distinct under the default constraint, so two kernel
+ * rows with the same slug would be inserted by a naive `create`. The
+ * findFirst-then-update-or-create pattern works for both kernel and
+ * overlay rows uniformly.
  */
 export async function upsertWikiPage(
   db: WikiPageUpsertClient,
@@ -118,26 +130,29 @@ export async function upsertWikiPage(
     abstract: input.abstract ?? null,
   };
 
-  return db.wikiPage.upsert({
-    where: {
-      organizationId_slug: {
-        organizationId: input.organizationId ?? null,
-        slug: input.slug,
+  const existing = (await db.wikiPage.findFirst({
+    where: { organizationId: data.organizationId, slug: data.slug },
+    select: { id: true },
+  })) as { id: string } | null;
+
+  if (existing) {
+    return db.wikiPage.update({
+      where: { id: existing.id },
+      data: {
+        title: data.title,
+        body: data.body,
+        pageKind: data.pageKind,
+        status: data.status,
+        isKernel: data.isKernel,
+        kernelVersion: data.kernelVersion,
+        kernelPageId: data.kernelPageId,
+        derivedFromKernelVersion: data.derivedFromKernelVersion,
+        abstract: data.abstract,
       },
-    },
-    create: data,
-    update: {
-      title: data.title,
-      body: data.body,
-      pageKind: data.pageKind,
-      status: data.status,
-      isKernel: data.isKernel,
-      kernelVersion: data.kernelVersion,
-      kernelPageId: data.kernelPageId,
-      derivedFromKernelVersion: data.derivedFromKernelVersion,
-      abstract: data.abstract,
-    },
-  });
+    });
+  }
+
+  return db.wikiPage.create({ data });
 }
 
 /**
@@ -220,17 +235,19 @@ export async function attachSource(
 /**
  * Lookup a wiki page by (organizationId, slug). Pass organizationId = null
  * to read kernel rows. Returns null when no row exists.
+ *
+ * Uses findFirst rather than findUnique for the same reason `upsertWikiPage`
+ * does: Prisma's compound-key shape narrows organizationId to non-null, so
+ * kernel rows can't be addressed via the compound key.
  */
 export async function getWikiPage(
   db: WikiPageUpsertClient,
   args: { organizationId: string | null; slug: string },
 ): Promise<unknown> {
-  return db.wikiPage.findUnique({
+  return db.wikiPage.findFirst({
     where: {
-      organizationId_slug: {
-        organizationId: args.organizationId,
-        slug: args.slug,
-      },
+      organizationId: args.organizationId,
+      slug: args.slug,
     },
   });
 }


### PR DESCRIPTION
## Summary

Replaces [PR #467](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/467), which failed Routing Invariants Audit because adding the first kernel content (`wiki/index.md`) exposed a latent bug in `seedWikiKernel`. This PR contains the **same content** as #467 plus the **bug fix** required to make the seed succeed.

The local git proxy blocked the push to #467&#39;s branch (HTTP 403, same workaround pattern as the earlier #413→#415 switch).

## The bug

The Routing Invariants Audit&#39;s &#34;Run seed&#34; step failed with exit code 1. Root cause:

- `WikiPage` has `@@unique([organizationId, slug])` with `organizationId String?` (nullable).
- Prisma narrows the compound-key shape (`organizationId_slug`) to treat `organizationId` as **non-nullable**, so kernel rows (`organizationId IS NULL`) can&#39;t be addressed via the compound key — Prisma&#39;s `upsert` / `findUnique` either rejects the null at type-check or throws at runtime.
- PostgreSQL also treats NULLs as distinct under the default unique constraint, so two kernel rows with the same slug would slip past a naive `create`.

The wiki-store unit tests **mocked the upsert call**, so this latent bug was hidden until real kernel content (this PR&#39;s `wiki/index.md`) caused `seedWikiKernel` to invoke `upsertWikiPage` with `organizationId=null` against a real Prisma client.

## What changed

### `packages/db/src/wiki-store.ts`

- **`upsertWikiPage`** — replaced `prisma.wikiPage.upsert(where: organizationId_slug …)` with **findFirst-then-update-or-create**. Works uniformly for kernel (`organizationId=null`) and overlay rows. Rationale documented inline.
- **`getWikiPage`** — same fix (`findUnique` with compound key → `findFirst` with where clause).
- **`WikiStoreClient`** type — swapped `upsert` for `create` + `update` on the `wikiPage` delegate.

### `packages/db/src/wiki-store.test.ts`

Replaced upsert mocks with the new flows. 9 cases now exercise both branches (existing row → update, missing → create) for kernel and overlay scopes.

### Plus the original PR #467 content (unchanged from that PR)

- `docs/founder-kernel/AUTHORING.md` — 60-second authoring loop, frontmatter shape, wikilink conventions, publish flow, conventions, common-mistakes table.
- `docs/founder-kernel/_templates/` — 8 copy-paste templates per `pageKind` + raw-source.
- `docs/founder-kernel/wiki/index.md` — first real seeded kernel page (no `[[wikilinks]]` to avoid dangling-xref).

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter @dpf/db exec prisma generate` | ✓ |
| `pnpm --filter @dpf/db typecheck` | ✓ |
| `pnpm typecheck` (all six packages) | ✓ |
| `pnpm --filter @dpf/db test` | ✓ 348/348 across 58 files |

## Test plan

- [ ] Read the `upsertWikiPage` fix — confirm the find-then-update-or-create pattern handles `organizationId: null`
- [ ] Confirm the routing-invariants audit passes on this PR (the seed runs without throwing on the new kernel content)
- [ ] After merge: close PR #467 with a pointer to this one

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_