### PR TITLE
fix(test): inline next-auth in Vitest resolver

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -18,6 +18,14 @@ export default defineConfig({
     globals: false,
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
+    server: {
+      deps: {
+        // Auth.js imports the Next server runtime by extensionless subpath.
+        // Keep it inside Vite's resolver so the alias below can normalize that
+        // import for Node/Vitest on both Windows and Linux CI.
+        inline: ["next-auth"],
+      },
+    },
   },
   resolve: {
     dedupe: ["react", "react-dom"],


### PR DESCRIPTION
## Summary
- Inline `next-auth` in Vitest's dependency pipeline so its extensionless `next/server` import is normalized by the existing resolver alias.
- Keeps the fix centralized in `apps/web/vitest.config.ts` rather than adding per-suite mocks.

## Verification
- `pnpm --filter web exec vitest run lib/backlog-enums.test.ts lib/mcp-governed-execute.test.ts lib/mcp-tools-coworker-self-assessment.test.ts lib/mcp-tools-ea.test.ts lib/mcp-tools-tool-marketplace.test.ts lib/mcp-tools-wiki-lint.test.ts lib/mcp-tools-wiki-query.test.ts lib/mcp-tools.test.ts tests/build-lifecycle.test.ts lib/integrate/build-orchestrator.test.ts app/api/mcp/v1/route.test.ts lib/mcp-tools-backlog.test.ts lib/mcp-tools-save-build-evidence.test.ts`
- `pnpm --filter web exec vitest run`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`
- `pnpm test`
- `pnpm typecheck`