### PR TITLE
docs(edge-node): publish six-phase implementation roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Publication outputs are generated from the Markdown sources of truth:
 | **Web-Hosted SaaS** | Customer-cloud deployment via Terraform on AWS / GCP / Azure — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). DPF stays single-tenant; "SaaS" here means "customer hosts on rented compute," not multi-tenant. |
 | **Mac & Linux Installers** | Code-complete and merged on `main` for native macOS Apple Silicon ([guide](docs/install/macos.md)) and native Linux ([guide](docs/install/linux.md)). Currently **early access** — please try it on your hardware and [tell us how it went](docs/install/verification-runbook.md). A handful of community verification reports per platform is what we need to graduate to GA. |
 | **TAPPaaS Module** | Self-hosted private-platform packaging via [TAPPaaS](https://tappaas.org/) — design in progress, see the [cloud deployment spec](docs/superpowers/specs/2026-05-09-cloud-deployment-design.md). |
+| **DPF Edge Node** | Host-resident component that sees the things the container can't — real LAN topology, host software, private-network MCP / A2A peers. Six-phase rollout sequenced in the [Edge Node roadmap](docs/superpowers/plans/2026-05-12-edge-node-roadmap.md); architectural rationale in the [Edge Node design spec](docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md). **Design partner wanted** — Apple Silicon and Windows verifiers will be needed once the binary lands. |
 
 ---
 

--- a/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md
+++ b/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md
@@ -85,10 +85,16 @@ else.
 Silicon and Linux test rigs).
 
 ### Epic B — Edge Node implementation
-**Status:** spec stub shipped; needs Research & Benchmarking,
-schema review, security review (heavy), and a slice plan before
-implementation.
+**Status:** spec stub shipped; roadmap shipped 2026-05-12; needs
+Research & Benchmarking, schema review, security review (heavy),
+and open-question resolution to close before any implementation
+PR lands.
 **Spec:** `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`
+**Roadmap:** `docs/superpowers/plans/2026-05-12-edge-node-roadmap.md`
+— six-phase sequencing (maturity gates → Phase 0 Authority Core
+foundation → Phase 1 binary pipeline + Linux Mode 1 → Phase 2
+macOS Mode 2 → Phase 3 macOS Mode 3 in-VM fallback → Phase 4
+Windows parity → Phase 5 status flip).
 **First slice:** `capability.discovery.network` only — Linux
 container with `network_mode: host`, plus the native helper binary
 (Mode B) for macOS / Windows hosts that need accurate host topology.

--- a/docs/superpowers/plans/2026-05-12-edge-node-roadmap.md
+++ b/docs/superpowers/plans/2026-05-12-edge-node-roadmap.md
@@ -1,0 +1,399 @@
+# DPF Edge Node — Implementation Roadmap
+
+> **Status: NOT STARTED — gated on spec finalization.**
+> The Edge Node is currently a research stub
+> ([docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md](../specs/2026-05-09-dpf-edge-node-design.md))
+> with unresolved open questions and unchecked maturity gates. No
+> Edge Node code (binary, API routes, Prisma models, token machinery)
+> exists on `main` yet. This roadmap sequences the work between
+> "research stub" and "shipped capability" so the slicing is visible
+> before any code lands.
+>
+> **Parent epic:** "Epic B — Edge Node implementation" in
+> [docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md](2026-05-09-deployment-architecture-and-rollout.md).
+>
+> **Sequencing constraint from the spec:** the Edge Node epic sits
+> *after* the macOS / Linux installer-parity roadmap ships its full
+> installer (Epic A, now in early access as of 2026-05-11). Until then
+> the network sweep keeps its current data path
+> (`windows_exporter` / `node-exporter` / container-local fallback).
+
+## What the Edge Node is (one-paragraph explanation for README / portal docs)
+
+The DPF Edge Node is a small, host-resident component that runs
+**outside** the Docker Desktop / container boundary so DPF can see
+the things the container can't: real network interfaces, the real
+LAN, host-installed software, host-level credentials and trust, and
+private-network MCP / A2A peers. It registers with a DPF Authority
+Core (the portal you already run), receives a machine-bound token
+(`dpfedge_*`), and reports observations back through a governed
+ingestion API. The same binary runs in three deployment modes
+depending on where it lives; the Authority Core is the only place
+that decides what each Edge Node is allowed to do.
+
+For the architectural rationale — capability envelope, identity
+boundary, token model, enrollment ceremony, quarantine /
+revocation, soft-fail policy — read the
+[Edge Node design spec](../specs/2026-05-09-dpf-edge-node-design.md).
+
+## Scope
+
+**In scope for this roadmap:**
+
+- The minimum schema, ingestion contract, and registration flow for
+  an Edge Node to enroll, heartbeat, rotate tokens, and submit
+  discovery observations to a DPF Authority Core.
+- Three deployment modes for the **first** capability slice
+  (`capability.discovery.network`):
+  - **Mode 1 — Linux container with `network_mode: host`** (the
+    default for native-Linux DPF installs).
+  - **Mode 2 — native binary on macOS / Windows**, run by the host's
+    own service manager (`launchd` on macOS, Windows Service on
+    Windows), because Docker Desktop's container networking does not
+    expose host topology truthfully on those platforms.
+  - **Mode 3 — in-VM container fallback** for Docker Desktop hosts
+    where a native binary cannot be installed. Capability set is
+    knowingly degraded.
+- Binary distribution: signed multi-platform release artifacts,
+  install scripts, self-update story.
+- Verification reports for each mode, on real hardware, per
+  [docs/install/verification-runbook.md](../../install/verification-runbook.md).
+
+**Out of scope (handled by later capability slices, *not* this
+roadmap):**
+
+- `capability.discovery.software` (installed-package inventory
+  beyond what the first network slice picks up incidentally).
+- `capability.metrics.host` (CPU / memory / disk / network
+  time-series — the Prometheus exporter retirement decision lives
+  in the macOS/Linux installer-parity plan, not here).
+- `capability.identity.broker`, `capability.mcp.gateway`,
+  `capability.a2a.gateway`, `capability.policy.enforcement`,
+  `capability.tunnel.private-link`.
+- A2A protocol gatewaying. The Edge Node architecture must accept
+  it without redesign, but A2A waits until the public protocol
+  contract stabilizes.
+- Retiring `windows_exporter` from the Windows installer. That
+  retirement is gated on the Windows native Edge Node landing — see
+  Phase 4 below — and the change itself happens in the Windows
+  installer's plan, not in this one.
+
+## Maturity gates (must close before Phase 0)
+
+These are inherited from the
+[spec's "Maturity gates before implementation" checklist](../specs/2026-05-09-dpf-edge-node-design.md)
+and *block* Phase 0 — no Edge Node code lands on `main` until each
+is checked off, with the security review weighted heaviest.
+
+- [ ] Research & Benchmarking section complete (per AGENTS.md §10):
+      Netbox-Agent, Nautobot, Steampipe, osquery, Falco, Wazuh,
+      Tailscale client, Cloudflare Tunnel; commercial comparators
+      Auvik, Lansweeper, ScienceLogic SL1, Tailscale, Cloudflare
+      Zero Trust, Twingate. Read data + trust models, not marketing.
+- [ ] Open questions in the spec resolved or explicitly deferred
+      (Linux default networking `host` vs `macvlan`; binary
+      distribution shape; update path; required Linux capabilities;
+      macOS entitlements; Windows service vs scheduled task).
+- [ ] Schema impact reviewed and migration drafted — `EdgeNode`,
+      `BootstrapToken`, `EdgeNodeCapability`,
+      `DiscoveryRun.edgeNodeId`; new
+      `persistSubmittedDiscoveryRun` sibling of
+      `persistBootstrapDiscoveryRun`.
+- [ ] Canonical contracts updated if this work changes shared
+      behavior (Contract 5 of the deployment doctrine references
+      this spec).
+- [ ] **Security review complete (heavy)** — token issuance and
+      rotation, bootstrap enrollment ceremony, quarantine /
+      revocation triggers, soft-fail policy windows, policy-cache
+      integrity, binary signing / attestation, Linux capability
+      surface, macOS entitlements, audit-trail consistency.
+- [ ] Release / rollback story defined — binary distribution,
+      self-update flow, downgrade path if a release is bad.
+- [ ] Test / verification gates defined — fresh install on
+      Windows / macOS / Linux; submission contract test against
+      `persistSubmittedDiscoveryRun`; air-gap behavior;
+      capability advertisement / Authority Core policy round-trip.
+
+## Phases
+
+Each phase below lands as a separate PR (or small PR set) per
+AGENTS.md §4 ("one concern per branch, one concern per PR").
+Phases are ordered by dependency — earlier phases unblock later
+ones. The roadmap is **strict** about Phase 0 → Phase 1 → Phase 2;
+Phases 3 and 4 can run in parallel once Phase 1 lands, and Phase 5
+is the closing gate that lets the README / portal docs flip the
+status from "design partner wanted" to "early access".
+
+### Phase 0 — Authority Core foundation (no Edge Node binary yet)
+
+**Goal:** make it possible for *something* to enroll, heartbeat,
+rotate tokens, and submit observations. No binary exists yet —
+this phase is exercised by tests and (optionally) a `curl`-based
+synthetic agent.
+
+**Deliverables:**
+
+1. Prisma models — `EdgeNode`, `BootstrapToken`,
+   `EdgeNodeCapability`; `DiscoveryRun.edgeNodeId` optional FK.
+   Migration committed and verified on a fresh install.
+2. `dpfedge_*` token namespace — hashed-at-rest, scope-bound,
+   machine-bound, rotating. Mirrors the `McpApiToken` pattern
+   (`packages/db/prisma/schema.prisma:2974`), with the differences
+   the spec calls out (machine ownership, shorter TTL, refresh via
+   heartbeat).
+3. Routes under `apps/web/app/api/v1/edge/`:
+   - `POST /api/v1/edge/enroll` — consumes a one-time bootstrap
+     token; issues a node token; records `enrollmentTokenId` on
+     the new `EdgeNode` row; auto-approves only when the bootstrap
+     token was issued by the local installer for the same host
+     (per the spec's approval policy).
+   - `POST /api/v1/edge/heartbeat` — keepalive + token rotation;
+     returns the rotated node token in the response.
+   - `POST /api/v1/edge/discovery-runs` — ingestion. Calls a new
+     `persistSubmittedDiscoveryRun` sibling of the existing
+     `persistBootstrapDiscoveryRun`; **does not** rerun
+     collectors server-side.
+4. Admin > Platform Development surface — list nodes, see
+   trust state, issue bootstrap tokens, approve / quarantine /
+   revoke.
+5. Contract tests for every route. Air-gap soft-fail test for the
+   ingestion path (queue locally, flush on reconnect).
+
+**Depends on:** all maturity gates above; no other epic.
+**Exit criteria:** a `curl` script can complete the full
+enrollment → heartbeat → submit → quarantine → revoke lifecycle
+end-to-end against a fresh install.
+**Risk:** schema migration risk on an existing install. The seed
+must populate the new models cleanly per the "DB fix = seed +
+migration" rule
+([CLAUDE.md memory](../../../CLAUDE.md)).
+
+### Phase 1 — Native binary build pipeline + Mode 1 (Linux container)
+
+**Goal:** produce the Edge Node binary as a real release artifact
+and ship Mode 1 (Linux container, `network_mode: host`) as the
+first deployment shape. This is the smallest mode to verify
+because the runner already has the right network visibility.
+
+**Deliverables:**
+
+1. Binary source under `apps/edge-node/` (language choice — Go or
+   Rust — locked during the spec's open-question resolution; the
+   spec lists both as acceptable, with bias toward Go for static
+   linking simplicity and ~5 MB target size).
+2. Build pipeline producing signed, multi-platform release
+   artifacts:
+   - `linux/amd64`, `linux/arm64`
+   - `darwin/arm64` (no Intel Mac per scope)
+   - `windows/amd64`
+   Published as a GitHub Release plus checksums + signatures.
+   New `.github/workflows/edge-node-release.yml` workflow; reuses
+   the multi-arch primitives from
+   [`.github/workflows/publish-image.yml`](../../../.github/workflows/publish-image.yml)
+   where it can.
+3. Mode 1 container image variant — minimal Linux container, runs
+   the binary, expects `network_mode: host`, documents minimum
+   required Linux capabilities (the spec calls out `CAP_NET_RAW`
+   and `CAP_NET_ADMIN` as the candidates; least privilege is
+   non-negotiable).
+4. `capability.discovery.network` collector ported into the
+   binary. The existing
+   [`packages/db/src/discovery-collectors/network.ts`](../../../packages/db/src/discovery-collectors/network.ts)
+   stays in place server-side as a fallback for Edge-Node-absent
+   installs; it is *not* retired in this phase.
+5. Verification report against a real Linux host (template at
+   [docs/install/verification-runbook.md](../../install/verification-runbook.md)).
+
+**Depends on:** Phase 0.
+**Exit criteria:** an Edge Node container on a Linux host enrolls
+against a fresh DPF install, completes a discovery sweep that
+agrees with the current `network.ts` collector output ±confidence,
+and survives a docker daemon restart.
+
+### Phase 2 — Mode 2 (native macOS binary + launchd)
+
+**Goal:** ship the macOS deployment mode that the
+[Edge Node spec's "Deployment modes" table](../specs/2026-05-09-dpf-edge-node-design.md)
+calls out specifically: a native LaunchAgent because Docker
+Desktop on macOS does *not* expose host topology truthfully (its
+"host networking" is L4-only — port reachability, not real NIC /
+ARP / LLDP visibility).
+
+**Deliverables:**
+
+1. `darwin/arm64` install script (`install-edge-node.sh` on
+   macOS), distributed with the release. Idempotent. Places the
+   binary in a standard path (`/usr/local/libexec/dpf-edge-node/`
+   per macOS conventions, exact path locked during Phase 1).
+2. `launchd` plist for boot-time + login-time start, with
+   relaunch-on-crash. Lives in `~/Library/LaunchAgents/` (per-user)
+   or `/Library/LaunchDaemons/` (system-wide) — the spec's
+   open question on which is the default needs to be resolved
+   before this phase starts; system-wide is the default working
+   assumption.
+3. macOS code signing + notarization for the binary. Entitlement
+   set minimized per the spec's gate; the exact entitlement list
+   is part of the spec's open-question resolution (network
+   discovery may need
+   `com.apple.developer.networking.multicast` or similar).
+4. Discovery extensions specific to macOS — `pkgutil` receipts,
+   Homebrew package inventory, `docker.raw.sock` detection,
+   `vmnet`-visible interfaces. These extensions are advertised as
+   capability evidence rows so the Authority Core can see what
+   the node actually collected.
+5. Verification report against a real Apple Silicon Mac (M1 / M2
+   / M3 / M4) running macOS 14+. Must include a reboot survival
+   test (launchd starts the agent at boot and the node resumes
+   heartbeating without operator action).
+
+**Depends on:** Phase 1 (binary + pipeline).
+**Hard prerequisite:** physical Apple Silicon hardware available
+to whoever runs the verification — no useful surrogate exists.
+
+### Phase 3 — Mode 3 (in-VM container fallback for Docker Desktop)
+
+**Goal:** ship the degraded-capability fallback for hosts where
+the native binary cannot be installed (locked-down corporate Macs,
+or admins who explicitly choose the container path). Capability
+set is knowingly restricted — see the spec's "Hard constraint"
+paragraph on Docker Desktop's L4-only networking.
+
+**Deliverables:**
+
+1. Container image variant for Docker Desktop's VM. Same binary
+   inside, but a manifest that advertises a restricted capability
+   set to the Authority Core (no real host NIC enumeration, no
+   ARP, no LLDP).
+2. Discovery items that *do* still work from inside the VM —
+   `docker.raw.sock` presence, in-VM software inventory,
+   Docker-Desktop-VM network introspection — flagged with reduced
+   `confidence` per
+   [`DiscoveredItem.confidence`](../../../packages/db/prisma/schema.prisma).
+3. Authority Core UI surface (Admin > Platform Development) shows
+   the degraded capability set explicitly so the operator
+   understands what they're giving up by choosing Mode 3 over
+   Mode 2.
+4. Verification report against Docker Desktop for Mac (Apple
+   Silicon, macOS 14+), confirming the degraded set is what the
+   spec predicts and no capability claims escape the restricted
+   manifest.
+
+**Depends on:** Phase 1 (binary + pipeline). **Can run in
+parallel** with Phase 2 once Phase 1 ships.
+
+### Phase 4 — Windows native (parity slice)
+
+**Goal:** Windows installs get the same native path macOS gets
+in Phase 2, closing the parity gap. Until this phase ships,
+Windows installs continue to use `windows_exporter` for network
+sweep data per the installer-parity plan's "Network sweep data
+path" decision. This phase is what unblocks `windows_exporter`
+retirement; the retirement itself is a follow-up in the
+installer plan, not here.
+
+**Deliverables:**
+
+1. Windows Service registration script (PowerShell). Idempotent.
+   Service runs under a least-privilege account with the
+   minimum Windows privileges needed for the network discovery
+   surface — the exact set is part of the spec's open-question
+   resolution.
+2. Authenticode signing of the `windows/amd64` binary using the
+   same signing infrastructure the Windows installer uses today.
+3. Discovery extensions specific to Windows — WMI / CIM
+   network-adapter enumeration, ARP cache, installed-software
+   inventory via the registry.
+4. Verification report against a real Windows 11 host with the
+   reboot survival test.
+
+**Depends on:** Phase 1. **Can run in parallel** with Phase 2
+once Phase 1 ships.
+
+### Phase 5 — Status flip + public doc surface
+
+**Goal:** with verification reports in hand for at least Modes 1
+and 2, flip the Edge Node from "design partner wanted" to "early
+access" in the README and the portal documentation. This phase
+is the gate between "the code exists" and "we are inviting users
+to deploy it".
+
+**Deliverables:**
+
+1. Update [README.md](../../../README.md) Edge Node section to
+   "early access" and link to this roadmap + the verification
+   runbook.
+2. Add an Edge Node page to the portal documentation surface
+   (under Admin > Platform Development > Edge Nodes) that
+   explains the three modes, links the install scripts, and
+   surfaces the verification status for the current install's
+   platform.
+3. Update [docs/install/verification-runbook.md](../../install/verification-runbook.md)
+   to flip Edge Node entries from "design partner wanted" to
+   "early access" for the modes that have shipped + verified.
+4. Update the deployment doctrine
+   ([docs/superpowers/specs/2026-05-09-deployment-contracts.md](../specs/2026-05-09-deployment-contracts.md))
+   if Contract 5 needs amending based on what was learned in
+   implementation.
+5. A "what we learned" addendum at the foot of this roadmap
+   (revision history pattern from the macOS / Linux native
+   support plan).
+
+**Depends on:** Phase 1 + Phase 2 verified on real hardware. Phase
+3 and Phase 4 may flip independently once each lands its
+verification report.
+
+## Cross-cutting decisions (resolve during the maturity-gate phase)
+
+These were called out as open questions in the spec. Closing them
+is part of the maturity gates above; pinning them here so they
+don't get re-litigated mid-implementation.
+
+- **Language for the binary** — Go or Rust. Default working
+  assumption: Go (static linking, small binary, mature
+  cross-compilation, mature signing toolchains). Final lock
+  during gate resolution.
+- **Linux default networking** — `network_mode: host` (observer
+  only) or `macvlan` (LAN peer with LLDP/CDP receive). Default
+  working assumption: `network_mode: host` for the first slice;
+  `macvlan` is a follow-up capability slice when LLDP/CDP receive
+  becomes necessary.
+- **Binary distribution shape** — GitHub Release assets (default)
+  vs bundled inside the GHCR portal image. Default working
+  assumption: GitHub Release assets, because the installer is
+  the natural distribution channel and we already have signing
+  primitives for it.
+- **Update path** — pull-on-schedule (default), platform-push,
+  or signal-and-download-via-installer.
+- **macOS launchd scope** — `LaunchDaemon` (system-wide,
+  default) vs `LaunchAgent` (per-user).
+- **Windows service vs scheduled task** — service (always
+  running, default) vs scheduled task. Default is "service".
+
+## Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Spec open questions land late and ripple back through Phase 0 schema | High | Treat the maturity-gate phase as a hard prerequisite; do not start Phase 0 until every open question is resolved or explicitly deferred. |
+| Security review surfaces token-model or attestation gaps after Phase 0 ships | High | Weight the security review heaviest in the maturity gates; have it close *before* Phase 0, not concurrently with it. |
+| macOS notarization friction blocks Phase 2 | Medium | Spike notarization during Phase 1 (Linux mode is shipping, but the build pipeline exists), so Phase 2 only inherits a known-good pipeline. |
+| Edge Node binary drifts from the Authority Core schema | Medium | Schema versioning in the registration envelope; Authority Core rejects unknown agentVersion ranges with a clear error per "Evidence before diagnosis". |
+| In-VM Mode 3 advertises capabilities it cannot deliver | Medium-High | Capability rows include evidence; Authority Core validates evidence against the advertised capability before trusting any submission. The "Obfuscated, not anonymous" / silent-failure rules apply. |
+| Verification reports never arrive (no Apple Silicon hardware) | Medium | Flip to "design partner wanted" status in the README and explicitly solicit early-access verifiers; do not flip to "early access" without at least one real-hardware report per mode. |
+| Concurrent macOS / Windows phases produce overlapping PRs | Low | The "Check overlap before opening PR" rule applies; phases 2, 3, 4 land into distinct directories (`apps/edge-node/platform/{darwin,linux,windows}/`) so they don't conflict at file level. |
+
+## References
+
+- Spec: [docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md](../specs/2026-05-09-dpf-edge-node-design.md)
+- Parent epic context: [docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md](2026-05-09-deployment-architecture-and-rollout.md)
+- Companion plan (predecessor): [docs/superpowers/plans/2026-05-09-macos-linux-native-support.md](2026-05-09-macos-linux-native-support.md)
+- Enterprise auth principle (authority / edge split): [docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md](../specs/2026-04-22-enterprise-auth-directory-federation-design.md)
+- Cloud deployment spec (deployment-target neutrality the Edge Node inherits): [docs/superpowers/specs/2026-05-09-cloud-deployment-design.md](../specs/2026-05-09-cloud-deployment-design.md)
+- Deployment doctrine: [docs/superpowers/specs/2026-05-09-deployment-contracts.md](../specs/2026-05-09-deployment-contracts.md)
+- Existing MCP transport (template for governance + audit + tokenization): [apps/web/app/api/mcp/v1/route.ts](../../../apps/web/app/api/mcp/v1/route.ts)
+- Existing token model (template for `dpfedge_*`): [packages/db/prisma/schema.prisma:2974](../../../packages/db/prisma/schema.prisma)
+- Existing network sweep collector (predecessor for `capability.discovery.network`): [packages/db/src/discovery-collectors/network.ts](../../../packages/db/src/discovery-collectors/network.ts)
+- Verification runbook: [docs/install/verification-runbook.md](../../install/verification-runbook.md)
+
+## Revision history
+
+- 2026-05-12 — initial roadmap.

--- a/docs/superpowers/specs/2026-05-09-deployment-contracts.md
+++ b/docs/superpowers/specs/2026-05-09-deployment-contracts.md
@@ -581,6 +581,11 @@ target-specific == owning spec.**
   implement contracts 1, 2, 3, 7, 8.
 - `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md` —
   Edge Node, the canonical implementation of contract 5.
+  Implementation sequencing in
+  `docs/superpowers/plans/2026-05-12-edge-node-roadmap.md`
+  (six phases: maturity gates → Authority Core foundation → binary
+  pipeline + Linux Mode 1 → macOS Mode 2 → macOS Mode 3 in-VM →
+  Windows parity → status flip).
 - `docs/superpowers/specs/2026-05-09-cloud-deployment-design.md`
   — customer-cloud deployment shapes; wraps contracts 1-8 per
   cloud substrate.

--- a/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
@@ -735,6 +735,17 @@ Acceptance:
 - candidate can create a backlog item through governed MCP/backlog workflow,
 - no candidate is auto-implemented without human review.
 
+### Immediate candidate fit: Hive Scout
+
+Hive Scout is a strong near-term proving ground for this doctrine. Its deterministic core already exists as a scheduled external-catalog ingest, but its higher-order judgments remain human-heavy: novelty, archetype fit, value-stream alignment, and proposal quality. That makes it a good match for the ladder in §4:
+
+1. deterministic fetch/parse/dedupe stays procedural,
+2. ambiguous novelty and fit move to a bounded coworker run,
+3. repeated review corrections become filters/mappings/rules,
+4. the resulting run becomes visible in the Operations Map as proactive work rather than hidden cron behavior.
+
+Because Hive Scout is low-risk, asynchronous, and reviewable, it is also a good candidate for background execution when provider policy indicates lagging prepaid subscription quota. A dedicated design note for this application lives in `2026-05-11-hive-scout-autonomous-coworker-design.md`.
+
 ## 11. Metrics
 
 ### 11.1 Outcome metrics

--- a/docs/superpowers/specs/2026-05-11-hive-scout-autonomous-coworker-design.md
+++ b/docs/superpowers/specs/2026-05-11-hive-scout-autonomous-coworker-design.md
@@ -1,0 +1,314 @@
+# Hive Scout Autonomous Coworker and Proceduralization Design
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-11 |
+| Status | Draft for review |
+| Related repo areas | `apps/web/lib/actions/hive-scout/ingest-500-agents.ts`, `apps/web/lib/queue/functions/hive-scout-ingest.ts`, `apps/web/scripts/hive-scout-manual-run.ts`, `skills/platform/scout-external-catalogs.skill.md`, `prompts/specialist/hive-scout-archetype-gap.prompt.md`, `apps/web/lib/actions/agent-task-scheduler.ts`, `apps/web/lib/tak/scheduled-task-runs.ts`, `apps/web/lib/ai-operations-map/*` |
+| Related specs | `2026-05-11-autonomous-coworker-runtime-design.md`, `2026-04-27-routing-control-data-plane-design.md`, `2026-04-23-ai-provider-finance-bridge-design.md`, `2026-04-18-purpose-first-product-estate-design.md` |
+
+## 1. Purpose
+
+Hive Scout already gives DPF a real external-pattern scout: it reads an upstream catalog of open-source AI agent projects, detects likely archetype gaps, and files `BacklogItem` suggestions instead of importing code.
+
+That is useful, but the May 2026 coworker/runtime work raises the bar. Background cognition should not remain a hidden cron script when the platform now has:
+
+- governed `TaskRun` identity for autonomous coworker work,
+- AI Operations Map visibility for proactive runs,
+- scheduled coworker execution isolation,
+- a stated doctrine of moving repeatable cognitive load from humans to coworkers and then into procedural code,
+- use-it-or-lose-it subscription economics that justify proactive low-risk background work when prepaid capacity is underused.
+
+This design updates the architectural direction for Hive Scout:
+
+> Hive Scout should evolve from a catalog-ingest job into a governed autonomous coworker pattern that combines deterministic scouting code with bounded AI reasoning for ambiguous novelty, taxonomy fit, and archetype synthesis.
+
+## 2. Current State
+
+### 2.1 Repo-verified implementation
+
+The current implementation is real and useful:
+
+- [ingest-500-agents.ts](D:/DPF/apps/web/lib/actions/hive-scout/ingest-500-agents.ts:1) fetches and parses the MIT-licensed `500-AI-Agents-Projects` README, maps industries to IT4IT value streams, detects likely gaps, and creates deduplicated `BacklogItem` rows.
+- [hive-scout-ingest.ts](D:/DPF/apps/web/lib/queue/functions/hive-scout-ingest.ts:1) runs the ingest weekly through Inngest.
+- [index.ts](D:/DPF/apps/web/lib/queue/functions/index.ts:1) registers the function in the queue runtime.
+- [scout-external-catalogs.skill.md](D:/DPF/skills/platform/scout-external-catalogs.skill.md:1) describes the operator-facing intent.
+- [hive-scout-archetype-gap.prompt.md](D:/DPF/prompts/specialist/hive-scout-archetype-gap.prompt.md:1) provides the backlog-item body template.
+- [hive-scout-manual-run.ts](D:/DPF/apps/web/scripts/hive-scout-manual-run.ts:1) supports local replays and idempotence checks.
+
+### 2.2 What it does not yet do
+
+Hive Scout is not yet aligned with the autonomous coworker runtime direction:
+
+- it is not represented as a first-class coworker `TaskRun`,
+- it does not project into the AI Operations Map as meaningful autonomous work,
+- it does not use AI reasoning for ambiguous gap detection,
+- it does not generate capability-needs or proceduralization candidates,
+- it does not yet participate in provider burn-rate-aware background work scheduling,
+- it does not yet create a governed review loop richer than filing backlog suggestions.
+
+### 2.3 Live-state note
+
+An attempted live Postgres check in this shell returned `ECONNREFUSED`, so this design does **not** claim a verified runtime count of Hive Scout runs, backlog items, or active queue state on 2026-05-11. The current-state statements above are repo-verified, not live-runtime counts.
+
+## 3. Why the Recent Work Applies
+
+### 3.1 Autonomous coworker runtime
+
+[2026-05-11-autonomous-coworker-runtime-design.md](D:/DPF/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md:1) establishes the platform doctrine:
+
+> Move repeatable cognitive load from humans to AI coworkers, then move stabilized coworker behavior into procedural code.
+
+Hive Scout is almost a textbook fit:
+
+- humans should not manually browse external agent catalogs and remember what DPF already covers,
+- coworkers can compare, summarize, and propose,
+- repeated patterns in those proposals should become deterministic filters, mappings, and rules.
+
+### 3.2 Scheduled coworker TaskRun substrate
+
+The newest scheduled-coworker work links proactive runs into `TaskRun` through [agent-task-scheduler.ts](D:/DPF/apps/web/lib/actions/agent-task-scheduler.ts:1) and [scheduled-task-runs.ts](D:/DPF/apps/web/lib/tak/scheduled-task-runs.ts:1).
+
+That makes Hive Scout a strong next consumer:
+
+- it is already periodic,
+- it is low-risk,
+- it produces operator-reviewable output,
+- it benefits from durable attribution and evidence.
+
+### 3.3 AI Operations Map visibility
+
+The AI Operations Map already projects proactive `TaskRun`, `ToolExecution`, receipt, backlog-evidence, and external-evidence records in [load-map-data.ts](D:/DPF/apps/web/lib/ai-operations-map/load-map-data.ts:1).
+
+Hive Scout should appear there as real AI workforce activity instead of being hidden inside a weekly queue function.
+
+### 3.4 Use-it-or-lose-it economics
+
+[2026-04-23-ai-provider-finance-bridge-design.md](D:/DPF/docs/superpowers/specs/2026-04-23-ai-provider-finance-bridge-design.md:32) and [2026-04-27-routing-control-data-plane-design.md](D:/DPF/docs/superpowers/specs/2026-04-27-routing-control-data-plane-design.md:448) already define use-it-or-lose-it handling for subscription providers.
+
+When prepaid AI capacity is lagging its quota window, background work like Hive Scout becomes economically rational:
+
+- bounded,
+- asynchronous,
+- reviewable,
+- and capable of generating durable platform value.
+
+This does **not** mean “burn credits for the sake of it.” It means Hive Scout is a valid candidate for low-priority background cognition when:
+
+- the run is safe,
+- the provider is lagging its committed usage window,
+- the work can be interrupted or deferred without operational harm.
+
+## 4. Target Architecture
+
+## 4.1 Deterministic core stays procedural
+
+The following parts should remain deterministic code:
+
+- upstream fetch and retry policy,
+- parser logic,
+- source URL deduplication,
+- idempotent backlog item creation,
+- stable value-stream alias mapping,
+- admin notification,
+- policy limits on which sources are allowed.
+
+These are already code-shaped concerns and should not be pushed into prompts.
+
+## 4.2 Ambiguous reasoning moves to the coworker
+
+The following parts are better treated as autonomous coworker cognition:
+
+- whether an external pattern is actually novel for DPF,
+- whether it is a new coworker archetype versus a new skill on an existing coworker,
+- how strongly it fits a given IT4IT/value-stream placement,
+- whether multiple external projects should collapse into one synthesized internal archetype,
+- whether the discovered idea is strategically relevant now versus informational only.
+
+These are the high-context, fuzzy, judgment-heavy parts where a coworker can reduce human cognitive load.
+
+## 4.3 Hybrid pattern
+
+Hive Scout v2 should therefore follow a hybrid model:
+
+1. Deterministic scout code fetches and normalizes raw catalog entries.
+2. A governed autonomous coworker run evaluates ambiguous items in batches.
+3. The coworker emits structured judgments, not prose-only output.
+4. Stable judgments are promoted into rules, mappings, filters, or typed schema.
+5. Human reviewers only see compact proposals and exceptions.
+
+This is the same ladder established by the autonomous runtime doctrine, applied to external-catalog scouting.
+
+## 5. Runtime Shape
+
+### 5.1 Trigger and identity
+
+Hive Scout should run as a proactive coworker task with `TaskRun` identity, not just as a free-floating queue function.
+
+Recommended shape:
+
+- trigger: `scheduled`
+- source: `proactive`
+- route context: `/platform/ai/operations` for runtime visibility, with deep links into backlog and skills
+- source reference: `external-catalog-scout`
+- evidence source tags: `hive-scout`, upstream catalog name, framework, value-stream confidence
+
+### 5.2 Coworker ownership
+
+Do not create a vague new “general scout” agent.
+
+Recommended ownership:
+
+- primary specialist: a platform/portfolio-facing coworker with backlog authority and strong archetype/skill context
+- candidate owners: `portfolio-advisor` or a dedicated `external-catalog-scout` specialist
+
+The coworker should have:
+
+- bounded tool grants,
+- read-only external scouting,
+- backlog proposal capability,
+- no direct auto-create authority for new coworkers or skills.
+
+### 5.3 Evidence and review
+
+Each meaningful Hive Scout run should produce:
+
+- `TaskRun` identity,
+- `ToolExecution` audit for the scout steps,
+- `BacklogItemActivity` or equivalent evidence linkage for created suggestions,
+- structured summary artifacts suitable for the AI Operations Map,
+- repeatable pattern markers for future proceduralization.
+
+## 6. Use-It-or-Lose-It Scheduling Policy
+
+Hive Scout is a good consumer of underused prepaid AI capacity, but only under policy.
+
+### 6.1 Safe use cases
+
+Burn-rate-aware preference is appropriate when:
+
+- the task is background-only,
+- the output is reviewable before irreversible action,
+- no sensitive external data is involved,
+- the run can be rate-limited, paused, or deferred.
+
+Hive Scout meets those conditions.
+
+### 6.2 Not a forced-consumption engine
+
+Do **not** let use-it-or-lose-it logic turn Hive Scout into busywork.
+
+Guardrails:
+
+- only run when there is new or stale source material worth evaluating,
+- cap spend per run and per quota window,
+- batch similar entries,
+- prefer cheapest capable model first,
+- stop when marginal novelty falls below a threshold,
+- log why a run happened: cadence, stale source, new source, lagging burn-rate assist, or explicit human trigger.
+
+### 6.3 Policy recommendation
+
+Hive Scout should be eligible for a background “subscription utilization assist” queue class:
+
+- lower priority than operational recovery,
+- higher priority than cosmetic research,
+- auto-paused when provider burn rate is already ahead,
+- safe to resume when quota lag is detected.
+
+## 7. Implementation Slices
+
+### Slice 1: TaskRun-ize Hive Scout
+
+Goal: make Hive Scout a first-class proactive coworker run.
+
+Scope:
+
+- route Hive Scout through the scheduled coworker substrate,
+- create `TaskRun` for each run,
+- write structured run summaries,
+- project runs into the AI Operations Map,
+- preserve the existing deterministic ingest logic.
+
+Acceptance:
+
+- each Hive Scout run has one `TaskRun`,
+- run appears in AI Operations Map,
+- backlog suggestions link back to source run evidence.
+
+### Slice 2: Add autonomous ambiguity review
+
+Goal: keep procedural code for parsing/dedupe, but let the coworker judge novelty and fit for ambiguous entries.
+
+Scope:
+
+- batch unresolved entries,
+- invoke coworker reasoning with structured output,
+- classify results as `new_archetype`, `existing_skill_gap`, `duplicate_pattern`, `out_of_scope`, or `needs_human_review`,
+- persist rationale/evidence,
+- keep human review on the final proposal layer.
+
+Acceptance:
+
+- deterministic path still handles obvious duplicates,
+- coworker only receives ambiguous entries,
+- proposals are structured and reviewable.
+
+### Slice 3: Add proceduralization loop
+
+Goal: stop re-solving the same archetype decisions forever.
+
+Scope:
+
+- detect repeated reviewer corrections and repeated coworker conclusions,
+- promote stable mappings and filters into code/policy,
+- record capability needs when the coworker repeatedly lacks the right tool/model/context,
+- surface Hive Scout as a proceduralization candidate source in AI Operations.
+
+Acceptance:
+
+- repeated false positives decline,
+- repeated out-of-scope classes become deterministic filters,
+- repeated “same existing coworker” outcomes become rules.
+
+### Slice 4: Add burn-rate-aware background scheduling
+
+Goal: use lagging prepaid quota intelligently.
+
+Scope:
+
+- add Hive Scout to the safe background queue class,
+- let routing/provider policy prefer lagging subscription providers for this task class,
+- record run trigger reasons and consumption outcomes,
+- cap budget and concurrency.
+
+Acceptance:
+
+- Hive Scout can be triggered by quota-lag conditions,
+- it remains bounded and reviewable,
+- it never crowds out higher-priority operational work.
+
+## 8. Recommended Next Move
+
+The next move should **not** be “make Hive Scout smarter everywhere at once.”
+
+The right next step is **Slice 1: TaskRun-ize Hive Scout**.
+
+Why:
+
+- the autonomous runtime substrate is now the platform direction,
+- the scheduled coworker/TaskRun seam already exists,
+- this gives immediate operator visibility and governance,
+- it creates the evidence foundation needed before any deeper AI reasoning is added.
+
+Only after that should DPF add autonomous novelty judgment and use-it-or-lose-it scheduling.
+
+## 9. Recommendation
+
+Adopt Hive Scout as one of the first non-build, non-recovery proof points of the new autonomous coworker runtime.
+
+That makes it useful in three ways at once:
+
+- it reduces human research/orchestration burden,
+- it produces governed evidence in the runtime control surface,
+- it creates a clean case for the platform’s “AI first, then procedure” doctrine.


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/plans/2026-05-12-edge-node-roadmap.md`, a six-phase implementation roadmap for the DPF Edge Node (Epic B in the deployment architecture rollout).
- Cross-links the roadmap from the README "What's coming" table (status: *design partner wanted*), the umbrella deployment-architecture plan (Epic B section), and the deployment doctrine (Contract 5 source list).
- No code, no schema, no behavior change.

## Why this PR exists

The Edge Node spec ([2026-05-09-dpf-edge-node-design.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md)) is a research stub with unresolved open questions, unchecked maturity gates, and no implementation on `main`. Before any code lands, the slicing needs to be visible. This roadmap sequences:

- **Maturity gates** (block all phases): research & benchmarking per AGENTS.md §10, open-question resolution, schema review, **heavy security review**, release / rollback story, verification gates.
- **Phase 0** — Authority Core foundation (Prisma models, `dpfedge_*` tokens, `/api/v1/edge/*` routes, admin UI, `persistSubmittedDiscoveryRun`).
- **Phase 1** — Native binary build pipeline + Linux Mode 1 (`network_mode: host`).
- **Phase 2** — macOS Mode 2 (native binary + launchd; **requires real Apple Silicon hardware to verify**).
- **Phase 3** — macOS Mode 3 (in-VM container fallback; can run parallel to Phase 2 after Phase 1).
- **Phase 4** — Windows native parity (unblocks `windows_exporter` retirement).
- **Phase 5** — Status flip + public doc surface (README + portal Edge Nodes admin page).

The roadmap honors the spec's stated sequencing constraint: this epic sits *after* the macOS / Linux installer-parity roadmap, which shipped early-access on 2026-05-11.

## Public doc surface

The roadmap opens with a one-paragraph plain-language explainer suitable for README and portal-doc exposure (what an Edge Node *is*, why it exists, how the three deployment modes relate). The README row added in this PR points readers to it for the architectural rationale (spec) plus the implementation sequencing (this roadmap).

## Test plan

- [x] Markdown links sanity-checked against repo paths.
- [x] Roadmap places Edge Node *after* installer-parity per the spec's "Sequencing" section.
- [x] Status framing matches "early access" / "design partner wanted" conventions established by PRs #470, #481, #483.
- [x] No code or schema changes — typecheck N/A.
- [ ] Reviewer agreement on phase ordering (Phase 0 strictly before Phase 1; Phase 3 + 4 may run parallel to Phase 2 after Phase 1).

## Related

- Spec: [docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md)
- Umbrella plan: [docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md)
- Predecessor (now early access): [docs/superpowers/plans/2026-05-09-macos-linux-native-support.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-09-macos-linux-native-support.md)
- Backlog item: `BI-4C4D9F05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)