### PR TITLE
Add operations map saved view preferences

### DIFF
--- a/apps/web/components/platform/ai-operations-map-prefs.test.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.test.ts
@@ -2,9 +2,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getOperationsMapQuickViewFilters } from "@/lib/ai-operations-map/project-events";
 import {
   clearOperationsMapViewPreference,
+  deleteOperationsMapSavedView,
   loadOperationsMapViewPreference,
+  loadOperationsMapSavedViews,
+  OPERATIONS_MAP_SAVED_VIEWS_KEY,
   OPERATIONS_MAP_VIEW_PREFERENCE_KEY,
   saveOperationsMapViewPreference,
+  upsertOperationsMapSavedView,
 } from "./ai-operations-map-prefs";
 
 const store = new Map<string, string>();
@@ -96,5 +100,92 @@ describe("AI operations map preferences", () => {
       quickViewId: "all",
       filters: getOperationsMapQuickViewFilters("all"),
     });
+  });
+
+  it("defaults saved operator views to an empty list", () => {
+    expect(loadOperationsMapSavedViews()).toEqual([]);
+  });
+
+  it("adds and updates saved operator views", () => {
+    upsertOperationsMapSavedView({
+      id: "failed-tools",
+      name: "Failed tool runs",
+      filters: {
+        sources: ["tool-execution"],
+        severities: ["warning", "critical"],
+      },
+    });
+    upsertOperationsMapSavedView({
+      id: "failed-tools",
+      name: "Failed tool activity",
+      filters: {
+        sources: ["task-run", "tool-execution"],
+        severities: ["attention", "warning", "critical"],
+      },
+    });
+
+    expect(loadOperationsMapSavedViews()).toEqual([
+      {
+        id: "failed-tools",
+        name: "Failed tool activity",
+        filters: {
+          sources: ["task-run", "tool-execution"],
+          severities: ["attention", "warning", "critical"],
+        },
+      },
+    ]);
+    expect(store.has(OPERATIONS_MAP_SAVED_VIEWS_KEY)).toBe(true);
+  });
+
+  it("deletes saved operator views by id", () => {
+    upsertOperationsMapSavedView({
+      id: "evidence-only",
+      name: "Evidence only",
+      filters: getOperationsMapQuickViewFilters("evidence"),
+    });
+
+    deleteOperationsMapSavedView("evidence-only");
+
+    expect(loadOperationsMapSavedViews()).toEqual([]);
+  });
+
+  it("ignores invalid saved operator views from storage", () => {
+    store.set(OPERATIONS_MAP_SAVED_VIEWS_KEY, JSON.stringify([
+      {
+        id: "valid",
+        name: "Valid",
+        filters: {
+          sources: ["tool-execution"],
+          severities: ["normal"],
+        },
+      },
+      {
+        id: "",
+        name: "Missing id",
+        filters: {
+          sources: ["tool-execution"],
+          severities: ["normal"],
+        },
+      },
+      {
+        id: "bad-source",
+        name: "Bad source",
+        filters: {
+          sources: ["unknown"],
+          severities: ["normal"],
+        },
+      },
+    ]));
+
+    expect(loadOperationsMapSavedViews()).toEqual([
+      {
+        id: "valid",
+        name: "Valid",
+        filters: {
+          sources: ["tool-execution"],
+          severities: ["normal"],
+        },
+      },
+    ]);
   });
 });

--- a/apps/web/components/platform/ai-operations-map-prefs.ts
+++ b/apps/web/components/platform/ai-operations-map-prefs.ts
@@ -10,11 +10,18 @@ import type {
 } from "@/lib/ai-operations-map/types";
 
 export const OPERATIONS_MAP_VIEW_PREFERENCE_KEY = "ai-operations-map:view";
+export const OPERATIONS_MAP_SAVED_VIEWS_KEY = "ai-operations-map:saved-views";
 
 export type OperationsMapStoredQuickViewId = OperationsMapQuickViewId | "custom";
 
 export type OperationsMapViewPreference = {
   quickViewId: OperationsMapStoredQuickViewId;
+  filters: OperationsMapProjectionFilters;
+};
+
+export type OperationsMapSavedView = {
+  id: string;
+  name: string;
   filters: OperationsMapProjectionFilters;
 };
 
@@ -67,6 +74,44 @@ export function clearOperationsMapViewPreference(): void {
   }
 }
 
+export function loadOperationsMapSavedViews(): OperationsMapSavedView[] {
+  try {
+    const raw = localStorage.getItem(OPERATIONS_MAP_SAVED_VIEWS_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(isSavedView).map((view) => ({
+      id: view.id,
+      name: view.name,
+      filters: {
+        sources: [...view.filters.sources],
+        severities: [...view.filters.severities],
+      },
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export function upsertOperationsMapSavedView(view: OperationsMapSavedView): void {
+  const normalized = normalizeSavedView(view);
+  if (!normalized) return;
+
+  const existing = loadOperationsMapSavedViews();
+  const next = [
+    normalized,
+    ...existing.filter((candidate) => candidate.id !== normalized.id),
+  ];
+  saveOperationsMapSavedViews(next);
+}
+
+export function deleteOperationsMapSavedView(viewId: string): void {
+  const next = loadOperationsMapSavedViews().filter((view) => view.id !== viewId);
+  saveOperationsMapSavedViews(next);
+}
+
 function isStoredQuickViewId(value: unknown): value is OperationsMapStoredQuickViewId {
   return value === "custom" || (typeof value === "string" && ALL_QUICK_VIEW_IDS.has(value as OperationsMapQuickViewId));
 }
@@ -81,4 +126,35 @@ function isValidFilters(value: unknown): value is OperationsMapProjectionFilters
     filters.sources.every((source): source is OperationsMapProjectionSource => ALL_SOURCES.has(source)) &&
     filters.severities.every((severity): severity is OperationsMapSeverity => ALL_SEVERITIES.has(severity))
   );
+}
+
+function saveOperationsMapSavedViews(views: OperationsMapSavedView[]): void {
+  try {
+    localStorage.setItem(OPERATIONS_MAP_SAVED_VIEWS_KEY, JSON.stringify(views));
+  } catch {
+    // localStorage can be unavailable or full; saved views are an operator convenience.
+  }
+}
+
+function normalizeSavedView(view: OperationsMapSavedView): OperationsMapSavedView | null {
+  const id = view.id.trim();
+  const name = view.name.trim();
+  if (!id || !name || !isValidFilters(view.filters)) return null;
+
+  return {
+    id,
+    name,
+    filters: {
+      sources: [...view.filters.sources],
+      severities: [...view.filters.severities],
+    },
+  };
+}
+
+function isSavedView(value: unknown): value is OperationsMapSavedView {
+  if (typeof value !== "object" || value === null) return false;
+  const view = value as Partial<OperationsMapSavedView>;
+  return typeof view.id === "string" && view.id.trim() !== ""
+    && typeof view.name === "string" && view.name.trim() !== ""
+    && isValidFilters(view.filters);
 }


### PR DESCRIPTION
## Summary
- Add local-storage backed saved operator view preferences for the AI Operations Map
- Store saved views as id, name, and validated source/severity filters
- Add upsert, delete, load, and invalid-data filtering coverage

## Verification
- pnpm --filter web exec vitest run components/platform/ai-operations-map-prefs.test.ts
- pnpm --filter web exec vitest run lib/ai-operations-map 'app/(shell)/platform/ai/operations-map/page.test.tsx' components/platform/AiOperationsMap.test.tsx components/platform/ai-operations-map-prefs.test.ts
- pnpm --filter web typecheck
- pnpm --filter web exec next build