### PR TITLE
docs(audits): build coworker tool rejection — evidence audit

### DIFF
--- a/docs/superpowers/audits/2026-05-12-build-coworker-tool-rejection-evidence.md
+++ b/docs/superpowers/audits/2026-05-12-build-coworker-tool-rejection-evidence.md
@@ -1,0 +1,94 @@
+# Build coworker tool rejection — evidence audit (2026-05-12)
+
+## Symptom
+
+A fresh Build Studio submission in the **ideate** phase produces a final assistant message of the form:
+
+> Every tool I call — `update_feature_brief`, `save_build_notes`, `assess_complexity`, `query_backlog`, `start_scout_research` — is being rejected by the runtime as "No such tool available," despite all being advertised in this turn's tool list. This is a platform-side registry issue blocking the build; nothing on the FB-… record can be persisted until the tool registry is restored.
+
+Build stays in ideate, `Advance to Plan` remains disabled, no `designDoc` is persisted.
+
+## Evidence chain (not speculation)
+
+### Adapter trace (portal logs)
+
+```
+[tools] route=/build agent=build-specialist buildPhase=ideate count=26 tools=[query_backlog, update_feature_brief, ... assess_complexity, ... start_scout_research, ...]
+[agentic-loop] iter=0 provider=anthropic-sub model=claude-opus-4-1-20250805 toolCalls=0 contentLen=2851 nudges=0 executedTools=0 content="I tried `start_scout_research`, `read_project_file` (both files), `start_ideate_research`, and `saveBuildEvidence` — every call was rejected with \"No such tool available\" despite all four appearing in this turn's advertised tool list…"
+[tool-trace] adapter=claude-cli extracted=0 names=[] mentioned=["read_project_file","saveBuildEvidence"]
+[tool-trace] adapter=claude-cli NO-CALL-BUT-MENTIONED raw=…
+```
+
+Reading these in isolation suggests the model is fabricating the rejection (because `extracted=0` and `toolCalls=0`). It is not. See next section.
+
+### Claude CLI session log (the ground truth)
+
+`/home/node/.claude/projects/-workspace/64c6b3fe-0373-47ed-9919-5d040bddfcb3.jsonl` (copied locally to `D:/DPF/.claude/cli-session-64c.jsonl` for archival). For the FB-D14EDB7C build, this session emitted **9 real `tool_use` content blocks** across 8 platform tool names with server-assigned `toolu_…` IDs. Every one was paired by the CLI itself with a synthesized `tool_result` content block:
+
+```json
+{
+  "type": "user",
+  "message": {
+    "role": "user",
+    "content": [{
+      "type": "tool_result",
+      "content": "<tool_use_error>Error: No such tool available: start_scout_research</tool_use_error>",
+      "is_error": true,
+      "tool_use_id": "toolu_01BCq9RwD5Ra6fM8MEFs6xim"
+    }]
+  }
+}
+```
+
+Observed tool names rejected this way in the session: `start_scout_research`, `search_project_files`, `read_project_file` (×2), `list_project_directory`, `check_sandbox`, `get_my_coworker_profile`, `query_backlog`, `assess_complexity`. The same `<tool_use_error>: No such tool available` pattern was also recorded in the older FB-72EB9C06 session.
+
+The model is reporting accurately. The platform tools are described in the system prompt but **not registered** with the Claude CLI as dispatchable tools, so the CLI's internal tool router auto-rejects every `tool_use` for those names and loops back to the model with `is_error: true`. `--output-format json` returns only the final assistant text, so the tool_use ↔ tool_result exchange never crosses the adapter's stdout — that's why `[tool-trace] extracted=0`.
+
+## Why this isn't a model regression
+
+- The cli-adapter's prompt builder ([`apps/web/lib/routing/cli-adapter.ts:302-308`](../../../apps/web/lib/routing/cli-adapter.ts)) tells the model: "output ONE JSON object using exactly this shape: `{\"type\":\"tool_use\",...}`".
+- That shape **is** an Anthropic-API `tool_use` content block. When Claude Code CLI emits one to its internal dispatcher, the dispatcher looks the name up in its registered tool catalog (Claude's native tools, minus everything in `--disallowedTools`).
+- Platform tools (`saveBuildEvidence`, `query_backlog`, `start_scout_research`, …) are not in that catalog. They never were. There is no `--mcp-config` mounting them as an MCP server (yet).
+- The CLI's auto-rejection is correct given the input. The defect is the missing tool registration on the adapter side.
+
+The existing comment at [`apps/web/lib/routing/cli-adapter.ts:31-46`](../../../apps/web/lib/routing/cli-adapter.ts) acknowledges this exact gap and points at the prepared fix:
+[docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md](../plans/2026-04-11-platform-mcp-tool-server-implementation.md).
+
+## Adapter comparison
+
+- **`cli-adapter.ts` (anthropic-sub → Claude CLI):** has no tool registration path; CLI auto-rejects every platform tool_use as shown.
+- **`codex-cli-adapter.ts` (codex / codex-agent → Codex CLI):** Codex `exec` returns plain text (not Anthropic content blocks). Tool calls are extracted from text by `extractToolCalls`. There is no internal dispatcher to reject. This is why the codex path can advance Build Studio builds while the anthropic-sub path cannot.
+- **`chat-adapter.ts` (anthropic API key):** uses the real Anthropic Messages API with `tools[]` registered in the request body. No registration mismatch possible. Not exercised today because no install has an `anthropic` (API key) provider configured — only `anthropic-sub`, `codex-agent`, `local`.
+
+## Implications
+
+- All routes whose agents are routed to `anthropic-sub` and rely on platform tool dispatch (most prominently `/build` with the `build-specialist` coworker) are non-functional in this state.
+- Reframing the failure as a model "hallucination" or "frustration" pattern in `agentic-loop.ts` would be incorrect — the model is doing the right thing under the rules it has.
+- Routes that go via `codex-cli-adapter` (where Codex's plain-text output bypasses native tool dispatch) are not affected by the same mechanism.
+
+## Repro
+
+1. Fresh install OR live install with `anthropic-sub` active and no `anthropic` API key configured.
+2. Sign in as admin, open `/build`, submit any new feature in the textbox.
+3. Observe: build appears in `ideate`; chat coworker quickly returns the message at the top of this doc; no `designDoc` is persisted; `Advance to Plan` stays disabled.
+4. Inspect: portal logs include `[tools] route=/build … count=26` followed by `toolCalls=0 executedTools=0` for every iteration. Sandbox CLI session log under `/home/node/.claude/projects/-workspace/*.jsonl` contains the `<tool_use_error>: No such tool available: <name>` pairs.
+
+## Fix scope (per existing plan)
+
+Implementing the plan at [docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md](../plans/2026-04-11-platform-mcp-tool-server-implementation.md):
+
+1. Add a short-lived signed session token helper.
+2. Make `/api/mcp/v1` accept session tokens with `userId`/`platformRole`/`agentId`/`routeContext`/`buildPhase`/`mode` claims; filter `tools/list` accordingly.
+3. In `cli-adapter.ts`, mint a session token per call, write an `mcp-config.json` into the sandbox declaring `dpf` as an HTTP MCP server pointing at `http://portal:3000/api/mcp/v1` with `Authorization: Bearer <session-token>`, and pass it to `claude` via `--mcp-config`.
+4. Have the agentic loop treat `cli-adapter` results that came back through native MCP execution as single-pass responses (no second platform-side dispatch).
+5. Share a `recordToolExecution()` helper between `agentic-loop.ts` and the MCP route so audit rows still land.
+
+The fix is non-trivial — see the plan's Section 2 (Spec Evaluation Summary) for corrections required against the original spec. It is the next logical work item; deferring to a focused implementation pass rather than a drive-by patch.
+
+## What this audit does NOT do
+
+- Does not propose a code change.
+- Does not retitle the existing plan.
+- Does not edit `cli-adapter.ts`, `agentic-loop.ts`, or the prompt template.
+
+Its only job is to record the evidence so the planned implementation can proceed without re-doing the diagnosis.

--- a/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
@@ -735,6 +735,17 @@ Acceptance:
 - candidate can create a backlog item through governed MCP/backlog workflow,
 - no candidate is auto-implemented without human review.
 
+### Immediate candidate fit: Hive Scout
+
+Hive Scout is a strong near-term proving ground for this doctrine. Its deterministic core already exists as a scheduled external-catalog ingest, but its higher-order judgments remain human-heavy: novelty, archetype fit, value-stream alignment, and proposal quality. That makes it a good match for the ladder in §4:
+
+1. deterministic fetch/parse/dedupe stays procedural,
+2. ambiguous novelty and fit move to a bounded coworker run,
+3. repeated review corrections become filters/mappings/rules,
+4. the resulting run becomes visible in the Operations Map as proactive work rather than hidden cron behavior.
+
+Because Hive Scout is low-risk, asynchronous, and reviewable, it is also a good candidate for background execution when provider policy indicates lagging prepaid subscription quota. A dedicated design note for this application lives in `2026-05-11-hive-scout-autonomous-coworker-design.md`.
+
 ## 11. Metrics
 
 ### 11.1 Outcome metrics

--- a/docs/superpowers/specs/2026-05-11-hive-scout-autonomous-coworker-design.md
+++ b/docs/superpowers/specs/2026-05-11-hive-scout-autonomous-coworker-design.md
@@ -1,0 +1,314 @@
+# Hive Scout Autonomous Coworker and Proceduralization Design
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-11 |
+| Status | Draft for review |
+| Related repo areas | `apps/web/lib/actions/hive-scout/ingest-500-agents.ts`, `apps/web/lib/queue/functions/hive-scout-ingest.ts`, `apps/web/scripts/hive-scout-manual-run.ts`, `skills/platform/scout-external-catalogs.skill.md`, `prompts/specialist/hive-scout-archetype-gap.prompt.md`, `apps/web/lib/actions/agent-task-scheduler.ts`, `apps/web/lib/tak/scheduled-task-runs.ts`, `apps/web/lib/ai-operations-map/*` |
+| Related specs | `2026-05-11-autonomous-coworker-runtime-design.md`, `2026-04-27-routing-control-data-plane-design.md`, `2026-04-23-ai-provider-finance-bridge-design.md`, `2026-04-18-purpose-first-product-estate-design.md` |
+
+## 1. Purpose
+
+Hive Scout already gives DPF a real external-pattern scout: it reads an upstream catalog of open-source AI agent projects, detects likely archetype gaps, and files `BacklogItem` suggestions instead of importing code.
+
+That is useful, but the May 2026 coworker/runtime work raises the bar. Background cognition should not remain a hidden cron script when the platform now has:
+
+- governed `TaskRun` identity for autonomous coworker work,
+- AI Operations Map visibility for proactive runs,
+- scheduled coworker execution isolation,
+- a stated doctrine of moving repeatable cognitive load from humans to coworkers and then into procedural code,
+- use-it-or-lose-it subscription economics that justify proactive low-risk background work when prepaid capacity is underused.
+
+This design updates the architectural direction for Hive Scout:
+
+> Hive Scout should evolve from a catalog-ingest job into a governed autonomous coworker pattern that combines deterministic scouting code with bounded AI reasoning for ambiguous novelty, taxonomy fit, and archetype synthesis.
+
+## 2. Current State
+
+### 2.1 Repo-verified implementation
+
+The current implementation is real and useful:
+
+- [ingest-500-agents.ts](D:/DPF/apps/web/lib/actions/hive-scout/ingest-500-agents.ts:1) fetches and parses the MIT-licensed `500-AI-Agents-Projects` README, maps industries to IT4IT value streams, detects likely gaps, and creates deduplicated `BacklogItem` rows.
+- [hive-scout-ingest.ts](D:/DPF/apps/web/lib/queue/functions/hive-scout-ingest.ts:1) runs the ingest weekly through Inngest.
+- [index.ts](D:/DPF/apps/web/lib/queue/functions/index.ts:1) registers the function in the queue runtime.
+- [scout-external-catalogs.skill.md](D:/DPF/skills/platform/scout-external-catalogs.skill.md:1) describes the operator-facing intent.
+- [hive-scout-archetype-gap.prompt.md](D:/DPF/prompts/specialist/hive-scout-archetype-gap.prompt.md:1) provides the backlog-item body template.
+- [hive-scout-manual-run.ts](D:/DPF/apps/web/scripts/hive-scout-manual-run.ts:1) supports local replays and idempotence checks.
+
+### 2.2 What it does not yet do
+
+Hive Scout is not yet aligned with the autonomous coworker runtime direction:
+
+- it is not represented as a first-class coworker `TaskRun`,
+- it does not project into the AI Operations Map as meaningful autonomous work,
+- it does not use AI reasoning for ambiguous gap detection,
+- it does not generate capability-needs or proceduralization candidates,
+- it does not yet participate in provider burn-rate-aware background work scheduling,
+- it does not yet create a governed review loop richer than filing backlog suggestions.
+
+### 2.3 Live-state note
+
+An attempted live Postgres check in this shell returned `ECONNREFUSED`, so this design does **not** claim a verified runtime count of Hive Scout runs, backlog items, or active queue state on 2026-05-11. The current-state statements above are repo-verified, not live-runtime counts.
+
+## 3. Why the Recent Work Applies
+
+### 3.1 Autonomous coworker runtime
+
+[2026-05-11-autonomous-coworker-runtime-design.md](D:/DPF/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md:1) establishes the platform doctrine:
+
+> Move repeatable cognitive load from humans to AI coworkers, then move stabilized coworker behavior into procedural code.
+
+Hive Scout is almost a textbook fit:
+
+- humans should not manually browse external agent catalogs and remember what DPF already covers,
+- coworkers can compare, summarize, and propose,
+- repeated patterns in those proposals should become deterministic filters, mappings, and rules.
+
+### 3.2 Scheduled coworker TaskRun substrate
+
+The newest scheduled-coworker work links proactive runs into `TaskRun` through [agent-task-scheduler.ts](D:/DPF/apps/web/lib/actions/agent-task-scheduler.ts:1) and [scheduled-task-runs.ts](D:/DPF/apps/web/lib/tak/scheduled-task-runs.ts:1).
+
+That makes Hive Scout a strong next consumer:
+
+- it is already periodic,
+- it is low-risk,
+- it produces operator-reviewable output,
+- it benefits from durable attribution and evidence.
+
+### 3.3 AI Operations Map visibility
+
+The AI Operations Map already projects proactive `TaskRun`, `ToolExecution`, receipt, backlog-evidence, and external-evidence records in [load-map-data.ts](D:/DPF/apps/web/lib/ai-operations-map/load-map-data.ts:1).
+
+Hive Scout should appear there as real AI workforce activity instead of being hidden inside a weekly queue function.
+
+### 3.4 Use-it-or-lose-it economics
+
+[2026-04-23-ai-provider-finance-bridge-design.md](D:/DPF/docs/superpowers/specs/2026-04-23-ai-provider-finance-bridge-design.md:32) and [2026-04-27-routing-control-data-plane-design.md](D:/DPF/docs/superpowers/specs/2026-04-27-routing-control-data-plane-design.md:448) already define use-it-or-lose-it handling for subscription providers.
+
+When prepaid AI capacity is lagging its quota window, background work like Hive Scout becomes economically rational:
+
+- bounded,
+- asynchronous,
+- reviewable,
+- and capable of generating durable platform value.
+
+This does **not** mean “burn credits for the sake of it.” It means Hive Scout is a valid candidate for low-priority background cognition when:
+
+- the run is safe,
+- the provider is lagging its committed usage window,
+- the work can be interrupted or deferred without operational harm.
+
+## 4. Target Architecture
+
+## 4.1 Deterministic core stays procedural
+
+The following parts should remain deterministic code:
+
+- upstream fetch and retry policy,
+- parser logic,
+- source URL deduplication,
+- idempotent backlog item creation,
+- stable value-stream alias mapping,
+- admin notification,
+- policy limits on which sources are allowed.
+
+These are already code-shaped concerns and should not be pushed into prompts.
+
+## 4.2 Ambiguous reasoning moves to the coworker
+
+The following parts are better treated as autonomous coworker cognition:
+
+- whether an external pattern is actually novel for DPF,
+- whether it is a new coworker archetype versus a new skill on an existing coworker,
+- how strongly it fits a given IT4IT/value-stream placement,
+- whether multiple external projects should collapse into one synthesized internal archetype,
+- whether the discovered idea is strategically relevant now versus informational only.
+
+These are the high-context, fuzzy, judgment-heavy parts where a coworker can reduce human cognitive load.
+
+## 4.3 Hybrid pattern
+
+Hive Scout v2 should therefore follow a hybrid model:
+
+1. Deterministic scout code fetches and normalizes raw catalog entries.
+2. A governed autonomous coworker run evaluates ambiguous items in batches.
+3. The coworker emits structured judgments, not prose-only output.
+4. Stable judgments are promoted into rules, mappings, filters, or typed schema.
+5. Human reviewers only see compact proposals and exceptions.
+
+This is the same ladder established by the autonomous runtime doctrine, applied to external-catalog scouting.
+
+## 5. Runtime Shape
+
+### 5.1 Trigger and identity
+
+Hive Scout should run as a proactive coworker task with `TaskRun` identity, not just as a free-floating queue function.
+
+Recommended shape:
+
+- trigger: `scheduled`
+- source: `proactive`
+- route context: `/platform/ai/operations` for runtime visibility, with deep links into backlog and skills
+- source reference: `external-catalog-scout`
+- evidence source tags: `hive-scout`, upstream catalog name, framework, value-stream confidence
+
+### 5.2 Coworker ownership
+
+Do not create a vague new “general scout” agent.
+
+Recommended ownership:
+
+- primary specialist: a platform/portfolio-facing coworker with backlog authority and strong archetype/skill context
+- candidate owners: `portfolio-advisor` or a dedicated `external-catalog-scout` specialist
+
+The coworker should have:
+
+- bounded tool grants,
+- read-only external scouting,
+- backlog proposal capability,
+- no direct auto-create authority for new coworkers or skills.
+
+### 5.3 Evidence and review
+
+Each meaningful Hive Scout run should produce:
+
+- `TaskRun` identity,
+- `ToolExecution` audit for the scout steps,
+- `BacklogItemActivity` or equivalent evidence linkage for created suggestions,
+- structured summary artifacts suitable for the AI Operations Map,
+- repeatable pattern markers for future proceduralization.
+
+## 6. Use-It-or-Lose-It Scheduling Policy
+
+Hive Scout is a good consumer of underused prepaid AI capacity, but only under policy.
+
+### 6.1 Safe use cases
+
+Burn-rate-aware preference is appropriate when:
+
+- the task is background-only,
+- the output is reviewable before irreversible action,
+- no sensitive external data is involved,
+- the run can be rate-limited, paused, or deferred.
+
+Hive Scout meets those conditions.
+
+### 6.2 Not a forced-consumption engine
+
+Do **not** let use-it-or-lose-it logic turn Hive Scout into busywork.
+
+Guardrails:
+
+- only run when there is new or stale source material worth evaluating,
+- cap spend per run and per quota window,
+- batch similar entries,
+- prefer cheapest capable model first,
+- stop when marginal novelty falls below a threshold,
+- log why a run happened: cadence, stale source, new source, lagging burn-rate assist, or explicit human trigger.
+
+### 6.3 Policy recommendation
+
+Hive Scout should be eligible for a background “subscription utilization assist” queue class:
+
+- lower priority than operational recovery,
+- higher priority than cosmetic research,
+- auto-paused when provider burn rate is already ahead,
+- safe to resume when quota lag is detected.
+
+## 7. Implementation Slices
+
+### Slice 1: TaskRun-ize Hive Scout
+
+Goal: make Hive Scout a first-class proactive coworker run.
+
+Scope:
+
+- route Hive Scout through the scheduled coworker substrate,
+- create `TaskRun` for each run,
+- write structured run summaries,
+- project runs into the AI Operations Map,
+- preserve the existing deterministic ingest logic.
+
+Acceptance:
+
+- each Hive Scout run has one `TaskRun`,
+- run appears in AI Operations Map,
+- backlog suggestions link back to source run evidence.
+
+### Slice 2: Add autonomous ambiguity review
+
+Goal: keep procedural code for parsing/dedupe, but let the coworker judge novelty and fit for ambiguous entries.
+
+Scope:
+
+- batch unresolved entries,
+- invoke coworker reasoning with structured output,
+- classify results as `new_archetype`, `existing_skill_gap`, `duplicate_pattern`, `out_of_scope`, or `needs_human_review`,
+- persist rationale/evidence,
+- keep human review on the final proposal layer.
+
+Acceptance:
+
+- deterministic path still handles obvious duplicates,
+- coworker only receives ambiguous entries,
+- proposals are structured and reviewable.
+
+### Slice 3: Add proceduralization loop
+
+Goal: stop re-solving the same archetype decisions forever.
+
+Scope:
+
+- detect repeated reviewer corrections and repeated coworker conclusions,
+- promote stable mappings and filters into code/policy,
+- record capability needs when the coworker repeatedly lacks the right tool/model/context,
+- surface Hive Scout as a proceduralization candidate source in AI Operations.
+
+Acceptance:
+
+- repeated false positives decline,
+- repeated out-of-scope classes become deterministic filters,
+- repeated “same existing coworker” outcomes become rules.
+
+### Slice 4: Add burn-rate-aware background scheduling
+
+Goal: use lagging prepaid quota intelligently.
+
+Scope:
+
+- add Hive Scout to the safe background queue class,
+- let routing/provider policy prefer lagging subscription providers for this task class,
+- record run trigger reasons and consumption outcomes,
+- cap budget and concurrency.
+
+Acceptance:
+
+- Hive Scout can be triggered by quota-lag conditions,
+- it remains bounded and reviewable,
+- it never crowds out higher-priority operational work.
+
+## 8. Recommended Next Move
+
+The next move should **not** be “make Hive Scout smarter everywhere at once.”
+
+The right next step is **Slice 1: TaskRun-ize Hive Scout**.
+
+Why:
+
+- the autonomous runtime substrate is now the platform direction,
+- the scheduled coworker/TaskRun seam already exists,
+- this gives immediate operator visibility and governance,
+- it creates the evidence foundation needed before any deeper AI reasoning is added.
+
+Only after that should DPF add autonomous novelty judgment and use-it-or-lose-it scheduling.
+
+## 9. Recommendation
+
+Adopt Hive Scout as one of the first non-build, non-recovery proof points of the new autonomous coworker runtime.
+
+That makes it useful in three ways at once:
+
+- it reduces human research/orchestration burden,
+- it produces governed evidence in the runtime control surface,
+- it creates a clean case for the platform’s “AI first, then procedure” doctrine.


### PR DESCRIPTION
## Summary
- Records the evidence chain showing why `/build`'s build-specialist coworker fails to dispatch any platform tool when routed to `anthropic-sub`.
- The Claude CLI session log proves the model emits real `tool_use` content blocks (valid `toolu_…` IDs, 9 calls across 8 platform tool names); the CLI's internal dispatcher auto-rejects each with `<tool_use_error>: No such tool available`. The model's "No such tool available" prose is accurate.
- Points at the prepared remedy: [`docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-04-11-platform-mcp-tool-server-implementation.md). Wire `--mcp-config` so platform tools become real MCP tools the CLI can call.

## Why this audit
- A previous diagnosis attempt mis-framed this as a model hallucination. The session log proves the model is reporting accurately — the rejection happens inside the CLI before the platform ever sees the dispatch.
- This audit only records the evidence so the planned implementation can proceed without re-doing the diagnosis. Adapter comparison (`cli-adapter` vs `codex-cli-adapter` vs `chat-adapter`) is included to explain why Build Studio can advance through `codex-agent` today but not through `anthropic-sub`.

## What is NOT in this PR
- No code changes.
- No prompt or seed edits.
- No retitling of the existing plan.

## Test plan
- [ ] Reviewer reads the audit doc end-to-end; cross-checks the trace excerpt against current portal logs on any install that routes `build-specialist` to `anthropic-sub`.
- [ ] Reviewer can repro the symptom (steps in `Repro` section) and confirm the session log under `/home/node/.claude/projects/-workspace/*.jsonl` shows the same `<tool_use_error>: No such tool available` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)