### PR TITLE
Tune code graph rebuild benchmark

### DIFF
--- a/apps/web/lib/integrate/code-graph-refresh-reconcile.test.ts
+++ b/apps/web/lib/integrate/code-graph-refresh-reconcile.test.ts
@@ -17,6 +17,7 @@ vi.mock("@dpf/db", () => ({
     },
     codeGraphFileHash: {
       upsert: vi.fn(),
+      createMany: vi.fn(),
       deleteMany: vi.fn(),
       count: vi.fn(),
     },
@@ -72,6 +73,7 @@ beforeEach(() => {
   vi.mocked(prisma.$executeRaw).mockResolvedValue(1 as never);
   vi.mocked(prisma.codeGraphFileHash.count).mockResolvedValue(1);
   vi.mocked(prisma.codeGraphFileHash.upsert).mockResolvedValue({} as never);
+  vi.mocked(prisma.codeGraphFileHash.createMany).mockResolvedValue({ count: 1 } as never);
   vi.mocked(prisma.codeGraphFileHash.deleteMany).mockResolvedValue({ count: 1 } as never);
   vi.mocked(prisma.codeGraphIndexState.upsert).mockResolvedValue({} as never);
   vi.mocked(prisma.codeGraphIndexState.update).mockResolvedValue({} as never);
@@ -117,6 +119,9 @@ describe("reconcileCodeGraph", () => {
       expect.stringContaining("MATCH (n {graphKey: $graphKey})"),
       expect.objectContaining({ graphKey: CODE_GRAPH_GRAPH_KEY }),
     );
+    const cypherStatements = mockRunCypher.mock.calls.map(([statement]) => String(statement));
+    expect(cypherStatements.some((statement) => statement.includes("MATCH ()-[r {graphKey: $graphKey, filePath: $filePath}]-()"))).toBe(false);
+    expect(cypherStatements.some((statement) => statement.includes("MATCH (n {graphKey: $graphKey, path: $filePath})"))).toBe(false);
     expect(prisma.codeGraphFileHash.deleteMany).toHaveBeenCalledWith({
       where: { graphKey: CODE_GRAPH_GRAPH_KEY },
     });
@@ -125,6 +130,96 @@ describe("reconcileCodeGraph", () => {
         where: { graphKey: CODE_GRAPH_GRAPH_KEY },
       }),
     );
+  });
+
+  it("batches structural projection by node label and relationship kind", async () => {
+    vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue(null);
+
+    mockExec.mockImplementation(async (command: string) => {
+      if (command === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
+      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (command.startsWith("git ls-files -- ")) {
+        return {
+          stdout: "apps/web/lib/integrate/multi-symbol.ts\n",
+          stderr: "",
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    mockReadFile.mockResolvedValue([
+      "export function firstSymbol() { return true; }",
+      "export function secondSymbol() { return false; }",
+    ].join("\n"));
+
+    await reconcileCodeGraph({ reason: "scheduled" });
+
+    const symbolProjectionCalls = mockRunCypher.mock.calls.filter(([statement]) => (
+      String(statement).includes("UNWIND $facts AS fact") &&
+      String(statement).includes("MERGE (n:CodeSymbol")
+    ));
+    expect(symbolProjectionCalls).toHaveLength(1);
+    expect(symbolProjectionCalls[0]?.[1]).toEqual(expect.objectContaining({
+      facts: expect.arrayContaining([
+        expect.objectContaining({ name: "firstSymbol" }),
+        expect.objectContaining({ name: "secondSymbol" }),
+      ]),
+    }));
+
+    const definesProjectionCalls = mockRunCypher.mock.calls.filter(([statement]) => (
+      String(statement).includes("UNWIND $facts AS fact") &&
+      String(statement).includes("MERGE (from)-[r:DEFINES")
+    ));
+    expect(definesProjectionCalls).toHaveLength(1);
+    expect(String(definesProjectionCalls[0]?.[0])).toContain("MATCH (from:CodeFile {codeFileKey: fact.fromKey})");
+    expect(String(definesProjectionCalls[0]?.[0])).toContain("MATCH (to:CodeSymbol {codeSymbolKey: fact.toKey})");
+    expect(definesProjectionCalls[0]?.[1]).toEqual(expect.objectContaining({
+      facts: expect.arrayContaining([
+        expect.objectContaining({ confidence: "exact" }),
+      ]),
+    }));
+    expect(mockRunCypher.mock.calls.some(([statement]) => String(statement).includes("WHERE any(key IN keys(from)"))).toBe(false);
+  });
+
+  it("batches CodeFile projection during full rebuilds", async () => {
+    vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue(null);
+
+    mockExec.mockImplementation(async (command: string) => {
+      if (command === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
+      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (command.startsWith("git ls-files -- ")) {
+        return {
+          stdout: "apps/web/lib/one.ts\napps/web/lib/two.ts\n",
+          stderr: "",
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    mockReadFile.mockResolvedValue("export function example() { return true; }");
+
+    await reconcileCodeGraph({ reason: "scheduled" });
+
+    const codeFileProjectionCalls = mockRunCypher.mock.calls.filter(([statement]) => (
+      String(statement).includes("UNWIND $files AS file") &&
+      String(statement).includes("MERGE (f:CodeFile")
+    ));
+    expect(codeFileProjectionCalls).toHaveLength(1);
+    expect(codeFileProjectionCalls[0]?.[1]).toEqual(expect.objectContaining({
+      files: expect.arrayContaining([
+        expect.objectContaining({ filePath: "apps/web/lib/one.ts" }),
+        expect.objectContaining({ filePath: "apps/web/lib/two.ts" }),
+      ]),
+    }));
+    expect(prisma.codeGraphFileHash.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.arrayContaining([
+        expect.objectContaining({ filePath: "apps/web/lib/one.ts" }),
+        expect.objectContaining({ filePath: "apps/web/lib/two.ts" }),
+      ]),
+    }));
+    expect(prisma.codeGraphFileHash.upsert).not.toHaveBeenCalled();
   });
 
   it("performs an incremental reconcile when HEAD changes", async () => {

--- a/apps/web/lib/integrate/code-graph/graph-queries.test.ts
+++ b/apps/web/lib/integrate/code-graph/graph-queries.test.ts
@@ -68,12 +68,20 @@ describe("searchCodeGraph", () => {
       },
     ]);
     expect(runCypher).toHaveBeenCalledWith(
-      expect.stringContaining("LIMIT toInteger($limit)"),
+      expect.stringContaining("LIMIT 5"),
       expect.objectContaining({
         graphKey: CODE_GRAPH_GRAPH_KEY,
         query: "code graph",
-        limit: 5,
       }),
+    );
+  });
+
+  it("uses a bounded integer literal for Neo4j LIMIT clauses", async () => {
+    await searchCodeGraph({ query: "code graph", limit: 10.9 });
+
+    expect(runCypher).toHaveBeenCalledWith(
+      expect.stringContaining("LIMIT 10"),
+      expect.not.objectContaining({ limit: expect.anything() }),
     );
   });
 
@@ -182,11 +190,23 @@ describe("findRelatedTests", () => {
       },
     ]);
     expect(runCypher).toHaveBeenCalledWith(
-      expect.stringContaining("LIMIT toInteger($limit)"),
+      expect.stringContaining("LIMIT 25"),
       expect.objectContaining({
         graphKey: CODE_GRAPH_GRAPH_KEY,
         filePath: "apps/web/lib/integrate/code-graph/graph-queries.ts",
       }),
+    );
+  });
+
+  it("uses a bounded integer literal when finding tests", async () => {
+    await findRelatedTests({
+      filePath: "apps/web/lib/integrate/code-graph/graph-queries.ts",
+      limit: 99.1,
+    });
+
+    expect(runCypher).toHaveBeenCalledWith(
+      expect.stringContaining("LIMIT 50"),
+      expect.not.objectContaining({ limit: expect.anything() }),
     );
   });
 });

--- a/apps/web/lib/integrate/code-graph/graph-queries.ts
+++ b/apps/web/lib/integrate/code-graph/graph-queries.ts
@@ -330,6 +330,7 @@ export async function searchCodeGraph(input: {
     };
   }
 
+  const limit = normalizeLimit(input.limit, 10);
   const rows = await runCypher<RawSearchRow>(
     [
       "MATCH (n)",
@@ -350,13 +351,12 @@ export async function searchCodeGraph(input: {
       "  WHEN toLower(coalesce(n.path, '')) = $query THEN 1",
       "  ELSE 2",
       "END, path ASC, name ASC",
-      "LIMIT toInteger($limit)",
+      `LIMIT ${limit}`,
     ].join("\n"),
     {
       graphKey,
       query,
       nodeLabels: SEARCH_NODE_LABELS,
-      limit: normalizeLimit(input.limit, 10),
     },
   );
 
@@ -431,6 +431,7 @@ export async function findRelatedTests(input: {
     };
   }
 
+  const limit = normalizeLimit(input.limit, 25);
   const rows = await runCypher<RawRelatedTestRow>(
     [
       "MATCH (test:TestFile {graphKey: $graphKey})-[r:TESTED_BY]->(source:CodeFile {graphKey: $graphKey, path: $filePath})",
@@ -440,12 +441,11 @@ export async function findRelatedTests(input: {
       "       r.startLine AS startLine,",
       "       r.endLine AS endLine",
       "ORDER BY confidence ASC, path ASC",
-      "LIMIT toInteger($limit)",
+      `LIMIT ${limit}`,
     ].join("\n"),
     {
       graphKey,
       filePath,
-      limit: normalizeLimit(input.limit, 25),
     },
   );
 

--- a/apps/web/lib/integrate/code-graph/neo4j-projection.ts
+++ b/apps/web/lib/integrate/code-graph/neo4j-projection.ts
@@ -5,13 +5,16 @@ import { CODE_GRAPH_EXTRACTORS } from "./extractors";
 import { checksumContent } from "./hash";
 import {
   deleteCodeGraphFileHash,
+  insertCodeGraphFileHashes,
   recordExtractionWarning,
   upsertCodeGraphFileHash,
 } from "./state-store";
 import {
   mergeExtractions,
+  type CodeGraphEdgeKind,
   type CodeGraphEdgeFact,
   type CodeGraphExtraction,
+  type CodeGraphNodeKind,
   type CodeGraphNodeFact,
 } from "./types";
 
@@ -24,6 +27,22 @@ const STRUCTURAL_NODE_LABELS = [
   "TestFile",
   "ExternalModule",
 ];
+const PROJECTION_BATCH_SIZE = 100;
+const EDGE_PROJECTION_BATCH_SIZE = 50;
+
+type CodeFileProjection = {
+  codeFileKey: string;
+  graphKey: string;
+  filePath: string;
+  extension: string;
+  checksum: string;
+  indexedAt: Date;
+};
+
+type NodeEndpointProjection = {
+  label: CodeGraphNodeKind;
+  keyField: string;
+};
 
 export function buildCodeFileKey(graphKey: string, filePath: string): string {
   return `${graphKey}:${filePath}`;
@@ -88,39 +107,161 @@ function keyFieldForLabel(label: string): string {
   return `${label.charAt(0).toLowerCase()}${label.slice(1)}Key`;
 }
 
-async function projectNodeFact(fact: CodeGraphNodeFact): Promise<void> {
-  const label = fact.kind;
-  const keyField = keyFieldForLabel(label);
-  await runCypher(
-    [
-      `MERGE (n:${label} {${keyField}: $key})`,
-      "SET n.graphKey = $graphKey,",
-      "    n.name = $name,",
-      "    n.path = $filePath,",
-      "    n.startLine = $startLine,",
-      "    n.endLine = $endLine,",
-      "    n.extractor = $extractor",
-    ].join("\n"),
-    fact,
-  );
+function endpointForKey(graphKey: string, key: string): NodeEndpointProjection | null {
+  const typedPrefixes: Array<{ prefix: string; label: CodeGraphNodeKind }> = [
+    { prefix: `${graphKey}:symbol:`, label: "CodeSymbol" },
+    { prefix: `${graphKey}:route:`, label: "CodeRoute" },
+    { prefix: `${graphKey}:tool:`, label: "CodeTool" },
+    { prefix: `${graphKey}:prisma-model:`, label: "PrismaModel" },
+    { prefix: `${graphKey}:test:`, label: "TestFile" },
+    { prefix: `${graphKey}:module:`, label: "ExternalModule" },
+  ];
+  const match = typedPrefixes.find((entry) => key.startsWith(entry.prefix));
+  const label = match?.label ?? (key.startsWith(`${graphKey}:`) ? "CodeFile" : null);
+  if (!label) return null;
+  return { label, keyField: keyFieldForLabel(label) };
 }
 
-async function projectEdgeFact(fact: CodeGraphEdgeFact): Promise<void> {
-  await runCypher(
-    [
-      "MATCH (from {graphKey: $graphKey})",
-      "WHERE any(key IN keys(from) WHERE from[key] = $fromKey)",
-      "MATCH (to {graphKey: $graphKey})",
-      "WHERE any(key IN keys(to) WHERE to[key] = $toKey)",
-      `MERGE (from)-[r:${fact.kind} {graphKey: $graphKey, fromKey: $fromKey, toKey: $toKey}]->(to)`,
-      "SET r.filePath = $filePath,",
-      "    r.startLine = $startLine,",
-      "    r.endLine = $endLine,",
-      "    r.confidence = $confidence,",
-      "    r.extractor = $extractor",
-    ].join("\n"),
-    fact,
-  );
+function groupByKind<T extends { kind: string }>(facts: T[]): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const fact of facts) {
+    const group = groups.get(fact.kind);
+    if (group) {
+      group.push(fact);
+    } else {
+      groups.set(fact.kind, [fact]);
+    }
+  }
+  return groups;
+}
+
+function chunks<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+}
+
+async function projectCodeFileFacts(files: CodeFileProjection[]): Promise<void> {
+  for (const batch of chunks(files, PROJECTION_BATCH_SIZE)) {
+    if (batch.length === 0) continue;
+    await runCypher(
+      [
+        "UNWIND $files AS file",
+        "MERGE (f:CodeFile {codeFileKey: file.codeFileKey})",
+        "SET f.graphKey = file.graphKey,",
+        "    f.path = file.filePath,",
+        "    f.extension = file.extension,",
+        "    f.checksum = file.checksum,",
+        "    f.indexedAt = datetime(file.indexedAt)",
+      ].join("\n"),
+      {
+        files: batch.map((file) => ({
+          ...file,
+          indexedAt: file.indexedAt.toISOString(),
+        })),
+      },
+    );
+  }
+}
+
+async function projectNodeFacts(label: CodeGraphNodeKind, facts: CodeGraphNodeFact[]): Promise<void> {
+  const keyField = keyFieldForLabel(label);
+  for (const batch of chunks(facts, PROJECTION_BATCH_SIZE)) {
+    if (batch.length === 0) continue;
+    await runCypher(
+      [
+        "UNWIND $facts AS fact",
+        `MERGE (n:${label} {${keyField}: fact.key})`,
+        "SET n.graphKey = fact.graphKey,",
+        "    n.name = fact.name,",
+        "    n.path = fact.filePath,",
+        "    n.startLine = fact.startLine,",
+        "    n.endLine = fact.endLine,",
+        "    n.extractor = fact.extractor",
+      ].join("\n"),
+      { facts: batch },
+    );
+  }
+}
+
+async function projectTypedEdgeFacts(
+  kind: CodeGraphEdgeKind,
+  from: NodeEndpointProjection,
+  to: NodeEndpointProjection,
+  facts: CodeGraphEdgeFact[],
+): Promise<void> {
+  for (const batch of chunks(facts, EDGE_PROJECTION_BATCH_SIZE)) {
+    if (batch.length === 0) continue;
+    await runCypher(
+      [
+        "UNWIND $facts AS fact",
+        `MATCH (from:${from.label} {${from.keyField}: fact.fromKey})`,
+        `MATCH (to:${to.label} {${to.keyField}: fact.toKey})`,
+        `MERGE (from)-[r:${kind} {graphKey: fact.graphKey, fromKey: fact.fromKey, toKey: fact.toKey}]->(to)`,
+        "SET r.filePath = fact.filePath,",
+        "    r.startLine = fact.startLine,",
+        "    r.endLine = fact.endLine,",
+        "    r.confidence = fact.confidence,",
+        "    r.extractor = fact.extractor",
+      ].join("\n"),
+      { facts: batch },
+    );
+  }
+}
+
+async function projectGenericEdgeFacts(kind: CodeGraphEdgeKind, facts: CodeGraphEdgeFact[]): Promise<void> {
+  for (const batch of chunks(facts, EDGE_PROJECTION_BATCH_SIZE)) {
+    if (batch.length === 0) continue;
+    await runCypher(
+      [
+        "UNWIND $facts AS fact",
+        "MATCH (from {graphKey: fact.graphKey})",
+        "WHERE any(key IN keys(from) WHERE from[key] = fact.fromKey)",
+        "MATCH (to {graphKey: fact.graphKey})",
+        "WHERE any(key IN keys(to) WHERE to[key] = fact.toKey)",
+        `MERGE (from)-[r:${kind} {graphKey: fact.graphKey, fromKey: fact.fromKey, toKey: fact.toKey}]->(to)`,
+        "SET r.filePath = fact.filePath,",
+        "    r.startLine = fact.startLine,",
+        "    r.endLine = fact.endLine,",
+        "    r.confidence = fact.confidence,",
+        "    r.extractor = fact.extractor",
+      ].join("\n"),
+      { facts: batch },
+    );
+  }
+}
+
+async function projectEdgeFacts(kind: CodeGraphEdgeKind, facts: CodeGraphEdgeFact[]): Promise<void> {
+  const typedGroups = new Map<string, {
+    from: NodeEndpointProjection;
+    to: NodeEndpointProjection;
+    facts: CodeGraphEdgeFact[];
+  }>();
+  const genericFacts: CodeGraphEdgeFact[] = [];
+
+  for (const fact of facts) {
+    const from = endpointForKey(fact.graphKey, fact.fromKey);
+    const to = endpointForKey(fact.graphKey, fact.toKey);
+    if (!from || !to) {
+      genericFacts.push(fact);
+      continue;
+    }
+
+    const groupKey = `${from.label}:${to.label}`;
+    const group = typedGroups.get(groupKey);
+    if (group) {
+      group.facts.push(fact);
+    } else {
+      typedGroups.set(groupKey, { from, to, facts: [fact] });
+    }
+  }
+
+  for (const group of typedGroups.values()) {
+    await projectTypedEdgeFacts(kind, group.from, group.to, group.facts);
+  }
+  await projectGenericEdgeFacts(kind, genericFacts);
 }
 
 async function extractStructuralFacts(
@@ -147,15 +288,20 @@ async function extractStructuralFacts(
 }
 
 async function projectStructuralFacts(extraction: CodeGraphExtraction): Promise<void> {
-  for (const node of extraction.nodes) {
-    await projectNodeFact(node);
+  for (const [kind, facts] of groupByKind(extraction.nodes)) {
+    await projectNodeFacts(kind as CodeGraphNodeKind, facts);
   }
-  for (const edge of extraction.edges) {
-    await projectEdgeFact(edge);
+  for (const [kind, facts] of groupByKind(extraction.edges)) {
+    await projectEdgeFacts(kind as CodeGraphEdgeKind, facts);
   }
 }
 
-export async function syncTrackedFile(graphKey: string, gitRoot: string, filePath: string): Promise<void> {
+export async function syncTrackedFile(
+  graphKey: string,
+  gitRoot: string,
+  filePath: string,
+  options: { skipStructuralClear?: boolean } = {},
+): Promise<void> {
   const { readFile } = lazyFsPromises();
   const fullPath = lazyPath().resolve(gitRoot, filePath);
   const codeFileKey = buildCodeFileKey(graphKey, filePath);
@@ -164,28 +310,20 @@ export async function syncTrackedFile(graphKey: string, gitRoot: string, filePat
     const content = await readFile(fullPath, "utf-8");
     const checksum = checksumContent(content);
     const indexedAt = new Date();
+    const codeFile: CodeFileProjection = {
+      codeFileKey,
+      graphKey,
+      filePath,
+      extension: lazyPath().extname(filePath).toLowerCase(),
+      checksum,
+      indexedAt,
+    };
 
-    await runCypher(
-      [
-        "MERGE (f:CodeFile {codeFileKey: $codeFileKey})",
-        "SET f.graphKey = $graphKey,",
-        "    f.path = $filePath,",
-        "    f.extension = $extension,",
-        "    f.checksum = $checksum,",
-        "    f.indexedAt = datetime($indexedAt)",
-      ].join("\n"),
-      {
-        codeFileKey,
-        graphKey,
-        filePath,
-        extension: lazyPath().extname(filePath).toLowerCase(),
-        checksum,
-        indexedAt: indexedAt.toISOString(),
-      },
-    );
-
+    await projectCodeFileFacts([codeFile]);
     await upsertCodeGraphFileHash({ graphKey, filePath, checksum, indexedAt });
-    await clearStructuralFactsForFile(graphKey, filePath);
+    if (!options.skipStructuralClear) {
+      await clearStructuralFactsForFile(graphKey, filePath);
+    }
     await projectStructuralFacts(await extractStructuralFacts(graphKey, filePath, content));
   } catch {
     await runCypher(
@@ -195,4 +333,38 @@ export async function syncTrackedFile(graphKey: string, gitRoot: string, filePat
     await clearStructuralFactsForFile(graphKey, filePath);
     await deleteCodeGraphFileHash(graphKey, filePath);
   }
+}
+
+export async function syncTrackedFilesFull(graphKey: string, gitRoot: string, filePaths: string[]): Promise<void> {
+  const { readFile } = lazyFsPromises();
+  const path = lazyPath();
+  const codeFiles: CodeFileProjection[] = [];
+  const nodes: CodeGraphNodeFact[] = [];
+  const edges: CodeGraphEdgeFact[] = [];
+
+  for (const filePath of filePaths) {
+    const fullPath = path.resolve(gitRoot, filePath);
+    try {
+      const content = await readFile(fullPath, "utf-8");
+      const checksum = checksumContent(content);
+      const indexedAt = new Date();
+      codeFiles.push({
+        codeFileKey: buildCodeFileKey(graphKey, filePath),
+        graphKey,
+        filePath,
+        extension: path.extname(filePath).toLowerCase(),
+        checksum,
+        indexedAt,
+      });
+      const extraction = await extractStructuralFacts(graphKey, filePath, content);
+      nodes.push(...extraction.nodes);
+      edges.push(...extraction.edges);
+    } catch {
+      await deleteCodeGraphFileHash(graphKey, filePath);
+    }
+  }
+
+  await insertCodeGraphFileHashes(codeFiles);
+  await projectCodeFileFacts(codeFiles);
+  await projectStructuralFacts({ nodes, edges });
 }

--- a/apps/web/lib/integrate/code-graph/reconcile.ts
+++ b/apps/web/lib/integrate/code-graph/reconcile.ts
@@ -13,6 +13,7 @@ import {
   clearCodeGraph,
   ensureCodeGraphNeo4jSchema,
   syncTrackedFile,
+  syncTrackedFilesFull,
 } from "./neo4j-projection";
 import {
   clearCodeGraphFileHashes,
@@ -154,9 +155,11 @@ export async function reconcileCodeGraph(input: ReconcileCodeGraphInput): Promis
     if (plan.mode === "full") {
       await clearCodeGraph(graphKey);
       await clearCodeGraphFileHashes(graphKey);
-    }
-    for (const filePath of files) {
-      await syncTrackedFile(graphKey, gitRoot, filePath);
+      await syncTrackedFilesFull(graphKey, gitRoot, files);
+    } else {
+      for (const filePath of files) {
+        await syncTrackedFile(graphKey, gitRoot, filePath);
+      }
     }
     const indexedFileCount = await countCodeGraphFileHashes(graphKey);
     await markCodeGraphReady(graphKey, {

--- a/apps/web/lib/integrate/code-graph/state-store.ts
+++ b/apps/web/lib/integrate/code-graph/state-store.ts
@@ -18,12 +18,29 @@ type CodeGraphPrisma = {
   };
   codeGraphFileHash: {
     upsert(args: Record<string, unknown>): Promise<unknown>;
+    createMany(args: Record<string, unknown>): Promise<unknown>;
     deleteMany(args: Record<string, unknown>): Promise<unknown>;
     count(args: { where: { graphKey: string } }): Promise<number>;
   };
 };
 
 const codeGraphPrisma = prisma as unknown as CodeGraphPrisma;
+const CODE_GRAPH_FILE_HASH_BATCH_SIZE = 500;
+
+type CodeGraphFileHashWrite = {
+  graphKey: string;
+  filePath: string;
+  checksum: string;
+  indexedAt: Date;
+};
+
+function chunks<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+}
 
 export async function findCodeGraphIndexState(graphKey: string): Promise<CodeGraphIndexStateRecord | null> {
   return codeGraphPrisma.codeGraphIndexState.findUnique({ where: { graphKey } });
@@ -164,6 +181,22 @@ export async function upsertCodeGraphFileHash(input: {
       lastIndexedAt: input.indexedAt,
     },
   });
+}
+
+export async function insertCodeGraphFileHashes(inputs: CodeGraphFileHashWrite[]): Promise<void> {
+  for (const batch of chunks(inputs, CODE_GRAPH_FILE_HASH_BATCH_SIZE)) {
+    if (batch.length === 0) continue;
+    await codeGraphPrisma.codeGraphFileHash.createMany({
+      data: batch.map((input) => ({
+        graphKey: input.graphKey,
+        filePath: input.filePath,
+        checksum: input.checksum,
+        authority: "git",
+        lastIndexedAt: input.indexedAt,
+      })),
+      skipDuplicates: true,
+    });
+  }
 }
 
 export async function deleteCodeGraphFileHash(graphKey: string, filePath: string): Promise<void> {

--- a/docs/superpowers/audits/2026-05-13-code-intelligence-benchmark-report.md
+++ b/docs/superpowers/audits/2026-05-13-code-intelligence-benchmark-report.md
@@ -1,47 +1,104 @@
 # Code Intelligence Benchmark Report
 
 **Date:** 2026-05-13
-**Branch:** `codex/code-intelligence-benchmark-fixes`
-**Branch commit:** `730b49c1`
-**Runtime graph snapshot:** `/workspace` branch `my-changes`, commit `7744f731b78dbf9f8ac67f2cef2d6a92e7c1bdf1`
-**Status:** Live MCP smoke and focused verification complete.
+**Branch:** `codex/code-intelligence-benchmark-rerun`
+**Previous PR:** #558
+**Runtime graph snapshot:** `/workspace` branch `my-changes`, commit `4bb9faf640563bb70cdf984058adcb3d05f582fb`
+**Status:** Live MCP benchmark rerun after conservative graph projection tuning and the MCP limit compatibility fix.
 
 ## Executive Summary
 
-The code graph is now useful, but it should be treated as a second lane beside source search rather than a replacement for it.
+The code graph is useful now, and the tuning pass changed the main conclusion about feasibility.
 
-For exact strings and runtime errors, source search still wins as the first move. For known symbols, tools, routes, models, and test targeting, graph-assisted discovery is faster, less noisy, and better at producing a verification set.
+Before tuning, the graph was valuable for structural discovery but too slow to rebuild routinely: the full live rebuild took about 364 seconds for 2,804 files. After tuning, the latest full rebuild completed in 13.1 seconds for 2,805 files, with 10,570 nodes and 13,266 relationships ready in Neo4j.
 
-The biggest remaining concern is not query usefulness. It is full-index performance: the latest full graph rebuild indexed 2,804 files in about 364 seconds. That is acceptable for a manual recovery run, but too slow for the target architecture's routine full-reindex goal.
+The right operating model is still two-lane discovery:
+
+- Use source search first for exact strings, raw errors, logs, and comments.
+- Use the graph first for known routes, MCP tools, Prisma models, symbols, files, and verification targeting.
+
+The graph should not replace source search. It should become the default structural navigation layer once the agent has a route, tool, model, symbol, or file to reason about.
 
 ## Runtime Evidence
 
-Live MCP and graph state after the fixes:
+Live MCP and graph state after the tuning pass:
 
 | Check | Result |
 | --- | --- |
 | MCP tools listed | 58 |
 | Code tools available | `get_code_graph_freshness`, `inspect_build_code_impact`, `search_code_graph`, `trace_code_surface`, `find_related_tests`, `search_project_files` |
 | Graph status | `ready` |
-| Indexed files | 2,804 |
+| Indexed files | 2,805 |
+| Nodes | 10,570 |
+| Relationships | 13,266 |
 | Workspace dirty | `false` |
 | Warnings | none |
-| `DEFINES` | 4,764 |
-| `IMPORTS` | 6,936 |
+| `DEFINES` | 4,766 |
+| `IMPORTS` | 6,940 |
 | `IMPLEMENTS_ROUTE` | 425 |
 | `EXPOSES_TOOL` | 165 |
 | `TESTED_BY` | 970 |
 
-Verification already run:
+Verification run during this pass:
 
 | Gate | Result |
 | --- | --- |
-| Focused Vitest suite | 9 files, 75 tests passed |
+| Focused graph Vitest suite | 5 files, 33 tests passed |
 | `pnpm --filter web typecheck` | passed |
+| `git diff --check` | passed |
 | `docker-entrypoint.sh` syntax check | passed |
 | Docker build for `portal` and `portal-init` | passed with existing Turbopack/NFT warnings |
 | Portal runtime | healthy |
-| Full live graph rebuild | passed, 2,804 files |
+| Full live graph rebuild | passed, 2,805 files, 13,123 ms |
+| MCP benchmark harness | exposed and then passed after fixing Neo4j `LIMIT` compatibility |
+
+Existing runtime noise observed but not caused by this change:
+
+- `portal-init` still emits non-fatal geographic duplicate and model-profile seed warnings.
+- `portal-init` still reports the missing founder-kernel manifest as a non-fatal seed warning.
+- The benchmark redo initially hit one invalid MCP run while the portal was restarting; the rerun was clean.
+
+## MCP Client Compatibility Finding
+
+The redo found one more practical issue before the final numbers were collected: graph read tools initially failed when the PowerShell MCP benchmark sent `limit = 10`. The value reached Neo4j as `10.0`, and the `LIMIT` clause rejected it as a non-integer.
+
+The fix keeps the public MCP contract unchanged and normalizes the limit at the graph-query boundary. `search_code_graph` and `find_related_tests` now render a bounded integer literal after validation instead of passing `LIMIT` as a Neo4j parameter. This matters because realistic external clients will not all preserve integer typing the same way.
+
+## Projection Tuning
+
+The full rebuild path was changed from per-file writes to conservative graph-level batches:
+
+| Area | Previous behavior | Tuned behavior |
+| --- | --- | --- |
+| Code file nodes | One Neo4j write per file | Batched `UNWIND $files` writes |
+| File hash rows | One Prisma `upsert` per file | Batched `createMany` after full hash clear |
+| Structural nodes | One Neo4j write per fact | Batched by node label |
+| Structural relationships | Dynamic endpoint lookup by scanning node keys | Batched by relationship kind and typed endpoint labels/key fields |
+| Full rebuild file clear | Global graph clear plus per-file structural clear | Global graph clear only |
+
+Two unsafe intermediate implementations are worth keeping in the learning record:
+
+- Batching relationships while retaining `WHERE any(key IN keys(node))` caused Neo4j to close the connection and the JVM to restart.
+- Larger typed batches reached a 12.1 second rebuild on one run, but a later rebased runtime exposed another Neo4j/JVM reset during projection.
+
+The final implementation uses smaller batches, resolves endpoints from graph key prefixes, and writes relationships through indexed key properties such as `CodeFile.codeFileKey`, `CodeSymbol.codeSymbolKey`, and `ExternalModule.externalModuleKey`.
+
+## Full Rebuild Timing
+
+| Run | Result |
+| --- | ---: |
+| Baseline full rebuild before tuning | ~364,000 ms |
+| Naive batched relationship attempt | failed after ~246,500 ms; Neo4j JVM restarted |
+| Aggressive typed batches | 12,114 ms once, then unstable on rebased rerun |
+| Final conservative typed batches | 13,123 ms latest clean-base run; 13,841 ms and 19,963 ms earlier stable runs |
+
+```mermaid
+xychart-beta
+  title "Full Graph Rebuild Time"
+  x-axis ["Before tuning", "After tuning"]
+  y-axis "Milliseconds" 0 --> 400000
+  bar [364000, 13123]
+```
 
 ## What Was Compared
 
@@ -60,7 +117,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File scripts\code-intelligence-be
 
 ## Benchmark Results
 
-Client-observed timings are from the MCP caller on 2026-05-13. They should be read as smoke-level measurements, not statistically stable performance numbers.
+Client-observed timings are from the MCP caller on 2026-05-13 after the tuned graph rebuild. They should still be read as smoke-level measurements, not statistically stable performance numbers.
 
 ### Target 1: Seed/P2002 Investigation
 
@@ -68,10 +125,10 @@ Task shape: find the implementation and test surface for the geographic seed P20
 
 | Lane | Calls | Wall time | Output quality |
 | --- | ---: | ---: | --- |
-| Source-only | 2 | 537 ms | Found P2002 references quickly, but the broad P2002 search returned unrelated areas before the seed source. A more specific source search found the seed regression test. |
-| Graph-assisted | 2 | 37 ms | `search_code_graph("seedCityOnce")` found `packages/db/src/seed-geographic-data.ts`; `find_related_tests` found `packages/db/src/seed-geographic-data.test.ts` with exact confidence. |
+| Source-only | 2 | 414 ms | Found P2002 references quickly, but the broad P2002 search returned unrelated areas before the seed source. A more specific source search found the seed regression test. |
+| Graph-assisted | 2 | 31 ms warm; 109 ms first clean post-rebuild run | `search_code_graph("seedCityOnce")` found the source symbol; `find_related_tests` found `packages/db/src/seed-geographic-data.test.ts` with exact confidence. |
 
-Interpretation: if the only input is "P2002", start with source search. Once the relevant symbol or file is known, the graph is much better at jumping to the owning source and test.
+Interpretation: if the only input is "P2002", start with source search. Once the relevant symbol or file is known, the graph is better at jumping to the owning source and test.
 
 ### Target 2: MCP Tool Surface
 
@@ -79,8 +136,8 @@ Task shape: understand the implementation and tests for `get_code_graph_freshnes
 
 | Lane | Calls | Wall time | Output quality |
 | --- | ---: | ---: | --- |
-| Source-only | 2 | 356 ms | Found useful lines, but returned mixed prompt guidance, tests, route context, grants, adapters, definitions, and handlers. Requires manual triage. |
-| Graph-assisted | 3 | 53 ms | Confirmed freshness, found the `CodeTool` node at `apps/web/lib/mcp-tools.ts:840`, then traced one implementation file and 15 related tests. |
+| Source-only | 2 | 403 ms | Found useful lines, but returned mixed prompt guidance, tests, route context, grants, adapters, definitions, and handlers. Requires manual triage. |
+| Graph-assisted | 3 | 54 ms | Confirmed freshness, found the `CodeTool` node at `apps/web/lib/mcp-tools.ts:840`, then traced one implementation file and 15 related tests. |
 
 Interpretation: for named MCP tools and structural surfaces, the graph is clearly better as the first move.
 
@@ -88,10 +145,10 @@ Interpretation: for named MCP tools and structural surfaces, the graph is clearl
 
 ```mermaid
 xychart-beta
-  title "MCP Discovery Wall Time"
+  title "MCP Discovery Wall Time After Tuning"
   x-axis ["Seed source", "Seed graph", "Tool source", "Tool graph"]
   y-axis "Milliseconds" 0 --> 600
-  bar [537, 37, 356, 53]
+  bar [414, 31, 403, 54]
 ```
 
 ## Triage Load Chart
@@ -103,10 +160,10 @@ xychart-beta
   title "Returned Items To Triage"
   x-axis ["Seed source", "Seed graph", "Tool source", "Tool graph"]
   y-axis "Items" 0 --> 35
-  bar [11, 2, 30, 17]
+  bar [11, 2, 30, 16]
 ```
 
-The graph still returns a broad related-test set for `apps/web/lib/mcp-tools.ts` because many MCP tests import the central tool module. That is not wrong, but it is not yet precise enough to run only a tiny test subset for large shared files.
+The graph still returns a broad related-test set for `apps/web/lib/mcp-tools.ts` because many MCP tests import the central tool module. That is correct enough for safe verification, but not precise enough to run only a tiny test subset for large shared files.
 
 ## Recommended Agent Routing
 
@@ -130,39 +187,42 @@ flowchart TD
 
 1. Keep both lanes. Source search should remain the default for exact strings and raw runtime symptoms. The graph should become the default for structural questions once a route, tool, model, symbol, or file is known.
 
-2. Update Build Studio and external-agent prompts to use this rule: `get_code_graph_freshness` at the start of plan/review/ship, then choose source search or graph based on the input shape.
+2. Update Build Studio and external-agent prompts to use this rule: call `get_code_graph_freshness` at the start of plan, review, and ready-to-ship; then choose source search or graph based on the input shape.
 
-3. Treat graph readiness as a gate, not trivia. If the graph is missing, failed, stale, dirty, or updating, agents should say that and fall back to source search.
+3. Treat graph readiness as a gate. If the graph is missing, failed, stale, dirty, or updating, agents should say that and fall back to source search.
 
-4. Optimize full reindex next. The current full rebuild time, about 364 seconds for 2,804 files, misses the design target. The next technical slice should batch Neo4j writes and use a two-phase projection so relationships are order-independent without relying on slow per-file writes.
+4. Keep the conservative tuned projection architecture. Full rebuild is now fast enough for routine recovery at current repo scale, but we should add a regression budget so future extractors cannot quietly push it back into minutes or trigger Neo4j instability.
 
 5. Improve ranking for `search_project_files`. Regression-test fixtures can pollute exact-source searches. Add a mode or ranking rule that can prefer implementation files over test files when the agent is looking for source, while still allowing test-first discovery.
 
-6. Make test targeting more precise for large shared files. `trace_code_surface` correctly found related tests for `get_code_graph_freshness`, but `apps/web/lib/mcp-tools.ts` is a large shared file, so the related-test set is broad. Add tool-handler-level or case-branch-level relationships before using graph output to narrow CI too aggressively.
+6. Make test targeting more precise for large shared files. `trace_code_surface` correctly found related tests for `get_code_graph_freshness`, but `apps/web/lib/mcp-tools.ts` is a large shared file. Add tool-handler-level or case-branch-level relationships before using graph output to narrow CI too aggressively.
 
-7. Add a repeatable benchmark harness. The ad hoc PowerShell benchmark should become a checked-in script or MCP-backed evaluation fixture that records timings, results, graph state, and ToolExecution IDs after every graph change.
+7. Keep MCP graph tools tolerant of real JSON clients. The `LIMIT 10.0` failure was small but revealing: tool contracts should normalize numeric inputs before they touch storage-specific query syntax.
+
+8. Add a checked-in performance benchmark. The PowerShell harness now works through the MCP token, but projection time should also be measured in CI or a scheduled local job with graph node/relationship counts and duration history.
 
 ## Decision
 
-Adopt graph-assisted discovery as the recommended second step after exact source search, and as the first step for known structural surfaces. Do not position the graph as a source-search replacement.
+Adopt graph-assisted discovery as the recommended structural lane for agents. Do not position the graph as a source-search replacement.
 
-The next smallest high-value implementation slice is:
+The next smallest high-value implementation slices are:
 
-1. Add a repeatable benchmark harness.
-2. Batch graph projection writes to reduce full rebuild time.
-3. Add ranking controls for source search.
-4. Refine related-test relationships for central files such as `apps/web/lib/mcp-tools.ts`.
+1. Add graph projection performance regression coverage.
+2. Add ranking controls for `search_project_files`.
+3. Refine related-test relationships for central files such as `apps/web/lib/mcp-tools.ts`.
+4. Add tool-handler-level graph nodes for MCP tool cases.
+5. Add MCP client-contract coverage for graph tool numeric arguments.
 
 ## Raw Benchmark Calls
 
 | ID | Tool | Duration | Summary |
 | ---: | --- | ---: | --- |
-| 101 | `search_project_files` | 360 ms | `P2002` returned 10 broad matches, including unrelated action/release code and the seed regression test. |
-| 102 | `search_project_files` | 177 ms | `contract under test is seedCityOnce` returned the seed regression test. |
-| 103 | `search_code_graph` | 26 ms | `seedCityOnce` returned `CodeSymbol` in `packages/db/src/seed-geographic-data.ts:151`. |
-| 104 | `find_related_tests` | 11 ms | Found `packages/db/src/seed-geographic-data.test.ts`. |
-| 201 | `search_project_files` | 164 ms | `get_code_graph_freshness` returned 16 mixed source/test/prompt/grant/adapter matches. |
-| 202 | `search_project_files` | 192 ms | `getCodeGraphFreshness` returned 14 implementation/test/query matches. |
-| 203 | `get_code_graph_freshness` | 18 ms | Graph ready for 2,804 files, no warnings. |
-| 204 | `search_code_graph` | 22 ms | Found `CodeTool` `get_code_graph_freshness` in `apps/web/lib/mcp-tools.ts:840`. |
+| 101 | `search_project_files` | 232 ms | `P2002` returned 10 broad matches, including unrelated action/release code and the seed regression test. |
+| 102 | `search_project_files` | 182 ms | `contract under test is seedCityOnce` returned the seed regression test. |
+| 103 | `search_code_graph` | 21 ms | `seedCityOnce` returned one code graph result. |
+| 104 | `find_related_tests` | 10 ms | Found `packages/db/src/seed-geographic-data.test.ts`. |
+| 201 | `search_project_files` | 214 ms | `get_code_graph_freshness` returned 16 mixed source/test/prompt/grant/adapter matches. |
+| 202 | `search_project_files` | 189 ms | `getCodeGraphFreshness` returned 14 implementation/test/query matches. |
+| 203 | `get_code_graph_freshness` | 17 ms | Graph ready for 2,805 files, no warnings. |
+| 204 | `search_code_graph` | 24 ms | Found `CodeTool` `get_code_graph_freshness` in `apps/web/lib/mcp-tools.ts:840`. |
 | 205 | `trace_code_surface` | 13 ms | Found one implementation file and 15 related tests. |

--- a/docs/superpowers/drafts/2026-05-13-code-intelligence-article-prompt.md
+++ b/docs/superpowers/drafts/2026-05-13-code-intelligence-article-prompt.md
@@ -1,0 +1,58 @@
+# Article Prompt: Lessons From Building a Code Graph for AI Agents
+
+Write a practical engineering article for software teams experimenting with AI coding agents.
+
+Working title: "A Code Graph Is Not a Search Replacement: What We Learned Benchmarking AI Agent Code Discovery"
+
+Audience:
+
+- Engineering leaders evaluating AI coding workflows.
+- Staff/principal engineers designing agentic development platforms.
+- Developers who have tried "just grep the repo" and found it both useful and insufficient.
+
+Core thesis:
+
+A code graph is useful when it gives agents structural context that text search cannot, but it should not replace source search. The durable pattern is a two-lane workflow: source search for exact text and runtime symptoms, graph navigation for known routes, tools, models, symbols, files, and test targeting.
+
+Use these concrete observations:
+
+- Exact source search still wins for raw errors like `P2002`, log lines, comments, and unknown phrasing.
+- Graph search wins once the agent has a structural handle such as an MCP tool name, route, Prisma model, symbol, or source file.
+- A graph that is stale, failed, or opaque is worse than no graph. Agents need a freshness/readiness check before trusting it.
+- Test targeting is where the graph starts to pay off: `find_related_tests` can turn source discovery into a verification set.
+- Large shared files remain hard. A central file such as `apps/web/lib/mcp-tools.ts` can produce a broad test set unless the graph models smaller handler-level relationships.
+- Full rebuild performance matters. In this benchmark, a naive version took about 364 seconds for 2,804 files. After batching file nodes, file hashes, structural nodes, and typed relationship writes with conservative transaction sizes, the latest full rebuild took 13.1 seconds for 2,805 files.
+- The tuning lesson was not just "batch writes." A naive batched relationship query that dynamically scanned node keys crashed Neo4j. The stable approach used typed endpoint labels and indexed key properties.
+- The benchmark redo exposed a client-contract bug: a PowerShell MCP caller sent a numeric `limit` that Neo4j saw as `10.0`, so graph tools failed until limits were normalized to bounded integer literals at the graph-query boundary.
+- The practical recommendation is not "use graphs everywhere." It is "route the agent based on input shape."
+
+Suggested structure:
+
+1. Open with the problem: AI agents waste time rediscovering code structure through repeated text search.
+2. Explain the first version of the graph and why we questioned whether it was useful.
+3. Describe the benchmark: source-only MCP calls versus graph-assisted MCP calls on two real tasks.
+4. Show the results:
+   - Seed/P2002: source 414 ms, graph 31 ms warm after a symbol was known.
+   - MCP tool surface: source 403 ms, graph 54 ms.
+   - Full rebuild: 364 seconds before tuning, 13.1 seconds after stable tuning.
+5. Explain where source search still wins.
+6. Explain where graph navigation wins.
+7. Discuss freshness, governance, and why agents should check graph readiness first.
+8. Discuss the performance tuning lesson: typed relationships beat dynamic endpoint scans.
+9. End with a concrete workflow rule that readers can adopt:
+   - Exact text or runtime symptom: search source first.
+   - Route/tool/model/symbol/file: check graph freshness, then use graph.
+   - Before editing: read the actual file.
+   - Before shipping: use graph-related tests as a starting verification set, not the only gate.
+
+Tone:
+
+Concrete, measured, and field-tested. Avoid hype. Make it clear that the value came from integrating the graph into agent workflow policy, not from the existence of graph data alone.
+
+Include a short "What we would build next" section:
+
+- Better ranking for source search.
+- Handler-level graph nodes for central files.
+- Projection performance regression tests.
+- MCP client-contract tests for numeric arguments.
+- Agent prompts that choose tools based on input shape.


### PR DESCRIPTION
## Summary
- Batch full code-graph rebuild projection for CodeFile, structural nodes, relationships, and full-rebuild file hashes.
- Fix graph read tools to normalize MCP numeric limits before Neo4j LIMIT clauses, covering real JSON clients that send values like 10.0.
- Refresh the code intelligence benchmark report and add an article prompt with the clean-base rerun results.

## Verification
- pnpm --filter web exec vitest run lib/integrate/code-graph-refresh-reconcile.test.ts lib/integrate/code-graph-refresh.test.ts lib/integrate/code-graph/graph-queries.test.ts lib/integrate/code-graph/extractors/tests.test.ts lib/integrate/code-graph-access.test.ts
- pnpm --filter web typecheck
- git diff --check
- docker compose --env-file D:\DPF\.env -p dpf build portal portal-init
- docker compose --env-file D:\DPF\.env -p dpf run --rm portal-init (completed with existing non-fatal seed warnings)
- docker compose --env-file D:\DPF\.env -p dpf up -d --no-deps --force-recreate portal
- forced full code graph rebuild: 2,805 files, 13,123 ms, 10,570 nodes, 13,266 relationships
- scripts\code-intelligence-benchmark.ps1 against D:\DPF\.mcp.json: source 414/403 ms vs graph 31/54 ms on the two benchmark tasks