### PR TITLE
docs: capture realtime HITL mobile companion track

### DIFF
--- a/docs/superpowers/audits/2026-05-13-realtime-hitl-mobile-readiness-report.md
+++ b/docs/superpowers/audits/2026-05-13-realtime-hitl-mobile-readiness-report.md
@@ -1,0 +1,256 @@
+# Realtime HITL and Mobile Companion Readiness Report
+
+**Date:** 2026-05-13
+**Status:** Recommendations
+**Related spec:** [Realtime HITL Notification and Mobile Companion Design](../specs/2026-05-13-realtime-hitl-mobile-companion-design.md)
+**Related plan:** [Paused AI Work Approval Surface Implementation Plan](../plans/2026-05-13-paused-ai-work-approval-surface.md)
+
+---
+
+## Executive Recommendation
+
+Move this track now, but keep the first release narrow:
+
+1. **Finish Paused Work in the portal.**
+2. **Add realtime HITL notifications and deep links.**
+3. **Ship a mobile companion for Paused Work only.**
+4. **Add richer mobile workflows after the decision/audit path is proven.**
+
+The mobile app should not start as "the whole portal on a phone." The first valuable app is a secure companion that wakes the right human when an autonomous coworker is blocked and presents the smallest accountable decision with enough context to approve, reject, or request changes.
+
+## Current Repo Readiness
+
+DPF already has the right foundation:
+
+- `TaskRun` is the work identity for autonomous coworker runs.
+- `input-required` and `auth-required` are the pause states.
+- `TaskMessage` and `AuthorizationDecisionLog` can preserve decision context.
+- `Notification`, `PlatformNotification`, and `PushDeviceRegistration` already exist.
+- `apps/web/lib/queue/notification-adapter.ts` is already a pluggable notification adapter, currently in-app only.
+- `apps/web/lib/tak/agent-event-bus.ts` already carries task, queue, build, verification, async, and deliberation events.
+- `/api/agent/stream` already provides a web SSE path.
+- `/api/v1/notifications/register-device` already exists as the starting device-registration endpoint.
+- `docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md` already chose React Native + Expo.
+
+The missing pieces are not basic primitives. The missing pieces are:
+
+- a canonical paused-work notification event,
+- a channel policy,
+- push delivery,
+- mobile auth,
+- store registration,
+- deep-link contracts,
+- operational accounts and credentials.
+
+## Account and Service Gaps
+
+### Required before App Store or Play Store release
+
+| Need | Recommendation | Owner action |
+|---|---|---|
+| Apple Developer Program | Enroll as an organization if DPF should publish under the company name. Apple lists the standard program membership as USD 99 per year. | Create or confirm Apple Developer account, legal entity, D-U-N-S details, two-factor Apple ID. |
+| Google Play Console | Create a Google Play developer account. Google lists a USD 25 one-time registration fee. | Create or confirm Play Console account under the publishing entity. |
+| Expo account | Use EAS Build/Submit for the first app build pipeline. Expo is the shortest path for an Expo-managed React Native app. | Create Expo organization/project, decide paid tier only when build volume requires it. |
+| Firebase project | Use Firebase Cloud Messaging for Android push. FCM is currently no-cost for push messaging. | Create Firebase project, Android app entry, server credentials, and FCM config. |
+| Apple push credentials | APNs key/certificate is required for iOS push via Expo/EAS. | Generate APNs Auth Key in Apple Developer, store in Expo/EAS credentials. |
+| Public web domain | Universal Links and Android App Links require `.well-known` files on the install domain. | Confirm production domain and HTTPS path for `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json`. |
+| Privacy policy URL | Both stores and app auth flows need a privacy policy. | Publish DPF mobile privacy policy before store submission. |
+| Support URL and support email | Both stores expect user support/contact metadata. | Decide public support email and support page. |
+| App name and bundle IDs | Stable identifiers are painful to change later. | Reserve name and IDs early: suggested `com.opendigitalproductfactory.mobile` or company-specific equivalent. |
+
+Official references:
+
+- Apple Developer Program: [Apple Developer Program enrollment](https://developer.apple.com/programs/enroll/)
+- Google Play Console: [Get started with Play Console](https://support.google.com/googleplay/android-developer/answer/6112435)
+- Expo EAS: [EAS Build introduction](https://docs.expo.dev/build/introduction/) and [EAS Submit introduction](https://docs.expo.dev/submit/introduction/)
+- Expo push: [Expo push notification setup](https://docs.expo.dev/push-notifications/push-notifications-setup/)
+- Firebase Cloud Messaging: [FCM pricing FAQ](https://firebase.google.com/support/faq#fcm-pricing)
+- Apple Universal Links: [Supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
+- Android App Links: [Verify Android App Links](https://developer.android.com/training/app-links/verify-android-applinks)
+
+### Likely required for smoother testing
+
+| Need | Recommendation | Owner action |
+|---|---|---|
+| Physical iPhone | Required for push, biometrics, deep links, and real App Store/TestFlight QA. Simulator is not enough. | Identify one modern iPhone on a current iOS version. |
+| Physical Android phone | Required for FCM, app links, notification permissions, and Play internal testing. | Identify one modern Android phone on a supported OS. |
+| TestFlight testers | Use internal TestFlight first, then external if needed. | Add Mark and any trusted testers to App Store Connect. |
+| Play internal testing track | Use Play internal testing first. Personal Play developer accounts may face extra production-access testing requirements; organization accounts are usually easier for company publishing. | Prefer organization publishing account if available. |
+| Apple App Store Connect access | Needed for TestFlight, app metadata, app privacy, builds, and review. | Add the developer/publisher Apple ID with least necessary role. |
+| Google Play Console access | Needed for internal testing, app signing, data safety, and releases. | Add the developer/publisher Google account with least necessary role. |
+
+## Apps and Local Tools to Install
+
+### Developer/build machine
+
+| Tool | Why | Timing |
+|---|---|---|
+| Node/pnpm from repo toolchain | Already required by DPF. | Existing. |
+| Expo CLI via `pnpm` scripts | Project scaffolding, local dev, EAS commands. | Slice 3. |
+| EAS CLI via `pnpm` scripts | Cloud builds and submit workflows. | Slice 3 or before first TestFlight. |
+| Android Studio | Android emulator, SDK inspection, local diagnostics. | Helpful before Android QA. |
+| Xcode on macOS | iOS simulator, local native diagnostics, Apple signing sanity checks. | Needed if you want local iOS simulator/debugging beyond EAS cloud builds. |
+| Maestro CLI | Mobile E2E tests as selected in the March mobile spec. | Before mobile PR verification. |
+| Expo Go | Fast early UI testing if no custom native modules are needed. | Early only. |
+| Development build app | Required once native notification/deep-link behavior matters. | Before push/deep-link QA. |
+
+### Phone apps/accounts
+
+| App/account | Why |
+|---|---|
+| TestFlight on iPhone | Install internal iOS test builds. |
+| Expo Go on iPhone/Android | Useful for early UI-only validation. |
+| Google account tied to Play testing | Needed for Android internal testing. |
+| Apple ID with 2FA | Required for Apple Developer/App Store Connect. |
+| Authenticator/password manager | Store Apple, Google, Firebase, Expo, and APNs credentials safely. |
+
+## Store and Compliance Gaps
+
+### Apple App Store metadata
+
+Prepare:
+
+- app name,
+- subtitle,
+- description,
+- keywords,
+- support URL,
+- marketing URL if available,
+- privacy policy URL,
+- screenshots,
+- app icon,
+- sign-in demo account or review notes,
+- app privacy nutrition labels.
+
+### Google Play metadata
+
+Prepare:
+
+- app name,
+- short description,
+- full description,
+- app icon,
+- feature graphic,
+- phone screenshots,
+- support email,
+- privacy policy URL,
+- Data safety form,
+- content rating questionnaire,
+- target audience declaration.
+
+### DPF-specific policy content
+
+The privacy policy and store metadata should explicitly cover:
+
+- account authentication,
+- push notifications,
+- AI coworker decision notifications,
+- audit logging of approvals/rejections/request-changes,
+- device token storage,
+- no sensitive prompt text in push payloads,
+- data retention tied to the DPF install.
+
+## Recommended Sequence
+
+### Phase 0: No-cost preparation
+
+Do now:
+
+1. Decide the app name.
+2. Decide bundle/package ID.
+3. Confirm production domain for universal/app links.
+4. Draft mobile privacy policy and support page.
+5. Decide whether publishing entity is individual or organization.
+6. Confirm physical iPhone and Android test devices.
+
+### Phase 1: Portal implementation
+
+Do before mobile build work:
+
+1. Implement Paused Work portal surface.
+2. Implement paused-work REST endpoints.
+3. Implement `Notification` rows for paused tasks.
+4. Implement portal badge/live refresh.
+5. Verify high-risk MCP pause, reject, and approve/resume locally.
+
+### Phase 2: Push foundation
+
+Do after portal behavior is stable:
+
+1. Harden device registration endpoint.
+2. Add Expo push notification adapter.
+3. Add channel policy.
+4. Test push payloads without sensitive prompt text.
+5. Add universal/app links.
+
+### Phase 3: Mobile app shell
+
+Do after accounts are ready:
+
+1. Scaffold `apps/mobile`.
+2. Implement login.
+3. Implement Paused Work inbox/detail.
+4. Register device for push.
+5. Open push/deep link into a paused-work detail.
+6. Add mobile decision actions only after portal decision module is stable.
+
+### Phase 4: Store/test distribution
+
+Do when first mobile shell passes local testing:
+
+1. EAS internal iOS build.
+2. TestFlight internal test.
+3. EAS internal Android build.
+4. Play internal test track.
+5. Store metadata and privacy/data-safety review.
+
+## Buy or Create Now
+
+### Create now
+
+- Apple Developer organization account, if not already present.
+- Google Play Console organization account, if not already present.
+- Expo organization/project.
+- Firebase project for DPF mobile push.
+- Public support email or alias.
+- Public privacy policy URL.
+
+### Do not buy yet
+
+- Paid Expo tier, unless build volume or team permissions require it.
+- Slack/Teams production apps, until portal/mobile paused-work notification path is proven.
+- Direct APNs/FCM infrastructure outside Expo, unless Expo push service becomes a constraint.
+- Mobile device farm subscription, until Maestro tests need CI device coverage.
+
+### Hardware to have available
+
+- One iPhone for TestFlight/push/deep-link QA.
+- One Android phone for Play/FCM/app-link QA.
+- A macOS machine with Xcode access if local iOS debugging becomes necessary.
+
+## Risk Register
+
+| Risk | Why it matters | Recommendation |
+|---|---|---|
+| Mobile scope creep | The March spec is broad enough to absorb months of work. | Keep first app to Paused Work only. |
+| Store account delay | Apple organization enrollment and app review can block release timing. | Start account setup before mobile implementation begins. |
+| Push data leakage | Prompt text may include sensitive data. | Put only safe summary fields in push payloads. |
+| Approval fatigue | Mobile can make every pause feel urgent. | Use channel policy and risk classes. |
+| Parallel decision path | Mobile might accidentally bypass portal audit logic. | All mobile decision endpoints call the same paused-work decision module as portal. |
+| Deep-link drift | Universal/App Links need domain files and app IDs to match. | Implement `.well-known` contracts early and test before store review. |
+| Personal Play account production gating | Personal accounts can have extra testing requirements before production access. | Prefer organization publishing account for DPF. |
+
+## Concrete Next Recommendation
+
+The next implementation thread should not start with `apps/mobile`.
+
+Start with:
+
+1. Paused Work portal implementation.
+2. Paused Work REST API endpoints shaped for mobile reuse.
+3. Notification event projection into `Notification`.
+4. Push-device registration hardening.
+
+Then start `apps/mobile` once the server contract is stable.
+
+This keeps the phone app from inventing its own data model, its own approval path, or its own view of HITL state. It also makes mobile a thin, secure companion to the governed coworker runtime, which is the architecture we want.

--- a/docs/superpowers/plans/2026-05-13-paused-ai-work-approval-surface.md
+++ b/docs/superpowers/plans/2026-05-13-paused-ai-work-approval-surface.md
@@ -10,6 +10,26 @@
 
 ---
 
+## Locked Architectural Decisions
+
+These are binding for V1. They are *decisions*, not judgment calls. They exist so that downstream slices (Active Runs surface, CWQ unification, V2 resume paths) do not collide with V1 contracts.
+
+1. **Status vocabulary is closed.** `TaskRun.status` continues to use the A2A-aligned set documented at `packages/db/prisma/schema.prisma:3914` — `submitted | working | input-required | auth-required | completed | failed | canceled | rejected | archived`. "Request changes" is not a new status; it appends a `TaskMessage` and leaves the run at `input-required`. No `needs-revision` / `paused` / `awaiting` strings introduced anywhere.
+2. **`AuthorizationDecisionLog.actionKey` vocabulary is locked to:** `task.paused.approve`, `task.paused.reject`, `task.paused.request_changes`. Future paused-work decision types extend this namespace; they do not invent parallel ones.
+3. **Decision `TaskMessage` shape is locked.** `role = "user"`, `metadata.kind = "operator-decision"`, `metadata.decision = "approve" | "reject" | "request_changes"`, `metadata.actorPrincipalId`, `metadata.actionKey`. Anything else goes in `metadata.detail`.
+4. **Principal convergence (AGENTS.md §11, 2026-05-09 addendum).** `AuthorizationDecisionLog.actorRef` and `humanContextRef` carry resolved `Principal` ids — never raw `User.id`. The alias kind (`mcp-token`, `mcp-session`, `web-session`, etc.) goes in the rationale payload alongside the decision context. `TaskRun.userId` continues to carry the `Principal` id per the runtime spec §9.2.
+5. **`auth-required` is "missing credential / authority", not "human judgment".** V1 lists `auth-required` runs in the inbox so they are not invisible, surfaces the missing scope or credential, and disables `Approve and resume` for them. The remediation flow (re-issue token, grant scope, attach delegation) is V2. Reject and request-changes remain available because they audit the decision to abandon or clarify.
+6. **Approve-and-resume scope.** V1 implements resume only for `a2aMetadata.trigger === "external-mcp"`. Paused `scheduled`, `build`, `interactive`, `deliberation`, and `capacity-continuity` runs appear in the inbox (so they are not invisible) and support reject + request-changes, but `Approve and resume` is disabled with a clear "resume not yet wired for this trigger" message. Each trigger's resume path is its own slice and must use the same `AutonomousWorkRun` seam.
+7. **Idempotency is enforced by status-conditional update, not by application checks.** Every decision writes through a Prisma `update` whose `where` includes the current status (`status: { in: ["input-required", "auth-required"] }`) and returns a count. Zero affected rows means another operator already decided; the action returns a conflict result without re-reading first.
+8. **Operator authorization rule.** A user may decide a paused `TaskRun` if (a) their resolved `Principal` matches `TaskRun.userId`, or (b) their platform role grants the `governance.approve_task` capability. Pick the existing capability key during implementation (`apps/web/lib/permissions.ts` is the source of truth — if no exact match, add it in the same commit as the decision module, not later). No "owner can always" carve-outs beyond (a).
+9. **`AgentActionProposal` is read-only linkage, never the owning record.** If a paused `TaskRun` has a related `AgentActionProposal` (via `AgentActionProposal.taskRunId`), the detail panel shows it as evidence. The decision still writes to `AuthorizationDecisionLog` + `TaskMessage` on the `TaskRun`. The proposal-card API path is not invoked.
+10. **No `WorkItem` rows created in V1.** `WorkItem` / `WorkQueue` (EP-CWQ-001) are a separate ownership/routing primitive. Re-evaluate unification when *either* (a) the same `TaskRun` legitimately needs to appear in multiple operator queues with independent claim state, *or* (b) the autonomous-runtime spec's "Active Runs" surface lands and Paused Work becomes a filtered view of it. Until then, Paused Work is a read-projection over `TaskRun`.
+11. **Naming alignment with the runtime spec.** The autonomous-coworker-runtime spec §8.1 names "Active Runs" as the broader surface; this slice ships the narrower, action-focused "Paused Work" first. When Active Runs lands, "Paused Work" becomes a default-filtered view inside it, not a sibling page. The route `/platform/ai/paused-work` is preserved as a stable deep-link target.
+12. **`a2aMetadata` JSON-path is the V1 query surface; columns are not promoted yet.** Loaders read `riskClass`, `trigger`, `sourceRef`, `apiTokenId` from `a2aMetadata` / `progressPayload`. Promotion of `triggerKind` or `riskClass` to indexed columns is deferred to autonomous-runtime spec Slice 5 metrics or to the point where the Operations-Map paused-count query exceeds 50 ms p95 — whichever comes first.
+13. **Hooks into existing escalation primitives are not built, but are not blocked either.** `ValueStreamHitlGate.channels`, `escalationPath`, and `escalationTimeoutMinutes` exist. V1 does not consume them and does not introduce a parallel notification stack. The V2 notification slice attaches to those.
+
+---
+
 ## Current State
 
 The runtime already has the important substrate:
@@ -74,21 +94,26 @@ Primary layout:
 - Use icons from the existing icon library if present in the touched files; otherwise keep text labels plain and compact.
 - Use only DPF theme CSS variables. No hardcoded Tailwind gray classes, no hardcoded hex colors, and no inline non-token color styles.
 
-The list row should show: title, status, risk class, trigger/source, coworker, route context, age, and decision SLA if available.
+The list row should show: title, status, risk class, trigger/source, coworker, route context, and age (time since `startedAt`).
+
+List ordering is fixed: **high-risk first, then bounded-write, then read; within each tier, oldest paused first (FIFO).** This is an approval queue, not an activity feed. Tests must pin this order — see Task 2.
+
+No "decision SLA" column in V1. Per Locked Decision 13, escalation timeouts live on `ValueStreamHitlGate` and are not consumed yet; we do not invent a parallel SLA on `TaskRun`.
 
 The detail panel should show:
 
-- decision brief,
+- **AI-prepared decision brief.** V1 source order: (a) `progressPayload.decisionBrief` if the coworker wrote one before pausing, (b) `progressPayload.summary` if present, (c) computed fallback = first 240 chars of the user prompt + a one-line tool/risk summary. The brief is always labeled "AI-prepared" so the operator knows it is not raw evidence. Future slices may have coworkers author the brief explicitly before pausing; the loader contract does not change.
+- **Raw requested action / prompt — unaltered.** This is the first `TaskMessage` with `role = "user"` for the run, rendered verbatim. It is shown adjacent to the AI brief, not nested inside it. This is the OWASP "Lies in the Loop" defense: the operator must always be able to compare AI summary against original text.
 - pause reason,
-- requested action or prompt,
 - risk class and authority scope,
 - initiating source (`mcp-token`, `mcp-session`, `scheduled-task`, etc.),
-- token/source attribution where present,
+- token/source attribution where present (`a2aMetadata.sourceRef`, `apiTokenId`),
 - coworker and route context,
 - prior `TaskMessage` entries,
-- related `ToolExecution` rows if any,
-- raw metadata disclosure in an advanced section,
-- action bar with `Approve and resume`, `Reject`, and `Request changes`.
+- related `ToolExecution` rows scoped by `taskRunId`,
+- related `AgentActionProposal` rows joined on `AgentActionProposal.taskRunId` — display-only evidence, never decided here,
+- raw `a2aMetadata` and `progressPayload` disclosure in an advanced section,
+- action bar with `Approve and resume`, `Reject`, and `Request changes`. `Approve and resume` is **disabled** for `auth-required` runs and for any trigger other than `external-mcp` in V1, with a tooltip explaining why and what slice will unlock it.
 
 ## Email and Messaging Approval Policy
 
@@ -172,9 +197,11 @@ Expected: PASS or only unrelated pre-existing failures, which must be documented
 Cover:
 
 - list returns only unarchived `input-required` and `auth-required` TaskRuns;
-- list sorts oldest waiting work first inside severity buckets or newest first consistently, with the chosen order documented in the test name;
+- list orders by `riskClass` (high-risk, bounded-write, read) then by `startedAt` ascending (FIFO within tier) — Locked Decision 11 plus the ordering rule in §UX Decision;
 - list extracts `riskClass`, `trigger`, `sourceRef`, `apiTokenId`, and summary from `a2aMetadata` / `progressPayload`;
-- detail includes `TaskMessage` entries and related `ToolExecution` rows by `taskRunId`;
+- detail includes `TaskMessage` entries (ordered `createdAt` asc) and related `ToolExecution` rows by `taskRunId`;
+- detail joins related `AgentActionProposal` rows via `AgentActionProposal.taskRunId` and returns them as evidence only — Locked Decision 9;
+- the raw-prompt field of the detail is exactly the first `TaskMessage` with `role = "user"`, unaltered — OWASP "Lies in the Loop" defense;
 - count returns only actionable paused work for nav badges.
 
 Run: `pnpm --filter web exec vitest run apps/web/lib/paused-ai-work/data.test.ts`
@@ -308,10 +335,11 @@ Cover:
 
 - reject only works for `input-required` / `auth-required`;
 - reject sets `status = "rejected"`, `completedAt`, and decision metadata in `progressPayload`;
-- request changes appends a `TaskMessage`, leaves status paused, and records decision metadata;
-- all decisions write `AuthorizationDecisionLog`;
-- duplicate decision attempts fail clearly;
-- unauthorized user cannot decide another user's paused work unless existing platform role checks allow it.
+- request changes appends a `TaskMessage` (role `user`, `metadata.kind = "operator-decision"`, `metadata.decision = "request_changes"` — Locked Decision 3), leaves status `input-required`, and records decision metadata in `progressPayload`;
+- all decisions write `AuthorizationDecisionLog` with `actionKey` in the locked vocabulary — `task.paused.approve` | `task.paused.reject` | `task.paused.request_changes` (Locked Decision 2) — and `actorRef` / `humanContextRef` set to the resolved `Principal` id, not `User.id` (Locked Decision 4);
+- idempotency: a duplicate decision attempt issued through a status-conditional update returns zero affected rows and the function returns a `{ kind: "conflict" }` result without re-reading state (Locked Decision 7);
+- operator authorization: only the originating `Principal` or a user with the `governance.approve_task` capability can decide; any other caller gets a `{ kind: "forbidden" }` result (Locked Decision 8) — the test uses the same capability key the implementation lands;
+- `auth-required` runs: reject and request-changes succeed; approve returns a structured `{ kind: "unsupported", reason: "auth-required-needs-credential" }` result and does **not** mutate status (Locked Decision 5).
 
 Run: `pnpm --filter web exec vitest run apps/web/lib/paused-ai-work/decisions.test.ts`
 
@@ -386,7 +414,7 @@ Keep parsing, idempotency lookup, and initial pause creation in `submitRemoteCow
 
 - [ ] **Step 4: Add approve decision wrapper**
 
-`approvePausedAiWork()` routes only `external-mcp` TaskRuns to remote resume in V1. Other paused triggers should return a clear unsupported-trigger error and remain paused.
+`approvePausedAiWork()` routes only `external-mcp` TaskRuns to remote resume in V1 (Locked Decision 6). For any other trigger, return `{ kind: "unsupported", reason: "approve-not-wired-for-trigger", trigger }` and leave status untouched. For `auth-required` runs of any trigger, return `{ kind: "unsupported", reason: "auth-required-needs-credential" }` per Locked Decision 5. In both cases, no status mutation, no `AuthorizationDecisionLog` row written — these are pre-decision validation failures, not decisions.
 
 - [ ] **Step 5: Run tests**
 
@@ -451,6 +479,18 @@ Run:
 git add apps/web/lib/ai-operations-map
 git commit -s -m "feat(ai): route paused map events to approval surface"
 ```
+
+## Per-Chunk Build-Gate Hygiene (AGENTS.md §4–§5)
+
+This work runs in a topic worktree, not the root clone. Before starting Chunk 1: `git worktree add ../DPF-paused-ai-work-approval -b doc/paused-ai-work-approval-surface` from the root clone, then `scripts/seed-worktree-mcp.ps1` (or `.sh`) inside the new worktree.
+
+At the end of every chunk (1 through 4), run:
+
+```bash
+pnpm --filter web typecheck
+```
+
+The pre-commit hook runs this on changed files, but per-chunk catches cross-file regressions before the chunk commits and stops failures from compounding into Chunk 5. Do not defer typecheck to E2E.
 
 ## Chunk 5: End-to-End Verification
 
@@ -558,18 +598,21 @@ Expected: draft PR created with verification evidence.
 
 ## Open Judgment Calls
 
-1. **Badge count:** V1 can omit a nav badge if the existing nav components do not have a badge pattern. If a badge is cheap and token-safe, show the paused count in `Paused Work`; otherwise rely on the tab and Operations Map attention links.
-2. **Auth-required behavior:** `auth-required` should appear in the inbox immediately, but V1 approval may only support `input-required` external MCP pauses. If stronger auth is not wired yet, the action should explain what credential or authority is missing.
-3. **Email/messaging:** Keep portal approval canonical in V1. Add Slack/Teams/email deep-link notifications only after this route proves the decision artifact and UX.
-4. **Collaborative Work Queue bridge:** Do not create `WorkItem` rows in this slice. Revisit once the queue implementation exists or once paused-work metrics show multi-worker assignment/escalation is needed.
-5. **Proceduralization feedback:** This slice should store enough decision metadata to support Slice 5 metrics. It does not need to build the proceduralization dashboard.
+Most of the prior open questions have been promoted into Locked Architectural Decisions above. Remaining open:
+
+1. **Badge count:** V1 can omit a nav badge if the existing nav components do not have a badge pattern. If a badge is cheap and token-safe, show the paused count on `Paused Work`; otherwise rely on the tab and Operations Map attention links. Pick during Task 3 implementation.
+2. **`governance.approve_task` capability key:** Locked Decision 8 binds the rule but lets implementation pick the capability key from existing `apps/web/lib/permissions.ts`. If no exact-fit key exists, add it in the same commit as `decisions.ts` — do not defer.
+3. **Email/messaging:** Per §Email and Messaging Approval Policy, V1 stays portal-canonical. The follow-on realtime/mobile notification track is captured in `docs/superpowers/specs/2026-05-13-realtime-hitl-mobile-companion-design.md`; add Slack/Teams/email deep-link notifications via the existing `ValueStreamHitlGate.channels` primitive only after this route proves the decision artifact and UX.
+4. **Decision-brief authorship by coworkers.** V1 falls back to `progressPayload.summary` + prompt prefix. Whether and when coworkers should populate `progressPayload.decisionBrief` explicitly before pausing is a coworker-prompt change owned by a separate slice — flagged here so the loader contract for `decisionBrief` is non-breaking when that lands.
+5. **Proceduralization feedback:** This slice stores enough decision metadata to support autonomous-runtime spec Slice 5 metrics (decision counts by `actionKey` + `trigger` + `riskClass`). It does not build the proceduralization dashboard.
 
 ## Done Criteria
 
 - A paused high-risk remote MCP TaskRun is visible without hunting through raw API endpoints.
-- The operator sees enough context to decide without reconstructing the entire run manually.
-- Approve resumes external MCP paused work through the existing autonomous runtime seam.
-- Reject and request-changes paths are audited and idempotent.
+- The operator sees enough context to decide without reconstructing the entire run manually, and the raw user prompt is always shown adjacent to (not nested inside) the AI-prepared brief.
+- Approve resumes `external-mcp` paused work through the existing autonomous runtime seam; non-`external-mcp` triggers and `auth-required` runs return a clear `unsupported` result without mutating state.
+- Reject and request-changes paths are audited (every decision writes `AuthorizationDecisionLog` with an `actionKey` from the locked vocabulary and a resolved `Principal` id) and idempotent by status-conditional update.
 - Operations Map attention events deep-link to the paused decision context.
-- Focused tests, typecheck, production build, Docker rebuild, and live MCP pause/approve/reject smokes pass.
+- Focused tests, typecheck (per chunk and at E2E), production build, Docker rebuild, and live MCP pause/approve/reject smokes pass.
 - The implementation reduces cognitive load and does not create a new approval-fatigue inbox without evidence and policy context.
+- Zero new status strings, zero new identity-bearing entities outside `Principal`, zero new approval API surfaces — all locked decisions hold.

--- a/docs/superpowers/specs/2026-05-13-realtime-hitl-mobile-companion-design.md
+++ b/docs/superpowers/specs/2026-05-13-realtime-hitl-mobile-companion-design.md
@@ -3,6 +3,7 @@
 **Date:** 2026-05-13
 **Status:** Draft addendum
 **Related work:** `2026-05-13-paused-ai-work-approval-surface.md`, `2026-03-19-mobile-companion-app-design.md`, `2026-03-16-async-agent-operations-design.md`, `2026-04-04-collaborative-work-queue-design.md`, `2026-05-11-autonomous-coworker-runtime-design.md`
+**Readiness report:** `docs/superpowers/audits/2026-05-13-realtime-hitl-mobile-readiness-report.md`
 
 ---
 

--- a/docs/superpowers/specs/2026-05-13-realtime-hitl-mobile-companion-design.md
+++ b/docs/superpowers/specs/2026-05-13-realtime-hitl-mobile-companion-design.md
@@ -1,0 +1,355 @@
+# Realtime HITL Notification and Mobile Companion Design
+
+**Date:** 2026-05-13
+**Status:** Draft addendum
+**Related work:** `2026-05-13-paused-ai-work-approval-surface.md`, `2026-03-19-mobile-companion-app-design.md`, `2026-03-16-async-agent-operations-design.md`, `2026-04-04-collaborative-work-queue-design.md`, `2026-05-11-autonomous-coworker-runtime-design.md`
+
+---
+
+## 1. Why This Moves Now
+
+The autonomous coworker runtime now has a concrete pause state: high-risk remote MCP work can create a `TaskRun`, persist context, and stop at `input-required` before side effects run. The Paused Work approval surface is the canonical portal destination for that human decision.
+
+That changes the timing for realtime messaging and mobile. They should move now, but as a narrow companion layer for autonomous coworker decisions rather than as a full replacement for the portal.
+
+The first mobile value proposition is not "DPF on a phone." It is:
+
+> An AI coworker is blocked, the human who holds authority is away from the desktop, and the platform needs to bring the smallest accountable decision to that human with enough context to act safely.
+
+This preserves the cognitive-load-transfer doctrine:
+
+1. Human intent and policy remain human-owned.
+2. AI coworkers prepare decision context and absorb orchestration burden.
+3. Repeated pause patterns become procedural policy, typed workflow, or code.
+4. Realtime/mobile surfaces reduce time-to-decision without creating approval fatigue.
+
+## 2. Current Starting Points
+
+### 2.1 Existing specs
+
+`docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md` already defines a broad native iOS and Android companion app. It chooses React Native + Expo, Expo Router, NativeWind, Zustand, Expo SQLite/MMKV, Expo notifications, EAS Build/Submit, Jest/RNTL/MSW/Maestro, and REST API boundaries.
+
+That spec is directionally useful but too broad for the next slice. It includes dashboards, backlog, customers, dynamic forms, agent conversations, offline reads, and governance approvals. This addendum narrows the first implementation slice to Paused Work, notifications, and approval deep links.
+
+`docs/superpowers/specs/2026-03-16-async-agent-operations-design.md` already identifies three layers: in-panel status, cross-page banner, and a multi-task hub. It recommends SSE for realtime updates.
+
+`docs/superpowers/specs/2026-04-04-collaborative-work-queue-design.md` defines messaging, notifications, escalation, quick approvals, and mobile push in the broader `WorkItem`/`WorkQueue` future. V1 must not jump straight to the whole queue. Paused Work remains a `TaskRun` projection until a real multi-worker claim/escalation need appears.
+
+`docs/superpowers/specs/2026-05-09-deployment-contracts.md` already reserves unauthenticated `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json` contracts for mobile universal links and Android App Links.
+
+### 2.2 Existing runtime primitives
+
+The repo already has:
+
+- `Notification` for user-targeted in-app notifications.
+- `PlatformNotification` for platform/system notifications.
+- `PushDeviceRegistration` for mobile push tokens.
+- `apps/web/lib/queue/notification-adapter.ts`, currently an in-app adapter over `Notification`.
+- `apps/web/lib/tak/agent-event-bus.ts`, a typed realtime event bus with `task:status`, `task:artifact`, queue events, build events, verification events, and async inference events.
+- `/api/agent/stream`, an SSE route for realtime agent progress.
+- `/api/v1/notifications/register-device`, a device registration endpoint.
+- `TaskRun.progressPayload`, used for status replay when in-memory SSE events are not enough.
+
+The gap is not "do we have any notifications?" The gap is a canonical HITL event contract, a delivery policy, and a mobile client that treats Paused Work as the first-class action surface.
+
+### 2.3 Live backlog check
+
+The DPF MCP backlog tools were queried on 2026-05-13. Exact searches for realtime/mobile/HITL notification wording did not return a direct active backlog item. Related open work exists around TAK/GAID governance and desktop control, but there is no current backlog owner surfaced by the MCP query for this narrower "Paused Work notification + mobile companion" slice.
+
+Do not create a parallel backlog taxonomy from this spec. Link future backlog items to the autonomous coworker runtime and TAK governance family unless a dedicated mobile epic is reopened.
+
+## 3. Research and Benchmarking
+
+### 3.1 Expo and React Native precedent
+
+The March mobile spec selected React Native + Expo. That remains the recommended first mobile stack.
+
+Current Expo documentation supports this direction:
+
+- Expo push notification setup uses `expo-notifications`, project push credentials, and Expo push tokens for iOS/Android notification delivery. Source: [Expo push notification setup](https://docs.expo.dev/push-notifications/push-notifications-setup/).
+- Expo linking documentation covers deep links, iOS Universal Links, and Android App Links for routing notifications into specific app screens. Source: [Expo Linking overview](https://docs.expo.dev/linking/overview/).
+- Expo EAS distribution documentation supports managed build and submission workflows for Apple App Store and Google Play. Source: [Expo distribution overview](https://docs.expo.dev/distribution/introduction/).
+
+Adopted:
+
+- Expo managed workflow for first mobile client.
+- EAS Build/Submit for reproducible iOS/Android builds.
+- Expo notifications for initial push transport.
+- Universal/App Links for secure portal-to-app and notification-to-app routing.
+
+Rejected for first slice:
+
+- Building separate native Swift/Kotlin clients.
+- Treating mobile as a full portal.
+- Relying on mobile foreground SSE as the primary delivery mechanism.
+
+### 3.2 Realtime transport precedent
+
+MDN describes SSE as a browser-native `EventSource` model for server-to-client event streams, with named events and automatic reconnect behavior. Source: [Using server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events).
+
+DPF already uses SSE successfully in web contexts. For mobile, SSE is useful only while the app is foregrounded. Background delivery must be push notifications. Therefore:
+
+- portal realtime uses SSE plus persisted replay from `TaskRun.progressPayload`;
+- mobile foreground may poll or subscribe later, but push is the first reliable background channel;
+- the canonical event is persisted before delivery, so losing a live connection does not lose the decision.
+
+### 3.3 HITL security precedent
+
+The Paused Work plan already points to OpenAI HITL, Azure orchestration guidance, and OWASP HITL risks. This companion spec inherits those constraints:
+
+- no high-risk one-tap approval from unauthenticated email or push;
+- mobile push opens an authenticated decision surface;
+- summaries are never the only evidence;
+- raw prompt/action text is visible beside the AI-prepared brief;
+- action attempts are audited through `AuthorizationDecisionLog` and `TaskMessage`.
+
+## 4. Product Scope
+
+### 4.1 V1 goal
+
+Build a realtime and mobile notification foundation for Paused Work:
+
+1. When a `TaskRun` enters `input-required` or `auth-required`, create a canonical HITL notification event.
+2. Show portal badges and live list updates for Paused Work.
+3. Store a user-targeted `Notification` row with a deep link to `/platform/ai/paused-work?taskRunId=...`.
+4. Push to registered mobile devices when channel policy permits.
+5. Open the mobile app directly to the paused-work detail when installed, or the portal route when not installed.
+6. Keep the actual approval decision authenticated and context-rich.
+
+### 4.2 Non-goals
+
+- Full mobile DPF portal.
+- Full Build Studio on mobile.
+- Full Collaborative Work Queue implementation.
+- Slack/Teams/email interactive buttons.
+- Unauthenticated approve/reject links for high-risk work.
+- Offline approval queueing.
+- Multi-tenant white-label app packaging.
+- Watch/desktop widgets.
+
+## 5. Experience Model
+
+### 5.1 Portal
+
+The portal remains canonical for first implementation.
+
+Required surfaces:
+
+- Paused Work tab badge: count of actionable paused `TaskRun`s.
+- In-app notification feed row: concise title, risk class, coworker/source, and deep link.
+- Operations Map attention link: direct to paused work detail.
+- Live update path: SSE event or polling fallback when a new paused task arrives.
+
+The portal must not rely on push or mobile to make paused work visible.
+
+### 5.2 Mobile
+
+The first mobile app is a companion, not a general-purpose client.
+
+Initial screens:
+
+1. Sign in.
+2. Paused Work inbox.
+3. Paused Work detail.
+4. Decision confirmation.
+5. Notification settings and device registration state.
+
+The detail screen mirrors the portal decision artifact:
+
+- AI-prepared brief.
+- Raw requested action/prompt.
+- risk class.
+- source and token/session attribution.
+- coworker and route context.
+- authority status.
+- approve/reject/request-changes actions where permitted.
+
+If approval is unsupported for a trigger or `auth-required` needs credential remediation, mobile shows the same unsupported state as the portal and deep-links to the portal for heavy remediation.
+
+### 5.3 Push notification copy
+
+Push notification content should be intentionally small:
+
+- Title: `AI work needs review`
+- Body: `<coworker or source> paused <riskClass> work: <short title>`
+- Data payload: `taskRunId`, `route = "paused-work"`, `riskClass`, `status`, `deepLink`
+
+Push notifications do not include raw prompt content by default because prompt text may include sensitive business data.
+
+## 6. Event Contract
+
+Introduce a canonical paused-work notification event in code, then project it into each transport:
+
+```ts
+type HitlNotificationEvent = {
+  eventId: string;
+  eventType: "task.paused" | "task.decision_requested" | "task.decision_recorded" | "task.resumed" | "task.completed" | "task.failed";
+  taskRunId: string;
+  status: "input-required" | "auth-required" | "working" | "completed" | "failed" | "rejected";
+  userId: string;
+  actorAgentId: string | null;
+  routeContext: string | null;
+  riskClass: "read" | "bounded-write" | "high-risk" | "unknown";
+  trigger: string | null;
+  sourceRef: { kind: string; id: string } | null;
+  title: string;
+  summary: string;
+  deepLink: string;
+  occurredAt: string;
+};
+```
+
+V1 may not need a new table if `Notification` plus `TaskRun.progressPayload` is enough. If delivery retries and per-channel state are required, add a narrow `NotificationDelivery` table rather than overloading `Notification`.
+
+Do not add a second task identity. `taskRunId` remains the work identity.
+
+## 7. Channel Policy
+
+Channel selection should be rule-driven:
+
+| Risk/status | Portal | Push | Email/messaging |
+|---|---|---|---|
+| `input-required`, high-risk | Required | Deep-link only | Later deep-link only |
+| `input-required`, bounded-write | Required | Deep-link only | Later optional |
+| `input-required`, read | Required | Optional | Later optional |
+| `auth-required` | Required | Deep-link only | Later deep-link only |
+| completed/failed after resume | Required event history | Optional summary | Later optional |
+
+No external channel may approve high-risk work directly in V1.
+
+## 8. Mobile App Architecture
+
+Use the March mobile spec as the base, but scope the first app to HITL:
+
+```text
+apps/mobile/
+  app/
+    (auth)/
+      login.tsx
+    (tabs)/
+      paused-work.tsx
+      settings.tsx
+    paused-work/
+      [taskRunId].tsx
+  src/
+    api/
+      client.ts
+      paused-work.ts
+      notifications.ts
+    components/
+      DecisionBrief.tsx
+      RiskBadge.tsx
+      StatusPill.tsx
+    features/
+      auth/
+      paused-work/
+      notifications/
+    stores/
+      auth-store.ts
+      paused-work-store.ts
+    test/
+      server.ts
+```
+
+Keep this app usable without offline mutation support. Cache the last inbox read for convenience, but decisions require online auth.
+
+## 9. Server API Surface
+
+The portal page can use server actions, but mobile needs REST endpoints:
+
+```text
+GET  /api/v1/paused-work
+GET  /api/v1/paused-work/:taskRunId
+POST /api/v1/paused-work/:taskRunId/approve
+POST /api/v1/paused-work/:taskRunId/reject
+POST /api/v1/paused-work/:taskRunId/request-changes
+GET  /api/v1/notifications
+PATCH /api/v1/notifications/:id/read
+POST /api/v1/notifications/register-device
+```
+
+The decision endpoints must call the same `apps/web/lib/paused-ai-work/decisions.ts` functions as the portal. No mobile-only decision path.
+
+## 10. Security and Identity
+
+- Mobile authentication resolves to the same `Principal` model used by portal decisions.
+- A device registration is an alias of a user/principal, not a new authority-bearing actor.
+- Push token storage must not imply approval authority; it is a delivery endpoint only.
+- Device loss revocation is handled by deleting `PushDeviceRegistration` rows and invalidating refresh tokens.
+- Decision audit writes `AuthorizationDecisionLog` and `TaskMessage` exactly as the Paused Work plan defines.
+- Push payloads avoid sensitive prompt text.
+- Universal/App Links route into authenticated app screens. If not authenticated, the app lands on login and then resumes the deep link after auth.
+
+## 11. Implementation Slices
+
+### Slice 1: Portal realtime and notification projection
+
+Depends on the Paused Work read/decision model.
+
+Build:
+
+- `task.paused` notification event creator.
+- `Notification` row creation for `input-required` / `auth-required`.
+- portal Paused Work badge/count.
+- SSE or polling refresh for the Paused Work page.
+- Operations Map remains the contextual map surface, not the notification source of truth.
+
+### Slice 2: Push delivery foundation
+
+Build:
+
+- harden `/api/v1/notifications/register-device` around platform values, user ownership, and token rotation;
+- add `sendPushNotification` adapter using Expo push service;
+- add channel policy for paused work;
+- add retry/error logging sufficient for local support.
+
+### Slice 3: Mobile app shell
+
+Build:
+
+- `apps/mobile` Expo app scaffold;
+- login/refresh/logout;
+- paused-work inbox/detail;
+- notification registration;
+- deep-link routing;
+- Jest/RNTL tests and one Maestro happy path.
+
+### Slice 4: Mobile decision actions
+
+Build:
+
+- approve/reject/request-changes endpoints;
+- mobile forms calling the same decision module as portal;
+- conflict/unsupported/auth-required states;
+- audit verification tests.
+
+### Slice 5: Channel expansion
+
+Only after portal and mobile are working:
+
+- email deep-link notifications;
+- Slack/Teams deep links;
+- escalation policies from `ValueStreamHitlGate.channels`;
+- low-risk signed action links, if and only if security review approves the class.
+
+## 12. Acceptance Criteria
+
+- A high-risk remote MCP `TaskRun` paused as `input-required` creates one user-targeted in-app notification.
+- The Paused Work portal surface updates without a full page hunt.
+- A registered mobile device receives a push notification with a safe deep link and no sensitive prompt content.
+- Opening the notification lands on the paused-work detail after auth.
+- Approve/reject/request-changes in mobile and portal call the same decision code.
+- High-risk work cannot be approved from an unauthenticated external channel.
+- All decision actions write the existing audit records.
+- The implementation does not create `WorkItem` rows until the Collaborative Work Queue slice is deliberately started.
+
+## 13. Open Questions
+
+1. Should the first mobile login use the March spec's JWT/refresh-token design, or should it use an existing OAuth/device-flow path first?
+   Recommendation: use the March JWT/refresh-token design only if the API auth middleware is already production-ready; otherwise ship portal deep links first and defer mobile decisions.
+2. Should mobile foreground use SSE or short polling?
+   Recommendation: start with short polling for the Paused Work inbox and push for background. Add foreground SSE only if live detail updates matter.
+3. Should push delivery use Expo push service directly or an abstraction that can later swap to direct APNs/FCM?
+   Recommendation: implement a `NotificationAdapter` abstraction now and make Expo the first adapter.
+4. Should a dedicated mobile epic be reopened?
+   Recommendation: yes, but scope it to "Mobile Companion for Paused AI Work" rather than reviving the whole March mobile spec at once.


### PR DESCRIPTION
## Summary

- Adds a focused realtime HITL notification and mobile companion design addendum.
- Grounds the track in the existing March mobile spec, async agent operations notes, Collaborative Work Queue design, deployment contracts, current Notification/PushDevice/SSE primitives, and the Paused Work plan.
- Narrows the first mobile slice to Paused Work notifications and authenticated decisions rather than reviving the whole mobile portal at once.
- Carries forward reviewed updates to the Paused Work plan and links its email/messaging follow-up to the new addendum.

## Verification

- Doc-only change.
- Checked live backlog through DPF MCP tools; exact realtime/mobile HITL wording did not surface a current active backlog owner.
- Checked repo specs and runtime primitives with `rg` and targeted file reads.
- Checked current Expo/MDN docs for push notifications, deep links, EAS distribution, and SSE references.