### PR TITLE
feat(edge-node): add dpfedge_* token machinery (bootstrap + node tokens)

### DIFF
--- a/apps/web/lib/edge-nodes/tokens.test.ts
+++ b/apps/web/lib/edge-nodes/tokens.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    bootstrapToken: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    edgeNodeToken: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    edgeNode: {
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "@dpf/db";
+
+import {
+  consumeBootstrapToken,
+  DEFAULT_NODE_SCOPES,
+  EDGE_TOKEN_PREFIX,
+  issueBootstrapToken,
+  issueNodeToken,
+  resolveNodeToken,
+  revokeAllNodeTokens,
+  revokeBootstrapToken,
+  revokeNodeToken,
+  rotateNodeToken,
+} from "./tokens";
+
+type Mock = ReturnType<typeof vi.fn>;
+
+const bootstrapCreate = prisma.bootstrapToken.create as unknown as Mock;
+const bootstrapFindUnique = prisma.bootstrapToken.findUnique as unknown as Mock;
+const bootstrapUpdate = prisma.bootstrapToken.update as unknown as Mock;
+const nodeTokenCreate = prisma.edgeNodeToken.create as unknown as Mock;
+const nodeTokenFindUnique = prisma.edgeNodeToken.findUnique as unknown as Mock;
+const nodeTokenUpdate = prisma.edgeNodeToken.update as unknown as Mock;
+const nodeTokenUpdateMany = prisma.edgeNodeToken.updateMany as unknown as Mock;
+const edgeNodeUpdate = prisma.edgeNode.update as unknown as Mock;
+const tx = prisma.$transaction as unknown as Mock;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  bootstrapCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+    id: "boot_123",
+    consumedAt: null,
+    consumedByEdgeNodeId: null,
+    revokedAt: null,
+    revocationReason: null,
+    metadata: null,
+    ...data,
+  }));
+  nodeTokenCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+    id: "tok_456",
+    rotatedAt: null,
+    revokedAt: null,
+    revocationReason: null,
+    lastUsedAt: null,
+    ...data,
+  }));
+  bootstrapUpdate.mockResolvedValue({} as never);
+  nodeTokenUpdate.mockResolvedValue({} as never);
+  edgeNodeUpdate.mockResolvedValue({} as never);
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("issueBootstrapToken", () => {
+  it("returns a dpfedge_-prefixed plaintext and persists only the hash", async () => {
+    const result = await issueBootstrapToken({ issuedByPrincipalId: "PRN-1" });
+    expect(result.plaintext.startsWith(EDGE_TOKEN_PREFIX)).toBe(true);
+    expect(result.prefix.startsWith(EDGE_TOKEN_PREFIX)).toBe(true);
+    expect(result.expiresAt).toBeInstanceOf(Date);
+    expect(bootstrapCreate).toHaveBeenCalledOnce();
+    const data = bootstrapCreate.mock.calls[0]![0].data;
+    expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(data)).not.toContain(result.plaintext);
+    expect(data.scope).toBe("edge:enroll");
+  });
+
+  it("uses 15-minute TTL by default", async () => {
+    const before = Date.now();
+    const result = await issueBootstrapToken({ issuedByPrincipalId: "PRN-1" });
+    const after = Date.now();
+    const ttl = result.expiresAt.getTime() - before;
+    expect(ttl).toBeGreaterThanOrEqual(15 * 60 * 1000 - 1);
+    expect(ttl).toBeLessThanOrEqual(15 * 60 * 1000 + (after - before));
+  });
+
+  it("honors a custom ttlMs override", async () => {
+    const before = Date.now();
+    const result = await issueBootstrapToken({ issuedByPrincipalId: "PRN-1", ttlMs: 60_000 });
+    const ttl = result.expiresAt.getTime() - before;
+    expect(ttl).toBeGreaterThanOrEqual(60_000 - 1);
+    expect(ttl).toBeLessThanOrEqual(60_000 + 1_000);
+  });
+});
+
+describe("consumeBootstrapToken", () => {
+  it("rejects non-dpfedge_ plaintext", async () => {
+    const result = await consumeBootstrapToken("nottherightprefix_abc", "edge_1");
+    expect(result).toEqual({ ok: false, error: "invalid_format" });
+    expect(bootstrapFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown hash", async () => {
+    bootstrapFindUnique.mockResolvedValue(null);
+    const result = await consumeBootstrapToken(`${EDGE_TOKEN_PREFIX}ABCDEFGHJKMN`, "edge_1");
+    expect(result).toEqual({ ok: false, error: "not_found" });
+  });
+
+  it("rejects a previously revoked token", async () => {
+    bootstrapFindUnique.mockResolvedValue({
+      id: "boot_1",
+      revokedAt: new Date(),
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const result = await consumeBootstrapToken(`${EDGE_TOKEN_PREFIX}AAAA`, "edge_1");
+    expect(result).toEqual({ ok: false, error: "revoked" });
+  });
+
+  it("rejects a previously consumed token", async () => {
+    bootstrapFindUnique.mockResolvedValue({
+      id: "boot_1",
+      revokedAt: null,
+      consumedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const result = await consumeBootstrapToken(`${EDGE_TOKEN_PREFIX}AAAA`, "edge_1");
+    expect(result).toEqual({ ok: false, error: "already_consumed" });
+  });
+
+  it("rejects an expired token", async () => {
+    bootstrapFindUnique.mockResolvedValue({
+      id: "boot_1",
+      revokedAt: null,
+      consumedAt: null,
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    const result = await consumeBootstrapToken(`${EDGE_TOKEN_PREFIX}AAAA`, "edge_1");
+    expect(result).toEqual({ ok: false, error: "expired" });
+  });
+
+  it("succeeds and stamps consumedByEdgeNodeId on a valid token", async () => {
+    bootstrapFindUnique.mockResolvedValue({
+      id: "boot_1",
+      revokedAt: null,
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const result = await consumeBootstrapToken(`${EDGE_TOKEN_PREFIX}AAAA`, "edge_1");
+    expect(result).toEqual({ ok: true, tokenId: "boot_1" });
+    expect(bootstrapUpdate).toHaveBeenCalledOnce();
+    const args = bootstrapUpdate.mock.calls[0]![0];
+    expect(args.where.id).toBe("boot_1");
+    expect(args.data.consumedByEdgeNodeId).toBe("edge_1");
+    expect(args.data.consumedAt).toBeInstanceOf(Date);
+  });
+
+  it("treats unique-violation on update as already_consumed (race protection)", async () => {
+    bootstrapFindUnique.mockResolvedValue({
+      id: "boot_1",
+      revokedAt: null,
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    bootstrapUpdate.mockRejectedValueOnce(new Error("unique violation"));
+    const result = await consumeBootstrapToken(`${EDGE_TOKEN_PREFIX}AAAA`, "edge_1");
+    expect(result).toEqual({ ok: false, error: "already_consumed" });
+  });
+});
+
+describe("revokeBootstrapToken", () => {
+  it("returns not_found when no row", async () => {
+    bootstrapFindUnique.mockResolvedValue(null);
+    const result = await revokeBootstrapToken("boot_x", "test");
+    expect(result).toEqual({ ok: false, error: "not_found" });
+  });
+
+  it("is a no-op when already consumed", async () => {
+    bootstrapFindUnique.mockResolvedValue({ revokedAt: null, consumedAt: new Date() });
+    const result = await revokeBootstrapToken("boot_x", "test");
+    expect(result).toEqual({ ok: true });
+    expect(bootstrapUpdate).not.toHaveBeenCalled();
+  });
+
+  it("stamps revokedAt + reason on an unconsumed token", async () => {
+    bootstrapFindUnique.mockResolvedValue({ revokedAt: null, consumedAt: null });
+    const result = await revokeBootstrapToken("boot_x", "operator action");
+    expect(result).toEqual({ ok: true });
+    expect(bootstrapUpdate).toHaveBeenCalledOnce();
+    const data = bootstrapUpdate.mock.calls[0]![0].data;
+    expect(data.revocationReason).toBe("operator action");
+    expect(data.revokedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("issueNodeToken", () => {
+  it("returns a dpfedge_-prefixed plaintext and persists only the hash", async () => {
+    const result = await issueNodeToken({ edgeNodeId: "edge_1" });
+    expect(result.plaintext.startsWith(EDGE_TOKEN_PREFIX)).toBe(true);
+    expect(result.scopes).toEqual([...DEFAULT_NODE_SCOPES]);
+    const data = nodeTokenCreate.mock.calls[0]![0].data;
+    expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(data)).not.toContain(result.plaintext);
+  });
+
+  it("honors custom scopes", async () => {
+    const result = await issueNodeToken({
+      edgeNodeId: "edge_1",
+      scopes: ["edge:heartbeat", "discovery:submit"],
+    });
+    expect(result.scopes).toEqual(["edge:heartbeat", "discovery:submit"]);
+  });
+
+  it("uses 24h TTL by default", async () => {
+    const before = Date.now();
+    const result = await issueNodeToken({ edgeNodeId: "edge_1" });
+    const ttl = result.expiresAt.getTime() - before;
+    expect(ttl).toBeGreaterThanOrEqual(24 * 60 * 60 * 1000 - 1);
+    expect(ttl).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 1_000);
+  });
+});
+
+describe("resolveNodeToken", () => {
+  it("rejects non-dpfedge_ plaintext", async () => {
+    const result = await resolveNodeToken("dpfmcp_AAAA");
+    expect(result).toEqual({ ok: false, error: "invalid_format" });
+  });
+
+  it("rejects unknown hash", async () => {
+    nodeTokenFindUnique.mockResolvedValue(null);
+    const result = await resolveNodeToken(`${EDGE_TOKEN_PREFIX}AAAA`);
+    expect(result).toEqual({ ok: false, error: "not_found" });
+  });
+
+  it("rejects revoked token", async () => {
+    nodeTokenFindUnique.mockResolvedValue({
+      id: "tok_1",
+      edgeNodeId: "edge_1",
+      revokedAt: new Date(),
+      rotatedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      scopes: ["edge:heartbeat"],
+    });
+    const result = await resolveNodeToken(`${EDGE_TOKEN_PREFIX}AAAA`);
+    expect(result).toEqual({ ok: false, error: "revoked" });
+  });
+
+  it("rejects expired token", async () => {
+    nodeTokenFindUnique.mockResolvedValue({
+      id: "tok_1",
+      edgeNodeId: "edge_1",
+      revokedAt: null,
+      rotatedAt: null,
+      expiresAt: new Date(Date.now() - 1_000),
+      scopes: ["edge:heartbeat"],
+    });
+    const result = await resolveNodeToken(`${EDGE_TOKEN_PREFIX}AAAA`);
+    expect(result).toEqual({ ok: false, error: "expired" });
+  });
+
+  it("accepts a token rotated within the grace window", async () => {
+    nodeTokenFindUnique.mockResolvedValue({
+      id: "tok_1",
+      edgeNodeId: "edge_1",
+      revokedAt: null,
+      rotatedAt: new Date(Date.now() - 30 * 60_000), // 30m ago
+      expiresAt: new Date(Date.now() + 60_000),
+      scopes: ["edge:heartbeat", "discovery:submit"],
+    });
+    const result = await resolveNodeToken(`${EDGE_TOKEN_PREFIX}AAAA`);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.token.edgeNodeId).toBe("edge_1");
+      expect(result.token.scopes).toEqual(["edge:heartbeat", "discovery:submit"]);
+    }
+  });
+
+  it("rejects a token rotated beyond the grace window", async () => {
+    nodeTokenFindUnique.mockResolvedValue({
+      id: "tok_1",
+      edgeNodeId: "edge_1",
+      revokedAt: null,
+      rotatedAt: new Date(Date.now() - 2 * 60 * 60_000), // 2h ago (> 1h default grace)
+      expiresAt: new Date(Date.now() + 60_000),
+      scopes: ["edge:heartbeat"],
+    });
+    const result = await resolveNodeToken(`${EDGE_TOKEN_PREFIX}AAAA`);
+    expect(result).toEqual({ ok: false, error: "rotated_out_of_grace" });
+  });
+
+  it("succeeds and resolves edgeNodeId + scopes for an active token", async () => {
+    nodeTokenFindUnique.mockResolvedValue({
+      id: "tok_1",
+      edgeNodeId: "edge_1",
+      revokedAt: null,
+      rotatedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      scopes: ["edge:heartbeat", "discovery:submit"],
+    });
+    const result = await resolveNodeToken(`${EDGE_TOKEN_PREFIX}AAAA`);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.token).toEqual({
+        tokenId: "tok_1",
+        edgeNodeId: "edge_1",
+        scopes: ["edge:heartbeat", "discovery:submit"],
+      });
+    }
+  });
+});
+
+describe("rotateNodeToken", () => {
+  it("propagates resolve failures", async () => {
+    nodeTokenFindUnique.mockResolvedValue(null);
+    const result = await rotateNodeToken({
+      currentTokenPlaintext: `${EDGE_TOKEN_PREFIX}AAAA`,
+    });
+    expect(result).toEqual({ ok: false, error: "not_found" });
+    expect(tx).not.toHaveBeenCalled();
+  });
+
+  it("stamps rotatedAt on the old token and issues a new one inside a transaction", async () => {
+    nodeTokenFindUnique.mockResolvedValue({
+      id: "tok_old",
+      edgeNodeId: "edge_1",
+      revokedAt: null,
+      rotatedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      scopes: ["edge:heartbeat", "discovery:submit"],
+    });
+    tx.mockImplementation(async (cb: (txClient: typeof prisma) => Promise<unknown>) => {
+      return cb({
+        edgeNodeToken: {
+          update: vi.fn().mockResolvedValue({}),
+          create: vi.fn().mockImplementation(async ({ data }) => ({ id: "tok_new", ...data })),
+        },
+        edgeNode: { update: vi.fn().mockResolvedValue({}) },
+      } as unknown as typeof prisma);
+    });
+
+    const result = await rotateNodeToken({
+      currentTokenPlaintext: `${EDGE_TOKEN_PREFIX}AAAA`,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.edgeNodeId).toBe("edge_1");
+      expect(result.tokenId).toBe("tok_new");
+      expect(result.plaintext.startsWith(EDGE_TOKEN_PREFIX)).toBe(true);
+      expect(result.scopes).toEqual(["edge:heartbeat", "discovery:submit"]);
+    }
+    expect(tx).toHaveBeenCalledOnce();
+  });
+});
+
+describe("revokeNodeToken / revokeAllNodeTokens", () => {
+  it("revokeNodeToken returns not_found when missing", async () => {
+    nodeTokenFindUnique.mockResolvedValue(null);
+    const result = await revokeNodeToken("tok_x", "test");
+    expect(result).toEqual({ ok: false, error: "not_found" });
+  });
+
+  it("revokeNodeToken stamps revokedAt + reason", async () => {
+    nodeTokenFindUnique.mockResolvedValue({ revokedAt: null });
+    const result = await revokeNodeToken("tok_x", "quarantine");
+    expect(result).toEqual({ ok: true });
+    expect(nodeTokenUpdate).toHaveBeenCalledOnce();
+    const data = nodeTokenUpdate.mock.calls[0]![0].data;
+    expect(data.revocationReason).toBe("quarantine");
+  });
+
+  it("revokeAllNodeTokens scopes the update to one edge node and the not-revoked subset", async () => {
+    nodeTokenUpdateMany.mockResolvedValue({ count: 3 });
+    const result = await revokeAllNodeTokens("edge_1", "node revoked");
+    expect(result).toEqual({ count: 3 });
+    const args = nodeTokenUpdateMany.mock.calls[0]![0];
+    expect(args.where).toEqual({ edgeNodeId: "edge_1", revokedAt: null });
+    expect(args.data.revocationReason).toBe("node revoked");
+  });
+});

--- a/apps/web/lib/edge-nodes/tokens.ts
+++ b/apps/web/lib/edge-nodes/tokens.ts
@@ -1,0 +1,418 @@
+// Edge Node token machinery for the DPF Authority Core.
+//
+// Two token classes, both `dpfedge_<base32>` on the wire, both sha256-hashed
+// at rest, both shaped after the McpApiToken pattern at
+// apps/web/lib/auth/mcp-api-token.ts.
+//
+//   - Bootstrap token: one-time, short-lived, scope:edge:enroll only.
+//     Consumed by exactly one EdgeNode during enrollment. Mirrors the
+//     osquery enroll_secret → node_key handshake and Tailscale's
+//     one-off auth keys per the spec's Research & Benchmarking section.
+//
+//   - Node token: machine-bound, rotates per heartbeat (default 24h
+//     TTL with a configurable grace window for the previous token so
+//     a lost heartbeat response doesn't lock the node out).
+//
+// Both classes are issued by the Authority Core (NOT by the user the
+// way MCP tokens are). The bootstrap token is issued by an operator
+// through Admin > Platform Development; the node token is issued
+// server-side as part of the enroll / heartbeat response.
+//
+// Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+// (Token model + Token namespaces and lifecycle sections).
+
+import { createHash, randomBytes } from "crypto";
+
+import { prisma } from "@dpf/db";
+
+export const EDGE_TOKEN_PREFIX = "dpfedge_";
+
+const SECRET_BYTES = 24;
+const PREFIX_DISPLAY_LENGTH = 12;
+
+// Crockford base32 alphabet — same as the MCP token surface. RFC-style
+// 32 symbols, excluding I/L/O/U for visual disambiguation. MUST be
+// exactly 32 characters; `& 31` indexes 0..31, so a shorter alphabet
+// produces `undefined` lookups that template-literal into the literal
+// text "undefined" inside generated tokens.
+const BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+if (BASE32_ALPHABET.length !== 32) {
+  throw new Error(
+    `BASE32_ALPHABET must be exactly 32 characters; got ${BASE32_ALPHABET.length}`,
+  );
+}
+
+const DEFAULT_BOOTSTRAP_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_NODE_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const DEFAULT_ROTATION_GRACE_MS = 60 * 60 * 1000; // 1 hour
+
+// Scope vocabulary for `dpfedge_*` tokens. Mirrors the catalog in the
+// spec's "Token model" section. Adding a new scope requires updating
+// this list and the AGENTS.md governance entry.
+export const EDGE_SCOPES = [
+  "edge:enroll",
+  "edge:heartbeat",
+  "edge:rotate",
+  "discovery:submit",
+  "metrics:submit",
+  "mcp:gateway",
+  "a2a:gateway",
+  "policy:fetch",
+] as const;
+
+export type EdgeScope = (typeof EDGE_SCOPES)[number];
+
+// Default scope set for a freshly-enrolled node. The Authority Core can
+// narrow per-node via capability policy; these are the baseline scopes
+// every trusted node gets.
+export const DEFAULT_NODE_SCOPES: ReadonlyArray<EdgeScope> = [
+  "edge:heartbeat",
+  "edge:rotate",
+  "discovery:submit",
+  "policy:fetch",
+];
+
+export type IssueBootstrapTokenInput = {
+  issuedByPrincipalId: string;
+  ttlMs?: number;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type IssueBootstrapTokenResult = {
+  tokenId: string;
+  plaintext: string;
+  prefix: string;
+  expiresAt: Date;
+};
+
+export type ConsumeBootstrapTokenResult =
+  | { ok: true; tokenId: string }
+  | {
+      ok: false;
+      error:
+        | "invalid_format"
+        | "not_found"
+        | "already_consumed"
+        | "revoked"
+        | "expired";
+    };
+
+export type IssueNodeTokenInput = {
+  edgeNodeId: string;
+  scopes?: ReadonlyArray<EdgeScope>;
+  ttlMs?: number;
+};
+
+export type IssueNodeTokenResult = {
+  tokenId: string;
+  plaintext: string;
+  prefix: string;
+  expiresAt: Date;
+  scopes: EdgeScope[];
+};
+
+export type RotateNodeTokenInput = {
+  currentTokenPlaintext: string;
+  scopes?: ReadonlyArray<EdgeScope>;
+  ttlMs?: number;
+  graceMs?: number;
+};
+
+export type RotateNodeTokenResult =
+  | (IssueNodeTokenResult & { ok: true; edgeNodeId: string })
+  | { ok: false; error: ResolveErrorReason };
+
+export type ResolvedNodeToken = {
+  tokenId: string;
+  edgeNodeId: string;
+  scopes: EdgeScope[];
+};
+
+export type ResolveErrorReason =
+  | "invalid_format"
+  | "not_found"
+  | "revoked"
+  | "expired"
+  | "rotated_out_of_grace";
+
+export type ResolveNodeTokenResult =
+  | { ok: true; token: ResolvedNodeToken }
+  | { ok: false; error: ResolveErrorReason };
+
+function encodeBase32(buf: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return out;
+}
+
+function generateToken(): { plaintext: string; hash: string; prefix: string } {
+  const secret = encodeBase32(randomBytes(SECRET_BYTES));
+  const plaintext = `${EDGE_TOKEN_PREFIX}${secret}`;
+  const hash = createHash("sha256").update(plaintext).digest("hex");
+  const prefix = plaintext.slice(0, PREFIX_DISPLAY_LENGTH);
+  return { plaintext, hash, prefix };
+}
+
+function hashSecret(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+function hasEdgePrefix(plaintext: unknown): plaintext is string {
+  return typeof plaintext === "string" && plaintext.startsWith(EDGE_TOKEN_PREFIX);
+}
+
+function isExpired(expiresAt: Date | null | undefined, now: Date = new Date()): boolean {
+  if (!expiresAt) return false;
+  return expiresAt.getTime() < now.getTime();
+}
+
+// --- Bootstrap tokens ----------------------------------------------------
+
+export async function issueBootstrapToken(
+  input: IssueBootstrapTokenInput,
+): Promise<IssueBootstrapTokenResult> {
+  const { plaintext, hash, prefix } = generateToken();
+  const ttl = input.ttlMs ?? DEFAULT_BOOTSTRAP_TTL_MS;
+  const expiresAt = new Date(Date.now() + ttl);
+
+  const row = await prisma.bootstrapToken.create({
+    data: {
+      tokenHash: hash,
+      prefix,
+      scope: "edge:enroll",
+      issuedByPrincipalId: input.issuedByPrincipalId,
+      expiresAt,
+      metadata: (input.metadata ?? undefined) as object | undefined,
+    },
+  });
+
+  return {
+    tokenId: row.id,
+    plaintext,
+    prefix,
+    expiresAt,
+  };
+}
+
+// Validates a bootstrap-token plaintext and marks it consumed by a
+// specific Edge Node. Single-use semantics enforced by the
+// `consumedByEdgeNodeId @unique` constraint on BootstrapToken.
+export async function consumeBootstrapToken(
+  plaintext: string,
+  edgeNodeId: string,
+): Promise<ConsumeBootstrapTokenResult> {
+  if (!hasEdgePrefix(plaintext)) {
+    return { ok: false, error: "invalid_format" };
+  }
+  const hash = hashSecret(plaintext);
+  const row = await prisma.bootstrapToken.findUnique({
+    where: { tokenHash: hash },
+  });
+  if (!row) return { ok: false, error: "not_found" };
+  if (row.revokedAt) return { ok: false, error: "revoked" };
+  if (row.consumedAt) return { ok: false, error: "already_consumed" };
+  if (isExpired(row.expiresAt)) return { ok: false, error: "expired" };
+
+  // Single-use enforced by `consumedByEdgeNodeId @unique`. If a race
+  // tries to consume the same token from two enrolls concurrently, one
+  // will succeed and the other will get a Prisma unique-constraint
+  // violation — treat that as already_consumed.
+  try {
+    await prisma.bootstrapToken.update({
+      where: { id: row.id },
+      data: {
+        consumedAt: new Date(),
+        consumedByEdgeNodeId: edgeNodeId,
+      },
+    });
+  } catch {
+    return { ok: false, error: "already_consumed" };
+  }
+
+  return { ok: true, tokenId: row.id };
+}
+
+export async function revokeBootstrapToken(
+  tokenId: string,
+  reason: string,
+): Promise<{ ok: boolean; error?: "not_found" }> {
+  const existing = await prisma.bootstrapToken.findUnique({
+    where: { id: tokenId },
+    select: { revokedAt: true, consumedAt: true },
+  });
+  if (!existing) return { ok: false, error: "not_found" };
+  if (existing.consumedAt) return { ok: true };
+  if (existing.revokedAt) return { ok: true };
+  await prisma.bootstrapToken.update({
+    where: { id: tokenId },
+    data: { revokedAt: new Date(), revocationReason: reason },
+  });
+  return { ok: true };
+}
+
+// --- Node tokens ---------------------------------------------------------
+
+export async function issueNodeToken(
+  input: IssueNodeTokenInput,
+): Promise<IssueNodeTokenResult> {
+  const { plaintext, hash, prefix } = generateToken();
+  const ttl = input.ttlMs ?? DEFAULT_NODE_TOKEN_TTL_MS;
+  const expiresAt = new Date(Date.now() + ttl);
+  const scopes = [...(input.scopes ?? DEFAULT_NODE_SCOPES)];
+
+  const row = await prisma.edgeNodeToken.create({
+    data: {
+      edgeNodeId: input.edgeNodeId,
+      tokenHash: hash,
+      prefix,
+      scopes,
+      expiresAt,
+    },
+  });
+
+  return {
+    tokenId: row.id,
+    plaintext,
+    prefix,
+    expiresAt,
+    scopes: scopes as EdgeScope[],
+  };
+}
+
+export async function resolveNodeToken(
+  plaintext: string,
+  options: { graceMs?: number; now?: Date } = {},
+): Promise<ResolveNodeTokenResult> {
+  if (!hasEdgePrefix(plaintext)) {
+    return { ok: false, error: "invalid_format" };
+  }
+  const hash = hashSecret(plaintext);
+  const row = await prisma.edgeNodeToken.findUnique({
+    where: { tokenHash: hash },
+  });
+  if (!row) return { ok: false, error: "not_found" };
+  if (row.revokedAt) return { ok: false, error: "revoked" };
+
+  const now = options.now ?? new Date();
+  const graceMs = options.graceMs ?? DEFAULT_ROTATION_GRACE_MS;
+
+  if (isExpired(row.expiresAt, now)) {
+    return { ok: false, error: "expired" };
+  }
+  if (row.rotatedAt) {
+    const graceCutoff = new Date(row.rotatedAt.getTime() + graceMs);
+    if (graceCutoff.getTime() < now.getTime()) {
+      return { ok: false, error: "rotated_out_of_grace" };
+    }
+  }
+
+  // Lazy lastUsedAt — fire-and-forget, never block the request.
+  prisma.edgeNodeToken
+    .update({ where: { id: row.id }, data: { lastUsedAt: now } })
+    .catch(() => {});
+
+  return {
+    ok: true,
+    token: {
+      tokenId: row.id,
+      edgeNodeId: row.edgeNodeId,
+      scopes: row.scopes as EdgeScope[],
+    },
+  };
+}
+
+// Atomic rotation: issue a fresh node token bound to the same EdgeNode
+// and stamp `rotatedAt` on the current one so it falls into the grace
+// window. The prior token remains valid for `graceMs` after rotation
+// to absorb heartbeat-race losses; after that it resolves to
+// `rotated_out_of_grace`.
+export async function rotateNodeToken(
+  input: RotateNodeTokenInput,
+): Promise<RotateNodeTokenResult> {
+  const resolved = await resolveNodeToken(input.currentTokenPlaintext, {
+    graceMs: input.graceMs,
+  });
+  if (!resolved.ok) {
+    return { ok: false, error: resolved.error };
+  }
+
+  const { edgeNodeId, tokenId: currentId } = resolved.token;
+  const scopes = input.scopes ?? (resolved.token.scopes as ReadonlyArray<EdgeScope>);
+
+  const result = await prisma.$transaction(async (tx) => {
+    await tx.edgeNodeToken.update({
+      where: { id: currentId },
+      data: { rotatedAt: new Date() },
+    });
+    const { plaintext, hash, prefix } = generateToken();
+    const expiresAt = new Date(Date.now() + (input.ttlMs ?? DEFAULT_NODE_TOKEN_TTL_MS));
+    const issued = await tx.edgeNodeToken.create({
+      data: {
+        edgeNodeId,
+        tokenHash: hash,
+        prefix,
+        scopes: [...scopes],
+        expiresAt,
+      },
+    });
+    await tx.edgeNode.update({
+      where: { id: edgeNodeId },
+      data: { tokenRotatedAt: new Date() },
+    });
+    return { issued, plaintext, prefix, expiresAt };
+  });
+
+  return {
+    ok: true,
+    edgeNodeId,
+    tokenId: result.issued.id,
+    plaintext: result.plaintext,
+    prefix: result.prefix,
+    expiresAt: result.expiresAt,
+    scopes: scopes as EdgeScope[],
+  };
+}
+
+export async function revokeNodeToken(
+  tokenId: string,
+  reason: string,
+): Promise<{ ok: boolean; error?: "not_found" }> {
+  const existing = await prisma.edgeNodeToken.findUnique({
+    where: { id: tokenId },
+    select: { revokedAt: true },
+  });
+  if (!existing) return { ok: false, error: "not_found" };
+  if (existing.revokedAt) return { ok: true };
+  await prisma.edgeNodeToken.update({
+    where: { id: tokenId },
+    data: { revokedAt: new Date(), revocationReason: reason },
+  });
+  return { ok: true };
+}
+
+// Revoke every non-revoked token belonging to an Edge Node. Used by the
+// quarantine and revocation flows so a compromised node cannot continue
+// to use any token it has cached.
+export async function revokeAllNodeTokens(
+  edgeNodeId: string,
+  reason: string,
+): Promise<{ count: number }> {
+  const result = await prisma.edgeNodeToken.updateMany({
+    where: { edgeNodeId, revokedAt: null },
+    data: { revokedAt: new Date(), revocationReason: reason },
+  });
+  return { count: result.count };
+}

--- a/packages/db/prisma/migrations/20260512020000_add_edge_node_token/migration.sql
+++ b/packages/db/prisma/migrations/20260512020000_add_edge_node_token/migration.sql
@@ -1,0 +1,34 @@
+-- Per-node rotating bearer token for the DPF Edge Node. dpfedge_<base32>
+-- on the wire; sha256 hash stored at rest. Mirrors the McpApiToken
+-- pattern with the differences the spec calls out: machine-bound (FK to
+-- EdgeNode), shorter-lived, rotates per heartbeat.
+--
+-- Multiple rows per EdgeNode are expected (current + recently-rotated),
+-- accepted within a grace window so heartbeat-race conditions don't
+-- lock the node out.
+
+-- CreateTable
+CREATE TABLE "EdgeNodeToken" (
+    "id" TEXT NOT NULL,
+    "edgeNodeId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "rotatedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "revocationReason" TEXT,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "EdgeNodeToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EdgeNodeToken_tokenHash_key" ON "EdgeNodeToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "EdgeNodeToken_edgeNodeId_revokedAt_expiresAt_idx" ON "EdgeNodeToken"("edgeNodeId", "revokedAt", "expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "EdgeNodeToken" ADD CONSTRAINT "EdgeNodeToken_edgeNodeId_fkey" FOREIGN KEY ("edgeNodeId") REFERENCES "EdgeNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2799,10 +2799,34 @@ model EdgeNode {
   capabilityRows EdgeNodeCapability[]
   observations   DiscoveryRun[]       @relation("EdgeNodeObservations")
   bootstrapToken BootstrapToken?      @relation("EdgeNodeBootstrapToken")
+  tokens         EdgeNodeToken[]
 
   @@index([status])
   @@index([trustState])
   @@index([lastSeenAt])
+}
+
+// Per-node rotating bearer token. dpfedge_<base32> on the wire; sha256
+// hash stored at rest. Replaces the bootstrap token after enroll; rotates
+// per heartbeat per the spec's rotation contract. Multiple rows per
+// EdgeNode are expected (current + recently-rotated, accepted within
+// a grace window so heartbeat-race conditions don't lock the node out).
+model EdgeNodeToken {
+  id               String    @id @default(cuid())
+  edgeNodeId       String
+  tokenHash        String    @unique
+  prefix           String
+  scopes           String[]  @default([])
+  issuedAt         DateTime  @default(now())
+  expiresAt        DateTime
+  rotatedAt        DateTime?
+  revokedAt        DateTime?
+  revocationReason String?
+  lastUsedAt       DateTime?
+
+  node EdgeNode @relation(fields: [edgeNodeId], references: [id], onDelete: Cascade)
+
+  @@index([edgeNodeId, revokedAt, expiresAt])
 }
 
 // One-time bootstrap token used in the Edge Node enrollment ceremony.


### PR DESCRIPTION
## Summary

Second slice of Phase 0 in the [Edge Node roadmap](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-12-edge-node-roadmap.md). Implements the bootstrap-token enrollment ceremony and rotating node-token machinery per the [spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md)'s *Token model* + *Enrollment, rotation, and lifecycle* sections.

**Stacked on #494** — once that merges, the base of this PR will rebase onto `main`.

## What's added

### Schema (small extension on PR #494's foundation)

- **`EdgeNodeToken`** model — per-node rotating bearer token. `dpfedge_<base32>` on the wire; sha256 hash stored at rest. Multiple rows per `EdgeNode` are expected (current + recently-rotated), accepted within a grace window so heartbeat-race conditions don't lock the node out.
- Back-relation `tokens EdgeNodeToken[]` on `EdgeNode`.

### Library (`apps/web/lib/edge-nodes/tokens.ts`)

| Function | Purpose |
|---|---|
| `issueBootstrapToken` | Single-use enroll credential, default 15-min TTL, scope `edge:enroll`. Plaintext returned exactly once. Mirrors the osquery `enroll_secret → node_key` handshake and Tailscale's one-off auth keys. |
| `consumeBootstrapToken` | Validates format, hash, revocation, expiry, prior consumption; marks `consumedByEdgeNodeId`. Single-use enforced both server-side and by the `@unique` constraint, with unique-violation treated as `already_consumed` for race protection. |
| `revokeBootstrapToken` | Operator pre-revocation before consumption. |
| `issueNodeToken` | Issues the rotating `dpfedge_*` node token bound to a specific `EdgeNode`. Default 24h TTL. Default scope set: `edge:heartbeat`, `edge:rotate`, `discovery:submit`, `policy:fetch`. High-stakes scopes (`mcp:gateway`, `a2a:gateway`, `metrics:submit`) are opt-in per least-privilege. |
| `resolveNodeToken` | Validates a token plaintext. Rejects on invalid format, missing hash, revocation, expiry, or `rotated_out_of_grace`. Honors a configurable grace window (default 1h) so the prior token remains accepted briefly after rotation. Lazy `lastUsedAt`, fire-and-forget. |
| `rotateNodeToken` | Atomic per-heartbeat rotation inside `$transaction` — validates current, stamps `rotatedAt`, issues new with same scopes, updates `EdgeNode.tokenRotatedAt`. A partial failure can't leave the node with two active tokens or zero. |
| `revokeNodeToken` / `revokeAllNodeTokens` | Manual revocation and the bulk-revoke used by quarantine / revocation flows. |

`EDGE_SCOPES` is exported as a `const` tuple so the type system enforces the closed scope set per the spec's *Token scope catalog* resolution.

## Verification

- **28 unit tests passing** (`pnpm --filter web exec vitest run lib/edge-nodes/tokens.test.ts`). Mocks `@dpf/db` so tests don't need a live Postgres.
- **Plaintext never persisted** — tests assert `tokenHash` is the only sha256-shaped string in the create-call data and that the plaintext is not present in the persisted JSON envelope.
- **Single-use race protection** verified — unique-violation path returns `already_consumed`.
- **Rotation grace window** verified — within-grace accepts; beyond rejects with `rotated_out_of_grace`.
- **`pnpm --filter web typecheck` clean.**

## Test plan

- [x] All token issuance / consumption / rotation / revocation paths covered
- [x] Format-rejection, not-found, revoked, expired paths covered
- [x] Race-protection on bootstrap consumption verified
- [x] Default scope set + custom scope override verified
- [x] Default TTLs verified (15m bootstrap, 24h node, 1h rotation grace)
- [ ] Reviewer agreement on the rotation-grace window default (1h)
- [ ] Reviewer agreement on the default node scope set (no `mcp:gateway`, no `a2a:gateway`, no `metrics:submit`)

## Security review alignment (spec)

- ✅ "Node-token storage on the host" — plaintext returned exactly once; only sha256 hash persisted server-side. Host-side OS-native secure store is the binary's responsibility (Phase 1 PR).
- ✅ "Bootstrap token reuse" — single-use enforced both by `consumedAt` guard AND `consumedByEdgeNodeId @unique`. Race-loss path treated as `already_consumed`.
- ✅ "Auto-approve scope creep" — token machinery is policy-neutral; the auto-approve decision lives in the enroll route (PR 5).

## Related

- Parent: #494 (Phase 0 schema)
- Roadmap: #490 (Phase 0 — Authority Core foundation)
- Spec: #491 (Token model section)
- Mirrors pattern: `apps/web/lib/auth/mcp-api-token.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)