### PR TITLE
feat(ai): link functional failure evidence to ops review

### DIFF
--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -3,7 +3,14 @@ import { getBacklogItems, getDigitalProductsForSelect, getTaxonomyNodesFlat, get
 import { OpsClient } from "@/components/ops/OpsClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
 
-export default async function OpsPage() {
+export const dynamic = "force-dynamic";
+
+type Props = {
+  searchParams?: Promise<{ itemId?: string }>;
+};
+
+export default async function OpsPage({ searchParams }: Props) {
+  const sp = await searchParams;
   const [items, digitalProducts, taxonomyNodes, epics, portfolios] = await Promise.all([
     getBacklogItems(),
     getDigitalProductsForSelect(),
@@ -29,6 +36,7 @@ export default async function OpsPage() {
         taxonomyNodes={taxonomyNodes}
         epics={epics}
         portfolios={portfolios}
+        focusedItemId={sp?.itemId}
       />
     </div>
   );

--- a/apps/web/app/(shell)/platform/ai/operations-map/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.tsx
@@ -1,6 +1,8 @@
 import { AiOperationsMap } from "@/components/platform/AiOperationsMap";
 import { loadOperationsMapData } from "@/lib/ai-operations-map/load-map-data";
 
+export const dynamic = "force-dynamic";
+
 export default async function OperationsMapPage() {
   const data = await loadOperationsMapData();
 

--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -10,9 +10,10 @@ import { AGENT_NAME_MAP } from "@/lib/agent-routing";
 type Props = {
   item: BacklogItemWithRelations;
   onEdit: (item: BacklogItemWithRelations) => void;
+  focused?: boolean;
 };
 
-export function BacklogItemRow({ item, onEdit }: Props) {
+export function BacklogItemRow({ item, onEdit, focused = false }: Props) {
   const router = useRouter();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -43,7 +44,16 @@ export function BacklogItemRow({ item, onEdit }: Props) {
   const statusColour = BACKLOG_STATUS_COLOURS[item.status] ?? "#8888a0";
 
   return (
-    <div className="flex items-start gap-3 p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)]">
+    <div
+      id={`backlog-item-${item.itemId}`}
+      aria-current={focused ? "true" : undefined}
+      className={[
+        "flex scroll-mt-24 items-start gap-3 rounded-lg border p-3",
+        focused
+          ? "border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)]"
+          : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]",
+      ].join(" ")}
+    >
       {/* Priority badge */}
       <span className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-[10px] font-mono bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]">
         {item.priority ?? "—"}

--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -42,11 +42,13 @@ type Props = {
   sort: EpicSort;
   onEdit: (epic: EpicWithRelations) => void;
   onItemEdit: (item: BacklogItemWithRelations) => void;
+  focusedItemId?: string;
 };
 
-export function EpicCard({ epic, sort, onEdit, onItemEdit }: Props) {
+export function EpicCard({ epic, sort, onEdit, onItemEdit, focusedItemId }: Props) {
   const router = useRouter();
-  const [expanded, setExpanded] = useState(false);
+  const hasFocusedItem = epic.items.some((item) => isFocusedBacklogItem(item, focusedItemId));
+  const [expanded, setExpanded] = useState(hasFocusedItem);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isPending, startTransition] = useTransition();
 
@@ -185,7 +187,12 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit }: Props) {
           ) : (
             <div className="flex flex-col gap-1.5">
               {sortedItems(epic.items, sort).map((item) => (
-                <BacklogItemRow key={item.id} item={item} onEdit={onItemEdit} />
+                <BacklogItemRow
+                  key={item.id}
+                  item={item}
+                  onEdit={onItemEdit}
+                  focused={isFocusedBacklogItem(item, focusedItemId)}
+                />
               ))}
             </div>
           )}
@@ -193,4 +200,8 @@ export function EpicCard({ epic, sort, onEdit, onItemEdit }: Props) {
       )}
     </div>
   );
+}
+
+function isFocusedBacklogItem(item: BacklogItemWithRelations, focusedItemId?: string): boolean {
+  return Boolean(focusedItemId && (item.itemId === focusedItemId || item.id === focusedItemId));
 }

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -33,6 +33,7 @@ type Props = {
   taxonomyNodes: TaxonomyNodeSelect[];
   epics: EpicWithRelations[];
   portfolios: PortfolioForSelect[];
+  focusedItemId?: string;
 };
 
 const TYPE_LABELS: Record<string, string> = {
@@ -92,7 +93,7 @@ function SortButton({ label, field, sort, onSort }: {
   );
 }
 
-export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfolios }: Props) {
+export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfolios, focusedItemId }: Props) {
   const [panel, setPanel] = useState<ItemPanelState>({ open: false });
   const [epicPanel, setEpicPanel] = useState<EpicPanelState>(null);
   const [epicSort, setEpicSort] = useState<SortState>(null);
@@ -196,7 +197,14 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
                   </div>
                 ) : (
                   sortEpics(filteredEpics, epicSort).map((epic) => (
-                    <EpicCard key={epic.id} epic={epic} sort={epicSort} onEdit={openEditEpic} onItemEdit={openEdit} />
+                    <EpicCard
+                      key={epic.id}
+                      epic={epic}
+                      sort={epicSort}
+                      onEdit={openEditEpic}
+                      onItemEdit={openEdit}
+                      focusedItemId={focusedItemId}
+                    />
                   ))
                 )}
               </div>
@@ -246,7 +254,12 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
               ) : (
                 <div className="flex flex-col gap-2">
                   {filteredItems.map((item) => (
-                    <BacklogItemRow key={item.id} item={item} onEdit={openEdit} />
+                    <BacklogItemRow
+                      key={item.id}
+                      item={item}
+                      onEdit={openEdit}
+                      focused={isFocusedBacklogItem(item, focusedItemId)}
+                    />
                   ))}
                 </div>
               )}
@@ -280,4 +293,8 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
       />
     </>
   );
+}
+
+function isFocusedBacklogItem(item: BacklogItemWithRelations, focusedItemId?: string): boolean {
+  return Boolean(focusedItemId && (item.itemId === focusedItemId || item.id === focusedItemId));
 }

--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -163,6 +163,11 @@ describe("loadOperationsMapData", () => {
         recordedById: true,
         recordedByAgentId: true,
         toolExecutionId: true,
+        backlogItem: {
+          select: {
+            itemId: true,
+          },
+        },
       },
     });
     expect(prisma.externalEvidenceRecord.findMany).toHaveBeenCalledWith({
@@ -257,6 +262,7 @@ function makeBacklogEvidenceRow() {
     recordedById: "user-1",
     recordedByAgentId: "support-specialist",
     toolExecutionId: "tool-1",
+    backlogItem: { itemId: "BI-123" },
   };
 }
 

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -148,6 +148,11 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
         recordedById: true,
         recordedByAgentId: true,
         toolExecutionId: true,
+        backlogItem: {
+          select: {
+            itemId: true,
+          },
+        },
       },
     }),
     prisma.externalEvidenceRecord.findMany({

--- a/apps/web/lib/ai-operations-map/project-events.test.ts
+++ b/apps/web/lib/ai-operations-map/project-events.test.ts
@@ -194,7 +194,21 @@ describe("AI operations map projection", () => {
     expect(projection.severity).toBe("normal");
     expect(projection.refs.backlogItemId).toBe("BI-123");
     expect(projection.refs.toolExecutionId).toBe("tool-3");
-    expect(projection.links.backlogHref).toBe("/platform/backlog?itemId=BI-123");
+    expect(projection.links.backlogHref).toBe("/ops?itemId=BI-123");
+  });
+
+  it("projects backlog evidence links with the human-readable item id when loaded", () => {
+    const projection = projectBacklogEvidence(
+      makeBacklogEvidence({
+        id: "activity-1",
+        backlogItemId: "internal-row-id",
+        backlogItem: { itemId: "BI-123" },
+        summary: "UX verification completed",
+      }),
+    );
+
+    expect(projection.refs.backlogItemId).toBe("BI-123");
+    expect(projection.links.backlogHref).toBe("/ops?itemId=BI-123");
   });
 
   it("projects external evidence through route context and history links", () => {

--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -296,6 +296,7 @@ export function projectBacklogEvidence(
   template: OperationsMapTemplate = SOFTWARE_PLATFORM_MAP_TEMPLATE,
 ): OperationsMapProjection {
   const stationId = resolveEvidenceStationId(row.summary, template);
+  const backlogItemRef = row.backlogItem?.itemId ?? row.backlogItemId;
 
   return {
     id: `backlog-evidence:${row.id}`,
@@ -311,11 +312,11 @@ export function projectBacklogEvidence(
     summary: row.summary,
     refs: {
       backlogItemActivityId: row.id,
-      backlogItemId: row.backlogItemId,
+      backlogItemId: backlogItemRef,
       toolExecutionId: row.toolExecutionId,
     },
     links: {
-      backlogHref: `/platform/backlog?itemId=${encodeURIComponent(row.backlogItemId)}`,
+      backlogHref: `/ops?itemId=${encodeURIComponent(backlogItemRef)}`,
       authorityHref: row.toolExecutionId
         ? `/platform/audit/ledger?toolExecutionId=${encodeURIComponent(row.toolExecutionId)}`
         : undefined,

--- a/apps/web/lib/ai-operations-map/types.ts
+++ b/apps/web/lib/ai-operations-map/types.ts
@@ -79,6 +79,9 @@ export type OperationsMapToolExecutionReceipt = {
 export type OperationsMapBacklogEvidence = {
   id: string;
   backlogItemId: string;
+  backlogItem?: {
+    itemId: string;
+  } | null;
   kind: string;
   summary: string;
   payload: unknown;


### PR DESCRIPTION
## Summary
- Force the AI Operations Map and Ops backlog page to render live data for review handoffs.
- Project backlog evidence with the human-readable backlog item id when available.
- Send backlog evidence drill-downs to /ops?itemId=... and focus the matching backlog row with aria-current.

## Verification
- pnpm --filter web exec vitest run 'lib/ai-operations-map/project-events.test.ts' 'lib/ai-operations-map/load-map-data.test.ts' 'app/(shell)/platform/ai/operations-map/page.test.tsx'
- pnpm --filter web typecheck
- pnpm --filter web build
- pnpm --filter web test

## Runtime evidence from prior proof
- Controlled functional failure evidence created BI-D0EC01F9.
- Browser verification confirmed the operations map inspector showed Backlog evidence, BI-D0EC01F9, and linked to /ops?itemId=BI-D0EC01F9 where the row was focused with aria-current=true.