### PR TITLE
test(operations-map): mock prisma.taskRun.findMany (drains 1 from issue #104)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx
@@ -4,6 +4,7 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     storefrontConfig: { findFirst: vi.fn() },
     agent: { findMany: vi.fn() },
+    taskRun: { findMany: vi.fn() },
     toolExecution: { findMany: vi.fn() },
     toolExecutionReceipt: { findMany: vi.fn() },
     backlogItemActivity: { findMany: vi.fn() },
@@ -59,6 +60,7 @@ describe("AI operations map page", () => {
       },
     ] as never);
     vi.mocked(prisma.toolExecutionReceipt.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.backlogItemActivity.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.externalEvidenceRecord.findMany).mockResolvedValue([] as never);
 


### PR DESCRIPTION
## Summary

Drains one item from issue #104 (Unit Tests broken-test backlog). PR #429 (AI operations map) added `prisma.taskRun.findMany` to `load-map-data.ts` but didn&#39;t add `taskRun` to the page test&#39;s `@dpf/db` mock, so the test was failing on every commit with:

```
TypeError: Cannot read properties of undefined (reading 'findMany')
  at loadOperationsMapData lib/ai-operations-map/load-map-data.ts:68:20
```

Surfaced while triaging the Unit Tests failure on PR #469. The test isn&#39;t in that PR&#39;s territory but the fix is small enough to land as a standalone drive-by.

## What changed

`apps/web/app/(shell)/platform/ai/operations-map/page.test.tsx` (+2 lines):
- Added `taskRun: { findMany: vi.fn() }` to the `vi.mock("@dpf/db")` block.
- Added `vi.mocked(prisma.taskRun.findMany).mockResolvedValue([] as never)` inside the test so the loader gets an empty array (matches what the rest of the test&#39;s assertions already assume).

## Build gate

| Check | Result |
|-------|--------|
| `pnpm --filter web test --run operations-map` | ✓ 22/22 across 4 test files (was 21/22 with 1 failure on `main`) |

## Independent of in-flight work

Drive-by fix. Drains one issue-#104 item; doesn&#39;t touch any wiki code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_