### PR TITLE
docs: polish public docs hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -309,9 +309,9 @@
 <header class="hero">
   <div class="wrap">
     <img class="hero-logo" src="assets/logos/OpenDigitalProductFactory.png" alt="Open Digital Product Factory" width="934" height="688" />
-    <h1>An open, AI-native platform that helps your organization build and run itself.</h1>
+    <h1>Open Digital Product Factory</h1>
     <p class="lede">
-      Open Digital Product Factory gives small teams and regulated enterprises the same digital-product, architecture, compliance, and AI-workforce capabilities that have historically been locked behind expensive enterprise suites &mdash; running on your own hardware, governed end-to-end, and extensible by AI coworkers under human approval.
+      An open, AI-native platform that helps your organization build and run itself. DPF gives small teams and regulated enterprises the same digital-product, architecture, compliance, and AI-workforce capabilities that have historically been locked behind expensive enterprise suites &mdash; running on your own hardware, governed end-to-end, and extensible by AI coworkers under human approval.
     </p>
     <div class="cta-row">
       <a class="btn primary" href="#install-on-windows">Install on Windows</a>


### PR DESCRIPTION
## Summary
- Changes the public docs hero H1 to `Open Digital Product Factory` so the first viewport leads with the product name.
- Moves the descriptive platform promise into supporting copy, preserving the refreshed docs-site messaging from #588.

## Verification
- `git diff --check`
- Playwright static public docs pass at 1280/1024/768/375: product H1 present, CTA visible above fold, no horizontal overflow, status labels present