### PR TITLE
feat(doc-mgmt): managed document foundation and workspace UX

### DIFF
--- a/apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx
+++ b/apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx
@@ -1,0 +1,172 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import { Archive, ArchiveRestore, ArrowLeft, CheckCircle2, FileText } from "lucide-react";
+import { auth } from "@/lib/auth";
+import { listManagedDocumentReferences, loadManagedDocument } from "@/lib/documents/document-store";
+import { changeDocumentStateAction } from "../actions";
+
+type Props = {
+  params: Promise<{ documentId: string }>;
+};
+
+function StateAction({ documentId, toState, label, icon }: { documentId: string; toState: string; label: string; icon: React.ReactNode }) {
+  return (
+    <form action={changeDocumentStateAction}>
+      <input type="hidden" name="documentId" value={documentId} />
+      <input type="hidden" name="toState" value={toState} />
+      <input type="hidden" name="reason" value={`Manual ${toState} from document detail`} />
+      <button type="submit" className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--dpf-border)] px-3 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-1)]">
+        {icon}
+        {label}
+      </button>
+    </form>
+  );
+}
+
+export default async function DocumentDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const { documentId } = await params;
+  const [document, references] = await Promise.all([
+    loadManagedDocument({ documentId: decodeURIComponent(documentId) }),
+    listManagedDocumentReferences(decodeURIComponent(documentId)),
+  ]);
+  if (!document) notFound();
+
+  const content = document.currentVersion?.contentText ?? document.currentVersion?.summary ?? "";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link href="/workspace/documents" className="inline-flex items-center gap-2 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Documents
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
+            <span>{document.documentId}</span>
+            <span className="rounded border border-[var(--dpf-border)] px-2 py-0.5 text-[var(--dpf-text)]">{document.currentState}</span>
+            <span>{document.documentKind}</span>
+            <span>v{document.currentVersion?.version ?? "-"}</span>
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{document.title}</h1>
+          <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
+            Updated {document.updatedAt.toLocaleString()} by {document.createdByName ?? document.ownerName ?? "unknown principal"}.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {document.currentState === "draft" && (
+            <StateAction documentId={document.documentId} toState="published" label="Publish" icon={<CheckCircle2 className="h-4 w-4" aria-hidden="true" />} />
+          )}
+          {document.currentState !== "archived" && (
+            <StateAction documentId={document.documentId} toState="archived" label="Archive" icon={<Archive className="h-4 w-4" aria-hidden="true" />} />
+          )}
+          {document.currentState === "archived" && (
+            <StateAction documentId={document.documentId} toState="draft" label="Restore" icon={<ArchiveRestore className="h-4 w-4" aria-hidden="true" />} />
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <article className="min-w-0 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+          <div className="mb-4 flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+            <FileText className="h-4 w-4" aria-hidden="true" />
+            Current Version
+          </div>
+          {document.contentFormat === "text/markdown" ? (
+            <div className="prose prose-sm max-w-none text-[var(--dpf-text)] prose-headings:text-[var(--dpf-text)] prose-p:text-[var(--dpf-text)] prose-strong:text-[var(--dpf-text)]">
+              <ReactMarkdown>{content}</ReactMarkdown>
+            </div>
+          ) : (
+            <pre className="whitespace-pre-wrap text-sm leading-6 text-[var(--dpf-text)]">{content || "Binary or external content is stored as a managed blob."}</pre>
+          )}
+        </article>
+
+        <aside className="space-y-4">
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Metadata</h2>
+            <dl className="mt-3 space-y-2 text-sm">
+              <div className="flex justify-between gap-3">
+                <dt className="text-[var(--dpf-muted)]">Format</dt>
+                <dd className="text-right text-[var(--dpf-text)]">{document.contentFormat}</dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-[var(--dpf-muted)]">Access</dt>
+                <dd className="text-right text-[var(--dpf-text)]">{document.accessScope}</dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-[var(--dpf-muted)]">Source</dt>
+                <dd className="text-right text-[var(--dpf-text)]">{document.sourceKind}</dd>
+              </div>
+            </dl>
+            <div className="mt-3 flex flex-wrap gap-1">
+              {document.tags.map((tag) => (
+                <span key={tag} className="rounded border border-[var(--dpf-border)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]">{tag}</span>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Versions</h2>
+            <div className="mt-3 space-y-2">
+              {document.versions.map((version) => (
+                <div key={version.id} className="border-l-2 border-[var(--dpf-border)] pl-3 text-sm">
+                  <p className="font-medium text-[var(--dpf-text)]">v{version.version}</p>
+                  <p className="text-xs text-[var(--dpf-muted)]">{version.summary ?? "No summary"}</p>
+                  <p className="text-[11px] text-[var(--dpf-muted)]">{version.createdAt.toLocaleString()}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Lifecycle</h2>
+            <div className="mt-3 space-y-2">
+              {document.lifecycleEvents.length === 0 ? (
+                <p className="text-sm text-[var(--dpf-muted)]">No lifecycle events yet.</p>
+              ) : (
+                document.lifecycleEvents.map((event) => (
+                  <div key={event.id} className="border-l-2 border-[var(--dpf-border)] pl-3 text-sm">
+                    <p className="font-medium text-[var(--dpf-text)]">
+                      {event.fromState ?? "created"} {"->"} {event.toState}
+                    </p>
+                    <p className="text-xs text-[var(--dpf-muted)]">{event.reason ?? "No reason recorded"}</p>
+                    <p className="text-[11px] text-[var(--dpf-muted)]">
+                      {event.createdAt.toLocaleString()} {event.actorName ? `by ${event.actorName}` : ""}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">References</h2>
+            <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+              {references.outbound.length} outbound · {references.inbound.length} inbound
+            </p>
+            <div className="mt-3 space-y-3 text-sm">
+              {references.outbound.map((ref: any) => (
+                <div key={ref.id} className="text-[var(--dpf-muted)]">
+                  <span className="text-[var(--dpf-text)]">{ref.refType}</span>{" "}
+                  {ref.targetDocument ? `${ref.targetDocument.documentId} ${ref.targetDocument.title}` : ref.targetExternalRef}
+                </div>
+              ))}
+              {references.inbound.map((ref: any) => (
+                <div key={ref.id} className="text-[var(--dpf-muted)]">
+                  <span className="text-[var(--dpf-text)]">used by</span>{" "}
+                  {ref.sourceDocument ? `${ref.sourceDocument.documentId} ${ref.sourceDocument.title}` : "unknown"}
+                </div>
+              ))}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/workspace/documents/actions.ts
+++ b/apps/web/app/(shell)/workspace/documents/actions.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { changeManagedDocumentState } from "@/lib/documents/document-store";
+import { syncUserPrincipal } from "@/lib/identity/principal-linking";
+
+export async function changeDocumentStateAction(formData: FormData) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/login");
+
+  const documentId = String(formData.get("documentId") ?? "");
+  const toState = String(formData.get("toState") ?? "");
+  const reason = String(formData.get("reason") ?? "");
+  const principal = await syncUserPrincipal(session.user.id).catch(() => null);
+
+  await changeManagedDocumentState({
+    documentId,
+    toState,
+    reason,
+    actorPrincipalId: principal?.id ?? null,
+  });
+
+  revalidatePath("/workspace/documents");
+  revalidatePath(`/workspace/documents/${encodeURIComponent(documentId)}`);
+}

--- a/apps/web/app/(shell)/workspace/documents/page.tsx
+++ b/apps/web/app/(shell)/workspace/documents/page.tsx
@@ -1,0 +1,196 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Archive, FileText, Search } from "lucide-react";
+import { auth } from "@/lib/auth";
+import { searchManagedDocuments } from "@/lib/documents/document-store";
+import { prisma } from "@dpf/db";
+
+type Props = {
+  searchParams: Promise<{
+    q?: string;
+    state?: string;
+    kind?: string;
+    tag?: string;
+    owner?: string;
+  }>;
+};
+
+const STATE_TABS = [
+  { label: "All", value: "" },
+  { label: "Draft", value: "draft" },
+  { label: "Published", value: "published" },
+  { label: "Archived", value: "archived" },
+];
+
+function buildHref(params: Record<string, string | undefined>) {
+  const url = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) url.set(key, value);
+  }
+  const query = url.toString();
+  return `/workspace/documents${query ? `?${query}` : ""}`;
+}
+
+export default async function DocumentsPage({ searchParams }: Props) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const sp = await searchParams;
+  const [documents, owners] = await Promise.all([
+    searchManagedDocuments({
+      query: sp.q ?? null,
+      currentState: sp.state || null,
+      documentKind: sp.kind || null,
+      ownerPrincipalId: sp.owner || null,
+      tags: sp.tag ? [sp.tag] : [],
+      limit: 50,
+    }),
+    prisma.principal.findMany({
+      where: { ownedDocuments: { some: {} } },
+      orderBy: { displayName: "asc" },
+      select: { id: true, displayName: true },
+      take: 100,
+    }),
+  ]);
+
+  const updated = documents.filter((doc) => doc.updatedAt.getTime() > Date.now() - 7 * 24 * 60 * 60 * 1000).length;
+  const published = documents.filter((doc) => doc.currentState === "published").length;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Workspace</p>
+          <h1 className="mt-1 text-2xl font-semibold text-[var(--dpf-text)]">Documents</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+            Managed briefs, policies, plans, and other coworker outputs with stable IDs, lifecycle state, references, and independent versions.
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-2 text-right">
+          <div className="border-l border-[var(--dpf-border)] pl-4">
+            <p className="text-xl font-semibold text-[var(--dpf-text)]">{documents.length}</p>
+            <p className="text-[11px] text-[var(--dpf-muted)]">shown</p>
+          </div>
+          <div className="border-l border-[var(--dpf-border)] pl-4">
+            <p className="text-xl font-semibold text-[var(--dpf-text)]">{published}</p>
+            <p className="text-[11px] text-[var(--dpf-muted)]">published</p>
+          </div>
+          <div className="border-l border-[var(--dpf-border)] pl-4">
+            <p className="text-xl font-semibold text-[var(--dpf-text)]">{updated}</p>
+            <p className="text-[11px] text-[var(--dpf-muted)]">this week</p>
+          </div>
+        </div>
+      </div>
+
+      <form className="grid gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 md:grid-cols-[minmax(0,1fr)_140px_140px_180px_auto]">
+        <label className="flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3">
+          <Search className="h-4 w-4 text-[var(--dpf-muted)]" aria-hidden="true" />
+          <input
+            name="q"
+            defaultValue={sp.q ?? ""}
+            placeholder="Search phrase, concept, title, or ID"
+            className="h-10 min-w-0 flex-1 bg-transparent text-sm text-[var(--dpf-text)] outline-none placeholder:text-[var(--dpf-muted)]"
+          />
+        </label>
+        <input
+          name="kind"
+          defaultValue={sp.kind ?? ""}
+          placeholder="Kind"
+          className="h-10 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm text-[var(--dpf-text)] outline-none placeholder:text-[var(--dpf-muted)]"
+        />
+        <input
+          name="tag"
+          defaultValue={sp.tag ?? ""}
+          placeholder="Tag"
+          className="h-10 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm text-[var(--dpf-text)] outline-none placeholder:text-[var(--dpf-muted)]"
+        />
+        <select
+          name="owner"
+          defaultValue={sp.owner ?? ""}
+          className="h-10 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm text-[var(--dpf-text)] outline-none"
+        >
+          <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Any owner</option>
+          {owners.map((owner) => (
+            <option key={owner.id} value={owner.id} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+              {owner.displayName}
+            </option>
+          ))}
+        </select>
+        <button type="submit" className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-[var(--dpf-accent)] px-4 text-sm font-medium text-white">
+          <Search className="h-4 w-4" aria-hidden="true" />
+          Search
+        </button>
+      </form>
+
+      <div className="flex flex-wrap gap-1 border-b border-[var(--dpf-border)]">
+        {STATE_TABS.map((tab) => {
+          const active = (sp.state ?? "") === tab.value;
+          return (
+            <Link
+              key={tab.label}
+              href={buildHref({ q: sp.q, kind: sp.kind, tag: sp.tag, owner: sp.owner, state: tab.value })}
+              className={[
+                "px-3 py-2 text-xs font-medium transition-colors",
+                active
+                  ? "border-b-2 border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                  : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+              ].join(" ")}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {documents.length === 0 ? (
+        <div className="flex items-center gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+          <Archive className="h-5 w-5 text-[var(--dpf-muted)]" aria-hidden="true" />
+          No managed documents match these filters.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-[var(--dpf-border)]">
+          <table className="min-w-full divide-y divide-[var(--dpf-border)] text-sm">
+            <thead className="bg-[var(--dpf-surface-1)] text-left text-[11px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Document</th>
+                <th className="px-4 py-3 font-medium">State</th>
+                <th className="px-4 py-3 font-medium">Kind</th>
+                <th className="px-4 py-3 font-medium">Owner</th>
+                <th className="px-4 py-3 font-medium">Tags</th>
+                <th className="px-4 py-3 text-right font-medium">Updated</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--dpf-border)] bg-[var(--dpf-bg)]">
+              {documents.map((doc) => (
+                <tr key={doc.documentId} className="hover:bg-[var(--dpf-surface-1)]">
+                  <td className="px-4 py-3">
+                    <Link href={`/workspace/documents/${encodeURIComponent(doc.documentId)}`} className="flex min-w-0 items-center gap-3">
+                      <FileText className="h-4 w-4 shrink-0 text-[var(--dpf-accent)]" aria-hidden="true" />
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium text-[var(--dpf-text)]">{doc.title}</span>
+                        <span className="block text-xs text-[var(--dpf-muted)]">{doc.documentId} · v{doc.currentVersion?.version ?? "-"}</span>
+                      </span>
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--dpf-text)]">{doc.currentState}</td>
+                  <td className="px-4 py-3 text-[var(--dpf-muted)]">{doc.documentKind}</td>
+                  <td className="px-4 py-3 text-[var(--dpf-muted)]">{doc.ownerName ?? doc.createdByName ?? "Unknown"}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {doc.tags.slice(0, 4).map((tag) => (
+                        <span key={tag} className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-muted)]">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right text-xs text-[var(--dpf-muted)]">{doc.updatedAt.toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/workspace/page.test.tsx
+++ b/apps/web/app/(shell)/workspace/page.test.tsx
@@ -18,4 +18,11 @@ describe("workspace tile derivation", () => {
     expect(hr000.some((t) => t.key === "admin")).toBe(true);
     expect(hr300.some((t) => t.key === "admin")).toBe(false);
   });
+
+  it("surfaces the document library from Workspace for platform operators", () => {
+    const tiles = getWorkspaceTiles({ platformRole: "HR-000", isSuperuser: false });
+    expect(tiles).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: "documents", route: "/workspace/documents" }),
+    ]));
+  });
 });

--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -44,6 +44,7 @@ export default async function WorkspacePage() {
     userCount,
     eaViewCount,
     buildCount,
+    documentCount,
     activeObligationCount,
     openIncidentCount,
     implementedControlCount,
@@ -72,6 +73,7 @@ export default async function WorkspacePage() {
     prisma.user.count(),
     prisma.eaView.count(),
     prisma.featureBuild.count(),
+    prisma.document.count(),
     prisma.obligation.count({ where: { status: "active" } }),
     prisma.complianceIncident.count({ where: { status: { in: ["open", "investigating"] } } }),
     prisma.control.count({ where: { implementationStatus: "implemented", status: "active" } }),
@@ -142,6 +144,11 @@ export default async function WorkspacePage() {
     build: {
       metrics: [
         { label: "Builds", value: buildCount, color: "var(--dpf-success)" },
+      ],
+    },
+    documents: {
+      metrics: [
+        { label: "Managed", value: documentCount, color: "var(--dpf-accent)" },
       ],
     },
     portfolio: {

--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -87,4 +87,24 @@ describe("AgentMessageBubble", () => {
     expect(html).toContain("Not sent");
     expect(html).toContain("Retry");
   });
+
+  it("renders managed document chips for assistant messages with stable document ids", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-5",
+          role: "assistant",
+          content: "Saved document DOC-ABC12345 v1: /workspace/documents/DOC-ABC12345.",
+          agentId: "policy-coworker",
+          routeContext: "/workspace",
+          createdAt: "2026-03-14T12:00:00.000Z",
+        }}
+        showAgentLabel={true}
+        agentName="Policy"
+      />,
+    );
+
+    expect(html).toContain("/workspace/documents/DOC-ABC12345");
+    expect(html).toContain("DOC-ABC12345");
+  });
 });

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import ReactMarkdown from "react-markdown";
+import { FileText } from "lucide-react";
 import type { AgentMessageRow } from "@/lib/agent-coworker-types";
 import type { ReactNode } from "react";
 import { AgentAttachmentCard } from "./AgentAttachmentCard";
@@ -31,6 +33,10 @@ const PARAM_LABELS: Record<string, string> = {
 
 // Keys to hide from proposal display (internal system values)
 const HIDDEN_PARAMS = new Set(["buildId", "digitalProductId", "featureBrief"]);
+
+function extractManagedDocumentIds(content: string): string[] {
+  return [...new Set(content.match(/\bDOC-[A-Z0-9]{8}\b/g) ?? [])].slice(0, 4);
+}
 
 function formatProposalParams(
   actionType: string,
@@ -370,6 +376,7 @@ export function AgentMessageBubble({
   }
 
   const isAssistantError = !isUser && looksLikeAgentError(message.content);
+  const managedDocumentIds = isUser ? [] : extractManagedDocumentIds(message.content);
 
   return (
     <div
@@ -434,6 +441,31 @@ export function AgentMessageBubble({
               </div>
             )}
             <ReactMarkdown components={MARKDOWN_COMPONENTS}>{message.content}</ReactMarkdown>
+            {managedDocumentIds.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 6 }}>
+                {managedDocumentIds.map((documentId) => (
+                  <Link
+                    key={documentId}
+                    href={`/workspace/documents/${encodeURIComponent(documentId)}`}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 4,
+                      border: "1px solid var(--dpf-border)",
+                      borderRadius: 6,
+                      color: "var(--dpf-text)",
+                      fontSize: 11,
+                      lineHeight: 1,
+                      padding: "5px 7px",
+                      textDecoration: "none",
+                    }}
+                  >
+                    <FileText size={12} aria-hidden="true" />
+                    {documentId}
+                  </Link>
+                ))}
+              </div>
+            )}
           </div>
         )}
         {message.attachments && message.attachments.length > 0 && (

--- a/apps/web/lib/documents/blob-storage.test.ts
+++ b/apps/web/lib/documents/blob-storage.test.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DOCUMENT_TEXT_INLINE_LIMIT_BYTES,
+  buildDocumentBlobStorageKey,
+  hashDocumentBlobContent,
+  resolveDocumentBlobStorageRoot,
+  writeDocumentBlob,
+} from "./blob-storage";
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "document-blob-storage-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("document blob storage", () => {
+  it("keeps the inline content threshold at 10MB", () => {
+    expect(DOCUMENT_TEXT_INLINE_LIMIT_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it("builds deterministic content-addressed keys", () => {
+    const hash = hashDocumentBlobContent(Buffer.from("hello document"));
+
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(buildDocumentBlobStorageKey(hash)).toBe(
+      `documents/sha256/${hash.slice(0, 2)}/${hash.slice(2, 4)}/${hash}`,
+    );
+  });
+
+  it("writes blobs idempotently under the content hash key", async () => {
+    const content = Buffer.from("managed document payload");
+    const first = await writeDocumentBlob({ content, storageRoot: tmpRoot });
+    const second = await writeDocumentBlob({ content, storageRoot: tmpRoot });
+
+    expect(second).toEqual(first);
+    expect(first.sizeBytes).toBe(content.byteLength);
+    await expect(fs.readFile(path.join(tmpRoot, first.storageKey), "utf-8")).resolves.toBe(content.toString("utf-8"));
+  });
+
+  it("resolves PlatformConfig upload roots before environment fallback", () => {
+    const cwd = path.join(tmpRoot, "cwd");
+    const envRoot = path.join(tmpRoot, "env");
+
+    expect(resolveDocumentBlobStorageRoot({ configuredPath: "./configured", cwd, env: { UPLOAD_STORAGE_PATH: envRoot } })).toBe(
+      path.resolve(cwd, "./configured"),
+    );
+    expect(resolveDocumentBlobStorageRoot({ configuredPath: "", cwd, env: { UPLOAD_STORAGE_PATH: envRoot } })).toBe(
+      envRoot,
+    );
+    expect(resolveDocumentBlobStorageRoot({ configuredPath: null, cwd, env: {} })).toBe(
+      path.resolve(cwd, "./data/uploads"),
+    );
+  });
+});

--- a/apps/web/lib/documents/blob-storage.ts
+++ b/apps/web/lib/documents/blob-storage.ts
@@ -1,0 +1,102 @@
+import { prisma } from "@dpf/db";
+import { lazyCrypto, lazyFsPromises, lazyPath } from "../shared/lazy-node";
+
+export const DOCUMENT_TEXT_INLINE_LIMIT_BYTES = 10 * 1024 * 1024;
+export const DOCUMENT_BLOB_PREFIX = "documents/sha256";
+
+type DocumentBlobContent = Buffer | Uint8Array | string;
+
+type ResolveDocumentBlobStorageRootOptions = {
+  configuredPath?: string | null;
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+};
+
+export type DocumentBlobWriteResult = {
+  sha256: string;
+  storageKey: string;
+  sizeBytes: number;
+};
+
+function toBuffer(content: DocumentBlobContent): Buffer {
+  if (Buffer.isBuffer(content)) return content;
+  if (typeof content === "string") return Buffer.from(content, "utf-8");
+  return Buffer.from(content);
+}
+
+export function hashDocumentBlobContent(content: DocumentBlobContent): string {
+  const crypto = lazyCrypto();
+  return crypto.createHash("sha256").update(toBuffer(content)).digest("hex");
+}
+
+export function buildDocumentBlobStorageKey(sha256: string): string {
+  if (!/^[a-f0-9]{64}$/.test(sha256)) {
+    throw new Error("Document blob storage keys require a lowercase SHA-256 hash.");
+  }
+
+  return `${DOCUMENT_BLOB_PREFIX}/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}`;
+}
+
+export function resolveDocumentBlobStorageRoot(options: ResolveDocumentBlobStorageRootOptions = {}): string {
+  const path = lazyPath();
+  const configuredPath = typeof options.configuredPath === "string" && options.configuredPath.trim().length > 0
+    ? options.configuredPath
+    : undefined;
+  const root = configuredPath ?? options.env?.UPLOAD_STORAGE_PATH ?? "./data/uploads";
+  return path.resolve(options.cwd ?? process.cwd(), root);
+}
+
+export async function getDocumentBlobStorageRoot(): Promise<string> {
+  const config = await prisma.platformConfig.findUnique({
+    where: { key: "upload_storage_path" },
+    select: { value: true },
+  });
+
+  return resolveDocumentBlobStorageRoot({
+    configuredPath: typeof config?.value === "string" ? config.value : null,
+    env: process.env,
+  });
+}
+
+export async function writeDocumentBlob(input: {
+  content: DocumentBlobContent;
+  storageRoot?: string;
+}): Promise<DocumentBlobWriteResult> {
+  const content = toBuffer(input.content);
+  const sha256 = hashDocumentBlobContent(content);
+  const storageKey = buildDocumentBlobStorageKey(sha256);
+  const storageRoot = input.storageRoot ?? await getDocumentBlobStorageRoot();
+  const fs = lazyFsPromises();
+  const path = lazyPath();
+  const absolutePath = path.join(storageRoot, storageKey);
+  const directory = path.dirname(absolutePath);
+  const result = { sha256, storageKey, sizeBytes: content.byteLength };
+
+  await fs.mkdir(directory, { recursive: true });
+
+  try {
+    await fs.access(absolutePath);
+    return result;
+  } catch {
+    // Missing content falls through to an atomic write below.
+  }
+
+  const { randomUUID } = lazyCrypto();
+  const temporaryPath = path.join(directory, `.${path.basename(absolutePath)}.${process.pid}.${randomUUID()}.tmp`);
+
+  try {
+    await fs.writeFile(temporaryPath, content, { flag: "wx" });
+    await fs.rename(temporaryPath, absolutePath);
+  } catch (error) {
+    await fs.unlink(temporaryPath).catch(() => {});
+
+    try {
+      await fs.access(absolutePath);
+      return result;
+    } catch {
+      throw error;
+    }
+  }
+
+  return result;
+}

--- a/apps/web/lib/documents/document-store.ts
+++ b/apps/web/lib/documents/document-store.ts
@@ -1,0 +1,613 @@
+import crypto from "node:crypto";
+import { prisma, type Prisma } from "@dpf/db";
+import { syncDocumentReference } from "@dpf/db/neo4j-sync";
+import { DOCUMENT_TEXT_INLINE_LIMIT_BYTES } from "./blob-storage";
+import { searchDocumentVectors, storeDocumentVector } from "./embeddings";
+
+export const DOCUMENT_STATES = ["draft", "published", "archived"] as const;
+export type DocumentState = typeof DOCUMENT_STATES[number];
+
+export type DocumentReferenceInput = {
+  targetDocumentId?: string | null;
+  targetExternalRef?: string | null;
+  refType: string;
+  anchor?: string | null;
+};
+
+export type SaveManagedDocumentInput = {
+  documentId?: string | null;
+  organizationId?: string | null;
+  title: string;
+  documentKind: string;
+  contentFormat: string;
+  contentText?: string | null;
+  contentBlobId?: string | null;
+  contentSha256?: string | null;
+  summary?: string | null;
+  tags?: string[];
+  references?: DocumentReferenceInput[];
+  accessScope?: string | null;
+  sourceKind?: string | null;
+  externalLocator?: Prisma.InputJsonValue | null;
+  ownerPrincipalId?: string | null;
+  createdByPrincipalId?: string | null;
+  actorPrincipalId?: string | null;
+};
+
+export type DocumentSearchInput = {
+  query?: string | null;
+  mode?: "metadata" | "full-text" | "semantic" | "hybrid";
+  organizationId?: string | null;
+  currentState?: string | null;
+  documentKind?: string | null;
+  ownerPrincipalId?: string | null;
+  tags?: string[];
+  limit?: number;
+};
+
+export type ManagedDocument = {
+  id: string;
+  documentId: string;
+  title: string;
+  documentKind: string;
+  contentFormat: string;
+  currentState: string;
+  accessScope: string;
+  sourceKind: string;
+  organizationId: string;
+  ownerPrincipalId: string | null;
+  createdByPrincipalId: string | null;
+  currentVersionId: string | null;
+  currentVersion: ManagedDocumentVersion | null;
+  versions: ManagedDocumentVersion[];
+  tags: string[];
+  ownerName: string | null;
+  createdByName: string | null;
+  updatedAt: Date;
+  createdAt: Date;
+  semanticScore?: number;
+  fullTextScore?: number;
+  lifecycleEvents: ManagedDocumentLifecycleEvent[];
+};
+
+export type ManagedDocumentVersion = {
+  id: string;
+  version: number;
+  title: string;
+  contentFormat: string;
+  contentText: string | null;
+  contentBlobId: string | null;
+  contentSha256: string | null;
+  summary: string | null;
+  sizeBytes: number | null;
+  createdAt: Date;
+};
+
+export type ManagedDocumentLifecycleEvent = {
+  id: string;
+  fromState: string | null;
+  toState: string;
+  reason: string | null;
+  actorName: string | null;
+  createdAt: Date;
+};
+
+type DocumentStoreDb = typeof prisma;
+
+const DOCUMENT_INCLUDE = {
+  currentVersion: true,
+  versions: { orderBy: { version: "desc" as const } },
+  tags: true,
+  ownerPrincipal: { select: { id: true, displayName: true } },
+  createdByPrincipal: { select: { id: true, displayName: true } },
+  lifecycleEvents: {
+    orderBy: { createdAt: "desc" as const },
+    take: 10,
+    include: {
+      actorPrincipal: { select: { id: true, displayName: true } },
+    },
+  },
+};
+
+function normalizeTags(tags: string[] | undefined): string[] {
+  return [...new Set((tags ?? []).map((tag) => tag.trim().toLowerCase()).filter(Boolean))].slice(0, 50);
+}
+
+function requireText(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required.`);
+  }
+  return value.trim();
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) return 25;
+  return Math.min(Math.max(Math.trunc(limit ?? 25), 1), 100);
+}
+
+function normalizeState(state: string | null | undefined): DocumentState | null {
+  if (!state) return null;
+  if ((DOCUMENT_STATES as readonly string[]).includes(state)) return state as DocumentState;
+  throw new Error(`Unsupported document state: ${state}`);
+}
+
+function nextDocumentId(): string {
+  return `DOC-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+async function resolveOrganizationId(db: DocumentStoreDb, organizationId?: string | null): Promise<string> {
+  if (organizationId) return organizationId;
+  const org = await db.organization.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true } });
+  if (!org) throw new Error("No Organization row exists for document ownership.");
+  return org.id;
+}
+
+function projectDocument(row: any, scores?: { semanticScore?: number; fullTextScore?: number }): ManagedDocument {
+  return {
+    id: row.id,
+    documentId: row.documentId,
+    title: row.title,
+    documentKind: row.documentKind,
+    contentFormat: row.contentFormat,
+    currentState: row.currentState,
+    accessScope: row.accessScope,
+    sourceKind: row.sourceKind,
+    organizationId: row.organizationId,
+    ownerPrincipalId: row.ownerPrincipalId ?? null,
+    createdByPrincipalId: row.createdByPrincipalId ?? null,
+    currentVersionId: row.currentVersionId ?? null,
+    currentVersion: row.currentVersion ? projectVersion(row.currentVersion) : null,
+    versions: (row.versions ?? []).map(projectVersion),
+    tags: (row.tags ?? []).map((tag: { tag: string }) => tag.tag),
+    ownerName: row.ownerPrincipal?.displayName ?? null,
+    createdByName: row.createdByPrincipal?.displayName ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    lifecycleEvents: (row.lifecycleEvents ?? []).map(projectLifecycleEvent),
+    ...(scores?.semanticScore !== undefined ? { semanticScore: scores.semanticScore } : {}),
+    ...(scores?.fullTextScore !== undefined ? { fullTextScore: scores.fullTextScore } : {}),
+  };
+}
+
+function projectVersion(row: any): ManagedDocumentVersion {
+  return {
+    id: row.id,
+    version: row.version,
+    title: row.title,
+    contentFormat: row.contentFormat,
+    contentText: row.contentText ?? null,
+    contentBlobId: row.contentBlobId ?? null,
+    contentSha256: row.contentSha256 ?? null,
+    summary: row.summary ?? null,
+    sizeBytes: row.sizeBytes ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+function projectLifecycleEvent(row: any): ManagedDocumentLifecycleEvent {
+  return {
+    id: row.id,
+    fromState: row.fromState ?? null,
+    toState: row.toState,
+    reason: row.reason ?? null,
+    actorName: row.actorPrincipal?.displayName ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+async function searchDocumentIdsByFullText(
+  query: string,
+  limit: number,
+  db: DocumentStoreDb,
+): Promise<Map<string, number>> {
+  if (!query.trim()) return new Map();
+  try {
+    const rows = await db.$queryRawUnsafe<Array<{ documentId: string; rank: number | string | null }>>(
+      `
+        SELECT d."documentId",
+               MAX(ts_rank_cd(v."searchVector", websearch_to_tsquery('english', $1)))::float AS rank
+        FROM "Document" d
+        JOIN "DocumentVersion" v ON v."documentId" = d."id"
+        WHERE v."searchVector" @@ websearch_to_tsquery('english', $1)
+        GROUP BY d."documentId"
+        ORDER BY rank DESC
+        LIMIT $2
+      `,
+      query,
+      limit,
+    );
+    return new Map(rows.map((row) => [row.documentId, Number(row.rank ?? 0)]));
+  } catch {
+    return new Map();
+  }
+}
+
+async function projectDocumentReferencesToGraph(documentDbId: string, db: DocumentStoreDb): Promise<void> {
+  const references = await db.documentReference.findMany({
+    where: { sourceDocumentId: documentDbId, targetDocumentId: { not: null } },
+    include: {
+      sourceDocument: { select: { documentId: true, title: true, currentState: true, documentKind: true } },
+      targetDocument: { select: { documentId: true, title: true, currentState: true, documentKind: true } },
+      sourceVersion: { select: { id: true } },
+      targetVersion: { select: { id: true } },
+    },
+  });
+
+  for (const reference of references) {
+    if (!reference.targetDocument) continue;
+    await syncDocumentReference({
+      sourceDocumentId: reference.sourceDocument.documentId,
+      sourceTitle: reference.sourceDocument.title,
+      sourceState: reference.sourceDocument.currentState,
+      sourceKind: reference.sourceDocument.documentKind,
+      sourceVersionId: reference.sourceVersion?.id ?? reference.sourceVersionId,
+      targetDocumentId: reference.targetDocument.documentId,
+      targetTitle: reference.targetDocument.title,
+      targetState: reference.targetDocument.currentState,
+      targetKind: reference.targetDocument.documentKind,
+      targetVersionId: reference.targetVersion?.id ?? reference.targetVersionId,
+      refType: reference.refType,
+      anchor: reference.anchor,
+    }).catch((err: unknown) => {
+      console.warn("[document-store] Neo4j document reference projection failed:", err);
+    });
+  }
+}
+
+export async function saveManagedDocument(input: SaveManagedDocumentInput, db: DocumentStoreDb = prisma): Promise<ManagedDocument> {
+  const title = requireText(input.title, "title");
+  const documentKind = requireText(input.documentKind, "documentKind");
+  const contentFormat = requireText(input.contentFormat, "contentFormat");
+  const contentText = input.contentText ?? null;
+  if (!contentText && !input.contentBlobId && input.sourceKind !== "external") {
+    throw new Error("contentText or contentBlobId is required for managed documents.");
+  }
+  if (contentText && Buffer.byteLength(contentText, "utf-8") > DOCUMENT_TEXT_INLINE_LIMIT_BYTES) {
+    throw new Error("contentText exceeds the inline document limit; store it as a DocumentBlob.");
+  }
+
+  const organizationId = await resolveOrganizationId(db, input.organizationId);
+  const tags = normalizeTags(input.tags);
+  const stableDocumentId = input.documentId?.trim() || nextDocumentId();
+
+  const saved = await db.$transaction(async (tx) => {
+    const existing = await tx.document.findUnique({
+      where: { documentId: stableDocumentId },
+      select: { id: true, documentId: true, currentState: true },
+    });
+    const latest = existing
+      ? await tx.documentVersion.findFirst({
+          where: { documentId: existing.id },
+          orderBy: { version: "desc" },
+          select: { version: true },
+        })
+      : null;
+
+    const document = existing
+      ? await tx.document.update({
+          where: { id: existing.id },
+          data: {
+            title,
+            documentKind,
+            contentFormat,
+            accessScope: input.accessScope?.trim() || "organization",
+            sourceKind: input.sourceKind?.trim() || "managed",
+            externalLocator: input.externalLocator ?? undefined,
+            ownerPrincipalId: input.ownerPrincipalId ?? input.actorPrincipalId ?? null,
+            createdByPrincipalId: input.createdByPrincipalId ?? input.actorPrincipalId ?? null,
+            fullTextIndexedAt: contentText ? new Date() : undefined,
+          },
+          select: { id: true },
+        })
+      : await tx.document.create({
+          data: {
+            documentId: stableDocumentId,
+            organizationId,
+            title,
+            documentKind,
+            contentFormat,
+            accessScope: input.accessScope?.trim() || "organization",
+            sourceKind: input.sourceKind?.trim() || "managed",
+            externalLocator: input.externalLocator ?? undefined,
+            currentState: "draft",
+            ownerPrincipalId: input.ownerPrincipalId ?? input.actorPrincipalId ?? null,
+            createdByPrincipalId: input.createdByPrincipalId ?? input.actorPrincipalId ?? null,
+            fullTextIndexedAt: contentText ? new Date() : undefined,
+          },
+          select: { id: true },
+        });
+
+    const version = await tx.documentVersion.create({
+      data: {
+        documentId: document.id,
+        version: (latest?.version ?? 0) + 1,
+        title,
+        contentFormat,
+        contentText,
+        contentBlobId: input.contentBlobId ?? null,
+        contentSha256: input.contentSha256 ?? null,
+        sizeBytes: contentText ? Buffer.byteLength(contentText, "utf-8") : null,
+        summary: input.summary ?? null,
+        createdByPrincipalId: input.createdByPrincipalId ?? input.actorPrincipalId ?? null,
+      },
+      select: { id: true },
+    });
+
+    await tx.document.update({
+      where: { id: document.id },
+      data: { currentVersionId: version.id },
+      select: { id: true },
+    });
+    await tx.documentTag.deleteMany({ where: { documentId: document.id } });
+    if (tags.length > 0) {
+      await tx.documentTag.createMany({
+        data: tags.map((tag) => ({ documentId: document.id, tag })),
+        skipDuplicates: true,
+      });
+    }
+
+    await tx.documentReference.deleteMany({ where: { sourceDocumentId: document.id, sourceVersionId: version.id } });
+    for (const ref of input.references ?? []) {
+      const refType = requireText(ref.refType, "refType");
+      const target = ref.targetDocumentId
+        ? await tx.document.findUnique({
+            where: { documentId: ref.targetDocumentId },
+            select: { id: true, currentVersionId: true },
+          })
+        : null;
+      await tx.documentReference.create({
+        data: {
+          sourceDocumentId: document.id,
+          sourceVersionId: version.id,
+          targetDocumentId: target?.id ?? null,
+          targetVersionId: target?.currentVersionId ?? null,
+          targetExternalRef: target ? ref.targetExternalRef ?? null : ref.targetExternalRef ?? ref.targetDocumentId ?? null,
+          refType,
+          anchor: ref.anchor ?? null,
+          createdByPrincipalId: input.actorPrincipalId ?? null,
+        },
+      });
+    }
+
+    return tx.document.findUniqueOrThrow({
+      where: { id: document.id },
+      include: DOCUMENT_INCLUDE,
+    });
+  });
+
+  const projected = projectDocument(saved);
+  const vectorStored = await storeDocumentVector({
+    id: projected.id,
+    documentId: projected.documentId,
+    documentVersionId: projected.currentVersionId ?? "",
+    organizationId: projected.organizationId,
+    title: projected.title,
+    documentKind: projected.documentKind,
+    contentFormat: projected.contentFormat,
+    currentState: projected.currentState,
+    ownerPrincipalId: projected.ownerPrincipalId,
+    tags: projected.tags,
+    contentText: projected.currentVersion?.contentText ?? null,
+    summary: projected.currentVersion?.summary ?? null,
+  }).catch(() => false);
+
+  if (vectorStored) {
+    await db.document.update({
+      where: { id: projected.id },
+      data: { semanticIndexedAt: new Date() },
+      select: { id: true },
+    }).catch(() => null);
+  }
+
+  await projectDocumentReferencesToGraph(projected.id, db).catch(() => null);
+
+  return projected;
+}
+
+export async function loadManagedDocument(input: { documentId: string; version?: number | null }, db: DocumentStoreDb = prisma): Promise<ManagedDocument | null> {
+  const documentId = requireText(input.documentId, "documentId");
+  const row = await db.document.findUnique({
+    where: { documentId },
+    include: DOCUMENT_INCLUDE,
+  });
+  if (!row) return null;
+  const projected = projectDocument(row);
+  if (input.version == null) return projected;
+  const version = projected.versions.find((candidate) => candidate.version === input.version) ?? null;
+  return { ...projected, currentVersion: version, currentVersionId: version?.id ?? null };
+}
+
+export async function searchManagedDocuments(input: DocumentSearchInput, db: DocumentStoreDb = prisma): Promise<ManagedDocument[]> {
+  const query = input.query?.trim() ?? "";
+  const limit = normalizeLimit(input.limit);
+  const tags = normalizeTags(input.tags);
+  const state = normalizeState(input.currentState);
+  const mode = input.mode ?? "hybrid";
+  const semanticResults = query && (mode === "semantic" || mode === "hybrid")
+    ? await searchDocumentVectors({
+        query,
+        organizationId: input.organizationId ?? null,
+        currentState: state,
+        documentKind: input.documentKind ?? null,
+        tags,
+        limit,
+      }).catch(() => [])
+    : [];
+  const semanticRank = new Map(semanticResults.map((result) => [result.documentId, result.score]));
+  const fullTextRank = query && (mode === "full-text" || mode === "hybrid")
+    ? await searchDocumentIdsByFullText(query, limit, db)
+    : new Map<string, number>();
+
+  const where: Record<string, unknown> = {};
+  if (input.organizationId) where.organizationId = input.organizationId;
+  if (state) where.currentState = state;
+  if (input.documentKind) where.documentKind = input.documentKind;
+  if (input.ownerPrincipalId) where.ownerPrincipalId = input.ownerPrincipalId;
+  if (tags.length > 0) where.tags = { some: { tag: { in: tags } } };
+  if (query) {
+    where.OR = [
+      { documentId: { contains: query, mode: "insensitive" } },
+      { title: { contains: query, mode: "insensitive" } },
+      { documentKind: { contains: query, mode: "insensitive" } },
+      { tags: { some: { tag: { contains: query, mode: "insensitive" } } } },
+      { versions: { some: { contentText: { contains: query, mode: "insensitive" } } } },
+      { versions: { some: { summary: { contains: query, mode: "insensitive" } } } },
+      ...(fullTextRank.size > 0 ? [{ documentId: { in: [...fullTextRank.keys()] } }] : []),
+      ...(semanticResults.length > 0 ? [{ documentId: { in: semanticResults.map((result) => result.documentId) } }] : []),
+    ];
+  }
+
+  const rows = await db.document.findMany({
+    where: where as never,
+    orderBy: [{ updatedAt: "desc" }],
+    take: limit,
+    include: DOCUMENT_INCLUDE,
+  });
+
+  return rows
+    .map((row) => projectDocument(row, {
+      semanticScore: semanticRank.get(row.documentId),
+      fullTextScore: fullTextRank.get(row.documentId),
+    }))
+    .sort((a, b) =>
+      (b.semanticScore ?? 0) - (a.semanticScore ?? 0)
+      || (b.fullTextScore ?? 0) - (a.fullTextScore ?? 0)
+      || b.updatedAt.getTime() - a.updatedAt.getTime(),
+    );
+}
+
+export async function linkManagedDocuments(input: {
+  sourceDocumentId: string;
+  targetDocumentId?: string | null;
+  targetExternalRef?: string | null;
+  refType: string;
+  anchor?: string | null;
+  actorPrincipalId?: string | null;
+}, db: DocumentStoreDb = prisma): Promise<{ referenceId: string }> {
+  const source = await db.document.findUnique({
+    where: { documentId: requireText(input.sourceDocumentId, "sourceDocumentId") },
+    select: { id: true, currentVersionId: true },
+  });
+  if (!source) throw new Error(`Source document not found: ${input.sourceDocumentId}`);
+  const target = input.targetDocumentId
+    ? await db.document.findUnique({
+        where: { documentId: input.targetDocumentId },
+        select: { id: true, currentVersionId: true },
+      })
+    : null;
+
+  const reference = await db.documentReference.create({
+    data: {
+      sourceDocumentId: source.id,
+      sourceVersionId: source.currentVersionId,
+      targetDocumentId: target?.id ?? null,
+      targetVersionId: target?.currentVersionId ?? null,
+      targetExternalRef: target ? input.targetExternalRef ?? null : input.targetExternalRef ?? input.targetDocumentId ?? null,
+      refType: requireText(input.refType, "refType"),
+      anchor: input.anchor ?? null,
+      createdByPrincipalId: input.actorPrincipalId ?? null,
+    },
+    select: { id: true },
+  });
+
+  if (target) {
+    await projectDocumentReferencesToGraph(source.id, db).catch(() => null);
+  }
+
+  return { referenceId: reference.id };
+}
+
+export async function listManagedDocumentVersions(documentId: string, db: DocumentStoreDb = prisma): Promise<ManagedDocumentVersion[]> {
+  const doc = await db.document.findUnique({
+    where: { documentId: requireText(documentId, "documentId") },
+    select: { id: true },
+  });
+  if (!doc) return [];
+  const versions = await db.documentVersion.findMany({
+    where: { documentId: doc.id },
+    orderBy: { version: "desc" },
+  });
+  return versions.map(projectVersion);
+}
+
+function assertAllowedTransition(fromState: string, toState: DocumentState): void {
+  if (fromState === toState) return;
+  const allowed =
+    (fromState === "draft" && (toState === "published" || toState === "archived")) ||
+    (fromState === "published" && toState === "archived") ||
+    (fromState === "archived" && toState === "draft");
+  if (!allowed) throw new Error(`Unsupported document lifecycle transition: ${fromState} -> ${toState}`);
+}
+
+export async function changeManagedDocumentState(input: {
+  documentId: string;
+  toState: string;
+  reason?: string | null;
+  actorPrincipalId?: string | null;
+  toolExecutionId?: string | null;
+}, db: DocumentStoreDb = prisma): Promise<ManagedDocument> {
+  const toState = normalizeState(input.toState);
+  if (!toState) throw new Error("toState is required.");
+
+  const row = await db.$transaction(async (tx) => {
+    const current = await tx.document.findUnique({
+      where: { documentId: requireText(input.documentId, "documentId") },
+      select: { id: true, currentState: true },
+    });
+    if (!current) throw new Error(`Document not found: ${input.documentId}`);
+    assertAllowedTransition(current.currentState, toState);
+    await tx.document.update({
+      where: { id: current.id },
+      data: {
+        currentState: toState,
+        archivedAt: toState === "archived" ? new Date() : null,
+      },
+      select: { id: true },
+    });
+    await tx.documentLifecycleEvent.create({
+      data: {
+        documentId: current.id,
+        fromState: current.currentState,
+        toState,
+        reason: input.reason ?? null,
+        actorPrincipalId: input.actorPrincipalId ?? null,
+        toolExecutionId: input.toolExecutionId ?? null,
+      },
+    });
+    return tx.document.findUniqueOrThrow({
+      where: { id: current.id },
+      include: DOCUMENT_INCLUDE,
+    });
+  });
+
+  return projectDocument(row);
+}
+
+export async function listManagedDocumentReferences(documentId: string, db: DocumentStoreDb = prisma) {
+  const doc = await db.document.findUnique({
+    where: { documentId: requireText(documentId, "documentId") },
+    select: { id: true },
+  });
+  if (!doc) return { inbound: [], outbound: [] };
+  const [outbound, inbound] = await Promise.all([
+    db.documentReference.findMany({
+      where: { sourceDocumentId: doc.id },
+      orderBy: { createdAt: "desc" },
+      include: {
+        targetDocument: { select: { documentId: true, title: true, currentState: true } },
+        sourceVersion: { select: { version: true } },
+        targetVersion: { select: { version: true } },
+      },
+    }),
+    db.documentReference.findMany({
+      where: { targetDocumentId: doc.id },
+      orderBy: { createdAt: "desc" },
+      include: {
+        sourceDocument: { select: { documentId: true, title: true, currentState: true } },
+        sourceVersion: { select: { version: true } },
+        targetVersion: { select: { version: true } },
+      },
+    }),
+  ]);
+  return { inbound, outbound };
+}

--- a/apps/web/lib/documents/embeddings.ts
+++ b/apps/web/lib/documents/embeddings.ts
@@ -1,0 +1,102 @@
+import { QDRANT_COLLECTIONS, searchSimilar, upsertVectors } from "@dpf/db";
+import { generateEmbedding } from "@/lib/inference/embedding";
+
+const ENTITY_TYPE = "document";
+const MAX_EMBED_LENGTH = 8000;
+
+export type StoreDocumentVectorInput = {
+  id: string;
+  documentId: string;
+  documentVersionId: string;
+  organizationId: string;
+  title: string;
+  documentKind: string;
+  contentFormat: string;
+  currentState: string;
+  ownerPrincipalId: string | null;
+  tags: string[];
+  contentText: string | null;
+  summary: string | null;
+};
+
+export type DocumentSemanticSearchInput = {
+  query: string;
+  organizationId?: string | null;
+  currentState?: string | null;
+  documentKind?: string | null;
+  tags?: string[];
+  limit?: number;
+  scoreThreshold?: number;
+};
+
+export type DocumentSemanticSearchResult = {
+  id: string;
+  documentId: string;
+  title: string;
+  contentPreview: string;
+  score: number;
+};
+
+export async function storeDocumentVector(input: StoreDocumentVectorInput): Promise<boolean> {
+  const embeddingInput = [
+    input.title,
+    input.summary ?? "",
+    input.contentText ?? "",
+  ].filter(Boolean).join("\n\n").slice(0, MAX_EMBED_LENGTH);
+  const vector = await generateEmbedding(embeddingInput);
+  if (!vector) return false;
+
+  await upsertVectors(QDRANT_COLLECTIONS.DOCUMENTS, [
+    {
+      id: `document-${input.id}`,
+      vector,
+      payload: {
+        entityType: ENTITY_TYPE,
+        entityId: input.id,
+        documentId: input.documentId,
+        documentVersionId: input.documentVersionId,
+        organizationId: input.organizationId,
+        title: input.title,
+        documentKind: input.documentKind,
+        contentFormat: input.contentFormat,
+        currentState: input.currentState,
+        ownerPrincipalId: input.ownerPrincipalId,
+        tags: input.tags,
+        contentPreview: (input.contentText ?? input.summary ?? "").slice(0, 500),
+        timestamp: new Date().toISOString(),
+      },
+    },
+  ]);
+  return true;
+}
+
+export async function searchDocumentVectors(input: DocumentSemanticSearchInput): Promise<DocumentSemanticSearchResult[]> {
+  const vector = await generateEmbedding(input.query);
+  if (!vector) return [];
+
+  const must: Array<Record<string, unknown>> = [
+    { key: "entityType", match: { value: ENTITY_TYPE } },
+  ];
+  if (input.organizationId) must.push({ key: "organizationId", match: { value: input.organizationId } });
+  if (input.currentState) must.push({ key: "currentState", match: { value: input.currentState } });
+  if (input.documentKind) must.push({ key: "documentKind", match: { value: input.documentKind } });
+  for (const tag of input.tags ?? []) {
+    must.push({ key: "tags", match: { value: tag } });
+  }
+
+  const raw = await searchSimilar(
+    QDRANT_COLLECTIONS.DOCUMENTS,
+    vector,
+    { must },
+    input.limit ?? 10,
+    input.scoreThreshold ?? 0.55,
+  );
+
+  return raw.map((result) => ({
+    id: String(result.payload["entityId"] ?? ""),
+    documentId: String(result.payload["documentId"] ?? ""),
+    title: String(result.payload["title"] ?? ""),
+    contentPreview: String(result.payload["contentPreview"] ?? ""),
+    score: result.score,
+  }));
+}

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -67,8 +67,11 @@ describe("getWorkspaceTiles()", () => {
     expect(tiles).not.toContain("inventory");
   });
 
-  it("superuser gets all 12 top-level tiles regardless of role", () => {
-    expect(getWorkspaceTiles(superuser).length).toBe(12);
+  it("superuser gets all 13 top-level tiles regardless of role", () => {
+    const tiles = getWorkspaceTiles(superuser);
+
+    expect(tiles.length).toBe(13);
+    expect(tiles.map((tile) => tile.key)).toContain("documents");
   });
 });
 

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -141,6 +141,7 @@ const ALL_TILES: WorkspaceTile[] = [
   { key: "ea_modeler",    label: "EA Modeler",    route: "/ea",           capabilityKey: "view_ea_modeler",  accentColor: "var(--dpf-accent)" },
   { key: "ai_workforce", label: "AI Workforce",  route: "/platform/ai",  capabilityKey: "view_platform",    accentColor: "var(--dpf-info)" },
   { key: "build",       label: "Build Studio", route: "/build",       capabilityKey: "view_platform",    accentColor: "var(--dpf-success)" },
+  { key: "documents",   label: "Documents",    route: "/workspace/documents", capabilityKey: "view_platform", accentColor: "var(--dpf-accent)" },
   { key: "portfolio",  label: "Portfolio",  route: "/portfolio", capabilityKey: "view_portfolio",   accentColor: "var(--dpf-success)" },
   { key: "employee",   label: "Employee",   route: "/employee",  capabilityKey: "view_employee",    accentColor: "var(--dpf-info)" },
   { key: "customer",   label: "Customer",   route: "/customer",  capabilityKey: "view_customer",    accentColor: "var(--dpf-accent)" },
@@ -188,6 +189,14 @@ const SHELL_ITEMS: ShellNavItem[] = [
     description: "See what needs attention next.",
     sectionKey: "workspace",
     capabilityKey: null,
+  },
+  {
+    key: "documents",
+    label: "Documents",
+    href: "/workspace/documents",
+    description: "Search, open, publish, and trace managed documents.",
+    sectionKey: "workspace",
+    capabilityKey: "view_platform",
   },
   {
     key: "customer",
@@ -321,7 +330,7 @@ const WORKSPACE_SECTION_BLUEPRINTS: Array<{
     key: "ai-control",
     label: "Direct AI coworkers",
     description: "A small human team can supervise specialists here while AI fills in deep expertise.",
-    tileKeys: ["ai_workforce", "build", "platform", "admin"],
+    tileKeys: ["ai_workforce", "build", "documents", "platform", "admin"],
   },
   {
     key: "product-oversight",

--- a/apps/web/lib/mcp-tools-doc-management.test.ts
+++ b/apps/web/lib/mcp-tools-doc-management.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const documentStore = vi.hoisted(() => ({
+  saveManagedDocument: vi.fn(),
+  loadManagedDocument: vi.fn(),
+  searchManagedDocuments: vi.fn(),
+  linkManagedDocuments: vi.fn(),
+  listManagedDocumentVersions: vi.fn(),
+  changeManagedDocumentState: vi.fn(),
+  listManagedDocumentReferences: vi.fn(),
+}));
+
+const principalLinking = vi.hoisted(() => ({
+  ensureAgentPrincipalIdentity: vi.fn(),
+  syncUserPrincipal: vi.fn(),
+}));
+
+vi.mock("@/lib/documents/document-store", () => documentStore);
+vi.mock("@/lib/identity/principal-linking", () => principalLinking);
+vi.mock("@dpf/db", () => ({
+  prisma: {},
+  DISCOVERY_TRIAGE_AGENT_ID: "DISCOVERY-TRIAGE",
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("document management MCP tools", () => {
+  it("registers document tools and grant mappings", async () => {
+    const { PLATFORM_TOOLS } = await import("./mcp-tools");
+    const { getToolGrantMapping } = await import("./tak/agent-grants");
+    const toolNames = PLATFORM_TOOLS.map((tool) => tool.name);
+    const grantMapping = getToolGrantMapping();
+
+    expect(toolNames).toEqual(expect.arrayContaining([
+      "doc_save",
+      "doc_load",
+      "doc_search",
+      "doc_link",
+      "doc_version_list",
+      "doc_state_change",
+      "doc_list_references",
+    ]));
+    expect(grantMapping.doc_save).toEqual(expect.arrayContaining(["document_write"]));
+    expect(grantMapping.doc_load).toEqual(expect.arrayContaining(["document_read"]));
+    expect(grantMapping.doc_state_change).toEqual(expect.arrayContaining(["document_publish"]));
+  });
+
+  it("doc_save attributes the write to the calling agent principal when available", async () => {
+    principalLinking.ensureAgentPrincipalIdentity.mockResolvedValue({ id: "principal-agent" });
+    principalLinking.syncUserPrincipal.mockResolvedValue({ id: "principal-user" });
+    documentStore.saveManagedDocument.mockResolvedValue({
+      documentId: "DOC-001",
+      version: 1,
+      title: "Licensing brief",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "doc_save",
+      {
+        title: "Licensing brief",
+        documentKind: "brief",
+        contentFormat: "text/markdown",
+        contentText: "# Licensing brief",
+        tags: ["licensing"],
+      },
+      "user-1",
+      { agentId: "AGT-LICENSING" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.entityId).toBe("DOC-001");
+    expect(documentStore.saveManagedDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Licensing brief",
+        actorPrincipalId: "principal-agent",
+        createdByPrincipalId: "principal-agent",
+      }),
+    );
+  });
+
+  it("doc_state_change records lifecycle transitions with the user principal fallback", async () => {
+    principalLinking.ensureAgentPrincipalIdentity.mockResolvedValue(null);
+    principalLinking.syncUserPrincipal.mockResolvedValue({ id: "principal-user" });
+    documentStore.changeManagedDocumentState.mockResolvedValue({
+      documentId: "DOC-001",
+      currentState: "published",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "doc_state_change",
+      { documentId: "DOC-001", toState: "published", reason: "Approved for library use" },
+      "user-1",
+      { agentId: "AGT-MISSING" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(documentStore.changeManagedDocumentState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: "DOC-001",
+        toState: "published",
+        actorPrincipalId: "principal-user",
+      }),
+    );
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -209,6 +209,24 @@ export type ToolResult = {
   data?: Record<string, unknown>;
 };
 
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+async function resolveDocumentActorPrincipalId(userId: string, agentId?: string): Promise<string | null> {
+  const { ensureAgentPrincipalIdentity, syncUserPrincipal } = await import("@/lib/identity/principal-linking");
+  if (agentId) {
+    const agentPrincipal = await ensureAgentPrincipalIdentity(agentId).catch(() => null);
+    if (agentPrincipal?.id) return agentPrincipal.id;
+  }
+  const userPrincipal = await syncUserPrincipal(userId).catch(() => null);
+  return userPrincipal?.id ?? null;
+}
+
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
@@ -1969,6 +1987,148 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: null,
     executionMode: "immediate",
+  },
+  // ─── Managed Document Store ───────────────────────────────────────────────
+  {
+    name: "doc_save",
+    description: "Create a managed document or append a new version. Use for coworker-authored briefs, policies, plans, and other durable non-code artifacts that need stable references, lifecycle, search, and version history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        documentId: { type: "string", description: "Existing stable document id to version, such as DOC-1234ABCD. Omit to create a new document." },
+        title: { type: "string", description: "Document title." },
+        documentKind: { type: "string", description: "Brief type, e.g. brief, policy, plan, audit, decision, runbook." },
+        contentFormat: { type: "string", description: "MIME-ish format, e.g. text/markdown, text/plain, text/html, application/pdf." },
+        contentText: { type: "string", description: "Inline content for text documents under the inline storage limit." },
+        contentBlobId: { type: "string", description: "DocumentBlob id for larger or binary content." },
+        contentSha256: { type: "string", description: "SHA-256 of the content when known." },
+        summary: { type: "string", description: "Version change summary or abstract." },
+        tags: { type: "array", items: { type: "string" }, description: "Searchable tags." },
+        references: {
+          type: "array",
+          description: "Stable references this version cites.",
+          items: {
+            type: "object",
+            properties: {
+              targetDocumentId: { type: "string" },
+              targetExternalRef: { type: "string" },
+              refType: { type: "string" },
+              anchor: { type: "string" },
+            },
+            required: ["refType"],
+          },
+        },
+        accessScope: { type: "string", enum: ["organization", "restricted"], description: "Default organization scope unless restricted." },
+        sourceKind: { type: "string", enum: ["managed", "external"], description: "managed for stored content, external for stable stubs to repo/filesystem artifacts." },
+        organizationId: { type: "string", description: "Organization id. Defaults to the install organization." },
+      },
+      required: ["title", "documentKind", "contentFormat"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "doc_load",
+    description: "Load a managed document by stable document id, optionally pinned to a version.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        documentId: { type: "string", description: "Stable document id, such as DOC-1234ABCD." },
+        version: { type: "number", description: "Optional version number. Defaults to current version." },
+      },
+      required: ["documentId"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, idempotentHint: true },
+  },
+  {
+    name: "doc_search",
+    description: "Search managed documents by metadata, tags, owner, lifecycle state, full text, and best-effort semantic similarity.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Phrase or natural-language concept to search for." },
+        mode: { type: "string", enum: ["metadata", "full-text", "semantic", "hybrid"], description: "Search mode. Hybrid combines Postgres filters and Qdrant semantic results." },
+        state: { type: "string", enum: ["draft", "published", "archived"], description: "Lifecycle state filter." },
+        documentKind: { type: "string", description: "Kind filter." },
+        ownerPrincipalId: { type: "string", description: "Principal DB id for owner filter." },
+        tags: { type: "array", items: { type: "string" }, description: "Tag filters." },
+        organizationId: { type: "string", description: "Organization id filter." },
+        limit: { type: "number", description: "Max results, default 25." },
+      },
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "doc_link",
+    description: "Add a managed document reference edge from one document to another document or external stable locator.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sourceDocumentId: { type: "string", description: "Source stable document id." },
+        targetDocumentId: { type: "string", description: "Target stable document id, if the target is managed." },
+        targetExternalRef: { type: "string", description: "External stable locator when the target is not managed." },
+        refType: { type: "string", description: "Reference type, e.g. cites, supersedes, derived-from, blocks, evidence-for." },
+        anchor: { type: "string", description: "Optional source anchor or section." },
+      },
+      required: ["sourceDocumentId", "refType"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "doc_version_list",
+    description: "List version metadata for a managed document.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        documentId: { type: "string", description: "Stable document id." },
+      },
+      required: ["documentId"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, idempotentHint: true },
+  },
+  {
+    name: "doc_state_change",
+    description: "Transition a managed document lifecycle state and record a DocumentLifecycleEvent.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        documentId: { type: "string", description: "Stable document id." },
+        toState: { type: "string", enum: ["draft", "published", "archived"], description: "Target lifecycle state." },
+        reason: { type: "string", description: "Reason for the transition." },
+        toolExecutionId: { type: "string", description: "Optional audit row id that produced this transition." },
+      },
+      required: ["documentId", "toState"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "doc_list_references",
+    description: "List inbound and outbound managed document references for a document.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        documentId: { type: "string", description: "Stable document id." },
+      },
+      required: ["documentId"],
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, idempotentHint: true },
   },
   // ─── EP-WIKI-001 Phase 3b2: Wiki Query ──────────────────────────────────────
   {
@@ -8482,6 +8642,149 @@ export async function executeTool(
         success: true,
         entityId: feedbackId,
         message: "Feedback submitted.",
+      };
+    }
+
+    case "doc_save": {
+      const {
+        saveManagedDocument,
+      } = await import("@/lib/documents/document-store");
+      const actorPrincipalId = await resolveDocumentActorPrincipalId(userId, context?.agentId);
+      const references = Array.isArray(params["references"])
+        ? params["references"].flatMap((entry) => {
+            if (!entry || typeof entry !== "object") return [];
+            const ref = entry as Record<string, unknown>;
+            const refType = optionalString(ref["refType"]);
+            if (!refType) return [];
+            return [{
+              targetDocumentId: optionalString(ref["targetDocumentId"]),
+              targetExternalRef: optionalString(ref["targetExternalRef"]),
+              refType,
+              anchor: optionalString(ref["anchor"]),
+            }];
+          })
+        : [];
+      const document = await saveManagedDocument({
+        documentId: optionalString(params["documentId"]),
+        organizationId: optionalString(params["organizationId"]),
+        title: String(params["title"] ?? ""),
+        documentKind: String(params["documentKind"] ?? ""),
+        contentFormat: String(params["contentFormat"] ?? ""),
+        contentText: optionalString(params["contentText"]),
+        contentBlobId: optionalString(params["contentBlobId"]),
+        contentSha256: optionalString(params["contentSha256"]),
+        summary: optionalString(params["summary"]),
+        tags: stringArray(params["tags"]),
+        references,
+        accessScope: optionalString(params["accessScope"]),
+        sourceKind: optionalString(params["sourceKind"]),
+        ownerPrincipalId: optionalString(params["ownerPrincipalId"]) ?? actorPrincipalId,
+        createdByPrincipalId: actorPrincipalId,
+        actorPrincipalId,
+      });
+      const version = (document as { version?: number }).version ?? document.currentVersion?.version ?? 1;
+      return {
+        success: true,
+        entityId: document.documentId,
+        message: `Saved document ${document.documentId} v${version}: /workspace/documents/${encodeURIComponent(document.documentId)}.`,
+        data: {
+          document: document as unknown as Record<string, unknown>,
+          route: `/workspace/documents/${encodeURIComponent(document.documentId)}`,
+        },
+      };
+    }
+
+    case "doc_load": {
+      const { loadManagedDocument } = await import("@/lib/documents/document-store");
+      const document = await loadManagedDocument({
+        documentId: String(params["documentId"] ?? ""),
+        version: typeof params["version"] === "number" ? params["version"] : null,
+      });
+      if (!document) return { success: false, message: "Document not found.", error: "Document not found." };
+      return {
+        success: true,
+        entityId: document.documentId,
+        message: `Loaded document ${document.documentId}.`,
+        data: { document: document as unknown as Record<string, unknown> },
+      };
+    }
+
+    case "doc_search": {
+      const { searchManagedDocuments } = await import("@/lib/documents/document-store");
+      const documents = await searchManagedDocuments({
+        query: optionalString(params["query"]),
+        mode: typeof params["mode"] === "string" ? params["mode"] as "metadata" | "full-text" | "semantic" | "hybrid" : "hybrid",
+        currentState: optionalString(params["state"]),
+        documentKind: optionalString(params["documentKind"]),
+        ownerPrincipalId: optionalString(params["ownerPrincipalId"]),
+        organizationId: optionalString(params["organizationId"]),
+        tags: stringArray(params["tags"]),
+        limit: typeof params["limit"] === "number" ? params["limit"] : undefined,
+      });
+      const summary = documents.length === 0
+        ? "No matching documents found."
+        : documents.map((doc) => `${doc.documentId} ${doc.currentState} ${doc.title}`).join("\n");
+      return {
+        success: true,
+        message: summary,
+        data: { results: documents as unknown as Record<string, unknown>[] },
+      };
+    }
+
+    case "doc_link": {
+      const { linkManagedDocuments } = await import("@/lib/documents/document-store");
+      const actorPrincipalId = await resolveDocumentActorPrincipalId(userId, context?.agentId);
+      const result = await linkManagedDocuments({
+        sourceDocumentId: String(params["sourceDocumentId"] ?? ""),
+        targetDocumentId: optionalString(params["targetDocumentId"]),
+        targetExternalRef: optionalString(params["targetExternalRef"]),
+        refType: String(params["refType"] ?? ""),
+        anchor: optionalString(params["anchor"]),
+        actorPrincipalId,
+      });
+      return {
+        success: true,
+        entityId: result.referenceId,
+        message: `Linked document reference ${result.referenceId}.`,
+        data: result,
+      };
+    }
+
+    case "doc_version_list": {
+      const { listManagedDocumentVersions } = await import("@/lib/documents/document-store");
+      const versions = await listManagedDocumentVersions(String(params["documentId"] ?? ""));
+      return {
+        success: true,
+        message: versions.length === 0 ? "No versions found." : `Found ${versions.length} document version${versions.length === 1 ? "" : "s"}.`,
+        data: { versions: versions as unknown as Record<string, unknown>[] },
+      };
+    }
+
+    case "doc_state_change": {
+      const { changeManagedDocumentState } = await import("@/lib/documents/document-store");
+      const actorPrincipalId = await resolveDocumentActorPrincipalId(userId, context?.agentId);
+      const document = await changeManagedDocumentState({
+        documentId: String(params["documentId"] ?? ""),
+        toState: String(params["toState"] ?? ""),
+        reason: optionalString(params["reason"]),
+        toolExecutionId: optionalString(params["toolExecutionId"]),
+        actorPrincipalId,
+      });
+      return {
+        success: true,
+        entityId: document.documentId,
+        message: `Document ${document.documentId} moved to ${document.currentState}.`,
+        data: { document: document as unknown as Record<string, unknown> },
+      };
+    }
+
+    case "doc_list_references": {
+      const { listManagedDocumentReferences } = await import("@/lib/documents/document-store");
+      const references = await listManagedDocumentReferences(String(params["documentId"] ?? ""));
+      return {
+        success: true,
+        message: `Document references loaded for ${String(params["documentId"] ?? "")}.`,
+        data: references,
       };
     }
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -63,6 +63,13 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   search_knowledge_base: ["registry_read"],
   create_knowledge_article: ["registry_write"],
   flag_stale_knowledge: ["registry_read"],
+  doc_save: ["document_write", "registry_write"],
+  doc_load: ["document_read", "registry_read"],
+  doc_search: ["document_read", "registry_read"],
+  doc_link: ["document_write", "registry_write"],
+  doc_version_list: ["document_read", "registry_read"],
+  doc_state_change: ["document_publish", "registry_write"],
+  doc_list_references: ["document_read", "registry_read"],
 
   // EP-WIKI-001 Phase 3b2: Founder kernel + per-org overlay wiki
   wiki_query: ["registry_read"],

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2294,7 +2294,10 @@
           "backlog_write",
           "decision_record_create",
           "architecture_read",
-          "spec_plan_read"
+          "spec_plan_read",
+          "document_read",
+          "document_write",
+          "document_publish"
         ],
         "memory": {
           "type": "session",

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -344,6 +344,44 @@
       "implies": []
     },
     {
+      "key": "document_publish",
+      "description": "Move managed documents through governed publication lifecycle states.",
+      "category": "registry",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "doc_state_change"
+      ],
+      "implies": [
+        "document_read"
+      ]
+    },
+    {
+      "key": "document_read",
+      "description": "Read managed documents, versions, references, lifecycle history, and searchable metadata.",
+      "category": "registry",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "doc_list_references",
+        "doc_load",
+        "doc_search",
+        "doc_version_list"
+      ],
+      "implies": []
+    },
+    {
+      "key": "document_write",
+      "description": "Create, update, and link managed documents in the governed document store.",
+      "category": "registry",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "doc_link",
+        "doc_save"
+      ],
+      "implies": [
+        "document_read"
+      ]
+    },
+    {
       "key": "dependency_audit",
       "description": "dependency audit.",
       "category": "governance",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -26,7 +26,8 @@
     "studio": "prisma studio",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "neo4j:rebuild-ea": "tsx src/neo4j-rebuild-ea.ts"
+    "neo4j:rebuild-ea": "tsx src/neo4j-rebuild-ea.ts",
+    "neo4j:rebuild-documents": "tsx src/neo4j-rebuild-documents.ts"
   },
   "dependencies": {
     "@dpf/storefront-templates": "workspace:*",

--- a/packages/db/prisma/migrations/20260513010500_add_document_management_foundation/migration.sql
+++ b/packages/db/prisma/migrations/20260513010500_add_document_management_foundation/migration.sql
@@ -1,0 +1,318 @@
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "ownerPrincipalId" TEXT,
+    "title" TEXT NOT NULL,
+    "slug" TEXT,
+    "documentKind" TEXT NOT NULL,
+    "contentFormat" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL DEFAULT 'managed',
+    "externalLocator" JSONB,
+    "currentVersionId" TEXT,
+    "currentState" TEXT NOT NULL DEFAULT 'draft',
+    "accessScope" TEXT NOT NULL DEFAULT 'organization',
+    "classification" TEXT,
+    "semanticIndexedAt" TIMESTAMP(3),
+    "fullTextIndexedAt" TIMESTAMP(3),
+    "archivedAt" TIMESTAMP(3),
+    "createdByPrincipalId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentVersion" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "contentFormat" TEXT NOT NULL,
+    "contentText" TEXT,
+    "contentBlobId" TEXT,
+    "contentSha256" TEXT,
+    "sizeBytes" INTEGER,
+    "summary" TEXT,
+    "createdByPrincipalId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentBlob" (
+    "id" TEXT NOT NULL,
+    "sha256" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentBlob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentReference" (
+    "id" TEXT NOT NULL,
+    "sourceDocumentId" TEXT NOT NULL,
+    "sourceVersionId" TEXT,
+    "targetDocumentId" TEXT,
+    "targetVersionId" TEXT,
+    "targetExternalRef" TEXT,
+    "refType" TEXT NOT NULL,
+    "anchor" TEXT,
+    "createdByPrincipalId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentReference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentTag" (
+    "documentId" TEXT NOT NULL,
+    "tag" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentTag_pkey" PRIMARY KEY ("documentId","tag")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentAccessGrant" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "principalId" TEXT,
+    "grantKind" TEXT NOT NULL,
+    "createdByPrincipalId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "DocumentAccessGrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentLifecycleEvent" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "fromState" TEXT,
+    "toState" TEXT NOT NULL,
+    "reason" TEXT,
+    "actorPrincipalId" TEXT,
+    "toolExecutionId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentLifecycleEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DocumentRendition" (
+    "id" TEXT NOT NULL,
+    "documentVersionId" TEXT NOT NULL,
+    "renditionKind" TEXT NOT NULL,
+    "contentText" TEXT,
+    "blobId" TEXT,
+    "mimeType" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentRendition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Document_documentId_key" ON "Document"("documentId");
+
+-- CreateIndex
+CREATE INDEX "Document_organizationId_currentState_idx" ON "Document"("organizationId", "currentState");
+
+-- CreateIndex
+CREATE INDEX "Document_ownerPrincipalId_idx" ON "Document"("ownerPrincipalId");
+
+-- CreateIndex
+CREATE INDEX "Document_createdByPrincipalId_idx" ON "Document"("createdByPrincipalId");
+
+-- CreateIndex
+CREATE INDEX "Document_documentKind_idx" ON "Document"("documentKind");
+
+-- CreateIndex
+CREATE INDEX "Document_contentFormat_idx" ON "Document"("contentFormat");
+
+-- CreateIndex
+CREATE INDEX "Document_sourceKind_idx" ON "Document"("sourceKind");
+
+-- CreateIndex
+CREATE INDEX "Document_updatedAt_idx" ON "Document"("updatedAt");
+
+-- CreateIndex
+CREATE INDEX "DocumentVersion_documentId_idx" ON "DocumentVersion"("documentId");
+
+-- CreateIndex
+CREATE INDEX "DocumentVersion_contentBlobId_idx" ON "DocumentVersion"("contentBlobId");
+
+-- CreateIndex
+CREATE INDEX "DocumentVersion_contentSha256_idx" ON "DocumentVersion"("contentSha256");
+
+-- CreateIndex
+CREATE INDEX "DocumentVersion_createdByPrincipalId_idx" ON "DocumentVersion"("createdByPrincipalId");
+
+-- CreateIndex
+CREATE INDEX "DocumentVersion_createdAt_idx" ON "DocumentVersion"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentVersion_documentId_version_key" ON "DocumentVersion"("documentId", "version");
+
+-- Full-text search projection for managed documents. Prisma does not model
+-- tsvector directly here; Postgres keeps it current through the trigger below.
+ALTER TABLE "DocumentVersion" ADD COLUMN "searchVector" tsvector;
+
+CREATE INDEX "DocumentVersion_searchVector_idx" ON "DocumentVersion" USING GIN ("searchVector");
+
+CREATE OR REPLACE FUNCTION "document_version_search_vector_update"()
+RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" := to_tsvector(
+    'english',
+    coalesce(NEW."title", '') || ' ' ||
+    coalesce(NEW."summary", '') || ' ' ||
+    coalesce(NEW."contentText", '')
+  );
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "document_version_search_vector_trigger"
+BEFORE INSERT OR UPDATE OF "title", "summary", "contentText"
+ON "DocumentVersion"
+FOR EACH ROW EXECUTE FUNCTION "document_version_search_vector_update"();
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentBlob_sha256_key" ON "DocumentBlob"("sha256");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentBlob_storageKey_key" ON "DocumentBlob"("storageKey");
+
+-- CreateIndex
+CREATE INDEX "DocumentBlob_sizeBytes_idx" ON "DocumentBlob"("sizeBytes");
+
+-- CreateIndex
+CREATE INDEX "DocumentReference_sourceDocumentId_idx" ON "DocumentReference"("sourceDocumentId");
+
+-- CreateIndex
+CREATE INDEX "DocumentReference_sourceVersionId_idx" ON "DocumentReference"("sourceVersionId");
+
+-- CreateIndex
+CREATE INDEX "DocumentReference_targetDocumentId_idx" ON "DocumentReference"("targetDocumentId");
+
+-- CreateIndex
+CREATE INDEX "DocumentReference_targetVersionId_idx" ON "DocumentReference"("targetVersionId");
+
+-- CreateIndex
+CREATE INDEX "DocumentReference_refType_idx" ON "DocumentReference"("refType");
+
+-- CreateIndex
+CREATE INDEX "DocumentReference_createdByPrincipalId_idx" ON "DocumentReference"("createdByPrincipalId");
+
+-- CreateIndex
+CREATE INDEX "DocumentTag_tag_idx" ON "DocumentTag"("tag");
+
+-- CreateIndex
+CREATE INDEX "DocumentAccessGrant_documentId_idx" ON "DocumentAccessGrant"("documentId");
+
+-- CreateIndex
+CREATE INDEX "DocumentAccessGrant_principalId_idx" ON "DocumentAccessGrant"("principalId");
+
+-- CreateIndex
+CREATE INDEX "DocumentAccessGrant_grantKind_idx" ON "DocumentAccessGrant"("grantKind");
+
+-- CreateIndex
+CREATE INDEX "DocumentAccessGrant_createdByPrincipalId_idx" ON "DocumentAccessGrant"("createdByPrincipalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentAccessGrant_documentId_principalId_grantKind_key" ON "DocumentAccessGrant"("documentId", "principalId", "grantKind");
+
+-- CreateIndex
+CREATE INDEX "DocumentLifecycleEvent_documentId_createdAt_idx" ON "DocumentLifecycleEvent"("documentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "DocumentLifecycleEvent_toState_idx" ON "DocumentLifecycleEvent"("toState");
+
+-- CreateIndex
+CREATE INDEX "DocumentLifecycleEvent_actorPrincipalId_idx" ON "DocumentLifecycleEvent"("actorPrincipalId");
+
+-- CreateIndex
+CREATE INDEX "DocumentLifecycleEvent_toolExecutionId_idx" ON "DocumentLifecycleEvent"("toolExecutionId");
+
+-- CreateIndex
+CREATE INDEX "DocumentRendition_documentVersionId_idx" ON "DocumentRendition"("documentVersionId");
+
+-- CreateIndex
+CREATE INDEX "DocumentRendition_blobId_idx" ON "DocumentRendition"("blobId");
+
+-- CreateIndex
+CREATE INDEX "DocumentRendition_renditionKind_idx" ON "DocumentRendition"("renditionKind");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentRendition_documentVersionId_renditionKind_key" ON "DocumentRendition"("documentVersionId", "renditionKind");
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_ownerPrincipalId_fkey" FOREIGN KEY ("ownerPrincipalId") REFERENCES "Principal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_createdByPrincipalId_fkey" FOREIGN KEY ("createdByPrincipalId") REFERENCES "Principal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_currentVersionId_fkey" FOREIGN KEY ("currentVersionId") REFERENCES "DocumentVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentVersion" ADD CONSTRAINT "DocumentVersion_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentVersion" ADD CONSTRAINT "DocumentVersion_contentBlobId_fkey" FOREIGN KEY ("contentBlobId") REFERENCES "DocumentBlob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentVersion" ADD CONSTRAINT "DocumentVersion_createdByPrincipalId_fkey" FOREIGN KEY ("createdByPrincipalId") REFERENCES "Principal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentReference" ADD CONSTRAINT "DocumentReference_sourceDocumentId_fkey" FOREIGN KEY ("sourceDocumentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentReference" ADD CONSTRAINT "DocumentReference_sourceVersionId_fkey" FOREIGN KEY ("sourceVersionId") REFERENCES "DocumentVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentReference" ADD CONSTRAINT "DocumentReference_targetDocumentId_fkey" FOREIGN KEY ("targetDocumentId") REFERENCES "Document"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentReference" ADD CONSTRAINT "DocumentReference_targetVersionId_fkey" FOREIGN KEY ("targetVersionId") REFERENCES "DocumentVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentReference" ADD CONSTRAINT "DocumentReference_createdByPrincipalId_fkey" FOREIGN KEY ("createdByPrincipalId") REFERENCES "Principal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentTag" ADD CONSTRAINT "DocumentTag_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentAccessGrant" ADD CONSTRAINT "DocumentAccessGrant_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentAccessGrant" ADD CONSTRAINT "DocumentAccessGrant_principalId_fkey" FOREIGN KEY ("principalId") REFERENCES "Principal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentAccessGrant" ADD CONSTRAINT "DocumentAccessGrant_createdByPrincipalId_fkey" FOREIGN KEY ("createdByPrincipalId") REFERENCES "Principal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentLifecycleEvent" ADD CONSTRAINT "DocumentLifecycleEvent_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentLifecycleEvent" ADD CONSTRAINT "DocumentLifecycleEvent_actorPrincipalId_fkey" FOREIGN KEY ("actorPrincipalId") REFERENCES "Principal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentLifecycleEvent" ADD CONSTRAINT "DocumentLifecycleEvent_toolExecutionId_fkey" FOREIGN KEY ("toolExecutionId") REFERENCES "ToolExecution"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentRendition" ADD CONSTRAINT "DocumentRendition_documentVersionId_fkey" FOREIGN KEY ("documentVersionId") REFERENCES "DocumentVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentRendition" ADD CONSTRAINT "DocumentRendition_blobId_fkey" FOREIGN KEY ("blobId") REFERENCES "DocumentBlob"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -229,6 +229,13 @@ model Principal {
   edgeNode              EdgeNode?        @relation("EdgeNodeIdentity")
   edgeNodesApproved     EdgeNode[]       @relation("EdgeNodeApprover")
   bootstrapTokensIssued BootstrapToken[] @relation("BootstrapTokenIssuer")
+  ownedDocuments        Document[]       @relation("DocumentOwner")
+  createdDocuments      Document[]       @relation("DocumentCreator")
+  documentVersions      DocumentVersion[] @relation("DocumentVersionCreator")
+  documentReferences    DocumentReference[] @relation("DocumentReferenceCreator")
+  documentAccessGrants  DocumentAccessGrant[] @relation("DocumentAccessGrantPrincipal")
+  documentAccessGrantsCreated DocumentAccessGrant[] @relation("DocumentAccessGrantCreator")
+  documentLifecycleEvents DocumentLifecycleEvent[] @relation("DocumentLifecycleActor")
   createdAt             DateTime         @default(now())
   updatedAt             DateTime         @updatedAt
 }
@@ -2218,6 +2225,7 @@ model Organization {
   wikiRawSources                RawSource[]
   wikiIngestEvents              WikiIngestEvent[]
   wikiLintFindings              WikiLintFinding[]
+  documents                     Document[]
 }
 
 model BusinessContext {
@@ -3248,6 +3256,7 @@ model ToolExecution {
   // Persisted by mcp-governed-execute.ts when context.taskRunId is provided.
   taskRunId     String?
   receipt       ToolExecutionReceipt?
+  documentLifecycleEvents DocumentLifecycleEvent[]
 
   @@index([agentId, createdAt])
   @@index([userId, createdAt])
@@ -3319,6 +3328,187 @@ model AgentAttachment {
 
   @@index([threadId])
   @@index([messageId])
+}
+
+// ─── Managed Document Store ─────────────────────────────────────────────────
+// Spec: docs/superpowers/specs/2026-05-12-document-management-capability.md
+//
+// This is the minimum Documentum-class foundation: stable document identity,
+// independent versions, durable references, lifecycle events, access metadata,
+// and content-addressed blob/rendition pointers. Postgres full-text, Qdrant,
+// and Neo4j remain projections; Postgres rows are authoritative.
+
+model Document {
+  id                   String                   @id @default(cuid())
+  documentId           String                   @unique
+  organizationId       String
+  ownerPrincipalId     String?
+  title                String
+  slug                 String?
+  documentKind         String
+  contentFormat        String
+  sourceKind           String                   @default("managed")
+  externalLocator      Json?
+  currentVersionId     String?
+  currentState         String                   @default("draft")
+  accessScope          String                   @default("organization")
+  classification       String?
+  semanticIndexedAt    DateTime?
+  fullTextIndexedAt    DateTime?
+  archivedAt           DateTime?
+  createdByPrincipalId String?
+  createdAt            DateTime                 @default(now())
+  updatedAt            DateTime                 @updatedAt
+  organization         Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  ownerPrincipal       Principal?               @relation("DocumentOwner", fields: [ownerPrincipalId], references: [id])
+  createdByPrincipal   Principal?               @relation("DocumentCreator", fields: [createdByPrincipalId], references: [id])
+  versions             DocumentVersion[]        @relation("DocumentVersions")
+  currentVersion       DocumentVersion?         @relation("DocumentCurrentVersion", fields: [currentVersionId], references: [id])
+  outgoingReferences   DocumentReference[]      @relation("DocumentReferenceSource")
+  incomingReferences   DocumentReference[]      @relation("DocumentReferenceTarget")
+  tags                 DocumentTag[]
+  accessGrants         DocumentAccessGrant[]
+  lifecycleEvents      DocumentLifecycleEvent[]
+
+  @@index([organizationId, currentState])
+  @@index([ownerPrincipalId])
+  @@index([createdByPrincipalId])
+  @@index([documentKind])
+  @@index([contentFormat])
+  @@index([sourceKind])
+  @@index([updatedAt])
+}
+
+model DocumentVersion {
+  id                         String              @id @default(cuid())
+  documentId                 String
+  version                    Int
+  title                      String
+  contentFormat              String
+  contentText                String?             @db.Text
+  contentBlobId              String?
+  contentSha256              String?
+  sizeBytes                  Int?
+  summary                    String?             @db.Text
+  createdByPrincipalId       String?
+  createdAt                  DateTime            @default(now())
+  document                   Document            @relation("DocumentVersions", fields: [documentId], references: [id], onDelete: Cascade)
+  currentForDocuments        Document[]          @relation("DocumentCurrentVersion")
+  contentBlob                DocumentBlob?       @relation(fields: [contentBlobId], references: [id], onDelete: SetNull)
+  createdByPrincipal         Principal?          @relation("DocumentVersionCreator", fields: [createdByPrincipalId], references: [id])
+  sourceReferences           DocumentReference[] @relation("DocumentReferenceSourceVersion")
+  targetReferences           DocumentReference[] @relation("DocumentReferenceTargetVersion")
+  renditions                 DocumentRendition[]
+
+  @@unique([documentId, version])
+  @@index([documentId])
+  @@index([contentBlobId])
+  @@index([contentSha256])
+  @@index([createdByPrincipalId])
+  @@index([createdAt])
+}
+
+model DocumentBlob {
+  id          String              @id @default(cuid())
+  sha256      String              @unique
+  storageKey  String              @unique
+  mimeType    String?
+  sizeBytes   Int
+  createdAt   DateTime            @default(now())
+  versions    DocumentVersion[]
+  renditions  DocumentRendition[]
+
+  @@index([sizeBytes])
+}
+
+model DocumentReference {
+  id                   String           @id @default(cuid())
+  sourceDocumentId     String
+  sourceVersionId      String?
+  targetDocumentId     String?
+  targetVersionId      String?
+  targetExternalRef    String?
+  refType              String
+  anchor               String?          @db.Text
+  createdByPrincipalId String?
+  createdAt            DateTime         @default(now())
+  sourceDocument       Document         @relation("DocumentReferenceSource", fields: [sourceDocumentId], references: [id], onDelete: Cascade)
+  sourceVersion        DocumentVersion? @relation("DocumentReferenceSourceVersion", fields: [sourceVersionId], references: [id], onDelete: SetNull)
+  targetDocument       Document?        @relation("DocumentReferenceTarget", fields: [targetDocumentId], references: [id], onDelete: SetNull)
+  targetVersion        DocumentVersion? @relation("DocumentReferenceTargetVersion", fields: [targetVersionId], references: [id], onDelete: SetNull)
+  createdByPrincipal   Principal?       @relation("DocumentReferenceCreator", fields: [createdByPrincipalId], references: [id])
+
+  @@index([sourceDocumentId])
+  @@index([sourceVersionId])
+  @@index([targetDocumentId])
+  @@index([targetVersionId])
+  @@index([refType])
+  @@index([createdByPrincipalId])
+}
+
+model DocumentTag {
+  documentId String
+  tag        String
+  createdAt  DateTime @default(now())
+  document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@id([documentId, tag])
+  @@index([tag])
+}
+
+model DocumentAccessGrant {
+  id                   String     @id @default(cuid())
+  documentId           String
+  principalId          String?
+  grantKind            String
+  createdByPrincipalId String?
+  createdAt            DateTime   @default(now())
+  expiresAt            DateTime?
+  document             Document   @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  principal            Principal? @relation("DocumentAccessGrantPrincipal", fields: [principalId], references: [id], onDelete: Cascade)
+  createdByPrincipal   Principal? @relation("DocumentAccessGrantCreator", fields: [createdByPrincipalId], references: [id])
+
+  @@unique([documentId, principalId, grantKind])
+  @@index([documentId])
+  @@index([principalId])
+  @@index([grantKind])
+  @@index([createdByPrincipalId])
+}
+
+model DocumentLifecycleEvent {
+  id                   String         @id @default(cuid())
+  documentId           String
+  fromState            String?
+  toState              String
+  reason               String?        @db.Text
+  actorPrincipalId     String?
+  toolExecutionId      String?
+  createdAt            DateTime       @default(now())
+  document             Document       @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  actorPrincipal       Principal?     @relation("DocumentLifecycleActor", fields: [actorPrincipalId], references: [id])
+  toolExecution        ToolExecution? @relation(fields: [toolExecutionId], references: [id])
+
+  @@index([documentId, createdAt])
+  @@index([toState])
+  @@index([actorPrincipalId])
+  @@index([toolExecutionId])
+}
+
+model DocumentRendition {
+  id                String          @id @default(cuid())
+  documentVersionId String
+  renditionKind     String
+  contentText       String?         @db.Text
+  blobId            String?
+  mimeType          String?
+  createdAt         DateTime        @default(now())
+  documentVersion   DocumentVersion @relation(fields: [documentVersionId], references: [id], onDelete: Cascade)
+  blob              DocumentBlob?   @relation(fields: [blobId], references: [id], onDelete: SetNull)
+
+  @@unique([documentVersionId, renditionKind])
+  @@index([documentVersionId])
+  @@index([blobId])
+  @@index([renditionKind])
 }
 
 model ApiToken {

--- a/packages/db/src/document-management-model.test.ts
+++ b/packages/db/src/document-management-model.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "../generated/client/client";
+
+describe("document management Prisma models", () => {
+  it("exposes the managed document store models", () => {
+    expect(Prisma.ModelName.Document).toBe("Document");
+    expect(Prisma.ModelName.DocumentVersion).toBe("DocumentVersion");
+    expect(Prisma.ModelName.DocumentBlob).toBe("DocumentBlob");
+    expect(Prisma.ModelName.DocumentReference).toBe("DocumentReference");
+    expect(Prisma.ModelName.DocumentTag).toBe("DocumentTag");
+    expect(Prisma.ModelName.DocumentAccessGrant).toBe("DocumentAccessGrant");
+    expect(Prisma.ModelName.DocumentLifecycleEvent).toBe("DocumentLifecycleEvent");
+    expect(Prisma.ModelName.DocumentRendition).toBe("DocumentRendition");
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -61,6 +61,8 @@ export {
   syncInventoryEntityAsInfraCI,
   syncInventoryRelationship,
   syncIT4ITLabels,
+  syncDocumentNode,
+  syncDocumentReference,
 } from "./neo4j-sync";
 export {
   buildDiscoveredKey,

--- a/packages/db/src/neo4j-rebuild-documents.ts
+++ b/packages/db/src/neo4j-rebuild-documents.ts
@@ -1,0 +1,69 @@
+// packages/db/src/neo4j-rebuild-documents.ts
+// Rebuild the managed-document reference graph projection from Postgres.
+// Usage: pnpm --filter @dpf/db neo4j:rebuild-documents
+
+import "./load-env.js";
+import { prisma } from "./client.js";
+import { closeNeo4j, runCypher } from "./neo4j.js";
+import { syncDocumentNode, syncDocumentReference } from "./neo4j-sync.js";
+
+async function rebuildDocuments(): Promise<void> {
+  console.log("Rebuilding managed document graph projection...");
+
+  await runCypher(`MATCH (doc:Document) DETACH DELETE doc`, {});
+  console.log("Dropped existing :Document nodes");
+
+  const documents = await prisma.document.findMany({
+    select: {
+      documentId: true,
+      title: true,
+      currentState: true,
+      documentKind: true,
+    },
+  });
+
+  for (const document of documents) {
+    await syncDocumentNode({
+      documentId: document.documentId,
+      title: document.title,
+      currentState: document.currentState,
+      documentKind: document.documentKind,
+    });
+  }
+  console.log(`Synced ${documents.length} Document nodes`);
+
+  const references = await prisma.documentReference.findMany({
+    where: { targetDocumentId: { not: null } },
+    include: {
+      sourceDocument: { select: { documentId: true, title: true, currentState: true, documentKind: true } },
+      targetDocument: { select: { documentId: true, title: true, currentState: true, documentKind: true } },
+      sourceVersion: { select: { id: true } },
+      targetVersion: { select: { id: true } },
+    },
+  });
+
+  for (const reference of references) {
+    if (!reference.targetDocument) continue;
+    await syncDocumentReference({
+      sourceDocumentId: reference.sourceDocument.documentId,
+      sourceTitle: reference.sourceDocument.title,
+      sourceState: reference.sourceDocument.currentState,
+      sourceKind: reference.sourceDocument.documentKind,
+      sourceVersionId: reference.sourceVersion?.id ?? reference.sourceVersionId,
+      targetDocumentId: reference.targetDocument.documentId,
+      targetTitle: reference.targetDocument.title,
+      targetState: reference.targetDocument.currentState,
+      targetKind: reference.targetDocument.documentKind,
+      targetVersionId: reference.targetVersion?.id ?? reference.targetVersionId,
+      refType: reference.refType,
+      anchor: reference.anchor,
+    });
+  }
+  console.log(`Synced ${references.length} DOC_REFERENCES edges`);
+
+  console.log("Managed document graph rebuild complete.");
+}
+
+rebuildDocuments()
+  .catch(console.error)
+  .finally(() => Promise.all([prisma.$disconnect(), closeNeo4j()]));

--- a/packages/db/src/neo4j-schema.ts
+++ b/packages/db/src/neo4j-schema.ts
@@ -8,6 +8,7 @@
 //   Portfolio       — mirrors Prisma Portfolio       (keyed on slug)
 //   InfraCI         — infrastructure configuration item (no Prisma mirror yet)
 //   CodeFile        — committed source-code file projection (keyed on codeFileKey)
+//   Document        — managed document projection (keyed on documentId)
 //
 // Relationship types:
 //   BELONGS_TO      — DigitalProduct → Portfolio
@@ -15,6 +16,7 @@
 //   CHILD_OF        — TaxonomyNode → TaxonomyNode (parent)
 //   DEPENDS_ON      — DigitalProduct|InfraCI → InfraCI  (with role, since props)
 //   PROVIDES_TO     — InfraCI → DigitalProduct
+//   DOC_REFERENCES  — Document → Document reference projection
 //
 // IT4IT value-stream labels (on DigitalProduct nodes):
 //   :S2P  Strategy to Portfolio  (ServiceCandidate / Portfolio)
@@ -43,6 +45,7 @@ const SCHEMA_STATEMENTS = [
   "CREATE CONSTRAINT p_slug       IF NOT EXISTS FOR (n:Portfolio)        REQUIRE n.slug      IS UNIQUE",
   "CREATE CONSTRAINT ci_ciId      IF NOT EXISTS FOR (n:InfraCI)          REQUIRE n.ciId      IS UNIQUE",
   "CREATE CONSTRAINT cf_codeFileKey IF NOT EXISTS FOR (n:CodeFile)       REQUIRE n.codeFileKey IS UNIQUE",
+  "CREATE CONSTRAINT doc_documentId IF NOT EXISTS FOR (n:Document)       REQUIRE n.documentId IS UNIQUE",
 
   // ── Existence constraints (enterprise only — skip on community) ───────────
   // Community Neo4j does not support property existence constraints; omitted.
@@ -55,6 +58,8 @@ const SCHEMA_STATEMENTS = [
   "CREATE INDEX ci_status IF NOT EXISTS FOR (n:InfraCI)       ON (n.status)",
   "CREATE INDEX cf_graphKey IF NOT EXISTS FOR (n:CodeFile)    ON (n.graphKey)",
   "CREATE INDEX cf_path     IF NOT EXISTS FOR (n:CodeFile)    ON (n.path)",
+  "CREATE INDEX doc_state   IF NOT EXISTS FOR (n:Document)    ON (n.currentState)",
+  "CREATE INDEX doc_kind    IF NOT EXISTS FOR (n:Document)    ON (n.documentKind)",
 
   // OSI-aware topology indexes
   "CREATE INDEX ci_osi_layer       IF NOT EXISTS FOR (n:InfraCI) ON (n.osiLayer)",

--- a/packages/db/src/neo4j-sync.test.ts
+++ b/packages/db/src/neo4j-sync.test.ts
@@ -6,7 +6,7 @@ vi.mock("./neo4j", () => ({
 }));
 
 import { runCypher } from "./neo4j";
-import { syncInfraCI, syncInventoryRelationship } from "./neo4j-sync";
+import { syncDocumentReference, syncInfraCI, syncInventoryRelationship } from "./neo4j-sync";
 
 const mockRunCypher = vi.mocked(runCypher);
 
@@ -169,5 +169,41 @@ describe("syncInventoryRelationship", () => {
     expect(mockRunCypher).toHaveBeenCalledTimes(1);
     const cypher = mockRunCypher.mock.calls[0]![0] as string;
     expect(cypher).toContain(":HOSTS");
+  });
+});
+
+describe("syncDocumentReference", () => {
+  beforeEach(() => {
+    mockRunCypher.mockClear();
+  });
+
+  it("projects stable document nodes and a DOC_REFERENCES edge", async () => {
+    await syncDocumentReference({
+      sourceDocumentId: "DOC-AAA11111",
+      sourceTitle: "Workspace pattern",
+      sourceState: "draft",
+      sourceKind: "spec",
+      sourceVersionId: "version-a",
+      targetDocumentId: "DOC-BBB22222",
+      targetTitle: "Document management",
+      targetState: "published",
+      targetKind: "spec",
+      targetVersionId: "version-b",
+      refType: "cites",
+      anchor: "section 7",
+    });
+
+    expect(mockRunCypher).toHaveBeenCalledTimes(1);
+    const cypher = mockRunCypher.mock.calls[0]![0] as string;
+    const params = mockRunCypher.mock.calls[0]![1] as Record<string, unknown>;
+    expect(cypher).toContain("MERGE (source:Document {documentId: $sourceDocumentId})");
+    expect(cypher).toContain(":DOC_REFERENCES");
+    expect(params).toMatchObject({
+      sourceDocumentId: "DOC-AAA11111",
+      targetDocumentId: "DOC-BBB22222",
+      refType: "cites",
+      sourceVersionId: "version-a",
+      targetVersionId: "version-b",
+    });
   });
 });

--- a/packages/db/src/neo4j-sync.ts
+++ b/packages/db/src/neo4j-sync.ts
@@ -108,6 +108,76 @@ export async function syncPortfolio(p: {
   );
 }
 
+export async function syncDocumentNode(doc: {
+  documentId: string;
+  title: string;
+  currentState?: string | null;
+  documentKind?: string | null;
+}): Promise<void> {
+  await runCypher(
+    `MERGE (doc:Document {documentId: $documentId})
+     SET doc.title = $title,
+         doc.currentState = $currentState,
+         doc.documentKind = $documentKind,
+         doc.syncedAt = datetime()`,
+    {
+      documentId: doc.documentId,
+      title: doc.title,
+      currentState: doc.currentState ?? null,
+      documentKind: doc.documentKind ?? null,
+    },
+  );
+}
+
+export async function syncDocumentReference(ref: {
+  sourceDocumentId: string;
+  sourceTitle: string;
+  sourceState?: string | null;
+  sourceKind?: string | null;
+  sourceVersionId?: string | null;
+  targetDocumentId: string;
+  targetTitle: string;
+  targetState?: string | null;
+  targetKind?: string | null;
+  targetVersionId?: string | null;
+  refType: string;
+  anchor?: string | null;
+}): Promise<void> {
+  await runCypher(
+    `MERGE (source:Document {documentId: $sourceDocumentId})
+     SET source.title = $sourceTitle,
+         source.currentState = $sourceState,
+         source.documentKind = $sourceKind,
+         source.syncedAt = datetime()
+     MERGE (target:Document {documentId: $targetDocumentId})
+     SET target.title = $targetTitle,
+         target.currentState = $targetState,
+         target.documentKind = $targetKind,
+         target.syncedAt = datetime()
+     MERGE (source)-[edge:DOC_REFERENCES {
+       refType: $refType,
+       sourceVersionId: $sourceVersionId,
+       targetVersionId: $targetVersionId
+     }]->(target)
+     SET edge.anchor = $anchor,
+         edge.syncedAt = datetime()`,
+    {
+      sourceDocumentId: ref.sourceDocumentId,
+      sourceTitle: ref.sourceTitle,
+      sourceState: ref.sourceState ?? null,
+      sourceKind: ref.sourceKind ?? null,
+      sourceVersionId: ref.sourceVersionId ?? null,
+      targetDocumentId: ref.targetDocumentId,
+      targetTitle: ref.targetTitle,
+      targetState: ref.targetState ?? null,
+      targetKind: ref.targetKind ?? null,
+      targetVersionId: ref.targetVersionId ?? null,
+      refType: ref.refType,
+      anchor: ref.anchor ?? null,
+    },
+  );
+}
+
 export interface InfraCIExtendedProps {
   baseUrl?: string;
   gpu?: string;

--- a/packages/db/src/qdrant.ts
+++ b/packages/db/src/qdrant.ts
@@ -5,6 +5,7 @@ const COLLECTIONS = {
   AGENT_MEMORY: "agent-memory",
   PLATFORM_KNOWLEDGE: "platform-knowledge",
   WIKI_PAGES: "wiki-pages",
+  DOCUMENTS: "documents",
 } as const;
 
 export { COLLECTIONS as QDRANT_COLLECTIONS };
@@ -102,6 +103,31 @@ export async function ensureCollections(): Promise<void> {
     ]) {
       await qdrantFetch(
         `/collections/${COLLECTIONS.WIKI_PAGES}/index`,
+        { method: "PUT", body: { field_name: field, field_schema: "keyword" } },
+      ).catch(() => {});
+    }
+  }
+
+  if (!names.has(COLLECTIONS.DOCUMENTS)) {
+    await qdrantFetch(`/collections/${COLLECTIONS.DOCUMENTS}`, {
+      method: "PUT",
+      body: {
+        vectors: { size: 768, distance: "Cosine" },
+      },
+    });
+    for (const field of [
+      "entityType",
+      "documentId",
+      "documentVersionId",
+      "organizationId",
+      "documentKind",
+      "currentState",
+      "contentFormat",
+      "tags",
+      "ownerPrincipalId",
+    ]) {
+      await qdrantFetch(
+        `/collections/${COLLECTIONS.DOCUMENTS}/index`,
         { method: "PUT", body: { field_name: field, field_schema: "keyword" } },
       ).catch(() => {});
     }
@@ -239,6 +265,17 @@ export async function ensurePayloadIndexes(): Promise<void> {
     "kernelVersion",
     "kernelPageId",
   ];
+  const documentKeywordFields = [
+    "entityType",
+    "documentId",
+    "documentVersionId",
+    "organizationId",
+    "documentKind",
+    "currentState",
+    "contentFormat",
+    "tags",
+    "ownerPrincipalId",
+  ];
 
   for (const field of platformKnowledgeKeywordFields) {
     await qdrantFetch(
@@ -259,6 +296,13 @@ export async function ensurePayloadIndexes(): Promise<void> {
       `/collections/${COLLECTIONS.WIKI_PAGES}/index`,
       { method: "PUT", body: { field_name: field, field_schema: "keyword" } },
     ).catch((err) => { console.warn("ensurePayloadIndexes: failed to create index for wiki-pages.", field, err); });
+  }
+
+  for (const field of documentKeywordFields) {
+    await qdrantFetch(
+      `/collections/${COLLECTIONS.DOCUMENTS}/index`,
+      { method: "PUT", body: { field_name: field, field_schema: "keyword" } },
+    ).catch((err) => { console.warn("ensurePayloadIndexes: failed to create index for documents.", field, err); });
   }
 }
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -968,7 +968,7 @@ async function seedCoworkerAgents(): Promise<void> {
     "data-architect":       ["file_read", "sandbox_execute", "architecture_read", "registry_read"],
     "admin-assistant":      ["admin_read", "admin_write", "agent_control_read", "registry_read", "web_search", "file_read"],
     "coo":                  ["portfolio_read", "registry_read", "backlog_read", "backlog_write", "agent_control_read"],
-    "doc-specialist":       ["file_read", "registry_read", "portfolio_read"],
+    "doc-specialist":       ["file_read", "registry_read", "portfolio_read", "document_read", "document_write", "document_publish"],
     "compliance-officer":   ["policy_write", "data_governance_validate", "file_read", "backlog_read", "backlog_write", "tool_evaluation_create"],
     "finance-controller":   ["registry_read", "backlog_read", "portfolio_read"],
   };


### PR DESCRIPTION
## Summary
- Adds the managed document foundation in Prisma/Postgres: documents, versions, content blobs, references, tags, lifecycle events, renditions, access grants, and a Postgres full-text trigger/index.
- Adds document service plumbing for save/load/search/link/version/state/reference operations, plus Qdrant document collection helpers and Neo4j document/reference projection/rebuild support.
- Adds governed MCP document tools and grant mappings, plus a real `/workspace/documents` list/detail UX with search, state/tag/owner filtering, version history, lifecycle actions, references, and document chips in coworker messages.

## Verification
- `pnpm --filter @dpf/db exec vitest run src/document-management-model.test.ts src/neo4j-sync.test.ts`
- `pnpm --filter web exec vitest run lib/documents/blob-storage.test.ts lib/mcp-tools-doc-management.test.ts 'app/(shell)/workspace/page.test.tsx' components/agent/AgentMessageBubble.test.tsx`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db exec prisma validate`
- Scratch `prisma migrate deploy` against a new Postgres database, including `20260513010500_add_document_management_foundation`
- `pnpm --filter web build` passed; it still emits the repo's existing Turbopack broad-file-tracing warnings from `apps/web/lib/backlog/spec-plan-search.ts` / `next.config.mjs`
- Rebuilt Docker production path from this branch: `docker compose --env-file D:\DPF\.env -p dpf build --no-cache portal portal-init sandbox` and `docker compose --env-file D:\DPF\.env -p dpf up -d portal portal-init sandbox`
- Browser-smoked the rebuilt portal at `http://localhost:3000/workspace/documents`: login, document list, owner/state/tag display, detail view, current version, version history, lifecycle events, and inbound/outbound references

## Notes / Follow-ups
- The local MCP bearer token did not have the new document grant categories, so the UX fixture was seeded in the local Docker database for browser verification rather than created through MCP.
- Qdrant semantic indexing is best-effort in this slice and depends on embedding/model availability.
- V1 includes access-grant storage and org/principal ownership, but richer per-document authorization policy should be a follow-up slice.