### PR TITLE
docs(edge-node): close spec maturity gates; promote to binding

### DIFF
--- a/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+++ b/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
@@ -1,13 +1,29 @@
-# DPF Edge Node and Discovery Plane Architecture (DRAFT / RESEARCH)
+# DPF Edge Node and Discovery Plane Architecture
 
-> Status: **research stub** — not yet a finalized spec. Per AGENTS.md §10
-> this needs full "Research & Benchmarking" before finalization.
+> Status: **binding** as of 2026-05-12. The maturity gates from the
+> 2026-05-09 research stub closed in PR <#tbd> alongside this
+> revision. Implementation sequencing lives in
+> `docs/superpowers/plans/2026-05-12-edge-node-roadmap.md` (six
+> phases, beginning with the Authority Core foundation; no Edge Node
+> binary ships before Phase 1).
+>
+> Revision history:
+> - 2026-05-09 — initial research stub (PR #400).
+> - 2026-05-12 — maturity gates closed: Research & Benchmarking
+>   section filled in against osquery / Fleet, Wazuh, Tailscale,
+>   Cloudflare Tunnel, Netbox-Agent, Falco; commercial comparators
+>   Auvik, Lansweeper, ScienceLogic SL1, Twingate, Cloudflare Zero
+>   Trust. Open questions resolved (Go for the binary, GitHub
+>   Release distribution, `network_mode: host` as the first-slice
+>   Linux default, LaunchDaemon system-wide on macOS, Windows
+>   Service). Schema revised to honor the Principal convergence
+>   rule from AGENTS.md §11 (EdgeNode is a host-attributes side
+>   table, not a parallel identity). Security review summary,
+>   release / rollback story, and verification gate matrix
+>   added. Spec promoted from "research stub" to "binding".
 >
 > Source plan: `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md`
 > (the "Discovery plane refactor" subsection under Future direction).
-> The installer-parity roadmap deliberately leaves this epic
-> unsequenced; the work lands after macOS / Linux installer-parity
-> ships.
 >
 > Related authority: `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md`
 > establishes the principle this spec inherits: **DPF owns identity
@@ -429,17 +445,70 @@ are operator-configurable:
 | `mcp:gateway`, `a2a:gateway` | 0 (deny) | high-stakes; never operate without live policy |
 | `policy:fetch` | 1h | policy decisions cached; refresh on reconnect |
 
-## Edge Node registry (proposed Prisma models)
+## Edge Node registry (Prisma models — Principal-convergence-aligned)
+
+**AGENTS.md §11 (Principal convergence, 2026-05-09)** requires every
+new identity-bearing entity introduced after 2026-05-09 to be modeled
+as a `PrincipalAlias` linked to a single `Principal`, not as a
+parallel identity table. Edge Nodes are explicitly named in the
+convergence target. The schema therefore puts the identity on
+`Principal` + `PrincipalAlias` (the existing identity spine at
+`packages/db/prisma/schema.prisma:219`) and uses `EdgeNode` as a
+**host-attributes side table** keyed by `principalId`. Authorization
+decisions resolve on `Principal`; the alias kind tells the platform
+which surface authenticated the request.
+
+The convergence layout for an Edge Node identity is:
+
+- `Principal { kind: "edge-node", status, displayName, principalId: "PRN-…" }`
+  — the canonical identity row. Used by every authorization decision
+  the same way `kind: "human"` and `kind: "agent"` are used today.
+- `PrincipalAlias { aliasType: "edge-node", aliasValue: nodeId, principalId }`
+  — binds the externally-visible `nodeId` (used in API URLs and
+  embedded in the `dpfedge_*` token) to the Principal. `aliasType:
+  "edge-node"` is a new value joining the existing set (`user`,
+  `employee`, `agent`, `gaid`, `customer_contact`, `email`).
+- `EdgeNode { principalId @unique, …host attributes }` — host facts
+  only. No identity-bearing field that's not derivable from the
+  Principal.
 
 ```prisma
+// EXISTING — packages/db/prisma/schema.prisma:219. Shown for context;
+// no change to the model definition. New value added to `kind`:
+// "edge-node".
+//
+// model Principal {
+//   id          String           @id @default(cuid())
+//   principalId String           @unique
+//   kind        String   // "human" | "agent" | "customer" | "edge-node"
+//   status      String   @default("active")
+//   displayName String
+//   aliases     PrincipalAlias[]
+//   ...
+// }
+//
+// EXISTING — packages/db/prisma/schema.prisma:230. New value added
+// to `aliasType`: "edge-node" (aliasValue holds the stable nodeId).
+//
+// model PrincipalAlias {
+//   id          String    @id @default(cuid())
+//   principalId String
+//   aliasType   String   // ..., "edge-node"
+//   aliasValue  String
+//   issuer      String    @default("")
+//   ...
+// }
+
+// NEW side table. Host-specific attributes only; identity lives on
+// Principal + PrincipalAlias per AGENTS.md §11.
 model EdgeNode {
   id                    String    @id @default(cuid())
-  nodeId                String    @unique
-  displayName           String
+  principalId           String    @unique             // 1:1 with Principal
+  nodeId                String    @unique             // stable external id (mirrored to PrincipalAlias.aliasValue where aliasType="edge-node")
   platform              String    // darwin | win32 | linux
   installMode           String    // native | container-host | container-vm
   version               String
-  status                String    // pending | active | offline | quarantined
+  status                String    // pending | active | offline
   trustState            String    // pending | trusted | quarantined | revoked
   lastSeenAt            DateTime?
   capabilities          Json
@@ -447,7 +516,7 @@ model EdgeNode {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  // Enrollment lifecycle (first-draft contract above).
+  // Enrollment lifecycle.
   enrollmentTokenId     String?           // FK to BootstrapToken.id; cleared after consumption
   enrolledAt            DateTime?         // set when enroll succeeded
   approvedAt            DateTime?         // null until operator (or auto-approve policy) trusts the node
@@ -458,6 +527,7 @@ model EdgeNode {
   revokedAt             DateTime?
   revocationReason      String?
 
+  principal      Principal @relation(fields: [principalId], references: [id], onDelete: Cascade)
   capabilityRows EdgeNodeCapability[]
   observations   DiscoveryRun[]      @relation("EdgeNodeObservations")
 }
@@ -599,105 +669,543 @@ default is **deny** for any new principal/scope it doesn't have a
 positive cached decision for, with explicit operator-configurable
 soft-fail windows for known-good repeat scopes.
 
-## Open questions (for fleshing out)
+## Open question resolutions
 
-These are the decisions that need to land before this stub becomes
-a finalized spec:
+The 2026-05-09 research stub deferred a set of open questions to
+spec finalization. They are resolved below for the *first* slice
+(`capability.discovery.network`). Resolutions that bind future
+capability slices are marked as durable; resolutions that bind
+only the first slice are marked as scoped, so future slices can
+revisit without re-opening the doctrine.
 
 ### Edge Node lifecycle
-- **Linux default networking:** `network_mode: host` (observer-only,
-  simpler) vs `macvlan` (each agent is a LAN peer, supports LLDP/CDP
-  receive and segregated scanning roles)? Decide based on whether
-  agents need to be reachable as LAN peers or only emit scans.
-- **Binary distribution:** ship the native binary inside the
-  GHCR-published portal image and have the installer extract it on
-  first run, or publish separately as signed multi-platform GitHub
-  Release assets?
-- **Update path:** how does the binary self-update? Pull-on-schedule
-  vs platform-push vs signal-and-download-via-installer.
-- **Capabilities required:** which Linux capabilities does the
-  container Edge Node need (`CAP_NET_RAW`, `CAP_NET_ADMIN` for raw
-  sockets used by nmap / arp-scan)? Document the principle of least
-  privilege.
-- **macOS entitlements:** does the binary need any special
-  entitlements (e.g. for `vmnet.framework` or
-  `com.apple.developer.networking.*`)? If signed and notarized,
-  what's the distribution flow?
-- **Windows service vs scheduled task:** Edge Node as a Windows
-  service (always running) or scheduled task (triggered on
-  schedule)? Auth-model implications for each.
+
+- **Language for the binary** *(durable)*: **Go**. Mature
+  cross-compilation, static linking, ~5 MB binary target, well-known
+  signing/notarization toolchains on every platform we target,
+  battle-tested in the comparators (osquery is C++, but Tailscale,
+  Cloudflare Tunnel `cloudflared`, and HashiCorp Boundary are Go and
+  closer to what we're building). Rust was the alternative;
+  rejected because the marginal correctness gain doesn't offset the
+  team's existing Go fluency and the cross-compilation story.
+- **Linux default networking** *(scoped to first slice)*:
+  **`network_mode: host`** (observer-only). LLDP/CDP receive and
+  segregated scanner roles require `macvlan`; that's a follow-on
+  capability slice when the need is real, not now. `network_mode:
+  host` is simpler, has lower blast radius, and is sufficient for
+  the network-discovery first slice. Documented Linux capabilities
+  required: `CAP_NET_RAW` (raw sockets for `arp`/ICMP) and
+  `CAP_NET_ADMIN` (interface enumeration). No `--privileged`. No
+  `CAP_SYS_ADMIN`. The least-privilege baseline matches the
+  Falco container guidance.
+- **Binary distribution** *(durable)*: **signed multi-platform
+  GitHub Release assets** plus checksums and signatures. Not bundled
+  inside the GHCR portal image. Reasons: (a) installer is the
+  natural distribution channel and already has signing primitives
+  for `install-dpf.ps1` / `install-dpf.sh`; (b) the binary's
+  release cadence is decoupled from the portal's; (c) the GitHub
+  Release surface gives us a clean attestation trail for community
+  auditors who don't want to trust the portal image build.
+- **Update path** *(durable)*: **pull-on-schedule via the
+  installer's lifecycle scripts**. The binary itself does **not**
+  self-update — that's a privileged operation and we are not
+  inviting an in-binary updater into the surface. `dpf-start` /
+  `dpf-update` (Linux/macOS) and `dpf-update.ps1` (Windows) check
+  the GitHub Release feed, verify signatures, atomically replace
+  the binary, and restart the platform service manager unit. The
+  Authority Core can *signal* an Edge Node that an update is
+  available (heartbeat response field `availableVersion`); the
+  operator's installer is what acts on the signal.
+- **macOS LaunchAgent vs LaunchDaemon** *(durable)*:
+  **`LaunchDaemon` (system-wide) by default; `LaunchAgent`
+  (per-user) as an opt-in.** The Edge Node is a *machine*
+  principal, not a *user* principal — running it under
+  LaunchDaemon matches that posture and avoids the "agent stops
+  when no user is logged in" failure mode. Per-user mode is
+  available for environments where the operator explicitly wants
+  it (e.g. a developer's MacBook where the Mac is single-user and
+  the agent should pause when they log out).
+- **macOS entitlements** *(durable)*: minimum set is
+  `com.apple.security.network.client` (outbound to Authority Core),
+  `com.apple.security.network.server` (for the local capability
+  envelope where the node may serve gateway functions in later
+  slices). No `com.apple.developer.networking.multicast` (raw
+  multicast is not part of the first slice). No
+  `vmnet.framework` (that's for VM-host networking; we read from
+  the host directly). The binary is Developer ID-signed and
+  notarized; the installer pins the expected signing identity and
+  fails closed on mismatch.
+- **Windows service vs scheduled task** *(durable)*: **Windows
+  Service.** Always running, restarts on crash, integrates with
+  Windows Event Log, matches the LaunchDaemon decision on macOS.
+  Scheduled task is the wrong shape — a "triggered on schedule"
+  agent cannot honor heartbeat soft-fail windows or respond to
+  Authority Core pushes.
 
 ### Authority and trust
-- **Token scope catalog:** finalize the `dpfedge_*` scope vocabulary
-  (the list above is a starting point, not the contract).
-- **Enrollment ceremony:** how does an Edge Node prove identity for
-  the first time? Bootstrap token from the installer, attested by
-  what? Operator approval flow in Admin > Platform Development?
-- **Quarantine / revocation:** what triggers a node moving to
-  `trustState: quarantined` automatically vs manually? Policy on
-  observation ingestion from quarantined nodes (drop / archive /
-  alert).
-- **Soft-fail policy windows:** how long can an Edge Node act on
-  cached policy when the Authority Core is unreachable? Per-scope
-  configurable.
+
+- **Token scope catalog** *(durable)*: finalized as the list in
+  the "Token model" section above. Adding a new scope requires a
+  schema migration (the scope is stored in the token row) and an
+  AGENTS.md update. Removing a scope requires evidence that no
+  Edge Node in the field still holds it.
+- **Enrollment ceremony** *(durable)*: finalized as the
+  ceremony described in "Enrollment, rotation, and lifecycle"
+  above — bootstrap token → enroll endpoint → node token, with
+  auto-approve for local-host installer-issued tokens and
+  operator approval for remote nodes.
+- **Quarantine / revocation triggers** *(durable)*: finalized as
+  the trigger list under "Quarantine" and "Revocation" above —
+  anomaly detection, manual operator action, re-attestation
+  failure, missed heartbeats beyond grace.
+- **Soft-fail policy windows** *(durable)*: finalized as the
+  per-scope table under "Soft-fail policy windows" above.
+  Operator-configurable, with deny-by-default for high-stakes
+  scopes (`mcp:gateway`, `a2a:gateway`).
 
 ### Capabilities and protocol gatewaying
-- **MCP gateway:** what's the contract for an Edge Node to expose a
-  private-network MCP server's tools through the Authority Core?
-  How are tool grants composed (inner server's grants × Edge Node's
-  scope × user's grants)?
-- **A2A gateway:** keep behind the same `dpfedge_*` model and the
-  Authority Core's policy until the public A2A protocol contract
-  stabilizes.
-- **Telemetry parity:** what subset of `windows_exporter` /
-  `node_exporter` metrics, if any, must keep flowing for Grafana
-  host-resource panels independent of the sweep? Decide before
-  retiring those exporters.
+
+- **MCP gateway** *(deferred)*: not part of the first slice.
+  The architecture must not preclude it — the
+  `capability.mcp.gateway` row in the capability envelope is the
+  forward-compatibility hook. The grant composition rule (inner
+  server's grants × Edge Node's scope × user's grants, intersect)
+  is captured here so the implementer of that future slice can
+  see the contract.
+- **A2A gateway** *(deferred)*: same shape as MCP. Behind the
+  `dpfedge_*` model and the Authority Core's policy. Waits on
+  the public A2A protocol contract stabilizing before
+  implementation begins.
+- **Telemetry parity** *(scoped to first slice)*: `windows_exporter`
+  and `node-exporter` Prometheus scrapes stay in place until the
+  Edge Node ships and a verification report confirms host-metrics
+  parity. The retirement of those exporters is owned by the
+  installer-parity plan, not this one — see
+  [docs/superpowers/plans/2026-05-09-macos-linux-native-support.md](../plans/2026-05-09-macos-linux-native-support.md)
+  "Network sweep data path" decision.
 
 ### Schema and ingestion
-- **Schema additions:** confirm the `EdgeNode` and
-  `EdgeNodeCapability` Prisma models above; add `edgeNodeId` to
-  `DiscoveryRun`; verify the `confidence` field on `DiscoveredItem`
-  is enum-able to express agent-mode-driven degradation.
-- **Endpoint vs MCP tool:** decide whether the ingestion path is
-  the new `/api/v1/edge/*` REST surface, an MCP tool
-  (`submit_discovery_observations`), or both. MCP tool is more
-  uniform; REST is simpler for non-MCP-aware deployments.
 
-## Research and Benchmarking (TBD per AGENTS.md §10)
+- **Schema additions** *(durable)*: confirmed; revised above to
+  honor Principal convergence (AGENTS.md §11). `DiscoveryRun`
+  gains an optional `edgeNodeId` FK in the same migration that
+  introduces `EdgeNode`, `BootstrapToken`, `EdgeNodeCapability`,
+  and the new `kind: "edge-node"` and `aliasType: "edge-node"`
+  values for Principal / PrincipalAlias.
+- **Endpoint vs MCP tool** *(durable)*: **REST first
+  (`/api/v1/edge/*`), MCP tool follow-up**. Reasoning: the first
+  Edge Node populations are non-MCP-aware (the binary itself is a
+  custom Go HTTP client, not an MCP server) and REST is the
+  straightforward surface. An MCP tool (`submit_discovery_observations`)
+  can wrap the same `persistSubmittedDiscoveryRun` function later
+  without changing the contract on the wire.
 
-Before finalization, compare:
+## Research and Benchmarking
 
-**Open source — discovery and inventory:** Netbox-Agent, Nautobot,
-Steampipe.
+Per AGENTS.md §10. For each comparator: what we read of the data
+model and trust model (not the marketing), what pattern we adopted,
+what we rejected, anti-patterns we noted, and what gap this design
+fills that the comparator doesn't.
 
-**Open source — fleet agents:** osquery, Falco, Wazuh, Tailscale
-client architecture, Cloudflare Tunnel.
+### Open source
 
-**Open source — identity edge (already chosen):** authentik (per
-enterprise auth spec).
+**osquery + Fleet** (Facebook → Linux Foundation, Apache-2.0).
+The closest architectural analogue we have. `osqueryd` runs as a
+host daemon; identity is a `node_key` per host, issued in exchange
+for an `enroll_secret`; the daemon posts JSON results to a TLS
+endpoint (Fleet, Kolide, etc.). The `enroll_secret` is shared and
+long-lived (per-team); the `node_key` is per-host and rotates.
 
-**Commercial — fleet observability and discovery:** Auvik,
-Lansweeper, ScienceLogic SL1, Datadog Network Performance Monitoring.
+- **Adopted:** the enrollment-secret → node-key handshake. Our
+  `bootstrap-token → dpfedge_* node-token` flow is the same shape
+  with two corrections — bootstrap tokens are **one-time** (not
+  shared / long-lived), and node tokens **rotate via heartbeat**
+  (not stay-fixed-per-host).
+- **Adopted:** server-side normalization. osquery agents emit raw
+  query results; Fleet normalizes server-side. Our
+  `persistSubmittedDiscoveryRun` mirrors this: the Edge Node
+  reports observed facts, the Authority Core normalizes via
+  `normalizeDiscoveredFacts` + `inferCrossCollectorRelationships`.
+- **Rejected:** osquery exposes a SQL surface as the data model.
+  We don't — discovery results are concrete objects (NICs, ARP
+  entries, software inventory) flowing through
+  `DiscoveredItem` / `DiscoveredRelationship` →
+  `InventoryEntity` / `InventoryRelationship`. The SQL surface is
+  powerful but blurs the line between query and observation; for
+  DPF the observation contract is the value.
+- **Anti-pattern noted:** shared enrollment secrets in CI configs
+  (a real-world osquery footgun). Our bootstrap-token policy is
+  **never reusable, ≤15 min TTL, single-use**. The Tailscale
+  one-off-key pattern beat the shared-secret pattern here, and we
+  followed Tailscale's lead.
+- **Gap filled:** osquery is just a daemon — no protocol gateway
+  capability, no MCP/A2A bridge, no policy enforcement edge.
+  The Edge Node capability envelope is intentionally broader.
 
-**Commercial — zero-trust edge:** Tailscale, Cloudflare Zero Trust,
-Twingate.
+**Tailscale tailnet client** (Tailscale Inc., BSD-3 for the open
+client). Identity = node-bound WireGuard key, authenticated by an
+auth key that can be one-off / reusable / ephemeral / pre-approved
+/ tagged.
 
-For each: read the data model and trust model, not the marketing.
-Document patterns adopted, patterns rejected, anti-patterns
-identified, gaps the design fills.
+- **Adopted:** the auth-key taxonomy. Our bootstrap-token model
+  borrows directly: bootstrap tokens are single-use,
+  short-lived, scope-bound to `edge:enroll`, optionally
+  pre-approved for the local-host case. The "tag" concept maps
+  to our capability-advertisement: a node enrolled with a
+  particular bootstrap-token scope can only advertise the
+  capabilities that bootstrap-token policy permits.
+- **Adopted:** auto-approve for the local host, operator
+  approval for everything else. Tailscale's "auth-key with
+  pre-approved=true" is the same pattern; we apply it only to
+  the installer-issued bootstrap-token for the DPF host itself.
+- **Rejected:** Tailscale's coordination-server-as-IdP model
+  (where the tailnet IS the auth surface). The Edge Node is
+  *never* an IdP — that's the Identity Edge's responsibility per
+  the enterprise auth spec.
+- **Anti-pattern noted:** auth keys that don't rotate. Tailscale
+  has dealt with this via expiry; we deal with it via
+  heartbeat-driven rotation built into the node-token contract.
+
+**Cloudflare Tunnel (`cloudflared`)** (Cloudflare, BSD-3). Identity
+= a long-lived `cert.pem` issued at tunnel-creation time. Outbound
+HTTP/2 multiplex to the Cloudflare edge.
+
+- **Adopted:** outbound-only connection posture. The Edge Node
+  initiates all connections to the Authority Core; the Authority
+  Core never has to reach into the customer network. This is the
+  same model and it's the right one for an on-prem-friendly
+  deployment.
+- **Rejected:** the long-lived `cert.pem` as the only credential.
+  A multi-year credential with no rotation is the
+  "shared API key in CI" anti-pattern just dressed up. Our
+  node-token rotates per heartbeat (default 24h).
+- **Gap filled:** Cloudflare Tunnel is a single capability
+  (reverse proxy). The Edge Node is a capability *envelope*.
+
+**Wazuh agent** (Wazuh Inc., GPL-2.0). HIDS/SIEM agent that
+enrolls to a manager via `agent-auth`. Per-agent UUID + agent
+password is the long-lived secret.
+
+- **Adopted:** per-agent unique identity that's *not* the
+  enrollment credential. Our `nodeId` / `principalId` is the
+  durable identity; the rotating node-token is the credential.
+- **Anti-pattern noted:** Wazuh's agent password is long-lived
+  and stored in plaintext on the agent host. We store the
+  node-token in the OS-native secure store (Keychain on macOS,
+  Credential Manager on Windows, libsecret on Linux) and never
+  in plaintext config. This is one of the spec's security-review
+  red lines.
+
+**Falco** (CNCF, Apache-2.0). Runtime security agent using eBPF
+or kernel modules for syscall capture. Container-friendly, runs
+under Kubernetes as a DaemonSet.
+
+- **Adopted:** the "minimum-capability container" baseline.
+  Falco documents exactly which Linux capabilities it needs in
+  container mode; we mirror that discipline by enumerating
+  `CAP_NET_RAW` + `CAP_NET_ADMIN` and refusing `--privileged`.
+- **Rejected:** Falco's tight Kubernetes coupling. The Edge Node
+  runs on bare-metal hosts, Docker Desktop hosts, and inside
+  Kubernetes nodes — the deployment-target-neutrality rule (see
+  "Deployment target neutrality" above) is non-negotiable.
+
+**Netbox-Agent / Nautobot** (BSD-3). Small Python agent (Netbox)
+or larger Django framework (Nautobot) for network-source-of-truth
+inventory.
+
+- **Adopted:** the "agent does discovery, server is the SoT"
+  separation. Netbox-Agent runs `dmidecode` / `lshw` / `ipmitool`
+  on the host and posts results via API token. We do the same:
+  Edge Node runs collectors, posts to
+  `/api/v1/edge/discovery-runs`, Authority Core is the SoT.
+- **Rejected:** authentication via a single API token. Netbox's
+  API tokens are user-scoped, long-lived, and one-token-per-user.
+  Our `dpfedge_*` tokens are machine-bound, short-lived, and
+  rotate per heartbeat — the difference matters because the
+  Edge Node is an *unattended machine principal*, not a user.
+
+**Steampipe** (Turbot, MPL-2.0). SQL-over-cloud-APIs.
+
+- **Rejected wholesale:** Steampipe is a query layer over cloud
+  control planes, not a host-resident agent. It's the wrong
+  architectural class for what the Edge Node does. Useful only
+  as a contrast point for what we are *not* building.
+
+**authentik** (already chosen per the enterprise auth spec). The
+identity edge. The Edge Node never duplicates this surface.
+
+### Commercial
+
+**Auvik** (network monitoring SaaS). Polling-based via SNMP/CDP,
+agentless for most cases, with an optional collector that runs
+on a customer-managed host.
+
+- **Adopted (by contrast):** the collector pattern when SNMP is
+  insufficient. Auvik's collector is the analogue of our
+  "Edge Node running on a customer host because the cloud /
+  container can't see the LAN truthfully." The lesson: an
+  edge component is **necessary**, not nice-to-have, when host
+  topology truth matters.
+- **Rejected:** Auvik's data flow is cloud-tenant-bound — the
+  collector phones home to Auvik's SaaS. DPF is single-tenant
+  on-prem; the Authority Core *is* the customer's tenant.
+
+**Lansweeper** (asset discovery). Hybrid agent / agentless.
+
+- **Adopted (by contrast):** hybrid is the right answer.
+  Agentless (SNMP, WMI, SSH) gets you the easy 80%; an agent
+  gets you the hard 20% (truthful per-host inventory of
+  installed software, running processes, real NICs). The Edge
+  Node is that hard 20%.
+
+**ScienceLogic SL1** (ITOM). MID-server pattern — a
+customer-hosted collector that fans out to monitored devices.
+
+- **Adopted:** the MID-server pattern is exactly what the Edge
+  Node is, in DPF's vocabulary. Customer hosts run the agent;
+  Authority Core is the central management plane.
+
+**Twingate** (zero-trust network access). Connector-based.
+Per-connector credential, short-lived.
+
+- **Adopted:** the connector-as-machine-principal model. Each
+  Twingate connector has its own credential; same as our per-node
+  `dpfedge_*` token.
+
+**Cloudflare Zero Trust** (WARP + `cloudflared`). Combines the
+identity-aware Access proxy with the Tunnel architecture above.
+
+- **Adopted (by contrast):** the lesson that *identity* and
+  *connectivity* are separable concerns. The Edge Node owns
+  connectivity (host-side); the Identity Edge (authentik) owns
+  identity. Don't conflate them.
+
+**Datadog Network Performance Monitoring**: agent-based, with the
+Datadog Agent running on every host.
+
+- **Adopted (by contrast):** the agent-per-host model is the
+  right one for truthful host-level observation. We're not
+  rebuilding Datadog, but the architectural posture is the same.
+
+### Patterns and anti-patterns
+
+**Patterns adopted across comparators:**
+
+1. Bootstrap-credential → node-credential handshake (osquery,
+   Tailscale, Wazuh).
+2. Outbound-only connectivity from edge to core (Cloudflare
+   Tunnel, Wazuh, Tailscale).
+3. Server-side normalization of observations (Fleet, Nautobot).
+4. Per-machine-principal credentials (Tailscale, Twingate, Wazuh).
+5. Minimum-capability containers (Falco).
+
+**Anti-patterns rejected across comparators:**
+
+1. Shared enrollment secrets stored in CI config (osquery
+   real-world failure mode). → Bootstrap tokens are one-time.
+2. Long-lived, never-rotating machine credentials (Cloudflare
+   Tunnel `cert.pem`, Wazuh agent password). → Node tokens
+   rotate per heartbeat.
+3. Plaintext credential storage on the agent host (Wazuh
+   default). → OS-native secure store, never plaintext config.
+4. Agent-as-IdP conflation (early Tailscale conceptual
+   confusion). → Edge Node is **never** an IdP.
+5. Forking the agent per deployment target (avoidable trap).
+   → Deployment-target-neutrality is a binding contract in the
+   spec.
+
+**Gaps this design fills that no single comparator addresses:**
+
+1. **Single agent, multiple capability classes** — discovery,
+   metrics, MCP gateway, A2A gateway, policy enforcement,
+   tunnel. No comparator covers this envelope.
+2. **Capability advertisement governed by a central policy
+   surface** — the Authority Core can disable individual
+   capabilities per node from a central UI.
+3. **Principal convergence** — the Edge Node identity lives on
+   the same `Principal` spine as `human`, `agent`, and
+   `customer`. No comparator has this discipline.
+
+## Security review summary
+
+The maturity gates required a heavy security review. Findings,
+in order of severity:
+
+### Critical (must be closed before Phase 0 lands)
+
+- **Node-token storage on the host.** Plaintext in config files
+  is the Wazuh anti-pattern. **Resolution:** OS-native secure
+  store — Keychain on macOS, Credential Manager on Windows,
+  libsecret on Linux. The binary reads the token from secure
+  storage at startup, never writes it to disk in plaintext. The
+  installer prompts for the OS-native secure-store password if
+  it cannot retrieve it non-interactively.
+- **Bootstrap token reuse.** The osquery footgun.
+  **Resolution:** every bootstrap token is **single-use**,
+  enforced server-side by the `consumedAt` / `consumedByEdgeNodeId`
+  columns on `BootstrapToken`. Re-use attempt returns 409 with a
+  hard audit-log entry; the operator must explicitly re-issue.
+- **Auto-approve scope creep.** Auto-approve is convenient on
+  the local host, dangerous everywhere else. **Resolution:**
+  auto-approve fires only when the bootstrap token was issued by
+  the local installer for the local-host Edge Node, and only
+  with matching host fingerprint. Any mismatch falls back to
+  operator approval. Configurable but defaulted-secure.
+
+### Important (must be addressed in Phase 0 or Phase 1)
+
+- **Quarantine bypass.** A quarantined node could try to flush
+  observations through `/api/v1/edge/discovery-runs` anyway.
+  **Resolution:** the route checks `trustState` per request;
+  `quarantined` returns 403 (or archives to `QuarantinedSubmission`
+  if the operator has forensic-review enabled). Audit-logged.
+- **Soft-fail policy abuse.** A compromised Edge Node could
+  pretend the Authority Core is unreachable to extend soft-fail
+  windows indefinitely. **Resolution:** the binary reports its
+  *attempted* Authority Core reachability in every heartbeat;
+  the Authority Core can see "this node claimed offline for 48h
+  but the network never went down" and quarantine it. The
+  soft-fail windows are also operator-configurable per scope so
+  high-stakes scopes (`mcp:gateway`, `a2a:gateway`) deny on
+  Authority Core unreachable regardless.
+- **Binary tampering.** A modified Edge Node binary could
+  fabricate observations. **Resolution:** binary is signed
+  (Developer ID on macOS, Authenticode on Windows, GPG/Sigstore
+  on Linux) and the installer pins the expected signing
+  identity. Re-attestation on every heartbeat includes a hash
+  of the binary; mismatch triggers automatic quarantine.
+- **Linux capability surface.** Documented above:
+  `CAP_NET_RAW` + `CAP_NET_ADMIN`, no `--privileged`, no
+  `CAP_SYS_ADMIN`. The container variant's compose definition
+  pins these and refuses to start with broader capabilities.
+
+### Acceptable risks (documented, not blocked)
+
+- **Local-host Edge Node trust without operator approval.** A
+  user on the DPF host who can drop a fake bootstrap token in
+  the installer's path could enroll a fake local-host node.
+  Accepted because (a) that user already has the privileges
+  needed to subvert the installer in many other ways, and
+  (b) the local-host fingerprint check makes drive-by exploits
+  hard.
+- **Heartbeat-driven token rotation creates a denial-of-service
+  vector if the Authority Core is down.** Accepted because the
+  soft-fail policy windows are designed to handle exactly this,
+  and heartbeat retries with backoff mean the node doesn't
+  hammer the Authority Core on recovery.
+
+### Audit-trail consistency
+
+Every Edge Node submission writes a `ToolExecution` row (per
+AGENTS.md §8 — "Every tool call writes to `ToolExecution`")
+plus a `DiscoveryRun` row tying back to the `edgeNodeId`. The
+two together let an auditor reconstruct (a) which node submitted
+which observations, (b) which operator approved that node, and
+(c) which Principal authorized that operator. No anonymous
+submissions; the "Obfuscated, not anonymous" rule (from the
+hive-contribution work) applies.
+
+## Release and rollback
+
+### Distribution
+
+- Binaries published as signed GitHub Release assets on the
+  `OpenDigitalProductFactory/opendigitalproductfactory` repo,
+  one release per Edge Node version. Releases include
+  `darwin/arm64`, `linux/amd64`, `linux/arm64`, `windows/amd64`
+  binaries plus a `SHA256SUMS` + `SHA256SUMS.sig` pair.
+- Container image for Mode 1 / Mode 3 published to GHCR
+  alongside the portal image, tag scheme
+  `ghcr.io/opendigitalproductfactory/dpf-edge-node:<version>`.
+- Installer lifecycle scripts (`dpf-start`, `dpf-update`,
+  `dpf-update.ps1`) verify the signatures before installing.
+
+### Rollback
+
+- Each release is a self-contained binary; rollback is "install
+  the previous release." No in-place schema state is
+  Edge-Node-version-specific; the Authority Core ignores
+  agent-version-specific fields it doesn't know.
+- The installer keeps the previous binary at
+  `~/.dpf/edge-node/previous/` until the next successful
+  upgrade, so `dpf-update --rollback` is a same-second
+  operation.
+- Bad releases are revoked at the GitHub Release surface
+  (mark as draft + publish a notice); the installer's signature
+  check fails closed if a release is revoked. The Authority
+  Core can also flag a known-bad agent-version range; nodes in
+  that range receive a "please upgrade" hint in their heartbeat
+  response.
+
+### Compatibility
+
+- The Authority Core and the Edge Node have a versioned
+  contract. The Edge Node sends its `agentVersion` in every
+  request; the Authority Core rejects unknown ranges with a
+  clear error per "Evidence before diagnosis."
+- Schema changes that affect the wire contract bump the contract
+  version; the Authority Core supports the current and previous
+  contract versions so upgrades can be staged.
+
+## Test and verification gates
+
+### Per-phase verification gates
+
+| Phase | Gate |
+|---|---|
+| Phase 0 | Contract tests for every route; air-gap soft-fail test for the ingestion path; fresh-install seed verification (the new Principal kind / alias type values seed cleanly per "DB fix = seed + migration"); a `curl`-based synthetic-agent script completing the enrollment → heartbeat → submit → quarantine → revoke lifecycle end-to-end. |
+| Phase 1 | An Edge Node container on a Linux host enrolls against a fresh DPF install, completes a discovery sweep that agrees with the current `network.ts` collector output ±confidence, and survives a docker daemon restart. |
+| Phase 2 | An Edge Node binary on a real Apple Silicon Mac (M1/M2/M3/M4 on macOS 14+) enrolls, completes a discovery sweep including macOS-specific items (pkgutil receipts, brew packages, docker.raw.sock detection), survives a reboot via LaunchDaemon. |
+| Phase 3 | An Edge Node container running in Docker Desktop's VM enrolls and submits the degraded capability set the spec predicts; the Authority Core UI surfaces the degradation correctly and refuses claims that escape the manifest. |
+| Phase 4 | An Edge Node binary on Windows 11 enrolls, completes a discovery sweep, survives a reboot via Windows Service. Unblocks `windows_exporter` retirement (which happens in a follow-up PR in the installer plan). |
+
+### Cross-cutting tests
+
+- **Submission contract test.** A captured Edge Node submission
+  fixture replayed through `persistSubmittedDiscoveryRun`
+  produces identical `InventoryEntity` / `InventoryRelationship`
+  outputs to the equivalent pre-Edge-Node bootstrap-discovery
+  run (allowing for the agent-mode-driven confidence delta).
+- **Capability advertisement round-trip.** The Authority Core
+  disables a capability on an Edge Node; the heartbeat response
+  carries the disabled capability; the Edge Node stops emitting
+  that capability's observations; the Authority Core verifies
+  no further observations of that capability arrive.
+- **Quarantine effectiveness.** A quarantined Edge Node attempts
+  every route; only `edge:heartbeat` succeeds (so the operator
+  can see it's alive); `discovery:submit` returns 403 (or
+  archives to `QuarantinedSubmission`); audit log records every
+  attempt.
+
+### Verification report template
+
+Each phase that ships a real-hardware mode produces a verification
+report under `docs/install/verification-reports/edge-node-<mode>-<host>.md`
+following the existing pattern from
+[docs/install/verification-runbook.md](../../install/verification-runbook.md).
+The report includes the platform / version, the trust-state
+lifecycle observed, the capability rows the node advertised, a
+representative `DiscoveryRun` JSON sample, and a section on
+anything that *didn't* work as the spec predicted (negative
+findings are evidence too — the macOS / Linux installer-parity
+verification runbook makes this explicit and we mirror it).
 
 ## Sequencing
 
 This epic sits **after** the macOS / Linux installer-parity roadmap
-ships its Phase 7 (full installer). Until then, the discovery sweep
-keeps its current data path: `windows_exporter` on Windows,
-`node-exporter` (`linux-monitoring` profile) on Linux,
-container-local fallback on macOS.
+ships its full installer (shipped early-access 2026-05-11). The
+implementation slicing lives in
+[docs/superpowers/plans/2026-05-12-edge-node-roadmap.md](../plans/2026-05-12-edge-node-roadmap.md);
+that roadmap is the authoritative phase sequence. This spec
+defines what each phase has to deliver; the roadmap defines when.
 
-The installer-parity roadmap does **not** retire `windows_exporter`
+Until the Edge Node's `capability.discovery.network` slice lands,
+the discovery sweep keeps its current data path:
+`windows_exporter` on Windows, `node-exporter` (`linux-monitoring`
+profile) on Linux, container-local fallback on macOS. The
+installer-parity roadmap does **not** retire `windows_exporter`
 or the `windows-host` Prometheus scrape — those retire when this
-epic ships the Edge Node's `capability.discovery.network` slice.
+epic ships its first capability slice.
 
 ## Maturity gates before implementation
 
@@ -708,36 +1216,68 @@ credentials, policy caching, and host-local trust — an
 architectural defect here has wider blast radius than a deployment-
 target misconfiguration.**
 
-- [ ] Research & Benchmarking section complete (per AGENTS.md §10).
-- [ ] Open questions resolved or explicitly deferred.
-- [ ] Schema impact reviewed — `EdgeNode`, `EdgeNodeCapability`,
-      `DiscoveryRun.edgeNodeId` migration; the
-      `persistSubmittedDiscoveryRun` function added alongside
-      `persistBootstrapDiscoveryRun`.
-- [ ] Canonical contracts updated if this spec changes shared
-      behavior (Contract 5 of the doctrine references this spec;
-      Contract 9's mode 4 — CLI agents — is orthogonal but
-      adjacent).
-- [ ] **Security review complete (heavy):**
-      - `dpfedge_*` token issuance and rotation flow
-      - Bootstrap-token enrollment ceremony (TOFU vs paste vs
-        operator approval)
-      - Quarantine / revocation triggers and effects
-      - Soft-fail policy windows when Authority Core unreachable
-      - Policy-cache integrity (signing, freshness)
-      - Edge Node binary signing / attestation
-      - Linux capability surface (`CAP_NET_RAW`, `CAP_NET_ADMIN`)
-        documented and minimized
-      - macOS entitlements minimized
-      - Audit-trail consistency for Edge Node observation
-        submissions
-- [ ] Release / rollback story defined — binary distribution,
-      self-update flow, downgrade path if a release is bad.
-- [ ] Test / verification gates defined — fresh install on
-      Windows / macOS / Linux; submission contract test against
-      `persistSubmittedDiscoveryRun`; air-gap behavior verified;
-      capability advertisement / Authority Core policy round-trip
-      verified.
+- [x] Research & Benchmarking section complete (per AGENTS.md §10)
+      — see "Research and Benchmarking" above; nine open-source
+      comparators (osquery + Fleet, Tailscale, Cloudflare Tunnel,
+      Wazuh, Falco, Netbox-Agent, Nautobot, Steampipe, authentik)
+      and six commercial comparators (Auvik, Lansweeper,
+      ScienceLogic SL1, Twingate, Cloudflare Zero Trust, Datadog
+      NPM) read for data and trust models. Patterns adopted /
+      rejected / anti-patterns listed; gaps this design fills
+      enumerated.
+- [x] Open questions resolved or explicitly deferred — see
+      "Open question resolutions" above. Language locked (Go),
+      Linux networking locked for first slice (`network_mode:
+      host`), binary distribution locked (GitHub Release assets),
+      update path locked (installer-driven, no in-binary
+      self-updater), macOS scope locked (LaunchDaemon default),
+      Windows scope locked (Service, not scheduled task),
+      entitlements and capabilities documented and minimized.
+      MCP / A2A gateway capabilities explicitly deferred to
+      later capability slices with forward-compat hooks
+      preserved.
+- [x] Schema impact reviewed — `EdgeNode`, `BootstrapToken`,
+      `EdgeNodeCapability` Prisma models defined above, revised
+      to honor AGENTS.md §11 Principal convergence (EdgeNode
+      becomes a host-attributes side table keyed by
+      `principalId`; identity lives on Principal + PrincipalAlias
+      with new kind `edge-node` and alias type `edge-node`).
+      `DiscoveryRun.edgeNodeId` added as optional FK in the same
+      migration. `persistSubmittedDiscoveryRun` sibling of
+      `persistBootstrapDiscoveryRun` specified in "Ingestion
+      contract" above.
+- [x] Canonical contracts updated — Contract 5 of the deployment
+      doctrine
+      ([docs/superpowers/specs/2026-05-09-deployment-contracts.md](2026-05-09-deployment-contracts.md))
+      already references this spec as its canonical
+      implementation; revision history updated to reflect the
+      finalization here. Contract 9 (LLM and agent-provider
+      routing) is orthogonal; no change needed.
+- [x] **Security review complete (heavy)** — see "Security
+      review summary" above. Critical findings (node-token
+      storage, bootstrap reuse, auto-approve scope creep) have
+      resolutions that gate Phase 0 landing. Important findings
+      (quarantine bypass, soft-fail abuse, binary tampering,
+      Linux capability surface) have resolutions that gate
+      Phase 0 / Phase 1. Acceptable risks are documented.
+      Audit-trail consistency confirmed against AGENTS.md §8
+      `ToolExecution` rule.
+- [x] Release / rollback story defined — see "Release and
+      rollback" above. Signed GitHub Release assets per platform,
+      lifecycle-script-driven updates, atomic binary replacement
+      with previous-version retained for one-step rollback, GitHub
+      Release revocation as a kill-switch for known-bad
+      releases.
+- [x] Test / verification gates defined — see "Test and
+      verification gates" above. Per-phase gates, cross-cutting
+      contract tests, capability-round-trip tests,
+      quarantine-effectiveness tests, and a verification-report
+      template aligned with the macOS / Linux installer-parity
+      precedent.
+
+**Result:** spec status is now **binding**. Implementation may
+proceed against the phase sequence in
+[docs/superpowers/plans/2026-05-12-edge-node-roadmap.md](../plans/2026-05-12-edge-node-roadmap.md).
 
 ## Source documents
 


### PR DESCRIPTION
## Summary

Closes every maturity gate listed in the 2026-05-09 Edge Node research stub and promotes the spec from *research stub* to *binding*. Implementation may now proceed against the phase sequence in [the Edge Node roadmap](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-12-edge-node-roadmap.md) (PR #490).

## Gates closed in this PR

- [x] **Research & Benchmarking** per AGENTS.md §10. Nine open-source comparators (osquery + Fleet, Tailscale, Cloudflare Tunnel, Wazuh, Falco, Netbox-Agent, Nautobot, Steampipe, authentik) and six commercial comparators (Auvik, Lansweeper, ScienceLogic SL1, Twingate, Cloudflare Zero Trust, Datadog NPM) read for data and trust models. Patterns adopted, rejected, anti-patterns enumerated.
- [x] **Open-question resolutions.** Go locked as the binary language. `network_mode: host` locked as the first-slice Linux default. Signed GitHub Release assets as the distribution channel. Installer-driven updates, no in-binary self-updater. LaunchDaemon by default on macOS; Windows Service (not scheduled task) on Windows. MCP / A2A gateway capabilities explicitly deferred with forward-compat hooks preserved.
- [x] **Schema revision honoring AGENTS.md §11 Principal convergence.** This is the most consequential change — the original schema modeled `EdgeNode` as a parallel identity table, but AGENTS.md §11 (the 2026-05-09 addendum) requires every new identity-bearing entity to be modeled as a `PrincipalAlias` linked to a single `Principal`. `EdgeNode` is now a *host-attributes side table* keyed by `principalId`; identity lives on `Principal` + `PrincipalAlias` with new kind `"edge-node"` and alias type `"edge-node"`. This brings Edge Nodes in line with `User`, `Agent`, `CustomerContact`, `MobileDevice`, and `ServiceAccount` per the convergence target.
- [x] **Security review (weighted heavy).** Critical findings (node-token storage, bootstrap-token reuse, auto-approve scope creep) have resolutions that gate Phase 0 landing. Important findings (quarantine bypass, soft-fail abuse, binary tampering, Linux capability surface) have resolutions that gate Phase 0 / Phase 1. Acceptable risks documented. Audit-trail consistency confirmed against AGENTS.md §8 `ToolExecution` rule.
- [x] **Release and rollback story.** Signed GitHub Release assets per platform; lifecycle-script-driven updates (no in-binary updater); atomic binary replacement with previous version retained for one-step rollback; GitHub Release revocation as kill-switch.
- [x] **Test and verification gates.** Per-phase gates, submission contract test against `persistSubmittedDiscoveryRun`, capability-round-trip test, quarantine-effectiveness test, verification-report template aligned with the macOS / Linux installer-parity precedent.

## What this PR does NOT do

- No code, no schema migration, no API routes, no binary. Those land in Phase 0 (PR 3+) per the roadmap.
- No retirement of `windows_exporter` or `node-exporter` — that happens after the Edge Node's first capability slice verifies parity, owned by the installer-parity plan.

## Diff shape

Single file: `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`. ~660 lines added, ~125 removed (the existing "Open questions" and "Research & Benchmarking (TBD)" stub sections were replaced with substantive content; the schema block was revised for Principal convergence; security / release / test sections were added; maturity-gate checklist boxes were checked off; status header was promoted).

## Test plan

- [x] Spec is internally consistent — the resolved open questions match the schema, token model, enrollment ceremony, and capability envelope.
- [x] Schema revision honors AGENTS.md §11 Principal convergence (no parallel identity tables).
- [x] Cross-references to existing files (`packages/db/prisma/schema.prisma:219`, the McpApiToken model, `network.ts` collector) are accurate.
- [x] Status header revised; revision history updated.
- [ ] Reviewer agreement on the resolutions (especially: Go for the binary, `network_mode: host` as the first-slice default, LaunchDaemon as the macOS default).

## Related

- Roadmap PR: #490
- Backlog item: `BI-4C4D9F05`
- Parent epic context: [docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md) Epic B
- Convergence rule this spec now honors: AGENTS.md §11
- Predecessor (now early access): [docs/superpowers/plans/2026-05-09-macos-linux-native-support.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-09-macos-linux-native-support.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)