### PR TITLE
doc(wiki): publish founder kernel 0.2.0 — flip 19 pages to status:published

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,9 +1,9 @@
 {
-  "kernelVersion": "0.2.0-draft",
+  "kernelVersion": "0.2.0",
   "schemaVersion": "0.2.0",
   "pageCount": 19,
   "sourceCount": 10,
   "embeddingModel": null,
   "builtAt": null,
-  "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. The 0.2.0-draft cut was synthesised from Mark's public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect, Architecture & Governance Magazine, ServiceNow community blogs, CSDM v5). Every page ships status:draft pending Mark's review. Schema 0.2.0 adds the `principle` page kind (tier + decision vector + applies-to + public-classification metadata) — see ../superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md and ./SCHEMA.md `principle` section."
+  "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. The 0.2.0 cut was synthesised from Mark's public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect, Architecture & Governance Magazine, ServiceNow community blogs, CSDM v5) and published on Mark's behalf for agent retrieval. Schema 0.2.0 adds the `principle` page kind (tier + decision vector + applies-to + public-classification metadata) — see ../superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md and ./SCHEMA.md `principle` section."
 }

--- a/docs/founder-kernel/wiki/entities/csdm.md
+++ b/docs/founder-kernel/wiki/entities/csdm.md
@@ -1,7 +1,7 @@
 ---
 title: CSDM (Common Service Data Model)
 pageKind: entity
-status: draft
+status: published
 abstract: The canonical data model that connects what naturally happens across asset, dev, ops, ITSM, and CSM.
 sources:
   - frameworks/csdm

--- a/docs/founder-kernel/wiki/entities/digital-product.md
+++ b/docs/founder-kernel/wiki/entities/digital-product.md
@@ -1,7 +1,7 @@
 ---
 title: Digital Product
 pageKind: entity
-status: draft
+status: published
 abstract: Anything that runs code that one party is responsible for that delivers outcomes for a consumer party.
 sources:
   - articles/why-product-centric-approach-needed

--- a/docs/founder-kernel/wiki/entities/it4it.md
+++ b/docs/founder-kernel/wiki/entities/it4it.md
@@ -1,7 +1,7 @@
 ---
 title: IT4IT
 pageKind: entity
-status: draft
+status: published
 abstract: The Open Group's reference architecture for managing the business of IT — a hub of seven value streams that integrate ITIL, COBIT, TOGAF, DevOps, and SAFe.
 sources:
   - frameworks/it4it-v3
@@ -37,4 +37,4 @@ A new application proposal moves through Evaluate (does it fit the portfolio str
 
 - Stance: `[[stances/it4it-is-substrate]]`
 - Heuristic: `[[heuristics/pitch-simple-adjust-per-audience]]` — how to introduce IT4IT to executives.
-- Raw source: `[[raw-sources/frameworks/it4it-v3]]`
+- Raw source: `[raw-sources/frameworks/it4it-v3](../../raw-sources/frameworks/it4it-v3.md)`

--- a/docs/founder-kernel/wiki/entities/portfolio.md
+++ b/docs/founder-kernel/wiki/entities/portfolio.md
@@ -1,7 +1,7 @@
 ---
 title: Portfolio
 pageKind: entity
-status: draft
+status: published
 abstract: A curated set of Digital Products grouped for a shared management purpose — investment, governance, or operations.
 sources:
   - articles/sibling-portfolios

--- a/docs/founder-kernel/wiki/entities/value-stream.md
+++ b/docs/founder-kernel/wiki/entities/value-stream.md
@@ -1,7 +1,7 @@
 ---
 title: Value Stream
 pageKind: entity
-status: draft
+status: published
 abstract: One of seven cross-cutting flows in IT4IT v3 — Evaluate, Explore, Integrate, Deploy, Release, Operate, Consume. The seam where ITIL, DevOps, SAFe, and TOGAF plug into the Digital Product spine.
 sources:
   - frameworks/it4it-v3
@@ -41,4 +41,4 @@ A new analytics application proposal moves Evaluate → Explore → Integrate �
 
 - Stance: `[[stances/it4it-is-substrate]]`
 - Entity: `[[entities/it4it]]`
-- Raw source: `[[raw-sources/frameworks/it4it-v3]]`
+- Raw source: `[raw-sources/frameworks/it4it-v3](../../raw-sources/frameworks/it4it-v3.md)`

--- a/docs/founder-kernel/wiki/heuristics/auto-populate-or-its-wrong.md
+++ b/docs/founder-kernel/wiki/heuristics/auto-populate-or-its-wrong.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-populate or it's already wrong
 pageKind: heuristic
-status: draft
+status: published
 abstract: It is not humanly possible to manually track the rapid inflation and deflation of virtualised cloud, hybrid, and on-prem resources. If your CMDB depends on humans to enter records, it's already lying to you.
 sources:
   - frameworks/csdm

--- a/docs/founder-kernel/wiki/heuristics/be-a-meteorologist.md
+++ b/docs/founder-kernel/wiki/heuristics/be-a-meteorologist.md
@@ -1,7 +1,7 @@
 ---
 title: Be a meteorologist — produce forecasts, not raw models
 pageKind: heuristic
-status: draft
+status: published
 abstract: Architects deliver forecasts and recommended actions to leadership, not exposed models. The deliverable is the guidance, not the diagram.
 sources:
   - articles/possible-futures-enterprise-architecture
@@ -32,4 +32,4 @@ This is also the philosophical core of the platform&#39;s wiki kernel: the "what
 ## See also
 
 - Parent stance: `[[stances/ea-is-meteorology]]`
-- Raw source: `[[raw-sources/articles/possible-futures-enterprise-architecture]]`
+- Raw source: `[raw-sources/articles/possible-futures-enterprise-architecture](../../raw-sources/articles/possible-futures-enterprise-architecture.md)`

--- a/docs/founder-kernel/wiki/heuristics/contextualize-before-transforming.md
+++ b/docs/founder-kernel/wiki/heuristics/contextualize-before-transforming.md
@@ -1,7 +1,7 @@
 ---
 title: Contextualize before transforming
 pageKind: heuristic
-status: draft
+status: published
 abstract: When adopting a standard, first map the existing operating model onto the standard's structure. Adoption follows mapping; transformation follows adoption.
 sources:
   - articles/open-group-2017-managing-business-of-it

--- a/docs/founder-kernel/wiki/heuristics/find-at-least-one-champion.md
+++ b/docs/founder-kernel/wiki/heuristics/find-at-least-one-champion.md
@@ -1,7 +1,7 @@
 ---
 title: Find at least one champion
 pageKind: heuristic
-status: draft
+status: published
 abstract: Standards adoption stalls without an internal evangelist. Hand out the physical reference book in executive sessions and watch who engages — those become the champions.
 sources:
   - articles/open-group-2017-managing-business-of-it

--- a/docs/founder-kernel/wiki/heuristics/model-what-naturally-happens.md
+++ b/docs/founder-kernel/wiki/heuristics/model-what-naturally-happens.md
@@ -1,7 +1,7 @@
 ---
 title: Model what naturally happens — don't build a data lake
 pageKind: heuristic
-status: draft
+status: published
 abstract: A canonical data model that connects the relationships that already exist beats a federated data lake that aggregates everything centrally.
 sources:
   - frameworks/csdm

--- a/docs/founder-kernel/wiki/heuristics/pitch-simple-adjust-per-audience.md
+++ b/docs/founder-kernel/wiki/heuristics/pitch-simple-adjust-per-audience.md
@@ -1,7 +1,7 @@
 ---
 title: Pitch simple, adjust per audience
 pageKind: heuristic
-status: draft
+status: published
 abstract: Lead with the simplest framing the audience can ingest. Adjust language per audience — "framework for managing IT," "operating model," "reference architecture." Never lead with the model itself.
 sources:
   - articles/open-group-2017-managing-business-of-it

--- a/docs/founder-kernel/wiki/heuristics/reuse-the-camera-in-your-pocket.md
+++ b/docs/founder-kernel/wiki/heuristics/reuse-the-camera-in-your-pocket.md
@@ -1,7 +1,7 @@
 ---
 title: Reuse the camera in your pocket — platform-native usually wins
 pageKind: heuristic
-status: draft
+status: published
 abstract: For most IT tooling decisions, the integrated platform-native capability wins on practicality even when the best-of-breed specialist wins on feature depth. The cost of integration is the silent killer.
 sources:
   - articles/think-twice-ea-platform-servicenow
@@ -35,4 +35,4 @@ For the rare case where the feature gap *is* big enough — and it&#39;s rarer t
 
 - Parent stance: `[[stances/dont-integrate-ea-platform]]`
 - Related stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — the consolidation only works if the CMDB is trustworthy.
-- Raw source: `[[raw-sources/articles/think-twice-ea-platform-servicenow]]`
+- Raw source: `[raw-sources/articles/think-twice-ea-platform-servicenow](../../raw-sources/articles/think-twice-ea-platform-servicenow.md)`

--- a/docs/founder-kernel/wiki/index.md
+++ b/docs/founder-kernel/wiki/index.md
@@ -1,7 +1,7 @@
 ---
 title: Founder Kernel
 pageKind: index
-status: draft
+status: published
 abstract: Top-level index for the founder kernel — stances, heuristics, entities, and the raw sources that back them.
 ---
 

--- a/docs/founder-kernel/wiki/stances/contextualize-dont-transform.md
+++ b/docs/founder-kernel/wiki/stances/contextualize-dont-transform.md
@@ -1,7 +1,7 @@
 ---
 title: Contextualize, don't transform — map first, evolve second
 pageKind: stance
-status: draft
+status: published
 abstract: Standards adoption that frames itself as transformation gets rejected. Frame it as contextualization — "how is our operating model the same or different from the standard?" — and adoption follows.
 sources:
   - articles/open-group-2017-managing-business-of-it
@@ -44,4 +44,4 @@ The same framing applies to every cross-framework adoption I&#39;ve led since.
 
 - Stance: `[[stances/it4it-is-substrate]]` — the standard most often being contextualized.
 - Entity: `[[entities/it4it]]`
-- Raw source: `[[raw-sources/articles/open-group-2017-managing-business-of-it]]`
+- Raw source: `[raw-sources/articles/open-group-2017-managing-business-of-it](../../raw-sources/articles/open-group-2017-managing-business-of-it.md)`

--- a/docs/founder-kernel/wiki/stances/digital-product-is-the-unit-of-organization.md
+++ b/docs/founder-kernel/wiki/stances/digital-product-is-the-unit-of-organization.md
@@ -1,7 +1,7 @@
 ---
 title: Digital Product is the unit of organization for IT
 pageKind: stance
-status: draft
+status: published
 abstract: Anything that runs code that one party is responsible for that delivers outcomes for a consumer party. That's the right primitive — for portfolio, team, funding, lifecycle, governance, everything.
 sources:
   - articles/why-product-centric-approach-needed

--- a/docs/founder-kernel/wiki/stances/dont-integrate-ea-platform.md
+++ b/docs/founder-kernel/wiki/stances/dont-integrate-ea-platform.md
@@ -1,7 +1,7 @@
 ---
 title: Don't integrate a third-party EA platform with ServiceNow — consolidate on one data model
 pageKind: stance
-status: draft
+status: published
 abstract: EA-platform-to-CMDB integrations go through Independent → Honeymoon → Ugly Reckoning. Pick one platform and one canonical data model (CSDM). The cost of consolidation is far less than the cost of the integration failing slowly.
 sources:
   - articles/think-twice-ea-platform-servicenow
@@ -46,4 +46,4 @@ The alternative is consolidation. Pick one platform and accept that you&#39;ll l
 - Stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — why consolidation only works if the CMDB is trustworthy.
 - Entity: `[[entities/csdm]]`
 - Entity: `[[entities/portfolio]]`
-- Related: `[[raw-sources/articles/sibling-portfolios]]` — the APM/SPM unification case study.
+- Related: `[raw-sources/articles/sibling-portfolios](../../raw-sources/articles/sibling-portfolios.md)` — the APM/SPM unification case study.

--- a/docs/founder-kernel/wiki/stances/ea-is-meteorology.md
+++ b/docs/founder-kernel/wiki/stances/ea-is-meteorology.md
@@ -1,7 +1,7 @@
 ---
 title: EA is meteorology — provide forecasts, not raw models
 pageKind: stance
-status: draft
+status: published
 abstract: Architects should be like meteorologists — produce forecasts and recommended actions, not exposed models. The deliverable to leadership is the guidance, not the diagram.
 sources:
   - articles/possible-futures-enterprise-architecture
@@ -47,4 +47,4 @@ This is also the philosophical frame behind DPF&#39;s wiki kernel. The platform 
 ## See also
 
 - Parent context: `[[entities/it4it]]` provides the substrate; this stance is about how to deploy the substrate to leadership.
-- Raw source: `[[raw-sources/articles/possible-futures-enterprise-architecture]]`
+- Raw source: `[raw-sources/articles/possible-futures-enterprise-architecture](../../raw-sources/articles/possible-futures-enterprise-architecture.md)`

--- a/docs/founder-kernel/wiki/stances/it4it-is-substrate.md
+++ b/docs/founder-kernel/wiki/stances/it4it-is-substrate.md
@@ -1,7 +1,7 @@
 ---
 title: IT4IT is the substrate — a hub of frameworks, not a competitor
 pageKind: stance
-status: draft
+status: published
 abstract: IT4IT integrates ITIL, COBIT, TOGAF, DevOps, and SAFe at the operating-model layer. It does not replace them. Pitch it as a framework for managing IT, or as an operating model, depending on audience.
 sources:
   - articles/briefings-direct-it4it-2019
@@ -45,4 +45,4 @@ The executive pitch reflects this: **"I pitch it as a framework for managing IT 
 
 - Entity: `[[entities/it4it]]`
 - Entity: `[[entities/value-stream]]`
-- Raw source: `[[raw-sources/articles/briefings-direct-it4it-2019]]`
+- Raw source: `[raw-sources/articles/briefings-direct-it4it-2019](../../raw-sources/articles/briefings-direct-it4it-2019.md)`

--- a/docs/founder-kernel/wiki/stances/persistent-product-teams-over-projects.md
+++ b/docs/founder-kernel/wiki/stances/persistent-product-teams-over-projects.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent product teams replace project teams; rolling investment replaces annual budgets
 pageKind: stance
-status: draft
+status: published
 abstract: Projects are time-bound and optimise for delivery deadlines rather than long-term sustainability. The fix is teams that persist with the product and money that flows where outcomes accrue.
 sources:
   - articles/why-product-centric-approach-needed

--- a/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
+++ b/docs/founder-kernel/wiki/stances/trust-the-cmdb-or-rebuild-it.md
@@ -1,7 +1,7 @@
 ---
 title: Trust the CMDB or rebuild it on the three pillars
 pageKind: stance
-status: draft
+status: published
 abstract: Most organisations have a CMDB; very few actually trust it. Trust is built through Ingestion (auto-populate), Insight (actually use the data), and Governance & Health (people and process). If any pillar is missing, the CMDB is lying to you.
 sources:
   - frameworks/csdm
@@ -47,4 +47,4 @@ The ROI conversation that lands with executives is tool consolidation: organisat
 
 - Entity: `[[entities/csdm]]`
 - Stance: `[[stances/dont-integrate-ea-platform]]` — why one trusted CMDB beats two integrated ones.
-- Raw source: `[[raw-sources/frameworks/csdm]]`
+- Raw source: `[raw-sources/frameworks/csdm](../../raw-sources/frameworks/csdm.md)`


### PR DESCRIPTION
## Summary

Flips the 19 kernel pages drafted in PR #482 from `status: draft` to `status: published`. After merge, the agent grounds answers in Mark&#39;s positions for every retrieval that matches.

You asked why I was asking you to do it. Fair. Doing it.

## What changed

- **19 wiki pages → `status: published`**: 7 stances + 7 heuristics + 5 entities. All authored from research on Mark&#39;s public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3, Architecture &amp; Governance Magazine, BriefingsDirect, ServiceNow community blogs).
- **`wiki/index.md` → `status: published`**.
- **Raw-source wikilinks converted to relative markdown links** — `[[raw-sources/articles/x]]` → `[raw-sources/articles/x](../../raw-sources/articles/x.md)`. Raw sources are `RawSource` rows, not `WikiPage` rows; the wiki dangling-xref detector would have flagged them as `severity: error` at publish. Standard markdown links are the correct shape for cross-table references.
- **`manifest.json`**: `kernelVersion: 0.2.0-draft → 0.2.0`; description updated.

## What this enables

- `/wiki` lists all 19 pages grouped by kind.
- `/wiki/stances/digital-product-is-the-unit-of-organization` and 18 others render as published kernel pages.
- `searchWikiPages` and the passive recall path (PR #449) surface these pages in Block 5 of every agent system prompt where the query matches.
- `wiki_query` MCP tool (PR #453) returns these pages on demand.
- `/admin/wiki/lint` runs against the published set; any drift surfaces there.

## How to verify

1. Merge.
2. Run seed: `pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts` (should report `pages=19 sources=10`).
3. Optional: build the embeddings sidecar: `tsx scripts/build-kernel-embeddings.ts` then re-run seed for `qdrant=19`.
4. Visit `/wiki` — all pages appear.
5. Ask an agent something kernel-relevant (e.g. *&#34;what&#39;s our stance on integrating an EA tool with the CMDB?&#34;*). The `RELEVANT WIKI CONTEXT` block should appear in the system prompt with `stances/dont-integrate-ea-platform` and its kernel context.

## Caveats

- **The conflict-of-interest disclosure on `dont-integrate-ea-platform`** (noting Mark&#39;s ServiceNow employment) is kept as drafted. If you want it softened, hardened, or removed, edit in place.
- **`wiki/principles/` is untouched** — that&#39;s a separate workstream (spec `2026-05-12-principles-as-wiki-kind-design.md` added the `principle` pageKind after my drafts landed).
- **Voice corrections**: every page lists its `sources:` frontmatter pointing back to the originating article. If a passage misrepresents Mark&#39;s position, pull up the source and edit in place — the kernel is meant to evolve with use.

## Files

21 changed, 31 lines added, 31 removed (each file: 1 line of `status: draft` → `status: published`; some files also fix raw-source link references; manifest tweaks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_