### PR TITLE
fix(installer): correct misleading GA framing; add runtime verification gate

### DIFF
--- a/.github/workflows/install-verification.yml
+++ b/.github/workflows/install-verification.yml
@@ -1,0 +1,118 @@
+name: Install Verification (E2E)
+
+# End-to-end runtime verification for the bash installer. Brings up
+# the full compose stack on ubuntu-latest, polls /api/health, captures
+# the doctor bundle, then tears down with uninstall-dpf.sh --purge.
+#
+# This is the gate that converts "we believe install-dpf.sh works" into
+# "install-dpf.sh was observed to reach /api/health=200 as of commit X".
+#
+# Triggers:
+#   - workflow_dispatch     Manual runs (e.g. before cutting a release).
+#   - push to tags v*       Automatic post-publish verification when a
+#                           release tag is pushed; the publish-image
+#                           workflow has already built multi-arch GHCR
+#                           images by the time this runs.
+#
+# Intentionally NOT triggered on every PR:
+#   The full local image build + multi-service compose-up takes 15-25
+#   minutes per run. The path-filtered release-gates workflow (dry-run +
+#   shellcheck) covers per-PR validation; this gate is reserved for
+#   release prep and on-demand verification.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Install mode: dev (build locally) or release (pull GHCR)"
+        type: choice
+        options: [dev, release]
+        default: dev
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-verification-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-e2e-install:
+    name: Linux E2E Install (ubuntu-latest, ${{ github.event.inputs.mode || 'release' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    env:
+      # CI-specific overrides per Doctrine Contract 9 (LLM provider):
+      # skip model pull so we don't burn 4-8 GB pulling a default model
+      # into a runner that's going to be torn down anyway. The portal
+      # comes up with embedding setup deferred — that's the verification
+      # target for "install path works"; full model lifecycle is a
+      # separate gate.
+      DPF_MODEL_PULL_MODE: skip
+      DPF_HEALTH_TIMEOUT: 900   # 15 min ceiling for image build + boot
+      DPF_HEALTH_URL: http://localhost:3000/api/health
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Show docker context (preinstalled on ubuntu-latest)
+        run: |
+          docker --version
+          docker compose version
+          docker info | head -30
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.2 --activate
+
+      - name: Run install-dpf.sh (real install, --no-autostart for CI)
+        # Skips the autostart unit step (no user session on a GHA runner).
+        # The install path itself — preflight, state, compose chain,
+        # `pnpm install`, host hardware detection, .env generation,
+        # `docker compose up -d`, and the /api/health poll — is what
+        # this gate validates.
+        run: bash install-dpf.sh --headless --${{ github.event.inputs.mode || 'release' }} --no-autostart
+
+      - name: Verify /api/health response shape
+        run: |
+          set -euo pipefail
+          curl --silent --fail "$DPF_HEALTH_URL" > /tmp/health.json
+          cat /tmp/health.json
+          # Minimal contract: the endpoint returns valid JSON with a
+          # truthy `ok` or `status` field. The installer already polled
+          # until 200; this step pins the response-shape invariant.
+          test -s /tmp/health.json
+          if command -v jq >/dev/null 2>&1; then
+            jq -e '(.ok // .status // "ok") != null' /tmp/health.json
+          fi
+
+      - name: Capture docker compose ps + service status
+        if: always()
+        run: |
+          docker compose -p dpf ps || true
+          echo "---"
+          docker compose -p dpf logs --tail=50 portal || true
+
+      - name: Capture doctor bundle
+        if: always()
+        run: bash install-dpf.sh doctor || true
+
+      - name: Upload doctor bundle artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doctor-bundle-${{ github.event.inputs.mode || 'release' }}-${{ github.run_id }}
+          path: ~/.dpf/doctor-*.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Tear down (uninstall --purge)
+        if: always()
+        run: bash uninstall-dpf.sh --purge --headless --yes || true

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ Both modes include the full platform with AI coworkers, Build Studio sandbox, an
 
 ### Quick Start
 
-| Platform | Install command | Full guide |
-|----------|-----------------|------------|
-| **Windows 10/11** | `powershell -ExecutionPolicy Bypass -File install-dpf.ps1` | (see below) |
-| **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) |
-| **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) |
+| Platform | Install command | Full guide | Status |
+|----------|-----------------|------------|--------|
+| **Windows 10/11** | `powershell -ExecutionPolicy Bypass -File install-dpf.ps1` | (see below) | **GA** — production usage by real users |
+| **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) | **preview** — code shipped, runtime verification pending |
+| **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) | **preview** — code shipped, runtime verification pending |
+
+The macOS and Linux installers have all their code on `main` and pass static CI gates (`shellcheck`, `docker compose config`, `install-dpf.sh --dry-run`), but the end-to-end runtime path has not yet been verified on real hardware. An ubuntu-latest end-to-end CI gate runs the full install on demand (`.github/workflows/install-verification.yml`); Apple Silicon, distro coverage beyond Ubuntu, and autostart-after-reboot still need fresh-hardware verification per [docs/install/verification-runbook.md](docs/install/verification-runbook.md) before either tier is promoted to GA.
 
 Choose your mode when prompted. The installer handles Docker (Desktop on Windows / Mac, distro pkg manager on Linux), hardware detection, AI model selection, credential generation, and auto-start. Expect 5–10 minutes for the platform itself, plus additional time for the initial AI model download.
 
@@ -237,7 +239,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | EA Modeling | ArchiMate 4 canvas, viewpoints, relationship rules, structured value streams |
 | AI Provider Registry | 17 providers, credential management, model discovery, profiling, cost tracking |
 | AI Coworker | Live LLM conversations, automatic failover, context-aware skills dropdown |
-| Docker Deployment | Zero-prerequisites installers for Windows (GA), macOS Apple Silicon ([guide](docs/install/macos.md)), and native Linux ([guide](docs/install/linux.md)). Multi-arch GHCR images. Lifecycle scripts (start/stop/reinstall/release) on all three. CI release gates per the [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). |
+| Docker Deployment | Zero-prerequisites Windows installer (GA — production usage). Code-complete macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) installers in **preview** — static CI gates green, runtime verification matrix in flight per [docs/install/verification-runbook.md](docs/install/verification-runbook.md). Multi-arch GHCR images. Lifecycle scripts on all three platforms. |
 
 ### What's coming
 
@@ -248,7 +250,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | **AI-Guided Setup Wizard** | On first install, the AI coworker walks you through company setup conversationally — no forms, just a conversation. |
 | **In-App PR Workflow** | Submit customizations back to the community directly from the platform UI. |
 | **Web-Hosted SaaS** | Customer-cloud deployment via Terraform on AWS / GCP / Azure — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). DPF stays single-tenant; "SaaS" here means "customer hosts on rented compute," not multi-tenant. |
-| **Mac & Linux Installers** | Native macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) installers have landed alongside the Windows GA installer. The [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md) tracks remaining hardening (CI release gates, long-tail discovery). |
+| **Mac & Linux Installers** | Code is complete for native macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) and merged on `main`. Currently **preview** — runtime verification on real hardware is the remaining gate before GA promotion. The [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md) ships code; the [verification runbook](docs/install/verification-runbook.md) tracks the end-to-end gates that need to land before either tier is promoted. |
 | **TAPPaaS Module** | Self-hosted private-platform packaging via [TAPPaaS](https://tappaas.org/) — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). |
 
 ---

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -3,6 +3,16 @@
 This is the end-user install guide for the Open Digital Product Factory
 on **native Linux Docker Engine** (no Docker Desktop).
 
+> **Status: preview.** The Linux installer code is complete and passes
+> static CI gates. An on-demand end-to-end install gate runs the full
+> compose stack on `ubuntu-latest`
+> ([`.github/workflows/install-verification.yml`](../../.github/workflows/install-verification.yml));
+> distro coverage beyond Ubuntu (Debian 12, Fedora 39) and the
+> autostart-after-reboot path still need fresh-hardware verification
+> per [verification-runbook.md](verification-runbook.md) before
+> promotion to GA. The Windows installer remains the only GA install
+> surface today.
+
 For the architectural background, see the
 [installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
 and the [deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md).

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -3,6 +3,15 @@
 This is the end-user install guide for the Open Digital Product Factory
 on **Apple Silicon Macs** (M1 / M2 / M3 / M4).
 
+> **Status: preview.** The macOS installer code is complete and passes
+> static CI gates, but end-to-end runtime verification on real Apple
+> Silicon hardware has not yet been completed (the `macos-14` GHA
+> runner can't nest-virtualize Docker Desktop, so CI only exercises
+> the `--dry-run` path). See
+> [verification-runbook.md](verification-runbook.md) for the matrix
+> that needs to land before promoting to GA. The Windows installer
+> remains the only GA install surface today.
+
 For the architectural background, see the
 [installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
 and the [deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md).

--- a/docs/install/verification-runbook.md
+++ b/docs/install/verification-runbook.md
@@ -1,0 +1,224 @@
+# DPF Install Verification Runbook
+
+**Purpose:** The CI gates in `.github/workflows/release-gates.yml` and
+`install-verification.yml` cover what GitHub-hosted runners can run.
+This runbook covers everything else — the environments and end-states
+that need a real human at a real host to verify.
+
+Until each row in the matrix below is checked off, the corresponding
+install path is **"shipped, runtime-verification pending"** — not
+**"GA"**. The README and roadmap status should reflect that until
+verification lands.
+
+## Verification matrix
+
+| Path | What CI proves | What this runbook covers | Status |
+|------|----------------|--------------------------|--------|
+| Windows installer | n/a (no CI gate today) | Production usage by real users | ✓ verified |
+| Linux end-to-end install | `install-verification.yml` (ubuntu-latest, dev + release modes) — full compose up, `/api/health=200`, doctor bundle | Distro coverage beyond Ubuntu: Debian 12, Fedora 39. Autostart-after-reboot. | **pending** |
+| macOS end-to-end install | dry-run only (`macos-14` can't nest-virt Docker Desktop) | The actual `.dmg` install + Docker Desktop boot + portal up + LaunchAgent reboot survival | **pending** |
+| Discovery collectors (darwin) | unit tests with mocked deps | Real `pkgutil --pkgs` / `brew list` enumeration emits sensible discovery items | **pending** |
+| Observability stack | compose-render only | Prometheus actually scrapes metrics; Grafana dashboards populate; `linux-monitoring` profile cAdvisor / node-exporter on real Linux | **pending** |
+| LLM provider — Docker Model Runner | dry-run | Real Model Runner serves chat completions to portal | **pending** |
+| LLM provider — Ollama (Linux) | compose-render | `ollama` service actually pulls + serves a model | **pending** |
+| LLM provider — external | code review | Real `LLM_BASE_URL` (Anthropic / OpenAI / hosted Ollama) round-trips | **pending** |
+| TAPPaaS deployment | none — spec only | Pilot deploy into a real TAPPaaS environment | **not started** |
+| DPF Edge Node enrollment | none — spec only | First-draft enrollment ceremony executed end-to-end | **not started** |
+| Cloud deployment (Single VM / Container / k8s) | none — spec only | At least one substrate pilot per packaging target | **not started** |
+
+## How to run each verification
+
+Each section below is paste-able. Copy the block, fill in the
+prompts, capture the artifacts named at the bottom of the section,
+and check the corresponding row off the matrix.
+
+### 1. Linux end-to-end install (real distro coverage)
+
+**Hardware:** any of Ubuntu 22.04+ / Debian 12+ / Fedora 39+. A fresh
+VM is ideal so you exercise the "user has nothing installed" path.
+
+```bash
+# Capture environment fingerprint before starting.
+uname -a > /tmp/dpf-verify-host.txt
+[ -r /etc/os-release ] && cat /etc/os-release >> /tmp/dpf-verify-host.txt
+
+# Prerequisites the installer expects you to bring.
+which git curl bash
+node -v          # must report v20.x or higher
+pnpm -v          # any recent version
+
+# Clone + install.
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory ~/dpf
+cd ~/dpf
+bash install-dpf.sh                 # interactive — say "Ready to go"
+# Or: bash install-dpf.sh --headless --release --no-autostart
+```
+
+**Expected outcomes (check each):**
+
+- [ ] Preflight passes; no unsupported-host refusal.
+- [ ] Port preflight passes (or fails with a clear "bound by X" message).
+- [ ] Docker Engine installs via apt-get / dnf and `systemctl enable --now docker` succeeds.
+- [ ] If user was added to `docker` group: installer exits 75 with a clear logout-or-newgrp instruction. Re-running succeeds.
+- [ ] `~/.dpf/install-state.json` exists with `"schemaVersion": 1`, `"platform": "linux"`.
+- [ ] `docker compose -p dpf ps` shows portal, postgres, neo4j, qdrant, redis, sandbox, promoter, inngest, adp, ollama all running.
+- [ ] `curl http://localhost:3000/api/health` returns 200.
+- [ ] Login at http://localhost:3000 with `admin@dpf.local` + the password printed at end of install (also in `.env`).
+- [ ] `systemctl --user status dpf.service` reports `active (exited)` (with `--no-autostart` skipped, this is enabled).
+- [ ] **Reboot the host.** Verify portal is back at `http://localhost:3000` within 60 seconds.
+- [ ] `bash dpf-stop.sh && bash dpf-start.sh` round-trip clean.
+- [ ] `bash uninstall-dpf.sh --purge --yes` removes volumes, `.env`, and `~/.dpf`. Verify with `docker volume ls --filter label=com.docker.compose.project=dpf` — empty.
+
+**Artifacts to capture:**
+
+- `/tmp/dpf-verify-host.txt`
+- `bash install-dpf.sh doctor` bundle from `~/.dpf/doctor-<ts>.tar.gz`
+- Screenshot of the portal home page (proves UI rendering works under Apple Silicon Chromium / Linux Firefox)
+
+### 2. macOS Apple Silicon end-to-end install
+
+**Hardware:** a real Apple Silicon Mac (M1 / M2 / M3 / M4). macOS 14
+(Sonoma) or newer. **A fresh user account or a VM is ideal** — you
+need to exercise the "no Docker Desktop installed yet" path.
+
+```bash
+# Capture environment fingerprint.
+sw_vers > /tmp/dpf-verify-host.txt
+uname -a >> /tmp/dpf-verify-host.txt
+
+# Prerequisites.
+xcode-select --install            # one-time, if not already installed
+which git curl bash
+node -v                           # v20.x or higher; brew install node or use nvm
+pnpm -v                           # npm install -g pnpm
+
+# Clone + install. Do NOT pre-install Docker Desktop — let the
+# installer exercise the `.dmg` flow.
+git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory ~/dpf
+cd ~/dpf
+bash install-dpf.sh
+```
+
+**Expected outcomes:**
+
+- [ ] Preflight passes; no Intel-Mac refusal.
+- [ ] Docker Desktop `.dmg` downloads from `desktop.docker.com`.
+- [ ] `hdiutil attach` mounts; installer `cp -R Docker.app /Applications`; `hdiutil detach`.
+- [ ] Docker Desktop launches; daemon reachable within ~60s.
+- [ ] Installer proceeds through compose up.
+- [ ] `curl http://localhost:3000/api/health` returns 200.
+- [ ] Login works.
+- [ ] `~/Library/LaunchAgents/local.dpf-autostart.plist` exists.
+- [ ] `launchctl print gui/$UID/local.dpf-autostart` shows the agent loaded.
+- [ ] **Reboot.** Log back in. Verify portal is reachable within 60s.
+- [ ] **Capture `xattr` state on the plist** — first-install machines sometimes have `com.apple.quarantine` set; the installer strips it; verify with `xattr -l ~/Library/LaunchAgents/local.dpf-autostart.plist` (should be empty or have `com.apple.metadata:_kMDItemUserTags` only).
+- [ ] `bash uninstall-dpf.sh --purge --yes` removes volumes + state + plist.
+
+**Artifacts to capture:**
+
+- `/tmp/dpf-verify-host.txt`
+- `bash install-dpf.sh doctor` bundle
+- `launchctl print gui/$UID/local.dpf-autostart` output (post-reboot)
+- Screenshot of the portal home page
+
+### 3. Discovery collectors — real macOS data
+
+After the macOS install above is green, verify the discovery pipeline
+emits real data, not just unit-test fixtures.
+
+```bash
+# Trigger a bootstrap discovery run from the portal:
+#   Settings -> Discovery -> Run Bootstrap
+
+# Then inspect the database for host evidence.
+docker compose -p dpf exec postgres psql -U dpf -c \
+  "SELECT count(*), \"evidenceSource\", \"packageManager\"
+   FROM \"DiscoveredSoftware\"
+   GROUP BY \"evidenceSource\", \"packageManager\";"
+```
+
+**Expected outcomes:**
+
+- [ ] At least one row with `packageManager = 'pkgutil'` (macOS system receipts).
+- [ ] If brew installed: rows with `packageManager = 'brew'` and `'brew-cask'`.
+- [ ] No rows with `packageManager = 'dpkg'` or `'rpm'` (those are Linux-only).
+- [ ] `DiscoveredItem` table has a row with `itemType = 'docker_runtime'` and a `sourcePath` matching one of the macOS Docker Desktop socket paths (`/var/run/docker.sock`, `~/.docker/run/docker.sock`, or `~/Library/Containers/com.docker.docker/Data/docker.raw.sock`).
+
+### 4. Observability stack — real metrics flow
+
+```bash
+# After a Linux install with the linux-monitoring profile active.
+curl --silent http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job, health}'
+```
+
+**Expected outcomes:**
+
+- [ ] Prometheus targets list includes `node-exporter`, `cadvisor`,
+      `postgres-exporter`, and the portal scrape — all with `health: "up"`.
+- [ ] Grafana at `http://localhost:3002` reachable. Dashboards under
+      "DPF" folder render with non-empty panels.
+- [ ] Network sweep in the portal (Settings → Topology) shows host
+      NICs (not just container-local interfaces). Confidence column
+      should read 0.95, not 0.70.
+
+### 5. LLM providers
+
+| Provider | Verification |
+|----------|--------------|
+| **Docker Model Runner** (macOS DD ≥ 4.40) | Settings → AI → run a prompt against the local model. Portal logs show `POST http://model-runner.docker.internal/engines/v1/chat/completions` returning 200. |
+| **Ollama** (Linux native Docker) | `docker compose -p dpf exec portal curl http://ollama:11434/api/tags` lists at least one model after first portal use. A chat completion round-trips. |
+| **External** | Set `LLM_BASE_URL=https://api.anthropic.com/v1` and a real `API_KEY` in `.env`; restart portal; verify a chat completion succeeds. |
+
+### 6. TAPPaaS pilot deployment
+
+**Status:** spec-only — no code shipped. This row stays "not started"
+until a Phase-0 spike lands.
+
+The spike should:
+
+- [ ] Identify a real TAPPaaS environment with admin access.
+- [ ] Define the packaging target — TAPPaaS module spec format, version, etc.
+- [ ] Build a minimum-viable TAPPaaS module that wraps `install-dpf.sh`'s
+      Single-VM substrate path.
+- [ ] Deploy + reach `/api/health=200` from outside the TAPPaaS network.
+- [ ] Document upgrade + rollback semantics.
+
+Linked spec: [docs/superpowers/specs/2026-05-09-cloud-deployment-design.md](../superpowers/specs/2026-05-09-cloud-deployment-design.md).
+
+### 7. DPF Edge Node enrollment
+
+**Status:** spec-only — no code shipped. This row stays "not started"
+until a Phase-0 spike lands.
+
+The spike should:
+
+- [ ] Implement the enrollment ceremony first-draft contract per the spec.
+- [ ] Stand up one Edge Node (container with `network_mode: host` on a separate Linux box) and enroll it against an Authority Core.
+- [ ] Run a discovery sweep from the Edge Node and verify items appear in the Authority Core's Postgres + Neo4j with the `edgeNodeId` foreign key populated.
+- [ ] Validate the "in-VM fallback" mode on a macOS host (Edge Node as a binary inside the Docker Desktop VM since `host` networking isn't supported there).
+
+Linked spec: [docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md](../superpowers/specs/2026-05-09-dpf-edge-node-design.md).
+
+### 8. Cloud deployment patterns
+
+**Status:** spec-only — no code shipped per substrate.
+
+Each of the three substrates needs its own pilot before declaring the
+substrate verified:
+
+- [ ] **Single VM** — `install-dpf.sh --headless` inside a cloud VM (EC2 / Compute Engine / Azure VM). Validate the same matrix as the Linux install above.
+- [ ] **Managed container service** — ECS / Cloud Run / Azure Container Apps. Pull from GHCR. Validate `/api/health=200`.
+- [ ] **Managed Kubernetes** — Helm chart deploy into a real EKS / GKE / AKS cluster. Validate the same plus a pod-restart survival test.
+
+Linked spec: [docs/superpowers/specs/2026-05-09-cloud-deployment-design.md](../superpowers/specs/2026-05-09-cloud-deployment-design.md).
+
+## Reporting verification results
+
+When a row in the matrix is verified, update its row to `✓ verified`
+plus the verifier's name, date, and a link to the captured artifacts
+(GitHub issue, Drive folder, etc.). Don't mark anything "✓ verified"
+without artifacts — the bar is "we have evidence", not "we believe".
+
+Until the Linux + macOS rows are both `✓ verified`, the README install
+section should say **"preview"** alongside macOS / Linux entries, not
+**"GA"**.

--- a/docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
+++ b/docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
@@ -1,12 +1,26 @@
 # Mac (Apple Silicon) + Linux Native Support — Roadmap
 
-> **Status: DELIVERED (2026-05-11).** All 11 phases (0–10) shipped
-> across 13 PRs. macOS Apple Silicon and native Linux installers are
-> now GA alongside the existing Windows installer. End-user install
-> docs: [docs/install/macos.md](../../install/macos.md),
-> [docs/install/linux.md](../../install/linux.md). CI release gates
-> live in [.github/workflows/release-gates.yml](../../../.github/workflows/release-gates.yml).
-> A delivery summary is at the bottom of this file.
+> **Status: CODE SHIPPED — RUNTIME VERIFICATION PENDING (2026-05-11).**
+> All 11 phases (0–10) of the *code* roadmap shipped across 13 PRs.
+> The bash installer, lifecycle scripts, CI release gates, and docs
+> are on `main`. **However**, the gates that ran in CI are
+> dry-run / static checks (`shellcheck`, `docker compose config`,
+> `install-dpf.sh --dry-run`) — they do **not** prove the installer
+> works end-to-end on a real host.
+>
+> What's verified vs. unverified is tracked in
+> [docs/install/verification-runbook.md](../../install/verification-runbook.md).
+> Until the matrix in that file is checked off for macOS and Linux,
+> the installers are **preview**, not GA. The Windows installer
+> remains GA (real production usage).
+>
+> An ubuntu-latest end-to-end install gate landed alongside this
+> stamp ([`.github/workflows/install-verification.yml`](../../../.github/workflows/install-verification.yml))
+> — on-demand + tag-triggered — that converts the Linux runtime row
+> from "believed correct" to "observed to reach `/api/health=200` as
+> of commit X". Apple Silicon, distro coverage beyond Ubuntu, TAPPaaS,
+> Edge Node, and cloud substrates still need real-hardware /
+> real-substrate verification (see the runbook).
 
 > Branch: `claude/mac-docker-compatibility-uN4Ya`
 > Deliverable for this branch: **this plan only**. Each phase below lands as a


### PR DESCRIPTION
Corrects misleading "GA" framing on PR #455's roadmap stamp and the
README, and lands the verification artifacts that make a GA promotion
actually possible.

## The honest framing problem

PR #455 stamped the macOS / Linux installer-parity roadmap as
**"DELIVERED"**, and the README claimed the installers had
**"landed alongside the Windows GA installer"**. That overstated what
shipped. The reality is:

- The **code** is on `main` for both platforms.
- The **static CI gates** are green (`shellcheck`, `docker compose config`,
  `install-dpf.sh --dry-run`).
- The **end-to-end runtime path has not been verified on a real host.**
  The `macos-14` GHA runner can't nest-virtualize Docker Desktop; the
  Linux CI gate is dry-run only — neither one actually brings up the
  stack or hits `/api/health`.

That gap means we cannot honestly claim the installers work. We can
honestly claim the code we believe will make them work is shipped and
passes static checks. Those are different things, and the README
should say so.

## What this PR ships

### `.github/workflows/install-verification.yml` (new)

End-to-end install on `ubuntu-latest`. Real install (not `--dry-run`):

1. `bash install-dpf.sh --headless --release --no-autostart`
2. Poll `/api/health` until 200 (15-minute timeout)
3. Verify response JSON shape
4. Capture `docker compose ps` + portal tail
5. Run `bash install-dpf.sh doctor` → upload bundle as artifact
6. Tear down with `bash uninstall-dpf.sh --purge --headless --yes`

Triggers: `workflow_dispatch` + on `v*` tag push. **Not on every PR**
— a full image build + boot is 15-25 minutes per run, too expensive
for per-PR. CI-specific override `DPF_MODEL_PULL_MODE=skip` keeps the
gate focused on "the install path works" without burning bandwidth
pulling a model into a runner that's about to be torn down.

### `docs/install/verification-runbook.md` (new)

A paste-able fresh-hardware verification matrix for everything CI
can't reach. Covers:

| Row | Hardware / substrate needed |
|-----|------------------------------|
| Linux distro coverage | Real Debian 12, Fedora 39 (CI only has Ubuntu) |
| macOS Apple Silicon | Real M-series Mac (CI can't nest-virt DD) |
| Discovery collectors (darwin) | Real macOS — `pkgutil` / `brew` enumeration |
| Observability stack | Real Linux host with metrics actually flowing |
| LLM providers | model-runner / ollama / external — each round-tripped |
| TAPPaaS pilot | Spec-only — Phase 0 spike required |
| DPF Edge Node enrollment | Spec-only — Phase 0 spike required |
| Cloud substrates (VM / Container / k8s) | Spec-only — one pilot per substrate |

Each row has expected outcomes + artifacts to capture. When you have
hardware in hand, the steps don't need to be re-derived.

### Framing corrections (no code change)

- **`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md`** —
  Status flipped from `DELIVERED` to `CODE SHIPPED — RUNTIME
  VERIFICATION PENDING`. Cross-links to the runbook.
- **`README.md`** — Quick Start grows a Status column:
  - Windows: **GA** (production usage)
  - macOS / Linux: **preview** (code shipped, runtime verification pending)
  - Roadmap "What's working now" and "What's coming" rows mirror this.
- **`docs/install/macos.md` and `docs/install/linux.md`** — both get an
  explicit `Status: preview` callout at the top, cross-linking the runbook.

## What's still required for GA (not in this PR)

This is what someone — with hardware — has to do next:

1. **Run the verification runbook** on a real Apple Silicon Mac (one
   row in the matrix). Capture artifacts. Flip the row to `verified`.
2. **Run the verification runbook** on a real Debian 12 box and a real
   Fedora 39 box. Same.
3. **Trigger `install-verification.yml`** at least once on a release
   tag and verify the artifact + green status.
4. Only **then** flip the README rows from `preview` to `GA`.

TAPPaaS, Edge Node, and cloud substrates each need their own Phase 0
spike before they're even runnable — the runbook documents them as
`not started`, not `pending`.

## No installer code changes

The bash installer ecosystem is exactly what it was at the close of
Phase 10. What changes is what we **claim** about it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_