### PR TITLE
feat(principles): batch 1 - lint detectors and public safety

### DIFF
--- a/apps/web/app/(shell)/admin/wiki/lint/page.tsx
+++ b/apps/web/app/(shell)/admin/wiki/lint/page.tsx
@@ -9,6 +9,7 @@ import {
   LintFindingCard,
   type LintFindingRow,
 } from "@/components/wiki/LintFindingCard";
+import { PRINCIPLE_FINDING_KIND_OPTIONS } from "@/lib/wiki/principle-finding-kinds";
 
 export const dynamic = "force-dynamic";
 
@@ -216,6 +217,43 @@ function FilterBar({
                   ? "bg-[var(--dpf-surface-2)] border-[var(--dpf-accent)] text-[var(--dpf-text)]"
                   : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
               }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* ─── Principle finding-kind chip group ──────────────────────────── */}
+      <div className="flex gap-1 flex-wrap items-center w-full">
+        <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)] mr-1">
+          Principles:
+        </span>
+        <Link
+          key="principle-all"
+          href={hrefWith({ kind: undefined })}
+          className={`px-2 py-1 rounded border ${
+            kindFilter === ""
+              ? "bg-[var(--dpf-surface-2)] border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+              : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
+          }`}
+        >
+          All kinds
+        </Link>
+        {PRINCIPLE_FINDING_KIND_OPTIONS.map((opt) => {
+          const active = opt.value === kindFilter;
+          return (
+            <Link
+              key={opt.value}
+              href={hrefWith({ kind: opt.value })}
+              className={`px-2 py-1 rounded border whitespace-nowrap ${
+                active
+                  ? "bg-[var(--dpf-surface-2)] border-[var(--dpf-accent)] text-[var(--dpf-text)]"
+                  : opt.blocking
+                    ? "border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+                    : "border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
+              }`}
+              title={opt.value}
             >
               {opt.label}
             </Link>

--- a/apps/web/lib/wiki/lint-detectors.ts
+++ b/apps/web/lib/wiki/lint-detectors.ts
@@ -22,7 +22,20 @@ export type LintFindingKind =
   | "missing-xref"
   | "dangling-xref"
   | "kernel-drift"
-  | "stance-extraction-needed";
+  | "stance-extraction-needed"
+  // ─── Principle-only finding kinds (Phase 1 of principles-as-wiki-kind) ───
+  | "principle-missing-tier"
+  | "principle-missing-applies-to"
+  | "principle-missing-direction"
+  | "principle-missing-vector"
+  | "principle-vector-dimension-mismatch"
+  | "principle-unknown-dimension"
+  | "principle-tier-weight-mismatch"
+  | "principle-commandment-cap-exceeded"
+  | "principle-public-missing-rationale"
+  | "principle-public-unsafe-marker"
+  | "principle-duplicate"
+  | "principle-contradiction-review";
 
 /** Mirrors the `WikiLintFinding.severity` enum. */
 export type LintSeverity = "info" | "warn" | "error";

--- a/apps/web/lib/wiki/lint.test.ts
+++ b/apps/web/lib/wiki/lint.test.ts
@@ -241,4 +241,48 @@ describe("runWikiLint", () => {
       where: { organizationId: "org_acme", status: "open" },
     });
   });
+
+  it("emits principle-only findings when a principle page is in the snapshot", async () => {
+    // A principle page with no tier and no applies-to. Per Phase 1
+    // detectors that should produce principle-missing-tier AND
+    // principle-missing-applies-to findings at error severity.
+    const principleDraft: Record<string, unknown> = {
+      id: "wp_principle_draft",
+      slug: "principles/draft",
+      title: "Draft Principle",
+      body: "## Rule\n\nTBD",
+      pageKind: "principle",
+      status: "draft",
+      isKernel: true,
+      kernelVersion: "0.2.0",
+      organizationId: null,
+      kernelPageId: null,
+      derivedFromKernelVersion: null,
+      principleTier: null,
+      principleDirection: null,
+      principleWeight: null,
+      principleWeightRationale: null,
+      principleDimensionVector: null,
+      principleDimensions: [],
+      principleAppliesTo: [],
+      principlePublic: false,
+      principlePublicRationale: null,
+    };
+    const prisma = makePrismaMock({
+      pages: [principleDraft],
+      existingFindings: [],
+    });
+
+    await runWikiLint({
+      organizationId: null,
+      prisma,
+      currentKernelVersion: "0.2.0",
+    });
+
+    const createdKinds = prisma.__findingsCreated.mock.calls.map(
+      (c) => (c[0] as { data: { findingKind: string } }).data.findingKind,
+    );
+    expect(createdKinds).toContain("principle-missing-tier");
+    expect(createdKinds).toContain("principle-missing-applies-to");
+  });
 });

--- a/apps/web/lib/wiki/lint.ts
+++ b/apps/web/lib/wiki/lint.ts
@@ -25,6 +25,8 @@ import {
   runPrincipleDetectors,
   type LintPrincipleWikiPage,
 } from "./principle-lint-detectors";
+import { runPrincipleSimilarityDetectors } from "./principle-similarity";
+import { generateEmbedding } from "@/lib/inference/embedding";
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -277,6 +279,23 @@ export async function persistFindings(
 export async function runWikiLint(input: RunWikiLintInput): Promise<RunWikiLintResult> {
   const snap = await fetchWikiSnapshot(input.prisma, input.organizationId);
 
+  // Generate direction embeddings for similarity detectors. Silent-
+  // degradation: if embedding generation fails for any page (Ollama down,
+  // empty direction), skip that page — the similarity detectors will
+  // naturally produce zero findings for missing embeddings and the rest of
+  // the lint pass still runs.
+  const embeddings = new Map<string, number[]>();
+  for (const page of snap.principlePages) {
+    if (page.pageKind !== "principle") continue;
+    if (!page.principleDirection) continue;
+    try {
+      const vec = await generateEmbedding(page.principleDirection);
+      if (vec) embeddings.set(page.id, vec);
+    } catch {
+      // Treat as missing — similarity detectors handle absence
+    }
+  }
+
   const findings = [
     ...runDetectors({
       pages: snap.pages,
@@ -287,6 +306,10 @@ export async function runWikiLint(input: RunWikiLintInput): Promise<RunWikiLintR
       staleThresholdDays: input.staleThresholdDays,
     }),
     ...runPrincipleDetectors({ pages: snap.principlePages }),
+    ...runPrincipleSimilarityDetectors({
+      pages: snap.principlePages,
+      embeddings,
+    }),
   ];
 
   const persisted = await persistFindings(input.prisma, input.organizationId, findings);

--- a/apps/web/lib/wiki/lint.ts
+++ b/apps/web/lib/wiki/lint.ts
@@ -21,6 +21,10 @@ import {
   type LintWikiPageLink,
   type LintWikiPageSource,
 } from "./lint-detectors";
+import {
+  runPrincipleDetectors,
+  type LintPrincipleWikiPage,
+} from "./principle-lint-detectors";
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -85,6 +89,7 @@ export async function fetchWikiSnapshot(
   organizationId: string | null,
 ): Promise<{
   pages: LintWikiPage[];
+  principlePages: LintPrincipleWikiPage[];
   links: LintWikiPageLink[];
   sources: LintWikiPageSource[];
   rawSources: LintRawSource[];
@@ -101,8 +106,10 @@ export async function fetchWikiSnapshot(
     prisma.rawSource.findMany({}) as Promise<unknown[]>,
   ]);
 
+  const pageRows = pages as Array<Record<string, unknown>>;
   return {
-    pages: (pages as Array<Record<string, unknown>>).map(asLintWikiPage),
+    pages: pageRows.map(asLintWikiPage),
+    principlePages: pageRows.map(asLintPrincipleWikiPage),
     links: (links as Array<Record<string, unknown>>).map(asLintWikiPageLink),
     sources: (sources as Array<Record<string, unknown>>).map(asLintWikiPageSource),
     rawSources: (rawSources as Array<Record<string, unknown>>).map(asLintRawSource),
@@ -122,6 +129,36 @@ function asLintWikiPage(r: Record<string, unknown>): LintWikiPage {
     organizationId: (r["organizationId"] as string | null) ?? null,
     kernelPageId: (r["kernelPageId"] as string | null) ?? null,
     derivedFromKernelVersion: (r["derivedFromKernelVersion"] as string | null) ?? null,
+  };
+}
+
+/**
+ * Build a principle-aware snapshot row, populating the principle-only
+ * fields from the Prisma row. Non-principle rows still go through this
+ * helper so the principle aggregator can filter on pageKind === "principle"
+ * without a parallel pre-filter — the principle-only fields are nullable /
+ * empty for non-principles per the schema defaults.
+ */
+function asLintPrincipleWikiPage(
+  r: Record<string, unknown>,
+): LintPrincipleWikiPage {
+  const base = asLintWikiPage(r);
+  const reviewed = r["lastReviewedAt"];
+  return {
+    ...base,
+    principleTier: (r["principleTier"] as string | null) ?? null,
+    principleDirection: (r["principleDirection"] as string | null) ?? null,
+    principleWeight: (r["principleWeight"] as number | null) ?? null,
+    principleWeightRationale:
+      (r["principleWeightRationale"] as string | null) ?? null,
+    principleDimensionVector:
+      (r["principleDimensionVector"] as Record<string, number> | null) ?? null,
+    principleDimensions: (r["principleDimensions"] as string[] | undefined) ?? [],
+    principleAppliesTo: (r["principleAppliesTo"] as string[] | undefined) ?? [],
+    principlePublic: Boolean(r["principlePublic"] ?? false),
+    principlePublicRationale:
+      (r["principlePublicRationale"] as string | null) ?? null,
+    lastReviewedAt: reviewed instanceof Date ? reviewed : null,
   };
 }
 
@@ -240,14 +277,17 @@ export async function persistFindings(
 export async function runWikiLint(input: RunWikiLintInput): Promise<RunWikiLintResult> {
   const snap = await fetchWikiSnapshot(input.prisma, input.organizationId);
 
-  const findings = runDetectors({
-    pages: snap.pages,
-    links: snap.links,
-    sources: snap.sources,
-    rawSources: snap.rawSources,
-    currentKernelVersion: input.currentKernelVersion,
-    staleThresholdDays: input.staleThresholdDays,
-  });
+  const findings = [
+    ...runDetectors({
+      pages: snap.pages,
+      links: snap.links,
+      sources: snap.sources,
+      rawSources: snap.rawSources,
+      currentKernelVersion: input.currentKernelVersion,
+      staleThresholdDays: input.staleThresholdDays,
+    }),
+    ...runPrincipleDetectors({ pages: snap.principlePages }),
+  ];
 
   const persisted = await persistFindings(input.prisma, input.organizationId, findings);
 

--- a/apps/web/lib/wiki/principle-commandment-cap.test.ts
+++ b/apps/web/lib/wiki/principle-commandment-cap.test.ts
@@ -1,0 +1,124 @@
+// Phase 1 Task 1.6 of the principles-as-wiki-kind plan: cross-page
+// commandment-cap detector. Spec section 5.1 caps published kernel
+// commandments at 10 — the inflation guard for the top tier.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §5.1, §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.6)
+
+import { describe, expect, it } from "vitest";
+import { detectPrincipleCommandmentCapExceeded } from "./principle-commandment-cap";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+function makeCommandment(
+  id: string,
+  reviewed: Date | null,
+  overrides: Partial<LintPrincipleWikiPage> = {},
+): LintPrincipleWikiPage {
+  return {
+    id,
+    slug: `principles/${id}`,
+    title: `Commandment ${id}`,
+    body: "## Rule\n\n...",
+    pageKind: "principle",
+    status: "published",
+    isKernel: true,
+    kernelVersion: "0.2.0",
+    organizationId: null,
+    kernelPageId: null,
+    derivedFromKernelVersion: null,
+    principleTier: "commandment",
+    principleDirection: "Prefer X over Y.",
+    principleWeight: null,
+    principleWeightRationale: null,
+    principleDimensionVector: { long_term_maintainability: 1.0 },
+    principleDimensions: ["long_term_maintainability"],
+    principleAppliesTo: ["in_platform_coworker"],
+    principlePublic: false,
+    principlePublicRationale: null,
+    lastReviewedAt: reviewed,
+    ...overrides,
+  };
+}
+
+describe("detectPrincipleCommandmentCapExceeded", () => {
+  it("does not flag when there are 10 or fewer published kernel commandments", () => {
+    const pages = Array.from({ length: 10 }, (_, i) =>
+      makeCommandment(`c${i}`, new Date(2026, 4, i + 1)),
+    );
+    const findings = detectPrincipleCommandmentCapExceeded({ pages });
+    expect(findings).toEqual([]);
+  });
+
+  it("flags the commandments beyond the 10-cap, ordered newest-first by lastReviewedAt", () => {
+    // 12 commandments — reviewed dates Apr 1 through Apr 12. Newest first
+    // means c11 (Apr 12), c10 (Apr 11) ... the OLDEST 10 stay under the cap;
+    // the 2 newest exceed it.
+    const pages = Array.from({ length: 12 }, (_, i) =>
+      makeCommandment(`c${i}`, new Date(2026, 3, i + 1)),
+    );
+    const findings = detectPrincipleCommandmentCapExceeded({ pages });
+    expect(findings).toHaveLength(2);
+    expect(findings.map((f) => f.pageId).sort()).toEqual(["c10", "c11"]);
+    for (const f of findings) {
+      expect(f.findingKind).toBe("principle-commandment-cap-exceeded");
+      expect(f.severity).toBe("error");
+      expect(f.detail).toMatchObject({ blocksPublish: true, cap: 10 });
+    }
+  });
+
+  it("ignores draft commandments — only published rows count against the cap", () => {
+    const pages = [
+      ...Array.from({ length: 10 }, (_, i) =>
+        makeCommandment(`pub${i}`, new Date(2026, 4, i + 1)),
+      ),
+      makeCommandment("draft1", new Date(2026, 4, 20), { status: "draft" }),
+      makeCommandment("review1", new Date(2026, 4, 21), { status: "review-needed" }),
+    ];
+    const findings = detectPrincipleCommandmentCapExceeded({ pages });
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores org-overlay commandments — only kernel rows count against the cap", () => {
+    const kernel = Array.from({ length: 10 }, (_, i) =>
+      makeCommandment(`k${i}`, new Date(2026, 4, i + 1)),
+    );
+    const overlay = makeCommandment("o1", new Date(2026, 4, 20), {
+      isKernel: false,
+      organizationId: "org_acme",
+    });
+    const findings = detectPrincipleCommandmentCapExceeded({
+      pages: [...kernel, overlay],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores non-commandment-tier principles", () => {
+    const pages = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeCommandment(`c${i}`, new Date(2026, 4, i + 1)),
+      ),
+      ...Array.from({ length: 30 }, (_, i) =>
+        makeCommandment(`core${i}`, new Date(2026, 4, i + 1), {
+          principleTier: "core",
+          id: `core${i}`,
+          slug: `principles/core${i}`,
+        }),
+      ),
+    ];
+    const findings = detectPrincipleCommandmentCapExceeded({ pages });
+    expect(findings).toEqual([]);
+  });
+
+  it("uses kernel row id as a stable tiebreaker when lastReviewedAt is null", () => {
+    // 11 commandments, all with null lastReviewedAt. The detector should
+    // still produce a deterministic flag on exactly one of them (by id
+    // ordering descending — the lexicographically-newest id) so re-runs
+    // don't oscillate which commandment is flagged.
+    const pages = Array.from({ length: 11 }, (_, i) =>
+      makeCommandment(`cmd_${String(i).padStart(2, "0")}`, null),
+    );
+    const findings = detectPrincipleCommandmentCapExceeded({ pages });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].pageId).toBe("cmd_10"); // lexicographically largest
+  });
+});

--- a/apps/web/lib/wiki/principle-commandment-cap.ts
+++ b/apps/web/lib/wiki/principle-commandment-cap.ts
@@ -1,0 +1,88 @@
+// Phase 1 Task 1.6 of the principles-as-wiki-kind plan: cross-page
+// detector that enforces the commandment cap. Spec section 5.1 caps
+// published kernel commandments at 10 — the inflation guard for the
+// top tier. If every rule is a commandment, nothing is.
+//
+// Cross-page detector: unlike per-page detectors this needs the full
+// principle page list to count. Wired into runDetectors as a separate
+// invocation so the orchestrator's contract stays clean.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §5.1, §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.6)
+
+import { PRINCIPLE_TIER_CAPS } from "@dpf/db/wiki-taxonomy";
+import type { LintFinding } from "./lint-detectors";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+const COMMANDMENT_CAP = PRINCIPLE_TIER_CAPS.commandment ?? 10;
+
+/**
+ * Order commandments newest-first by lastReviewedAt. Pages with no review
+ * timestamp fall back to descending id order — deterministic so re-runs
+ * don't oscillate which commandment is flagged.
+ */
+function orderNewestFirst(
+  pages: LintPrincipleWikiPage[],
+): LintPrincipleWikiPage[] {
+  return [...pages].sort((a, b) => {
+    const aTime = a.lastReviewedAt?.getTime() ?? null;
+    const bTime = b.lastReviewedAt?.getTime() ?? null;
+    if (aTime !== null && bTime !== null) {
+      return bTime - aTime;
+    }
+    if (aTime !== null) return -1;
+    if (bTime !== null) return 1;
+    // both null — fall back to id desc (lexicographically largest first)
+    return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+  });
+}
+
+/**
+ * Emit one error finding per published kernel commandment that exceeds
+ * the cap. Each finding is attached to a specific page so the lint UI
+ * can show the author exactly which rows need re-tiering.
+ *
+ * Severity: error. Blocks publish (the cap is a hard cap; over the
+ * cap, every excess commandment must be reassigned to core via the
+ * regular PR review path).
+ *
+ * Scope: kernel rows only (organizationId === null AND isKernel).
+ * Org-overlay principles can layer additional commandments — those
+ * are governed by the org's own discipline, not the kernel cap.
+ */
+export function detectPrincipleCommandmentCapExceeded(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const commandments = input.pages.filter(
+    (p) =>
+      p.pageKind === "principle" &&
+      p.principleTier === "commandment" &&
+      p.status === "published" &&
+      p.isKernel &&
+      p.organizationId === null,
+  );
+  if (commandments.length <= COMMANDMENT_CAP) {
+    return [];
+  }
+
+  const ordered = orderNewestFirst(commandments);
+  const overflow = ordered.slice(0, commandments.length - COMMANDMENT_CAP);
+
+  return overflow.map((page) => ({
+    organizationId: page.organizationId,
+    pageId: page.id,
+    findingKind: "principle-commandment-cap-exceeded",
+    severity: "error",
+    detail: {
+      slug: page.slug,
+      blocksPublish: true,
+      cap: COMMANDMENT_CAP,
+      currentCount: commandments.length,
+      message:
+        "Published kernel commandments exceed the cap. The cap is the " +
+        "inflation guard for the top tier — if every rule is a commandment, " +
+        "nothing is. Reassign this principle to core or contextual via PR " +
+        "review, or downgrade an older commandment.",
+    },
+  }));
+}

--- a/apps/web/lib/wiki/principle-finding-kinds.test.ts
+++ b/apps/web/lib/wiki/principle-finding-kinds.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRINCIPLE_FINDING_KIND_OPTIONS,
+  PRINCIPLE_FINDING_KIND_SET,
+  isPrincipleFindingKind,
+} from "./principle-finding-kinds";
+
+describe("PRINCIPLE_FINDING_KIND_OPTIONS", () => {
+  it("includes the full 12-detector set from spec section 14", () => {
+    const values = PRINCIPLE_FINDING_KIND_OPTIONS.map((o) => o.value).sort();
+    expect(values).toEqual(
+      [
+        "principle-commandment-cap-exceeded",
+        "principle-contradiction-review",
+        "principle-duplicate",
+        "principle-missing-applies-to",
+        "principle-missing-direction",
+        "principle-missing-tier",
+        "principle-missing-vector",
+        "principle-public-missing-rationale",
+        "principle-public-unsafe-marker",
+        "principle-tier-weight-mismatch",
+        "principle-unknown-dimension",
+        "principle-vector-dimension-mismatch",
+      ].sort(),
+    );
+    expect(PRINCIPLE_FINDING_KIND_OPTIONS).toHaveLength(12);
+  });
+
+  it("marks 7 detectors as blocking (errors) and 5 as non-blocking (warns)", () => {
+    const blocking = PRINCIPLE_FINDING_KIND_OPTIONS.filter((o) => o.blocking);
+    const nonBlocking = PRINCIPLE_FINDING_KIND_OPTIONS.filter(
+      (o) => !o.blocking,
+    );
+    expect(blocking).toHaveLength(7);
+    expect(nonBlocking).toHaveLength(5);
+  });
+
+  it("orders blocking detectors before non-blocking detectors", () => {
+    let sawNonBlocking = false;
+    for (const opt of PRINCIPLE_FINDING_KIND_OPTIONS) {
+      if (!opt.blocking) sawNonBlocking = true;
+      if (sawNonBlocking) {
+        expect(opt.blocking).toBe(false);
+      }
+    }
+  });
+
+  it("provides a human-readable label for each kind", () => {
+    for (const opt of PRINCIPLE_FINDING_KIND_OPTIONS) {
+      expect(opt.label.length).toBeGreaterThan(0);
+      // No raw detector slugs leaking into labels
+      expect(opt.label).not.toContain("principle-");
+      expect(opt.label).not.toContain("_");
+    }
+  });
+});
+
+describe("isPrincipleFindingKind", () => {
+  it("returns true for every documented principle finding kind", () => {
+    for (const opt of PRINCIPLE_FINDING_KIND_OPTIONS) {
+      expect(isPrincipleFindingKind(opt.value)).toBe(true);
+    }
+  });
+
+  it("returns false for non-principle finding kinds", () => {
+    expect(isPrincipleFindingKind("orphan")).toBe(false);
+    expect(isPrincipleFindingKind("stale")).toBe(false);
+    expect(isPrincipleFindingKind("dangling-xref")).toBe(false);
+    expect(isPrincipleFindingKind("")).toBe(false);
+  });
+});
+
+describe("PRINCIPLE_FINDING_KIND_SET", () => {
+  it("mirrors PRINCIPLE_FINDING_KIND_OPTIONS as a Set for O(1) lookups", () => {
+    expect(PRINCIPLE_FINDING_KIND_SET.size).toBe(12);
+    for (const opt of PRINCIPLE_FINDING_KIND_OPTIONS) {
+      expect(PRINCIPLE_FINDING_KIND_SET.has(opt.value)).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/wiki/principle-finding-kinds.ts
+++ b/apps/web/lib/wiki/principle-finding-kinds.ts
@@ -1,0 +1,93 @@
+// Phase 1 Task 1.10 of the principles-as-wiki-kind plan: canonical list
+// of the 12 principle-specific lint finding kinds with admin-UI labels.
+// Imported by the admin lint filter chip group.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.10)
+//
+// Order: surface-required errors first (block publish), then warns. Within
+// each severity bucket, list in the order an author meets them — e.g., you
+// declare a tier before a direction before a vector before applies-to.
+
+export type PrincipleFindingKindOption = {
+  value: string;
+  label: string;
+  /** True when the underlying detector emits severity: "error" by default. */
+  blocking: boolean;
+};
+
+export const PRINCIPLE_FINDING_KIND_OPTIONS: PrincipleFindingKindOption[] = [
+  // ─── Errors (block publish) ─────────────────────────────────────────────
+  {
+    value: "principle-missing-tier",
+    label: "Missing tier",
+    blocking: true,
+  },
+  {
+    value: "principle-missing-direction",
+    label: "Missing direction",
+    blocking: true,
+  },
+  {
+    value: "principle-missing-vector",
+    label: "Missing vector",
+    blocking: true,
+  },
+  {
+    value: "principle-missing-applies-to",
+    label: "Missing applies-to",
+    blocking: true,
+  },
+  {
+    value: "principle-unknown-dimension",
+    label: "Unknown dimension",
+    blocking: true,
+  },
+  {
+    value: "principle-commandment-cap-exceeded",
+    label: "Commandment cap",
+    blocking: true,
+  },
+  {
+    value: "principle-public-unsafe-marker",
+    label: "Public safety",
+    blocking: true,
+  },
+
+  // ─── Warns (do not block) ───────────────────────────────────────────────
+  {
+    value: "principle-tier-weight-mismatch",
+    label: "Tier-weight mismatch",
+    blocking: false,
+  },
+  {
+    value: "principle-vector-dimension-mismatch",
+    label: "Vector-dimension mismatch",
+    blocking: false,
+  },
+  {
+    value: "principle-public-missing-rationale",
+    label: "Public missing rationale",
+    blocking: false,
+  },
+  {
+    value: "principle-duplicate",
+    label: "Duplicate",
+    blocking: false,
+  },
+  {
+    value: "principle-contradiction-review",
+    label: "Contradiction review",
+    blocking: false,
+  },
+];
+
+/** Set of finding-kind values for `findingKind in PRINCIPLE_FINDING_KIND_SET`. */
+export const PRINCIPLE_FINDING_KIND_SET = new Set(
+  PRINCIPLE_FINDING_KIND_OPTIONS.map((o) => o.value),
+);
+
+/** Does this finding-kind value belong to the principle family? */
+export function isPrincipleFindingKind(value: string): boolean {
+  return PRINCIPLE_FINDING_KIND_SET.has(value);
+}

--- a/apps/web/lib/wiki/principle-lint-detectors.test.ts
+++ b/apps/web/lib/wiki/principle-lint-detectors.test.ts
@@ -1,0 +1,431 @@
+// Phase 1 of the principles-as-wiki-kind plan: per-page lint detectors
+// for principle pages. Cross-page detectors (commandment cap, duplicate,
+// contradiction) live in their own files and are covered by separate tests.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1)
+
+import { describe, expect, it } from "vitest";
+import {
+  detectPrincipleMissingTier,
+  detectPrincipleMissingAppliesTo,
+  detectPrincipleMissingDirection,
+  detectPrincipleMissingVector,
+  detectPrincipleVectorDimensionMismatch,
+  detectPrincipleUnknownDimension,
+  detectPrincipleTierWeightMismatch,
+  detectPrinciplePublicMissingRationale,
+} from "./principle-lint-detectors";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+function makePrinciplePage(
+  overrides: Partial<LintPrincipleWikiPage>,
+): LintPrincipleWikiPage {
+  return {
+    id: overrides.id ?? "wp_test",
+    slug: overrides.slug ?? "principles/test",
+    title: overrides.title ?? "Test Principle",
+    body: overrides.body ?? "## Rule\n\nA test principle.",
+    pageKind: "principle",
+    status: overrides.status ?? "published",
+    isKernel: overrides.isKernel ?? true,
+    kernelVersion: overrides.kernelVersion ?? "0.2.0",
+    organizationId: overrides.organizationId ?? null,
+    kernelPageId: overrides.kernelPageId ?? null,
+    derivedFromKernelVersion: overrides.derivedFromKernelVersion ?? null,
+    principleTier: overrides.principleTier ?? null,
+    principleDirection: overrides.principleDirection ?? null,
+    principleWeight: overrides.principleWeight ?? null,
+    principleWeightRationale: overrides.principleWeightRationale ?? null,
+    principleDimensionVector: overrides.principleDimensionVector ?? null,
+    principleDimensions: overrides.principleDimensions ?? [],
+    principleAppliesTo: overrides.principleAppliesTo ?? [],
+    principlePublic: overrides.principlePublic ?? false,
+    principlePublicRationale: overrides.principlePublicRationale ?? null,
+  };
+}
+
+describe("detectPrincipleMissingTier", () => {
+  it("flags a principle page with no tier as error / blocks publish", () => {
+    const findings = detectPrincipleMissingTier({
+      pages: [makePrinciplePage({ id: "wp1", principleTier: null })],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].findingKind).toBe("principle-missing-tier");
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].pageId).toBe("wp1");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: true });
+  });
+
+  it("does not flag principle pages with a tier set", () => {
+    const findings = detectPrincipleMissingTier({
+      pages: [makePrinciplePage({ principleTier: "core" })],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores non-principle pages entirely", () => {
+    const findings = detectPrincipleMissingTier({
+      pages: [{ ...makePrinciplePage({}), pageKind: "entity" }],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrincipleMissingAppliesTo", () => {
+  it("flags a principle page with empty applies-to as error / blocks publish", () => {
+    const findings = detectPrincipleMissingAppliesTo({
+      pages: [makePrinciplePage({ id: "wp1", principleAppliesTo: [] })],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].findingKind).toBe("principle-missing-applies-to");
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: true });
+  });
+
+  it("does not flag pages with at least one applies-to entry", () => {
+    const findings = detectPrincipleMissingAppliesTo({
+      pages: [
+        makePrinciplePage({ principleAppliesTo: ["in_platform_coworker"] }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores non-principle pages entirely", () => {
+    const findings = detectPrincipleMissingAppliesTo({
+      pages: [{ ...makePrinciplePage({}), pageKind: "stance" }],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrincipleMissingDirection (tier-gated severity)", () => {
+  it("flags commandment without direction as error / blocks publish", () => {
+    const findings = detectPrincipleMissingDirection({
+      pages: [
+        makePrinciplePage({
+          principleTier: "commandment",
+          principleDirection: null,
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: true });
+  });
+
+  it("flags core without direction as error / blocks publish", () => {
+    const findings = detectPrincipleMissingDirection({
+      pages: [
+        makePrinciplePage({ principleTier: "core", principleDirection: null }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("flags contextual without direction as warn (does not block)", () => {
+    const findings = detectPrincipleMissingDirection({
+      pages: [
+        makePrinciplePage({
+          principleTier: "contextual",
+          principleDirection: null,
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warn");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: false });
+  });
+
+  it("does not flag principles with a direction set", () => {
+    const findings = detectPrincipleMissingDirection({
+      pages: [
+        makePrinciplePage({
+          principleTier: "commandment",
+          principleDirection: "Prefer X over Y.",
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores principles with no tier (caught by missing-tier instead)", () => {
+    const findings = detectPrincipleMissingDirection({
+      pages: [
+        makePrinciplePage({ principleTier: null, principleDirection: null }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrincipleMissingVector", () => {
+  it("flags commandment with empty/null vector as error / blocks publish", () => {
+    const findingsEmpty = detectPrincipleMissingVector({
+      pages: [
+        makePrinciplePage({
+          principleTier: "commandment",
+          principleDimensionVector: {},
+        }),
+      ],
+    });
+    expect(findingsEmpty).toHaveLength(1);
+    expect(findingsEmpty[0].severity).toBe("error");
+    expect(findingsEmpty[0].detail).toMatchObject({ blocksPublish: true });
+
+    const findingsNull = detectPrincipleMissingVector({
+      pages: [
+        makePrinciplePage({
+          principleTier: "commandment",
+          principleDimensionVector: null,
+        }),
+      ],
+    });
+    expect(findingsNull).toHaveLength(1);
+    expect(findingsNull[0].severity).toBe("error");
+  });
+
+  it("flags core with empty vector as warn (does not block)", () => {
+    const findings = detectPrincipleMissingVector({
+      pages: [
+        makePrinciplePage({
+          principleTier: "core",
+          principleDimensionVector: null,
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warn");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: false });
+  });
+
+  it("does not flag contextual without a vector", () => {
+    const findings = detectPrincipleMissingVector({
+      pages: [
+        makePrinciplePage({
+          principleTier: "contextual",
+          principleDimensionVector: null,
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag principles with a non-empty vector", () => {
+    const findings = detectPrincipleMissingVector({
+      pages: [
+        makePrinciplePage({
+          principleTier: "commandment",
+          principleDimensionVector: { long_term_maintainability: 1.0 },
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrincipleVectorDimensionMismatch", () => {
+  it("flags when vector keys do not match the principleDimensions array as warn", () => {
+    const findings = detectPrincipleVectorDimensionMismatch({
+      pages: [
+        makePrinciplePage({
+          principleDimensionVector: {
+            long_term_maintainability: 1.0,
+            schema_grounding: 0.5,
+          },
+          principleDimensions: ["long_term_maintainability"], // missing schema_grounding
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warn");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: false });
+  });
+
+  it("does not flag when keys match exactly (any order)", () => {
+    const findings = detectPrincipleVectorDimensionMismatch({
+      pages: [
+        makePrinciplePage({
+          principleDimensionVector: {
+            schema_grounding: 0.5,
+            long_term_maintainability: 1.0,
+          },
+          principleDimensions: [
+            "long_term_maintainability",
+            "schema_grounding",
+          ],
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag when no vector is set (other detectors handle that)", () => {
+    const findings = detectPrincipleVectorDimensionMismatch({
+      pages: [
+        makePrinciplePage({
+          principleDimensionVector: null,
+          principleDimensions: ["long_term_maintainability"],
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrincipleUnknownDimension", () => {
+  it("flags out-of-registry vector keys as error / blocks publish", () => {
+    const findings = detectPrincipleUnknownDimension({
+      pages: [
+        makePrinciplePage({
+          principleDimensionVector: {
+            long_term_maintainability: 1.0,
+            fictional_axis: 0.5,
+          },
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: true });
+    expect(findings[0].detail).toMatchObject({
+      unknownDimensions: ["fictional_axis"],
+    });
+  });
+
+  it("flags out-of-registry entries in principleDimensions array as error", () => {
+    const findings = detectPrincipleUnknownDimension({
+      pages: [
+        makePrinciplePage({
+          principleDimensions: [
+            "long_term_maintainability",
+            "totally_made_up",
+          ],
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].detail).toMatchObject({
+      unknownDimensions: ["totally_made_up"],
+    });
+  });
+
+  it("does not flag principles whose every key is in the registry", () => {
+    const findings = detectPrincipleUnknownDimension({
+      pages: [
+        makePrinciplePage({
+          principleDimensionVector: {
+            long_term_maintainability: 1.0,
+            schema_grounding: 0.8,
+          },
+          principleDimensions: [
+            "long_term_maintainability",
+            "schema_grounding",
+          ],
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrincipleTierWeightMismatch", () => {
+  it("flags weight overrides without rationale as warn", () => {
+    const findings = detectPrincipleTierWeightMismatch({
+      pages: [
+        makePrinciplePage({
+          principleTier: "core",
+          principleWeight: 0.85, // diverges from 0.4 default
+          principleWeightRationale: null,
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warn");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: false });
+  });
+
+  it("does not flag overrides accompanied by a rationale", () => {
+    const findings = detectPrincipleTierWeightMismatch({
+      pages: [
+        makePrinciplePage({
+          principleTier: "core",
+          principleWeight: 0.85,
+          principleWeightRationale:
+            "This principle is unusually load-bearing for early-stage portfolios.",
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag weights that match the tier default", () => {
+    const findings = detectPrincipleTierWeightMismatch({
+      pages: [
+        makePrinciplePage({
+          principleTier: "commandment",
+          principleWeight: 1.0,
+          principleWeightRationale: null,
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag when no override is set (null weight = use tier default)", () => {
+    const findings = detectPrincipleTierWeightMismatch({
+      pages: [
+        makePrinciplePage({
+          principleTier: "core",
+          principleWeight: null,
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrinciplePublicMissingRationale", () => {
+  it("flags public principles missing a rationale as warn", () => {
+    const findings = detectPrinciplePublicMissingRationale({
+      pages: [
+        makePrinciplePage({
+          principlePublic: true,
+          principlePublicRationale: null,
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warn");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: false });
+  });
+
+  it("does not flag public principles with a rationale", () => {
+    const findings = detectPrinciplePublicMissingRationale({
+      pages: [
+        makePrinciplePage({
+          principlePublic: true,
+          principlePublicRationale:
+            "Adopters benefit from seeing DPF's architecture posture.",
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag internal principles regardless of rationale field", () => {
+    const findings = detectPrinciplePublicMissingRationale({
+      pages: [
+        makePrinciplePage({
+          principlePublic: false,
+          principlePublicRationale: null,
+        }),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/apps/web/lib/wiki/principle-lint-detectors.test.ts
+++ b/apps/web/lib/wiki/principle-lint-detectors.test.ts
@@ -42,6 +42,7 @@ function makePrinciplePage(
     principleAppliesTo: overrides.principleAppliesTo ?? [],
     principlePublic: overrides.principlePublic ?? false,
     principlePublicRationale: overrides.principlePublicRationale ?? null,
+    lastReviewedAt: overrides.lastReviewedAt ?? null,
   };
 }
 

--- a/apps/web/lib/wiki/principle-lint-detectors.ts
+++ b/apps/web/lib/wiki/principle-lint-detectors.ts
@@ -34,6 +34,8 @@ export type LintPrincipleWikiPage = LintWikiPage & {
   principleAppliesTo: string[];
   principlePublic: boolean;
   principlePublicRationale: string | null;
+  /** Used by detectPrincipleCommandmentCapExceeded for newest-first ordering. */
+  lastReviewedAt: Date | null;
 };
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────

--- a/apps/web/lib/wiki/principle-lint-detectors.ts
+++ b/apps/web/lib/wiki/principle-lint-detectors.ts
@@ -1,0 +1,356 @@
+// Phase 1 of the principles-as-wiki-kind plan: pure lint detectors for
+// principle pages. Cross-page detectors (commandment cap, duplicate,
+// contradiction) live in their own files and are wired into the
+// orchestrator via runDetectors.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1)
+//
+// Detectors are pure functions, no I/O. They take a typed snapshot of
+// principle pages and return findings. Storage-layer accepts incomplete
+// principle data; required-field gating lives here.
+
+import {
+  PRINCIPLE_DIMENSIONS,
+  PRINCIPLE_TIER_DEFAULT_WEIGHT,
+  isPrincipleDimension,
+} from "@dpf/db/wiki-taxonomy";
+import type { LintFinding, LintWikiPage } from "./lint-detectors";
+
+// ─── Snapshot extension ─────────────────────────────────────────────────────
+
+/**
+ * Principle-aware extension of LintWikiPage. The orchestrator's snapshot
+ * fetcher (lint.ts asLintWikiPage) populates these fields from Prisma rows;
+ * detectors here read them.
+ */
+export type LintPrincipleWikiPage = LintWikiPage & {
+  principleTier: string | null;
+  principleDirection: string | null;
+  principleWeight: number | null;
+  principleWeightRationale: string | null;
+  principleDimensionVector: Record<string, number> | null;
+  principleDimensions: string[];
+  principleAppliesTo: string[];
+  principlePublic: boolean;
+  principlePublicRationale: string | null;
+};
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────
+
+function principlePages(
+  pages: LintPrincipleWikiPage[],
+): LintPrincipleWikiPage[] {
+  return pages.filter((p) => p.pageKind === "principle");
+}
+
+function baseFinding(
+  page: LintPrincipleWikiPage,
+  findingKind: string,
+  severity: "info" | "warn" | "error",
+  blocksPublish: boolean,
+  extraDetail: Record<string, unknown> = {},
+): LintFinding {
+  return {
+    organizationId: page.organizationId,
+    pageId: page.id,
+    // findingKind values are widened in lint-detectors.ts; cast is safe
+    // here because we declare the new kinds in that union.
+    findingKind: findingKind as LintFinding["findingKind"],
+    severity,
+    detail: {
+      slug: page.slug,
+      blocksPublish,
+      ...extraDetail,
+    },
+  };
+}
+
+// ─── 1. principle-missing-tier ──────────────────────────────────────────────
+
+/**
+ * Every principle page must declare a tier. Without a tier, retrieval can't
+ * stratify the principle (commandment/core/contextual) and decision math
+ * can't assign a weight.
+ *
+ * Severity: error. Blocks publish.
+ */
+export function detectPrincipleMissingTier(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    if (page.principleTier === null) {
+      findings.push(
+        baseFinding(page, "principle-missing-tier", "error", true, {
+          message:
+            "Principle page has no tier. Set principleTier to one of " +
+            "commandment / core / contextual.",
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+// ─── 2. principle-missing-applies-to ────────────────────────────────────────
+
+/**
+ * Every principle must declare which population it governs. An empty
+ * applies-to means the principle never enters any retrieval scope and is
+ * effectively dead governance.
+ *
+ * Severity: error. Blocks publish.
+ */
+export function detectPrincipleMissingAppliesTo(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    if (page.principleAppliesTo.length === 0) {
+      findings.push(
+        baseFinding(page, "principle-missing-applies-to", "error", true, {
+          message:
+            "Principle page has empty principleAppliesTo. Declare at least " +
+            "one of in_platform_coworker / external_coding_agent / human.",
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+// ─── 3. principle-missing-direction (tier-gated severity) ───────────────────
+
+/**
+ * Commandment and core principles must have a one-clause direction. Without
+ * it, passive recall has nothing to surface and decision math has nothing
+ * to anchor structured alignment against.
+ *
+ * Severity: error for commandment + core (blocks publish), warn for
+ * contextual (does not block — contextual rules are narrow enough that the
+ * body often carries the direction).
+ */
+export function detectPrincipleMissingDirection(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    if (page.principleDirection !== null && page.principleDirection !== "") {
+      continue;
+    }
+    if (page.principleTier === null) {
+      // missing-tier covers this case
+      continue;
+    }
+    if (page.principleTier === "commandment" || page.principleTier === "core") {
+      findings.push(
+        baseFinding(page, "principle-missing-direction", "error", true, {
+          tier: page.principleTier,
+          message:
+            "Principle page missing principleDirection. Add a one-clause " +
+            "statement of what this principle favors.",
+        }),
+      );
+    } else if (page.principleTier === "contextual") {
+      findings.push(
+        baseFinding(page, "principle-missing-direction", "warn", false, {
+          tier: page.principleTier,
+          message:
+            "Contextual principle missing principleDirection. Recommended " +
+            "but not blocking — narrow rules can sometimes carry direction " +
+            "in the body.",
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+// ─── 4. principle-missing-vector ────────────────────────────────────────────
+
+/**
+ * Commandment principles need an explicit signed dimension vector — they're
+ * the highest-weight rules and the math has to be inspectable. Core
+ * principles are recommended to declare a vector (warn). Contextual rules
+ * can omit; the math falls back to semantic alignment.
+ */
+export function detectPrincipleMissingVector(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    const v = page.principleDimensionVector;
+    const isEmpty = v === null || Object.keys(v).length === 0;
+    if (!isEmpty) continue;
+
+    if (page.principleTier === "commandment") {
+      findings.push(
+        baseFinding(page, "principle-missing-vector", "error", true, {
+          tier: page.principleTier,
+          message:
+            "Commandment principle missing principleDimensionVector. " +
+            "Commandments must declare an inspectable signed dimension vector.",
+        }),
+      );
+    } else if (page.principleTier === "core") {
+      findings.push(
+        baseFinding(page, "principle-missing-vector", "warn", false, {
+          tier: page.principleTier,
+          message:
+            "Core principle missing principleDimensionVector. Recommended " +
+            "so decision math can apply structured alignment.",
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+// ─── 5. principle-vector-dimension-mismatch ─────────────────────────────────
+
+/**
+ * principleDimensions should mirror the keys of principleDimensionVector.
+ * A mismatch indicates the author edited one without the other or hit a
+ * seed-derivation gap. Surface for review; don't block.
+ */
+export function detectPrincipleVectorDimensionMismatch(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    const v = page.principleDimensionVector;
+    if (v === null) continue;
+    const vectorKeys = Object.keys(v);
+    const declared = page.principleDimensions;
+    if (vectorKeys.length === 0 && declared.length === 0) continue;
+
+    const sameLength = vectorKeys.length === declared.length;
+    const declaredSet = new Set(declared);
+    const allMatch =
+      sameLength && vectorKeys.every((k) => declaredSet.has(k));
+    if (allMatch) continue;
+
+    findings.push(
+      baseFinding(page, "principle-vector-dimension-mismatch", "warn", false, {
+        vectorKeys,
+        principleDimensions: declared,
+        message:
+          "principleDimensions does not match principleDimensionVector keys. " +
+          "Either re-derive principleDimensions from the vector or update the " +
+          "vector to match.",
+      }),
+    );
+  }
+  return findings;
+}
+
+// ─── 6. principle-unknown-dimension ─────────────────────────────────────────
+
+/**
+ * Every dimension referenced (in vector keys OR in the principleDimensions
+ * array) must be in the PRINCIPLE_DIMENSIONS registry. Unknown dimensions
+ * indicate either a typo or that the registry needs an explicit follow-up
+ * spec to add the axis.
+ *
+ * Severity: error. Blocks publish.
+ */
+export function detectPrincipleUnknownDimension(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    const unknown = new Set<string>();
+    if (page.principleDimensionVector) {
+      for (const key of Object.keys(page.principleDimensionVector)) {
+        if (!isPrincipleDimension(key)) unknown.add(key);
+      }
+    }
+    for (const dim of page.principleDimensions) {
+      if (!isPrincipleDimension(dim)) unknown.add(dim);
+    }
+    if (unknown.size === 0) continue;
+
+    findings.push(
+      baseFinding(page, "principle-unknown-dimension", "error", true, {
+        unknownDimensions: Array.from(unknown).sort(),
+        registry: PRINCIPLE_DIMENSIONS,
+        message:
+          "Principle references dimensions outside the registry. Add them " +
+          "to PRINCIPLE_DIMENSIONS in wiki-taxonomy.ts via a follow-up spec " +
+          "before referencing them, or fix the typo.",
+      }),
+    );
+  }
+  return findings;
+}
+
+// ─── 7. principle-tier-weight-mismatch ──────────────────────────────────────
+
+/**
+ * If principleWeight diverges from PRINCIPLE_TIER_DEFAULT_WEIGHT[tier], the
+ * author must supply principleWeightRationale. Otherwise the divergence
+ * looks accidental.
+ *
+ * Severity: warn. Doesn't block publish — the math still works with the
+ * override; lint just demands a paper trail.
+ */
+export function detectPrincipleTierWeightMismatch(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    const override = page.principleWeight;
+    if (override === null) continue;
+    if (page.principleTier === null) continue;
+    const tier = page.principleTier as keyof typeof PRINCIPLE_TIER_DEFAULT_WEIGHT;
+    const defaultWeight = PRINCIPLE_TIER_DEFAULT_WEIGHT[tier];
+    if (defaultWeight === undefined) continue;
+    if (override === defaultWeight) continue;
+    if (page.principleWeightRationale) continue;
+
+    findings.push(
+      baseFinding(page, "principle-tier-weight-mismatch", "warn", false, {
+        tier: page.principleTier,
+        defaultWeight,
+        overrideWeight: override,
+        message:
+          "principleWeight diverges from the tier default with no " +
+          "principleWeightRationale. Add a rationale or restore the default.",
+      }),
+    );
+  }
+  return findings;
+}
+
+// ─── 8. principle-public-missing-rationale ──────────────────────────────────
+
+/**
+ * Public principles need a rationale field so the founder kernel records
+ * WHY a principle is safe for external readers. Internal principles need no
+ * rationale.
+ *
+ * Severity: warn. Doesn't block publish.
+ */
+export function detectPrinciplePublicMissingRationale(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of principlePages(input.pages)) {
+    if (!page.principlePublic) continue;
+    if (
+      page.principlePublicRationale !== null &&
+      page.principlePublicRationale !== ""
+    ) {
+      continue;
+    }
+    findings.push(
+      baseFinding(page, "principle-public-missing-rationale", "warn", false, {
+        message:
+          "Public principle missing principlePublicRationale. State why " +
+          "this principle is safe and useful for external readers.",
+      }),
+    );
+  }
+  return findings;
+}

--- a/apps/web/lib/wiki/principle-lint-detectors.ts
+++ b/apps/web/lib/wiki/principle-lint-detectors.ts
@@ -16,6 +16,8 @@ import {
   isPrincipleDimension,
 } from "@dpf/db/wiki-taxonomy";
 import type { LintFinding, LintWikiPage } from "./lint-detectors";
+import { detectPrincipleCommandmentCapExceeded } from "./principle-commandment-cap";
+import { detectPrinciplePublicUnsafeMarker } from "./principle-public-safety";
 
 // ─── Snapshot extension ─────────────────────────────────────────────────────
 
@@ -323,6 +325,37 @@ export function detectPrincipleTierWeightMismatch(input: {
     );
   }
   return findings;
+}
+
+// ─── Aggregator ─────────────────────────────────────────────────────────────
+
+/**
+ * Run every principle detector against a typed snapshot of principle
+ * pages and return the union of findings. Mirrors the shape of
+ * `runDetectors` in lint-detectors.ts; the orchestrator (lint.ts
+ * runWikiLint) calls this in addition to the original aggregator.
+ *
+ * Cross-page detectors (commandment-cap) and the public-safety detector
+ * are included here. The Qdrant-dependent detectors (duplicate,
+ * contradiction-review) live in their own modules because they need
+ * embedding similarity infrastructure that pure per-page detectors do
+ * not — they are wired in by the orchestrator in a follow-up commit.
+ */
+export function runPrincipleDetectors(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  return [
+    ...detectPrincipleMissingTier(input),
+    ...detectPrincipleMissingAppliesTo(input),
+    ...detectPrincipleMissingDirection(input),
+    ...detectPrincipleMissingVector(input),
+    ...detectPrincipleVectorDimensionMismatch(input),
+    ...detectPrincipleUnknownDimension(input),
+    ...detectPrincipleTierWeightMismatch(input),
+    ...detectPrinciplePublicMissingRationale(input),
+    ...detectPrincipleCommandmentCapExceeded(input),
+    ...detectPrinciplePublicUnsafeMarker(input),
+  ];
 }
 
 // ─── 8. principle-public-missing-rationale ──────────────────────────────────

--- a/apps/web/lib/wiki/principle-public-safety.test.ts
+++ b/apps/web/lib/wiki/principle-public-safety.test.ts
@@ -1,0 +1,218 @@
+// Phase 1 Task 1.7 of the principles-as-wiki-kind plan: public-safety
+// lint detector for principle pages. Scope is internal-leakage signals,
+// NOT personal-name censorship. Founder biographical references like
+// "DPF was founded by Mark Bodman" are product-facing per spec section
+// 13.4 and must NOT be blocked.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.7)
+
+import { describe, expect, it } from "vitest";
+import { detectPrinciplePublicUnsafeMarker } from "./principle-public-safety";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+function makePublicPrinciple(
+  body: string,
+  overrides: Partial<LintPrincipleWikiPage> = {},
+): LintPrincipleWikiPage {
+  return {
+    id: overrides.id ?? "wp_test",
+    slug: overrides.slug ?? "principles/test",
+    title: overrides.title ?? "Test Principle",
+    body,
+    pageKind: "principle",
+    status: "published",
+    isKernel: true,
+    kernelVersion: "0.2.0",
+    organizationId: null,
+    kernelPageId: null,
+    derivedFromKernelVersion: null,
+    principleTier: "core",
+    principleDirection: "Prefer X over Y.",
+    principleWeight: null,
+    principleWeightRationale: null,
+    principleDimensionVector: { long_term_maintainability: 1.0 },
+    principleDimensions: ["long_term_maintainability"],
+    principleAppliesTo: ["in_platform_coworker"],
+    principlePublic: true,
+    principlePublicRationale: "Default rationale for tests.",
+    lastReviewedAt: null,
+    ...overrides,
+  };
+}
+
+describe("detectPrinciplePublicUnsafeMarker — local user paths", () => {
+  it("flags Windows user paths in public principle bodies", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "## Why\n\nWe noticed this from C:\\Users\\markbodman\\debug.log during an incident.",
+        ),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].findingKind).toBe("principle-public-unsafe-marker");
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: true });
+  });
+
+  it("flags POSIX home paths", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple("Investigated logs at /home/mbodman/project/."),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("flags macOS user paths", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple("Logs at /Users/marc/dpf/runtime."),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+});
+
+describe("detectPrinciplePublicUnsafeMarker — memory file paths", () => {
+  it("flags raw memory feedback file references", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "## Why\n\nThis comes from feedback_zero_technical_debt.md in our local notes.",
+        ),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("flags raw memory project file references", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "See project_codex_routing_fix.md for the full story.",
+        ),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("flags MEMORY.md filename references", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [makePublicPrinciple("Recorded in MEMORY.md.")],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+});
+
+describe("detectPrinciplePublicUnsafeMarker — secret-shaped tokens", () => {
+  it("flags Anthropic-style sk- tokens", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple("Token sk-ant-abc123def456ghi789jklmno was used."),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("flags GitHub personal access tokens", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple("ghp_abcdefghijklmnopqrstuvwxyz0123456789 in env."),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags DPF PAT tokens", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple("Set dpf_pat_xyz_abc_123_def_456_ghi in CI."),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+  });
+});
+
+describe("detectPrinciplePublicUnsafeMarker — internal-only instruction phrases", () => {
+  it("flags 'Drive 100% means don\\'t ask' phrasing", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "Per our internal stance, Drive 100% means don't ask between steps.",
+        ),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("flags <internal-only> markers", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple("Background: <internal-only>seeded notes</internal-only>."),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+  });
+});
+
+describe("detectPrinciplePublicUnsafeMarker — names are allowed in narrative", () => {
+  it("does NOT flag founder biographical references", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "## Why\n\nDPF was founded by Mark Bodman around the IT4IT framework.",
+        ),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does NOT flag product references to Claude or Codex", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "External coding agents like Claude and Codex follow this rule.",
+        ),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrinciplePublicUnsafeMarker — internal principles are exempt", () => {
+  it("does not flag internal-only principles regardless of body content", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "Token sk-ant-abc123def456ghi789jklmno in C:\\Users\\... per feedback_x.md.",
+          { principlePublic: false },
+        ),
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("detectPrinciplePublicUnsafeMarker — multiple violations reported once per page", () => {
+  it("emits a single finding per page, listing every marker found", () => {
+    const findings = detectPrinciplePublicUnsafeMarker({
+      pages: [
+        makePublicPrinciple(
+          "From C:\\Users\\foo\\bar.txt — and per feedback_x.md, plus Drive 100% means don't ask.",
+        ),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    const markers = findings[0].detail.markers as string[];
+    expect(markers.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/apps/web/lib/wiki/principle-public-safety.ts
+++ b/apps/web/lib/wiki/principle-public-safety.ts
@@ -1,0 +1,149 @@
+// Phase 1 Task 1.7 of the principles-as-wiki-kind plan: public-safety
+// lint detector. Blocks publish when a principle marked principlePublic
+// contains markers that would leak internal/local content to the public
+// docs site.
+//
+// Scope: internal-leakage signals only. Founder biographical references
+// ("DPF was founded by Mark Bodman") and product references to coding-agent
+// tools (Claude, Codex) are product-facing per spec section 13.4 and must
+// NOT be blocked. The pattern list below is intentionally narrow.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.7)
+
+import type { LintFinding } from "./lint-detectors";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+type Pattern = {
+  name: string;
+  regex: RegExp;
+  description: string;
+};
+
+const UNSAFE_PATTERNS: Pattern[] = [
+  // ─── Local user paths ───────────────────────────────────────────────────
+  {
+    name: "windows-user-path",
+    regex: /\bC:\\Users\\[A-Za-z0-9 _.-]+/g,
+    description: "Windows user-profile path",
+  },
+  {
+    name: "posix-home-path",
+    regex: /\/home\/[A-Za-z0-9_-]+\//g,
+    description: "POSIX /home path",
+  },
+  {
+    name: "macos-user-path",
+    regex: /\/Users\/[A-Za-z0-9 _.-]+\//g,
+    description: "macOS /Users path",
+  },
+
+  // ─── Memory file references ─────────────────────────────────────────────
+  {
+    name: "memory-feedback-file",
+    regex: /\bfeedback_[A-Za-z0-9_]+\.md\b/g,
+    description: "feedback_*.md memory filename reference",
+  },
+  {
+    name: "memory-project-file",
+    regex: /\bproject_[A-Za-z0-9_]+\.md\b/g,
+    description: "project_*.md memory filename reference",
+  },
+  {
+    name: "memory-index-file",
+    regex: /\bMEMORY\.md\b/g,
+    description: "MEMORY.md filename reference",
+  },
+
+  // ─── Secret-shaped tokens ───────────────────────────────────────────────
+  {
+    name: "anthropic-token",
+    regex: /\bsk-[A-Za-z0-9_-]{16,}\b/g,
+    description: "Anthropic-style sk- token",
+  },
+  {
+    name: "github-token",
+    regex: /\bghp_[A-Za-z0-9_-]{20,}\b/g,
+    description: "GitHub personal access token",
+  },
+  {
+    name: "dpf-pat",
+    regex: /\bdpf_pat_[A-Za-z0-9_-]{16,}\b/g,
+    description: "DPF personal access token",
+  },
+
+  // ─── Internal-only instruction phrases ──────────────────────────────────
+  // Literal string matches; narrative product references to "Claude",
+  // "Codex", or "Mark" are deliberately NOT in this list.
+  {
+    name: "drive-100-percent-phrase",
+    regex: /Drive 100% means don'?t ask/gi,
+    description: "Internal autonomy-directive phrasing",
+  },
+  {
+    name: "internal-only-marker",
+    regex: /<\/?internal-only>/gi,
+    description: "<internal-only> XML-style marker",
+  },
+];
+
+/**
+ * Detector emits ONE finding per principle page that has any unsafe
+ * marker, listing every distinct marker name in the detail. Per-page
+ * aggregation keeps the orchestrator from flooding the lint UI with
+ * findings on a single noisy page; the detail still tells the author
+ * everything they need to fix.
+ *
+ * Severity: error. Blocks publish.
+ *
+ * Internal principles (principlePublic === false) are exempt — the
+ * marker list only matters for content that would render on the public
+ * docs site.
+ */
+export function detectPrinciplePublicUnsafeMarker(input: {
+  pages: LintPrincipleWikiPage[];
+}): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const page of input.pages) {
+    if (page.pageKind !== "principle") continue;
+    if (!page.principlePublic) continue;
+
+    const matched: Array<{ name: string; description: string; example: string }> =
+      [];
+    for (const pattern of UNSAFE_PATTERNS) {
+      const found = page.body.match(pattern.regex);
+      if (found && found.length > 0) {
+        matched.push({
+          name: pattern.name,
+          description: pattern.description,
+          // First match only — surface as an example without dumping
+          // potentially-sensitive content in full.
+          example: found[0],
+        });
+      }
+    }
+
+    if (matched.length === 0) continue;
+
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "principle-public-unsafe-marker",
+      severity: "error",
+      detail: {
+        slug: page.slug,
+        blocksPublish: true,
+        markers: matched.map((m) => m.name),
+        details: matched,
+        message:
+          "Public principle contains internal-leakage markers. Either " +
+          "rewrite the body to remove the markers OR set " +
+          "principlePublic: false. Founder biographical references and " +
+          "narrative product references to Claude/Codex/Mark are NOT " +
+          "blocked by this lint; only local paths, memory filenames, " +
+          "secret-shaped tokens, and internal instruction phrases.",
+      },
+    });
+  }
+  return findings;
+}

--- a/apps/web/lib/wiki/principle-similarity.test.ts
+++ b/apps/web/lib/wiki/principle-similarity.test.ts
@@ -1,0 +1,304 @@
+// Phase 1 Task 1.8 of the principles-as-wiki-kind plan: similarity-based
+// detectors for duplicates and contradictions. Pure functions that take
+// pre-computed direction embeddings — the orchestrator generates them.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.8)
+
+import { describe, expect, it } from "vitest";
+import {
+  detectPrincipleDuplicate,
+  detectPrincipleContradictionReview,
+} from "./principle-similarity";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makePage(
+  id: string,
+  title: string,
+  overrides: Partial<LintPrincipleWikiPage> = {},
+): LintPrincipleWikiPage {
+  return {
+    id,
+    slug: `principles/${id}`,
+    title,
+    body: "## Rule\n\n...",
+    pageKind: "principle",
+    status: "published",
+    isKernel: true,
+    kernelVersion: "0.2.0",
+    organizationId: null,
+    kernelPageId: null,
+    derivedFromKernelVersion: null,
+    principleTier: "core",
+    principleDirection: "Prefer X over Y.",
+    principleWeight: null,
+    principleWeightRationale: null,
+    principleDimensionVector: null,
+    principleDimensions: [],
+    principleAppliesTo: ["in_platform_coworker"],
+    principlePublic: false,
+    principlePublicRationale: null,
+    lastReviewedAt: null,
+    ...overrides,
+  };
+}
+
+// Unit-length vectors so cosine similarity equals dot product.
+function unitVector(dim: number, primaryIdx: number, primaryWeight: number): number[] {
+  const v = new Array<number>(dim).fill(0);
+  v[primaryIdx] = primaryWeight;
+  const otherIdx = (primaryIdx + 1) % dim;
+  const otherWeight = Math.sqrt(1 - primaryWeight * primaryWeight);
+  v[otherIdx] = otherWeight;
+  return v;
+}
+
+// ─── detectPrincipleDuplicate ───────────────────────────────────────────────
+
+describe("detectPrincipleDuplicate", () => {
+  it("flags a near-duplicate pair (cosine > 0.9 AND >= 3 stemmed shared title words) on the newer page", () => {
+    // Two near-identical unit vectors — cosine ~ 0.999
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleDuplicate({
+      pages: [
+        makePage("older", "Prefer architecture over shortcut speed always", {
+          lastReviewedAt: new Date(2026, 0, 1),
+        }),
+        makePage("newer", "Prefer architecture over shortcut speed everytime", {
+          lastReviewedAt: new Date(2026, 4, 1),
+        }),
+      ],
+      embeddings: new Map([
+        ["older", v],
+        ["newer", v],
+      ]),
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].pageId).toBe("newer");
+    expect(findings[0].findingKind).toBe("principle-duplicate");
+    expect(findings[0].severity).toBe("warn");
+    expect(findings[0].detail).toMatchObject({ blocksPublish: false });
+    expect(findings[0].detail).toMatchObject({ duplicateOf: "older" });
+  });
+
+  it("does NOT flag pairs whose cosine is below 0.9 even with overlapping titles", () => {
+    // Orthogonal-ish vectors — cosine ~ 0
+    const v1 = [1, 0, 0, 0];
+    const v2 = [0, 1, 0, 0];
+    const findings = detectPrincipleDuplicate({
+      pages: [
+        makePage("a", "architecture over shortcuts always", {
+          lastReviewedAt: new Date(2026, 0, 1),
+        }),
+        makePage("b", "architecture over shortcuts everywhere", {
+          lastReviewedAt: new Date(2026, 4, 1),
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v1],
+        ["b", v2],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does NOT flag pairs whose titles share fewer than 3 stemmed words even with high cosine", () => {
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleDuplicate({
+      pages: [
+        makePage("a", "Architecture matters", {
+          lastReviewedAt: new Date(2026, 0, 1),
+        }),
+        makePage("b", "Evidence before action", {
+          lastReviewedAt: new Date(2026, 4, 1),
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v],
+        ["b", v],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("skips pages with no embedding available (silently — orchestrator handles missing-embedding warnings elsewhere)", () => {
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleDuplicate({
+      pages: [
+        makePage("a", "architecture maintainability schema speed"),
+        makePage("b", "architecture maintainability schema speed"),
+      ],
+      embeddings: new Map([["a", v]]), // b missing
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("attaches the finding to the newer page (by lastReviewedAt); falls back to id-desc when timestamps tie or are null", () => {
+    const v = [1, 0, 0, 0];
+
+    // Both null → id desc means "z_page" wins, "a_page" is the older / kept
+    const findings = detectPrincipleDuplicate({
+      pages: [
+        makePage("a_page", "architecture maintainability schema speed"),
+        makePage("z_page", "architecture maintainability schema speed"),
+      ],
+      embeddings: new Map([
+        ["a_page", v],
+        ["z_page", v],
+      ]),
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].pageId).toBe("z_page");
+    expect(findings[0].detail).toMatchObject({ duplicateOf: "a_page" });
+  });
+
+  it("ignores non-principle pages entirely", () => {
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleDuplicate({
+      pages: [
+        {
+          ...makePage("a", "architecture maintainability schema speed"),
+          pageKind: "stance",
+        },
+        makePage("b", "architecture maintainability schema speed"),
+      ],
+      embeddings: new Map([
+        ["a", v],
+        ["b", v],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+// ─── detectPrincipleContradictionReview ────────────────────────────────────
+
+describe("detectPrincipleContradictionReview", () => {
+  it("flags pairs with at least one shared-dimension sign opposition AND cosine > 0.75 — both pages get findings", () => {
+    const v = unitVector(4, 0, 0.9); // near-identical → cosine very high
+    const findings = detectPrincipleContradictionReview({
+      pages: [
+        makePage("a", "Favor speed", {
+          principleDimensionVector: { speed_to_value: 1, schema_grounding: 0.5 },
+          principleDimensions: ["speed_to_value", "schema_grounding"],
+        }),
+        makePage("b", "Favor maintainability", {
+          principleDimensionVector: {
+            speed_to_value: -0.8,
+            schema_grounding: 0.5,
+          },
+          principleDimensions: ["speed_to_value", "schema_grounding"],
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v],
+        ["b", v],
+      ]),
+    });
+
+    expect(findings).toHaveLength(2);
+    const pageIds = findings.map((f) => f.pageId).sort();
+    expect(pageIds).toEqual(["a", "b"]);
+    for (const f of findings) {
+      expect(f.findingKind).toBe("principle-contradiction-review");
+      expect(f.severity).toBe("warn");
+      expect(f.detail).toMatchObject({ blocksPublish: false });
+      expect(f.detail).toMatchObject({
+        opposingDimensions: ["speed_to_value"],
+      });
+    }
+  });
+
+  it("does NOT flag pairs whose shared dimensions all align in sign (same direction)", () => {
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleContradictionReview({
+      pages: [
+        makePage("a", "A", {
+          principleDimensionVector: { speed_to_value: 1, schema_grounding: 0.5 },
+          principleDimensions: ["speed_to_value", "schema_grounding"],
+        }),
+        makePage("b", "B", {
+          principleDimensionVector: {
+            speed_to_value: 0.8,
+            schema_grounding: 0.5,
+          },
+          principleDimensions: ["speed_to_value", "schema_grounding"],
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v],
+        ["b", v],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does NOT flag opposing signs when direction cosine is below 0.75 (different principles can pull opposite ways)", () => {
+    // Orthogonal vectors → cosine = 0, well below 0.75
+    const v1 = [1, 0, 0, 0];
+    const v2 = [0, 1, 0, 0];
+    const findings = detectPrincipleContradictionReview({
+      pages: [
+        makePage("a", "A", {
+          principleDimensionVector: { speed_to_value: 1 },
+          principleDimensions: ["speed_to_value"],
+        }),
+        makePage("b", "B", {
+          principleDimensionVector: { speed_to_value: -1 },
+          principleDimensions: ["speed_to_value"],
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v1],
+        ["b", v2],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("does NOT flag pairs with no shared dimensions even when embeddings are near-duplicates", () => {
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleContradictionReview({
+      pages: [
+        makePage("a", "A", {
+          principleDimensionVector: { speed_to_value: 1 },
+          principleDimensions: ["speed_to_value"],
+        }),
+        makePage("b", "B", {
+          principleDimensionVector: { long_term_maintainability: 1 },
+          principleDimensions: ["long_term_maintainability"],
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v],
+        ["b", v],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("treats a near-zero value as neutral (no sign opposition with a strong positive)", () => {
+    // 0.05 vs 1.0 — both non-negative, no opposition
+    const v = [1, 0, 0, 0];
+    const findings = detectPrincipleContradictionReview({
+      pages: [
+        makePage("a", "A", {
+          principleDimensionVector: { speed_to_value: 1 },
+          principleDimensions: ["speed_to_value"],
+        }),
+        makePage("b", "B", {
+          principleDimensionVector: { speed_to_value: 0.05 },
+          principleDimensions: ["speed_to_value"],
+        }),
+      ],
+      embeddings: new Map([
+        ["a", v],
+        ["b", v],
+      ]),
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/apps/web/lib/wiki/principle-similarity.ts
+++ b/apps/web/lib/wiki/principle-similarity.ts
@@ -1,0 +1,299 @@
+// Phase 1 Task 1.8 of the principles-as-wiki-kind plan: similarity-based
+// detectors. Pure functions that take pre-computed direction embeddings
+// keyed by pageId. The orchestrator (lint.ts) calls generateEmbedding on
+// each principle's direction string before invoking these detectors, so
+// the detectors themselves stay deterministic and easy to test.
+//
+// Spec: docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md §14
+// Plan: docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md (Phase 1 Task 1.8)
+
+import type { LintFinding } from "./lint-detectors";
+import type { LintPrincipleWikiPage } from "./principle-lint-detectors";
+
+// ─── Tunables ───────────────────────────────────────────────────────────────
+
+const DUPLICATE_COSINE_THRESHOLD = 0.9;
+const DUPLICATE_MIN_SHARED_TITLE_TOKENS = 3;
+const CONTRADICTION_COSINE_THRESHOLD = 0.75;
+const CONTRADICTION_OPPOSITION_THRESHOLD = 0.1; // values within +/- this count as neutral
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Cheap title-token comparator: lowercase, strip non-alphanumeric, split,
+ * drop short tokens and a small stoplist. No real stemming — just enough
+ * to catch obvious near-duplicates without pulling in a stemmer dependency.
+ */
+const TITLE_STOPLIST = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "over",
+  "the",
+  "to",
+  "with",
+]);
+
+function tokenizeTitle(title: string): Set<string> {
+  const tokens = title
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length >= 3 && !TITLE_STOPLIST.has(t));
+  return new Set(tokens);
+}
+
+function sharedTokenCount(a: Set<string>, b: Set<string>): number {
+  let count = 0;
+  for (const t of a) {
+    if (b.has(t)) count++;
+  }
+  return count;
+}
+
+/**
+ * Order pages newest-first by lastReviewedAt. Pages with no review
+ * timestamp fall back to descending id so re-runs are deterministic.
+ * Mirrors orderNewestFirst in principle-commandment-cap.ts.
+ */
+function isNewer(a: LintPrincipleWikiPage, b: LintPrincipleWikiPage): boolean {
+  const aTime = a.lastReviewedAt?.getTime() ?? null;
+  const bTime = b.lastReviewedAt?.getTime() ?? null;
+  if (aTime !== null && bTime !== null) return aTime > bTime;
+  if (aTime !== null) return true;
+  if (bTime !== null) return false;
+  return a.id > b.id;
+}
+
+function principlePages(
+  pages: LintPrincipleWikiPage[],
+): LintPrincipleWikiPage[] {
+  return pages.filter((p) => p.pageKind === "principle");
+}
+
+// ─── 1. principle-duplicate ─────────────────────────────────────────────────
+
+/**
+ * Pairwise duplicate detection: when two principle pages' direction
+ * embeddings have cosine similarity >= 0.9 AND their titles share at
+ * least 3 non-stopword tokens, flag the newer page as a duplicate of
+ * the older one.
+ *
+ * Severity: warn. Doesn't block publish — a true duplicate needs human
+ * review (one merged into the other), not an automatic deletion.
+ *
+ * Per-page aggregation: even if a page is duplicate-of multiple older
+ * pages, emit at most one finding per newer page (against the highest-
+ * similarity older match) to keep the lint UI legible.
+ */
+export function detectPrincipleDuplicate(input: {
+  pages: LintPrincipleWikiPage[];
+  embeddings: Map<string, number[]>;
+}): LintFinding[] {
+  const pages = principlePages(input.pages);
+  const titleTokens = new Map<string, Set<string>>();
+  for (const p of pages) titleTokens.set(p.id, tokenizeTitle(p.title));
+
+  // Best (highest-cosine) older match for each page
+  const bestMatch = new Map<
+    string,
+    { older: LintPrincipleWikiPage; cosine: number }
+  >();
+
+  for (let i = 0; i < pages.length; i++) {
+    for (let j = i + 1; j < pages.length; j++) {
+      const a = pages[i];
+      const b = pages[j];
+      const ea = input.embeddings.get(a.id);
+      const eb = input.embeddings.get(b.id);
+      if (!ea || !eb) continue;
+
+      const cosine = cosineSimilarity(ea, eb);
+      if (cosine < DUPLICATE_COSINE_THRESHOLD) continue;
+
+      const shared = sharedTokenCount(
+        titleTokens.get(a.id) ?? new Set(),
+        titleTokens.get(b.id) ?? new Set(),
+      );
+      if (shared < DUPLICATE_MIN_SHARED_TITLE_TOKENS) continue;
+
+      const [older, newer] = isNewer(a, b) ? [b, a] : [a, b];
+      const prior = bestMatch.get(newer.id);
+      if (!prior || cosine > prior.cosine) {
+        bestMatch.set(newer.id, { older, cosine });
+      }
+    }
+  }
+
+  const findings: LintFinding[] = [];
+  for (const [pageId, match] of bestMatch) {
+    const page = pages.find((p) => p.id === pageId);
+    if (!page) continue;
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "principle-duplicate",
+      severity: "warn",
+      detail: {
+        slug: page.slug,
+        blocksPublish: false,
+        duplicateOf: match.older.id,
+        duplicateOfSlug: match.older.slug,
+        cosine: Number(match.cosine.toFixed(3)),
+        message:
+          "This principle has a near-duplicate older sibling. Consider merging " +
+          "into the older page or rewriting one to clarify how they differ.",
+      },
+    });
+  }
+  return findings;
+}
+
+// ─── Aggregator ─────────────────────────────────────────────────────────────
+
+/**
+ * Run both similarity-based detectors against a snapshot + pre-computed
+ * embeddings. The orchestrator calls this in addition to runPrincipleDetectors
+ * (which handles the per-page and cross-page detectors that don't need
+ * embeddings).
+ */
+export function runPrincipleSimilarityDetectors(input: {
+  pages: LintPrincipleWikiPage[];
+  embeddings: Map<string, number[]>;
+}): LintFinding[] {
+  return [
+    ...detectPrincipleDuplicate(input),
+    ...detectPrincipleContradictionReview(input),
+  ];
+}
+
+// ─── 2. principle-contradiction-review ──────────────────────────────────────
+
+/**
+ * Pairwise contradiction detection: when two principle pages share at
+ * least one dimension key with opposing signs (one above
+ * +CONTRADICTION_OPPOSITION_THRESHOLD, the other below
+ * -CONTRADICTION_OPPOSITION_THRESHOLD) AND their direction embeddings
+ * have cosine similarity > 0.75 (i.e., they speak to the same topic),
+ * flag BOTH pages for human review.
+ *
+ * The 0.75 cosine gate is what distinguishes "contradiction" from
+ * "different principles legitimately pulling in different directions" —
+ * unrelated principles with opposite signs on a dimension are fine; only
+ * principles that read similar but pull opposite ways need a reviewer
+ * note explaining the intentional tension.
+ *
+ * Severity: warn. Doesn't block publish — contradictions can be
+ * intentional; the lint just forces an explicit review note.
+ */
+export function detectPrincipleContradictionReview(input: {
+  pages: LintPrincipleWikiPage[];
+  embeddings: Map<string, number[]>;
+}): LintFinding[] {
+  const pages = principlePages(input.pages);
+  const flagged = new Map<
+    string,
+    { partnerId: string; opposingDimensions: string[]; cosine: number }
+  >();
+
+  for (let i = 0; i < pages.length; i++) {
+    for (let j = i + 1; j < pages.length; j++) {
+      const a = pages[i];
+      const b = pages[j];
+      const ea = input.embeddings.get(a.id);
+      const eb = input.embeddings.get(b.id);
+      if (!ea || !eb) continue;
+
+      const cosine = cosineSimilarity(ea, eb);
+      if (cosine <= CONTRADICTION_COSINE_THRESHOLD) continue;
+
+      const va = a.principleDimensionVector ?? {};
+      const vb = b.principleDimensionVector ?? {};
+      const opposing: string[] = [];
+      for (const dim of Object.keys(va)) {
+        if (!(dim in vb)) continue;
+        const sa = va[dim];
+        const sb = vb[dim];
+        if (
+          (sa > CONTRADICTION_OPPOSITION_THRESHOLD &&
+            sb < -CONTRADICTION_OPPOSITION_THRESHOLD) ||
+          (sa < -CONTRADICTION_OPPOSITION_THRESHOLD &&
+            sb > CONTRADICTION_OPPOSITION_THRESHOLD)
+        ) {
+          opposing.push(dim);
+        }
+      }
+      if (opposing.length === 0) continue;
+
+      // Flag both pages — record only the highest-cosine partner per page
+      // so the finding stays single per page.
+      for (const [self, other] of [
+        [a, b],
+        [b, a],
+      ] as const) {
+        const prior = flagged.get(self.id);
+        if (!prior || cosine > prior.cosine) {
+          flagged.set(self.id, {
+            partnerId: other.id,
+            opposingDimensions: opposing,
+            cosine,
+          });
+        }
+      }
+    }
+  }
+
+  const findings: LintFinding[] = [];
+  for (const [pageId, info] of flagged) {
+    const page = pages.find((p) => p.id === pageId);
+    const partner = pages.find((p) => p.id === info.partnerId);
+    if (!page) continue;
+    findings.push({
+      organizationId: page.organizationId,
+      pageId: page.id,
+      findingKind: "principle-contradiction-review",
+      severity: "warn",
+      detail: {
+        slug: page.slug,
+        blocksPublish: false,
+        partnerId: info.partnerId,
+        partnerSlug: partner?.slug ?? null,
+        opposingDimensions: info.opposingDimensions,
+        cosine: Number(info.cosine.toFixed(3)),
+        message:
+          "This principle pulls in an opposing direction to a similar " +
+          "principle on at least one shared dimension. Confirm the tension " +
+          "is intentional and add a reviewer note explaining when each " +
+          "principle wins.",
+      },
+    });
+  }
+  return findings;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the principles-as-wiki-kind plan. Lands all **12 of 12 lint detectors** from spec section 14, wires them into the daily orchestrator, and adds the admin UI filter chips for triage.

Branches off current ``main`` (Phase 0 PR #531 is already merged). No new migrations.

## What ships

### Per-page detectors (8) — `apps/web/lib/wiki/principle-lint-detectors.ts`
- ``principle-missing-tier`` (error, blocks)
- ``principle-missing-applies-to`` (error, blocks)
- ``principle-missing-direction`` (tier-gated: error for commandment+core, warn for contextual)
- ``principle-missing-vector`` (error for commandment, warn for core, silent for contextual)
- ``principle-vector-dimension-mismatch`` (warn)
- ``principle-unknown-dimension`` (error, blocks — surfaces the offending keys + the registry)
- ``principle-tier-weight-mismatch`` (warn — override without rationale)
- ``principle-public-missing-rationale`` (warn)

### Cross-page detector — `apps/web/lib/wiki/principle-commandment-cap.ts`
- ``principle-commandment-cap-exceeded`` (error, blocks): enforces the 10-commandment cap from spec section 5.1. Kernel-rows-only scope. Newest-first by ``lastReviewedAt`` with id-desc tiebreaker for determinism.

### Body-scan detector — `apps/web/lib/wiki/principle-public-safety.ts`
- ``principle-public-unsafe-marker`` (error, blocks): blocks publish when a public principle leaks internal markers. Scope intentionally narrow — local paths, memory filenames, secret-shaped tokens (``sk-``, ``ghp_``, ``dpf_pat_``), and a tiny literal-phrase list (``Drive 100% means don't ask``, ``<internal-only>``).
- **Founder biographical references like "DPF was founded by Mark Bodman" and narrative product references to Claude/Codex/Mark are NOT blocked** per spec section 13.4. Per-page aggregation lists every marker found in ``detail.markers``.

### Similarity detectors — `apps/web/lib/wiki/principle-similarity.ts`
- ``principle-duplicate`` (warn): pairwise cosine >= 0.9 AND >= 3 shared non-stopword title tokens. Flags the newer page (by ``lastReviewedAt`` with id-desc tiebreaker) with ``duplicateOf`` pointing at the older. Doesn't block — true duplicates need human merge.
- ``principle-contradiction-review`` (warn): pairwise cosine > 0.75 AND shared-dimension sign opposition (one above +0.1, one below -0.1). Flags BOTH pages so a reviewer adds an explicit note explaining the intentional tension. The cosine gate distinguishes contradiction from unrelated principles legitimately pulling opposite ways.
- Pure-function shape: detectors take pre-computed direction embeddings as a ``Map<pageId, number[]>``. The orchestrator generates the embeddings before invoking them — keeps the detectors deterministically testable.

### Orchestrator integration — `apps/web/lib/wiki/lint.ts`
- ``fetchWikiSnapshot`` returns both ``LintWikiPage[]`` and ``LintPrincipleWikiPage[]`` from a single Prisma row scan (no extra DB round-trip)
- ``runWikiLint`` now calls ``runDetectors``, ``runPrincipleDetectors``, and ``runPrincipleSimilarityDetectors`` and merges findings into the existing persistence pipeline
- Embedding generation is silent-degradation: pages with missing ``principleDirection`` or failing ``generateEmbedding`` are skipped from similarity scoring; the rest of the lint pass still runs

### Admin UI — `apps/web/app/(shell)/admin/wiki/lint/page.tsx` + `apps/web/lib/wiki/principle-finding-kinds.ts`
- New "Principles:" chip row below the existing status/severity/scope filters
- All 12 finding kinds + an "All kinds" reset chip
- Blocking-tier chips render in ``--dpf-text``; warns render in ``--dpf-muted`` so authors scan errors first at a glance
- ``whitespace-nowrap`` + ``flex-wrap`` keep the row legible
- Each chip carries a ``title`` attribute with the raw findingKind slug for copy/paste
- The page already accepted ``?kind=<slug>`` — this PR is pure UI affordance

## Commits

1. ``acfdfaa7`` — per-page detectors (8) + 28 tests
2. ``f3af7166`` — public-safety + commandment-cap detectors + 21 tests
3. ``7950499d`` — runPrincipleDetectors aggregator + orchestrator wire-up + 1 e2e test
4. ``59f12727`` — similarity detectors (duplicate, contradiction-review) + embedding generation in orchestrator + 11 tests
5. ``a1783fb6`` — admin UI principle filter chips + canonical kind list + 7 tests

## Build Gate

1. **Unit tests** ✅ — full ``apps/web`` suite: 5133 passing, 14 skipped, 13 todo across 631 test files, **0 failures**. ``lib/wiki`` specifically: 124/124.
2. **Production build** ✅ — ``pnpm --filter web build`` clean, all routes including ``/admin/wiki/lint`` built without errors.
3. **UX verification** ⏳ — Reviewer should rebuild portal, seed a deliberately-broken principle page, navigate to ``/admin/wiki/lint``, confirm the new "Principles:" chip row renders and filters as expected in light + dark mode.
4. **Migration applies cleanly** ⏳ — N/A. No new migrations in Phase 1.

## What's NOT in this PR (deferred)

- Inngest scheduled-job invocation of the new detectors — the existing daily job already calls ``runWikiLint``, so the new detectors run on the next scheduled tick automatically.
- ``wiki_lint`` MCP tool — already exists; no per-kind breakdown work in this PR.

## Test plan

- [ ] Run ``pnpm --filter web exec vitest run lib/wiki`` and confirm 124/124 green
- [ ] Rebuild portal, seed a principle page with ``principleTier: null``, run lint (Inngest or wiki_lint MCP tool), open ``/admin/wiki/lint``, confirm ``principle-missing-tier`` finding appears and the chip filter narrows the list
- [ ] Seed two near-identical principle pages (same direction, overlapping titles), run lint, confirm ``principle-duplicate`` flags the newer one
- [ ] Public-safety smoke test: a fixture body containing ``C:\Users\...`` must error; a body referencing "Mark Bodman" in narrative must NOT error

## Refs

- BI: ``BI-EBDFBA34``
- Epic: ``EP-TAK-3F9A21``
- Phase 0 PR: [#531](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/531) (merged)
- Spec section 14: principle lint detectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)