### PR TITLE
feat(edge-node): (edgeNodeId, runKey) idempotency for discovery ingest

### DIFF
--- a/apps/web/app/api/v1/edge/discovery-runs/route.test.ts
+++ b/apps/web/app/api/v1/edge/discovery-runs/route.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
-const { mockResolveAuth } = vi.hoisted(() => ({
+const { mockResolveAuth, mockDiscoveryRunFindUnique } = vi.hoisted(() => ({
   mockResolveAuth: vi.fn(),
+  mockDiscoveryRunFindUnique: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/edge-node-token", () => ({
   resolveEdgeNodeAuth: mockResolveAuth,
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    discoveryRun: {
+      findUnique: mockDiscoveryRunFindUnique,
+    },
+  },
 }));
 
 import { POST } from "./route";
@@ -18,22 +26,34 @@ const AUTHED = {
   trustState: "trusted" as const,
 };
 
-const VALID_BODY = {
-  runKey: "run_a1b2c3",
-  agentMode: "container-host",
-  agentVersion: "0.1.0",
-  observedAt: "2026-05-12T12:00:00Z",
-  capabilities: ["discovery.network"],
-  items: [
-    {
-      observedKey: "host:linux:abcdef",
-      itemType: "host",
-      name: "edge-test",
-      rawData: { kernel: "6.5.0" },
-    },
-  ],
-  relationships: [],
-};
+// observedAt must be within the route's freshness window (+/- 24h
+// from server time). Compute relative to test-run wall time so the
+// fixture doesn't go stale six months from now.
+function freshObservedAt(): string {
+  return new Date().toISOString();
+}
+
+function makeValidBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    runKey: "run_a1b2c3",
+    agentMode: "container-host",
+    agentVersion: "0.1.0",
+    observedAt: freshObservedAt(),
+    capabilities: ["discovery.network"],
+    items: [
+      {
+        observedKey: "host:linux:abcdef",
+        itemType: "host",
+        name: "edge-test",
+        rawData: { kernel: "6.5.0" },
+      },
+    ],
+    relationships: [],
+    ...overrides,
+  };
+}
+
+const VALID_BODY = makeValidBody();
 
 function makeReq(
   body: unknown,
@@ -49,6 +69,10 @@ function makeReq(
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // Default: no prior run exists, so the idempotency lookup returns null
+  // and the route falls through to the 202 stub branch. Tests that need
+  // the idempotent-replay path override this per-test.
+  mockDiscoveryRunFindUnique.mockResolvedValue(null);
 });
 
 describe("POST /api/v1/edge/discovery-runs — auth gate", () => {
@@ -160,12 +184,13 @@ describe("POST /api/v1/edge/discovery-runs — happy path (A4 not yet wired)", (
   });
 
   it("counts items + relationships from the parsed envelope", async () => {
+    const existingItems = VALID_BODY.items as Array<Record<string, unknown>>;
     const res = await POST(
       makeReq(
         {
           ...VALID_BODY,
           items: [
-            ...VALID_BODY.items,
+            ...existingItems,
             {
               observedKey: "host:linux:xyz",
               itemType: "host",
@@ -188,5 +213,120 @@ describe("POST /api/v1/edge/discovery-runs — happy path (A4 not yet wired)", (
     const body = await res.json();
     expect(body.itemCount).toBe(2);
     expect(body.relationshipCount).toBe(1);
+  });
+});
+
+describe("POST /api/v1/edge/discovery-runs — freshness window", () => {
+  beforeEach(() => mockResolveAuth.mockResolvedValue(AUTHED));
+
+  it("returns 400 stale_observation when observedAt is > 24h in the past", async () => {
+    const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    const res = await POST(
+      makeReq(
+        makeValidBody({ observedAt: stale }),
+        { Authorization: "Bearer x" },
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("stale_observation");
+    // Freshness gate must fire BEFORE the idempotency lookup so stale
+    // submissions never hit the DB.
+    expect(mockDiscoveryRunFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 stale_observation when observedAt is > 24h in the future (clock skew)", async () => {
+    const future = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString();
+    const res = await POST(
+      makeReq(
+        makeValidBody({ observedAt: future }),
+        { Authorization: "Bearer x" },
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("stale_observation");
+  });
+
+  it("accepts observedAt at the recent edge of the window", async () => {
+    // 23h ago — comfortably inside the 24h window.
+    const recent = new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString();
+    const res = await POST(
+      makeReq(
+        makeValidBody({ observedAt: recent }),
+        { Authorization: "Bearer x" },
+      ),
+    );
+    expect(res.status).toBe(202);
+  });
+});
+
+describe("POST /api/v1/edge/discovery-runs — (edgeNodeId, runKey) idempotency", () => {
+  beforeEach(() => mockResolveAuth.mockResolvedValue(AUTHED));
+
+  it("returns 200 idempotentReplay when the same (edgeNodeId, runKey) was already persisted", async () => {
+    const priorStartedAt = new Date(Date.now() - 60_000);
+    const priorCompletedAt = new Date(Date.now() - 30_000);
+    mockDiscoveryRunFindUnique.mockResolvedValue({
+      id: "run_db_1",
+      status: "completed",
+      itemCount: 5,
+      relationshipCount: 2,
+      startedAt: priorStartedAt,
+      completedAt: priorCompletedAt,
+    });
+
+    const res = await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.accepted).toBe(true);
+    expect(body.idempotentReplay).toBe(true);
+    expect(body.runId).toBe("run_db_1");
+    expect(body.runKey).toBe("run_a1b2c3");
+    expect(body.status).toBe("completed");
+    expect(body.itemCount).toBe(5);
+    expect(body.relationshipCount).toBe(2);
+    expect(body.startedAt).toBe(priorStartedAt.toISOString());
+    expect(body.completedAt).toBe(priorCompletedAt.toISOString());
+  });
+
+  it("looks up by the composite (edgeNodeId, runKey) key — each node owns its runKey namespace", async () => {
+    mockDiscoveryRunFindUnique.mockResolvedValue(null);
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    expect(mockDiscoveryRunFindUnique).toHaveBeenCalledOnce();
+    const args = mockDiscoveryRunFindUnique.mock.calls[0]![0];
+    expect(args.where).toEqual({
+      edgeNodeId_runKey: {
+        edgeNodeId: "edgenode_cuid_1",
+        runKey: "run_a1b2c3",
+      },
+    });
+  });
+
+  it("falls through to 202 stub when no prior run exists for (edgeNodeId, runKey)", async () => {
+    mockDiscoveryRunFindUnique.mockResolvedValue(null);
+    const res = await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.idempotentReplay).toBeUndefined();
+    expect(body.persistencePending).toBe(true);
+  });
+
+  it("preserves null completedAt for an in-flight prior run", async () => {
+    mockDiscoveryRunFindUnique.mockResolvedValue({
+      id: "run_db_2",
+      status: "running",
+      itemCount: 0,
+      relationshipCount: 0,
+      startedAt: new Date(),
+      completedAt: null,
+    });
+    const res = await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.idempotentReplay).toBe(true);
+    expect(body.completedAt).toBeNull();
+    expect(body.status).toBe("running");
   });
 });

--- a/apps/web/app/api/v1/edge/discovery-runs/route.ts
+++ b/apps/web/app/api/v1/edge/discovery-runs/route.ts
@@ -1,23 +1,32 @@
 // POST /api/v1/edge/discovery-runs
 //
 // Edge Node submits a prepared discovery-run envelope. The Authority
-// validates auth + envelope shape and forwards to
+// validates auth + envelope shape, runs the idempotency check from
+// the spec's REST ingestion controls, and forwards to
 // `persistSubmittedDiscoveryRun` for normalization + persistence.
 //
-// Phase 0 status: this route validates the envelope and refuses if the
-// EdgeNode's trustState is not `trusted`. The actual persistence call
-// to `persistSubmittedDiscoveryRun` lands in A4 (collector extraction
-// + persistence sibling). Until A4 lands, this route returns 202
-// Accepted with `{ persistencePending: true }` so the Edge Node can
-// retry later or the test harness can validate the path is wired.
+// Phase 0 status: this route now enforces (edgeNodeId, runKey)
+// idempotency and the freshness window on observedAt. The actual
+// persistence wiring (calling persistSubmittedDiscoveryRun with the
+// normalized envelope) is still pending — the route returns 202
+// Accepted with `{ persistencePending: true }` after the gates pass,
+// so the Edge Node can retry later or the test harness can validate
+// the contract is wired.
 //
 // Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
 //   § Ingestion contract: submit observations, don't trigger sweeps
+//   § REST ingestion controls (Phase 0) — idempotency, freshness window
 
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { prisma } from "@dpf/db";
+
 import { resolveEdgeNodeAuth } from "@/lib/auth/edge-node-token";
+
+// Per spec § REST ingestion controls (Phase 0): observedAt must be
+// within +/- this window of server time, else 400 stale_observation.
+const FRESHNESS_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
 
 const ObservationItem = z
   .object({
@@ -90,19 +99,80 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // TODO(A4): replace with `persistSubmittedDiscoveryRun({
+  // Freshness window: reject submissions outside +/- 24h of server
+  // time per spec § REST ingestion controls. Prevents back-dated
+  // submissions polluting inventory history; also catches Edge Nodes
+  // with badly skewed clocks before they pollute attribution.
+  const observedAt = new Date(parsed.data.observedAt);
+  const skewMs = Math.abs(Date.now() - observedAt.getTime());
+  if (skewMs > FRESHNESS_WINDOW_MS) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "stale_observation",
+        message: `observedAt must be within ${FRESHNESS_WINDOW_MS / 1000 / 3600}h of server time`,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Idempotency check per spec § REST ingestion controls:
+  //   "First submission with a given (edgeNodeId, runKey) is
+  //    persisted normally. Re-submission of the same pair returns
+  //    the prior result snapshot — idempotent."
+  // The schema's @@unique([edgeNodeId, runKey]) backs this contract;
+  // the lookup uses the same composite key so a duplicate is a 200
+  // (not 202) with the prior run's state.
+  const prior = await prisma.discoveryRun.findUnique({
+    where: {
+      edgeNodeId_runKey: {
+        edgeNodeId: authResult.edgeNodeRowId,
+        runKey: parsed.data.runKey,
+      },
+    },
+    select: {
+      id: true,
+      status: true,
+      itemCount: true,
+      relationshipCount: true,
+      startedAt: true,
+      completedAt: true,
+    },
+  });
+  if (prior) {
+    return NextResponse.json(
+      {
+        ok: true,
+        accepted: true,
+        idempotentReplay: true,
+        runKey: parsed.data.runKey,
+        runId: prior.id,
+        status: prior.status,
+        itemCount: prior.itemCount,
+        relationshipCount: prior.relationshipCount,
+        startedAt: prior.startedAt.toISOString(),
+        completedAt: prior.completedAt?.toISOString() ?? null,
+      },
+      { status: 200 },
+    );
+  }
+
+  // TODO(persistence wiring): replace with `persistSubmittedDiscoveryRun({
   //   edgeNodeId: authResult.edgeNodeRowId,
   //   nodeId: authResult.nodeId,
   //   runKey: parsed.data.runKey,
   //   agentMode: parsed.data.agentMode,
   //   agentVersion: parsed.data.agentVersion,
-  //   observedAt: new Date(parsed.data.observedAt),
+  //   observedAt,
   //   capabilities: parsed.data.capabilities,
   //   items: parsed.data.items,
   //   relationships: parsed.data.relationships ?? [],
   //   warnings: parsed.data.warnings ?? [],
-  // })`. Until A4 lands, the route accepts the envelope and returns
-  // 202 so end-to-end auth + validation can be exercised by tests.
+  // })`. Until the persistence pipeline is fully wired (it needs the
+  // normalize → infer → persist chain hooked up against the route's
+  // input shape), the route accepts the envelope, exercises the
+  // idempotency + freshness gates, and returns 202 so the contract
+  // is testable end-to-end.
   return NextResponse.json(
     {
       ok: true,
@@ -111,7 +181,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       itemCount: parsed.data.items.length,
       relationshipCount: parsed.data.relationships?.length ?? 0,
       persistencePending: true,
-      note: "persistSubmittedDiscoveryRun ships in A4; envelope was validated and auth was checked",
+      note: "envelope validated, auth/freshness/idempotency gates passed; full persistence pipeline wiring is a follow-up",
     },
     { status: 202 },
   );

--- a/packages/db/prisma/migrations/20260512220000_discovery_run_edge_idempotency/migration.sql
+++ b/packages/db/prisma/migrations/20260512220000_discovery_run_edge_idempotency/migration.sql
@@ -1,0 +1,41 @@
+-- DiscoveryRun.runKey uniqueness retrofit for Edge Node idempotency.
+--
+-- The original schema enforced runKey uniqueness globally:
+--   CREATE UNIQUE INDEX "DiscoveryRun_runKey_key" ON "DiscoveryRun"("runKey");
+--
+-- The Edge Node spec's "REST ingestion controls (Phase 0)" section
+-- (docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md, finalized
+-- in PR #509) requires per-(edgeNodeId, runKey) uniqueness:
+--
+--   "First submission with a given (edgeNodeId, runKey) is persisted
+--    normally. Re-submission of the same pair returns the prior
+--    result snapshot — idempotent. Submission with a runKey already
+--    used by a different edgeNodeId is silent: each node has its own
+--    runKey namespace."
+--
+-- This migration:
+--   1. Drops the global runKey unique constraint
+--   2. Adds a composite unique constraint on (edgeNodeId, runKey)
+--      so each Edge Node owns its own runKey namespace
+--   3. Adds a partial unique index on runKey WHERE edgeNodeId IS NULL
+--      so bootstrap-discovery runs (no Edge Node attribution) retain
+--      global runKey uniqueness for free
+--
+-- All existing rows survive: pre-Phase-0 bootstrap runs have
+-- edgeNodeId = NULL and runKey values like "DISC-<timestamp>", so
+-- the partial unique index admits them. No row movement; index swap
+-- only.
+
+-- DropIndex
+DROP INDEX "DiscoveryRun_runKey_key";
+
+-- CreateIndex (composite for Edge Node idempotency)
+CREATE UNIQUE INDEX "DiscoveryRun_edgeNodeId_runKey_key" ON "DiscoveryRun"("edgeNodeId", "runKey");
+
+-- CreateIndex (partial unique for the bootstrap path — edgeNodeId IS NULL).
+-- Postgres partial unique index: enforces uniqueness on runKey ONLY
+-- for rows where edgeNodeId IS NULL. Edge Node rows (edgeNodeId NOT NULL)
+-- are unaffected by this index and are governed by the composite above.
+CREATE UNIQUE INDEX "DiscoveryRun_runKey_bootstrap_key"
+  ON "DiscoveryRun"("runKey")
+  WHERE "edgeNodeId" IS NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2750,7 +2750,12 @@ model RuntimeAdvisory {
 
 model DiscoveryRun {
   id                      String                            @id @default(cuid())
-  runKey                  String                            @unique
+  // runKey is unique PER (edgeNodeId, runKey) — each Edge Node owns
+  // its own runKey namespace per the Edge Node spec's REST ingestion
+  // controls section. Bootstrap-discovery runs (edgeNodeId IS NULL)
+  // retain global runKey uniqueness via a partial unique index,
+  // defined in the migration alongside the composite constraint.
+  runKey                  String
   sourceSlug              String
   trigger                 String                            @default("bootstrap")
   status                  String                            @default("running")
@@ -2773,6 +2778,7 @@ model DiscoveryRun {
   confirmedRelations      InventoryRelationship[]           @relation("InventoryRelationshipConfirmedRun")
   edgeNode                EdgeNode?                         @relation("EdgeNodeDiscoveryRuns", fields: [edgeNodeId], references: [id])
 
+  @@unique([edgeNodeId, runKey])
   @@index([edgeNodeId])
 }
 


### PR DESCRIPTION
## Summary

Phase 0 schema follow-up I flagged in [#509](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/509). The Edge Node spec's REST ingestion controls section requires per-`(edgeNodeId, runKey)` idempotency:

> "Submission with a `runKey` already used by a *different* `edgeNodeId` is silent: each node has its own runKey namespace, so the schema's existing `runKey @unique` on `DiscoveryRun` must be revised to `@@unique([edgeNodeId, runKey])` in a follow-up migration."

This PR delivers that follow-up.

## What changes

### Schema (`packages/db/prisma/schema.prisma`)

- `DiscoveryRun.runKey` loses its column-level `@unique`
- `DiscoveryRun` gains `@@unique([edgeNodeId, runKey])` — composite backs the idempotency lookup
- Bootstrap-discovery runs (`edgeNodeId IS NULL`) retain global `runKey` uniqueness via a partial unique index in the migration SQL — pre-existing `DISC-<ts>` keys survive unchanged

### Migration (`20260512220000_discovery_run_edge_idempotency`)

```sql
DROP INDEX "DiscoveryRun_runKey_key";

CREATE UNIQUE INDEX "DiscoveryRun_edgeNodeId_runKey_key"
  ON "DiscoveryRun"("edgeNodeId", "runKey");

CREATE UNIQUE INDEX "DiscoveryRun_runKey_bootstrap_key"
  ON "DiscoveryRun"("runKey")
  WHERE "edgeNodeId" IS NULL;
```

### Route (`apps/web/app/api/v1/edge/discovery-runs/route.ts`)

Two new gates fire **before** the existing 202 stub branch:

1. **Freshness window** — `observedAt` must be within ±24h of server time. Else `400 stale_observation`. Fires before the DB lookup so stale submissions never hit Postgres.
2. **Idempotency lookup** — `discoveryRun.findUnique` on the composite `(edgeNodeId, runKey)`. If a prior run exists:

   ```json
   200 {
     "ok": true,
     "accepted": true,
     "idempotentReplay": true,
     "runKey": "run_a1b2c3",
     "runId": "run_db_1",
     "status": "completed",
     "itemCount": 5,
     "relationshipCount": 2,
     "startedAt": "...",
     "completedAt": "..." | null
   }
   ```

   If no prior run, fall through to the existing 202 stub (full persistence pipeline wiring is still a separate follow-up).

## Verification

| Gate | Result |
|---|---|
| `prisma validate` | clean |
| `prisma migrate diff` | reproduces the schema-only portion of migration.sql; the partial unique index is the hand-written portion |
| `@dpf/db` typecheck + tests | 65 files, **394 tests passing** |
| `@dpf/web` typecheck | clean |
| Route tests | **56 passing** (49 prior + 7 new — freshness window past / future / boundary, idempotency replay completed / in-flight, composite-key lookup shape, fall-through to 202) |
| Pre-commit typecheck gate | passed |

## Why each gate fires in this order

1. **Auth → Body schema → Freshness → Idempotency → (persistence stub).** The order matters: auth gates expensive DB work, body-schema gates wasted Postgres roundtrips, freshness rejects clock-skew + back-dated submissions before they could pollute audit history, idempotency replays cheaply if the run was already seen. The persistence stub is the most expensive and runs last.
2. **Freshness window matches both directions** — `±24h`. Future-dated submissions (clock-skew red flag) are rejected the same as far-past stale ones.
3. **Idempotency key is composite by spec contract** — each Edge Node owns its `runKey` namespace. Two nodes picking the same UUID v4 do NOT collide; that's the intended behavior. Bootstrap-discovery uniqueness is preserved by the partial index.

## Spec linkage

- [docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md) § "REST ingestion controls (Phase 0)" — finalized in #509
- AGENTS.md §11 — Principal convergence (unaffected; this is a constraint change, not a model change)

## Test plan

- [x] Composite unique constraint enforces `(edgeNodeId, runKey)` uniqueness
- [x] Partial unique index preserves global `runKey` uniqueness for bootstrap-discovery rows
- [x] Existing bootstrap-discovery rows survive the migration (no row movement)
- [x] Freshness window rejects past + future stale observations before DB lookup
- [x] Idempotency replay returns the prior run's state with `idempotentReplay: true`
- [x] Lookup uses the composite `edgeNodeId_runKey` key (verified by test)
- [x] Fall-through path (no prior) still returns 202 stub
- [ ] Reviewer agreement on the freshness window default (±24h)
- [ ] Reviewer agreement on returning 200 (not 202) for the replay path so clients can distinguish "your run was accepted again" from "your envelope was accepted but persistence is pending"

## Related

- #509 — Security review repair (flagged this follow-up)
- #498 — Authority API endpoints (the routes being amended)
- #499 — `persistSubmittedDiscoveryRun` (the persistence sibling this route will eventually call instead of the 202 stub)
- #501 — Edge Node service skeleton (the consumer of this endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
