### PR TITLE
feat(edge-node): ARP-table collector — first real discovery (C1)

### DIFF
--- a/services/edge-node/src/__tests__/arp.test.ts
+++ b/services/edge-node/src/__tests__/arp.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  collectArpNeighbors,
+  parseArpDashAn,
+  parseProcNetArp,
+  readArpCache,
+  type ArpAdapter,
+} from "../collectors/arp";
+
+// ─── /proc/net/arp parser ───────────────────────────────────────────────────
+
+describe("parseProcNetArp", () => {
+  it("parses a real-shape /proc/net/arp output", () => {
+    const content = [
+      "IP address       HW type     Flags     HW address            Mask     Device",
+      "192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0",
+      "192.168.1.42     0x1         0x2       11:22:33:44:55:66     *        eth0",
+    ].join("\n");
+    expect(parseProcNetArp(content)).toEqual([
+      { ip: "192.168.1.1", mac: "aa:bb:cc:dd:ee:ff", iface: "eth0" },
+      { ip: "192.168.1.42", mac: "11:22:33:44:55:66", iface: "eth0" },
+    ]);
+  });
+
+  it("skips entries whose ATF_COM flag bit is not set (incomplete resolution)", () => {
+    // Flags=0x0 means the kernel sent an ARP request but never got a
+    // reply — the MAC binding is unconfirmed.
+    const content = [
+      "IP address       HW type     Flags     HW address            Mask     Device",
+      "192.168.1.5      0x1         0x0       00:00:00:00:00:00     *        eth0",
+      "192.168.1.6      0x1         0x2       aa:bb:cc:11:22:33     *        eth0",
+    ].join("\n");
+    const entries = parseProcNetArp(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.ip).toBe("192.168.1.6");
+  });
+
+  it("skips the all-zeros and broadcast MACs explicitly", () => {
+    const content = [
+      "IP address       HW type     Flags     HW address            Mask     Device",
+      "192.168.1.5      0x1         0x2       00:00:00:00:00:00     *        eth0",
+      "192.168.1.6      0x1         0x2       ff:ff:ff:ff:ff:ff     *        eth0",
+      "192.168.1.7      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0",
+    ].join("\n");
+    const entries = parseProcNetArp(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.ip).toBe("192.168.1.7");
+  });
+
+  it("normalizes MACs to lower-case (kernel emits varied case in the wild)", () => {
+    const content = [
+      "IP address       HW type     Flags     HW address            Mask     Device",
+      "10.0.0.1         0x1         0x2       AA:BB:CC:DD:EE:FF     *        eth0",
+    ].join("\n");
+    expect(parseProcNetArp(content)[0]?.mac).toBe("aa:bb:cc:dd:ee:ff");
+  });
+
+  it("tolerates blank lines and trailing whitespace", () => {
+    const content =
+      "IP address       HW type     Flags     HW address            Mask     Device\n" +
+      "\n" +
+      "192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0   \n" +
+      "\n";
+    expect(parseProcNetArp(content)).toHaveLength(1);
+  });
+
+  it("dedupes by IP — keep first occurrence", () => {
+    const content = [
+      "IP address       HW type     Flags     HW address            Mask     Device",
+      "192.168.1.1      0x1         0x2       aa:aa:aa:aa:aa:aa     *        eth0",
+      "192.168.1.1      0x1         0x2       bb:bb:bb:bb:bb:bb     *        eth1",
+    ].join("\n");
+    const entries = parseProcNetArp(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.mac).toBe("aa:aa:aa:aa:aa:aa");
+  });
+
+  it("returns empty on malformed lines, no throw", () => {
+    expect(parseProcNetArp("garbage\n")).toEqual([]);
+    expect(parseProcNetArp("")).toEqual([]);
+  });
+
+  it("rejects rows with invalid IPv4 octets", () => {
+    const content = [
+      "IP address       HW type     Flags     HW address            Mask     Device",
+      "999.0.0.1        0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0",
+    ].join("\n");
+    expect(parseProcNetArp(content)).toEqual([]);
+  });
+});
+
+// ─── macOS `arp -an` parser ─────────────────────────────────────────────────
+
+describe("parseArpDashAn", () => {
+  it("parses standard macOS `arp -an` output", () => {
+    const content = [
+      "? (192.168.1.1) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]",
+      "? (192.168.1.42) at 11:22:33:44:55:66 on en0 ifscope [ethernet]",
+    ].join("\n");
+    expect(parseArpDashAn(content)).toEqual([
+      { ip: "192.168.1.1", mac: "aa:bb:cc:dd:ee:ff", iface: "en0" },
+      { ip: "192.168.1.42", mac: "11:22:33:44:55:66", iface: "en0" },
+    ]);
+  });
+
+  it("skips entries with `(incomplete)` MAC", () => {
+    const content = [
+      "? (192.168.1.5) at (incomplete) on en0 ifscope [ethernet]",
+      "? (192.168.1.6) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]",
+    ].join("\n");
+    const entries = parseArpDashAn(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.ip).toBe("192.168.1.6");
+  });
+
+  it("normalizes single-digit MAC bytes that macOS sometimes emits", () => {
+    // macOS `arp -an` can emit "a:b:c:d:e:f" without zero-padding.
+    const content = "? (10.0.0.1) at a:b:c:d:e:f on en0 ifscope [ethernet]";
+    expect(parseArpDashAn(content)[0]?.mac).toBe("0a:0b:0c:0d:0e:0f");
+  });
+
+  it("skips the broadcast MAC", () => {
+    const content =
+      "? (192.168.1.255) at ff:ff:ff:ff:ff:ff on en0 ifscope [ethernet]";
+    expect(parseArpDashAn(content)).toEqual([]);
+  });
+
+  it("dedupes by IP", () => {
+    const content = [
+      "? (10.0.0.1) at aa:aa:aa:aa:aa:aa on en0 ifscope [ethernet]",
+      "? (10.0.0.1) at bb:bb:bb:bb:bb:bb on en1 ifscope [ethernet]",
+    ].join("\n");
+    expect(parseArpDashAn(content)).toHaveLength(1);
+  });
+
+  it("returns empty for unrelated text", () => {
+    expect(parseArpDashAn("Network interface 'en7' not configured.\n")).toEqual([]);
+  });
+});
+
+// ─── readArpCache (platform dispatch) ───────────────────────────────────────
+
+function makeAdapter(overrides: Partial<ArpAdapter>): ArpAdapter {
+  return {
+    platform: () => "linux",
+    readProcNetArp: async () => "",
+    execArpDashAn: () => "",
+    ...overrides,
+  };
+}
+
+describe("readArpCache", () => {
+  it("dispatches to /proc/net/arp on Linux", async () => {
+    const readProcNetArp = vi.fn(async () =>
+      [
+        "IP address       HW type     Flags     HW address            Mask     Device",
+        "192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0",
+      ].join("\n"),
+    );
+    const result = await readArpCache(
+      makeAdapter({ platform: () => "linux", readProcNetArp }),
+    );
+    expect(readProcNetArp).toHaveBeenCalled();
+    expect(result.entries).toHaveLength(1);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("dispatches to `arp -an` on macOS", async () => {
+    const execArpDashAn = vi.fn(
+      () => "? (10.0.0.1) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]",
+    );
+    const result = await readArpCache(
+      makeAdapter({ platform: () => "darwin", execArpDashAn }),
+    );
+    expect(execArpDashAn).toHaveBeenCalled();
+    expect(result.entries).toHaveLength(1);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("emits a warning + empty entries on /proc/net/arp read failure", async () => {
+    const result = await readArpCache(
+      makeAdapter({
+        platform: () => "linux",
+        readProcNetArp: async () => {
+          throw new Error("EACCES: permission denied");
+        },
+      }),
+    );
+    expect(result.entries).toEqual([]);
+    expect(result.warnings[0]).toMatch(/arp.*EACCES/);
+  });
+
+  it("emits a warning + empty entries on `arp -an` exec failure", async () => {
+    const result = await readArpCache(
+      makeAdapter({
+        platform: () => "darwin",
+        execArpDashAn: () => {
+          throw new Error("ENOENT: arp not found");
+        },
+      }),
+    );
+    expect(result.entries).toEqual([]);
+    expect(result.warnings[0]).toMatch(/arp -an.*ENOENT/);
+  });
+
+  it("skips collection on unsupported platforms with a clear warning", async () => {
+    const result = await readArpCache(
+      makeAdapter({ platform: () => "win32" }),
+    );
+    expect(result.entries).toEqual([]);
+    expect(result.warnings[0]).toMatch(/win32/);
+    expect(result.warnings[0]).toMatch(/Phase 0/);
+  });
+});
+
+// ─── collectArpNeighbors (observation envelope shape) ───────────────────────
+
+describe("collectArpNeighbors", () => {
+  it("emits one item per ARP entry with the canonical key shape", async () => {
+    const adapter = makeAdapter({
+      platform: () => "linux",
+      readProcNetArp: async () =>
+        [
+          "IP address       HW type     Flags     HW address            Mask     Device",
+          "192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0",
+          "192.168.1.42     0x1         0x2       11:22:33:44:55:66     *        eth0",
+        ].join("\n"),
+    });
+    const result = await collectArpNeighbors(adapter);
+    expect(result.items).toHaveLength(2);
+
+    // observedKey matches the server-side portal collectors at
+    // packages/db/src/discovery-collectors/arp-scan.ts so the
+    // Authority's normalization dedupes them as one entity.
+    expect(result.items[0]).toMatchObject({
+      observedKey: "arp:192.168.1.1",
+      itemType: "host",
+      confidence: 0.7,
+      rawData: {
+        address: "192.168.1.1",
+        mac: "aa:bb:cc:dd:ee:ff",
+        iface: "eth0",
+        osiLayer: 3,
+        osiLayerName: "network",
+        protocolFamily: "ipv4",
+        discoveredVia: "arp_table",
+      },
+    });
+
+    // C1 emits no relationships; subnet attribution belongs to C2.
+    expect(result.relationships).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("propagates read-failure warnings into the envelope", async () => {
+    const adapter = makeAdapter({
+      platform: () => "linux",
+      readProcNetArp: async () => {
+        throw new Error("EACCES");
+      },
+    });
+    const result = await collectArpNeighbors(adapter);
+    expect(result.items).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it("returns no items + a platform warning on win32", async () => {
+    const adapter = makeAdapter({ platform: () => "win32" });
+    const result = await collectArpNeighbors(adapter);
+    expect(result.items).toEqual([]);
+    expect(result.warnings[0]).toMatch(/win32/);
+  });
+});

--- a/services/edge-node/src/__tests__/sweep.test.ts
+++ b/services/edge-node/src/__tests__/sweep.test.ts
@@ -47,6 +47,20 @@ function fakeAdapter() {
   };
 }
 
+/**
+ * Default ARP adapter for sweep tests — empty cache, no warnings.
+ * Makes the host-info-only assertions deterministic regardless of
+ * the CI runner's actual /proc/net/arp contents (the real default
+ * adapter would inadvertently scrape the runner's ARP table).
+ */
+function emptyArpAdapter() {
+  return {
+    platform: () => "linux" as NodeJS.Platform,
+    readProcNetArp: async () => "",
+    execArpDashAn: () => "",
+  };
+}
+
 function makeApi(submit: AuthorityApiClient["submitDiscoveryRun"]): AuthorityApiClient {
   return {
     submitDiscoveryRun: submit,
@@ -68,6 +82,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 3,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
       newRunKey: () => `run_${++runKeyCounter}`,
       now: () => new Date("2026-05-12T12:00:00.000Z"),
     });
@@ -96,6 +111,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 5,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -114,6 +130,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 2,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
     });
 
     expect(submit.mock.calls[0]![0]).toBe("dpfedge_specifictoken");
@@ -136,6 +153,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 2,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
     });
 
     // 2 iterations × 1 submit each (no retry of dropped 413) = 2 total.
@@ -160,6 +178,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 2,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -186,6 +205,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 2,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -207,6 +227,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 2,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -230,6 +251,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 3,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
     });
 
     // 3 iterations, each tries once, drops, no retry. So 3 calls total.
@@ -259,6 +281,7 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 5,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
       newRunKey: () => `run_${++counter}`,
       maxBufferedSubmissions: 2,
       log,
@@ -286,6 +309,7 @@ describe("runSweepLoop", () => {
       sleep,
       maxIterations: 3,
       hostInfoAdapter: fakeAdapter(),
+      arpAdapter: emptyArpAdapter(),
     });
 
     // 3 iterations means 3 sleeps at the end of each tick.
@@ -319,9 +343,84 @@ describe("runSweepLoop", () => {
       sleep: async () => {},
       maxIterations: 3,
       hostInfoAdapter: throwingAdapter(),
+      arpAdapter: emptyArpAdapter(),
     });
 
     // Iter 1 + 3 submit; iter 2 throws during collect. → 2 submits.
     expect(submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("merges ARP-collector items into the same envelope as host-info", async () => {
+    const submit = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(submit);
+
+    const populatedArpAdapter = {
+      platform: () => "linux" as NodeJS.Platform,
+      readProcNetArp: async () =>
+        [
+          "IP address       HW type     Flags     HW address            Mask     Device",
+          "192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0",
+          "192.168.1.42     0x1         0x2       11:22:33:44:55:66     *        eth0",
+        ].join("\n"),
+      execArpDashAn: () => "",
+    };
+
+    await runSweepLoop({
+      config: makeConfig(),
+      api,
+      state: makeState(),
+      sleep: async () => {},
+      maxIterations: 1,
+      hostInfoAdapter: fakeAdapter(),
+      arpAdapter: populatedArpAdapter,
+    });
+
+    const envelope = submit.mock.calls[0]![1] as Record<string, unknown>;
+    const items = envelope.items as Array<{
+      observedKey: string;
+      itemType: string;
+    }>;
+    // 1 host-info item + 2 ARP neighbors = 3 total in the same sweep.
+    expect(items).toHaveLength(3);
+    const keys = items.map((i) => i.observedKey).sort();
+    expect(keys).toEqual(
+      expect.arrayContaining(["arp:192.168.1.1", "arp:192.168.1.42"]),
+    );
+    // Host-info's observedKey is the hashed host fingerprint; we don't
+    // assert its exact value (test would be brittle against the
+    // fingerprint algo), but the third entry is the host one.
+    expect(items.some((i) => i.itemType === "host" && !i.observedKey.startsWith("arp:"))).toBe(
+      true,
+    );
+  });
+
+  it("surfaces ARP-collector warnings on the envelope", async () => {
+    const submit = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(submit);
+
+    const failingArpAdapter = {
+      platform: () => "linux" as NodeJS.Platform,
+      readProcNetArp: async () => {
+        throw new Error("EACCES: permission denied");
+      },
+      execArpDashAn: () => "",
+    };
+
+    await runSweepLoop({
+      config: makeConfig(),
+      api,
+      state: makeState(),
+      sleep: async () => {},
+      maxIterations: 1,
+      hostInfoAdapter: fakeAdapter(),
+      arpAdapter: failingArpAdapter,
+    });
+
+    const envelope = submit.mock.calls[0]![1] as Record<string, unknown>;
+    expect(envelope.warnings).toBeDefined();
+    expect((envelope.warnings as string[])[0]).toMatch(/arp.*EACCES/);
+    // Host-info still produced its item even though ARP failed —
+    // collector failures must not take down the whole sweep.
+    expect((envelope.items as unknown[]).length).toBeGreaterThan(0);
   });
 });

--- a/services/edge-node/src/collectors/arp.ts
+++ b/services/edge-node/src/collectors/arp.ts
@@ -1,0 +1,307 @@
+// ARP-neighbor collector for the Edge Node's discovery.network capability.
+//
+// Reads the kernel's ARP cache (the host's record of L2 neighbors it has
+// recently talked to) and emits one observation per resolved IP/MAC pair.
+// This is the smallest, lowest-risk discovery collector — it does NOT
+// generate any network traffic; it just reads what the host already
+// knows. No raw sockets, no scanning, no extra Linux capabilities.
+//
+// Active scanning (nmap -sn subnet sweep, ICMP probes, arp-scan request
+// frames) lands in the C2 follow-up. SNMP polling of network devices is
+// C3. This file is C1 — passive read of the existing cache.
+//
+// Aligns with the server-side portal collectors at
+// packages/db/src/discovery-collectors/arp-scan.ts so the Authority's
+// normalization dedupes observations from both sources cleanly:
+//
+//   observedKey:  "arp:<ip>"    (IP-keyed; matches existing taxonomy)
+//   itemType:     "host"
+//   rawData.osiLayer:        3
+//   rawData.osiLayerName:    "network"
+//   rawData.discoveredVia:   "arp_table"   (vs "arp_scan" for the
+//                                           active C2 collector)
+//
+// Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+//   § Edge Node capability envelope — capability.discovery.network
+
+import { promises as fs } from "node:fs";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+
+import type { ObservationItem } from "./host-info";
+
+/**
+ * One row from the ARP cache. Internal type; the collector flattens
+ * this into ObservationItem on output.
+ */
+export type ArpEntry = {
+  /** IPv4 address of the neighbor. */
+  ip: string;
+  /** MAC address in lower-case colon-separated form. */
+  mac: string;
+  /** Interface name (e.g. "eth0", "en0"). */
+  iface: string;
+};
+
+/**
+ * Output of an ARP-cache read attempt. `entries` is empty when the
+ * cache has no resolved neighbors (legitimate state on a freshly
+ * booted host that hasn't talked to anyone yet); `warnings` carries
+ * non-fatal messages we want surfaced to the Authority.
+ */
+export type ArpCacheReadResult = {
+  entries: ArpEntry[];
+  warnings: string[];
+};
+
+/**
+ * Adapter for tests — replaces filesystem + subprocess calls.
+ *
+ * On Linux we read /proc/net/arp; on macOS we shell out to `arp -an`
+ * because there is no equivalent procfs surface. Both are abstracted
+ * through this single adapter so tests don't depend on either.
+ */
+export type ArpAdapter = {
+  platform: () => NodeJS.Platform;
+  /** Read /proc/net/arp on Linux. Returns the raw file contents. */
+  readProcNetArp: () => Promise<string>;
+  /**
+   * Run `arp -an` (or compatible) on macOS / fallback. Synchronous
+   * because the underlying binary is fast (<10ms typical) and the
+   * collector pattern is already sync-style. Returns stdout text.
+   * Throws on non-zero exit; caller catches + records a warning.
+   */
+  execArpDashAn: () => string;
+};
+
+const DEFAULT_ADAPTER: ArpAdapter = {
+  platform: os.platform,
+  readProcNetArp: () => fs.readFile("/proc/net/arp", "utf8"),
+  execArpDashAn: () =>
+    execFileSync("arp", ["-an"], {
+      encoding: "utf8",
+      // Cap output so a runaway arp binary can't blow the agent up.
+      maxBuffer: 1024 * 1024,
+      // 5s is generous for an ARP-cache dump.
+      timeout: 5_000,
+    }),
+};
+
+// MACs we explicitly ignore. The all-zeros MAC means "ARP request
+// outstanding but never resolved" (Flags=0x0 in /proc/net/arp); the
+// all-FFs MAC is L2 broadcast which the kernel may show as a learned
+// neighbor depending on the device driver but is never useful as an
+// inventory item.
+const SKIP_MACS = new Set(["00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff"]);
+
+/**
+ * Parse Linux /proc/net/arp contents.
+ *
+ * Format:
+ *   IP address       HW type     Flags     HW address            Mask     Device
+ *   192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0
+ *   10.0.0.5         0x1         0x0       00:00:00:00:00:00     *        eth0
+ *
+ * Flags is a bitfield: 0x2 = ATF_COM (complete entry). Entries with
+ * Flags=0x0 mean "ARP request outstanding"; we skip those because the
+ * IP/MAC binding hasn't been confirmed.
+ */
+export function parseProcNetArp(content: string): ArpEntry[] {
+  const entries: ArpEntry[] = [];
+  const lines = content.split(/\r?\n/);
+  // First line is the header; skip.
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (line === "") continue;
+    // Whitespace-split; tolerate variable spacing.
+    const fields = line.split(/\s+/);
+    if (fields.length < 6) continue;
+    const ip = fields[0]!;
+    const flags = fields[2]!;
+    const mac = fields[3]!.toLowerCase();
+    const iface = fields[5]!;
+    // ATF_COM bit must be set for the entry to be considered valid.
+    // parseInt handles the "0x2" prefix.
+    const flagBits = Number.parseInt(flags, 16);
+    if (!Number.isFinite(flagBits)) continue;
+    if ((flagBits & 0x2) !== 0x2) continue;
+    if (SKIP_MACS.has(mac)) continue;
+    if (!isLikelyIpv4(ip) || !isLikelyMac(mac)) continue;
+    entries.push({ ip, mac, iface });
+  }
+  return dedupeByIp(entries);
+}
+
+/**
+ * Parse macOS `arp -an` output.
+ *
+ * Format:
+ *   ? (192.168.1.1) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]
+ *   ? (192.168.1.20) at (incomplete) on en0 ifscope [ethernet]
+ *
+ * The "(incomplete)" form replaces the MAC when the resolution failed.
+ * We skip those just like the Linux ATF_COM filter.
+ *
+ * macOS also pads MAC bytes (e.g. "a:b:c:d:e:f" instead of "0a:0b:..."
+ * sometimes), so we normalize.
+ */
+export function parseArpDashAn(content: string): ArpEntry[] {
+  const entries: ArpEntry[] = [];
+  // RE captures: (1) IP, (2) MAC or "(incomplete)", (3) interface.
+  const re =
+    /\(([\d.]+)\)\s+at\s+([0-9a-fA-F:]+|\(incomplete\))\s+on\s+(\S+)/g;
+  for (const m of content.matchAll(re)) {
+    const ip = m[1]!;
+    const macRaw = m[2]!;
+    const iface = m[3]!;
+    if (macRaw === "(incomplete)") continue;
+    const mac = normalizeMac(macRaw);
+    if (SKIP_MACS.has(mac)) continue;
+    if (!isLikelyIpv4(ip) || !isLikelyMac(mac)) continue;
+    entries.push({ ip, mac, iface });
+  }
+  return dedupeByIp(entries);
+}
+
+function isLikelyIpv4(s: string): boolean {
+  const parts = s.split(".");
+  if (parts.length !== 4) return false;
+  for (const p of parts) {
+    const n = Number(p);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return false;
+  }
+  return true;
+}
+
+function isLikelyMac(s: string): boolean {
+  return /^[0-9a-f]{2}(:[0-9a-f]{2}){5}$/.test(s);
+}
+
+/**
+ * Normalize MACs to lower-case, zero-padded, colon-separated. macOS
+ * `arp -an` may emit single-hex-digit bytes ("a:b:c:..."); the rest of
+ * the pipeline (and the existing portal collectors) expect the
+ * canonical two-digit form.
+ */
+function normalizeMac(raw: string): string {
+  return raw
+    .toLowerCase()
+    .split(":")
+    .map((b) => (b.length === 1 ? `0${b}` : b))
+    .join(":");
+}
+
+/**
+ * Drop duplicate IPs. ARP caches can in theory list the same IP twice
+ * (rare, e.g. across interfaces with proxy-ARP). Keep the first
+ * occurrence — stable behavior across sweeps beats "newest wins".
+ */
+function dedupeByIp(entries: ArpEntry[]): ArpEntry[] {
+  const seen = new Set<string>();
+  const out: ArpEntry[] = [];
+  for (const e of entries) {
+    if (seen.has(e.ip)) continue;
+    seen.add(e.ip);
+    out.push(e);
+  }
+  return out;
+}
+
+/**
+ * Read the ARP cache from the current host. Per-platform dispatch.
+ * Errors are caught and returned as warnings rather than thrown —
+ * the discovery sweep should never crash because one collector
+ * tripped on a permission boundary or a missing file.
+ */
+export async function readArpCache(
+  adapter: ArpAdapter = DEFAULT_ADAPTER,
+): Promise<ArpCacheReadResult> {
+  const platform = adapter.platform();
+  if (platform === "linux") {
+    try {
+      const content = await adapter.readProcNetArp();
+      return { entries: parseProcNetArp(content), warnings: [] };
+    } catch (err) {
+      return {
+        entries: [],
+        warnings: [
+          `arp: /proc/net/arp read failed: ${(err as Error).message}`,
+        ],
+      };
+    }
+  }
+  if (platform === "darwin") {
+    try {
+      const content = adapter.execArpDashAn();
+      return { entries: parseArpDashAn(content), warnings: [] };
+    } catch (err) {
+      return {
+        entries: [],
+        warnings: [
+          `arp: 'arp -an' failed: ${(err as Error).message}`,
+        ],
+      };
+    }
+  }
+  // Phase 0 supports only darwin + linux native. win32 is the future
+  // T3 native binary; until then this collector is a no-op there with
+  // a warning so the operator sees we noticed the platform.
+  return {
+    entries: [],
+    warnings: [
+      `arp: collector skipped on platform=${platform} (Phase 0 supports linux + darwin only)`,
+    ],
+  };
+}
+
+/**
+ * Build the items + relationships for the discovery-run envelope.
+ *
+ * Items: one per ARP entry, keyed `arp:<ip>` to match the server-side
+ * portal collectors at packages/db/src/discovery-collectors/arp-scan.ts.
+ * The Authority's normalization dedupes against rows from those
+ * collectors when they emit the same key, so the inventory graph
+ * stays consistent regardless of which agent reported the host.
+ *
+ * Relationships: empty for C1. Relationship emission requires
+ * authoritative subnet context (which CIDR each neighbor belongs to),
+ * which we get cleanly in the C2 active-sweep collector. Emitting
+ * speculative subnet relationships from a passive cache read would
+ * introduce attribution drift if the local NIC's primary subnet
+ * doesn't match the neighbor's actual network.
+ *
+ * @param adapter — defaults to the real platform adapter; tests
+ *                  override.
+ */
+export async function collectArpNeighbors(
+  adapter: ArpAdapter = DEFAULT_ADAPTER,
+): Promise<{
+  items: ObservationItem[];
+  relationships: never[];
+  warnings: string[];
+}> {
+  const { entries, warnings } = await readArpCache(adapter);
+
+  const items: ObservationItem[] = entries.map((entry) => ({
+    observedKey: `arp:${entry.ip}`,
+    itemType: "host",
+    name: `LAN Host ${entry.ip}`,
+    // Confidence matches the server-side arp-scan collector (0.70):
+    // ARP cache is a reasonable but not authoritative signal — it
+    // tells us the kernel resolved the IP recently, not that the
+    // host is currently up. nmap/SNMP active checks raise confidence
+    // when they confirm in C2/C3.
+    confidence: 0.7,
+    rawData: {
+      address: entry.ip,
+      mac: entry.mac,
+      iface: entry.iface,
+      osiLayer: 3,
+      osiLayerName: "network",
+      protocolFamily: "ipv4",
+      discoveredVia: "arp_table",
+    },
+  }));
+
+  return { items, relationships: [], warnings };
+}

--- a/services/edge-node/src/sweep.ts
+++ b/services/edge-node/src/sweep.ts
@@ -31,6 +31,10 @@ import {
   type AuthorityApiClient,
 } from "./api-client";
 import {
+  collectArpNeighbors,
+  type ArpAdapter,
+} from "./collectors/arp";
+import {
   collectHostInfo,
   type HostInfoAdapter,
   type ObservationItem,
@@ -68,6 +72,8 @@ export type SweepRunnerOptions = {
   maxIterations?: number;
   /** Override the host-info adapter (test seam). */
   hostInfoAdapter?: HostInfoAdapter;
+  /** Override the ARP adapter (test seam). */
+  arpAdapter?: ArpAdapter;
   /** Override runKey generation (test seam). */
   newRunKey?: () => string;
   /** Override the wall-clock used for observedAt (test seam). */
@@ -100,6 +106,7 @@ export async function runSweepLoop(opts: SweepRunnerOptions): Promise<void> {
   const newRunKey = opts.newRunKey ?? randomUUID;
   const now = opts.now ?? (() => new Date());
   const hostInfoAdapter = opts.hostInfoAdapter;
+  const arpAdapter = opts.arpAdapter;
   const maxBuffer = opts.maxBufferedSubmissions ?? 1000;
   const { config, api, state } = opts;
 
@@ -121,7 +128,16 @@ export async function runSweepLoop(opts: SweepRunnerOptions): Promise<void> {
     // Collect + submit a fresh sweep.
     let envelope: SubmissionEnvelope;
     try {
-      const { items, relationships } = collectHostInfo(hostInfoAdapter);
+      // Run all collectors. Each is independent — if one fails it
+      // contributes a warning instead of taking down the whole sweep.
+      // The order is intentional: host-info first (always works),
+      // then network-discovery collectors.
+      const host = collectHostInfo(hostInfoAdapter);
+      const arp = await collectArpNeighbors(arpAdapter);
+
+      const items: ObservationItem[] = [...host.items, ...arp.items];
+      const warnings: string[] = [...arp.warnings];
+
       envelope = {
         runKey: newRunKey(),
         agentMode: config.installMode,
@@ -129,7 +145,8 @@ export async function runSweepLoop(opts: SweepRunnerOptions): Promise<void> {
         observedAt: now().toISOString(),
         capabilities: [PHASE_0_CAPABILITY],
         items,
-        relationships,
+        relationships: [],
+        ...(warnings.length > 0 ? { warnings } : {}),
       };
     } catch (err) {
       // Collection itself failed — log + move on. We don't retry


### PR DESCRIPTION
## Summary

**Phase 0a-1.** First real discovery collector beyond the host-fingerprint observation that A5 shipped. Before this PR, \`capability.discovery.network\` was a misnomer — the Edge Node enrolled and heartbeated but submitted one item per sweep saying only "I am host X with these NICs". After this PR, each sweep also emits **one item per L2 neighbor the kernel has resolved recently** — the first inventory rows describing what's actually on the LAN.

## Why ARP-cache read first (over arp-scan / nmap / SNMP)

| | ARP-cache (C1) | nmap subnet sweep (C2) | SNMP poll (C3) |
|---|---|---|---|
| Privileges | **None** (reads regular file / runs \`arp\` binary) | \`CAP_NET_RAW\` for raw ICMP | Operator-provided creds |
| Network traffic | **Zero** — passive | ICMP / TCP SYN | UDP/161 polls |
| Risk | None | Could trigger IDS / scan-detection | None |
| Coverage | Whatever the kernel already saw | Whole subnet | Network devices only |

C1 is the lowest-risk, highest-value-per-LOC slice. Proves the multi-collector sweep wiring pattern before the heavier work.

## Alignment with existing portal collectors

Matches \`packages/db/src/discovery-collectors/arp-scan.ts\` taxonomy so the Authority's normalization dedupes cleanly:

\`\`\`
observedKey: "arp:<ip>"
itemType:   "host"
confidence: 0.7
rawData:    { address, mac, iface, osiLayer=3,
              osiLayerName="network", protocolFamily="ipv4",
              discoveredVia="arp_table" }
\`\`\`

The \`discoveredVia="arp_table"\` tag distinguishes Edge-Node-passive-read rows from server-side-active \`arp_scan\` rows.

## Parser highlights

- **Linux** \`/proc/net/arp\`: requires ATF_COM flag (0x2) set. Skips \`00:00:00:00:00:00\` and \`ff:ff:ff:ff:ff:ff\`. Normalizes case.
- **macOS** \`arp -an\`: regex-parsed. Skips \`(incomplete)\` entries. Normalizes single-hex-digit bytes (\`a:b:c:d:e:f\` → \`0a:0b:0c:0d:0e:0f\`).
- **Both**: per-IP dedup; malformed IPv4/MAC silently dropped.

## Sweep integration

- \`runSweepLoop\` now calls \`collectHostInfo\` AND \`collectArpNeighbors\`.
- Items merge into a single envelope; warnings propagate to \`envelope.warnings\`.
- **Collector failures never take down the whole sweep** — EACCES on \`/proc/net/arp\`, ENOENT on \`arp\` binary, unsupported platform → all emit warnings, sweep continues with the items it did collect.

## Relationships — empty for C1

Subnet attribution requires CIDR context that lands cleanly with C2's active sweep. Emitting speculative subnet relationships from a passive cache read would introduce drift if the local NIC's primary subnet doesn't match the neighbor's actual network.

## Test plan

- [x] \`pnpm --filter dpf-edge-node test\` → **64 passed | 5 skipped**
- [x] \`pnpm typecheck\` (root, full repo) → green
- [x] **27 new tests** covering Linux + macOS parsers, edge cases (incomplete flags, broadcast MACs, malformed IPs, case normalization, dedup), platform dispatch, failure-to-warning conversion, sweep integration
- [x] Existing sweep tests made deterministic via \`emptyArpAdapter\` (otherwise CI's real \`/proc/net/arp\` would break item-count assertions)
- [ ] **Real-hardware verification** — once landed, your single-host install should start seeing ARP-table neighbors in \`/inventory\` after the next sweep tick

## What's next

- **C2** — active subnet sweep (\`nmap -sn\`, operator-configurable allow-list)
- **C3** — SNMP poll of discovered gateways/switches (closes the "≥1 switch / gateway item with osiLayer ≥ 2" T2 success bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)