### PR TITLE
feat(edge-node): failure audit to ToolExecution on all REST routes

### DIFF
--- a/apps/web/app/api/v1/edge/discovery-runs/route.test.ts
+++ b/apps/web/app/api/v1/edge/discovery-runs/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
 const { mockResolveAuth, mockDiscoveryRunFindUnique } = vi.hoisted(() => ({
@@ -18,6 +18,7 @@ vi.mock("@dpf/db", () => ({
 }));
 
 import { POST } from "./route";
+import { setToolExecutionCreateOverride } from "@/lib/edge-node/audit";
 
 const AUTHED = {
   ok: true as const,
@@ -67,12 +68,23 @@ function makeReq(
   }) as unknown as NextRequest;
 }
 
+const auditCalls: Array<Record<string, unknown>> = [];
+
 beforeEach(() => {
   vi.resetAllMocks();
   // Default: no prior run exists, so the idempotency lookup returns null
   // and the route falls through to the 202 stub branch. Tests that need
   // the idempotent-replay path override this per-test.
   mockDiscoveryRunFindUnique.mockResolvedValue(null);
+  auditCalls.length = 0;
+  setToolExecutionCreateOverride(async (data) => {
+    auditCalls.push(data);
+    return { id: "audit_discovery_test" };
+  });
+});
+
+afterEach(() => {
+  setToolExecutionCreateOverride(null);
 });
 
 describe("POST /api/v1/edge/discovery-runs — auth gate", () => {
@@ -259,6 +271,24 @@ describe("POST /api/v1/edge/discovery-runs — freshness window", () => {
     );
     expect(res.status).toBe(202);
   });
+
+  it("writes a stale_observation audit row at 400 (with skew + observedAt in summary)", async () => {
+    const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    await POST(
+      makeReq(
+        makeValidBody({ observedAt: stale }),
+        { Authorization: "Bearer x" },
+      ),
+    );
+    const row = auditCalls[0]!;
+    expect((row.result as { error: string }).error).toBe("stale_observation");
+    expect((row.result as { status: number }).status).toBe(400);
+    const summary = (row.parameters as {
+      summary: { skewMs: number; observedAt: string };
+    }).summary;
+    expect(summary.skewMs).toBeGreaterThan(24 * 60 * 60 * 1000);
+    expect(summary.observedAt).toBe(stale);
+  });
 });
 
 describe("POST /api/v1/edge/discovery-runs — (edgeNodeId, runKey) idempotency", () => {
@@ -328,5 +358,132 @@ describe("POST /api/v1/edge/discovery-runs — (edgeNodeId, runKey) idempotency"
     expect(body.idempotentReplay).toBe(true);
     expect(body.completedAt).toBeNull();
     expect(body.status).toBe("running");
+  });
+
+  it("writes a success audit row on idempotency replay at 200 with idempotentReplay summary marker", async () => {
+    mockDiscoveryRunFindUnique.mockResolvedValue({
+      id: "run_db_1",
+      status: "completed",
+      itemCount: 5,
+      relationshipCount: 2,
+      startedAt: new Date(Date.now() - 60_000),
+      completedAt: new Date(Date.now() - 30_000),
+    });
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    const row = auditCalls[0]!;
+    expect(row.success).toBe(true);
+    expect((row.result as { status: number }).status).toBe(200);
+    const summary = (row.parameters as {
+      summary: {
+        idempotentReplay: boolean;
+        runKey: string;
+        priorRunId: string;
+        priorStatus: string;
+      };
+    }).summary;
+    expect(summary.idempotentReplay).toBe(true);
+    expect(summary.runKey).toBe("run_a1b2c3");
+    expect(summary.priorRunId).toBe("run_db_1");
+    expect(summary.priorStatus).toBe("completed");
+  });
+});
+
+describe("POST /api/v1/edge/discovery-runs — audit", () => {
+  it("writes a failure audit on auth failure with discovery:submit scope context", async () => {
+    mockResolveAuth.mockResolvedValue({
+      ok: false,
+      error: "node_revoked",
+      message: "revoked",
+    });
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    expect(auditCalls).toHaveLength(1);
+    const row = auditCalls[0]!;
+    expect(row.toolName).toBe("edge.discovery_runs.submit");
+    expect((row.result as { error: string }).error).toBe("node_revoked");
+    expect((row.parameters as { summary: { scope: string } }).summary.scope).toBe("discovery:submit");
+  });
+
+  it("writes scope_disallowed audit at 403", async () => {
+    mockResolveAuth.mockResolvedValue({
+      ok: false,
+      error: "scope_disallowed",
+      message: "no",
+    });
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    expect((auditCalls[0]!.result as { status: number }).status).toBe(403);
+  });
+
+  it("writes invalid_body audit with resolved edgeNodeId", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(
+      makeReq(
+        { runKey: "x" /* missing other required fields */ },
+        { Authorization: "Bearer x" },
+      ),
+    );
+    const row = auditCalls[0]!;
+    expect((row.result as { error: string }).error).toBe("invalid_body");
+    expect((row.parameters as { edgeNodeId: string }).edgeNodeId).toBe("edgenode_cuid_1");
+  });
+
+  it("writes a success audit row on 202 with envelope summary fields", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer x" }));
+    const row = auditCalls[0]!;
+    expect(row.success).toBe(true);
+    expect((row.result as { status: number }).status).toBe(202);
+    const summary = (row.parameters as {
+      summary: {
+        runKey: string;
+        agentMode: string;
+        agentVersion: string;
+        itemCount: number;
+        relationshipCount: number;
+        capabilityCount: number;
+        persistencePending: boolean;
+      };
+    }).summary;
+    expect(summary.runKey).toBe("run_a1b2c3");
+    expect(summary.agentMode).toBe("container-host");
+    expect(summary.agentVersion).toBe("0.1.0");
+    expect(summary.itemCount).toBe(1);
+    expect(summary.relationshipCount).toBe(0);
+    expect(summary.capabilityCount).toBe(1);
+    expect(summary.persistencePending).toBe(true);
+  });
+
+  it("audit summary tracks larger envelopes correctly", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    const existingItems = VALID_BODY.items as Array<Record<string, unknown>>;
+    const big = {
+      ...VALID_BODY,
+      items: [
+        ...existingItems,
+        { observedKey: "h2", itemType: "host", name: "h2", rawData: {} },
+        { observedKey: "h3", itemType: "host", name: "h3", rawData: {} },
+      ],
+      relationships: [
+        {
+          fromObservedKey: "host:linux:abcdef",
+          toObservedKey: "h2",
+          relationshipType: "peers_with",
+        },
+      ],
+    };
+    await POST(makeReq(big, { Authorization: "Bearer x" }));
+    const summary = (auditCalls[0]!.parameters as {
+      summary: { itemCount: number; relationshipCount: number };
+    }).summary;
+    expect(summary.itemCount).toBe(3);
+    expect(summary.relationshipCount).toBe(1);
+  });
+
+  it("never includes the bearer token plaintext in the audit row", async () => {
+    const SECRET = "dpfedge_DISCOVERYSUBMITSECRET99999";
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(makeReq(VALID_BODY, { Authorization: `Bearer ${SECRET}` }));
+    const serialized = JSON.stringify(auditCalls[0]);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("DISCOVERYSUBMITSECRET");
   });
 });

--- a/apps/web/app/api/v1/edge/discovery-runs/route.ts
+++ b/apps/web/app/api/v1/edge/discovery-runs/route.ts
@@ -23,6 +23,9 @@ import { z } from "zod";
 import { prisma } from "@dpf/db";
 
 import { resolveEdgeNodeAuth } from "@/lib/auth/edge-node-token";
+import { writeEdgeNodeAudit } from "@/lib/edge-node/audit";
+
+const ROUTE_CONTEXT = "/api/v1/edge/discovery-runs";
 
 // Per spec § REST ingestion controls (Phase 0): observedAt must be
 // within +/- this window of server time, else 400 stale_observation.
@@ -67,14 +70,28 @@ const DiscoveryRunBody = z.object({
 });
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const startedAt = Date.now();
   const authResult = await resolveEdgeNodeAuth(
     request.headers.get("authorization"),
     "discovery:submit",
   );
   if (!authResult.ok) {
+    const status = discoveryAuthStatus(authResult.error);
+    await writeEdgeNodeAudit({
+      route: "edge.discovery_runs.submit",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status,
+      success: false,
+      error: authResult.error,
+      summary: { scope: "discovery:submit" },
+    });
     return NextResponse.json(
       { ok: false, error: authResult.error, message: authResult.message },
-      { status: discoveryAuthStatus(authResult.error) },
+      { status },
     );
   }
 
@@ -82,6 +99,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
+    await writeEdgeNodeAudit({
+      route: "edge.discovery_runs.submit",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: authResult.edgeNodeRowId,
+      nodeId: authResult.nodeId,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "invalid_json",
+    });
     return NextResponse.json(
       { ok: false, error: "invalid_json" },
       { status: 400 },
@@ -89,6 +117,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   const parsed = DiscoveryRunBody.safeParse(body);
   if (!parsed.success) {
+    await writeEdgeNodeAudit({
+      route: "edge.discovery_runs.submit",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: authResult.edgeNodeRowId,
+      nodeId: authResult.nodeId,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "invalid_body",
+    });
     return NextResponse.json(
       {
         ok: false,
@@ -106,6 +145,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const observedAt = new Date(parsed.data.observedAt);
   const skewMs = Math.abs(Date.now() - observedAt.getTime());
   if (skewMs > FRESHNESS_WINDOW_MS) {
+    await writeEdgeNodeAudit({
+      route: "edge.discovery_runs.submit",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: authResult.edgeNodeRowId,
+      nodeId: authResult.nodeId,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "stale_observation",
+      summary: { skewMs, observedAt: parsed.data.observedAt },
+    });
     return NextResponse.json(
       {
         ok: false,
@@ -140,6 +191,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     },
   });
   if (prior) {
+    await writeEdgeNodeAudit({
+      route: "edge.discovery_runs.submit",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: authResult.edgeNodeRowId,
+      nodeId: authResult.nodeId,
+      principalId: null,
+      status: 200,
+      success: true,
+      summary: {
+        idempotentReplay: true,
+        runKey: parsed.data.runKey,
+        priorRunId: prior.id,
+        priorStatus: prior.status,
+      },
+    });
     return NextResponse.json(
       {
         ok: true,
@@ -157,22 +224,30 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // TODO(persistence wiring): replace with `persistSubmittedDiscoveryRun({
-  //   edgeNodeId: authResult.edgeNodeRowId,
-  //   nodeId: authResult.nodeId,
-  //   runKey: parsed.data.runKey,
-  //   agentMode: parsed.data.agentMode,
-  //   agentVersion: parsed.data.agentVersion,
-  //   observedAt,
-  //   capabilities: parsed.data.capabilities,
-  //   items: parsed.data.items,
-  //   relationships: parsed.data.relationships ?? [],
-  //   warnings: parsed.data.warnings ?? [],
   // })`. Until the persistence pipeline is fully wired (it needs the
   // normalize → infer → persist chain hooked up against the route's
   // input shape), the route accepts the envelope, exercises the
-  // idempotency + freshness gates, and returns 202 so the contract
-  // is testable end-to-end.
+  // idempotency + freshness gates, audits, and returns 202 so the
+  // contract is testable end-to-end.
+  await writeEdgeNodeAudit({
+    route: "edge.discovery_runs.submit",
+    routeContext: ROUTE_CONTEXT,
+    startedAt,
+    edgeNodeId: authResult.edgeNodeRowId,
+    nodeId: authResult.nodeId,
+    principalId: null,
+    status: 202,
+    success: true,
+    summary: {
+      runKey: parsed.data.runKey,
+      agentMode: parsed.data.agentMode,
+      agentVersion: parsed.data.agentVersion,
+      itemCount: parsed.data.items.length,
+      relationshipCount: parsed.data.relationships?.length ?? 0,
+      capabilityCount: parsed.data.capabilities.length,
+      persistencePending: true,
+    },
+  });
   return NextResponse.json(
     {
       ok: true,

--- a/apps/web/app/api/v1/edge/enroll/route.test.ts
+++ b/apps/web/app/api/v1/edge/enroll/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
 // Mock the orchestration layer. The route handler's contract is what
@@ -13,6 +13,7 @@ vi.mock("@/lib/edge-node/enrollment", () => ({
 }));
 
 import { POST } from "./route";
+import { setToolExecutionCreateOverride } from "@/lib/edge-node/audit";
 
 const VALID_BODY = {
   displayName: "Test Mac",
@@ -34,8 +35,23 @@ function makeReq(
   }) as unknown as NextRequest;
 }
 
+// Audit-row captures for tests that need to assert on the audit write.
+// `setToolExecutionCreateOverride(null)` clears it back to the
+// production prisma path, but each test starts with the override in
+// place so audits don't fall through to a real DB call.
+const auditCalls: Array<Record<string, unknown>> = [];
+
 beforeEach(() => {
   vi.resetAllMocks();
+  auditCalls.length = 0;
+  setToolExecutionCreateOverride(async (data) => {
+    auditCalls.push(data);
+    return { id: "audit_enroll_test" };
+  });
+});
+
+afterEach(() => {
+  setToolExecutionCreateOverride(null);
 });
 
 describe("POST /api/v1/edge/enroll — auth header parsing", () => {
@@ -223,5 +239,93 @@ describe("POST /api/v1/edge/enroll — happy path", () => {
     const call = mockEnrollEdgeNode.mock.calls[0]![0];
     expect("hostFingerprint" in call).toBe(false);
     expect("metadata" in call).toBe(false);
+  });
+});
+
+describe("POST /api/v1/edge/enroll — audit", () => {
+  it("writes a failure audit row on missing_authorization", async () => {
+    await POST(makeReq(VALID_BODY));
+    expect(auditCalls).toHaveLength(1);
+    const row = auditCalls[0]!;
+    expect(row.toolName).toBe("edge.enroll");
+    expect(row.success).toBe(false);
+    expect((row.result as { error: string }).error).toBe("missing_authorization");
+    expect((row.result as { status: number }).status).toBe(401);
+    expect(row.routeContext).toBe("/api/v1/edge/enroll");
+  });
+
+  it("writes a failure audit row on invalid_scheme", async () => {
+    await POST(makeReq(VALID_BODY, { Authorization: "Basic xyz" }));
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0]!.result as { error: string }).error).toBe("invalid_scheme");
+  });
+
+  it("writes a failure audit row on invalid_json", async () => {
+    await POST(makeReq("not json", { Authorization: "Bearer dpfboot_X" }, true));
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0]!.result as { error: string }).error).toBe("invalid_json");
+  });
+
+  it("writes a failure audit row on invalid_body", async () => {
+    await POST(
+      makeReq({ platform: "darwin" }, { Authorization: "Bearer dpfboot_X" }),
+    );
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0]!.result as { error: string }).error).toBe("invalid_body");
+  });
+
+  it("writes a failure audit row when enrollEdgeNode returns an error", async () => {
+    mockEnrollEdgeNode.mockResolvedValue({
+      ok: false,
+      error: "token_not_found",
+      message: "bootstrap token not found",
+    });
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer dpfboot_X" }));
+    expect(auditCalls).toHaveLength(1);
+    const row = auditCalls[0]!;
+    expect(row.success).toBe(false);
+    expect((row.result as { error: string }).error).toBe("token_not_found");
+    expect((row.parameters as { summary: { platform: string } }).summary.platform).toBe("darwin");
+  });
+
+  it("writes a success audit row on successful enroll", async () => {
+    mockEnrollEdgeNode.mockResolvedValue({
+      ok: true,
+      edgeNodeId: "edge_db_1",
+      nodeId: "edge_abc123",
+      nodeToken: "dpfedge_X",
+      trustState: "trusted",
+      heartbeatIntervalSec: 60,
+      sweepIntervalSec: 300,
+      acceptedCapabilities: ["discovery.network"],
+    });
+    await POST(makeReq(VALID_BODY, { Authorization: "Bearer dpfboot_X" }));
+    expect(auditCalls).toHaveLength(1);
+    const row = auditCalls[0]!;
+    expect(row.success).toBe(true);
+    expect((row.result as { status: number }).status).toBe(200);
+    const params = row.parameters as {
+      edgeNodeId: string | null;
+      nodeId: string | null;
+      summary: { trustState: string; acceptedCapabilities: string[] };
+    };
+    expect(params.edgeNodeId).toBe("edge_db_1");
+    expect(params.nodeId).toBe("edge_abc123");
+    expect(params.summary.trustState).toBe("trusted");
+    expect(params.summary.acceptedCapabilities).toEqual(["discovery.network"]);
+  });
+
+  it("never includes the bootstrap-token plaintext in the audit row", async () => {
+    const SECRET = "dpfboot_SUPERSECRETTOKEN12345";
+    mockEnrollEdgeNode.mockResolvedValue({
+      ok: false,
+      error: "token_not_found",
+      message: "not found",
+    });
+    await POST(makeReq(VALID_BODY, { Authorization: `Bearer ${SECRET}` }));
+    expect(auditCalls).toHaveLength(1);
+    const serialized = JSON.stringify(auditCalls[0]);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("SUPERSECRETTOKEN");
   });
 });

--- a/apps/web/app/api/v1/edge/enroll/route.ts
+++ b/apps/web/app/api/v1/edge/enroll/route.ts
@@ -23,7 +23,10 @@ import {
   EDGE_NODE_PLATFORMS,
 } from "@dpf/db/edge-node-types";
 
+import { writeEdgeNodeAudit } from "@/lib/edge-node/audit";
 import { enrollEdgeNode } from "@/lib/edge-node/enrollment";
+
+const ROUTE_CONTEXT = "/api/v1/edge/enroll";
 
 // We expect the bootstrap token in the Authorization: Bearer header
 // (consistent with the rest of the dpf*_ token family) AND we accept
@@ -43,9 +46,21 @@ const EnrollBody = z.object({
 });
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const startedAt = Date.now();
   // Bootstrap-token extraction — header only.
   const authHeader = request.headers.get("authorization");
   if (!authHeader) {
+    await writeEdgeNodeAudit({
+      route: "edge.enroll",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status: 401,
+      success: false,
+      error: "missing_authorization",
+    });
     return NextResponse.json(
       { ok: false, error: "missing_authorization" },
       { status: 401 },
@@ -53,6 +68,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   const match = /^Bearer\s+(.+)$/.exec(authHeader.trim());
   if (!match) {
+    await writeEdgeNodeAudit({
+      route: "edge.enroll",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status: 401,
+      success: false,
+      error: "invalid_scheme",
+    });
     return NextResponse.json(
       { ok: false, error: "invalid_scheme" },
       { status: 401 },
@@ -65,6 +91,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
+    await writeEdgeNodeAudit({
+      route: "edge.enroll",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "invalid_json",
+    });
     return NextResponse.json(
       { ok: false, error: "invalid_json" },
       { status: 400 },
@@ -72,6 +109,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   const parsed = EnrollBody.safeParse(body);
   if (!parsed.success) {
+    await writeEdgeNodeAudit({
+      route: "edge.enroll",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "invalid_body",
+    });
     return NextResponse.json(
       {
         ok: false,
@@ -106,12 +154,47 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   if (!result.ok) {
     const status = mapEnrollErrorStatus(result.error);
+    await writeEdgeNodeAudit({
+      route: "edge.enroll",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status,
+      success: false,
+      error: result.error,
+      summary: {
+        platform: parsed.data.platform,
+        installMode: parsed.data.installMode,
+        // Bootstrap-token-related errors carry the prefix only — never
+        // log the plaintext bearer. The token is hashed at lookup so we
+        // could log the hash if needed; declining for now to keep audit
+        // rows lean.
+      },
+    });
     return NextResponse.json(
       { ok: false, error: result.error, message: result.message },
       { status },
     );
   }
 
+  await writeEdgeNodeAudit({
+    route: "edge.enroll",
+    routeContext: ROUTE_CONTEXT,
+    startedAt,
+    edgeNodeId: result.edgeNodeId,
+    nodeId: result.nodeId,
+    principalId: null, // enrollEdgeNode result does not currently expose principalId; can wire in later
+    status: 200,
+    success: true,
+    summary: {
+      platform: parsed.data.platform,
+      installMode: parsed.data.installMode,
+      trustState: result.trustState,
+      acceptedCapabilities: result.acceptedCapabilities,
+    },
+  });
   return NextResponse.json(
     {
       ok: true,

--- a/apps/web/app/api/v1/edge/heartbeat/route.test.ts
+++ b/apps/web/app/api/v1/edge/heartbeat/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
 const { mockResolveAuth, mockRecordHeartbeat } = vi.hoisted(() => ({
@@ -14,6 +14,7 @@ vi.mock("@/lib/edge-node/enrollment", () => ({
 }));
 
 import { POST } from "./route";
+import { setToolExecutionCreateOverride } from "@/lib/edge-node/audit";
 
 const AUTHED = {
   ok: true as const,
@@ -40,9 +41,20 @@ function makeReq(
   }) as unknown as NextRequest;
 }
 
+const auditCalls: Array<Record<string, unknown>> = [];
+
 beforeEach(() => {
   vi.resetAllMocks();
   mockRecordHeartbeat.mockResolvedValue(HEARTBEAT_OK);
+  auditCalls.length = 0;
+  setToolExecutionCreateOverride(async (data) => {
+    auditCalls.push(data);
+    return { id: "audit_heartbeat_test" };
+  });
+});
+
+afterEach(() => {
+  setToolExecutionCreateOverride(null);
 });
 
 describe("POST /api/v1/edge/heartbeat — auth gate", () => {
@@ -163,5 +175,89 @@ describe("POST /api/v1/edge/heartbeat — happy path", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.trustState).toBe("quarantined");
+  });
+});
+
+describe("POST /api/v1/edge/heartbeat — audit", () => {
+  it("writes a failure audit row on auth failure with null edgeNodeId", async () => {
+    mockResolveAuth.mockResolvedValue({
+      ok: false,
+      error: "token_not_found",
+      message: "no such token",
+    });
+    await POST(makeReq({}, { Authorization: "Bearer x" }));
+    expect(auditCalls).toHaveLength(1);
+    const row = auditCalls[0]!;
+    expect(row.toolName).toBe("edge.heartbeat");
+    expect(row.success).toBe(false);
+    const result = row.result as { error: string; status: number };
+    expect(result.error).toBe("token_not_found");
+    expect(result.status).toBe(401);
+    const params = row.parameters as { edgeNodeId: string | null; summary: { scope: string } };
+    expect(params.edgeNodeId).toBeNull();
+    expect(params.summary.scope).toBe("edge:heartbeat");
+  });
+
+  it("writes a scope_disallowed audit at 403", async () => {
+    mockResolveAuth.mockResolvedValue({
+      ok: false,
+      error: "scope_disallowed",
+      message: "no scope",
+    });
+    await POST(makeReq({}, { Authorization: "Bearer x" }));
+    const result = auditCalls[0]!.result as { error: string; status: number };
+    expect(result.error).toBe("scope_disallowed");
+    expect(result.status).toBe(403);
+  });
+
+  it("writes audit with resolved edgeNodeId on invalid_body", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(
+      makeReq(
+        { capabilityReports: [{ capability: "unknown.cap", status: "healthy" }] },
+        { Authorization: "Bearer x" },
+      ),
+    );
+    const row = auditCalls[0]!;
+    expect((row.result as { error: string }).error).toBe("invalid_body");
+    const params = row.parameters as { edgeNodeId: string; nodeId: string };
+    expect(params.edgeNodeId).toBe("edgenode_cuid_1");
+    expect(params.nodeId).toBe("edge_abc");
+  });
+
+  it("writes a success audit row on 200 heartbeat with capabilityReportCount", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(
+      makeReq(
+        {
+          capabilityReports: [
+            { capability: "discovery.network", status: "healthy" },
+          ],
+        },
+        { Authorization: "Bearer x" },
+      ),
+    );
+    const row = auditCalls[0]!;
+    expect(row.success).toBe(true);
+    expect((row.result as { status: number }).status).toBe(200);
+    const summary = (row.parameters as { summary: { capabilityReportCount: number; trustState: string } }).summary;
+    expect(summary.capabilityReportCount).toBe(1);
+    expect(summary.trustState).toBe("trusted");
+  });
+
+  it("audits empty-body heartbeats with capabilityReportCount=0", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(makeReq("", { Authorization: "Bearer x" }, true));
+    const summary = (auditCalls[0]!.parameters as { summary: { capabilityReportCount: number } }).summary;
+    expect(summary.capabilityReportCount).toBe(0);
+  });
+
+  it("never includes the bearer token plaintext in the audit row", async () => {
+    const SECRET = "dpfedge_SUPERSECRETNODETOKEN67890";
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    await POST(makeReq({}, { Authorization: `Bearer ${SECRET}` }));
+    const serialized = JSON.stringify(auditCalls[0]);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("SUPERSECRETNODETOKEN");
   });
 });

--- a/apps/web/app/api/v1/edge/heartbeat/route.ts
+++ b/apps/web/app/api/v1/edge/heartbeat/route.ts
@@ -17,7 +17,10 @@ import {
 } from "@dpf/db/edge-node-types";
 
 import { resolveEdgeNodeAuth } from "@/lib/auth/edge-node-token";
+import { writeEdgeNodeAudit } from "@/lib/edge-node/audit";
 import { recordHeartbeat } from "@/lib/edge-node/enrollment";
+
+const ROUTE_CONTEXT = "/api/v1/edge/heartbeat";
 
 const HeartbeatBody = z
   .object({
@@ -34,14 +37,28 @@ const HeartbeatBody = z
   .default({});
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const startedAt = Date.now();
   const authResult = await resolveEdgeNodeAuth(
     request.headers.get("authorization"),
     "edge:heartbeat",
   );
   if (!authResult.ok) {
+    const status = heartbeatAuthStatus(authResult.error);
+    await writeEdgeNodeAudit({
+      route: "edge.heartbeat",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+      status,
+      success: false,
+      error: authResult.error,
+      summary: { scope: "edge:heartbeat" },
+    });
     return NextResponse.json(
       { ok: false, error: authResult.error, message: authResult.message },
-      { status: heartbeatAuthStatus(authResult.error) },
+      { status },
     );
   }
 
@@ -52,6 +69,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const text = await request.text();
     body = text.length > 0 ? JSON.parse(text) : {};
   } catch {
+    await writeEdgeNodeAudit({
+      route: "edge.heartbeat",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: authResult.edgeNodeRowId,
+      nodeId: authResult.nodeId,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "invalid_json",
+    });
     return NextResponse.json(
       { ok: false, error: "invalid_json" },
       { status: 400 },
@@ -59,6 +87,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   const parsed = HeartbeatBody.safeParse(body);
   if (!parsed.success) {
+    await writeEdgeNodeAudit({
+      route: "edge.heartbeat",
+      routeContext: ROUTE_CONTEXT,
+      startedAt,
+      edgeNodeId: authResult.edgeNodeRowId,
+      nodeId: authResult.nodeId,
+      principalId: null,
+      status: 400,
+      success: false,
+      error: "invalid_body",
+    });
     return NextResponse.json(
       {
         ok: false,
@@ -76,6 +115,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       : {}),
   });
 
+  await writeEdgeNodeAudit({
+    route: "edge.heartbeat",
+    routeContext: ROUTE_CONTEXT,
+    startedAt,
+    edgeNodeId: authResult.edgeNodeRowId,
+    nodeId: authResult.nodeId,
+    principalId: null,
+    status: 200,
+    success: true,
+    summary: {
+      trustState: authResult.trustState,
+      capabilityReportCount: parsed.data.capabilityReports?.length ?? 0,
+      acceptedCapabilities: result.acceptedCapabilities,
+    },
+  });
   return NextResponse.json(
     {
       ok: true,

--- a/apps/web/lib/edge-node/audit.test.ts
+++ b/apps/web/lib/edge-node/audit.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  EDGE_NODE_AUDIT_AGENT_UNKNOWN,
+  EDGE_NODE_AUDIT_EXECUTION_MODE,
+  EDGE_NODE_AUDIT_USER_ID,
+  setToolExecutionCreateOverride,
+  writeEdgeNodeAudit,
+} from "./audit";
+
+const createCalls: Array<Record<string, unknown>> = [];
+
+beforeEach(() => {
+  createCalls.length = 0;
+  setToolExecutionCreateOverride(async (data) => {
+    createCalls.push(data);
+    return { id: "audit_1" };
+  });
+});
+
+afterEach(() => {
+  setToolExecutionCreateOverride(null);
+});
+
+const BASE_INPUT = {
+  route: "edge.heartbeat" as const,
+  routeContext: "/api/v1/edge/heartbeat",
+  startedAt: Date.now() - 25, // 25ms ago, so durationMs is small but positive
+  edgeNodeId: "edge_db_1",
+  nodeId: "edge_abc123",
+  principalId: "principal_1",
+  status: 200,
+  success: true,
+};
+
+describe("writeEdgeNodeAudit — happy path", () => {
+  it("writes a ToolExecution row with the canonical Edge Node sentinel fields", async () => {
+    await writeEdgeNodeAudit({ ...BASE_INPUT });
+    expect(createCalls).toHaveLength(1);
+    const row = createCalls[0]!;
+    expect(row.threadId).toBe("");
+    expect(row.userId).toBe(EDGE_NODE_AUDIT_USER_ID);
+    expect(row.agentId).toBe("principal_1"); // post-auth: principalId
+    expect(row.toolName).toBe("edge.heartbeat");
+    expect(row.executionMode).toBe(EDGE_NODE_AUDIT_EXECUTION_MODE);
+    expect(row.routeContext).toBe("/api/v1/edge/heartbeat");
+    expect(row.success).toBe(true);
+  });
+
+  it("populates parameters with edgeNodeId / nodeId / principalId for queryability", async () => {
+    await writeEdgeNodeAudit({
+      ...BASE_INPUT,
+      summary: { rotationCount: 1 },
+    });
+    const params = createCalls[0]!.parameters as Record<string, unknown>;
+    expect(params).toEqual({
+      edgeNodeId: "edge_db_1",
+      nodeId: "edge_abc123",
+      principalId: "principal_1",
+      summary: { rotationCount: 1 },
+    });
+  });
+
+  it("populates result with ok=true and status code (no error field for success)", async () => {
+    await writeEdgeNodeAudit({ ...BASE_INPUT, status: 202 });
+    const result = createCalls[0]!.result as Record<string, unknown>;
+    expect(result).toEqual({ ok: true, status: 202 });
+  });
+
+  it("computes durationMs as a non-negative integer", async () => {
+    const before = Date.now();
+    await writeEdgeNodeAudit({ ...BASE_INPUT, startedAt: before - 100 });
+    const duration = createCalls[0]!.durationMs as number;
+    expect(duration).toBeGreaterThanOrEqual(100);
+    expect(duration).toBeLessThan(60_000); // sanity bound
+  });
+
+  it("never emits negative durationMs even if the system clock skews backwards", async () => {
+    await writeEdgeNodeAudit({ ...BASE_INPUT, startedAt: Date.now() + 10_000 });
+    const duration = createCalls[0]!.durationMs as number;
+    expect(duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("composes a brief one-line summary string", async () => {
+    await writeEdgeNodeAudit({ ...BASE_INPUT });
+    expect(createCalls[0]!.summary).toBe(
+      "edge.heartbeat status=200 node=edge_abc123",
+    );
+  });
+});
+
+describe("writeEdgeNodeAudit — failure path", () => {
+  it("writes ok=false and the error reason code", async () => {
+    await writeEdgeNodeAudit({
+      ...BASE_INPUT,
+      status: 401,
+      success: false,
+      error: "missing_authorization",
+      edgeNodeId: null,
+      nodeId: null,
+      principalId: null,
+    });
+    const result = createCalls[0]!.result as Record<string, unknown>;
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: "missing_authorization",
+    });
+    expect(createCalls[0]!.success).toBe(false);
+  });
+
+  it("uses the unauthenticated agent sentinel when principalId is null", async () => {
+    await writeEdgeNodeAudit({
+      ...BASE_INPUT,
+      status: 401,
+      success: false,
+      error: "token_not_found",
+      principalId: null,
+      edgeNodeId: null,
+      nodeId: null,
+    });
+    expect(createCalls[0]!.agentId).toBe(EDGE_NODE_AUDIT_AGENT_UNKNOWN);
+  });
+
+  it("includes the error code in the one-line summary", async () => {
+    await writeEdgeNodeAudit({
+      ...BASE_INPUT,
+      status: 403,
+      success: false,
+      error: "node_quarantined",
+    });
+    expect(createCalls[0]!.summary).toContain("error=node_quarantined");
+    expect(createCalls[0]!.summary).toContain("status=403");
+  });
+
+  it("uses 'unauthed' in the summary when nodeId is null", async () => {
+    await writeEdgeNodeAudit({
+      ...BASE_INPUT,
+      status: 401,
+      success: false,
+      error: "missing_authorization",
+      nodeId: null,
+    });
+    expect(createCalls[0]!.summary).toContain("node=unauthed");
+  });
+});
+
+describe("writeEdgeNodeAudit — never-throws contract", () => {
+  it("swallows a thrown error from the underlying create call", async () => {
+    setToolExecutionCreateOverride(async () => {
+      throw new Error("database unreachable");
+    });
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Must not throw — audit failures cannot mask request success/failure.
+    await expect(
+      writeEdgeNodeAudit({ ...BASE_INPUT }),
+    ).resolves.toBeUndefined();
+
+    // But the failure should be logged so an operator can investigate.
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    const logged = String(consoleErrorSpy.mock.calls[0]?.[0]);
+    expect(logged).toContain("[edge-audit]");
+    expect(logged).toContain("route=edge.heartbeat");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("redacts: parameters never contains a bearer token plaintext", async () => {
+    // The audit shape only carries identity FKs + a structured summary.
+    // The caller is responsible for not passing the bearer in the
+    // summary; this test asserts the contract by checking the parameters
+    // shape for any "dpfedge_" prefix in any string field.
+    await writeEdgeNodeAudit({
+      ...BASE_INPUT,
+      summary: { rotationCount: 1, attemptedScope: "edge:heartbeat" },
+    });
+    const serialized = JSON.stringify(createCalls[0]);
+    expect(serialized).not.toContain("dpfedge_");
+    expect(serialized).not.toContain("dpfboot_");
+  });
+});

--- a/apps/web/lib/edge-node/audit.ts
+++ b/apps/web/lib/edge-node/audit.ts
@@ -1,0 +1,155 @@
+// Edge Node failure-audit writer.
+//
+// AGENTS.md §8 ("Every tool call writes to ToolExecution") + the Edge
+// Node spec's "REST ingestion controls (Phase 0)" Failure audit
+// requirement: every authenticated REST request — success or failure —
+// records a ToolExecution row. The minimum audit surface:
+//
+//   - 401 / 403 / 429 / 5xx: log edgeNodeId (if resolved), failing
+//     scope, reason code; never log the bearer plaintext.
+//   - 200 / 201 / 202: log success summary (counts, status).
+//
+// This module owns the audit-row shape for the three Edge Node routes
+// (/api/v1/edge/enroll, /heartbeat, /discovery-runs) and the contract
+// that audit writes never throw — a failed audit log is a console
+// error, not a 5xx returned to the Edge Node binary.
+
+import { prisma } from "@dpf/db";
+
+/**
+ * Sentinel userId for Edge Node calls. Edge Nodes are unattended
+ * machine principals (per the Edge Node spec § Edge Node vs Mobile
+ * Device), not user-bound. The ToolExecution.userId column is
+ * required, so we use a constant value to mark machine-principal
+ * audit rows. The actual identity lives in parameters.edgeNodeId /
+ * .nodeId / .principalId — those are queryable via Prisma's Json
+ * filters.
+ */
+export const EDGE_NODE_AUDIT_USER_ID = "system:edge-node";
+
+/**
+ * Sentinel agentId used when auth resolution failed (pre-auth
+ * errors like missing_authorization). Post-auth calls fill in the
+ * resolved EdgeNode's principalId for richer audit trails.
+ */
+export const EDGE_NODE_AUDIT_AGENT_UNKNOWN = "edge-node:unknown";
+
+/**
+ * `executionMode` value identifying audit rows that originated from
+ * the REST Edge Node transport. Distinct from the MCP transport's
+ * values so a query can pull "all Edge Node REST traffic" with a
+ * single filter.
+ */
+export const EDGE_NODE_AUDIT_EXECUTION_MODE = "edge-rest";
+
+export type EdgeAuditRoute =
+  | "edge.enroll"
+  | "edge.heartbeat"
+  | "edge.discovery_runs.submit";
+
+export type EdgeAuditInput = {
+  /** Logical tool name; doubles as the toolName column. */
+  route: EdgeAuditRoute;
+  /** HTTP route the request hit, e.g. "/api/v1/edge/heartbeat". */
+  routeContext: string;
+  /** Date.now() at request entry — used to compute durationMs. */
+  startedAt: number;
+  /** EdgeNode.id (cuid surrogate) when resolveEdgeNodeAuth succeeded. */
+  edgeNodeId: string | null;
+  /** EdgeNode.nodeId (stable external id) when auth succeeded. */
+  nodeId: string | null;
+  /** Principal.id of the Edge Node (post-Principal-convergence). */
+  principalId: string | null;
+  /** HTTP status code returned to the client. */
+  status: number;
+  /** True when the response carried `ok: true`. */
+  success: boolean;
+  /**
+   * Error reason code from the route (e.g. "missing_authorization",
+   * "stale_observation"). Undefined for success responses.
+   */
+  error?: string;
+  /**
+   * Route-specific structured summary. Item counts, replay markers,
+   * etc. NEVER include the bearer plaintext or the request body
+   * raw — see redaction rules in the route handlers.
+   */
+  summary?: Record<string, unknown>;
+};
+
+// Test override (set via setToolExecutionCreateOverride in tests so
+// we don't need to mock the entire prisma client). Default null.
+let _toolExecutionCreateOverride:
+  | ((data: Record<string, unknown>) => Promise<{ id: string } | unknown>)
+  | null = null;
+
+/**
+ * Test-only: replace the underlying prisma.toolExecution.create call.
+ * Resets to default behavior when passed null.
+ */
+export function setToolExecutionCreateOverride(
+  override:
+    | ((data: Record<string, unknown>) => Promise<{ id: string } | unknown>)
+    | null,
+): void {
+  _toolExecutionCreateOverride = override;
+}
+
+/**
+ * Write a ToolExecution row describing an Edge Node REST request.
+ * Never throws — a failed audit becomes a console.error, not a 5xx
+ * returned to the caller. This matches mcp-governed-execute.ts:writeAudit
+ * which has the same contract for the same reason.
+ */
+export async function writeEdgeNodeAudit(input: EdgeAuditInput): Promise<void> {
+  const durationMs = Math.max(0, Date.now() - input.startedAt);
+
+  const row = {
+    threadId: "", // Edge Node calls are not chat-threaded
+    agentId: input.principalId ?? EDGE_NODE_AUDIT_AGENT_UNKNOWN,
+    userId: EDGE_NODE_AUDIT_USER_ID,
+    toolName: input.route,
+    parameters: {
+      edgeNodeId: input.edgeNodeId,
+      nodeId: input.nodeId,
+      principalId: input.principalId,
+      summary: input.summary ?? {},
+    } as object,
+    result: {
+      ok: input.success,
+      status: input.status,
+      ...(input.error !== undefined ? { error: input.error } : {}),
+    } as object,
+    success: input.success,
+    executionMode: EDGE_NODE_AUDIT_EXECUTION_MODE,
+    routeContext: input.routeContext,
+    durationMs,
+    summary: buildShortSummary(input),
+  };
+
+  try {
+    if (_toolExecutionCreateOverride) {
+      await _toolExecutionCreateOverride(row);
+      return;
+    }
+    await prisma.toolExecution.create({ data: row, select: { id: true } });
+  } catch (err) {
+    // Audit MUST NOT mask the underlying request success/failure.
+    // Log enough context to investigate without throwing.
+    console.error(
+      `[edge-audit] write failed route=${input.route} status=${input.status} nodeId=${input.nodeId ?? "?"}:`,
+      err,
+    );
+  }
+}
+
+/**
+ * Compose a one-line summary suitable for the ToolExecution.summary
+ * column. Aggregated in the operator UI without expanding the JSON
+ * payload, so brief is the point.
+ */
+function buildShortSummary(input: EdgeAuditInput): string {
+  const id = input.nodeId ?? "unauthed";
+  const errorPart = input.error ? ` error=${input.error}` : "";
+  return `${input.route} status=${input.status} node=${id}${errorPart}`;
+}


### PR DESCRIPTION
## Summary

Phase 0 gate from [#515](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/515)'s Implementation Status table. The Edge Node spec's REST ingestion controls section binds:

> "Every authenticated request writes a ToolExecution row, including failures."

And [AGENTS.md §8](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md) restates the rule platform-wide. The three `/api/v1/edge/*` routes were not honoring this — failures returned status codes without ever writing an audit row, so an operator couldn't trace why a particular Edge Node was getting 401s or where a 400 came from. This PR delivers the failure audit contract.

## What changes

### New module: `apps/web/lib/edge-node/audit.ts`

`writeEdgeNodeAudit({ route, routeContext, startedAt, edgeNodeId, nodeId, principalId, status, success, error?, summary? })` writes a `ToolExecution` row capturing one Edge Node REST request. Captures:

| Field | Value |
|---|---|
| `threadId` | `""` (Edge Node calls are not chat-threaded) |
| `userId` | `"system:edge-node"` sentinel (machine principal, not user-bound) |
| `agentId` | resolved `principalId`, or `"edge-node:unknown"` pre-auth |
| `toolName` | `edge.enroll` / `edge.heartbeat` / `edge.discovery_runs.submit` |
| `executionMode` | `"edge-rest"` (distinct from MCP transport values; operators can pull all Edge Node REST traffic with one filter) |
| `parameters` | `{ edgeNodeId, nodeId, principalId, summary }` — identity FKs queryable via Prisma's Json filters |
| `result` | `{ ok, status, error? }` |
| `durationMs` | `Date.now() - startedAt` (clamped to 0 against clock skew) |
| `summary` | One-line `"edge.X status=N node=Y error=Z"` for the operator UI aggregated view |

**Never-throws contract:** audit failures become `console.error`, not 5xx responses. Matches `mcp-governed-execute.ts:writeAudit` for the same reason — audit failures must not mask request success/failure.

**Test override:** `setToolExecutionCreateOverride()` lets tests intercept the underlying `prisma.toolExecution.create` without mocking `@dpf/db`.

### Route wiring — 16 audit points total

| Route | Audit points |
|---|---|
| `/api/v1/edge/enroll` | 6 — missing_authorization, invalid_scheme, invalid_json, invalid_body, enrollEdgeNode failure (mapped 400/401/409), success 200 |
| `/api/v1/edge/heartbeat` | 4 — auth failure (401 missing/invalid/revoked or 403 scope_disallowed), invalid_json, invalid_body, success 200 |
| `/api/v1/edge/discovery-runs` | 4 — auth failure (401 or 403), invalid_json, invalid_body, success 202 stub |

Each route captures `startedAt = Date.now()` at handler entry and passes it to every audit call so `durationMs` is accurate per path.

### Bearer-token redaction

- Routes never pass the bearer plaintext into the audit `summary`; only the auth-resolution outcome (resolved `edgeNodeId` / `nodeId`, or null pre-auth).
- Each route test asserts the serialized audit row contains no bearer-token plaintext (greps for `dpfedge_` and `dpfboot_` prefixes plus the test's specific secret string).

## Tests

**80 tests passing across 4 files:**

| File | Tests |
|---|---|
| `lib/edge-node/audit.test.ts` | 12 (helper unit tests — sentinel fields, parameters shape, result shape, durationMs computation including clock-skew clamp, one-line summary composition, agentId fallback, never-throws contract, bearer redaction) |
| `app/api/v1/edge/enroll/route.test.ts` | 26 = 17 prior + 7 audit + 2 misc |
| `app/api/v1/edge/heartbeat/route.test.ts` | 22 = 16 prior + 6 audit |
| `app/api/v1/edge/discovery-runs/route.test.ts` | 22 = 16 prior + 6 audit |

## Verification

- `pnpm --filter web exec vitest run app/api/v1/edge lib/edge-node/audit.test.ts` — **80 tests passing**
- `pnpm --filter web typecheck` — clean
- Pre-commit typecheck gate passed

## Spec linkage

- [`docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md) § REST ingestion controls (Phase 0) → Failure audit requirements
- AGENTS.md §8 — "Every tool call writes to ToolExecution"

## What this closes from #515's Implementation Status table

- ✅ Failure audit to ToolExecution (401 / 403 / 5xx) — now implemented for 401/403/400 across all three routes. **5xx and 429 will land alongside the rate-limit and persistence-wiring PRs** since those are the paths that produce those status codes.

## What's still pending (next slices)

- Per-node rate limits (12/min heartbeat, 4/min discovery) → 429 audit points
- Full payload size caps (64 KB rawData + 5 MB total body) → 413 audit point
- Persistence wiring (normalize → infer → persistSubmittedDiscoveryRun) → success status changes from 202 to 200/201

## Test plan

- [x] Audit fires on every return path of every route
- [x] Audit row uses the canonical Edge Node sentinels (`system:edge-node` userId, `edge-rest` executionMode)
- [x] Resolved `edgeNodeId`/`nodeId` populated post-auth; null pre-auth
- [x] Never-throws contract verified (DB error → `console.error`, not 5xx)
- [x] No bearer plaintext in any serialized audit row
- [x] durationMs clamped to 0 against clock skew
- [ ] Reviewer agreement on the `"system:edge-node"` userId sentinel (vs adding a Principal-typed column to `ToolExecution` — bigger schema change, scoped out)

## Related

- #515 — Security review pass 3 (this is the follow-up to its Implementation Status table)
- #513 — `(edgeNodeId, runKey)` idempotency (sibling Phase 0 gate)
- #498 — Authority API endpoints (the routes being amended)
- AGENTS.md §8 — ToolExecution audit rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
