### PR TITLE
fix(build-studio): seed happyPathState.intake at promote time (BI-E9CD1B92)

### DIFF
--- a/apps/web/lib/governed-backlog-tee-up.test.ts
+++ b/apps/web/lib/governed-backlog-tee-up.test.ts
@@ -9,6 +9,9 @@ const mockPrisma = {
     findMany: vi.fn(),
     update: vi.fn(),
   },
+  epic: {
+    create: vi.fn(),
+  },
   featureBuild: {
     create: vi.fn(),
   },
@@ -166,8 +169,9 @@ describe("governed backlog tee-up", () => {
         activeBuildId: null,
         digitalProductId: "product-1",
         epicId: "epic-1",
+        taxonomyNodeId: "taxonomy-node-1",
         createdAt: new Date("2026-04-24T10:00:00.000Z"),
-        epic: { status: "open" },
+        epic: { epicId: "EP-WORKFLOW-1" },
       })
       .mockResolvedValueOnce({
         id: "backlog-bootstrap",
@@ -180,9 +184,15 @@ describe("governed backlog tee-up", () => {
         activeBuildId: null,
         digitalProductId: null,
         epicId: null,
+        taxonomyNodeId: null,
         createdAt: new Date("2026-04-24T11:00:00.000Z"),
         epic: null,
       });
+
+    mockPrisma.epic.create.mockResolvedValueOnce({
+      id: "epic-cuid-bootstrap",
+      epicId: "EP-BUILD-AAAAAA",
+    });
 
     mockPrisma.featureBuild.create
       .mockResolvedValueOnce({ id: "build-row-1", buildId: "FB-11111111" })
@@ -264,5 +274,153 @@ describe("governed backlog tee-up", () => {
     });
     expect(mockPrisma.backlogItem.findMany).not.toHaveBeenCalled();
     expect(mockPrisma.featureBuild.create).not.toHaveBeenCalled();
+  });
+
+  describe("promoteBacklogItemToBuildDraft intake initialization", () => {
+    it("seeds happyPathState.intake from a BI with an existing epic and taxonomy", async () => {
+      mockPrisma.backlogItem.findUnique.mockResolvedValueOnce({
+        id: "bi-cuid-1",
+        itemId: "BI-EPIC-OK",
+        title: "Add taxonomy filter to operations map",
+        body: "Operators need to scope the map by taxonomy node.",
+        status: "open",
+        triageOutcome: "build",
+        effortSize: "medium",
+        activeBuildId: null,
+        digitalProductId: "product-1",
+        epicId: "epic-cuid-1",
+        taxonomyNodeId: "taxonomy-cuid-ops",
+        epic: { epicId: "EP-OPS-001" },
+      });
+      mockPrisma.featureBuild.create.mockResolvedValueOnce({
+        id: "build-row-1",
+        buildId: "FB-12345678",
+      });
+
+      const { promoteBacklogItemToBuildDraft } = await import("./governed-backlog-tee-up");
+      const result = await promoteBacklogItemToBuildDraft({
+        tx: mockPrisma,
+        itemId: "BI-EPIC-OK",
+        userId: "user-1",
+        governedBacklogEnabled: true,
+      });
+
+      expect(result.kind).toBe("success");
+      expect(mockPrisma.epic.create).not.toHaveBeenCalled();
+
+      const createCall = mockPrisma.featureBuild.create.mock.calls[0]![0];
+      const intake = createCall.data.plan.happyPathState.intake;
+      expect(intake).toEqual({
+        status: "ready",
+        backlogItemId: "BI-EPIC-OK",
+        epicId: "EP-OPS-001",
+        taxonomyNodeId: "taxonomy-cuid-ops",
+        constrainedGoal: "Add taxonomy filter to operations map",
+        failureReason: null,
+      });
+    });
+
+    it("auto-creates a solo epic and falls back to a triaged-bi taxonomy anchor when BI has neither", async () => {
+      mockPrisma.backlogItem.findUnique.mockResolvedValueOnce({
+        id: "bi-cuid-solo",
+        itemId: "BI-SOLO",
+        title: "Surface stale agent grants in admin",
+        body: null,
+        status: "open",
+        triageOutcome: "build",
+        effortSize: "small",
+        activeBuildId: null,
+        digitalProductId: null,
+        epicId: null,
+        taxonomyNodeId: null,
+        epic: null,
+      });
+      mockPrisma.epic.create.mockResolvedValueOnce({
+        id: "epic-cuid-solo",
+        epicId: "EP-BUILD-ABCDEF",
+      });
+      mockPrisma.featureBuild.create.mockResolvedValueOnce({
+        id: "build-row-solo",
+        buildId: "FB-SOLO0001",
+      });
+
+      const { promoteBacklogItemToBuildDraft } = await import("./governed-backlog-tee-up");
+      const result = await promoteBacklogItemToBuildDraft({
+        tx: mockPrisma,
+        itemId: "BI-SOLO",
+        userId: "user-1",
+        governedBacklogEnabled: true,
+      });
+
+      expect(result.kind).toBe("success");
+
+      // Epic was minted from the BI title and linked back to the BI before
+      // the build was created.
+      expect(mockPrisma.epic.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: "Surface stale agent grants in admin",
+            status: "open",
+            epicId: expect.stringMatching(/^EP-BUILD-[A-F0-9]{6}$/),
+          }),
+        }),
+      );
+      expect(mockPrisma.backlogItem.update).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: { itemId: "BI-SOLO" },
+          data: { epicId: "epic-cuid-solo" },
+        }),
+      );
+
+      const mintedEpicId = mockPrisma.epic.create.mock.calls[0]![0].data.epicId;
+      const createCall = mockPrisma.featureBuild.create.mock.calls[0]![0];
+      const intake = createCall.data.plan.happyPathState.intake;
+      expect(intake).toEqual({
+        status: "ready",
+        backlogItemId: "BI-SOLO",
+        epicId: mintedEpicId,
+        taxonomyNodeId: "triaged-bi:bi-cuid-solo",
+        constrainedGoal: "Surface stale agent grants in admin",
+        failureReason: null,
+      });
+    });
+
+    it("derives constrainedGoal from the BI title, truncated to 280 chars", async () => {
+      const longTitle = "Long feature title ".repeat(20).trim(); // ~ 380 chars
+      mockPrisma.backlogItem.findUnique.mockResolvedValueOnce({
+        id: "bi-cuid-long",
+        itemId: "BI-LONG",
+        title: longTitle,
+        body: "Even longer body. ".repeat(200),
+        status: "open",
+        triageOutcome: "build",
+        effortSize: "medium",
+        activeBuildId: null,
+        digitalProductId: null,
+        epicId: "epic-cuid-long",
+        taxonomyNodeId: null,
+        epic: { epicId: "EP-LONG-001" },
+      });
+      mockPrisma.featureBuild.create.mockResolvedValueOnce({
+        id: "build-row-long",
+        buildId: "FB-LONG0001",
+      });
+
+      const { promoteBacklogItemToBuildDraft } = await import("./governed-backlog-tee-up");
+      const result = await promoteBacklogItemToBuildDraft({
+        tx: mockPrisma,
+        itemId: "BI-LONG",
+        userId: "user-1",
+        governedBacklogEnabled: true,
+      });
+
+      expect(result.kind).toBe("success");
+
+      const createCall = mockPrisma.featureBuild.create.mock.calls[0]![0];
+      const intake = createCall.data.plan.happyPathState.intake;
+      expect(intake.constrainedGoal).toHaveLength(280);
+      expect(longTitle.startsWith(intake.constrainedGoal)).toBe(true);
+    });
   });
 });

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -1,4 +1,5 @@
-import { generateBuildId } from "@/lib/feature-build-types";
+import * as crypto from "crypto";
+import { generateBuildId, mergeHappyPathStateIntoPlan } from "@/lib/feature-build-types";
 
 const ELIGIBLE_EFFORT_SIZES = new Set(["small", "medium", "large"]);
 const ACTIVE_EPIC_STATUSES = new Set(["open", "in-progress"]);
@@ -34,6 +35,9 @@ type GovernedBacklogTeeUpPrisma = {
     findMany(args: any): Promise<any>;
     findUnique(args: any): Promise<any>;
     update(args: any): Promise<any>;
+  };
+  epic: {
+    create(args: any): Promise<any>;
   };
   featureBuild: {
     create(args: any): Promise<any>;
@@ -107,7 +111,10 @@ export async function promoteBacklogItemToBuildDraft(
   input: PromoteBacklogItemToBuildDraftInput,
 ): Promise<PromoteBacklogItemToBuildDraftResult> {
   const { tx, itemId, userId, governedBacklogEnabled, activity } = input;
-  const item = await tx.backlogItem.findUnique({ where: { itemId } });
+  const item = await tx.backlogItem.findUnique({
+    where: { itemId },
+    include: { epic: { select: { epicId: true } } },
+  });
 
   if (!item) {
     return { kind: "error", error: "Item not found", message: `Item ${itemId} not found` };
@@ -129,6 +136,42 @@ export async function promoteBacklogItemToBuildDraft(
     };
   }
 
+  // Resolve or auto-create the epic semantic id. The happy-path-rescue spec
+  // requires an epic anchor in FeatureBuild.plan.happyPathState.intake; if the
+  // BacklogItem isn't linked, mint a solo epic from the item title and link it
+  // so the ideate→plan gate clears at promote time.
+  let epicSemanticId: string;
+  if (item.epicId && item.epic?.epicId) {
+    epicSemanticId = item.epic.epicId;
+  } else {
+    epicSemanticId = `EP-BUILD-${crypto.randomUUID().slice(0, 6).toUpperCase()}`;
+    const epicTitle = item.title.trim().slice(0, 200) || "Build Studio feature";
+    const createdEpic = await tx.epic.create({
+      data: { epicId: epicSemanticId, title: epicTitle, status: "open" },
+      select: { id: true, epicId: true },
+    });
+    await tx.backlogItem.update({
+      where: { itemId },
+      data: { epicId: createdEpic.id },
+    });
+  }
+
+  const constrainedGoal = item.title.trim().slice(0, 280);
+  const plan = mergeHappyPathStateIntoPlan(null, {
+    intake: {
+      status: "ready",
+      backlogItemId: item.itemId,
+      epicId: epicSemanticId,
+      // Use the BI's persisted taxonomy node when present, else anchor on the
+      // triaged BI itself — its existence + triage outcome IS the
+      // categorization signal for the gate. Mirrors the auto-intake fallback
+      // in reviewDesignDoc (apps/web/lib/mcp-tools.ts:5153) so promote-time
+      // and review-time paths produce the same shape.
+      taxonomyNodeId: item.taxonomyNodeId ?? `triaged-bi:${item.id}`,
+      constrainedGoal,
+    },
+  });
+
   const created = await tx.featureBuild.create({
     data: {
       buildId: generateBuildId(),
@@ -138,6 +181,7 @@ export async function promoteBacklogItemToBuildDraft(
       digitalProductId: item.digitalProductId ?? null,
       originatingBacklogItemId: item.id,
       draftApprovedAt: null,
+      plan,
     },
   });
 

--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -12,6 +12,7 @@ const mockPrisma = {
     create: vi.fn(),
   },
   epic: {
+    create: vi.fn(),
     update: vi.fn(),
   },
   featureBuild: {
@@ -131,9 +132,15 @@ describe("backlog MCP tool execution", () => {
       activeBuildId: null,
       digitalProductId: null,
       epicId: null,
+      taxonomyNodeId: null,
+      epic: null,
     };
 
     mockPrisma.backlogItem.findUnique.mockResolvedValue(backlogRow);
+    mockPrisma.epic.create.mockResolvedValue({
+      id: "epic-cuid-auto",
+      epicId: "EP-BUILD-AAAAAA",
+    });
     mockPrisma.featureBuild.create.mockResolvedValue({
       id: "build-row-1",
       buildId: "FB-12345678",


### PR DESCRIPTION
## Summary
- `promote_to_build_studio` left `FeatureBuild.plan.happyPathState.intake` unpopulated, so every promoted build hit the ideate→plan gate with `Intake is incomplete. Missing: taxonomy, backlog item, epic, constrained goal.` until `reviewDesignDoc`'s auto-intake fallback caught it later. Surfaced during the BI-E9CD1B92 lifecycle test on 2026-05-13.
- `promoteBacklogItemToBuildDraft` ([apps/web/lib/governed-backlog-tee-up.ts](apps/web/lib/governed-backlog-tee-up.ts)) now seeds all four anchors from the BacklogItem at create time using `mergeHappyPathStateIntoPlan`:
  - `backlogItemId` ← `item.itemId` (semantic)
  - `epicId` ← linked epic's semantic id; if the BI has no epic, mint `EP-BUILD-XXXXXX` from the title and link it inside the same transaction (matches the happy-path-rescue spec's "create or assign during intake")
  - `taxonomyNodeId` ← `item.taxonomyNodeId`, else the `triaged-bi:<cuid>` anchor pattern already used by the existing review-time fallback ([apps/web/lib/mcp-tools.ts:5155](apps/web/lib/mcp-tools.ts:5155))
  - `constrainedGoal` ← `item.title` trimmed to 280 chars

## Test plan
- [x] `lib/governed-backlog-tee-up.test.ts` — 3 new cases: with-existing-epic, no-epic-auto-creates-and-links, long-title-truncates-constrained-goal
- [x] `lib/mcp-tools-backlog.test.ts` — `promote_to_build_studio` happy path updated to mock `epic.create` + new `include.epic` shape
- [x] Pre-commit typecheck (`pnpm --filter web typecheck`) passes
- [x] `npx vitest run lib/governed-backlog-tee-up.test.ts lib/mcp-tools-backlog.test.ts` — 15/15 pass
- [ ] Manual UX: promote a BI without an epic and confirm the resulting FeatureBuild advances past ideate→plan without a coworker fixup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)