### PR TITLE
[codex] doc(wiki): close review follow-ups

### DIFF
--- a/docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md
+++ b/docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md
@@ -15,7 +15,7 @@
 Each phase ends with all four passing:
 
 1. Unit tests — `pnpm --filter <pkg> exec vitest run` for affected files.
-2. Production build — `cd apps/web && npx next build` with zero errors.
+2. Production build — `pnpm --filter web exec next build` with zero errors.
 3. UX verification — exercise the affected path against the running app.
 4. Migration applies cleanly — if a migration was added.
 
@@ -82,7 +82,7 @@ Adds the new wiki models and Qdrant collection without touching `KnowledgeArticl
 - Qdrant collection `wiki-pages` exists with the documented payload indexes after `ensureCollections()` + `ensurePayloadIndexes()` run.
 - Helpers round-trip a kernel page and an org override; uniqueness on `(organizationId, slug)` is enforced.
 - `KnowledgeArticle` UI / routes / actions / MCP tools continue to function (touched by no changes).
-- Build gate green: `pnpm typecheck`, `cd apps/web && npx next build`, vitest on the new test file.
+- Build gate green: `pnpm --filter web typecheck`, `pnpm --filter web exec next build`, vitest on the new test file.
 
 ### Phase 1b — Deprecate `KnowledgeArticle` once kernel content validates the new models (later PR)
 
@@ -306,7 +306,7 @@ Reuses the existing `@xyflow/react` v12 + `elkjs` v0.11.1 toolchain from Phase E
 
 1. **Migration apply**: `pnpm --filter @dpf/db exec prisma migrate dev` against fresh + existing DBs; both clean.
 2. **Seed**: `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts` produces kernel rows + Qdrant points; `manifest.json` counts match DB.
-3. **Build gate**: `pnpm --filter web typecheck` and `cd apps/web && npx next build` clean.
+3. **Build gate**: `pnpm --filter web typecheck` and `pnpm --filter web exec next build` clean.
 4. **Tests**: per-phase test suites green.
 5. **MCP tool exercise**: from a coworker chat, call `wiki_query` for a kernel concept and verify a kernel page returns; call `wiki_propose_edit` against the same slug, approve the override, re-query and verify the override masks the kernel; call `wiki_ingest` on a sample source and verify the draft revision + `WikiIngestEvent`.
 6. **Lint**: trigger the scheduled job manually; verify each detector produces its expected finding on the seeded fixture; verify findings page renders with theme tokens.

--- a/docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md
+++ b/docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md
@@ -93,7 +93,7 @@ This design applies that pattern to a multi-tenant SaaS: the kernel ships in the
 | P3 | **Two-layer overlay with explicit lineage** | Kernel pages and per-org overrides are physically separate rows joined by `kernelPageId` + `derivedFromKernelVersion`. Kernel upgrades cleanly; drift is a first-class lint signal. |
 | P4 | **Source-cite enforcement** | Every published page cites at least one `RawSource`. Lint blocks publish if `WikiPageSource[]` is empty or if any `[[link]]` is dangling. |
 | P5 | **Schema-grounded ingest** | The LLM slots claims into a canonical entity registry defined in `SCHEMA.md`. New entities require an explicit `propose_new` step. |
-| P6 | **Reuse, don't duplicate** | Bridge `WikiPage.linkedArticleId → KnowledgeArticle`. Add `RawSource` as a standalone primitive rather than overload `EvidenceSource` (which is FK-bound to `EvidenceBundle` for deliberation). |
+| P6 | **Reuse, don't duplicate** | Absorb the `KnowledgeArticle` shape into `WikiPage` over the staged migration path in §11. Add `RawSource` as a standalone primitive rather than overload `EvidenceSource` (which is FK-bound to `EvidenceBundle` for deliberation). |
 
 ---
 
@@ -216,7 +216,6 @@ model WikiPage {
   inLinks                  WikiPageLink[] @relation("WikiInLinks")
   sources                  WikiPageSource[]
 
-  @@unique([organizationId, slug])
   @@index([slug])
   @@index([pageKind])
   @@index([status])
@@ -289,6 +288,20 @@ model WikiLintFinding {
   @@index([findingKind])
 }
 ```
+
+**Slug uniqueness note.** The schema block omits slug uniqueness because Prisma cannot express the exact Postgres constraint needed for nullable `organizationId`: a normal `@@unique([organizationId, slug])` would still allow duplicate kernel rows where `organizationId IS NULL`. Phase 1a must add partial unique indexes in the migration SQL:
+
+```sql
+CREATE UNIQUE INDEX "WikiPage_kernel_slug_key"
+  ON "WikiPage" ("slug")
+  WHERE "organizationId" IS NULL;
+
+CREATE UNIQUE INDEX "WikiPage_org_slug_key"
+  ON "WikiPage" ("organizationId", "slug")
+  WHERE "organizationId" IS NOT NULL;
+```
+
+These two indexes are load-bearing for kernel fallback, overlay masking, and kernel-drift detection.
 
 ### 4.2 Relations Added to Existing Models
 
@@ -460,5 +473,5 @@ Implementation note: because `KnowledgeArticle` carries zero production rows, th
 
 - `wiki_resolve_drift` 3-way merge tool.
 - Neo4j projection of `WikiPage` / `RawSource` for graph traversal — same pattern as today's `DigitalProduct` projection. Add when a query pattern emerges that Postgres + Qdrant cannot answer cleanly.
-- Promotion of `wiki_query` answers into `KnowledgeArticle` rows.
+- Promotion of `wiki_query` answers into draft `WikiPage` rows.
 - Search-rank tuning across `wiki-pages` + `platform-knowledge` + `agent-memory`.


### PR DESCRIPTION
## Summary
- Replaces stale WikiPage-to-KnowledgeArticle bridge language with the staged absorption path.
- Documents Postgres partial unique indexes for kernel and org wiki slugs instead of nullable compound uniqueness.
- Updates wiki plan build-gate commands to pinned pnpm workspace commands.

## Validation
- rg checks for the stale bridge/build-command markers.
- git diff --check.