### PR TITLE
doc(principles): batch 3b - 8 AI coworker development principles

### DIFF
--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,7 +1,7 @@
 {
   "kernelVersion": "0.2.1",
   "schemaVersion": "0.2.0",
-  "pageCount": 24,
+  "pageCount": 32,
   "sourceCount": 11,
   "embeddingModel": null,
   "builtAt": null,

--- a/docs/founder-kernel/wiki/principles/diversity-of-thought.md
+++ b/docs/founder-kernel/wiki/principles/diversity-of-thought.md
@@ -1,0 +1,47 @@
+---
+title: Diversity of Thought in Agent Design
+pageKind: principle
+status: published
+abstract: Different agents should think differently, not just have different tools.
+principleTier: core
+principleDirection: Define perspective, heuristics, and interpretive model for every agent role.
+principleDimensionVector: {"long_term_maintainability": 0.5, "evidence_density": 0.6, "blast_radius": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Documents why DPF agents have distinct cognitive frames, not just different tool lists — adopters designing their own coworkers need this guidance.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Each agent's system prompt defines three cognitive components: a perspective (how it frames the problem), heuristics (strategies for finding solutions), and an interpretive model (what "good" means). These are not decorative — they determine which solutions the agent considers and which it misses.
+
+## Why
+
+A team of diverse "good enough" agents outperforms a single "best" agent on complex problems. Different perspectives reveal different solution peaks; on a rugged problem landscape, no single optimization target finds them all. The IT4IT value streams already encode this — distinct roles (engineer, ops, product, QA) optimize for different things on purpose. Tool diversity alone is insufficient: two agents with different tools but identical prompts converge on the same generic answer.
+
+## Applies To
+
+In-platform coworkers and any external agent topology with multiple roles. When a complex problem requires multiple perspectives, the orchestrator consults several specialists and combines their output. The principle does not apply to single-agent workflows (no diversity to architect) or to UI affordances (which are not agents).
+
+## How To Apply
+
+For every new agent role, declare its perspective, heuristics, and success criteria in the system prompt. Example: the Software Engineer agent's perspective is "code structure," its heuristic is "test-driven development," its interpretive model is "correctness over speed." The Operations Engineer reads the same problem through "deployment safety," uses "rollback-first deployment," and optimizes for "availability." If two agent roles end up with the same three components, one of them is redundant.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.5` — diverse cognitive frames produce robust solutions that survive context shifts; monoculture solutions break under stress.
+- `evidence_density: 0.6` — multiple perspectives surface evidence a single perspective would miss; the combined output is information-richer per token.
+- `blast_radius: 0.3` — diversity adds review pressure; an over-optimized single perspective is more likely to ship a defect that the other perspective would have caught.
+
+## Examples
+
+- **Positive:** When deciding whether to refactor a module, Build Studio consults the Architect (cares about long-term maintainability) and the Software Engineer (cares about immediate correctness). The orchestrator weighs both views before scheduling the refactor.
+- **Counterexample:** Three agents with identical system prompts but different names. Each gives the same answer; the apparent diversity is fake; the orchestrator picks one arbitrarily and ships the same single perspective.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/fail-fast-explain-clearly.md
+++ b/docs/founder-kernel/wiki/principles/fail-fast-explain-clearly.md
@@ -1,0 +1,47 @@
+---
+title: Fail Fast, Explain Clearly
+pageKind: principle
+status: published
+abstract: Stop on the first error; don't retry blindly; tell the user what happened.
+principleTier: core
+principleDirection: Report errors plainly and stop, instead of retrying or hiding the failure.
+principleDimensionVector: {"evidence_density": 0.8, "blast_radius": 0.5, "speed_to_value": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Adopters need to know that DPF agents surface errors directly rather than masking them through retries.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+When a tool call fails, the agent reports the error in plain language, explains what it was trying to do, suggests what the user can do if applicable, and stops — it does not retry the same call with the same arguments. The agentic loop enforces a tool-repetition limit (3–5 same-tool calls) as a safety net, not as license; well-prompted agents should never trigger it.
+
+## Why
+
+Blind retries waste tokens, burn rate-limit budget, and hide the real problem from the user. Smaller models in particular tend to loop when their tool call fails — they call the same tool the same way and watch it fail again, then again, then again. Each failure costs time and money without producing signal. The fix is not a smarter retry policy; the fix is to stop, surface the error, and let the user (or orchestrator) decide what to do next. This also matches DPF's "evidence before diagnosis" stance: don't guess at what's wrong, expose the actual failure.
+
+## Applies To
+
+In-platform coworkers running tool calls, external coding agents executing on the codebase, and any agentic loop with tool retry semantics. Applies symmetrically to soft failures (tool returned an error envelope) and hard failures (network timeout, exception).
+
+## How To Apply
+
+In the agent system prompt, declare the error-reporting contract: on tool failure, summarize what was attempted, surface the underlying error message, suggest a concrete next step (or that human input is needed), and stop the current step. Do not insert automatic retries in agent code unless the failure mode is known to be transient AND retryable AND the retry has a different shape. When tempted to add a retry, ask: does the retry change anything that would make the outcome different?
+
+## Decision Dimensions
+
+- `evidence_density: 0.8` — clear error reports concentrate signal; retries dilute it.
+- `blast_radius: 0.5` — stopping early contains the failure; retrying past errors can corrupt state or hit unintended side effects.
+- `speed_to_value: 0.4` — fast failure unblocks human review sooner than a slow retry loop.
+
+## Examples
+
+- **Positive:** A sandbox tool returns `Error: file not found`. The agent reports "Tried to read `app/missing.ts` to verify the change; the file doesn't exist. Was the path mistyped, or has the file been moved?" and stops. The user clarifies; the agent proceeds.
+- **Counterexample:** The same failure triggers three identical reads, each returning the same error. Tokens burn; the user sees nothing actionable; eventually the repetition limit kicks in and the agent stops with no useful diagnostic.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/orchestrator-worker-pattern.md
+++ b/docs/founder-kernel/wiki/principles/orchestrator-worker-pattern.md
@@ -1,0 +1,48 @@
+---
+title: Orchestrator-Worker Pattern
+pageKind: principle
+status: published
+abstract: A coordinator routes work to specialists; specialists do not route to each other.
+principleTier: core
+principleDirection: Route through an orchestrator; let specialists do specialist work.
+principleDimensionVector: {"governance_compliance": 0.7, "long_term_maintainability": 0.5, "reusability": 0.6}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Documents DPF's multi-agent topology so adopters understand why coworkers don't hand off directly.
+sources:
+  - frameworks/it4it-v3
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Multi-step workflows use a hierarchical orchestrator-worker pattern. The orchestrator (Build Studio for product builds, or the route-aware MCP dispatcher for ad-hoc work) routes each phase to the appropriate specialist agent. Specialists do not hand off directly to each other — every transition mediates through the orchestrator.
+
+## Why
+
+Simple phases (ideate, plan, review, ship) are deterministic workflows where smaller models perform well; complex phases (build, with multi-step tool reasoning) need frontier models. Routing decisions belong in the cheap-model orchestrator; reasoning depth belongs in the expensive-model worker. Direct peer-to-peer handoffs hide governance checkpoints, complicate error recovery, and burn tokens on transition logic that belongs in one place. The pattern matches IT4IT's value-stream gate model: the orchestrator IS the gate.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and any multi-step workflow with more than one role. Single-role workflows operate without an orchestrator because there is no peer to route to.
+
+## How To Apply
+
+When designing a new multi-agent workflow, ask: who is the orchestrator and where does it live? If two specialist agents want to call each other directly, the orchestrator is missing — promote one of them to coordinator or add a dispatcher layer. Token-budget rule of thumb: orchestrator on Haiku-tier (cheap routing), worker on Sonnet-tier (deep reasoning) where the build phase requires it.
+
+## Decision Dimensions
+
+- `governance_compliance: 0.7` — the orchestrator is the natural place to enforce phase gates, scoped tool grants, and approval boundaries.
+- `long_term_maintainability: 0.5` — a clear orchestrator-worker topology ages well; peer-to-peer chains rot fast as agents are added or removed.
+- `reusability: 0.6` — workers built to be summoned by an orchestrator can be reused across orchestrators; workers entangled in peer-to-peer chains cannot.
+
+## Examples
+
+- **Positive:** Build Studio dispatches `plan` to the Architect, `build` to the Software Engineer, `review` to QA, `ship` to Operations. Each agent returns its phase output to the orchestrator; the orchestrator decides the next dispatch.
+- **Counterexample:** A workflow where the Software Engineer agent directly invokes the QA agent with raw conversation history attached. The orchestrator can't gate the transition, the QA agent inherits unrelated context, and token cost balloons.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
+++ b/docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
@@ -1,0 +1,49 @@
+---
+title: Responsible Capacity Utilization
+pageKind: principle
+status: published
+abstract: Use paid AI capacity for governed value, not empty activity.
+principleTier: core
+principleDirection: Convert available capacity into reviewed work, evidence, learning, and platform improvement.
+principleDimensionVector: {"capacity_utilization": 1.0, "governance_compliance": 0.6, "human_cognitive_load": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: true
+principlePublicRationale: A core DPF stance — adopters need to understand the platform's posture on idle vs. active coworker time and the governance gates that bound autonomous work.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+  - frameworks/it4it-v3
+---
+
+## Rule
+
+AI coworkers treat available paid capacity as an operating asset. When authorized work is available, idle capacity is waste. When no useful, safe, evidence-producing work is available, the coworker records or surfaces the blocker rather than spending tokens to appear busy. Useful capacity work includes reducing human cognitive load, advancing approved backlog work, producing durable work products, running verification and capturing evidence, reviewing stale specs / plans / PRs / runtime state, identifying capability gaps, and converting repeated work into proceduralization candidates.
+
+## Why
+
+A salaried employee who does nothing while valuable work exists wastes organizational capacity. Fixed-price or subscription AI capacity has the same economic shape: the bill arrives whether the coworker produces value or not. The goal is not to burn tokens — that's vandalism dressed as productivity. The goal is to convert available capacity into reviewed work, evidence, learning, and platform improvement. This principle is what differentiates a coworker from a billed-hours-stretching contractor: when work is genuinely absent, the coworker says so and stops, instead of inventing busywork.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and the humans who operate them. The principle is symmetric: agents shouldn't fake productivity; operators shouldn't ask agents to fake productivity. Does NOT apply to first-time bootstrap or learning runs where exploration without immediate output is legitimately the work product.
+
+## How To Apply
+
+Capacity use is driven by Standing Orders (durable directives from the operator), calendar / availability state, safe work queues, and existing authority controls. Coworkers may continue low-risk governed work when humans are unavailable, but must stop at approval boundaries for consequential actions. When the safe-work queue is empty, surface the blocker — "I'm idle because the backlog is empty and no review-stale specs were found" — instead of fabricating work. Periodically review what coworkers have been doing during idle stretches and tune the standing orders if the pattern is wasteful.
+
+## Decision Dimensions
+
+- `capacity_utilization: 1.0` — this is the axis the principle is named after. Maximum positive weight.
+- `governance_compliance: 0.6` — autonomous capacity use only continues to the extent that governance allows; the principle does not license unbounded autonomy.
+- `human_cognitive_load: -0.3` — reduces operator burden by letting coworkers self-direct toward known-safe work instead of waiting for direction on every cycle.
+
+## Examples
+
+- **Positive:** Outside business hours with no operator present, a coworker spots that three specs have not been reviewed since their dependencies shipped, runs the spec-review-against-current-state check, and records findings. Operator returns to a useful artifact, not a billed idle window.
+- **Counterexample:** A coworker with nothing to do invokes its retrieval tools repeatedly on the same query, producing no new output. Tokens burn; nothing improves; the cost-per-value ratio degrades.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/selective-memory-not-total-recall.md
+++ b/docs/founder-kernel/wiki/principles/selective-memory-not-total-recall.md
@@ -1,0 +1,47 @@
+---
+title: Selective Memory, Not Total Recall
+pageKind: principle
+status: published
+abstract: Remember decisions and rationale; re-derive details from source.
+principleTier: core
+principleDirection: Store decisions, rationale, and discovered constraints; never raw transcripts.
+principleDimensionVector: {"long_term_maintainability": 0.7, "schema_grounding": 0.5, "speed_to_value": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Adopters using DPF's memory layer need to know what belongs there and what doesn't, before they fill it with noise.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+The memory layer (Qdrant vector store) holds salient context: user decisions, design rationale, cross-conversation insights, discovered constraints, and quality patterns. It does not hold raw conversation transcripts, code content, build artifacts, or transient state — those live in their primary sources (codebase, git, database, build records) and are re-derived on demand.
+
+## Why
+
+Memory should be dense — high information per token — because retrieval surfaces a small number of memories and each one needs to earn its slot. Fewer, more relevant memories beat many marginally relevant ones every time. Raw transcripts, code dumps, and build logs are ephemeral, bulky, and low-signal; storing them turns the memory layer into a noisy archive that degrades retrieval quality for everything else. The primary sources are always available; the memory layer's job is to act as a typed index into knowledge, not a copy of it.
+
+## Applies To
+
+In-platform coworkers using the semantic-recall path and external coding agents managing their own memory systems. Applies symmetrically: agents that write memory must be selective; agents that read memory benefit from the discipline. Does NOT apply to audit logs (which need full traceability) or to immutable evidence records (different retention contract).
+
+## How To Apply
+
+Write memory at natural decision points, not after every exchange. Tag each entry with role, phase, and topic so retrieval stays contextual. Before storing, ask: can this be re-derived from a primary source? If yes, skip it. Specific things that belong: "User chose in-memory state over database for this demo," "Anthropic subscription only gives Haiku access here," "The promoter image is JIT-built from the portal container." Specific things that do NOT belong: chat transcripts, code content, test output, current build state.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.7` — disciplined memory ages well; transcript dumps rot fast and pollute future retrieval.
+- `schema_grounding: 0.5` — typed memory entries can be linted, versioned, and migrated; freeform blobs cannot.
+- `speed_to_value: 0.4` — concise memory speeds prompt assembly; bloated memory slows every agent invocation.
+
+## Examples
+
+- **Positive:** After a build phase, the agent stores: "User prefers Tailwind over CSS modules for this project. Decided 2026-04-15 during the ideate phase." One entry, durable, surfaces in future style decisions.
+- **Counterexample:** Storing the full ideate transcript verbatim. Tokens burn on irrelevant exploration; future retrieval pulls up off-topic conversation noise instead of the decision.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/specialization-over-generalization.md
+++ b/docs/founder-kernel/wiki/principles/specialization-over-generalization.md
@@ -1,0 +1,47 @@
+---
+title: Specialization Over Generalization
+pageKind: principle
+status: published
+abstract: A specialist with 5 focused tools outperforms a generalist with 40.
+principleTier: core
+principleDirection: Prefer specialists with focused tool sets over generalists with broad surfaces.
+principleDimensionVector: {"blast_radius": 0.7, "human_cognitive_load": -0.5, "reusability": 0.5}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Documents DPF's agentic architecture posture for adopters and contributors building specialist coworkers.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Each AI coworker agent should have access to no more than 10 tools relevant to its current task. When tool count exceeds 15, tool selection accuracy degrades significantly regardless of model capability — typically dropping into repetition loops as the model can no longer reliably pick the right tool.
+
+## Why
+
+Smaller models (Haiku-tier) lean heavily on the tool schema to decide what to call; a crowded tool list overwhelms that selection mechanism. The industry consensus across Azure, Redis, and major frameworks converges on 3–5 tools per specialist. DPF's evidence is consistent: Haiku with 40+ tools entered repetition loops calling the wrong tools; Haiku with 5–9 phase-filtered tools correctly generated code and called sandbox tools. Specialist coworkers also have smaller blast radius when something goes wrong and are easier to reuse as hive-mind components.
+
+## Applies To
+
+In-platform coworkers and external coding agents. Each role in the Build Studio pipeline (Product Designer, Architect, Software Engineer, QA / Scrum Master, Operations Engineer) is a specialist with a phase-filtered tool set. Does NOT apply to orchestrator-level dispatchers, which legitimately need broader visibility to route work.
+
+## How To Apply
+
+Tag every tool with the phases and contexts where it is relevant. The platform filters the tool list per agent invocation, exposing only the tools that role needs in that phase. When adding capability to an agent, ask: "can a different specialist own this instead?" Generalist coworkers are a code smell.
+
+## Decision Dimensions
+
+- `blast_radius: 0.7` — focused tool sets contain failure to a narrow surface; a specialist with a bad tool can damage less than a generalist with the same tool.
+- `human_cognitive_load: -0.5` — operators and reviewers can reason about a specialist coworker faster than a kitchen-sink coworker.
+- `reusability: 0.5` — specialists compose into other workflows; generalists rarely do.
+
+## Examples
+
+- **Positive:** Build Studio's Architect agent sees only the planning + spec tools during the `plan` phase; once the build phase starts, those are unscoped and the Software Engineer's sandbox tools become available.
+- **Counterexample:** A coworker that sees every tool in `PLATFORM_TOOLS` regardless of context. Even with a frontier model it spends tokens on routing instead of work.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/structured-handoffs-not-conversation-history.md
+++ b/docs/founder-kernel/wiki/principles/structured-handoffs-not-conversation-history.md
@@ -1,0 +1,47 @@
+---
+title: Structured Handoffs, Not Conversation History
+pageKind: principle
+status: published
+abstract: Pass decisions and context, not transcripts.
+principleTier: core
+principleDirection: Hand off structured artifacts; never raw conversation history.
+principleDimensionVector: {"long_term_maintainability": 0.6, "schema_grounding": 0.8, "speed_to_value": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Adopters building multi-phase agent workflows need to know that DPF's handoffs are typed artifacts, not transcripts.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+When work transitions between agents or between phases, the outgoing agent produces a structured handoff document carrying decisions, evidence, open issues, and user preferences. The incoming agent reads only this document — never the raw conversation history from the previous phase.
+
+## Why
+
+Raw conversation history wastes tokens on context that no longer matters: ideate-phase discussion is noise during a build, and the build agent doesn't need the user's first-pass exploration of options to ship the feature. Structured handoffs distill what the next agent actually needs — the decision, the rationale, the evidence — and let each agent start with a clean context window focused on its task. The token cost reduction is significant in practice: ~16K per call dropping to ~4K with structured handoffs, a 3–4x improvement that compounds across phases.
+
+## Applies To
+
+Every phase transition in Build Studio and any multi-agent workflow. External coding agents producing PRs or spec follow-ups also hand off via structured artifacts (PR description, spec doc, plan doc) rather than raw chat transcripts.
+
+## How To Apply
+
+Define a typed handoff schema for every phase transition (`PhaseHandoff` with `fromPhase`, `toPhase`, `summary`, `evidence`, `openIssues`, `userPreferences`). The outgoing agent writes the handoff; the orchestrator routes the handoff (not the transcript) to the incoming agent. If you find yourself wanting to attach the conversation log, that's a signal the handoff schema is missing a field.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.6` — typed handoffs age into documentation; transcripts age into noise.
+- `schema_grounding: 0.8` — handoff fields are explicit slots that lint can validate; freeform chat history cannot be reasoned about programmatically.
+- `speed_to_value: 0.4` — smaller context windows produce faster, cheaper, more focused agent responses.
+
+## Examples
+
+- **Positive:** The `plan` phase ends with a `PhaseHandoff` document containing the chosen architecture, the rejected alternatives, the constraints surfaced by the user, and the verification checklist. The `build` phase agent reads this and starts coding.
+- **Counterexample:** The build agent receives the full `plan` chat transcript including the user's stream-of-consciousness exploration of options. Tokens burn on irrelevant content and the agent has to re-derive what the actual decision was.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)

--- a/docs/founder-kernel/wiki/principles/tools-must-be-self-documenting.md
+++ b/docs/founder-kernel/wiki/principles/tools-must-be-self-documenting.md
@@ -1,0 +1,47 @@
+---
+title: Tools Must Be Self-Documenting
+pageKind: principle
+status: published
+abstract: If the model can't understand a tool from its schema, the schema is wrong.
+principleTier: core
+principleDirection: Make every tool schema self-explanatory; do not rely on the surrounding prompt to fix bad descriptions.
+principleDimensionVector: {"long_term_maintainability": 0.5, "human_cognitive_load": -0.4, "schema_grounding": 0.7}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Adopters building MCP tools or coworker skills need this rule front and center — the tool schema is the contract.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Every tool definition includes a description that explains what it does and when to use it, parameter descriptions with types and examples, and clearly marked required parameters. The build-phase system prompt may include a tool usage guide that maps common tasks to specific tools — but the tools themselves must stand alone. If you find yourself adding a prompt section to compensate for a confusing schema, fix the schema instead.
+
+## Why
+
+Smaller models (Haiku-tier) lean heavily on description quality for tool selection — a model that sees `write_sandbox_file(path, content: "The full file content to write")` knows to pass the entire file; a model that sees `write_sandbox_file(path, content: string)` may omit content or pass a description instead. The difference is success vs. retry loop. Even frontier models benefit: a well-described tool reduces the model's reasoning load and frees that capacity for the actual task. Documentation that lives next to the tool also ages with it — prompt-side instructions drift out of sync the moment the tool changes.
+
+## Applies To
+
+In-platform coworkers consuming `PLATFORM_TOOLS`, external coding agents calling DPF's MCP surface, and any tool registered for agent use. Applies to MCP tool authors, skill authors, and coworker-prompt authors equally.
+
+## How To Apply
+
+When adding a tool, write the description as if the user knows nothing about the surrounding system. Include: what the tool does, when to use it (and when NOT to), example inputs, what success looks like, what failure means. For parameters, types alone are insufficient — add a one-line example for non-obvious shapes (`features: { "schema_grounding": 0.8 }`). After writing the schema, read it back with no other context and ask: would I call this tool correctly?
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.5` — schema-resident documentation survives prompt rewrites and refactors; prompt-resident documentation rots.
+- `human_cognitive_load: -0.4` — well-described tools reduce review burden for both human reviewers and downstream agents.
+- `schema_grounding: 0.7` — explicit, typed, exemplified schemas are the contract; everything else is implementation detail.
+
+## Examples
+
+- **Positive:** `wiki_query(query, pageKind?, tier?, appliesTo?, publicOnly?, limit?)` with every parameter described, enum values listed, and the description explaining when to filter by tier vs. just by kind. Smaller models pick the right combination on the first call.
+- **Counterexample:** A tool whose description reads "search wiki" with parameters `q: string, k?: string`. Even a frontier model will need 2–3 retries to figure out the right argument shape.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)


### PR DESCRIPTION
## Summary

Phase 3b of the principles-as-wiki-kind plan. Authors the 8 remaining AI-coworker-development kernel principles from `docs/architecture/ai-coworker-development-principles.md`. Principle 7 (Human-in-the-Loop at Phase Boundaries) ships separately in [#566](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/566).

Branched off current `main`. Will need a manifest.json rebase if #566 merges first — trivial pageCount conflict; pattern already exercised on the smoke-test PR.

## What ships

Eight new kernel principle pages under `docs/founder-kernel/wiki/principles/`. All `tier: core`, `principlePublic: true`, `principleAppliesTo: [in_platform_coworker, external_coding_agent]` (plus `human` for Principle 9, which is platform-wide):

| Slug | Principle | Direction | Vector |
|---|---|---|---|
| `specialization-over-generalization` | P1 | Prefer specialists with focused tool sets | `blast_radius: 0.7, human_cognitive_load: -0.5, reusability: 0.5` |
| `orchestrator-worker-pattern` | P2 | Route through an orchestrator | `governance_compliance: 0.7, long_term_maintainability: 0.5, reusability: 0.6` |
| `structured-handoffs-not-conversation-history` | P3 | Hand off structured artifacts | `long_term_maintainability: 0.6, schema_grounding: 0.8, speed_to_value: 0.4` |
| `diversity-of-thought` | P4 | Define perspective + heuristics + interpretive model per agent | `long_term_maintainability: 0.5, evidence_density: 0.6, blast_radius: 0.3` |
| `selective-memory-not-total-recall` | P5 | Store decisions, rationale, constraints; never transcripts | `long_term_maintainability: 0.7, schema_grounding: 0.5, speed_to_value: 0.4` |
| `tools-must-be-self-documenting` | P6 | Tool schema is the contract | `long_term_maintainability: 0.5, human_cognitive_load: -0.4, schema_grounding: 0.7` |
| `fail-fast-explain-clearly` | P8 | Report errors plainly and stop | `evidence_density: 0.8, blast_radius: 0.5, speed_to_value: 0.4` |
| `responsible-capacity-utilization` | P9 | Convert capacity into reviewed work | `capacity_utilization: 1.0, governance_compliance: 0.6, human_cognitive_load: -0.3` |

Every page:
- Frontmatter uses canonical `principle*` field names (no short aliases)
- Body follows the seven required sections from spec section 7.2: Rule / Why / Applies To / How To Apply / Decision Dimensions / Examples / Sources
- Public-safety pre-scan clean — no memory paths, local user paths, secret-shaped tokens, or internal-only phrases
- Source-cited (`articles/why-we-ended-up-proposing-two-standards-for-ai-agents` as canonical Mark source for agent governance; P2 also cites `frameworks/it4it-v3`)

`manifest.json`: pageCount 24 → 32.

## After this + #566 merge and the seed runs

`/wiki?kind=principle` should render three tier sections:
- **Commandments (1):** Human-in-the-Loop at Phase Boundaries (from #566)
- **Core (8 from this PR + 3 from #565):** the eight here plus `one-data-model`, `trust-the-data-spine`, `contextualize-before-transforming`
- **Contextual (0):** empty until later batches

The `principle_decide` MCP tool from #564 now has 12 real kernel principles to evaluate over.

## Test plan

- [ ] Reviewer: run `pnpm --filter @dpf/db exec vitest run src/seed-wiki-kernel.test.ts` — no regression
- [ ] Reviewer: rebuild local portal, run the kernel seed
- [ ] Reviewer: visit `/wiki?kind=principle` — eight Core rows added; metadata panel populated on each
- [ ] Reviewer: `/admin/wiki/lint` — zero blocking principle findings; possibly a `principle-duplicate` or `principle-contradiction-review` warn surfaces for review (that's the lint working, not a problem)
- [ ] Reviewer: via `principle_decide` MCP, call with a "Should I take the quick patch or refactor?" decision and two synthetic options — contribution ledger should now include rich entries from these principles

## Refs

- BI: `BI-EBDFBA34`
- Epic: `EP-TAK-3F9A21`
- Smoke test (Principle 7): [#566](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/566)
- Substrate stack: #531, #538, #542, #564, #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)