### PR TITLE
feat(principles): batch 0 - schema, constants, authoring contract

### DIFF
--- a/apps/web/components/wiki/WikiPageKindBadge.test.ts
+++ b/apps/web/components/wiki/WikiPageKindBadge.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  WIKI_PAGE_KIND_LABELS,
+  getWikiPageKindLabel,
+} from "./WikiPageKindBadge";
+
+describe("WIKI_PAGE_KIND_LABELS", () => {
+  it("includes a label for every documented wiki page kind", () => {
+    expect(WIKI_PAGE_KIND_LABELS).toEqual({
+      entity: "Entity",
+      summary: "Summary",
+      decision: "Decision",
+      runbook: "Runbook",
+      index: "Index",
+      stance: "Stance",
+      heuristic: "Heuristic",
+      principle: "Principle",
+    });
+  });
+
+  it("adds a Principle label as the 8th kind", () => {
+    expect(WIKI_PAGE_KIND_LABELS.principle).toBe("Principle");
+    expect(Object.keys(WIKI_PAGE_KIND_LABELS)).toHaveLength(8);
+  });
+});
+
+describe("getWikiPageKindLabel", () => {
+  it("resolves the documented label for known kinds", () => {
+    expect(getWikiPageKindLabel("principle")).toBe("Principle");
+    expect(getWikiPageKindLabel("entity")).toBe("Entity");
+    expect(getWikiPageKindLabel("stance")).toBe("Stance");
+  });
+
+  it("falls back to the raw kind string for unknown values so badges still render legibly", () => {
+    expect(getWikiPageKindLabel("unknown_kind")).toBe("unknown_kind");
+    expect(getWikiPageKindLabel("")).toBe("");
+  });
+});

--- a/apps/web/components/wiki/WikiPageKindBadge.tsx
+++ b/apps/web/components/wiki/WikiPageKindBadge.tsx
@@ -9,7 +9,7 @@
 
 import type { ReactNode } from "react";
 
-const KIND_LABELS: Record<string, string> = {
+export const WIKI_PAGE_KIND_LABELS: Record<string, string> = {
   entity: "Entity",
   summary: "Summary",
   decision: "Decision",
@@ -17,17 +17,26 @@ const KIND_LABELS: Record<string, string> = {
   index: "Index",
   stance: "Stance",
   heuristic: "Heuristic",
+  principle: "Principle",
 };
+
+/**
+ * Pure helper: resolve the human-readable label for a page kind. Falls
+ * back to the raw kind string for unknown values so unrecognized kinds
+ * still render legibly instead of as a blank badge.
+ */
+export function getWikiPageKindLabel(pageKind: string): string {
+  return WIKI_PAGE_KIND_LABELS[pageKind] ?? pageKind;
+}
 
 type Props = {
   pageKind: string;
 };
 
 export function WikiPageKindBadge({ pageKind }: Props): ReactNode {
-  const label = KIND_LABELS[pageKind] ?? pageKind;
   return (
     <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-[var(--dpf-border)] text-[var(--dpf-muted)] bg-[var(--dpf-surface-2)]">
-      {label}
+      {getWikiPageKindLabel(pageKind)}
     </span>
   );
 }

--- a/apps/web/components/wiki/WikiPageList.test.ts
+++ b/apps/web/components/wiki/WikiPageList.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupPrinciplesByTier,
+  type WikiPageListItem,
+} from "./WikiPageList";
+
+function makeItem(
+  id: string,
+  tier: string | null | undefined,
+): WikiPageListItem {
+  return {
+    id,
+    slug: `principles/${id}`,
+    title: id,
+    pageKind: "principle",
+    status: "published",
+    isKernel: true,
+    abstract: null,
+    principleTier: tier,
+  };
+}
+
+describe("groupPrinciplesByTier", () => {
+  it("groups items in Commandments -> Core -> Contextual order", () => {
+    const groups = groupPrinciplesByTier([
+      makeItem("a", "core"),
+      makeItem("b", "commandment"),
+      makeItem("c", "contextual"),
+      makeItem("d", "commandment"),
+      makeItem("e", "core"),
+    ]);
+
+    expect(groups.map((g) => g.tier)).toEqual([
+      "commandment",
+      "core",
+      "contextual",
+    ]);
+    expect(groups[0].label).toBe("Commandments");
+    expect(groups[1].label).toBe("Core");
+    expect(groups[2].label).toBe("Contextual");
+    expect(groups[0].items.map((i) => i.id)).toEqual(["b", "d"]);
+    expect(groups[1].items.map((i) => i.id)).toEqual(["a", "e"]);
+    expect(groups[2].items.map((i) => i.id)).toEqual(["c"]);
+  });
+
+  it("drops empty tiers from the output", () => {
+    const groups = groupPrinciplesByTier([makeItem("a", "core")]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].tier).toBe("core");
+  });
+
+  it("collects untiered drafts into a trailing Untiered group", () => {
+    const groups = groupPrinciplesByTier([
+      makeItem("a", "commandment"),
+      makeItem("b", null),
+      makeItem("c", undefined),
+    ]);
+
+    expect(groups.map((g) => g.tier)).toEqual(["commandment", "untiered"]);
+    expect(groups[1].label).toBe("Untiered");
+    expect(groups[1].items.map((i) => i.id)).toEqual(["b", "c"]);
+  });
+
+  it("preserves input order within each tier (callers sort upstream)", () => {
+    const groups = groupPrinciplesByTier([
+      makeItem("first", "core"),
+      makeItem("second", "core"),
+      makeItem("third", "core"),
+    ]);
+    expect(groups[0].items.map((i) => i.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("returns an empty array when given no items", () => {
+    expect(groupPrinciplesByTier([])).toEqual([]);
+  });
+
+  it("places unknown tier values into the Untiered bucket so misconfigured rows stay visible", () => {
+    // Defense in depth: schema/lint should prevent unrecognized tier values
+    // from reaching the UI, but if one does, surfacing it as Untiered keeps
+    // it visible for the admin to fix rather than hiding it.
+    const groups = groupPrinciplesByTier([
+      makeItem("a", "imaginary_tier"),
+      makeItem("b", "commandment"),
+    ]);
+    expect(groups.map((g) => g.tier)).toEqual(["commandment", "untiered"]);
+    expect(groups[1].items.map((i) => i.id)).toEqual(["a"]);
+  });
+});

--- a/apps/web/components/wiki/WikiPageList.tsx
+++ b/apps/web/components/wiki/WikiPageList.tsx
@@ -1,4 +1,6 @@
 // EP-WIKI-001 Phase 6a: list view of wiki pages with simple grouping.
+// Principles-as-wiki-kind Phase 0: principles are grouped by tier
+// (Commandments → Core → Contextual) within their kind section.
 // Server component. Pages are passed in already filtered + sorted.
 
 import Link from "next/link";
@@ -14,6 +16,8 @@ export type WikiPageListItem = {
   status: string;
   isKernel: boolean;
   abstract: string | null;
+  /** Only meaningful when pageKind === "principle". Drives tier sub-grouping. */
+  principleTier?: string | null;
 };
 
 type Props = {
@@ -21,6 +25,7 @@ type Props = {
 };
 
 const KIND_ORDER = [
+  "principle", // governance comes first when present — the heaviest signal
   "stance",
   "heuristic",
   "decision",
@@ -31,6 +36,7 @@ const KIND_ORDER = [
 ];
 
 const KIND_GROUP_LABEL: Record<string, string> = {
+  principle: "Principles",
   stance: "Stances",
   heuristic: "Heuristics",
   decision: "Decisions",
@@ -39,6 +45,63 @@ const KIND_GROUP_LABEL: Record<string, string> = {
   runbook: "Runbooks",
   index: "Indices",
 };
+
+// Tier order is fixed — Commandments first (highest weight, smallest cohort),
+// then Core, then Contextual. Reflects PRINCIPLE_TIERS in wiki-taxonomy.
+const PRINCIPLE_TIER_ORDER = ["commandment", "core", "contextual"];
+
+const PRINCIPLE_TIER_LABEL: Record<string, string> = {
+  commandment: "Commandments",
+  core: "Core",
+  contextual: "Contextual",
+};
+
+/**
+ * Sub-group principle items by tier. Returns groups in canonical
+ * Commandments → Core → Contextual order, dropping empty tiers. Items
+ * with an unknown or missing tier are collected into a trailing
+ * "Untiered" group so drafts pending review remain visible.
+ */
+export type PrincipleTierGroup = {
+  tier: string;
+  label: string;
+  items: WikiPageListItem[];
+};
+
+export function groupPrinciplesByTier(
+  items: WikiPageListItem[],
+): PrincipleTierGroup[] {
+  const buckets = new Map<string, WikiPageListItem[]>();
+  for (const item of items) {
+    // Coerce missing or unrecognized tier values into the "untiered" bucket
+    // so misconfigured rows stay visible to the admin instead of vanishing.
+    const declared = item.principleTier;
+    const tier =
+      declared && PRINCIPLE_TIER_ORDER.includes(declared)
+        ? declared
+        : "untiered";
+    let bucket = buckets.get(tier);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(tier, bucket);
+    }
+    bucket.push(item);
+  }
+
+  const groups: PrincipleTierGroup[] = [];
+  for (const tier of PRINCIPLE_TIER_ORDER) {
+    const bucket = buckets.get(tier);
+    if (bucket && bucket.length > 0) {
+      groups.push({ tier, label: PRINCIPLE_TIER_LABEL[tier] ?? tier, items: bucket });
+    }
+  }
+  // Untiered drafts come last so they're easy to spot.
+  const untiered = buckets.get("untiered");
+  if (untiered && untiered.length > 0) {
+    groups.push({ tier: "untiered", label: "Untiered", items: untiered });
+  }
+  return groups;
+}
 
 export function WikiPageList({ pages }: Props): ReactNode {
   if (pages.length === 0) {
@@ -72,49 +135,75 @@ export function WikiPageList({ pages }: Props): ReactNode {
     ...Array.from(byKind.keys()).filter((k) => !KIND_ORDER.includes(k)),
   ];
 
+  function renderItemRow(p: WikiPageListItem): ReactNode {
+    return (
+      <li key={p.id}>
+        <Link
+          href={`/wiki/${p.slug}`}
+          className="block px-3 py-2 hover:bg-[var(--dpf-surface-2)]"
+        >
+          <div className="flex items-center gap-2 flex-wrap">
+            <WikiPageKindBadge pageKind={p.pageKind} />
+            <span className="text-sm font-medium text-[var(--dpf-text)]">
+              {p.title}
+            </span>
+            {!p.isKernel && (
+              <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+                overlay
+              </span>
+            )}
+            {p.status !== "published" && (
+              <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+                · {p.status}
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-[var(--dpf-muted)] font-mono mt-0.5">
+            {p.slug}
+          </p>
+          {p.abstract && (
+            <p className="text-xs text-[var(--dpf-muted)] mt-1 line-clamp-2">
+              {p.abstract}
+            </p>
+          )}
+        </Link>
+      </li>
+    );
+  }
+
   return (
     <div className="space-y-6">
       {orderedKinds.map((kind) => {
         const items = byKind.get(kind) ?? [];
+        if (kind === "principle") {
+          const tierGroups = groupPrinciplesByTier(items);
+          return (
+            <section key={kind}>
+              <h2 className="text-xs uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+                {KIND_GROUP_LABEL[kind] ?? kind} · {items.length}
+              </h2>
+              <div className="space-y-3">
+                {tierGroups.map((group) => (
+                  <div key={group.tier}>
+                    <h3 className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)] mb-1 ml-1">
+                      {group.label} · {group.items.length}
+                    </h3>
+                    <ul className="divide-y divide-[var(--dpf-border)] border border-[var(--dpf-border)] rounded">
+                      {group.items.map(renderItemRow)}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </section>
+          );
+        }
         return (
           <section key={kind}>
             <h2 className="text-xs uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
               {KIND_GROUP_LABEL[kind] ?? kind} · {items.length}
             </h2>
             <ul className="divide-y divide-[var(--dpf-border)] border border-[var(--dpf-border)] rounded">
-              {items.map((p) => (
-                <li key={p.id}>
-                  <Link
-                    href={`/wiki/${p.slug}`}
-                    className="block px-3 py-2 hover:bg-[var(--dpf-surface-2)]"
-                  >
-                    <div className="flex items-center gap-2">
-                      <WikiPageKindBadge pageKind={p.pageKind} />
-                      <span className="text-sm font-medium text-[var(--dpf-text)]">
-                        {p.title}
-                      </span>
-                      {!p.isKernel && (
-                        <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
-                          overlay
-                        </span>
-                      )}
-                      {p.status !== "published" && (
-                        <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
-                          · {p.status}
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-xs text-[var(--dpf-muted)] font-mono mt-0.5">
-                      {p.slug}
-                    </p>
-                    {p.abstract && (
-                      <p className="text-xs text-[var(--dpf-muted)] mt-1 line-clamp-2">
-                        {p.abstract}
-                      </p>
-                    )}
-                  </Link>
-                </li>
-              ))}
+              {items.map(renderItemRow)}
             </ul>
           </section>
         );

--- a/apps/web/components/wiki/WikiPageViewer.test.ts
+++ b/apps/web/components/wiki/WikiPageViewer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getPrincipleDisplayWeight } from "./WikiPageViewer";
+
+describe("getPrincipleDisplayWeight", () => {
+  it("returns the explicit override when one is set", () => {
+    expect(getPrincipleDisplayWeight("commandment", 0.85)).toBe(0.85);
+    expect(getPrincipleDisplayWeight("core", 0.5)).toBe(0.5);
+    expect(getPrincipleDisplayWeight("contextual", 0)).toBe(0);
+  });
+
+  it("returns the tier default when no override is set", () => {
+    expect(getPrincipleDisplayWeight("commandment", null)).toBe(1.0);
+    expect(getPrincipleDisplayWeight("core", null)).toBe(0.4);
+    expect(getPrincipleDisplayWeight("contextual", null)).toBe(0.1);
+  });
+
+  it("returns the tier default when the override is undefined", () => {
+    expect(getPrincipleDisplayWeight("commandment", undefined)).toBe(1.0);
+  });
+
+  it("returns null for unknown / untiered principles so callers fall back to a neutral display", () => {
+    expect(getPrincipleDisplayWeight(null, null)).toBeNull();
+    expect(getPrincipleDisplayWeight(undefined, null)).toBeNull();
+    expect(getPrincipleDisplayWeight("imaginary_tier", null)).toBeNull();
+  });
+
+  it("still respects an explicit override even when the tier is unknown", () => {
+    // An admin could legitimately want to weight a draft principle before
+    // the tier is finalized. The override takes precedence over the tier
+    // default lookup.
+    expect(getPrincipleDisplayWeight("imaginary_tier", 0.25)).toBe(0.25);
+    expect(getPrincipleDisplayWeight(null, 0.7)).toBe(0.7);
+  });
+});

--- a/apps/web/components/wiki/WikiPageViewer.tsx
+++ b/apps/web/components/wiki/WikiPageViewer.tsx
@@ -1,10 +1,15 @@
 // EP-WIKI-001 Phase 6a: page detail viewer.
-// Displays a wiki page's metadata header (title, kind, kernel/overlay
-// origin, citations count, last reviewed) above its rendered body.
-// Server component.
+// Principles-as-wiki-kind Phase 0: principle pages get an extra metadata
+// panel below the title (tier, applies-to, public state, weight, dimension
+// vector). Server component.
 
 import Link from "next/link";
 import type { ReactNode } from "react";
+
+import {
+  PRINCIPLE_TIER_DEFAULT_WEIGHT,
+  isPrincipleTier,
+} from "@dpf/db/wiki-taxonomy";
 
 import { WikiBodyRenderer } from "./WikiBodyRenderer";
 import { WikiPageKindBadge } from "./WikiPageKindBadge";
@@ -26,6 +31,45 @@ export type WikiPageDetail = {
   lastReviewedAt: Date | null;
   updatedAt: Date;
   sources: WikiSourceCitation[];
+  // ─── Principle-only (only meaningful when pageKind === "principle") ─────
+  principleTier?: string | null;
+  principleDirection?: string | null;
+  principleWeight?: number | null;
+  principleDimensionVector?: Record<string, number> | null;
+  principleDimensions?: string[];
+  principleAppliesTo?: string[];
+  principlePublic?: boolean;
+};
+
+/**
+ * Resolve the effective weight a principle contributes to decision math:
+ * the explicit override if set, otherwise the tier default. Returns null
+ * for principles without a recognized tier so the UI can fall back to a
+ * neutral display.
+ */
+export function getPrincipleDisplayWeight(
+  tier: string | null | undefined,
+  override: number | null | undefined,
+): number | null {
+  if (typeof override === "number") {
+    return override;
+  }
+  if (tier && isPrincipleTier(tier)) {
+    return PRINCIPLE_TIER_DEFAULT_WEIGHT[tier];
+  }
+  return null;
+}
+
+const TIER_LABEL: Record<string, string> = {
+  commandment: "Commandment",
+  core: "Core",
+  contextual: "Contextual",
+};
+
+const APPLIES_TO_LABEL: Record<string, string> = {
+  in_platform_coworker: "In-platform coworker",
+  external_coding_agent: "External coding agent",
+  human: "Human",
 };
 
 type Props = {
@@ -42,6 +86,98 @@ function formatOrigin(page: WikiPageDetail): string {
       : "Org overlay";
   }
   return "Org-original";
+}
+
+function PrincipleMetadataPanel({ page }: { page: WikiPageDetail }): ReactNode {
+  const tier = page.principleTier;
+  const tierLabel = tier ? TIER_LABEL[tier] ?? tier : "Untiered";
+  const weight = getPrincipleDisplayWeight(tier, page.principleWeight);
+  const appliesTo = page.principleAppliesTo ?? [];
+  const dimensions = page.principleDimensions ?? [];
+  const vector = page.principleDimensionVector ?? null;
+
+  return (
+    <section
+      aria-label="Principle metadata"
+      className="mb-6 p-4 border border-[var(--dpf-border)] rounded bg-[var(--dpf-surface-2)]"
+    >
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-[var(--dpf-border)] text-[var(--dpf-text)] bg-[var(--dpf-surface-1)]">
+          {tierLabel}
+        </span>
+        {weight !== null && (
+          <span className="text-xs text-[var(--dpf-muted)]">
+            weight {weight.toFixed(2)}
+          </span>
+        )}
+        <span className="text-xs text-[var(--dpf-muted)]">
+          · {page.principlePublic ? "Public" : "Internal"}
+        </span>
+        <span className="text-xs text-[var(--dpf-muted)]">
+          · {page.sources.length} source{page.sources.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      {page.principleDirection && (
+        <p className="text-sm text-[var(--dpf-text)] mb-3 leading-relaxed">
+          {page.principleDirection}
+        </p>
+      )}
+
+      {appliesTo.length > 0 && (
+        <div className="mb-3">
+          <h3 className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)] mb-1">
+            Applies to
+          </h3>
+          <div className="flex flex-wrap gap-1">
+            {appliesTo.map((aud) => (
+              <span
+                key={aud}
+                className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] border border-[var(--dpf-border)] text-[var(--dpf-muted)] bg-[var(--dpf-surface-1)]"
+              >
+                {APPLIES_TO_LABEL[aud] ?? aud}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {dimensions.length > 0 && (
+        <div>
+          <h3 className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)] mb-1">
+            Decision dimensions
+          </h3>
+          {vector ? (
+            <table className="text-xs w-full">
+              <tbody>
+                {dimensions.map((dim) => (
+                  <tr key={dim} className="border-t border-[var(--dpf-border)]">
+                    <td className="py-1 text-[var(--dpf-text)]">{dim}</td>
+                    <td className="py-1 text-right text-[var(--dpf-muted)] font-mono">
+                      {typeof vector[dim] === "number"
+                        ? vector[dim].toFixed(2)
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="flex flex-wrap gap-1">
+              {dimensions.map((dim) => (
+                <span
+                  key={dim}
+                  className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+                >
+                  {dim}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
 }
 
 export function WikiPageViewer({ page }: Props): ReactNode {
@@ -73,6 +209,8 @@ export function WikiPageViewer({ page }: Props): ReactNode {
           </p>
         )}
       </header>
+
+      {page.pageKind === "principle" && <PrincipleMetadataPanel page={page} />}
 
       <section className="mb-8">
         <WikiBodyRenderer body={page.body} />

--- a/apps/web/lib/wiki/embeddings.test.ts
+++ b/apps/web/lib/wiki/embeddings.test.ts
@@ -77,6 +77,114 @@ describe("storeWikiPage", () => {
     );
   });
 
+  it("includes canonical principle metadata in the payload when pageKind is principle", async () => {
+    generateEmbedding.mockResolvedValueOnce(stub(768));
+
+    await storeWikiPage({
+      pageId: "wp_principle_1",
+      slug: "principles/architecture-over-shortcuts",
+      title: "Architecture Over Shortcuts",
+      body: "## Rule\n\nPrefer long-term maintainability.",
+      abstract: "One-line direction.",
+      pageKind: "principle",
+      status: "published",
+      isKernel: true,
+      kernelVersion: "0.2.0",
+      organizationId: null,
+      kernelPageId: null,
+      principleTier: "commandment",
+      principleAppliesTo: [
+        "in_platform_coworker",
+        "external_coding_agent",
+      ],
+      principleDimensions: [
+        "long_term_maintainability",
+        "schema_grounding",
+        "speed_to_value",
+      ],
+      principlePublic: true,
+    });
+
+    expect(upsertVectors).toHaveBeenCalledWith(
+      "wiki-pages",
+      [
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            pageKind: "principle",
+            principleTier: "commandment",
+            principleAppliesTo: [
+              "in_platform_coworker",
+              "external_coding_agent",
+            ],
+            principleDimensions: [
+              "long_term_maintainability",
+              "schema_grounding",
+              "speed_to_value",
+            ],
+            principlePublic: true,
+          }),
+        }),
+      ],
+    );
+  });
+
+  it("does NOT include principle keys when pageKind is not principle (absence is the marker)", async () => {
+    generateEmbedding.mockResolvedValueOnce(stub(768));
+
+    await storeWikiPage({
+      pageId: "wp_entity_1",
+      slug: "entities/edge-node",
+      title: "Edge Node",
+      body: "An edge node is the customer-owned compute appliance...",
+      abstract: null,
+      pageKind: "entity",
+      status: "published",
+      isKernel: true,
+      kernelVersion: "0.2.0",
+      organizationId: null,
+      kernelPageId: null,
+    });
+
+    const call = upsertVectors.mock.calls[0] as unknown as [
+      string,
+      Array<{ payload: Record<string, unknown> }>,
+    ];
+    const payload = call[1][0].payload;
+    expect(payload).not.toHaveProperty("principleTier");
+    expect(payload).not.toHaveProperty("principleAppliesTo");
+    expect(payload).not.toHaveProperty("principleDimensions");
+    expect(payload).not.toHaveProperty("principlePublic");
+  });
+
+  it("does NOT include principle keys when pageKind is principle but caller omitted them (incomplete drafts)", async () => {
+    generateEmbedding.mockResolvedValueOnce(stub(768));
+
+    await storeWikiPage({
+      pageId: "wp_principle_draft",
+      slug: "principles/draft",
+      title: "Draft",
+      body: "TBD",
+      abstract: null,
+      pageKind: "principle",
+      status: "draft",
+      isKernel: true,
+      kernelVersion: null,
+      organizationId: null,
+      kernelPageId: null,
+    });
+
+    const call = upsertVectors.mock.calls[0] as unknown as [
+      string,
+      Array<{ payload: Record<string, unknown> }>,
+    ];
+    const payload = call[1][0].payload;
+    expect(payload.pageKind).toBe("principle");
+    expect(payload).not.toHaveProperty("principleTier");
+    expect(payload).not.toHaveProperty("principleAppliesTo");
+    expect(payload).not.toHaveProperty("principleDimensions");
+    expect(payload).not.toHaveProperty("principlePublic");
+  });
+
   it("returns false silently when the embedding model is unavailable", async () => {
     generateEmbedding.mockResolvedValueOnce(null);
 

--- a/apps/web/lib/wiki/embeddings.ts
+++ b/apps/web/lib/wiki/embeddings.ts
@@ -36,6 +36,19 @@ export type StoreWikiPageInput = {
   kernelVersion: string | null;
   organizationId: string | null;
   kernelPageId: string | null;
+  // ─── Principle-only payload fields ────────────────────────────────────────
+  // Only meaningful when `pageKind === "principle"`. Used by Phase 2 retrieval
+  // filters (`recallPrincipleContext`, `wiki_query` tier/appliesTo). Stored
+  // as canonical key names (no short aliases) per the chief-architect review
+  // applied to docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md.
+  // The dimension VECTOR (signed weights) lives in Postgres only — it's
+  // decision-time data, not a retrieval filter axis. The dimension KEY LIST
+  // surfaces in Qdrant so filters can scope retrieval to principles that
+  // care about a given axis.
+  principleTier?: string | null;
+  principleAppliesTo?: string[];
+  principleDimensions?: string[];
+  principlePublic?: boolean;
 };
 
 export type WikiSearchResult = {
@@ -82,27 +95,51 @@ export async function storeWikiPage(input: StoreWikiPageInput): Promise<boolean>
   const vector = await generateEmbedding(truncated);
   if (!vector) return false;
 
+  // Build the base payload first, then conditionally add principle-only
+  // keys when the caller supplied them. Absence is the marker that a
+  // payload does not carry principle metadata; we never write
+  // `principleTier: null` or empty arrays for non-principle pages because
+  // that would force a backfill of every existing Qdrant payload and
+  // muddle filter semantics. See spec section 5.5 and the chief-architect
+  // review applied to the implementation plan.
+  const payload: Record<string, unknown> = {
+    entityType: ENTITY_TYPE,
+    entityId: input.pageId,
+    slug: input.slug,
+    title: input.title,
+    contentPreview: input.body.slice(0, 500),
+    pageKind: input.pageKind,
+    status: input.status,
+    isKernel: input.isKernel,
+    // Qdrant payload null vs missing matters for keyword filters:
+    // kernel rows have organizationId = null, which the filter
+    // builder represents as `match: { value: null }`.
+    organizationId: input.organizationId,
+    kernelVersion: input.kernelVersion,
+    kernelPageId: input.kernelPageId,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (input.pageKind === "principle") {
+    if (input.principleTier !== undefined && input.principleTier !== null) {
+      payload.principleTier = input.principleTier;
+    }
+    if (input.principleAppliesTo !== undefined) {
+      payload.principleAppliesTo = input.principleAppliesTo;
+    }
+    if (input.principleDimensions !== undefined) {
+      payload.principleDimensions = input.principleDimensions;
+    }
+    if (input.principlePublic !== undefined) {
+      payload.principlePublic = input.principlePublic;
+    }
+  }
+
   await upsertVectors(QDRANT_COLLECTIONS.WIKI_PAGES, [
     {
       id: `wiki-page-${input.pageId}`,
       vector,
-      payload: {
-        entityType: ENTITY_TYPE,
-        entityId: input.pageId,
-        slug: input.slug,
-        title: input.title,
-        contentPreview: input.body.slice(0, 500),
-        pageKind: input.pageKind,
-        status: input.status,
-        isKernel: input.isKernel,
-        // Qdrant payload null vs missing matters for keyword filters:
-        // kernel rows have organizationId = null, which the filter
-        // builder represents as `match: { value: null }`.
-        organizationId: input.organizationId,
-        kernelVersion: input.kernelVersion,
-        kernelPageId: input.kernelPageId,
-        timestamp: new Date().toISOString(),
-      },
+      payload,
     },
   ]);
   return true;

--- a/docs/founder-kernel/AUTHORING.md
+++ b/docs/founder-kernel/AUTHORING.md
@@ -18,6 +18,7 @@ docs/founder-kernel/
 │   ├── entity.template.md
 │   ├── stance.template.md
 │   ├── heuristic.template.md
+│   ├── principle.template.md
 │   ├── decision.template.md
 │   ├── summary.template.md
 │   ├── runbook.template.md
@@ -33,6 +34,7 @@ docs/founder-kernel/
     ├── entities/
     ├── stances/
     ├── heuristics/
+    ├── principles/
     ├── decisions/
     ├── summaries/
     └── runbooks/
@@ -44,7 +46,7 @@ The seed walker (`packages/db/src/seed-wiki-kernel.ts`) only scans `raw-sources/
 
 ## 2. Add a new wiki page in 60 seconds
 
-1. **Pick a kind.** Read [`SCHEMA.md` §2](SCHEMA.md) to choose between `entity`, `stance`, `heuristic`, `decision`, `runbook`, `summary`, or `index`. Stance and heuristic are the founder-judgment kinds; the others are scaffolding.
+1. **Pick a kind.** Read [`SCHEMA.md` §2](SCHEMA.md) to choose between `entity`, `stance`, `heuristic`, `principle`, `decision`, `runbook`, `summary`, or `index`. Stance, heuristic, and principle are the founder-judgment kinds; the others are scaffolding. `principle` is the heaviest of the three — it carries tier, applies-to scope, and a decision vector that contribute to advisory aggregation across every matching context.
 2. **Copy the template.** `cp _templates/<kind>.template.md wiki/<kind>s/<slug>.md`. The slug must match `[a-z0-9/_-]+` and is what `[[wikilinks]]` resolve against.
 3. **Fill the frontmatter.** At minimum: `title`, `pageKind`, plus optional `abstract`, `status`, `sources:`.
 4. **Write the body.** Markdown. Use `[[wiki/path]]` to link other pages. Cite a raw source by adding its slug to the frontmatter `sources:` array.

--- a/docs/founder-kernel/SCHEMA.md
+++ b/docs/founder-kernel/SCHEMA.md
@@ -45,6 +45,39 @@ Required sections:
 - **Worked example** — a short concrete case.
 - **Counterexamples** — where the heuristic fails.
 
+### `principle`
+
+A durable, tiered governance rule that contributes to decision aggregation across every matching context. More universal than a `stance` (which is a position on one topic) and more weight-bearing than a `heuristic` (which is situational). Spec: [`../superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md`](../superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md).
+
+Required frontmatter (in addition to `title` and `pageKind: principle`):
+- `principleTier` — `commandment` | `core` | `contextual` (see tier semantics below).
+- `principleDirection` — one declarative sentence naming what the principle favors. Used as the canonical retrieval text. Required for `commandment` and `core`.
+- `principleDimensionVector` — inline JSON map keyed by dimensions from the registry in [`packages/db/src/wiki-taxonomy.ts`](../../packages/db/src/wiki-taxonomy.ts), values signed in `[-1, 1]`. Required for `commandment`; recommended for `core`.
+- `principleAppliesTo` — array; one or more of `in_platform_coworker`, `external_coding_agent`, `human`.
+- `principlePublic` — `true` if safe to surface on the public docs site, `false` otherwise. Defaults to `false`.
+- `principlePublicRationale` — short justification when `principlePublic: true`.
+
+Optional:
+- `principleWeight` — explicit override of the tier default (`1.0` / `0.4` / `0.1`). Requires `principleWeightRationale`.
+- `principleWeightRationale`.
+- `principleDimensions` — array of dimension keys. Auto-derived from `principleDimensionVector` keys when omitted.
+
+Required body sections (per spec §7.2):
+- **Rule** — one declarative sentence.
+- **Why** — strategic rationale.
+- **Applies To** — population and context boundaries (mirrors `principleAppliesTo` with prose).
+- **How To Apply** — concrete operating guidance.
+- **Decision Dimensions** — human-readable explanation of the signed dimension vector.
+- **Examples** — at least one positive example and one non-example.
+- **Sources** — frontmatter-driven; the viewer renders citations from `WikiPageSource`.
+
+**Tier semantics** (weights in [`packages/db/src/wiki-taxonomy.ts`](../../packages/db/src/wiki-taxonomy.ts)):
+- `commandment` — default weight `1.0`; non-negotiable doctrine; hard cap of 10 published kernel commandments enforced by the lint detector `principle-commandment-cap-exceeded`.
+- `core` — default weight `0.4`; strong defaults; soft cap ~30.
+- `contextual` — default weight `0.1`; narrow operational rules; uncapped.
+
+Situational notes — operational reminders, project-specific quirks, dated decisions — do **not** belong here. They live in local memory, backlog comments, execution evidence, or dated specs. Promotion to the wiki principle layer requires that the rule be durable enough to retrieve across many sessions and product-safe enough for at least the in-platform coworkers to read.
+
 ### `decision`
 
 A formal decision codified for posterity. Mirrors the format of `docs/superpowers/decisions/`.

--- a/docs/founder-kernel/_templates/principle.template.md
+++ b/docs/founder-kernel/_templates/principle.template.md
@@ -1,0 +1,46 @@
+---
+title: <Principle name in Title Case>
+pageKind: principle
+status: draft
+abstract: One-sentence summary that mirrors `principleDirection`. This is what passive recall surfaces in coworker prompts.
+principleTier: core
+principleDirection: Prefer <X> over <Y>.
+principleDimensionVector: {"long_term_maintainability": 1.0, "schema_grounding": 0.8, "speed_to_value": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: false
+principlePublicRationale: ""
+sources:
+  - papers/example-source
+  - articles/relevant-article
+---
+
+## Rule
+
+One declarative sentence. The shortest possible statement of what this principle requires.
+
+## Why
+
+The strategic rationale. Why does DPF take this position? What incident, standard, or design pressure made this rule necessary? Cite sources via the `sources:` frontmatter array — the viewer renders citations automatically.
+
+## Applies To
+
+Who this principle governs and where. Mirrors `principleAppliesTo` with prose. Name the populations and the contexts they operate in. If the rule does NOT apply in some otherwise-relevant context, say so here — the absence is what makes the principle trustworthy.
+
+## How To Apply
+
+Concrete operating guidance. When you reach a decision that this principle touches, what do you do? What do you check? What do you refuse to do? Two or three sentences.
+
+## Decision Dimensions
+
+Human-readable explanation of the signed dimension vector in `principleDimensionVector`. For each non-zero dimension, name the axis (per `packages/db/src/wiki-taxonomy.ts`) and explain why this principle pulls in that direction with that magnitude. Reviewers should be able to read this section and predict what the vector says without looking at the JSON.
+
+## Examples
+
+- **Positive:** A concrete decision where applying this principle led to the right outcome.
+- **Counterexample:** A decision where ignoring this principle (or applying it incorrectly) caused harm.
+
+## Sources
+
+Rendered from the `sources:` frontmatter array via `WikiSourceCitations`. Do not duplicate citation prose here.

--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,9 +1,9 @@
 {
   "kernelVersion": "0.2.0-draft",
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.2.0",
   "pageCount": 19,
   "sourceCount": 10,
   "embeddingModel": null,
   "builtAt": null,
-  "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. The 0.2.0-draft cut was synthesised from Mark's public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect, Architecture & Governance Magazine, ServiceNow community blogs, CSDM v5). Every page ships status:draft pending Mark's review. See ../superpowers/specs/2026-05-09-platform-kernel-wiki-design.md for the design and ./SCHEMA.md for the wiki contract."
+  "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. The 0.2.0-draft cut was synthesised from Mark's public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect, Architecture & Governance Magazine, ServiceNow community blogs, CSDM v5). Every page ships status:draft pending Mark's review. Schema 0.2.0 adds the `principle` page kind (tier + decision vector + applies-to + public-classification metadata) — see ../superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md and ./SCHEMA.md `principle` section."
 }

--- a/docs/founder-kernel/wiki/principles/.gitkeep
+++ b/docs/founder-kernel/wiki/principles/.gitkeep
@@ -1,0 +1,5 @@
+# Principles land here as kernel markdown files following
+# ../../_templates/principle.template.md and SCHEMA.md section "principle".
+#
+# Phase 0 lands the scaffolding only — actual principles are seeded in
+# Phase 3 of docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,7 +15,8 @@
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",
     "./location-normalize": "./src/location-normalize.ts",
     "./seed-deliberation": "./src/seed-deliberation.ts",
-    "./edge-node-types": "./src/edge-node-types.ts"
+    "./edge-node-types": "./src/edge-node-types.ts",
+    "./wiki-taxonomy": "./src/wiki-taxonomy.ts"
   },
   "scripts": {
     "postinstall": "prisma generate",

--- a/packages/db/prisma/migrations/20260513000000_add_principle_fields_to_wikipage/migration.sql
+++ b/packages/db/prisma/migrations/20260513000000_add_principle_fields_to_wikipage/migration.sql
@@ -1,0 +1,44 @@
+-- Phase 0 of the principles-as-wiki-kind plan: extend WikiPage with the
+-- nullable principle-only fields, two indexes for retrieval filters, and a
+-- partial unique index that closes the kernel slug uniqueness gap (NULL
+-- organizationId rows previously allowed duplicate slugs because Postgres
+-- treats NULLs as distinct under the default composite unique constraint).
+--
+-- Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md (§9)
+-- Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 0 Task 0.3)
+--
+-- Additive only. Existing pages and call sites are unaffected.
+
+-- ─── Principle-only columns ─────────────────────────────────────────────────
+
+ALTER TABLE "WikiPage" ADD COLUMN "principleTier" TEXT;
+ALTER TABLE "WikiPage" ADD COLUMN "principleDirection" TEXT;
+ALTER TABLE "WikiPage" ADD COLUMN "principleWeight" DOUBLE PRECISION;
+ALTER TABLE "WikiPage" ADD COLUMN "principleWeightRationale" TEXT;
+ALTER TABLE "WikiPage" ADD COLUMN "principleDimensionVector" JSONB;
+ALTER TABLE "WikiPage" ADD COLUMN "principleDimensions" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "WikiPage" ADD COLUMN "principleAppliesTo" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "WikiPage" ADD COLUMN "principlePublic" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "WikiPage" ADD COLUMN "principlePublicRationale" TEXT;
+
+-- ─── Indexes ────────────────────────────────────────────────────────────────
+
+CREATE INDEX "WikiPage_principleTier_idx" ON "WikiPage"("principleTier");
+CREATE INDEX "WikiPage_principlePublic_idx" ON "WikiPage"("principlePublic");
+
+-- ─── Kernel slug uniqueness guard (Prisma-invisible — managed only here) ────
+--
+-- @@unique([organizationId, slug]) does not prevent duplicate slugs when
+-- organizationId IS NULL because Postgres treats NULLs as distinct under
+-- composite unique constraints. The application code already guards against
+-- this at the helper layer (see wiki-store.ts upsertWikiPage), but any code
+-- path that bypasses the helper could still insert duplicate kernel rows.
+-- This partial unique index makes the duplicate impossible at the DB level
+-- regardless of which code path performs the write.
+--
+-- Prisma's schema language cannot model partial indexes, so this stays a
+-- hand-managed migration artifact. Schema drift detection on this index is
+-- accepted intentionally; do not let `prisma migrate dev` "remove" it.
+CREATE UNIQUE INDEX "WikiPage_kernel_slug_key"
+    ON "WikiPage"("slug")
+    WHERE "organizationId" IS NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -234,13 +234,13 @@ model Principal {
 }
 
 model PrincipalAlias {
-  id          String    @id @default(cuid())
-  principalId String
-  aliasType   String
-  aliasValue  String
-  issuer      String    @default("")
-  createdAt   DateTime  @default(now())
-  principal   Principal @relation(fields: [principalId], references: [id], onDelete: Cascade)
+  id                   String                @id @default(cuid())
+  principalId          String
+  aliasType            String
+  aliasValue           String
+  issuer               String                @default("")
+  createdAt            DateTime              @default(now())
+  principal            Principal             @relation(fields: [principalId], references: [id], onDelete: Cascade)
   personLicenseRecords PersonLicenseRecord[]
 
   @@unique([aliasType, aliasValue, issuer])
@@ -432,23 +432,23 @@ model Region {
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model City {
-  id              String    @id @default(cuid())
-  name            String
-  nameNormalized  String    @default("")
-  regionId        String
-  localityType    String    @default("city")
-  source          String    @default("seed")
-  sourceProvider  String?
-  sourceRef       String?
-  confidence      Decimal?  @db.Decimal(5, 4)
-  disambiguator   String?
-  addedByUserId   String?
-  status          String    @default("active")
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
-  addedByUser     User?     @relation("CityAddedByUser", fields: [addedByUserId], references: [id])
-  addresses       Address[]
-  region          Region    @relation(fields: [regionId], references: [id])
+  id             String    @id @default(cuid())
+  name           String
+  nameNormalized String    @default("")
+  regionId       String
+  localityType   String    @default("city")
+  source         String    @default("seed")
+  sourceProvider String?
+  sourceRef      String?
+  confidence     Decimal?  @db.Decimal(5, 4)
+  disambiguator  String?
+  addedByUserId  String?
+  status         String    @default("active")
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  addedByUser    User?     @relation("CityAddedByUser", fields: [addedByUserId], references: [id])
+  addresses      Address[]
+  region         Region    @relation(fields: [regionId], references: [id])
 
   @@index([regionId, name])
   @@index([regionId])
@@ -899,14 +899,14 @@ model TaxonomyNode {
 }
 
 model BacklogItem {
-  id                    String                @id @default(cuid())
-  itemId                String                @unique
+  id                    String                   @id @default(cuid())
+  itemId                String                   @unique
   title                 String
   status                String
   type                  String
   body                  String?
-  createdAt             DateTime              @default(now())
-  updatedAt             DateTime              @updatedAt
+  createdAt             DateTime                 @default(now())
+  updatedAt             DateTime                 @updatedAt
   priority              Int?
   digitalProductId      String?
   taxonomyNodeId        String?
@@ -915,12 +915,12 @@ model BacklogItem {
   triageOutcome         String?
   effortSize            String?
   proposedOutcome       String?
-  activeBuildId         String?               @unique
+  activeBuildId         String?                  @unique
   duplicateOfId         String?
   resolution            String?
   abandonReason         String?
   stalenessDetectedAt   DateTime?
-  occurrenceCount       Int                   @default(1)
+  occurrenceCount       Int                      @default(1)
   lastSeenAt            DateTime?
   submittedById         String?
   completedAt           DateTime?
@@ -933,15 +933,15 @@ model BacklogItem {
   upstreamIssueNumber   Int?
   upstreamIssueUrl      String?
   upstreamSyncedAt      DateTime?
-  accountableEmployee   EmployeeProfile?      @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
-  activeBuild           FeatureBuild?         @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
-  digitalProduct        DigitalProduct?       @relation(fields: [digitalProductId], references: [id])
-  duplicateOf           BacklogItem?          @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
-  duplicates            BacklogItem[]         @relation("BacklogItemDuplicates")
-  epic                  Epic?                 @relation(fields: [epicId], references: [id])
-  featureBuilds         FeatureBuild[]        @relation("BacklogItemOriginator")
-  submittedBy           User?                 @relation("BacklogSubmissions", fields: [submittedById], references: [id])
-  taxonomyNode          TaxonomyNode?         @relation(fields: [taxonomyNodeId], references: [id])
+  accountableEmployee   EmployeeProfile?         @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
+  activeBuild           FeatureBuild?            @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
+  digitalProduct        DigitalProduct?          @relation(fields: [digitalProductId], references: [id])
+  duplicateOf           BacklogItem?             @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
+  duplicates            BacklogItem[]            @relation("BacklogItemDuplicates")
+  epic                  Epic?                    @relation(fields: [epicId], references: [id])
+  featureBuilds         FeatureBuild[]           @relation("BacklogItemOriginator")
+  submittedBy           User?                    @relation("BacklogSubmissions", fields: [submittedById], references: [id])
+  taxonomyNode          TaxonomyNode?            @relation(fields: [taxonomyNodeId], references: [id])
   activities            BacklogItemActivity[]
   coworkerNeeds         CoworkerCapabilityNeed[] @relation("BacklogItemCoworkerCapabilityNeeds")
 }
@@ -2266,32 +2266,32 @@ model OrganizationTaxProfile {
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
-  organization  Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  registrations TaxRegistration[]
-  issues        TaxIssue[]
-  decisionSnapshots  TaxDecisionSnapshot[]
-  liabilityEntries   TaxLiabilityEntry[]
+  organization         Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  registrations        TaxRegistration[]
+  issues               TaxIssue[]
+  decisionSnapshots    TaxDecisionSnapshot[]
+  liabilityEntries     TaxLiabilityEntry[]
   authorityCredentials TaxAuthorityCredential[]
 }
 
 model OrganizationLicenseProfile {
-  id                       String    @id @default(cuid())
-  organizationId           String    @unique
-  setupStatus              String    @default("draft")
-  investigationMode        String    @default("unknown")
-  homeCountryCode          String?
-  primaryRegionCode        String?
+  id                        String    @id @default(cuid())
+  organizationId            String    @unique
+  setupStatus               String    @default("draft")
+  investigationMode         String    @default("unknown")
+  homeCountryCode           String?
+  primaryRegionCode         String?
   operatingFootprintSummary String?
-  legalActivityConfidence  String    @default("medium")
-  researchCoverageStatus   String    @default("draft")
-  notes                    String?
-  lastVerifiedAt           DateTime?
-  createdAt                DateTime  @default(now())
-  updatedAt                DateTime  @updatedAt
+  legalActivityConfidence   String    @default("medium")
+  researchCoverageStatus    String    @default("draft")
+  notes                     String?
+  lastVerifiedAt            DateTime?
+  createdAt                 DateTime  @default(now())
+  updatedAt                 DateTime  @updatedAt
 
-  organization     Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  licenseRecords   OrganizationLicenseRecord[]
-  readinessIssues  LicenseReadinessIssue[]
+  organization    Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  licenseRecords  OrganizationLicenseRecord[]
+  readinessIssues LicenseReadinessIssue[]
 }
 
 model TaxJurisdictionReference {
@@ -2362,8 +2362,8 @@ model TaxRegistration {
 }
 
 model TaxDecisionSnapshot {
-  id                       String    @id @default(cuid())
-  snapshotId               String    @unique
+  id                       String   @id @default(cuid())
+  snapshotId               String   @unique
   organizationTaxProfileId String
   registrationId           String
   sourceType               String
@@ -2372,14 +2372,14 @@ model TaxDecisionSnapshot {
   taxType                  String
   taxCode                  String?
   direction                String
-  taxableAmount            Decimal   @default(0)
+  taxableAmount            Decimal  @default(0)
   taxRate                  Decimal?
-  taxAmount                Decimal   @default(0)
+  taxAmount                Decimal  @default(0)
   jurisdictionRefId        String?
   occurredAt               DateTime
-  evidence                 Json      @default("{}")
-  createdAt                DateTime  @default(now())
-  updatedAt                DateTime  @updatedAt
+  evidence                 Json     @default("{}")
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
 
   organizationTaxProfile OrganizationTaxProfile @relation(fields: [organizationTaxProfileId], references: [id], onDelete: Cascade)
   registration           TaxRegistration        @relation(fields: [registrationId], references: [id], onDelete: Cascade)
@@ -2391,8 +2391,8 @@ model TaxDecisionSnapshot {
 }
 
 model TaxLiabilityEntry {
-  id                       String    @id @default(cuid())
-  entryId                  String    @unique
+  id                       String   @id @default(cuid())
+  entryId                  String   @unique
   organizationTaxProfileId String
   registrationId           String
   periodId                 String?
@@ -2401,13 +2401,13 @@ model TaxLiabilityEntry {
   sourceId                 String
   sourceLineItemId         String?
   direction                String
-  taxableAmount            Decimal   @default(0)
-  taxAmount                Decimal   @default(0)
-  currency                 String    @default("GBP")
+  taxableAmount            Decimal  @default(0)
+  taxAmount                Decimal  @default(0)
+  currency                 String   @default("GBP")
   notes                    String?
   occurredAt               DateTime
-  createdAt                DateTime  @default(now())
-  updatedAt                DateTime  @updatedAt
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
 
   organizationTaxProfile OrganizationTaxProfile @relation(fields: [organizationTaxProfileId], references: [id], onDelete: Cascade)
   registration           TaxRegistration        @relation(fields: [registrationId], references: [id], onDelete: Cascade)
@@ -2442,9 +2442,9 @@ model TaxObligationPeriod {
   createdAt              DateTime  @default(now())
   updatedAt              DateTime  @updatedAt
 
-  registration TaxRegistration     @relation(fields: [registrationId], references: [id], onDelete: Cascade)
-  artifacts    TaxFilingArtifact[]
-  issues       TaxIssue[]
+  registration     TaxRegistration     @relation(fields: [registrationId], references: [id], onDelete: Cascade)
+  artifacts        TaxFilingArtifact[]
+  issues           TaxIssue[]
   liabilityEntries TaxLiabilityEntry[]
   remittanceRuns   TaxRemittanceRun[]
 
@@ -2524,33 +2524,33 @@ model TaxAuthorityCredential {
 }
 
 model LicenseRequirementReference {
-  id                 String   @id @default(cuid())
-  requirementRefId   String   @unique
-  countryCode        String
-  stateProvinceCode  String?
-  jurisdictionLabel  String
-  authorityName      String
-  authorityType      String
-  requirementType    String
-  scopeLevel         String
+  id                  String    @id @default(cuid())
+  requirementRefId    String    @unique
+  countryCode         String
+  stateProvinceCode   String?
+  jurisdictionLabel   String
+  authorityName       String
+  authorityType       String
+  requirementType     String
+  scopeLevel          String
   archetypeCategories String[]
-  activityTags       String[]
-  summary            String
-  officialWebsiteUrl String?
-  applicationUrl     String?
-  renewalUrl         String?
-  helpUrl            String?
-  displayRuleSummary String?
-  renewalCadenceHint String?
-  sourceUrls         String[]
-  sourceKind         String   @default("official")
-  lastResearchedAt   DateTime?
-  lastVerifiedAt     DateTime?
-  confidence         String   @default("medium")
-  staleAfterDays     Int      @default(180)
-  tags               String[] @default([])
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  activityTags        String[]
+  summary             String
+  officialWebsiteUrl  String?
+  applicationUrl      String?
+  renewalUrl          String?
+  helpUrl             String?
+  displayRuleSummary  String?
+  renewalCadenceHint  String?
+  sourceUrls          String[]
+  sourceKind          String    @default("official")
+  lastResearchedAt    DateTime?
+  lastVerifiedAt      DateTime?
+  confidence          String    @default("medium")
+  staleAfterDays      Int       @default(180)
+  tags                String[]  @default([])
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   organizationLicenseRecords OrganizationLicenseRecord[]
   personLicenseRecords       PersonLicenseRecord[]
@@ -2561,31 +2561,31 @@ model LicenseRequirementReference {
 }
 
 model OrganizationLicenseRecord {
-  id                          String    @id @default(cuid())
-  licenseRecordId             String    @unique
+  id                           String    @id @default(cuid())
+  licenseRecordId              String    @unique
   organizationLicenseProfileId String
-  requirementReferenceId      String?
-  licenseKind                 String
-  status                      String    @default("draft")
-  licenseNumber               String?
-  issuedAt                    DateTime?
-  effectiveFrom               DateTime?
-  expiresAt                   DateTime?
-  renewalCadence              String?
-  renewalFeeAmount            Decimal?  @db.Decimal(12, 2)
-  renewalFeeCurrency          String?
-  displayRequirementStatus    String    @default("unknown")
-  officialSourceUrl           String?
-  lastVerifiedAt              DateTime?
-  verificationNotes           String?
-  createdAt                   DateTime  @default(now())
-  updatedAt                   DateTime  @updatedAt
+  requirementReferenceId       String?
+  licenseKind                  String
+  status                       String    @default("draft")
+  licenseNumber                String?
+  issuedAt                     DateTime?
+  effectiveFrom                DateTime?
+  expiresAt                    DateTime?
+  renewalCadence               String?
+  renewalFeeAmount             Decimal?  @db.Decimal(12, 2)
+  renewalFeeCurrency           String?
+  displayRequirementStatus     String    @default("unknown")
+  officialSourceUrl            String?
+  lastVerifiedAt               DateTime?
+  verificationNotes            String?
+  createdAt                    DateTime  @default(now())
+  updatedAt                    DateTime  @updatedAt
 
-  organizationLicenseProfile OrganizationLicenseProfile @relation(fields: [organizationLicenseProfileId], references: [id], onDelete: Cascade)
-  requirementReference      LicenseRequirementReference? @relation(fields: [requirementReferenceId], references: [id], onDelete: SetNull)
-  displayObligations        LicenseDisplayObligation[]
-  feeSchedules              LicenseFeeSchedule[]
-  readinessIssues           LicenseReadinessIssue[]
+  organizationLicenseProfile OrganizationLicenseProfile   @relation(fields: [organizationLicenseProfileId], references: [id], onDelete: Cascade)
+  requirementReference       LicenseRequirementReference? @relation(fields: [requirementReferenceId], references: [id], onDelete: SetNull)
+  displayObligations         LicenseDisplayObligation[]
+  feeSchedules               LicenseFeeSchedule[]
+  readinessIssues            LicenseReadinessIssue[]
 
   @@index([organizationLicenseProfileId])
   @@index([requirementReferenceId])
@@ -2593,26 +2593,26 @@ model OrganizationLicenseRecord {
 }
 
 model PersonLicenseRecord {
-  id                    String    @id @default(cuid())
-  personLicenseRecordId String    @unique
-  principalAliasId      String
-  organizationId        String
-  requirementReferenceId String?
-  credentialType        String
-  status                String    @default("draft")
-  credentialNumber      String?
-  issuingAuthority      String?
-  issuedAt              DateTime?
-  expiresAt             DateTime?
-  renewalCadence        String?
+  id                       String    @id @default(cuid())
+  personLicenseRecordId    String    @unique
+  principalAliasId         String
+  organizationId           String
+  requirementReferenceId   String?
+  credentialType           String
+  status                   String    @default("draft")
+  credentialNumber         String?
+  issuingAuthority         String?
+  issuedAt                 DateTime?
+  expiresAt                DateTime?
+  renewalCadence           String?
   supervisoryOrDisplayRole String?
-  officialSourceUrl     String?
-  lastVerifiedAt        DateTime?
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
+  officialSourceUrl        String?
+  lastVerifiedAt           DateTime?
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
 
-  principalAlias       PrincipalAlias              @relation(fields: [principalAliasId], references: [id], onDelete: Cascade)
-  organization         Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  principalAlias       PrincipalAlias               @relation(fields: [principalAliasId], references: [id], onDelete: Cascade)
+  organization         Organization                 @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   requirementReference LicenseRequirementReference? @relation(fields: [requirementReferenceId], references: [id], onDelete: SetNull)
   displayObligations   LicenseDisplayObligation[]
   feeSchedules         LicenseFeeSchedule[]
@@ -2625,18 +2625,18 @@ model PersonLicenseRecord {
 }
 
 model LicenseDisplayObligation {
-  id                       String   @id @default(cuid())
-  displayObligationId      String   @unique
+  id                          String   @id @default(cuid())
+  displayObligationId         String   @unique
   organizationLicenseRecordId String?
-  personLicenseRecordId    String?
-  evidenceId               String?
-  displayType              String
-  requirementLevel         String
-  displayLocation          String?
-  isSatisfied              Boolean  @default(false)
-  notes                    String?
-  createdAt                DateTime @default(now())
-  updatedAt                DateTime @updatedAt
+  personLicenseRecordId       String?
+  evidenceId                  String?
+  displayType                 String
+  requirementLevel            String
+  displayLocation             String?
+  isSatisfied                 Boolean  @default(false)
+  notes                       String?
+  createdAt                   DateTime @default(now())
+  updatedAt                   DateTime @updatedAt
 
   organizationLicenseRecord OrganizationLicenseRecord? @relation(fields: [organizationLicenseRecordId], references: [id], onDelete: SetNull)
   personLicenseRecord       PersonLicenseRecord?       @relation(fields: [personLicenseRecordId], references: [id], onDelete: SetNull)
@@ -2649,20 +2649,20 @@ model LicenseDisplayObligation {
 }
 
 model LicenseFeeSchedule {
-  id                       String   @id @default(cuid())
-  feeScheduleId            String   @unique
+  id                          String    @id @default(cuid())
+  feeScheduleId               String    @unique
   organizationLicenseRecordId String?
-  personLicenseRecordId    String?
-  feeType                  String
-  amount                   Decimal  @db.Decimal(12, 2)
-  currency                 String   @default("USD")
-  dueDate                  DateTime?
-  paymentStatus            String   @default("pending")
-  financeHandoffMode       String   @default("track_only")
-  externalReference        String?
-  notes                    String?
-  createdAt                DateTime @default(now())
-  updatedAt                DateTime @updatedAt
+  personLicenseRecordId       String?
+  feeType                     String
+  amount                      Decimal   @db.Decimal(12, 2)
+  currency                    String    @default("USD")
+  dueDate                     DateTime?
+  paymentStatus               String    @default("pending")
+  financeHandoffMode          String    @default("track_only")
+  externalReference           String?
+  notes                       String?
+  createdAt                   DateTime  @default(now())
+  updatedAt                   DateTime  @updatedAt
 
   organizationLicenseRecord OrganizationLicenseRecord? @relation(fields: [organizationLicenseRecordId], references: [id], onDelete: SetNull)
   personLicenseRecord       PersonLicenseRecord?       @relation(fields: [personLicenseRecordId], references: [id], onDelete: SetNull)
@@ -2673,20 +2673,20 @@ model LicenseFeeSchedule {
 }
 
 model LicenseReadinessIssue {
-  id                         String    @id @default(cuid())
-  issueId                    String    @unique
+  id                           String    @id @default(cuid())
+  issueId                      String    @unique
   organizationLicenseProfileId String
-  organizationLicenseRecordId String?
-  personLicenseRecordId      String?
-  issueType                  String
-  severity                   String    @default("medium")
-  status                     String    @default("open")
-  title                      String
-  details                    String?
-  openedAt                   DateTime  @default(now())
-  resolvedAt                 DateTime?
-  createdAt                  DateTime  @default(now())
-  updatedAt                  DateTime  @updatedAt
+  organizationLicenseRecordId  String?
+  personLicenseRecordId        String?
+  issueType                    String
+  severity                     String    @default("medium")
+  status                       String    @default("open")
+  title                        String
+  details                      String?
+  openedAt                     DateTime  @default(now())
+  resolvedAt                   DateTime?
+  createdAt                    DateTime  @default(now())
+  updatedAt                    DateTime  @updatedAt
 
   organizationLicenseProfile OrganizationLicenseProfile @relation(fields: [organizationLicenseProfileId], references: [id], onDelete: Cascade)
   organizationLicenseRecord  OrganizationLicenseRecord? @relation(fields: [organizationLicenseRecordId], references: [id], onDelete: SetNull)
@@ -2718,7 +2718,7 @@ model TaxRemittanceRun {
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 
-  period     TaxObligationPeriod    @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  period     TaxObligationPeriod     @relation(fields: [periodId], references: [id], onDelete: Cascade)
   credential TaxAuthorityCredential? @relation(fields: [credentialId], references: [id], onDelete: SetNull)
 
   @@index([periodId, status])
@@ -4679,27 +4679,27 @@ model ControlObligationLink {
 }
 
 model ComplianceEvidence {
-  id                    String               @id @default(cuid())
-  evidenceId            String               @unique
-  title                 String
-  evidenceType          String
-  description           String?
-  obligationId          String?
-  controlId             String?
-  collectedAt           DateTime             @default(now())
-  collectedByEmployeeId String?
-  fileRef               String?
-  retentionUntil        DateTime?
-  supersededById        String?
-  agentId               String?
-  status                String               @default("active")
-  createdAt             DateTime             @default(now())
-  updatedAt             DateTime             @updatedAt
-  collectedBy           EmployeeProfile?     @relation("EvidenceCollector", fields: [collectedByEmployeeId], references: [id])
-  control               Control?             @relation(fields: [controlId], references: [id])
-  obligation            Obligation?          @relation(fields: [obligationId], references: [id])
-  supersededBy          ComplianceEvidence?  @relation("EvidenceSupersession", fields: [supersededById], references: [id])
-  supersedes            ComplianceEvidence[] @relation("EvidenceSupersession")
+  id                        String                     @id @default(cuid())
+  evidenceId                String                     @unique
+  title                     String
+  evidenceType              String
+  description               String?
+  obligationId              String?
+  controlId                 String?
+  collectedAt               DateTime                   @default(now())
+  collectedByEmployeeId     String?
+  fileRef                   String?
+  retentionUntil            DateTime?
+  supersededById            String?
+  agentId                   String?
+  status                    String                     @default("active")
+  createdAt                 DateTime                   @default(now())
+  updatedAt                 DateTime                   @updatedAt
+  collectedBy               EmployeeProfile?           @relation("EvidenceCollector", fields: [collectedByEmployeeId], references: [id])
+  control                   Control?                   @relation(fields: [controlId], references: [id])
+  obligation                Obligation?                @relation(fields: [obligationId], references: [id])
+  supersededBy              ComplianceEvidence?        @relation("EvidenceSupersession", fields: [supersededById], references: [id])
+  supersedes                ComplianceEvidence[]       @relation("EvidenceSupersession")
   licenseDisplayObligations LicenseDisplayObligation[]
 
   @@index([obligationId])
@@ -6723,7 +6723,7 @@ model WikiPage {
   slug                     String
   title                    String
   body                     String             @db.Text
-  pageKind                 String // entity | summary | decision | runbook | index | stance | heuristic
+  pageKind                 String // entity | summary | decision | runbook | index | stance | heuristic | principle
   status                   String             @default("draft") // draft | published | review-needed | archived
   isKernel                 Boolean            @default(false)
   kernelVersion            String?
@@ -6742,6 +6742,21 @@ model WikiPage {
   inLinks                  WikiPageLink[]     @relation("WikiInLinks")
   sources                  WikiPageSource[]
 
+  // ─── Principle-only fields ──────────────────────────────────────────────
+  // Nullable or defaulted; only populated when pageKind = "principle". See
+  // docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §9.
+  // Storage-layer accepts incomplete principle data; required-field gating
+  // lives in lint detectors (spec §14).
+  principleTier            String? // commandment | core | contextual
+  principleDirection       String?  @db.Text
+  principleWeight          Float?
+  principleWeightRationale String?  @db.Text
+  principleDimensionVector Json?
+  principleDimensions      String[] @default([])
+  principleAppliesTo       String[] @default([]) // in_platform_coworker | external_coding_agent | human
+  principlePublic          Boolean  @default(false)
+  principlePublicRationale String?  @db.Text
+
   @@unique([organizationId, slug])
   @@index([slug])
   @@index([pageKind])
@@ -6749,6 +6764,8 @@ model WikiPage {
   @@index([kernelPageId])
   @@index([organizationId])
   @@index([isKernel])
+  @@index([principleTier])
+  @@index([principlePublic])
 }
 
 model WikiPageRevision {
@@ -7262,18 +7279,18 @@ model EvidenceSource {
 // successful enrollment.
 
 model EdgeNode {
-  id          String  @id @default(cuid())
+  id          String @id @default(cuid())
   // Identity for an Edge Node lives on Principal + PrincipalAlias per
   // AGENTS.md §11 Principal convergence (kind="edge-node",
   // aliasType="edge-node"). EdgeNode is a host-attributes side table
   // keyed 1:1 to Principal via principalId. `displayName` reads from
   // the joined Principal row, never directly from EdgeNode.
-  principalId String  @unique
+  principalId String @unique
   // Stable external identifier used in API URLs and tokens. Distinct
   // from `id` (the cuid surrogate) and from `principalId` (the
   // identity FK). Mirrored to PrincipalAlias.aliasValue where
   // aliasType="edge-node". Per spec, do not conflate the three.
-  nodeId      String  @unique
+  nodeId      String @unique
   // darwin | win32 | linux
   platform    String
   // native | container-host | container-vm
@@ -7348,7 +7365,7 @@ model EdgeNode {
 }
 
 model BootstrapToken {
-  id String @id @default(cuid())
+  id        String @id @default(cuid())
   // Hashed at rest (mirrors McpApiToken pattern). Plaintext is shown
   // to the operator exactly once at issuance and never persisted.
   tokenHash String @unique
@@ -7386,7 +7403,7 @@ model BootstrapToken {
 }
 
 model EdgeNodeCapability {
-  id         String @id @default(cuid())
+  id         String   @id @default(cuid())
   // FK to EdgeNode.id (the cuid surrogate); distinct from EdgeNode.nodeId.
   edgeNodeId String
   // Capability identifier from the spec § Edge Node capability envelope.
@@ -7396,10 +7413,10 @@ model EdgeNodeCapability {
   //   enabled         - capability is active
   //   reporting-only  - agent advertises it but Authority doesn't accept submissions
   //   disabled        - agent cannot use this capability
-  mode       String @default("disabled")
+  mode       String   @default("disabled")
   // Last-known health from the agent's self-report.
   //   healthy | degraded | failing | unknown
-  status     String @default("unknown")
+  status     String   @default("unknown")
   // Free-form: error messages, metric snapshots the agent attached.
   evidence   Json?
   reportedAt DateTime @default(now())

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -32,7 +32,30 @@ export {
   type AppendRevisionInput,
   type LinkPagesInput,
   type AttachSourceInput,
+  type WikiPagePrincipleInput,
 } from "./wiki-store";
+
+// Principles-as-wiki-kind Phase 0: taxonomy constants + predicates so
+// retrieval, lint, MCP, and UI consumers in apps/web import them through
+// the @dpf/db barrel.
+export {
+  WIKI_PAGE_KINDS,
+  WIKI_PAGE_STATUSES,
+  PRINCIPLE_TIERS,
+  PRINCIPLE_APPLIES_TO,
+  PRINCIPLE_DIMENSIONS,
+  PRINCIPLE_TIER_DEFAULT_WEIGHT,
+  PRINCIPLE_TIER_CAPS,
+  PRINCIPLE_DECIDE_DEFAULTS,
+  isWikiPageKind,
+  isWikiPageStatus,
+  isPrincipleTier,
+  isPrincipleAppliesTo,
+  isPrincipleDimension,
+  type PrincipleTier,
+  type PrincipleAppliesTo,
+  type PrincipleDimension,
+} from "./wiki-taxonomy";
 export { initNeo4jSchema, backfillOsiLayers, NETWORK_RELATIONSHIP_TYPES } from "./neo4j-schema";
 export {
   getDownstreamImpact,

--- a/packages/db/src/seed-wiki-kernel.test.ts
+++ b/packages/db/src/seed-wiki-kernel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildKernelQdrantPoints,
   deriveSlug,
+  extractPrinciplePayload,
   extractWikilinks,
   parseFrontmatter,
   type SeedablePage,
@@ -74,6 +75,174 @@ Body.`;
 
   it("throws on missing frontmatter delimiters", () => {
     expect(() => parseFrontmatter("no frontmatter here")).toThrow(/frontmatter delimiters/);
+  });
+
+  it("parses inline JSON objects (used for principleDimensionVector)", () => {
+    const raw = `---
+title: T
+pageKind: principle
+principleDimensionVector: {"long_term_maintainability": 1.0, "schema_grounding": 0.8, "speed_to_value": -0.4}
+---
+
+Body.`;
+    const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(raw);
+    expect(frontmatter.principleDimensionVector).toEqual({
+      long_term_maintainability: 1.0,
+      schema_grounding: 0.8,
+      speed_to_value: -0.4,
+    });
+  });
+
+  it("coerces true/false scalars to booleans", () => {
+    const raw = `---
+title: T
+pageKind: principle
+principlePublic: true
+---
+
+Body.`;
+    const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(raw);
+    expect(frontmatter.principlePublic).toBe(true);
+  });
+
+  it("coerces numeric scalars to numbers", () => {
+    const raw = `---
+title: T
+pageKind: principle
+principleWeight: 0.85
+---
+
+Body.`;
+    const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(raw);
+    expect(frontmatter.principleWeight).toBe(0.85);
+  });
+
+  it("keeps quoted booleans/numbers as strings (escape hatch for values that look numeric)", () => {
+    const raw = `---
+title: T
+pageKind: principle
+principleWeightRationale: "0.8"
+---
+
+Body.`;
+    const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(raw);
+    expect(frontmatter.principleWeightRationale).toBe("0.8");
+  });
+});
+
+describe("seed-wiki-kernel: extractPrinciplePayload", () => {
+  it("returns the principle subset of frontmatter for a principle page", () => {
+    const payload = extractPrinciplePayload({
+      title: "Architecture Over Shortcuts",
+      pageKind: "principle",
+      principleTier: "commandment",
+      principleDirection:
+        "Prefer long-term maintainability over short-term speed.",
+      principleDimensionVector: {
+        long_term_maintainability: 1.0,
+        schema_grounding: 0.8,
+      },
+      principleAppliesTo: ["in_platform_coworker", "external_coding_agent"],
+      principlePublic: true,
+      principlePublicRationale:
+        "Adopters need to understand DPF's architecture posture.",
+    });
+
+    expect(payload).toEqual({
+      principleTier: "commandment",
+      principleDirection:
+        "Prefer long-term maintainability over short-term speed.",
+      principleDimensionVector: {
+        long_term_maintainability: 1.0,
+        schema_grounding: 0.8,
+      },
+      principleDimensions: ["long_term_maintainability", "schema_grounding"],
+      principleAppliesTo: ["in_platform_coworker", "external_coding_agent"],
+      principlePublic: true,
+      principlePublicRationale:
+        "Adopters need to understand DPF's architecture posture.",
+    });
+  });
+
+  it("derives principleDimensions from vector keys when not explicit", () => {
+    const payload = extractPrinciplePayload({
+      title: "T",
+      pageKind: "principle",
+      principleTier: "core",
+      principleDimensionVector: {
+        capacity_utilization: 1.0,
+        governance_compliance: 0.7,
+      },
+      principleAppliesTo: ["in_platform_coworker"],
+    });
+    expect(payload.principleDimensions).toEqual([
+      "capacity_utilization",
+      "governance_compliance",
+    ]);
+  });
+
+  it("preserves explicit principleDimensions (even when sparser than vector keys)", () => {
+    const payload = extractPrinciplePayload({
+      title: "T",
+      pageKind: "principle",
+      principleTier: "core",
+      principleDimensions: ["capacity_utilization"],
+      principleDimensionVector: {
+        capacity_utilization: 1.0,
+        governance_compliance: 0.7,
+      },
+      principleAppliesTo: ["in_platform_coworker"],
+    });
+    expect(payload.principleDimensions).toEqual(["capacity_utilization"]);
+  });
+
+  it("throws with a clear message when the vector references an unknown dimension", () => {
+    expect(() =>
+      extractPrinciplePayload({
+        title: "T",
+        pageKind: "principle",
+        principleTier: "commandment",
+        principleDimensionVector: {
+          fictional_axis: 1.0,
+          long_term_maintainability: 0.5,
+        },
+        principleAppliesTo: ["in_platform_coworker"],
+      }),
+    ).toThrow(/fictional_axis/);
+  });
+
+  it("throws when an explicit dimension is outside the registry", () => {
+    expect(() =>
+      extractPrinciplePayload({
+        title: "T",
+        pageKind: "principle",
+        principleTier: "core",
+        principleDimensions: ["long_term_maintainability", "totally_made_up"],
+        principleAppliesTo: ["in_platform_coworker"],
+      }),
+    ).toThrow(/totally_made_up/);
+  });
+
+  it("returns an empty payload for non-principle pages", () => {
+    const payload = extractPrinciplePayload({
+      title: "Edge Node",
+      pageKind: "entity",
+    });
+    expect(payload).toEqual({});
+  });
+
+  it("accepts incomplete principle data — validation lives in lint", () => {
+    // A draft principle missing direction and vector should still extract;
+    // lint detectors (spec section 14) surface the missing fields later.
+    const payload = extractPrinciplePayload({
+      title: "Draft",
+      pageKind: "principle",
+      principleTier: "core",
+      principleAppliesTo: ["human"],
+    });
+    expect(payload.principleTier).toBe("core");
+    expect(payload.principleAppliesTo).toEqual(["human"]);
+    expect(payload.principleDirection).toBeUndefined();
   });
 });
 

--- a/packages/db/src/seed-wiki-kernel.ts
+++ b/packages/db/src/seed-wiki-kernel.ts
@@ -17,10 +17,15 @@ import { join } from "path";
 import type { PrismaClient } from "../generated/client/client";
 import { QDRANT_COLLECTIONS, upsertVectors, type VectorPoint } from "./qdrant";
 import {
+  PRINCIPLE_DIMENSIONS,
+  isPrincipleDimension,
+} from "./wiki-taxonomy";
+import {
   appendRevision,
   attachSource,
   linkPages,
   upsertWikiPage,
+  type WikiPagePrincipleInput,
   type WikiPageKind,
   type WikiPageStatus,
 } from "./wiki-store";
@@ -49,6 +54,19 @@ export type WikiPageFrontmatter = {
   abstract?: string;
   /** Source slugs (relative to raw-sources/) that this page cites. */
   sources?: string[];
+  // ─── Principle-only frontmatter (spec section 9) ───
+  // Required-field gating lives in lint detectors per spec section 14, not
+  // here. The seed walker accepts incomplete principle data so lint can
+  // surface findings on saved drafts.
+  principleTier?: string;
+  principleDirection?: string;
+  principleWeight?: number;
+  principleWeightRationale?: string;
+  principleDimensionVector?: Record<string, number>;
+  principleDimensions?: string[];
+  principleAppliesTo?: string[];
+  principlePublic?: boolean;
+  principlePublicRationale?: string;
 };
 
 // ─── Manifest ───────────────────────────────────────────────────────────────
@@ -140,12 +158,129 @@ export function parseFrontmatter<T extends Record<string, unknown>>(
       continue;
     }
 
-    // Scalar (with optional surrounding quotes)
-    fm[key] = value.replace(/^["']|["']$/g, "");
+    // Inline JSON object: { "key": value, ... }
+    // Used primarily for principleDimensionVector. Authors must use JSON
+    // syntax (quoted keys); YAML-style unquoted keys are not supported here.
+    if (value.startsWith("{") && value.endsWith("}")) {
+      try {
+        fm[key] = JSON.parse(value);
+        i++;
+        continue;
+      } catch {
+        // Fall through to scalar handling if the JSON parse fails — better
+        // to surface as a typed-value mismatch downstream than to silently
+        // accept a malformed value.
+      }
+    }
+
+    // Scalar (with optional surrounding quotes). Quoted values stay strings;
+    // unquoted true/false/numbers coerce to their typed shape so principle
+    // frontmatter (principlePublic: true, principleWeight: 0.85, etc.)
+    // round-trips with the right type.
+    const hasQuotes = /^["'].*["']$/.test(value);
+    const scalarRaw = value.replace(/^["']|["']$/g, "");
+    if (!hasQuotes && scalarRaw === "true") {
+      fm[key] = true;
+    } else if (!hasQuotes && scalarRaw === "false") {
+      fm[key] = false;
+    } else if (!hasQuotes && scalarRaw !== "" && /^-?\d+(\.\d+)?$/.test(scalarRaw)) {
+      fm[key] = parseFloat(scalarRaw);
+    } else {
+      fm[key] = scalarRaw;
+    }
     i++;
   }
 
   return { frontmatter: fm as T, body };
+}
+
+// ─── Principle Payload Extractor ───────────────────────────────────────────
+
+/**
+ * Pull the principle-only fields out of a `WikiPageFrontmatter` and shape
+ * them for `upsertWikiPage`'s `WikiPagePrincipleInput`.
+ *
+ * - Returns `{}` for non-principle pages so callers can spread the result
+ *   unconditionally without leaking principle keys onto other kinds.
+ * - Validates every key in `principleDimensionVector` and every entry in
+ *   `principleDimensions` against the `PRINCIPLE_DIMENSIONS` registry.
+ *   Throws with a clear message naming the offending key — per
+ *   `feedback_check_tool_signals.md`, silent skip on bad frontmatter is
+ *   the failure mode to avoid.
+ * - Derives `principleDimensions` from `Object.keys(principleDimensionVector)`
+ *   when the frontmatter omits it, so authors do not have to repeat the
+ *   axis list in two places.
+ * - Required-field gating (direction present for commandment/core, etc.)
+ *   lives in lint detectors per spec section 14, not in this helper.
+ */
+export function extractPrinciplePayload(
+  frontmatter: WikiPageFrontmatter,
+): WikiPagePrincipleInput {
+  if (frontmatter.pageKind !== "principle") {
+    return {};
+  }
+
+  // Validate dimension vector keys against the registry.
+  if (frontmatter.principleDimensionVector) {
+    for (const dim of Object.keys(frontmatter.principleDimensionVector)) {
+      if (!isPrincipleDimension(dim)) {
+        throw new Error(
+          `Unknown principle dimension "${dim}" in principleDimensionVector. ` +
+            `Allowed dimensions: ${PRINCIPLE_DIMENSIONS.join(", ")}. ` +
+            `Add the dimension to PRINCIPLE_DIMENSIONS in wiki-taxonomy.ts ` +
+            `via a follow-up spec/PR before referencing it from frontmatter.`,
+        );
+      }
+    }
+  }
+
+  // Validate explicit principleDimensions if supplied.
+  if (frontmatter.principleDimensions) {
+    for (const dim of frontmatter.principleDimensions) {
+      if (!isPrincipleDimension(dim)) {
+        throw new Error(
+          `Unknown principle dimension "${dim}" in principleDimensions. ` +
+            `Allowed dimensions: ${PRINCIPLE_DIMENSIONS.join(", ")}.`,
+        );
+      }
+    }
+  }
+
+  const dimensions =
+    frontmatter.principleDimensions ??
+    (frontmatter.principleDimensionVector
+      ? Object.keys(frontmatter.principleDimensionVector)
+      : undefined);
+
+  const payload: WikiPagePrincipleInput = {};
+  if (frontmatter.principleTier !== undefined) {
+    payload.principleTier = frontmatter.principleTier as never;
+  }
+  if (frontmatter.principleDirection !== undefined) {
+    payload.principleDirection = frontmatter.principleDirection;
+  }
+  if (frontmatter.principleWeight !== undefined) {
+    payload.principleWeight = frontmatter.principleWeight;
+  }
+  if (frontmatter.principleWeightRationale !== undefined) {
+    payload.principleWeightRationale = frontmatter.principleWeightRationale;
+  }
+  if (frontmatter.principleDimensionVector !== undefined) {
+    payload.principleDimensionVector = frontmatter.principleDimensionVector;
+  }
+  if (dimensions !== undefined) {
+    payload.principleDimensions = dimensions as never;
+  }
+  if (frontmatter.principleAppliesTo !== undefined) {
+    payload.principleAppliesTo = frontmatter.principleAppliesTo as never;
+  }
+  if (frontmatter.principlePublic !== undefined) {
+    payload.principlePublic = frontmatter.principlePublic;
+  }
+  if (frontmatter.principlePublicRationale !== undefined) {
+    payload.principlePublicRationale = frontmatter.principlePublicRationale;
+  }
+  return payload;
 }
 
 // ─── Wikilink Extractor ─────────────────────────────────────────────────────
@@ -288,6 +423,8 @@ async function seedWikiPages(
     const slug = frontmatter.slug ?? deriveSlug(file, wikiDir);
     const status = frontmatter.status ?? "published";
 
+    const principlePayload = extractPrinciplePayload(frontmatter);
+
     const upserted = (await upsertWikiPage(prisma, {
       slug,
       title: frontmatter.title,
@@ -297,6 +434,7 @@ async function seedWikiPages(
       isKernel: true,
       kernelVersion,
       abstract: frontmatter.abstract ?? null,
+      ...principlePayload,
     })) as { id: string };
 
     slugToId.set(slug, upserted.id);

--- a/packages/db/src/wiki-store.test.ts
+++ b/packages/db/src/wiki-store.test.ts
@@ -1,11 +1,43 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  WIKI_PAGE_KINDS,
+  WIKI_PAGE_STATUSES,
   appendRevision,
   attachSource,
   getWikiPage,
   linkPages,
   upsertWikiPage,
 } from "./wiki-store";
+
+describe("wiki-store re-exports from wiki-taxonomy", () => {
+  it("re-exports WIKI_PAGE_KINDS including the principle kind", () => {
+    expect(WIKI_PAGE_KINDS).toContain("principle");
+    expect(WIKI_PAGE_KINDS).toHaveLength(8);
+  });
+
+  it("preserves the seven pre-existing kinds", () => {
+    expect(WIKI_PAGE_KINDS).toEqual(
+      expect.arrayContaining([
+        "entity",
+        "summary",
+        "decision",
+        "runbook",
+        "index",
+        "stance",
+        "heuristic",
+      ]),
+    );
+  });
+
+  it("re-exports WIKI_PAGE_STATUSES for callers using the wiki-store entry point", () => {
+    expect(WIKI_PAGE_STATUSES).toEqual([
+      "draft",
+      "published",
+      "review-needed",
+      "archived",
+    ]);
+  });
+});
 
 function makeWikiPageMocks() {
   const findFirst = vi.fn();

--- a/packages/db/src/wiki-store.test.ts
+++ b/packages/db/src/wiki-store.test.ts
@@ -39,6 +39,146 @@ describe("wiki-store re-exports from wiki-taxonomy", () => {
   });
 });
 
+describe("upsertWikiPage with principle-only fields", () => {
+  it("forwards principle metadata to create when no row exists", async () => {
+    const { db, findFirst, create, update } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce(null);
+    create.mockResolvedValueOnce({ id: "wp_principle_new" });
+
+    await upsertWikiPage(db, {
+      slug: "principles/architecture-over-shortcuts",
+      title: "Architecture Over Shortcuts",
+      body: "## Rule\n\nPrefer architecturally sound solutions...",
+      pageKind: "principle",
+      isKernel: true,
+      kernelVersion: "0.2.0",
+      principleTier: "commandment",
+      principleDirection:
+        "Prefer long-term maintainability over short-term speed.",
+      principleDimensionVector: {
+        long_term_maintainability: 1.0,
+        schema_grounding: 0.8,
+        speed_to_value: -0.4,
+      },
+      principleDimensions: [
+        "long_term_maintainability",
+        "schema_grounding",
+        "speed_to_value",
+      ],
+      principleAppliesTo: ["in_platform_coworker", "external_coding_agent"],
+      principlePublic: true,
+      principlePublicRationale:
+        "Surface architecture posture to adopters and contributors.",
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        slug: "principles/architecture-over-shortcuts",
+        pageKind: "principle",
+        principleTier: "commandment",
+        principleDirection:
+          "Prefer long-term maintainability over short-term speed.",
+        principleDimensionVector: {
+          long_term_maintainability: 1.0,
+          schema_grounding: 0.8,
+          speed_to_value: -0.4,
+        },
+        principleDimensions: [
+          "long_term_maintainability",
+          "schema_grounding",
+          "speed_to_value",
+        ],
+        principleAppliesTo: ["in_platform_coworker", "external_coding_agent"],
+        principlePublic: true,
+        principlePublicRationale:
+          "Surface architecture posture to adopters and contributors.",
+      }),
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("forwards principle metadata to update when a row already exists", async () => {
+    const { db, findFirst, create, update } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce({ id: "wp_principle_existing" });
+    update.mockResolvedValueOnce({ id: "wp_principle_existing" });
+
+    await upsertWikiPage(db, {
+      slug: "principles/evidence-before-diagnosis",
+      title: "Evidence Before Diagnosis",
+      body: "## Rule\n\nConfirm cause by querying state...",
+      pageKind: "principle",
+      isKernel: true,
+      principleTier: "commandment",
+      principleDirection: "Prefer queried state over inferred causes.",
+      principleDimensionVector: { evidence_density: 1.0, blast_radius: 0.3 },
+      principleDimensions: ["evidence_density", "blast_radius"],
+      principleAppliesTo: ["in_platform_coworker", "external_coding_agent"],
+      principlePublic: true,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "wp_principle_existing" },
+      data: expect.objectContaining({
+        principleTier: "commandment",
+        principleDirection: "Prefer queried state over inferred causes.",
+        principleDimensionVector: {
+          evidence_density: 1.0,
+          blast_radius: 0.3,
+        },
+        principleDimensions: ["evidence_density", "blast_radius"],
+        principleAppliesTo: ["in_platform_coworker", "external_coding_agent"],
+        principlePublic: true,
+      }),
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("defaults principle arrays + principlePublic when caller omits them", async () => {
+    const { db, findFirst, create } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce(null);
+    create.mockResolvedValueOnce({ id: "wp_non_principle" });
+
+    // A non-principle page should not receive principle-only fields in the
+    // outgoing data payload; absence is the contract, not explicit nulls.
+    await upsertWikiPage(db, {
+      slug: "entities/edge-node",
+      title: "Edge Node",
+      body: "## Definition\n\nAn edge node is...",
+      pageKind: "entity",
+      isKernel: true,
+    });
+
+    const createArgs = create.mock.calls[0]?.[0];
+    expect(createArgs.data.pageKind).toBe("entity");
+    expect(createArgs.data).not.toHaveProperty("principleTier");
+    expect(createArgs.data).not.toHaveProperty("principleDirection");
+    expect(createArgs.data).not.toHaveProperty("principleDimensionVector");
+  });
+
+  it("does not require principleDirection for the DB layer (validation lives in lint)", async () => {
+    const { db, findFirst, create } = makeWikiPageMocks();
+    findFirst.mockResolvedValueOnce(null);
+    create.mockResolvedValueOnce({ id: "wp_principle_partial" });
+
+    // Spec section 14: principle-missing-direction is a LINT finding, not a
+    // store-layer rejection. The store accepts incomplete principle data so
+    // that lint can surface findings on saved drafts.
+    await expect(
+      upsertWikiPage(db, {
+        slug: "principles/draft-without-direction",
+        title: "Draft principle missing direction",
+        body: "## Rule\n\nTBD",
+        pageKind: "principle",
+        isKernel: true,
+        principleTier: "core",
+        principleAppliesTo: ["human"],
+      }),
+    ).resolves.toBeDefined();
+
+    expect(create).toHaveBeenCalled();
+  });
+});
+
 function makeWikiPageMocks() {
   const findFirst = vi.fn();
   const create = vi.fn();

--- a/packages/db/src/wiki-store.ts
+++ b/packages/db/src/wiki-store.ts
@@ -39,18 +39,13 @@ type WikiPageSourceClient = Pick<WikiStoreClient, "wikiPageSource">;
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-/** Page kinds defined in docs/founder-kernel/SCHEMA.md and EP-WIKI-001 §4. */
-export type WikiPageKind =
-  | "entity"
-  | "summary"
-  | "decision"
-  | "runbook"
-  | "index"
-  | "stance"
-  | "heuristic";
-
-/** Status lifecycle defined in EP-WIKI-001 §4. */
-export type WikiPageStatus = "draft" | "published" | "review-needed" | "archived";
+// Page kinds and statuses live in wiki-taxonomy.ts (the single source of
+// truth used by seed, lint, MCP schemas, retrieval, and UI). Imported for
+// local use in this file's input types AND re-exported so existing callers
+// importing from wiki-store keep working.
+import type { WikiPageKind, WikiPageStatus } from "./wiki-taxonomy";
+export { WIKI_PAGE_KINDS, WIKI_PAGE_STATUSES } from "./wiki-taxonomy";
+export type { WikiPageKind, WikiPageStatus };
 
 /** Revision provenance defined in EP-WIKI-001 §4. */
 export type WikiRevisionChangeKind = "ingest" | "manual" | "lint-fix" | "kernel-merge";

--- a/packages/db/src/wiki-store.ts
+++ b/packages/db/src/wiki-store.ts
@@ -39,13 +39,51 @@ type WikiPageSourceClient = Pick<WikiStoreClient, "wikiPageSource">;
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-// Page kinds and statuses live in wiki-taxonomy.ts (the single source of
-// truth used by seed, lint, MCP schemas, retrieval, and UI). Imported for
-// local use in this file's input types AND re-exported so existing callers
-// importing from wiki-store keep working.
-import type { WikiPageKind, WikiPageStatus } from "./wiki-taxonomy";
+// Page kinds, statuses, and the principle-only taxonomy live in
+// wiki-taxonomy.ts (the single source of truth used by seed, lint, MCP
+// schemas, retrieval, and UI). Imported for local use in this file's input
+// types AND re-exported so existing callers importing from wiki-store keep
+// working.
+import type {
+  PrincipleAppliesTo,
+  PrincipleDimension,
+  PrincipleTier,
+  WikiPageKind,
+  WikiPageStatus,
+} from "./wiki-taxonomy";
 export { WIKI_PAGE_KINDS, WIKI_PAGE_STATUSES } from "./wiki-taxonomy";
-export type { WikiPageKind, WikiPageStatus };
+export type {
+  PrincipleAppliesTo,
+  PrincipleDimension,
+  PrincipleTier,
+  WikiPageKind,
+  WikiPageStatus,
+};
+
+/**
+ * Optional principle-only fields. Only meaningful when pageKind === "principle".
+ * The store layer accepts incomplete principle data; required-field gating
+ * (tier present, direction present for commandment/core, dimension vector
+ * dimensions in registry, applies-to populated, etc.) lives in lint
+ * detectors per spec section 14.
+ */
+export type WikiPagePrincipleInput = {
+  principleTier?: PrincipleTier | null;
+  principleDirection?: string | null;
+  principleWeight?: number | null;
+  principleWeightRationale?: string | null;
+  /**
+   * Signed dimension vector keyed by registry dimensions, values in [-1..1].
+   * Validation against PRINCIPLE_DIMENSIONS happens at the seed/lint layer;
+   * the store passes through whatever the caller supplies so a draft with
+   * an unknown key can still be saved for lint to surface.
+   */
+  principleDimensionVector?: Record<PrincipleDimension | string, number> | null;
+  principleDimensions?: PrincipleDimension[] | string[];
+  principleAppliesTo?: PrincipleAppliesTo[] | string[];
+  principlePublic?: boolean;
+  principlePublicRationale?: string | null;
+};
 
 /** Revision provenance defined in EP-WIKI-001 §4. */
 export type WikiRevisionChangeKind = "ingest" | "manual" | "lint-fix" | "kernel-merge";
@@ -64,7 +102,50 @@ export type UpsertWikiPageInput = {
   kernelPageId?: string | null;
   derivedFromKernelVersion?: string | null;
   abstract?: string | null;
-};
+} & WikiPagePrincipleInput;
+
+/**
+ * Build the principle-field subset of the create/update data object. Only
+ * emits keys when the caller supplied a principle-shaped input — preserves
+ * the contract that non-principle pages never carry principle metadata at
+ * the DB layer (their absence is the marker, not explicit nulls).
+ */
+function principleDataFromInput(
+  input: UpsertWikiPageInput,
+): Record<string, unknown> {
+  if (input.pageKind !== "principle") {
+    return {};
+  }
+  const data: Record<string, unknown> = {};
+  if (input.principleTier !== undefined) {
+    data.principleTier = input.principleTier;
+  }
+  if (input.principleDirection !== undefined) {
+    data.principleDirection = input.principleDirection;
+  }
+  if (input.principleWeight !== undefined) {
+    data.principleWeight = input.principleWeight;
+  }
+  if (input.principleWeightRationale !== undefined) {
+    data.principleWeightRationale = input.principleWeightRationale;
+  }
+  if (input.principleDimensionVector !== undefined) {
+    data.principleDimensionVector = input.principleDimensionVector;
+  }
+  if (input.principleDimensions !== undefined) {
+    data.principleDimensions = input.principleDimensions;
+  }
+  if (input.principleAppliesTo !== undefined) {
+    data.principleAppliesTo = input.principleAppliesTo;
+  }
+  if (input.principlePublic !== undefined) {
+    data.principlePublic = input.principlePublic;
+  }
+  if (input.principlePublicRationale !== undefined) {
+    data.principlePublicRationale = input.principlePublicRationale;
+  }
+  return data;
+}
 
 export type AppendRevisionInput = {
   pageId: string;
@@ -111,6 +192,7 @@ export async function upsertWikiPage(
   db: WikiPageUpsertClient,
   input: UpsertWikiPageInput,
 ): Promise<unknown> {
+  const principleData = principleDataFromInput(input);
   const data = {
     slug: input.slug,
     title: input.title,
@@ -123,6 +205,7 @@ export async function upsertWikiPage(
     kernelPageId: input.kernelPageId ?? null,
     derivedFromKernelVersion: input.derivedFromKernelVersion ?? null,
     abstract: input.abstract ?? null,
+    ...principleData,
   };
 
   const existing = (await db.wikiPage.findFirst({
@@ -143,6 +226,7 @@ export async function upsertWikiPage(
         kernelPageId: data.kernelPageId,
         derivedFromKernelVersion: data.derivedFromKernelVersion,
         abstract: data.abstract,
+        ...principleData,
       },
     });
   }

--- a/packages/db/src/wiki-taxonomy.test.ts
+++ b/packages/db/src/wiki-taxonomy.test.ts
@@ -1,0 +1,213 @@
+// Phase 0 Task 0.1 — typed constants for wiki page kinds, statuses, and
+// principle-only taxonomy. Single source of truth imported by seed, lint, MCP
+// schemas, retrieval, and UI. Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 0)
+
+import { describe, expect, it } from "vitest";
+import {
+  WIKI_PAGE_KINDS,
+  WIKI_PAGE_STATUSES,
+  PRINCIPLE_TIERS,
+  PRINCIPLE_APPLIES_TO,
+  PRINCIPLE_DIMENSIONS,
+  PRINCIPLE_TIER_DEFAULT_WEIGHT,
+  PRINCIPLE_TIER_CAPS,
+  PRINCIPLE_DECIDE_DEFAULTS,
+  isWikiPageKind,
+  isWikiPageStatus,
+  isPrincipleTier,
+  isPrincipleAppliesTo,
+  isPrincipleDimension,
+} from "./wiki-taxonomy";
+
+describe("wiki-taxonomy: WIKI_PAGE_KINDS", () => {
+  it("includes the 8 expected kinds in the documented order", () => {
+    expect(WIKI_PAGE_KINDS).toEqual([
+      "entity",
+      "summary",
+      "decision",
+      "runbook",
+      "index",
+      "stance",
+      "heuristic",
+      "principle",
+    ]);
+  });
+
+  it("preserves the 7 pre-existing kinds from EP-WIKI-001 unchanged", () => {
+    expect(WIKI_PAGE_KINDS).toContain("entity");
+    expect(WIKI_PAGE_KINDS).toContain("summary");
+    expect(WIKI_PAGE_KINDS).toContain("decision");
+    expect(WIKI_PAGE_KINDS).toContain("runbook");
+    expect(WIKI_PAGE_KINDS).toContain("index");
+    expect(WIKI_PAGE_KINDS).toContain("stance");
+    expect(WIKI_PAGE_KINDS).toContain("heuristic");
+  });
+
+  it("adds principle as the 8th kind", () => {
+    expect(WIKI_PAGE_KINDS).toContain("principle");
+    expect(WIKI_PAGE_KINDS).toHaveLength(8);
+  });
+});
+
+describe("wiki-taxonomy: WIKI_PAGE_STATUSES", () => {
+  it("matches the EP-WIKI-001 lifecycle", () => {
+    expect(WIKI_PAGE_STATUSES).toEqual([
+      "draft",
+      "published",
+      "review-needed",
+      "archived",
+    ]);
+  });
+});
+
+describe("wiki-taxonomy: PRINCIPLE_TIERS", () => {
+  it("has exactly three tiers in descending weight order", () => {
+    expect(PRINCIPLE_TIERS).toEqual(["commandment", "core", "contextual"]);
+  });
+});
+
+describe("wiki-taxonomy: PRINCIPLE_APPLIES_TO", () => {
+  it("covers the three governed populations from spec section 5.3", () => {
+    expect(PRINCIPLE_APPLIES_TO).toEqual([
+      "in_platform_coworker",
+      "external_coding_agent",
+      "human",
+    ]);
+  });
+});
+
+describe("wiki-taxonomy: PRINCIPLE_DIMENSIONS", () => {
+  it("matches the spec section 10 dimension registry verbatim", () => {
+    expect(PRINCIPLE_DIMENSIONS).toEqual([
+      "long_term_maintainability",
+      "blast_radius",
+      "reusability",
+      "evidence_density",
+      "human_cognitive_load",
+      "capacity_utilization",
+      "governance_compliance",
+      "public_safety",
+      "speed_to_value",
+      "schema_grounding",
+    ]);
+  });
+
+  it("contains exactly ten starter dimensions", () => {
+    expect(PRINCIPLE_DIMENSIONS).toHaveLength(10);
+  });
+});
+
+describe("wiki-taxonomy: PRINCIPLE_TIER_DEFAULT_WEIGHT", () => {
+  it("encodes the tier weight hierarchy from spec section 5.1", () => {
+    expect(PRINCIPLE_TIER_DEFAULT_WEIGHT.commandment).toBe(1.0);
+    expect(PRINCIPLE_TIER_DEFAULT_WEIGHT.core).toBe(0.4);
+    expect(PRINCIPLE_TIER_DEFAULT_WEIGHT.contextual).toBe(0.1);
+  });
+
+  it("makes a single commandment outweigh ten contextual at peak alignment", () => {
+    expect(
+      PRINCIPLE_TIER_DEFAULT_WEIGHT.commandment,
+    ).toBeGreaterThanOrEqual(PRINCIPLE_TIER_DEFAULT_WEIGHT.contextual * 10);
+  });
+});
+
+describe("wiki-taxonomy: PRINCIPLE_TIER_CAPS", () => {
+  it("caps commandments at 10 published kernel principles", () => {
+    expect(PRINCIPLE_TIER_CAPS.commandment).toBe(10);
+  });
+
+  it("soft-caps core at 30", () => {
+    expect(PRINCIPLE_TIER_CAPS.core).toBe(30);
+  });
+
+  it("leaves contextual uncapped (null)", () => {
+    expect(PRINCIPLE_TIER_CAPS.contextual).toBeNull();
+  });
+});
+
+describe("wiki-taxonomy: PRINCIPLE_DECIDE_DEFAULTS", () => {
+  it("matches the principle_decide defaults from spec section 11", () => {
+    expect(PRINCIPLE_DECIDE_DEFAULTS.maxPrinciples).toBe(20);
+    expect(PRINCIPLE_DECIDE_DEFAULTS.tieMargin).toBe(0.2);
+    expect(PRINCIPLE_DECIDE_DEFAULTS.contextualSimilarityThreshold).toBe(0.75);
+    expect(PRINCIPLE_DECIDE_DEFAULTS.semanticFallbackWarnRatio).toBe(0.4);
+  });
+});
+
+describe("wiki-taxonomy: isWikiPageKind", () => {
+  it("accepts every documented kind", () => {
+    for (const kind of WIKI_PAGE_KINDS) {
+      expect(isWikiPageKind(kind)).toBe(true);
+    }
+  });
+
+  it("rejects unknown strings", () => {
+    expect(isWikiPageKind("article")).toBe(false);
+    expect(isWikiPageKind("")).toBe(false);
+    expect(isWikiPageKind("PRINCIPLE")).toBe(false); // case-sensitive
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isWikiPageKind(null)).toBe(false);
+    expect(isWikiPageKind(undefined)).toBe(false);
+    expect(isWikiPageKind(42)).toBe(false);
+    expect(isWikiPageKind({})).toBe(false);
+  });
+});
+
+describe("wiki-taxonomy: isWikiPageStatus", () => {
+  it("accepts every documented status", () => {
+    for (const status of WIKI_PAGE_STATUSES) {
+      expect(isWikiPageStatus(status)).toBe(true);
+    }
+  });
+
+  it("rejects unknown values", () => {
+    expect(isWikiPageStatus("pending")).toBe(false);
+    expect(isWikiPageStatus(null)).toBe(false);
+  });
+});
+
+describe("wiki-taxonomy: isPrincipleTier", () => {
+  it("accepts every documented tier", () => {
+    for (const tier of PRINCIPLE_TIERS) {
+      expect(isPrincipleTier(tier)).toBe(true);
+    }
+  });
+
+  it("rejects unknown tiers and non-strings", () => {
+    expect(isPrincipleTier("situational")).toBe(false);
+    expect(isPrincipleTier("")).toBe(false);
+    expect(isPrincipleTier(null)).toBe(false);
+    expect(isPrincipleTier(undefined)).toBe(false);
+  });
+});
+
+describe("wiki-taxonomy: isPrincipleAppliesTo", () => {
+  it("accepts every documented population", () => {
+    for (const population of PRINCIPLE_APPLIES_TO) {
+      expect(isPrincipleAppliesTo(population)).toBe(true);
+    }
+  });
+
+  it("rejects unknown populations", () => {
+    expect(isPrincipleAppliesTo("agent")).toBe(false);
+    expect(isPrincipleAppliesTo("all")).toBe(false); // `all` is not in the registry per spec section 5.3
+    expect(isPrincipleAppliesTo(null)).toBe(false);
+  });
+});
+
+describe("wiki-taxonomy: isPrincipleDimension", () => {
+  it("accepts every dimension in the registry", () => {
+    for (const dimension of PRINCIPLE_DIMENSIONS) {
+      expect(isPrincipleDimension(dimension)).toBe(true);
+    }
+  });
+
+  it("rejects unknown dimensions", () => {
+    expect(isPrincipleDimension("fictional_axis")).toBe(false);
+    expect(isPrincipleDimension("long_term")).toBe(false); // partial match should fail
+    expect(isPrincipleDimension(null)).toBe(false);
+  });
+});

--- a/packages/db/src/wiki-taxonomy.ts
+++ b/packages/db/src/wiki-taxonomy.ts
@@ -1,0 +1,161 @@
+// Phase 0 Task 0.1 — single source of truth for wiki page kinds, statuses,
+// and the principle-only taxonomy (tier, applies-to, dimension registry,
+// weight defaults, caps, decision defaults).
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 0)
+//
+// Imported by seed, lint, MCP schemas, retrieval, and UI. wiki-store.ts
+// re-exports WikiPageKind / WikiPageStatus from this module so callers keep
+// working through the existing import path.
+
+// ─── Wiki page kinds and statuses ───────────────────────────────────────────
+
+/**
+ * The eight page kinds supported by the founder kernel wiki. Defined in
+ * docs/founder-kernel/SCHEMA.md and EP-WIKI-001 section 4. `principle` was
+ * added by the principles-as-wiki-kind work (spec section 7).
+ */
+export const WIKI_PAGE_KINDS = [
+  "entity",
+  "summary",
+  "decision",
+  "runbook",
+  "index",
+  "stance",
+  "heuristic",
+  "principle",
+] as const;
+export type WikiPageKind = (typeof WIKI_PAGE_KINDS)[number];
+
+/** Status lifecycle for wiki pages, defined in EP-WIKI-001 section 4. */
+export const WIKI_PAGE_STATUSES = [
+  "draft",
+  "published",
+  "review-needed",
+  "archived",
+] as const;
+export type WikiPageStatus = (typeof WIKI_PAGE_STATUSES)[number];
+
+// ─── Principle taxonomy ─────────────────────────────────────────────────────
+
+/**
+ * Tiers control how strongly a principle pulls on decision aggregation and how
+ * strictly lint enforces required fields. Order is high-to-low weight so
+ * callers can iterate in priority order. See spec section 5.1.
+ */
+export const PRINCIPLE_TIERS = ["commandment", "core", "contextual"] as const;
+export type PrincipleTier = (typeof PRINCIPLE_TIERS)[number];
+
+/**
+ * Populations a principle governs. Used by retrieval (`recallPrincipleContext`)
+ * to filter principles to the calling agent's scope. See spec section 5.3.
+ */
+export const PRINCIPLE_APPLIES_TO = [
+  "in_platform_coworker",
+  "external_coding_agent",
+  "human",
+] as const;
+export type PrincipleAppliesTo = (typeof PRINCIPLE_APPLIES_TO)[number];
+
+/**
+ * Option-feature axes that principle dimension vectors can score against.
+ * V1 ships a small registry — growth is gated by PR review so the registry
+ * stays auditable. See spec section 10.
+ */
+export const PRINCIPLE_DIMENSIONS = [
+  "long_term_maintainability",
+  "blast_radius",
+  "reusability",
+  "evidence_density",
+  "human_cognitive_load",
+  "capacity_utilization",
+  "governance_compliance",
+  "public_safety",
+  "speed_to_value",
+  "schema_grounding",
+] as const;
+export type PrincipleDimension = (typeof PRINCIPLE_DIMENSIONS)[number];
+
+/**
+ * Default weight magnitude for each tier. A principle can override via
+ * `principleWeight` + `principleWeightRationale`; lint warns on divergence.
+ * Ratios chosen so one commandment outweighs ten contextual at peak alignment
+ * (1.0 vs 10 * 0.1 = 1.0 — the hierarchy degrades gracefully, no hard
+ * categorical override). See spec section 5.1.
+ */
+export const PRINCIPLE_TIER_DEFAULT_WEIGHT: Record<PrincipleTier, number> = {
+  commandment: 1.0,
+  core: 0.4,
+  contextual: 0.1,
+};
+
+/**
+ * Hard cap on commandments (10) is the central inflation guard — if every rule
+ * is a commandment, nothing is. Core has a soft cap (30) enforced by `warn`-
+ * severity lint. Contextual is uncapped. See spec section 5.1 and section 14.
+ */
+export const PRINCIPLE_TIER_CAPS: Record<PrincipleTier, number | null> = {
+  commandment: 10,
+  core: 30,
+  contextual: null,
+};
+
+/**
+ * Defaults for the `principle_decide` advisory MCP tool. Callers can override
+ * per-invocation but the defaults reflect the spec section 11 contract.
+ */
+export const PRINCIPLE_DECIDE_DEFAULTS = {
+  maxPrinciples: 20,
+  tieMargin: 0.2,
+  contextualSimilarityThreshold: 0.75,
+  semanticFallbackWarnRatio: 0.4,
+} as const;
+
+// ─── Type-narrowing predicates ──────────────────────────────────────────────
+
+/**
+ * String-narrowing predicates used by seed parsing, MCP input validation, and
+ * lint detectors. Each predicate accepts `unknown` and narrows on success so
+ * callers can pipe DB rows, frontmatter values, and MCP arguments through the
+ * same gate without separate type assertions.
+ */
+
+export function isWikiPageKind(value: unknown): value is WikiPageKind {
+  return (
+    typeof value === "string" &&
+    (WIKI_PAGE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function isWikiPageStatus(value: unknown): value is WikiPageStatus {
+  return (
+    typeof value === "string" &&
+    (WIKI_PAGE_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function isPrincipleTier(value: unknown): value is PrincipleTier {
+  return (
+    typeof value === "string" &&
+    (PRINCIPLE_TIERS as readonly string[]).includes(value)
+  );
+}
+
+export function isPrincipleAppliesTo(
+  value: unknown,
+): value is PrincipleAppliesTo {
+  return (
+    typeof value === "string" &&
+    (PRINCIPLE_APPLIES_TO as readonly string[]).includes(value)
+  );
+}
+
+export function isPrincipleDimension(
+  value: unknown,
+): value is PrincipleDimension {
+  return (
+    typeof value === "string" &&
+    (PRINCIPLE_DIMENSIONS as readonly string[]).includes(value)
+  );
+}


### PR DESCRIPTION
## Summary

Phase 0 of the principles-as-wiki-kind plan ([spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md), [plan](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md)). Lands the schema, constants, CRUD, seed parsing, Qdrant payload write path, UI scaffolding, and founder-kernel authoring contract for the new ``principle`` page kind. No content yet — that's Phase 3.

## What ships

- **Constants** ([packages/db/src/wiki-taxonomy.ts](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/feat/principles-batch-0-schema/packages/db/src/wiki-taxonomy.ts)) — single source of truth for ``WIKI_PAGE_KINDS``, ``WIKI_PAGE_STATUSES``, ``PRINCIPLE_TIERS``, ``PRINCIPLE_APPLIES_TO``, ``PRINCIPLE_DIMENSIONS`` (10 starter axes), tier default weights (1.0 / 0.4 / 0.1), tier caps (10 / 30 / null), ``principle_decide`` defaults, and 5 type-narrowing predicates. ``wiki-store.ts`` re-exports ``WikiPageKind`` and ``WikiPageStatus`` from here so the duplicate union is gone.
- **Schema + migration** — 9 nullable / defaulted principle-only columns on ``WikiPage`` (``principleTier``, ``principleDirection``, ``principleWeight``, ``principleWeightRationale``, ``principleDimensionVector`` JSONB, ``principleDimensions``/``principleAppliesTo`` text arrays, ``principlePublic``, ``principlePublicRationale``) plus two indexes for tier-stratified retrieval. Migration also closes the kernel-slug uniqueness gap with a partial unique index (``WikiPage_kernel_slug_key`` WHERE ``organizationId IS NULL``) flagged by the chief-architect review — not principle-specific but lands here.
- **CRUD** — ``WikiPagePrincipleInput`` mixed into ``UpsertWikiPageInput``. The helper only emits principle keys when ``pageKind === "principle"`` and the caller supplied a value (absence is the marker, no implicit nulls).
- **Seed parsing** — ``parseFrontmatter`` gains inline JSON object support (for ``principleDimensionVector``) and unquoted true/false/number coercion. New ``extractPrinciplePayload`` validates every dimension key against ``PRINCIPLE_DIMENSIONS``, throws on unknown (no silent skip), and derives ``principleDimensions`` from vector keys when omitted.
- **Qdrant payload** — ``storeWikiPage`` writes canonical ``principleTier``, ``principleAppliesTo``, ``principleDimensions``, ``principlePublic`` keys for principle pages. Other kinds unchanged — no backfill required. Dimension vector stays Postgres-only (it's decision-time data, not a retrieval filter axis).
- **UI** — Badge renders the ``Principle`` label. List groups by ``pageKind`` then sub-groups principles by tier (Commandments → Core → Contextual → Untiered, with unrecognized tiers coerced into Untiered so misconfigured rows stay visible). Viewer renders a metadata panel between header and body: tier badge, effective weight, public/internal state, source count, direction prose, applies-to chips, and a dimension-vector table.
- **Founder-kernel contract** — ``SCHEMA.md`` gets a ``principle`` page-kind section with required frontmatter, required body sections, and tier semantics. ``AUTHORING.md`` folder map + 60-second guide updated. New ``_templates/principle.template.md`` with all 9 fields scaffolded and the 7 required body sections prompted. ``wiki/principles/`` placeholder folder lands via ``.gitkeep``. ``manifest.json`` schemaVersion 0.1.0 → 0.2.0.

## Phase -1 preflight (already complete)

| Check | Result |
|---|---|
| Worktree on fresh branch off ``origin/main`` (``a0866961``) | ✅ |
| ``WikiPage`` / ``WikiPageKind`` / ``searchWikiPages`` / ``wiki_query`` anchors | ✅ shapes match the spec's §1.1 verified state |
| Principle 9 / capacity-continuity in branch HEAD | ✅ present at ``docs/architecture/ai-coworker-development-principles.md:232`` — scope is 9 principles (Phase 3 conditional resolves to "yes") |
| Kernel slug uniqueness gap | ✅ confirmed real, closed by the partial index in this PR |
| Live MCP planning state | ✅ ``search_specs_and_plans`` returned 0 indexed matches for this work; ``EP-TAK-3F9A21`` is the adjacent epic per spec §1.1 |
| Backlog linkage | ✅ umbrella BI ``BI-EBDFBA34`` created under ``EP-TAK-3F9A21`` |

## Build Gate

1. **Unit tests** ✅ — ``@dpf/db`` 437/437; ``apps/web`` 5065/5092 (rest skipped/todo, 0 failures).
2. **Production build** ✅ — ``pnpm --filter web build`` clean; ``/wiki`` and ``/wiki/[...slug]`` routes built without errors.
3. **UX verification** ⏳ — Deferred to CI / reviewer's local Docker stack. The viewer's principle metadata panel needs at least one seeded principle to exercise; Phase 3 lands that content. Local verification: rebuild the portal, run the seed, visit ``/wiki?kind=principle`` and confirm the badge + tiered groupings render.
4. **Migration applies cleanly** ⏳ — ``ALTER TABLE`` + ``CREATE INDEX`` + partial unique index are additive only. Verify on a fresh DB with ``pnpm --filter @dpf/db exec prisma migrate dev`` before merge.

## Commits

This PR squashes cleanly to one feature, but the 8 commits below are intentionally bite-sized for review:

1. ``feat(db): add wiki taxonomy constants module`` (``bbe47bd2``)
2. ``refactor(db): centralize WikiPageKind/Status in wiki-taxonomy`` (``8b331150``)
3. ``feat(db): add principle-only fields to WikiPage with kernel slug guard`` (``ef8ef93f``)
4. ``feat(db): parse principle frontmatter in seedWikiKernel`` (``4c528809``)
5. ``feat(wiki): add principle-only Qdrant payload keys`` (``b3a26a4e``)
6. ``feat(wiki-ui): render principle kind in badge and tier-group the list`` (``807da086``)
7. ``feat(wiki-ui): render principle metadata panel in WikiPageViewer`` (``5e85ef65``)
8. ``doc(founder-kernel): add principle kind to schema, authoring, template`` (``d73a9f9b``)

## Test plan

- [ ] Reviewer: run ``pnpm --filter @dpf/db exec vitest run`` and confirm 437/437 green (no regressions)
- [ ] Reviewer: run ``pnpm --filter web exec vitest run lib/wiki components/wiki`` and confirm wiki tests green
- [ ] Reviewer: run ``pnpm --filter @dpf/db exec prisma migrate dev`` against a fresh DB; confirm migration applies cleanly, kernel slug uniqueness index exists, and existing rows unaffected
- [ ] Reviewer: rebuild portal, seed an example principle page (use the template in ``docs/founder-kernel/_templates/principle.template.md``), visit ``/wiki?kind=principle`` in light + dark mode, confirm badge + tier grouping + metadata panel render correctly
- [ ] Reviewer: try seeding a principle with an unknown dimension; confirm seed throws with a clear message naming the offending key

## What's NOT in this PR (later phases)

- Phase 1 — Lint detectors (12 from spec §14 including the commandment cap enforcement)
- Phase 2 — Retrieval (``recallPrincipleContext``) + MCP tools (``wiki_query`` filter extensions and the advisory ``principle_decide``)
- Phase 3 — Seed the first 9-10 kernel principles
- Phase 4 — AGENTS.md selective governance promotion
- Phase 5 — Memory-corpus principle promotion (3 tier-ordered sub-PRs)
- Phase 6 — Public docs generation (``docs/principles.md``)

## Refs

- BI: ``BI-EBDFBA34`` (umbrella for Phase 0)
- Epic: ``EP-TAK-3F9A21`` (TAK/GAID Refresh — adjacent governed-memory work)
- Spec PR: [#518](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/518) (merged)
- Plan review PR: [#524](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/524) (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)