### PR TITLE
fix(build-studio): harden taskResults boundary against shape drift

### DIFF
--- a/apps/web/lib/build/process-graph-builder.test.ts
+++ b/apps/web/lib/build/process-graph-builder.test.ts
@@ -228,6 +228,45 @@ describe("getTaskNodeStatus", () => {
   });
 });
 
+describe("normalizeBuildSnapshot — shape drift tolerance", () => {
+  // Regression: a rogue writer (snake_case claim summary) used to crash the
+  // Build Studio with "Cannot read properties of undefined (reading 'split')".
+  it("skips task entries missing the required string fields", () => {
+    const row = makeRow({
+      phase: "ideate",
+      // Shape that crashed the renderer in production: a triage/claim summary
+      // stored under taskResults with no title/specialist on the entries.
+      taskResults: {
+        tasks: [{ status: "claimed_by_ai_coworker", item_id: "BI-B6423E18" }],
+      } as unknown as FeatureBuildRow["taskResults"],
+    });
+
+    expect(() => normalizeBuildSnapshot(row)).not.toThrow();
+    const snap = normalizeBuildSnapshot(row);
+    expect(snap.storedTaskResults.size).toBe(0);
+    expect(snap.taskActors.size).toBe(0);
+  });
+
+  it("keeps valid entries when malformed entries are mixed in", () => {
+    const row = makeRow({
+      phase: "build",
+      taskResults: {
+        tasks: [
+          { title: "Add schema", specialist: "data-architect", outcome: "DONE", durationMs: 1000 },
+          { status: "claimed_by_ai_coworker", item_id: "BI-1234" },
+          { title: "Add API", specialist: "software-engineer", outcome: "DONE", durationMs: 2000 },
+        ],
+      } as unknown as FeatureBuildRow["taskResults"],
+    });
+
+    const snap = normalizeBuildSnapshot(row);
+    expect(snap.storedTaskResults.size).toBe(2);
+    expect(snap.storedTaskResults.has("Add schema")).toBe(true);
+    expect(snap.storedTaskResults.has("Add API")).toBe(true);
+    expect(snap.taskActors.get("Add schema")?.label).toBe("Data Architect");
+  });
+});
+
 describe("buildTaskGraph", () => {
   it("returns empty nodes and edges when buildPlan is null", () => {
     const row = makeRow({ buildPlan: null });

--- a/apps/web/lib/build/process-graph-builder.ts
+++ b/apps/web/lib/build/process-graph-builder.ts
@@ -312,12 +312,29 @@ export function normalizeBuildSnapshot(
       };
 
       if (Array.isArray(runtimeResult.tasks)) {
-        for (const t of runtimeResult.tasks) {
+        for (const raw of runtimeResult.tasks) {
+          // Defensive: the Json column is untyped at runtime. Skip entries
+          // that don't match the orchestrator's StoredTaskResult shape — e.g.
+          // a misbehaving writer that stuffed claim/triage summaries here.
+          if (
+            raw == null ||
+            typeof raw !== "object" ||
+            typeof (raw as { title?: unknown }).title !== "string" ||
+            typeof (raw as { specialist?: unknown }).specialist !== "string"
+          ) {
+            continue;
+          }
+          const t = raw as {
+            title: string;
+            specialist: string;
+            outcome?: unknown;
+            durationMs?: unknown;
+          };
           storedTaskResults.set(t.title, {
             title: t.title,
             specialist: t.specialist,
-            outcome: t.outcome,
-            durationMs: t.durationMs,
+            outcome: typeof t.outcome === "string" ? t.outcome : "",
+            durationMs: typeof t.durationMs === "number" ? t.durationMs : 0,
           });
           taskActors.set(t.title, {
             kind: "ai_coworker",
@@ -364,7 +381,10 @@ export function normalizeBuildSnapshot(
   return { storedTaskResults, activeTaskTitles, taskActors, phaseActors };
 }
 
-function formatSpecialistLabel(specialist: string): string {
+function formatSpecialistLabel(specialist: string | null | undefined): string {
+  if (typeof specialist !== "string" || specialist.length === 0) {
+    return "AI Coworker";
+  }
   return specialist
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))

--- a/apps/web/lib/mcp-tools-save-build-evidence.test.ts
+++ b/apps/web/lib/mcp-tools-save-build-evidence.test.ts
@@ -158,4 +158,71 @@ describe("saveBuildEvidence", () => {
       }),
     );
   });
+
+  // Regression: a writer once stored a backlog claim summary under taskResults,
+  // causing the Build Studio process graph to crash with "Cannot read
+  // properties of undefined (reading 'split')". Reject that shape at the
+  // boundary so it can't reach the column.
+  it("rejects taskResults entries that lack title/specialist", async () => {
+    const { executeTool } = await import("./mcp-tools");
+
+    const result = await executeTool(
+      "saveBuildEvidence",
+      {
+        field: "taskResults",
+        value: {
+          tasks: [{ status: "claimed_by_ai_coworker", item_id: "BI-B6423E18" }],
+        },
+      },
+      "user-1",
+      { threadId: "thread-1", routeContext: "/build" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/missing title\/specialist/);
+    expect(mockPrisma.featureBuild.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts taskResults with the canonical orchestrator shape", async () => {
+    const { executeTool } = await import("./mcp-tools");
+
+    const result = await executeTool(
+      "saveBuildEvidence",
+      {
+        field: "taskResults",
+        value: {
+          completedTasks: 1,
+          totalTasks: 1,
+          tasks: [
+            { title: "Add schema", specialist: "data-architect", outcome: "DONE", durationMs: 1200 },
+          ],
+        },
+      },
+      "user-1",
+      { threadId: "thread-1", routeContext: "/build" },
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts taskResults summary writes that omit the tasks array", async () => {
+    const { executeTool } = await import("./mcp-tools");
+
+    const result = await executeTool(
+      "saveBuildEvidence",
+      {
+        field: "taskResults",
+        value: {
+          agenticResult: "Build complete",
+          toolsExecuted: ["generate_code"],
+          filesChanged: 3,
+          ranTests: true,
+        },
+      },
+      "user-1",
+      { threadId: "thread-1", routeContext: "/build" },
+    );
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4800,6 +4800,40 @@ export async function executeTool(
         console.log(`[saveBuildEvidence] buildPlan validated: ${fileStructure.length} files, ${tasks.length} tasks`);
       }
 
+      // ── taskResults shape validation ─────────────────────────────────────
+      // The orchestrator's canonical shape carries tasks as
+      //   Array<{ title: string, specialist: string, outcome?: string, durationMs?: number }>.
+      // Other legitimate writers (post-build summaries, contributionAssessment)
+      // omit `tasks` entirely. Reject any write where `tasks` is present but
+      // its entries lack the required string fields — that's the failure mode
+      // that crashes the Build Studio process graph downstream.
+      if (field === "taskResults") {
+        const value = normalizedValue;
+        if (value != null && typeof value === "object" && "tasks" in value) {
+          const tasksField = (value as { tasks?: unknown }).tasks;
+          if (!Array.isArray(tasksField)) {
+            return {
+              success: false,
+              error: "taskResults.tasks must be an array.",
+              message: `REJECTED: taskResults contained a "tasks" key that wasn't an array. Either omit "tasks" (for summary-only writes) or provide an array of { title, specialist, outcome, durationMs? } entries.`,
+            };
+          }
+          for (let i = 0; i < tasksField.length; i++) {
+            const entry = tasksField[i];
+            const title = (entry as { title?: unknown } | null)?.title;
+            const specialist = (entry as { specialist?: unknown } | null)?.specialist;
+            if (typeof title !== "string" || typeof specialist !== "string") {
+              const got = entry == null ? "null" : `keys: ${Object.keys(entry as object).join(", ")}`;
+              return {
+                success: false,
+                error: "taskResults.tasks entry missing title/specialist.",
+                message: `REJECTED: taskResults.tasks[${i}] must have string "title" and "specialist" fields. Got ${got}. This shape is consumed by the Build Studio process graph; do not use taskResults to store backlog claim or triage summaries.`,
+              };
+            }
+          }
+        }
+      }
+
       // When the AI saves verificationOut, ensure typecheckPassed is explicitly set.
       // The AI often omits it, causing the gate to treat null as false.
       let fieldValue = normalizedValue as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- **Bug**: `/build` crashed with `Cannot read properties of undefined (reading 'split')` because `normalizeBuildSnapshot` cast `FeatureBuild.taskResults` (Prisma `Json`) to the orchestrator's shape without validating, then called `formatSpecialistLabel(t.specialist).split("-")` on entries that didn't have a `specialist`.
- **Root cause**: a writer (via `saveBuildEvidence` with `field=taskResults`) stored a backlog claim summary `{tasks:[{status,item_id}]}` in a column the renderer expects to hold `{tasks:[{title,specialist,outcome,durationMs}]}`. One column, two writers, no schema validation.
- **Fix, two layers, one concern (the `taskResults` contract)**:
  1. **Renderer** ([process-graph-builder.ts](apps/web/lib/build/process-graph-builder.ts)) — skip task entries lacking string `title`/`specialist`; make `formatSpecialistLabel` defensive. A single bad entry can no longer crash the page.
  2. **Writer** ([mcp-tools.ts `saveBuildEvidence`](apps/web/lib/mcp-tools.ts)) — when `field === "taskResults"` and the value contains a `tasks` array, every entry must have string `title` and `specialist`. Same boundary-validation pattern already used for `buildPlan`. Summary-only writes that omit `tasks` (post-build summary, `contributionAssessment`) still pass.
- **Data cleanup** (local only, not in this PR): one row had the bogus shape and was set to `taskResults=NULL` so the page renders. No other rows had matching drift.

## Why this is the long-term fix, not a quick patch

`FeatureBuild.taskResults` is `Json?` in Prisma — there's no schema-level shape. Multiple writers legitimately use it (orchestrator task results, `stepRunBuild` summary, `contributionAssessment`). Splitting it into separate columns would be the structural answer but breaks compatibility with the orchestrator's optimistic locking and version field. Boundary validation at the agent-facing API (`saveBuildEvidence`) plus defensive parsing in the renderer is the architectural equivalent: every write goes through the validator, every read survives drift.

## Test plan

- [x] Unit tests: 4734 pass (`pnpm --filter web test`)
- [x] New regression test for the exact crash shape (`status`/`item_id` entries) in [process-graph-builder.test.ts](apps/web/lib/build/process-graph-builder.test.ts)
- [x] New `saveBuildEvidence` validator tests in [mcp-tools-save-build-evidence.test.ts](apps/web/lib/mcp-tools-save-build-evidence.test.ts): rejects drift shape, accepts canonical shape, accepts summary-only writes
- [x] Typecheck (`pnpm --filter web typecheck`)
- [x] Production build (`pnpm --filter web exec next build`) — exit 0
- [ ] UX verification: load `/build` after rebuild; confirm Build Studio renders without the error boundary

## Follow-up worth doing (separate change)

That an `ideate`-phase build had `taskResults` written at all suggests a misbehaving writer worth tracing. The validator added here will now reject it loudly with a useful error message if it happens again — first reproduction will tell us who.

🤖 Generated with [Claude Code](https://claude.com/claude-code)