### PR TITLE
[codex] Add Git promotion review handoff

### DIFF
--- a/apps/web/app/(shell)/ops/promotions/page.tsx
+++ b/apps/web/app/(shell)/ops/promotions/page.tsx
@@ -1,4 +1,4 @@
-import { getGitPromotionCandidates, getPromotions } from "@/lib/actions/promotions";
+import { createPromotionReviewFromGitCandidateForm, getGitPromotionCandidates, getPromotions } from "@/lib/actions/promotions";
 import PromotionsClient from "@/components/ops/PromotionsClient";
 import { GitPromotionCandidatesPanel } from "@/components/ops/GitPromotionCandidatesPanel";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
@@ -17,7 +17,10 @@ export default async function PromotionsPage() {
         </p>
       </div>
       <OpsTabNav />
-      <GitPromotionCandidatesPanel candidates={JSON.parse(JSON.stringify(gitCandidates))} />
+      <GitPromotionCandidatesPanel
+        candidates={JSON.parse(JSON.stringify(gitCandidates))}
+        createReviewAction={createPromotionReviewFromGitCandidateForm}
+      />
       <PromotionsClient promotions={JSON.parse(JSON.stringify(promotions))} />
     </div>
   );

--- a/apps/web/components/ops/GitPromotionCandidatesPanel.test.tsx
+++ b/apps/web/components/ops/GitPromotionCandidatesPanel.test.tsx
@@ -24,11 +24,12 @@ const baseCandidate = {
     stderr: "",
   },
   createdAt: "2026-05-11T17:59:00.000Z",
+  promotionReview: null,
 };
 
 describe("GitPromotionCandidatesPanel", () => {
   it("renders sandbox-verified Git candidates with source and evidence", () => {
-    render(<GitPromotionCandidatesPanel candidates={[baseCandidate]} />);
+    render(<GitPromotionCandidatesPanel candidates={[baseCandidate]} createReviewAction={() => undefined} />);
 
     expect(screen.getByText("Git update candidates")).toBeInTheDocument();
     expect(screen.getByText("OpenDigitalProductFactory/opendigitalproductfactory")).toBeInTheDocument();
@@ -36,7 +37,30 @@ describe("GitPromotionCandidatesPanel", () => {
     expect(screen.getByText("abcdef123456")).toBeInTheDocument();
     expect(screen.getByText("Sandbox verified")).toBeInTheDocument();
     expect(screen.getByText("local-docker")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create review" })).toBeInTheDocument();
     expect(screen.getByText(/typecheck ok/)).toBeInTheDocument();
+  });
+
+  it("shows linked promotion review details instead of a duplicate handoff action", () => {
+    render(
+      <GitPromotionCandidatesPanel
+        candidates={[
+          {
+            ...baseCandidate,
+            promotionReview: {
+              promotionId: "CP-12345678",
+              promotionStatus: "pending",
+              rfcId: "RFC-2026-12345678",
+              rfcStatus: "draft",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("CP-12345678")).toBeInTheDocument();
+    expect(screen.getByText("RFC-2026-12345678 - pending")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create review" })).not.toBeInTheDocument();
   });
 
   it("renders a quiet empty state", () => {

--- a/apps/web/components/ops/GitPromotionCandidatesPanel.tsx
+++ b/apps/web/components/ops/GitPromotionCandidatesPanel.tsx
@@ -15,6 +15,12 @@ export type GitPromotionCandidateRow = {
   verificationCompletedAt: string | null;
   verificationResult: unknown;
   createdAt: string;
+  promotionReview: {
+    promotionId: string;
+    promotionStatus: string;
+    rfcId: string;
+    rfcStatus: string;
+  } | null;
 };
 
 type VerificationResult = {
@@ -77,10 +83,13 @@ function evidencePreview(candidate: GitPromotionCandidateRow): string | null {
 
 export function GitPromotionCandidatesPanel({
   candidates,
+  createReviewAction,
 }: {
   candidates: GitPromotionCandidateRow[];
+  createReviewAction?: (formData: FormData) => void | Promise<void>;
 }) {
   const verifiedCount = candidates.filter((candidate) => candidate.status === "sandbox-verification-complete").length;
+  const readyForReviewCount = candidates.filter((candidate) => candidate.status === "sandbox-verification-complete" && !candidate.promotionReview).length;
   const runningCount = candidates.filter((candidate) => candidate.status === "sandbox-verification-running" || candidate.status === "queued").length;
   const failedCount = candidates.filter((candidate) => candidate.status === "failed").length;
 
@@ -95,7 +104,7 @@ export function GitPromotionCandidatesPanel({
             Default-branch Git updates that have entered sandbox verification before production promotion review.
           </p>
         </div>
-        <div className="grid grid-cols-3 gap-2 text-center text-xs">
+        <div className="grid grid-cols-4 gap-2 text-center text-xs">
           <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
             <div className="font-semibold text-[var(--dpf-text)]">{runningCount}</div>
             <div className="text-[var(--dpf-muted)]">Active</div>
@@ -103,6 +112,10 @@ export function GitPromotionCandidatesPanel({
           <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
             <div className="font-semibold text-[var(--dpf-text)]">{verifiedCount}</div>
             <div className="text-[var(--dpf-muted)]">Verified</div>
+          </div>
+          <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
+            <div className="font-semibold text-[var(--dpf-text)]">{readyForReviewCount}</div>
+            <div className="text-[var(--dpf-muted)]">Ready</div>
           </div>
           <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
             <div className="font-semibold text-[var(--dpf-text)]">{failedCount}</div>
@@ -152,9 +165,25 @@ export function GitPromotionCandidatesPanel({
                       </div>
                     </div>
                   </div>
-                  <div className="text-right text-xs text-[var(--dpf-muted)]">
+                  <div className="space-y-2 text-right text-xs text-[var(--dpf-muted)]">
                     <div>{new Date(candidate.createdAt).toLocaleString()}</div>
                     {candidate.sandboxId && <div className="mt-1 font-mono">{candidate.sandboxId}</div>}
+                    {candidate.promotionReview ? (
+                      <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-left">
+                        <div className="font-mono text-[var(--dpf-text)]">{candidate.promotionReview.promotionId}</div>
+                        <div>{candidate.promotionReview.rfcId} - {candidate.promotionReview.promotionStatus}</div>
+                      </div>
+                    ) : candidate.status === "sandbox-verification-complete" && createReviewAction ? (
+                      <form action={createReviewAction}>
+                        <input type="hidden" name="candidateId" value={candidate.candidateId} />
+                        <button
+                          type="submit"
+                          className="rounded border border-[var(--dpf-accent)] bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                        >
+                          Create review
+                        </button>
+                      </form>
+                    ) : null}
                   </div>
                 </div>
 

--- a/apps/web/lib/actions/promotions.test.ts
+++ b/apps/web/lib/actions/promotions.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockCan, mockRevalidatePath, mockPrisma } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+  mockPrisma: {
+    $transaction: vi.fn(),
+    gitPromotionCandidate: {
+      findUnique: vi.fn(),
+    },
+    digitalProduct: {
+      findUnique: vi.fn(),
+    },
+    changeItem: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: mockCan,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("./change-management", () => ({
+  generateRfcId: vi.fn(() => "RFC-2026-GITGATE"),
+}));
+
+import { createPromotionReviewFromGitCandidate } from "./promotions";
+
+const session = {
+  user: {
+    id: "user-1",
+    platformRole: "HR-000",
+    isSuperuser: false,
+  },
+};
+
+function verifiedCandidate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "candidate-db-1",
+    candidateId: "GPC-ABC123",
+    provider: "github",
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    repositoryCloneUrl: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git",
+    branch: "main",
+    beforeSha: "before-sha",
+    afterSha: "abcdef1234567890",
+    status: "sandbox-verification-complete",
+    statusReason: null,
+    sandboxProviderId: "local-docker",
+    sandboxId: "sandbox-1",
+    verificationStartedAt: new Date("2026-05-11T10:00:00Z"),
+    verificationCompletedAt: new Date("2026-05-11T10:05:00Z"),
+    verificationResult: {
+      exitCode: 0,
+      stdout: "typecheck passed\nnext build passed",
+      durationMs: 300000,
+    },
+    payload: { delivery: "delivery-1" },
+    createdAt: new Date("2026-05-11T09:55:00Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue(session);
+  mockCan.mockReturnValue(true);
+  mockPrisma.digitalProduct.findUnique.mockResolvedValue({ id: "dp-odpf" });
+});
+
+describe("createPromotionReviewFromGitCandidate", () => {
+  it("creates a pending ChangePromotion and RFC from a sandbox-verified candidate", async () => {
+    mockPrisma.gitPromotionCandidate.findUnique.mockResolvedValue(verifiedCandidate());
+    mockPrisma.changeItem.findFirst.mockResolvedValue(null);
+
+    const tx = {
+      productVersion: {
+        create: vi.fn().mockResolvedValue({ id: "pv-1" }),
+      },
+      changePromotion: {
+        create: vi.fn().mockResolvedValue({ id: "cp-1" }),
+      },
+      changeRequest: {
+        create: vi.fn().mockResolvedValue({ id: "cr-1" }),
+      },
+      changeItem: {
+        create: vi.fn().mockResolvedValue({ id: "ci-1" }),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(async (fn: (txClient: typeof tx) => Promise<unknown>) => fn(tx));
+
+    const result = await createPromotionReviewFromGitCandidate("GPC-ABC123");
+
+    expect(result).toEqual({
+      created: true,
+      promotionId: expect.stringMatching(/^CP-/),
+      rfcId: "RFC-2026-GITGATE",
+    });
+    expect(tx.productVersion.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        digitalProductId: "dp-odpf",
+        version: "git-gpc-abc123",
+        gitTag: "git-main-abcdef123456",
+        gitCommitHash: "abcdef1234567890",
+        shippedBy: "user-1",
+        changeSummary: expect.stringContaining("Sandbox-verified Git update"),
+      }),
+      select: { id: true },
+    });
+    expect(tx.changePromotion.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        productVersionId: "pv-1",
+        status: "pending",
+        requestedBy: "user-1",
+        deploymentLog: expect.stringContaining("sandbox-1"),
+      }),
+      select: { id: true },
+    });
+    expect(tx.changeRequest.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        rfcId: "RFC-2026-GITGATE",
+        status: "draft",
+        scope: "platform",
+        impactReport: expect.objectContaining({
+          source: "git-promotion-candidate",
+          candidateId: "GPC-ABC123",
+          sandbox: expect.objectContaining({ id: "sandbox-1" }),
+          verificationResult: expect.objectContaining({ exitCode: 0 }),
+        }),
+      }),
+      select: { id: true },
+    });
+    expect(tx.changeItem.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeRequestId: "cr-1",
+        changePromotionId: "cp-1",
+        itemType: "promotion",
+        externalSystemRef: "git-promotion-candidate:GPC-ABC123",
+        status: "pending",
+      }),
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/ops/promotions");
+  });
+
+  it("rejects candidates that have not completed sandbox verification", async () => {
+    mockPrisma.gitPromotionCandidate.findUnique.mockResolvedValue(verifiedCandidate({ status: "queued" }));
+
+    await expect(createPromotionReviewFromGitCandidate("GPC-ABC123")).rejects.toThrow(
+      "Only sandbox-verified Git candidates can enter promotion review.",
+    );
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing review instead of creating duplicates", async () => {
+    mockPrisma.gitPromotionCandidate.findUnique.mockResolvedValue(verifiedCandidate());
+    mockPrisma.changeItem.findFirst.mockResolvedValue({
+      changePromotion: { promotionId: "CP-EXISTING" },
+      changeRequest: { rfcId: "RFC-EXISTING" },
+    });
+
+    const result = await createPromotionReviewFromGitCandidate("GPC-ABC123");
+
+    expect(result).toEqual({
+      created: false,
+      promotionId: "CP-EXISTING",
+      rfcId: "RFC-EXISTING",
+    });
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -2,8 +2,11 @@
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { prisma } from "@dpf/db";
+import { prisma, type Prisma } from "@dpf/db";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { revalidatePath } from "next/cache";
+import { generateRfcId } from "./change-management";
+import { generatePromotionId } from "@/lib/version-tracking";
 
 async function requireOpsAccess(): Promise<string> {
   const session = await auth();
@@ -45,7 +48,7 @@ export async function getPromotions(status?: string) {
 
 export async function getGitPromotionCandidates() {
   await requireOpsAccess();
-  return prisma.gitPromotionCandidate.findMany({
+  const candidates = await prisma.gitPromotionCandidate.findMany({
     orderBy: { createdAt: "desc" },
     take: 25,
     select: {
@@ -65,11 +68,244 @@ export async function getGitPromotionCandidates() {
       createdAt: true,
     },
   });
+
+  const refs = candidates.map((candidate) => candidateReviewRef(candidate.candidateId));
+  const reviewItems = refs.length > 0
+    ? await prisma.changeItem.findMany({
+        where: { externalSystemRef: { in: refs } },
+        select: {
+          externalSystemRef: true,
+          changePromotion: { select: { promotionId: true, status: true } },
+          changeRequest: { select: { rfcId: true, status: true } },
+        },
+      })
+    : [];
+  const reviewsByRef = new Map(reviewItems.map((item) => [item.externalSystemRef, item]));
+
+  return candidates.map((candidate) => {
+    const review = reviewsByRef.get(candidateReviewRef(candidate.candidateId));
+    return {
+      ...candidate,
+      promotionReview: review?.changePromotion && review.changeRequest
+        ? {
+            promotionId: review.changePromotion.promotionId,
+            promotionStatus: review.changePromotion.status,
+            rfcId: review.changeRequest.rfcId,
+            rfcStatus: review.changeRequest.status,
+          }
+        : null,
+    };
+  });
 }
 
 // Re-export Promotion type shape for the UI component
 export type PromotionRow = Awaited<ReturnType<typeof getPromotions>>[number];
 export type GitPromotionCandidateRow = Awaited<ReturnType<typeof getGitPromotionCandidates>>[number];
+
+function candidateReviewRef(candidateId: string): string {
+  return `git-promotion-candidate:${candidateId}`;
+}
+
+function shortSha(value: string | null): string {
+  return value?.slice(0, 12) ?? "unknown";
+}
+
+function slugPart(value: string | null): string {
+  const slug = (value ?? "unknown")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "unknown";
+}
+
+function buildCandidateImpactReport(candidate: {
+  candidateId: string;
+  provider: string;
+  repositoryFullName: string;
+  repositoryCloneUrl: string | null;
+  branch: string | null;
+  beforeSha: string | null;
+  afterSha: string | null;
+  sandboxProviderId: string | null;
+  sandboxId: string | null;
+  verificationStartedAt: Date | null;
+  verificationCompletedAt: Date | null;
+  verificationResult: Prisma.JsonValue | null;
+  payload: Prisma.JsonValue | null;
+}): Prisma.InputJsonObject {
+  return {
+    source: "git-promotion-candidate",
+    candidateId: candidate.candidateId,
+    provider: candidate.provider,
+    repository: {
+      fullName: candidate.repositoryFullName,
+      cloneUrl: candidate.repositoryCloneUrl,
+      branch: candidate.branch,
+      beforeSha: candidate.beforeSha,
+      afterSha: candidate.afterSha,
+    },
+    sandbox: {
+      providerId: candidate.sandboxProviderId,
+      id: candidate.sandboxId,
+      verificationStartedAt: candidate.verificationStartedAt?.toISOString() ?? null,
+      verificationCompletedAt: candidate.verificationCompletedAt?.toISOString() ?? null,
+    },
+    verificationResult: candidate.verificationResult ?? null,
+    webhookPayload: candidate.payload ?? null,
+  };
+}
+
+function buildCandidateDeploymentLog(candidate: {
+  candidateId: string;
+  repositoryFullName: string;
+  branch: string | null;
+  afterSha: string | null;
+  sandboxProviderId: string | null;
+  sandboxId: string | null;
+  verificationCompletedAt: Date | null;
+}): string {
+  return [
+    `Git promotion candidate: ${candidate.candidateId}`,
+    `Repository: ${candidate.repositoryFullName}`,
+    `Branch: ${candidate.branch ?? "unknown"}`,
+    `Commit: ${candidate.afterSha ?? "unknown"}`,
+    `Sandbox provider: ${candidate.sandboxProviderId ?? "unknown"}`,
+    `Sandbox ID: ${candidate.sandboxId ?? "unknown"}`,
+    `Sandbox verification completed: ${candidate.verificationCompletedAt?.toISOString() ?? "unknown"}`,
+    "Production deployment has not been executed. This record is waiting for operator review in /ops/promotions.",
+  ].join("\n");
+}
+
+export async function createPromotionReviewFromGitCandidate(candidateId: string): Promise<{
+  created: boolean;
+  promotionId: string;
+  rfcId: string;
+}> {
+  const userId = await requireOpsAccess();
+  const candidate = await prisma.gitPromotionCandidate.findUnique({
+    where: { candidateId },
+    select: {
+      candidateId: true,
+      provider: true,
+      repositoryFullName: true,
+      repositoryCloneUrl: true,
+      branch: true,
+      beforeSha: true,
+      afterSha: true,
+      status: true,
+      sandboxProviderId: true,
+      sandboxId: true,
+      verificationStartedAt: true,
+      verificationCompletedAt: true,
+      verificationResult: true,
+      payload: true,
+    },
+  });
+
+  if (!candidate) throw new Error(`Git promotion candidate not found: ${candidateId}`);
+  if (candidate.status !== "sandbox-verification-complete") {
+    throw new Error("Only sandbox-verified Git candidates can enter promotion review.");
+  }
+  if (!candidate.afterSha) {
+    throw new Error("Git promotion candidate is missing the verified commit SHA.");
+  }
+
+  const externalSystemRef = candidateReviewRef(candidate.candidateId);
+  const existingReview = await prisma.changeItem.findFirst({
+    where: { externalSystemRef, itemType: "promotion" },
+    select: {
+      changePromotion: { select: { promotionId: true } },
+      changeRequest: { select: { rfcId: true } },
+    },
+  });
+  if (existingReview?.changePromotion && existingReview.changeRequest) {
+    return {
+      created: false,
+      promotionId: existingReview.changePromotion.promotionId,
+      rfcId: existingReview.changeRequest.rfcId,
+    };
+  }
+
+  const platformProduct = await prisma.digitalProduct.findUnique({
+    where: { productId: "DP-ODPF" },
+    select: { id: true },
+  });
+  if (!platformProduct) {
+    throw new Error("Platform product DP-ODPF is not seeded; cannot create a governed promotion review.");
+  }
+
+  const afterSha = candidate.afterSha;
+  const promotionId = generatePromotionId();
+  const rfcId = await generateRfcId();
+  const sha = shortSha(afterSha);
+  const branch = slugPart(candidate.branch);
+  const summary = `Sandbox-verified Git update ${candidate.repositoryFullName}@${sha}`;
+
+  const result = await prisma.$transaction(async (tx) => {
+    const productVersion = await tx.productVersion.create({
+      data: {
+        digitalProductId: platformProduct.id,
+        version: `git-${candidate.candidateId.toLowerCase()}`,
+        gitTag: `git-${branch}-${sha}`,
+        gitCommitHash: afterSha,
+        shippedBy: userId,
+        changeCount: 1,
+        changeSummary: summary,
+      },
+      select: { id: true },
+    });
+
+    const promotion = await tx.changePromotion.create({
+      data: {
+        promotionId,
+        productVersionId: productVersion.id,
+        status: "pending",
+        requestedBy: userId,
+        deploymentLog: buildCandidateDeploymentLog(candidate),
+      },
+      select: { id: true },
+    });
+
+    const rfc = await tx.changeRequest.create({
+      data: {
+        rfcId,
+        title: `Review Git update ${sha}`,
+        description: summary,
+        type: "normal",
+        scope: "platform",
+        riskLevel: "medium",
+        status: "draft",
+        impactReport: buildCandidateImpactReport(candidate),
+      },
+      select: { id: true },
+    });
+
+    await tx.changeItem.create({
+      data: {
+        changeRequestId: rfc.id,
+        changePromotionId: promotion.id,
+        itemType: "promotion",
+        title: `Promote Git update ${sha}`,
+        description: summary,
+        impactDescription: "Sandbox verification completed successfully; operator approval is required before production deployment.",
+        digitalProductId: platformProduct.id,
+        externalSystemRef,
+        status: "pending",
+      },
+    });
+
+    return { promotionId, rfcId };
+  });
+
+  revalidatePath("/ops/promotions");
+  return { created: true, ...result };
+}
+
+export async function createPromotionReviewFromGitCandidateForm(formData: FormData) {
+  const candidateId = String(formData.get("candidateId") ?? "");
+  if (!candidateId) throw new Error("candidateId is required");
+  await createPromotionReviewFromGitCandidate(candidateId);
+}
 
 export async function approvePromotion(promotionId: string, rationale: string) {
   const userId = await requireOpsAccess();


### PR DESCRIPTION
## Summary
- convert sandbox-verified GitPromotionCandidate rows into existing ChangePromotion and ChangeRequest review records
- dedupe handoff through ChangeItem.externalSystemRef and surface linked review state in /ops/promotions
- carry sandbox verification output into RFC impactReport and promotion deploymentLog without auto-deploying production

## Validation
- pnpm --filter web exec vitest run lib/actions/promotions.test.ts components/ops/GitPromotionCandidatesPanel.test.tsx
- pnpm --filter web typecheck
- pnpm --filter web exec next build

Note: next build passes with existing Turbopack tracing warnings around spec-plan-search and next.config.mjs NFT tracing.