### PR TITLE
fix(ai): isolate scheduled agent execution context

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -235,6 +235,54 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
     );
   });
 
+  it("uses the structured scheduled summary for task-facing agent messages when a triage tool ran", async () => {
+    arrangeScheduledTask();
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "I stopped because I was still describing work without using the required tools.",
+      executedTools: [
+        {
+          name: "run_discovery_triage",
+          args: { trigger: "cadence" },
+          result: {
+            success: true,
+            message: "ok",
+            data: {
+              trigger: "cadence",
+              processedAt: "2026-05-12T00:25:12.506Z",
+              runIdempotencyKey: "2026-05-12:inventory-specialist:cadence",
+              metrics: {
+                processed: 1,
+                decisionsCreated: 1,
+                autoAttributed: 0,
+                humanReview: 0,
+                taxonomyGap: 0,
+                needsMoreEvidence: 1,
+                dismissed: 0,
+                escalationQueueDepth: 0,
+                repeatUnresolved: 1,
+                autoApplyRate: 0,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    const agentTaskMessage = mocks.prisma.taskMessage.create.mock.calls.find(
+      ([args]) => args.data.role === "agent",
+    )?.[0];
+
+    expect(agentTaskMessage?.data.parts).toEqual([
+      {
+        type: "message",
+        text: expect.stringContaining("Discovery triage cadence processed=1"),
+      },
+    ]);
+    expect(agentTaskMessage?.data.parts[0].text).not.toContain("I stopped because");
+  });
+
   it("marks the TaskRun failed and preserves the next schedule when the loop throws", async () => {
     arrangeScheduledTask();
     mocks.runAgenticLoop.mockRejectedValue(new Error("LLM unavailable"));
@@ -260,6 +308,32 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
           taskRunId: "TR-SCHED-ABCDE",
           nextRunAt: expect.any(Date),
         }),
+      }),
+    );
+  });
+
+  it("executes scheduled tasks with only the current scheduled prompt, not stale thread history", async () => {
+    arrangeScheduledTask();
+    mocks.prisma.agentMessage.findMany.mockResolvedValue([
+      { role: "user", content: "Prior scheduled prompt." },
+      { role: "assistant", content: "Previous tool failure." },
+      { role: "assistant", content: "[Scheduled summary: old run]" },
+    ]);
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "Done.",
+      executedTools: [],
+    });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    expect(mocks.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatHistory: [
+          {
+            role: "user",
+            content: "[Scheduled task: Discovery Taxonomy Gap Triage]\n\nTriage taxonomy gaps.",
+          },
+        ],
       }),
     );
   });

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -242,17 +242,13 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       userContext,
     );
 
-    // Build message history
-    const rawMessages = await prisma.agentMessage.findMany({
-      where: { threadId: thread.id },
-      orderBy: { createdAt: "asc" },
-      take: 20,
-      select: { role: true, content: true },
-    });
-    const chatHistory = rawMessages.map((m) => ({
-      role: m.role as "user" | "assistant" | "system",
-      content: m.content,
-    }));
+    const scheduledPrompt = `[Scheduled task: ${task.title}]\n\n${task.prompt}`;
+    const chatHistory = [
+      {
+        role: "user" as const,
+        content: scheduledPrompt,
+      },
+    ];
 
     const { runAgenticLoop } = await import("@/lib/tak/agentic-loop");
     const { getAvailableTools, toolsToOpenAIFormat, executeTool } = await import(
@@ -275,6 +271,9 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       taskRunId: taskRunRef.taskRunId,
     });
 
+    const scheduledSummary = extractDiscoveryTriageSummary(result.executedTools);
+    const taskMessageContent = scheduledSummary?.compactStatus ?? result.content ?? "(No response)";
+
     // Persist agent response
     await prisma.agentMessage.create({
       data: {
@@ -291,7 +290,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       taskRunRecordId: taskRunRef.id,
       contextId: taskRunRef.contextId,
       role: "agent",
-      content: result.content ?? "(No response)",
+      content: taskMessageContent,
       metadata: {
         source: "scheduled",
         taskId: task.taskId,
@@ -299,7 +298,6 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       },
     });
 
-    const scheduledSummary = extractDiscoveryTriageSummary(result.executedTools);
     if (scheduledSummary) {
       await prisma.agentMessage.create({
         data: {


### PR DESCRIPTION
## Summary
- execute scheduled agent runs with only the current scheduled prompt instead of stale thread history
- keep AgentThread/TaskRun persistence for audit while preventing old assistant/tool failure text from contaminating the next autonomous run
- prefer structured scheduled summaries for task-facing TaskMessage content when discovery triage tools run

## Verification
- pnpm --filter web exec vitest run lib/actions/agent-task-scheduler.test.ts
- pnpm --filter web exec vitest run lib/actions/agent-task-scheduler.test.ts lib/discovery-triage-runner.test.ts lib/ai-operations-map/project-events.test.ts lib/ai-operations-map/load-map-data.test.ts lib/api/__tests__/internal-task-endpoints.test.ts
- pnpm --filter web typecheck
- git diff --check
- docker compose -p dpf --env-file D:\DPF\.env build portal portal-init
- live scheduled run from this branch: TR-SCHED-06B5BCA5 completed with executedToolCount=1 and linked successful run_discovery_triage ToolExecution

## Notes
The prior merged-main rerun proved dispatcher execution but failed before tool use because configured inference endpoints were unavailable or incompatible: Codex OAuth required re-authentication, anthropic-sub was rate-limited, and local rejected stale assistant-prefill context. This patch removes the stale scheduled-job context source.