### PR TITLE
fix(release): tag origin main without mutating local checkout

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -235,7 +235,7 @@
         "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap (docs/superpowers/plans/2026-05-09-macos-linux-native-support.md). Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
       },
       "problemMatcher": [],
-      "detail": "Pull latest main, bump minor version (v0.85.0 -> v0.86.0), tag and push (Windows; Mac/Linux equivalent in Phase 8)"
+      "detail": "Fetch origin/main, bump minor version (v0.85.0 -> v0.86.0), tag that commit and push the tag (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Release Patch",
@@ -252,7 +252,7 @@
         "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap. Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
       },
       "problemMatcher": [],
-      "detail": "Pull latest main, bump patch version (v0.85.0 -> v0.85.1), tag and push (Windows; Mac/Linux equivalent in Phase 8)"
+      "detail": "Fetch origin/main, bump patch version (v0.85.0 -> v0.85.1), tag that commit and push the tag (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Release Major",
@@ -269,7 +269,7 @@
         "args": ["-lc", "echo 'DPF release scripts are Windows-only today. The macOS/Linux dpf-release.sh is sequenced for Phase 8 of the installer-parity roadmap. Until then, run: git tag vX.Y.Z && git push origin vX.Y.Z' && exit 1"]
       },
       "problemMatcher": [],
-      "detail": "Pull latest main, bump major version (v0.85.0 -> v1.0.0), tag and push (Windows; Mac/Linux equivalent in Phase 8)"
+      "detail": "Fetch origin/main, bump major version (v0.85.0 -> v1.0.0), tag that commit and push the tag (Windows; Mac/Linux equivalent in Phase 8)"
     },
     {
       "label": "DPF: Clean Reinstall from Git (WIPES ALL DATA)",

--- a/dpf-release.ps1
+++ b/dpf-release.ps1
@@ -8,109 +8,142 @@ param(
 # Usage: .\dpf-release.ps1          (minor bump, e.g. v0.85.0 -> v0.86.0)
 #        .\dpf-release.ps1 patch    (patch bump, e.g. v0.85.0 -> v0.85.1)
 #        .\dpf-release.ps1 major    (major bump, e.g. v0.85.0 -> v1.0.0)
+#
+# Releases are tag-only. The tag is created on origin/main after a fetch so
+# local branches, dirty files, and local-only main commits are not mutated.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# Switch to main if not already there
-$branch = git rev-parse --abbrev-ref HEAD
-$stashed = $false
-if ($branch -ne "main") {
-    Write-Host "Switching from $branch to main..." -ForegroundColor Cyan
-    # Use SilentlyContinue locally so git informational stderr (e.g. "Ignoring path ...")
-    # does not trip PowerShell's error handling when ErrorActionPreference = Stop.
-    $prev = $ErrorActionPreference
-    $ErrorActionPreference = "SilentlyContinue"
-    git stash --include-untracked -q 2>$null
-    $stashed = ($LASTEXITCODE -eq 0)
-    $ErrorActionPreference = $prev
-    git checkout main -q
+function Invoke-GitOrExit {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ErrorMessage
+    )
+
+    & git @Arguments
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "ERROR: Could not switch to main." -ForegroundColor Red
-        if ($stashed) { git stash pop -q 2>$null }
+        Write-Host "ERROR: $ErrorMessage" -ForegroundColor Red
         exit 1
     }
 }
 
-# Pull latest main from remote (this is what prevents the rejected push)
-Write-Host "Pulling latest main from origin..." -ForegroundColor Cyan
-git pull origin main --ff-only
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "ERROR: Fast-forward pull failed. You may have local commits on main that diverge from origin." -ForegroundColor Red
-    Write-Host "Run 'git log origin/main..main' to see divergent commits." -ForegroundColor Yellow
-    if ($branch -ne "main") {
-        git checkout $branch -q 2>$null
-        if ($stashed) { git stash pop -q 2>$null }
+function Get-GitOutputOrExit {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ErrorMessage
+    )
+
+    $output = & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: $ErrorMessage" -ForegroundColor Red
+        exit 1
     }
-    exit 1
+    return $output
 }
 
-# Get latest tag and compute next version
-$latestTag = git tag --sort=-v:refname | Select-Object -First 1
-if (-not $latestTag -or $latestTag -notmatch '^v(\d+)\.(\d+)\.(\d+)$') {
-    Write-Host "ERROR: Could not parse latest tag: $latestTag" -ForegroundColor Red
-    if ($branch -ne "main") {
-        git checkout $branch -q 2>$null
-        if ($stashed) { git stash pop -q 2>$null }
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $scriptRoot
+try {
+    $insideWorkTree = (& git rev-parse --is-inside-work-tree 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $insideWorkTree -ne "true") {
+        Write-Host "ERROR: dpf-release.ps1 must run inside a git working tree." -ForegroundColor Red
+        exit 1
     }
-    exit 1
-}
 
-$major = [int]$Matches[1]
-$minor = [int]$Matches[2]
-$patch = [int]$Matches[3]
+    $currentBranch = (Get-GitOutputOrExit -Arguments @("rev-parse", "--abbrev-ref", "HEAD") -ErrorMessage "Could not read current branch.").Trim()
 
-switch ($Bump) {
-    "major" { $major++; $minor = 0; $patch = 0 }
-    "minor" { $minor++; $patch = 0 }
-    "patch" { $patch++ }
-}
+    Write-Host "Fetching origin/main and tags..." -ForegroundColor Cyan
+    Invoke-GitOrExit -Arguments @("fetch", "--tags", "origin", "+refs/heads/main:refs/remotes/origin/main") -ErrorMessage "Could not fetch origin/main and tags."
 
-$newTag = "v$major.$minor.$patch"
+    $releaseTarget = (Get-GitOutputOrExit -Arguments @("rev-parse", "--verify", "refs/remotes/origin/main") -ErrorMessage "Could not resolve origin/main.").Trim()
+    $releaseTargetShort = $releaseTarget.Substring(0, [Math]::Min(8, $releaseTarget.Length))
 
-Write-Host "Current version: $latestTag" -ForegroundColor Gray
-Write-Host "New version:     $newTag ($Bump bump)" -ForegroundColor Green
-Write-Host ""
+    Write-Host "Current branch: $currentBranch" -ForegroundColor Gray
+    Write-Host "Release target: origin/main ($releaseTargetShort)" -ForegroundColor Gray
 
-# Confirm
-$confirm = Read-Host "Tag and push ${newTag}? [y/N]"
-if ($confirm -ne "y" -and $confirm -ne "Y") {
-    Write-Host "Aborted." -ForegroundColor Yellow
-    if ($branch -ne "main") {
-        git checkout $branch -q 2>$null
-        if ($stashed) { git stash pop -q 2>$null }
+    if ($currentBranch -eq "main") {
+        $localMain = (Get-GitOutputOrExit -Arguments @("rev-parse", "--verify", "HEAD") -ErrorMessage "Could not resolve local HEAD.").Trim()
+        if ($localMain -ne $releaseTarget) {
+            Write-Host "Local main differs from origin/main; leaving local checkout unchanged." -ForegroundColor Yellow
+        }
     }
-    exit 0
-}
 
-# Tag and push only the tag
-git tag $newTag
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "ERROR: Failed to create tag $newTag" -ForegroundColor Red
-    if ($branch -ne "main") {
-        git checkout $branch -q 2>$null
-        if ($stashed) { git stash pop -q 2>$null }
+    # Get latest semver tag and compute next version.
+    $latestTag = Get-GitOutputOrExit -Arguments @("tag", "--sort=-v:refname", "--list", "v*") -ErrorMessage "Could not list release tags." |
+        Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } |
+        Select-Object -First 1
+
+    if (-not $latestTag) {
+        Write-Host "No semver tags found. Starting from v0.0.0." -ForegroundColor Yellow
+        $major = 0
+        $minor = 0
+        $patch = 0
+    } elseif ($latestTag -match '^v(\d+)\.(\d+)\.(\d+)$') {
+        $major = [int]$Matches[1]
+        $minor = [int]$Matches[2]
+        $patch = [int]$Matches[3]
+    } else {
+        Write-Host "ERROR: Could not parse latest tag: $latestTag" -ForegroundColor Red
+        exit 1
     }
-    exit 1
-}
 
-git push origin $newTag
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "ERROR: Failed to push tag $newTag" -ForegroundColor Red
-    Write-Host "The tag was created locally. Remove it with: git tag -d $newTag" -ForegroundColor Yellow
-    if ($branch -ne "main") {
-        git checkout $branch -q 2>$null
-        if ($stashed) { git stash pop -q 2>$null }
+    switch ($Bump) {
+        "major" { $major++; $minor = 0; $patch = 0 }
+        "minor" { $minor++; $patch = 0 }
+        "patch" { $patch++ }
     }
-    exit 1
+
+    $newTag = "v$major.$minor.$patch"
+
+    $existingLocalTag = Get-GitOutputOrExit -Arguments @("tag", "--list", $newTag) -ErrorMessage "Could not check local tag state."
+    if ($existingLocalTag) {
+        Write-Host "ERROR: Tag $newTag already exists locally." -ForegroundColor Red
+        exit 1
+    }
+
+    $existingRemoteTag = Get-GitOutputOrExit -Arguments @("ls-remote", "--tags", "--refs", "origin", $newTag) -ErrorMessage "Could not check remote tag state."
+    if ($existingRemoteTag) {
+        Write-Host "ERROR: Tag $newTag already exists on origin." -ForegroundColor Red
+        exit 1
+    }
+
+    if ($latestTag) {
+        $currentVersion = $latestTag
+    } else {
+        $currentVersion = "<none>"
+    }
+
+    Write-Host "Current version: $currentVersion" -ForegroundColor Gray
+    Write-Host "New version:     $newTag ($Bump bump)" -ForegroundColor Green
+    Write-Host ""
+
+    # Confirm
+    $confirm = Read-Host "Tag origin/main ($releaseTargetShort) as ${newTag} and push? [y/N]"
+    if ($confirm -ne "y" -and $confirm -ne "Y") {
+        Write-Host "Aborted." -ForegroundColor Yellow
+        exit 0
+    }
+
+    # Tag and push only the tag.
+    Invoke-GitOrExit -Arguments @("tag", $newTag, $releaseTarget) -ErrorMessage "Failed to create tag $newTag."
+
+    & git push origin $newTag
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Failed to push tag $newTag" -ForegroundColor Red
+        Write-Host "The tag was created locally. Remove it with: git tag -d $newTag" -ForegroundColor Yellow
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "Released $newTag" -ForegroundColor Green
 }
-
-Write-Host ""
-Write-Host "Released $newTag" -ForegroundColor Green
-
-# Return to original branch if we switched away
-if ($branch -ne "main") {
-    git checkout $branch -q 2>$null
-    if ($stashed) { git stash pop -q 2>$null }
-    Write-Host "Returned to $branch" -ForegroundColor Gray
+finally {
+    Pop-Location
 }

--- a/tests/release/dpf-release-remote-main.test.ps1
+++ b/tests/release/dpf-release-remote-main.test.ps1
@@ -1,0 +1,111 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-TestGit {
+    & git.exe @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($args -join ' ') failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-PowerShellCommand {
+    $command = Get-Command powershell -ErrorAction SilentlyContinue
+    if (-not $command) {
+        $command = Get-Command pwsh -ErrorAction Stop
+    }
+    return $command.Source
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$releaseScript = Join-Path $repoRoot "dpf-release.ps1"
+if (-not (Test-Path -LiteralPath $releaseScript)) {
+    throw "Missing release script at $releaseScript"
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dpf-release-test-" + [Guid]::NewGuid().ToString("N"))
+$tempRoot = [System.IO.Path]::GetTempPath()
+
+try {
+    $remote = Join-Path $testRoot "remote.git"
+    $seed = Join-Path $testRoot "seed"
+    $local = Join-Path $testRoot "local"
+
+    New-Item -ItemType Directory -Path $testRoot | Out-Null
+
+    Invoke-TestGit init --bare --initial-branch=main $remote
+
+    Invoke-TestGit init --initial-branch=main $seed
+    Invoke-TestGit "-C" $seed config user.email "release-test@example.invalid"
+    Invoke-TestGit "-C" $seed config user.name "Release Test"
+    Set-Content -Path (Join-Path $seed "release.txt") -Value "base" -Encoding ASCII
+    Invoke-TestGit "-C" $seed add release.txt
+    Invoke-TestGit "-C" $seed commit -m "base"
+    Invoke-TestGit "-C" $seed tag v1.0.0
+    Invoke-TestGit "-C" $seed remote add origin $remote
+    Invoke-TestGit "-C" $seed push origin main --tags
+
+    Invoke-TestGit clone $remote $local
+    Invoke-TestGit "-C" $local config user.email "release-test@example.invalid"
+    Invoke-TestGit "-C" $local config user.name "Release Test"
+    Set-Content -Path (Join-Path $local "release.txt") -Value "local-only" -Encoding ASCII
+    Invoke-TestGit "-C" $local commit -am "local-only"
+    $localHead = (& git "-C" $local rev-parse HEAD).Trim()
+    $scriptUnderTest = Join-Path $local "dpf-release.ps1"
+    Copy-Item -LiteralPath $releaseScript -Destination $scriptUnderTest
+
+    Set-Content -Path (Join-Path $seed "release.txt") -Value "remote-only" -Encoding ASCII
+    Invoke-TestGit "-C" $seed commit -am "remote-only"
+    Invoke-TestGit "-C" $seed push origin main
+
+    $powerShell = Get-PowerShellCommand
+    $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $processInfo.FileName = $powerShell
+    $processInfo.WorkingDirectory = $local
+    $processInfo.UseShellExecute = $false
+    $processInfo.RedirectStandardInput = $true
+    $processInfo.RedirectStandardOutput = $true
+    $processInfo.RedirectStandardError = $true
+    $processInfo.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptUnderTest`" minor"
+
+    $process = [System.Diagnostics.Process]::Start($processInfo)
+    $process.StandardInput.WriteLine("n")
+    $process.StandardInput.Close()
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+    $output = "$stdout`n$stderr"
+
+    if ($process.ExitCode -ne 0) {
+        throw "Expected release script to abort cleanly after confirmation; got exit code $($process.ExitCode). Output: $output"
+    }
+    if ($output -match "Fast-forward pull failed") {
+        throw "Release script still tried to fast-forward local main. Output: $output"
+    }
+    if ($output -notmatch "Release target:\s+origin/main") {
+        throw "Release script did not report origin/main as the release target. Output: $output"
+    }
+    if ($output -notmatch "Aborted\.") {
+        throw "Release script did not abort at operator confirmation. Output: $output"
+    }
+
+    $headAfter = (& git "-C" $local rev-parse HEAD).Trim()
+    if ($headAfter -ne $localHead) {
+        throw "Release script changed local HEAD. Before: $localHead After: $headAfter"
+    }
+
+    $createdTag = ((& git "-C" $local tag --list v1.1.0) | Out-String).Trim()
+    if ($createdTag) {
+        throw "Release script created v1.1.0 even though operator rejected confirmation."
+    }
+
+    Write-Host "PASS: dpf-release.ps1 uses origin/main without mutating divergent local main."
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        $resolvedTestRoot = (Resolve-Path -LiteralPath $testRoot).Path
+        if (-not $resolvedTestRoot.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove test root outside temp directory: $resolvedTestRoot"
+        }
+        Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary
- Updates the VS Code release tasks/script so major/minor releases target `origin/main` without trying to fast-forward the stale local `main` checkout.
- Adds PowerShell coverage for the release script's remote-main/tag behavior.

## Verification
- `powershell -NoProfile -ExecutionPolicy Bypass -File tests/release/dpf-release-remote-main.test.ps1`
- PowerShell parser check for `dpf-release.ps1`
- JSON parse check for `.vscode/tasks.json`