### PR TITLE
fix(ai): treat action tools as authoritative progress

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -127,6 +127,15 @@ describe("shouldNudge", () => {
     })).toBe(true);
   });
 
+  it("does not nudge a short summary after an authoritative action tool", () => {
+    expect(shouldNudge({
+      continuationNudges: 0, iteration: 3, maxIterations: 40,
+      hasTools: true, executedToolCount: 1, responseLength: 42,
+      responseText: "Discovery triage skipped for today's cadence.",
+      hasAuthoritativeToolExecution: true,
+    })).toBe(false);
+  });
+
   it("does not nudge if already nudged once", () => {
     expect(shouldNudge({
       continuationNudges: 1, iteration: 0, maxIterations: 40,
@@ -252,6 +261,16 @@ describe("detectFabrication", () => {
     expect(detectFabrication(
       "Here's what I added to the code.",
       3, false, ["saveBuildEvidence", "propose_file_change"],
+    )).toBe(false);
+  });
+
+  it("does not flag completion after a side-effect action tool was used", () => {
+    expect(detectFabrication(
+      "Discovery triage completed for today's cadence.",
+      1,
+      false,
+      ["run_discovery_triage"],
+      new Set(["run_discovery_triage"]),
     )).toBe(false);
   });
 });

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -137,24 +137,34 @@ const BUILD_PROGRESS_TOOL_NAMES = new Set([
   "propose_file_change",
 ]);
 
-/** Detect when the agent claims completion or narrates code without having called build tools. */
+function hasAuthoritativeToolProgress(
+  executedToolNames: string[] | undefined,
+  authoritativeToolNames?: Set<string>,
+): boolean {
+  return executedToolNames?.some((name) =>
+    BUILD_TOOL_NAMES.has(name) || authoritativeToolNames?.has(name),
+  ) ?? false;
+}
+
+/** Detect when the agent claims completion or narrates code without having called authoritative tools. */
 export function detectFabrication(
   response: string,
   executedToolCount: number,
   hasProposal: boolean,
   executedToolNames?: string[],
+  authoritativeToolNames?: Set<string>,
 ): boolean {
   if (hasProposal) return false;
 
   // If no tools were called at all, any completion claim is fabrication
   if (executedToolCount === 0) return COMPLETION_CLAIM_PATTERN.test(response);
 
-  // If tools were called but none were BUILD tools (only read/search), the
+  // If tools were called but none were authoritative action tools (only read/search), the
   // agent still cannot claim completion or narrate implementation as if it
   // persisted build-state evidence. Read-only investigation is not enough to
   // say a plan is ready, implementation started, or code was changed.
-  const usedBuildTool = executedToolNames?.some((n) => BUILD_TOOL_NAMES.has(n)) ?? false;
-  if (!usedBuildTool && (
+  const usedAuthoritativeTool = hasAuthoritativeToolProgress(executedToolNames, authoritativeToolNames);
+  if (!usedAuthoritativeTool && (
     COMPLETION_CLAIM_PATTERN.test(response) ||
     NARRATION_PATTERN.test(response)
   )) return true;
@@ -218,6 +228,7 @@ export function shouldNudge(params: {
   executedToolCount: number;
   responseLength: number;
   responseText?: string;
+  hasAuthoritativeToolExecution?: boolean;
 }): boolean {
   // One nudge maximum. Extra nudges multiply cost — if the model doesn't respond
   // to one targeted nudge, it won't respond to more and will just burn tokens.
@@ -243,7 +254,18 @@ export function shouldNudge(params: {
     return true;
   }
 
-  // Short response after using tools — model may have stalled
+  // Short response after using tools — model may have stalled. A short response
+  // after an authoritative action tool is allowed because scheduled/procedural
+  // runs often summarize a persisted tool result in one sentence.
+  if (
+    params.hasAuthoritativeToolExecution
+    && params.executedToolCount > 0
+    && params.responseText
+    && !NARRATION_PATTERN.test(params.responseText)
+    && !PERMISSION_SEEKING_PATTERN.test(params.responseText)
+  ) return false;
+
+  // Short response after using only read/context tools — model may have stalled
   if (params.executedToolCount > 0 && params.responseLength < 200) return true;
 
   // Agent is narrating code instead of using tools — nudge to use build tools
@@ -896,6 +918,7 @@ export async function runAgenticLoop(params: {
         executedTools.length,
         false,
         executedTools.map((t) => t.name),
+        new Set(tools.filter((tool) => tool.sideEffect).map((tool) => tool.name)),
       );
 
       const isBuildRoute = BUILD_ROUTE_PATTERN.test(routeContext);
@@ -1016,6 +1039,11 @@ export async function runAgenticLoop(params: {
         executedToolCount: executedTools.length,
         responseLength: trimmed.length,
         responseText: trimmed,
+        hasAuthoritativeToolExecution: executedTools.some(
+          (executedTool) => executedTool.result.success && tools.some(
+            (tool) => tool.name === executedTool.name && tool.sideEffect,
+          ),
+        ),
       });
 
         if (shouldNudgeNow) {
@@ -1258,6 +1286,7 @@ export async function runAgenticLoop(params: {
     executedTools.length,
     false,
     executedTools.map((tool) => tool.name),
+    new Set(tools.filter((tool) => tool.sideEffect).map((tool) => tool.name)),
   );
   return {
     content: fallbackIsFabricated


### PR DESCRIPTION
## Summary
- Treat successful side-effect/action tools as authoritative progress in the TAK agentic loop.
- Allow short factual summaries after action tools so scheduled/procedural coworkers do not get nudged into duplicate tool calls.
- Add regression coverage for action-tool fabrication detection and post-tool nudging.

## Verification
- pnpm --filter web exec vitest run lib/tak/agentic-loop.test.ts
- pnpm --filter web exec vitest run lib/actions/agent-task-scheduler.test.ts lib/discovery-triage-runner.test.ts lib/tak/agentic-loop.test.ts
- pnpm --filter web typecheck
- pnpm --filter web exec next build
- docker compose -p dpf --env-file D:\DPF\.env build portal portal-init
- docker compose -p dpf --env-file D:\DPF\.env up -d portal portal-init
- Live scheduled run: TR-SCHED-3F6E106B completed with executedToolCount=1 and one successful run_discovery_triage ToolExecution linked to the TaskRun.
- Authenticated task endpoint returned 200 for TR-SCHED-3F6E106B; Operations Map returned 200 and contained the TaskRun id.