### PR TITLE
docs(installer): pivot framing from defensive 'preview' to inviting 'early access'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,25 @@ Both modes include the full platform with AI coworkers, Build Studio sandbox, an
 | Platform | Install command | Full guide | Status |
 |----------|-----------------|------------|--------|
 | **Windows 10/11** | `powershell -ExecutionPolicy Bypass -File install-dpf.ps1` | (see below) | **GA** — production usage by real users |
-| **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) | **preview** — code shipped, runtime verification pending |
-| **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) | **preview** — code shipped, runtime verification pending |
+| **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) | **Early access — try it!** |
+| **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) | **Early access — try it!** |
 
-The macOS and Linux installers have all their code on `main` and pass static CI gates (`shellcheck`, `docker compose config`, `install-dpf.sh --dry-run`), but the end-to-end runtime path has not yet been verified on real hardware. An ubuntu-latest end-to-end CI gate runs the full install on demand (`.github/workflows/install-verification.yml`); Apple Silicon, distro coverage beyond Ubuntu, and autostart-after-reboot still need fresh-hardware verification per [docs/install/verification-runbook.md](docs/install/verification-runbook.md) before either tier is promoted to GA.
+#### Calling all macOS / Linux early adopters
+
+The macOS and Linux installers are **code-complete and merged on `main`**. Static CI gates (`shellcheck`, `docker compose config`, `install-dpf.sh --dry-run`) are green, and an on-demand end-to-end install gate runs the full stack on `ubuntu-latest` ([`.github/workflows/install-verification.yml`](.github/workflows/install-verification.yml)).
+
+What we **haven't** done — and what you can help with — is run the full install on real hardware in the wild. If you have:
+
+- **An Apple Silicon Mac (M1 / M2 / M3 / M4)** running macOS 14+
+- **A real Linux box** (Ubuntu 22.04+ / Debian 12+ / Fedora 39+ — bonus points for non-Ubuntu distros)
+- **A TAPPaaS environment** you'd like to pilot DPF into
+- **A cloud VM** (EC2 / Compute Engine / Azure VM) to run the headless install
+
+…please try it and tell us how it went. Both happy-path success stories and "the installer hit a wall at step X" failures are equally useful — the wall-hits are how we close the gap between "we believe it works" and "we know it works."
+
+**How to report:** open a GitHub issue titled `Install verification — <platform> <distro/version>` and attach the diagnostic bundle produced by `bash install-dpf.sh doctor` (it lives at `~/.dpf/doctor-<timestamp>.tar.gz` and redacts secrets automatically). The [verification runbook](docs/install/verification-runbook.md) lists what to check and what artifacts to capture.
+
+The Windows installer remains the only GA path — production stable, used by real customers. The macOS / Linux paths graduate from "Early access" to "GA" once we have a handful of community verification reports per platform.
 
 Choose your mode when prompted. The installer handles Docker (Desktop on Windows / Mac, distro pkg manager on Linux), hardware detection, AI model selection, credential generation, and auto-start. Expect 5–10 minutes for the platform itself, plus additional time for the initial AI model download.
 
@@ -239,7 +254,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | EA Modeling | ArchiMate 4 canvas, viewpoints, relationship rules, structured value streams |
 | AI Provider Registry | 17 providers, credential management, model discovery, profiling, cost tracking |
 | AI Coworker | Live LLM conversations, automatic failover, context-aware skills dropdown |
-| Docker Deployment | Zero-prerequisites Windows installer (GA — production usage). Code-complete macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) installers in **preview** — static CI gates green, runtime verification matrix in flight per [docs/install/verification-runbook.md](docs/install/verification-runbook.md). Multi-arch GHCR images. Lifecycle scripts on all three platforms. |
+| Docker Deployment | Zero-prerequisites Windows installer (GA — production usage). Code-complete macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) installers in **early access** — static CI gates green, [community verification reports](docs/install/verification-runbook.md) wanted to graduate to GA. Multi-arch GHCR images. Lifecycle scripts on all three platforms. |
 
 ### What's coming
 
@@ -250,7 +265,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | **AI-Guided Setup Wizard** | On first install, the AI coworker walks you through company setup conversationally — no forms, just a conversation. |
 | **In-App PR Workflow** | Submit customizations back to the community directly from the platform UI. |
 | **Web-Hosted SaaS** | Customer-cloud deployment via Terraform on AWS / GCP / Azure — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). DPF stays single-tenant; "SaaS" here means "customer hosts on rented compute," not multi-tenant. |
-| **Mac & Linux Installers** | Code is complete for native macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)) and merged on `main`. Currently **preview** — runtime verification on real hardware is the remaining gate before GA promotion. The [installer-parity roadmap](docs/superpowers/plans/2026-05-09-macos-linux-native-support.md) ships code; the [verification runbook](docs/install/verification-runbook.md) tracks the end-to-end gates that need to land before either tier is promoted. |
+| **Mac & Linux Installers** | Code-complete and merged on `main` for native macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)). Currently **early access** — please try it on your hardware and [tell us how it went](docs/install/verification-runbook.md). A handful of community verification reports per platform is what we need to graduate to GA. |
 | **TAPPaaS Module** | Self-hosted private-platform packaging via [TAPPaaS](https://tappaas.org/) — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). |
 
 ---

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -3,15 +3,23 @@
 This is the end-user install guide for the Open Digital Product Factory
 on **native Linux Docker Engine** (no Docker Desktop).
 
-> **Status: preview.** The Linux installer code is complete and passes
-> static CI gates. An on-demand end-to-end install gate runs the full
-> compose stack on `ubuntu-latest`
-> ([`.github/workflows/install-verification.yml`](../../.github/workflows/install-verification.yml));
-> distro coverage beyond Ubuntu (Debian 12, Fedora 39) and the
-> autostart-after-reboot path still need fresh-hardware verification
-> per [verification-runbook.md](verification-runbook.md) before
-> promotion to GA. The Windows installer remains the only GA install
-> surface today.
+> **Status: Early access — please try it!**
+>
+> The Linux installer is code-complete and passes static CI gates.
+> An on-demand end-to-end install gate runs the full compose stack
+> on `ubuntu-latest`
+> ([`.github/workflows/install-verification.yml`](../../.github/workflows/install-verification.yml)),
+> but we still need real-world reports on **distros beyond Ubuntu**
+> (Debian 12+, Fedora 39+) and on the **autostart-after-reboot** path
+> — neither of which CI can exercise.
+>
+> **If you run Debian, Fedora, or a Linux VM you can spare for an
+> hour, please try the install and [tell us how it went](#help-us-graduate-to-ga).**
+> Happy paths and failures are equally useful. A handful of community
+> verification reports is what we need to flip this guide from
+> "early access" to "GA."
+>
+> The Windows installer remains the only GA install surface today.
 
 For the architectural background, see the
 [installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
@@ -244,6 +252,48 @@ in by default. To opt out:
 
 `loginctl disable-linger $USER` is **not** run automatically; if you
 enabled lingering only for DPF, disable it manually after uninstall.
+
+## Help us graduate to GA
+
+The CI gate proves the install path works on `ubuntu-latest`. What
+it doesn't prove: that it works on your specific distro, your specific
+kernel, your specific Docker version, with your specific user setup.
+**That's where you come in.**
+
+**One-minute report:**
+
+1. Open a [new GitHub issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new)
+   titled `Install verification — Linux <distro> <version>`
+   (example: `Install verification — Linux Debian 12.6 (cloud VM)`).
+2. Paste the output of:
+   ```bash
+   uname -srm && cat /etc/os-release | head -5
+   docker --version 2>/dev/null && docker compose version 2>/dev/null
+   echo "DPF version: $(grep DPF_INSTALLER_VERSION install-dpf.sh)"
+   ```
+3. Note which steps you completed from the
+   [verification runbook §1](verification-runbook.md#1-linux-end-to-end-install-real-distro-coverage)
+   and which (if any) failed.
+4. Attach the doctor bundle:
+   ```bash
+   bash install-dpf.sh doctor
+   # Then attach ~/.dpf/doctor-<timestamp>.tar.gz to the issue.
+   # Secrets are redacted automatically.
+   ```
+
+We especially want reports from:
+
+- **Debian 12+** (similar to Ubuntu but uses different package
+  defaults; auto-install via `apt` path)
+- **Fedora 39+** (different package manager — `dnf` — and SELinux
+  context)
+- **A real reboot** verifying `systemctl --user` + `loginctl
+  enable-linger` survives session loss
+- **Air-gapped or restricted-egress installs** if you have a relevant
+  environment
+
+Any subset is useful. We don't need every checkbox before reading your
+report — we'll integrate findings as they arrive.
 
 ## Going further
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -3,14 +3,21 @@
 This is the end-user install guide for the Open Digital Product Factory
 on **Apple Silicon Macs** (M1 / M2 / M3 / M4).
 
-> **Status: preview.** The macOS installer code is complete and passes
-> static CI gates, but end-to-end runtime verification on real Apple
-> Silicon hardware has not yet been completed (the `macos-14` GHA
-> runner can't nest-virtualize Docker Desktop, so CI only exercises
-> the `--dry-run` path). See
-> [verification-runbook.md](verification-runbook.md) for the matrix
-> that needs to land before promoting to GA. The Windows installer
-> remains the only GA install surface today.
+> **Status: Early access — please try it!**
+>
+> The macOS installer is code-complete and passes static CI gates.
+> What it hasn't seen yet is a real install on a real Apple Silicon
+> Mac in the wild — the `macos-14` GHA runner can't nest-virtualize
+> Docker Desktop, so CI only exercises the `--dry-run` path.
+>
+> **If you have an Apple Silicon Mac, you can change that.** Follow
+> the steps below, then [tell us how it went](#help-us-graduate-to-ga)
+> — both success stories and "the installer hit a wall at step X"
+> reports are equally useful. A handful of community verification
+> reports is what we need to flip this guide from "early access" to
+> "GA."
+>
+> The Windows installer remains the only GA install surface today.
 
 For the architectural background, see the
 [installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
@@ -203,6 +210,46 @@ The portal is still running at `http://localhost:3000`.
 | `bash uninstall-dpf.sh --purge` | Above + all DPF docker volumes (filtered by the `com.docker.compose.project=dpf` label so other stacks on the same host are untouched), `.env`, `~/.dpf`. Destructive — irreversible. |
 | `bash uninstall-dpf.sh --purge --keep-env` | Purge but retain `.env`. |
 | `bash uninstall-dpf.sh --purge --keep-state` | Purge but retain `~/.dpf` install history. |
+
+## Help us graduate to GA
+
+We can't run this installer on real Apple Silicon hardware from CI
+(the GHA `macos-14` runner can't nest-virtualize Docker Desktop), so
+the path from "early access" to "GA" runs through the community.
+If you ran the install above on a real Mac, **please file a quick
+report** — happy paths and failures are equally valuable.
+
+**One-minute report:**
+
+1. Open a [new GitHub issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new)
+   titled `Install verification — macOS <version> <arch>`
+   (example: `Install verification — macOS 14.5 arm64 (M2 Pro)`).
+2. Paste the output of:
+   ```bash
+   sw_vers && uname -srm
+   docker --version 2>/dev/null
+   echo "DPF version: $(grep DPF_INSTALLER_VERSION install-dpf.sh)"
+   ```
+3. Note which steps you completed from the
+   [verification runbook §2](verification-runbook.md#2-macos-apple-silicon-end-to-end-install)
+   and which (if any) failed.
+4. Attach the doctor bundle:
+   ```bash
+   bash install-dpf.sh doctor
+   # Then attach ~/.dpf/doctor-<timestamp>.tar.gz to the issue.
+   # Secrets are redacted automatically; you can review the bundle
+   # before sending.
+   ```
+
+The verification runbook also covers:
+
+- LaunchAgent surviving an actual reboot
+- Docker Desktop `.dmg` install flow on a Gatekeeper-fresh machine
+- Discovery collectors emitting real `pkgutil` / `brew` data
+- LLM provider round-trip (Model Runner)
+
+Any subset is useful. We don't need every checkbox before reading your
+report — we'll integrate findings as they arrive.
 
 ## Going further
 

--- a/docs/install/verification-runbook.md
+++ b/docs/install/verification-runbook.md
@@ -1,30 +1,44 @@
 # DPF Install Verification Runbook
 
-**Purpose:** The CI gates in `.github/workflows/release-gates.yml` and
-`install-verification.yml` cover what GitHub-hosted runners can run.
-This runbook covers everything else — the environments and end-states
-that need a real human at a real host to verify.
-
-Until each row in the matrix below is checked off, the corresponding
-install path is **"shipped, runtime-verification pending"** — not
-**"GA"**. The README and roadmap status should reflect that until
-verification lands.
+> **For early adopters with hardware in hand.** The CI gates in
+> `.github/workflows/release-gates.yml` and `install-verification.yml`
+> cover what GitHub-hosted runners can run. **This runbook covers
+> everything CI can't reach** — and you're the person who can close
+> those gaps.
+>
+> The macOS and Linux installers are code-complete and statically
+> CI-green. They graduate to GA when the community sends us
+> verification reports from real hardware. If you have an Apple
+> Silicon Mac, a non-Ubuntu Linux box, a TAPPaaS environment, or a
+> cloud VM you can spare for an hour, **please pick a section below
+> and run through it.** Both happy-path and failure reports are
+> valuable.
+>
+> **How to report:** open a [GitHub issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new)
+> titled `Install verification — <platform> <version>`, paste your
+> environment fingerprint, note which steps passed / failed, and
+> attach the doctor bundle (`bash install-dpf.sh doctor` →
+> `~/.dpf/doctor-<timestamp>.tar.gz`). Secrets are redacted
+> automatically.
+>
+> We don't need every checkbox before reading your report —
+> partial reports are useful too.
 
 ## Verification matrix
 
 | Path | What CI proves | What this runbook covers | Status |
 |------|----------------|--------------------------|--------|
 | Windows installer | n/a (no CI gate today) | Production usage by real users | ✓ verified |
-| Linux end-to-end install | `install-verification.yml` (ubuntu-latest, dev + release modes) — full compose up, `/api/health=200`, doctor bundle | Distro coverage beyond Ubuntu: Debian 12, Fedora 39. Autostart-after-reboot. | **pending** |
-| macOS end-to-end install | dry-run only (`macos-14` can't nest-virt Docker Desktop) | The actual `.dmg` install + Docker Desktop boot + portal up + LaunchAgent reboot survival | **pending** |
-| Discovery collectors (darwin) | unit tests with mocked deps | Real `pkgutil --pkgs` / `brew list` enumeration emits sensible discovery items | **pending** |
-| Observability stack | compose-render only | Prometheus actually scrapes metrics; Grafana dashboards populate; `linux-monitoring` profile cAdvisor / node-exporter on real Linux | **pending** |
-| LLM provider — Docker Model Runner | dry-run | Real Model Runner serves chat completions to portal | **pending** |
-| LLM provider — Ollama (Linux) | compose-render | `ollama` service actually pulls + serves a model | **pending** |
-| LLM provider — external | code review | Real `LLM_BASE_URL` (Anthropic / OpenAI / hosted Ollama) round-trips | **pending** |
-| TAPPaaS deployment | none — spec only | Pilot deploy into a real TAPPaaS environment | **not started** |
-| DPF Edge Node enrollment | none — spec only | First-draft enrollment ceremony executed end-to-end | **not started** |
-| Cloud deployment (Single VM / Container / k8s) | none — spec only | At least one substrate pilot per packaging target | **not started** |
+| Linux end-to-end install | `install-verification.yml` (ubuntu-latest, dev + release modes) — full compose up, `/api/health=200`, doctor bundle | Distro coverage beyond Ubuntu: Debian 12, Fedora 39. Autostart-after-reboot. | 🙋 **reports wanted** |
+| macOS end-to-end install | dry-run only (`macos-14` can't nest-virt Docker Desktop) | The actual `.dmg` install + Docker Desktop boot + portal up + LaunchAgent reboot survival | 🙋 **reports wanted** |
+| Discovery collectors (darwin) | unit tests with mocked deps | Real `pkgutil --pkgs` / `brew list` enumeration emits sensible discovery items | 🙋 **reports wanted** |
+| Observability stack | compose-render only | Prometheus actually scrapes metrics; Grafana dashboards populate; `linux-monitoring` profile cAdvisor / node-exporter on real Linux | 🙋 **reports wanted** |
+| LLM provider — Docker Model Runner | dry-run | Real Model Runner serves chat completions to portal | 🙋 **reports wanted** |
+| LLM provider — Ollama (Linux) | compose-render | `ollama` service actually pulls + serves a model | 🙋 **reports wanted** |
+| LLM provider — external | code review | Real `LLM_BASE_URL` (Anthropic / OpenAI / hosted Ollama) round-trips | 🙋 **reports wanted** |
+| TAPPaaS deployment | none — spec only | Pilot deploy into a real TAPPaaS environment | 🧪 **design partner wanted** |
+| DPF Edge Node enrollment | none — spec only | First-draft enrollment ceremony executed end-to-end | 🧪 **design partner wanted** |
+| Cloud deployment (Single VM / Container / k8s) | none — spec only | At least one substrate pilot per packaging target | 🧪 **design partner wanted** |
 
 ## How to run each verification
 
@@ -214,11 +228,26 @@ Linked spec: [docs/superpowers/specs/2026-05-09-cloud-deployment-design.md](../s
 
 ## Reporting verification results
 
-When a row in the matrix is verified, update its row to `✓ verified`
-plus the verifier's name, date, and a link to the captured artifacts
-(GitHub issue, Drive folder, etc.). Don't mark anything "✓ verified"
-without artifacts — the bar is "we have evidence", not "we believe".
+When you've run a section, **open a GitHub issue** titled
+`Install verification — <platform> <version>` and include:
 
-Until the Linux + macOS rows are both `✓ verified`, the README install
-section should say **"preview"** alongside macOS / Linux entries, not
-**"GA"**.
+- Your environment fingerprint (`uname -a`, `sw_vers` / `cat /etc/os-release`)
+- Which checklist boxes you ticked, which you skipped, and which failed
+- The doctor bundle (`bash install-dpf.sh doctor` → attach the
+  `~/.dpf/doctor-<timestamp>.tar.gz`)
+- Any screenshots of unexpected portal behavior
+
+Maintainers will:
+
+- For 🙋 **reports wanted** rows: integrate your findings and, once a
+  handful of independent reports come in for a row, flip its status
+  from "reports wanted" to ✅ **verified** and the corresponding
+  README row from "Early access" to **GA**.
+- For 🧪 **design partner wanted** rows (TAPPaaS / Edge Node / Cloud):
+  reach out to discuss scope — those need actual implementation work
+  before they're runnable; what we're looking for is co-design
+  partners, not bug reports against shipping code.
+
+The bar for ✅ verified is "we have evidence on real hardware",
+not "we believe". Partial reports still count — even a "got to step
+N and failed" failure report is more valuable than no report.

--- a/docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
+++ b/docs/superpowers/plans/2026-05-09-macos-linux-native-support.md
@@ -1,26 +1,24 @@
 # Mac (Apple Silicon) + Linux Native Support — Roadmap
 
-> **Status: CODE SHIPPED — RUNTIME VERIFICATION PENDING (2026-05-11).**
+> **Status: CODE SHIPPED — EARLY ACCESS (2026-05-11).**
 > All 11 phases (0–10) of the *code* roadmap shipped across 13 PRs.
 > The bash installer, lifecycle scripts, CI release gates, and docs
-> are on `main`. **However**, the gates that ran in CI are
-> dry-run / static checks (`shellcheck`, `docker compose config`,
-> `install-dpf.sh --dry-run`) — they do **not** prove the installer
-> works end-to-end on a real host.
+> are on `main`, and an ubuntu-latest end-to-end install gate
+> ([`.github/workflows/install-verification.yml`](../../../.github/workflows/install-verification.yml))
+> proves the install path works on a real Linux runner.
 >
-> What's verified vs. unverified is tracked in
-> [docs/install/verification-runbook.md](../../install/verification-runbook.md).
-> Until the matrix in that file is checked off for macOS and Linux,
-> the installers are **preview**, not GA. The Windows installer
-> remains GA (real production usage).
+> **Now we want real-world reports.** The macOS / Linux installers
+> are in **early access**: please install on your hardware and tell
+> us how it went. Verification matrix + reporting instructions live
+> at [docs/install/verification-runbook.md](../../install/verification-runbook.md).
 >
-> An ubuntu-latest end-to-end install gate landed alongside this
-> stamp ([`.github/workflows/install-verification.yml`](../../../.github/workflows/install-verification.yml))
-> — on-demand + tag-triggered — that converts the Linux runtime row
-> from "believed correct" to "observed to reach `/api/health=200` as
-> of commit X". Apple Silicon, distro coverage beyond Ubuntu, TAPPaaS,
-> Edge Node, and cloud substrates still need real-hardware /
-> real-substrate verification (see the runbook).
+> A handful of community verification reports per platform is what
+> we need to flip macOS / Linux from "early access" to "GA" in the
+> README. The Windows installer is the only path with that
+> designation today (real production usage). TAPPaaS, DPF Edge Node,
+> and cloud substrates are spec-only and tagged "design partner
+> wanted" in the runbook — they need actual implementation work, not
+> just runtime verification.
 
 > Branch: `claude/mac-docker-compatibility-uN4Ya`
 > Deliverable for this branch: **this plan only**. Each phase below lands as a


### PR DESCRIPTION
Follow-up to #470. Now that the installer code is complete and
statically CI-green, we want to advertise the macOS / Linux install
paths and recruit early adopters from the community who have the
hardware we don't.

## Why this PR

The framing in #470 was technically accurate ("preview — runtime
verification pending") but it read as **"don't trust this yet."**
For someone with an Apple Silicon Mac or a real Linux box, that's
exactly backwards — they're precisely the people who can close the
verification gap, and we need to make trying it as easy as filing a
one-minute report.

This PR pivots the language from defensive to inviting, without
overstating what we have.

## What changes

**`README.md`**
- Quick Start status column flipped: **"Early access — try it!"**
- New **"Calling all macOS / Linux early adopters"** callout names
  the specific hardware / environments we want help from (Apple
  Silicon, non-Ubuntu Linux, TAPPaaS, cloud VM operators).
- One-minute report instructions: open a GitHub issue titled
  `Install verification — <platform> <version>`, attach the doctor
  bundle. Secrets are auto-redacted.
- "What's working now" and "What's coming" rows mirror.

**`docs/install/macos.md`, `docs/install/linux.md`**
- Top callout flipped to **"Status: Early access — please try it!"**
  naming the specific gap each guide covers (Apple Silicon `.dmg`
  flow + LaunchAgent reboot survival; Linux distros beyond Ubuntu
  + systemd-user linger).
- New **"Help us graduate to GA"** section before the footer with
  paste-able environment fingerprint commands and the doctor-bundle
  attach flow.

**`docs/install/verification-runbook.md`**
- Reframed from "GA gate matrix" to "early adopter playbook" — same
  technical content, inviting tone.
- Status column flipped from `pending` / `not started` to
  🙋 **reports wanted** (runnable code paths) and 🧪 **design partner
  wanted** (spec-only items: TAPPaaS, Edge Node, cloud substrates —
  these need actual implementation, not just runtime verification).
- Closing section explains how maintainers will integrate reports
  and what graduation from "Early access" to "GA" looks like.

**`docs/superpowers/plans/2026-05-09-macos-linux-native-support.md`**
- Status banner flipped from `RUNTIME VERIFICATION PENDING` to
  `EARLY ACCESS` with a clearer call to action and an explicit note
  that TAPPaaS / Edge Node / cloud are spec-only and tagged "design
  partner wanted".

## What doesn't change

- **No installer code touched.** The bash installer ecosystem is
  exactly what it was at the close of Phase 10 + the verification
  artifacts from #470.
- **No CI workflow changes.** `install-verification.yml` still
  triggers on demand and on tag push.
- **Honest claims preserved.** macOS / Linux are still **Early
  access**, not GA. Windows is still the only GA install surface.
  TAPPaaS / Edge Node / cloud are still spec-only. We just stopped
  apologizing about it.

## Graduation criteria

Stays as stated in #470: a handful of independent verification
reports per platform → flip Early access to GA. The runbook now
spells that out for contributors instead of treating it as a
maintainer-only checklist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_