### PR TITLE
doc(wiki): founder-kernel 0.2.0-draft — first synthesized cut from Mark&#39;s corpus

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,9 +1,9 @@
 {
-  "kernelVersion": "0.1.0",
+  "kernelVersion": "0.2.0-draft",
   "schemaVersion": "0.1.0",
-  "pageCount": 0,
-  "sourceCount": 0,
+  "pageCount": 19,
+  "sourceCount": 10,
   "embeddingModel": null,
   "builtAt": null,
-  "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. See ../superpowers/specs/2026-05-09-platform-kernel-wiki-design.md for the design and ./SCHEMA.md for the wiki contract."
+  "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. The 0.2.0-draft cut was synthesised from Mark's public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect, Architecture & Governance Magazine, ServiceNow community blogs, CSDM v5). Every page ships status:draft pending Mark's review. See ../superpowers/specs/2026-05-09-platform-kernel-wiki-design.md for the design and ./SCHEMA.md for the wiki contract."
 }

--- a/docs/founder-kernel/raw-sources/articles/briefings-direct-it4it-2019.md
+++ b/docs/founder-kernel/raw-sources/articles/briefings-direct-it4it-2019.md
@@ -1,0 +1,32 @@
+---
+sourceType: article
+title: "Where the Rubber Meets the Road: How Users See IT4IT Building Competitive Advantage"
+authors:
+  - Gardner, Dana (BriefingsDirect)
+  - Bodman, Mark
+publishedAt: 2019-03-01
+url: https://www.briefingsdirecttranscriptsblogs.com/2019/03/where-rubber-meets-road-how-users-see.html
+license: third-party
+abstract: |
+  BriefingsDirect podcast transcript. Mark articulates the "IT4IT is a hub
+  of many different frameworks — all designed as one architecture" framing
+  that becomes his standard executive pitch. Includes the
+  framework-for-managing-IT executive lens and the substrate-not-competitor
+  positioning. Third-party publication; abstract + locator per
+  RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+Primary source for the **IT4IT is the substrate, not a framework competitor** stance. Direct quote: *"a hub of many different frameworks — all designed as one architecture."*
+
+## Key claims
+
+- IT4IT integrates ITIL, COBIT, TOGAF, DevOps, SAFe — it does not replace them.
+- "I pitch it as a framework for managing IT and leave it at that. I might also say it's an operating model."
+- The integration value of IT4IT is what gets executive buy-in, not the model itself.
+
+## See also
+
+- Stance: `[[stances/it4it-is-substrate]]`
+- Entity: `[[entities/it4it]]`

--- a/docs/founder-kernel/raw-sources/articles/open-group-2017-managing-business-of-it.md
+++ b/docs/founder-kernel/raw-sources/articles/open-group-2017-managing-business-of-it.md
@@ -1,0 +1,36 @@
+---
+sourceType: article
+title: "Gaining Executive Buy-In for Managing the Business of IT"
+authors:
+  - The Open Group Blog
+  - Bodman, Mark
+publishedAt: 2017-01-25
+url: https://blog.opengroup.org/2017/01/25/it4it-managing-the-business-of-it/
+license: third-party
+abstract: |
+  Open Group blog interview with Mark (then leading IT4IT adoption at HPE).
+  Establishes the "contextualize, don't transform" approach to IT4IT adoption,
+  the "at least one champion" heuristic, and the executive-pitch pattern
+  ("framework for managing IT" or "operating model" — pick based on audience).
+  Includes the 300-tools-doing-the-same-job anecdote that Mark reuses across
+  later talks. Third-party publication; abstract + locator per
+  RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+Anchor for the **contextualize, don't transform** stance and the related heuristics (`find at least one champion`, `pitch simple, adjust per audience`). Earliest published source of the executive-buy-in playbook.
+
+## Key claims
+
+- Don't try to flip the organization — map the current operating model onto the standard first ("contextualize").
+- Find at least one champion at the executive level; without it, adoption stalls.
+- Pitch IT4IT as "a framework for managing IT" or "an operating model" depending on audience.
+- Tool sprawl is the canonical ROI story (300 tools doing one job).
+
+## See also
+
+- Stance: `[[stances/contextualize-dont-transform]]`
+- Stance: `[[stances/it4it-is-substrate]]`
+- Heuristic: `[[heuristics/contextualize-before-transforming]]`
+- Heuristic: `[[heuristics/find-at-least-one-champion]]`

--- a/docs/founder-kernel/raw-sources/articles/possible-futures-enterprise-architecture.md
+++ b/docs/founder-kernel/raw-sources/articles/possible-futures-enterprise-architecture.md
@@ -1,0 +1,32 @@
+---
+sourceType: article
+title: Possible Futures for Enterprise Architecture
+authors:
+  - Bodman, Mark
+url: https://www.architectureandgovernance.com/elevating-ea/possible-futures-enterprise-architecture/
+license: third-party
+abstract: |
+  Architecture & Governance Magazine piece on where EA must move. Introduces
+  the meteorology analogy — architects should "provide forecasts and models
+  that produce guidance" rather than exposing raw architecture models to
+  leadership. Includes the assertion that "most IT organizations have little
+  to no business architecture in play, effectively making most current and
+  future technology investment impossible to trace to business outcomes."
+  Published by Architecture & Governance Magazine; bundled here as abstract
+  + locator per RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+Foundational source for the **EA is meteorology, not model exposition** stance and the **be a meteorologist** heuristic. Closest published material to the "judgment lens" framing the platform is built on. Third-party publication; abstract-and-locator only.
+
+## Key claims
+
+- EA's value to the business is forecasts and guidance, not raw model exposure.
+- Most IT organizations have no business architecture in play; investment cannot be traced to outcomes.
+- The fix is a judgment surface on top of the models, not more diagrams.
+
+## See also
+
+- Stance: `[[stances/ea-is-meteorology]]`
+- Heuristic: `[[heuristics/be-a-meteorologist]]`

--- a/docs/founder-kernel/raw-sources/articles/sibling-portfolios.md
+++ b/docs/founder-kernel/raw-sources/articles/sibling-portfolios.md
@@ -1,0 +1,32 @@
+---
+sourceType: article
+title: "Application Portfolio and Services Portfolio are Sibling Portfolios"
+authors:
+  - Bodman, Mark
+  - Thigpen, David
+url: https://www.servicenow.com/community/itsm-blog/application-portfolio-and-services-portfolio-are-quot-sibling/ba-p/2268961
+license: third-party
+abstract: |
+  ServiceNow community blog. Mark + David Thigpen explain why Application
+  Portfolio Management (APM, Dev side) and Services Portfolio Management
+  (SPM, Ops side) belong in one platform on a shared data model rather than
+  in separate tools glued together. Foundational to the four-year Digital
+  Portfolio Management arc that merged the two. Third-party publication;
+  abstract + locator per RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+Backs the position that **portfolios are siblings; they live in one house** — an operational corollary of the EA-consolidation stance. Names the DevOps-at-enterprise-level argument: "Digital Portfolio Management brings together Business Applications from the Dev world and Services from the Ops world to make DevOps work at an enterprise level."
+
+## Key claims
+
+- APM and SPM are siblings, not competitors — both are facets of the same Digital Product.
+- Separating them across tools creates structural pain that integration cannot fix.
+- DPM unifies them on the CSDM data spine.
+
+## See also
+
+- Stance: `[[stances/dont-integrate-ea-platform]]`
+- Entity: `[[entities/portfolio]]`
+- Entity: `[[entities/csdm]]`

--- a/docs/founder-kernel/raw-sources/articles/think-twice-ea-platform-servicenow.md
+++ b/docs/founder-kernel/raw-sources/articles/think-twice-ea-platform-servicenow.md
@@ -1,0 +1,34 @@
+---
+sourceType: article
+title: Think Twice When Integrating your EA Platform with ServiceNow
+authors:
+  - Bodman, Mark
+url: https://www.linkedin.com/pulse/think-twice-when-integrating-your-ea-platform-mark-bodman
+license: Apache-2.0
+abstract: |
+  Mark's sharpest published opinion on platform consolidation. Argues that
+  third-party EA tools integrated with ServiceNow almost always fail, naming
+  the failure pattern: Independent → Honeymoon → Ugly Reckoning. Notable
+  analogy: dedicated EA tools vs ServiceNow APM is "like making an argument
+  that using a dedicated camera over the one built-into your phone is better."
+  Conflict-of-interest note: Mark is a ServiceNow employee; his read on this
+  is shaped by 18 years of watching the integration pattern fail across Dell,
+  Troux, HPE, and ServiceNow.
+---
+
+## Why it's cited
+
+Foundational source for the **don't integrate the EA platform — consolidate on one data model** stance and the **reuse the camera in your pocket** heuristic. Apache-2.0 because Mark authored it.
+
+## Key claims
+
+- EA-platform-to-CMDB integration progresses through Independent → Honeymoon → Ugly Reckoning.
+- Scope creep, semantic mismatches, and chicken-vs-egg ownership compound until the integration is "unachievable as originally intended."
+- Pick one platform; CSDM is the canonical data spine.
+- Best-of-breed loses on practicality even when it wins on feature depth (the camera-in-your-pocket analogy).
+
+## See also
+
+- Stance: `[[stances/dont-integrate-ea-platform]]`
+- Heuristic: `[[heuristics/reuse-the-camera-in-your-pocket]]`
+- Entity: `[[entities/csdm]]`

--- a/docs/founder-kernel/raw-sources/articles/why-product-centric-approach-needed.md
+++ b/docs/founder-kernel/raw-sources/articles/why-product-centric-approach-needed.md
@@ -1,0 +1,32 @@
+---
+sourceType: article
+title: Why the Product-Centric Approach Is Needed
+authors:
+  - Bodman, Mark
+publishedAt: 2025-05-04
+url: https://www.linkedin.com/pulse/why-product-centric-approach-need-mark-bodman-bkc8c
+license: Apache-2.0
+abstract: |
+  Long-form LinkedIn article making the definitive case against project-based IT.
+  Replaces it with persistent product teams and rolling investment in digital
+  products. Includes Mark's simplified definition: "Anything that runs code that
+  one party is responsible for that delivers outcomes for a consumer party."
+  States the position that projects are time-bound, often optimizing for delivery
+  deadlines rather than long-term sustainability.
+---
+
+## Why it's cited
+
+Foundational source for the **Digital Product as the unit of organization** stance and the **persistent product teams over projects** stance. The simplified definition of Digital Product comes from this piece. Bundled under Apache-2.0 as Mark's original LinkedIn article.
+
+## Key claims
+
+- Digital Product = "anything that runs code that one party is responsible for that delivers outcomes for a consumer party."
+- Project-based IT optimises for delivery deadlines, not business outcomes or long-term sustainability.
+- The fix is persistent product teams, rolling investment, outcome-based measurement.
+
+## See also
+
+- Stance: `[[stances/digital-product-is-the-unit-of-organization]]`
+- Stance: `[[stances/persistent-product-teams-over-projects]]`
+- Earlier framing: `[[raw-sources/articles/why-product-centricity-critical]]`

--- a/docs/founder-kernel/raw-sources/articles/why-product-centricity-critical.md
+++ b/docs/founder-kernel/raw-sources/articles/why-product-centricity-critical.md
@@ -1,0 +1,30 @@
+---
+sourceType: article
+title: Why Product-Centricity within IT is Critical
+authors:
+  - Bodman, Mark
+publishedAt: 2024-12-24
+url: https://www.linkedin.com/pulse/why-product-centricity-within-critical-mark-bodman-dbhfc
+license: Apache-2.0
+abstract: |
+  Earlier framing of the product-centric thesis. Treats every system, application,
+  or service as a digital product with defined consumers and providers. Direct
+  quote: "A product-centric model transforms this dynamic by treating each system,
+  application, or service as a digital product with defined consumers and
+  providers."
+---
+
+## Why it's cited
+
+Companion to the May 2025 Pulse. Establishes the consumer/provider framing that recurs across DPROM and IT4IT v3. Bundled under Apache-2.0 as Mark's original LinkedIn article.
+
+## Key claims
+
+- Each system / application / service is a digital product with defined consumers and providers.
+- The consumer/provider framing replaces the ticket-centric ITSM mindset.
+- Outcomes, not uptime or feature-completion, are the measure.
+
+## See also
+
+- Stance: `[[stances/digital-product-is-the-unit-of-organization]]`
+- Later framing: `[[raw-sources/articles/why-product-centric-approach-needed]]`

--- a/docs/founder-kernel/raw-sources/frameworks/csdm.md
+++ b/docs/founder-kernel/raw-sources/frameworks/csdm.md
@@ -1,0 +1,32 @@
+---
+sourceType: framework
+title: "Common Service Data Model (CSDM)"
+authors:
+  - ServiceNow
+url: https://www.servicenow.com/csdm
+license: third-party
+abstract: |
+  ServiceNow's Common Service Data Model — the unified data spine connecting
+  Asset, Dev, Ops, ITSM, and CSM. Originated to solve the technical-debt
+  reporting problem that didn't have a single source of truth. Mark's framing:
+  "The vision was to create a common model that connects what naturally
+  happens. CSDM was born." Currently at v5. ServiceNow product documentation;
+  abstract + locator per RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+Backs the **trust the CMDB or rebuild it** stance and the **model what naturally happens** heuristic. The "shared data foundation" position rests on CSDM as the substrate that makes Digital Product, Portfolio, and Service-Now-the-platform self-consistent.
+
+## Key claims
+
+- Connect what naturally happens across asset/dev/ops/ITSM/CSM — don't aggregate into a data lake.
+- The CMDB is only useful if it's trusted; trust is built via Ingestion + Insight + Governance.
+- CSDM is the canonical model; everything else is a projection.
+
+## See also
+
+- Stance: `[[stances/trust-the-cmdb-or-rebuild-it]]`
+- Heuristic: `[[heuristics/model-what-naturally-happens]]`
+- Heuristic: `[[heuristics/auto-populate-or-its-wrong]]`
+- Entity: `[[entities/csdm]]`

--- a/docs/founder-kernel/raw-sources/frameworks/it4it-v3.md
+++ b/docs/founder-kernel/raw-sources/frameworks/it4it-v3.md
@@ -1,0 +1,31 @@
+---
+sourceType: framework
+title: "IT4IT Standard, Version 3.0"
+authors:
+  - The Open Group
+publishedAt: 2022-10-01
+url: https://www.opengroup.org/it4it
+license: third-party
+abstract: |
+  The Open Group's IT4IT standard, v3.0. Significantly refactored around
+  Digital Product — Mark was a major contributor. Replaces the prior 4 value
+  streams with 7; renames the Service Model Backbone to the Digital Product
+  Backbone. The substrate that DPF treats as canonical for IT operations.
+  Open Group standard; abstract + locator per RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+Defines the seven value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume) that DPF's portfolio routing and lifecycle reference throughout. The "hub-of-frameworks" framing Mark uses everywhere is anchored on this standard.
+
+## Key claims
+
+- Seven value streams replace the prior four; Digital Product is the spine.
+- IT4IT integrates ITIL, COBIT, TOGAF, DevOps, SAFe at the operating-model layer.
+- The standard is intentionally a substrate, not a delivery methodology.
+
+## See also
+
+- Stance: `[[stances/it4it-is-substrate]]`
+- Entity: `[[entities/it4it]]`
+- Entity: `[[entities/value-stream]]`

--- a/docs/founder-kernel/raw-sources/papers/shift-to-digital-product-w205.md
+++ b/docs/founder-kernel/raw-sources/papers/shift-to-digital-product-w205.md
@@ -1,0 +1,33 @@
+---
+sourceType: paper
+title: "Shift to Digital Product: A Full Lifecycle Perspective (W205)"
+authors:
+  - Bodman, Mark
+  - Warfield, Dan
+publishedAt: 2020-12-01
+url: https://publications.opengroup.org/white-papers/w205
+license: third-party
+abstract: |
+  Open Group white paper. Foundational position paper: Digital Product is "the
+  single, simple, unifying element to manage IT and smart products and
+  services." Reframes IT4IT's Service Model Backbone as the Digital Product
+  Backbone — the conceptual move that landed in IT4IT v3 as a full refactor.
+  The Open Group publication W205; abstract + locator per
+  RAW-SOURCES-LICENSE.md.
+---
+
+## Why it's cited
+
+The published-paper anchor for the **Digital Product as the unit of organization** stance. Earliest formal statement of the unification thesis that drives both IT4IT v3 and DPROM.
+
+## Key claims
+
+- Digital Product is the single unifying element across IT, smart products, and services.
+- The IT4IT Service Model Backbone should be reframed as a Digital Product Backbone.
+- A full-lifecycle perspective replaces the project-bounded model.
+
+## See also
+
+- Stance: `[[stances/digital-product-is-the-unit-of-organization]]`
+- Entity: `[[entities/digital-product]]`
+- Entity: `[[entities/it4it]]`

--- a/docs/founder-kernel/wiki/entities/csdm.md
+++ b/docs/founder-kernel/wiki/entities/csdm.md
@@ -1,0 +1,36 @@
+---
+title: CSDM (Common Service Data Model)
+pageKind: entity
+status: draft
+abstract: The canonical data model that connects what naturally happens across asset, dev, ops, ITSM, and CSM.
+sources:
+  - frameworks/csdm
+---
+
+## What it is
+
+CSDM — the Common Service Data Model — is the canonical data spine that connects Asset, Dev (APM), Ops (SPM), ITSM, and CSM. It originated to solve the technical-debt reporting problem that didn&#39;t have a single source of truth. **The vision was to create a common model that connects what naturally happens. CSDM was born.**
+
+CSDM is not a data lake. It is not a federated query layer. It is a *model* that names the entities and the relationships that already exist between them, and lets every product on the platform agree on which row means what.
+
+Currently at v5.
+
+## How DPF uses it
+
+DPF treats CSDM as the canonical reference model for Digital Product structure. The Prisma `DigitalProduct`, `Portfolio`, and `Service` models map directly onto CSDM&#39;s hierarchy (Business Application → Application Service → CI). When agents reason about cross-product impact, dependency mapping, or rationalisation, they reason in CSDM terms.
+
+## Relationships
+
+- Describes: `[[entities/digital-product]]`, `[[entities/portfolio]]`.
+- Substrate for: APM, SPM, DPM — all converge on CSDM as the data spine.
+- Aligned with: `[[entities/it4it]]` — CSDM&#39;s entities populate the IT4IT functional-component lattice.
+
+## Examples
+
+A single "Customer Portal" Digital Product has one Business Application row (the product itself), multiple Application Service rows (auth, catalog, checkout), and many CI rows under each service. The same row IDs are used by APM (Dev), SPM (Ops), and CSM (Customer) — so a customer support ticket about a checkout failure traces back to the same CI that the Dev team is patching in the same pull request.
+
+## See also
+
+- Stance: `[[stances/trust-the-cmdb-or-rebuild-it]]`
+- Heuristic: `[[heuristics/model-what-naturally-happens]]`
+- Heuristic: `[[heuristics/auto-populate-or-its-wrong]]`

--- a/docs/founder-kernel/wiki/entities/digital-product.md
+++ b/docs/founder-kernel/wiki/entities/digital-product.md
@@ -1,0 +1,38 @@
+---
+title: Digital Product
+pageKind: entity
+status: draft
+abstract: Anything that runs code that one party is responsible for that delivers outcomes for a consumer party.
+sources:
+  - articles/why-product-centric-approach-needed
+  - articles/why-product-centricity-critical
+  - papers/shift-to-digital-product-w205
+---
+
+## What it is
+
+A Digital Product is **anything that runs code that one party is responsible for that delivers outcomes for a consumer party**. The simplest possible framing of a 25-year-arc through APM, SPM, IT4IT, and CSDM.
+
+The point of the definition is what it excludes. A Digital Product is not a project (projects end; products persist). It is not a ticket queue (tickets are symptoms; products produce outcomes). It is not an application or a service in isolation (those are facets — the Digital Product is the whole that contains both).
+
+## How DPF uses it
+
+Digital Product is the unit of organization for everything DPF tracks. Portfolios contain Digital Products. Teams own Digital Products. Investment flows to Digital Products. Lifecycle stages apply to Digital Products. EA models, IT4IT value streams, and CSDM data all reduce to Digital Products as the anchor.
+
+The platform&#39;s `DigitalProduct` Prisma model is the canonical row; everything else is a projection of it.
+
+## Relationships
+
+- `[[entities/portfolio]]` — a Portfolio is a curated set of Digital Products.
+- `[[entities/it4it]]` — IT4IT v3&#39;s seven value streams operate on Digital Products; the Service Model Backbone was renamed the Digital Product Backbone for this reason.
+- `[[entities/csdm]]` — CSDM is the canonical data model; Digital Product is the entity it&#39;s built to describe.
+- `[[entities/value-stream]]` — value streams are where Digital Products are evaluated, built, run, and consumed.
+
+## Examples
+
+A SaaS customer portal that engineering owns and the storefront team consumes. A logging stack that platform engineering owns and every application team consumes. A reporting service that data platform owns and finance consumes. None of these is a project; each is a persistent Digital Product with named consumers, named providers, and outcomes that can be measured.
+
+## See also
+
+- Stance: `[[stances/digital-product-is-the-unit-of-organization]]`
+- Stance: `[[stances/persistent-product-teams-over-projects]]`

--- a/docs/founder-kernel/wiki/entities/it4it.md
+++ b/docs/founder-kernel/wiki/entities/it4it.md
@@ -1,0 +1,40 @@
+---
+title: IT4IT
+pageKind: entity
+status: draft
+abstract: The Open Group's reference architecture for managing the business of IT — a hub of seven value streams that integrate ITIL, COBIT, TOGAF, DevOps, and SAFe.
+sources:
+  - frameworks/it4it-v3
+  - articles/briefings-direct-it4it-2019
+  - articles/open-group-2017-managing-business-of-it
+  - papers/shift-to-digital-product-w205
+---
+
+## What it is
+
+IT4IT is The Open Group&#39;s reference architecture for the operating model of IT itself. v3 (2022) refactored the standard around `[[entities/digital-product]]`: seven value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume) operate on the Digital Product Backbone — renamed from the Service Model Backbone in v3 specifically because Digital Product turned out to be the right spine.
+
+IT4IT does not replace ITIL, COBIT, TOGAF, DevOps, or SAFe. It integrates them. It is the substrate on which those frameworks coexist as one operating model.
+
+## How DPF uses it
+
+DPF&#39;s portfolio and product surfaces are organised around the seven IT4IT value streams. Lifecycle states reference them. The MCP tool surface routes capability discovery through them. Agent coworkers categorise their work by value stream.
+
+The platform&#39;s position is that **IT4IT is canonical**. Customers may operate other frameworks (and should — they own ITIL processes, deploy SAFe trains, run TOGAF reviews), but those connect to the platform&#39;s spine via IT4IT&#39;s value-stream contract.
+
+## Relationships
+
+- Substrate for: ITIL, COBIT, TOGAF, DevOps, SAFe — see `[[stances/it4it-is-substrate]]`.
+- Operates on: `[[entities/digital-product]]` (via the Digital Product Backbone introduced in v3).
+- Defines: `[[entities/value-stream]]` (the seven that make up the standard).
+- Anchors data: `[[entities/csdm]]` represents IT4IT functional components and value-stream activity.
+
+## Examples
+
+A new application proposal moves through Evaluate (does it fit the portfolio strategy?), Explore (which option is right?), Integrate (build/buy/compose), Deploy, Release, Operate, and finally Consume — each value stream owning a distinct contract with the Digital Product.
+
+## See also
+
+- Stance: `[[stances/it4it-is-substrate]]`
+- Heuristic: `[[heuristics/pitch-simple-adjust-per-audience]]` — how to introduce IT4IT to executives.
+- Raw source: `[[raw-sources/frameworks/it4it-v3]]`

--- a/docs/founder-kernel/wiki/entities/portfolio.md
+++ b/docs/founder-kernel/wiki/entities/portfolio.md
@@ -1,0 +1,36 @@
+---
+title: Portfolio
+pageKind: entity
+status: draft
+abstract: A curated set of Digital Products grouped for a shared management purpose — investment, governance, or operations.
+sources:
+  - articles/sibling-portfolios
+  - papers/shift-to-digital-product-w205
+---
+
+## What it is
+
+A Portfolio is a **curated set of `[[entities/digital-product]]`s grouped for a shared management purpose**. Application Portfolio Management (APM) is a portfolio that groups applications under the Dev lens. Services Portfolio Management (SPM) is a portfolio that groups services under the Ops lens. Digital Portfolio Management (DPM) is the unification — both grouped under a Digital Product spine.
+
+Portfolios are not categories; they are **management surfaces**. The right question to ask of a portfolio isn&#39;t "which products belong to it?" but "what decisions does this grouping enable that the constituent Digital Products couldn&#39;t answer on their own?"
+
+## How DPF uses it
+
+DPF&#39;s `Portfolio` Prisma model groups Digital Products with explicit lifecycle metadata, ownership, and investment context. The portfolio is the **default management surface** for cross-product judgment: which products to consolidate, which to retire, which to invest in next.
+
+Portfolios are also the unit of agent context — a coworker on a portfolio page sees the portfolio&#39;s Digital Products, their value-stream coverage, their lifecycle states, and the portfolio-scoped wiki overlay.
+
+## Relationships
+
+- Contains: `[[entities/digital-product]]`s.
+- Sibling concept: `[[entities/digital-product]]` is the unit; Portfolio is the curation.
+- `[[entities/csdm]]` represents portfolios via the BusinessApplication / Service hierarchies that DPM unifies.
+
+## Examples
+
+The "Customer-facing experience" portfolio groups the storefront, customer portal, mobile app, and customer-data services together because investment decisions span them. The "Foundational platform" portfolio groups CI/CD, observability, secrets management, and runtime infrastructure together because they share governance posture and SLO discipline.
+
+## See also
+
+- Stance: `[[stances/dont-integrate-ea-platform]]` — why portfolios belong on one platform.
+- Stance: `[[stances/digital-product-is-the-unit-of-organization]]` — what fills a portfolio.

--- a/docs/founder-kernel/wiki/entities/value-stream.md
+++ b/docs/founder-kernel/wiki/entities/value-stream.md
@@ -1,0 +1,44 @@
+---
+title: Value Stream
+pageKind: entity
+status: draft
+abstract: One of seven cross-cutting flows in IT4IT v3 — Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume. The seam where ITIL, DevOps, SAFe, and TOGAF plug into the Digital Product spine.
+sources:
+  - frameworks/it4it-v3
+---
+
+## What it is
+
+A Value Stream in `[[entities/it4it]]` v3 is one of **seven cross-cutting flows** that operate on the Digital Product Backbone:
+
+1. **Evaluate** — strategy, portfolio fit, investment justification.
+2. **Explore** — design, options, architecture, build-vs-buy.
+3. **Integrate** — engineering, composition, build.
+4. **Deploy** — release engineering, packaging, environment promotion.
+5. **Release** — orchestration into production.
+6. **Operate** — run, monitor, incident, change.
+7. **Consume** — request, fulfilment, customer-facing experience.
+
+Each value stream owns a distinct contract with the `[[entities/digital-product]]`. ITIL plugs into Operate. DevOps plugs into Integrate / Deploy / Release. TOGAF plugs into Explore. COBIT threads through all seven.
+
+## How DPF uses it
+
+DPF&#39;s lifecycle and routing surfaces are organised around the seven value streams. Portfolio pages categorise products by value-stream coverage. Agent coworkers tag their work by value stream so the platform can report on activity by flow.
+
+The platform uses the canonical slugs `evaluate`, `explore`, `integrate`, `deploy`, `release`, `operate`, `consume` everywhere a value stream appears.
+
+## Relationships
+
+- Defined by: `[[entities/it4it]]`.
+- Operates on: `[[entities/digital-product]]`.
+- The seam for: ITIL (Operate), DevOps/SAFe (Integrate, Deploy, Release), TOGAF (Explore), COBIT (all).
+
+## Examples
+
+A new analytics application proposal moves Evaluate → Explore → Integrate → Deploy → Release → Operate → Consume across its first eighteen months. The agent surfaces relevant tools, runbooks, and approvals depending on which value stream the work is currently in.
+
+## See also
+
+- Stance: `[[stances/it4it-is-substrate]]`
+- Entity: `[[entities/it4it]]`
+- Raw source: `[[raw-sources/frameworks/it4it-v3]]`

--- a/docs/founder-kernel/wiki/heuristics/auto-populate-or-its-wrong.md
+++ b/docs/founder-kernel/wiki/heuristics/auto-populate-or-its-wrong.md
@@ -1,0 +1,36 @@
+---
+title: Auto-populate or it's already wrong
+pageKind: heuristic
+status: draft
+abstract: It is not humanly possible to manually track the rapid inflation and deflation of virtualised cloud, hybrid, and on-prem resources. If your CMDB depends on humans to enter records, it's already lying to you.
+sources:
+  - frameworks/csdm
+---
+
+## The heuristic
+
+> Any configuration, asset, or inventory record that depends on a human to enter or maintain it is **already wrong**. Auto-populate or accept that the record is decoration.
+
+## When it applies
+
+Designing a CMDB, an asset inventory, a software catalog, a service registry, or any operational data source that needs to reflect current reality. Also: AI-co-worker context surfaces that rely on platform data being accurate.
+
+## Why it works
+
+The rate of change of virtualised cloud resources, hybrid environments, and on-prem fleets exceeds what manual entry can keep up with. Records age in minutes; humans update on weekly or quarterly cycles. The gap compounds. By the time anyone looks at the CMDB to make a decision, the data is stale enough that the decision is wrong.
+
+The fix is structural: every record in the CMDB has an automated discovery source feeding it. Manual edits are exceptions, and they trigger review. The first pillar of trusted data — Ingestion — is non-negotiable.
+
+The second-order consequence: if you can&#39;t auto-discover an entity, you probably can&#39;t reason about it operationally either. The lack of a discovery pathway is itself a signal that the entity isn&#39;t operationally tracked.
+
+## Counterexamples
+
+- Strategic-intent records that genuinely live in someone&#39;s head — "this product is scheduled for retirement next year." Those need manual entry, but they should be flagged as forward-looking rather than current-state.
+- Compliance attestations that require human sign-off.
+- Records about people / teams / org structure, where the source of truth is HR, not the infrastructure layer.
+
+## See also
+
+- Parent stance: `[[stances/trust-the-cmdb-or-rebuild-it]]`
+- Related heuristic: `[[heuristics/model-what-naturally-happens]]`
+- Entity: `[[entities/csdm]]`

--- a/docs/founder-kernel/wiki/heuristics/be-a-meteorologist.md
+++ b/docs/founder-kernel/wiki/heuristics/be-a-meteorologist.md
@@ -1,0 +1,35 @@
+---
+title: Be a meteorologist — produce forecasts, not raw models
+pageKind: heuristic
+status: draft
+abstract: Architects deliver forecasts and recommended actions to leadership, not exposed models. The deliverable is the guidance, not the diagram.
+sources:
+  - articles/possible-futures-enterprise-architecture
+---
+
+## The heuristic
+
+> When presenting architecture work to leadership, **produce the forecast** (recommendation, confidence, trade-offs) — not the raw architecture model. Architects are meteorologists, not radar operators.
+
+## When it applies
+
+Executive briefings. Investment-committee architecture reviews. Portfolio rationalisation recommendations. Any time a non-architect is asking "what should we do?" rather than "what does the model say?"
+
+## Why it works
+
+Leadership decisions need three things: a recommendation, a confidence level, and the trade-offs they&#39;re accepting. The architecture model is the *input* to those — not the output. Showing leadership the radar imagery instead of the weather forecast misallocates everyone&#39;s time and produces decisions made on the wrong abstraction.
+
+The meteorology framing also disciplines the architect&#39;s own work. A meteorologist who can&#39;t state confidence levels isn&#39;t doing forecasting. An architect who can&#39;t say "I&#39;m 70% confident option B is the right call because of X, Y, Z" isn&#39;t doing EA — they&#39;re doing modeling exhibition.
+
+This is also the philosophical core of the platform&#39;s wiki kernel: the "what would Mark do?" question is a forecast question. The kernel produces guidance, not raw model output.
+
+## Counterexamples
+
+- Peer-to-peer architecture review where the model *is* the medium.
+- Engineering hand-offs where the next team needs the model to build against.
+- Compliance / audit contexts where the model is required as record.
+
+## See also
+
+- Parent stance: `[[stances/ea-is-meteorology]]`
+- Raw source: `[[raw-sources/articles/possible-futures-enterprise-architecture]]`

--- a/docs/founder-kernel/wiki/heuristics/contextualize-before-transforming.md
+++ b/docs/founder-kernel/wiki/heuristics/contextualize-before-transforming.md
@@ -1,0 +1,34 @@
+---
+title: Contextualize before transforming
+pageKind: heuristic
+status: draft
+abstract: When adopting a standard, first map the existing operating model onto the standard's structure. Adoption follows mapping; transformation follows adoption.
+sources:
+  - articles/open-group-2017-managing-business-of-it
+---
+
+## The heuristic
+
+> When introducing a new standard or framework, first **map** the existing operating model onto its structure. Don&#39;t try to transform until the map is shared.
+
+## When it applies
+
+Any standard adoption against an organisation that already runs — `[[entities/it4it]]`, TOGAF, ArchiMate, `[[entities/csdm]]`, BIAN, COBIT, ITIL refactor. Especially when the executive audience is fluent in their current operating model and skeptical of "yet another framework."
+
+## Why it works
+
+Mapping is a low-stakes activity. It doesn&#39;t commit anyone to change. It surfaces where the current model is strong (those parts stay) and where the standard adds value (those parts get adopted deliberately). The conversation moves from "are we wrong?" to "where is the standard most useful for us?" — which is a question executives engage with.
+
+The phrase to use: *"How is our current operating model the same or different from this standard?"*
+
+## Counterexamples
+
+- Greenfield builds where there&#39;s no current operating model to contextualize against — go straight to the standard.
+- Compliance-driven mandates where the standard is non-negotiable. You still contextualize internally for adoption planning, but the framing externally is "adopt this."
+- Operating models that are visibly broken and the org agrees they&#39;re broken. Contextualization is too patient for a fire-drill; transformation is the right frame.
+
+## See also
+
+- Parent stance: `[[stances/contextualize-dont-transform]]`
+- Related heuristic: `[[heuristics/find-at-least-one-champion]]`
+- Related heuristic: `[[heuristics/pitch-simple-adjust-per-audience]]`

--- a/docs/founder-kernel/wiki/heuristics/find-at-least-one-champion.md
+++ b/docs/founder-kernel/wiki/heuristics/find-at-least-one-champion.md
@@ -1,0 +1,33 @@
+---
+title: Find at least one champion
+pageKind: heuristic
+status: draft
+abstract: Standards adoption stalls without an internal evangelist. Hand out the physical reference book in executive sessions and watch who engages — those become the champions.
+sources:
+  - articles/open-group-2017-managing-business-of-it
+---
+
+## The heuristic
+
+> Any standard or framework adoption needs **at least one internal champion** — preferably more — who will evangelise the standard between meetings. Without that, adoption stalls regardless of how good the standard is.
+
+## When it applies
+
+Adopting `[[entities/it4it]]`, TOGAF, `[[entities/csdm]]`, or any operating-model framework inside an organisation that doesn&#39;t yet use it. Also: introducing a new architectural pattern, a new tooling category, or a new portfolio discipline.
+
+## Why it works
+
+Standards adoption is a multi-quarter slog. The consultant or vendor evangelising the framework leaves the building when the meeting ends; the champion stays inside the organisation and shapes the next thirty conversations that the framework needs to survive. No champion → no continuity → adoption decays back to baseline within a quarter.
+
+The tactic for finding champions: hand out the physical reference book (e.g., the printed IT4IT standard) in executive sessions. Watch who picks it up, who reads it on the plane home, who emails you back the next week with concrete questions. Those people are the champions. They self-select; you just create the conditions.
+
+## Counterexamples
+
+- Top-down mandates with executive air cover. Champions still help, but adoption can survive without them.
+- Tiny organisations where the entire IT leadership is in the room. The whole room can be the champion collective.
+- Standards that ship with built-in tooling. The tool itself can carry the framing if the tool is good enough — though even then, a champion is the difference between "the tool is installed" and "the tool is used."
+
+## See also
+
+- Parent stance: `[[stances/contextualize-dont-transform]]`
+- Related heuristic: `[[heuristics/pitch-simple-adjust-per-audience]]`

--- a/docs/founder-kernel/wiki/heuristics/model-what-naturally-happens.md
+++ b/docs/founder-kernel/wiki/heuristics/model-what-naturally-happens.md
@@ -1,0 +1,34 @@
+---
+title: Model what naturally happens — don't build a data lake
+pageKind: heuristic
+status: draft
+abstract: A canonical data model that connects the relationships that already exist beats a federated data lake that aggregates everything centrally.
+sources:
+  - frameworks/csdm
+---
+
+## The heuristic
+
+> When scoping a cross-domain platform, **model the relationships that already exist** between asset, dev, ops, ITSM, and CSM. Don&#39;t aggregate data into a central lake just because you can.
+
+## When it applies
+
+Designing `[[entities/csdm]]`-style data foundations. Standing up a CMDB. Scoping a discovery / inventory platform. Any cross-domain data architecture where the temptation is "let&#39;s put it all in one place."
+
+## Why it works
+
+The mistake people make with cross-domain data is assuming the value is in *centralising* it. The actual value is in *connecting* it. Asset, Dev, Ops, ITSM, and CSM already have data — the gap is that they don&#39;t agree on which row means what. A canonical model that names the entities and the relationships gets you the cross-domain insight without paying the centralisation cost.
+
+The CSDM origin story is exactly this lesson: the early technical-debt reporting work needed a single source of truth, but trying to aggregate the data centrally was both expensive and politically intractable. **The vision was to create a common model that connects what naturally happens. CSDM was born.**
+
+## Counterexamples
+
+- Analytics workloads where you genuinely do need physically co-located data (e.g., joins at scale across hundreds of millions of rows). Build the lake for those; keep the canonical model for the cross-domain agreement.
+- Compliance audit scenarios where regulators require a single authoritative store.
+- Real-time joins that can&#39;t tolerate the latency of distributed sources.
+
+## See also
+
+- Parent stance: `[[stances/trust-the-cmdb-or-rebuild-it]]`
+- Related heuristic: `[[heuristics/auto-populate-or-its-wrong]]`
+- Entity: `[[entities/csdm]]`

--- a/docs/founder-kernel/wiki/heuristics/pitch-simple-adjust-per-audience.md
+++ b/docs/founder-kernel/wiki/heuristics/pitch-simple-adjust-per-audience.md
@@ -1,0 +1,40 @@
+---
+title: Pitch simple, adjust per audience
+pageKind: heuristic
+status: draft
+abstract: Lead with the simplest framing the audience can ingest. Adjust language per audience — "framework for managing IT," "operating model," "reference architecture." Never lead with the model itself.
+sources:
+  - articles/open-group-2017-managing-business-of-it
+  - articles/briefings-direct-it4it-2019
+---
+
+## The heuristic
+
+> When evangelising a standard or framework, **lead with the simplest framing the specific audience can ingest** and adjust per audience. Never lead with the model.
+>
+> *"I pitch it as a framework for managing IT and leave it at that. I might also say it&#39;s an operating model."*
+
+## When it applies
+
+Introducing `[[entities/it4it]]`, TOGAF, `[[entities/csdm]]`, or any framework to a new audience. Executive briefings. Board-level investment conversations. Cross-functional alignment meetings where the audience is mixed.
+
+## Why it works
+
+Frameworks have layers. The audience doesn&#39;t need the whole stack on first contact — they need the entry point that lets them place the framework in their existing mental model. Once it&#39;s placed, depth follows naturally as questions surface.
+
+For executives at commercial enterprises, "framework for managing IT" or "operating model" works. For federal CIOs, connect to FITARA and FEA — those are the words that map onto the framework they&#39;re already operating in. For architects in a TOGAF-fluent org, lead with reference architecture; the value-stream layer follows.
+
+The corollary: **don&#39;t evangelise depth that the audience didn&#39;t ask for**. If they engage, they&#39;ll ask. If they don&#39;t engage, more detail won&#39;t change their mind.
+
+## Counterexamples
+
+- Peer-to-peer technical reviews where everyone already knows the framework — pitch the depth.
+- Compliance contexts where the standard&#39;s specific structure matters for audit.
+- Adoption planning sessions where you&#39;re past the "what is this?" stage and into the "how do we contextualise it?" stage.
+
+## See also
+
+- Parent stance: `[[stances/contextualize-dont-transform]]`
+- Parent stance: `[[stances/it4it-is-substrate]]`
+- Related heuristic: `[[heuristics/find-at-least-one-champion]]`
+- Related heuristic: `[[heuristics/contextualize-before-transforming]]`

--- a/docs/founder-kernel/wiki/heuristics/reuse-the-camera-in-your-pocket.md
+++ b/docs/founder-kernel/wiki/heuristics/reuse-the-camera-in-your-pocket.md
@@ -1,0 +1,38 @@
+---
+title: Reuse the camera in your pocket — platform-native usually wins
+pageKind: heuristic
+status: draft
+abstract: For most IT tooling decisions, the integrated platform-native capability wins on practicality even when the best-of-breed specialist wins on feature depth. The cost of integration is the silent killer.
+sources:
+  - articles/think-twice-ea-platform-servicenow
+---
+
+## The heuristic
+
+> Choosing between a specialist best-of-breed tool and a platform-native capability that&#39;s already integrated? **Pick platform-native** unless the feature gap is large enough to justify the integration cost.
+>
+> *"Like making an argument that using a dedicated camera over the one built-into your phone is better."*
+
+## When it applies
+
+Tool consolidation decisions. EA platform vs. platform-native EA capability. Project portfolio management vs. platform-native PPM. Asset management vs. platform-native asset. Specialist analytics vs. platform-native reporting.
+
+## Why it works
+
+The dedicated-camera-vs-phone-camera analogy works because everyone has lived it personally. The phone camera is worse on every spec sheet — but it&#39;s in your pocket, it shares the network with everything else, it&#39;s automatically backed up, the photos auto-tag with location and faces. Practicality dominates spec sheets for almost every use case.
+
+The same logic applies to enterprise tooling. The specialist EA tool has features ServiceNow lacks (or vice-versa). Those features cost feature-licence + integration build + ongoing reconciliation maintenance + the silent tax of two systems of record disagreeing. The platform-native version is in your pocket already.
+
+For the rare case where the feature gap *is* big enough — and it&#39;s rarer than vendors will admit — the right answer is to accept the cost honestly: the integration will go through Independent → Honeymoon → Ugly Reckoning. Plan for the Reckoning.
+
+## Counterexamples
+
+- Industry-specific capability that the platform genuinely doesn&#39;t cover (e.g., specialised regulatory modelling).
+- Read-only specialist tools that don&#39;t need to write back to the platform — no integration risk to manage.
+- Tools your customers/regulators require you to use regardless of your platform choice.
+
+## See also
+
+- Parent stance: `[[stances/dont-integrate-ea-platform]]`
+- Related stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — the consolidation only works if the CMDB is trustworthy.
+- Raw source: `[[raw-sources/articles/think-twice-ea-platform-servicenow]]`

--- a/docs/founder-kernel/wiki/index.md
+++ b/docs/founder-kernel/wiki/index.md
@@ -1,47 +1,81 @@
 ---
 title: Founder Kernel
 pageKind: index
-status: published
-abstract: Top-level index for the founder kernel. Lists what's authored, what's planned, and how to navigate.
+status: draft
+abstract: Top-level index for the founder kernel — stances, heuristics, entities, and the raw sources that back them.
 ---
 
 ## What this is
 
-The founder kernel is the wisdom layer that ships with DPF. It answers the question every user eventually asks: **&#34;what would Mark do?&#34;** Pages here are not summaries of external material; they are the platform's stance, organised by kind.
+The founder kernel is the wisdom layer that ships with DPF. It answers the question every user eventually asks: **&#34;what would Mark do?&#34;** Pages here are not summaries of external material; they are the platform&#39;s stance, organised by kind.
 
-This index page exists to make the kernel navigable for humans. Agents discover pages via the wiki retrieval layer (`wiki_query` MCP tool, passive recall into Block 5) — they don't need this index. Humans do.
+This first cut was researched and drafted from Mark&#39;s public corpus (LinkedIn long-form articles, Open Group publications including the W205 *Shift to Digital Product* white paper, BriefingsDirect interviews, Architecture &amp; Governance Magazine, ServiceNow community blogs, IT4IT v3 contributions, DPROM, and CSDM v5 materials). Every page is **`status: draft`** — Mark reviews, edits, and flips to `published` what survives.
 
-## Page kinds
+## Stances — Mark&#39;s positions
 
-Six kinds live under `wiki/`. Their roles are defined formally in [`SCHEMA.md`](../SCHEMA.md); briefly:
+The judgment kernel. Cite these when grounding an answer in his thinking.
 
-| Kind | Role |
-|---|---|
-| **stance** | A position. &#34;Mark's view on X.&#34; First-person, cited, opinionated. The judgment surface. |
-| **heuristic** | An operational rule of thumb derived from a stance. Smaller, more specific, often quantitative. |
-| **entity** | A canonical concept the platform refers to repeatedly (Digital Product, Portfolio, Value Stream, …). Neutral voice. |
-| **decision** | A formal record of a choice with context, options considered, and consequences. `DEC-YYYY-…` slug. |
-| **summary** | A distillation of external source material, with at least one extracted stance or heuristic. |
-| **runbook** | Operational procedure for a specific task. Step-by-step. |
-| **index** | Scaffolding — pages like this one that help navigate the kernel. |
+- `[[stances/digital-product-is-the-unit-of-organization]]` — Digital Product is the right primitive for portfolio, team, funding, lifecycle, governance.
+- `[[stances/persistent-product-teams-over-projects]]` — Replace project teams with persistent teams; annual budgets with rolling investment.
+- `[[stances/it4it-is-substrate]]` — IT4IT integrates ITIL, COBIT, TOGAF, DevOps, SAFe at the operating-model layer. It does not compete.
+- `[[stances/dont-integrate-ea-platform]]` — Consolidate on one data model (CSDM); don&#39;t integrate a third-party EA tool with ServiceNow. The integration goes through Independent → Honeymoon → Ugly Reckoning.
+- `[[stances/trust-the-cmdb-or-rebuild-it]]` — Most organisations have a CMDB; very few trust it. Trust requires three pillars: Ingestion, Insight, Governance.
+- `[[stances/ea-is-meteorology]]` — Architects produce forecasts and guidance, not raw model exhibits.
+- `[[stances/contextualize-dont-transform]]` — When introducing a standard, map first. Adoption follows mapping; transformation follows adoption.
 
-Read [`AUTHORING.md`](../AUTHORING.md) to add a page in under 60 seconds.
+## Heuristics — operational rules
 
-## What's authored right now
+Smaller and more specific than stances. Useful when an agent needs to act, not just reason.
 
-Nothing. This index is the first kernel page seeded.
+- `[[heuristics/contextualize-before-transforming]]` — map existing operations onto the standard first.
+- `[[heuristics/find-at-least-one-champion]]` — adoption without an internal evangelist stalls.
+- `[[heuristics/pitch-simple-adjust-per-audience]]` — lead with the simplest framing; adjust language per audience.
+- `[[heuristics/model-what-naturally-happens]]` — connect relationships that already exist; don&#39;t build a data lake.
+- `[[heuristics/auto-populate-or-its-wrong]]` — manually-maintained inventory data is already lying to you.
+- `[[heuristics/reuse-the-camera-in-your-pocket]]` — platform-native usually wins over specialist best-of-breed.
+- `[[heuristics/be-a-meteorologist]]` — produce the forecast, not the radar image.
 
-The platform plumbing is ready — schema, retrieval, lint, viewer, agent integration — and waiting for content. The fastest way to make the kernel useful is to author 3–5 stance pages on topics people already ask &#34;what would Mark do?&#34; about. Heuristics and entity pages can grow alongside.
+## Entities — canonical concepts
 
-## How to find your way around
+Neutral definitions the rest of the kernel cross-references.
 
-Once content lands:
+- `[[entities/digital-product]]` — anything that runs code, one party responsible, delivers outcomes for a consumer party.
+- `[[entities/portfolio]]` — a curated set of Digital Products grouped for a shared management purpose.
+- `[[entities/it4it]]` — The Open Group reference architecture; substrate that integrates ITIL/COBIT/TOGAF/DevOps/SAFe.
+- `[[entities/csdm]]` — Common Service Data Model; the canonical data spine.
+- `[[entities/value-stream]]` — one of the seven IT4IT v3 flows.
 
-- **Browse**: `/wiki` lists every published page grouped by kind. Stances and heuristics surface at the top.
-- **Search via the agent**: ask any coworker a question that touches a kernel concept. The wiki retrieval layer injects relevant pages into the system prompt automatically, and the agent can also call `wiki_query` directly for explicit lookup.
-- **Author**: copy a template from [`_templates/`](../_templates/) into `wiki/&lt;kind&gt;s/&lt;slug&gt;.md`, fill it in, run the seed.
-- **Audit**: `/admin/wiki/lint` shows findings (orphans, dangling refs, stale citations, summary pages missing extracted stances). The daily Inngest job populates this; the `wiki_lint` MCP tool triggers it on-demand.
+## Raw sources
 
-## Org overlay
+Cited by the stances and heuristics above. See [`RAW-SOURCES-LICENSE.md`](../RAW-SOURCES-LICENSE.md) for the licensing policy — Mark&#39;s own LinkedIn articles bundle fully under Apache-2.0; third-party material is abstract + locator only.
 
-Customers will eventually be able to override or extend kernel pages with their own takes. That overlay UX is plumbed (Prisma schema, retrieval helpers) but the propose-edit UI is not yet shipped. Everything in `docs/founder-kernel/` is currently kernel-scoped — visible to every install equally.
+- `raw-sources/articles/why-product-centric-approach-needed` — May 2025 LinkedIn Pulse.
+- `raw-sources/articles/why-product-centricity-critical` — Dec 2024 LinkedIn Pulse.
+- `raw-sources/articles/think-twice-ea-platform-servicenow` — LinkedIn Pulse on EA-platform consolidation.
+- `raw-sources/articles/possible-futures-enterprise-architecture` — Architecture &amp; Governance Magazine.
+- `raw-sources/articles/open-group-2017-managing-business-of-it` — Open Group blog interview, Jan 2017.
+- `raw-sources/articles/briefings-direct-it4it-2019` — BriefingsDirect podcast transcript, March 2019.
+- `raw-sources/articles/sibling-portfolios` — ServiceNow community blog (with David Thigpen).
+- `raw-sources/papers/shift-to-digital-product-w205` — The Open Group white paper W205, Dec 2020.
+- `raw-sources/frameworks/it4it-v3` — The Open Group IT4IT standard v3.
+- `raw-sources/frameworks/csdm` — ServiceNow Common Service Data Model (currently v5).
+
+## What&#39;s still missing
+
+This is a first cut. Pages that the research digest surfaced but haven&#39;t been drafted yet:
+
+- **Stance: agentic AI without governance is the 36-vendors scenario** — referenced repeatedly in Mark&#39;s 2024–2025 LinkedIn posts; the canonical satirical post needs a verified URL before drafting.
+- **Entity: DPROM** — co-authored 2025; deserves its own entity page once the source paper is bundled.
+- **Decision pages** — none yet. As Mark records explicit DEC-* style decisions (e.g., DEC-2020-shift-to-digital-product, DEC-2022-it4it-v3-refactor) these will land under `wiki/decisions/`.
+- **Apple-to-orange comparison pages** — explicit "framework vs framework" pages where his nuance lives (IT4IT vs ITIL, IT4IT vs COBIT, CSDM vs ArchiMate).
+
+## How to navigate
+
+- **Browse**: `/wiki` lists every published page grouped by kind. Until pages flip from `draft` to `published`, they won&#39;t appear in the default published view.
+- **Search via the agent**: ask any coworker a question that touches a kernel concept. The wiki retrieval layer injects relevant pages into the system prompt automatically once they&#39;re published.
+- **Author / edit**: copy a template from [`../_templates/`](../_templates/), or edit any page on this branch directly. See [`../AUTHORING.md`](../AUTHORING.md) for the 60-second loop.
+- **Audit**: `/admin/wiki/lint` shows findings. The five live detectors will flag orphans, dangling refs, stale citations, etc.
+
+## Status of this index page
+
+Drafted by Claude from research on Mark&#39;s public writing. Marked `status: draft` like the rest. Mark reviews and either edits in place or replaces with a version in his own voice.

--- a/docs/founder-kernel/wiki/stances/contextualize-dont-transform.md
+++ b/docs/founder-kernel/wiki/stances/contextualize-dont-transform.md
@@ -1,0 +1,47 @@
+---
+title: Contextualize, don't transform — map first, evolve second
+pageKind: stance
+status: draft
+abstract: Standards adoption that frames itself as transformation gets rejected. Frame it as contextualization — "how is our operating model the same or different from the standard?" — and adoption follows.
+sources:
+  - articles/open-group-2017-managing-business-of-it
+---
+
+## The position
+
+When introducing `[[entities/it4it]]`, TOGAF, ArchiMate, `[[entities/csdm]]`, or any other standard to an organisation that already runs, **frame the work as contextualization, not transformation**. The question is: *"How is our current operating model the same or different from the standard?"*
+
+Adoption follows mapping. Transformation follows adoption. Skip the first step and the second never lands.
+
+## Why
+
+Executives reach their position by experience with what works. Introducing a "new framework" feels like a threat to that experience — it implies the current operating model is wrong, which implicates the people who built it. Resistance is rational.
+
+Contextualization side-steps the threat. It says: your operating model exists; it works; let&#39;s name it in the standard&#39;s vocabulary so we can compare. Where the standard adds value, you adopt it deliberately. Where your current model is already strong, you keep it. The standard becomes a tool, not a verdict.
+
+This was the lesson that landed in the 2017 IT4IT executive-adoption work. The phrase: *"I like to use the word &#39;contextualize,&#39; and the way I view the challenge is that if I contextualize our current operating model against IT4IT, how are we the same or different?"*
+
+The same framing applies to every cross-framework adoption I&#39;ve led since.
+
+## When this applies
+
+- Introducing any standard (IT4IT, TOGAF, CSDM, ArchiMate, BIAN) to an operating organisation.
+- Cross-framework reconciliation work (e.g., mapping existing ITIL processes onto IT4IT value streams).
+- Strategic planning where you want executives to engage with a model they didn&#39;t design.
+
+## When it doesn&#39;t
+
+- Greenfield. There&#39;s nothing to contextualize *against*; pick a standard and build to it.
+- Compliance-driven adoption where the standard is mandatory. Contextualization is still useful internally, but the framing externally is different.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/contextualize-before-transforming]]` — the mechanic.
+- `[[heuristics/find-at-least-one-champion]]` — without a champion, the contextualization conversation doesn&#39;t start.
+- `[[heuristics/pitch-simple-adjust-per-audience]]` — language matters; pick the right framing per audience.
+
+## See also
+
+- Stance: `[[stances/it4it-is-substrate]]` — the standard most often being contextualized.
+- Entity: `[[entities/it4it]]`
+- Raw source: `[[raw-sources/articles/open-group-2017-managing-business-of-it]]`

--- a/docs/founder-kernel/wiki/stances/digital-product-is-the-unit-of-organization.md
+++ b/docs/founder-kernel/wiki/stances/digital-product-is-the-unit-of-organization.md
@@ -1,0 +1,47 @@
+---
+title: Digital Product is the unit of organization for IT
+pageKind: stance
+status: draft
+abstract: Anything that runs code that one party is responsible for that delivers outcomes for a consumer party. That's the right primitive — for portfolio, team, funding, lifecycle, governance, everything.
+sources:
+  - articles/why-product-centric-approach-needed
+  - articles/why-product-centricity-critical
+  - papers/shift-to-digital-product-w205
+---
+
+## The position
+
+A `[[entities/digital-product]]` is **anything that runs code that one party is responsible for that delivers outcomes for a consumer party**. That definition is the right primitive for organising IT. Portfolio strategy, team structure, investment, lifecycle, governance, EA, ITSM — all of it should reduce to Digital Product.
+
+This isn&#39;t a refinement of the application-centric or service-centric models. It is a replacement for both. Application and service are facets of the same underlying thing; treating them as separate management surfaces is what produces the structural pain Dev and Ops keep blaming on each other.
+
+## Why
+
+I&#39;ve been watching IT misalign with business outcomes for 25 years across Dell, Troux, HPE, and ServiceNow. The misalignments are always the same shape: ITSM optimises for tickets, project management optimises for completion, APM optimises for application inventory, SPM optimises for service availability. None of those measure whether the consumer got the outcome they were promised.
+
+A product-centric model fixes the misalignment by **defining consumers and providers explicitly for every system**. Once you do that, every other framework — IT4IT, ITIL, ArchiMate, CSDM — reorganises around the same anchor and stops contradicting itself.
+
+The Open Group W205 paper (2020) was the first formal statement. IT4IT v3 (2022) carried it into the standard — the Service Model Backbone became the Digital Product Backbone for exactly this reason. DPROM (2025) carries it into the operating model.
+
+## When this applies
+
+- Setting up a new IT operating model.
+- Rationalising overlapping portfolios.
+- Funding ops vs. dev work that was previously split.
+- Designing a CMDB, an EA model, or a service catalog.
+- Building agents and AI co-workers that need a stable target to reason about.
+
+## When it doesn't
+
+- Pure infrastructure projects with no consumer party in the IT sense (cabling, datacenter buildouts, raw network gear). Those are inputs to Digital Products, not Digital Products themselves.
+- Pure business processes with no system component. Those are operated by Digital Products but aren&#39;t Digital Products.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/contextualize-before-transforming]]` — map existing portfolios onto Digital Product structure before changing anything.
+
+## See also
+
+- Stance: `[[stances/persistent-product-teams-over-projects]]` — the team-side corollary.
+- Stance: `[[stances/it4it-is-substrate]]` — the framework-integration corollary.
+- Entity: `[[entities/digital-product]]`

--- a/docs/founder-kernel/wiki/stances/dont-integrate-ea-platform.md
+++ b/docs/founder-kernel/wiki/stances/dont-integrate-ea-platform.md
@@ -1,0 +1,49 @@
+---
+title: Don't integrate a third-party EA platform with ServiceNow — consolidate on one data model
+pageKind: stance
+status: draft
+abstract: EA-platform-to-CMDB integrations go through Independent → Honeymoon → Ugly Reckoning. Pick one platform and one canonical data model (CSDM). The cost of consolidation is far less than the cost of the integration failing slowly.
+sources:
+  - articles/think-twice-ea-platform-servicenow
+  - articles/sibling-portfolios
+---
+
+## The position
+
+Don&#39;t integrate a third-party EA platform with ServiceNow (or with any operational system of record). **Consolidate on one platform with one canonical data model — `[[entities/csdm]]`**. Best-of-breed EA loses on practicality even when it wins on feature depth.
+
+> Disclosure: I&#39;m a ServiceNow Senior PM, and this stance aligns with ServiceNow&#39;s commercial interest. It also aligns with 18 years of watching the integration pattern fail at Dell, Troux, HPE, and ServiceNow. The pattern is real; my employer happens to be the consolidation target most often.
+
+## Why
+
+The integration progresses through three predictable phases:
+
+1. **Independent** — both platforms work fine. EA team owns the EA model; Ops team owns the CMDB. Each is correct on its own terms.
+2. **Honeymoon** — the integration ships. Everyone reports success. The first ~6 months look great.
+3. **Ugly Reckoning** — scope creep, semantic mismatches, chicken-vs-egg ownership questions, and reconciliation drift compound. The integration becomes "unachievable as originally intended." Data quality collapses. People stop trusting the model.
+
+The failure mode is structural. You have two systems of record claiming authority over the same entities. Reconciliation requires either a third authoritative source (which nobody can afford) or a one-way master-slave relationship (which one team has to accept losing). Both options usually fail to ship; the integration limps along producing increasingly stale views.
+
+The alternative is consolidation. Pick one platform and accept that you&#39;ll lose 10–20% of the specialist EA feature depth in exchange for never running the integration. The maths almost always favours the consolidation — see `[[heuristics/reuse-the-camera-in-your-pocket]]`.
+
+## When this applies
+
+- Choosing between a dedicated EA tool and an integrated platform that includes EA capability.
+- Inheriting an existing dedicated-EA-tool deployment with a CMDB integration in trouble.
+- Designing a CSDM rollout where someone proposes "let&#39;s keep the existing EA tool as the source for application data."
+
+## When it doesn&#39;t
+
+- Pure modeling work that doesn&#39;t need to flow into operations — academic EA exercises, future-state target architectures with no current-state tie-in.
+- Specialist domains the consolidation target genuinely doesn&#39;t cover (some industry-specific EA tools have capability ServiceNow lacks; those *might* justify the integration cost, but the bar is high).
+
+## Heuristics derived from this stance
+
+- `[[heuristics/reuse-the-camera-in-your-pocket]]` — the camera analogy makes the trade-off concrete.
+
+## See also
+
+- Stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — why consolidation only works if the CMDB is trustworthy.
+- Entity: `[[entities/csdm]]`
+- Entity: `[[entities/portfolio]]`
+- Related: `[[raw-sources/articles/sibling-portfolios]]` — the APM/SPM unification case study.

--- a/docs/founder-kernel/wiki/stances/ea-is-meteorology.md
+++ b/docs/founder-kernel/wiki/stances/ea-is-meteorology.md
@@ -1,0 +1,50 @@
+---
+title: EA is meteorology — provide forecasts, not raw models
+pageKind: stance
+status: draft
+abstract: Architects should be like meteorologists — produce forecasts and recommended actions, not exposed models. The deliverable to leadership is the guidance, not the diagram.
+sources:
+  - articles/possible-futures-enterprise-architecture
+---
+
+## The position
+
+Enterprise Architecture&#39;s job is to be a **judgment surface on top of the models**, not the model exhibit. Architects should function like meteorologists: collect the inputs, run the models internally, and produce a forecast that drives the decision. The deliverable to leadership is the recommendation, not the diagram.
+
+Most IT organisations have little to no business architecture in play, effectively making most current and future technology investment impossible to trace to business outcomes. The fix for that isn&#39;t more diagrams — it&#39;s a *guidance layer* on top of whatever model you have.
+
+## Why
+
+Showing leadership the raw architecture model is showing them the radar imagery instead of the weather forecast. They are not radar specialists. They are decision-makers. They need to know whether to invest, retire, consolidate, hire, or wait — not which functional component sits behind which API in the application portfolio.
+
+The meteorology analogy carries further. Weather forecasts:
+
+- Use a model the consumer doesn&#39;t see.
+- State confidence levels explicitly.
+- Update as conditions change.
+- Are useful even when they&#39;re wrong, because they made the unknowns legible.
+
+EA should produce outputs with the same properties.
+
+This is also the philosophical frame behind DPF&#39;s wiki kernel. The platform exists to be the guidance layer, not the model exhibit — "what would Mark do?" is a forecast question, not a diagram question.
+
+## When this applies
+
+- Executive-level architecture reviews.
+- Investment decisions on portfolios or platforms.
+- Any time an architect is asked to "show the model" by someone who isn&#39;t an architect.
+
+## When it doesn&#39;t
+
+- Peer-to-peer architecture discussions where the model *is* the medium.
+- Compliance / audit contexts that require the model on record.
+- Engineering hand-off where the next team needs the model to build against.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/be-a-meteorologist]]`
+
+## See also
+
+- Parent context: `[[entities/it4it]]` provides the substrate; this stance is about how to deploy the substrate to leadership.
+- Raw source: `[[raw-sources/articles/possible-futures-enterprise-architecture]]`

--- a/docs/founder-kernel/wiki/stances/it4it-is-substrate.md
+++ b/docs/founder-kernel/wiki/stances/it4it-is-substrate.md
@@ -1,0 +1,48 @@
+---
+title: IT4IT is the substrate — a hub of frameworks, not a competitor
+pageKind: stance
+status: draft
+abstract: IT4IT integrates ITIL, COBIT, TOGAF, DevOps, and SAFe at the operating-model layer. It does not replace them. Pitch it as a framework for managing IT, or as an operating model, depending on audience.
+sources:
+  - articles/briefings-direct-it4it-2019
+  - articles/open-group-2017-managing-business-of-it
+  - frameworks/it4it-v3
+  - papers/shift-to-digital-product-w205
+---
+
+## The position
+
+`[[entities/it4it]]` is not a framework that competes with ITIL, COBIT, TOGAF, DevOps, or SAFe. It is **the substrate that integrates all of them at the operating-model layer**. A hub of frameworks, designed as one architecture.
+
+This positioning matters because every framework conversation tends to devolve into framework-vs-framework debate. IT4IT short-circuits that: ITIL owns service operations; COBIT owns governance; TOGAF owns the modeling vocabulary; DevOps and SAFe own delivery; IT4IT owns the integration between them.
+
+## Why
+
+I&#39;ve worked with IT4IT since the forum&#39;s 2014 inception (100+ engagements since 2013). Every successful adoption I&#39;ve seen starts with the same insight: the customer already has ITIL, already has some flavour of COBIT, often has TOGAF, and increasingly has DevOps and SAFe. The question isn&#39;t "which framework wins?" — it&#39;s "how do they coexist without contradicting each other?"
+
+IT4IT&#39;s seven value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume) are the seam where the other frameworks plug in. ITIL processes attach to Operate. DevOps practices attach to Integrate/Deploy/Release. TOGAF models attach to Explore. COBIT controls thread through all seven.
+
+The executive pitch reflects this: **"I pitch it as a framework for managing IT and leave it at that. I might also say it&#39;s an operating model."** Lead with the simple framing the audience can ingest; let the integration value reveal itself through use.
+
+## When this applies
+
+- Any conversation that&#39;s starting to turn into framework-vs-framework.
+- Executive sponsor briefings where the audience is fluent in ITIL or TOGAF but not IT4IT.
+- Standards adoption decisions where the question is "which standard do we pick?"
+
+## When it doesn&#39;t
+
+- Pure ITIL or pure TOGAF shops with no cross-framework reconciliation problem. They don&#39;t need a substrate; they have one framework working.
+- Greenfield startups where there&#39;s no installed framework base yet. IT4IT can be the starting point, but so can many things.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/contextualize-before-transforming]]` — map IT4IT onto current operations, don&#39;t flip the operating model.
+- `[[heuristics/pitch-simple-adjust-per-audience]]` — the executive-pitch tactic.
+- `[[heuristics/find-at-least-one-champion]]` — adoption needs an evangelist.
+
+## See also
+
+- Entity: `[[entities/it4it]]`
+- Entity: `[[entities/value-stream]]`
+- Raw source: `[[raw-sources/articles/briefings-direct-it4it-2019]]`

--- a/docs/founder-kernel/wiki/stances/persistent-product-teams-over-projects.md
+++ b/docs/founder-kernel/wiki/stances/persistent-product-teams-over-projects.md
@@ -1,0 +1,45 @@
+---
+title: Persistent product teams replace project teams; rolling investment replaces annual budgets
+pageKind: stance
+status: draft
+abstract: Projects are time-bound and optimise for delivery deadlines rather than long-term sustainability. The fix is teams that persist with the product and money that flows where outcomes accrue.
+sources:
+  - articles/why-product-centric-approach-needed
+  - articles/why-product-centricity-critical
+---
+
+## The position
+
+Replace project teams with **persistent teams that own a `[[entities/digital-product]]` across its full lifecycle**. Replace annual project budgets with **rolling investment** in those products. Measure by business outcomes, not by project completion or service uptime.
+
+Projects end. Products don&#39;t. The mismatch between bounded funding and unbounded ownership is where most IT-vs-business friction lives.
+
+## Why
+
+Projects are time-bound. They optimise for delivery deadlines rather than long-term sustainability. The team disbands at go-live, ownership scatters, the product enters a "maintenance" phase that nobody is accountable for, technical debt compounds, and three years later someone proposes a "modernisation project" that&#39;s really a do-over.
+
+The persistent-team model breaks the cycle. Teams that own a product across its lifecycle care about its evolvability, not just its delivery. They make architectural decisions with the second decade in mind. They turn down feature scope that would compound debt.
+
+Funding follows. If teams persist, money has to too — annual budget gates fight the very stability the team is set up to provide. Rolling investment that flows with the product, tied to outcome measures, is the operating-model corollary.
+
+DPROM (2025, co-authored with Dan Warfield, Dave Lounsbury, John Spirko, David Mosko) formalises this — explicitly built around the Inverse Conway Maneuver. The org shape produces the architecture; design the org to produce the architecture you want.
+
+## When this applies
+
+- Any IT capability you intend to run for more than one funding cycle.
+- Strategic investments where outcomes are uncertain at the start.
+- Any product where evolvability matters more than predictability.
+
+## When it doesn&#39;t
+
+- Genuinely time-bounded one-time work — a migration with a clean end-date, a regulatory compliance project that retires after audit. Don&#39;t force these into product shape; project shape is correct for them.
+- Pilot work that&#39;s explicitly throwaway. Persistent teams are an investment; pilots are an option.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/contextualize-before-transforming]]` — adopt persistent teams against the current operating model, not in place of it.
+
+## See also
+
+- Parent stance: `[[stances/digital-product-is-the-unit-of-organization]]`
+- Entity: `[[entities/digital-product]]`

--- a/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
+++ b/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
@@ -1,0 +1,50 @@
+---
+title: Trust the CMDB or rebuild it on the three pillars
+pageKind: stance
+status: draft
+abstract: Most organisations have a CMDB; very few actually trust it. Trust is built through Ingestion (auto-populate), Insight (actually use the data), and Governance & Health (people and process). If any pillar is missing, the CMDB is lying to you.
+sources:
+  - frameworks/csdm
+---
+
+## The position
+
+Most organisations have a CMDB. Very few actually trust it. **Trust is the only quality of a CMDB that matters** — an untrusted CMDB is technical debt that compounds.
+
+Trust rests on three pillars:
+
+1. **Ingestion** — auto-populate. It is not humanly possible to manually track the rapid inflation and deflation of virtualised cloud resources, hybrid environments, and on-premises infrastructure.
+2. **Insight** — actually use the data for operations and planning. A CMDB nobody queries is a CMDB nobody fixes.
+3. **Governance &amp; Health** — people and process, not just tech. Someone has to own the model, someone has to triage discoveries, someone has to retire stale rows.
+
+If any pillar is missing, the CMDB is lying to you — and acting on it produces wrong decisions you&#39;ll only discover months later.
+
+## Why
+
+The CMDB problem isn&#39;t that the data model is hard. `[[entities/csdm]]` (currently at v5) has settled the model question — it&#39;s the canonical spine. The problem is that organisations stand up the data model without standing up the three pillars, then are surprised when the CMDB stops being useful.
+
+The technical-debt use case was where this lesson originally landed. The early ServiceNow Technology Portfolio Management work hit the wall on technical-debt reporting because there was no single source of truth across asset, dev, ops, ITSM, and CSM. **The vision was to create a common model that connects what naturally happens. CSDM was born.** The same lesson kept replaying across every customer: model alone isn&#39;t enough.
+
+The ROI conversation that lands with executives is tool consolidation: organisations routinely have 300+ tools doing the same IT function (monitoring is the canonical example). You can&#39;t rationalise that without a trusted CMDB to tell you which tool does what. Build the three pillars; the rationalisation funds itself.
+
+## When this applies
+
+- Standing up a new CMDB.
+- Rescuing a CMDB that&#39;s lost the team&#39;s trust.
+- Designing data foundations for cross-product reasoning, AI co-workers, or rationalisation initiatives.
+
+## When it doesn&#39;t
+
+- Small organisations where the manual-tracking burden is genuinely tractable (rare; usually self-deception).
+- Read-only reporting use cases where stale data is acceptable.
+
+## Heuristics derived from this stance
+
+- `[[heuristics/auto-populate-or-its-wrong]]` — the first pillar in operational form.
+- `[[heuristics/model-what-naturally-happens]]` — how to build the data model without becoming a data-lake project.
+
+## See also
+
+- Entity: `[[entities/csdm]]`
+- Stance: `[[stances/dont-integrate-ea-platform]]` — why one trusted CMDB beats two integrated ones.
+- Raw source: `[[raw-sources/frameworks/csdm]]`


### PR DESCRIPTION
## Summary

First synthesized cut of the **founder kernel**. Drafted by Claude from research on Mark&#39;s public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect podcast, Architecture &amp; Governance Magazine, ServiceNow community blogs, CSDM v5 materials).

**Every page ships `status: draft`.** Mark reviews, edits in place, and flips to `published` what survives. Nothing here is asserted as Mark&#39;s authoritative voice until he says so.

## What&#39;s in this PR (30 new markdown files + index/manifest updates)

### Raw sources (10)

Cited by the stances/heuristics below. Per `RAW-SOURCES-LICENSE.md`: Mark&#39;s own LinkedIn articles bundle fully under Apache-2.0; third-party material is abstract + locator only.

- **Articles (7)**: `why-product-centric-approach-needed` (LinkedIn Pulse, May 2025), `why-product-centricity-critical` (Dec 2024), `think-twice-ea-platform-servicenow`, `possible-futures-enterprise-architecture` (A&amp;G), `open-group-2017-managing-business-of-it`, `briefings-direct-it4it-2019`, `sibling-portfolios` (with David Thigpen).
- **Papers (1)**: `shift-to-digital-product-w205` (Open Group white paper, Dec 2020).
- **Frameworks (2)**: `it4it-v3` (The Open Group standard), `csdm` (ServiceNow Common Service Data Model v5).

### Entities (5) — canonical concepts

- `digital-product` — &#34;anything that runs code that one party is responsible for that delivers outcomes for a consumer party.&#34;
- `portfolio` — a curated set of Digital Products grouped for a shared management purpose.
- `it4it` — Open Group reference architecture; substrate that integrates ITIL/COBIT/TOGAF/DevOps/SAFe.
- `csdm` — canonical data spine.
- `value-stream` — the seven IT4IT v3 flows (Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume).

### Stances (7) — Mark&#39;s judgment positions

- `digital-product-is-the-unit-of-organization` — the right primitive for portfolio, team, funding, lifecycle, governance.
- `persistent-product-teams-over-projects` — replace project teams with persistent ones; annual budgets with rolling investment.
- `it4it-is-substrate` — a hub of frameworks, not a competitor.
- `dont-integrate-ea-platform` — consolidate on one data model; Independent → Honeymoon → Ugly Reckoning. **Includes explicit conflict-of-interest disclosure** noting Mark&#39;s ServiceNow employment.
- `trust-the-cmdb-or-rebuild-it` — Ingestion + Insight + Governance.
- `ea-is-meteorology` — produce forecasts, not raw model exhibits.
- `contextualize-dont-transform` — map first, evolve second.

### Heuristics (7) — operational rules of thumb

- `contextualize-before-transforming`
- `find-at-least-one-champion`
- `pitch-simple-adjust-per-audience`
- `model-what-naturally-happens`
- `auto-populate-or-its-wrong`
- `reuse-the-camera-in-your-pocket`
- `be-a-meteorologist`

### Updates

- `wiki/index.md` — refreshed table of contents (was placeholder; now lists all 19 wiki pages).
- `manifest.json` — bumped `kernelVersion: 0.1.0 → 0.2.0-draft`; `pageCount: 0 → 19`; `sourceCount: 0 → 10`.

## Research methodology

A general-purpose subagent was dispatched to research Mark&#39;s public corpus: LinkedIn profile + posts/articles, Open Group publications (W205, IT4IT v3, DPROM, Member Spotlight), Architecture &amp; Governance Magazine, ServiceNow community blogs, BriefingsDirect podcast, Knowledge17/23/26 interviews, YouTube, GitHub.

The agent returned a ~5K-word structured digest with profile, article inventory, themes, stances, heuristics, verbatim quotes with attribution, and accuracy notes. This commit is the synthesised first cut from that digest.

Pages drafted in Mark&#39;s voice using direct quotes and close paraphrases from cited sources. Where source attribution couldn&#39;t be verified to canonical URL (notably the &#34;36 vendors&#34; agentic-AI satire and the ODPF launch article), the page was **not** drafted — it&#39;s called out in `wiki/index.md` under &#34;What&#39;s still missing.&#34;

## What&#39;s deliberately not drafted

Surfaced by the research but withheld pending verification or further direction:

- **Stance on agentic-AI governance** — the &#34;36 vendors don&#39;t know why they were paid&#34; satire is referenced in search snippets but the canonical post URL wasn&#39;t retrievable. Verify before drafting.
- **DPROM entity page** — co-authored 2025; deserves a full page once the source paper is bundled.
- **DEC-YYYY decision pages** — none yet. As Mark records explicit decisions in his voice (e.g., DEC-2020-shift-to-digital-product, DEC-2022-it4it-v3-refactor), these will land under `wiki/decisions/`.
- **Framework-comparison pages** — explicit &#34;IT4IT vs ITIL&#34; / &#34;CSDM vs ArchiMate&#34; pages where nuance lives. Need Mark&#39;s direct words to do justice.

## Conflict-of-interest disclosure

The `dont-integrate-ea-platform` stance aligns with ServiceNow&#39;s commercial interest, and Mark is a ServiceNow Senior PM. The page calls this out explicitly in a disclosure block. If you (Mark) want that softened, hardened, or removed, edit in place.

## How to review

1. **Skim `wiki/index.md`** — the new table of contents tells you what landed.
2. **Read the stances first** — these are the judgment surface; everything else cites them. Start with `digital-product-is-the-unit-of-organization` and `it4it-is-substrate`.
3. **Spot-check quotes against your articles** — every page&#39;s `sources:` frontmatter cites the article it&#39;s drawn from. Pull up the original and compare.
4. **Edit in place on this branch** — fix voice, sharpen positions, add what I missed. The PR description above documents what was drafted; commits on top of this can revise without losing the trail.
5. **Flip to `status: published`** on pages you&#39;re happy with. Leave `status: draft` on the rest — the published filter in `searchWikiPages` excludes drafts, so the agent only grounds in pages you&#39;ve approved.
6. **Mark `wiki/index.md` to `status: published`** once you&#39;re happy with the inventory; same for `manifest.json` (drop `-draft` from kernelVersion).

## Test plan

- [ ] Spot-check 3–5 stance pages against the source articles cited in their `sources:` frontmatter
- [ ] Confirm the conflict-of-interest disclosure on `dont-integrate-ea-platform` reads correctly
- [ ] Run `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts` against a fresh DB; confirm seed succeeds and reports `pages=19 sources=10 qdrant=no-sidecar`
- [ ] Visit `/wiki` in a running dev server (note: only `published` pages show — drafts won&#39;t until flipped)
- [ ] Visit `/admin/wiki/lint` after the daily Inngest job runs; address any orphans / dangling refs / stale citations

## Build gate

No code changed in this PR. All Markdown content matches the frontmatter shape from `docs/founder-kernel/_templates/` and parses via the established `parseFrontmatter` in `packages/db/src/seed-wiki-kernel.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_