### PR TITLE
fix(mcp): harden connectivity onboarding

### DIFF
--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -96,11 +96,7 @@ describe("POST — transport guards", () => {
     expect(res.status).toBe(401); // got past TLS guard, failed at auth
   });
 
-  // Regression: when Next.js runs inside a container or behind a proxy,
-  // request.url reflects the *internal* bind address (e.g. 0.0.0.0). The
-  // transport guard must consult the forwarded host/proto headers — what
-  // the client actually connected to — not the URL Next reconstructed.
-  it("allows containerized request when X-Forwarded-Host points to localhost", async () => {
+  it("rejects spoofed X-Forwarded-Host on plain HTTP", async () => {
     resolveMock.mockResolvedValue(null);
     const res = await POST(
       makeRequest({
@@ -110,7 +106,7 @@ describe("POST — transport guards", () => {
         body: { jsonrpc: "2.0", id: 1, method: "initialize" },
       }),
     );
-    expect(res.status).toBe(401); // past transport guard, fails at auth
+    expect(res.status).toBe(403);
   });
 
   it("allows containerized request when X-Forwarded-Proto is https", async () => {
@@ -173,7 +169,6 @@ describe("POST — transport guards", () => {
         makeRequest({
           url: "http://portal:3000/api/mcp/v1",
           bearer: "dpfmcp_X",
-          forwardedHost: "portal:3000",
           body: { jsonrpc: "2.0", id: 1, method: "initialize" },
         }),
       );
@@ -186,7 +181,6 @@ describe("POST — transport guards", () => {
         makeRequest({
           url: "http://other-internal:3000/api/mcp/v1",
           bearer: "dpfmcp_X",
-          forwardedHost: "other-internal:3000",
           body: { jsonrpc: "2.0", id: 1, method: "initialize" },
         }),
       );
@@ -200,11 +194,23 @@ describe("POST — transport guards", () => {
         makeRequest({
           url: "http://portal:3000/api/mcp/v1",
           bearer: "dpfmcp_X",
-          forwardedHost: "portal:3000",
           body: { jsonrpc: "2.0", id: 1, method: "initialize" },
         }),
       );
       expect(res.status).toBe(401);
+    });
+
+    it("does not use X-Forwarded-Host to satisfy MCP_INSECURE_INTERNAL_HOSTS", async () => {
+      process.env.MCP_INSECURE_INTERNAL_HOSTS = "portal";
+      const res = await POST(
+        makeRequest({
+          url: "http://evil.example.com/api/mcp/v1",
+          bearer: "dpfmcp_X",
+          forwardedHost: "portal:3000",
+          body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+        }),
+      );
+      expect(res.status).toBe(403);
     });
   });
 

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -131,8 +131,10 @@ function isOriginAllowed(origin: string | null): boolean {
 //
 // When the portal runs behind a proxy or inside a container, `request.url`
 // reflects the *internal* bind address (e.g. 0.0.0.0) and protocol, not what
-// the client actually connected to. We must consult X-Forwarded-Proto and
-// X-Forwarded-Host (or the Host header) to know the client's view.
+// the client actually connected to. We trust X-Forwarded-Proto only for the
+// proxy's TLS termination signal. Host authorization for plain HTTP must use
+// the actual Host/request URL because X-Forwarded-Host is caller-controlled in
+// direct CLI/container traffic.
 //
 // MCP_INSECURE_INTERNAL_HOSTS — comma-separated hostnames that are trusted
 // to call the MCP transport over plain HTTP. Required for sandbox→portal
@@ -146,9 +148,8 @@ function isTransportAllowed(request: Request): boolean {
   const proto = (xfProto?.split(",")[0]?.trim() || url.protocol.replace(/:$/, "")).toLowerCase();
   if (proto === "https") return true;
 
-  const xfHost = request.headers.get("x-forwarded-host");
   const hostHeader = request.headers.get("host");
-  const rawHost = (xfHost?.split(",")[0]?.trim() || hostHeader || url.host).toLowerCase();
+  const rawHost = (hostHeader || url.host).toLowerCase();
   // Strip port; bracketed IPv6 retains brackets after URL.host parsing.
   const hostname = rawHost.replace(/^\[(.+)\]:?\d*$/, "$1").replace(/:\d+$/, "");
   if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -152,6 +152,12 @@ describe("issueMyMcpToken", () => {
     expect(result.setupSnippets.claudeCode).toContain("Bearer dpfmcp_SECRET");
     expect(result.setupSnippets.vscode).toContain("Bearer dpfmcp_SECRET");
     expect(result.setupSnippets.codex).toContain("Bearer dpfmcp_SECRET");
+    const claudeCode = JSON.parse(result.setupSnippets.claudeCode);
+    const codex = JSON.parse(result.setupSnippets.codex);
+    const vscode = JSON.parse(result.setupSnippets.vscode);
+    expect(claudeCode.mcpServers.dpf.type).toBe("http");
+    expect(codex.mcpServers.dpf.type).toBe("http");
+    expect(vscode.servers.dpf.type).toBe("http");
   });
 });
 

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -84,6 +84,7 @@ function buildSetupSnippets(plaintext: string, baseUrl: string): {
     {
       mcpServers: {
         dpf: {
+          type: "http",
           url,
           headers: { Authorization: `Bearer ${plaintext}` },
         },
@@ -97,6 +98,7 @@ function buildSetupSnippets(plaintext: string, baseUrl: string): {
     {
       mcpServers: {
         dpf: {
+          type: "http",
           url,
           headers: { Authorization: `Bearer ${plaintext}` },
         },
@@ -110,6 +112,7 @@ function buildSetupSnippets(plaintext: string, baseUrl: string): {
     {
       servers: {
         dpf: {
+          type: "http",
           url,
           headers: { Authorization: `Bearer ${plaintext}` },
         },


### PR DESCRIPTION
## Summary
- add explicit `type: "http"` to generated Claude Code, Codex, and VS Code MCP setup snippets
- harden the MCP JSON-RPC transport gate so plain-HTTP host authorization ignores caller-controlled `X-Forwarded-Host`
- keep `X-Forwarded-Proto: https` support for TLS-terminated proxy paths and retain `MCP_INSECURE_INTERNAL_HOSTS` for explicit internal Docker hosts

## Verification
- `pnpm --filter web exec vitest run app/api/mcp/v1/route.test.ts lib/actions/mcp-tokens.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passes; existing Turbopack/NFT broad-trace warnings remain)
- `git diff --check`

## Notes
- This is the first implementation slice after the reviewed agent workspace pattern docs: MCP connectivity/onboarding repair only.
- A model-mediated sandbox CLI probe still needs to be rerun after this branch is deployed into the running portal image; this PR covers the generated config and route guard that blocked that path.
