### PR TITLE
fix(discovery): resolve triage taxonomy FK ids

### DIFF
--- a/apps/web/lib/discovery-triage-runner.test.ts
+++ b/apps/web/lib/discovery-triage-runner.test.ts
@@ -16,6 +16,9 @@ function createRunnerDb() {
     portfolioQualityIssue: {
       findMany: vi.fn(),
     },
+    taxonomyNode: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     discoveryTriageDecision: {
       findFirst: vi.fn().mockResolvedValue(null),
       create: vi.fn().mockResolvedValue({}),
@@ -26,6 +29,12 @@ function createRunnerDb() {
 describe("runDiscoveryTriagePass", () => {
   it("auto-applies safe high-confidence matches and records the decision", async () => {
     const db = createRunnerDb();
+    db.taxonomyNode.findMany.mockResolvedValue([
+      {
+        id: "tax-node-container-platform",
+        nodeId: "foundational/platform_services/container_platform",
+      },
+    ]);
     db.inventoryEntity.findMany.mockResolvedValue([
       {
         id: "entity-1",
@@ -61,7 +70,7 @@ describe("runDiscoveryTriagePass", () => {
     expect(db.inventoryEntity.update).toHaveBeenCalledWith({
       where: { id: "entity-1" },
       data: expect.objectContaining({
-        taxonomyNodeId: "foundational/platform_services/container_platform",
+        taxonomyNodeId: "tax-node-container-platform",
         attributionStatus: "attributed",
         attributionMethod: "ai-proposed",
       }),
@@ -72,7 +81,15 @@ describe("runDiscoveryTriagePass", () => {
         actorType: "agent",
         actorId: "inventory-specialist",
         outcome: "auto-attributed",
+        selectedTaxonomyNodeId: "tax-node-container-platform",
         requiresHumanReview: false,
+        evidencePacket: expect.objectContaining({
+          candidateTaxonomy: expect.arrayContaining([
+            expect.objectContaining({
+              nodeId: "foundational/platform_services/container_platform",
+            }),
+          ]),
+        }),
       }),
     });
     expect(result.metrics.autoAttributed).toBe(1);

--- a/apps/web/lib/discovery-triage-runner.ts
+++ b/apps/web/lib/discovery-triage-runner.ts
@@ -55,6 +55,9 @@ export type DiscoveryTriageRunnerDb = {
   portfolioQualityIssue: {
     findMany(args: Record<string, unknown>): Promise<DiscoveryTriageRunnerIssue[]>;
   };
+  taxonomyNode: {
+    findMany(args: Record<string, unknown>): Promise<Array<{ id: string; nodeId: string }>>;
+  };
   discoveryTriageDecision: {
     findFirst(args: Record<string, unknown>): Promise<{ decisionId: string } | null>;
     create(args: { data: Record<string, unknown> }): Promise<unknown>;
@@ -181,6 +184,38 @@ function finalizeMetrics(metrics: DiscoveryTriageRunMetrics): DiscoveryTriageRun
   };
 }
 
+async function loadTaxonomyNodeLookup(
+  db: DiscoveryTriageRunnerDb,
+  entities: DiscoveryTriageRunnerEntity[],
+): Promise<Map<string, string>> {
+  const candidateIds = new Set<string>();
+  for (const entity of entities) {
+    for (const candidate of normalizeCandidateTaxonomy(entity.candidateTaxonomy)) {
+      if (candidate.nodeId.trim()) candidateIds.add(candidate.nodeId);
+    }
+  }
+
+  if (candidateIds.size === 0) return new Map();
+
+  const candidates = [...candidateIds];
+  const nodes = await db.taxonomyNode.findMany({
+    where: {
+      OR: [
+        { id: { in: candidates } },
+        { nodeId: { in: candidates } },
+      ],
+    },
+    select: { id: true, nodeId: true },
+  });
+
+  const lookup = new Map<string, string>();
+  for (const node of nodes) {
+    lookup.set(node.id, node.id);
+    lookup.set(node.nodeId, node.id);
+  }
+  return lookup;
+}
+
 export async function runDiscoveryTriagePass(
   db: DiscoveryTriageRunnerDb = prisma as unknown as DiscoveryTriageRunnerDb,
   options: {
@@ -217,6 +252,7 @@ export async function runDiscoveryTriagePass(
     }),
   ]);
 
+  const taxonomyNodeIdByCandidate = await loadTaxonomyNodeLookup(db, entities);
   const issueByEntityId = new Map(
     issues
       .filter((issue) => issue.inventoryEntityId)
@@ -240,7 +276,10 @@ export async function runDiscoveryTriagePass(
     const outcome = resolveDiscoveryTriageOutcome(score, packetWithRunMetadata, thresholds);
     const requiresHumanReview = outcome === "human-review" || outcome === "taxonomy-gap";
     const autoApply = shouldAutoApplyTriageDecision(score, packetWithRunMetadata, thresholds);
-    const selectedTaxonomyNodeId = packetWithRunMetadata.candidateTaxonomy[0]?.nodeId ?? null;
+    const selectedTaxonomyCandidateId = packetWithRunMetadata.candidateTaxonomy[0]?.nodeId ?? null;
+    const selectedTaxonomyNodeId = selectedTaxonomyCandidateId
+      ? taxonomyNodeIdByCandidate.get(selectedTaxonomyCandidateId) ?? null
+      : null;
     const selectedIdentity = packetWithRunMetadata.identityCandidates[0]
       ? {
           label: packetWithRunMetadata.identityCandidates[0].identity,
@@ -250,7 +289,10 @@ export async function runDiscoveryTriagePass(
         }
       : null;
     const proposedRule = outcome === "auto-attributed"
-      ? synthesizeDiscoveryFingerprintRule(packetWithRunMetadata, score, thresholds)
+      ? withResolvedProposedRuleTaxonomyNodeId(
+        synthesizeDiscoveryFingerprintRule(packetWithRunMetadata, score, thresholds),
+        selectedTaxonomyNodeId,
+      )
       : null;
 
     if (autoApply && selectedTaxonomyNodeId) {
@@ -359,6 +401,17 @@ export async function runDiscoveryTriageDaily(
     runIdempotencyKey,
     thresholds: options.thresholds,
   });
+}
+
+function withResolvedProposedRuleTaxonomyNodeId<T extends { taxonomyNodeId: string } | null>(
+  proposedRule: T,
+  selectedTaxonomyNodeId: string | null,
+): T {
+  if (!proposedRule || !selectedTaxonomyNodeId) return proposedRule;
+  return {
+    ...proposedRule,
+    taxonomyNodeId: selectedTaxonomyNodeId,
+  };
 }
 
 export async function maybeTriggerDiscoveryTriageForVolume(


### PR DESCRIPTION
## Summary
- resolve discovery triage candidate taxonomy slugs to canonical TaxonomyNode IDs before FK writes
- keep the original candidate slug in the evidence packet for audit/provenance
- add a regression test covering auto-apply and decision FK writes

## Verification
- pnpm --filter web exec vitest run lib/discovery-triage-runner.test.ts
- pnpm --filter web exec vitest run lib/discovery-triage-runner.test.ts lib/actions/agent-task-scheduler.test.ts lib/mcp-tools.test.ts
- pnpm --filter web typecheck
- docker compose -p dpf --env-file D:\DPF\.env build portal portal-init
- live governed call: POST /api/mcp/call run_discovery_triage returned success and created a DiscoveryTriageDecision linked to TaxonomyNode.id while preserving candidateTaxonomy[0].nodeId in evidence

## Backlog
- Addresses BI-594D404E / BI-PIR-aefc9f63 / BI-942F3D00 duplicate cluster