### PR TITLE
feat(ai): add remote autonomous coworker submission

### DIFF
--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -12,9 +12,23 @@ vi.mock("@/lib/mcp-governed-execute", () => ({
   governedExecuteTool: vi.fn(),
 }));
 
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: vi.fn(),
+  executeAutonomousAgenticLoop: vi.fn(),
+  resolveAutonomousWorkAgent: vi.fn(),
+  resolveAutonomousWorkTools: vi.fn(),
+}));
+
+vi.mock("@/lib/tak/task-records", () => ({
+  createTaskMessage: vi.fn(),
+}));
+
 vi.mock("@dpf/db", () => ({
   prisma: {
     user: { findUnique: vi.fn() },
+    taskRun: { findFirst: vi.fn(), update: vi.fn() },
+    agentThread: { upsert: vi.fn() },
+    taskMessage: { create: vi.fn() },
   },
 }));
 
@@ -22,12 +36,27 @@ import { prisma } from "@dpf/db";
 import { resolveMcpApiToken } from "@/lib/auth/mcp-api-token";
 import { verifyMcpSessionToken } from "@/lib/mcp/session-token";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
+import {
+  createAutonomousWorkRun,
+  executeAutonomousAgenticLoop,
+  resolveAutonomousWorkAgent,
+  resolveAutonomousWorkTools,
+} from "@/lib/tak/autonomous-work-run";
+import { createTaskMessage } from "@/lib/tak/task-records";
 import { GET, POST } from "./route";
 
 const resolveMock = resolveMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const verifySessionMock = verifyMcpSessionToken as unknown as ReturnType<typeof vi.fn>;
 const govMock = governedExecuteTool as unknown as ReturnType<typeof vi.fn>;
 const userMock = prisma.user.findUnique as unknown as ReturnType<typeof vi.fn>;
+const taskRunFindFirstMock = prisma.taskRun.findFirst as unknown as ReturnType<typeof vi.fn>;
+const taskRunUpdateMock = prisma.taskRun.update as unknown as ReturnType<typeof vi.fn>;
+const agentThreadUpsertMock = prisma.agentThread.upsert as unknown as ReturnType<typeof vi.fn>;
+const createRunMock = createAutonomousWorkRun as unknown as ReturnType<typeof vi.fn>;
+const executeLoopMock = executeAutonomousAgenticLoop as unknown as ReturnType<typeof vi.fn>;
+const resolveAgentMock = resolveAutonomousWorkAgent as unknown as ReturnType<typeof vi.fn>;
+const resolveToolsMock = resolveAutonomousWorkTools as unknown as ReturnType<typeof vi.fn>;
+const createTaskMessageMock = createTaskMessage as unknown as ReturnType<typeof vi.fn>;
 
 function makeRequest(opts: {
   url?: string;
@@ -66,6 +95,19 @@ beforeEach(() => {
     isSuperuser: true,
     groups: [{ platformRole: { roleId: "HR-000" } }],
   } as never);
+  taskRunFindFirstMock.mockResolvedValue(null);
+  taskRunUpdateMock.mockResolvedValue({} as never);
+  agentThreadUpsertMock.mockResolvedValue({ id: "thread-remote-1" } as never);
+  createRunMock.mockResolvedValue({ id: "task-row-1", taskRunId: "TR-MCP-12345678", contextId: "thread-remote-1" } as never);
+  resolveAgentMock.mockResolvedValue({
+    agentId: "AGT-REMOTE",
+    systemPrompt: "You are a governed autonomous coworker.",
+    sensitivity: "internal",
+    displayName: "Remote Coworker",
+  } as never);
+  resolveToolsMock.mockResolvedValue({ tools: [], toolsForProvider: [] } as never);
+  executeLoopMock.mockResolvedValue({ content: "Done.", executedTools: [] } as never);
+  createTaskMessageMock.mockResolvedValue(undefined as never);
 });
 
 afterEach(() => {
@@ -715,5 +757,214 @@ describe("POST — ping", () => {
     );
     const body = await res.json();
     expect(body.result).toEqual({});
+  });
+});
+
+describe("POST — tasks/submit", () => {
+  it("returns invalid_params when idempotencyKey or riskClass is missing", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_x",
+      userId: "u1",
+      agentId: "AGT-REMOTE",
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 11,
+          method: "tasks/submit",
+          params: {
+            agentId: "AGT-REMOTE",
+            routeContext: "/platform/tools/discovery",
+            objective: "Investigate discovery backlog.",
+            prompt: "Summarize discovery backlog.",
+          },
+        },
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(createRunMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects write-risk submissions from read-only tokens before creating a TaskRun", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_read",
+      userId: "u1",
+      agentId: "AGT-REMOTE",
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 12,
+          method: "tasks/submit",
+          params: {
+            agentId: "AGT-REMOTE",
+            routeContext: "/platform/tools/discovery",
+            objective: "Prepare a backlog update.",
+            prompt: "Create a backlog item if needed.",
+            idempotencyKey: "remote-read-denied-1",
+            riskClass: "bounded-write",
+          },
+        },
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toMatch(/read-only/i);
+    expect(createRunMock).not.toHaveBeenCalled();
+    expect(executeLoopMock).not.toHaveBeenCalled();
+  });
+
+  it("replays an existing TaskRun for the same idempotencyKey without re-running the coworker", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_write",
+      userId: "u1",
+      agentId: "AGT-REMOTE",
+      scopes: ["backlog_read", "backlog_write"],
+      capability: "write",
+    });
+    taskRunFindFirstMock.mockResolvedValue({
+      taskRunId: "TR-MCP-OLD",
+      status: "completed",
+      progressPayload: { summary: "Already done." },
+      a2aMetadata: { idempotencyKey: "remote-replay-1", riskClass: "read" },
+    } as never);
+
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 13,
+          method: "tasks/submit",
+          params: {
+            agentId: "AGT-REMOTE",
+            routeContext: "/platform/tools/discovery",
+            objective: "Summarize current state.",
+            prompt: "Summarize current state.",
+            idempotencyKey: "remote-replay-1",
+            riskClass: "read",
+          },
+        },
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.result.taskRunId).toBe("TR-MCP-OLD");
+    expect(body.result.idempotentReplay).toBe(true);
+    expect(createRunMock).not.toHaveBeenCalled();
+    expect(executeLoopMock).not.toHaveBeenCalled();
+  });
+
+  it("creates an external-mcp TaskRun and executes read tasks with token attribution", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_read",
+      userId: "u1",
+      agentId: "AGT-REMOTE",
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 14,
+          method: "tasks/submit",
+          params: {
+            agentId: "AGT-REMOTE",
+            routeContext: "/platform/tools/discovery",
+            title: "Remote discovery summary",
+            objective: "Summarize discovery backlog.",
+            prompt: "Summarize discovery backlog and cite what you used.",
+            idempotencyKey: "remote-read-1",
+            riskClass: "read",
+          },
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(createRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      trigger: "external-mcp",
+      userId: "u1",
+      agentId: "AGT-REMOTE",
+      routeContext: "/platform/tools/discovery",
+      sourceRef: { kind: "mcp-token", id: "tok_read" },
+      metadata: expect.objectContaining({
+        idempotencyKey: "remote-read-1",
+        riskClass: "read",
+        apiTokenId: "tok_read",
+      }),
+    }));
+    expect(resolveToolsMock).toHaveBeenCalledWith(expect.objectContaining({
+      mode: "advise",
+      externalAccessEnabled: true,
+    }));
+    expect(executeLoopMock).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-12345678",
+      apiTokenId: "tok_read",
+      chatHistory: [{ role: "user", content: "Summarize discovery backlog and cite what you used." }],
+    }));
+    expect(taskRunUpdateMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: { taskRunId: "TR-MCP-12345678" },
+      data: expect.objectContaining({ status: "completed" }),
+    }));
+    const body = await res.json();
+    expect(body.result.taskRunId).toBe("TR-MCP-12345678");
+    expect(body.result.idempotentReplay).toBe(false);
+    expect(body.result.requiresApproval).toBe(false);
+  });
+
+  it("pauses high-risk submissions before executing tools", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_write",
+      userId: "u1",
+      agentId: "AGT-REMOTE",
+      scopes: ["backlog_read", "backlog_write"],
+      capability: "write",
+    });
+
+    const res = await POST(
+      makeRequest({
+        bearer: "dpfmcp_X",
+        body: {
+          jsonrpc: "2.0",
+          id: 15,
+          method: "tasks/submit",
+          params: {
+            agentId: "AGT-REMOTE",
+            routeContext: "/platform/tools/discovery",
+            objective: "Make broad production changes.",
+            prompt: "Make broad production changes.",
+            idempotencyKey: "remote-high-risk-1",
+            riskClass: "high-risk",
+          },
+        },
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.result.taskRunId).toBe("TR-MCP-12345678");
+    expect(body.result.requiresApproval).toBe(true);
+    expect(body.result.status).toBe("input-required");
+    expect(taskRunUpdateMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: { taskRunId: "TR-MCP-12345678" },
+      data: expect.objectContaining({ status: "input-required" }),
+    }));
+    expect(executeLoopMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -17,6 +17,7 @@ import { resolveMcpApiToken, type ResolvedMcpToken } from "@/lib/auth/mcp-api-to
 import { verifyMcpSessionToken } from "@/lib/mcp/session-token";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { PLATFORM_TOOLS, resolveAnnotations, type ToolDefinition } from "@/lib/mcp-tools";
+import { submitRemoteCoworkerTask } from "@/lib/mcp-task-submit";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 import { can, type CapabilityKey, type UserContext } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
@@ -229,6 +230,28 @@ function annotateTool(tool: ToolDefinition) {
       openWorldHint: ann.openWorldHint,
     },
   };
+}
+
+async function handleTasksSubmit(
+  id: JsonRpcId,
+  token: ResolvedAuth,
+  params: Record<string, unknown> | undefined,
+): Promise<Response> {
+  const userContext = await loadUserContext(token.userId);
+  const outcome = await submitRemoteCoworkerTask({
+    token: {
+      tokenId: token.tokenId,
+      userId: token.userId,
+      capability: token.capability,
+      source: token.source,
+    },
+    userContext,
+    params,
+  });
+  if (outcome.kind === "invalid_params") {
+    return jsonRpcError(id, JSONRPC_INVALID_PARAMS, outcome.message);
+  }
+  return jsonRpcOk(id, outcome.result);
 }
 
 async function handleInitialize(id: JsonRpcId): Promise<Response> {
@@ -445,6 +468,12 @@ export async function POST(request: Request): Promise<Response> {
           return new Response(null, { status: 202 });
         }
         return await handleToolsCall(body.id ?? null, token, body.params);
+
+      case "tasks/submit":
+        if (isNotification) {
+          return new Response(null, { status: 202 });
+        }
+        return await handleTasksSubmit(body.id ?? null, token, body.params);
 
       case "ping":
         if (isNotification) {

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -1,0 +1,296 @@
+import { prisma } from "@dpf/db";
+import type { UserContext } from "@/lib/permissions";
+import {
+  createAutonomousWorkRun,
+  executeAutonomousAgenticLoop,
+  resolveAutonomousWorkAgent,
+  resolveAutonomousWorkTools,
+} from "@/lib/tak/autonomous-work-run";
+import { createTaskMessage } from "@/lib/tak/task-records";
+
+export const REMOTE_RISK_CLASSES = ["read", "bounded-write", "high-risk"] as const;
+export type RemoteRiskClass = (typeof REMOTE_RISK_CLASSES)[number];
+
+export type RemoteTaskSubmitParams = {
+  agentId: string;
+  routeContext: string;
+  title: string;
+  objective: string;
+  prompt: string;
+  idempotencyKey: string;
+  riskClass: RemoteRiskClass;
+  threadId?: string | null;
+  authorityScope?: string[];
+};
+
+export type RemoteTaskSubmitAuth = {
+  tokenId: string;
+  userId: string;
+  capability: "read" | "write";
+  source: "pat" | "session-jwt";
+};
+
+export type RemoteTaskSubmitOutcome =
+  | { kind: "invalid_params"; message: string }
+  | { kind: "result"; result: Record<string, unknown> };
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function remoteTaskContent(text: string) {
+  return [{ type: "text", text }];
+}
+
+export function parseRemoteTaskSubmitParams(params: Record<string, unknown> | undefined): RemoteTaskSubmitParams | string {
+  if (!params) return "tasks/submit requires params";
+  const agentId = optionalString(params["agentId"]);
+  const routeContext = optionalString(params["routeContext"]);
+  const objective = optionalString(params["objective"]);
+  const prompt = optionalString(params["prompt"]);
+  const idempotencyKey = optionalString(params["idempotencyKey"]);
+  const riskClass = optionalString(params["riskClass"]);
+
+  if (!agentId) return "tasks/submit requires params.agentId (string)";
+  if (!routeContext) return "tasks/submit requires params.routeContext (string)";
+  if (!objective) return "tasks/submit requires params.objective (string)";
+  if (!prompt) return "tasks/submit requires params.prompt (string)";
+  if (!idempotencyKey) return "tasks/submit requires params.idempotencyKey (string)";
+  if (!riskClass || !REMOTE_RISK_CLASSES.includes(riskClass as RemoteRiskClass)) {
+    return `tasks/submit requires params.riskClass (${REMOTE_RISK_CLASSES.join(" | ")})`;
+  }
+
+  const authorityScope = Array.isArray(params["authorityScope"])
+    ? params["authorityScope"].filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : undefined;
+
+  return {
+    agentId,
+    routeContext,
+    title: optionalString(params["title"]) ?? objective.slice(0, 120),
+    objective,
+    prompt,
+    idempotencyKey,
+    riskClass: riskClass as RemoteRiskClass,
+    threadId: optionalString(params["threadId"]),
+    authorityScope,
+  };
+}
+
+export async function submitRemoteCoworkerTask(input: {
+  token: RemoteTaskSubmitAuth;
+  userContext: UserContext;
+  params: Record<string, unknown> | undefined;
+}): Promise<RemoteTaskSubmitOutcome> {
+  const parsed = parseRemoteTaskSubmitParams(input.params);
+  if (typeof parsed === "string") {
+    return { kind: "invalid_params", message: parsed };
+  }
+
+  const { token, userContext } = input;
+  if (token.capability === "read" && parsed.riskClass !== "read") {
+    return {
+      kind: "result",
+      result: {
+        content: remoteTaskContent(
+          `This token is read-only and cannot submit ${parsed.riskClass} autonomous coworker work. Re-issue a write-capable token for bounded write tasks.`,
+        ),
+        isError: true,
+      },
+    };
+  }
+
+  const existing = await prisma.taskRun.findFirst({
+    where: {
+      userId: token.userId,
+      a2aMetadata: {
+        path: ["idempotencyKey"],
+        equals: parsed.idempotencyKey,
+      },
+    },
+    orderBy: [{ createdAt: "desc" }],
+    select: {
+      taskRunId: true,
+      status: true,
+      progressPayload: true,
+      a2aMetadata: true,
+    },
+  });
+
+  if (existing) {
+    return {
+      kind: "result",
+      result: {
+        taskRunId: existing.taskRunId,
+        status: existing.status,
+        idempotentReplay: true,
+        requiresApproval: existing.status === "input-required",
+        progressPayload: existing.progressPayload,
+        a2aMetadata: existing.a2aMetadata,
+      },
+    };
+  }
+
+  const contextKey = parsed.threadId ?? `mcp:${token.tokenId}:${parsed.idempotencyKey}`;
+  const thread = await prisma.agentThread.upsert({
+    where: { userId_contextKey: { userId: token.userId, contextKey } },
+    update: {},
+    create: { userId: token.userId, contextKey },
+    select: { id: true },
+  });
+
+  const sourceKind = token.source === "session-jwt" ? "mcp-session" : "mcp-token";
+  const run = await createAutonomousWorkRun({
+    trigger: "external-mcp",
+    userId: token.userId,
+    agentId: parsed.agentId,
+    routeContext: parsed.routeContext,
+    title: parsed.title,
+    objective: parsed.objective,
+    prompt: parsed.prompt,
+    threadId: thread.id,
+    authorityScope: parsed.authorityScope ?? [],
+    sourceRef: { kind: sourceKind, id: token.tokenId },
+    metadata: {
+      idempotencyKey: parsed.idempotencyKey,
+      riskClass: parsed.riskClass,
+      apiTokenId: token.tokenId,
+      tokenSource: token.source,
+      requestedThreadId: parsed.threadId ?? null,
+    },
+  });
+
+  await createTaskMessage({
+    taskRunId: run.taskRunId,
+    taskRunRecordId: run.id,
+    contextId: run.contextId,
+    role: "user",
+    content: parsed.prompt,
+    metadata: {
+      source: "mcp.tasks/submit",
+      idempotencyKey: parsed.idempotencyKey,
+      riskClass: parsed.riskClass,
+      apiTokenId: token.tokenId,
+    },
+  });
+
+  if (parsed.riskClass === "high-risk") {
+    await prisma.taskRun.update({
+      where: { taskRunId: run.taskRunId },
+      data: {
+        status: "input-required",
+        progressPayload: {
+          summary: "Remote submission paused for human approval before side-effecting work can run.",
+          riskClass: parsed.riskClass,
+          requiresApproval: true,
+        },
+      },
+    });
+
+    return {
+      kind: "result",
+      result: {
+        taskRunId: run.taskRunId,
+        status: "input-required",
+        idempotentReplay: false,
+        requiresApproval: true,
+        content: remoteTaskContent("Remote task submitted and paused for human approval."),
+        isError: false,
+      },
+    };
+  }
+
+  const agent = await resolveAutonomousWorkAgent({
+    agentId: parsed.agentId,
+    routeContext: parsed.routeContext,
+    userContext,
+  });
+  const resolvedAgentId = agent.agentId ?? parsed.agentId;
+  const toolMode = parsed.riskClass === "read" ? "advise" : "act";
+  const tools = await resolveAutonomousWorkTools({
+    userContext,
+    agentId: resolvedAgentId,
+    mode: toolMode,
+    externalAccessEnabled: true,
+  });
+
+  try {
+    const result = await executeAutonomousAgenticLoop({
+      systemPrompt: agent.systemPrompt,
+      chatHistory: [{ role: "user", content: parsed.prompt }],
+      sensitivity: agent.sensitivity ?? "internal",
+      tools: tools.tools,
+      toolsForProvider: tools.toolsForProvider,
+      userId: token.userId,
+      routeContext: parsed.routeContext,
+      agentId: resolvedAgentId,
+      threadId: thread.id,
+      taskRunId: run.taskRunId,
+      apiTokenId: token.tokenId,
+      taskType: "external-mcp",
+      agentDisplayName: optionalString(agent.displayName) ?? resolvedAgentId,
+    });
+
+    await createTaskMessage({
+      taskRunId: run.taskRunId,
+      taskRunRecordId: run.id,
+      contextId: run.contextId,
+      role: "assistant",
+      content: result.content,
+      metadata: {
+        source: "mcp.tasks/submit",
+        executedToolCount: result.executedTools?.length ?? 0,
+      },
+    });
+
+    await prisma.taskRun.update({
+      where: { taskRunId: run.taskRunId },
+      data: {
+        status: "completed",
+        completedAt: new Date(),
+        progressPayload: {
+          summary: result.content,
+          riskClass: parsed.riskClass,
+          executedToolCount: result.executedTools?.length ?? 0,
+        },
+      },
+    });
+
+    return {
+      kind: "result",
+      result: {
+        taskRunId: run.taskRunId,
+        status: "completed",
+        idempotentReplay: false,
+        requiresApproval: false,
+        content: remoteTaskContent(result.content),
+        executedToolCount: result.executedTools?.length ?? 0,
+        isError: false,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown remote coworker execution error";
+    await prisma.taskRun.update({
+      where: { taskRunId: run.taskRunId },
+      data: {
+        status: "failed",
+        completedAt: new Date(),
+        progressPayload: {
+          summary: message,
+          riskClass: parsed.riskClass,
+        },
+      },
+    });
+    return {
+      kind: "result",
+      result: {
+        taskRunId: run.taskRunId,
+        status: "failed",
+        idempotentReplay: false,
+        requiresApproval: false,
+        content: remoteTaskContent(message),
+        isError: true,
+      },
+    };
+  }
+}

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -388,6 +388,43 @@ describe("runAgenticLoop", () => {
     );
   });
 
+  it("forwards apiTokenId into governedExecuteTool context on external coworker runs", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    const mockExecuteTool = vi.mocked(executeTool);
+
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Searching.",
+        toolCalls: [{ id: "toolu_01A", name: "search_project_files", arguments: { query: "agent" } }],
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "I found the relevant files and summarized the implementation path with enough detail for the next step to continue cleanly.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "The search output lists the relevant files and the likely implementation path. It gives enough context for a follow-up step and keeps the answer limited to investigation notes.",
+      }));
+
+    mockExecuteTool.mockResolvedValueOnce({
+      success: true,
+      message: "Found files",
+    });
+
+    await runAgenticLoop({
+      ...baseParams,
+      taskRunId: "TR-MCP-TESTRUN",
+      apiTokenId: "tok_remote",
+    });
+
+    expect(governedExecuteTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          taskRunId: "TR-MCP-TESTRUN",
+          apiTokenId: "tok_remote",
+        }),
+      }),
+    );
+  });
+
   it("creates structured messages with tool call IDs after tool execution", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     const mockExecuteTool = vi.mocked(executeTool);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -614,6 +614,11 @@ export async function runAgenticLoop(params: {
    * records the same TaskRun id in ToolExecution audit rows.
    */
   taskRunId?: string | null;
+  /**
+   * External MCP token that submitted this loop. When set, each governed tool
+   * call records the same token id in ToolExecution audit rows.
+   */
+  apiTokenId?: string | null;
 }): Promise<AgenticResult> {
   const {
     chatHistory,
@@ -631,6 +636,7 @@ export async function runAgenticLoop(params: {
     requireTools,
     agentDisplayName,
     taskRunId,
+    apiTokenId,
   } = params;
 
   const userContext = await resolveUserContext(userId);
@@ -1293,7 +1299,13 @@ export async function runAgenticLoop(params: {
           rawParams: tc.arguments,
           userId,
           userContext,
-          context: { routeContext, agentId, threadId, taskRunId: taskRunId ?? undefined },
+          context: {
+            routeContext,
+            agentId,
+            threadId,
+            taskRunId: taskRunId ?? undefined,
+            apiTokenId: apiTokenId ?? undefined,
+          },
           source: "agentic-loop",
         });
       } catch (err) {

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -260,6 +260,34 @@ describe("createAutonomousWorkRun", () => {
     );
   });
 
+  it("forwards MCP token identity into the agentic loop", async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);
+
+    const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+
+    await executeAutonomousAgenticLoop({
+      systemPrompt: "You are helpful.",
+      chatHistory: [{ role: "user", content: "Run it." }],
+      sensitivity: "internal",
+      tools: [],
+      toolsForProvider: [],
+      userId: "user-1",
+      routeContext: "/platform/tools/discovery",
+      agentId: "inventory-specialist",
+      threadId: "thread-1",
+      taskRunId: "TR-MCP-ABCDEF12",
+      apiTokenId: "tok_remote",
+    });
+
+    expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: "TR-MCP-ABCDEF12",
+        apiTokenId: "tok_remote",
+      }),
+    );
+  });
+
   it("executes a single governed tool with TaskRun attribution", async () => {
     const governed = await import("@/lib/mcp-governed-execute");
     vi.mocked(governed.governedExecuteTool).mockResolvedValue({ success: true, message: "ok" } as never);

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -184,6 +184,7 @@ export async function executeAutonomousAgenticLoop(input: {
   buildPhase?: string | null;
   featureBuildId?: string | null;
   modelRequirements?: Record<string, unknown>;
+  apiTokenId?: string | null;
   onProgress?: (event: AgentEvent) => void;
 }) {
   const { runAgenticLoop } = await import("@/lib/tak/agentic-loop");
@@ -199,6 +200,7 @@ export async function executeAutonomousAgenticLoop(input: {
     agentId: input.agentId,
     threadId: input.threadId,
     taskRunId: input.taskRunId,
+    apiTokenId: input.apiTokenId,
     taskType: input.taskType,
     agentDisplayName: input.agentDisplayName,
     buildPhase: input.buildPhase,
@@ -217,6 +219,7 @@ export async function executeAutonomousWorkTool(input: {
   agentId: string;
   threadId: string;
   taskRunId: string;
+  apiTokenId?: string | null;
 }): Promise<ToolResult> {
   const { governedExecuteTool } = await import("@/lib/mcp-governed-execute");
 
@@ -231,6 +234,7 @@ export async function executeAutonomousWorkTool(input: {
       agentId: input.agentId,
       threadId: input.threadId,
       taskRunId: input.taskRunId,
+      apiTokenId: input.apiTokenId ?? undefined,
     },
   });
 }


### PR DESCRIPTION
## Summary
- add JSON-RPC `tasks/submit` to the canonical MCP `/api/mcp/v1` endpoint for remote autonomous coworker submission
- create remote submissions as `external-mcp` TaskRuns with idempotency-key replay, MCP token source metadata, and TaskMessage persistence
- route read/bounded-write runs through the autonomous agentic loop and pass `apiTokenId` into governed tool audit context; pause high-risk submissions at `input-required`
- extract the remote submission workflow into `apps/web/lib/mcp-task-submit.ts` so the MCP route remains a transport adapter

## Verification
- `pnpm --filter web exec vitest run app/api/mcp/v1/route.test.ts lib/tak/autonomous-work-run.test.ts lib/tak/agentic-loop.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passes; existing Turbopack broad-tracing warnings remain around `spec-plan-search.ts` / `next.config.mjs`)
- `docker compose build --no-cache portal portal-init sandbox`
- `docker compose up -d`
- live MCP initialize against rebuilt portal returned `serverInfo.name = dpf-platform`
- live `tasks/submit` high-risk run created `TR-MCP-11A80190` with status `input-required`, `requiresApproval: true`, and zero ToolExecution rows
- live `tasks/submit` read run created `TR-MCP-FDF97724` with status `completed` and `a2aMetadata.sourceRef.kind = mcp-token`

## Notes
- No schema migration required; this uses existing `TaskRun.a2aMetadata`, `TaskRun.progressPayload`, `TaskMessage`, `AgentThread`, and `ToolExecution.apiTokenId` surfaces.