### PR TITLE
[codex] Fix discovery triage taxonomy FK normalization

### DIFF
--- a/packages/db/src/discovery-triage.test.ts
+++ b/packages/db/src/discovery-triage.test.ts
@@ -169,8 +169,7 @@ describe("discovery triage scoring and routing", () => {
 });
 
 describe("recordDiscoveryTriageDecision", () => {
-  it("persists the decision payload with scores, evidence, and rule candidate", async () => {
-    const create = vi.fn().mockResolvedValue({ id: "decision-row" });
+  function buildDecisionFixture() {
     const packet = buildDiscoveryEvidencePacket({
       id: "entity-7",
       entityKey: "service:test:decision",
@@ -194,6 +193,13 @@ describe("recordDiscoveryTriageDecision", () => {
     const score = scoreDiscoveryTriageCandidate(packet, DEFAULT_DISCOVERY_TRIAGE_THRESHOLDS);
     const proposedRule = synthesizeDiscoveryFingerprintRule(packet, score, DEFAULT_DISCOVERY_TRIAGE_THRESHOLDS);
 
+    return { packet, score, proposedRule };
+  }
+
+  it("persists the decision payload with scores, evidence, and rule candidate", async () => {
+    const create = vi.fn().mockResolvedValue({ id: "decision-row" });
+    const { packet, score, proposedRule } = buildDecisionFixture();
+
     await recordDiscoveryTriageDecision(
       {
         discoveryTriageDecision: { create },
@@ -203,7 +209,7 @@ describe("recordDiscoveryTriageDecision", () => {
         inventoryEntityId: "entity-7",
         qualityIssueId: "issue-1",
         actorType: "agent",
-      actorId: "inventory-specialist",
+        actorId: "inventory-specialist",
         outcome: "auto-attributed",
         score,
         evidencePacket: packet,
@@ -226,6 +232,75 @@ describe("recordDiscoveryTriageDecision", () => {
         evidencePacket: packet,
         proposedRule,
         requiresHumanReview: false,
+      }),
+    });
+  });
+
+  it("resolves taxonomy node keys before writing the decision foreign key", async () => {
+    const create = vi.fn().mockResolvedValue({ id: "decision-row" });
+    const findFirst = vi.fn().mockResolvedValue({ id: "tax-node-servers" });
+    const { packet, score, proposedRule } = buildDecisionFixture();
+
+    await recordDiscoveryTriageDecision(
+      {
+        discoveryTriageDecision: { create },
+        taxonomyNode: { findFirst },
+      },
+      {
+        decisionId: "triage-1",
+        inventoryEntityId: "entity-7",
+        actorType: "agent",
+        outcome: "auto-attributed",
+        score,
+        evidencePacket: packet,
+        proposedRule,
+        selectedTaxonomyNodeId: "foundational/compute/servers",
+        requiresHumanReview: false,
+      },
+    );
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { id: "foundational/compute/servers" },
+          { nodeId: "foundational/compute/servers" },
+        ],
+      },
+      select: { id: true },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        selectedTaxonomyNodeId: "tax-node-servers",
+      }),
+    });
+  });
+
+  it("drops unresolved taxonomy node keys instead of writing an invalid foreign key", async () => {
+    const create = vi.fn().mockResolvedValue({ id: "decision-row" });
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const { packet, score, proposedRule } = buildDecisionFixture();
+
+    await recordDiscoveryTriageDecision(
+      {
+        discoveryTriageDecision: { create },
+        taxonomyNode: { findFirst },
+      },
+      {
+        decisionId: "triage-1",
+        inventoryEntityId: "entity-7",
+        actorType: "agent",
+        outcome: "auto-attributed",
+        score,
+        evidencePacket: packet,
+        proposedRule,
+        selectedTaxonomyNodeId: "foundational/compute/retired-node",
+        requiresHumanReview: false,
+      },
+    );
+
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        selectedTaxonomyNodeId: null,
       }),
     });
   });

--- a/packages/db/src/discovery-triage.ts
+++ b/packages/db/src/discovery-triage.ts
@@ -146,6 +146,13 @@ export type DiscoveryTriageClient = {
   discoveryTriageDecision: {
     create(args: { data: Record<string, unknown> }): Promise<unknown>;
   };
+  taxonomyNode?: {
+    [operation: string]: unknown;
+    findFirst?(args: {
+      where: { OR: Array<{ id: string } | { nodeId: string }> };
+      select: { id: true };
+    }): Promise<{ id: string } | null>;
+  };
 };
 
 export const DEFAULT_DISCOVERY_TRIAGE_THRESHOLDS: DiscoveryTriageThresholds = {
@@ -501,6 +508,8 @@ export async function recordDiscoveryTriageDecision(
   client: DiscoveryTriageClient,
   decision: DiscoveryTriageDecisionInput,
 ): Promise<unknown> {
+  const selectedTaxonomyNodeId = await resolveSelectedTaxonomyNodeId(client, decision.selectedTaxonomyNodeId);
+
   return client.discoveryTriageDecision.create({
     data: {
       decisionId: decision.decisionId,
@@ -513,7 +522,7 @@ export async function recordDiscoveryTriageDecision(
       taxonomyConfidence: decision.score.taxonomyConfidence,
       evidenceCompleteness: decision.score.evidenceCompleteness,
       reproducibilityScore: decision.score.reproducibilityScore,
-      selectedTaxonomyNodeId: decision.selectedTaxonomyNodeId ?? null,
+      selectedTaxonomyNodeId,
       selectedIdentity: decision.selectedIdentity ?? null,
       evidencePacket: decision.evidencePacket,
       proposedRule: decision.proposedRule ?? null,
@@ -522,4 +531,25 @@ export async function recordDiscoveryTriageDecision(
       humanReviewedAt: decision.humanReviewedAt ?? null,
     },
   });
+}
+
+async function resolveSelectedTaxonomyNodeId(
+  client: DiscoveryTriageClient,
+  selectedTaxonomyNodeId: string | null | undefined,
+): Promise<string | null> {
+  const candidate = selectedTaxonomyNodeId?.trim();
+  if (!candidate) return null;
+
+  if (typeof client.taxonomyNode?.findFirst !== "function") {
+    return candidate;
+  }
+
+  const node = await client.taxonomyNode.findFirst({
+    where: {
+      OR: [{ id: candidate }, { nodeId: candidate }],
+    },
+    select: { id: true },
+  });
+
+  return node?.id ?? null;
 }


### PR DESCRIPTION
## Summary
- harden `recordDiscoveryTriageDecision` so selected taxonomy references are normalized through `TaxonomyNode.id` or `TaxonomyNode.nodeId` before writing the FK
- drop unresolved selected taxonomy references to `null` instead of letting scheduled triage fail on `DiscoveryTriageDecision_selectedTaxonomyNodeId_fkey`
- add regression coverage for raw `nodeId` inputs and unresolved taxonomy candidates

## Field Test
- selected real backlog item `BI-594D404E` from the governed backlog
- live `ToolExecution` history confirmed prior `run_discovery_triage` FK failures on 2026-04-30, 2026-05-01, and 2026-05-10
- current running scheduled path smoke-tested successfully: `processed=1`, `decisionsCreated=1`, no FK violation
- attached manual, test, and build evidence to `BI-594D404E` through the DPF MCP backlog tool and moved the item to `in-progress`

## Code Graph / MCP Notes
- `get_code_graph_freshness` succeeded and showed the graph was ready
- deployed `search_code_graph` is still blocked by the `LIMIT 10.0` numeric bug until PR #560 lands/deploys
- the current worktree MCP token lacks `registry_write`, so `run_discovery_triage` could not be invoked directly through MCP; runtime smoke used the running portal container instead

## Verification
- `pnpm --filter @dpf/db exec vitest run src/discovery-triage.test.ts`
- `pnpm --filter web exec vitest run lib/discovery-triage-runner.test.ts`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`

Build passed with existing Turbopack broad file-tracing warnings around `spec-plan-search.ts` / `next.config.mjs` import traces.