### PR TITLE
fix(integrate): pre-PR destructive-ops gate now scans full file blocks

### DIFF
--- a/apps/web/lib/integrate/pre-pr-gates.test.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { runPrePRGates } from "./pre-pr-gates";
+
+describe("runPrePRGates — destructive-ops gate", () => {
+  it("blocks on a destructive migration", () => {
+    const destructiveDiff = `diff --git a/prisma/migrations/20260513_drop/migration.sql b/prisma/migrations/20260513_drop/migration.sql
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/prisma/migrations/20260513_drop/migration.sql
+@@ -0,0 +1,1 @@
++DROP TABLE users;
+`;
+    const result = runPrePRGates(destructiveDiff);
+    expect(result.canProceed).toBe(false);
+    const destructiveGate = result.gates.find((g) => g.gate === "destructive-ops");
+    expect(destructiveGate?.verdict).toBe("block");
+    expect(destructiveGate?.findings.join("\n")).toMatch(/DROP TABLE/i);
+  });
+
+  it("blocks when the destructive migration is one of several files in the diff", () => {
+    // Regression for the multi-file case: extractAddedLinesForFile previously
+    // truncated to the first newline, so a migration that wasn't the first
+    // block would still be missed.
+    const diff = `diff --git a/apps/web/lib/foo.ts b/apps/web/lib/foo.ts
+index aaa..bbb 100644
+--- a/apps/web/lib/foo.ts
++++ b/apps/web/lib/foo.ts
+@@ -1,2 +1,3 @@
+ export const x = 1;
++export const y = 2;
+ export const z = 3;
+diff --git a/prisma/migrations/20260513_truncate/migration.sql b/prisma/migrations/20260513_truncate/migration.sql
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/prisma/migrations/20260513_truncate/migration.sql
+@@ -0,0 +1,2 @@
++TRUNCATE TABLE sessions;
++DROP COLUMN legacy_id;
+`;
+    const result = runPrePRGates(diff);
+    expect(result.canProceed).toBe(false);
+    const destructiveGate = result.gates.find((g) => g.gate === "destructive-ops");
+    expect(destructiveGate?.verdict).toBe("block");
+    expect(destructiveGate?.findings.some((f) => /TRUNCATE/i.test(f))).toBe(true);
+    expect(destructiveGate?.findings.some((f) => /DROP\s+COLUMN/i.test(f))).toBe(true);
+  });
+
+  it("passes on a benign additive migration", () => {
+    const diff = `diff --git a/prisma/migrations/20260513_add_col/migration.sql b/prisma/migrations/20260513_add_col/migration.sql
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/prisma/migrations/20260513_add_col/migration.sql
+@@ -0,0 +1,1 @@
++ALTER TABLE users ADD COLUMN nickname TEXT;
+`;
+    const result = runPrePRGates(diff);
+    const destructiveGate = result.gates.find((g) => g.gate === "destructive-ops");
+    expect(destructiveGate?.verdict).toBe("pass");
+    expect(destructiveGate?.findings).toHaveLength(0);
+  });
+
+  it("ignores destructive keywords that only appear in removed lines", () => {
+    // Lines starting with "-" are removals — the gate should only scan added lines.
+    const diff = `diff --git a/prisma/migrations/20260513_edit/migration.sql b/prisma/migrations/20260513_edit/migration.sql
+index 4444444..5555555 100644
+--- a/prisma/migrations/20260513_edit/migration.sql
++++ b/prisma/migrations/20260513_edit/migration.sql
+@@ -1,2 +1,1 @@
+-DROP TABLE old_thing;
+ CREATE TABLE new_thing (id TEXT PRIMARY KEY);
+`;
+    const result = runPrePRGates(diff);
+    const destructiveGate = result.gates.find((g) => g.gate === "destructive-ops");
+    expect(destructiveGate?.verdict).toBe("pass");
+  });
+});
+
+describe("runPrePRGates — dependency-audit gate", () => {
+  it("flags a new dependency added to package.json", () => {
+    // Regression for the same extractAddedLinesForFile bug: dependency adds
+    // were being missed because the file's added lines were never extracted.
+    // Uses a last-position add (no trailing comma) so the existing dep-line
+    // regex (which requires `"$`) actually matches — the helper-bug fix alone
+    // is what's being asserted here.
+    const diff = `diff --git a/package.json b/package.json
+index aaaaaaa..bbbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,5 +10,6 @@
+     "react": "^18.2.0",
+     "next": "^14.0.0",
+-    "zod": "^3.22.0"
++    "zod": "^3.22.0",
++    "lodash": "^4.17.21"
+   },
+`;
+    const result = runPrePRGates(diff);
+    const depGate = result.gates.find((g) => g.gate === "dependency-audit");
+    expect(depGate?.verdict).toBe("warn");
+    expect(depGate?.findings.some((f) => /lodash@\^4\.17\.21/.test(f))).toBe(true);
+  });
+
+  it("passes when no package.json files are in the diff", () => {
+    const diff = `diff --git a/apps/web/lib/foo.ts b/apps/web/lib/foo.ts
+index aaa..bbb 100644
+--- a/apps/web/lib/foo.ts
++++ b/apps/web/lib/foo.ts
+@@ -1,1 +1,2 @@
+ export const x = 1;
++export const y = 2;
+`;
+    const result = runPrePRGates(diff);
+    const depGate = result.gates.find((g) => g.gate === "dependency-audit");
+    expect(depGate?.verdict).toBe("pass");
+  });
+});

--- a/apps/web/lib/integrate/pre-pr-gates.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.ts
@@ -40,15 +40,15 @@ function extractFilePaths(diff: string): string[] {
 }
 
 function extractAddedLinesForFile(diff: string, filePath: string): string[] {
-  const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const fileRegex = new RegExp(
-    `^diff --git a/${escaped} b/.+\\n[\\s\\S]*?(?=^diff --git|$)`,
-    "m",
-  );
-  const match = fileRegex.exec(diff);
-  if (!match) return [];
+  // Split the diff on file-block boundaries so we can isolate one file's hunk
+  // without relying on a multiline regex (the previous `^...(?=^diff --git|$)/m`
+  // version stopped at the first newline because `$` matches end-of-line under /m).
+  const blocks = diff.split(/^(?=diff --git )/m);
+  const header = `diff --git a/${filePath} `;
+  const target = blocks.find((b) => b.startsWith(header));
+  if (!target) return [];
 
-  return match[0]
+  return target
     .split("\n")
     .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
     .map((line) => line.slice(1));


### PR DESCRIPTION
## Summary

- `extractAddedLinesForFile` in [apps/web/lib/integrate/pre-pr-gates.ts](apps/web/lib/integrate/pre-pr-gates.ts) used a `/m`-flag regex whose `(?=^diff --git|$)` terminator matched **end-of-line** instead of next-file-or-EOF. `match[0]` was just the `diff --git` header line, so no added lines were ever extracted.
- Effect: `runDestructiveOpsGate` and `runDependencyGate` silently returned `pass` for every migration. `DROP TABLE`, `TRUNCATE`, `DROP COLUMN` all slipped through the pre-PR gate.
- Fix: split the diff on `^(?=diff --git )/m` boundaries and `find` the target file's block. No regex-multiline subtleties.

## Changes

- [apps/web/lib/integrate/pre-pr-gates.ts](apps/web/lib/integrate/pre-pr-gates.ts) — rewrote helper; added comment explaining the prior failure mode so it doesn't regress.
- [apps/web/lib/integrate/pre-pr-gates.test.ts](apps/web/lib/integrate/pre-pr-gates.test.ts) — new file, 6 tests:
  - destructive migration alone → blocks
  - destructive migration mixed with code change in diff → blocks (the multi-file regression)
  - benign `ADD COLUMN` migration → passes
  - destructive keyword only in removed (`-`) lines → passes
  - new dep in `package.json` → warns
  - no `package.json` in diff → passes (early-return path)

## Follow-up surfaced (not in this PR)

The dep-line regex at [pre-pr-gates.ts:156](apps/web/lib/integrate/pre-pr-gates.ts:156) anchors with `"$`, so it only matches the **last** dep in a block (trailing-comma entries never match) and can't distinguish a version bump from a new add. Worth a separate fix — flagged here so reviewers know the dep-audit test uses a last-position add to work around it.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/pre-pr-gates.test.ts` — 6/6 pass
- [x] `pnpm --filter web typecheck` — clean
- [ ] CI vitest job is green on this PR

Surfaced during BI-E9CD1B92 debugging of `create_portal_pr` (separate `?.filter` bug, fixed elsewhere).

Co-authored by Claude Code.