### PR TITLE
fix(build): compact current work layout

### DIFF
--- a/apps/web/components/build/BuildListItem.test.tsx
+++ b/apps/web/components/build/BuildListItem.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BuildListItem } from "@/components/build/BuildListItem";
+import { BUILD_STUDIO_TEST_IDS } from "@/components/build/build-studio-layout";
+import {
+  normalizeHappyPathState,
+  type FeatureBuildRow,
+} from "@/lib/feature-build-types";
+
+function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    id: "build-row-1",
+    buildId: "FB-9B19098C",
+    title: "Fix Build Studio current work layout",
+    description: "Keep current work scannable while work is in progress.",
+    portfolioId: null,
+    originatingBacklogItemId: "backlog-row-1",
+    brief: null,
+    plan: null,
+    phase: "build",
+    sandboxId: null,
+    sandboxPort: null,
+    diffSummary: null,
+    diffPatch: null,
+    codingProvider: null,
+    threadId: null,
+    digitalProductId: null,
+    product: null,
+    createdById: "user-1",
+    createdAt: new Date("2026-04-25T12:00:00Z"),
+    updatedAt: new Date("2026-04-25T14:30:00Z"),
+    draftApprovedAt: null,
+    designDoc: null,
+    designReview: null,
+    buildPlan: null,
+    planReview: null,
+    taskResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    scoutFindings: null,
+    uxTestResults: null,
+    uxVerificationStatus: null,
+    accountableEmployeeId: null,
+    claimedByAgentId: null,
+    claimedAt: null,
+    claimStatus: null,
+    buildExecState: null,
+    deliberationSummary: null,
+    happyPathState: normalizeHappyPathState(null),
+    originator: {
+      id: "backlog-row-1",
+      itemId: "BI-5B839D74",
+      title: "Fix Build Studio current work layout",
+      status: "in-progress",
+      triageOutcome: "build",
+      effortSize: "small",
+      proposedOutcome: null,
+      activeBuildId: "build-row-1",
+      resolution: null,
+      abandonReason: null,
+    },
+    phaseHandoffs: [],
+    ...overrides,
+  };
+}
+
+describe("BuildListItem", () => {
+  it("renders a bounded, accessible current-work row", () => {
+    const title = "Repair disconnected Build Studio current work surface with an intentionally long title that should not dominate the sidebar";
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild({ title })}
+        active
+        index={2}
+        lifecycleLabel="In build"
+        isDevEnvironment={false}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain(`data-testid="${BUILD_STUDIO_TEST_IDS.buildListItem}"`);
+    expect(html).toContain(`title="${title}"`);
+    expect(html).toContain(`aria-label="Open build ${title}"`);
+    expect(html).toMatch(/class=\"line-clamp-2 max-h-\[2\.5rem\] min-w-0 overflow-hidden break-words text-sm font-semibold leading-5 text-\[var\(--dpf-text\)\]\"/);
+    expect(html).toContain("min-h-[88px]");
+    expect(html).toContain("max-h-[128px]");
+    expect(html).toContain("Updated Apr 25");
+    expect(html).toContain("In build");
+  });
+
+  it("keeps delete as a separate control instead of nesting it inside the select button", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('aria-label="Open build Fix Build Studio current work layout"');
+    expect(html).toContain('aria-label="Delete Fix Build Studio current work layout"');
+    const openControlStart = html.indexOf('aria-label="Open build Fix Build Studio current work layout"');
+    const deleteControlStart = html.indexOf('aria-label="Delete Fix Build Studio current work layout"');
+    expect(openControlStart).toBeGreaterThan(-1);
+    expect(deleteControlStart).toBeGreaterThan(openControlStart);
+    expect(html.slice(openControlStart, deleteControlStart)).toContain("</button>");
+  });
+});

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import type { FeatureBuildRow } from "@/lib/feature-build-types";
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+type BuildListItemProps = {
+  build: FeatureBuildRow;
+  active: boolean;
+  index: number;
+  lifecycleLabel: string | null;
+  isDevEnvironment: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+};
+
+function formatUpdatedAt(value: Date | string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
+export function BuildListItem({
+  build,
+  active,
+  index,
+  lifecycleLabel,
+  isDevEnvironment,
+  onSelect,
+  onDelete,
+}: BuildListItemProps) {
+  return (
+    <div
+      data-testid={BUILD_STUDIO_TEST_IDS.buildListItem}
+      className="group mb-1 flex max-h-[128px] min-h-[88px] min-w-0 rounded-md border transition-all duration-150 hover:bg-[var(--dpf-surface-2)] hover:shadow-dpf-xs animate-slide-up"
+      style={{
+        animationDelay: `${index * 30}ms`,
+        animationFillMode: "backwards",
+        borderColor: active ? "var(--dpf-accent)" : "transparent",
+        background: active ? "var(--dpf-surface-2)" : "transparent",
+      }}
+    >
+      <button
+        type="button"
+        aria-label={`Open build ${build.title}`}
+        aria-pressed={active}
+        onClick={onSelect}
+        className="min-w-0 flex-1 cursor-pointer rounded-l-md px-3 py-2.5 text-left focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
+      >
+        <div
+          title={build.title}
+          className="line-clamp-2 max-h-[2.5rem] min-w-0 overflow-hidden break-words text-sm font-semibold leading-5 text-[var(--dpf-text)]"
+        >
+          {build.title}
+        </div>
+        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-[var(--dpf-muted)]">
+          <span className="font-mono">{build.buildId}</span>
+          {build.originator && (
+            <span className="inline-flex max-w-full min-w-0 items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-1.5 py-0.5 font-medium text-[var(--dpf-text)]">
+              {build.originator.itemId}
+            </span>
+          )}
+          <span className="capitalize">{build.phase}</span>
+          <span>Updated {formatUpdatedAt(build.updatedAt)}</span>
+        </div>
+        <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5">
+          {lifecycleLabel && (
+            <span className="inline-flex max-w-full min-w-0 items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.04em] text-[var(--dpf-text)]">
+              <span className="truncate">{lifecycleLabel}</span>
+            </span>
+          )}
+          {build.product && (
+            <span className="truncate text-xs text-[var(--dpf-muted)]">
+              v{build.product.version} · {build.product.backlogCount} item{build.product.backlogCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </button>
+      <button
+        type="button"
+        aria-label={`Delete ${build.title}`}
+        disabled={isDevEnvironment}
+        onClick={onDelete}
+        className="grid w-8 shrink-0 cursor-pointer place-items-start rounded-r-md px-2 py-2 text-xs text-[var(--dpf-muted)] transition-colors hover:text-[var(--dpf-error)] focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/build/BuildStudio.test.ts
+++ b/apps/web/components/build/BuildStudio.test.ts
@@ -17,6 +17,8 @@ describe("build-studio-layout", () => {
   it("keeps the graph panel container-driven instead of using old fullscreen math", () => {
     expect(getBuildStudioGraphPanelClassName()).toContain("min-h-[420px]");
     expect(getBuildStudioGraphPanelClassName()).toContain("flex-1");
+    expect(getBuildStudioGraphPanelClassName()).toContain("flex-col");
+    expect(getBuildStudioGraphPanelClassName()).toContain("min-w-0");
     expect(getBuildStudioGraphPanelClassName()).not.toContain("100vh");
   });
 
@@ -26,6 +28,7 @@ describe("build-studio-layout", () => {
     expect(getBuildStudioSidebarClassName(false)).toContain("w-0");
     expect(BUILD_STUDIO_TEST_IDS.shell).toBe("build-studio-shell");
     expect(BUILD_STUDIO_TEST_IDS.graphPanel).toBe("build-studio-graph-panel");
+    expect(BUILD_STUDIO_TEST_IDS.buildListItem).toBe("build-studio-build-list-item");
   });
 });
 

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -12,6 +12,7 @@ import { ProcessGraph } from "./ProcessGraph";
 import { ReleaseDecisionPanel } from "./ReleaseDecisionPanel";
 import { BuildStudioWorkflowActionCard } from "./BuildStudioWorkflowActionCard";
 import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
+import { BuildListItem } from "./BuildListItem";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
 import { createFeatureBuild, deleteFeatureBuild } from "@/lib/actions/build";
@@ -378,58 +379,26 @@ export function BuildStudio({
                 });
 
                 return (
-                <button
-                  key={build.buildId}
-                  onClick={() => { setActiveBuild(build); setSidebarOpen(true); }}
-                  className="block w-full text-left px-3 py-2.5 mb-1 rounded-md cursor-pointer transition-all duration-150 hover:bg-[var(--dpf-surface-2)] hover:shadow-dpf-xs animate-slide-up focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
-                  style={{
-                    animationDelay: `${idx * 30}ms`,
-                    animationFillMode: "backwards",
-                    border: activeBuild?.buildId === build.buildId
-                      ? "1px solid var(--dpf-accent)"
-                      : "1px solid transparent",
-                    background: activeBuild?.buildId === build.buildId
-                      ? "var(--dpf-surface-2)"
-                      : "transparent",
-                  }}
-                >
-                  <div className="flex min-w-0 items-start justify-between gap-2">
-                    <div className="mb-0.5 min-w-0 flex-1 break-words text-sm font-semibold text-[var(--dpf-text)]">{build.title}</div>
-                    <button
-                      type="button"
-                      aria-label={`Delete ${build.title}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (isDevEnvironment) return;
-                        if (!confirm(`Delete "${build.title}"?`)) return;
-                        deleteFeatureBuild(build.buildId).then(() => {
-                          if (activeBuild?.buildId === build.buildId) setActiveBuild(null);
-                          router.refresh();
-                        });
-                      }}
-                      className="text-[var(--dpf-muted)] hover:text-[var(--dpf-error)] text-xs ml-2 shrink-0 cursor-pointer focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 rounded"
-                    >
-                      &times;
-                    </button>
-                  </div>
-                  <div className="text-xs text-[var(--dpf-muted)]">
-                    {build.buildId}
-                    {build.originator && (
-                      <span> &middot; {build.originator.itemId}</span>
-                    )}
-                    <span> &middot; {build.phase}</span>
-                    {build.product && (
-                      <span> &middot; v{build.product.version} &middot; {build.product.backlogCount} item{build.product.backlogCount !== 1 ? "s" : ""}</span>
-                    )}
-                  </div>
-                  {lifecycleLabel && (
-                    <div className="mt-2">
-                      <span className="inline-flex items-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.04em] text-[var(--dpf-text)]">
-                        {lifecycleLabel}
-                      </span>
-                    </div>
-                  )}
-                </button>
+                  <BuildListItem
+                    key={build.buildId}
+                    build={build}
+                    active={activeBuild?.buildId === build.buildId}
+                    index={idx}
+                    lifecycleLabel={lifecycleLabel}
+                    isDevEnvironment={isDevEnvironment}
+                    onSelect={() => {
+                      setActiveBuild(build);
+                      setSidebarOpen(true);
+                    }}
+                    onDelete={() => {
+                      if (isDevEnvironment) return;
+                      if (!confirm(`Delete "${build.title}"?`)) return;
+                      deleteFeatureBuild(build.buildId).then(() => {
+                        if (activeBuild?.buildId === build.buildId) setActiveBuild(null);
+                        router.refresh();
+                      });
+                    }}
+                  />
                 );
               })
             )}
@@ -443,7 +412,12 @@ export function BuildStudio({
               <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="m-0 min-w-0 break-words text-base font-bold text-[var(--dpf-text)]">{activeBuild.title}</h2>
+                    <h2
+                      title={activeBuild.title}
+                      className="m-0 max-h-[3rem] min-w-0 overflow-hidden break-words text-base font-bold leading-6 text-[var(--dpf-text)] line-clamp-2"
+                    >
+                      {activeBuild.title}
+                    </h2>
                     <ClaimBadge agentId={activeBuild.claimedByAgentId ?? null} claimStatus={activeBuild.claimStatus ?? null} claimedAt={activeBuild.claimedAt ?? null} />
                   </div>
                   <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -164,6 +164,22 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain("First build</h2>");
   });
 
+  it("bounds the active-build title so long work names cannot take over the canvas", () => {
+    const longTitle = "Investigate and repair disconnected Build Studio current work surfaces with a very long backlog-derived title that used to consume the entire header";
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild({ title: longTitle })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain(`title="${longTitle}"`);
+    expect(html).toMatch(/class=\"m-0 max-h-\[3rem\] min-w-0 overflow-hidden break-words text-base font-bold leading-6 text-\[var\(--dpf-text\)\] line-clamp-2\"/);
+  });
+
   it("renders the submission branch badge in a truncating wrapper instead of an unconstrained inline chip", () => {
     const html = renderToStaticMarkup(
       <BuildStudio

--- a/apps/web/components/build/build-studio-layout.ts
+++ b/apps/web/components/build/build-studio-layout.ts
@@ -1,6 +1,7 @@
 export const BUILD_STUDIO_TEST_IDS = {
   shell: "build-studio-shell",
   graphPanel: "build-studio-graph-panel",
+  buildListItem: "build-studio-build-list-item",
 } as const;
 
 export function getBuildStudioShellClassName() {
@@ -26,5 +27,5 @@ export function getBuildStudioSidebarClassName(sidebarOpen: boolean) {
 }
 
 export function getBuildStudioGraphPanelClassName() {
-  return "flex min-h-[420px] flex-1 overflow-hidden px-4 pb-4 pt-3";
+  return "flex min-h-[420px] min-w-0 flex-1 flex-col overflow-hidden px-4 pb-4 pt-3";
 }


### PR DESCRIPTION
## Summary

Compact the Build Studio current-work surface so active/in-progress items stay scannable instead of letting long titles and nested controls take over the layout.

## Changes

- Extracted the sidebar build row into `BuildListItem` with bounded height, two-line title clamping, updated timestamp, and separate select/delete controls.
- Bounded the active build header title and retained the full title via tooltip.
- Made the graph panel explicitly column-oriented and min-width constrained.
- Added focused tests for bounded rows, header title bounds, test ids, and the non-nested delete control.

## Test plan

- [x] `pnpm --filter web exec vitest run components/build/BuildStudio.test.ts components/build/BuildStudioHeaderLayout.test.tsx components/build/BuildListItem.test.tsx`
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web build`
- [ ] Shared-portal manual verification after the shared `D:\DPF` main checkout/runtime is safe to refresh

## Notes for the reviewer

The production build still emits the existing Turbopack broad-trace warnings around `apps/web/lib/backlog/spec-plan-search.ts` / `next.config.mjs`; this PR does not add new build warnings.