### PR TITLE
fix(integrate): dep-audit gate matches mid-block adds and skips version bumps

### DIFF
--- a/apps/web/lib/integrate/pre-pr-gates.test.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.test.ts
@@ -80,12 +80,28 @@ index 4444444..5555555 100644
 });
 
 describe("runPrePRGates — dependency-audit gate", () => {
-  it("flags a new dependency added to package.json", () => {
-    // Regression for the same extractAddedLinesForFile bug: dependency adds
-    // were being missed because the file's added lines were never extracted.
-    // Uses a last-position add (no trailing comma) so the existing dep-line
-    // regex (which requires `"$`) actually matches — the helper-bug fix alone
-    // is what's being asserted here.
+  it("flags a new dependency added mid-block (trailing comma)", () => {
+    // Mid-block adds have a trailing comma. The previous regex anchored on `"$`,
+    // so it missed every dep entry that wasn't the last in its block — i.e. most
+    // adds in practice. This is the real case the gate needs to catch.
+    const diff = `diff --git a/package.json b/package.json
+index aaaaaaa..bbbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,4 +10,5 @@
+     "react": "^18.2.0",
++    "lodash": "^4.17.21",
+     "next": "^14.0.0",
+     "zod": "^3.22.0"
+   },
+`;
+    const result = runPrePRGates(diff);
+    const depGate = result.gates.find((g) => g.gate === "dependency-audit");
+    expect(depGate?.verdict).toBe("warn");
+    expect(depGate?.findings.some((f) => /lodash@\^4\.17\.21/.test(f))).toBe(true);
+  });
+
+  it("flags a new dependency added at the end of a block (no trailing comma)", () => {
     const diff = `diff --git a/package.json b/package.json
 index aaaaaaa..bbbbbbb 100644
 --- a/package.json
@@ -102,6 +118,68 @@ index aaaaaaa..bbbbbbb 100644
     const depGate = result.gates.find((g) => g.gate === "dependency-audit");
     expect(depGate?.verdict).toBe("warn");
     expect(depGate?.findings.some((f) => /lodash@\^4\.17\.21/.test(f))).toBe(true);
+    // zod's reformat (added a trailing comma) is not a new dep — must not warn.
+    expect(depGate?.findings.some((f) => /zod/.test(f))).toBe(false);
+  });
+
+  it("does not warn on a version bump (paired - and + for the same key)", () => {
+    // A bump line looks identical to a new add in isolation. The gate must
+    // pair the `-` and `+` for the same key and treat that as a bump, not a
+    // new dependency.
+    const diff = `diff --git a/package.json b/package.json
+index aaaaaaa..bbbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,5 +10,5 @@
+     "react": "^18.2.0",
+-    "next": "^14.0.0",
++    "next": "^14.1.0",
+     "zod": "^3.22.0"
+   },
+`;
+    const result = runPrePRGates(diff);
+    const depGate = result.gates.find((g) => g.gate === "dependency-audit");
+    expect(depGate?.verdict).toBe("pass");
+    expect(depGate?.findings).toHaveLength(0);
+  });
+
+  it("treats a name change as a new add (different key on the + side)", () => {
+    // A renamed dep removes one key and adds a different key — the new key
+    // has no matching `-` line, so it should be flagged as a new dependency.
+    const diff = `diff --git a/package.json b/package.json
+index aaaaaaa..bbbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,5 +10,5 @@
+     "react": "^18.2.0",
+-    "moment": "^2.29.0",
++    "dayjs": "^1.11.0",
+     "zod": "^3.22.0"
+   },
+`;
+    const result = runPrePRGates(diff);
+    const depGate = result.gates.find((g) => g.gate === "dependency-audit");
+    expect(depGate?.verdict).toBe("warn");
+    expect(depGate?.findings.some((f) => /dayjs@\^1\.11\.0/.test(f))).toBe(true);
+    expect(depGate?.findings.some((f) => /moment/.test(f))).toBe(false);
+  });
+
+  it("passes when a dependency is only removed", () => {
+    const diff = `diff --git a/package.json b/package.json
+index aaaaaaa..bbbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,5 +10,4 @@
+     "react": "^18.2.0",
+-    "lodash": "^4.17.21",
+     "next": "^14.0.0",
+     "zod": "^3.22.0"
+   },
+`;
+    const result = runPrePRGates(diff);
+    const depGate = result.gates.find((g) => g.gate === "dependency-audit");
+    expect(depGate?.verdict).toBe("pass");
+    expect(depGate?.findings).toHaveLength(0);
   });
 
   it("passes when no package.json files are in the diff", () => {

--- a/apps/web/lib/integrate/pre-pr-gates.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.ts
@@ -39,19 +39,30 @@ function extractFilePaths(diff: string): string[] {
   return [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((m) => m[1]);
 }
 
-function extractAddedLinesForFile(diff: string, filePath: string): string[] {
+function extractDiffLinesForFile(
+  diff: string,
+  filePath: string,
+): { added: string[]; removed: string[] } {
   // Split the diff on file-block boundaries so we can isolate one file's hunk
   // without relying on a multiline regex (the previous `^...(?=^diff --git|$)/m`
   // version stopped at the first newline because `$` matches end-of-line under /m).
   const blocks = diff.split(/^(?=diff --git )/m);
   const header = `diff --git a/${filePath} `;
   const target = blocks.find((b) => b.startsWith(header));
-  if (!target) return [];
+  if (!target) return { added: [], removed: [] };
 
-  return target
-    .split("\n")
-    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
-    .map((line) => line.slice(1));
+  const added: string[] = [];
+  const removed: string[] = [];
+  for (const line of target.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) added.push(line.slice(1));
+    else if (line.startsWith("-")) removed.push(line.slice(1));
+  }
+  return { added, removed };
+}
+
+function extractAddedLinesForFile(diff: string, filePath: string): string[] {
+  return extractDiffLinesForFile(diff, filePath).added;
 }
 
 // ─── Gate 1: Security Scan ──────────────────────────────────────────────────
@@ -140,6 +151,21 @@ function runArchitectureGate(diff: string): GateResult {
 
 // ─── Gate 4: Dependency Audit ───────────────────────────────────────────────
 
+// Matches a single dep entry line: `    "name": "^1.2.3",` or `"name": "1.2.3"` (no comma).
+// Version must start with a digit (optionally prefixed by ~ or ^), which keeps the regex from
+// matching section headers like `"dependencies": {`. Trailing comma is optional so mid-block
+// and end-of-block adds both match.
+const DEP_LINE_RE = /^\s*"([^"]+)"\s*:\s*"([~^]?\d[^"]*)",?\s*$/;
+
+function parseDepLines(lines: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const line of lines) {
+    const m = line.match(DEP_LINE_RE);
+    if (m) out.set(m[1], m[2]);
+  }
+  return out;
+}
+
 function runDependencyGate(diff: string): GateResult {
   const files = extractFilePaths(diff);
   const packageFiles = files.filter((f) => f.endsWith("package.json"));
@@ -150,14 +176,17 @@ function runDependencyGate(diff: string): GateResult {
 
   const findings: string[] = [];
   for (const pf of packageFiles) {
-    const lines = extractAddedLinesForFile(diff, pf);
-    for (const line of lines) {
-      // Match new dependency additions: "name": "^version"
-      const depMatch = line.match(/^\s*"([^"]+)"\s*:\s*"([~^]?\d[^"]*)"$/);
-      if (depMatch) {
-        const [, name, version] = depMatch;
-        findings.push(`New dependency: ${name}@${version} (in ${pf}) — verify it is vetted and license-compatible`);
-      }
+    const { added, removed } = extractDiffLinesForFile(diff, pf);
+    const addedDeps = parseDepLines(added);
+    const removedDeps = parseDepLines(removed);
+
+    // A pure add (name appears only in `+` lines) is a new dependency.
+    // A `+` paired with a matching `-` for the same name is a version bump — skip.
+    for (const [name, version] of addedDeps) {
+      if (removedDeps.has(name)) continue;
+      findings.push(
+        `New dependency: ${name}@${version} (in ${pf}) — verify it is vetted and license-compatible`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

PR #580's `extractAddedLinesForFile` fix made the pre-PR gates actually see added lines — which uncovered two more bugs in the dependency-audit gate at [pre-pr-gates.ts:143-169](apps/web/lib/integrate/pre-pr-gates.ts):

1. **Anchored on `"$`** — the dep-line regex matched only the LAST entry in a `dependencies` block, silently missing every mid-block entry (the common case, since most entries have a trailing comma).
2. **Couldn't tell adds from bumps** — `+    "next": "^14.1.0",` looked identical to a brand-new add, so every routine version bump triggered a false-positive warning, and the gate added no real security signal even if (1) were fixed.

## Changes

- **`extractDiffLinesForFile`** (new helper) returns both added and removed lines for a given file path, using the same `split(/^(?=diff --git )/m)` boundary the destructive-ops fix introduced. `extractAddedLinesForFile` becomes a thin wrapper so existing callers (destructive-ops, architecture) are unaffected.
- **`DEP_LINE_RE`** allows an optional trailing comma (`,?\s*$`) so mid-block and end-of-block adds both match.
- **`runDependencyGate`** pairs `+` and `-` by key name: a `+` with no matching `-` is a new dep; a paired `+`/`-` for the same key is a version bump (skipped). Name changes naturally fall through as new adds.
- Existing dep-gate test updated from a last-position add (no comma) to a mid-block add (with comma) so it actually exercises the real case.
- New tests: end-of-block add, version bump (must not warn), name change (treat as new add), removal only (must pass).
- Semantics preserved: `findings.length > 0 → warn`. This is an audit gate, not a blocker.

## Stacking note

Stacked on top of [#580](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/580). The destructive-ops fix from #580 (one commit, `ae0debaa`) is the prerequisite this branch was built on; once #580 merges, this branch fast-forwards cleanly.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/pre-pr-gates.test.ts` — 10/10 pass
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web test` (full web suite) — 4768 pass, 14 skipped, 13 todo

Signed-off-by: Mark Bodman <markdbodman@gmail.com>