### PR TITLE
docs(coworker): recover autonomous runtime spec updates

### DIFF
--- a/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-11-autonomous-coworker-runtime-design.md
@@ -391,7 +391,42 @@ Every autonomous run should record cognitive-load transfer signals:
 | `exceptionClass` | failed tool, auth, missing data, policy, model, schema | Shows what to fix next. |
 | `evidenceCompleteness` | receipts, artifacts, backlog evidence | Avoids "AI did something" claims without proof. |
 
-### 5.6 Proceduralization path
+### 5.6 Run lifecycle: concurrency, cancellation, failure, handoff
+
+The doctrine and ladder in §4 are only safe if the run itself has well-defined dynamics. These four are not optional; every slice in §10 must satisfy them.
+
+**Concurrency.** Each `(agentId, contextId)` pair admits at most one `working` `TaskRun` at a time. A second trigger for the same pair while the first is `working` either attaches as a `TaskNode` child if it is a continuation, or is rejected with `status = "rejected"` and a structured reason if it is a competing top-level run. The runtime must never allow two `working` siblings for the same `(agentId, contextId)`. Cross-pair concurrency is bounded by per-user and per-provider quotas resolved through the existing routing/rate-limit layer; the runtime does not invent a second rate limiter.
+
+**Cancellation.** A run can be canceled by its `userId`, by a supervisor with cancel authority, or by the runtime itself on policy breach. Cancellation is cooperative at the agent-loop boundary and synchronous at the tool boundary:
+
+1. The runtime marks `TaskRun.status = "canceled"` and stops the agentic loop before the next inference call.
+2. In-flight `governedExecuteTool()` calls run to completion; the tool side effect either lands or does not land, and the runtime does not invent compensating actions it cannot prove are safe.
+3. Any tool with a defined rollback receipt can offer a `cancel-followup` task. The runtime does not auto-execute rollback without an explicit policy that pre-authorizes it.
+4. `TaskMessage` records the canceler identity, reason, and timestamp.
+
+Canceling a parent `TaskRun` cascades to its `working` children with the same rules. Canceling a `submitted` or `input-required` run is immediate and writes no rollback follow-up because no side effects have run.
+
+**Failure taxonomy.** `exceptionClass` (§5.5) is not free-form. It is a closed enum that drives routing for proceduralization, retries, and operator triage:
+
+| Class | Meaning | Default disposition |
+| --- | --- | --- |
+| `tool-error` | A tool returned an error or threw. | Retry-eligible per the tool retry policy; surface to operator after N retries. |
+| `tool-denied` | Grant or capability check denied the call. | No retry. File `CoworkerCapabilityNeed`. |
+| `auth-required` | Tool needs delegated credentials or external authorization. | Move run to `auth-required`. |
+| `policy-violation` | Tool result or run state violates a policy gate. | No retry. Operator review. |
+| `prompt-injection-suspected` | External tool result contained suspected injection content. | Quarantine result, escalate, and do not feed it back to the model uncritically. |
+| `model-error` | Provider returned an unrecoverable error. | Retry through routing fallback; if all fallbacks fail, fail run. |
+| `rate-limited` | Provider or internal quota refused the call. | Back off per routing policy; not a run-level failure unless exhausted. |
+| `schema-violation` | Structured output, parser output, or typed payload failed to validate. | Retry with corrective prompt or deterministic fallback up to N times. |
+| `missing-data` | Required context, grant, memory, or upstream record is absent. | Move run to `input-required` or file a capability need. |
+| `human-rejected` | Approval card was rejected. | End run as `rejected`, not `failed`. |
+| `runtime-defect` | Invariant violation in the runtime itself. | Fail run, page operator, and file a defect backlog item. |
+
+A run can fail without any `exceptionClass` only if the failure cannot be classified. That case itself files a `runtime-defect` follow-up because unclassified failure is itself a defect.
+
+**Handoff (`currentAgentId` transitions).** When one coworker hands work to another through specialist handoff, orchestrator-worker delegation, or escalation, `currentAgentId` advances but `initiatingAgentId` does not change. Each handoff writes a `TaskMessage` recording prior agent, new agent, reason, and authority delta. Authority is not inherited unconditionally: the new `currentAgentId` operates under the intersection of the run's `authorityScope` and the new agent's grants. If the intersection is empty, the handoff fails as `tool-denied` rather than silently expanding authority.
+
+### 5.7 Proceduralization path
 
 When a repeated autonomous pattern appears, DPF should file or update a backlog item with:
 
@@ -472,6 +507,24 @@ Prefer the A2A-aligned `TaskRun.status` vocabulary for autonomous work:
 Do not invent a second scheduled-task status machine beyond `ScheduledAgentTask.lastStatus`. `ScheduledAgentTask` status is schedule health; `TaskRun.status` is work health.
 
 `archived` is not a normal completion state. It is reserved for runs intentionally removed from active operational views after retention, supersession, or operator review. Slice 4 owns the first archival policy because self-assessment and capability-need runs are the first expected source of long-lived review queues. Until that policy lands, implementation slices must not emit `archived`; they should use `completed`, `failed`, `canceled`, or `rejected`.
+
+### 6.4 Retention and archival
+
+Retention applies to `TaskRun`s and their projected records, not to the underlying audit trail. `ToolExecution`, `ToolExecutionReceipt`, and `BacklogItemActivity` are audit truth and follow their own retention policy, owned by the audit/governance specs rather than this one.
+
+Default retention bands for terminal `TaskRun`s, applied when Slice 4 lands:
+
+| Terminal status | Active operational visibility | Eligible for `archived` after |
+| --- | --- | --- |
+| `completed` | 30 days | 30 days, unless linked to an open backlog item, open capability need, or unresolved proceduralization candidate |
+| `failed` (non-`runtime-defect`) | 30 days | 30 days, after exception class is reviewed and either filed or dismissed |
+| `failed` (`runtime-defect`) | indefinite | only after the defect backlog item is closed |
+| `canceled` | 14 days | 14 days |
+| `rejected` | 14 days | 14 days |
+
+Archival never deletes the `TaskRun` row. It moves the run out of default operational views such as Operations Map, Active Runs, and capability-needs review while keeping audit, evidence, and proceduralization-candidate references intact. An archived run can be unarchived by a supervisor with the same authority that could cancel it.
+
+These bands are starting defaults, not policy law. Slice 4 must capture one week of baseline data before they become enforced behavior.
 
 ## 7. Runtime Flow Requirements
 
@@ -767,14 +820,9 @@ Acceptance:
 
 ### Immediate candidate fit: Hive Scout
 
-Hive Scout is a strong near-term proving ground for this doctrine. Its deterministic core already exists as a scheduled external-catalog ingest, but its higher-order judgments remain human-heavy: novelty, archetype fit, value-stream alignment, and proposal quality. That makes it a good match for the ladder in §4:
+Hive Scout is the recommended first non-build, non-recovery consumer of Slice 1's substrate: low-risk, asynchronous, reviewable, with a deterministic core already in place and clearly ambiguous higher-order judgments (novelty, archetype fit, value-stream alignment) that the ladder in §4 fits naturally. It is also the first realistic test case for burn-rate-aware background scheduling.
 
-1. deterministic fetch/parse/dedupe stays procedural,
-2. ambiguous novelty and fit move to a bounded coworker run,
-3. repeated review corrections become filters/mappings/rules,
-4. the resulting run becomes visible in the Operations Map as proactive work rather than hidden cron behavior.
-
-Because Hive Scout is low-risk, asynchronous, and reviewable, it is also a good candidate for background execution when provider policy indicates lagging prepaid subscription quota. A dedicated design note for this application lives in `2026-05-11-hive-scout-autonomous-coworker-design.md`.
+Detail on slices, ownership, burn-rate triggers, failure modes, and open decisions lives in [2026-05-11-hive-scout-autonomous-coworker-design.md](2026-05-11-hive-scout-autonomous-coworker-design.md). This spec owns the substrate; that spec owns the application.
 
 ## 11. Metrics
 

--- a/docs/superpowers/specs/2026-05-11-hive-scout-autonomous-coworker-design.md
+++ b/docs/superpowers/specs/2026-05-11-hive-scout-autonomous-coworker-design.md
@@ -49,7 +49,7 @@ Hive Scout is not yet aligned with the autonomous coworker runtime direction:
 
 ### 2.3 Live-state note
 
-An attempted live Postgres check in this shell returned `ECONNREFUSED`, so this design does **not** claim a verified runtime count of Hive Scout runs, backlog items, or active queue state on 2026-05-11. The current-state statements above are repo-verified, not live-runtime counts.
+The current-state statements above are repo-verified, not live-runtime counts. The local Postgres instance was unreachable from the original shell on 2026-05-11, so run counts, backlog deltas, and active queue state must be re-confirmed against a running install before Slice 1 acceptance.
 
 ## 3. Why the Recent Work Applies
 
@@ -101,7 +101,7 @@ This does **not** mean “burn credits for the sake of it.” It means Hive Scou
 
 ## 4. Target Architecture
 
-## 4.1 Deterministic core stays procedural
+### 4.1 Deterministic core stays procedural
 
 The following parts should remain deterministic code:
 
@@ -115,7 +115,7 @@ The following parts should remain deterministic code:
 
 These are already code-shaped concerns and should not be pushed into prompts.
 
-## 4.2 Ambiguous reasoning moves to the coworker
+### 4.2 Ambiguous reasoning moves to the coworker
 
 The following parts are better treated as autonomous coworker cognition:
 
@@ -127,7 +127,7 @@ The following parts are better treated as autonomous coworker cognition:
 
 These are the high-context, fuzzy, judgment-heavy parts where a coworker can reduce human cognitive load.
 
-## 4.3 Hybrid pattern
+### 4.3 Hybrid pattern
 
 Hive Scout v2 should therefore follow a hybrid model:
 
@@ -155,19 +155,20 @@ Recommended shape:
 
 ### 5.2 Coworker ownership
 
-Do not create a vague new “general scout” agent.
+Ownership is a dedicated `external-catalog-scout` specialist. Do **not** attach the scouting role to `portfolio-advisor` or any other broad-authority coworker.
 
-Recommended ownership:
+Reasons:
 
-- primary specialist: a platform/portfolio-facing coworker with backlog authority and strong archetype/skill context
-- candidate owners: `portfolio-advisor` or a dedicated `external-catalog-scout` specialist
+- DPF's agent standards mandate small, context-specific tool surfaces. A dedicated specialist makes the grant surface auditable in one place instead of diluting a multi-purpose advisor.
+- Self-assessment and capability-need attribution are meaningful only when gaps are scoped to one coworker's job. Folding scouting into `portfolio-advisor` blurs whose capability is lacking when, for example, novelty detection is weak.
+- Hive contribution attribution needs a stable, distinguishable coworker role so cross-install contribution provenance can remain obfuscated-but-not-anonymous.
 
-The coworker should have:
+The `external-catalog-scout` agent must have:
 
-- bounded tool grants,
-- read-only external scouting,
-- backlog proposal capability,
-- no direct auto-create authority for new coworkers or skills.
+- bounded tool grants restricted to external catalog fetch, backlog item create/propose, `BacklogItemActivity` write, self-assessment write, and capability-need write,
+- read-only access to existing `Agent`, `SkillDefinition`, and `Archetype` rows for fit reasoning,
+- no authority to register `Agent`, `SkillDefinition`, or `Archetype` rows directly; those remain human-reviewed proposals,
+- no internet write authority and no MCP token issuance.
 
 ### 5.3 Evidence and review
 
@@ -179,11 +180,39 @@ Each meaningful Hive Scout run should produce:
 - structured summary artifacts suitable for the AI Operations Map,
 - repeatable pattern markers for future proceduralization.
 
+### 5.4 Authority resolution
+
+The scout run authenticates as the `external-catalog-scout` agent acting under a system principal, typically the same principal that owns other proactive scheduled work on the install. `TaskRun.userId` must carry the resolved `Principal` id, not the agent id and not a bespoke scout identity (AGENTS.md §11 principal convergence, parent spec §9.2). The agent's identity belongs in `currentAgentId`; the surface the schedule fired through belongs in `a2aMetadata.sourceRef.kind = "scheduled-task"`. Do not introduce a new identity-bearing row for the scout. The existing `Agent` row plus its `PrincipalAlias` linkage is sufficient.
+
 ## 6. Use-It-or-Lose-It Scheduling Policy
 
 Hive Scout is a good consumer of underused prepaid AI capacity, but only under policy.
 
-### 6.1 Safe use cases
+### 6.1 Concrete trigger signal
+
+Do not invent new burn-rate terminology. Reuse the existing `burn_rate_score` and regime model already defined in [2026-04-27-routing-control-data-plane-design.md §6.5 and §11](2026-04-27-routing-control-data-plane-design.md):
+
+```text
+burn_rate_score = quota_consumed_fraction / window_elapsed_fraction
+```
+
+Regimes already defined in the routing spec:
+
+- `regime == "lagging"` when `burn_rate_score < 0.85`,
+- `regime == "on-track"` when `0.85 <= burn_rate_score <= 1.15`,
+- `regime == "ahead"` when `burn_rate_score > 1.15`,
+- `regime == "unknown"` when the cap is not known yet; no burn-rate adjustment.
+
+Hive Scout's burn-rate-aware trigger fires only when all of the following are true:
+
+1. At least one subscription-served provider is in `regime == "lagging"`.
+2. `timeToWindowEndMs < 25%` of `windowDuration`, matching the existing watchdog detector in the routing spec.
+3. The deterministic scout core has new or stale source material to evaluate.
+4. No higher-priority operational `TaskRun` is queued for the same provider class.
+
+A run triggered by burn-rate assist must record `a2aMetadata.triggerReason = "burn-rate-lagging"` plus the observed `burn_rate_score` at trigger time. Manual and scheduled-cadence triggers record their own reasons: `"manual"`, `"cadence"`, `"stale-source"`, or `"new-source"`.
+
+### 6.2 Safe use cases
 
 Burn-rate-aware preference is appropriate when:
 
@@ -194,27 +223,29 @@ Burn-rate-aware preference is appropriate when:
 
 Hive Scout meets those conditions.
 
-### 6.2 Not a forced-consumption engine
+### 6.3 Not a forced-consumption engine
 
 Do **not** let use-it-or-lose-it logic turn Hive Scout into busywork.
 
 Guardrails:
 
 - only run when there is new or stale source material worth evaluating,
-- cap spend per run and per quota window,
+- cap spend per run and per quota window, with the implementation setting the actual budget variable,
 - batch similar entries,
-- prefer cheapest capable model first,
+- prefer the cheapest capable model first through dynamic routing; do not pin Hive Scout to one provider,
 - stop when marginal novelty falls below a threshold,
-- log why a run happened: cadence, stale source, new source, lagging burn-rate assist, or explicit human trigger.
+- emit `triggerReason` in `a2aMetadata` so operators can audit why each run happened.
 
-### 6.3 Policy recommendation
+### 6.4 Policy recommendation
 
-Hive Scout should be eligible for a background “subscription utilization assist” queue class:
+Hive Scout should be eligible for a background "subscription utilization assist" queue class:
 
 - lower priority than operational recovery,
 - higher priority than cosmetic research,
-- auto-paused when provider burn rate is already ahead,
-- safe to resume when quota lag is detected.
+- auto-paused when no provider is in `regime == "lagging"` near window end,
+- safe to resume when the §6.1 trigger condition becomes true again.
+
+This queue class is a new concept; it does not exist yet. Slice 4 introduces it and must coordinate with the routing scorer so background scout runs are not double-counted against the same lagging provider.
 
 ## 7. Implementation Slices
 
@@ -224,17 +255,22 @@ Goal: make Hive Scout a first-class proactive coworker run.
 
 Scope:
 
-- route Hive Scout through the scheduled coworker substrate,
-- create `TaskRun` for each run,
-- write structured run summaries,
-- project runs into the AI Operations Map,
-- preserve the existing deterministic ingest logic.
+- create a `ScheduledAgentTask` row owned by `external-catalog-scout` that replaces the current Inngest-only schedule,
+- route execution through the scheduled coworker substrate added in the parent spec's Slice 1,
+- create one `TaskRun` per scheduled execution before the first fetch or tool call,
+- preserve the existing deterministic fetch, parse, and dedupe logic inside the run as tool calls or pre-tool steps, not as a parallel queue function,
+- emit `TaskMessage` for run start, batch checkpoints, and final summary,
+- record `BacklogItemActivity` evidence linking each created suggestion back to the source run,
+- retire `hive-scout-ingest.ts` as the durable schedule entry point once the scheduled-task path is verified; keep `hive-scout-manual-run.ts` as an operator-only replay tool.
 
 Acceptance:
 
-- each Hive Scout run has one `TaskRun`,
-- run appears in AI Operations Map,
-- backlog suggestions link back to source run evidence.
+- each Hive Scout execution produces exactly one `TaskRun`, with zero scheduled executions missing `taskRunId` over a rolling 7-day window,
+- `TaskRun` is created before any external fetch or tool call, verified by an ordering test and matching the parent spec §5.1 invariant,
+- each created `BacklogItem` has a `BacklogItemActivity` row pointing at the source `TaskRun`,
+- the run appears in AI Operations Map alongside other proactive runs,
+- failure modes are explicit: upstream fetch failure ends the run as `failed` with `exceptionClass = "tool-error"` and `exceptionDetail.kind = "upstream-unavailable"`; parser failure ends as `failed` with `exceptionClass = "schema-violation"` and `exceptionDetail.kind = "parse-error"`, then writes the raw payload as a `TaskArtifact` for diagnosis; partial success ends as `completed` with skipped-entry count in `progressPayload`,
+- build gate passes: vitest for affected code, `apps/web` production build, migration apply if any, and UX verification of the Operations Map projection.
 
 ### Slice 2: Add autonomous ambiguity review
 
@@ -242,17 +278,21 @@ Goal: keep procedural code for parsing/dedupe, but let the coworker judge novelt
 
 Scope:
 
-- batch unresolved entries,
-- invoke coworker reasoning with structured output,
+- batch unresolved entries inside the same parent `TaskRun`,
+- invoke coworker reasoning through the parent spec's `AutonomousWorkRun` service; do not call `runAgenticLoop()` directly, because that bypasses the governance and audit choke point,
+- represent each ambiguity-review pass as a `TaskNode` child of the scout's parent `TaskRun`, matching the Build Studio decomposition rule in parent §7.4,
+- request structured JSON output,
 - classify results as `new_archetype`, `existing_skill_gap`, `duplicate_pattern`, `out_of_scope`, or `needs_human_review`,
-- persist rationale/evidence,
+- persist rationale and evidence pointers on `TaskArtifact`,
 - keep human review on the final proposal layer.
 
 Acceptance:
 
-- deterministic path still handles obvious duplicates,
-- coworker only receives ambiguous entries,
-- proposals are structured and reviewable.
+- deterministic path still handles obvious duplicates with zero LLM cost,
+- coworker only receives entries the deterministic path could not classify,
+- every coworker classification has a structured rationale persisted as `TaskArtifact`,
+- proposals appear in operator review with classification and rationale, not raw chat,
+- prompt-injection guard: external catalog text passed to the coworker is treated as untrusted, so classifications cannot create backlog items directly; the proposal-mode tool boundary still applies.
 
 ### Slice 3: Add proceduralization loop
 
@@ -288,27 +328,40 @@ Acceptance:
 - it remains bounded and reviewable,
 - it never crowds out higher-priority operational work.
 
-## 8. Recommended Next Move
+## 8. Open Decisions
 
-The next move should **not** be “make Hive Scout smarter everywhere at once.”
+1. Where does deterministic fetch live after Slice 1: in the coworker run as a tool, or in a pre-run pipeline step that hands parsed entries to the run?
+   Recommendation: deterministic fetch becomes a governed MCP/tool surface the scout coworker calls in its first step. That keeps a single audit/grant choke point and avoids splitting work between Inngest and the runtime. Reconsider if fetch latency dominates and pre-run parallelism becomes necessary.
 
-The right next step is **Slice 1: TaskRun-ize Hive Scout**.
+2. Should Slice 2 classification outputs auto-create draft `BacklogItem` rows, or only proposals queued for human review?
+   Recommendation: proposals only. The classification model can be wrong about novelty, and Slice 3's proceduralization loop needs human-corrected ground truth to compute repeated-correction signal. Reconsider after Slice 3 evidence shows classifier precision is stable.
 
-Why:
+3. Is there value in a per-source schedule, one cron per upstream catalog, versus one schedule that fans out across all sources?
+   Recommendation: one parent `TaskRun` per scheduled execution and one `TaskNode` per source. This matches the Build Studio mapping rule in parent §7.4 and keeps the operator's "one scout run" mental model intact.
 
-- the autonomous runtime substrate is now the platform direction,
-- the scheduled coworker/TaskRun seam already exists,
-- this gives immediate operator visibility and governance,
-- it creates the evidence foundation needed before any deeper AI reasoning is added.
+4. Do Hive Scout runs need a tighter retention band than the parent spec's defaults?
+   Recommendation: start by inheriting the parent spec's §6.4 defaults. Hive Scout produces low-risk, reviewable output, so there is no obvious reason to deviate. Revisit if backlog-evidence chains depend on scout runs that have already archived; in that case promote the retention floor for runs linked to open backlog items.
 
-Only after that should DPF add autonomous novelty judgment and use-it-or-lose-it scheduling.
+## 9. Recommended Next Move
 
-## 9. Recommendation
+The next move should **not** be "make Hive Scout smarter everywhere at once." Start with **Slice 1: TaskRun-ize Hive Scout**.
 
-Adopt Hive Scout as one of the first non-build, non-recovery proof points of the new autonomous coworker runtime.
+Why this sequencing:
 
-That makes it useful in three ways at once:
+- the scheduled-coworker/`TaskRun` substrate from the parent spec's Slice 1 exists, so the new substrate is reused rather than expanded,
+- governed evidence through the `TaskRun`, `TaskArtifact`, and `BacklogItemActivity` chain is the prerequisite for later autonomous novelty reasoning,
+- Hive Scout is low-risk, asynchronous, reviewable, and a strong fit for the cognitive-load ladder,
+- it is also the first realistic test of use-it-or-lose-it scheduling without putting irreversible work onto a burn-rate-triggered queue.
+
+## 10. Recommendation
+
+Adopt Hive Scout as one of the first non-build, non-recovery proof points of the autonomous coworker runtime.
+
+That makes it useful in four ways at once:
 
 - it reduces human research/orchestration burden,
 - it produces governed evidence in the runtime control surface,
-- it creates a clean case for the platform’s “AI first, then procedure” doctrine.
+- it creates a clean case for the platform's "AI first, then procedure" doctrine,
+- it supplies a bounded background-work candidate for capacity-aware scheduling.
+
+Adopt autonomous novelty judgment (Slice 2), proceduralization loop (Slice 3), and burn-rate-aware scheduling (Slice 4) only after Slice 1 ships and produces at least a week of clean evidence.


### PR DESCRIPTION
## Summary
- Recovers the useful autonomous coworker runtime spec updates onto current `origin/main`.
- Preserves current mainline Capacity Continuity and shipped Slice 1 language while adding lifecycle, failure taxonomy, retention, Hive Scout ownership, authority, burn-rate trigger, and acceptance detail.

## Verification
- `git diff --check`