### PR TITLE
feat(installer): bundle Edge Node in single-host install (auto-approve)

### DIFF
--- a/apps/web/app/api/v1/edge/enroll/route.test.ts
+++ b/apps/web/app/api/v1/edge/enroll/route.test.ts
@@ -189,7 +189,13 @@ describe("POST /api/v1/edge/enroll — happy path", () => {
     });
   });
 
-  it("forces autoApprove=false (Phase 0 default — token metadata, not route, decides)", async () => {
+  it("omits autoApprove from the enroll call so the token row is the source of truth", async () => {
+    // Per spec § Approval policy + the installer-bundled-Edge-Node
+    // work: auto-approval is decided by the BootstrapToken row's
+    // persisted `autoApprove` flag (set true for installer-issued
+    // local-host tokens, false for paste-provisioned tokens). The
+    // route layer no longer hardcodes a value — it leaves the field
+    // undefined so the enrollment helper reads it off the token.
     mockEnrollEdgeNode.mockResolvedValue({
       ok: true,
       nodeId: "edge_abc",
@@ -201,7 +207,10 @@ describe("POST /api/v1/edge/enroll — happy path", () => {
     });
     await POST(makeReq(VALID_BODY, { Authorization: "Bearer dpfboot_X" }));
     const call = mockEnrollEdgeNode.mock.calls[0]![0];
-    expect(call.autoApprove).toBe(false);
+    // The field must NOT be set — `undefined` lets the token row
+    // drive. Setting it to false would force pending even when the
+    // installer-issued the token, defeating the bundled install path.
+    expect(call.autoApprove).toBeUndefined();
   });
 
   it("forwards optional hostFingerprint + metadata when present", async () => {

--- a/apps/web/app/api/v1/edge/enroll/route.ts
+++ b/apps/web/app/api/v1/edge/enroll/route.ts
@@ -130,12 +130,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // Phase 0 does not auto-approve via this route — the bootstrap-token
-  // metadata decides. Local-host installer-issued tokens carry an
-  // implicit auto-approve flag in the issuance path; for Phase 0 we
-  // default to operator-approval (`autoApprove: false`). Future
-  // refinement may read a flag off the BootstrapToken row to make this
-  // explicit per token; punting until A7's portal UI lands.
+  // Auto-approval is driven by the BootstrapToken row's persisted
+  // `autoApprove` flag — set true at issuance time for installer-
+  // issued local-host tokens (per spec § Approval policy: "Auto-
+  // approve when the bootstrap token is issued by the local installer
+  // for the DPF host's own Edge Node") and for operator-issued bulk-
+  // onboarding tokens. Paste-provisioned tokens default false; the
+  // node lands in `pending` until an operator clicks Approve in
+  // Admin > Platform Development. The route layer leaves
+  // `autoApprove` undefined so the token row is the source of truth.
   const result = await enrollEdgeNode({
     bootstrapToken,
     displayName: parsed.data.displayName,
@@ -149,7 +152,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ...(parsed.data.metadata !== undefined
       ? { metadata: parsed.data.metadata }
       : {}),
-    autoApprove: false,
   });
 
   if (!result.ok) {

--- a/apps/web/lib/edge-node/enrollment.test.ts
+++ b/apps/web/lib/edge-node/enrollment.test.ts
@@ -70,6 +70,42 @@ describe("issueBootstrapToken", () => {
     expect(persistedData.tokenHash).toBe(hashToken(result.plaintext));
     expect(persistedData.tokenHash).not.toBe(result.plaintext);
   });
+
+  it("defaults autoApprove=false when not specified", async () => {
+    tokCreate.mockImplementation(async ({ data }: { data: { tokenHash: string; expiresAt: Date } }) => ({
+      id: "btok_cuid_default",
+      ...data,
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+    }));
+
+    await issueBootstrapToken({ issuedByPrincipalId: "principal_user_admin" });
+
+    const persistedData = tokCreate.mock.calls[0]?.[0]?.data;
+    // Paste-provisioned tokens (the common case) MUST NOT auto-approve
+    // — otherwise an operator sharing a token with a remote host
+    // skips the Approve click intended as the trust boundary.
+    expect(persistedData?.autoApprove).toBe(false);
+  });
+
+  it("persists autoApprove=true when the caller flags it", async () => {
+    tokCreate.mockImplementation(async ({ data }: { data: { tokenHash: string; expiresAt: Date } }) => ({
+      id: "btok_cuid_installer",
+      ...data,
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+    }));
+
+    await issueBootstrapToken({
+      issuedByPrincipalId: "principal_installer",
+      autoApprove: true,
+    });
+
+    const persistedData = tokCreate.mock.calls[0]?.[0]?.data;
+    expect(persistedData?.autoApprove).toBe(true);
+  });
 });
 
 // ── enrollEdgeNode — validation paths (no transaction needed) ────────────────
@@ -422,6 +458,142 @@ describe("enrollEdgeNode — happy path", () => {
     if (!result.ok) return;
     expect(result.acceptedCapabilities).toEqual(["discovery.network"]);
     expect(capabilityRowsCreated).toBe(1);
+  });
+
+  it("trustState=trusted when token row.autoApprove=true and caller omits override", async () => {
+    // Installer-issued token: persisted autoApprove=true. Route layer
+    // doesn't pass an explicit autoApprove so the token row drives.
+    tokFindUnique.mockResolvedValueOnce({
+      id: "btok_installer",
+      tokenHash: "hash",
+      prefix: "dpfboot_inst",
+      scope: "edge:enroll",
+      issuedAt: new Date(),
+      issuedByPrincipalId: "principal_installer",
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+      autoApprove: true,
+    });
+
+    let observedMode: string | undefined;
+    $transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        bootstrapToken: { update: vi.fn(async () => ({})) },
+        principal: { create: vi.fn(async () => ({ id: "principal_edge_installer" })) },
+        principalAlias: { create: vi.fn(async () => ({})) },
+        edgeNode: { create: vi.fn(async () => ({ id: "edgenode_installer" })) },
+        edgeNodeCapability: {
+          create: vi.fn(async (args: { data: { mode: string } }) => {
+            observedMode = args.data.mode;
+            return {};
+          }),
+        },
+      };
+      return fn(tx);
+    });
+
+    const result = await enrollEdgeNode({
+      bootstrapToken: "dpfboot_INSTALLER",
+      displayName: "Installer-issued node",
+      platform: "linux",
+      installMode: "container-host",
+      version: "0.1.0",
+      advertisedCapabilities: ["discovery.network"],
+      // intentionally NO autoApprove field — the token row drives.
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.trustState).toBe("trusted");
+    expect(observedMode).toBe("enabled");
+  });
+
+  it("trustState=pending when token row.autoApprove=false and caller omits override", async () => {
+    // Paste-provisioned token: the default for remote-host enrollment.
+    // No installer flag, no caller override — node must land in pending.
+    tokFindUnique.mockResolvedValueOnce({
+      id: "btok_paste",
+      tokenHash: "hash",
+      prefix: "dpfboot_paste",
+      scope: "edge:enroll",
+      issuedAt: new Date(),
+      issuedByPrincipalId: "principal_admin",
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+      autoApprove: false,
+    });
+
+    $transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        bootstrapToken: { update: vi.fn(async () => ({})) },
+        principal: { create: vi.fn(async () => ({ id: "principal_edge_paste" })) },
+        principalAlias: { create: vi.fn(async () => ({})) },
+        edgeNode: { create: vi.fn(async () => ({ id: "edgenode_paste" })) },
+        edgeNodeCapability: { create: vi.fn(async () => ({})) },
+      };
+      return fn(tx);
+    });
+
+    const result = await enrollEdgeNode({
+      bootstrapToken: "dpfboot_PASTED",
+      displayName: "Paste-provisioned node",
+      platform: "linux",
+      installMode: "container-host",
+      version: "0.1.0",
+      advertisedCapabilities: ["discovery.network"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.trustState).toBe("pending");
+  });
+
+  it("explicit caller autoApprove=false overrides token row.autoApprove=true (defense in depth)", async () => {
+    // Token row says auto-approve, but caller explicitly demotes it.
+    // Useful for tests + future paths where the route layer wants to
+    // force operator approval regardless of issuance metadata.
+    tokFindUnique.mockResolvedValueOnce({
+      id: "btok_override",
+      tokenHash: "hash",
+      prefix: "dpfboot_ov",
+      scope: "edge:enroll",
+      issuedAt: new Date(),
+      issuedByPrincipalId: "principal_installer",
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+      autoApprove: true,
+    });
+
+    $transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        bootstrapToken: { update: vi.fn(async () => ({})) },
+        principal: { create: vi.fn(async () => ({ id: "principal_edge_override" })) },
+        principalAlias: { create: vi.fn(async () => ({})) },
+        edgeNode: { create: vi.fn(async () => ({ id: "edgenode_override" })) },
+        edgeNodeCapability: { create: vi.fn(async () => ({})) },
+      };
+      return fn(tx);
+    });
+
+    const result = await enrollEdgeNode({
+      bootstrapToken: "dpfboot_OVERRIDE",
+      displayName: "Override-demoted node",
+      platform: "linux",
+      installMode: "container-host",
+      version: "0.1.0",
+      advertisedCapabilities: ["discovery.network"],
+      autoApprove: false, // caller override wins
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.trustState).toBe("pending");
   });
 });
 

--- a/apps/web/lib/edge-node/enrollment.ts
+++ b/apps/web/lib/edge-node/enrollment.ts
@@ -61,6 +61,25 @@ export type IssueBootstrapInput = {
    * not here.
    */
   scope?: string;
+  /**
+   * If true, persist `autoApprove=true` on the BootstrapToken row.
+   * When the Edge Node consumes this token at enrollment, the new
+   * EdgeNode lands directly in `trustState=trusted` instead of
+   * `pending` — per spec § Approval policy.
+   *
+   * Intended for two paths:
+   *   1. Installer auto-issuance for the DPF host's own Edge Node
+   *      (single-host install — the operator running install-dpf.sh
+   *      has already proven host access; the Approve click would be
+   *      ceremonial).
+   *   2. Operator bulk-onboarding via Admin > Platform Development
+   *      where the operator wants to skip the per-node approval.
+   *
+   * Defaults to false. Paste-provisioned tokens for remote nodes
+   * should always be false (the Approve click is the friction that
+   * makes remote enrollment opt-in).
+   */
+  autoApprove?: boolean;
 };
 
 export type IssueBootstrapResult = {
@@ -92,6 +111,7 @@ export async function issueBootstrapToken(
       scope: input.scope ?? "edge:enroll",
       issuedByPrincipalId: input.issuedByPrincipalId,
       expiresAt,
+      autoApprove: input.autoApprove === true,
     },
   });
 
@@ -123,9 +143,16 @@ export type EnrollInput = {
   /** Free-form metadata — hostname, tags, OS details. */
   metadata?: Record<string, unknown>;
   /**
-   * Whether this enrollment should auto-approve per spec § Approval
-   * policy. Default false (operator approval required); installer-
-   * issued local-host enrollments pass true.
+   * Force-override the token's `autoApprove` flag. Optional —
+   * when omitted, the BootstrapToken row's persisted `autoApprove`
+   * column is the source of truth per spec § Approval policy.
+   *
+   * Callers should leave this undefined in normal operation. The
+   * route layer hardcoded `false` historically and is being moved
+   * to undefined as part of installer-bundled-Edge-Node work; the
+   * field is retained as an override for tests and for future
+   * paths that need to demote an auto-approve token without
+   * re-issuing it.
    */
   autoApprove?: boolean;
 };
@@ -244,8 +271,15 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
 
   const nodeId = `edge_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
   const nodeToken = generateNodeToken();
-  const trustState = input.autoApprove ? "trusted" : "pending";
-  const status = input.autoApprove ? "active" : "pending";
+  // Effective auto-approve: explicit override wins; otherwise the
+  // token's persisted flag drives. This lets the route layer stop
+  // hardcoding `false` and trust the issuance contract — paste-
+  // provisioned tokens default to autoApprove=false on the row,
+  // installer-issued ones default to true.
+  const effectiveAutoApprove =
+    input.autoApprove !== undefined ? input.autoApprove : tokenRow.autoApprove;
+  const trustState = effectiveAutoApprove ? "trusted" : "pending";
+  const status = effectiveAutoApprove ? "active" : "pending";
   const now = new Date();
 
   // Atomic transaction: consume the bootstrap token + create the
@@ -313,7 +347,7 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
         tokenPrefix: nodeToken.prefix,
         tokenRotatedAt: now,
         enrolledAt: now,
-        ...(input.autoApprove
+        ...(effectiveAutoApprove
           ? { approvedAt: now, approvedByPrincipalId: tokenRow.issuedByPrincipalId }
           : {}),
       },
@@ -329,7 +363,7 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
     //    for auto-approved nodes; `disabled` for pending nodes (they
     //    can heartbeat but Authority does not yet accept their
     //    submissions).
-    const mode = input.autoApprove ? "enabled" : "disabled";
+    const mode = effectiveAutoApprove ? "enabled" : "disabled";
     for (const capability of acceptedCapabilities) {
       await tx.edgeNodeCapability.create({
         data: {

--- a/apps/web/scripts/issue-edge-bootstrap-token.ts
+++ b/apps/web/scripts/issue-edge-bootstrap-token.ts
@@ -37,10 +37,12 @@ const INSTALLER_PRINCIPAL_EXTERNAL_ID = "service_account:installer:local-host";
 
 type Args = {
   ttlMinutes: number;
+  autoApprove: boolean;
 };
 
 function parseArgs(argv: readonly string[]): Args {
   let ttlMinutes = 15;
+  let autoApprove = false;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--ttl-minutes" || arg === "-t") {
@@ -52,6 +54,13 @@ function parseArgs(argv: readonly string[]): Args {
       }
       ttlMinutes = Math.floor(parsed);
       i++;
+    } else if (arg === "--auto-approve") {
+      // Per spec § Approval policy: local-host installer-issued
+      // tokens auto-approve the new EdgeNode at enrollment. Required
+      // flag for single-host installs where the operator running
+      // install-dpf.sh has already proven host access — the Approve
+      // click would be ceremonial.
+      autoApprove = true;
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -59,7 +68,7 @@ function parseArgs(argv: readonly string[]): Args {
       fatal(`unknown argument: ${arg}`);
     }
   }
-  return { ttlMinutes };
+  return { ttlMinutes, autoApprove };
 }
 
 function printHelp(): void {
@@ -69,6 +78,11 @@ function printHelp(): void {
       "",
       "Flags:",
       "  --ttl-minutes, -t N    TTL in minutes (default 15; max 1440)",
+      "  --auto-approve         Mark the token so the new EdgeNode lands",
+      "                         directly in trustState=trusted at enroll",
+      "                         (skips the Admin > Edge Nodes Approve click).",
+      "                         Use ONLY for the DPF host's own Edge Node;",
+      "                         see spec § Approval policy. Default: off.",
       "  --help, -h             Show this help",
       "",
       "Output:",
@@ -78,6 +92,7 @@ function printHelp(): void {
       "Spec:",
       "  docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md",
       "  § Token namespaces and lifecycle",
+      "  § Approval policy",
     ].join("\n"),
   );
 }
@@ -138,11 +153,14 @@ async function main(): Promise<void> {
   const result = await issueBootstrapToken({
     issuedByPrincipalId: principalId,
     ttlMs: args.ttlMinutes * 60_000,
+    autoApprove: args.autoApprove,
   });
 
   // Diagnostics to stderr so stdout is pipeable.
   console.error(
-    `Issued bootstrap token ${result.prefix}…  expires ${result.expiresAt.toISOString()}  tokenId=${result.tokenId}`,
+    `Issued bootstrap token ${result.prefix}…  expires ${result.expiresAt.toISOString()}  tokenId=${result.tokenId}${
+      args.autoApprove ? "  autoApprove=true" : ""
+    }`,
   );
 
   // Plaintext token to stdout. SHOWN ONCE.

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -80,8 +80,12 @@ bash install-dpf.sh --headless --release
 2. **`~/.dpf/install-state.json`** — initializes or migrates the install
    state file (schema-versioned). Honors `XDG_STATE_HOME`.
 3. **Compose chain** — assembles `docker-compose.yml` +
-   `docker-compose.linux.yml` (+ `docker-compose.release.yml` if
-   `--release`).
+   `docker-compose.linux.yml` + `docker-compose.edge.yml` (+
+   `docker-compose.release.yml` if `--release`). The Edge Node
+   container is bundled by default for single-host installs; pass
+   `--no-edge` to skip it for Authority-only deployments (cloud,
+   headless installs where Edge Nodes will be added later from
+   separate hosts).
 4. **Docker Engine** — installs via distro pkg manager if missing
    (Docker's official `apt`/`dnf` repos), runs `systemctl enable --now
    docker`, adds your user to the `docker` group.
@@ -99,9 +103,18 @@ bash install-dpf.sh --headless --release
     `linux-monitoring` profile for cAdvisor + node-exporter).
 11. **Health check** — polls `http://localhost:3000/api/health` for up
     to 5 minutes (configurable via `DPF_HEALTH_TIMEOUT`).
-12. **Persist state** — records `lastSuccessfulInstallVersion` and
+12. **Edge Node bootstrap** (unless `--no-edge`) — mints a single-use
+    auto-approve bootstrap token via
+    `apps/web/scripts/issue-edge-bootstrap-token.ts --auto-approve`,
+    writes it to `.env` as `DPF_BOOTSTRAP_TOKEN`, restarts the
+    `edge-node` container so it enrolls. The new EdgeNode lands
+    directly in `trustState=trusted` per spec § Approval policy —
+    the operator running `install-dpf.sh` has already proven host
+    access, so the Approve click in `/platform/edge-nodes` would be
+    ceremonial. The node appears in the admin UI within ~10 seconds.
+13. **Persist state** — records `lastSuccessfulInstallVersion` and
     `lastHealthCheck`.
-13. **systemd user unit** — installs
+14. **systemd user unit** — installs
     `~/.config/systemd/user/dpf.service` and runs
     `loginctl enable-linger $USER` so the stack auto-starts at boot
     (skip with `--no-autostart`).
@@ -123,7 +136,7 @@ Login credentials are written to `.env` in the install directory:
 |------|---------|
 | Start the stack | `bash dpf-start.sh` |
 | Stop the stack | `bash dpf-stop.sh` |
-| Tail logs | `docker compose -f docker-compose.yml -f docker-compose.linux.yml logs -f` |
+| Tail logs | `docker compose -f docker-compose.yml -f docker-compose.linux.yml -f docker-compose.edge.yml logs -f` |
 | Diagnostic bundle | `bash install-dpf.sh doctor` |
 | Wipe + reinstall (destructive) | `bash dpf-reinstall.sh` |
 | Tag + push a release | `bash dpf-release.sh --bump minor` |
@@ -131,6 +144,51 @@ Login credentials are written to `.env` in the install directory:
 | Full uninstall (wipe data) | `bash uninstall-dpf.sh --purge` |
 
 Pass `--help` to any of those scripts to see all flags.
+
+## Edge Node — what's running and why
+
+A single-host install bundles a **DPF Edge Node** alongside the
+Authority Core. The Edge Node is a small Node.js container that:
+
+- Reports its host (hostname + LAN IP addresses) to the Authority
+- Submits discovery observations on a regular sweep cadence (default
+  5 min)
+- Receives policy + interval updates from the Authority on each
+  heartbeat (default 60s)
+
+It enrolls automatically on first install (the installer mints a
+single-use `dpfboot_*` token flagged as installer-issued, writes it
+to `.env`, and the container consumes it on startup). Per spec §
+Approval policy the new node lands directly in `trustState=trusted`
+— no Approve click needed because the operator running
+`install-dpf.sh` already has host access.
+
+Verify it's running:
+
+```bash
+# Container is up
+docker compose -f docker-compose.yml -f docker-compose.linux.yml \
+               -f docker-compose.edge.yml \
+               ps edge-node
+
+# Node appears in the admin UI at /platform/edge-nodes with
+# trustState=trusted, a recent lastSeenAt, and (after a few minutes)
+# a DiscoveryRun count > 0.
+```
+
+**Skip the Edge Node:** `bash install-dpf.sh --no-edge` for
+Authority-only deployments (cloud / headless installs where Edge
+Nodes will be added later from separate hosts via the
+`docker-compose.edge-standalone.yml` path —
+[multi-host runbook](edge-node-multi-host.md)).
+
+**Add Edge Nodes from other hosts later:** when you want to
+discover topology on a second machine (different physical box, VM,
+LAN segment), follow the
+[multi-host runbook](edge-node-multi-host.md). The remote host
+runs only the Edge Node container, points it at this Authority's
+URL, and goes through the operator Approve click (paste-provisioned
+tokens always require explicit approval per spec § Approval policy).
 
 ## LLM provider
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -74,8 +74,10 @@ bash install-dpf.sh --headless --release
 2. **`~/.dpf/install-state.json`** — initializes or migrates the install
    state file (schema-versioned).
 3. **Compose chain** — assembles `docker-compose.yml` +
-   `docker-compose.macos.yml` (+ `docker-compose.release.yml` if
-   `--release`).
+   `docker-compose.macos.yml` + `docker-compose.edge.yml` (+
+   `docker-compose.release.yml` if `--release`). The Edge Node
+   container is bundled by default for single-host installs; pass
+   `--no-edge` to skip it.
 4. **Docker Desktop** — installs the `.dmg` if missing
    (`hdiutil attach` + `cp -R /Applications`), then starts it and waits
    for the daemon.
@@ -89,9 +91,21 @@ bash install-dpf.sh --headless --release
 9. **`docker compose up -d`** on the macOS overlay.
 10. **Health check** — polls `http://localhost:3000/api/health` for up
     to 5 minutes (configurable via `DPF_HEALTH_TIMEOUT`).
-11. **Persist state** — records `lastSuccessfulInstallVersion` and
+11. **Edge Node bootstrap** (unless `--no-edge`) — mints a single-use
+    auto-approve bootstrap token, writes it to `.env` as
+    `DPF_BOOTSTRAP_TOKEN`, restarts the `edge-node` container so it
+    enrolls. The new EdgeNode lands directly in `trustState=trusted`
+    per spec § Approval policy. **macOS limitation:** the Edge Node
+    runs in bridge mode (Docker Desktop doesn't honor
+    `network_mode: host` the way Linux does), so its discovery output
+    sees the Docker Desktop VM's interfaces rather than your Mac's
+    real NICs. That's a known constraint resolved by the future
+    native macOS Edge Node binary (T3) — until then, the Edge Node
+    here demonstrates the enrollment + heartbeat + submission path
+    but not L2 host-network discovery.
+12. **Persist state** — records `lastSuccessfulInstallVersion` and
     `lastHealthCheck`.
-12. **LaunchAgent** — installs `~/Library/LaunchAgents/local.dpf-autostart.plist`
+13. **LaunchAgent** — installs `~/Library/LaunchAgents/local.dpf-autostart.plist`
     so the stack auto-starts at login (skip with `--no-autostart`).
 
 Total wall time: ~10 minutes including the AI-model download (varies

--- a/dpf-start.sh
+++ b/dpf-start.sh
@@ -39,6 +39,9 @@ Flags:
                   overlay). Default if install-state.json records release
                   mode; otherwise dev.
   --dev           Force dev mode (build images locally).
+  --no-edge       Skip bringing up the Edge Node container. Default is
+                  to include it (matches install-dpf.sh's default
+                  bundling). Honors DPF_INCLUDE_EDGE=0 from the env.
   --no-browser    Don't try to open the portal in a browser after start.
   --dry-run       Print the planned compose command without running it.
   -h, --help      Show this help.
@@ -56,6 +59,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --release)     DPF_MODE="release" ;;
     --dev)         DPF_MODE="dev" ;;
+    --no-edge)     DPF_INCLUDE_EDGE=0 ;;
     --no-browser)  DPF_NO_BROWSER=1 ;;
     --dry-run)     DPF_DRY_RUN=1 ;;
     -h|--help)     usage; exit 0 ;;
@@ -67,6 +71,11 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+# Export so dpf_compose_files picks it up. The compose helper defaults
+# to including the edge overlay; --no-edge or a pre-set
+# DPF_INCLUDE_EDGE=0 in the environment turns it off.
+export DPF_INCLUDE_EDGE="${DPF_INCLUDE_EDGE:-1}"
 
 cd "$REPO_ROOT"
 dpf_platform

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -82,6 +82,13 @@ Flags:
                 Skip the LaunchAgent / systemd-user autostart install
                 step. The platform comes up but won't auto-start at
                 login / boot.
+  --no-edge     Skip bundling the Edge Node container alongside the
+                Authority Core. Use this for cloud / Authority-only
+                deployments where Edge Nodes will be added later from
+                separate hosts (docker-compose.edge-standalone.yml).
+                Default: Edge Node IS bundled for single-host installs.
+                The bundled node auto-approves at enrollment per spec
+                § Approval policy.
   -h, --help    Show this help.
 
 Status: Phase 6 (framework vertical slice). Full end-user install (Docker
@@ -98,6 +105,7 @@ EOF
 DPF_DRY_RUN=0
 DPF_MODE="dev"   # dev | release
 DPF_AUTOSTART=1
+DPF_INCLUDE_EDGE="${DPF_INCLUDE_EDGE:-1}"   # 1 = bundle Edge Node; 0 = skip
 SUBCOMMAND=""
 
 while [ $# -gt 0 ]; do
@@ -107,6 +115,7 @@ while [ $# -gt 0 ]; do
     --release)              DPF_MODE="release" ;;
     --dev)                  DPF_MODE="dev" ;;
     --no-autostart)         DPF_AUTOSTART=0 ;;
+    --no-edge)              DPF_INCLUDE_EDGE=0 ;;
     --force-unsupported-host)
                             DPF_FORCE_UNSUPPORTED_HOST=1
                             export DPF_FORCE_UNSUPPORTED_HOST ;;
@@ -292,11 +301,63 @@ if [ "${HEALTH_OK:-0}" != "1" ]; then
   exit 1
 fi
 
-# 12. Persist successful install state.
+# 12. Edge Node bootstrap. Mint an auto-approve bootstrap token, wire
+#     it into .env, and restart the edge-node container so it enrolls.
+#     Per spec § Approval policy: tokens issued by the local installer
+#     auto-approve at enrollment, so the operator doesn't have to click
+#     Approve in Admin > Platform Development for the host's own node.
+if [ "$DPF_INCLUDE_EDGE" = "1" ]; then
+  step "Edge Node bootstrap"
+
+  # Mint a single-use auto-approve token via the same helper the verify
+  # wrapper uses. The token's plaintext appears once on stdout; we
+  # capture it without echoing.
+  if EDGE_TOKEN="$(pnpm --filter web exec tsx scripts/issue-edge-bootstrap-token.ts \
+       --ttl-minutes 30 \
+       --auto-approve 2>/dev/null | tail -1)"; then
+    if [ -z "$EDGE_TOKEN" ] || [[ "$EDGE_TOKEN" != dpfboot_* ]]; then
+      warn "Edge Node bootstrap-token output not recognized; skipping enrollment wiring."
+      info "  You can re-issue manually via Admin > Platform Development > Edge Nodes."
+    else
+      # Append (or replace) DPF_BOOTSTRAP_TOKEN in .env so the
+      # edge-node container picks it up on next restart. Idempotent:
+      # successive installer runs replace the prior token.
+      if grep -q "^DPF_BOOTSTRAP_TOKEN=" .env 2>/dev/null; then
+        dpf_sed_inplace "s|^DPF_BOOTSTRAP_TOKEN=.*|DPF_BOOTSTRAP_TOKEN=$EDGE_TOKEN|" .env
+      else
+        printf '\n# Edge Node bootstrap token — installer-issued, auto-approve.\n' >> .env
+        printf 'DPF_BOOTSTRAP_TOKEN=%s\n' "$EDGE_TOKEN" >> .env
+      fi
+      # Same for the operator-friendly node name so the admin UI shows
+      # something descriptive instead of the container hostname.
+      if ! grep -q "^DPF_EDGE_NODE_NAME=" .env 2>/dev/null; then
+        printf 'DPF_EDGE_NODE_NAME=%s\n' "${HOSTNAME:-$(hostname 2>/dev/null || echo edge-node-local)}" >> .env
+      fi
+
+      # Restart the edge-node service so it picks up the new env. The
+      # service was started in step 10 but enrolled with no token (or
+      # a stale one); recreate-without-deps avoids touching the portal.
+      if docker compose "${DPF_COMPOSE_FILES[@]}" up -d --no-deps --force-recreate edge-node >/dev/null 2>&1; then
+        ok "Edge Node bootstrapped — auto-approve token wired into .env"
+        info "  The node enrolls within ~10s; check Admin > Platform Development > Edge Nodes."
+      else
+        warn "edge-node container restart failed; node may not have enrolled."
+        info "  Inspect: docker compose ${DPF_COMPOSE_FILES[*]} logs edge-node --tail 50"
+      fi
+    fi
+  else
+    warn "Edge Node bootstrap-token issuance failed; skipping enrollment wiring."
+    info "  You can re-issue manually via Admin > Platform Development > Edge Nodes."
+  fi
+else
+  info "Edge Node bundling skipped (--no-edge). Add Edge Nodes later from separate hosts via docker-compose.edge-standalone.yml."
+fi
+
+# 13. Persist successful install state.
 dpf_state_write lastSuccessfulInstallVersion "$DPF_INSTALLER_VERSION" 2>/dev/null || true
 dpf_state_write lastHealthCheck "$(date -u +%Y-%m-%dT%H:%M:%SZ)" 2>/dev/null || true
 
-# 13. Autostart unit (LaunchAgent on macOS, systemd-user unit on Linux).
+# 14. Autostart unit (LaunchAgent on macOS, systemd-user unit on Linux).
 #     Gated by --no-autostart for operators who manage their own.
 if [ "$DPF_AUTOSTART" = "1" ]; then
   step "Autostart"

--- a/packages/db/prisma/migrations/20260514000000_bootstrap_token_auto_approve/migration.sql
+++ b/packages/db/prisma/migrations/20260514000000_bootstrap_token_auto_approve/migration.sql
@@ -1,0 +1,26 @@
+-- Add BootstrapToken.autoApprove per spec § Approval policy.
+--
+-- The Phase 0 schema in 20260512000000_add_edge_node_phase0 left
+-- auto-approval implicit: the /api/v1/edge/enroll route hardcoded
+-- `autoApprove: false`, so every paste-provisioned token landed
+-- the new EdgeNode in trustState=pending. That's the right default
+-- for remote-host enrollment (an operator must intend to admit the
+-- node), but it forces a redundant Approve click for the single-
+-- host install where the operator running install-dpf.sh has
+-- already proven host access.
+--
+-- This migration adds a column the issuer can set when the token
+-- represents an already-authorized intent (installer for local
+-- host, or operator pre-approving bulk enrollment). The enroll
+-- route reads the column and skips the pending state when set.
+--
+-- Threat model: an attacker who can flip this column either (a)
+-- has DB write access (in which case they could create their own
+-- trusted EdgeNode anyway) or (b) issued the token themselves
+-- (operator action or installer; both require host access that
+-- defeats most lighter controls). The column is not a security
+-- boundary; it's an automation toggle for paths where the
+-- operator-approval click adds friction without adding signal.
+
+ALTER TABLE "BootstrapToken"
+  ADD COLUMN "autoApprove" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7583,6 +7583,20 @@ model BootstrapToken {
   // Operators can pre-revoke a token before consumption.
   revokedAt DateTime?
 
+  // Per spec § Approval policy: tokens flagged as installer-issued
+  // for the DPF host's own Edge Node enroll directly into
+  // trustState=trusted, skipping the operator-approval click. Paste-
+  // provisioned tokens (the default for remote nodes) leave this
+  // false so the new node lands in `pending` until an operator
+  // approves in Admin > Platform Development.
+  //
+  // Threat model: marking this true requires either Admin > Platform
+  // Development action (the operator chose to auto-approve, e.g. for
+  // bulk enrollment) or installer-side issuance (the installer runs
+  // with host access already, so a flag carrying that intent is no
+  // weaker than the install path itself).
+  autoApprove Boolean @default(false)
+
   // Relations
   issuedBy           Principal @relation("BootstrapTokenIssuer", fields: [issuedByPrincipalId], references: [id])
   consumedByEdgeNode EdgeNode? @relation("BootstrapTokenConsumer", fields: [consumedByEdgeNodeId], references: [id])

--- a/packages/db/src/edge-node-types.test.ts
+++ b/packages/db/src/edge-node-types.test.ts
@@ -71,6 +71,9 @@ function makeToken(overrides: Partial<BootstrapToken> = {}): BootstrapToken {
     consumedAt: null,
     consumedByEdgeNodeId: null,
     revokedAt: null,
+    // Paste-provisioned default per spec § Approval policy. Tests that
+    // care about the auto-approve path override via `overrides`.
+    autoApprove: false,
     ...overrides,
   };
 }

--- a/scripts/installer/lib/compose.sh
+++ b/scripts/installer/lib/compose.sh
@@ -80,6 +80,22 @@ dpf_compose_files() {
     *)       : ;;  # no platform overlay
   esac
 
+  # Edge Node bundling. Default ON for single-host installs; set
+  # DPF_INCLUDE_EDGE=0 (or pass --no-edge to install-dpf.sh) to skip
+  # — useful for cloud / Authority-only deployments where Edge Nodes
+  # will be added later from separate hosts via
+  # docker-compose.edge-standalone.yml.
+  #
+  # The overlay's default `edge-node` service uses bridge networking
+  # so it works on both Linux (no privileged caps required) and macOS
+  # Docker Desktop (where host networking maps to the VM, not the
+  # user's machine). Operators who want real-NIC visibility on Linux
+  # can opt into the host-network profile by setting
+  # COMPOSE_PROFILES=linux-host-network in the environment.
+  if [ "${DPF_INCLUDE_EDGE:-1}" = "1" ]; then
+    DPF_COMPOSE_FILES+=(-f docker-compose.edge.yml)
+  fi
+
   # Append any caller-provided extras (e.g. docker-compose.dev.yml for
   # the developer port-exposing overlay).
   while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
## Summary

Single-host installs (Authority + Edge Node on one machine) used to
require two manual steps after \`bash install-dpf.sh\`. Per spec §
Approval policy ("Auto-approve when the bootstrap token is issued by
the local installer for the DPF host's own Edge Node"), this PR makes
the single-host install a **one-command operation**:

\`\`\`bash
bash install-dpf.sh   #  →  portal + Edge Node up, enrolled, trustState=trusted
\`\`\`

For Authority-only deployments (cloud / headless / multi-host
expansion later):

\`\`\`bash
bash install-dpf.sh --no-edge
\`\`\`

## Footprints

| Footprint | Command | Edge Node onboarding |
|---|---|---|
| **Combined (single host)** | \`bash install-dpf.sh\` | Auto: installer issues an auto-approve token, container enrolls in ~10s, no operator click |
| **Authority-only** (cloud / headless) | \`bash install-dpf.sh --no-edge\` | None at install. Operator issues tokens later for remote nodes |
| **Edge-only** (second host) | n/a — no portal | T2.1 path: \`docker-compose.edge-standalone.yml\` + paste-provisioned token + operator Approve |

## Changes

**Schema:**
- \`BootstrapToken.autoApprove\` Boolean @default(false)
- Migration \`20260514000000_bootstrap_token_auto_approve\` with threat-model header comment

**Plumbing:**
- \`issueBootstrapToken\`: accepts + persists \`autoApprove\`
- \`enrollEdgeNode\`: reads \`tokenRow.autoApprove\`; explicit input override still wins (defense in depth)
- \`/api/v1/edge/enroll\`: drops hardcoded \`autoApprove: false\` — token row is now source of truth

**CLI:**
- \`apps/web/scripts/issue-edge-bootstrap-token.ts --auto-approve\` flag

**Installer:**
- \`install-dpf.sh --no-edge\` flag
- \`scripts/installer/lib/compose.sh\` appends \`docker-compose.edge.yml\` by default; \`DPF_INCLUDE_EDGE=0\` skips
- New install step: mint auto-approve token → append to \`.env\` → recreate \`edge-node\` (no-deps, doesn't touch portal). Idempotent.
- \`dpf-start.sh\` gains \`--no-edge\` for symmetry

## Why bridge networking (not host)

The bundled overlay uses Docker bridge mode. Works everywhere — Linux without privileged caps, macOS Docker Desktop without VM-host network confusion. Operators who want real-NIC visibility on Linux opt in via \`COMPOSE_PROFILES=linux-host-network\`. macOS won't see real host NICs until the T3 native binary work — limitation documented in \`docs/install/macos.md\`.

## Test plan

- [x] \`pnpm --filter web exec vitest run lib/edge-node/enrollment.test.ts app/api/v1/edge/enroll\` → **45 passed**
- [x] Full web vitest run → **5260 passed | 14 skipped | 13 todo**
- [x] \`pnpm --filter web typecheck\` → green
- [x] \`bash -n\` syntax check on \`install-dpf.sh\`, \`dpf-start.sh\`, \`compose.sh\` → ok
- [x] \`dpf_compose_files dev\` includes \`-f docker-compose.edge.yml\` by default
- [x] \`DPF_INCLUDE_EDGE=0 dpf_compose_files dev\` excludes it
- [ ] **Real-hardware verification** — Mark's single-host machine; want to land the PR, then run \`bash install-dpf.sh\` and confirm the Edge Node appears in \`/platform/edge-nodes\` as trusted within 30s

## New tests highlighted

- \`issueBootstrapToken\`: defaults \`autoApprove=false\`; persists \`true\` when flagged
- \`enrollEdgeNode\`: token row.autoApprove=true + no caller override → \`trusted\` + capability mode \`enabled\`
- \`enrollEdgeNode\`: token row.autoApprove=false + no caller override → \`pending\` (the remote-host default)
- \`enrollEdgeNode\`: explicit caller \`autoApprove=false\` demotes a row with \`autoApprove=true\` (defense in depth)
- \`/api/v1/edge/enroll\`: route now leaves \`autoApprove\` undefined so the token row drives

🤖 Generated with [Claude Code](https://claude.com/claude-code)