### PR TITLE
feat(db): Edge Node Phase 0 schema + invariant types (A1)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,7 +14,8 @@
     "./discovery-triage-enums": "./src/discovery-triage-enums.ts",
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",
     "./location-normalize": "./src/location-normalize.ts",
-    "./seed-deliberation": "./src/seed-deliberation.ts"
+    "./seed-deliberation": "./src/seed-deliberation.ts",
+    "./edge-node-types": "./src/edge-node-types.ts"
   },
   "scripts": {
     "postinstall": "prisma generate",

--- a/packages/db/prisma/migrations/20260512000000_add_edge_node_phase0/migration.sql
+++ b/packages/db/prisma/migrations/20260512000000_add_edge_node_phase0/migration.sql
@@ -1,0 +1,120 @@
+-- DPF Edge Node Phase 0 (A1) — schema only.
+-- Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+-- Roadmap: docs/superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md
+--
+-- Three new tables:
+--   EdgeNode               Host-resident agent. Operational state +
+--                          machine-bound dpfedge_* token (hashed).
+--   BootstrapToken         One-time enrollment token issued by an
+--                          operator (or installer for local-host).
+--   EdgeNodeCapability     Per-(node, capability) decision row.
+--                          Authority's accepted set lives here.
+--
+-- Plus an additive optional FK on DiscoveryRun for edgeNodeId
+-- attribution. Nullable because (a) historical runs predate this
+-- model and (b) bootstrap-discovery runs run inside the portal
+-- container and have no edgeNodeId.
+
+-- ── EdgeNode ────────────────────────────────────────────────────────────────
+
+CREATE TABLE "EdgeNode" (
+    "id" TEXT NOT NULL,
+    "nodeId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "installMode" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "trustState" TEXT NOT NULL DEFAULT 'pending',
+    "lastSeenAt" TIMESTAMP(3),
+    "capabilities" JSONB NOT NULL,
+    "metadata" JSONB,
+    "tokenHash" TEXT,
+    "tokenPrefix" TEXT,
+    "tokenRotatedAt" TIMESTAMP(3),
+    "enrolledAt" TIMESTAMP(3),
+    "approvedAt" TIMESTAMP(3),
+    "approvedByPrincipalId" TEXT,
+    "quarantinedAt" TIMESTAMP(3),
+    "quarantineReason" TEXT,
+    "revokedAt" TIMESTAMP(3),
+    "revocationReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EdgeNode_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EdgeNode_nodeId_key" ON "EdgeNode"("nodeId");
+CREATE UNIQUE INDEX "EdgeNode_tokenHash_key" ON "EdgeNode"("tokenHash");
+CREATE INDEX "EdgeNode_trustState_idx" ON "EdgeNode"("trustState");
+CREATE INDEX "EdgeNode_status_idx" ON "EdgeNode"("status");
+CREATE INDEX "EdgeNode_tokenHash_idx" ON "EdgeNode"("tokenHash");
+CREATE INDEX "EdgeNode_lastSeenAt_idx" ON "EdgeNode"("lastSeenAt");
+
+ALTER TABLE "EdgeNode" ADD CONSTRAINT "EdgeNode_approvedByPrincipalId_fkey"
+    FOREIGN KEY ("approvedByPrincipalId") REFERENCES "Principal"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ── BootstrapToken ──────────────────────────────────────────────────────────
+
+CREATE TABLE "BootstrapToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "scope" TEXT NOT NULL DEFAULT 'edge:enroll',
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "issuedByPrincipalId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "consumedByEdgeNodeId" TEXT,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "BootstrapToken_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "BootstrapToken_tokenHash_key" ON "BootstrapToken"("tokenHash");
+CREATE INDEX "BootstrapToken_tokenHash_idx" ON "BootstrapToken"("tokenHash");
+CREATE INDEX "BootstrapToken_expiresAt_idx" ON "BootstrapToken"("expiresAt");
+CREATE INDEX "BootstrapToken_consumedAt_idx" ON "BootstrapToken"("consumedAt");
+
+ALTER TABLE "BootstrapToken" ADD CONSTRAINT "BootstrapToken_issuedByPrincipalId_fkey"
+    FOREIGN KEY ("issuedByPrincipalId") REFERENCES "Principal"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "BootstrapToken" ADD CONSTRAINT "BootstrapToken_consumedByEdgeNodeId_fkey"
+    FOREIGN KEY ("consumedByEdgeNodeId") REFERENCES "EdgeNode"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ── EdgeNodeCapability ──────────────────────────────────────────────────────
+
+CREATE TABLE "EdgeNodeCapability" (
+    "id" TEXT NOT NULL,
+    "edgeNodeId" TEXT NOT NULL,
+    "capability" TEXT NOT NULL,
+    "mode" TEXT NOT NULL DEFAULT 'disabled',
+    "status" TEXT NOT NULL DEFAULT 'unknown',
+    "evidence" JSONB,
+    "reportedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EdgeNodeCapability_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EdgeNodeCapability_edgeNodeId_capability_key"
+    ON "EdgeNodeCapability"("edgeNodeId", "capability");
+CREATE INDEX "EdgeNodeCapability_capability_idx"
+    ON "EdgeNodeCapability"("capability");
+
+ALTER TABLE "EdgeNodeCapability" ADD CONSTRAINT "EdgeNodeCapability_edgeNodeId_fkey"
+    FOREIGN KEY ("edgeNodeId") REFERENCES "EdgeNode"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ── DiscoveryRun.edgeNodeId (additive, nullable) ────────────────────────────
+
+ALTER TABLE "DiscoveryRun" ADD COLUMN "edgeNodeId" TEXT;
+
+CREATE INDEX "DiscoveryRun_edgeNodeId_idx" ON "DiscoveryRun"("edgeNodeId");
+
+ALTER TABLE "DiscoveryRun" ADD CONSTRAINT "DiscoveryRun_edgeNodeId_fkey"
+    FOREIGN KEY ("edgeNodeId") REFERENCES "EdgeNode"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -217,14 +217,16 @@ model TeamMembership {
 }
 
 model Principal {
-  id          String           @id @default(cuid())
-  principalId String           @unique
-  kind        String
-  status      String           @default("active")
-  displayName String
-  aliases     PrincipalAlias[]
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  id                    String           @id @default(cuid())
+  principalId           String           @unique
+  kind                  String
+  status                String           @default("active")
+  displayName           String
+  aliases               PrincipalAlias[]
+  edgeNodesApproved     EdgeNode[]       @relation("EdgeNodeApprover")
+  bootstrapTokensIssued BootstrapToken[] @relation("BootstrapTokenIssuer")
+  createdAt             DateTime         @default(now())
+  updatedAt             DateTime         @updatedAt
 }
 
 model PrincipalAlias {
@@ -2753,11 +2755,21 @@ model DiscoveryRun {
   itemCount               Int                               @default(0)
   relationshipCount       Int                               @default(0)
   notes                   Json?
+  // Edge Node attribution per spec § Edge Node registry. Optional FK
+  // because (a) historical runs predate the Edge Node concept and
+  // (b) bootstrap-discovery runs (portal-resident) have no edgeNodeId.
+  // When set, this DiscoveryRun was submitted by an Edge Node via
+  // /api/v1/edge/discovery-runs and routed through
+  // persistSubmittedDiscoveryRun.
+  edgeNodeId              String?
   discoveredItems         DiscoveredItem[]
   discoveredRelations     DiscoveredRelationship[]
   fingerprintObservations DiscoveryFingerprintObservation[]
   confirmedEntities       InventoryEntity[]                 @relation("InventoryEntityConfirmedRun")
   confirmedRelations      InventoryRelationship[]           @relation("InventoryRelationshipConfirmedRun")
+  edgeNode                EdgeNode?                         @relation("EdgeNodeDiscoveryRuns", fields: [edgeNodeId], references: [id])
+
+  @@index([edgeNodeId])
 }
 
 model DiscoveredItem {
@@ -7224,4 +7236,158 @@ model EvidenceSource {
 
   @@index([evidenceBundleId])
   @@index([sourceType])
+}
+
+// ── DPF Edge Node (Phase 0 — A1) ────────────────────────────────────────────
+//
+// Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+// Roadmap: docs/superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md
+//
+// Per AGENTS.md §11 principal-convergence rule, an EdgeNode's identity
+// is also represented as a PrincipalAlias row (aliasType = "edge_node",
+// aliasValue = EdgeNode.nodeId). The EdgeNode model itself stores
+// operational state; authorization decisions resolve through the
+// convergent Principal model. The application layer (A2) creates the
+// Principal + PrincipalAlias pair atomically with the EdgeNode row on
+// successful enrollment.
+
+model EdgeNode {
+  id          String  @id @default(cuid())
+  // Stable external identifier used in API URLs and tokens. Distinct
+  // from `id` (the cuid surrogate). Per spec, do not conflate the two.
+  nodeId      String  @unique
+  displayName String
+  // darwin | win32 | linux
+  platform    String
+  // native | container-host | container-vm
+  installMode String
+  version     String
+
+  // Operational state (changes on heartbeat / timeout):
+  //   pending  - enrolled but no heartbeat yet
+  //   active   - heartbeat received within the soft-fail window
+  //   offline  - heartbeat missed past threshold
+  //   quarantined - alive but submissions dropped (see trustState)
+  status     String    @default("pending")
+  // Trust state (changes on operator action / lifecycle events):
+  //   pending     - awaiting operator approval (default for remote nodes)
+  //   trusted     - submissions accepted into inventory
+  //   quarantined - alive but submissions dropped (operator can investigate)
+  //   revoked     - tokens invalidated; row preserved for audit
+  trustState String    @default("pending")
+  lastSeenAt DateTime?
+
+  // Capability advertisement (the agent's claim of what it can do).
+  // Authority's accepted set lives in EdgeNodeCapability rows. Stored
+  // here as a denormalized JSON array for fast read; the
+  // EdgeNodeCapability rows are the source of truth for per-capability
+  // mode + status.
+  capabilities Json
+  // Free-form: hostname, host fingerprint, operator-assigned tags.
+  // Hostname / IP intentionally not first-class fields per Wazuh-IP-as-key
+  // anti-pattern (R&B section).
+  metadata     Json?
+
+  // ── Auth (per spec § Token namespaces and lifecycle) ─────────────
+  // dpfedge_* node token, hashed at rest (mirrors McpApiToken pattern).
+  // Null until enrollment completes.
+  // Phase 0: single hash (atomic rotation; no grace window).
+  // Phase 1+: may add `previousTokenHash` for graceful rotation.
+  tokenHash      String?   @unique
+  // First 8 chars after `dpfedge_` prefix, for visual ID only. Not auth.
+  tokenPrefix    String?
+  tokenRotatedAt DateTime?
+
+  // ── Enrollment lifecycle (per spec § Enrollment, rotation, lifecycle)
+  enrolledAt            DateTime?
+  // Set when the trustState transitions from `pending` to `trusted`,
+  // either by operator approval or auto-approve policy.
+  approvedAt            DateTime?
+  // FK to the Principal that approved this node. NULL for auto-approve
+  // (installer-issued local-host bootstrap); populated for operator
+  // approval flows.
+  approvedByPrincipalId String?
+
+  // Quarantine + revocation (per spec § Quarantine / § Revocation)
+  quarantinedAt    DateTime?
+  quarantineReason String?
+  revokedAt        DateTime?
+  revocationReason String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  approvedBy     Principal?           @relation("EdgeNodeApprover", fields: [approvedByPrincipalId], references: [id])
+  capabilityRows EdgeNodeCapability[]
+  discoveryRuns  DiscoveryRun[]       @relation("EdgeNodeDiscoveryRuns")
+  consumedTokens BootstrapToken[]     @relation("BootstrapTokenConsumer")
+
+  @@index([trustState])
+  @@index([status])
+  @@index([tokenHash])
+  @@index([lastSeenAt])
+}
+
+model BootstrapToken {
+  id String @id @default(cuid())
+  // Hashed at rest (mirrors McpApiToken pattern). Plaintext is shown
+  // to the operator exactly once at issuance and never persisted.
+  tokenHash String @unique
+  // First 8 chars after `dpfboot_` prefix, for visual ID in UI lists.
+  prefix    String
+  // Phase 0 ships only `edge:enroll` scope. Reserved column for future
+  // token kinds that might share this table.
+  scope     String @default("edge:enroll")
+
+  issuedAt            DateTime @default(now())
+  // FK to the Principal that issued this token (operator action via
+  // Admin > Platform Development, or the installer auto-issuing for
+  // local-host bootstrap).
+  issuedByPrincipalId String
+  // Per spec § Token namespaces and lifecycle: ≤15 min default TTL,
+  // operator-configurable up to 24h max. Application enforces the cap.
+  expiresAt           DateTime
+
+  // Single-use semantics. consumedAt + consumedByEdgeNodeId set when
+  // an EdgeNode successfully enrolls with this token. After that, the
+  // token is no longer valid for any further enrollment attempt.
+  consumedAt           DateTime?
+  consumedByEdgeNodeId String?
+
+  // Operators can pre-revoke a token before consumption.
+  revokedAt DateTime?
+
+  // Relations
+  issuedBy           Principal @relation("BootstrapTokenIssuer", fields: [issuedByPrincipalId], references: [id])
+  consumedByEdgeNode EdgeNode? @relation("BootstrapTokenConsumer", fields: [consumedByEdgeNodeId], references: [id])
+
+  @@index([tokenHash])
+  @@index([expiresAt])
+  @@index([consumedAt])
+}
+
+model EdgeNodeCapability {
+  id         String @id @default(cuid())
+  // FK to EdgeNode.id (the cuid surrogate); distinct from EdgeNode.nodeId.
+  edgeNodeId String
+  // Capability identifier from the spec § Edge Node capability envelope.
+  // Phase 0 accepts only "discovery.network".
+  capability String
+  // Authority's per-node decision:
+  //   enabled         - capability is active
+  //   reporting-only  - agent advertises it but Authority doesn't accept submissions
+  //   disabled        - agent cannot use this capability
+  mode       String @default("disabled")
+  // Last-known health from the agent's self-report.
+  //   healthy | degraded | failing | unknown
+  status     String @default("unknown")
+  // Free-form: error messages, metric snapshots the agent attached.
+  evidence   Json?
+  reportedAt DateTime @default(now())
+
+  node EdgeNode @relation(fields: [edgeNodeId], references: [id], onDelete: Cascade)
+
+  @@unique([edgeNodeId, capability])
+  @@index([capability])
 }

--- a/packages/db/src/edge-node-types.test.ts
+++ b/packages/db/src/edge-node-types.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from "vitest";
+
+import type { BootstrapToken, EdgeNode } from "./edge-node-types";
+import {
+  BOOTSTRAP_TOKEN_DEFAULT_TTL_MS,
+  BOOTSTRAP_TOKEN_MAX_TTL_MS,
+  BOOTSTRAP_TOKEN_PREFIX,
+  EDGE_NODE_ALIAS_KIND,
+  EDGE_NODE_CAPABILITY_MODES,
+  EDGE_NODE_CAPABILITY_STATUSES,
+  EDGE_NODE_INSTALL_MODES,
+  EDGE_NODE_PLATFORMS,
+  EDGE_NODE_STATUSES,
+  EDGE_NODE_TOKEN_PREFIX,
+  EDGE_NODE_TRUST_STATES,
+  NODE_TOKEN_DEFAULT_TTL_MS,
+  PHASE_0_CAPABILITIES,
+  RESERVED_CAPABILITIES,
+  canEdgeNodeAuthenticateRequest,
+  canEdgeNodeSubmitObservations,
+  isBootstrapTokenConsumed,
+  isBootstrapTokenUsable,
+  isEdgeNodeApprovalConsistent,
+  isEdgeNodeRevocationConsistent,
+} from "./edge-node-types";
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+function makeNode(overrides: Partial<EdgeNode> = {}): EdgeNode {
+  const now = new Date("2026-05-12T12:00:00Z");
+  return {
+    id: "edgenode_cuid_1",
+    nodeId: "edge_a1b2c3",
+    displayName: "Test Edge Node",
+    platform: "linux",
+    installMode: "container-host",
+    version: "0.1.0",
+    status: "pending",
+    trustState: "pending",
+    lastSeenAt: null,
+    capabilities: ["discovery.network"],
+    metadata: null,
+    tokenHash: null,
+    tokenPrefix: null,
+    tokenRotatedAt: null,
+    enrolledAt: null,
+    approvedAt: null,
+    approvedByPrincipalId: null,
+    quarantinedAt: null,
+    quarantineReason: null,
+    revokedAt: null,
+    revocationReason: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeToken(overrides: Partial<BootstrapToken> = {}): BootstrapToken {
+  const now = new Date("2026-05-12T12:00:00Z");
+  return {
+    id: "btok_cuid_1",
+    tokenHash: "hashedtoken",
+    prefix: "abcdef12",
+    scope: "edge:enroll",
+    issuedAt: now,
+    issuedByPrincipalId: "principal_user_1",
+    expiresAt: new Date(now.getTime() + 15 * 60 * 1000),
+    consumedAt: null,
+    consumedByEdgeNodeId: null,
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+describe("edge-node-types — constants", () => {
+  it("EDGE_NODE_PLATFORMS matches the spec's three values", () => {
+    expect(EDGE_NODE_PLATFORMS).toEqual(["darwin", "win32", "linux"]);
+  });
+
+  it("EDGE_NODE_INSTALL_MODES matches the spec", () => {
+    expect(EDGE_NODE_INSTALL_MODES).toEqual([
+      "native",
+      "container-host",
+      "container-vm",
+    ]);
+  });
+
+  it("EDGE_NODE_STATUSES + EDGE_NODE_TRUST_STATES are distinct enums per spec", () => {
+    // status = operational, trustState = trust lifecycle. The shared
+    // value `quarantined` is intentional: a node that's quarantined is
+    // also operationally `quarantined` (per spec § Quarantine).
+    expect(EDGE_NODE_STATUSES).toContain("active");
+    expect(EDGE_NODE_TRUST_STATES).toContain("trusted");
+    expect(EDGE_NODE_TRUST_STATES).not.toContain("active");
+    expect(EDGE_NODE_STATUSES).not.toContain("trusted");
+  });
+
+  it("EDGE_NODE_CAPABILITY_MODES + STATUSES match spec", () => {
+    expect(EDGE_NODE_CAPABILITY_MODES).toEqual([
+      "enabled",
+      "reporting-only",
+      "disabled",
+    ]);
+    expect(EDGE_NODE_CAPABILITY_STATUSES).toEqual([
+      "healthy",
+      "degraded",
+      "failing",
+      "unknown",
+    ]);
+  });
+
+  it("PHASE_0_CAPABILITIES is the strict subset of RESERVED_CAPABILITIES", () => {
+    expect(PHASE_0_CAPABILITIES).toEqual(["discovery.network"]);
+    for (const cap of PHASE_0_CAPABILITIES) {
+      expect(RESERVED_CAPABILITIES).toContain(cap);
+    }
+    // Other reserved capabilities exist for forward-compat but are not
+    // accepted in Phase 0.
+    expect(RESERVED_CAPABILITIES.length).toBeGreaterThan(
+      PHASE_0_CAPABILITIES.length,
+    );
+  });
+
+  it("token prefixes follow the dpf*_ family convention", () => {
+    expect(EDGE_NODE_TOKEN_PREFIX).toBe("dpfedge_");
+    expect(BOOTSTRAP_TOKEN_PREFIX).toBe("dpfboot_");
+  });
+
+  it("bootstrap-token TTL constants enforce the spec's bounds", () => {
+    expect(BOOTSTRAP_TOKEN_DEFAULT_TTL_MS).toBe(15 * 60 * 1000);
+    expect(BOOTSTRAP_TOKEN_MAX_TTL_MS).toBe(24 * 60 * 60 * 1000);
+    expect(BOOTSTRAP_TOKEN_DEFAULT_TTL_MS).toBeLessThan(
+      BOOTSTRAP_TOKEN_MAX_TTL_MS,
+    );
+  });
+
+  it("node-token default TTL aligns with the spec's 24h refresh", () => {
+    expect(NODE_TOKEN_DEFAULT_TTL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("PrincipalAlias kind for EdgeNode identity convergence", () => {
+    expect(EDGE_NODE_ALIAS_KIND).toBe("edge_node");
+  });
+});
+
+// ── BootstrapToken invariants ────────────────────────────────────────────────
+
+describe("isBootstrapTokenConsumed", () => {
+  it("false when never consumed", () => {
+    expect(isBootstrapTokenConsumed(makeToken())).toBe(false);
+  });
+
+  it("true when both consumedAt and consumedByEdgeNodeId are set", () => {
+    const t = makeToken({
+      consumedAt: new Date(),
+      consumedByEdgeNodeId: "edgenode_cuid_1",
+    });
+    expect(isBootstrapTokenConsumed(t)).toBe(true);
+  });
+
+  it("false if only one of the two consumption fields is set (defensive)", () => {
+    expect(
+      isBootstrapTokenConsumed(makeToken({ consumedAt: new Date() })),
+    ).toBe(false);
+    expect(
+      isBootstrapTokenConsumed(
+        makeToken({ consumedByEdgeNodeId: "edgenode_cuid_1" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isBootstrapTokenUsable", () => {
+  const now = new Date("2026-05-12T12:00:00Z");
+
+  it("true for a fresh, unconsumed, unrevoked token before expiry", () => {
+    expect(isBootstrapTokenUsable(makeToken(), now)).toBe(true);
+  });
+
+  it("false once consumed (single-use)", () => {
+    expect(
+      isBootstrapTokenUsable(
+        makeToken({
+          consumedAt: now,
+          consumedByEdgeNodeId: "edgenode_cuid_1",
+        }),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("false once revoked", () => {
+    expect(
+      isBootstrapTokenUsable(makeToken({ revokedAt: now }), now),
+    ).toBe(false);
+  });
+
+  it("false at exact expiry boundary (>= rule)", () => {
+    expect(
+      isBootstrapTokenUsable(makeToken({ expiresAt: now }), now),
+    ).toBe(false);
+  });
+
+  it("false past expiry", () => {
+    const past = new Date(now.getTime() - 1000);
+    expect(
+      isBootstrapTokenUsable(makeToken({ expiresAt: past }), now),
+    ).toBe(false);
+  });
+});
+
+// ── EdgeNode invariants ──────────────────────────────────────────────────────
+
+describe("isEdgeNodeApprovalConsistent", () => {
+  it("trusted nodes must have approvedAt", () => {
+    expect(
+      isEdgeNodeApprovalConsistent(makeNode({ trustState: "trusted" })),
+    ).toBe(false);
+    expect(
+      isEdgeNodeApprovalConsistent(
+        makeNode({ trustState: "trusted", approvedAt: new Date() }),
+      ),
+    ).toBe(true);
+  });
+
+  it("non-trusted states are unconstrained by approvedAt", () => {
+    for (const state of ["pending", "quarantined", "revoked"] as const) {
+      expect(
+        isEdgeNodeApprovalConsistent(makeNode({ trustState: state })),
+      ).toBe(true);
+      expect(
+        isEdgeNodeApprovalConsistent(
+          makeNode({ trustState: state, approvedAt: new Date() }),
+        ),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("isEdgeNodeRevocationConsistent", () => {
+  it("revoked nodes must have revokedAt", () => {
+    expect(
+      isEdgeNodeRevocationConsistent(makeNode({ trustState: "revoked" })),
+    ).toBe(false);
+    expect(
+      isEdgeNodeRevocationConsistent(
+        makeNode({ trustState: "revoked", revokedAt: new Date() }),
+      ),
+    ).toBe(true);
+  });
+
+  it("non-revoked states unconstrained", () => {
+    for (const state of ["pending", "trusted", "quarantined"] as const) {
+      expect(
+        isEdgeNodeRevocationConsistent(makeNode({ trustState: state })),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("canEdgeNodeSubmitObservations", () => {
+  it("only trusted nodes may submit", () => {
+    expect(
+      canEdgeNodeSubmitObservations(makeNode({ trustState: "trusted" })),
+    ).toBe(true);
+    for (const state of ["pending", "quarantined", "revoked"] as const) {
+      expect(
+        canEdgeNodeSubmitObservations(makeNode({ trustState: state })),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("canEdgeNodeAuthenticateRequest", () => {
+  it("requires a tokenHash", () => {
+    expect(canEdgeNodeAuthenticateRequest(makeNode())).toBe(false);
+  });
+
+  it("works for trusted node with token", () => {
+    expect(
+      canEdgeNodeAuthenticateRequest(
+        makeNode({
+          trustState: "trusted",
+          tokenHash: "hashed",
+          approvedAt: new Date(),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("works for pending node with token (so heartbeat works pre-approval)", () => {
+    // Important: a pending-trustState node still needs to be able to
+    // heartbeat so it shows up in the operator's Edge Nodes list.
+    expect(
+      canEdgeNodeAuthenticateRequest(
+        makeNode({
+          trustState: "pending",
+          tokenHash: "hashed",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects revoked node even with token", () => {
+    expect(
+      canEdgeNodeAuthenticateRequest(
+        makeNode({
+          trustState: "revoked",
+          tokenHash: "hashed",
+          revokedAt: new Date(),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects node with revokedAt set even if trustState lags (defensive)", () => {
+    expect(
+      canEdgeNodeAuthenticateRequest(
+        makeNode({
+          trustState: "trusted",
+          tokenHash: "hashed",
+          revokedAt: new Date(),
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/db/src/edge-node-types.ts
+++ b/packages/db/src/edge-node-types.ts
@@ -1,0 +1,169 @@
+// Type re-exports + invariant helpers for the Phase 0 Edge Node models.
+// Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+// Roadmap: docs/superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md
+//
+// Application code (A2 onwards) imports the Prisma-generated types from
+// here so the import surface is stable even if the Prisma client output
+// path changes.
+
+import type {
+  BootstrapToken,
+  EdgeNode,
+  EdgeNodeCapability,
+} from "../generated/client/client";
+
+export type { BootstrapToken, EdgeNode, EdgeNodeCapability };
+
+// Allowed string-literal values for the enum-shaped columns. Kept as
+// const arrays so they can be used both at type-check time and at
+// runtime (e.g. Zod schemas in A2).
+
+export const EDGE_NODE_PLATFORMS = ["darwin", "win32", "linux"] as const;
+export type EdgeNodePlatform = (typeof EDGE_NODE_PLATFORMS)[number];
+
+export const EDGE_NODE_INSTALL_MODES = [
+  "native",
+  "container-host",
+  "container-vm",
+] as const;
+export type EdgeNodeInstallMode = (typeof EDGE_NODE_INSTALL_MODES)[number];
+
+export const EDGE_NODE_STATUSES = [
+  "pending",
+  "active",
+  "offline",
+  "quarantined",
+] as const;
+export type EdgeNodeStatus = (typeof EDGE_NODE_STATUSES)[number];
+
+export const EDGE_NODE_TRUST_STATES = [
+  "pending",
+  "trusted",
+  "quarantined",
+  "revoked",
+] as const;
+export type EdgeNodeTrustState = (typeof EDGE_NODE_TRUST_STATES)[number];
+
+export const EDGE_NODE_CAPABILITY_MODES = [
+  "enabled",
+  "reporting-only",
+  "disabled",
+] as const;
+export type EdgeNodeCapabilityMode =
+  (typeof EDGE_NODE_CAPABILITY_MODES)[number];
+
+export const EDGE_NODE_CAPABILITY_STATUSES = [
+  "healthy",
+  "degraded",
+  "failing",
+  "unknown",
+] as const;
+export type EdgeNodeCapabilityStatus =
+  (typeof EDGE_NODE_CAPABILITY_STATUSES)[number];
+
+// Phase 0 ships only this single capability. Reserved capability strings
+// from the spec § Edge Node capability envelope are not yet acceptable.
+export const PHASE_0_CAPABILITIES = ["discovery.network"] as const;
+export type Phase0Capability = (typeof PHASE_0_CAPABILITIES)[number];
+
+// All capability strings the spec reserves; A2's accepted-capabilities
+// negotiation rejects anything outside this set.
+export const RESERVED_CAPABILITIES = [
+  "discovery.network",
+  "discovery.software",
+  "metrics.host",
+  "identity.broker",
+  "mcp.gateway",
+  "a2a.gateway",
+  "policy.enforcement",
+  "tunnel.private-link",
+] as const;
+export type ReservedCapability = (typeof RESERVED_CAPABILITIES)[number];
+
+// Token namespace prefixes (mirrors the dpfmcp_/dpfedge_/dpfboot_ family).
+export const EDGE_NODE_TOKEN_PREFIX = "dpfedge_";
+export const BOOTSTRAP_TOKEN_PREFIX = "dpfboot_";
+
+// Token TTL constants per spec § Token namespaces and lifecycle.
+export const BOOTSTRAP_TOKEN_DEFAULT_TTL_MS = 15 * 60 * 1000; // 15 min
+export const BOOTSTRAP_TOKEN_MAX_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+export const NODE_TOKEN_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h refresh
+
+// PrincipalAlias kind for EdgeNode identity convergence
+// (per AGENTS.md §11 principal-convergence rule).
+export const EDGE_NODE_ALIAS_KIND = "edge_node";
+
+// ── Invariant predicates ─────────────────────────────────────────────────────
+// These guard the EdgeNode lifecycle state machine. A2 (the API layer)
+// uses them to refuse operations that would put a row in an invalid
+// state. Pure functions; no DB access.
+
+/**
+ * A BootstrapToken is consumed iff both `consumedAt` and
+ * `consumedByEdgeNodeId` are set, and never reset to null thereafter
+ * (single-use semantics).
+ */
+export function isBootstrapTokenConsumed(token: BootstrapToken): boolean {
+  return token.consumedAt !== null && token.consumedByEdgeNodeId !== null;
+}
+
+/**
+ * A BootstrapToken is usable for enrollment iff it is not consumed,
+ * not revoked, and not past its expiresAt.
+ */
+export function isBootstrapTokenUsable(
+  token: BootstrapToken,
+  now: Date = new Date(),
+): boolean {
+  if (isBootstrapTokenConsumed(token)) return false;
+  if (token.revokedAt !== null) return false;
+  if (token.expiresAt.getTime() <= now.getTime()) return false;
+  return true;
+}
+
+/**
+ * Per spec, an EdgeNode in `trustState: trusted` MUST have a non-null
+ * `approvedAt`. The converse is not required: a node can be approved
+ * (approvedAt set) and then quarantined (trustState moves on).
+ */
+export function isEdgeNodeApprovalConsistent(node: EdgeNode): boolean {
+  if (node.trustState === "trusted") {
+    return node.approvedAt !== null;
+  }
+  return true;
+}
+
+/**
+ * Per spec, a `revoked` EdgeNode MUST have a non-null `revokedAt`.
+ * Submissions from revoked nodes are rejected at the auth-middleware
+ * layer in A2.
+ */
+export function isEdgeNodeRevocationConsistent(node: EdgeNode): boolean {
+  if (node.trustState === "revoked") {
+    return node.revokedAt !== null;
+  }
+  return true;
+}
+
+/**
+ * A node may submit observations only when trustState is "trusted".
+ * "pending" nodes can heartbeat (so operators see them) but cannot
+ * yet submit. "quarantined" nodes can heartbeat but submissions are
+ * dropped at the application layer (we keep the row alive for forensic
+ * inspection rather than refusing the connection).
+ */
+export function canEdgeNodeSubmitObservations(node: EdgeNode): boolean {
+  return node.trustState === "trusted";
+}
+
+/**
+ * The token is valid auth material iff the node has a tokenHash, is not
+ * revoked, and the trust state is not `pending` (pending nodes can
+ * enroll but not yet authenticate further requests).
+ */
+export function canEdgeNodeAuthenticateRequest(node: EdgeNode): boolean {
+  if (node.tokenHash === null) return false;
+  if (node.trustState === "revoked") return false;
+  if (node.revokedAt !== null) return false;
+  return true;
+}


### PR DESCRIPTION
First implementation slice of the Edge Node Phase 0 roadmap (#493).
**Schema-only** — no API routes, no service binary, no UI yet. Those
ship as A2 / A3 / A7 against this schema.

- Spec: [`docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`](docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md)
- Roadmap: [`docs/superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md`](docs/superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md)

## What ships

### Three new tables

| Table | Purpose |
|-------|---------|
| **`EdgeNode`** | Host-resident agent. Operational state (`status`), trust state (`trustState` — `pending`/`trusted`/`quarantined`/`revoked`), enrollment timestamps, machine-bound `dpfedge_*` token (hashed at rest, mirrors `McpApiToken` pattern). `approvedByPrincipalId` FK to Principal so the operator who approved a node is queryable; null for auto-approve. |
| **`BootstrapToken`** | One-time enrollment token. Single-use semantics enforced by `consumedAt` + `consumedByEdgeNodeId` pair. Default 15 min TTL per spec. `issuedByPrincipalId` FK so audit can attribute issuance. |
| **`EdgeNodeCapability`** | Per-(node, capability) Authority decision row. `mode = enabled \| reporting-only \| disabled`. Composite unique on `(edgeNodeId, capability)`. |

### Additive change to existing table

`DiscoveryRun.edgeNodeId` — optional FK. Nullable because (a)
historical runs predate this model and (b) bootstrap-discovery runs
have no edgeNodeId. When set, this run was submitted by an Edge Node
via `/api/v1/edge/discovery-runs` (lands in A2).

### Principal-convergence linkage

Per AGENTS.md §11. EdgeNode is identified by a `PrincipalAlias` row
(`aliasType = "edge_node"`, `aliasValue = EdgeNode.nodeId`). Schema
doesn't enforce the linkage — A2 creates the Principal +
PrincipalAlias pair atomically with the EdgeNode row. The two new
Principal FKs (`approvedByPrincipalId`, `issuedByPrincipalId`) are the
first non-PrincipalAlias references into Principal; back-relations
declared on the Principal model so Prisma type inference works.

### Type re-exports + invariant predicates

`packages/db/src/edge-node-types.ts`:
- Re-exports `EdgeNode` / `BootstrapToken` / `EdgeNodeCapability`
- Const arrays for enum-shaped columns (for use in Zod schemas in A2)
- `PHASE_0_CAPABILITIES` strict subset of `RESERVED_CAPABILITIES` —
  Phase 0 accepts only `discovery.network`
- Token-prefix constants (`dpfedge_`, `dpfboot_`) and TTL constants
- Invariant predicates: `isBootstrapTokenConsumed`,
  `isBootstrapTokenUsable`, `isEdgeNodeApprovalConsistent`,
  `isEdgeNodeRevocationConsistent`, `canEdgeNodeSubmitObservations`,
  `canEdgeNodeAuthenticateRequest`. Pure functions; no DB.

### Migration

Hand-written `20260512000000_add_edge_node_phase0/migration.sql` —
three CREATE TABLE blocks plus the additive ALTER on DiscoveryRun.
All FKs declared with appropriate ON DELETE behavior:
- `CASCADE` for child rows (e.g. EdgeNodeCapability when EdgeNode
  deleted)
- `SET NULL` for principal references so a deleted operator account
  doesn't cascade-delete the audit trail

Hand-written because the local env has no DB to run `prisma migrate
dev`; pattern matches recent migrations
(e.g. `20260511013000_add_build_sandbox_model`).

## Verification

```
pnpm --filter @dpf/db exec prisma validate     OK
pnpm --filter @dpf/db exec prisma generate     OK
pnpm --filter @dpf/db typecheck                clean
pnpm --filter @dpf/db exec vitest run          387 tests pass (27 new)
pnpm --filter web typecheck                    clean
```

## Gating

Per spec § Maturity gates and roadmap, Phase 0 implementation cannot
merge to `main` until **heavy security review** passes (the one
remaining maturity gate on the spec). Reviewer scope documented in
PR #492. This PR is ready for that review.

## Sequencing

1. ✅ Spec R&B + open-question resolutions — PR #492
2. ✅ Phase 0 roadmap — PR #493
3. ✅ **THIS PR** — A1 schema
4. Pending heavy security review on the spec
5. Then A2 (API endpoints) → A3 (service skeleton) → ...

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_