### PR TITLE
doc(principles): batch 4c - promote 6 contextual rules from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Tool-specific files (`CLAUDE.md`, `.cursor/rules/`, `.clinerules/`, `.github/cop
 - **Live state over seed data.** Query the database for current epics, backlog, users, capabilities, status. → [kernel principle](docs/founder-kernel/wiki/principles/live-state-over-seed-data.md)
 - **Single source of truth.** Each rule, fact, or decision in exactly one place. Pointers, not copies. → [kernel principle](docs/founder-kernel/wiki/principles/single-source-of-truth.md)
 - **Architecture over shortcuts.** Choose the architecturally sound solution. Quick fixes that bypass the design create more debt than they save. → [kernel principle](docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md)
-- **Plan before acting on install/seed/template paths.** A symptom on one install is usually a defect for every install. Use `writing-plans` for anything touching setup, seeds, or shared templates.
+- **Plan before acting on install/seed/template paths.** A symptom on one install is usually a defect for every install. Use `writing-plans` for anything touching setup, seeds, or shared templates. → [kernel principle](docs/founder-kernel/wiki/principles/plan-before-install-paths.md)
 - **Use paid AI capacity responsibly.** → [kernel principle](docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md)
 
 ## 2. Project Architecture (current as of 2026-04-27)
@@ -49,11 +49,11 @@ Hyphens, not underscores. Adding a new value requires updating both `backlog.ts`
 - **All changes land via PR against `main`** — including the maintainer's. Branch protection enforces it. → [kernel principle](docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md)
 - **One concern per branch, one concern per PR.** Topic branches named by intent: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `doc/<slug>`, `clean/<slug>`. Branch from `main`. → [kernel principle](docs/founder-kernel/wiki/principles/one-concern-per-pr.md)
 - **DCO sign-off required on every commit.** Use `git commit -s`. The DCO bot blocks merge until every commit has a `Signed-off-by:` trailer. → [kernel principle](docs/founder-kernel/wiki/principles/dco-sign-off-required.md)
-- **Always push** after committing. Local-only commits are invisible to CI.
+- **Always push** after committing. Local-only commits are invisible to CI. → [kernel principle](docs/founder-kernel/wiki/principles/always-push-after-committing.md)
 - **Squash-and-delete on merge:** `gh pr merge <n> --squash --delete-branch`.
 - **Concurrent sessions:** one thread = one branch + one git worktree. Create with `git worktree add ../DPF-<topic> -b <prefix>/<topic>`. Never share a working tree across sessions; doing so causes index/HEAD collisions and cross-thread file sweeps. → [kernel principle](docs/founder-kernel/wiki/principles/worktree-per-session.md)
 - **After creating a worktree, seed its MCP config:** `.mcp.json` and `.vscode/mcp.json` are gitignored (they carry your local `dpfmcp_...` bearer token), so `git worktree add` does not carry them across. Run `scripts/seed-worktree-mcp.ps1` (Windows) or `scripts/seed-worktree-mcp.sh` (macOS / Linux) from inside the new worktree to copy them from the root clone. The script is predicated on the platform being installed and an MCP token already generated at Admin > Platform Development. Restart Claude Code in the worktree afterwards so `/mcp` picks up the `dpf` connector.
-- **Keep the root clone as the merge/release worktree** — read-only for active feature work. Conventional locations: `d:\DPF` on Windows, `~/dpf` on macOS/Linux. Topic worktrees go alongside (`d:\DPF-<topic>` or `~/dpf-worktrees/<topic>`).
+- **Keep the root clone as the merge/release worktree** — read-only for active feature work. Conventional locations: `d:\DPF` on Windows, `~/dpf` on macOS/Linux. Topic worktrees go alongside (`d:\DPF-<topic>` or `~/dpf-worktrees/<topic>`). → [kernel principle](docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md)
 - **Branch guard before implementation and commit:** if `git status --short --branch` reports `HEAD (no branch)` or `git branch --show-current` returns `main`, abort before serious implementation. Create/switch to a topic branch first. Do not claim work is complete while commits are local-only; completion requires a pushed branch or PR unless the user explicitly asked not to publish. → [kernel principle](docs/founder-kernel/wiki/principles/branch-guard-before-implementation.md)
 
 ## 5. Verification — Build Gate (mandatory)
@@ -77,9 +77,9 @@ TypeScript errors only surface in `next build`, not in `vitest` or IDE checks. R
 
 - **Backlog lives in PostgreSQL** (`Epic`, `BacklogItem`). Always query live state before planning or changing backlog work. → [kernel principle](docs/founder-kernel/wiki/principles/backlog-lives-in-postgresql.md)
 - **Use the DPF MCP backlog tools first when available.** Local agent clients are configured by the untracked `.mcp.json` generated from Admin > Platform Development. It points the `dpf` server at the canonical MCP endpoint `/api/mcp/v1`, which exposes backlog/planning tools such as `list_backlog_items`, `get_backlog_item`, `create_backlog_item`, `update_backlog_item_status`, `list_epics`, `link_backlog_item_to_epic`, `search_specs_and_plans`, and `record_execution_evidence` according to the caller's token scopes.
-- **DB fallback must be explicit.** If the `dpf` MCP server is unavailable in the current agent session, query the live Postgres database directly and say that you used DB fallback. Do not substitute `packages/db/src/seed.ts`, generated Prisma files, or stale docs for current backlog state.
+- **DB fallback must be explicit.** If the `dpf` MCP server is unavailable in the current agent session, query the live Postgres database directly and say that you used DB fallback. Do not substitute `packages/db/src/seed.ts`, generated Prisma files, or stale docs for current backlog state. → [kernel principle](docs/founder-kernel/wiki/principles/db-fallback-explicit.md)
 - **Specs and plans** live in `docs/superpowers/specs/` and `docs/superpowers/plans/`. Check for an existing design before starting work — some are ready to implement.
-- **Before creating a new epic:** query existing epics for overlap. Prefer extending an existing epic over creating a new one. If superseding an old epic, mark it done in the same operation.
+- **Before creating a new epic:** query existing epics for overlap. Prefer extending an existing epic over creating a new one. If superseding an old epic, mark it done in the same operation. → [kernel principle](docs/founder-kernel/wiki/principles/check-epic-overlap-before-creating.md)
 - **On completing items:** update status in the DB immediately. The system auto-closes epics when all items are done/deferred. Direct DB ops require manually flipping the parent epic.
 - **Periodic hygiene:** epics with 0 items + status `open` are noise — add items or delete. Epics where all items are done but status is still `open` must be flipped.
 
@@ -163,7 +163,7 @@ Every release passes the QA test plan at `tests/e2e/platform-qa-plan.md` (15 pha
 
 ## 15. Communication
 
-- If uncommitted changes exist, mention them before starting new work.
+- If uncommitted changes exist, mention them before starting new work. → [kernel principle](docs/founder-kernel/wiki/principles/mention-uncommitted-changes.md)
 - When committing, list what's included.
 - State results and decisions directly. No running commentary on internal deliberation. → [kernel principle](docs/founder-kernel/wiki/principles/state-results-directly.md)
 - Maintain forward momentum: when the current work naturally implies a next step, name the next smallest useful step from the thread direction and company context. Keep it quiet and operational - no sales pitch, no broad re-planning unless asked.

--- a/docs/founder-kernel/manifest.json
+++ b/docs/founder-kernel/manifest.json
@@ -1,7 +1,7 @@
 {
   "kernelVersion": "0.2.1",
   "schemaVersion": "0.2.0",
-  "pageCount": 54,
+  "pageCount": 60,
   "sourceCount": 11,
   "embeddingModel": null,
   "builtAt": null,

--- a/docs/founder-kernel/wiki/principles/always-push-after-committing.md
+++ b/docs/founder-kernel/wiki/principles/always-push-after-committing.md
@@ -1,0 +1,48 @@
+---
+title: Always Push After Committing
+pageKind: principle
+status: published
+abstract: Local-only commits are invisible to CI and to other agents. Push every commit so the work exists.
+principleTier: contextual
+principleDirection: Push after every commit; never leave work as local-only.
+principleDimensionVector: {"evidence_density": 0.5, "governance_compliance": 0.4, "blast_radius": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: true
+principlePublicRationale: Adopters working in DPF need to know that completion requires pushed evidence — claiming "done" with unpushed commits is a real failure mode the principle prevents.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+After committing, push. Local-only commits are invisible to CI, invisible to reviewers, and invisible to other concurrent sessions — they may as well not exist. Completion claims require pushed evidence, not local-only commits.
+
+## Why
+
+A commit that exists only locally is in a state that looks done to the author but is not done from anyone else's perspective. CI hasn't run; the DCO bot hasn't checked sign-off; reviewers can't see the diff; other concurrent agents can't depend on the change. The window between local commit and push is the window where work can silently vanish — a corrupted disk, a deleted worktree, a forgotten branch. Push closes that window.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and humans running git locally. Symmetric. Applies after every commit. Does NOT apply when the user has explicitly asked for local-only work — but that's the exception, not the default.
+
+## How To Apply
+
+After `git commit`, run `git push` (or `git push -u origin <branch>` for the first push of a new branch). Configure shell aliases or git hooks to make the push the default tail of every commit if local discipline keeps slipping. When claiming work is complete, verify `git status` shows zero unpushed commits before the claim.
+
+## Decision Dimensions
+
+- `evidence_density: 0.5` — pushed commits are verifiable evidence; local-only commits are author-claimed evidence only.
+- `governance_compliance: 0.4` — CI / DCO / branch protection only fire on pushed commits.
+- `blast_radius: 0.3` — local-only commits aren't shared, so their loss doesn't propagate; the principle is about preventing the loss, not containing it.
+
+## Examples
+
+- **Positive:** Agent commits five changes locally, runs `git push`, sees CI pick them up, reports "done" only after the push completes.
+- **Counterexample:** Agent commits five changes, says "done," and stops. An hour later the operator asks for the PR link; the commits are still local; the agent has to push and re-validate that CI passes before the operator can review.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)

--- a/docs/founder-kernel/wiki/principles/check-epic-overlap-before-creating.md
+++ b/docs/founder-kernel/wiki/principles/check-epic-overlap-before-creating.md
@@ -1,0 +1,48 @@
+---
+title: Check Epic Overlap Before Creating
+pageKind: principle
+status: published
+abstract: Before creating a new epic, query existing epics for overlap. Prefer extending an existing epic; supersede explicitly when warranted.
+principleTier: contextual
+principleDirection: Search the existing epic list before creating a new one; extend rather than parallel.
+principleDimensionVector: {"long_term_maintainability": 0.5, "reusability": 0.4, "schema_grounding": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: true
+principlePublicRationale: Adopters managing the DPF backlog benefit from the no-parallel-epic discipline — duplicate epics are a real source of confusion.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Before creating a new epic, query existing epics for overlap (`list_epics` via MCP, or a Postgres query). Prefer extending an existing epic over creating a new one. If the new epic genuinely supersedes an old one, mark the old epic `done` in the same operation so the lineage is explicit.
+
+## Why
+
+Parallel epics for the same conceptual work fracture the backlog: items get filed under the wrong one, status rollups stop being meaningful, and the operator loses the ability to ask "what's the state of X?" with one query. The discipline is cheap (one MCP call) and pays back every time someone looks at the backlog. The platform's epic auto-close mechanism only works if there is one epic per concept; parallel epics break that mechanism silently.
+
+## Applies To
+
+In-platform coworkers managing the backlog (Build Studio, recommendation agents), external coding agents authoring new work, and humans setting product direction. Applies before any `create_epic` call. Does NOT apply to genuinely new conceptual surfaces that don't overlap any existing epic — those legitimately need a new epic.
+
+## How To Apply
+
+Before creating an epic, run `list_epics` (filtered by `hasOpenItems` if appropriate) and search the result for conceptual overlap with the work you're about to file. If overlap exists, extend the existing epic by adding items to it rather than creating a parallel epic. If the new work supersedes an old epic (e.g., a v2 design replaces v1), mark the old one `done` in the same operation and link the new items to the new epic.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.5` — consolidated epics age better than fragmented ones.
+- `reusability: 0.4` — items filed under the consolidated epic compose with each other; parallel filings don't.
+- `schema_grounding: 0.3` — the `Epic` model expects one epic per concept; the principle enforces that constraint.
+
+## Examples
+
+- **Positive:** Before filing EP-PRIN-* for "principles-as-wiki-kind," the implementer runs `list_epics` and finds `EP-TAK-3F9A21` (governed memory + MCP surfaces). The principles work attaches as items under the existing TAK epic instead of creating a parallel.
+- **Counterexample:** Same scenario, but the implementer files `EP-PRIN-001` as a parallel epic. Six months later the backlog rollup shows TAK as "92% done" and PRIN as "30% done" — but they're the same conceptual workstream, and the operator can't tell at a glance.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)

--- a/docs/founder-kernel/wiki/principles/db-fallback-explicit.md
+++ b/docs/founder-kernel/wiki/principles/db-fallback-explicit.md
@@ -1,0 +1,47 @@
+---
+title: DB Fallback Must Be Explicit
+pageKind: principle
+status: published
+abstract: When the DPF MCP backlog tools are unavailable, query Postgres directly AND say you used DB fallback.
+principleTier: contextual
+principleDirection: When falling back to direct Postgres, name the fallback path in the response.
+principleDimensionVector: {"evidence_density": 0.6, "governance_compliance": 0.4, "human_cognitive_load": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principlePublic: true
+principlePublicRationale: Adopters consuming agent responses need to know which retrieval path produced the answer — silent fallbacks confuse downstream debugging.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+When the DPF MCP backlog tools are unavailable in the current agent session, query the live Postgres database directly AND say that DB fallback is in use. Do not substitute `packages/db/src/seed.ts`, generated Prisma files, or stale docs for current backlog state. The disclosure is a one-line addition to the response.
+
+## Why
+
+A silent fallback corrupts the downstream debugging chain. If an operator sees an unexpected answer and the agent didn't say which retrieval path produced it, the operator can't tell whether the agent used the MCP tools (and the MCP returned wrong data) or fell back to Postgres (and the agent queried a stale slot). Naming the path eliminates that ambiguity; the operator knows immediately where to look for the bug. The principle is about transparency of provenance, not about the fallback itself — the fallback is fine, the silent fallback is the failure mode.
+
+## Applies To
+
+In-platform coworkers and external coding agents using the DPF MCP backlog surface. Does NOT apply when the MCP tools are working as expected — those calls don't need a disclosure.
+
+## How To Apply
+
+When an MCP tool call fails or the MCP server is unavailable, log the failure, fall back to a direct Postgres query, and add a one-liner to the response: "DB fallback in use; MCP backlog tools were unavailable for this query." Then proceed with the answer. The operator now knows which path produced the data and can correlate any unexpected results with the fallback rather than the tool layer.
+
+## Decision Dimensions
+
+- `evidence_density: 0.6` — naming the provenance keeps the response auditable; silent fallbacks lose that audit.
+- `governance_compliance: 0.4` — the disclosure pattern is part of DPF's transparency contract for agent responses.
+- `human_cognitive_load: -0.3` — operators don't have to chase down "why is this weird?" when they can see the path the agent used.
+
+## Examples
+
+- **Positive:** Asked "what's the BI list for EP-X?", the agent tries `list_backlog_items` via MCP, gets a connection error, falls back to Postgres, and responds: "DB fallback in use. Items under EP-X: ..."
+- **Counterexample:** Same scenario, but the agent silently falls back and answers as if MCP worked. Operator sees rows that don't match the expected list; debugging the MCP server takes an hour before someone notices the agent never actually hit it.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)

--- a/docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md
+++ b/docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md
@@ -1,0 +1,48 @@
+---
+title: Keep the Root Clone as the Merge/Release Worktree
+pageKind: principle
+status: published
+abstract: Treat the root clone as read-only for active feature work. Topic worktrees go alongside.
+principleTier: contextual
+principleDirection: Reserve the root clone for merges and releases; do feature work in dedicated worktrees.
+principleDimensionVector: {"blast_radius": 0.5, "long_term_maintainability": 0.3, "governance_compliance": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: true
+principlePublicRationale: Documents DPF's worktree layout convention so contributors don't accidentally turn the root clone into a feature workspace.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Treat the root clone (`d:\DPF` on Windows, `~/dpf` on macOS/Linux) as read-only for active feature work. Topic worktrees live alongside: `d:\DPF-<topic>` or `~/dpf-worktrees/<topic>`. The root clone is reserved for merges, releases, and verifying that the latest main state is operational.
+
+## Why
+
+The root clone is what every concurrent agent and every release script expects to find at the canonical path. If the root has uncommitted feature work, switching to main for a merge requires stashing first; if the stash gets lost or applied wrong, work disappears. Keeping the root clean — always on main, always synced to origin — eliminates that whole failure mode. Topic worktrees give each feature its own isolated working tree without contaminating the root.
+
+## Applies To
+
+Humans and AI agents running git locally. Symmetric. Applies to every feature, fix, doc, or chore branch. Does NOT apply to small one-off operational tasks (running `pnpm install`, viewing release notes) that don't involve commits.
+
+## How To Apply
+
+When starting a new piece of feature work, create a worktree: `git worktree add ../DPF-<topic> -b <prefix>/<topic>`. Do the work there. Push from there. Open the PR from there. Return to the root clone only for `git pull` on main and for occasional inspection of the canonical state. When a worktree is no longer needed (PR merged, branch deleted), run `git worktree remove ../DPF-<topic>` to clean up.
+
+## Decision Dimensions
+
+- `blast_radius: 0.5` — keeping the root clean prevents cross-task contamination at the canonical clone.
+- `long_term_maintainability: 0.3` — discipline compounds: a year of clean-root habit makes every merge / release / inspection cheaper.
+- `governance_compliance: 0.3` — release scripts that target the root clone work reliably when the root is in a known state.
+
+## Examples
+
+- **Positive:** Three concurrent agents work in `D:\DPF-feature-a`, `D:\DPF-feature-b`, `D:\DPF-feature-c`. `D:\DPF` stays on `main` synced to origin. Mark runs a release script from `D:\DPF` and everything just works.
+- **Counterexample:** An agent does feature work directly in the root clone, leaves uncommitted changes, and Mark's release script picks up the half-finished state. The release ships partially-completed feature code by accident.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)

--- a/docs/founder-kernel/wiki/principles/mention-uncommitted-changes.md
+++ b/docs/founder-kernel/wiki/principles/mention-uncommitted-changes.md
@@ -1,0 +1,48 @@
+---
+title: Mention Uncommitted Changes Before Starting New Work
+pageKind: principle
+status: published
+abstract: When the working tree has uncommitted changes, name them before starting something else.
+principleTier: contextual
+principleDirection: Disclose uncommitted state before pivoting; never silently leave work in limbo.
+principleDimensionVector: {"evidence_density": 0.4, "human_cognitive_load": -0.4, "blast_radius": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: true
+principlePublicRationale: Documents the transparency expectation around uncommitted state — agents that pivot without disclosing leave the operator wondering what happened to the prior work.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+When the working tree has uncommitted changes and the agent is about to start something else, mention them. Name what's there, whether it should be committed first, stashed, or discarded. Never silently leave work in limbo while pivoting to a new task.
+
+## Why
+
+Uncommitted work is invisible to anyone but the current session — and even the current session loses track if the pivot is large enough. When the operator asks for new work, they expect the agent to either complete the prior work or explicitly hand it off. A silent pivot leaves both pieces of work in a half-state: the prior work has no PR, no commit, no record; the new work proceeds against a working tree that has unexplained modifications. Disclosing the state takes one sentence and prevents the whole class of "what was I doing again?" recovery.
+
+## Applies To
+
+In-platform coworkers running multi-step operations, external coding agents handling user prompts, and humans context-switching mid-task. Applies when the user pivots to a new request and the working tree has unstaged or staged changes from the prior request.
+
+## How To Apply
+
+Before starting a new task, run `git status --short`. If there are uncommitted changes, mention them in the response: "Working tree has uncommitted changes in <paths>. Should I commit them first, stash, or discard?" Then proceed based on the answer. When the operator's new request is a continuation of the prior work (e.g., "OK, do that next"), no disclosure is needed — the uncommitted state is in scope.
+
+## Decision Dimensions
+
+- `evidence_density: 0.4` — uncommitted state is durable but invisible; naming it makes it visible.
+- `human_cognitive_load: -0.4` — operators don't have to remember what the agent was doing before they pivoted.
+- `blast_radius: 0.3` — silent pivots compound; disclosure prevents the compounding.
+
+## Examples
+
+- **Positive:** Agent finishes editing three files, then the operator asks for a tangential bug fix. The agent responds: "Working tree has uncommitted edits to a.ts, b.ts, c.ts from the spec task. Want me to commit those before pivoting to the bug fix?"
+- **Counterexample:** Same scenario, but the agent pivots silently. An hour later the operator says "OK ship the spec task" and the agent has to explain that the spec edits are still in the working tree alongside the bug-fix edits, mixed.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)

--- a/docs/founder-kernel/wiki/principles/plan-before-install-paths.md
+++ b/docs/founder-kernel/wiki/principles/plan-before-install-paths.md
@@ -1,0 +1,48 @@
+---
+title: Plan Before Acting on Install/Seed/Template Paths
+pageKind: principle
+status: published
+abstract: A symptom on one install is usually a defect for every install. Use writing-plans for anything touching setup, seeds, or shared templates.
+principleTier: contextual
+principleDirection: Plan before editing install / seed / template paths; the change ripples across every install.
+principleDimensionVector: {"blast_radius": 0.7, "long_term_maintainability": 0.4, "governance_compliance": 0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principlePublic: true
+principlePublicRationale: Adopters need to know that DPF treats install / seed / template changes with extra care — every install inherits the change.
+sources:
+  - articles/why-we-ended-up-proposing-two-standards-for-ai-agents
+---
+
+## Rule
+
+Before editing install scripts, seed files, or shared templates, write a plan. A symptom that surfaces on one install is usually a defect for every install — the change ripples across every existing and future install, so the design needs to be thought through before code lands. Use the `writing-plans` flow for these surfaces.
+
+## Why
+
+Install / seed / template paths have the largest blast radius of any code in the platform: a one-line edit in `packages/db/src/seed.ts` propagates to every fresh install going forward, and a poorly-thought-through change can corrupt downstream state in ways that only surface days later when an adopter hits the broken state. The planning step costs an hour and forces the implementer to think through migration paths, rollback, and idempotency before code lands. The cost asymmetry is what makes this contextual (the principle applies in a narrow set of code paths) but high-weight on `blast_radius` (the rare hit has a big impact).
+
+## Applies To
+
+In-platform coworkers and external coding agents touching install scripts, `packages/db/src/seed.ts`, founder-kernel content, kernel manifests, or shared templates. Does NOT apply to feature code that doesn't touch these surfaces — those have a normal commit cadence.
+
+## How To Apply
+
+When the change you're about to make touches an install / seed / template path, stop and write a plan in `docs/superpowers/plans/`. The plan covers what data shape changes, what the migration looks like, how fresh installs handle it, how existing installs handle it, and how rollback works if the change is wrong. Then implement against the plan. The `writing-plans` slash command produces the right format.
+
+## Decision Dimensions
+
+- `blast_radius: 0.7` — install / seed / template changes propagate to every install. This is the axis the principle exists to manage.
+- `long_term_maintainability: 0.4` — planned changes age better than ad-hoc patches.
+- `governance_compliance: 0.3` — the plan is the audit artifact that explains why the change was made.
+
+## Examples
+
+- **Positive:** Adding a new `principle` page kind required a plan document covering the schema migration, seed walker changes, lint detector additions, and UI surface — all reviewed before any code landed.
+- **Counterexample:** A one-line edit to `seed.ts` that "just fixes the agent grant" without a plan. The fix works on the dev install but breaks fresh installs because the migration path wasn't thought through.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)


### PR DESCRIPTION
## Summary

Phase 4.2c of the principles-as-wiki-kind plan — closes the AGENTS.md governance promotion sweep. Authors the 6 contextual-tier kernel pages from the Phase 4 audit ([#571](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/571)) and replaces the corresponding AGENTS.md prose with pointer paragraphs.

## What ships

Six new contextual-tier kernel principle pages:

| Slug | Source rule | Vector signature |
|---|---|---|
| `plan-before-install-paths` | §1 Plan before install paths | `blast_radius: 0.7, long_term_maintainability: 0.4, governance_compliance: 0.3` |
| `always-push-after-committing` | §4 Always push | `evidence_density: 0.5, governance_compliance: 0.4, blast_radius: 0.3` |
| `keep-root-clone-as-merge-worktree` | §4 Root clone | `blast_radius: 0.5, long_term_maintainability: 0.3, governance_compliance: 0.3` |
| `db-fallback-explicit` | §6 DB fallback explicit | `evidence_density: 0.6, governance_compliance: 0.4, human_cognitive_load: -0.3` |
| `check-epic-overlap-before-creating` | §6 Check epic overlap | `long_term_maintainability: 0.5, reusability: 0.4, schema_grounding: 0.3` |
| `mention-uncommitted-changes` | §15 Mention uncommitted | `evidence_density: 0.4, human_cognitive_load: -0.4, blast_radius: 0.3` |

AGENTS.md pointer updates (operational mechanics kept inline):
- §1 plan-before-install bullet gets pointer
- §4 always-push and keep-root bullets get pointers (`git worktree add`, conventional paths stay inline)
- §6 db-fallback and check-epic-overlap bullets get pointers
- §15 mention-uncommitted bullet gets pointer

Manifest `pageCount`: 40 → 46. May rebase to 60 if [#589](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/589) (Phase 4.2b, +14 pages) merges first — trivial manifest conflict.

## Cap math after Phase 4 promotion sweep complete

| Tier | Count |
|---|---|
| Commandment | 9 (within cap of 10) |
| Core | 25 (within soft cap of 30) |
| Contextual | 6 |
| **Total kernel principles** | **40** |
| Plus EP-WIKI-001 base pages | 11 |
| **Total wiki kernel pages** | **51** |

## What's left for Phase 4

After this merges, Phase 4.3 is the only remaining Phase 4 step: add a short pointer paragraph to the top of AGENTS.md naming the `wiki_query` MCP retrieval path. That's gated on confirming external MCP visibility for `registry_read` tokens (already shipped in PR #564), so it can land immediately after this.

## Test plan

- [ ] `pnpm --filter @dpf/db exec vitest run src/seed-wiki-kernel.test.ts` — no regression
- [ ] Rebuild local portal, run the kernel seed
- [ ] `/wiki?kind=principle` — Contextual tier shows 6 rows
- [ ] `/admin/wiki/lint` — zero blocking principle findings
- [ ] AGENTS.md reads end-to-end as a standalone operational guide
- [ ] All new pointer links resolve

## Refs

- BI: `BI-EBDFBA34`
- Epic: `EP-TAK-3F9A21`
- Audit: [#571](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/571)
- Phase 4.2a: [#579](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/579) (merged)
- Phase 4.2b: [#589](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/589) (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)