### PR TITLE
docs(installer): install verification issue template for community reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/install_verification.md
+++ b/.github/ISSUE_TEMPLATE/install_verification.md
@@ -1,0 +1,103 @@
+---
+name: Install verification report
+about: Tried install-dpf.sh on macOS or Linux? Tell us how it went.
+title: "Install verification — "
+labels: ["install-verification", "community-report"]
+assignees: []
+---
+
+<!-- Thank you for trying the early-access macOS / Linux installer!
+     The information below helps us close the gap between "we believe
+     it works" and "we've seen it work on real hardware." Partial
+     reports are useful too — fill in what you can. -->
+
+## Quick fingerprint
+
+**Platform:** <!-- macOS / Linux -->
+**OS version:** <!-- e.g. macOS 14.5, Ubuntu 22.04.4, Debian 12.6, Fedora 39 -->
+**Architecture:** <!-- arm64 / x86_64 -->
+**Hardware notes:** <!-- e.g. M2 Pro MacBook Air; bare-metal Ryzen; AWS t3.large; etc. -->
+
+Paste the output of (one block, redact anything you don't want public):
+
+```
+uname -a
+# macOS:
+sw_vers 2>/dev/null
+# Linux:
+cat /etc/os-release 2>/dev/null | head -5
+
+docker --version 2>/dev/null
+docker compose version 2>/dev/null
+node -v
+pnpm -v
+grep DPF_INSTALLER_VERSION install-dpf.sh
+```
+
+<details>
+<summary>Environment output</summary>
+
+```
+<paste here>
+```
+
+</details>
+
+## How it went
+
+**Install command used:**
+
+```bash
+# e.g. bash install-dpf.sh
+# or:  bash install-dpf.sh --headless --release
+```
+
+**Outcome:** <!-- pick one -->
+- [ ] Installed cleanly; portal at `http://localhost:3000` reachable; login worked
+- [ ] Installed with warnings (described below)
+- [ ] Hit a wall — install did not complete
+
+## Runbook checklist
+
+Tick the boxes for steps you observed working. Skipped steps are
+fine — leave them unchecked.
+
+<!-- See docs/install/verification-runbook.md for context on each. -->
+
+**Preflight + install:**
+- [ ] Preflight passed (no unsupported-host refusal)
+- [ ] Port-conflict preflight passed
+- [ ] Docker auto-install completed (Docker Desktop `.dmg` on macOS / Docker Engine via `apt`/`dnf` on Linux)
+- [ ] `~/.dpf/install-state.json` exists with `"schemaVersion": 1`
+- [ ] `docker compose -p dpf ps` shows expected services running
+- [ ] `curl http://localhost:3000/api/health` returned 200
+- [ ] Login at the portal with `admin@dpf.local` succeeded
+
+**Autostart:**
+- [ ] LaunchAgent (macOS) `~/Library/LaunchAgents/local.dpf-autostart.plist` present
+- [ ] OR systemd-user unit (Linux) `~/.config/systemd/user/dpf.service` present + enabled
+- [ ] **Rebooted host; portal came back at `localhost:3000` within 60 seconds**
+
+**Discovery / observability (optional but valuable):**
+- [ ] Discovery sweep emitted real installed-software rows (`pkgutil` on macOS, `dpkg`/`rpm` on Linux)
+- [ ] Prometheus targets at `http://localhost:9090/api/v1/targets` show `health: "up"`
+- [ ] Grafana at `http://localhost:3002` reachable
+
+**Lifecycle:**
+- [ ] `bash dpf-stop.sh && bash dpf-start.sh` round-tripped cleanly
+- [ ] `bash uninstall-dpf.sh --purge --yes` removed volumes + state + `.env`
+
+## Diagnostic bundle
+
+Please attach the diagnostic bundle. Secrets are redacted automatically:
+
+```bash
+bash install-dpf.sh doctor
+# Then drag-and-drop ~/.dpf/doctor-<timestamp>.tar.gz into this issue.
+```
+
+## Anything else
+
+<!-- Surprises, papercuts, copy issues in the install output, anything
+     unexpected. Failure reports are equally valuable — tell us where
+     it broke and what the error said. -->

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ What we **haven't** done — and what you can help with — is run the full inst
 
 …please try it and tell us how it went. Both happy-path success stories and "the installer hit a wall at step X" failures are equally useful — the wall-hits are how we close the gap between "we believe it works" and "we know it works."
 
-**How to report:** open a GitHub issue titled `Install verification — <platform> <distro/version>` and attach the diagnostic bundle produced by `bash install-dpf.sh doctor` (it lives at `~/.dpf/doctor-<timestamp>.tar.gz` and redacts secrets automatically). The [verification runbook](docs/install/verification-runbook.md) lists what to check and what artifacts to capture.
+**How to report:** open a GitHub issue using the [Install verification report template](.github/ISSUE_TEMPLATE/install_verification.md) (titled `Install verification — <platform> <version>`) and attach the diagnostic bundle produced by `bash install-dpf.sh doctor` (it lives at `~/.dpf/doctor-<timestamp>.tar.gz` and redacts secrets automatically). The [verification runbook](docs/install/verification-runbook.md) lists what to check and what artifacts to capture.
 
 The Windows installer remains the only GA path — production stable, used by real customers. The macOS / Linux paths graduate from "Early access" to "GA" once we have a handful of community verification reports per platform.
 

--- a/docs/install/verification-runbook.md
+++ b/docs/install/verification-runbook.md
@@ -14,12 +14,13 @@
 > and run through it.** Both happy-path and failure reports are
 > valuable.
 >
-> **How to report:** open a [GitHub issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new)
-> titled `Install verification — <platform> <version>`, paste your
-> environment fingerprint, note which steps passed / failed, and
-> attach the doctor bundle (`bash install-dpf.sh doctor` →
-> `~/.dpf/doctor-<timestamp>.tar.gz`). Secrets are redacted
-> automatically.
+> **How to report:** open an issue using the
+> [Install verification report template](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new?template=install_verification.md)
+> (it pre-fills the title prefix `Install verification — ` and the
+> `install-verification` label). Paste your environment fingerprint,
+> tick the checklist items you observed, and attach the doctor bundle
+> (`bash install-dpf.sh doctor` → `~/.dpf/doctor-<timestamp>.tar.gz`).
+> Secrets are redacted automatically.
 >
 > We don't need every checkbox before reading your report —
 > partial reports are useful too.
@@ -228,14 +229,22 @@ Linked spec: [docs/superpowers/specs/2026-05-09-cloud-deployment-design.md](../s
 
 ## Reporting verification results
 
-When you've run a section, **open a GitHub issue** titled
-`Install verification — <platform> <version>` and include:
+When you've run a section, file your report through the
+[Install verification report template](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new?template=install_verification.md).
+The form mirrors the checklist above and pre-fills:
 
-- Your environment fingerprint (`uname -a`, `sw_vers` / `cat /etc/os-release`)
-- Which checklist boxes you ticked, which you skipped, and which failed
-- The doctor bundle (`bash install-dpf.sh doctor` → attach the
+- Title prefix `Install verification — `
+- Labels: `install-verification`, `community-report`
+
+The template prompts for everything maintainers need:
+
+- Environment fingerprint (`uname -a`, `sw_vers` / `cat /etc/os-release`,
+  Docker version, Node + pnpm versions, installer version)
+- Install command + outcome (cleanly / with warnings / hit a wall)
+- Checklist of preflight, install, autostart, discovery, lifecycle steps
+- Doctor bundle attachment (`bash install-dpf.sh doctor` → attach
   `~/.dpf/doctor-<timestamp>.tar.gz`)
-- Any screenshots of unexpected portal behavior
+- Free-text "anything else" for surprises, papercuts, copy issues
 
 Maintainers will:
 


### PR DESCRIPTION
Closes the enablement loop on the early-access advertising shipped
in #470 / #481: contributors who run `install-dpf.sh` on real Apple
Silicon or Linux hardware now have a **structured issue template** to
file their report into, instead of free-form prose that maintainers
would otherwise have to chase follow-ups on.

## What ships

### `.github/ISSUE_TEMPLATE/install_verification.md` (new)

Legacy-markdown template matching the repo's existing
`bug_report.md` / `feature_request.md` style (frontmatter + body).
Pre-fills:

- **Title prefix:** `Install verification — `
- **Labels:** `install-verification`, `community-report`

Prompts the reporter for:

| Section | Content |
|---------|---------|
| Quick fingerprint | Platform / OS version / architecture / hardware notes + a paste-able command block |
| How it went | Install command used + outcome (cleanly / with warnings / hit a wall) |
| Runbook checklist | Mirrors the [verification runbook](docs/install/verification-runbook.md) sections — preflight + install, autostart, discovery / observability, lifecycle |
| Diagnostic bundle | `bash install-dpf.sh doctor` instructions + attach prompt |
| Anything else | Free-text for surprises, papercuts, copy issues |

### Cross-links updated

- **`README.md`** — "How to report" now points at the template URL.
- **`docs/install/verification-runbook.md`** — both the top-of-file
  "How to report" callout and the bottom-of-file "Reporting
  verification results" section now point at the template URL using
  `?template=install_verification.md` so GitHub pre-fills the title
  prefix and labels.

## Why a structured form

Without it, the community reports we asked for in #481 would arrive
in arbitrary shapes — missing the doctor bundle, missing the OS
version, missing whether autostart-after-reboot survived. Maintainers
would burn time chasing follow-ups. The template puts the prompts
inline so the cost of filing a useful report is one paste + one drag-
and-drop.

## What doesn't change

No installer code. No CI workflows. No claims about the installer's
maturity (still "Early access" for macOS / Linux, still "GA" for
Windows only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_