### PR TITLE
feat: add shared External Access permission flow

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -40,6 +40,7 @@ import {
   saveElevatedAssistPreference,
 } from "./agent-form-assist-prefs";
 import {
+  buildExternalAccessContinuationPrompt,
   loadExternalAccessSessionState,
   saveExternalAccessSessionState,
   loadCoworkerMode,
@@ -383,11 +384,21 @@ export function AgentCoworkerPanel({
   }
 
   function handleToggleExternalAccess() {
-    setExternalAccessEnabled((prev) => {
-      const next = !prev;
-      saveExternalAccessSessionState(preferenceUserKey, pathname, next);
-      return next;
-    });
+    const next = !externalAccessEnabled;
+    setExternalAccessEnabled(next);
+    saveExternalAccessSessionState(preferenceUserKey, pathname, next);
+
+    if (next && !isBusy) {
+      const continuation = buildExternalAccessContinuationPrompt(messages);
+      if (continuation) {
+        submitMessage(
+          continuation,
+          createOptimisticUserMessage(continuation, effectiveRoute),
+          true,
+          { externalAccessEnabled: true },
+        );
+      }
+    }
   }
 
   function handleToggleCoworkerMode() {
@@ -406,6 +417,7 @@ export function AgentCoworkerPanel({
     content: string,
     optimisticMessage = createOptimisticUserMessage(content, effectiveRoute),
     appendOptimistic = true,
+    runtimeOverride?: { externalAccessEnabled?: boolean },
   ) {
     if (!threadId) return;
     const formAssistContext = activeFormAssistRef.current
@@ -425,7 +437,7 @@ export function AgentCoworkerPanel({
       devMode,
       useUnifiedCoworker,
       coworkerMode,
-      externalAccessEnabled,
+      externalAccessEnabled: runtimeOverride?.externalAccessEnabled ?? externalAccessEnabled,
     });
 
     // EP-ASYNC-COWORKER-001: Non-blocking fetch to API route.

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -86,6 +86,6 @@ describe("AgentPanelHeader", () => {
     );
 
     expect(html).toContain("Act");
-    expect(html).not.toContain("External Off");
+    expect(html).toContain("External Off");
   });
 });

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -154,7 +154,7 @@ export function AgentPanelHeader({
               fontSize: 9,
               textTransform: "uppercase",
               letterSpacing: "0.08em",
-              color: elevatedAssistEnabled ? "#241700" : "var(--dpf-muted)",
+              color: elevatedAssistEnabled ? "var(--dpf-text)" : "var(--dpf-muted)",
               background: elevatedAssistEnabled ? "var(--dpf-warning)" : "transparent",
               border: `1px solid ${elevatedAssistEnabled ? "var(--dpf-warning)" : "var(--dpf-border)"}`,
               borderRadius: 999,
@@ -195,36 +195,35 @@ export function AgentPanelHeader({
             >
               {coworkerMode === "act" ? "Act" : "Advise"}
             </button>
-          ) : (
-            <button
-              type="button"
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleExternalAccess();
-              }}
-              title={
-                externalAccessEnabled
-                  ? "External On: this page's coworker can use approved public web search and fetch tools during this session"
-                  : "External Off: this page's coworker cannot access approved public web search and fetch tools during this session"
-              }
-              style={{
-                fontSize: 9,
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-                color: externalAccessEnabled ? "var(--dpf-success)" : "var(--dpf-muted)",
-                background: externalAccessEnabled ? "color-mix(in srgb, var(--dpf-success) 16%, transparent)" : "transparent",
-                border: `1px solid ${externalAccessEnabled ? "color-mix(in srgb, var(--dpf-success) 55%, transparent)" : "var(--dpf-border)"}`,
-                borderRadius: 999,
-                padding: "2px 6px",
-                fontWeight: externalAccessEnabled ? 700 : 500,
-                cursor: "pointer",
-                lineHeight: 1.2,
-              }}
-            >
-              {externalAccessEnabled ? "External Access On" : "External Access Off"}
-            </button>
-          )}
+          ) : null}
+          <button
+            type="button"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleExternalAccess();
+            }}
+            title={
+              externalAccessEnabled
+                ? "External On: this page's coworker can use approved public web search and fetch tools during this session"
+                : "External Off: this page's coworker cannot access approved public web search and fetch tools during this session"
+            }
+            style={{
+              fontSize: 9,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: externalAccessEnabled ? "var(--dpf-success)" : "var(--dpf-muted)",
+              background: externalAccessEnabled ? "color-mix(in srgb, var(--dpf-success) 16%, transparent)" : "transparent",
+              border: `1px solid ${externalAccessEnabled ? "color-mix(in srgb, var(--dpf-success) 55%, transparent)" : "var(--dpf-border)"}`,
+              borderRadius: 999,
+              padding: "2px 6px",
+              fontWeight: externalAccessEnabled ? 700 : 500,
+              cursor: "pointer",
+              lineHeight: 1.2,
+            }}
+          >
+            {externalAccessEnabled ? "External Access On" : "External Access Off"}
+          </button>
           {canUseDev && onToggleDev && (
             <button
               type="button"

--- a/apps/web/components/agent/agent-external-access-session.test.ts
+++ b/apps/web/components/agent/agent-external-access-session.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  buildExternalAccessContinuationPrompt,
   getExternalAccessSessionKey,
   loadExternalAccessSessionState,
   saveExternalAccessSessionState,
@@ -41,6 +42,17 @@ describe("agent external access session", () => {
   it("uses a session-scoped storage key", () => {
     expect(getExternalAccessSessionKey("user-1", "/admin")).toBe(
       "agent-external-access-session:user-1:/admin",
+    );
+  });
+
+  it("builds a continuation prompt from the latest External Access request", () => {
+    expect(
+      buildExternalAccessContinuationPrompt([
+        { role: "user", content: "Research official sales tax authority guidance." },
+        { role: "assistant", content: "External Access is off. Please enable External Access so I can verify official sources." },
+      ]),
+    ).toBe(
+      "External Access is now enabled for this page. Continue the previous request: Research official sales tax authority guidance.",
     );
   });
 });

--- a/apps/web/components/agent/agent-external-access-session.ts
+++ b/apps/web/components/agent/agent-external-access-session.ts
@@ -18,6 +18,39 @@ export function saveExternalAccessSessionState(
   sessionStorage.setItem(getExternalAccessSessionKey(userId, routeContext), String(enabled));
 }
 
+type ContinuationMessage = {
+  role: string;
+  content: string;
+  retryContent?: string | null;
+};
+
+const EXTERNAL_ACCESS_REQUEST_PATTERN =
+  /\bexternal access\b[\s\S]{0,160}\b(enable|enabled|turn on|off|verify|official|public)\b/i;
+
+export function buildExternalAccessContinuationPrompt(
+  messages: ContinuationMessage[],
+): string | null {
+  const requestIndex = [...messages]
+    .map((message, index) => ({ message, index }))
+    .reverse()
+    .find(({ message }) =>
+      (message.role === "assistant" || message.role === "system") &&
+      EXTERNAL_ACCESS_REQUEST_PATTERN.test(message.content),
+    )?.index;
+
+  if (requestIndex == null) return null;
+
+  for (let i = requestIndex - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role !== "user") continue;
+    const content = (message.retryContent ?? message.content).trim();
+    if (!content) return null;
+    return `External Access is now enabled for this page. Continue the previous request: ${content}`;
+  }
+
+  return null;
+}
+
 // ─── Advise / Act session state (per-route-scoped) ───────────────────────────
 
 export type CoworkerMode = "advise" | "act";

--- a/apps/web/components/agent/coworker-runtime-mode.test.ts
+++ b/apps/web/components/agent/coworker-runtime-mode.test.ts
@@ -62,7 +62,7 @@ describe("resolveCoworkerRuntimeMode", () => {
     });
   });
 
-  it("forces external access on in unified act mode", () => {
+  it("keeps external access separate from unified act mode", () => {
     expect(
       resolveCoworkerRuntimeMode({
         pathname: "/compliance/licensing",
@@ -73,7 +73,7 @@ describe("resolveCoworkerRuntimeMode", () => {
       }),
     ).toEqual({
       coworkerMode: "act",
-      externalAccessEnabled: true,
+      externalAccessEnabled: false,
     });
   });
 });

--- a/apps/web/components/agent/coworker-runtime-mode.ts
+++ b/apps/web/components/agent/coworker-runtime-mode.ts
@@ -30,7 +30,6 @@ export function resolveCoworkerRuntimeMode(input: Input): Output {
 
   return {
     coworkerMode: input.coworkerMode,
-    externalAccessEnabled:
-      input.coworkerMode === "act" ? true : input.externalAccessEnabled,
+    externalAccessEnabled: input.externalAccessEnabled,
   };
 }

--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -148,6 +148,7 @@ vi.mock("@dpf/db", () => ({
 import { auth } from "@/lib/auth";
 import { resolveAgentForRouteWithPrompts } from "@/lib/tak/agent-routing-server";
 import { routeAndCall } from "@/lib/routed-inference";
+import { classifyTask } from "@/lib/task-classifier";
 import { executeTool, getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { prisma } from "@dpf/db";
@@ -156,6 +157,7 @@ import { sendMessage } from "./agent-coworker";
 const mockAuth = auth as ReturnType<typeof vi.fn>;
 const mockResolveAgentForRoute = resolveAgentForRouteWithPrompts as ReturnType<typeof vi.fn>;
 const mockRouteAndCall = routeAndCall as ReturnType<typeof vi.fn>;
+const mockClassifyTask = classifyTask as ReturnType<typeof vi.fn>;
 const mockGetAvailableTools = getAvailableTools as ReturnType<typeof vi.fn>;
 const mockToolsToOpenAIFormat = toolsToOpenAIFormat as ReturnType<typeof vi.fn>;
 const mockExecuteTool = executeTool as ReturnType<typeof vi.fn>;
@@ -197,6 +199,13 @@ describe("agent coworker external access", () => {
     });
     mockPrisma.agentModelConfig.findUnique.mockResolvedValue(null);
     mockPrisma.toolExecution.create.mockResolvedValue({});
+    mockClassifyTask.mockReturnValue({
+      taskType: "conversation",
+      confidence: 0.8,
+      requiresCodeExecution: false,
+      requiresWebSearch: false,
+      requiresComputerUse: false,
+    });
     mockGovernedExecuteTool.mockImplementation(async () => {
       return {
         success: true,
@@ -255,6 +264,128 @@ describe("agent coworker external access", () => {
         isSuperuser: false,
       },
       expect.objectContaining({ externalAccessEnabled: true }),
+    );
+  });
+
+  it("adds shared External Access request guidance and audit when web tools are withheld", async () => {
+    mockClassifyTask.mockReturnValue({
+      taskType: "web-search",
+      confidence: 0.8,
+      requiresWebSearch: true,
+      requiresCodeExecution: false,
+      requiresComputerUse: false,
+    });
+    mockGetAvailableTools.mockImplementation((_userContext, options) =>
+      options?.externalAccessEnabled
+        ? [
+            {
+              name: "search_public_web",
+              description: "Search the public web",
+              inputSchema: {},
+              requiredCapability: null,
+              requiresExternalAccess: true,
+              executionMode: "immediate",
+              sideEffect: false,
+            },
+            {
+              name: "fetch_public_website",
+              description: "Fetch a public website",
+              inputSchema: {},
+              requiredCapability: null,
+              requiresExternalAccess: true,
+              executionMode: "immediate",
+              sideEffect: false,
+            },
+          ]
+        : [],
+    );
+    mockRouteAndCall.mockResolvedValue({
+      content: "External Access is off. Enable it so I can verify official sources.",
+      providerId: "ollama-local",
+      modelId: "llama3.1",
+      inputTokens: 1,
+      outputTokens: 1,
+      toolCalls: [],
+      downgraded: false,
+      downgradeMessage: null,
+      routeDecision: {},
+    });
+
+    await sendMessage({
+      threadId: "thread-1",
+      content: "Look up current sales tax authority guidance.",
+      routeContext: "/finance",
+      externalAccessEnabled: false,
+    });
+
+    expect(mockRouteAndCall.mock.calls[0][1]).toContain("EXTERNAL ACCESS DISABLED");
+    expect(mockRouteAndCall.mock.calls[0][1]).toContain("search_public_web");
+    expect(mockRouteAndCall.mock.calls[0][1]).toContain("ask the employee to enable External Access");
+    expect(mockPrisma.toolExecution.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          toolName: "external_access_permission_request",
+          executionMode: "permission",
+          routeContext: "/finance",
+          success: true,
+          parameters: expect.objectContaining({
+            requestedTools: ["search_public_web", "fetch_public_website"],
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("audits External Access approval when a web task continues with access enabled", async () => {
+    mockClassifyTask.mockReturnValue({
+      taskType: "web-search",
+      confidence: 0.8,
+      requiresWebSearch: true,
+      requiresCodeExecution: false,
+      requiresComputerUse: false,
+    });
+    mockGetAvailableTools.mockReturnValue([
+      {
+        name: "search_public_web",
+        description: "Search the public web",
+        inputSchema: {},
+        requiredCapability: null,
+        requiresExternalAccess: true,
+        executionMode: "immediate",
+        sideEffect: false,
+      },
+    ]);
+    mockRouteAndCall.mockResolvedValue({
+      content: "I checked official sources.",
+      providerId: "ollama-local",
+      modelId: "llama3.1",
+      inputTokens: 1,
+      outputTokens: 1,
+      toolCalls: [],
+      downgraded: false,
+      downgradeMessage: null,
+      routeDecision: {},
+    });
+
+    await sendMessage({
+      threadId: "thread-1",
+      content: "External Access is enabled. Continue the tax authority research.",
+      routeContext: "/finance",
+      externalAccessEnabled: true,
+    });
+
+    expect(mockPrisma.toolExecution.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          toolName: "external_access_permission_approval",
+          executionMode: "permission",
+          routeContext: "/finance",
+          success: true,
+          parameters: expect.objectContaining({
+            requestedTools: ["search_public_web"],
+          }),
+        }),
+      }),
     );
   });
 

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -21,7 +21,7 @@ import {
   type AgentFormAssistContext,
 } from "@/lib/agent-form-assist";
 // mcp-tools is imported dynamically at call sites to avoid NFT whole-project tracing
-import type { BuildPhaseTag } from "@/lib/mcp-tools";
+import type { BuildPhaseTag, ToolDefinition } from "@/lib/mcp-tools";
 import { getActionsForRoute } from "@/lib/agent-action-registry";
 import { getBuildContextSection } from "@/lib/build-agent-prompts";
 import { getFeatureBuildForContext } from "@/lib/feature-build-data";
@@ -41,8 +41,28 @@ import {
   executeAutonomousAgenticLoop,
   findCurrentAutonomousWorkRun,
 } from "@/lib/tak/autonomous-work-run";
+import {
+  buildExternalAccessDisabledInstruction,
+  getExternalAccessToolSummaries,
+  recordExternalAccessPermissionAudit,
+  shouldRequestExternalAccess,
+} from "@/lib/agent-external-access-permission";
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
+
+function filterToolsForCoworkerRuntime(
+  tools: ToolDefinition[],
+  input: { coworkerMode?: "advise" | "act"; activeBuildPhase: string | null },
+): ToolDefinition[] {
+  return tools.filter((tool) => {
+    if (input.coworkerMode === "advise" && tool.sideEffect) return false;
+    if (input.activeBuildPhase) {
+      if (!tool.buildPhases) return false;
+      return tool.buildPhases.includes(input.activeBuildPhase as BuildPhaseTag);
+    }
+    return true;
+  });
+}
 
 async function requireAuthUser() {
   const session = await auth();
@@ -374,6 +394,11 @@ export async function sendMessage(input: {
     role: m.role as ChatMessage["role"],
     content: m.content,
   }));
+  const recentContentForClassification = chatHistory
+    .slice(-3)
+    .map((m) => typeof m.content === "string" ? m.content : JSON.stringify(m.content));
+  const taskClassification = classifyTask(trimmedContent, recentContentForClassification);
+  let taskTypeId: string = taskClassification.taskType;
 
   // Enrich the last user message with file content so the LLM sees it inline,
   // not just in the system prompt. LLMs pay more attention to message content
@@ -636,10 +661,11 @@ export async function sendMessage(input: {
 
   // Get ALL platform tools (no mode filtering — we filter the merged set below)
   const { getAvailableTools, toolsToOpenAIFormat } = await import("@/lib/mcp-tools");
-  const allPlatformTools = await getAvailableTools({
+  const toolUserContext = {
     platformRole: user.platformRole,
     isSuperuser: user.isSuperuser,
-  }, {
+  };
+  const allPlatformTools = await getAvailableTools(toolUserContext, {
     externalAccessEnabled: input.externalAccessEnabled === true,
     // Skip mode filtering here — applied to merged set
     unifiedMode: useUnified,
@@ -676,18 +702,25 @@ export async function sendMessage(input: {
     }
   }
 
-  const availableTools = mergedTools.filter((t) => {
-    // Advise mode: exclude side-effect tools
-    if (input.coworkerMode === "advise" && t.sideEffect) return false;
-    // Build phase filtering: when in a build, ONLY include tools that are
-    // explicitly assigned to the current phase. This prevents tool overload
-    // (53+ tools) which causes smaller models to miss critical tools.
-    if (activeBuildPhase) {
-      if (!t.buildPhases) return false; // Exclude general-purpose tools during builds
-      return t.buildPhases.includes(activeBuildPhase as BuildPhaseTag);
-    }
-    return true;
+  const availableTools = filterToolsForCoworkerRuntime(mergedTools, {
+    coworkerMode: input.coworkerMode,
+    activeBuildPhase,
   });
+
+  let disabledExternalTools: Array<{ name: string; description: string }> = [];
+  if (input.externalAccessEnabled !== true) {
+    const externalEnabledPlatformTools = await getAvailableTools(toolUserContext, {
+      externalAccessEnabled: true,
+      unifiedMode: useUnified,
+      agentId: agent.agentId,
+    });
+    disabledExternalTools = getExternalAccessToolSummaries(
+      filterToolsForCoworkerRuntime(externalEnabledPlatformTools, {
+        coworkerMode: input.coworkerMode,
+        activeBuildPhase,
+      }),
+    );
+  }
 
   // Conversation-only detection: if the message is a conversational skill (analyze, advise),
   // strip tools entirely so the model responds with text instead of trying to call tools.
@@ -850,7 +883,37 @@ export async function sendMessage(input: {
         toolList,
         "Use these tools when the user asks about external websites, URLs, web searches, or public information.",
       ].join("\n");
+      if (shouldRequestExternalAccess({
+        content: trimmedContent,
+        taskRequiresWebSearch: taskClassification.requiresWebSearch,
+        externalTools,
+      })) {
+        await recordExternalAccessPermissionAudit({
+          decision: "approval",
+          threadId: input.threadId,
+          agentId: agent.agentId,
+          userId: user.id!,
+          routeContext: input.routeContext,
+          content: trimmedContent,
+          requestedTools: externalTools.map((tool) => tool.name),
+        });
+      }
     }
+  } else if (shouldRequestExternalAccess({
+    content: trimmedContent,
+    taskRequiresWebSearch: taskClassification.requiresWebSearch,
+    externalTools: disabledExternalTools,
+  })) {
+    populatedPrompt += buildExternalAccessDisabledInstruction(disabledExternalTools);
+    await recordExternalAccessPermissionAudit({
+      decision: "request",
+      threadId: input.threadId,
+      agentId: agent.agentId,
+      userId: user.id!,
+      routeContext: input.routeContext,
+      content: trimmedContent,
+      requestedTools: disabledExternalTools.map((tool) => tool.name),
+    });
   }
 
   // Surface MCP service resources that are discoverable but not yet enabled for this org
@@ -923,25 +986,17 @@ export async function sendMessage(input: {
   // --- Task classification and performance profile injection ---
   // EP-INF-009b: Routing is handled by the agentic loop via routeAndCall().
   // We classify here for metadata and performance profile instruction injection.
-  let taskTypeId: string = "unknown";
-
-  {
-    const recentContent = chatHistory.slice(-3).map((m) => typeof m.content === "string" ? m.content : JSON.stringify(m.content));
-    const classification = classifyTask(trimmedContent, recentContent);
-    taskTypeId = classification.taskType;
-
-    // Inject task-specific instructions from performance profile (if confident classification)
-    if (classification.taskType !== "unknown" && classification.confidence >= 0.5) {
-      try {
-        const profiles = await loadPerformanceProfiles(classification.taskType);
-        // Find the best performance profile to inject guidance from
-        const profile = profiles[0];
-        if (profile?.currentInstructions) {
-          populatedPrompt += `\n\n--- TASK GUIDANCE ---\n${profile.currentInstructions}`;
-        }
-      } catch (err) {
-        console.error("[routing] performance profile load error:", err);
+  // Inject task-specific instructions from performance profile (if confident classification)
+  if (taskClassification.taskType !== "unknown" && taskClassification.confidence >= 0.5) {
+    try {
+      const profiles = await loadPerformanceProfiles(taskClassification.taskType);
+      // Find the best performance profile to inject guidance from
+      const profile = profiles[0];
+      if (profile?.currentInstructions) {
+        populatedPrompt += `\n\n--- TASK GUIDANCE ---\n${profile.currentInstructions}`;
       }
+    } catch (err) {
+      console.error("[routing] performance profile load error:", err);
     }
   }
 

--- a/apps/web/lib/agent-external-access-permission.ts
+++ b/apps/web/lib/agent-external-access-permission.ts
@@ -1,0 +1,95 @@
+import { prisma } from "@dpf/db";
+import type { ToolDefinition } from "@/lib/mcp-tools";
+
+type AccessDecision = "request" | "approval";
+
+const EXTERNAL_ACCESS_NEED_PATTERN =
+  /\b(external access|public web|web search|website|https?:\/\/|www\.|url|official source|authority source|look up|find online|google|latest (news|guidance|rate|rule|version)|recent (news|guidance|change|update)|research (online|public|official|website|web))\b/i;
+
+export function getExternalAccessToolSummaries(tools: ToolDefinition[]): Array<{
+  name: string;
+  description: string;
+}> {
+  const seen = new Set<string>();
+  return tools
+    .filter((tool) => tool.requiresExternalAccess)
+    .filter((tool) => {
+      if (seen.has(tool.name)) return false;
+      seen.add(tool.name);
+      return true;
+    })
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+    }));
+}
+
+export function shouldRequestExternalAccess(input: {
+  content: string;
+  taskRequiresWebSearch?: boolean;
+  externalTools: Array<{ name: string }>;
+}): boolean {
+  if (input.externalTools.length === 0) return false;
+  return input.taskRequiresWebSearch === true || EXTERNAL_ACCESS_NEED_PATTERN.test(input.content);
+}
+
+export function buildExternalAccessDisabledInstruction(
+  tools: Array<{ name: string; description: string }>,
+): string {
+  const toolList = tools.map((tool) => `- ${tool.name}: ${tool.description}`).join("\n");
+  return [
+    "",
+    "",
+    "--- EXTERNAL ACCESS DISABLED ---",
+    "The employee's request appears to need public web or official-source verification, but External Access is off for this page and session.",
+    "Do not fabricate, do not imply that you checked public sources, and do not create a backlog item for this permission boundary.",
+    "Instead, ask the employee to enable External Access, explain why it is needed in plain language, and name the first public sources or search targets you will check.",
+    "Preserve the task context so the employee can enable External Access and continue in this thread.",
+    "Tools that become available after enablement:",
+    toolList,
+  ].join("\n");
+}
+
+export async function recordExternalAccessPermissionAudit(input: {
+  decision: AccessDecision;
+  threadId: string;
+  agentId: string;
+  userId: string;
+  routeContext: string;
+  content: string;
+  requestedTools: string[];
+}) {
+  const isApproval = input.decision === "approval";
+  try {
+    await prisma.toolExecution.create({
+      data: {
+        threadId: input.threadId,
+        agentId: input.agentId,
+        userId: input.userId,
+        toolName: isApproval
+          ? "external_access_permission_approval"
+          : "external_access_permission_request",
+        parameters: {
+          requestedTools: input.requestedTools,
+          routeContext: input.routeContext,
+          userRequestPreview: input.content.slice(0, 500),
+        },
+        result: {
+          decision: input.decision,
+          status: isApproval ? "enabled_for_session" : "requested_from_user",
+        },
+        success: true,
+        executionMode: "permission",
+        routeContext: input.routeContext,
+        durationMs: 0,
+        auditClass: "ledger",
+        capabilityId: "web_search",
+        summary: isApproval
+          ? `External Access enabled for ${input.requestedTools.join(", ")}`
+          : `External Access requested for ${input.requestedTools.join(", ")}`,
+      },
+    });
+  } catch (err) {
+    console.warn("[external-access] permission audit failed:", err);
+  }
+}

--- a/apps/web/lib/tak/agent-routing.test.ts
+++ b/apps/web/lib/tak/agent-routing.test.ts
@@ -129,9 +129,10 @@ describe("resolveAgentForRoute", () => {
     expect(result.agentDescription).toBeTruthy();
   });
 
-  it("prefers codex for the build route by default", () => {
+  it("does not pin the build route to a single provider by default", () => {
     const result = resolveAgentForRoute("/build", superuser);
-    expect(result.modelRequirements?.preferredProviderId).toBe("codex");
+    expect(result.modelRequirements?.preferredProviderId).toBeUndefined();
+    expect(result.modelRequirements?.defaultMinimumTier).toBe("strong");
   });
 
   it("mentions public website branding analysis in the admin assistant prompt", () => {

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -120,6 +120,18 @@ describe("shouldNudge", () => {
     })).toBe(true);
   });
 
+  it("does not nudge governed External Access permission requests", () => {
+    expect(shouldNudge({
+      continuationNudges: 0,
+      iteration: 0,
+      maxIterations: 40,
+      hasTools: true,
+      executedToolCount: 0,
+      responseLength: 140,
+      responseText: "External Access is off for this page. Would you like me to use External Access so I can verify the official public sources before I answer?",
+    })).toBe(false);
+  });
+
   it("nudges when tools were used and model stalls with short response", () => {
     expect(shouldNudge({
       continuationNudges: 0, iteration: 3, maxIterations: 40,


### PR DESCRIPTION
## Summary
- Adds a shared External Access disabled instruction/audit helper used by the coworker send path when public web tools are withheld.
- Keeps External Access separate from unified Act mode and keeps the External Access toggle visible beside Act/Advise.
- Auto-continues the previous request after the user enables External Access, with session-scoped approval/request audit rows.

## Findings
- Before this branch, External Access requests were not universal: tools were filtered when access was off, while Finance had persona-specific prompt text.
- Hands On is form-assist permission for approved field updates; Build Studio supersedes Dev for platform-build work, but not Hands On. Dev still exists as a privileged diagnostic mode and should be folded into governed permission UX in a follow-up rather than removed here.

## Verification
- pnpm --filter web exec vitest run components/agent/agent-external-access-session.test.ts components/agent/coworker-runtime-mode.test.ts components/agent/AgentPanelHeader.test.tsx lib/actions/agent-coworker-external.test.ts lib/tak/agentic-loop.test.ts lib/mcp-tools.test.ts lib/tak/agent-grants.test.ts lib/tak/agent-routing.test.ts lib/tak/route-context.test.ts
- pnpm --filter web typecheck
- pnpm --filter web build
- Playwright smoke against http://127.0.0.1:4017/storefront verified the coworker panel renders Hands Off, Dev, External Access Off, and toggles External Access On.

Build note: production build passes with existing Turbopack broad NFT tracing warnings in spec-plan-search.ts / next.config.mjs.