### PR TITLE
fix(test): inline next-auth in Vitest so next/server alias applies

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -18,6 +18,20 @@ export default defineConfig({
     globals: false,
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
+    // Auth.js v5 (next-auth@5.0.0-beta.31) imports `next/server` (no extension)
+    // from `next-auth/lib/env.js`. Under Node ESM strict resolution that fails
+    // with "Cannot find module .../next/server. Did you mean to import
+    // 'next/server.js'?" The `resolve.alias` below already maps `next/server`
+    // to the .js file, but Vite's aliases only apply to deps Vite actually
+    // transforms. By default Vitest externalizes `next-auth` (lets Node load
+    // it natively), bypassing the alias. Inlining `next-auth` brings it back
+    // inside the Vite resolver so the alias takes effect on every Linux + CI
+    // run, not just the ones where Node happened to honor the deep export.
+    server: {
+      deps: {
+        inline: ["next-auth"],
+      },
+    },
   },
   resolve: {
     dedupe: ["react", "react-dom"],


### PR DESCRIPTION
## Summary

Fixes the CI Unit Tests failure that has been red on main since the most recent dep state — `Cannot find module .../node_modules/next/server imported from .../node_modules/next-auth/lib/env.js`.

Auth.js v5 (`next-auth@5.0.0-beta.31`) imports `next/server` without an extension from `next-auth/lib/env.js`. Vitest defaults externalize `next-auth`, which bypasses the existing `resolve.alias` entry that maps `next/server` → `next/server.js`. Adding `next-auth` to `test.server.deps.inline` brings it back inside Vite's resolver so the alias takes effect.

## What changed

`apps/web/vitest.config.ts` — 14 added lines (block comment + the `server.deps.inline` entry). No other files.

## Verification

Ran locally in a fresh worktree off origin/main with the fix applied:

- 13 previously-failing test files all pass: `lib/mcp-tools-save-build-evidence.test.ts`, `lib/mcp-tools-backlog.test.ts`, `lib/mcp-tools.test.ts`, `lib/mcp-governed-execute.test.ts`, `lib/mcp-tools-ea.test.ts`, `app/api/mcp/v1/route.test.ts`, `tests/build-lifecycle.test.ts`, `lib/backlog-enums.test.ts`, `lib/integrate/build-orchestrator.test.ts`, `lib/mcp-tools-coworker-self-assessment.test.ts`, `lib/mcp-tools-tool-marketplace.test.ts`, `lib/mcp-tools-wiki-lint.test.ts`, `lib/mcp-tools-wiki-query.test.ts`.
- Full `pnpm --filter web exec vitest run`: **619 passed, 3 skipped, 0 failures, 4902 tests**.

## Concurrent-session note

A stale local-only WIP branch `codex/ci-next-auth-server-vitest` (never pushed) on a parallel worktree contains the same one-line vitest.config change plus a handful of incidental snapshot edits that look like local-env noise. This PR lands the same fix cleanly off main, snapshots untouched.

## Test plan

- [ ] CI Unit Tests turn green on this PR.
- [ ] After merge, rebase open PRs (#506 docs-audit, others) and confirm their CI also turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)