### PR TITLE
docs(edge-node): multi-host LAN verification template + runbook (T2.5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/edge_node_multi_host_verification.md
+++ b/.github/ISSUE_TEMPLATE/edge_node_multi_host_verification.md
@@ -1,0 +1,194 @@
+---
+name: Edge Node multi-host LAN verification report
+about: Ran a DPF Edge Node on a second host across a real LAN? Tell us how it went.
+title: "Edge Node multi-host verification — "
+labels: ["install-verification", "edge-node", "community-report"]
+assignees: []
+---
+
+<!-- Thank you for verifying the DPF Edge Node across a real LAN!
+     This template is for the T2 multi-host scenario specifically —
+     Authority Core on Host A, Edge Node on a different physical or
+     virtual Host B, separated by at least one switch.
+
+     If you ran the single-host demo (Authority + Edge Node on the
+     same machine) please use the install_verification.md template
+     instead — that's a different verification ledger row.
+
+     Both happy-path and failure reports are valuable. Fill in what
+     you can; leave the rest. -->
+
+## LAN topology
+
+**Authority host (Host A):**
+- Hardware / VM: <!-- e.g. NUC i7, Debian 12; or AWS t3.medium, Ubuntu 22.04 -->
+- LAN reachability: <!-- e.g. dpf-authority.lan via mDNS / 192.168.1.42 static / 10.0.0.5 DHCP reservation -->
+
+**Edge Node host (Host B):**
+- Hardware / VM: <!-- e.g. Raspberry Pi 5, Debian 12; or Hyper-V guest, Ubuntu 22.04 -->
+- LAN reachability: <!-- e.g. edge-warehouse-2.lan via DHCP -->
+
+**Between them:**
+- Number of switches: <!-- 1 / 2 / "same broadcast domain" -->
+- Cross-segment / VLAN: <!-- yes / no -->
+- Firewall between hosts: <!-- yes / no -->
+- Authority port reachable from Host B: `curl -sS http://<host-a>:3000/api/health` → <!-- 200 / connection refused / timeout -->
+
+## Versions
+
+```
+# On Host A
+bash install-dpf.sh doctor 2>&1 | grep -E "Installer version|Portal version|Docker version" | head -3
+
+# On Host B
+docker --version
+docker compose version
+docker compose -f docker-compose.edge-standalone.yml exec edge-node node -v
+```
+
+<details>
+<summary>Version output</summary>
+
+```
+<paste here>
+```
+
+</details>
+
+## Path taken
+
+- [ ] **HTTP path** (Phase 0 floor): `DPF_AUTHORITY_URL=http://...:3000`
+- [ ] **HTTPS path** (T2.2): `DPF_AUTHORITY_URL=https://...:443` with CA bundle from `scripts/issue-authority-tls-cert.sh`
+
+## T2 verification checklist
+
+The full runbook lives at
+[`docs/install/edge-node-multi-host.md`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/install/edge-node-multi-host.md).
+Tick what you observed working.
+
+**Step 1 — Authority Core preflight (Host A):**
+- [ ] `curl http://<host-a-lan-url>:3000/api/health` returns 200 **from Host B** (not just from Host A)
+- [ ] Firewall on Host A allows the inbound port
+
+**Step 2 — Bootstrap token (Host A):**
+- [ ] Issued a bootstrap token via `/platform/edge-nodes` → "Issue bootstrap token"
+- [ ] Copied the plaintext within the 15min TTL
+
+**Step 3 — Edge Node bring-up (Host B):**
+- [ ] Cloned the repo / copied `docker-compose.edge-standalone.yml` and `.env.edge-standalone.example`
+- [ ] Set `DPF_AUTHORITY_URL` to the routable URL (NOT `localhost`, NOT `host.docker.internal`)
+- [ ] `docker compose -f docker-compose.edge-standalone.yml up -d` succeeded
+- [ ] Logs show `Enrolling Edge Node "<hostname>" against http(s)://...`
+- [ ] Logs show `Enrolled as nodeId=edge_xxxxxxxx (trustState=pending)` within ~10s
+
+**Step 4 — Operator approval (Host A):**
+- [ ] New node appears in `/platform/edge-nodes` with `trustState=pending`
+- [ ] Clicked **Approve** — node flipped to `trustState=trusted`
+
+**Step 5 — First discovery run:**
+- [ ] Within one sweep interval (default 5 min), logs show `Discovery run accepted`
+- [ ] No `stale_observation` 400s in logs (if there are, your hosts need NTP — see runbook § Clock sync prerequisite)
+
+**Step 6 — Verify on Authority (Host A) SQL:**
+
+The verification gate from `2026-05-12-edge-node-t2-multi-host-lan.md` § T2 scope:
+
+```sql
+-- Run on Host A:
+--   docker compose -p dpf exec postgres psql -U dpf -d dpf
+
+-- T2.4 admin UI surface — IP / hostname in metadata.host
+SELECT
+  e."nodeId",
+  p."displayName",
+  e."trustState",
+  e."lastSeenAt",
+  e."metadata"->'host'->>'hostname' AS host_hostname,
+  jsonb_path_query_array(e."metadata"::jsonb, '$.host.ipAddresses[*]') AS host_ips
+FROM "EdgeNode" e
+JOIN "Principal" p ON p.id = e."principalId"
+ORDER BY e."createdAt" DESC LIMIT 5;
+
+-- Attribution check — DiscoveryRun has edgeNodeId
+SELECT id, "runKey", "edgeNodeId", "sourceSlug", "startedAt"
+FROM "DiscoveryRun"
+WHERE "edgeNodeId" IS NOT NULL
+ORDER BY "startedAt" DESC LIMIT 5;
+
+-- Real LAN address landed (not bridge IP)
+SELECT
+  "name",
+  "rawData"->>'hostname' AS hostname,
+  jsonb_path_query_array("rawData"::jsonb, '$.networkInterfaces[*].addresses[*].address')
+    AS addresses
+FROM "DiscoveredItem"
+WHERE "itemType" = 'host'
+ORDER BY "createdAt" DESC LIMIT 5;
+```
+
+Tick what you saw:
+
+- [ ] `EdgeNode` row with `trustState=trusted`, `lastSeenAt` within 60s
+- [ ] `host_hostname` is the actual Host B hostname (not the container name)
+- [ ] `host_ips` includes Host B's real LAN IP (e.g. `192.168.1.42`), NOT `127.0.0.1` and NOT a Docker bridge IP like `172.17.x.x`
+- [ ] `DiscoveryRun` row has `edgeNodeId` populated, `sourceSlug` matches `edge-node:<nodeId>`
+- [ ] `DiscoveredItem` of `itemType='host'` includes the LAN IP in its `rawData.networkInterfaces[*].addresses[*].address` list
+- [ ] **At least one switch / gateway / non-portal-host item with `osiLayer >= 2`** appears in the discovery results — the T2 success bar from the gap-list doc
+
+**Audit chain spot check:**
+
+```sql
+-- Every edge route invocation should produce a ToolExecution row.
+SELECT "toolName", "executionMode",
+       "parameters"->>'nodeId' AS nodeId,
+       "result"->>'status' AS status,
+       success
+FROM "ToolExecution"
+WHERE "executionMode" = 'edge-rest'
+ORDER BY "createdAt" DESC LIMIT 10;
+```
+
+- [ ] At least one `success=true` row per route exercised
+- [ ] If you exercised failure paths (bad token, oversized body, stale clock): the corresponding 401 / 413 / 400 / 429 rows are present
+
+## Surprises and papercuts
+
+<!-- Anything unexpected. The runbook said X; what happened was Y.
+     "I had to do Z which wasn't in the docs." Failure reports are
+     valuable — name the symptom and the LAN topology. -->
+
+## Doctor bundle
+
+Run on **Host A**:
+
+```bash
+bash install-dpf.sh doctor
+# → ~/.dpf/doctor-<timestamp>.tar.gz
+```
+
+Drag-and-drop the tarball into this issue. Secrets are auto-redacted.
+
+For **Host B** (no full installer; capture an Edge-Node-only fingerprint):
+
+```bash
+docker compose -f docker-compose.edge-standalone.yml exec edge-node \
+  node -e 'console.log(JSON.stringify({
+    uname: require("os").platform(),
+    release: require("os").release(),
+    hostname: require("os").hostname(),
+    ifaces: require("os").networkInterfaces(),
+  }, null, 2))' > /tmp/edge-host-fingerprint.json
+docker compose -f docker-compose.edge-standalone.yml logs --tail=200 edge-node \
+  > /tmp/edge-node.log
+tar -czf /tmp/edge-host-bundle.tar.gz \
+  /tmp/edge-host-fingerprint.json /tmp/edge-node.log
+```
+
+Attach `/tmp/edge-host-bundle.tar.gz` from Host B as well.
+
+## What would have made this easier
+
+<!-- Free-text for the kind of small wins that aren't bug reports
+     but would have saved you 20 minutes. Example: "The runbook
+     could have noted that ufw blocks 3000/tcp by default on Debian."
+     -->

--- a/docs/install/verification-runbook.md
+++ b/docs/install/verification-runbook.md
@@ -38,7 +38,8 @@
 | LLM provider — Ollama (Linux) | compose-render | `ollama` service actually pulls + serves a model | 🙋 **reports wanted** |
 | LLM provider — external | code review | Real `LLM_BASE_URL` (Anthropic / OpenAI / hosted Ollama) round-trips | 🙋 **reports wanted** |
 | TAPPaaS deployment | none — spec only | Pilot deploy into a real TAPPaaS environment | 🧪 **design partner wanted** |
-| DPF Edge Node enrollment | none — spec only | First-draft enrollment ceremony executed end-to-end | 🧪 **design partner wanted** |
+| DPF Edge Node enrollment (single-host) | none — spec only | First-draft enrollment ceremony executed end-to-end | 🙋 **reports wanted** |
+| DPF Edge Node — multi-host LAN (T2) | none — code-complete via T2.1-T2.4 | Authority on Host A, Edge Node on Host B over a real LAN with a switch; non-loopback IP attribution; ARP / nmap / SNMP collector output reaching Postgres + Neo4j | 🙋 **reports wanted** |
 | Cloud deployment (Single VM / Container / k8s) | none — spec only | At least one substrate pilot per packaging target | 🧪 **design partner wanted** |
 
 ## Fastest path: one command for the whole sweep
@@ -351,6 +352,106 @@ WHERE "toolName" = 'edge.discovery_runs.submit'
   AND "result"->>'error' = 'stale_observation'
 ORDER BY "createdAt" DESC LIMIT 5;
 ```
+
+### 7b. Edge Node multi-host LAN verification (T2)
+
+**Status:** T2 code-complete per T2.1 through T2.4. **Real-hardware
+reports wanted** for a real second-host Edge Node enrolling against a
+remote Authority Core across a LAN.
+
+This is the next verification rung up from § 7 (which covers
+single-host enrollment). The bar:
+
+```
+Authority Core on Host A
+   │  (over a real LAN, separated by at least one switch)
+   ▼
+Edge Node on Host B   ← a different machine, native Linux Docker
+```
+
+The Authority portal shows the Edge Node enrolled with a **non-loopback
+IP attributed to it**, and the discovery rows include real LAN-side
+IPs plus at least one switch / gateway / non-portal-host item with
+`osiLayer >= 2`.
+
+#### Full runbook
+
+The end-to-end ceremony — Authority preflight, bootstrap token,
+operator approval, first sweep, and the SQL that verifies it landed —
+is in [`docs/install/edge-node-multi-host.md`](edge-node-multi-host.md).
+
+It also walks the optional HTTPS path (T2.2 — Caddy sidecar on the
+Authority, `NODE_EXTRA_CA_CERTS` on the Edge Node).
+
+#### Operational notes you'll want before starting
+
+These are the gotchas the T2 verification gap list (G4 + G7) called
+out — they bite operators who jump straight to `docker compose up -d`:
+
+**1. Authority Core URL stability (G4).** The Edge Node persists the
+`DPF_AUTHORITY_URL` it enrolled against. If Host A reboots and DHCP
+hands it a different IP, every enrolled Edge Node on the LAN loses
+contact until you reconfigure. Use one of:
+
+- Static IP / DHCP reservation for Host A on your router
+- mDNS `.local` name via `avahi-daemon` (Linux) or Bonjour (macOS)
+- DNS A record on your LAN
+
+A dynamic DHCP IP is fine for the first verification run, but plan
+to pin it before you treat the deployment as durable. Authority
+auto-discovery (mDNS-SD, Zeroconf, etc.) is deferred to a later
+thread — T2's expectation is "operator pins it."
+
+**2. Operator approval gate (G7).** Paste-provisioned bootstrap
+tokens always land in `trustState=pending` per spec § Approval
+policy. The node enrolls successfully but **cannot submit
+observations** until an operator clicks **Approve** in
+`/platform/edge-nodes`. This is the friction that makes Edge Node
+enrollment opt-in, not silent.
+
+The Phase 0 single-host demo glosses over this because the local
+installer-issued bootstrap token auto-approves. The multi-host path
+does NOT — if you skip the Approve click, your sweeps will keep
+failing with `node_not_trusted` errors and your `DiscoveryRun` table
+will stay empty. Watch for this in your first run.
+
+**3. NTP on both hosts.** See § 7's "Clock sync prerequisite (NTP)"
+subsection above. The Authority's `/api/v1/edge/discovery-runs` route
+rejects submissions whose `observedAt` falls outside the asymmetric
+freshness window. Fresh VMs without NTP can drift tens of seconds
+and silently fail their first sweep.
+
+#### Verification gate
+
+Same checklist as § 7's Phase 0 matrix, plus the multi-host-specific
+rows from the
+[Edge Node multi-host verification template](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new?template=edge_node_multi_host_verification.md):
+
+- [ ] Authority is reachable from Host B (not just from Host A)
+- [ ] Edge Node enrolls and lands in `pending`
+- [ ] Operator approves; node flips to `trusted`
+- [ ] First sweep submits within one sweep interval
+- [ ] `EdgeNode.metadata.host.ipAddresses` includes the Host B LAN IP
+- [ ] `DiscoveredItem` rows include real LAN-side addresses (not
+      Docker bridge IPs)
+- [ ] At least one switch / gateway / non-portal-host item with
+      `osiLayer >= 2`
+- [ ] Audit chain rows in `ToolExecution` for every route exercised
+- [ ] (Optional) TLS path: bring up `docker-compose.tls.yml` on
+      Host A; distribute `ca-bundle.crt` to Host B; switch
+      `DPF_AUTHORITY_URL` to `https://...`; re-verify
+
+When that happens, **T2 flips to `verified on real LAN`** in the
+parent thread ledger.
+
+#### File a report
+
+Open an issue with the
+[Edge Node multi-host verification template](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new?template=edge_node_multi_host_verification.md).
+The template asks for LAN topology, the path you took (HTTP / HTTPS),
+the T2 checklist tick-list, the SQL output, and a doctor bundle from
+each host. Partial reports are valuable — failure reports name the
+symptom and the LAN topology and are more useful than no report.
 
 ### 8. Cloud deployment patterns
 


### PR DESCRIPTION
## Summary

Closes **G4, G7, and the verification-report deliverable** from
[\`docs/superpowers/plans/2026-05-12-edge-node-t2-multi-host-lan.md\`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-05-12-edge-node-t2-multi-host-lan.md).

Phase 0 single-host enrollment has a verification template
(\`install_verification.md\`) but **no path tailored to the T2
multi-host ceremony**. An operator who provisions two Linux hosts on
a real LAN needs to know which gotchas to expect and what shape of
evidence to file when they're done.

## What's added

| File | Purpose |
|---|---|
| \`.github/ISSUE_TEMPLATE/edge_node_multi_host_verification.md\` | New issue template. Pre-fills labels (\`edge-node\`, \`install-verification\`, \`community-report\`) and title prefix. Walks LAN topology, HTTP vs HTTPS path, T2 checklist including the **Approve click** (G7), SQL spot-checks for \`EdgeNode.metadata.host\` + \`DiscoveryRun.edgeNodeId\` attribution + audit chain, and doctor bundles from both hosts. |
| \`docs/install/verification-runbook.md § 7b\` | New section dedicated to multi-host. Calls out **G4** (stable Authority URL — DHCP reboot loses every enrolled node until reconfigure) and **G7** (paste-provisioned tokens always land in \`pending\`; the demo's "auto-enroll within 30s" gloss does NOT apply on multi-host). Cross-refs to T2.1 standalone compose runbook + T2.2 HTTPS path + T2.3 NTP gate + T2.4 admin UI surface. |
| Verification matrix table update | Adds the multi-host row, flips the single-host Edge Node row from "design partner wanted" to "reports wanted" now that Phase 0 has shipped. |

## What this PR does NOT do

- **Provide a Host-B wrapper script** analogous to \`verify-install-edge.sh\`. The single-host wrapper assumes the doctor bundle + bootstrap-token helper run on the same host; a Host-B version needs to coordinate across two hosts, which is real new scaffolding. Defer to T2.5a follow-up if community reports show the manual flow is too cumbersome.
- **File an actual verification report.** Hardware verification is a human-in-the-loop task on a real LAN, not something CI can simulate. The template is ready for the first operator who runs the runbook end-to-end.

## Stacked context

This is the **last slice** in the T2 group. The runbook section
references compose files + scripts that ship in T2.1-T2.4:

- #553 T2.1 — standalone compose + cap_add + routable Authority URL
- #554 T2.2 — HTTPS + CA bundle
- #555 T2.3 — asymmetric freshness window + NTP
- #556 T2.4 — admin UI IP / hostname surface

If T2.5 lands before any of T2.1-T2.4, the runbook's forward links
will be broken until those land. Recommend reviewing the stack and
merging in order T2.1 → T2.4 → T2.5 (T2.2/T2.3 are independent and
can land in any order).

## Test plan

- [x] \`docs/install/verification-runbook.md\` renders cleanly in GitHub's markdown preview (verified locally).
- [x] Issue template metadata block validates (labels exist on the repo: \`install-verification\`, \`community-report\`; \`edge-node\` will auto-create on first use per GitHub's labeling behavior).
- [ ] **Real-hardware verification** — the meta-deliverable. The template + runbook are scaffolding; the first community report against them closes the verification loop. Tracked in the T2 thread ledger separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)