### PR TITLE
feat: add capacity continuity runtime foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Hyphens, not underscores. Adding a new value requires updating both `backlog.ts`
 - **Concurrent sessions:** one thread = one branch + one git worktree. Create with `git worktree add ../DPF-<topic> -b <prefix>/<topic>`. Never share a working tree across sessions; doing so causes index/HEAD collisions and cross-thread file sweeps.
 - **After creating a worktree, seed its MCP config:** `.mcp.json` and `.vscode/mcp.json` are gitignored (they carry your local `dpfmcp_...` bearer token), so `git worktree add` does not carry them across. Run `scripts/seed-worktree-mcp.ps1` (Windows) or `scripts/seed-worktree-mcp.sh` (macOS / Linux) from inside the new worktree to copy them from the root clone. The script is predicated on the platform being installed and an MCP token already generated at Admin > Platform Development. Restart Claude Code in the worktree afterwards so `/mcp` picks up the `dpf` connector.
 - **Keep the root clone as the merge/release worktree** — read-only for active feature work. Conventional locations: `d:\DPF` on Windows, `~/dpf` on macOS/Linux. Topic worktrees go alongside (`d:\DPF-<topic>` or `~/dpf-worktrees/<topic>`).
-- **Branch guard before commit:** if `git branch --show-current` returns `main`, abort.
+- **Branch guard before implementation and commit:** if `git status --short --branch` reports `HEAD (no branch)` or `git branch --show-current` returns `main`, abort before serious implementation. Create/switch to a topic branch first. Do not claim work is complete while commits are local-only; completion requires a pushed branch or PR unless the user explicitly asked not to publish.
 
 ## 5. Verification — Build Gate (mandatory)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Tool-specific files (`CLAUDE.md`, `.cursor/rules/`, `.clinerules/`, `.github/cop
 - **Single source of truth.** Each rule, fact, or decision lives in exactly one place. Pointers, not copies.
 - **Architecture over shortcuts.** Choose the architecturally sound solution. Quick fixes that bypass the design create more debt than they save.
 - **Plan before acting on install/seed/template paths.** A symptom on one install is usually a defect for every install. Use `writing-plans` for anything touching setup, seeds, or shared templates.
+- **Use paid AI capacity responsibly.** DPF treats AI capacity as an operating asset. If valuable, authorized, evidence-producing work exists, agents should keep making governed progress rather than idle. If no safe work exists, record or surface the blocker. Token spend without durable value, evidence, or learning is waste.
 
 ## 2. Project Architecture (current as of 2026-04-27)
 

--- a/apps/web/app/(shell)/platform/ai/capacity-continuity/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/capacity-continuity/page.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+
+const CONTINUITY_STATES = [
+  {
+    state: "normal",
+    description: "Humans are available; agents assist, prepare decisions, and accelerate active work.",
+  },
+  {
+    state: "low-attention",
+    description: "Humans are busy; agents continue safe work and batch non-urgent interruptions.",
+  },
+  {
+    state: "away",
+    description: "Planned absence; agents pull from approved queues and escalate only meaningful blockers.",
+  },
+  {
+    state: "holiday",
+    description: "Reduced business availability; agents favor quiet maintenance, monitoring, and review prep.",
+  },
+  {
+    state: "event",
+    description: "Trade show, launch, audit, or migration; agents shift toward event support and evidence capture.",
+  },
+  {
+    state: "paused",
+    description: "Operator stop; no new autonomous capacity work starts.",
+  },
+];
+
+const SAFE_WORK = [
+  "stale spec and plan review",
+  "failing CI or build-gate repair",
+  "approved backlog slices with bounded scope",
+  "UX and QA evidence collection",
+  "coworker self-assessment and capability needs",
+  "proceduralization candidate analysis",
+];
+
+export default function CapacityContinuityPage() {
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">
+            AI Operations
+          </p>
+          <h1 className="mt-1 text-xl font-bold text-[var(--dpf-text)]">
+            Capacity Continuity
+          </h1>
+          <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
+            Operating policy for using paid AI capacity while human attention is available,
+            reduced, away, or redirected to business events.
+          </p>
+        </div>
+        <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs text-[var(--dpf-muted)]">
+          Design slice active
+        </div>
+      </header>
+
+      <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+        <div className="max-w-3xl">
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+            Responsible AI capacity utilization
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-[var(--dpf-muted)]">
+            DPF treats AI capacity as an operating asset. If valuable, authorized,
+            evidence-producing work exists, agents should keep making governed progress.
+            If no safe work exists, the platform should record the blocker instead of
+            spending tokens to appear busy.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-3">
+        <StatusCard label="Current implementation" value="Doctrine and UX home" />
+        <StatusCard label="Canonical route" value="/platform/ai/capacity-continuity" />
+        <StatusCard label="Next slice" value="Standing Orders" />
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+            Continuity states
+          </h2>
+          <div className="mt-4 grid gap-3">
+            {CONTINUITY_STATES.map((item) => (
+              <div
+                key={item.state}
+                className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+              >
+                <div className="font-mono text-xs font-semibold text-[var(--dpf-text)]">
+                  {item.state}
+                </div>
+                <p className="mt-1 text-sm leading-5 text-[var(--dpf-muted)]">
+                  {item.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+              Safe work queues
+            </h2>
+            <ul className="mt-3 space-y-2 text-sm text-[var(--dpf-muted)]">
+              {SAFE_WORK.map((item) => (
+                <li key={item} className="flex gap-2">
+                  <span className="mt-2 h-1.5 w-1.5 rounded-full bg-[var(--dpf-accent)]" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+              Related surfaces
+            </h2>
+            <div className="mt-3 flex flex-col gap-2 text-sm">
+              <Link href="/platform/ai/operations-map" className="text-[var(--dpf-accent)] hover:underline">
+                Operations Map
+              </Link>
+              <Link href="/platform/ai/capability-needs" className="text-[var(--dpf-accent)] hover:underline">
+                Capability Needs
+              </Link>
+              <Link href="/workspace" className="text-[var(--dpf-accent)] hover:underline">
+                My Workspace
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatusCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="text-xs font-medium uppercase text-[var(--dpf-muted)]">{label}</div>
+      <div className="mt-2 text-sm font-semibold text-[var(--dpf-text)]">{value}</div>
+    </div>
+  );
+}

--- a/apps/web/components/platform/AiTabNav.tsx
+++ b/apps/web/components/platform/AiTabNav.tsx
@@ -6,9 +6,12 @@ import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
 
 const TABS = [
   { label: "Overview", href: "/platform/ai" },
+  { label: "Operations Map", href: "/platform/ai/operations-map" },
+  { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },
   { label: "Assignments", href: "/platform/ai/assignments" },
   { label: "Prompts", href: "/platform/ai/prompts" },
   { label: "Skills", href: "/platform/ai/skills" },
+  { label: "Capability Needs", href: "/platform/ai/capability-needs" },
   { label: "Providers & Routing", href: "/platform/ai/providers" },
   { label: BUILD_STUDIO_CONFIG_ROUTE_COPY.navLabel, href: "/platform/ai/build-studio" },
 ];

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -52,6 +52,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
     subItems: [
       { label: "Overview", href: "/platform/ai" },
       { label: "Operations Map", href: "/platform/ai/operations-map" },
+      { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },
       { label: "Assignments", href: "/platform/ai/assignments" },
       { label: "Prompts", href: "/platform/ai/prompts" },
       { label: "Skills", href: "/platform/ai/skills" },

--- a/apps/web/lib/capacity-continuity/backlog-selector.test.ts
+++ b/apps/web/lib/capacity-continuity/backlog-selector.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const backlogFindManyMock = vi.fn();
+const taskRunFindManyMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    backlogItem: {
+      findMany: backlogFindManyMock,
+    },
+    taskRun: {
+      findMany: taskRunFindManyMock,
+    },
+  },
+}));
+
+vi.mock("./finance-signals", () => ({
+  getCapacityProviderFinanceSignals: vi.fn().mockResolvedValue([
+    {
+      providerId: "openai",
+      providerClass: "fixed-cost",
+      status: "active",
+      utilizationPct: 40,
+      projectedUnusedValue: 100,
+      overageRisk: false,
+    },
+  ]),
+}));
+
+vi.mock("@/lib/tak/agent-grants", () => ({
+  getToolGrantMapping: vi.fn().mockReturnValue({
+    list_backlog_items: ["backlog_read"],
+    deploy_release: ["release_gate_create"],
+  }),
+}));
+
+describe("selectBacklogReviewCapacityCandidates", () => {
+  beforeEach(() => {
+    backlogFindManyMock.mockReset();
+    taskRunFindManyMock.mockReset();
+  });
+
+  it("builds read-only backlog review candidates enriched with finance routing hints", async () => {
+    taskRunFindManyMock.mockResolvedValue([]);
+    backlogFindManyMock.mockResolvedValue([
+      {
+        id: "internal-1",
+        itemId: "BI-123",
+        title: "Clarify stale AI operations spec",
+        body: "Review the spec and identify drift against runtime.",
+        priority: 1,
+        updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+        epic: { epicId: "EP-AI", title: "AI operations" },
+      },
+    ]);
+
+    const { selectBacklogReviewCapacityCandidates } = await import("./backlog-selector");
+
+    await expect(
+      selectBacklogReviewCapacityCandidates({
+        agentId: "agent-capacity",
+        ownerPrincipalId: "principal-owner",
+        capacityWindowId: "window-1",
+        limit: 2,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        candidateId: "backlog-review:BI-123",
+        dedupeKey: "capacity:backlog-review:BI-123",
+        source: "backlog",
+        title: "Review backlog item BI-123: Clarify stale AI operations spec",
+        routeContext: "/workspace/my-queue",
+        agentId: "agent-capacity",
+        ownerPrincipalId: "principal-owner",
+        riskClass: "read-only",
+        sourceRef: { kind: "backlog-item", id: "BI-123" },
+        capacityWindowId: "window-1",
+        routingHints: expect.objectContaining({
+          budgetClass: "minimize_cost",
+          preferredProviderClass: "fixed-cost",
+          reasonCodes: ["underused_commitment", "safe_background_work"],
+        }),
+        financeTracking: expect.objectContaining({
+          observedProviderClasses: ["fixed-cost"],
+          sourceProviderIds: ["openai"],
+          projectedUnusedValue: 100,
+          utilizationPct: 40,
+        }),
+      }),
+    ]);
+  });
+
+  it("skips backlog items with recent capacity dedupe keys", async () => {
+    taskRunFindManyMock.mockResolvedValue([
+      {
+        a2aMetadata: {
+          cognitiveLoad: {
+            dedupeKey: "capacity:backlog-review:BI-123",
+          },
+        },
+      },
+    ]);
+    backlogFindManyMock.mockResolvedValue([
+      {
+        id: "internal-1",
+        itemId: "BI-123",
+        title: "Clarify stale AI operations spec",
+        body: null,
+        priority: 1,
+        updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+        epic: null,
+      },
+    ]);
+
+    const { selectBacklogReviewCapacityCandidates } = await import("./backlog-selector");
+
+    await expect(
+      selectBacklogReviewCapacityCandidates({
+        agentId: "agent-capacity",
+        ownerPrincipalId: "principal-owner",
+      }),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("selectBacklogReviewCapacityWorkInputs", () => {
+  beforeEach(() => {
+    backlogFindManyMock.mockReset();
+    taskRunFindManyMock.mockReset();
+  });
+
+  it("maps selected backlog candidates to ready autonomous work inputs", async () => {
+    taskRunFindManyMock.mockResolvedValue([]);
+    backlogFindManyMock.mockResolvedValue([
+      {
+        id: "internal-1",
+        itemId: "BI-123",
+        title: "Clarify stale AI operations spec",
+        body: null,
+        priority: 1,
+        updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+        epic: null,
+      },
+    ]);
+
+    const { selectBacklogReviewCapacityWorkInputs } = await import("./backlog-selector");
+
+    const result = await selectBacklogReviewCapacityWorkInputs({
+      agentId: "agent-capacity",
+      ownerPrincipalId: "principal-owner",
+      resolvedTools: [{ name: "list_backlog_items" }],
+    });
+
+    expect(result.inputs).toEqual([
+      expect.objectContaining({
+        trigger: "capacity-continuity",
+        userId: "principal-owner",
+        agentId: "agent-capacity",
+        sourceRef: { kind: "backlog-item", id: "BI-123" },
+      }),
+    ]);
+    expect(result.rejections).toEqual([]);
+  });
+
+  it("returns structured rejections when selected work requires forbidden grants", async () => {
+    taskRunFindManyMock.mockResolvedValue([]);
+    backlogFindManyMock.mockResolvedValue([
+      {
+        id: "internal-1",
+        itemId: "BI-123",
+        title: "Clarify stale AI operations spec",
+        body: null,
+        priority: 1,
+        updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+        epic: null,
+      },
+    ]);
+
+    const { selectBacklogReviewCapacityWorkInputs } = await import("./backlog-selector");
+
+    const result = await selectBacklogReviewCapacityWorkInputs({
+      agentId: "agent-capacity",
+      ownerPrincipalId: "principal-owner",
+      resolvedTools: [{ name: "deploy_release" }],
+    });
+
+    expect(result.inputs).toEqual([]);
+    expect(result.rejections).toEqual([
+      {
+        candidateId: "backlog-review:BI-123",
+        rejection: expect.objectContaining({
+          code: "forbidden_grant",
+        }),
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/capacity-continuity/backlog-selector.test.ts
+++ b/apps/web/lib/capacity-continuity/backlog-selector.test.ts
@@ -188,6 +188,7 @@ describe("selectBacklogReviewCapacityWorkInputs", () => {
     expect(result.rejections).toEqual([
       {
         candidateId: "backlog-review:BI-123",
+        sourceRef: { kind: "backlog-item", id: "BI-123" },
         rejection: expect.objectContaining({
           code: "forbidden_grant",
         }),

--- a/apps/web/lib/capacity-continuity/backlog-selector.ts
+++ b/apps/web/lib/capacity-continuity/backlog-selector.ts
@@ -1,0 +1,209 @@
+import { prisma } from "@dpf/db";
+
+import type { AutonomousWorkRunInput } from "@/lib/tak/autonomous-work-run";
+import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import {
+  mapCapacityCandidateToAutonomousWorkRunInput,
+  type CapacityContinuityCandidate,
+} from "./candidates";
+import { getCapacityProviderFinanceSignals } from "./finance-signals";
+import { planCapacityFinanceRouting } from "./finance-routing";
+
+type BacklogCandidateRow = {
+  itemId: string;
+  title: string;
+  body: string | null;
+  priority: number | null;
+  updatedAt: Date;
+  epic: {
+    epicId: string;
+    title: string;
+  } | null;
+};
+
+type CapacityTaskRunRow = {
+  a2aMetadata: unknown;
+};
+
+export type BacklogReviewCapacityOptions = {
+  agentId: string;
+  ownerPrincipalId: string;
+  capacityWindowId?: string;
+  limit?: number;
+};
+
+export type BacklogReviewCapacityWorkInputOptions = BacklogReviewCapacityOptions & {
+  resolvedTools?: Array<{ name: string }>;
+};
+
+export type BacklogReviewCapacityWorkInputResult = {
+  inputs: AutonomousWorkRunInput[];
+  rejections: Array<{
+    candidateId: string;
+    rejection: Exclude<
+      ReturnType<typeof mapCapacityCandidateToAutonomousWorkRunInput>,
+      { ok: true }
+    >["rejection"];
+  }>;
+};
+
+const DEFAULT_LIMIT = 5;
+
+export async function selectBacklogReviewCapacityCandidates(
+  options: BacklogReviewCapacityOptions,
+): Promise<CapacityContinuityCandidate[]> {
+  const [items, recentDedupeKeys, financeSignals] = await Promise.all([
+    listSafeBacklogReviewRows(options.limit ?? DEFAULT_LIMIT),
+    listRecentCapacityDedupeKeys(),
+    getCapacityProviderFinanceSignals(),
+  ]);
+
+  return items
+    .map((item) => buildBacklogReviewCandidate(item, options, financeSignals))
+    .filter((candidate) => !recentDedupeKeys.has(candidate.dedupeKey));
+}
+
+export async function selectBacklogReviewCapacityWorkInputs(
+  options: BacklogReviewCapacityWorkInputOptions,
+): Promise<BacklogReviewCapacityWorkInputResult> {
+  const candidates = await selectBacklogReviewCapacityCandidates(options);
+  const toolGrantMapping = getToolGrantMapping();
+  const result: BacklogReviewCapacityWorkInputResult = {
+    inputs: [],
+    rejections: [],
+  };
+
+  for (const candidate of candidates) {
+    const mapped = mapCapacityCandidateToAutonomousWorkRunInput(candidate, {
+      resolvedTools: options.resolvedTools,
+      toolGrantMapping,
+      existingDedupeKeys: candidates
+        .filter((other) => other.candidateId !== candidate.candidateId)
+        .map((other) => other.dedupeKey),
+    });
+
+    if (mapped.ok) {
+      result.inputs.push(mapped.input);
+    } else {
+      result.rejections.push({
+        candidateId: candidate.candidateId,
+        rejection: mapped.rejection,
+      });
+    }
+  }
+
+  return result;
+}
+
+async function listSafeBacklogReviewRows(limit: number): Promise<BacklogCandidateRow[]> {
+  return prisma.backlogItem.findMany({
+    where: {
+      status: "open",
+      activeBuildId: null,
+      duplicateOfId: null,
+      claimedAt: null,
+    },
+    orderBy: [{ priority: "asc" }, { updatedAt: "asc" }],
+    take: limit,
+    select: {
+      itemId: true,
+      title: true,
+      body: true,
+      priority: true,
+      updatedAt: true,
+      epic: {
+        select: {
+          epicId: true,
+          title: true,
+        },
+      },
+    },
+  });
+}
+
+async function listRecentCapacityDedupeKeys() {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const runs = await prisma.taskRun.findMany({
+    where: {
+      createdAt: { gte: since },
+      a2aMetadata: {
+        path: ["trigger"],
+        equals: "capacity-continuity",
+      },
+      status: { in: ["submitted", "working", "input-required", "completed"] },
+    },
+    select: {
+      a2aMetadata: true,
+    },
+  });
+
+  return new Set(
+    (runs as CapacityTaskRunRow[])
+      .map((run) => extractDedupeKey(run.a2aMetadata))
+      .filter((key): key is string => typeof key === "string" && key.length > 0),
+  );
+}
+
+function buildBacklogReviewCandidate(
+  item: BacklogCandidateRow,
+  options: BacklogReviewCapacityOptions,
+  financeSignals: Awaited<ReturnType<typeof getCapacityProviderFinanceSignals>>,
+): CapacityContinuityCandidate {
+  const baseCandidate: CapacityContinuityCandidate = {
+    candidateId: `backlog-review:${item.itemId}`,
+    dedupeKey: `capacity:backlog-review:${item.itemId}`,
+    source: "backlog",
+    title: `Review backlog item ${item.itemId}: ${item.title}`,
+    objective: buildObjective(item),
+    routeContext: "/workspace/my-queue",
+    agentId: options.agentId,
+    ownerPrincipalId: options.ownerPrincipalId,
+    riskClass: "read-only",
+    evidenceRequired: [
+      "Backlog item reviewed against current docs and runtime signals",
+      "Recommended next action captured with evidence or blocker reason",
+    ],
+    capacityFit: {
+      providerClassHint: "fixed-cost",
+      modelTierHint: "standard",
+      reason: "Read-only backlog review can use already-paid background capacity.",
+    },
+    sourceRef: {
+      kind: "backlog-item",
+      id: item.itemId,
+    },
+    capacityState: "surplus",
+    ...(options.capacityWindowId ? { capacityWindowId: options.capacityWindowId } : {}),
+  };
+
+  const financePlan = planCapacityFinanceRouting(baseCandidate, {
+    financeSignals,
+  });
+
+  return {
+    ...baseCandidate,
+    routingHints: financePlan.routingHints,
+    financeTracking: financePlan.financeTracking,
+  };
+}
+
+function buildObjective(item: BacklogCandidateRow) {
+  const epicContext = item.epic ? ` Epic: ${item.epic.epicId} - ${item.epic.title}.` : "";
+  const bodyContext = item.body ? ` Notes: ${item.body.slice(0, 500)}` : "";
+
+  return `Review backlog item ${item.itemId} for safe next action, stale assumptions, missing evidence, and capacity-suitable follow-up.${epicContext}${bodyContext}`;
+}
+
+function extractDedupeKey(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  const cognitiveLoad = (metadata as { cognitiveLoad?: unknown }).cognitiveLoad;
+  if (!cognitiveLoad || typeof cognitiveLoad !== "object") {
+    return null;
+  }
+
+  const dedupeKey = (cognitiveLoad as { dedupeKey?: unknown }).dedupeKey;
+  return typeof dedupeKey === "string" ? dedupeKey : null;
+}

--- a/apps/web/lib/capacity-continuity/backlog-selector.ts
+++ b/apps/web/lib/capacity-continuity/backlog-selector.ts
@@ -40,6 +40,7 @@ export type BacklogReviewCapacityWorkInputResult = {
   inputs: AutonomousWorkRunInput[];
   rejections: Array<{
     candidateId: string;
+    sourceRef: CapacityContinuityCandidate["sourceRef"];
     rejection: Exclude<
       ReturnType<typeof mapCapacityCandidateToAutonomousWorkRunInput>,
       { ok: true }
@@ -87,6 +88,7 @@ export async function selectBacklogReviewCapacityWorkInputs(
     } else {
       result.rejections.push({
         candidateId: candidate.candidateId,
+        sourceRef: candidate.sourceRef,
         rejection: mapped.rejection,
       });
     }

--- a/apps/web/lib/capacity-continuity/candidates.test.ts
+++ b/apps/web/lib/capacity-continuity/candidates.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mapCapacityCandidateToAutonomousWorkRunInput,
+  type CapacityContinuityCandidate,
+} from "./candidates";
+
+const baseCandidate: CapacityContinuityCandidate = {
+  candidateId: "cap-cand-1",
+  dedupeKey: "standing-order:weekly-backlog-hygiene:2026-05-12",
+  source: "standing-order",
+  title: "Weekly backlog hygiene",
+  objective: "Review open backlog items and produce evidence-backed cleanup recommendations.",
+  routeContext: "/platform/backlog",
+  agentId: "agent-capacity",
+  ownerPrincipalId: "user-owner",
+  riskClass: "read-only",
+  evidenceRequired: ["Backlog items reviewed", "Recommended status changes captured"],
+  capacityFit: {
+    providerClassHint: "fixed-cost",
+    modelTierHint: "standard",
+    reason: "Uses already-paid capacity for low-risk review work.",
+  },
+  sourceRef: {
+    kind: "standing-order",
+    id: "standing-order-weekly-backlog-hygiene",
+  },
+  capacityState: "surplus",
+  capacityWindowId: "window-2026-05-12-am",
+};
+
+describe("mapCapacityCandidateToAutonomousWorkRunInput", () => {
+  it("maps an accepted capacity candidate to the autonomous work run seam", () => {
+    const result = mapCapacityCandidateToAutonomousWorkRunInput(baseCandidate, {
+      resolvedTools: [{ name: "list_backlog_items" }],
+      toolGrantMapping: { list_backlog_items: ["backlog_read"] },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.rejection.reason);
+    }
+
+    expect(result.input).toMatchObject({
+      trigger: "capacity-continuity",
+      userId: "user-owner",
+      agentId: "agent-capacity",
+      routeContext: "/platform/backlog",
+      title: "Weekly backlog hygiene",
+      objective:
+        "Review open backlog items and produce evidence-backed cleanup recommendations.",
+      prompt:
+        "Review open backlog items and produce evidence-backed cleanup recommendations.",
+      sourceRef: {
+        kind: "standing-order",
+        id: "standing-order-weekly-backlog-hygiene",
+      },
+    });
+    expect(result.input.metadata).toEqual({
+      cognitiveLoad: {
+        capacityState: "surplus",
+        capacityWindowId: "window-2026-05-12-am",
+        dedupeKey: "standing-order:weekly-backlog-hygiene:2026-05-12",
+        evidenceRequired: [
+          "Backlog items reviewed",
+          "Recommended status changes captured",
+        ],
+        fundingFitHint: {
+          providerClassHint: "fixed-cost",
+          modelTierHint: "standard",
+          reason: "Uses already-paid capacity for low-risk review work.",
+        },
+        riskClass: "read-only",
+      },
+    });
+  });
+
+  it("rejects candidates that require forbidden tool grants before creating a run", () => {
+    const result = mapCapacityCandidateToAutonomousWorkRunInput(baseCandidate, {
+      resolvedTools: [{ name: "deploy_release" }],
+      toolGrantMapping: { deploy_release: ["release_gate_create"] },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      rejection: {
+        code: "forbidden_grant",
+        reason:
+          "Capacity continuity cannot start work that requires the release_gate_create grant.",
+        details: {
+          grant: "release_gate_create",
+          toolName: "deploy_release",
+        },
+      },
+    });
+  });
+
+  it("rejects vague work that has no resolvable artifact target", () => {
+    const result = mapCapacityCandidateToAutonomousWorkRunInput({
+      ...baseCandidate,
+      objective: "Think about strategy.",
+      evidenceRequired: [],
+      sourceRef: {
+        kind: "standing-order",
+        id: "standing-order-strategy",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected vague work to be rejected.");
+    }
+    expect(result.rejection.code).toBe("ambiguous_objective");
+  });
+
+  it("keeps standing-order attribution in sourceRef when the standing order is the source", () => {
+    const result = mapCapacityCandidateToAutonomousWorkRunInput(baseCandidate);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.rejection.reason);
+    }
+    expect(result.input.sourceRef).toEqual({
+      kind: "standing-order",
+      id: "standing-order-weekly-backlog-hygiene",
+    });
+    expect(result.input.metadata).not.toMatchObject({
+      cognitiveLoad: {
+        viaStandingOrderId: expect.any(String),
+      },
+    });
+  });
+
+  it("records viaStandingOrderId only when another artifact is the sourceRef", () => {
+    const result = mapCapacityCandidateToAutonomousWorkRunInput({
+      ...baseCandidate,
+      source: "backlog",
+      sourceRef: {
+        kind: "backlog-item",
+        id: "BI-123",
+      },
+      viaStandingOrderId: "standing-order-weekly-backlog-hygiene",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.rejection.reason);
+    }
+    expect(result.input.sourceRef).toEqual({
+      kind: "backlog-item",
+      id: "BI-123",
+    });
+    expect(result.input.metadata).toMatchObject({
+      cognitiveLoad: {
+        viaStandingOrderId: "standing-order-weekly-backlog-hygiene",
+      },
+    });
+  });
+
+  it("carries finance and routing hints in metadata without provider pinning", () => {
+    const result = mapCapacityCandidateToAutonomousWorkRunInput({
+      ...baseCandidate,
+      routingHints: {
+        budgetClass: "minimize_cost",
+        interactionMode: "background",
+        modelTierHint: "standard",
+        preferredProviderClass: "fixed-cost",
+        reasonCodes: ["underused_commitment", "safe_background_work"],
+      },
+      financeTracking: {
+        candidateId: "cap-cand-1",
+        dedupeKey: "standing-order:weekly-backlog-hygiene:2026-05-12",
+        observedProviderClasses: ["fixed-cost"],
+        sourceProviderIds: ["openai-subscription"],
+        projectedUnusedValue: 120,
+        utilizationPct: 35,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.rejection.reason);
+    }
+    expect(result.input.metadata).toMatchObject({
+      cognitiveLoad: {
+        routingHints: {
+          budgetClass: "minimize_cost",
+          interactionMode: "background",
+          modelTierHint: "standard",
+          preferredProviderClass: "fixed-cost",
+          reasonCodes: ["underused_commitment", "safe_background_work"],
+        },
+        financeTracking: {
+          observedProviderClasses: ["fixed-cost"],
+          sourceProviderIds: ["openai-subscription"],
+          projectedUnusedValue: 120,
+          utilizationPct: 35,
+        },
+      },
+    });
+    expect(JSON.stringify(result.input.metadata)).not.toContain("allowedProviders");
+    expect(JSON.stringify(result.input.metadata)).not.toContain("preferredProviderId");
+  });
+});

--- a/apps/web/lib/capacity-continuity/candidates.ts
+++ b/apps/web/lib/capacity-continuity/candidates.ts
@@ -1,0 +1,268 @@
+import type { AutonomousWorkRunInput } from "@/lib/tak/autonomous-work-run";
+import type {
+  CapacityFinanceTracking,
+  CapacityModelTierHint,
+  CapacityProviderClass,
+  CapacityRoutingHints,
+} from "./finance-routing";
+
+export type CapacityContinuityCandidateSource =
+  | "standing-order"
+  | "backlog"
+  | "pull-request"
+  | "qa-gap"
+  | "spec-drift"
+  | "capability-need"
+  | "proceduralization";
+
+export type CapacityContinuitySourceRef =
+  | { kind: "standing-order"; id: string }
+  | { kind: "backlog-item"; id: string }
+  | { kind: "pull-request"; id: string }
+  | { kind: "qa-gap"; id: string }
+  | { kind: "spec"; id: string }
+  | { kind: "capability-need"; id: string }
+  | { kind: "proceduralization-candidate"; id: string };
+
+export type CapacityContinuityRiskClass =
+  | "read-only"
+  | "review-after"
+  | "approval-required";
+
+export type CapacityContinuityState =
+  | "normal"
+  | "surplus"
+  | "away-mode"
+  | "holiday"
+  | "event";
+
+export type CapacityContinuityCandidate = {
+  candidateId: string;
+  dedupeKey: string;
+  source: CapacityContinuityCandidateSource;
+  title: string;
+  objective: string;
+  routeContext: string;
+  agentId: string;
+  ownerPrincipalId: string;
+  riskClass: CapacityContinuityRiskClass;
+  evidenceRequired: string[];
+  capacityFit: {
+    providerClassHint?: CapacityProviderClass;
+    modelTierHint?: CapacityModelTierHint;
+    reason?: string;
+  };
+  sourceRef: CapacityContinuitySourceRef;
+  capacityState?: CapacityContinuityState;
+  capacityWindowId?: string;
+  viaStandingOrderId?: string;
+  routingHints?: CapacityRoutingHints;
+  financeTracking?: CapacityFinanceTracking;
+};
+
+type CapacityContinuityToolProbe = {
+  name: string;
+};
+
+type CapacityContinuityMappingOptions = {
+  resolvedTools?: CapacityContinuityToolProbe[];
+  toolGrantMapping?: Record<string, string[]>;
+  existingDedupeKeys?: Iterable<string>;
+};
+
+type CapacityContinuityRejection = {
+  code:
+    | "forbidden_grant"
+    | "phase_gated_route"
+    | "ambiguous_objective"
+    | "duplicate_candidate";
+  reason: string;
+  details?: Record<string, string>;
+};
+
+export type CapacityContinuityMappingResult =
+  | { ok: true; input: AutonomousWorkRunInput }
+  | { ok: false; rejection: CapacityContinuityRejection };
+
+const HARD_REJECTED_GRANTS = new Set([
+  "deploy",
+  "publish-external",
+  "schema-migrate",
+  "data-delete",
+  "spend-money",
+  "admin_write",
+  "deployment_plan_create",
+  "iac_execute",
+  "release_gate_create",
+  "release_plan_create",
+]);
+
+const PHASE_GATED_ROUTE_PATTERNS = [
+  /^\/build(?:\/|$)/,
+  /^\/platform\/ai\/build-studio(?:\/|$)/,
+  /deliberation/i,
+];
+
+export function mapCapacityCandidateToAutonomousWorkRunInput(
+  candidate: CapacityContinuityCandidate,
+  options: CapacityContinuityMappingOptions = {},
+): CapacityContinuityMappingResult {
+  const duplicateRejection = rejectDuplicateCandidate(candidate, options);
+  if (duplicateRejection) {
+    return duplicateRejection;
+  }
+
+  const routeRejection = rejectPhaseGatedRoute(candidate);
+  if (routeRejection) {
+    return routeRejection;
+  }
+
+  const grantRejection = rejectForbiddenGrants(options);
+  if (grantRejection) {
+    return grantRejection;
+  }
+
+  const ambiguityRejection = rejectAmbiguousObjective(candidate);
+  if (ambiguityRejection) {
+    return ambiguityRejection;
+  }
+
+  const cognitiveLoad: Record<string, unknown> = {
+    capacityState: candidate.capacityState ?? "normal",
+    dedupeKey: candidate.dedupeKey,
+    evidenceRequired: candidate.evidenceRequired,
+    fundingFitHint: candidate.capacityFit,
+    riskClass: candidate.riskClass,
+  };
+
+  if (candidate.capacityWindowId) {
+    cognitiveLoad.capacityWindowId = candidate.capacityWindowId;
+  }
+
+  if (candidate.routingHints) {
+    cognitiveLoad.routingHints = candidate.routingHints;
+  }
+
+  if (candidate.financeTracking) {
+    cognitiveLoad.financeTracking = candidate.financeTracking;
+  }
+
+  if (
+    candidate.viaStandingOrderId &&
+    candidate.sourceRef.kind !== "standing-order"
+  ) {
+    cognitiveLoad.viaStandingOrderId = candidate.viaStandingOrderId;
+  }
+
+  return {
+    ok: true,
+    input: {
+      trigger: "capacity-continuity",
+      userId: candidate.ownerPrincipalId,
+      agentId: candidate.agentId,
+      routeContext: candidate.routeContext,
+      title: candidate.title,
+      objective: candidate.objective,
+      prompt: candidate.objective,
+      sourceRef: candidate.sourceRef,
+      metadata: {
+        cognitiveLoad,
+      },
+    },
+  };
+}
+
+function rejectDuplicateCandidate(
+  candidate: CapacityContinuityCandidate,
+  options: CapacityContinuityMappingOptions,
+): CapacityContinuityMappingResult | null {
+  const existingKeys = new Set(options.existingDedupeKeys ?? []);
+  if (!existingKeys.has(candidate.dedupeKey)) {
+    return null;
+  }
+
+  return {
+    ok: false,
+    rejection: {
+      code: "duplicate_candidate",
+      reason:
+        "Capacity continuity already has an open or recent run for this dedupe key.",
+      details: {
+        dedupeKey: candidate.dedupeKey,
+      },
+    },
+  };
+}
+
+function rejectPhaseGatedRoute(
+  candidate: CapacityContinuityCandidate,
+): CapacityContinuityMappingResult | null {
+  if (!PHASE_GATED_ROUTE_PATTERNS.some((pattern) => pattern.test(candidate.routeContext))) {
+    return null;
+  }
+
+  return {
+    ok: false,
+    rejection: {
+      code: "phase_gated_route",
+      reason:
+        "Capacity continuity cannot initiate work on a route with its own phase gate.",
+      details: {
+        routeContext: candidate.routeContext,
+      },
+    },
+  };
+}
+
+function rejectForbiddenGrants(
+  options: CapacityContinuityMappingOptions,
+): CapacityContinuityMappingResult | null {
+  for (const tool of options.resolvedTools ?? []) {
+    const grants = options.toolGrantMapping?.[tool.name] ?? [];
+    const forbiddenGrant = grants.find((grant) => HARD_REJECTED_GRANTS.has(grant));
+
+    if (forbiddenGrant) {
+      return {
+        ok: false,
+        rejection: {
+          code: "forbidden_grant",
+          reason: `Capacity continuity cannot start work that requires the ${forbiddenGrant} grant.`,
+          details: {
+            grant: forbiddenGrant,
+            toolName: tool.name,
+          },
+        },
+      };
+    }
+  }
+
+  return null;
+}
+
+function rejectAmbiguousObjective(
+  candidate: CapacityContinuityCandidate,
+): CapacityContinuityMappingResult | null {
+  if (hasResolvableArtifactTarget(candidate)) {
+    return null;
+  }
+
+  return {
+    ok: false,
+    rejection: {
+      code: "ambiguous_objective",
+      reason:
+        "Capacity continuity requires a resolvable artifact target before starting autonomous work.",
+      details: {
+        candidateId: candidate.candidateId,
+      },
+    },
+  };
+}
+
+function hasResolvableArtifactTarget(candidate: CapacityContinuityCandidate) {
+  if (candidate.evidenceRequired.length > 0) {
+    return true;
+  }
+
+  return candidate.sourceRef.kind !== "standing-order";
+}

--- a/apps/web/lib/capacity-continuity/finance-routing.test.ts
+++ b/apps/web/lib/capacity-continuity/finance-routing.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planCapacityFinanceRouting,
+  type CapacityProviderFinanceSignal,
+} from "./finance-routing";
+import type { CapacityContinuityCandidate } from "./candidates";
+
+const baseCandidate: CapacityContinuityCandidate = {
+  candidateId: "cap-cand-1",
+  dedupeKey: "qa-evidence:2026-05-12",
+  source: "qa-gap",
+  title: "Collect QA evidence",
+  objective: "Run read-only QA evidence collection for the platform AI operations page.",
+  routeContext: "/platform/ai/operations-map",
+  agentId: "agent-capacity",
+  ownerPrincipalId: "principal-owner",
+  riskClass: "read-only",
+  evidenceRequired: ["QA evidence captured"],
+  capacityFit: {
+    modelTierHint: "standard",
+    reason: "Safe evidence work can use already-paid capacity.",
+  },
+  sourceRef: {
+    kind: "qa-gap",
+    id: "QA-123",
+  },
+};
+
+const underusedFixedCost: CapacityProviderFinanceSignal = {
+  providerId: "openai-subscription",
+  providerClass: "fixed-cost",
+  status: "active",
+  utilizationPct: 35,
+  projectedUnusedValue: 120,
+  overageRisk: false,
+};
+
+describe("planCapacityFinanceRouting", () => {
+  it("prefers underused fixed-cost capacity for routine or standard safe work without pinning a provider", () => {
+    const plan = planCapacityFinanceRouting(baseCandidate, {
+      financeSignals: [underusedFixedCost],
+    });
+
+    expect(plan.routingHints).toEqual({
+      budgetClass: "minimize_cost",
+      interactionMode: "background",
+      modelTierHint: "standard",
+      preferredProviderClass: "fixed-cost",
+      reasonCodes: ["underused_commitment", "safe_background_work"],
+    });
+    expect(plan.financeTracking).toEqual({
+      candidateId: "cap-cand-1",
+      dedupeKey: "qa-evidence:2026-05-12",
+      observedProviderClasses: ["fixed-cost"],
+      sourceProviderIds: ["openai-subscription"],
+      projectedUnusedValue: 120,
+      utilizationPct: 35,
+    });
+    expect(JSON.stringify(plan)).not.toContain("allowedProviders");
+    expect(JSON.stringify(plan.routingHints)).not.toContain("openai-subscription");
+  });
+
+  it("uses quality-first routing for frontier work even when fixed-cost capacity is underused", () => {
+    const plan = planCapacityFinanceRouting(
+      {
+        ...baseCandidate,
+        capacityFit: {
+          modelTierHint: "frontier",
+          reason: "Architecture review requires frontier reasoning.",
+        },
+      },
+      { financeSignals: [underusedFixedCost] },
+    );
+
+    expect(plan.routingHints).toMatchObject({
+      budgetClass: "quality_first",
+      modelTierHint: "frontier",
+      preferredProviderClass: "fixed-cost",
+    });
+    expect(plan.routingHints.reasonCodes).toContain("frontier_required");
+  });
+
+  it("avoids token-priced overage risk for safe background work", () => {
+    const plan = planCapacityFinanceRouting(baseCandidate, {
+      financeSignals: [
+        {
+          providerId: "token-provider",
+          providerClass: "token-priced",
+          status: "active",
+          utilizationPct: 98,
+          projectedUnusedValue: 0,
+          overageRisk: true,
+        },
+      ],
+    });
+
+    expect(plan.routingHints).toEqual({
+      budgetClass: "minimize_cost",
+      interactionMode: "background",
+      modelTierHint: "standard",
+      avoidProviderClasses: ["token-priced"],
+      reasonCodes: ["overage_risk", "safe_background_work"],
+    });
+  });
+});

--- a/apps/web/lib/capacity-continuity/finance-routing.ts
+++ b/apps/web/lib/capacity-continuity/finance-routing.ts
@@ -1,0 +1,166 @@
+import type { CapacityContinuityCandidate } from "./candidates";
+
+export type CapacityProviderClass =
+  | "fixed-cost"
+  | "quota"
+  | "token-priced"
+  | "local";
+
+export type CapacityModelTierHint = "routine" | "standard" | "frontier";
+
+export type CapacityProviderFinanceSignal = {
+  providerId: string;
+  providerClass: CapacityProviderClass;
+  status?: "active" | "degraded" | "inactive";
+  utilizationPct?: number | null;
+  projectedUnusedValue?: number | null;
+  overageRisk?: boolean;
+};
+
+export type CapacityRoutingHints = {
+  budgetClass: "minimize_cost" | "balanced" | "quality_first";
+  interactionMode: "background";
+  modelTierHint: CapacityModelTierHint;
+  preferredProviderClass?: CapacityProviderClass;
+  avoidProviderClasses?: CapacityProviderClass[];
+  reasonCodes: string[];
+};
+
+export type CapacityFinanceTracking = {
+  candidateId: string;
+  dedupeKey: string;
+  observedProviderClasses: CapacityProviderClass[];
+  sourceProviderIds: string[];
+  projectedUnusedValue: number;
+  utilizationPct: number | null;
+};
+
+export type CapacityFinanceRoutingPlan = {
+  routingHints: CapacityRoutingHints;
+  financeTracking: CapacityFinanceTracking;
+};
+
+type CapacityFinanceRoutingOptions = {
+  financeSignals: CapacityProviderFinanceSignal[];
+};
+
+export function planCapacityFinanceRouting(
+  candidate: CapacityContinuityCandidate,
+  options: CapacityFinanceRoutingOptions,
+): CapacityFinanceRoutingPlan {
+  const usableSignals = options.financeSignals.filter((signal) =>
+    signal.status === undefined || signal.status === "active" || signal.status === "degraded"
+  );
+  const preferredSignal = choosePreferredSignal(usableSignals);
+  const modelTierHint = normalizeModelTier(candidate.capacityFit.modelTierHint);
+  const reasonCodes = buildReasonCodes(candidate, modelTierHint, preferredSignal, usableSignals);
+  const avoidProviderClasses = buildAvoidProviderClasses(usableSignals);
+
+  return {
+    routingHints: {
+      budgetClass: budgetClassFor(modelTierHint, preferredSignal, avoidProviderClasses),
+      interactionMode: "background",
+      modelTierHint,
+      ...(preferredSignal ? { preferredProviderClass: preferredSignal.providerClass } : {}),
+      ...(avoidProviderClasses.length > 0 ? { avoidProviderClasses } : {}),
+      reasonCodes,
+    },
+    financeTracking: {
+      candidateId: candidate.candidateId,
+      dedupeKey: candidate.dedupeKey,
+      observedProviderClasses: unique(usableSignals.map((signal) => signal.providerClass)),
+      sourceProviderIds: usableSignals.map((signal) => signal.providerId),
+      projectedUnusedValue: sumProjectedUnusedValue(usableSignals),
+      utilizationPct: averageUtilization(usableSignals),
+    },
+  };
+}
+
+function choosePreferredSignal(signals: CapacityProviderFinanceSignal[]) {
+  const underusedFixed = signals.find((signal) =>
+    (signal.providerClass === "fixed-cost" || signal.providerClass === "quota" || signal.providerClass === "local") &&
+    !signal.overageRisk &&
+    Number(signal.projectedUnusedValue ?? 0) > 0
+  );
+
+  return underusedFixed ?? signals.find((signal) => signal.providerClass === "local" && !signal.overageRisk);
+}
+
+function normalizeModelTier(input: string | undefined): CapacityModelTierHint {
+  if (input === "routine" || input === "standard" || input === "frontier") {
+    return input;
+  }
+
+  return "standard";
+}
+
+function budgetClassFor(
+  modelTierHint: CapacityModelTierHint,
+  preferredSignal: CapacityProviderFinanceSignal | undefined,
+  avoidProviderClasses: CapacityProviderClass[],
+): CapacityRoutingHints["budgetClass"] {
+  if (modelTierHint === "frontier") {
+    return "quality_first";
+  }
+
+  if (preferredSignal || avoidProviderClasses.includes("token-priced")) {
+    return "minimize_cost";
+  }
+
+  return modelTierHint === "routine" ? "minimize_cost" : "balanced";
+}
+
+function buildReasonCodes(
+  candidate: CapacityContinuityCandidate,
+  modelTierHint: CapacityModelTierHint,
+  preferredSignal: CapacityProviderFinanceSignal | undefined,
+  signals: CapacityProviderFinanceSignal[],
+) {
+  const reasonCodes: string[] = [];
+
+  if (preferredSignal && Number(preferredSignal.projectedUnusedValue ?? 0) > 0) {
+    reasonCodes.push("underused_commitment");
+  }
+
+  if (signals.some((signal) => signal.overageRisk)) {
+    reasonCodes.push("overage_risk");
+  }
+
+  if (modelTierHint === "frontier") {
+    reasonCodes.push("frontier_required");
+  }
+
+  if (candidate.riskClass === "read-only" || candidate.riskClass === "review-after") {
+    reasonCodes.push("safe_background_work");
+  }
+
+  return unique(reasonCodes);
+}
+
+function buildAvoidProviderClasses(signals: CapacityProviderFinanceSignal[]) {
+  const avoid = signals
+    .filter((signal) => signal.providerClass === "token-priced" && signal.overageRisk)
+    .map((signal) => signal.providerClass);
+
+  return unique(avoid);
+}
+
+function sumProjectedUnusedValue(signals: CapacityProviderFinanceSignal[]) {
+  return signals.reduce((sum, signal) => sum + Number(signal.projectedUnusedValue ?? 0), 0);
+}
+
+function averageUtilization(signals: CapacityProviderFinanceSignal[]) {
+  const values = signals
+    .map((signal) => signal.utilizationPct)
+    .filter((value): value is number => typeof value === "number");
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  return Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 100) / 100;
+}
+
+function unique<T>(items: T[]) {
+  return Array.from(new Set(items));
+}

--- a/apps/web/lib/capacity-continuity/finance-signals.test.ts
+++ b/apps/web/lib/capacity-continuity/finance-signals.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findManyMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    aiProviderFinanceProfile: {
+      findMany: findManyMock,
+    },
+  },
+}));
+
+describe("getCapacityProviderFinanceSignals", () => {
+  beforeEach(() => {
+    findManyMock.mockReset();
+  });
+
+  it("maps live finance profiles to provider-class signals", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        providerId: "openai",
+        provider: { providerId: "openai", status: "active", costBand: "medium" },
+        supplierContracts: [
+          {
+            monthlyCommittedAmount: { toString: () => "200" },
+            allowsOverage: false,
+            allowances: [{ includedQuantity: { toString: () => "1000000" } }],
+            usageSnapshots: [
+              {
+                utilizationPct: 42,
+                projectedUnusedValue: { toString: () => "80" },
+                projectedOverageCost: { toString: () => "0" },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        providerId: "usage-metered",
+        provider: { providerId: "usage-metered", status: "active", costBand: "high" },
+        supplierContracts: [
+          {
+            monthlyCommittedAmount: null,
+            allowsOverage: true,
+            allowances: [],
+            usageSnapshots: [
+              {
+                utilizationPct: 99,
+                projectedUnusedValue: { toString: () => "0" },
+                projectedOverageCost: { toString: () => "15" },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        providerId: "ollama",
+        provider: { providerId: "ollama", status: "active", costBand: "free" },
+        supplierContracts: [],
+      },
+    ]);
+
+    const { getCapacityProviderFinanceSignals } = await import("./finance-signals");
+
+    await expect(getCapacityProviderFinanceSignals()).resolves.toEqual([
+      {
+        providerId: "openai",
+        providerClass: "fixed-cost",
+        status: "active",
+        utilizationPct: 42,
+        projectedUnusedValue: 80,
+        overageRisk: false,
+      },
+      {
+        providerId: "usage-metered",
+        providerClass: "token-priced",
+        status: "active",
+        utilizationPct: 99,
+        projectedUnusedValue: 0,
+        overageRisk: true,
+      },
+      {
+        providerId: "ollama",
+        providerClass: "local",
+        status: "active",
+        utilizationPct: null,
+        projectedUnusedValue: 0,
+        overageRisk: false,
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/capacity-continuity/finance-signals.ts
+++ b/apps/web/lib/capacity-continuity/finance-signals.ts
@@ -1,0 +1,142 @@
+import { prisma } from "@dpf/db";
+import type {
+  CapacityProviderClass,
+  CapacityProviderFinanceSignal,
+} from "./finance-routing";
+
+type DecimalLike = {
+  toString(): string;
+};
+
+type FinanceProfileRow = {
+  providerId: string;
+  provider: {
+    providerId: string;
+    status: string;
+    costBand: string | null;
+  };
+  supplierContracts: Array<{
+    monthlyCommittedAmount: DecimalLike | number | null;
+    allowsOverage: boolean;
+    allowances: Array<{
+      includedQuantity: DecimalLike | number;
+    }>;
+    usageSnapshots: Array<{
+      utilizationPct: number | null;
+      projectedUnusedValue: DecimalLike | number | null;
+      projectedOverageCost: DecimalLike | number | null;
+    }>;
+  }>;
+};
+
+export async function getCapacityProviderFinanceSignals(): Promise<CapacityProviderFinanceSignal[]> {
+  const profiles = await prisma.aiProviderFinanceProfile.findMany({
+    where: {
+      provider: {
+        endpointType: "llm",
+      },
+    },
+    select: {
+      providerId: true,
+      provider: {
+        select: {
+          providerId: true,
+          status: true,
+          costBand: true,
+        },
+      },
+      supplierContracts: {
+        where: {
+          status: { in: ["draft", "active"] },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: {
+          monthlyCommittedAmount: true,
+          allowsOverage: true,
+          allowances: {
+            orderBy: { sortOrder: "asc" },
+            take: 1,
+            select: {
+              includedQuantity: true,
+            },
+          },
+          usageSnapshots: {
+            orderBy: { snapshotDate: "desc" },
+            take: 1,
+            select: {
+              utilizationPct: true,
+              projectedUnusedValue: true,
+              projectedOverageCost: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return (profiles as FinanceProfileRow[]).map((profile) => {
+    const contract = profile.supplierContracts[0];
+    const snapshot = contract?.usageSnapshots[0];
+
+    return {
+      providerId: profile.providerId,
+      providerClass: classifyProvider(profile, contract),
+      status: normalizeStatus(profile.provider.status),
+      utilizationPct: snapshot?.utilizationPct ?? null,
+      projectedUnusedValue: toNumber(snapshot?.projectedUnusedValue) ?? 0,
+      overageRisk: isOverageRisk(contract, snapshot),
+    };
+  });
+}
+
+function classifyProvider(
+  profile: FinanceProfileRow,
+  contract: FinanceProfileRow["supplierContracts"][number] | undefined,
+): CapacityProviderClass {
+  if (
+    profile.provider.providerId === "local" ||
+    profile.provider.providerId === "ollama" ||
+    profile.provider.costBand === "free"
+  ) {
+    return "local";
+  }
+
+  if (toNumber(contract?.monthlyCommittedAmount) && toNumber(contract?.monthlyCommittedAmount)! > 0) {
+    return "fixed-cost";
+  }
+
+  const allowance = contract?.allowances[0];
+  if (toNumber(allowance?.includedQuantity) && toNumber(allowance?.includedQuantity)! > 0) {
+    return "quota";
+  }
+
+  return "token-priced";
+}
+
+function isOverageRisk(
+  contract: FinanceProfileRow["supplierContracts"][number] | undefined,
+  snapshot: FinanceProfileRow["supplierContracts"][number]["usageSnapshots"][number] | undefined,
+) {
+  if ((toNumber(snapshot?.projectedOverageCost) ?? 0) > 0) {
+    return true;
+  }
+
+  return contract?.allowsOverage === true && (snapshot?.utilizationPct ?? 0) >= 95;
+}
+
+function normalizeStatus(status: string): CapacityProviderFinanceSignal["status"] {
+  if (status === "active" || status === "degraded" || status === "inactive") {
+    return status;
+  }
+
+  return "inactive";
+}
+
+function toNumber(value: DecimalLike | number | null | undefined) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return typeof value === "number" ? value : Number(value.toString());
+}

--- a/apps/web/lib/capacity-continuity/runner.test.ts
+++ b/apps/web/lib/capacity-continuity/runner.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selectInputsMock = vi.fn();
+const createRunMock = vi.fn();
+const backlogFindUniqueMock = vi.fn();
+const activityCreateMock = vi.fn();
+
+vi.mock("./backlog-selector", () => ({
+  selectBacklogReviewCapacityWorkInputs: selectInputsMock,
+}));
+
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: createRunMock,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    backlogItem: {
+      findUnique: backlogFindUniqueMock,
+    },
+    backlogItemActivity: {
+      create: activityCreateMock,
+    },
+  },
+}));
+
+describe("runBacklogReviewCapacityContinuity", () => {
+  beforeEach(() => {
+    selectInputsMock.mockReset();
+    createRunMock.mockReset();
+    backlogFindUniqueMock.mockReset();
+    activityCreateMock.mockReset();
+  });
+
+  it("creates TaskRuns through AutonomousWorkRun and does not execute tools directly", async () => {
+    selectInputsMock.mockResolvedValue({
+      inputs: [
+        {
+          trigger: "capacity-continuity",
+          userId: "principal-owner",
+          agentId: "agent-capacity",
+          routeContext: "/workspace/my-queue",
+          title: "Review backlog item BI-123",
+          objective: "Review backlog item BI-123 for safe next action.",
+          prompt: "Review backlog item BI-123 for safe next action.",
+          sourceRef: { kind: "backlog-item", id: "BI-123" },
+          metadata: {
+            cognitiveLoad: {
+              dedupeKey: "capacity:backlog-review:BI-123",
+            },
+          },
+        },
+      ],
+      rejections: [],
+    });
+    createRunMock.mockResolvedValue({
+      id: "internal-task-run",
+      taskRunId: "TR-CAP-12345678",
+      contextId: null,
+    });
+
+    const { runBacklogReviewCapacityContinuity } = await import("./runner");
+
+    await expect(
+      runBacklogReviewCapacityContinuity({
+        agentId: "agent-capacity",
+        ownerPrincipalId: "principal-owner",
+        resolvedTools: [{ name: "list_backlog_items" }],
+      }),
+    ).resolves.toEqual({
+      started: [
+        {
+          id: "internal-task-run",
+          taskRunId: "TR-CAP-12345678",
+          contextId: null,
+        },
+      ],
+      rejections: [],
+      recordedRejectionCount: 0,
+    });
+
+    expect(createRunMock).toHaveBeenCalledTimes(1);
+    expect(createRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "capacity-continuity",
+        sourceRef: { kind: "backlog-item", id: "BI-123" },
+      }),
+    );
+    expect(activityCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("records backlog activity for rejected capacity candidates", async () => {
+    selectInputsMock.mockResolvedValue({
+      inputs: [],
+      rejections: [
+        {
+          candidateId: "backlog-review:BI-123",
+          sourceRef: { kind: "backlog-item", id: "BI-123" },
+          rejection: {
+            code: "forbidden_grant",
+            reason:
+              "Capacity continuity cannot start work that requires the release_gate_create grant.",
+            details: { grant: "release_gate_create", toolName: "deploy_release" },
+          },
+        },
+      ],
+    });
+    backlogFindUniqueMock.mockResolvedValue({ id: "internal-backlog-id" });
+    activityCreateMock.mockResolvedValue({ id: "activity-id" });
+
+    const { runBacklogReviewCapacityContinuity } = await import("./runner");
+
+    const result = await runBacklogReviewCapacityContinuity({
+      agentId: "agent-capacity",
+      ownerPrincipalId: "principal-owner",
+      resolvedTools: [{ name: "deploy_release" }],
+    });
+
+    expect(result).toMatchObject({
+      started: [],
+      recordedRejectionCount: 1,
+      rejections: [
+        {
+          candidateId: "backlog-review:BI-123",
+          rejection: { code: "forbidden_grant" },
+        },
+      ],
+    });
+    expect(createRunMock).not.toHaveBeenCalled();
+    expect(activityCreateMock).toHaveBeenCalledWith({
+      data: {
+        backlogItemId: "internal-backlog-id",
+        kind: "capacity_continuity_rejected",
+        summary:
+          "Capacity continuity rejected backlog-review:BI-123: Capacity continuity cannot start work that requires the release_gate_create grant.",
+        recordedByAgentId: "agent-capacity",
+        payload: {
+          candidateId: "backlog-review:BI-123",
+          ownerPrincipalId: "principal-owner",
+          rejection: {
+            code: "forbidden_grant",
+            reason:
+              "Capacity continuity cannot start work that requires the release_gate_create grant.",
+            details: { grant: "release_gate_create", toolName: "deploy_release" },
+          },
+          sourceRef: { kind: "backlog-item", id: "BI-123" },
+        },
+      },
+    });
+  });
+});

--- a/apps/web/lib/capacity-continuity/runner.ts
+++ b/apps/web/lib/capacity-continuity/runner.ts
@@ -1,0 +1,82 @@
+import { prisma } from "@dpf/db";
+
+import {
+  createAutonomousWorkRun,
+  type AutonomousWorkRunRef,
+} from "@/lib/tak/autonomous-work-run";
+import {
+  selectBacklogReviewCapacityWorkInputs,
+  type BacklogReviewCapacityWorkInputOptions,
+  type BacklogReviewCapacityWorkInputResult,
+} from "./backlog-selector";
+
+export type BacklogReviewCapacityRunResult = {
+  started: AutonomousWorkRunRef[];
+  rejections: BacklogReviewCapacityWorkInputResult["rejections"];
+  recordedRejectionCount: number;
+};
+
+export async function runBacklogReviewCapacityContinuity(
+  options: BacklogReviewCapacityWorkInputOptions,
+): Promise<BacklogReviewCapacityRunResult> {
+  const selection = await selectBacklogReviewCapacityWorkInputs(options);
+  const started: AutonomousWorkRunRef[] = [];
+
+  for (const input of selection.inputs) {
+    started.push(await createAutonomousWorkRun(input));
+  }
+
+  let recordedRejectionCount = 0;
+  for (const rejection of selection.rejections) {
+    const recorded = await recordCapacityRejection({
+      rejection,
+      agentId: options.agentId,
+      ownerPrincipalId: options.ownerPrincipalId,
+    });
+    if (recorded) {
+      recordedRejectionCount += 1;
+    }
+  }
+
+  return {
+    started,
+    rejections: selection.rejections,
+    recordedRejectionCount,
+  };
+}
+
+async function recordCapacityRejection(input: {
+  rejection: BacklogReviewCapacityWorkInputResult["rejections"][number];
+  agentId: string;
+  ownerPrincipalId: string;
+}) {
+  if (input.rejection.sourceRef.kind !== "backlog-item") {
+    return false;
+  }
+
+  const backlogItem = await prisma.backlogItem.findUnique({
+    where: { itemId: input.rejection.sourceRef.id },
+    select: { id: true },
+  });
+
+  if (!backlogItem) {
+    return false;
+  }
+
+  await prisma.backlogItemActivity.create({
+    data: {
+      backlogItemId: backlogItem.id,
+      kind: "capacity_continuity_rejected",
+      summary: `Capacity continuity rejected ${input.rejection.candidateId}: ${input.rejection.rejection.reason}`,
+      recordedByAgentId: input.agentId,
+      payload: {
+        candidateId: input.rejection.candidateId,
+        ownerPrincipalId: input.ownerPrincipalId,
+        rejection: input.rejection.rejection,
+        sourceRef: input.rejection.sourceRef,
+      },
+    },
+  });
+
+  return true;
+}

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => {
+  const create = vi.fn();
+  return {
+    prisma: {
+      taskRun: { create },
+    },
+  };
+});
+
+describe("createAutonomousWorkRun", () => {
+  beforeEach(async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockReset();
+  });
+
+  it("creates a scheduled TaskRun through the shared autonomous work seam", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_1",
+      taskRunId: "TR-SCHED-ABCDE",
+      contextId: "thread-1",
+    } as never);
+
+    const { createAutonomousWorkRun } = await import("./autonomous-work-run");
+
+    const ref = await createAutonomousWorkRun({
+      trigger: "scheduled",
+      userId: "user-1",
+      agentId: "inventory-specialist",
+      routeContext: "/platform/tools/discovery",
+      title: "Discovery Taxonomy Gap Triage",
+      objective: "Triage taxonomy gaps from discovery.",
+      prompt: "Triage taxonomy gaps from discovery.",
+      threadId: "thread-1",
+      sourceRef: {
+        kind: "scheduled-task",
+        id: "discovery-taxonomy-gap-triage-daily",
+      },
+    });
+
+    expect(ref).toEqual({
+      id: "tr_internal_1",
+      taskRunId: "TR-SCHED-ABCDE",
+      contextId: "thread-1",
+    });
+
+    const arg = vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0];
+    expect(arg?.data).toMatchObject({
+      userId: "user-1",
+      threadId: "thread-1",
+      contextId: "thread-1",
+      initiatingAgentId: "inventory-specialist",
+      currentAgentId: "inventory-specialist",
+      routeContext: "/platform/tools/discovery",
+      title: "Discovery Taxonomy Gap Triage",
+      objective: "Triage taxonomy gaps from discovery.",
+      source: "proactive",
+      status: "working",
+      authorityScope: [],
+      a2aMetadata: {
+        trigger: "scheduled",
+        sourceRef: {
+          kind: "scheduled-task",
+          id: "discovery-taxonomy-gap-triage-daily",
+        },
+      },
+    });
+    expect(String(arg?.data?.taskRunId)).toMatch(/^TR-SCHED-/);
+  });
+
+  it("creates capacity-continuity TaskRuns with capacity metadata and no tool execution", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_capacity",
+      taskRunId: "TR-CAP-ABCDE",
+      contextId: "thread-capacity",
+    } as never);
+
+    const { createAutonomousWorkRun } = await import("./autonomous-work-run");
+
+    await createAutonomousWorkRun({
+      trigger: "capacity-continuity",
+      userId: "principal-1",
+      agentId: "platform-engineer",
+      routeContext: "/platform/ai/capacity-continuity",
+      title: "Review stale specs",
+      objective: "Review stale specs and produce evidence-backed follow-up notes.",
+      prompt: "Review stale specs and produce evidence-backed follow-up notes.",
+      threadId: "thread-capacity",
+      sourceRef: {
+        kind: "standing-order",
+        id: "standing-order-1",
+      },
+      metadata: {
+        cognitiveLoad: {
+          capacityState: "away",
+          standingOrderId: "standing-order-1",
+          dedupeKey: "spec-drift:2026-05-12",
+          fundingFitHint: {
+            providerClassHint: "fixed-cost",
+            modelTierHint: "standard",
+          },
+        },
+      },
+    });
+
+    expect(prisma.taskRun.create).toHaveBeenCalledOnce();
+    const arg = vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0];
+    expect(arg?.data).toMatchObject({
+      userId: "principal-1",
+      source: "proactive",
+      status: "working",
+      a2aMetadata: {
+        trigger: "capacity-continuity",
+        sourceRef: {
+          kind: "standing-order",
+          id: "standing-order-1",
+        },
+        cognitiveLoad: {
+          capacityState: "away",
+          standingOrderId: "standing-order-1",
+          dedupeKey: "spec-drift:2026-05-12",
+          fundingFitHint: {
+            providerClassHint: "fixed-cost",
+            modelTierHint: "standard",
+          },
+        },
+      },
+    });
+    expect(String(arg?.data?.taskRunId)).toMatch(/^TR-CAP-/);
+  });
+});

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "crypto";
+import { prisma } from "@dpf/db";
+
+export type AutonomousWorkTrigger =
+  | "interactive"
+  | "scheduled"
+  | "external-mcp"
+  | "build"
+  | "deliberation"
+  | "radar"
+  | "system-recovery"
+  | "capacity-continuity";
+
+export type AutonomousWorkRunRef = {
+  id: string;
+  taskRunId: string;
+  contextId: string | null;
+};
+
+export type AutonomousWorkRunInput = {
+  trigger: AutonomousWorkTrigger;
+  userId: string;
+  agentId: string;
+  routeContext: string;
+  title: string;
+  objective: string;
+  prompt: string;
+  threadId?: string | null;
+  parentTaskRunId?: string | null;
+  authorityScope?: string[];
+  sourceRef?: {
+    kind: string;
+    id: string;
+  };
+  metadata?: Record<string, unknown>;
+};
+
+const TRIGGER_PREFIX: Record<AutonomousWorkTrigger, string> = {
+  interactive: "CHAT",
+  scheduled: "SCHED",
+  "external-mcp": "MCP",
+  build: "BUILD",
+  deliberation: "DELIB",
+  radar: "RADAR",
+  "system-recovery": "RECOV",
+  "capacity-continuity": "CAP",
+};
+
+function taskRunSourceForTrigger(trigger: AutonomousWorkTrigger): string {
+  if (trigger === "interactive") return "coworker";
+  if (trigger === "build") return "build";
+  if (trigger === "deliberation") return "skill";
+  return "proactive";
+}
+
+function initialStatusForTrigger(trigger: AutonomousWorkTrigger): string {
+  return trigger === "interactive" ? "submitted" : "working";
+}
+
+function createPublicTaskRunId(trigger: AutonomousWorkTrigger): string {
+  return `TR-${TRIGGER_PREFIX[trigger]}-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+export async function createAutonomousWorkRun(
+  input: AutonomousWorkRunInput,
+): Promise<AutonomousWorkRunRef> {
+  const threadId = input.threadId ?? null;
+
+  return prisma.taskRun.create({
+    data: {
+      taskRunId: createPublicTaskRunId(input.trigger),
+      userId: input.userId,
+      threadId,
+      contextId: threadId,
+      initiatingAgentId: input.agentId,
+      currentAgentId: input.agentId,
+      parentTaskRunId: input.parentTaskRunId ?? null,
+      routeContext: input.routeContext,
+      title: input.title,
+      objective: input.objective.slice(0, 1000),
+      source: taskRunSourceForTrigger(input.trigger),
+      status: initialStatusForTrigger(input.trigger),
+      authorityScope: input.authorityScope ?? [],
+      a2aMetadata: {
+        trigger: input.trigger,
+        ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
+        ...(input.metadata ?? {}),
+      },
+    },
+    select: { id: true, taskRunId: true, contextId: true },
+  });
+}

--- a/apps/web/lib/tak/scheduled-task-runs.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "crypto";
-import { prisma } from "@dpf/db";
+import { createAutonomousWorkRun } from "@/lib/tak/autonomous-work-run";
 
 export type ScheduledTaskRunRef = {
   id: string;
@@ -16,30 +15,18 @@ export async function createTaskRunForScheduledTask(input: {
   title: string;
   prompt: string;
 }): Promise<ScheduledTaskRunRef> {
-  const taskRunId = `TR-SCHED-${randomUUID().slice(0, 8).toUpperCase()}`;
-
-  return prisma.taskRun.create({
-    data: {
-      taskRunId,
-      userId: input.ownerUserId,
-      threadId: input.threadId,
-      contextId: input.threadId,
-      initiatingAgentId: input.agentId,
-      currentAgentId: input.agentId,
-      routeContext: input.routeContext,
-      title: input.title,
-      objective: input.prompt.slice(0, 1000),
-      source: "proactive",
-      status: "working",
-      authorityScope: [],
-      a2aMetadata: {
-        trigger: "scheduled",
-        sourceRef: {
-          kind: "scheduled-task",
-          id: input.taskId,
-        },
-      },
+  return createAutonomousWorkRun({
+    trigger: "scheduled",
+    userId: input.ownerUserId,
+    agentId: input.agentId,
+    routeContext: input.routeContext,
+    title: input.title,
+    objective: input.prompt,
+    prompt: input.prompt,
+    threadId: input.threadId,
+    sourceRef: {
+      kind: "scheduled-task",
+      id: input.taskId,
     },
-    select: { id: true, taskRunId: true, contextId: true },
   });
 }

--- a/docs/architecture/ai-coworker-development-principles.md
+++ b/docs/architecture/ai-coworker-development-principles.md
@@ -229,6 +229,30 @@ The agentic loop enforces a **tool repetition limit** (3-5 calls of the same too
 
 ---
 
+## Principle 9: Responsible Capacity Utilization
+
+**Use paid AI capacity for governed value, not empty activity.**
+
+### Rule
+AI coworkers should treat available paid capacity as an operating asset. When authorized work is available, idle capacity is waste. When no useful, safe, evidence-producing work is available, the coworker should record or surface the blocker rather than spend tokens to appear busy.
+
+Useful capacity work includes:
+- reducing human cognitive load
+- advancing approved backlog work
+- producing durable work products
+- running verification and capturing evidence
+- reviewing stale specs, plans, PRs, or runtime state
+- identifying capability gaps
+- converting repeated work into proceduralization candidates
+
+### Implementation
+Capacity use should be driven by Standing Orders, calendar/availability state, safe work queues, and existing authority controls. Coworkers may continue low-risk governed work when humans are unavailable, but must stop at approval boundaries for consequential actions.
+
+### Rationale
+A salaried employee who does nothing while valuable work exists wastes organizational capacity. Fixed-price or subscription AI capacity has the same economic shape. The goal is not to burn tokens. The goal is to convert available capacity into reviewed work, evidence, learning, and platform improvement.
+
+---
+
 ## Application
 
 These principles apply to:
@@ -237,5 +261,6 @@ These principles apply to:
 - Agent tool registration and schema design
 - Memory and context management
 - Multi-agent orchestration and handoff
+- External coding agents working on DPF, including Codex and Claude, through the canonical project rulebook
 
 When these principles conflict with expediency, the principles win. A well-structured agent that works reliably is worth more than a quick hack that fails unpredictably.

--- a/docs/superpowers/plans/2026-05-12-capacity-continuity-autonomous-runtime-attachment.md
+++ b/docs/superpowers/plans/2026-05-12-capacity-continuity-autonomous-runtime-attachment.md
@@ -24,6 +24,7 @@ Capacity Continuity selects useful, authorized work when paid AI capacity is ava
 - `apps/web/lib/capacity-continuity/finance-routing.ts` turns finance utilization signals into provider-class/model-tier routing hints and finance tracking metadata without pinning a provider.
 - `apps/web/lib/capacity-continuity/finance-signals.ts` reads live AI-provider finance profiles, active/draft supplier contracts, allowances, and latest usage snapshots into normalized capacity finance signals.
 - `apps/web/lib/capacity-continuity/backlog-selector.ts` provides the first live safe-queue adapter: open backlog items become read-only review candidates, enriched with finance/routing metadata, deduped against recent capacity-triggered `TaskRun`s, and optionally mapped to `AutonomousWorkRunInput`s through the shared grant map.
+- `apps/web/lib/capacity-continuity/runner.ts` provides the first governed runner entrypoint: it starts accepted backlog-review work only by creating `TaskRun`s through `AutonomousWorkRun` and records rejected backlog candidates as `BacklogItemActivity` evidence.
 - Focused tests cover the capacity mapper, finance/routing hints, finance-signal normalization, backlog safe-queue selection, hard-rejection behavior, and standing-order attribution rules.
 
 **Schema already in place** (re-verified 2026-05-12):
@@ -245,4 +246,4 @@ Build the attachment seam before deep funding optimization.
 
 The platform needs a safe execution path first. Funding research then improves ranking and provider choice without changing the core authority model.
 
-Concrete next action: add the first governed runner entrypoint that calls `selectBacklogReviewCapacityWorkInputs()`, creates `TaskRun`s through `AutonomousWorkRun`, and records idle/blocker entries for every rejection. That runner must still perform no direct MCP/tool execution; the autonomous runtime remains the only execution path.
+Concrete next action: connect the governed runner to an explicit operator-triggered action from `/platform/ai/capacity-continuity`, then project capacity-triggered `TaskRun`s and `BacklogItemActivity` rejection evidence into Operations Map/return briefing views. The runner must continue to perform no direct MCP/tool execution; the autonomous runtime remains the only execution path.

--- a/docs/superpowers/plans/2026-05-12-capacity-continuity-autonomous-runtime-attachment.md
+++ b/docs/superpowers/plans/2026-05-12-capacity-continuity-autonomous-runtime-attachment.md
@@ -1,0 +1,248 @@
+# Capacity Continuity to Autonomous Runtime Attachment Plan
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-12 |
+| Status | In implementation |
+| Related specs | `docs/superpowers/specs/2026-05-12-ai-capacity-continuity-design.md`, `docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md` |
+
+## Objective
+
+Attach Capacity Continuity to the autonomous coworker runtime as a policy and scheduling layer, not a separate execution system.
+
+Capacity Continuity selects useful, authorized work when paid AI capacity is available. `AutonomousWorkRun` executes that work under the existing task, tool, approval, and evidence controls.
+
+## Dependencies and current state
+
+**Dependency status**: autonomous runtime Slice 2 (`AutonomousWorkRun` service extraction) has started. The first seam is `apps/web/lib/tak/autonomous-work-run.ts`, with `createTaskRunForScheduledTask()` now acting as a scheduled-task adapter over that shared service. Capacity candidate selection now targets this seam through the pure mapper in `apps/web/lib/capacity-continuity/candidates.ts`.
+
+**Implemented foundation** (2026-05-12):
+
+- `apps/web/lib/tak/autonomous-work-run.ts` creates shared `TaskRun` identity for scheduled and capacity-continuity triggers.
+- `apps/web/lib/capacity-continuity/candidates.ts` defines the `CapacityContinuityCandidate` shape and maps accepted candidates into `AutonomousWorkRunInput`.
+- `apps/web/lib/capacity-continuity/candidates.ts` also performs the first conservative pre-run rejection checks for duplicate dedupe keys, phase-gated routes, forbidden grant classes, and ambiguous objectives.
+- `apps/web/lib/capacity-continuity/finance-routing.ts` turns finance utilization signals into provider-class/model-tier routing hints and finance tracking metadata without pinning a provider.
+- `apps/web/lib/capacity-continuity/finance-signals.ts` reads live AI-provider finance profiles, active/draft supplier contracts, allowances, and latest usage snapshots into normalized capacity finance signals.
+- `apps/web/lib/capacity-continuity/backlog-selector.ts` provides the first live safe-queue adapter: open backlog items become read-only review candidates, enriched with finance/routing metadata, deduped against recent capacity-triggered `TaskRun`s, and optionally mapped to `AutonomousWorkRunInput`s through the shared grant map.
+- Focused tests cover the capacity mapper, finance/routing hints, finance-signal normalization, backlog safe-queue selection, hard-rejection behavior, and standing-order attribution rules.
+
+**Schema already in place** (re-verified 2026-05-12):
+
+- `ScheduledAgentTask.taskRunId` — schema line 4329.
+- `ToolExecution.taskRunId` — schema line 3029.
+- `AgentMessage.taskRunId` — schema line 2886.
+- `Principal` / `PrincipalAlias` — schema lines 219/230.
+
+No new schema migration is required for the attachment seam itself. All capacity metadata lives in `TaskRun.a2aMetadata` for the first slice (consistent with runtime spec §6.2). New tables (`StandingOrder`, `ReturnBriefing`, etc.) are introduced by later capacity-continuity slices, not by this attachment plan.
+
+## Boundary
+
+Capacity Continuity owns:
+
+- capacity inventory,
+- calendar and availability interpretation,
+- standing-order evaluation,
+- safe work queue ranking,
+- provider/funding fit,
+- idle reason accounting,
+- return briefing assembly.
+
+Autonomous runtime owns:
+
+- `TaskRun` identity,
+- prompt/context/tool resolution,
+- agentic loop execution,
+- approval pauses,
+- `governedExecuteTool()` calls,
+- evidence, receipts, and audit linkage.
+
+No capacity runner may call MCP tools directly. It must submit work through `AutonomousWorkRun`.
+
+## Phase 1: Interface Definition
+
+Define a small selection type:
+
+```ts
+type CapacityContinuityCandidate = {
+  candidateId: string;
+  // Idempotency key for cross-window dedup. The selector skips a candidate
+  // whose dedupeKey already maps to an open or recently-completed TaskRun
+  // (a `TaskRun` carrying this dedupeKey in `a2aMetadata.cognitiveLoad.dedupeKey`).
+  // Lookback window comes from `StandingOrder.dedupeLookbackHours` (capacity
+  // spec §7 — Standing Orders). If not set, default is 24h.
+  dedupeKey: string;
+  source:
+    | "standing-order"
+    | "backlog"
+    | "pull-request"
+    | "qa-gap"
+    | "spec-drift"
+    | "capability-need"
+    | "proceduralization";
+  title: string;
+  objective: string;
+  routeContext: string;
+  agentId: string;
+  ownerPrincipalId: string;        // standing-order owner Principal (capacity spec §11.0a)
+  riskClass: "read-only" | "review-after" | "approval-required";
+  evidenceRequired: string[];
+  // Routing HINTS — fed to the existing dynamic router. Never a hard pin.
+  // The runtime is free to choose a different provider/model when the
+  // router determines a better fit on capability tier or task type.
+  capacityFit: {
+    providerClassHint: "fixed-cost" | "quota" | "token-priced" | "local";
+    modelTierHint: "routine" | "standard" | "frontier";
+    reason: string;
+  };
+  sourceRef: {
+    kind:
+      | "standing-order"
+      | "backlog-item"
+      | "pull-request"
+      | "qa-gap"
+      | "spec"
+      | "capability-need"
+      | "proceduralization-candidate";
+    id: string;
+  };
+};
+```
+
+Map accepted candidates to `AutonomousWorkRunInput` with `trigger: "capacity-continuity"` and `userId` resolved from `ownerPrincipalId`. The mapper is the only place `CapacityContinuityCandidate` shape converts; everything downstream operates on the runtime spec's `AutonomousWorkRunInput` contract.
+
+Acceptance:
+
+- candidate selection is pure and testable,
+- candidate-to-run mapping is deterministic and implemented in `apps/web/lib/capacity-continuity/candidates.ts`,
+- `dedupeKey` prevents re-selection within the configured lookback,
+- candidates with `riskClass: "approval-required"` are **selected** (not filtered) but the resulting `TaskRun` pauses at the first side-effecting tool call as `input-required` via proposal-mode — the policy layer never elevates approval-required candidates above the runtime's approval gates,
+- no tool execution occurs during selection.
+
+## Phase 2: Metadata Contract
+
+Store capacity metadata in `TaskRun.a2aMetadata`, aligned with the runtime spec's `AutonomousWorkTrigger` union and the shape already used by `scheduled-task-runs.ts`:
+
+```json
+{
+  "trigger": "capacity-continuity",
+  "sourceRef": { "kind": "standing-order", "id": "<orderId>" },
+  "cognitiveLoad": {
+    "capacityState": "<away|holiday|after-hours|...>",
+    "capacityWindowId": "<windowId-if-available>",
+    "fundingFitHint": { "providerClassHint": "...", "modelTierHint": "..." },
+    "routingHints": {
+      "budgetClass": "<minimize_cost|balanced|quality_first>",
+      "interactionMode": "background",
+      "modelTierHint": "<routine|standard|frontier>",
+      "preferredProviderClass": "<fixed-cost|quota|token-priced|local>",
+      "reasonCodes": ["underused_commitment", "safe_background_work"]
+    },
+    "financeTracking": {
+      "observedProviderClasses": ["fixed-cost"],
+      "sourceProviderIds": ["<providerId-for-audit-not-routing>"],
+      "projectedUnusedValue": 0,
+      "utilizationPct": 0
+    },
+    "dedupeKey": "<candidate.dedupeKey>"
+  }
+}
+```
+
+The standing-order id is `sourceRef.id` when `sourceRef.kind = "standing-order"`; do not duplicate it under `cognitiveLoad`. When the candidate's `sourceRef.kind` is a non-standing-order kind (e.g. `backlog-item`), the originating standing-order id moves to `cognitiveLoad.viaStandingOrderId` so the run still attributes back to the capacity policy that selected it.
+
+Idle reasons are recorded **outside** `TaskRun` (no TaskRun was created), against `CapacityWindow` rows when those exist or against a transient idle-reason event log until then. A `TaskRun` is never created solely to record idle — that would inflate run cardinality and confuse the Operations Map projection.
+
+`returnBriefingId` is set on the briefing's own `TaskRun` (Slice 4 of the capacity spec); it is not copied onto every summarized run. Slice 4 indexes briefings by `sourceTaskRunIds`.
+
+The metadata key is `trigger` (not `triggerKind`) to match the live `a2aMetadata` shape written by `scheduled-task-runs.ts` and the `AutonomousWorkTrigger` union in the runtime spec.
+
+`routingHints` are contract hints only. They may influence future `RequestContract` inputs such as `budgetClass`, `interactionMode`, and capability tier, but they must not become `allowedProviders`, `preferredProviderId`, `pinnedProviderId`, or model pins. `financeTracking.sourceProviderIds` exists only to explain which finance signals informed the policy decision.
+
+Acceptance:
+
+- Operations Map filters capacity-triggered work by `a2aMetadata.trigger = "capacity-continuity"`,
+- the briefing's `TaskRun` can be located from any summarized run via the briefing index,
+- no new table is needed for the first attachment slice.
+
+## Phase 3: Conservative Selector
+
+Start with safe queues only:
+
+- stale spec review,
+- QA evidence collection,
+- read-only backlog analysis,
+- capability-need review,
+- docs/runtime drift checks.
+
+Hard-rejected work — the selector must drop any candidate matching any of these signals before producing an `AutonomousWorkRunInput`:
+
+- the candidate's resolved tool set (the same resolution `runAgenticLoop` would perform for the candidate's agent + route) contains a tool whose `TOOL_TO_GRANTS` entry includes any grant in the rejection set: `deploy`, `publish-external`, `schema-migrate`, `data-delete`, `spend-money`, plus the live high-risk grant classes currently used by the governed tool layer (`admin_write`, `deployment_plan_create`, `iac_execute`, `release_gate_create`, `release_plan_create`). The selector consumes the same tool-to-grant mapping shape exposed by `getToolGrantMapping()` so the check can be wired to the runtime policy source.
+- the candidate's `routeContext` matches a phase-gated workflow that owns its own initiation contract (Build Studio phase routes, deliberation initiation routes) — capacity continuity does not initiate those flows, it only assists work already inside them.
+- the candidate's objective parses as an "ambiguous product decision" per the heuristic owned by §13.1 of the capacity spec ("useful work" inverse: a candidate whose objective has no resolvable artifact target is rejected as ambiguous).
+
+The first rejection check lives next to the mapper in `apps/web/lib/capacity-continuity/candidates.ts` and is unit-tested against synthetic candidates covering the current rejection signals.
+
+Approval-required candidates from allowed work **are** selected but execute under the runtime's existing approval gates: the resulting `TaskRun` pauses as `input-required` at the first side-effecting tool call (via proposal-mode in the agentic loop). The selector does not elevate, pre-authorize, or bypass any approval.
+
+Acceptance:
+
+- hard-rejected work never produces an `AutonomousWorkRunInput` (verified by tests that exercise each rejection signal independently and in combination),
+- approval-required candidates from allowed work produce `TaskRun`s that demonstrably pause at proposal-mode before any side effect (verified by a test that asserts no `ToolExecution` with a side-effecting grant runs before an approval is recorded),
+- rejected work produces a structured idle/blocker entry against the capacity window (or transient log per Phase 2) with the matching rejection-signal code so operators can tell *why* a candidate was rejected, not just *that* it was.
+
+## Phase 4: Funding Research
+
+Research phase that runs **after** Phases 1–3 are in production. Not on the critical path of the attachment seam; do not block Phases 1–3 on this. Phase 4 tunes ranking inputs only — it does not change execution authority or alter the contracts from Phases 1–3.
+
+Inputs to research:
+
+- Which capacity is fixed-cost, quota-based, token-priced, or local? (Inventory.)
+- Which capability tiers are best for review, refactor, QA, research, and coding? (Capability tier, not provider name — the no-pinning rule still applies.)
+- Which work can run off-hours without human interruption?
+- Which idle reasons indicate missing funding, missing tools, or missing standing orders?
+
+Deliverables:
+
+- a capability-tier × work-class fit matrix (no provider names),
+- utilization metric definitions concrete enough to compute against `TaskRun` + `ToolExecution` + provider usage telemetry,
+- recommended `StandingOrder` defaults (queue ranking weights, idle-reason follow-up rules),
+- backlog items for missing provider integrations, evidence capture gaps, or routing-hint feedback the router does not yet honor.
+
+Acceptance:
+
+- the fit matrix is checked in as part of the capacity spec or a linked appendix and referenced from `StandingOrder` defaults,
+- every utilization metric defined here has a query against shipped tables (no metric defined against tables that do not yet exist),
+- no recommendation pins a provider; every recommendation expresses a hint shape (`providerClassHint`/`modelTierHint`) the router already consumes,
+- gap-driven backlog items are filed with linked evidence from real capacity runs, not hypothetical scenarios.
+
+## Verification
+
+For the attachment slice (mirrors AGENTS.md §5 build gate):
+
+- unit tests for candidate selection and mapping (pure functions; no DB),
+- integration test: a synthetic standing-order candidate flows through `AutonomousWorkRun`, produces a `TaskRun` with `a2aMetadata.trigger = "capacity-continuity"`, and every resulting `ToolExecution` row carries the `taskRunId`,
+- invariant test: zero `TaskRun`s with `a2aMetadata.trigger = "capacity-continuity"` and a hard-rejected `sourceRef.kind`,
+- invariant test: zero side-effecting `ToolExecution` rows from an approval-required capacity candidate without a preceding approval record,
+- typecheck and full vitest pass,
+- `apps/web` next production build,
+- UX walkthrough of `/platform/ai/capacity-continuity` against the running install (per the platform's UI-verification requirement — type-checks do not verify UX),
+- Operations Map evidence that capacity-triggered runs appear as real work and are filterable by trigger.
+
+## Risks at the seam
+
+| Risk | Mitigation |
+| --- | --- |
+| Selector and runtime grant-resolution drift (a candidate the selector judged safe trips a runtime grant check). | Phase 3 rejection check uses the shared grant-resolution helper from `mcp-governed-execute.ts`; an integration test wires both call sites to the same fixture set. |
+| Dedup escape via objective rewording. | `dedupeKey` is owned by the selector and computed from `sourceRef` + canonical work fingerprint, not from `title`/`objective` free text. |
+| Capacity metadata accumulates on `TaskRun.a2aMetadata` and becomes unsearchable as volume grows. | Phase 2 limits metadata to a fixed key set; promotion-to-column criteria live in runtime spec §6.2. Review key-set growth at the Slice 5 baseline. |
+| Idle accounting tables (`CapacityWindow`) not yet present when this plan ships. | Phase 2 documents the transient idle-reason path; the seam does not depend on `CapacityWindow` existing. Capacity spec Slice 4 takes over once it ships. |
+| `ownerPrincipalId` resolution drifts from `StandingOrder.ownerPrincipalId`. | Mapper reads the principal id from the standing-order row at selection time, not from cached candidate state; rejection if the order has been disabled or its owner alias revoked. |
+| Approval-required candidates pile up unattended during long absences. | The capacity spec's return briefing surfaces every `input-required` paused run; idle accounting flags growth over time as a capacity-effectiveness signal. |
+
+## Recommendation
+
+Build the attachment seam before deep funding optimization.
+
+The platform needs a safe execution path first. Funding research then improves ranking and provider choice without changing the core authority model.
+
+Concrete next action: add the first governed runner entrypoint that calls `selectBacklogReviewCapacityWorkInputs()`, creates `TaskRun`s through `AutonomousWorkRun`, and records idle/blocker entries for every rejection. That runner must still perform no direct MCP/tool execution; the autonomous runtime remains the only execution path.

--- a/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
@@ -7,7 +7,7 @@
 | Related epics | EP-TAK-3F9A21, EP-CTRL-5E21A4 |
 | Related repo areas | `apps/web/lib/actions/agent-coworker.ts`, `apps/web/lib/actions/agent-task-scheduler.ts`, `apps/web/lib/tak/agentic-loop.ts`, `apps/web/lib/mcp-governed-execute.ts`, `apps/web/app/api/mcp/v1/route.ts`, `apps/web/lib/queue/functions/agent-task-dispatch.ts`, `apps/web/lib/tak/task-records.ts`, `apps/web/lib/ai-operations-map/*`, `packages/db/prisma/schema.prisma` |
 | Related DPF standards | `docs/architecture/trusted-ai-kernel.md`, `docs/architecture/GAID.md`, `docs/architecture/agent-standards-dpf-conformance.md`, `docs/architecture/ai-coworker-development-principles.md` |
-| Related specs | `2026-03-23-task-graph-orchestration-design.md`, `2026-03-23-task-governance-control-plane-design.md`, `2026-04-23-a2a-aligned-coworker-runtime-design.md`, `2026-04-29-coworker-execution-adapter-substrate-design.md`, `2026-04-29-orchestration-primitives-design.md`, `2026-04-30-ai-coworker-operator-pattern.md`, `2026-05-10-ai-coworker-visual-control-surface-design.md`, `2026-05-10-build-studio-business-intake-innovation-radar-design.md` |
+| Related specs | `2026-03-23-task-graph-orchestration-design.md`, `2026-03-23-task-governance-control-plane-design.md`, `2026-04-23-a2a-aligned-coworker-runtime-design.md`, `2026-04-29-coworker-execution-adapter-substrate-design.md`, `2026-04-29-orchestration-primitives-design.md`, `2026-04-30-ai-coworker-operator-pattern.md`, `2026-05-10-ai-coworker-visual-control-surface-design.md`, `2026-05-10-build-studio-business-intake-innovation-radar-design.md`, `2026-05-12-ai-capacity-continuity-design.md` |
 
 ## 1. Purpose
 
@@ -30,6 +30,8 @@ The design principle at the center is:
 This is not a slogan. It is the product strategy. Humans should spend attention on intent, judgment, exception handling, and governance. AI coworkers should absorb ambiguous, high-context, cross-system cognitive work. Once the pattern stabilizes, the platform should capture the repeated behavior as deterministic workflow, typed schema, policy, tests, or procedural code so future humans and future agents do not have to rediscover it.
 
 ## 2. Current State, Verified 2026-05-11
+
+> **Snapshot caveat.** §2 captures the pre-PR #468 state used as the design baseline. Slice 1 (§10) shipped after this snapshot; §2.3's "not yet a first-class `TaskRun`" claim and the `TaskRun` count in §2.1 are historical, not current. The post-Slice 1 schema is the authoritative state in §6.2.
 
 ### 2.1 Live runtime facts
 
@@ -240,6 +242,16 @@ The following are rejected:
 
 ## 5. Target Architecture
 
+### 5.0 Relationship to Capacity Continuity
+
+Capacity Continuity is the scheduling, funding, prioritization, and operating-tempo layer above this runtime. It decides which authorized work should consume available AI capacity during normal work, low-attention windows, vacations, holidays, events, after-hours periods, and owner inactivity.
+
+This autonomous runtime remains the execution layer. Capacity Continuity must submit work through `AutonomousWorkRun`; it must not invoke tools directly, create a parallel task identity, or bypass approval and evidence paths. Capacity-triggered work is just another governed trigger source whose execution still produces `TaskRun`, `ToolExecution`, receipts, evidence, Operations Map events, and return-briefing entries.
+
+The `AutonomousWorkTrigger` union (§5.1) includes `"capacity-continuity"` precisely so capacity-selected work is distinguishable in Operations Map projections without leaking capacity-policy concerns into the runtime. Provider/model preferences expressed by Capacity Continuity are *hints* fed to the existing dynamic routing; the runtime never honors a hardcoded provider pin (per the platform's no-provider-pinning principle).
+
+Routing hints have one canonical location: `TaskRun.a2aMetadata.cognitiveLoad.fundingFitHint` (shape: `{ providerClassHint, modelTierHint }`). The `AutonomousWorkRunInput` contract does **not** carry a top-level routing field — the router reads the hint off the persisted `a2aMetadata` so the audit record matches the decision. A trigger that needs no hint simply omits `fundingFitHint`; the router falls back to its default capability-tier/task-type resolution.
+
 ### 5.1 Canonical primitive: `AutonomousWorkRun`
 
 `AutonomousWorkRun` is a **service facade name**, not a parallel entity. The persistent work identity is `TaskRun`. This spec does not introduce a second ID space, a second status machine, or a second projection model. The `AutonomousWorkRun` service is the single function that every trigger calls to create or link a `TaskRun`, assemble context, resolve tools, and hand off to the agentic loop. The shape below is the service input contract, not a table:
@@ -252,7 +264,8 @@ type AutonomousWorkTrigger =
   | "build"
   | "deliberation"
   | "radar"
-  | "system-recovery";
+  | "system-recovery"
+  | "capacity-continuity";
 
 type AutonomousWorkRunInput = {
   trigger: AutonomousWorkTrigger;
@@ -266,7 +279,19 @@ type AutonomousWorkRunInput = {
   parentTaskRunId?: string;
   authorityScope?: string[];
   sourceRef?: {
-    kind: "scheduled-task" | "mcp-token" | "feature-build" | "backlog-item" | "manual-thread" | "deliberation-run";
+    kind:
+      | "scheduled-task"
+      | "mcp-token"
+      | "feature-build"
+      | "backlog-item"
+      | "manual-thread"
+      | "deliberation-run"
+      | "standing-order"
+      | "pull-request"
+      | "qa-gap"
+      | "spec"
+      | "capability-need"
+      | "proceduralization-candidate";
     id: string;
   };
 };
@@ -301,7 +326,7 @@ Required fields:
 | `contextId` | A2A-aligned continuity id. |
 | `initiatingAgentId` | Agent that accepted the work. |
 | `currentAgentId` | Agent currently responsible. |
-| `source` | `coworker`, `build`, `skill`, `proactive`, or extended enum if needed. |
+| `source` | `coworker`, `build`, `skill`, or `proactive`. Capacity-continuity runs use `source="proactive"` and are distinguished from scheduled runs by `a2aMetadata.trigger`; do not invent a `"capacity"` source value. |
 | `status` | A2A-shaped state: submitted, working, input-required, auth-required, completed, failed, canceled, rejected, archived. |
 | `authorityScope` | Narrowed scope for this run. |
 | `a2aMetadata` | Trigger, source ref, schedule id, MCP token id, route context, operating profile fingerprint. |
@@ -313,7 +338,7 @@ All run types should converge on:
 
 ```mermaid
 flowchart TD
-    A["Trigger: UI, schedule, MCP, Build Studio, radar, recovery"] --> B["AutonomousWorkRun service"]
+    A["Trigger: UI, schedule, MCP, Build Studio, radar, recovery, capacity-continuity"] --> B["AutonomousWorkRun service"]
     B --> C["TaskRun created or linked"]
     C --> D["Prompt, skills, memory, route context assembled"]
     D --> E["Tool list resolved by user capability and agent grants"]
@@ -361,7 +386,7 @@ Every autonomous run should record cognitive-load transfer signals:
 | --- | --- | --- |
 | `humanTouches` | approvals, clarifications, manual retries | Measures whether automation reduced or shifted burden. |
 | `agentSteps` | tool calls, task messages, artifacts | Shows cognitive work absorbed by coworker. |
-| `repetitionPatternKey` | `TaskRun.repeatedPatternKey` | Groups repeated cognitive burdens. |
+| `repetitionPatternKey` | `TaskRun.a2aMetadata.cognitiveLoad.repeatedPatternKey` (derived hash of `sourceRef.kind` + normalized `objective`) | Groups repeated cognitive burdens. Promote to a column only after Slice 5 baseline metrics stabilize (§13 open decision 3). |
 | `proceduralizationCandidate` | task metadata or backlog item | Marks patterns ready for deterministic code. |
 | `exceptionClass` | failed tool, auth, missing data, policy, model, schema | Shows what to fix next. |
 | `evidenceCompleteness` | receipts, artifacts, backlog evidence | Avoids "AI did something" claims without proof. |
@@ -409,19 +434,26 @@ Use:
 - `CoworkerCapabilityNeed` for agent-submitted needs,
 - `BacklogItemActivity` for backlog evidence.
 
-### 6.2 Likely schema changes
+### 6.2 Schema status
 
-Minimal first-slice changes (verified against `packages/db/prisma/schema.prisma` 2026-05-11):
+Re-verified against `packages/db/prisma/schema.prisma` 2026-05-12 (after PR #468):
 
-1. Add `taskRunId String?` to `ScheduledAgentTask` (currently absent — see schema lines 4281–4305) with an index on `(taskRunId)`.
-2. Add `taskRunId String?` to `ToolExecution` (currently absent — see schema lines 3007–3036) with an index on `(taskRunId, createdAt)`. `AgentMessage.taskRunId` (line 2886) and `AgentActionProposal.taskRunId` (line 2935) already exist and are the pattern to follow; code paths that pass `taskRunId` into `ToolExecution.create()` today are silently dropping it on the floor and must be reconciled in the same migration.
-3. Place `sourceRef`, `cognitiveLoad`, and `triggerKind` inside `TaskRun.a2aMetadata` rather than as new columns at first. Promote to columns only after Slice 5 metrics stabilize (§13 open decision 3).
+**Shipped (no further migration required for the attachment seam):**
 
-Potential later changes:
+1. `ScheduledAgentTask.taskRunId String?` — schema line 4329, indexed at line 4338. Set by `scheduled-task-runs.ts` to the latest TaskRun spawned by the schedule.
+2. `ToolExecution.taskRunId String?` — schema line 3029, indexed at line 3039. Persisted by `mcp-governed-execute.ts` when `context.taskRunId` is provided.
+3. `AgentMessage.taskRunId String?` and `AgentActionProposal.taskRunId String?` — schema lines 2886 and 2935. Pre-existing pattern that 1 and 2 followed.
 
-1. `AutonomousWorkPattern` for repeated proceduralization candidates.
-2. `HumanTouchpoint` if approval/clarification metrics outgrow `TaskMessage` and `AgentActionProposal`.
-3. `ProceduralizationCandidate` if backlog linkage alone is not enough.
+**Active recommendation:**
+
+Place `sourceRef`, `cognitiveLoad`, `triggerKind` (i.e. `trigger`, matching the `AutonomousWorkTrigger` union in §5.1), and `repeatedPatternKey` inside `TaskRun.a2aMetadata` rather than as new columns. Promote individual keys to columns only after Slice 5 metrics stabilize (§13 open decision 3) and the column is queried on a hot path the JSON path index cannot serve.
+
+**Potential later additions:**
+
+1. `TaskRun.repeatedPatternKey String?` indexed column — only if Slice 5 shows the metadata-path query is a bottleneck.
+2. `AutonomousWorkPattern` for repeated proceduralization candidates.
+3. `HumanTouchpoint` if approval/clarification metrics outgrow `TaskMessage` and `AgentActionProposal`.
+4. `ProceduralizationCandidate` if backlog linkage alone is not enough.
 
 ### 6.3 Status model
 
@@ -582,6 +614,7 @@ The model never owns authority. The runtime carries authority from:
 - service principal,
 - MCP token,
 - scheduled task owner,
+- standing-order owner (capacity-continuity trigger; see capacity spec §11.0a),
 - explicit delegation grant,
 - build/run policy.
 
@@ -628,38 +661,34 @@ This prevents "the agent did it twice, so hardcode it" from becoming a new short
 
 ## 10. Implementation Slices
 
-### Slice 1: Scheduled coworker as TaskRun
+### Slice 1: Scheduled coworker as TaskRun — SHIPPED (PR #468)
+
+Status: SHIPPED 2026-05-11 via PR #468 ("link scheduled runs to TaskRun"). Retained here as the historical record of the architectural choices the remaining slices build on.
 
 Goal: make the one existing scheduled coworker task a first-class autonomous work run.
 
-Scope:
+Shipped scope:
 
-- migration: add nullable `ScheduledAgentTask.taskRunId` and `ToolExecution.taskRunId` (§6.2),
-- create the `TaskRun` in `executeScheduledAgentTask()` **before** the first tool call,
-- pass `taskRunId` into `runAgenticLoop()` and through `governedExecuteTool()` so every `ToolExecution` row written during the run carries it,
-- write `TaskMessage` for scheduled prompt and final summary,
-- project blocked/failure/completed state into `progressPayload`,
-- preserve existing `ScheduledAgentTask` and `ScheduledJob` behavior,
-- verify the daily discovery triage task still runs.
+- migration: nullable `ScheduledAgentTask.taskRunId` and `ToolExecution.taskRunId` (§6.2 — schema lines 4329 and 3029 respectively),
+- `apps/web/lib/tak/scheduled-task-runs.ts:createTaskRunForScheduledTask()` creates the `TaskRun` **before** the agentic loop fires the first tool call, with `source="proactive"`, `a2aMetadata.trigger="scheduled"`, and `a2aMetadata.sourceRef={kind:"scheduled-task", id:taskId}`,
+- `taskRunId` flows through `runAgenticLoop()` and `governedExecuteTool()` into every `ToolExecution` row written during the run,
+- existing `ScheduledAgentTask` and `ScheduledJob` behavior preserved; the daily `discovery-taxonomy-gap-triage-daily` task continues running.
 
-Slice 1 is the first consumer of the shared seam that Slice 2 will extract. Implement the new code as a self-contained function on day one so Slice 2's extraction is a move, not a rewrite.
+Open follow-ups carried into later slices:
 
-Acceptance:
+- `TaskMessage` projection of scheduled prompt and final summary (Slice 2),
+- timezone honoring in cron computation or explicit "unsupported" UI surfacing (cross-cutting; tracked separately as a runtime-trust defect),
+- migration-blocking invariant test that every non-system `ToolExecution` from a scheduled run carries `taskRunId` (Slice 2 acceptance).
 
-- a scheduled run creates exactly one `TaskRun` and creates it before any tool call,
-- 100% of `ToolExecution` rows from the run carry the `taskRunId` FK (verified by a migration-blocking invariant test),
-- the run appears in the internal task endpoint output and the Operations Map,
-- failure marks the `TaskRun` failed and keeps next schedule intact,
-- timezone behavior is either implemented or clearly marked unsupported in UI (no silent ignore — that is a runtime-trust defect),
-- build gate (AGENTS.md §5) passes: vitest, `apps/web` next build, migration applies cleanly, UX exercised against the running install.
+The shipped implementation is the self-contained function Slice 2 will reuse — extraction is a move, not a rewrite.
 
-### Slice 2: AutonomousWorkRun service extraction
+### Slice 2: AutonomousWorkRun service extraction — STARTED
 
 Goal: reduce duplication between interactive and scheduled coworker paths.
 
 Scope:
 
-- introduce service wrapper around prompt/tool/run setup,
+- introduce service wrapper around `TaskRun` creation and trigger metadata,
 - preserve existing `sendMessage()` behavior,
 - reuse for scheduled execution,
 - centralize `TaskRun` creation/linking,
@@ -668,7 +697,8 @@ Scope:
 Acceptance:
 
 - no behavior regression in `/api/agent/send`,
-- scheduled and interactive paths use shared context/tool resolution,
+- scheduled execution uses the shared `AutonomousWorkRun` creation seam,
+- capacity-continuity can create `TaskRun` identity with `a2aMetadata.trigger = "capacity-continuity"` without tool execution,
 - existing agentic-loop tests still pass,
 - service can be called without Next route objects.
 
@@ -722,7 +752,7 @@ Goal: turn repeated cognitive load into code/workflow/policy candidates.
 Scope:
 
 - capture a one-week baseline before applying decline targets,
-- compute repeated pattern candidates from `TaskRun.repeatedPatternKey`, tool failures, approvals, and manual touches,
+- compute repeated pattern candidates from `TaskRun.a2aMetadata.cognitiveLoad.repeatedPatternKey` (per §5.5), tool failures, approvals, and manual touches; if the metadata-path query is a bottleneck under load, promote to the indexed column described in §6.2 as part of this slice's scope,
 - show candidates in AI Operations,
 - file governed backlog proposals,
 - link back to evidence.
@@ -791,25 +821,23 @@ Slice 5 must capture a one-week baseline before interpreting decline targets. Un
 
 The autonomous coworker runtime is considered coherent when:
 
-1. every scheduled coworker run has `TaskRun` identity (zero scheduled runs without `taskRunId` over a rolling 7-day window),
+1. every scheduled coworker run has `TaskRun` identity (zero scheduled runs without `taskRunId` over a rolling 7-day window) — **achieved by PR #468**,
 2. every external tool call and future remote task submission is governed through the same authority path (zero `ToolExecution` rows with `apiTokenId` set and `taskRunId` null when the call originated from `tasks/submit`),
-3. interactive, scheduled, remote, Build Studio, and deliberation work appear in one Operations Map projection,
-4. capability needs flow from runtime evidence to review/backlog with submitter attribution (zero open `CoworkerCapabilityNeed` older than the defined review SLA),
-5. repeated cognitive burdens are visible as proceduralization candidates,
-6. humans approve meaningful boundaries and exceptions, not routine internal steps,
-7. at least three proceduralization candidates have been promoted to procedural code, deterministic workflow, typed schema, or policy with linked evidence; the promotion record (§9.5) is the measurable artifact, not a vibes-level claim that "the agent learned."
+3. every capacity-continuity-triggered run has `TaskRun` identity (zero `TaskRun`s with `a2aMetadata.trigger = "capacity-continuity"` lacking an `ownerPrincipalId`-resolvable `userId`, and zero capacity-selected work invoking tools outside `AutonomousWorkRun`),
+4. interactive, scheduled, remote, Build Studio, deliberation, and capacity-continuity work appear in one Operations Map projection,
+5. capability needs flow from runtime evidence to review/backlog with submitter attribution (zero open `CoworkerCapabilityNeed` older than the defined review SLA),
+6. repeated cognitive burdens are visible as proceduralization candidates,
+7. humans approve meaningful boundaries and exceptions, not routine internal steps,
+8. at least three proceduralization candidates have been promoted to procedural code, deterministic workflow, typed schema, or policy with linked evidence; the promotion record (§9.5) is the measurable artifact, not a vibes-level claim that "the agent learned."
 
 ## 15. Recommendation
 
-Proceed with Slice 1 first: scheduled coworker as `TaskRun`.
+With Slice 1 shipped (PR #468) and Slice 2 in progress at `apps/web/lib/tak/autonomous-work-run.ts`, the next call is to **finish Slice 2 and use it to land the capacity-continuity attachment seam** (capacity spec Slice 3 / attachment plan Phases 1–3).
 
-It is the smallest slice that proves the architecture:
+Order of operations:
 
-- one active live scheduled coworker exists,
-- current code path is narrow,
-- schema already has `ScheduledAgentTask` and `TaskRun`,
-- `runAgenticLoop()` already accepts task context,
-- `governedExecuteTool()` already centralizes audit and grants,
-- the AI Operations Map can consume the resulting records.
+1. Complete the Slice 2 extraction: every interactive path that today calls `createTaskRunForScheduledTask`-shaped code (and the scheduled-task adapter itself) goes through the shared `AutonomousWorkRun` service, with the `AutonomousWorkTrigger` union as the only branching axis.
+2. Land the capacity-continuity attachment under the new seam: a `CapacityContinuityCandidate` flows through the same service, produces a `TaskRun` with `a2aMetadata.trigger = "capacity-continuity"`, and inherits all governance from §9.
+3. Defer Slice 3 (remote `tasks/submit`) and Slice 5 (proceduralization candidates) until the seam carries at least two trigger sources in production — that is the minimum evidence that the abstraction holds before adding more callers.
 
-This slice turns autonomous coworker work from "a scheduled chat message that happens to call tools" into "a governed, observable, resumable work run." That is the right foundation for remote invocation, self-assessment, capability needs, and proceduralization.
+Slice 4 (capability-needs flywheel) can proceed in parallel with Slice 2 because it consumes `TaskRun` evidence rather than producing it.

--- a/docs/superpowers/specs/2026-05-12-ai-capacity-continuity-design.md
+++ b/docs/superpowers/specs/2026-05-12-ai-capacity-continuity-design.md
@@ -1,0 +1,688 @@
+# AI Capacity Continuity and Responsible Utilization Design
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-12 |
+| Status | Draft for review |
+| Related epics | EP-TAK-3F9A21 |
+| Related repo areas | `AGENTS.md`, `docs/architecture/ai-coworker-development-principles.md`, `apps/web/app/(shell)/platform/ai/*`, `apps/web/components/platform/platform-nav.ts`, `apps/web/lib/actions/agent-task-scheduler.ts`, `apps/web/lib/queue/functions/agent-task-dispatch.ts`, `apps/web/lib/mcp-governed-execute.ts`, `packages/db/prisma/schema.prisma` |
+| Related specs | `2026-05-11-autonomous-coworker-runtime-design.md`, `2026-05-10-ai-coworker-visual-control-surface-design.md`, `2026-04-30-ai-coworker-operator-pattern.md`, `2026-04-29-orchestration-primitives-design.md` |
+
+## 1. Purpose
+
+DPF pays for AI capacity as an operating asset. When that capacity is fixed-price, subscription-based, or otherwise already paid for, unused capacity is not harmless. It is lost operating leverage.
+
+The platform should not depend on one human being at the keyboard to turn available AI capacity into value. If the owner goes on a trip for a week, if an employee takes a month-long vacation, if the business is closed for a holiday, or if the team is focused on a trade show, DPF should still use authorized AI capacity to produce governed, reviewable progress.
+
+This spec defines **AI Capacity Continuity**: the doctrine, runtime model, UX home, and first implementation slices needed to ensure that paid AI capacity becomes useful work instead of vanished opportunity.
+
+The shorthand principle is:
+
+> **Use it or lose it.**
+
+The formal platform principle is:
+
+> **Responsible AI Capacity Utilization.** DPF treats paid AI capacity as an operating asset. AI coworkers and coding agents are expected to use available capacity to create governed value: reduce human cognitive load, inspect stale state, improve quality, produce durable work products, capture evidence, advance backlog work, identify capability gaps, and convert repeated effort into procedures. Idle capacity is waste when valuable authorized work exists. Token spending without durable value, evidence, or learning is also waste.
+
+This is pressure toward useful work, not pressure toward activity.
+
+## 2. Current State
+
+DPF already has pieces of the required architecture:
+
+- `ScheduledAgentTask` and `ScheduledJob` can run recurring work.
+- `ToolExecution` records tool calls and supports audit.
+- `TaskRun` is the intended durable work identity for autonomous work.
+- AI Operations already has routes for overview, Operations Map, assignments, prompts, skills, capability needs, providers, and Build Runtime.
+- `apps/web/components/platform/platform-nav.ts` is the canonical platform navigation source.
+- The autonomous coworker runtime spec already defines governed work runs, cognitive-load transfer, and proceduralization candidates.
+- The coworker visual control surface spec already gives AI Operations a map and inspector model.
+
+The missing pieces are:
+
+1. no explicit principle that paid AI capacity should be used responsibly instead of idling,
+2. no capacity-continuity policy model for vacations, holidays, business events, store hours, and inactivity,
+3. no standing-orders system that tells agents what safe work to do when humans are away,
+4. no UX entry for operators to configure or inspect this behavior,
+5. no return briefing that shows what happened while attention was elsewhere,
+6. no metric that distinguishes useful capacity use from empty token spend.
+
+## 3. Scope
+
+This design applies to:
+
+- in-platform AI coworkers,
+- scheduled and event-triggered agents,
+- Build Studio agents,
+- external coding agents such as Codex and Claude when working on DPF,
+- future MCP or desktop-control workforce nodes,
+- any provider/model capacity that is paid for or contractually available.
+
+This design does not authorize agents to bypass human authority, skip verification, spend money, deploy, publish, or change high-risk systems without existing approval gates.
+
+## 4. Research and Benchmarking
+
+### 4.1 NIST AI RMF
+
+NIST AI RMF frames trustworthy AI risk management around Govern, Map, Measure, and Manage. Capacity continuity should follow the same pattern:
+
+- govern what agents are allowed to do,
+- map available capacity to authorized work queues,
+- measure useful work and residual idle capacity,
+- manage escalation, risk, and policy changes.
+
+Reference: [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework).
+
+### 4.2 OpenAI Agents SDK
+
+OpenAI Agents SDK guidance supports human-in-the-loop approval for sensitive tool calls and tracing for agent runs. DPF should adopt the same shape: capacity runners may proceed through low-risk work, but sensitive actions pause for human approval and every run remains traceable.
+
+References:
+
+- [OpenAI Agents SDK human-in-the-loop](https://openai.github.io/openai-agents-python/human_in_the_loop/)
+- [OpenAI Agents SDK tracing](https://openai.github.io/openai-agents-python/tracing/)
+
+### 4.3 Microsoft Agent Orchestration Patterns
+
+Microsoft's agent orchestration guidance distinguishes sequential, concurrent, group-chat, and handoff patterns, with explicit human-in-the-loop points. Capacity continuity should use orchestrated work queues rather than one giant autonomous prompt.
+
+Reference: [Microsoft AI agent orchestration patterns](https://learn.microsoft.com/azure/architecture/ai-ml/guide/ai-agent-design-patterns).
+
+### 4.4 Model Context Protocol
+
+MCP's authorization model reinforces that external tool and agent access should operate through explicit bearer-token and resource-owner authority rather than hidden local assumptions. DPF should treat Codex, Claude, and other external workforce nodes as governed clients with scoped standing orders, not as informal chat sessions.
+
+Reference: [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization).
+
+### 4.5 Workforce scheduling precedent
+
+Human workforce systems distinguish working hours, holidays, leave, events, and on-call coverage. DPF should apply the same operating calendar concept to AI workforce planning. The goal is not to mimic HR software; the goal is to let AI capacity continue useful work when human attention is unavailable, reduced, or redirected.
+
+## 5. Core Doctrine
+
+### 5.1 Use capacity for governed value
+
+AI capacity should be consumed when it can produce one of these durable outcomes:
+
+- backlog movement,
+- draft PRs or commits,
+- test and build evidence,
+- UX verification evidence,
+- spec or plan review,
+- documentation/runtime drift detection,
+- stale PR or CI repair,
+- self-assessment and capability-need capture,
+- refactoring proposals or small approved refactors,
+- proceduralization candidates,
+- operational monitoring and return briefings.
+
+### 5.2 Do not confuse activity with value
+
+The platform must reject:
+
+- decorative analysis,
+- repeated summaries with no new evidence,
+- token burning to appear busy,
+- unbounded research with no decision artifact,
+- speculative changes outside authority,
+- autonomous work that cannot be reviewed or traced.
+
+### 5.3 Idle capacity is a signal
+
+If capacity is available and no work runs, the platform should record why:
+
+- no approved work queue,
+- no safe authority scope,
+- human approval required,
+- provider unavailable,
+- tools missing,
+- repository/worktree unavailable,
+- calendar state explicitly paused,
+- policy disallows work in the current window.
+
+Unused capacity should become either evidence or a capability need.
+
+## 6. Capacity Continuity States
+
+Capacity behavior should derive from business and workforce context, not only user presence.
+
+| State | Meaning | Default AI posture |
+| --- | --- | --- |
+| `normal` | Humans are generally available. | Assist, accelerate, and prepare decisions. |
+| `low-attention` | Humans are busy or intermittently available. | Continue safe work; batch interruptions. |
+| `away` | Planned absence such as vacation, travel, or leave. | Pull from approved queues; escalate only meaningful blockers. |
+| `holiday` | Organization or region is closed or reduced. | Prefer quiet internal maintenance and monitoring. |
+| `event` | Trade show, launch, audit, migration, sales push, or other business event. | Shift priorities to event support, monitoring, briefing, and follow-up prep. |
+| `after-hours` | Outside configured working or store hours. | Run background work that does not create noisy human interruptions. |
+| `emergency` | Incident or policy override. | Prioritize response and escalation over ordinary capacity use. |
+| `paused` | Explicit stop. | Do not start new autonomous capacity work. |
+
+Inputs include:
+
+- store or business hours,
+- employee work schedules,
+- vacations and leave,
+- holidays by region,
+- scheduled platform activity,
+- business events,
+- owner inactivity,
+- explicit operator overrides.
+
+## 7. Standing Orders
+
+Standing Orders are durable instructions for what AI coworkers and external agents should do when capacity is available.
+
+Examples:
+
+- review stale specs and propose corrections,
+- repair failing CI on active PRs,
+- run affected QA phases and record evidence,
+- pick approved backlog items labeled safe-for-autonomy,
+- inspect capability needs after repeated denied tools,
+- prepare return briefings during owner absence,
+- identify repeated manual work that should become procedural code.
+
+Standing Orders must include:
+
+- scope,
+- allowed agents or agent classes,
+- allowed work queues,
+- disallowed action classes,
+- required evidence,
+- approval boundaries,
+- maximum runtime or capacity budget,
+- escalation destination,
+- return-briefing format.
+
+## 8. Work Queue Ranking
+
+The capacity scheduler should rank work by value and safety:
+
+1. blocked or failing work with clear reproduction and low-risk fix path,
+2. active PR repair and verification,
+3. approved backlog items with bounded scope,
+4. QA and UX evidence collection,
+5. stale spec/doc/runtime drift checks,
+6. coworker self-assessment and capability-needs review,
+7. refactoring candidates with local tests,
+8. proceduralization candidate analysis,
+9. research only when it produces a linked decision artifact.
+
+The scheduler should not select work that lacks an owner, authority basis, repository isolation plan, verification path, or review destination.
+
+## 9. External Coding Agents
+
+Codex, Claude, and similar tools should be modeled as external AI workforce nodes when they work on DPF.
+
+They should receive:
+
+- the canonical `AGENTS.md` rulebook,
+- a scoped task or standing order,
+- a branch/worktree isolation rule,
+- MCP backlog access when available,
+- verification requirements,
+- output and evidence expectations,
+- review and PR requirements.
+
+The platform should not assume these agents are always interactive. A future capacity runner should be able to assign safe work to them, collect results, and record evidence back into DPF.
+
+## 10. UX and Navigation
+
+Capacity continuity must be visible, configurable, and reviewable.
+
+Canonical UX home:
+
+- global family: `Platform`
+- section: `AI Operations`
+- page: `Capacity Continuity`
+- route: `/platform/ai/capacity-continuity`
+
+Required AI Operations navigation siblings:
+
+- Overview
+- Operations Map
+- Capacity Continuity
+- Assignments
+- Prompts
+- Skills
+- Capability Needs
+- Providers & Routing
+- Build Runtime
+
+The page should provide:
+
+- current capacity-continuity state,
+- upcoming calendar drivers,
+- standing orders,
+- safe work queues,
+- capacity use versus idle capacity,
+- active and recent capacity runs,
+- blocked capacity with reason codes,
+- return briefings,
+- approval and escalation queue,
+- links into Operations Map, Capability Needs, PRs, backlog, and evidence.
+
+`My Workspace` should show the personal view:
+
+- current/next availability state,
+- return briefing after absence,
+- AI work waiting for review,
+- blocked decisions that need the user.
+
+The Operations Map should show active capacity runs as real AI work. They must not be hidden as background jobs.
+
+## 11. Runtime Architecture
+
+Capacity Continuity is **not** a second autonomous-agent runtime.
+
+It is the scheduling, funding, prioritization, and operating-tempo layer that decides when available AI capacity should become governed work. The actual work execution belongs to the autonomous coworker runtime defined in `2026-05-11-autonomous-coworker-runtime-design.md`.
+
+The interface is:
+
+```mermaid
+flowchart LR
+  A["Funding and capacity inventory"] --> B["Capacity Continuity policy"]
+  C["Calendar, availability, events"] --> B
+  D["Standing Orders"] --> B
+  E["Backlog, PRs, QA, specs, capability needs"] --> B
+  B --> F["AutonomousWorkRun service"]
+  F --> G["TaskRun"]
+  G --> H["governedExecuteTool"]
+  H --> I["Evidence, approvals, receipts, blockers"]
+  I --> J["Operations Map and return briefing"]
+```
+
+Capacity Continuity owns:
+
+- provider and subscription capacity inventory,
+- standing-order selection,
+- calendar and operating-tempo interpretation,
+- work queue ranking,
+- idle reason accounting,
+- return briefing assembly,
+- funding/utilization metrics.
+
+The autonomous runtime owns:
+
+- `TaskRun` identity,
+- context assembly,
+- prompt and skill loading,
+- agent/tool resolution,
+- approval pauses,
+- tool execution through `governedExecuteTool()`,
+- task state transitions,
+- evidence and audit linkage.
+
+This boundary prevents the capacity feature from becoming a parallel scheduler, a parallel task model, or a hidden automation path.
+
+### 11.0a Principal convergence
+
+Capacity-triggered runs use the same `Principal` model as every other autonomous run (autonomous runtime spec §9.2; `2026-04-22-enterprise-auth-directory-federation-design.md` addendum 2026-05-09). The `TaskRun.userId` of a capacity-triggered run resolves to the **standing-order owner's `Principal`**, never to a synthetic "capacity-system" account. The `a2aMetadata.sourceRef.kind` becomes `"standing-order"` (or `"capacity-window"` for ad-hoc windows) and `sourceRef.id` is the standing-order id; this preserves the chain from human authority to agent action.
+
+A standing order without a resolvable `Principal` owner is invalid and the policy layer must reject it before any candidate selection.
+
+### 11.0b Status "paused" belongs to the policy, not to runs
+
+Capacity Continuity state `paused` (§6) is a property of the **policy/window**, not of `TaskRun`. An individual `TaskRun` keeps the A2A-aligned status vocabulary (`submitted`/`working`/`input-required`/`auth-required`/`completed`/`failed`/`canceled`/`rejected`/`archived`) defined in the autonomous runtime spec §6.3. When a window enters `paused`, the policy stops *starting* new runs; in-flight runs continue under their existing run-level status or are canceled with `canceled` if the pause is explicit and immediate.
+
+### 11.1 Capacity scheduler
+
+Introduce a scheduler service that:
+
+1. resolves current capacity-continuity state,
+2. calculates available provider and agent capacity,
+3. loads standing orders,
+4. ranks authorized work queues,
+5. starts governed `TaskRun`s,
+6. records evidence and idle reasons,
+7. produces return briefings.
+
+### 11.2 TaskRun as work identity
+
+Capacity work should use the autonomous coworker runtime direction:
+
+- every meaningful run gets `TaskRun` identity,
+- every tool call goes through `governedExecuteTool()`,
+- every side-effecting or high-risk action follows existing proposal/approval rules,
+- every external coding-agent assignment records its source and evidence.
+
+### 11.3 Calendar integration
+
+The scheduler should consume calendar and availability signals through a normalized policy layer rather than hardcoding one calendar provider.
+
+Calendar sources should eventually include:
+
+- workspace calendar,
+- store/business hours,
+- employee leave,
+- holiday calendars,
+- business events,
+- release windows,
+- manual overrides.
+
+### 11.4 Capacity accounting
+
+The platform should classify each capacity window:
+
+- `used-for-work`,
+- `blocked-by-policy`,
+- `blocked-by-approval`,
+- `blocked-by-missing-tool`,
+- `blocked-by-provider`,
+- `blocked-by-worktree`,
+- `no-approved-work`,
+- `paused`.
+
+This turns unused capacity into a diagnosable operating signal.
+
+### 11.5 Funding optimization loop
+
+Funding optimization should tune Capacity Continuity's selection policy. It must not change execution authority and must not pin providers or models.
+
+The loop is:
+
+1. inventory paid capacity by provider, model, subscription, quota, reset window, marginal cost, fixed cost, and tool/runtime fit,
+2. classify work by required capability, risk, expected duration, evidence type, and approval posture,
+3. emit a **routing hint** (capability tier + cost class) onto the candidate; the existing dynamic router decides the concrete provider/model,
+4. prefer hints toward fixed-cost or already-paid capacity for safe backlog/spec/QA/refactor work first,
+5. reserve scarce frontier-tier hints for work that demonstrably needs it,
+6. allow lower-tier hints for review, triage, summarization, documentation drift, and low-risk verification where quality is acceptable,
+7. measure useful output, idle reasons, failures, and rework,
+8. update standing-order priorities based on evidence.
+
+**No provider pinning.** Candidate `capacityFit.providerClass` and `modelTier` are *hints* — inputs to dynamic routing keyed on capability tier and task type. They never bypass the router and never write to `AgentModelConfig` overrides. A standing order that hard-pins a provider is invalid and must be rejected by the policy layer.
+
+Initial implementation status: the pure finance/routing planner lives at `apps/web/lib/capacity-continuity/finance-routing.ts`, with live signal normalization in `apps/web/lib/capacity-continuity/finance-signals.ts`. It consumes finance signals such as provider class, utilization percent, projected unused value, and overage risk, then emits `routingHints` (`budgetClass`, `interactionMode`, `modelTierHint`, provider-class preference/avoidance, reason codes) and `financeTracking` metadata. Provider ids are recorded only as audit evidence for which finance signals were observed; they are not routing directives.
+
+The platform must optimize for **useful governed output (§13.1) per paid capacity window**, not raw token volume.
+
+## 12. Data Model Direction
+
+Start with minimal schema expansion after validating existing models.
+
+Likely new concepts (introduced only when the metadata-first approach proves insufficient — see slice gating below):
+
+- `CapacityContinuityPolicy` — calendar/availability-driven state machine and overrides.
+- `StandingOrder` — durable instruction owned by a `Principal` (§11.6).
+- `CapacityWindow` — observed/blocked/used time slice with reason code (§11.4).
+- `CapacityIdleReason` — enum row referenced by windows and metrics.
+- `ReturnBriefing` — see schema sketch below.
+
+Reuse rules:
+
+- `TaskRun` carries run identity for every capacity-triggered execution (no `CapacityRun` parallel ID space).
+- `ToolExecution` carries tool audit (no capacity-specific tool log).
+- `BacklogItemActivity` carries backlog evidence.
+- `CoworkerCapabilityNeed` carries missing-ability signals.
+- `ScheduledAgentTask` carries recurring agent work.
+
+Do not create a parallel execution substrate.
+
+### 12.1 ReturnBriefing schema sketch
+
+A return briefing summarizes governed activity that happened during a capacity window — typically while the briefing's audience was unavailable. It is projection, not authoring: every claim must cite an underlying `TaskRun`, `ToolExecution`, `BacklogItemActivity`, or evidence record.
+
+```ts
+type ReturnBriefing = {
+  id: string;
+  principalId: string;             // audience — owner returning to attention, per §9.2 Principal convergence
+  capacityWindowStart: Date;
+  capacityWindowEnd: Date;
+  generatedAt: Date;
+  generatedByAgentId: string;      // coworker that assembled the briefing (itself a governed TaskRun)
+  generationTaskRunId: string;     // FK to the TaskRun that produced this briefing
+  sourceTaskRunIds: string[];      // every TaskRun summarized
+  sections: {
+    completed: BriefingEntry[];    // taskRunId + one-line outcome + artifact links
+    blocked: BriefingEntry[];      // taskRunId + idle/blocker reason code
+    awaitingApproval: BriefingEntry[]; // proposals or input-required pauses
+    capabilityNeedsRaised: string[]; // CoworkerCapabilityNeed ids
+    proceduralizationCandidates: string[]; // pattern keys ready for §5 promotion
+  };
+  evidenceCompleteness: number;    // 0–1 score: % of summarized runs with at least one durable artifact/receipt
+  status: "draft" | "delivered" | "acknowledged";
+};
+
+type BriefingEntry = {
+  taskRunId: string;
+  title: string;
+  outcomeSummary: string;          // single sentence
+  artifacts: string[];             // TaskArtifact ids, PR urls, receipt ids
+};
+```
+
+The briefing is itself produced by a governed `TaskRun` (Slice 4) so its assembly is auditable. A briefing without an associated `generationTaskRunId` is invalid.
+
+## 13. Metrics
+
+### 13.1 Defining "useful work"
+
+A capacity-triggered `TaskRun` counts as **useful** when it ends in `completed`, `input-required`, or `auth-required` AND produces at least one of:
+
+- a `TaskArtifact`,
+- a `ToolExecutionReceipt` (verifiable side effect),
+- a `BacklogItemActivity` row attributing observable backlog movement,
+- an `ExternalEvidenceRecord`,
+- a `CoworkerCapabilityNeed` with reviewable detail,
+- a `ProceduralizationCandidate` (or backlog item proposing one) with linked evidence,
+- a PR opened or repaired (recorded via the integration's evidence path),
+- a return-briefing entry that cites at least one of the above.
+
+A run that ends `completed` but produces none of the above is **not** useful — it is token spend dressed as activity. The "useful work per capacity window" metric is computed against this definition, not against run count or token volume.
+
+### 13.2 Outcome metrics
+
+- percentage of paid capacity windows used for governed work,
+- useful work produced per capacity window (per §13.1),
+- token-and-cost spend per useful artifact (provider-reported usage, normalized; tracked per `TaskRun.a2aMetadata.cognitiveLoad.spend`),
+- idle capacity by reason code,
+- backlog items advanced,
+- PRs opened, repaired, or verified,
+- evidence records produced,
+- capability needs filed and reviewed,
+- human touches avoided,
+- return briefing completeness (`ReturnBriefing.evidenceCompleteness`).
+
+Safety metrics:
+
+- side-effecting action without approval where approval was required: target zero,
+- capacity run without `TaskRun`: target zero for meaningful work,
+- tool execution without agent/user attribution: target zero,
+- token spend without linked evidence or work artifact: declining trend,
+- repeated idle reason older than SLA without backlog/capability follow-up: target zero.
+
+## 14. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Agents burn tokens to look busy. | Require durable artifact, evidence, or idle reason for every capacity run. |
+| Agents work outside human intent. | Standing Orders are scoped, reviewable, and approval-gated. |
+| Away Mode creates noisy interruptions. | Capacity states define interruption posture and briefing cadence. |
+| Vacations and holidays differ by region. | Use calendar/provider abstractions and regional holiday sources, not hardcoded assumptions. |
+| External coding agents collide in git. | One thread/agent/worktree/branch per concern; reuse AGENTS.md branch hygiene. |
+| Capacity work becomes invisible background automation. | Surface runs in Capacity Continuity and Operations Map. |
+| Refactoring becomes unbounded. | Limit autonomous refactoring to approved scope, tests, and reviewable PRs. |
+
+## 15. Implementation Slices
+
+### Slice 1: Doctrine and UX entry
+
+Goal: make the principle visible and discoverable.
+
+Scope:
+
+- add the principle to `AGENTS.md`,
+- add the principle to `docs/architecture/ai-coworker-development-principles.md`,
+- add `Capacity Continuity` to AI Operations navigation,
+- create a read-only placeholder route explaining the policy and current gaps,
+- update AI Operations user guide.
+
+Acceptance:
+
+- `Platform > AI Operations > Capacity Continuity` appears in navigation,
+- the page states current implementation status truthfully,
+- Codex/Claude inherit the principle through `AGENTS.md`,
+- no hardcoded UI colors,
+- affected tests pass.
+
+### Slice 2: Standing Orders model
+
+Goal: define durable work policies without launching autonomous execution yet.
+
+Scope:
+
+- model standing orders,
+- associate orders with agents, queues, risk classes, and evidence requirements,
+- expose CRUD in Capacity Continuity,
+- add validation for approval boundaries.
+
+Acceptance:
+
+- an operator can define safe work for planned absence,
+- orders can be disabled without deleting history,
+- policy violations are rejected before scheduling.
+
+### Slice 3: AutonomousWorkRun attachment
+
+Goal: connect Capacity Continuity to the autonomous runtime without creating a second execution model.
+
+Status: started. The shared `AutonomousWorkRun` service, the first pure capacity-candidate mapper/rejection seam, the finance/routing hint planner, live finance signal adapter, and the first backlog safe-queue selector exist in `apps/web/lib/tak/autonomous-work-run.ts`, `apps/web/lib/capacity-continuity/candidates.ts`, `apps/web/lib/capacity-continuity/finance-routing.ts`, `apps/web/lib/capacity-continuity/finance-signals.ts`, and `apps/web/lib/capacity-continuity/backlog-selector.ts`. The remaining work is governed runner integration, idle/blocker persistence, and Operations Map projection.
+
+Scope:
+
+- define the `CapacityContinuityCandidate` selection shape,
+- map selected candidates into `AutonomousWorkRunInput`,
+- derive finance-aware routing hints from AI-provider finance snapshots without provider/model pins,
+- select read-only backlog review candidates from existing open backlog items as the first safe queue,
+- store capacity metadata in `TaskRun.a2aMetadata`,
+- link idle/blocker reasons to capability needs or backlog proposals,
+- ensure every selected capacity run appears in Operations Map.
+
+Acceptance:
+
+- every capacity-started work item creates or links a `TaskRun`,
+- capacity policy never invokes tools directly,
+- `governedExecuteTool()` remains the tool execution choke point,
+- Operations Map can distinguish capacity-triggered work from interactive, scheduled, remote, build, and deliberation work.
+
+### Slice 4: Return briefing and idle accounting
+
+Goal: make absence outcomes visible.
+
+Scope:
+
+- compute capacity windows,
+- record used/idle/blocked reason codes,
+- generate a return briefing from existing evidence and runs,
+- show blocked capacity in the UI.
+
+Acceptance:
+
+- after a simulated week away, the page can explain what ran, what was blocked, and why,
+- repeated idle reasons can become capability needs or backlog proposals.
+
+### Slice 5: Safe capacity runner
+
+Goal: start low-risk governed work from approved queues.
+
+Scope:
+
+- start `TaskRun`s from Standing Orders,
+- select only safe read/review/verification/refactor tasks,
+- run through `governedExecuteTool()`,
+- stop at approval boundaries,
+- record evidence and return briefing entries.
+
+Acceptance:
+
+- no side-effecting action bypasses approval,
+- every run has `TaskRun` identity,
+- Operations Map shows active/recent capacity runs,
+- failures produce evidence and blocker notes.
+
+### Slice 6: Funding optimization research and policy tuning
+
+Goal: maximize value from paid AI subscriptions and provider capacity without creating fake work.
+
+Scope:
+
+- inventory fixed-cost, quota-based, token-priced, and local capacity,
+- classify work types by provider fit and required model tier,
+- define selection heuristics for off-hours, vacations, holidays, and low-attention windows,
+- define metrics for useful output per paid capacity window,
+- identify where Codex, Claude, OpenAI, local models, and future providers should be used.
+
+Acceptance:
+
+- the platform can explain why a capacity window used one provider or left capacity idle,
+- fixed-cost capacity is preferred for safe backlog/spec/QA/refactor work when available,
+- frontier capacity is reserved for tasks that need it,
+- token-priced capacity is not consumed merely to improve utilization percentages,
+- funding gaps produce backlog or capability-need proposals.
+
+### Slice 7: External coding-agent workforce node
+
+Goal: allocate safe work to Codex/Claude-style agents.
+
+Scope:
+
+- represent external coding agents as workforce nodes resolving to a `Principal` (typically the standing-order owner; the alias kind records the agent surface),
+- assign scoped backlog/spec/QA/refactor work,
+- enforce one-concern-per-worktree isolation (each external session runs in its own `git worktree add ../DPF-<topic>` — branches alone are insufficient when sessions run concurrently),
+- inherit the AGENTS.md PR workflow: short-lived topic branch, PR against `main`, no direct pushes to `main`,
+- require DCO sign-off on every commit (`git commit -s`); the workforce-node integration must surface a `Signed-off-by:` trailer in every patch it ingests,
+- collect patch/PR/evidence output through governed integrations (never via raw filesystem writes from the workforce node),
+- record results back into DPF as `TaskRun` evidence + `ToolExecutionReceipt` + `BacklogItemActivity`.
+
+Per Open Question 3 (§16), launch authority follows a gating rule, not a one-off recommendation: this slice begins with human-triggered assignment (operator opens the Codex/Claude session, DPF ingests results) and only progresses to DPF-launched sessions after authority resolution, sandboxing, and result ingestion have been demonstrated in production for at least 30 days.
+
+Acceptance:
+
+- a planned absence can produce draft PRs or review artifacts attributed to a real `Principal`,
+- every commit ingested carries DCO sign-off; commits without sign-off are rejected before evidence is recorded,
+- branches and worktrees remain isolated (no two concurrent external sessions share a working directory),
+- verification results and blockers are recorded as `TaskRun` evidence and visible in Operations Map.
+
+## 16. Open Questions
+
+1. Should capacity windows be first-class rows from slice 1, or computed from jobs and evidence until slice 3?
+   Recommendation: compute first; persist once the reason-code vocabulary stabilizes.
+
+2. Should vacations and holidays live in HR/employee records or a shared organization calendar?
+   Recommendation: use a shared availability abstraction that can read HR, workspace calendar, and business events.
+
+3. ~~Should external coding-agent capacity be launched by DPF directly or by prompting a human to open a Codex/Claude session?~~ **Decided.** Begin with human-triggered assignment and DPF-side evidence ingestion (Slice 7 acceptance). Automated launch is gated on 30 days of production evidence that authority resolution, sandboxing, and result ingestion are working — see Slice 7 gating rule.
+
+4. What is the minimum useful return briefing?
+   Recommendation: changed artifacts, PRs, evidence, blockers, idle reasons, approvals needed, and next recommended decisions.
+
+5. Should funding optimization land before the safe capacity runner?
+   Recommendation: no. Implement the attachment seam first, then use funding research to improve ranking. The first safe runner can use conservative defaults; funding optimization should tune, not block, the architecture.
+
+## 17. Definition of Done
+
+Capacity continuity is coherent when:
+
+1. operators can see and configure capacity behavior at `/platform/ai/capacity-continuity`,
+2. planned human absence produces governed work or explicit idle reasons,
+3. return briefings summarize what happened while attention was away,
+4. capacity runs appear in Operations Map and audit surfaces,
+5. missing tools or blocked authority become capability needs,
+6. external coding agents follow the same DPF rulebook and evidence expectations,
+7. useful work is measured separately from token spend.
+
+## 18. Reusability and hive contribution
+
+Capacity Continuity is a generic operating pattern, not a DPF-specific one. Any installation running paid AI capacity has the same idle-asset problem. Per the platform's reusability-by-design principle and the recursive-self-improvement loop, the Capacity Continuity policy model, standing-order schema, idle reason vocabulary, and return briefing format should be designed for hive-mind contribution from the first slice: domain-specific concepts (sales-push events, store hours, holiday calendars) are parameterized, not hardcoded, so other installations can adopt the pattern without forking.
+
+The candidate hive contribution surface includes the `StandingOrder` schema, the `CapacityContinuityCandidate` shape, and the idle-reason enum — all of which are policy artifacts, not execution artifacts.
+
+## 19. Recommendation
+
+Proceed with Slice 1, then finish Slice 3.
+
+Slice 1 turns the principle from a chat decision into visible platform doctrine and gives the product a navigable UX home. Slice 3 is the architectural join: Capacity Continuity selects work, the `AutonomousWorkRun` service (autonomous runtime spec Slice 2) executes it, `TaskRun` carries identity, `governedExecuteTool()` enforces authority, and Operations Map/return briefings make the result visible. The first mapper/rejection portion of Slice 3 is implemented; the next slice should wire real safe queues into that seam.
+
+**Sequencing dependency.** Slice 3 depends on autonomous runtime Slice 2 (`AutonomousWorkRun` service extraction) being merged first. Slice 1 of this spec can ship independently. Continue Slice 3 only through the shared runtime seam; do not add a separate capacity execution path.
+
+Do funding optimization as Slice 6, after the attachment seam exists. Otherwise the platform risks over-researching capacity economics before it has a safe place to put the work.

--- a/docs/superpowers/specs/2026-05-12-ai-capacity-continuity-design.md
+++ b/docs/superpowers/specs/2026-05-12-ai-capacity-continuity-design.md
@@ -546,7 +546,7 @@ Acceptance:
 
 Goal: connect Capacity Continuity to the autonomous runtime without creating a second execution model.
 
-Status: started. The shared `AutonomousWorkRun` service, the first pure capacity-candidate mapper/rejection seam, the finance/routing hint planner, live finance signal adapter, and the first backlog safe-queue selector exist in `apps/web/lib/tak/autonomous-work-run.ts`, `apps/web/lib/capacity-continuity/candidates.ts`, `apps/web/lib/capacity-continuity/finance-routing.ts`, `apps/web/lib/capacity-continuity/finance-signals.ts`, and `apps/web/lib/capacity-continuity/backlog-selector.ts`. The remaining work is governed runner integration, idle/blocker persistence, and Operations Map projection.
+Status: started. The shared `AutonomousWorkRun` service, the first pure capacity-candidate mapper/rejection seam, the finance/routing hint planner, live finance signal adapter, backlog safe-queue selector, and governed backlog-review runner exist in `apps/web/lib/tak/autonomous-work-run.ts`, `apps/web/lib/capacity-continuity/candidates.ts`, `apps/web/lib/capacity-continuity/finance-routing.ts`, `apps/web/lib/capacity-continuity/finance-signals.ts`, `apps/web/lib/capacity-continuity/backlog-selector.ts`, and `apps/web/lib/capacity-continuity/runner.ts`. The remaining work is operator-triggered action wiring, broader idle/blocker persistence, and Operations Map projection.
 
 Scope:
 
@@ -554,6 +554,8 @@ Scope:
 - map selected candidates into `AutonomousWorkRunInput`,
 - derive finance-aware routing hints from AI-provider finance snapshots without provider/model pins,
 - select read-only backlog review candidates from existing open backlog items as the first safe queue,
+- start accepted backlog-review work only by creating `TaskRun`s through `AutonomousWorkRun`,
+- record rejected backlog candidates as entity-scoped `BacklogItemActivity` evidence,
 - store capacity metadata in `TaskRun.a2aMetadata`,
 - link idle/blocker reasons to capability needs or backlog proposals,
 - ensure every selected capacity run appears in Operations Map.

--- a/docs/user-guide/platform/ai-operations.md
+++ b/docs/user-guide/platform/ai-operations.md
@@ -9,18 +9,23 @@ updatedBy: Codex
 ## Use This Doc For
 
 - `/platform/ai`
+- `/platform/ai/capacity-continuity`
 - `/platform/ai/operations`
+- `/platform/ai/operations-map`
 - `/platform/ai/history`
 - `/platform/ai/assignments`
 
 ## Workflow
 
 1. Start with the current operating picture: health, recent activity, and assignment posture.
-2. Review history when a result looks wrong, slow, or inconsistent.
-3. Adjust assignments only after you understand whether the problem is role design, model selection, or tool access.
+2. Review Capacity Continuity when paid AI capacity is idle, blocked, or expected to keep working during holidays, vacations, business events, after-hours windows, or owner inactivity.
+3. Review history when a result looks wrong, slow, or inconsistent.
+4. Adjust assignments only after you understand whether the problem is role design, model selection, tool access, standing orders, or calendar state.
 
 ## What To Watch
 
 - work being routed to the wrong specialist
+- paid AI capacity going unused without a clear blocker
 - repeated retries or stalled history patterns
 - assignment changes that solve one route but weaken another
+- capacity work that produces token spend without durable evidence, backlog movement, or reviewable output


### PR DESCRIPTION
## Summary
- add Responsible AI Capacity Utilization doctrine and Capacity Continuity docs
- add AI Operations Capacity Continuity navigation and read-only UX entry
- add shared AutonomousWorkRun TaskRun seam with capacity-continuity trigger support
- add capacity candidate mapping, finance/routing hint planning, live finance signal normalization, and backlog safe-queue selection

## Verification
- pnpm --filter web exec vitest run lib/capacity-continuity/backlog-selector.test.ts lib/capacity-continuity/finance-signals.test.ts lib/capacity-continuity/finance-routing.test.ts lib/capacity-continuity/candidates.test.ts lib/tak/autonomous-work-run.test.ts lib/tak/scheduled-task-runs.test.ts lib/actions/agent-task-scheduler.test.ts lib/tak/agentic-loop.test.ts
- pnpm --filter web typecheck
- git diff --check
- pnpm --filter web exec next build

Notes: next build passes with existing Turbopack trace warnings around spec-plan-search.ts / next.config.mjs.