### PR TITLE
test(ai): mock task runs in operations map page test

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -4,6 +4,7 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     storefrontConfig: { findFirst: vi.fn() },
     agent: { findMany: vi.fn() },
+    taskRun: { findMany: vi.fn() },
     toolExecution: { findMany: vi.fn() },
     toolExecutionReceipt: { findMany: vi.fn() },
     backlogItemActivity: { findMany: vi.fn() },
@@ -41,6 +42,7 @@ describe("AI operations map page", () => {
       },
     ] as never);
 
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.toolExecution.findMany).mockResolvedValue([
       {
         id: "tool-1",


### PR DESCRIPTION
## Summary
- Fixes the unit-test failure from PR #469 by adding the missing taskRun Prisma mock to the AI Operations Map page test.
- Keeps the change scoped to the stale test mock; production code is unchanged.

## Verification
- pnpm --filter web exec vitest run 'app/(shell)/platform/ai/operations-map/page.test.tsx'
- pnpm --filter web test

## CI context
- PR #469 merged with Unit Tests red because loadOperationsMapData now calls prisma.taskRun.findMany, but the page test mock did not define taskRun.