### PR TITLE
docs(wiki): seed founder kernel with three core principles

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,8 +1,8 @@
 {
-  "kernelVersion": "0.2.0",
+  "kernelVersion": "0.2.1",
   "schemaVersion": "0.2.0",
-  "pageCount": 19,
-  "sourceCount": 10,
+  "pageCount": 23,
+  "sourceCount": 11,
   "embeddingModel": null,
   "builtAt": null,
   "description": "DPF Founder Kernel — Mark Bodman's research, articles, and platform thinking, captured as a Karpathy-style wiki. The 0.2.0 cut was synthesised from Mark's public corpus (LinkedIn long-form, Open Group W205 + IT4IT v3 + DPROM, BriefingsDirect, Architecture & Governance Magazine, ServiceNow community blogs, CSDM v5) and published on Mark's behalf for agent retrieval. Schema 0.2.0 adds the `principle` page kind (tier + decision vector + applies-to + public-classification metadata) — see ../superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md and ./SCHEMA.md `principle` section."

--- a/docs/founder-kernel/wiki/index.md
+++ b/docs/founder-kernel/wiki/index.md
@@ -28,6 +28,14 @@ The kernel was cross-referenced against its cited sources in a separate audit. S
 | [IT4IT v3 framework](../raw-sources/frameworks/it4it-v3.md) | ✓ Public-facing standard metadata verified. |
 | [CSDM framework](../raw-sources/frameworks/csdm.md) | ✓ Public-facing product documentation verified. |
 
+## Principles — durable governance
+
+Tier-weighted rules that contribute to decision aggregation across every matching context. Heavier than stances (which take a position on one topic), more durable than heuristics (which fire situationally). See [`SCHEMA.md`](../SCHEMA.md) for the `principle` page-kind contract and tier semantics.
+
+- `[[principles/trust-the-data-spine]]` — core. Prefer a trusted, auto-populated data spine over reasoning on a model nobody trusts.
+- `[[principles/one-data-model]]` — core. Prefer one canonical data model over two integrated systems of record over the same entities.
+- `[[principles/contextualize-before-transforming]]` — core. Map the existing operating model against a new standard before changing the operating model.
+
 ## Stances — Mark&#39;s positions
 
 The judgment kernel. Cite these when grounding an answer in his thinking.
@@ -95,4 +103,4 @@ This is a first cut. Pages that the research digest surfaced but haven&#39;t bee
 
 ## Status of this index page
 
-Drafted by Claude from research on Mark&#39;s public writing. Marked `status: draft` like the rest. Mark reviews and either edits in place or replaces with a version in his own voice.
+Drafted by Claude from research on Mark&#39;s public writing, then published after Mark&#39;s review. The principle pages above were drafted on top of already-published stances and are pending Mark&#39;s tier/public-promotion review before any tier escalation to `commandment` or `principlePublic: true`.

--- a/docs/founder-kernel/wiki/principles/contextualize-before-transforming.md
+++ b/docs/founder-kernel/wiki/principles/contextualize-before-transforming.md
@@ -1,0 +1,63 @@
+---
+title: Contextualize before transforming
+pageKind: principle
+status: published
+abstract: Prefer mapping the existing operating model against a new standard before changing the operating model. Adoption follows mapping; transformation follows adoption. Skip the first step and the second never lands.
+principleTier: core
+principleDirection: Prefer mapping the existing operating model against a new standard before changing the operating model.
+principleDimensionVector: {"human_cognitive_load": -0.7, "blast_radius": -0.6, "governance_compliance": 0.4, "speed_to_value": -0.2}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: false
+principlePublicRationale: ""
+sources:
+  - articles/open-group-2017-managing-business-of-it
+---
+
+## Rule
+
+When introducing a standard, framework, or new operating model, map the current state onto it first. Change the operating model only after the mapping has produced a shared vocabulary and shared evidence of where the gaps actually are.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and human operators leading change. Coworkers and agents must resist proposing "transform X to Y" when the gap between current X and target Y has not yet been articulated in the target's vocabulary. Humans must resist framing standards adoption as transformation, especially in conversations with executives who reached their position by experience with what currently works.
+
+## Why
+
+Executives reach their position by experience with what works. Introducing a "new framework" feels like a threat to that experience — it implies the current operating model is wrong, which implicates the people who built it. Resistance is rational.
+
+Contextualization side-steps the threat. It says: your operating model exists; it works; let's name it in the standard's vocabulary so we can compare. Where the standard adds value, you adopt it deliberately. Where your current model is already strong, you keep it. The standard becomes a tool, not a verdict.
+
+The same dynamic plays out below the executive layer. Engineering teams reject "transform to IT4IT" and accept "let's map our ITIL processes onto the IT4IT value streams and see where the gaps are." The mapping creates the artefact that later change-work can be grounded in. Without it, transformation work argues against shadow versions of the current state held in different heads.
+
+## How To Apply
+
+When facing a standards-adoption decision, ask: do we have the current state mapped into the target's vocabulary? If not, that's the next step — not deciding which parts to transform. Resist questions of the form "should we adopt X?" until they've been reframed as "where is our current model the same or different from X, and where does X add value we don't have?" Produce the mapping artefact before recommending changes; it grounds every subsequent conversation.
+
+## Decision Dimensions
+
+- `human_cognitive_load: -0.7` — the strongest pull. Contextualization works because it reduces the cognitive threat of the new framework. Options that demand executives discard mental models they trust will be rejected regardless of technical merit.
+- `blast_radius: -0.6` — mapping is bounded; transformation is not. The principle prefers options whose failure mode is "the mapping was wrong" over options whose failure mode is "the operating model is broken."
+- `governance_compliance: 0.4` — the mapping artefact is what subsequent compliance, audit, and review work attach to. Without it, compliance work is repeated inference.
+- `speed_to_value: -0.2` — modest concession. Mapping is slower than charging into transformation. The principle accepts that cost because skipping the mapping makes the transformation itself slower or impossible.
+
+## Examples
+
+- **Positive:** A federal CIO wants to align IT operations to FITARA and FEA. The architect leads with "let's contextualize our current operating model against IT4IT — how is what we do today the same or different?" The mapping produces a small, named set of gaps; transformation work scopes to those gaps and ships in stages.
+- **Counterexample:** A "we're transforming to TOGAF this year" announcement lands on a team that already has a working operating model. Within a quarter the announcement has produced two consultancies, no mapping, escalating resistance, and a planning artefact that bears no relation to how work actually flows. The mapping step was skipped; transformation never anchors.
+
+## When this does not apply
+
+- Greenfield. There is nothing to contextualize against; pick a standard and build to it.
+- Compliance-driven adoption where the standard is externally mandatory. Mapping is still useful internally, but the framing externally is different.
+
+## See also
+
+- Originating stance: `[[stances/contextualize-dont-transform]]`
+- Heuristic: `[[heuristics/contextualize-before-transforming]]` — the mechanic in operational form.
+- Heuristic: `[[heuristics/find-at-least-one-champion]]` — without a champion, the contextualization conversation doesn't start.
+- Heuristic: `[[heuristics/pitch-simple-adjust-per-audience]]` — language matters; pick the right framing per audience.
+- Stance: `[[stances/it4it-is-substrate]]` — the standard most often being contextualized.
+- Entity: `[[entities/it4it]]`

--- a/docs/founder-kernel/wiki/principles/one-data-model.md
+++ b/docs/founder-kernel/wiki/principles/one-data-model.md
@@ -1,0 +1,66 @@
+---
+title: One data model, not two integrated
+pageKind: principle
+status: published
+abstract: Prefer one canonical data model over two integrated systems of record claiming authority over the same entities. The integration progresses Independent → Honeymoon → Ugly Reckoning; consolidation pays back the depth you lose many times over.
+principleTier: core
+principleDirection: Prefer one canonical data model over two integrated systems of record over the same entities.
+principleDimensionVector: {"long_term_maintainability": 1.0, "schema_grounding": 0.9, "human_cognitive_load": -0.5, "speed_to_value": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: false
+principlePublicRationale: ""
+sources:
+  - articles/think-twice-ea-platform-servicenow
+  - articles/sibling-portfolios
+---
+
+## Rule
+
+When two systems would claim authority over the same entities, consolidate onto one canonical data model rather than integrating both.
+
+## Why
+
+The integration pattern is structural, not technological. With two systems of record, reconciliation requires either a third authoritative source nobody can afford or a one-way master-slave relationship one team must accept losing. Both options usually fail to ship, and the integration limps along producing increasingly stale views.
+
+The lifecycle is predictable: **Independent** (both work fine on their own terms) → **Honeymoon** (integration ships; first six months look great) → **Ugly Reckoning** (scope creep, semantic mismatches, chicken-vs-egg ownership, reconciliation drift). Data quality collapses. People stop trusting the model.
+
+Consolidation accepts a known cost — typically 10–20% of specialist feature depth — in exchange for never running the integration. The maths almost always favour consolidation: you lose depth you'd use occasionally and gain reliability you'd use every day.
+
+The same logic produced the APM/SPM merge into Digital Portfolio Management: two portfolios that share the same dependency map belong in one house on a shared CMDB, not in separate tools glued together.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and human operators. Coworkers and agents must avoid creating parallel systems of record (a second graph, a side cache, an export-then-recompute) when a canonical one already exists. Humans must resist the "we'll integrate them later" pattern when choosing between best-of-breed point tools and a consolidated platform.
+
+## How To Apply
+
+When you spot two systems being asked to own the same entity (application, service, CI, portfolio item), surface the consolidation question explicitly. Name the alternatives: consolidate on one, accept the specialist gap on the other, or commit to running the integration with full reconciliation discipline. Prefer the first. If you must integrate, design the master-slave contract before shipping, not after.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 1.0` — the strongest pull. Two-system integrations decay; one-system consolidations compound.
+- `schema_grounding: 0.9` — one model = one schema, one vocabulary, one set of relationships. Two models guarantee semantic mismatches.
+- `human_cognitive_load: -0.5` — pulls toward options that reduce cognitive load on operators. Two systems mean two mental models, two query languages, two trust postures.
+- `speed_to_value: -0.4` — modest concession. Consolidation is slower up front than running two tools that "already work." The principle accepts that cost.
+
+## Examples
+
+- **Positive:** A team inherits a deployment with a dedicated EA tool integrated to the CMDB. Reconciliation has drifted; the EA model says one thing, operations says another. Rather than fix the integration for the third time, the team migrates the high-value EA artefacts onto the CMDB's data model and retires the integration. Trust returns within a quarter.
+- **Counterexample:** A "we'll keep the existing EA tool as the source for application data, and ServiceNow as the source for everything else" decision is made to avoid migration cost. Twelve months later, neither team trusts the application data, both teams blame the integration, and the depth advantage of the specialist tool went unused because nobody trusts the joined view.
+
+## When this does not apply
+
+- Pure modelling work that doesn't need to flow into operations — academic EA exercises, future-state target architectures with no current-state tie-in.
+- Specialist domains the consolidation target genuinely doesn't cover (some industry-specific EA tools have capability ServiceNow lacks; those *might* justify the integration cost, but the bar is high).
+
+## See also
+
+- Originating stance: `[[stances/dont-integrate-ea-platform]]` (includes the ServiceNow-employment conflict-of-interest disclosure)
+- Sibling stance: `[[stances/trust-the-cmdb-or-rebuild-it]]` — consolidation only works if the surviving spine is trustworthy.
+- Heuristic: `[[heuristics/reuse-the-camera-in-your-pocket]]` — the trade-off in concrete form.
+- Sibling principle: `[[principles/trust-the-data-spine]]`
+- Entity: `[[entities/csdm]]`
+- Entity: `[[entities/portfolio]]`

--- a/docs/founder-kernel/wiki/principles/trust-the-data-spine.md
+++ b/docs/founder-kernel/wiki/principles/trust-the-data-spine.md
@@ -1,0 +1,57 @@
+---
+title: Trust the data spine before anything built on it
+pageKind: principle
+status: published
+abstract: Prefer working from a trusted, auto-populated data spine over reasoning on a model nobody trusts. An untrusted CMDB is technical debt that compounds — every dependent decision inherits the doubt.
+principleTier: core
+principleDirection: Prefer a trusted, auto-populated data spine (Ingestion + Insight + Governance) over reasoning on a model nobody trusts.
+principleDimensionVector: {"evidence_density": 1.0, "schema_grounding": 0.8, "governance_compliance": 0.6, "speed_to_value": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: false
+principlePublicRationale: ""
+sources:
+  - frameworks/csdm
+---
+
+## Rule
+
+Do not build decisions on a data spine you cannot trust. Either fix the spine on the three pillars (Ingestion, Insight, Governance & Health) or stop pretending it is the source of truth.
+
+## Why
+
+The CMDB problem isn't that the data model is hard. `[[entities/csdm]]` settled the model question — it's the canonical spine. The problem is that organisations stand up the model without standing up the three pillars, then are surprised when the CMDB stops being useful.
+
+Every downstream decision — rationalisation, ROI, AI-assisted operations, risk reporting — inherits the spine's trustworthiness. If the spine is wrong, the answer is wrong, and the wrongness only surfaces months later when the consequences land. This is why "trust is the only quality of a CMDB that matters." A spine you cannot trust is worse than no spine, because it absorbs effort that would otherwise go into building one.
+
+For DPF specifically, the same logic governs every retrieval and recall surface: the wiki, the memory store, the code graph, the CSDM projection. If a coworker can't trust what comes back from the retrieval layer, the agent stops grounding answers in it — and starts hallucinating against the user instead.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and human operators. Coworkers and agents must check whether the data they're reasoning about comes from a governed, auto-populated source before treating it as authoritative. Humans must own one of the three pillars — usually Governance & Health — or the spine decays whether or not it was set up correctly originally.
+
+## How To Apply
+
+When you reach a decision that depends on platform state (inventory, ownership, capacity, dependencies, configuration drift): ask first whether the state was auto-populated and currently governed, or whether it was hand-entered and unowned. If the latter, surface the doubt before acting. Prefer options that build or extend the spine over options that route around it with bespoke queries, exports, or screenshots. If the spine isn't trustworthy and won't be made so, escalate before recommending decisions that depend on it.
+
+## Decision Dimensions
+
+- `evidence_density: 1.0` — the strongest pull. This principle is about evidence over intuition; options that produce or rely on dense, governed evidence are strictly preferred.
+- `schema_grounding: 0.8` — a trusted spine is a schema-grounded one. Options that respect CSDM (or the platform's equivalent) reinforce the spine; options that invent their own shape erode it.
+- `governance_compliance: 0.6` — Governance & Health is the third pillar. Options that bring an owner, a review cadence, and a triage process attached to the data are favoured.
+- `speed_to_value: -0.3` — modest concession. Building the three pillars is slower than skipping them. The principle accepts that cost because the alternative is faster wrong answers.
+
+## Examples
+
+- **Positive:** A coworker is asked to summarise a portfolio's risk posture. It checks that the underlying CIs are auto-populated from discovery and reconciled in the last 24 hours before answering. When discovery is stale, it flags the doubt in the response instead of inventing a number.
+- **Counterexample:** A team builds a custom reporting layer on top of a hand-maintained spreadsheet "because the CMDB is incomplete." Six months later the spreadsheet has diverged from reality; decisions made against it have to be unwound. The right move was to invest in the spine, not route around it.
+
+## See also
+
+- Originating stance: `[[stances/trust-the-cmdb-or-rebuild-it]]`
+- Heuristic: `[[heuristics/auto-populate-or-its-wrong]]` — the first pillar in operational form.
+- Heuristic: `[[heuristics/model-what-naturally-happens]]` — how to build the model without becoming a data-lake project.
+- Entity: `[[entities/csdm]]`
+- Sibling principle: `[[principles/one-data-model]]` — consolidation only works if the resulting spine is trustworthy.


### PR DESCRIPTION
## Summary

First content for the `principle` page-kind shipped in #538/#542. The kind exists, lint/retrieval/MCP/admin UI all support it, but the kernel had **zero** principle pages — so the new machinery had nothing to serve. This PR fills that gap with three principles derived from already-published stances, plus an index refresh.

```
docs/founder-kernel/wiki/principles/
├── trust-the-data-spine.md             (from stances/trust-the-cmdb-or-rebuild-it)
├── one-data-model.md                   (from stances/dont-integrate-ea-platform)
└── contextualize-before-transforming.md (from stances/contextualize-dont-transform)
```

All three are `tier: core`, `principlePublic: false`. Deliberately conservative on the first batch:
- **Tier:** the commandment budget (cap of 10) is preserved for Mark to assign. Any of these can be promoted later with a `principleWeightRationale`.
- **Public:** per spec §9, public exposure is a deliberate promotion decision, not a tier default. Each page has `principlePublicRationale: ""` ready for Mark to fill when promoting.

## Authoring notes

Each principle pairs with its originating stance (the stance retains the narrative voice; the principle carries the durable tier/vector metadata). The stances stay as-is.

| Principle | Direction | Dimension vector |
|---|---|---|
| `trust-the-data-spine` | Prefer a trusted, auto-populated data spine (Ingestion + Insight + Governance) over reasoning on a model nobody trusts. | `evidence_density: 1.0, schema_grounding: 0.8, governance_compliance: 0.6, speed_to_value: -0.3` |
| `one-data-model` | Prefer one canonical data model over two integrated systems of record over the same entities. | `long_term_maintainability: 1.0, schema_grounding: 0.9, human_cognitive_load: -0.5, speed_to_value: -0.4` |
| `contextualize-before-transforming` | Prefer mapping the existing operating model against a new standard before changing the operating model. | `human_cognitive_load: -0.7, blast_radius: -0.6, governance_compliance: 0.4, speed_to_value: -0.2` |

All dimensions are from the v1 registry in `packages/db/src/wiki-taxonomy.ts`. Each principle is `appliesTo: [in_platform_coworker, external_coding_agent, human]`.

## Also in this PR

- `wiki/index.md` — adds a Principles section above Stances; fixes the stale "Marked `status: draft` like the rest" line on the index itself (the index is published, as is every page it lists).
- `manifest.json` — `kernelVersion: 0.2.0 → 0.2.1` (content-only bump per SCHEMA §8; schema unchanged). `pageCount: 19 → 23`, `sourceCount: 10 → 11` — corrects counts that had drifted from disk after PR #553 added a 7th article and this PR adds 3 principle pages.

## Test plan

- [x] Parsed all three pages through `parseFrontmatter` + `extractPrinciplePayload` — every field reaches the expected payload shape (tier, dimensions, applies-to).
- [x] Grep'd every `[[wikilink]]` in the three principle pages and the index; **all targets resolve** — no `dangling-xref` lint findings expected.
- [x] `pnpm exec vitest run src/seed-wiki-kernel.test.ts src/wiki-store.test.ts src/wiki-taxonomy.test.ts` — 76 tests pass on the changes.
- [ ] Post-merge: re-seed (`pnpm --filter @dpf/db exec tsx packages/db/src/seed.ts`) to confirm idempotent and that the rows land with the right principle metadata.
- [ ] Post-merge: rebuild kernel embeddings (`tsx scripts/build-kernel-embeddings.ts`) so the principles are retrievable via `wiki_query` and passive recall.

## Out of scope

- Tier escalation to `commandment` — Mark's call, with rationale.
- `principlePublic: true` — promotes a principle to the static public docs site; Mark's call, requires the rationale field.
- Authoring principles from the AGENTS.md / TAK / GAID material (separate work, broader scope).

https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_