### PR TITLE
feat(ai): extract autonomous coworker runtime service

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -37,6 +37,10 @@ import { classifyTask } from "@/lib/task-classifier";
 import { getTaskType } from "@/lib/task-types";
 import { loadPerformanceProfiles, ensurePerformanceProfile } from "@/lib/agent-router-data";
 import type { RoutingMeta } from "@/lib/process-observer-hook";
+import {
+  executeAutonomousAgenticLoop,
+  findCurrentAutonomousWorkRun,
+} from "@/lib/tak/autonomous-work-run";
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
@@ -907,14 +911,9 @@ export async function sendMessage(input: {
   let responseModelId: string | null = null;
   let formAssistUpdate: Record<string, unknown> | undefined;
   let systemMessage: AgentMessageRow | undefined;
-  const currentTaskRun = await prisma.taskRun.findFirst({
-    where: {
-      userId: user.id!,
-      threadId: input.threadId,
-      archivedAt: null,
-    },
-    orderBy: [{ startedAt: "desc" }, { createdAt: "desc" }],
-    select: { taskRunId: true },
+  const currentTaskRun = await findCurrentAutonomousWorkRun({
+    userId: user.id!,
+    threadId: input.threadId,
   }).catch(() => null);
 
   // EP-AI-WORKFORCE-001: Provider pinning is now via AgentModelConfig.pinnedProviderId
@@ -1031,7 +1030,6 @@ export async function sendMessage(input: {
   try {
     // ── Agentic execution loop ──────────────────────────────────────────────
     // EP-INF-009b: The loop handles V2 routing internally via routeAndCall().
-    const { runAgenticLoop } = await import("@/lib/agentic-loop");
     const { agentEventBus } = await import("@/lib/agent-event-bus");
 
     // Build Specialist Operator Contract platform guards (clauses 2.2/2.4/2.6)
@@ -1043,7 +1041,7 @@ export async function sendMessage(input: {
       select: { id: true, phase: true },
     }).catch(() => null);
 
-    const agenticResult = await runAgenticLoop({
+    const agenticResult = await executeAutonomousAgenticLoop({
       chatHistory,
       systemPrompt: populatedPrompt,
       sensitivity: agent.sensitivity,

--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -31,6 +31,9 @@ const mocks = vi.hoisted(() => ({
     taskMessage: {
       create: vi.fn(),
     },
+    toolExecution: {
+      findFirst: vi.fn(),
+    },
   },
   resolveAgentForRouteWithPrompts: vi.fn(),
   resolveAgentByIdWithPrompts: vi.fn(),
@@ -38,6 +41,7 @@ const mocks = vi.hoisted(() => ({
   getAvailableTools: vi.fn(),
   toolsToOpenAIFormat: vi.fn(),
   executeTool: vi.fn(),
+  governedExecuteTool: vi.fn(),
 }));
 
 vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
@@ -53,6 +57,9 @@ vi.mock("@/lib/mcp-tools", () => ({
   getAvailableTools: mocks.getAvailableTools,
   toolsToOpenAIFormat: mocks.toolsToOpenAIFormat,
   executeTool: mocks.executeTool,
+}));
+vi.mock("@/lib/mcp-governed-execute", () => ({
+  governedExecuteTool: mocks.governedExecuteTool,
 }));
 
 import {
@@ -194,6 +201,7 @@ function arrangeScheduledTask() {
     },
   ]);
   mocks.toolsToOpenAIFormat.mockReturnValue([]);
+  mocks.governedExecuteTool.mockResolvedValue({ success: true, message: "ok" });
   mocks.prisma.taskRun.create.mockResolvedValue({
     id: "task-run-row-1",
     taskRunId: "TR-SCHED-ABCDE",
@@ -201,6 +209,7 @@ function arrangeScheduledTask() {
   });
   mocks.prisma.taskMessage.create.mockResolvedValue({});
   mocks.prisma.taskRun.update.mockResolvedValue({});
+  mocks.prisma.toolExecution.findFirst.mockResolvedValue({ id: "tool-execution-1" });
   mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
   mocks.prisma.scheduledJob.update.mockResolvedValue({});
 }
@@ -245,6 +254,7 @@ function arrangeHiveScoutTask() {
     },
   ]);
   mocks.toolsToOpenAIFormat.mockReturnValue([]);
+  mocks.governedExecuteTool.mockResolvedValue({ success: true, message: "ok" });
   mocks.prisma.taskRun.create.mockResolvedValue({
     id: "task-run-row-1",
     taskRunId: "TR-SCHED-HIVE1",
@@ -252,6 +262,7 @@ function arrangeHiveScoutTask() {
   });
   mocks.prisma.taskMessage.create.mockResolvedValue({});
   mocks.prisma.taskRun.update.mockResolvedValue({});
+  mocks.prisma.toolExecution.findFirst.mockResolvedValue({ id: "tool-execution-1" });
   mocks.prisma.scheduledAgentTask.update.mockResolvedValue({});
   mocks.prisma.scheduledJob.update.mockResolvedValue({});
 }
@@ -282,6 +293,7 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
         where: { taskId: "discovery-taxonomy-gap-triage-daily" },
         data: expect.objectContaining({
           lastStatus: "ok",
+          lastError: null,
           taskRunId: "TR-SCHED-ABCDE",
         }),
       }),
@@ -292,6 +304,15 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
         data: expect.objectContaining({
           status: "completed",
           completedAt: expect.any(Date),
+        }),
+      }),
+    );
+    expect(mocks.prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "discovery-taxonomy-gap-triage-daily" },
+        data: expect.objectContaining({
+          lastStatus: "ok",
+          lastError: null,
         }),
       }),
     );
@@ -343,6 +364,146 @@ describe("executeScheduledAgentTask TaskRun lifecycle", () => {
       },
     ]);
     expect(agentTaskMessage?.data.parts[0].text).not.toContain("I stopped because");
+  });
+
+  it("procedurally executes required discovery triage when the model narrates instead of calling the tool", async () => {
+    arrangeScheduledTask();
+    mocks.prisma.toolExecution.findFirst.mockResolvedValue(null);
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "The tool subsystem is not available.",
+      executedTools: [],
+    });
+    mocks.governedExecuteTool.mockResolvedValue({
+      success: true,
+      message: "Duplicate cadence triage run already recorded today.",
+      data: {
+        trigger: "cadence",
+        processedAt: "2026-05-12T05:50:17.968Z",
+        runIdempotencyKey: "2026-05-12:inventory-specialist:cadence",
+        skipped: true,
+        skipReason: "Duplicate cadence triage run already recorded today.",
+        metrics: {
+          processed: 0,
+          decisionsCreated: 0,
+          autoAttributed: 0,
+          humanReview: 0,
+          taxonomyGap: 0,
+          needsMoreEvidence: 0,
+          dismissed: 0,
+          escalationQueueDepth: 0,
+          repeatUnresolved: 0,
+          autoApplyRate: 0,
+        },
+      },
+    });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    expect(mocks.governedExecuteTool).toHaveBeenCalledWith({
+      toolName: "run_discovery_triage",
+      rawParams: { trigger: "cadence" },
+      userId: "user-1",
+      userContext: { userId: "user-1", platformRole: null, isSuperuser: true },
+      source: "agentic-loop",
+      context: {
+        routeContext: "/platform/tools/discovery",
+        agentId: "inventory-specialist",
+        threadId: "thread-1",
+        taskRunId: "TR-SCHED-ABCDE",
+      },
+    });
+    const agentTaskMessage = mocks.prisma.taskMessage.create.mock.calls.find(
+      ([args]) => args.data.role === "agent",
+    )?.[0];
+
+    expect(agentTaskMessage?.data.parts[0].text).toContain("Discovery triage skipped");
+    expect(agentTaskMessage?.data.parts[0].text).not.toContain("tool subsystem");
+    expect(mocks.prisma.taskRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "task-run-row-1" },
+        data: expect.objectContaining({
+          progressPayload: expect.objectContaining({
+            executedToolCount: 1,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("persists a required discovery triage receipt when the loop reports an unrecorded tool call", async () => {
+    arrangeScheduledTask();
+    mocks.prisma.toolExecution.findFirst.mockResolvedValue(null);
+    mocks.runAgenticLoop.mockResolvedValue({
+      content: "Done.",
+      executedTools: [
+        {
+          name: "run_discovery_triage",
+          args: { trigger: "cadence" },
+          result: {
+            success: true,
+            message: "Duplicate cadence triage run already recorded today.",
+            data: {
+              trigger: "cadence",
+              processedAt: "2026-05-12T06:35:12.297Z",
+              runIdempotencyKey: "2026-05-12:inventory-specialist:cadence",
+              skipped: true,
+              skipReason: "Duplicate cadence triage run already recorded today.",
+              metrics: {
+                processed: 0,
+                decisionsCreated: 0,
+                autoAttributed: 0,
+                humanReview: 0,
+                taxonomyGap: 0,
+                needsMoreEvidence: 0,
+                dismissed: 0,
+                escalationQueueDepth: 0,
+                repeatUnresolved: 0,
+                autoApplyRate: 0,
+              },
+            },
+          },
+        },
+      ],
+    });
+    mocks.governedExecuteTool.mockResolvedValue({
+      success: true,
+      message: "Duplicate cadence triage run already recorded today.",
+      data: { skipped: true, trigger: "cadence" },
+    });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    expect(mocks.prisma.toolExecution.findFirst).toHaveBeenCalledWith({
+      where: {
+        taskRunId: "TR-SCHED-ABCDE",
+        toolName: "run_discovery_triage",
+        success: true,
+      },
+      select: { id: true },
+    });
+    expect(mocks.governedExecuteTool).toHaveBeenCalledWith({
+      toolName: "run_discovery_triage",
+      rawParams: { trigger: "cadence" },
+      userId: "user-1",
+      userContext: { userId: "user-1", platformRole: null, isSuperuser: true },
+      source: "agentic-loop",
+      context: {
+        routeContext: "/platform/tools/discovery",
+        agentId: "inventory-specialist",
+        threadId: "thread-1",
+        taskRunId: "TR-SCHED-ABCDE",
+      },
+    });
+    expect(mocks.prisma.taskRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "task-run-row-1" },
+        data: expect.objectContaining({
+          progressPayload: expect.objectContaining({
+            executedToolCount: 1,
+          }),
+        }),
+      }),
+    );
   });
 
   it("uses a structured Hive Scout summary for task-facing agent messages when the scout tool ran", async () => {

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -9,6 +9,12 @@ import {
   type ScheduledTaskRunRef,
 } from "@/lib/tak/scheduled-task-runs";
 import { createTaskMessage } from "@/lib/tak/task-records";
+import {
+  executeAutonomousAgenticLoop,
+  executeAutonomousWorkTool,
+  resolveAutonomousWorkAgent,
+  resolveAutonomousWorkTools,
+} from "@/lib/tak/autonomous-work-run";
 
 // ─── Cron helpers ───────────────────────────────────────────────────────────
 
@@ -47,6 +53,20 @@ function computeNextCronRun(cronExpr: string, from: Date): Date {
   }
 
   return next;
+}
+
+function getRequiredProceduralToolForScheduledTask(taskId: string): {
+  name: string;
+  args: Record<string, unknown>;
+} | null {
+  if (taskId === "discovery-taxonomy-gap-triage-daily") {
+    return {
+      name: "run_discovery_triage",
+      args: { trigger: "cadence" },
+    };
+  }
+
+  return null;
 }
 
 // ─── Public actions ─────────────────────────────────────────────────────────
@@ -233,18 +253,11 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       isSuperuser: owner?.isSuperuser ?? false,
     };
 
-    // Resolve agent prompts
-    const { resolveAgentByIdWithPrompts, resolveAgentForRouteWithPrompts } = await import(
-      "@/lib/tak/agent-routing-server"
-    );
-    const routedAgentInfo = await resolveAgentForRouteWithPrompts(
-      task.routeContext,
+    const agentInfo = await resolveAutonomousWorkAgent({
+      agentId: task.agentId,
+      routeContext: task.routeContext,
       userContext,
-    );
-    const agentInfo =
-      routedAgentInfo.agentId === task.agentId
-        ? routedAgentInfo
-        : await resolveAgentByIdWithPrompts(task.agentId, userContext);
+    });
 
     const scheduledPrompt = `[Scheduled task: ${task.title}]\n\n${task.prompt}`;
     const chatHistory = [
@@ -254,15 +267,13 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       },
     ];
 
-    const { runAgenticLoop } = await import("@/lib/tak/agentic-loop");
-    const { getAvailableTools, toolsToOpenAIFormat, executeTool } = await import(
-      "@/lib/mcp-tools"
-    );
+    const { tools, toolsForProvider } = await resolveAutonomousWorkTools({
+      userContext,
+      mode: "act",
+      agentId: task.agentId,
+    });
 
-    const tools = await getAvailableTools(userContext, { mode: "act", agentId: task.agentId });
-    const toolsForProvider = toolsToOpenAIFormat(tools);
-
-    const result = await runAgenticLoop({
+    const result = await executeAutonomousAgenticLoop({
       systemPrompt: agentInfo.systemPrompt,
       chatHistory,
       sensitivity: agentInfo.sensitivity ?? "internal",
@@ -274,8 +285,44 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       threadId: thread.id,
       taskRunId: taskRunRef.taskRunId,
     });
+    const executedTools = [...(result.executedTools ?? [])];
 
-    const scheduledSummary = extractScheduledTaskSummary(result.executedTools);
+    const requiredTool = getRequiredProceduralToolForScheduledTask(task.taskId);
+    if (requiredTool) {
+      const hasPersistedRequiredTool = await prisma.toolExecution.findFirst({
+        where: {
+          taskRunId: taskRunRef.taskRunId,
+          toolName: requiredTool.name,
+          success: true,
+        },
+        select: { id: true },
+      });
+
+      if (!hasPersistedRequiredTool) {
+        const alreadyCountedRequiredTool = executedTools.some(
+          (tool) => tool.name === requiredTool.name,
+        );
+        const toolResult = await executeAutonomousWorkTool({
+          toolName: requiredTool.name,
+          args: requiredTool.args,
+          userId: task.ownerUserId,
+          userContext,
+          routeContext: task.routeContext,
+          agentId: task.agentId,
+          threadId: thread.id,
+          taskRunId: taskRunRef.taskRunId,
+        });
+        if (!alreadyCountedRequiredTool) {
+          executedTools.push({
+            name: requiredTool.name,
+            args: requiredTool.args,
+            result: toolResult,
+          });
+        }
+      }
+    }
+
+    const scheduledSummary = extractScheduledTaskSummary(executedTools);
     const taskMessageContent = scheduledSummary?.compactStatus ?? result.content ?? "(No response)";
 
     // Persist agent response
@@ -322,7 +369,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       data: {
         lastRunAt: now,
         lastStatus: "ok",
-        lastError: scheduledSummary?.compactStatus ?? null,
+        lastError: null,
         lastThreadId: thread.id,
         taskRunId: taskRunRef.taskRunId,
         nextRunAt,
@@ -336,7 +383,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
         completedAt: new Date(),
         progressPayload: {
           scheduledSummary: scheduledSummary?.compactStatus ?? null,
-          executedToolCount: result.executedTools?.length ?? 0,
+          executedToolCount: executedTools.length,
         },
       },
     });
@@ -346,7 +393,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       data: {
         lastRunAt: now,
         lastStatus: "ok",
-        lastError: scheduledSummary?.compactStatus ?? null,
+        lastError: null,
         nextRunAt,
       },
     }).catch(() => {});

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -2,17 +2,48 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@dpf/db", () => {
   const create = vi.fn();
+  const findFirst = vi.fn();
   return {
     prisma: {
-      taskRun: { create },
+      taskRun: { create, findFirst },
     },
   };
 });
+
+vi.mock("@/lib/tak/agentic-loop", () => ({ runAgenticLoop: vi.fn() }));
+vi.mock("@/lib/mcp-tools", () => ({
+  executeTool: vi.fn(),
+  getAvailableTools: vi.fn(),
+  toolsToOpenAIFormat: vi.fn(),
+}));
+vi.mock("@/lib/mcp-governed-execute", () => ({
+  governedExecuteTool: vi.fn(),
+}));
+vi.mock("@/lib/tak/agent-routing-server", () => ({
+  resolveAgentForRouteWithPrompts: vi.fn(),
+  resolveAgentByIdWithPrompts: vi.fn(),
+}));
 
 describe("createAutonomousWorkRun", () => {
   beforeEach(async () => {
     const { prisma } = await import("@dpf/db");
     vi.mocked(prisma.taskRun.create).mockReset();
+    vi.mocked(prisma.taskRun.findFirst).mockReset();
+
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockReset();
+
+    const tools = await import("@/lib/mcp-tools");
+    vi.mocked(tools.executeTool).mockReset();
+    vi.mocked(tools.getAvailableTools).mockReset();
+    vi.mocked(tools.toolsToOpenAIFormat).mockReset();
+
+    const governed = await import("@/lib/mcp-governed-execute");
+    vi.mocked(governed.governedExecuteTool).mockReset();
+
+    const routing = await import("@/lib/tak/agent-routing-server");
+    vi.mocked(routing.resolveAgentForRouteWithPrompts).mockReset();
+    vi.mocked(routing.resolveAgentByIdWithPrompts).mockReset();
   });
 
   it("creates a scheduled TaskRun through the shared autonomous work seam", async () => {
@@ -130,5 +161,134 @@ describe("createAutonomousWorkRun", () => {
       },
     });
     expect(String(arg?.data?.taskRunId)).toMatch(/^TR-CAP-/);
+  });
+
+  it("finds the newest unarchived TaskRun for an interactive thread", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.findFirst).mockResolvedValue({ taskRunId: "TR-CHAT-123" } as never);
+
+    const { findCurrentAutonomousWorkRun } = await import("./autonomous-work-run");
+
+    await expect(findCurrentAutonomousWorkRun({
+      userId: "user-1",
+      threadId: "thread-1",
+    })).resolves.toEqual({ taskRunId: "TR-CHAT-123" });
+
+    expect(prisma.taskRun.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        threadId: "thread-1",
+        archivedAt: null,
+      },
+      orderBy: [{ startedAt: "desc" }, { createdAt: "desc" }],
+      select: { taskRunId: true },
+    });
+  });
+
+  it("resolves the task agent when the route persona differs", async () => {
+    const routing = await import("@/lib/tak/agent-routing-server");
+    vi.mocked(routing.resolveAgentForRouteWithPrompts).mockResolvedValue({
+      agentId: "platform-engineer",
+      systemPrompt: "route prompt",
+    } as never);
+    vi.mocked(routing.resolveAgentByIdWithPrompts).mockResolvedValue({
+      agentId: "external-catalog-scout",
+      systemPrompt: "task prompt",
+    } as never);
+
+    const { resolveAutonomousWorkAgent } = await import("./autonomous-work-run");
+
+    const agent = await resolveAutonomousWorkAgent({
+      agentId: "external-catalog-scout",
+      routeContext: "/platform/ai/operations",
+      userContext: { userId: "user-1", platformRole: null, isSuperuser: true },
+    });
+
+    expect(agent).toMatchObject({ agentId: "external-catalog-scout", systemPrompt: "task prompt" });
+    expect(routing.resolveAgentByIdWithPrompts).toHaveBeenCalledWith(
+      "external-catalog-scout",
+      { userId: "user-1", platformRole: null, isSuperuser: true },
+    );
+  });
+
+  it("resolves tools and provider tool schemas through one runtime helper", async () => {
+    const mcpTools = await import("@/lib/mcp-tools");
+    const toolList = [{ name: "run_discovery_triage", sideEffect: true }];
+    vi.mocked(mcpTools.getAvailableTools).mockResolvedValue(toolList as never);
+    vi.mocked(mcpTools.toolsToOpenAIFormat).mockReturnValue([{ type: "function" }]);
+
+    const { resolveAutonomousWorkTools } = await import("./autonomous-work-run");
+
+    const resolved = await resolveAutonomousWorkTools({
+      userContext: { userId: "user-1", platformRole: null, isSuperuser: true },
+      agentId: "inventory-specialist",
+      mode: "act",
+    });
+
+    expect(resolved).toEqual({ tools: toolList, toolsForProvider: [{ type: "function" }] });
+    expect(mcpTools.getAvailableTools).toHaveBeenCalledWith(
+      { userId: "user-1", platformRole: null, isSuperuser: true },
+      { mode: "act", agentId: "inventory-specialist" },
+    );
+  });
+
+  it("forwards TaskRun identity into the agentic loop", async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);
+
+    const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+
+    await executeAutonomousAgenticLoop({
+      systemPrompt: "You are helpful.",
+      chatHistory: [{ role: "user", content: "Run it." }],
+      sensitivity: "internal",
+      tools: [],
+      toolsForProvider: [],
+      userId: "user-1",
+      routeContext: "/platform/tools/discovery",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      taskRunId: "TR-SCHED-ABCDEF12",
+    });
+
+    expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: "TR-SCHED-ABCDEF12",
+        agentId: "inventory-specialist",
+        threadId: "thread-1",
+      }),
+    );
+  });
+
+  it("executes a single governed tool with TaskRun attribution", async () => {
+    const governed = await import("@/lib/mcp-governed-execute");
+    vi.mocked(governed.governedExecuteTool).mockResolvedValue({ success: true, message: "ok" } as never);
+
+    const { executeAutonomousWorkTool } = await import("./autonomous-work-run");
+
+    await executeAutonomousWorkTool({
+      toolName: "run_discovery_triage",
+      args: { trigger: "cadence" },
+      userId: "user-1",
+      userContext: { userId: "user-1", platformRole: null, isSuperuser: true },
+      routeContext: "/platform/tools/discovery",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      taskRunId: "TR-SCHED-ABCDEF12",
+    });
+
+    expect(governed.governedExecuteTool).toHaveBeenCalledWith({
+      toolName: "run_discovery_triage",
+      rawParams: { trigger: "cadence" },
+      userId: "user-1",
+      userContext: { userId: "user-1", platformRole: null, isSuperuser: true },
+      source: "agentic-loop",
+      context: {
+        routeContext: "/platform/tools/discovery",
+        agentId: "inventory-specialist",
+        threadId: "thread-1",
+        taskRunId: "TR-SCHED-ABCDEF12",
+      },
+    });
   });
 });

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "crypto";
 import { prisma } from "@dpf/db";
+import type { ChatMessage } from "@/lib/ai-inference";
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { AgentEvent } from "@/lib/tak/agent-event-bus";
 
 export type AutonomousWorkTrigger =
   | "interactive"
@@ -15,6 +18,21 @@ export type AutonomousWorkRunRef = {
   id: string;
   taskRunId: string;
   contextId: string | null;
+};
+
+type AgentSensitivity = "public" | "internal" | "confidential" | "restricted";
+
+export type AutonomousWorkUserContext = {
+  userId?: string;
+  platformRole: string | null;
+  isSuperuser: boolean;
+};
+
+type AgentPromptInfo = {
+  agentId?: string | null;
+  systemPrompt: string;
+  sensitivity?: AgentSensitivity | null;
+  [key: string]: unknown;
 };
 
 export type AutonomousWorkRunInput = {
@@ -88,5 +106,131 @@ export async function createAutonomousWorkRun(
       },
     },
     select: { id: true, taskRunId: true, contextId: true },
+  });
+}
+
+export async function findCurrentAutonomousWorkRun(input: {
+  userId: string;
+  threadId: string;
+}): Promise<{ taskRunId: string } | null> {
+  return prisma.taskRun.findFirst({
+    where: {
+      userId: input.userId,
+      threadId: input.threadId,
+      archivedAt: null,
+    },
+    orderBy: [{ startedAt: "desc" }, { createdAt: "desc" }],
+    select: { taskRunId: true },
+  });
+}
+
+export async function resolveAutonomousWorkAgent(input: {
+  agentId: string;
+  routeContext: string;
+  userContext: AutonomousWorkUserContext;
+}): Promise<AgentPromptInfo> {
+  const { resolveAgentByIdWithPrompts, resolveAgentForRouteWithPrompts } = await import(
+    "@/lib/tak/agent-routing-server"
+  );
+  const routedAgentInfo = await resolveAgentForRouteWithPrompts(
+    input.routeContext,
+    input.userContext,
+  ) as AgentPromptInfo;
+
+  if (routedAgentInfo.agentId === input.agentId) {
+    return routedAgentInfo;
+  }
+
+  return resolveAgentByIdWithPrompts(input.agentId, input.userContext) as Promise<AgentPromptInfo>;
+}
+
+export async function resolveAutonomousWorkTools(input: {
+  userContext: AutonomousWorkUserContext;
+  agentId: string;
+  mode?: "advise" | "act";
+  externalAccessEnabled?: boolean;
+  unifiedMode?: boolean;
+}): Promise<{
+  tools: ToolDefinition[];
+  toolsForProvider: Array<Record<string, unknown>>;
+}> {
+  const { getAvailableTools, toolsToOpenAIFormat } = await import("@/lib/mcp-tools");
+  const tools = await getAvailableTools(input.userContext, {
+    mode: input.mode,
+    externalAccessEnabled: input.externalAccessEnabled,
+    unifiedMode: input.unifiedMode,
+    agentId: input.agentId,
+  });
+
+  return {
+    tools,
+    toolsForProvider: toolsToOpenAIFormat(tools),
+  };
+}
+
+export async function executeAutonomousAgenticLoop(input: {
+  systemPrompt: string;
+  chatHistory: ChatMessage[];
+  sensitivity: AgentSensitivity;
+  tools: ToolDefinition[];
+  toolsForProvider?: Array<Record<string, unknown>>;
+  userId: string;
+  routeContext: string;
+  agentId: string;
+  threadId: string;
+  taskRunId?: string | null;
+  taskType?: string;
+  agentDisplayName?: string;
+  buildPhase?: string | null;
+  featureBuildId?: string | null;
+  modelRequirements?: Record<string, unknown>;
+  onProgress?: (event: AgentEvent) => void;
+}) {
+  const { runAgenticLoop } = await import("@/lib/tak/agentic-loop");
+
+  return runAgenticLoop({
+    systemPrompt: input.systemPrompt,
+    chatHistory: input.chatHistory,
+    sensitivity: input.sensitivity,
+    tools: input.tools,
+    toolsForProvider: input.toolsForProvider,
+    userId: input.userId,
+    routeContext: input.routeContext,
+    agentId: input.agentId,
+    threadId: input.threadId,
+    taskRunId: input.taskRunId,
+    taskType: input.taskType,
+    agentDisplayName: input.agentDisplayName,
+    buildPhase: input.buildPhase,
+    featureBuildId: input.featureBuildId,
+    ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
+    onProgress: input.onProgress,
+  });
+}
+
+export async function executeAutonomousWorkTool(input: {
+  toolName: string;
+  args: Record<string, unknown>;
+  userId: string;
+  userContext: AutonomousWorkUserContext;
+  routeContext: string;
+  agentId: string;
+  threadId: string;
+  taskRunId: string;
+}): Promise<ToolResult> {
+  const { governedExecuteTool } = await import("@/lib/mcp-governed-execute");
+
+  return governedExecuteTool({
+    toolName: input.toolName,
+    rawParams: input.args,
+    userId: input.userId,
+    userContext: input.userContext,
+    source: "agentic-loop",
+    context: {
+      routeContext: input.routeContext,
+      agentId: input.agentId,
+      threadId: input.threadId,
+      taskRunId: input.taskRunId,
+    },
   });
 }

--- a/apps/web/lib/tak/scheduled-task-runs.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.ts
@@ -1,10 +1,9 @@
-import { createAutonomousWorkRun } from "@/lib/tak/autonomous-work-run";
+import {
+  createAutonomousWorkRun,
+  type AutonomousWorkRunRef,
+} from "@/lib/tak/autonomous-work-run";
 
-export type ScheduledTaskRunRef = {
-  id: string;
-  taskRunId: string;
-  contextId: string | null;
-};
+export type ScheduledTaskRunRef = AutonomousWorkRunRef;
 
 export async function createTaskRunForScheduledTask(input: {
   taskId: string;


### PR DESCRIPTION
## Summary
- Extracts shared autonomous coworker runtime helpers for TaskRun lookup/creation, agent/tool resolution, agentic loop execution, and governed tool execution.
- Routes scheduled coworker runs and interactive coworker send flow through the shared autonomous work-run seam.
- Promotes the required discovery-triage scheduled action into a procedural fallback: if the model narrates or reports an unreceipted tool path, the scheduler invokes `run_discovery_triage` through `governedExecuteTool` so the TaskRun has durable ToolExecution evidence.
- Clears `lastError` on successful scheduled runs and leaves the compact outcome in TaskRun/message evidence.

## Verification
- `pnpm --filter web exec vitest run lib/tak/autonomous-work-run.test.ts lib/actions/agent-task-scheduler.test.ts lib/tak/scheduled-task-runs.test.ts lib/actions/agent-coworker-external.test.ts` — 4 files, 23 tests passed.
- `pnpm --filter web test` — 611 files passed, 3 skipped; 4795 passed, 14 skipped, 13 todo.
- `pnpm --filter web typecheck` — passed after regenerating Prisma client against latest main.
- `pnpm --filter web build` — passed; existing Turbopack/NFT broad-tracing warnings remain.
- `docker compose -p dpf --env-file D:\DPF\.env build portal portal-init` — passed; same existing build warnings.
- `docker compose -p dpf --env-file D:\DPF\.env up -d portal portal-init` — rebuilt local stack started.
- Live scheduled coworker proof: forced `discovery-taxonomy-gap-triage-daily`; latest run `TR-SCHED-513ABD28` completed with source `proactive`, `executedToolCount: 1`, `lastError` cleared, and a successful `ToolExecution` for `run_discovery_triage` tied to `TR-SCHED-513ABD28`.
