### PR TITLE
fix(platform): clarify provider cost and authority sources

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -3,8 +3,9 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
-import { getProviderById, getProviders, getDiscoveredModels, getModelProfiles, getRecipesForProvider, getModelClassCounts } from "@/lib/ai-provider-data";
+import { getProviderById, getProviders, getDiscoveredModels, getModelProfiles, getRecipesForProvider, getModelClassCounts, getTokenSpendByProvider } from "@/lib/ai-provider-data";
 import { ProviderDetailForm } from "@/components/platform/ProviderDetailForm";
+import { ProviderCostSourcePanel } from "@/components/platform/ProviderCostSourcePanel";
 import { getInfraCIs } from "@dpf/db";
 import { getEndpointPerformance, getRoutingProfiles, getRecentRouteDecisions } from "@/lib/actions/endpoint-performance";
 import EndpointPerformancePanel from "@/components/platform/EndpointPerformancePanel";
@@ -15,12 +16,15 @@ import { RecipePanel } from "@/components/platform/RecipePanel";
 import { OAuthConnectionStatus } from "@/components/platform/OAuthConnectionStatus";
 import { AiProviderFinancePanel } from "@/components/finance/AiProviderFinancePanel";
 import { getAiProviderFinanceDetail } from "@/lib/finance/ai-provider-finance";
+import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 
 type Props = { params: Promise<{ providerId: string }> };
 
 export default async function ProviderDetailPage({ params }: Props) {
   const { providerId } = await params;
-  const [pw, models, profiles, allProviders, perfData, routingProfiles, routeDecisions, recipes, modelClassCounts, financeDetail] = await Promise.all([
+  const now = new Date();
+  const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+  const [pw, models, profiles, allProviders, perfData, routingProfiles, routeDecisions, recipes, modelClassCounts, financeDetail, tokenSpend] = await Promise.all([
     getProviderById(providerId),
     getDiscoveredModels(providerId),
     getModelProfiles(providerId),
@@ -31,8 +35,14 @@ export default async function ProviderDetailPage({ params }: Props) {
     getRecipesForProvider(providerId),
     getModelClassCounts(providerId),
     getAiProviderFinanceDetail(providerId),
+    getTokenSpendByProvider(currentMonth),
   ]);
   if (!pw) notFound();
+  const costView = buildProviderCostView({
+    provider: pw.provider,
+    financeProfile: financeDetail,
+    internalUsage: tokenSpend.find((row) => row.providerId === providerId) ?? null,
+  });
 
   const hasActiveProvider = allProviders.some((p) => p.provider.status === "active");
 
@@ -101,7 +111,7 @@ export default async function ProviderDetailPage({ params }: Props) {
       {pw.provider.costPerformanceNotes && (
         <div style={{
           background: "var(--dpf-surface-1)",
-          borderLeft: "3px solid #7c8cf8",
+          borderLeft: "3px solid var(--dpf-info)",
           borderRadius: 6,
           padding: "12px 16px",
           marginBottom: 16,
@@ -127,6 +137,9 @@ export default async function ProviderDetailPage({ params }: Props) {
           )}
           <div style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", borderRadius: 8, padding: 20 }}>
             <ProviderDetailForm pw={pw} canWrite={canWrite} models={models} profiles={profiles} hasActiveProvider={hasActiveProvider} routingProfiles={routingProfiles} />
+          </div>
+          <div style={{ marginTop: 16 }}>
+            <ProviderCostSourcePanel view={costView} />
           </div>
           <div style={{ marginTop: 16 }}>
             <AiProviderFinancePanel detail={financeDetail} />
@@ -161,7 +174,7 @@ function McpServiceDetail({ provider }: { provider: import("@/lib/ai-provider-ty
       {isPluginManaged && (
         <div style={{
           background: "var(--dpf-surface-1)",
-          borderLeft: "3px solid #38bdf8",
+          borderLeft: "3px solid var(--dpf-info)",
           borderRadius: 6,
           padding: "12px 16px",
           marginBottom: 16,
@@ -188,15 +201,15 @@ function McpServiceDetail({ provider }: { provider: import("@/lib/ai-provider-ty
         </div>
         <div>
           <div style={{ fontSize: 10, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>Status</div>
-          <div style={{ fontSize: 13, color: provider.status === "active" ? "#4ade80" : "#fbbf24" }}>{provider.status}</div>
+          <div style={{ fontSize: 13, color: provider.status === "active" ? "var(--dpf-success)" : "var(--dpf-warning)" }}>{provider.status}</div>
         </div>
         <div>
           <div style={{ fontSize: 10, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>Capability Tier</div>
           <div style={{ fontSize: 13, color: "var(--dpf-text)" }}>{provider.capabilityTier ?? "basic"}</div>
         </div>
         <div>
-          <div style={{ fontSize: 10, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>Cost Band</div>
-          <div style={{ fontSize: 13, color: "var(--dpf-text)" }}>{provider.costBand ?? "free"}</div>
+          <div style={{ fontSize: 10, color: "var(--dpf-muted)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>Routing Cost Band</div>
+          <div style={{ fontSize: 13, color: "var(--dpf-text)" }}>{provider.costBand || "unspecified"}</div>
         </div>
       </div>
 

--- a/apps/web/app/(shell)/platform/audit/page.tsx
+++ b/apps/web/app/(shell)/platform/audit/page.tsx
@@ -1,20 +1,15 @@
-import { prisma } from "@dpf/db";
 import { PlatformSummaryCard } from "@/components/platform/PlatformSummaryCard";
 import { getProposalStats } from "@/lib/evaluate/proposal-data";
 import { getToolExecutionStats } from "@/lib/tool-execution-data";
+import { buildAuthoritySummaryMetrics, getPlatformAuthoritySummary } from "@/lib/platform-authority-summary";
 
 export default async function AuditHubPage() {
-  const now = new Date();
-  const [proposalStats, toolStats, activeGrants] = await Promise.all([
+  const [proposalStats, toolStats, authoritySummary] = await Promise.all([
     getProposalStats(),
     getToolExecutionStats(),
-    prisma.delegationGrant.count({
-      where: {
-        status: "active",
-        expiresAt: { gt: now },
-      },
-    }),
+    getPlatformAuthoritySummary(),
   ]);
+  const authorityMetrics = buildAuthoritySummaryMetrics(authoritySummary);
 
   return (
     <div className="space-y-6">
@@ -48,12 +43,12 @@ export default async function AuditHubPage() {
         />
         <PlatformSummaryCard
           title="Authority"
-          description="Trace role coverage, delegation chains, and effective permissions."
+          description="Trace temporary delegation chains and standing coworker tool grants."
           href="/platform/audit/authority"
           accent="var(--dpf-warning)"
           metrics={[
-            { label: "Active grants", value: activeGrants },
-            { label: "Governed agents", value: toolStats.uniqueAgents },
+            authorityMetrics[0],
+            { ...authorityMetrics[1], note: `${authoritySummary.governedAgents} governed agent${authoritySummary.governedAgents === 1 ? "" : "s"} configured.` },
           ]}
         />
         <PlatformSummaryCard

--- a/apps/web/app/(shell)/platform/page.tsx
+++ b/apps/web/app/(shell)/platform/page.tsx
@@ -3,16 +3,16 @@ import { PlatformTabNav } from "@/components/platform/PlatformTabNav";
 import { PlatformSummaryCard } from "@/components/platform/PlatformSummaryCard";
 import { getProposalStats } from "@/lib/evaluate/proposal-data";
 import { getToolExecutionStats } from "@/lib/tool-execution-data";
+import { buildAuthoritySummaryMetrics, getPlatformAuthoritySummary } from "@/lib/platform-authority-summary";
 
 export default async function PlatformPage() {
-  const now = new Date();
   const [
     agentCount,
     activeProviderCount,
     catalogCount,
     activeServiceCount,
     enabledToolCount,
-    activeGrantCount,
+    authoritySummary,
     toolStats,
     proposalStats,
     userCount,
@@ -24,18 +24,14 @@ export default async function PlatformPage() {
     prisma.mcpIntegration.count({ where: { status: "active" } }),
     prisma.mcpServer.count({ where: { status: "active" } }),
     prisma.mcpServerTool.count({ where: { isEnabled: true } }),
-    prisma.delegationGrant.count({
-      where: {
-        status: "active",
-        expiresAt: { gt: now },
-      },
-    }),
+    getPlatformAuthoritySummary(),
     getToolExecutionStats(),
     getProposalStats(),
     prisma.user.count(),
     prisma.platformRole.count(),
     prisma.platformCapability.count(),
   ]);
+  const authorityMetrics = buildAuthoritySummaryMetrics(authoritySummary);
 
   return (
     <div className="space-y-6">
@@ -71,12 +67,12 @@ export default async function PlatformPage() {
         />
         <PlatformSummaryCard
           title="Governance & Audit"
-          description="Review proposals, execution evidence, and temporary authority grants."
+          description="Review proposals, execution evidence, temporary delegations, and standing tool grants."
           href="/platform/audit"
           accent="var(--dpf-warning)"
           metrics={[
-            { label: "Active grants", value: activeGrantCount },
-            { label: "Executions", value: toolStats.total },
+            authorityMetrics[0],
+            authorityMetrics[1],
           ]}
         />
         <PlatformSummaryCard

--- a/apps/web/components/platform/PlatformSummaryCard.tsx
+++ b/apps/web/components/platform/PlatformSummaryCard.tsx
@@ -5,6 +5,7 @@ import type { DataSourceProvenance } from "@/lib/surface-data-provenance";
 type Metric = {
   label: string;
   value: string | number;
+  note?: string;
   provenance?: DataSourceProvenance;
 };
 
@@ -50,6 +51,11 @@ export function PlatformSummaryCard({
               <p className="mt-1 text-xl font-semibold text-[var(--dpf-text)]">
                 {metric.value}
               </p>
+              {metric.note && (
+                <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                  {metric.note}
+                </p>
+              )}
               {metric.provenance && (
                 <div className="mt-2">
                   <DataSourceBadge compact provenance={metric.provenance} />

--- a/apps/web/components/platform/ProviderCostSourcePanel.tsx
+++ b/apps/web/components/platform/ProviderCostSourcePanel.tsx
@@ -1,0 +1,41 @@
+import { DataSourceBadge } from "@/components/ui/DataSourceBadge";
+import type { ProviderCostView } from "@/lib/inference/ai-provider-cost-view";
+
+export function ProviderCostSourcePanel({ view }: { view: ProviderCostView }) {
+  const metrics = [
+    view.routingCostBand,
+    view.catalogPricing,
+    view.configuredBillingProfile,
+    view.internalTokenUsage,
+    view.externalProviderBilling,
+  ];
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-[var(--dpf-text)]">Cost source truth</p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            Routing metadata, catalog pricing, DPF token usage, and provider billing are tracked separately.
+          </p>
+        </div>
+        {view.externalProviderBilling.actionHref && (
+          <a href={view.externalProviderBilling.actionHref} className="text-xs font-medium text-[var(--dpf-accent)]">
+            Reconcile billing →
+          </a>
+        )}
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">{metric.label}</p>
+            <p className="mt-1 text-sm font-semibold text-[var(--dpf-text)]">{metric.value}</p>
+            <div className="mt-2">
+              <DataSourceBadge compact provenance={metric.provenance} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/platform/ServiceRow.tsx
+++ b/apps/web/components/platform/ServiceRow.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import type { ProviderWithCredential, ProviderModelSummary } from "@/lib/ai-provider-types";
-import { getBillingLabel } from "@/lib/ai-provider-types";
+import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
+import { DataSourceBadge } from "@/components/ui/DataSourceBadge";
 import { ModelClassBadges } from "./ModelClassBadge";
 import { ProviderStatusToggle } from "./ProviderStatusToggle";
 
@@ -97,12 +98,12 @@ export function ServiceRow({ pw, modelSummary }: Props) {
   };
   const statusColor = STATUS_COLORS_EXT[effectiveStatus] ?? "var(--dpf-muted)";
   const typeLabel   = provider.endpointType === "service" ? "MCP" : "LLM";
-  const billingLabel = getBillingLabel(provider);
+  const costView = buildProviderCostView({ provider, financeProfile: null, internalUsage: null });
 
   return (
     <div
       style={{
-        borderBottom: "1px solid var(--dpf-border, #2a2a40)",
+        borderBottom: "1px solid var(--dpf-border)",
       }}
     >
       {/* Collapsed row */}
@@ -119,7 +120,7 @@ export function ServiceRow({ pw, modelSummary }: Props) {
           gap: 8,
           padding: "6px 10px",
           cursor: "pointer",
-          background: hovered ? "var(--dpf-surface-2, #1a1a2e)" : "transparent",
+          background: hovered ? "var(--dpf-surface-2)" : "transparent",
           transition: "background 0.1s",
         }}
       >
@@ -218,7 +219,7 @@ export function ServiceRow({ pw, modelSummary }: Props) {
                 style={{
                   fontSize: 9,
                   color: "var(--dpf-muted)",
-                  background: "#ffffff0f",
+                  background: "color-mix(in srgb, var(--dpf-text) 6%, transparent)",
                   padding: "1px 4px",
                   borderRadius: 2,
                 }}
@@ -244,15 +245,9 @@ export function ServiceRow({ pw, modelSummary }: Props) {
           </span>
         )}
 
-        {/* Cost band — hidden on small screens */}
-        {provider.costBand && (
-          <span
-            className="hidden sm:inline"
-            style={{ color: "var(--dpf-muted)", fontSize: 10, flexShrink: 0 }}
-          >
-            {provider.costBand}
-          </span>
-        )}
+        <span className="hidden sm:inline" style={{ color: "var(--dpf-muted)", fontSize: 10, flexShrink: 0 }}>
+          {costView.externalProviderBilling.value}
+        </span>
 
         {/* Status toggle */}
         <span
@@ -271,8 +266,8 @@ export function ServiceRow({ pw, modelSummary }: Props) {
         <div
           style={{
             padding: "10px 14px 12px 26px",
-            background: "var(--dpf-surface-1, #13131f)",
-            borderTop: "1px solid var(--dpf-border, #2a2a40)",
+            background: "var(--dpf-surface-1)",
+            borderTop: "1px solid var(--dpf-border)",
           }}
         >
           {/* Detail grid */}
@@ -291,7 +286,9 @@ export function ServiceRow({ pw, modelSummary }: Props) {
             )}
             <DetailItem label="Sensitivity"      value={provider.sensitivityClearance.join(", ") || "—"} />
             <DetailItem label="Capability Tier"  value={provider.capabilityTier || "—"} />
-            <DetailItem label="Cost Band"        value={provider.costBand || "—"} />
+            <DetailItem label={costView.routingCostBand.label} value={costView.routingCostBand.value} />
+            <DetailItem label={costView.catalogPricing.label} value={costView.catalogPricing.value} />
+            <DetailItem label={costView.externalProviderBilling.label} value={costView.externalProviderBilling.value} />
           </div>
 
           {/* Task tags */}
@@ -304,7 +301,7 @@ export function ServiceRow({ pw, modelSummary }: Props) {
                   style={{
                     fontSize: 10,
                     color: "var(--dpf-muted)",
-                    background: "#ffffff0a",
+                    background: "color-mix(in srgb, var(--dpf-text) 4%, transparent)",
                     border: "1px solid var(--dpf-border)",
                     padding: "1px 6px",
                     borderRadius: 3,
@@ -324,12 +321,16 @@ export function ServiceRow({ pw, modelSummary }: Props) {
             </div>
           )}
 
-          {/* Billing label */}
-          {billingLabel && (
-            <div style={{ color: "var(--dpf-muted)", fontSize: 10, marginBottom: 8 }}>
-              {billingLabel}
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 8 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>{costView.catalogPricing.label}</span>
+              <DataSourceBadge compact provenance={costView.catalogPricing.provenance} />
             </div>
-          )}
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <span style={{ color: "var(--dpf-muted)", fontSize: 10 }}>{costView.externalProviderBilling.label}</span>
+              <DataSourceBadge compact provenance={costView.externalProviderBilling.provenance} />
+            </div>
+          </div>
 
           {/* Credential hint */}
           {credential?.secretHint && (

--- a/apps/web/components/platform/TokenSpendPanel.test.tsx
+++ b/apps/web/components/platform/TokenSpendPanel.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TokenSpendPanel } from "./TokenSpendPanel";
+
+describe("TokenSpendPanel", () => {
+  it("explains token spend as internal TokenUsage data and labels unknown providers", () => {
+    const html = renderToStaticMarkup(
+      <TokenSpendPanel
+        initialMonth={{ year: 2026, month: 5 }}
+        byProvider={[
+          {
+            providerId: "",
+            providerName: "Unknown provider",
+            totalInputTokens: 1000,
+            totalOutputTokens: 2000,
+            totalCostUsd: 0.12,
+            provenance: {
+              kind: "live-db",
+              label: "TokenUsage",
+              sourceTable: "TokenUsage",
+              description: "DPF recorded token usage for this provider.",
+            },
+          },
+        ]}
+        byAgent={[]}
+      />,
+    );
+
+    expect(html).toContain("Internal token usage");
+    expect(html).toContain("TokenUsage");
+    expect(html).toContain("Unknown provider");
+  });
+});

--- a/apps/web/components/platform/TokenSpendPanel.tsx
+++ b/apps/web/components/platform/TokenSpendPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { SpendByProvider, SpendByAgent } from "@/lib/ai-provider-types";
+import { DataSourceBadge } from "@/components/ui/DataSourceBadge";
 
 // Month selector (switching between months) is deferred to a later phase —
 // TokenUsage will be empty in Phase 7A. Current month is fixed server-side.
@@ -36,9 +37,23 @@ export function TokenSpendPanel({ initialMonth, byProvider, byAgent }: Props) {
     <div>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
         <div>
-          <div style={{ color: "var(--dpf-accent)", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>
-            Token Spend — {monthLabel}
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <div style={{ color: "var(--dpf-accent)", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+              Internal token usage — {monthLabel}
+            </div>
+            <DataSourceBadge
+              compact
+              provenance={{
+                kind: "live-db",
+                label: "TokenUsage",
+                sourceTable: "TokenUsage",
+                description: "DPF recorded token usage; this is not external provider account billing.",
+              }}
+            />
           </div>
+          <p style={{ color: "var(--dpf-muted)", fontSize: 11, margin: "4px 0 0" }}>
+            Recorded by DPF from coworker runs; provider invoices require a connected finance source.
+          </p>
           {!isEmpty && (
             <div style={{ color: "var(--dpf-text)", fontSize: 18, fontWeight: 700, marginTop: 2 }}>
               {formatCost(totalCost)} total
@@ -69,11 +84,16 @@ export function TokenSpendPanel({ initialMonth, byProvider, byAgent }: Props) {
 
       {!isEmpty && tab === "provider" && (
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
-          {byProvider.map((r) => {
+          {byProvider.map((r, index) => {
             const pct = totalCost > 0 ? Math.round((r.totalCostUsd / totalCost) * 100) : 0;
             return (
-              <div key={r.providerId} style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", borderRadius: 6, padding: 10 }}>
-                <div style={{ color: "var(--dpf-muted)", fontSize: 10, marginBottom: 2 }}>{r.providerId}</div>
+              <div key={r.providerId || `unknown-${index}`} style={{ background: "var(--dpf-surface-1)", border: "1px solid var(--dpf-border)", borderRadius: 6, padding: 10 }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 6, marginBottom: 2 }}>
+                  <div style={{ color: "var(--dpf-muted)", fontSize: 10, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {r.providerName}
+                  </div>
+                  <DataSourceBadge compact provenance={r.provenance} />
+                </div>
                 <div style={{ color: "var(--dpf-text)", fontSize: 16, fontWeight: 700 }}>{formatCost(r.totalCostUsd)}</div>
                 <div style={{ color: "var(--dpf-muted)", fontSize: 10, marginTop: 2 }}>
                   {formatTokens(r.totalInputTokens)} in · {formatTokens(r.totalOutputTokens)} out

--- a/apps/web/lib/inference/ai-provider-cost-view.test.ts
+++ b/apps/web/lib/inference/ai-provider-cost-view.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderRow, SpendByProvider } from "./ai-provider-types";
+import {
+  buildProviderCostView,
+  getProviderDisplayNameForSpend,
+  type ProviderFinanceSource,
+} from "./ai-provider-cost-view";
+
+function provider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  return {
+    id: "provider-row",
+    providerId: "openai",
+    name: "OpenAI",
+    families: [],
+    enabledFamilies: [],
+    status: "active",
+    costModel: "token",
+    category: "direct",
+    baseUrl: null,
+    authMethod: "api_key",
+    supportedAuthMethods: ["api_key"],
+    authHeader: null,
+    endpoint: null,
+    inputPricePerMToken: null,
+    outputPricePerMToken: null,
+    computeWatts: null,
+    electricityRateKwh: null,
+    docsUrl: null,
+    consoleUrl: null,
+    billingLabel: null,
+    costPerformanceNotes: null,
+    endpointType: "llm",
+    serviceKind: null,
+    sensitivityClearance: [],
+    capabilityTier: "basic",
+    costBand: "free",
+    taskTags: [],
+    mcpTransport: null,
+    maxConcurrency: null,
+    reasoning: 50,
+    codegen: 50,
+    toolFidelity: 50,
+    instructionFollowing: 50,
+    structuredOutput: 50,
+    conversational: 50,
+    contextRetention: 50,
+    authorizeUrl: null,
+    tokenUrl: null,
+    oauthClientId: null,
+    oauthRedirectUri: null,
+    ...overrides,
+  };
+}
+
+function finance(overrides: Partial<ProviderFinanceSource> = {}): ProviderFinanceSource {
+  return {
+    status: "seeded",
+    billingUrl: null,
+    usageUrl: null,
+    supplier: null,
+    supplierContracts: [],
+    ...overrides,
+  };
+}
+
+describe("buildProviderCostView", () => {
+  it("keeps routing cost band separate from external billing", () => {
+    const view = buildProviderCostView({
+      provider: provider({ costBand: "economy" }),
+      financeProfile: null,
+      internalUsage: null,
+    });
+
+    expect(view.routingCostBand.value).toBe("economy");
+    expect(view.routingCostBand.provenance.sourceTable).toBe("ModelProvider.costBand");
+    expect(view.externalProviderBilling.value).toBe("Not connected");
+    expect(view.externalProviderBilling.provenance.kind).toBe("not-connected");
+  });
+
+  it("treats seeded finance profiles as configuration, not billing evidence", () => {
+    const view = buildProviderCostView({
+      provider: provider(),
+      financeProfile: finance({ status: "seeded" }),
+      internalUsage: null,
+    });
+
+    expect(view.configuredBillingProfile.value).toBe("Seeded finance profile");
+    expect(view.configuredBillingProfile.provenance.kind).toBe("seed-default");
+    expect(view.externalProviderBilling.value).toBe("Not connected");
+  });
+
+  it("classifies provider usage snapshots as connected external billing", () => {
+    const view = buildProviderCostView({
+      provider: provider(),
+      financeProfile: finance({
+        status: "active",
+        supplier: { name: "OpenAI LLC" },
+        supplierContracts: [
+          {
+            status: "active",
+            usageSnapshots: [{ sourceType: "provider_api", snapshotDate: new Date("2026-05-01T00:00:00Z") }],
+          },
+        ],
+      }),
+      internalUsage: null,
+    });
+
+    expect(view.externalProviderBilling.value).toBe("Provider billing snapshot");
+    expect(view.externalProviderBilling.provenance.kind).toBe("connected-account");
+    expect(view.externalProviderBilling.provenance.sourceTable).toBe("ContractUsageSnapshot");
+  });
+
+  it("marks internal token usage as DPF live DB data", () => {
+    const usage: SpendByProvider = {
+      providerId: "openai",
+      providerName: "OpenAI",
+      totalInputTokens: 1200,
+      totalOutputTokens: 800,
+      totalCostUsd: 0.42,
+      provenance: {
+        kind: "live-db",
+        label: "TokenUsage",
+        sourceTable: "TokenUsage",
+        description: "DPF recorded token usage for this provider.",
+      },
+    };
+
+    const view = buildProviderCostView({
+      provider: provider(),
+      financeProfile: null,
+      internalUsage: usage,
+    });
+
+    expect(view.internalTokenUsage.value).toBe("$0.42 internal token usage");
+    expect(view.internalTokenUsage.provenance.sourceTable).toBe("TokenUsage");
+  });
+});
+
+describe("getProviderDisplayNameForSpend", () => {
+  it("labels blank or unknown provider usage as Unknown provider", () => {
+    const names = new Map([["openai", "OpenAI"]]);
+
+    expect(getProviderDisplayNameForSpend("", names)).toBe("Unknown provider");
+    expect(getProviderDisplayNameForSpend("missing", names)).toBe("Unknown provider (missing)");
+    expect(getProviderDisplayNameForSpend("openai", names)).toBe("OpenAI");
+  });
+});

--- a/apps/web/lib/inference/ai-provider-cost-view.ts
+++ b/apps/web/lib/inference/ai-provider-cost-view.ts
@@ -1,0 +1,142 @@
+import type { DataSourceProvenance } from "@/lib/surface-data-provenance";
+import type { ProviderRow, SpendByProvider } from "./ai-provider-types";
+import { getBillingLabel } from "./ai-provider-types";
+
+export type ProviderFinanceSource = {
+  status: string;
+  billingUrl: string | null;
+  usageUrl: string | null;
+  supplier: { name: string } | null;
+  supplierContracts: Array<{
+    status: string;
+    usageSnapshots: Array<{
+      sourceType: string;
+      snapshotDate: Date | string;
+    }>;
+  }>;
+};
+
+export type ProviderCostMetric = {
+  label: string;
+  value: string;
+  provenance: DataSourceProvenance;
+  actionHref?: string;
+};
+
+export type ProviderCostView = {
+  routingCostBand: ProviderCostMetric;
+  catalogPricing: ProviderCostMetric;
+  configuredBillingProfile: ProviderCostMetric;
+  internalTokenUsage: ProviderCostMetric;
+  externalProviderBilling: ProviderCostMetric;
+};
+
+const TOKEN_USAGE_PROVENANCE: DataSourceProvenance = {
+  kind: "live-db",
+  label: "TokenUsage",
+  sourceTable: "TokenUsage",
+  description: "DPF recorded token usage for this provider.",
+};
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+function latestUsageSnapshot(profile: ProviderFinanceSource | null) {
+  return profile?.supplierContracts
+    .flatMap((contract) => contract.usageSnapshots)
+    .sort((a, b) => new Date(b.snapshotDate).getTime() - new Date(a.snapshotDate).getTime())[0] ?? null;
+}
+
+export function getProviderDisplayNameForSpend(providerId: string, providerNames: Map<string, string>): string {
+  const normalized = providerId.trim();
+  if (!normalized) return "Unknown provider";
+  return providerNames.get(normalized) ?? `Unknown provider (${normalized})`;
+}
+
+export function buildProviderCostView(input: {
+  provider: ProviderRow;
+  financeProfile: ProviderFinanceSource | null;
+  internalUsage: SpendByProvider | null;
+}): ProviderCostView {
+  const { provider, financeProfile, internalUsage } = input;
+  const catalogLabel = getBillingLabel(provider) ?? "No catalog pricing";
+  const snapshot = latestUsageSnapshot(financeProfile);
+
+  const configuredProfile: ProviderCostMetric = financeProfile
+    ? {
+        label: "Configured billing profile",
+        value: financeProfile.status === "seeded" ? "Seeded finance profile" : financeProfile.status.replace(/_/g, " "),
+        provenance: {
+          kind: financeProfile.status === "seeded" ? "seed-default" : "live-db",
+          label: financeProfile.status === "seeded" ? "Seeded finance profile" : "Configured billing profile",
+          sourceTable: "AiProviderFinanceProfile",
+          description: "Finance configuration exists for this provider, but it is not the same as external account billing.",
+        },
+        actionHref: `/finance/spend/ai`,
+      }
+    : {
+        label: "Configured billing profile",
+        value: "Not configured",
+        provenance: {
+          kind: "not-connected",
+          label: "Not configured",
+          sourceTable: "AiProviderFinanceProfile",
+          description: "No finance profile is configured for this provider.",
+        },
+        actionHref: `/finance/spend/ai`,
+      };
+
+  return {
+    routingCostBand: {
+      label: "Routing cost band",
+      value: provider.costBand || "unspecified",
+      provenance: {
+        kind: "live-db",
+        label: "Routing metadata",
+        sourceTable: "ModelProvider.costBand",
+        description: "Routing cost band used by DPF selection logic. This is not external account billing.",
+      },
+    },
+    catalogPricing: {
+      label: "Provider catalog",
+      value: catalogLabel,
+      provenance: {
+        kind: provider.billingLabel || provider.inputPricePerMToken != null || provider.outputPricePerMToken != null ? "catalog" : "not-connected",
+        label: provider.billingLabel ? "Provider catalog" : "No catalog pricing",
+        sourceTable: "ModelProvider",
+        description: "Pricing metadata from the provider catalog or local provider configuration.",
+      },
+    },
+    configuredBillingProfile: configuredProfile,
+    internalTokenUsage: {
+      label: "Internal token usage",
+      value: `${formatUsd(internalUsage?.totalCostUsd ?? 0)} internal token usage`,
+      provenance: internalUsage?.provenance ?? TOKEN_USAGE_PROVENANCE,
+    },
+    externalProviderBilling: snapshot
+      ? {
+          label: "External provider billing",
+          value: "Provider billing snapshot",
+          provenance: {
+            kind: snapshot.sourceType === "provider_api" || snapshot.sourceType === "provider_portal" ? "connected-account" : "live-db",
+            label: "Provider billing snapshot",
+            sourceTable: "ContractUsageSnapshot",
+            description: "A finance usage snapshot exists for this provider account.",
+            lastVerifiedAt: new Date(snapshot.snapshotDate).toISOString(),
+          },
+          actionHref: financeProfile?.usageUrl ?? financeProfile?.billingUrl ?? "/finance/spend/ai",
+        }
+      : {
+          label: "External provider billing",
+          value: "Not connected",
+          provenance: {
+            kind: "not-connected",
+            label: "Not connected",
+            sourceTable: "ContractUsageSnapshot",
+            description: "No reconciled provider billing snapshot is connected for this provider.",
+          },
+          actionHref: financeProfile?.usageUrl ?? financeProfile?.billingUrl ?? "/finance/spend/ai",
+        },
+  };
+}

--- a/apps/web/lib/inference/ai-provider-data.test.ts
+++ b/apps/web/lib/inference/ai-provider-data.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Use vi.hoisted so mockPrisma is available when vi.mock factory runs
 const mockPrisma = vi.hoisted(() => ({
+  tokenUsage: {
+    groupBy: vi.fn(),
+  },
+  modelProvider: {
+    findMany: vi.fn(),
+  },
   modelProfile: {
     findMany: vi.fn(),
     groupBy: vi.fn(),
@@ -31,6 +37,7 @@ import {
   getRecipesForProvider,
   getActivatedMcpServers,
   getAsyncOperations,
+  getTokenSpendByProvider,
 } from "./ai-provider-data";
 
 beforeEach(() => { vi.clearAllMocks(); });
@@ -100,5 +107,36 @@ describe("getAsyncOperations", () => {
     expect(mockPrisma.asyncInferenceOp.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ take: 50, orderBy: { createdAt: "desc" } }),
     );
+  });
+});
+
+describe("getTokenSpendByProvider", () => {
+  it("keeps blank or unknown provider usage visible with TokenUsage provenance", async () => {
+    mockPrisma.tokenUsage.groupBy.mockResolvedValue([
+      {
+        providerId: "",
+        _sum: { inputTokens: 100, outputTokens: 50, costUsd: 0.05 },
+      },
+      {
+        providerId: "missing-provider",
+        _sum: { inputTokens: 10, outputTokens: 5, costUsd: 0.01 },
+      },
+      {
+        providerId: "openai",
+        _sum: { inputTokens: 200, outputTokens: 100, costUsd: 0.25 },
+      },
+    ]);
+    mockPrisma.modelProvider.findMany.mockResolvedValue([
+      { providerId: "openai", name: "OpenAI" },
+    ]);
+
+    const result = await getTokenSpendByProvider({ year: 2026, month: 5 });
+
+    expect(result.map((row) => row.providerName)).toEqual([
+      "Unknown provider",
+      "Unknown provider (missing-provider)",
+      "OpenAI",
+    ]);
+    expect(result.every((row) => row.provenance.sourceTable === "TokenUsage")).toBe(true);
   });
 });

--- a/apps/web/lib/inference/ai-provider-data.ts
+++ b/apps/web/lib/inference/ai-provider-data.ts
@@ -17,6 +17,7 @@ import type {
   AsyncOpRow,
   ToolInventoryItem,
 } from "./ai-provider-types";
+import { getProviderDisplayNameForSpend } from "./ai-provider-cost-view";
 
 /** Mask a secret to `••••••1234` (last 4 chars visible). */
 function maskSecret(value: string | null): string | null {
@@ -143,11 +144,27 @@ export const getTokenSpendByProvider = cache(
       where: { createdAt: range },
       _sum: { inputTokens: true, outputTokens: true, costUsd: true },
     });
+    const providerIds = rows.map((r) => r.providerId.trim()).filter(Boolean);
+    const providers = providerIds.length > 0
+      ? await prisma.modelProvider.findMany({
+          where: { providerId: { in: providerIds } },
+          select: { providerId: true, name: true },
+        })
+      : [];
+    const providerNames = new Map(providers.map((p) => [p.providerId, p.name]));
+
     return rows.map((r) => ({
       providerId:        r.providerId,
+      providerName:      getProviderDisplayNameForSpend(r.providerId, providerNames),
       totalInputTokens:  r._sum.inputTokens  ?? 0,
       totalOutputTokens: r._sum.outputTokens ?? 0,
       totalCostUsd:      r._sum.costUsd      ?? 0,
+      provenance: {
+        kind: "live-db",
+        label: "TokenUsage",
+        sourceTable: "TokenUsage",
+        description: "DPF recorded token usage for this provider.",
+      },
     }));
   }
 );

--- a/apps/web/lib/inference/ai-provider-types.ts
+++ b/apps/web/lib/inference/ai-provider-types.ts
@@ -1,4 +1,5 @@
 // apps/web/lib/ai-provider-types.ts
+import type { DataSourceProvenance } from "@/lib/surface-data-provenance";
 
 // ─── Schedule helpers ─────────────────────────────────────────────────────────
 
@@ -112,9 +113,11 @@ export type ProviderWithCredential = {
 
 export type SpendByProvider = {
   providerId: string;
+  providerName: string;
   totalInputTokens: number;
   totalOutputTokens: number;
   totalCostUsd: number;
+  provenance: DataSourceProvenance;
 };
 
 export type SpendByAgent = {

--- a/apps/web/lib/platform-authority-summary.test.ts
+++ b/apps/web/lib/platform-authority-summary.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  delegationGrant: {
+    count: vi.fn(),
+  },
+  agentToolGrant: {
+    count: vi.fn(),
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+
+import {
+  buildAuthoritySummaryMetrics,
+  getPlatformAuthoritySummary,
+} from "./platform-authority-summary";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getPlatformAuthoritySummary", () => {
+  it("separates temporary delegation grants from standing tool grants", async () => {
+    mockPrisma.delegationGrant.count.mockResolvedValue(0);
+    mockPrisma.agentToolGrant.count.mockResolvedValue(12);
+    mockPrisma.agentToolGrant.findMany.mockResolvedValue([{ agentId: "agent-a" }, { agentId: "agent-b" }]);
+
+    const summary = await getPlatformAuthoritySummary(new Date("2026-05-14T00:00:00Z"));
+
+    expect(summary).toEqual({
+      temporaryDelegationGrants: 0,
+      standingToolGrants: 12,
+      governedAgents: 2,
+    });
+    expect(mockPrisma.delegationGrant.count).toHaveBeenCalledWith({
+      where: {
+        status: "active",
+        expiresAt: { gt: new Date("2026-05-14T00:00:00Z") },
+      },
+    });
+    expect(mockPrisma.agentToolGrant.findMany).toHaveBeenCalledWith({
+      distinct: ["agentId"],
+      select: { agentId: true },
+    });
+  });
+});
+
+describe("buildAuthoritySummaryMetrics", () => {
+  it("uses accurate labels and live-db provenance", () => {
+    const metrics = buildAuthoritySummaryMetrics({
+      temporaryDelegationGrants: 0,
+      standingToolGrants: 12,
+      governedAgents: 2,
+    });
+
+    expect(metrics.map((metric) => metric.label)).toEqual([
+      "Temporary delegation grants",
+      "Standing tool grants",
+    ]);
+    expect(metrics[0].note).toContain("0 is normal");
+    expect(metrics[0].provenance.sourceTable).toBe("DelegationGrant");
+    expect(metrics[1].provenance.sourceTable).toBe("AgentToolGrant");
+  });
+});

--- a/apps/web/lib/platform-authority-summary.ts
+++ b/apps/web/lib/platform-authority-summary.ts
@@ -1,0 +1,64 @@
+import { prisma } from "@dpf/db";
+import type { DataSourceProvenance } from "@/lib/surface-data-provenance";
+
+export type PlatformAuthoritySummary = {
+  temporaryDelegationGrants: number;
+  standingToolGrants: number;
+  governedAgents: number;
+};
+
+export type AuthoritySummaryMetric = {
+  label: string;
+  value: number;
+  note: string;
+  provenance: DataSourceProvenance;
+};
+
+export async function getPlatformAuthoritySummary(now = new Date()): Promise<PlatformAuthoritySummary> {
+  const [temporaryDelegationGrants, standingToolGrants, governedAgentRows] = await Promise.all([
+    prisma.delegationGrant.count({
+      where: {
+        status: "active",
+        expiresAt: { gt: now },
+      },
+    }),
+    prisma.agentToolGrant.count(),
+    prisma.agentToolGrant.findMany({
+      distinct: ["agentId"],
+      select: { agentId: true },
+    }),
+  ]);
+
+  return {
+    temporaryDelegationGrants,
+    standingToolGrants,
+    governedAgents: governedAgentRows.length,
+  };
+}
+
+export function buildAuthoritySummaryMetrics(summary: PlatformAuthoritySummary): AuthoritySummaryMetric[] {
+  return [
+    {
+      label: "Temporary delegation grants",
+      value: summary.temporaryDelegationGrants,
+      note: "0 is normal when no time-limited delegation is active.",
+      provenance: {
+        kind: "live-db",
+        label: "DelegationGrant",
+        sourceTable: "DelegationGrant",
+        description: "Active, unexpired temporary delegation grants.",
+      },
+    },
+    {
+      label: "Standing tool grants",
+      value: summary.standingToolGrants,
+      note: `${summary.governedAgents} governed agent${summary.governedAgents === 1 ? "" : "s"} have standing tool grants.`,
+      provenance: {
+        kind: "live-db",
+        label: "AgentToolGrant",
+        sourceTable: "AgentToolGrant",
+        description: "Standing tool grants configured for AI coworkers.",
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Adds a provider cost source view model that separates routing cost bands, catalog/configuration pricing, internal DPF token usage, and external provider billing evidence.
- Updates provider list/detail surfaces so missing provider billing is shown as `Not connected` instead of looking like `free` spend.
- Labels token spend as internal `TokenUsage` data and preserves blank/unknown provider rows as `Unknown provider`.
- Renames authority hub metrics from generic active grants to temporary delegation grants plus standing tool grants, with source provenance.

## Validation

- `pnpm --filter web exec vitest run lib/inference/ai-provider-cost-view.test.ts components/platform/TokenSpendPanel.test.tsx lib/platform-authority-summary.test.ts lib/inference/ai-provider-data.test.ts components/platform/PlatformSummaryCard.test.tsx "app/(shell)/platform/ai/providers/page.test.tsx" "app/(shell)/platform/page.test.tsx"`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`

Note: production build passes with pre-existing Turbopack/NFT broad tracing warnings around `spec-plan-search.ts` / `next.config.mjs`.