### PR TITLE
feat: add licensing compliance workspace

### DIFF
--- a/apps/web/app/(shell)/compliance/licensing/page.tsx
+++ b/apps/web/app/(shell)/compliance/licensing/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { getLicensingWorkspace } from "@/lib/actions/licensing-compliance";
+import { LicensingWorkspacePanel } from "@/components/compliance/licensing/LicensingWorkspacePanel";
+
+export default async function ComplianceLicensingPage() {
+  const workspace = await getLicensingWorkspace();
+
+  return (
+    <div>
+      <div className="mb-2">
+        <Link
+          href="/compliance"
+          className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+        >
+          Compliance
+        </Link>
+        <span className="text-xs text-[var(--dpf-muted)]"> / </span>
+        <span className="text-xs text-[var(--dpf-text)]">Licensing</span>
+      </div>
+
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Licensing Readiness</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Track organization licenses, person-held credentials, display obligations, fee readiness, and licensing gaps in one factual Compliance workspace.
+        </p>
+      </div>
+
+      <div className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Workspace context</p>
+        <p className="mt-1 text-sm text-[var(--dpf-text)]">{workspace.organization.name}</p>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          Compliance remains the operational home here, with factual cross-links into Finance for fees, Staff for holders, and Evidence for public-display proof.
+        </p>
+      </div>
+
+      <LicensingWorkspacePanel workspace={workspace} />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/compliance/page.tsx
+++ b/apps/web/app/(shell)/compliance/page.tsx
@@ -70,10 +70,10 @@ export default async function CompliancePage() {
 
       {/* Posture Summary */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <MetricCard label="Obligations" value={activeObligationCount} color="#ef4444" />
-        <MetricCard label="Control Coverage" value={`${coveragePct}%`} color={coveragePct >= 80 ? "#4ade80" : "#fbbf24"} />
-        <MetricCard label="Open Incidents" value={openIncidentCount} color={openIncidentCount > 0 ? "#ef4444" : "#4ade80"} />
-        <MetricCard label="Overdue Actions" value={overdueActionCount} color={overdueActionCount > 0 ? "#ef4444" : "#4ade80"} />
+        <MetricCard label="Obligations" value={activeObligationCount} accent="var(--dpf-accent)" />
+        <MetricCard label="Control Coverage" value={`${coveragePct}%`} accent={coveragePct >= 80 ? "var(--dpf-success)" : "var(--dpf-warning)"} />
+        <MetricCard label="Open Incidents" value={openIncidentCount} accent={openIncidentCount > 0 ? "var(--dpf-error)" : "var(--dpf-success)"} />
+        <MetricCard label="Overdue Actions" value={overdueActionCount} accent={overdueActionCount > 0 ? "var(--dpf-error)" : "var(--dpf-success)"} />
       </div>
 
       {/* Regulatory Alerts */}
@@ -143,19 +143,25 @@ export default async function CompliancePage() {
       <section className="mt-8">
         <h2 className="text-xs text-[var(--dpf-muted)] uppercase tracking-widest mb-3">Policy Compliance</h2>
         <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-          <MetricCard label="Published Policies" value={publishedPolicyCount} color="#a78bfa" />
-          <MetricCard label="Total Acknowledgments" value={totalAcks} color="#4ade80" />
+          <MetricCard label="Published Policies" value={publishedPolicyCount} accent="var(--dpf-accent)" />
+          <MetricCard label="Total Acknowledgments" value={totalAcks} accent="var(--dpf-success)" />
         </div>
       </section>
     </div>
   );
 }
 
-function MetricCard({ label, value, color }: { label: string; value: number | string; color: string }) {
+function MetricCard({ label, value, accent }: { label: string; value: number | string; accent: string }) {
   return (
-    <div className="p-4 rounded-lg border border-[var(--dpf-border)]">
+    <div
+      className="p-4 rounded-lg border"
+      style={{
+        borderColor: `color-mix(in srgb, ${accent} 28%, var(--dpf-border))`,
+        background: `color-mix(in srgb, ${accent} 8%, var(--dpf-surface-1))`,
+      }}
+    >
       <p className="text-xs text-[var(--dpf-muted)] mb-1">{label}</p>
-      <p className="text-2xl font-bold" style={{ color }}>{value}</p>
+      <p className="text-2xl font-bold" style={{ color: accent }}>{value}</p>
     </div>
   );
 }

--- a/apps/web/components/compliance/ComplianceTabNav.test.tsx
+++ b/apps/web/components/compliance/ComplianceTabNav.test.tsx
@@ -23,6 +23,7 @@ describe("ComplianceTabNav", () => {
     const html = renderToStaticMarkup(<ComplianceTabNav />);
 
     expect(html).toContain(">Overview<");
+    expect(html).toContain(">Licensing<");
     expect(html).toContain(">Library<");
     expect(html).toContain(">Controls<");
     expect(html).toContain(">Assurance<");
@@ -42,5 +43,14 @@ describe("ComplianceTabNav", () => {
     expect(html).toContain('href="/compliance/gaps"');
     expect(html).not.toContain(">Policies<");
     expect(html).not.toContain(">Regulations<");
+  });
+
+  it("shows the licensing family when the licensing workspace is active", () => {
+    pathname = "/compliance/licensing";
+    const html = renderToStaticMarkup(<ComplianceTabNav />);
+
+    expect(html).toContain('href="/compliance/licensing"');
+    expect(html).toContain("Operate licensing, permit, credential, fee, and display-readiness workflows");
+    expect(html).not.toContain(">Onboard<");
   });
 });

--- a/apps/web/components/compliance/ComplianceTabNav.tsx
+++ b/apps/web/components/compliance/ComplianceTabNav.tsx
@@ -20,6 +20,13 @@ const FAMILIES: ComplianceFamily[] = [
     subItems: [],
   },
   {
+    label: "Licensing",
+    href: "/compliance/licensing",
+    description: "Operate licensing, permit, credential, fee, and display-readiness workflows across the business.",
+    matchPrefixes: ["/compliance/licensing"],
+    subItems: [{ label: "Licensing workspace", href: "/compliance/licensing" }],
+  },
+  {
     label: "Library",
     href: "/compliance/policies",
     description: "Manage the rules you are accountable to and the internal policy library around them.",

--- a/apps/web/components/compliance/licensing/CreateOrganizationLicenseRecordForm.tsx
+++ b/apps/web/components/compliance/licensing/CreateOrganizationLicenseRecordForm.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ComplianceModal } from "@/components/compliance/ComplianceModal";
+import { createOrganizationLicenseRecord } from "@/lib/actions/licensing-compliance";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-transparent px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+type RequirementOption = {
+  id: string;
+  requirementRefId: string;
+  jurisdictionLabel: string;
+  authorityName: string;
+  requirementType: string;
+  scopeLevel: string;
+};
+
+type Props = {
+  requirementOptions: RequirementOption[];
+};
+
+export function CreateOrganizationLicenseRecordForm({ requirementOptions }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    const form = new FormData(event.currentTarget);
+    const result = await createOrganizationLicenseRecord({
+      requirementReferenceId: (form.get("requirementReferenceId") as string) || "",
+      licenseKind: form.get("licenseKind") as string,
+      status: form.get("status") as string,
+      licenseNumber: (form.get("licenseNumber") as string) || "",
+      issuedAt: (form.get("issuedAt") as string) || "",
+      effectiveFrom: (form.get("effectiveFrom") as string) || "",
+      expiresAt: (form.get("expiresAt") as string) || "",
+      renewalCadence: (form.get("renewalCadence") as string) || "",
+      renewalFeeAmount: (form.get("renewalFeeAmount") as string) || "",
+      renewalFeeCurrency: (form.get("renewalFeeCurrency") as string) || "",
+      displayRequirementStatus: form.get("displayRequirementStatus") as string,
+      officialSourceUrl: (form.get("officialSourceUrl") as string) || "",
+      verificationNotes: (form.get("verificationNotes") as string) || "",
+      displayType: (form.get("displayType") as string) || "",
+      displayLocation: (form.get("displayLocation") as string) || "",
+      displayRequirementLevel: (form.get("displayRequirementLevel") as string) || "",
+      feeType: (form.get("feeType") as string) || "",
+      feeAmount: (form.get("feeAmount") as string) || "",
+      feeCurrency: (form.get("feeCurrency") as string) || "",
+      feeDueDate: (form.get("feeDueDate") as string) || "",
+      financeHandoffMode: (form.get("financeHandoffMode") as string) || "",
+      feeNotes: (form.get("feeNotes") as string) || "",
+    });
+    setLoading(false);
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+      >
+        Add company license
+      </button>
+      <ComplianceModal open={open} onClose={() => setOpen(false)} title="Add Company License">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className={labelClasses}>Requirement reference</label>
+            <select name="requirementReferenceId" className={inputClasses} defaultValue="">
+              <option value="">Manual record</option>
+              {requirementOptions
+                .filter((option) => option.scopeLevel === "organization" || option.scopeLevel === "activity" || option.scopeLevel === "premises")
+                .map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.authorityName} · {option.jurisdictionLabel}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>License kind *</label>
+              <input name="licenseKind" required className={inputClasses} placeholder="contractor_license" />
+            </div>
+            <div>
+              <label className={labelClasses}>Status *</label>
+              <select name="status" className={inputClasses} defaultValue="active">
+                <option value="draft">Draft</option>
+                <option value="researching">Researching</option>
+                <option value="applied">Applied</option>
+                <option value="active">Active</option>
+                <option value="expired">Expired</option>
+                <option value="suspended">Suspended</option>
+                <option value="blocked">Blocked</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>License number</label>
+              <input name="licenseNumber" className={inputClasses} placeholder="NV-12345" />
+            </div>
+            <div>
+              <label className={labelClasses}>Display status</label>
+              <select name="displayRequirementStatus" className={inputClasses} defaultValue="unknown">
+                <option value="unknown">Unknown</option>
+                <option value="required">Required</option>
+                <option value="not_required">Not required</option>
+                <option value="satisfied">Satisfied</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className={labelClasses}>Issued</label>
+              <input name="issuedAt" type="date" className={inputClasses} />
+            </div>
+            <div>
+              <label className={labelClasses}>Effective</label>
+              <input name="effectiveFrom" type="date" className={inputClasses} />
+            </div>
+            <div>
+              <label className={labelClasses}>Expires</label>
+              <input name="expiresAt" type="date" className={inputClasses} />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>Renewal cadence</label>
+              <input name="renewalCadence" className={inputClasses} placeholder="annual" />
+            </div>
+            <div>
+              <label className={labelClasses}>Source URL</label>
+              <input name="officialSourceUrl" className={inputClasses} placeholder="https://authority.example/license/123" />
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Display obligation</p>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              <div>
+                <label className={labelClasses}>Display type</label>
+                <input name="displayType" className={inputClasses} placeholder="wall_certificate" />
+              </div>
+              <div>
+                <label className={labelClasses}>Location</label>
+                <input name="displayLocation" className={inputClasses} placeholder="front_desk" />
+              </div>
+              <div>
+                <label className={labelClasses}>Requirement level</label>
+                <select name="displayRequirementLevel" className={inputClasses} defaultValue="required">
+                  <option value="required">Required</option>
+                  <option value="recommended">Recommended</option>
+                  <option value="marketing_optional">Marketing optional</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Fee tracking</p>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClasses}>Fee type</label>
+                <input name="feeType" className={inputClasses} placeholder="renewal" />
+              </div>
+              <div>
+                <label className={labelClasses}>Finance handoff</label>
+                <select name="financeHandoffMode" className={inputClasses} defaultValue="track_only">
+                  <option value="track_only">Track only</option>
+                  <option value="finance_review">Finance review</option>
+                  <option value="external_accounting">External accounting</option>
+                </select>
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              <div>
+                <label className={labelClasses}>Amount</label>
+                <input name="feeAmount" className={inputClasses} placeholder="250.00" />
+              </div>
+              <div>
+                <label className={labelClasses}>Currency</label>
+                <input name="feeCurrency" className={inputClasses} defaultValue="USD" />
+              </div>
+              <div>
+                <label className={labelClasses}>Due date</label>
+                <input name="feeDueDate" type="date" className={inputClasses} />
+              </div>
+            </div>
+            <div className="mt-3">
+              <label className={labelClasses}>Fee notes</label>
+              <textarea name="feeNotes" rows={2} className={inputClasses} />
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClasses}>Verification notes</label>
+            <textarea name="verificationNotes" rows={2} className={inputClasses} />
+          </div>
+
+          {error ? <p className="text-xs text-[var(--dpf-error)]">{error}</p> : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={() => setOpen(false)} className="px-3 py-1.5 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {loading ? "Saving..." : "Create"}
+            </button>
+          </div>
+        </form>
+      </ComplianceModal>
+    </>
+  );
+}

--- a/apps/web/components/compliance/licensing/CreatePersonLicenseRecordForm.tsx
+++ b/apps/web/components/compliance/licensing/CreatePersonLicenseRecordForm.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ComplianceModal } from "@/components/compliance/ComplianceModal";
+import { createPersonLicenseRecord } from "@/lib/actions/licensing-compliance";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-transparent px-3 py-1.5 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "block text-xs text-[var(--dpf-muted)] mb-1";
+
+type RequirementOption = {
+  id: string;
+  requirementRefId: string;
+  jurisdictionLabel: string;
+  authorityName: string;
+  requirementType: string;
+  scopeLevel: string;
+};
+
+type HolderOption = {
+  id: string;
+  aliasType: string;
+  aliasValue: string;
+  displayName: string;
+};
+
+type Props = {
+  requirementOptions: RequirementOption[];
+  holderOptions: HolderOption[];
+};
+
+export function CreatePersonLicenseRecordForm({ requirementOptions, holderOptions }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    const form = new FormData(event.currentTarget);
+    const result = await createPersonLicenseRecord({
+      principalAliasId: form.get("principalAliasId") as string,
+      requirementReferenceId: (form.get("requirementReferenceId") as string) || "",
+      credentialType: form.get("credentialType") as string,
+      status: form.get("status") as string,
+      credentialNumber: (form.get("credentialNumber") as string) || "",
+      issuingAuthority: (form.get("issuingAuthority") as string) || "",
+      issuedAt: (form.get("issuedAt") as string) || "",
+      expiresAt: (form.get("expiresAt") as string) || "",
+      renewalCadence: (form.get("renewalCadence") as string) || "",
+      supervisoryOrDisplayRole: (form.get("supervisoryOrDisplayRole") as string) || "",
+      officialSourceUrl: (form.get("officialSourceUrl") as string) || "",
+      displayType: (form.get("displayType") as string) || "",
+      displayLocation: (form.get("displayLocation") as string) || "",
+      displayRequirementLevel: (form.get("displayRequirementLevel") as string) || "",
+      feeType: (form.get("feeType") as string) || "",
+      feeAmount: (form.get("feeAmount") as string) || "",
+      feeCurrency: (form.get("feeCurrency") as string) || "",
+      feeDueDate: (form.get("feeDueDate") as string) || "",
+      financeHandoffMode: (form.get("financeHandoffMode") as string) || "",
+      feeNotes: (form.get("feeNotes") as string) || "",
+    });
+    setLoading(false);
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)]"
+      >
+        Add person credential
+      </button>
+      <ComplianceModal open={open} onClose={() => setOpen(false)} title="Add Person Credential">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className={labelClasses}>Credential holder *</label>
+            <select name="principalAliasId" className={inputClasses} defaultValue="" required>
+              <option value="">Choose a principal alias</option>
+              {holderOptions.map((holder) => (
+                <option key={holder.id} value={holder.id}>
+                  {holder.displayName} · {holder.aliasValue}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className={labelClasses}>Requirement reference</label>
+            <select name="requirementReferenceId" className={inputClasses} defaultValue="">
+              <option value="">Manual record</option>
+              {requirementOptions
+                .filter((option) => option.scopeLevel === "person")
+                .map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.authorityName} · {option.jurisdictionLabel}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>Credential type *</label>
+              <input name="credentialType" required className={inputClasses} placeholder="plumber_license" />
+            </div>
+            <div>
+              <label className={labelClasses}>Status *</label>
+              <select name="status" className={inputClasses} defaultValue="active">
+                <option value="draft">Draft</option>
+                <option value="researching">Researching</option>
+                <option value="applied">Applied</option>
+                <option value="active">Active</option>
+                <option value="expired">Expired</option>
+                <option value="suspended">Suspended</option>
+                <option value="blocked">Blocked</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>Credential number</label>
+              <input name="credentialNumber" className={inputClasses} placeholder="LIC-99881" />
+            </div>
+            <div>
+              <label className={labelClasses}>Display / supervisory role</label>
+              <input name="supervisoryOrDisplayRole" className={inputClasses} placeholder="Responsible managing employee" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className={labelClasses}>Issued</label>
+              <input name="issuedAt" type="date" className={inputClasses} />
+            </div>
+            <div>
+              <label className={labelClasses}>Expires</label>
+              <input name="expiresAt" type="date" className={inputClasses} />
+            </div>
+            <div>
+              <label className={labelClasses}>Renewal cadence</label>
+              <input name="renewalCadence" className={inputClasses} placeholder="biennial" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>Issuing authority</label>
+              <input name="issuingAuthority" className={inputClasses} placeholder="State plumbing board" />
+            </div>
+            <div>
+              <label className={labelClasses}>Source URL</label>
+              <input name="officialSourceUrl" className={inputClasses} placeholder="https://authority.example/credential/123" />
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Display obligation</p>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              <div>
+                <label className={labelClasses}>Display type</label>
+                <input name="displayType" className={inputClasses} placeholder="badge" />
+              </div>
+              <div>
+                <label className={labelClasses}>Location</label>
+                <input name="displayLocation" className={inputClasses} placeholder="website_footer" />
+              </div>
+              <div>
+                <label className={labelClasses}>Requirement level</label>
+                <select name="displayRequirementLevel" className={inputClasses} defaultValue="required">
+                  <option value="required">Required</option>
+                  <option value="recommended">Recommended</option>
+                  <option value="marketing_optional">Marketing optional</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Fee tracking</p>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClasses}>Fee type</label>
+                <input name="feeType" className={inputClasses} placeholder="renewal" />
+              </div>
+              <div>
+                <label className={labelClasses}>Finance handoff</label>
+                <select name="financeHandoffMode" className={inputClasses} defaultValue="track_only">
+                  <option value="track_only">Track only</option>
+                  <option value="finance_review">Finance review</option>
+                  <option value="external_accounting">External accounting</option>
+                </select>
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              <div>
+                <label className={labelClasses}>Amount</label>
+                <input name="feeAmount" className={inputClasses} placeholder="75.00" />
+              </div>
+              <div>
+                <label className={labelClasses}>Currency</label>
+                <input name="feeCurrency" className={inputClasses} defaultValue="USD" />
+              </div>
+              <div>
+                <label className={labelClasses}>Due date</label>
+                <input name="feeDueDate" type="date" className={inputClasses} />
+              </div>
+            </div>
+            <div className="mt-3">
+              <label className={labelClasses}>Fee notes</label>
+              <textarea name="feeNotes" rows={2} className={inputClasses} />
+            </div>
+          </div>
+
+          {error ? <p className="text-xs text-[var(--dpf-error)]">{error}</p> : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={() => setOpen(false)} className="px-3 py-1.5 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {loading ? "Saving..." : "Create"}
+            </button>
+          </div>
+        </form>
+      </ComplianceModal>
+    </>
+  );
+}

--- a/apps/web/components/compliance/licensing/LicensingWorkspacePanel.tsx
+++ b/apps/web/components/compliance/licensing/LicensingWorkspacePanel.tsx
@@ -1,0 +1,469 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  updateOrganizationLicenseProfile,
+  type UpdateOrganizationLicenseProfileInput,
+} from "@/lib/actions/licensing-compliance";
+import { CreateOrganizationLicenseRecordForm } from "@/components/compliance/licensing/CreateOrganizationLicenseRecordForm";
+import { CreatePersonLicenseRecordForm } from "@/components/compliance/licensing/CreatePersonLicenseRecordForm";
+
+const inputClasses =
+  "rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none";
+
+type Workspace = Awaited<ReturnType<typeof import("@/lib/actions/licensing-compliance").getLicensingWorkspace>>;
+
+type Props = {
+  workspace: Workspace;
+};
+
+function formatDate(value: string | Date | null | undefined) {
+  if (!value) return "Not set";
+  const date = typeof value === "string" ? new Date(value) : value;
+  return Number.isNaN(date.getTime()) ? "Not set" : date.toLocaleDateString();
+}
+
+function MetricCard({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number | string;
+  accent: string;
+}) {
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: `color-mix(in srgb, ${accent} 28%, var(--dpf-border))`,
+        background: `color-mix(in srgb, ${accent} 8%, var(--dpf-surface-1))`,
+      }}
+    >
+      <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">{label}</p>
+      <p className="mt-2 text-2xl font-semibold" style={{ color: accent }}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function LicensingWorkspacePanel({ workspace }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<UpdateOrganizationLicenseProfileInput>({
+    setupStatus: workspace.profile.setupStatus,
+    investigationMode: workspace.profile.investigationMode,
+    homeCountryCode: workspace.profile.homeCountryCode ?? "",
+    primaryRegionCode: workspace.profile.primaryRegionCode ?? "",
+    operatingFootprintSummary: workspace.profile.operatingFootprintSummary ?? "",
+    legalActivityConfidence: workspace.profile.legalActivityConfidence,
+    researchCoverageStatus: workspace.profile.researchCoverageStatus,
+    notes: workspace.profile.notes ?? "",
+  });
+
+  function updateField<K extends keyof UpdateOrganizationLicenseProfileInput>(
+    key: K,
+    value: UpdateOrganizationLicenseProfileInput[K],
+  ) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaved(false);
+    setError(null);
+
+    startTransition(async () => {
+      const result = await updateOrganizationLicenseProfile(form);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setSaved(true);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+              Licensing posture
+            </p>
+            <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+              Record what is known about legality, licensing coverage, and investigation confidence without mixing coworker dialog into the operational page.
+            </p>
+          </div>
+          <span className="rounded-full border border-[var(--dpf-border)] px-2.5 py-1 text-[11px] text-[var(--dpf-text)]">
+            {workspace.organization.slug}
+          </span>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Setup status
+            <select
+              value={form.setupStatus}
+              onChange={(event) => updateField("setupStatus", event.target.value)}
+              className={`mt-1 w-full ${inputClasses}`}
+            >
+              <option value="draft" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Draft</option>
+              <option value="investigating" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Investigating</option>
+              <option value="ready" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Ready</option>
+              <option value="blocked" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Blocked</option>
+            </select>
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Investigation mode
+            <select
+              value={form.investigationMode}
+              onChange={(event) => updateField("investigationMode", event.target.value)}
+              className={`mt-1 w-full ${inputClasses}`}
+            >
+              <option value="unknown" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Unknown</option>
+              <option value="existing" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Already operating</option>
+              <option value="new_business" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">New business</option>
+              <option value="expanding" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Expanding footprint</option>
+            </select>
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Home country
+            <input
+              value={form.homeCountryCode ?? ""}
+              onChange={(event) => updateField("homeCountryCode", event.target.value.toUpperCase())}
+              className={`mt-1 w-full ${inputClasses}`}
+              placeholder="US"
+              maxLength={2}
+            />
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Primary region or state
+            <input
+              value={form.primaryRegionCode ?? ""}
+              onChange={(event) => updateField("primaryRegionCode", event.target.value.toUpperCase())}
+              className={`mt-1 w-full ${inputClasses}`}
+              placeholder="NV"
+            />
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Legal activity confidence
+            <select
+              value={form.legalActivityConfidence}
+              onChange={(event) => updateField("legalActivityConfidence", event.target.value)}
+              className={`mt-1 w-full ${inputClasses}`}
+            >
+              <option value="low" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Low</option>
+              <option value="medium" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Medium</option>
+              <option value="high" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">High</option>
+            </select>
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Research coverage
+            <select
+              value={form.researchCoverageStatus}
+              onChange={(event) => updateField("researchCoverageStatus", event.target.value)}
+              className={`mt-1 w-full ${inputClasses}`}
+            >
+              <option value="draft" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Draft</option>
+              <option value="partial" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Partial</option>
+              <option value="covered" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Covered</option>
+              <option value="stale" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Stale</option>
+            </select>
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)] md:col-span-2">
+            Operating footprint
+            <textarea
+              value={form.operatingFootprintSummary ?? ""}
+              onChange={(event) => updateField("operatingFootprintSummary", event.target.value)}
+              className={`mt-1 min-h-24 w-full ${inputClasses}`}
+              placeholder="Where the business operates, where staff work, and where regulated services are delivered."
+            />
+          </label>
+
+          <label className="text-xs text-[var(--dpf-muted)] md:col-span-2">
+            Notes
+            <textarea
+              value={form.notes ?? ""}
+              onChange={(event) => updateField("notes", event.target.value)}
+              className={`mt-1 min-h-24 w-full ${inputClasses}`}
+              placeholder="Known gaps, licensing counsel notes, or operator-owned follow-up."
+            />
+          </label>
+
+          <div className="md:col-span-2 flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={isPending}
+              className="rounded bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+            >
+              {isPending ? "Saving..." : "Save licensing posture"}
+            </button>
+            {saved && !isPending ? <span className="text-xs text-[var(--dpf-success)]">Saved.</span> : null}
+            {error ? <span className="text-xs text-[var(--dpf-error)]">{error}</span> : null}
+          </div>
+        </form>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-5">
+        <MetricCard label="Company licenses" value={workspace.summary.organizationLicenseCount} accent="var(--dpf-accent)" />
+        <MetricCard label="Staff credentials" value={workspace.summary.personCredentialCount} accent="var(--dpf-success)" />
+        <MetricCard label="Unsatisfied display rules" value={workspace.summary.unsatisfiedDisplayCount} accent="var(--dpf-warning)" />
+        <MetricCard label="Pending fees" value={workspace.summary.pendingFeeCount} accent="var(--dpf-warning)" />
+        <MetricCard label="Open issues" value={workspace.summary.openIssueCount} accent="var(--dpf-error)" />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
+        <div className="space-y-6">
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Organization licenses</p>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                  Operating permissions, permits, registrations, and legality gates that the company itself must maintain.
+                </p>
+              </div>
+              <CreateOrganizationLicenseRecordForm requirementOptions={workspace.requirementOptions} />
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {workspace.organizationLicenses.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-5 text-sm text-[var(--dpf-muted)]">
+                  No company-held licenses or permits have been recorded yet.
+                </div>
+              ) : (
+                workspace.organizationLicenses.map((record) => (
+                  <div key={record.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-sm font-semibold text-[var(--dpf-text)]">
+                          {record.requirementReference?.authorityName ?? record.licenseKind}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          {record.licenseKind} · {record.status}
+                          {record.licenseNumber ? ` · ${record.licenseNumber}` : ""}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          Expires {formatDate(record.expiresAt)}
+                        </p>
+                      </div>
+                      <span className="rounded-full border border-[var(--dpf-border)] px-2.5 py-1 text-[11px] text-[var(--dpf-text)]">
+                        {record.displayRequirementStatus.replaceAll("_", " ")}
+                      </span>
+                    </div>
+                    {(record.displayObligations.length > 0 || record.feeSchedules.length > 0) && (
+                      <div className="mt-3 grid gap-3 md:grid-cols-2">
+                        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
+                          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Display obligations</p>
+                          {record.displayObligations.map((item) => (
+                            <p key={item.id} className="mt-2 text-xs text-[var(--dpf-text)]">
+                              {item.displayType}
+                              {item.displayLocation ? ` · ${item.displayLocation}` : ""}
+                            </p>
+                          ))}
+                        </div>
+                        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
+                          <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Fee tracking</p>
+                          {record.feeSchedules.map((item) => (
+                            <p key={item.id} className="mt-2 text-xs text-[var(--dpf-text)]">
+                              {item.feeType} · {String(item.amount)} {item.currency} · {item.paymentStatus}
+                            </p>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Person-held credentials</p>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                  Professional or role-based credentials that belong to staff, owners, or responsible parties.
+                </p>
+              </div>
+              <CreatePersonLicenseRecordForm
+                requirementOptions={workspace.requirementOptions}
+                holderOptions={workspace.holderOptions}
+              />
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {workspace.personCredentials.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-5 text-sm text-[var(--dpf-muted)]">
+                  No person-held credentials have been recorded yet.
+                </div>
+              ) : (
+                workspace.personCredentials.map((record) => (
+                  <div key={record.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-sm font-semibold text-[var(--dpf-text)]">
+                          {record.principalAlias.principal.displayName}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          {record.credentialType} · {record.status}
+                          {record.credentialNumber ? ` · ${record.credentialNumber}` : ""}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          Expires {formatDate(record.expiresAt)}
+                        </p>
+                      </div>
+                      <span className="rounded-full border border-[var(--dpf-border)] px-2.5 py-1 text-[11px] text-[var(--dpf-text)]">
+                        {record.supervisoryOrDisplayRole ?? "Role not set"}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+
+        <div className="space-y-6">
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Display obligations</p>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                  Public posting and trust-signal requirements linked to licenses and credentials.
+                </p>
+              </div>
+              <Link href="/compliance/evidence" className="text-xs text-[var(--dpf-accent)] hover:underline">
+                Evidence
+              </Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {workspace.displayObligations.length === 0 ? (
+                <p className="text-sm text-[var(--dpf-muted)]">No display obligations are tracked yet.</p>
+              ) : (
+                workspace.displayObligations.map((item) => (
+                  <div key={item.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-sm font-medium text-[var(--dpf-text)]">{item.sourceLabel}</p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          {item.displayType}
+                          {item.displayLocation ? ` · ${item.displayLocation}` : ""}
+                          {item.holderLabel ? ` · ${item.holderLabel}` : ""}
+                        </p>
+                      </div>
+                      <span
+                        className="rounded-full border px-2.5 py-1 text-[11px]"
+                        style={{
+                          borderColor: item.isSatisfied ? "var(--dpf-success)" : "var(--dpf-warning)",
+                          color: item.isSatisfied ? "var(--dpf-success)" : "var(--dpf-warning)",
+                        }}
+                      >
+                        {item.isSatisfied ? "Satisfied" : "Needs attention"}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Fee readiness</p>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                  Licensing fees stay grounded in Compliance while handing payment review and execution into Finance when needed.
+                </p>
+              </div>
+              <Link href="/finance" className="text-xs text-[var(--dpf-accent)] hover:underline">
+                Finance
+              </Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {workspace.feeSchedules.length === 0 ? (
+                <p className="text-sm text-[var(--dpf-muted)]">No licensing fees are tracked yet.</p>
+              ) : (
+                workspace.feeSchedules.map((item) => (
+                  <div key={item.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-sm font-medium text-[var(--dpf-text)]">{item.sourceLabel}</p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          {item.feeType} · {String(item.amount)} {item.currency} · due {formatDate(item.dueDate)}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          Holder: {item.holderLabel} · {item.financeHandoffMode.replaceAll("_", " ")}
+                        </p>
+                      </div>
+                      <span
+                        className="rounded-full border px-2.5 py-1 text-[11px]"
+                        style={{
+                          borderColor: item.paymentStatus === "paid" ? "var(--dpf-success)" : "var(--dpf-warning)",
+                          color: item.paymentStatus === "paid" ? "var(--dpf-success)" : "var(--dpf-warning)",
+                        }}
+                      >
+                        {item.paymentStatus.replaceAll("_", " ")}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">Open issues</p>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                  Gaps that still block readiness. Coworker-created investigation issues can layer into this list in the next slice.
+                </p>
+              </div>
+              <Link href="/employee" className="text-xs text-[var(--dpf-accent)] hover:underline">
+                Staff
+              </Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {workspace.openIssues.length === 0 ? (
+                <p className="text-sm text-[var(--dpf-muted)]">No licensing readiness issues are currently open.</p>
+              ) : (
+                workspace.openIssues.map((issue) => (
+                  <div key={issue.id} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-sm font-medium text-[var(--dpf-text)]">{issue.title}</p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">{issue.details ?? issue.issueType}</p>
+                      </div>
+                      <span
+                        className="rounded-full border px-2.5 py-1 text-[11px]"
+                        style={{
+                          borderColor: issue.severity === "critical" || issue.severity === "high" ? "var(--dpf-error)" : "var(--dpf-warning)",
+                          color: issue.severity === "critical" || issue.severity === "high" ? "var(--dpf-error)" : "var(--dpf-warning)",
+                        }}
+                      >
+                        {issue.severity}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/actions/licensing-compliance.test.ts
+++ b/apps/web/lib/actions/licensing-compliance.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: {
+      findFirst: vi.fn(),
+    },
+    organizationLicenseProfile: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    licenseRequirementReference: {
+      findMany: vi.fn(),
+    },
+    organizationLicenseRecord: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    personLicenseRecord: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    licenseDisplayObligation: {
+      createMany: vi.fn(),
+    },
+    licenseFeeSchedule: {
+      createMany: vi.fn(),
+    },
+    licenseReadinessIssue: {
+      findMany: vi.fn(),
+    },
+    principalAlias: {
+      findMany: vi.fn(),
+    },
+    employeeProfile: {
+      findUnique: vi.fn(),
+    },
+    complianceAuditLog: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
+import {
+  createOrganizationLicenseRecord,
+  getLicensingWorkspace,
+} from "./licensing-compliance";
+
+const mockSession = {
+  user: {
+    id: "user-1",
+    email: "admin@test.com",
+    platformRole: "HR-000",
+    isSuperuser: false,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(auth).mockResolvedValue(mockSession as never);
+  vi.mocked(can).mockReturnValue(true);
+  vi.mocked(prisma.organization.findFirst).mockResolvedValue({
+    id: "org-1",
+    name: "Acme Services",
+    slug: "acme-services",
+  } as never);
+  vi.mocked(prisma.employeeProfile.findUnique).mockResolvedValue({ id: "emp-1" } as never);
+});
+
+describe("getLicensingWorkspace", () => {
+  it("returns licensing workspace sections with computed summary counts", async () => {
+    vi.mocked(prisma.organizationLicenseProfile.findFirst).mockResolvedValue({
+      id: "profile-1",
+      organizationId: "org-1",
+      setupStatus: "investigating",
+      investigationMode: "existing",
+      homeCountryCode: "US",
+      primaryRegionCode: "NV",
+      operatingFootprintSummary: "Nevada and Arizona service operations",
+      legalActivityConfidence: "medium",
+      researchCoverageStatus: "draft",
+      notes: null,
+      lastVerifiedAt: null,
+      createdAt: new Date("2026-05-01T00:00:00Z"),
+      updatedAt: new Date("2026-05-01T00:00:00Z"),
+    } as never);
+    vi.mocked(prisma.licenseRequirementReference.findMany).mockResolvedValue([
+      {
+        id: "req-1",
+        requirementRefId: "LIC-US-NV-CONTRACTOR",
+        jurisdictionLabel: "Nevada",
+        authorityName: "Nevada State Contractors Board",
+        requirementType: "license",
+        scopeLevel: "organization",
+      },
+    ] as never);
+    vi.mocked(prisma.organizationLicenseRecord.findMany).mockResolvedValue([
+      {
+        id: "org-license-1",
+        status: "active",
+        expiresAt: new Date("2026-05-20T00:00:00Z"),
+        displayObligations: [{ id: "display-1", isSatisfied: false }],
+        feeSchedules: [{ id: "fee-1", paymentStatus: "pending", dueDate: new Date("2026-05-18T00:00:00Z") }],
+      },
+    ] as never);
+    vi.mocked(prisma.personLicenseRecord.findMany).mockResolvedValue([
+      {
+        id: "person-license-1",
+        status: "active",
+        expiresAt: new Date("2026-05-25T00:00:00Z"),
+        displayObligations: [],
+        feeSchedules: [],
+        principalAlias: { aliasValue: "plumber-lic-1", principal: { displayName: "Jamie Rivera" } },
+      },
+    ] as never);
+    vi.mocked(prisma.licenseReadinessIssue.findMany).mockResolvedValue([
+      { id: "issue-1", severity: "high", status: "open" },
+    ] as never);
+    vi.mocked(prisma.principalAlias.findMany).mockResolvedValue([
+      { id: "alias-1", aliasValue: "plumber-lic-1", principal: { displayName: "Jamie Rivera" } },
+    ] as never);
+
+    const workspace = await getLicensingWorkspace();
+
+    expect(workspace.organization.name).toBe("Acme Services");
+    expect(workspace.summary.organizationLicenseCount).toBe(1);
+    expect(workspace.summary.personCredentialCount).toBe(1);
+    expect(workspace.summary.unsatisfiedDisplayCount).toBe(1);
+    expect(workspace.summary.pendingFeeCount).toBe(1);
+    expect(workspace.summary.openIssueCount).toBe(1);
+    expect(workspace.requirementOptions[0]?.authorityName).toBe("Nevada State Contractors Board");
+    expect(workspace.holderOptions[0]?.displayName).toBe("Jamie Rivera");
+  });
+});
+
+describe("createOrganizationLicenseRecord", () => {
+  it("creates linked display and fee records when the input includes them", async () => {
+    vi.mocked(prisma.organizationLicenseProfile.findFirst).mockResolvedValue({
+      id: "profile-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(prisma.organizationLicenseRecord.create).mockResolvedValue({
+      id: "org-license-1",
+      licenseRecordId: "LIC-ORG-1",
+    } as never);
+
+    const transaction = {
+      organizationLicenseRecord: {
+        create: vi.fn().mockResolvedValue({
+          id: "org-license-1",
+          licenseRecordId: "LIC-ORG-1",
+        }),
+      },
+      licenseDisplayObligation: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      licenseFeeSchedule: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      complianceAuditLog: {
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+    vi.mocked(prisma.$transaction).mockImplementation(
+      (async (callback: (tx: typeof transaction) => Promise<unknown>) => callback(transaction)) as never,
+    );
+
+    const result = await createOrganizationLicenseRecord({
+      requirementReferenceId: "req-1",
+      licenseKind: "contractor_license",
+      status: "active",
+      licenseNumber: "NV-12345",
+      effectiveFrom: "2026-05-01",
+      expiresAt: "2027-05-01",
+      displayRequirementStatus: "required",
+      displayType: "wall_certificate",
+      displayLocation: "front_desk",
+      displayRequirementLevel: "required",
+      feeType: "renewal",
+      feeAmount: "250.00",
+      feeCurrency: "USD",
+      feeDueDate: "2027-04-15",
+      financeHandoffMode: "finance_review",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(transaction.organizationLicenseRecord.create).toHaveBeenCalledOnce();
+    expect(transaction.licenseDisplayObligation.createMany).toHaveBeenCalledOnce();
+    expect(transaction.licenseFeeSchedule.createMany).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/actions/licensing-compliance.ts
+++ b/apps/web/lib/actions/licensing-compliance.ts
@@ -1,0 +1,493 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { revalidatePath } from "next/cache";
+import { nanoid } from "nanoid";
+
+type ComplianceActionResult = { ok: boolean; message: string; id?: string };
+
+export type UpdateOrganizationLicenseProfileInput = {
+  setupStatus: string;
+  investigationMode: string;
+  homeCountryCode?: string;
+  primaryRegionCode?: string;
+  operatingFootprintSummary?: string;
+  legalActivityConfidence: string;
+  researchCoverageStatus: string;
+  notes?: string;
+};
+
+export type CreateOrganizationLicenseRecordInput = {
+  requirementReferenceId?: string;
+  licenseKind: string;
+  status: string;
+  licenseNumber?: string;
+  issuedAt?: string;
+  effectiveFrom?: string;
+  expiresAt?: string;
+  renewalCadence?: string;
+  renewalFeeAmount?: string;
+  renewalFeeCurrency?: string;
+  displayRequirementStatus: string;
+  officialSourceUrl?: string;
+  verificationNotes?: string;
+  displayType?: string;
+  displayLocation?: string;
+  displayRequirementLevel?: string;
+  feeType?: string;
+  feeAmount?: string;
+  feeCurrency?: string;
+  feeDueDate?: string;
+  financeHandoffMode?: string;
+  feeNotes?: string;
+};
+
+export type CreatePersonLicenseRecordInput = {
+  principalAliasId: string;
+  requirementReferenceId?: string;
+  credentialType: string;
+  status: string;
+  credentialNumber?: string;
+  issuingAuthority?: string;
+  issuedAt?: string;
+  expiresAt?: string;
+  renewalCadence?: string;
+  supervisoryOrDisplayRole?: string;
+  officialSourceUrl?: string;
+  displayType?: string;
+  displayLocation?: string;
+  displayRequirementLevel?: string;
+  feeType?: string;
+  feeAmount?: string;
+  feeCurrency?: string;
+  feeDueDate?: string;
+  financeHandoffMode?: string;
+  feeNotes?: string;
+};
+
+async function requireViewCompliance() {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_compliance")) {
+    throw new Error("Unauthorized");
+  }
+  return user;
+}
+
+async function requireManageCompliance() {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_compliance")) {
+    throw new Error("Unauthorized");
+  }
+  return user;
+}
+
+async function requireOrganization() {
+  const organization = await prisma.organization.findFirst({
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (!organization) {
+    throw new Error("No organization configured");
+  }
+
+  return organization;
+}
+
+async function getSessionEmployeeId() {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+  const profile = await prisma.employeeProfile.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true },
+  });
+  return profile?.id ?? null;
+}
+
+async function getOrCreateLicenseProfile(organizationId: string) {
+  const existing = await prisma.organizationLicenseProfile.findFirst({
+    where: { organizationId },
+  });
+
+  if (existing) return existing;
+
+  return prisma.organizationLicenseProfile.create({
+    data: {
+      organizationId,
+      setupStatus: "draft",
+      investigationMode: "unknown",
+      legalActivityConfidence: "medium",
+      researchCoverageStatus: "draft",
+    },
+  });
+}
+
+function nullableString(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function nullableDate(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? new Date(trimmed) : null;
+}
+
+function numberValue(value?: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function organizationLicenseRecordId() {
+  return `LIC-ORG-${nanoid(8).toUpperCase()}`;
+}
+
+function personLicenseRecordId() {
+  return `LIC-PER-${nanoid(8).toUpperCase()}`;
+}
+
+function displayObligationId() {
+  return `LIC-DIS-${nanoid(8).toUpperCase()}`;
+}
+
+function feeScheduleId() {
+  return `LIC-FEE-${nanoid(8).toUpperCase()}`;
+}
+
+function revalidateLicensingRoutes() {
+  revalidatePath("/compliance");
+  revalidatePath("/compliance/licensing");
+}
+
+export async function getLicensingWorkspace() {
+  await requireViewCompliance();
+  const organization = await requireOrganization();
+  const profile = await getOrCreateLicenseProfile(organization.id);
+
+  const [requirementOptions, organizationLicenses, personCredentials, openIssues, holderOptions] =
+    await Promise.all([
+      prisma.licenseRequirementReference.findMany({
+        orderBy: [
+          { countryCode: "asc" },
+          { stateProvinceCode: "asc" },
+          { authorityName: "asc" },
+        ],
+        select: {
+          id: true,
+          requirementRefId: true,
+          jurisdictionLabel: true,
+          authorityName: true,
+          requirementType: true,
+          scopeLevel: true,
+        },
+      }),
+      prisma.organizationLicenseRecord.findMany({
+        where: { organizationLicenseProfileId: profile.id },
+        include: {
+          requirementReference: {
+            select: {
+              authorityName: true,
+              jurisdictionLabel: true,
+              requirementType: true,
+            },
+          },
+          displayObligations: true,
+          feeSchedules: true,
+        },
+        orderBy: [{ expiresAt: "asc" }, { createdAt: "desc" }],
+      }),
+      prisma.personLicenseRecord.findMany({
+        where: { organizationId: organization.id },
+        include: {
+          principalAlias: {
+            select: {
+              aliasValue: true,
+              principal: { select: { displayName: true } },
+            },
+          },
+          requirementReference: {
+            select: {
+              authorityName: true,
+              jurisdictionLabel: true,
+              requirementType: true,
+            },
+          },
+          displayObligations: true,
+          feeSchedules: true,
+        },
+        orderBy: [{ expiresAt: "asc" }, { createdAt: "desc" }],
+      }),
+      prisma.licenseReadinessIssue.findMany({
+        where: { organizationLicenseProfileId: profile.id },
+        orderBy: [{ severity: "desc" }, { openedAt: "desc" }],
+      }),
+      prisma.principalAlias.findMany({
+        orderBy: [{ principal: { displayName: "asc" } }, { aliasValue: "asc" }],
+        select: {
+          id: true,
+          aliasType: true,
+          aliasValue: true,
+          principal: { select: { displayName: true } },
+        },
+      }),
+    ]);
+
+  const displayObligations = [
+    ...organizationLicenses.flatMap((record) =>
+      (record.displayObligations ?? []).map((obligation) => ({
+        ...obligation,
+        sourceLabel: record.requirementReference?.authorityName ?? record.licenseKind,
+        holderLabel: organization.name,
+      })),
+    ),
+    ...personCredentials.flatMap((record) =>
+      (record.displayObligations ?? []).map((obligation) => ({
+        ...obligation,
+        sourceLabel: record.requirementReference?.authorityName ?? record.credentialType,
+        holderLabel: record.principalAlias.principal.displayName,
+      })),
+    ),
+  ];
+
+  const feeSchedules = [
+    ...organizationLicenses.flatMap((record) =>
+      (record.feeSchedules ?? []).map((fee) => ({
+        ...fee,
+        sourceLabel: record.requirementReference?.authorityName ?? record.licenseKind,
+        holderLabel: organization.name,
+      })),
+    ),
+    ...personCredentials.flatMap((record) =>
+      (record.feeSchedules ?? []).map((fee) => ({
+        ...fee,
+        sourceLabel: record.requirementReference?.authorityName ?? record.credentialType,
+        holderLabel: record.principalAlias.principal.displayName,
+      })),
+    ),
+  ];
+
+  return {
+    organization,
+    profile,
+    requirementOptions,
+    holderOptions: holderOptions.map((holder) => ({
+      id: holder.id,
+      aliasType: holder.aliasType,
+      aliasValue: holder.aliasValue,
+      displayName: holder.principal.displayName,
+    })),
+    organizationLicenses,
+    personCredentials,
+    displayObligations,
+    feeSchedules,
+    openIssues,
+    summary: {
+      organizationLicenseCount: organizationLicenses.length,
+      personCredentialCount: personCredentials.length,
+      unsatisfiedDisplayCount: displayObligations.filter((item) => !item.isSatisfied).length,
+      pendingFeeCount: feeSchedules.filter((item) => item.paymentStatus !== "paid" && item.paymentStatus !== "waived").length,
+      openIssueCount: openIssues.filter((item) => item.status !== "resolved").length,
+    },
+  };
+}
+
+export async function updateOrganizationLicenseProfile(
+  input: UpdateOrganizationLicenseProfileInput,
+): Promise<ComplianceActionResult> {
+  await requireManageCompliance();
+  const organization = await requireOrganization();
+  const profile = await getOrCreateLicenseProfile(organization.id);
+
+  await prisma.organizationLicenseProfile.update({
+    where: { id: profile.id },
+    data: {
+      setupStatus: input.setupStatus,
+      investigationMode: input.investigationMode,
+      homeCountryCode: nullableString(input.homeCountryCode)?.toUpperCase() ?? null,
+      primaryRegionCode: nullableString(input.primaryRegionCode)?.toUpperCase() ?? null,
+      operatingFootprintSummary: nullableString(input.operatingFootprintSummary),
+      legalActivityConfidence: input.legalActivityConfidence,
+      researchCoverageStatus: input.researchCoverageStatus,
+      notes: nullableString(input.notes),
+    },
+  });
+
+  revalidateLicensingRoutes();
+  return { ok: true, message: "Licensing posture saved." };
+}
+
+export async function createOrganizationLicenseRecord(
+  input: CreateOrganizationLicenseRecordInput,
+): Promise<ComplianceActionResult> {
+  await requireManageCompliance();
+  const organization = await requireOrganization();
+  const profile = await getOrCreateLicenseProfile(organization.id);
+  const employeeId = await getSessionEmployeeId();
+
+  if (!nullableString(input.licenseKind)) {
+    return { ok: false, message: "License kind is required." };
+  }
+
+  if (!nullableString(input.status)) {
+    return { ok: false, message: "Status is required." };
+  }
+
+  const created = await prisma.$transaction(async (tx) => {
+    const record = await tx.organizationLicenseRecord.create({
+      data: {
+        licenseRecordId: organizationLicenseRecordId(),
+        organizationLicenseProfileId: profile.id,
+        requirementReferenceId: nullableString(input.requirementReferenceId),
+        licenseKind: input.licenseKind.trim(),
+        status: input.status.trim(),
+        licenseNumber: nullableString(input.licenseNumber),
+        issuedAt: nullableDate(input.issuedAt),
+        effectiveFrom: nullableDate(input.effectiveFrom),
+        expiresAt: nullableDate(input.expiresAt),
+        renewalCadence: nullableString(input.renewalCadence),
+        renewalFeeAmount: numberValue(input.renewalFeeAmount),
+        renewalFeeCurrency: nullableString(input.renewalFeeCurrency)?.toUpperCase() ?? null,
+        displayRequirementStatus: input.displayRequirementStatus.trim(),
+        officialSourceUrl: nullableString(input.officialSourceUrl),
+        verificationNotes: nullableString(input.verificationNotes),
+      },
+    });
+
+    if (nullableString(input.displayType)) {
+      await tx.licenseDisplayObligation.createMany({
+        data: [
+          {
+            displayObligationId: displayObligationId(),
+            organizationLicenseRecordId: record.id,
+            displayType: input.displayType!.trim(),
+            displayLocation: nullableString(input.displayLocation),
+            requirementLevel: nullableString(input.displayRequirementLevel) ?? "required",
+            isSatisfied: false,
+          },
+        ],
+      });
+    }
+
+    if (numberValue(input.feeAmount) !== null && nullableString(input.feeType)) {
+      await tx.licenseFeeSchedule.createMany({
+        data: [
+          {
+            feeScheduleId: feeScheduleId(),
+            organizationLicenseRecordId: record.id,
+            feeType: input.feeType!.trim(),
+            amount: numberValue(input.feeAmount)!,
+            currency: nullableString(input.feeCurrency)?.toUpperCase() ?? "USD",
+            dueDate: nullableDate(input.feeDueDate),
+            financeHandoffMode: nullableString(input.financeHandoffMode) ?? "track_only",
+            notes: nullableString(input.feeNotes),
+          },
+        ],
+      });
+    }
+
+    await tx.complianceAuditLog.create({
+      data: {
+        entityType: "licensing-organization-record",
+        entityId: record.id,
+        action: "created",
+        performedByEmployeeId: employeeId,
+        agentId: null,
+        notes: `Created ${input.licenseKind.trim()} licensing record`,
+      },
+    });
+
+    return record;
+  });
+
+  revalidateLicensingRoutes();
+  return { ok: true, message: "Organization license saved.", id: created.id };
+}
+
+export async function createPersonLicenseRecord(
+  input: CreatePersonLicenseRecordInput,
+): Promise<ComplianceActionResult> {
+  await requireManageCompliance();
+  const organization = await requireOrganization();
+  await getOrCreateLicenseProfile(organization.id);
+  const employeeId = await getSessionEmployeeId();
+
+  if (!nullableString(input.principalAliasId)) {
+    return { ok: false, message: "License holder is required." };
+  }
+
+  if (!nullableString(input.credentialType)) {
+    return { ok: false, message: "Credential type is required." };
+  }
+
+  const created = await prisma.$transaction(async (tx) => {
+    const record = await tx.personLicenseRecord.create({
+      data: {
+        personLicenseRecordId: personLicenseRecordId(),
+        principalAliasId: input.principalAliasId,
+        organizationId: organization.id,
+        requirementReferenceId: nullableString(input.requirementReferenceId),
+        credentialType: input.credentialType.trim(),
+        status: input.status.trim(),
+        credentialNumber: nullableString(input.credentialNumber),
+        issuingAuthority: nullableString(input.issuingAuthority),
+        issuedAt: nullableDate(input.issuedAt),
+        expiresAt: nullableDate(input.expiresAt),
+        renewalCadence: nullableString(input.renewalCadence),
+        supervisoryOrDisplayRole: nullableString(input.supervisoryOrDisplayRole),
+        officialSourceUrl: nullableString(input.officialSourceUrl),
+      },
+    });
+
+    if (nullableString(input.displayType)) {
+      await tx.licenseDisplayObligation.createMany({
+        data: [
+          {
+            displayObligationId: displayObligationId(),
+            personLicenseRecordId: record.id,
+            displayType: input.displayType!.trim(),
+            displayLocation: nullableString(input.displayLocation),
+            requirementLevel: nullableString(input.displayRequirementLevel) ?? "required",
+            isSatisfied: false,
+          },
+        ],
+      });
+    }
+
+    if (numberValue(input.feeAmount) !== null && nullableString(input.feeType)) {
+      await tx.licenseFeeSchedule.createMany({
+        data: [
+          {
+            feeScheduleId: feeScheduleId(),
+            personLicenseRecordId: record.id,
+            feeType: input.feeType!.trim(),
+            amount: numberValue(input.feeAmount)!,
+            currency: nullableString(input.feeCurrency)?.toUpperCase() ?? "USD",
+            dueDate: nullableDate(input.feeDueDate),
+            financeHandoffMode: nullableString(input.financeHandoffMode) ?? "track_only",
+            notes: nullableString(input.feeNotes),
+          },
+        ],
+      });
+    }
+
+    await tx.complianceAuditLog.create({
+      data: {
+        entityType: "licensing-person-record",
+        entityId: record.id,
+        action: "created",
+        performedByEmployeeId: employeeId,
+        agentId: null,
+        notes: `Created ${input.credentialType.trim()} credential record`,
+      },
+    });
+
+    return record;
+  });
+
+  revalidateLicensingRoutes();
+  return { ok: true, message: "Person-held credential saved.", id: created.id };
+}

--- a/tests/e2e/platform-qa-plan.md
+++ b/tests/e2e/platform-qa-plan.md
@@ -109,6 +109,7 @@ When adding or changing a QA ID for Build Studio, Ops/backlog, Discovery, Storef
 | GRC-05 | Navigate to Policies tab | Page loads |
 | GRC-06 | Navigate to Incidents tab | Page loads |
 | GRC-07 | Navigate to Gaps analysis | Gap analysis loads (may be empty) |
+| GRC-08 | Navigate to `/compliance/licensing`, save licensing posture, create a company license with display/fee details, then create a person credential | Licensing workspace loads with the Licensing tab active, the main page stays factual with no coworker dialog content, the posture save succeeds, and both new records appear in their sections while display obligations and fee readiness update on the same page |
 
 ## Phase 7: Operations & Backlog
 


### PR DESCRIPTION
## Summary
- add the Compliance > Licensing workspace with factual posture, license, credential, fee, and display-readiness surfaces
- add dedicated licensing compliance server actions and focused tests for workspace data and nav exposure
- extend the release QA plan with a licensing workspace verification case

## Verification
- pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/components/compliance/ComplianceTabNav.test.tsx apps/web/lib/actions/licensing-compliance.test.ts
- pnpm --filter web typecheck
- cd apps/web && npx next build
- Docker-served UX verification at /compliance/licensing against http://192.168.0.200:3000

## Backlog
- BI-LIC-247DB1 done