### PR TITLE
Add operations map reset view

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -4,6 +4,7 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     storefrontConfig: { findFirst: vi.fn() },
     agent: { findMany: vi.fn() },
+    taskRun: { findMany: vi.fn() },
     toolExecution: { findMany: vi.fn() },
     toolExecutionReceipt: { findMany: vi.fn() },
     backlogItemActivity: { findMany: vi.fn() },
@@ -58,6 +59,7 @@ describe("AI operations map page", () => {
         summary: "Write blocked by policy",
       },
     ] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);

--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -12,6 +12,9 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("Quick views");
     expect(source).toContain("OPERATIONS_MAP_QUICK_VIEWS");
     expect(source).toContain("applyQuickView");
+    expect(source).toContain("Reset view");
+    expect(source).toContain("resetView");
+    expect(source).toContain("clearOperationsMapViewPreference");
     expect(source).toContain("loadOperationsMapViewPreference");
     expect(source).toContain("saveOperationsMapViewPreference");
     expect(source).toContain("toggleSourceFilter");

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -17,6 +17,7 @@ import {
   summarizeProjectionCounts,
 } from "@/lib/ai-operations-map/project-events";
 import {
+  clearOperationsMapViewPreference,
   loadOperationsMapViewPreference,
   saveOperationsMapViewPreference,
   type OperationsMapStoredQuickViewId,
@@ -113,6 +114,12 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
     setSourceFilters(filters.sources);
     setSeverityFilters(filters.severities);
   };
+  const resetView = () => {
+    clearOperationsMapViewPreference();
+    setActiveQuickViewId(DEFAULT_QUICK_VIEW_ID);
+    setSourceFilters(getOperationsMapQuickViewFilters(DEFAULT_QUICK_VIEW_ID).sources);
+    setSeverityFilters(getOperationsMapQuickViewFilters(DEFAULT_QUICK_VIEW_ID).severities);
+  };
   const toggleSourceFilter = (source: OperationsMapProjectionSource) => {
     setActiveQuickViewId("custom");
     setSourceFilters((current) => toggleFilterOption(current, source, SOURCE_OPTIONS));
@@ -152,6 +159,13 @@ export function AiOperationsMap({ template, agents, projections, recentWindowLab
             <p className="mt-1 text-xs text-[var(--dpf-muted)]">
               Showing {filteredProjections.length} of {projections.length} activities
             </p>
+            <button
+              type="button"
+              onClick={resetView}
+              className="mt-2 text-xs font-medium text-[var(--dpf-accent)] hover:underline focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+            >
+              Reset view
+            </button>
           </div>
           <div className="grid gap-3 lg:grid-cols-3">
             <FilterGroup label="Quick views">

--- a/apps/web/components/platform/ai-operations-map-prefs.test.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { getOperationsMapQuickViewFilters } from "@/lib/ai-operations-map/project-events";
 import {
+  clearOperationsMapViewPreference,
   loadOperationsMapViewPreference,
   OPERATIONS_MAP_VIEW_PREFERENCE_KEY,
   saveOperationsMapViewPreference,
@@ -12,6 +13,9 @@ const localStorageMock = {
   getItem: (key: string) => store.get(key) ?? null,
   setItem: (key: string, value: string) => {
     store.set(key, value);
+  },
+  removeItem: (key: string) => {
+    store.delete(key);
   },
   clear: () => {
     store.clear();
@@ -70,6 +74,24 @@ describe("AI operations map preferences", () => {
       },
     }));
 
+    expect(loadOperationsMapViewPreference()).toEqual({
+      quickViewId: "all",
+      filters: getOperationsMapQuickViewFilters("all"),
+    });
+  });
+
+  it("clears stored preferences back to the default view", () => {
+    saveOperationsMapViewPreference({
+      quickViewId: "custom",
+      filters: {
+        sources: ["tool-execution"],
+        severities: ["warning"],
+      },
+    });
+
+    clearOperationsMapViewPreference();
+
+    expect(store.has(OPERATIONS_MAP_VIEW_PREFERENCE_KEY)).toBe(false);
     expect(loadOperationsMapViewPreference()).toEqual({
       quickViewId: "all",
       filters: getOperationsMapQuickViewFilters("all"),

--- a/apps/web/components/platform/ai-operations-map-prefs.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.ts
@@ -59,6 +59,14 @@ export function saveOperationsMapViewPreference(preference: OperationsMapViewPre
   }
 }
 
+export function clearOperationsMapViewPreference(): void {
+  try {
+    localStorage.removeItem(OPERATIONS_MAP_VIEW_PREFERENCE_KEY);
+  } catch {
+    // localStorage can be unavailable; resetting in-memory state still keeps the map usable.
+  }
+}
+
 function isStoredQuickViewId(value: unknown): value is OperationsMapStoredQuickViewId {
   return value === "custom" || (typeof value === "string" && ALL_QUICK_VIEW_IDS.has(value as OperationsMapQuickViewId));
 }


### PR DESCRIPTION
## Summary
- Add a Reset view action to return the AI Operations Map to the default All activity view
- Clear persisted operations-map filter preferences when reset is used
- Update the Operations Map page test mock for the current taskRun evidence source

## Verification
- pnpm --filter web exec vitest run components/platform/ai-operations-map-prefs.test.ts components/platform/AiOperationsMap.test.tsx
- pnpm --filter web exec vitest run lib/ai-operations-map 'app/(shell)/platform/ai/operations-map/page.test.tsx' components/platform/AiOperationsMap.test.tsx components/platform/ai-operations-map-prefs.test.ts
- pnpm --filter web typecheck
- pnpm --filter web exec next build