### PR TITLE
test(integrate): cover the architecture pre-PR gate

### DIFF
--- a/apps/web/lib/integrate/pre-pr-gates.test.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.test.ts
@@ -196,3 +196,118 @@ index aaa..bbb 100644
     expect(depGate?.verdict).toBe("pass");
   });
 });
+
+describe("runPrePRGates — architecture gate", () => {
+  it("warns on a deep relative import (4+ levels up)", () => {
+    const diff = `diff --git a/apps/web/lib/foo.ts b/apps/web/lib/foo.ts
+index aaa..bbb 100644
+--- a/apps/web/lib/foo.ts
++++ b/apps/web/lib/foo.ts
+@@ -1,1 +1,2 @@
+ export const x = 1;
++import { bar } from "../../../../packages/db/bar";
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("warn");
+    expect(archGate?.findings.some((f) => /Deep relative import/.test(f))).toBe(true);
+    expect(archGate?.findings.some((f) => /apps\/web\/lib\/foo\.ts/.test(f))).toBe(true);
+  });
+
+  it("passes on a shallow relative import (3 levels or fewer)", () => {
+    const diff = `diff --git a/apps/web/lib/foo.ts b/apps/web/lib/foo.ts
+index aaa..bbb 100644
+--- a/apps/web/lib/foo.ts
++++ b/apps/web/lib/foo.ts
+@@ -1,1 +1,2 @@
+ export const x = 1;
++import { bar } from "../../../bar";
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("pass");
+    expect(archGate?.findings).toHaveLength(0);
+  });
+
+  it("ignores deep relative imports that only appear in removed lines", () => {
+    // The deep-import scan should only see added lines. A removal of a deep
+    // import is exactly the kind of cleanup the gate is supposed to encourage.
+    const diff = `diff --git a/apps/web/lib/foo.ts b/apps/web/lib/foo.ts
+index aaa..bbb 100644
+--- a/apps/web/lib/foo.ts
++++ b/apps/web/lib/foo.ts
+@@ -1,2 +1,2 @@
+-import { bar } from "../../../../packages/db/bar";
++import { bar } from "@/lib/db/bar";
+ export const x = 1;
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("pass");
+  });
+
+  it("warns on a file in an unexpected top-level directory", () => {
+    const diff = `diff --git a/random-dir/foo.ts b/random-dir/foo.ts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/random-dir/foo.ts
+@@ -0,0 +1,1 @@
++export const x = 1;
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("warn");
+    expect(archGate?.findings.some((f) => /Unexpected directory: random-dir\/foo\.ts/.test(f))).toBe(true);
+  });
+
+  it("does not warn on a root-level file (no slash in path)", () => {
+    // The `file.includes("/")` guard exempts top-level files like README.md
+    // and tsconfig.json — they have no top-dir to check.
+    const diff = `diff --git a/README.md b/README.md
+index aaa..bbb 100644
+--- a/README.md
++++ b/README.md
+@@ -1,1 +1,2 @@
+ # DPF
++New line.
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("pass");
+  });
+
+  it("allows files in every recognized top-level directory", () => {
+    // Smoke test: at least one file from each ALLOWED_TOP_DIRS entry should
+    // not produce an "Unexpected directory" finding. If someone removes an
+    // entry from ALLOWED_TOP_DIRS without realizing portals use it, this fails.
+    const recognized = [
+      "apps/web/lib/foo.ts",
+      "packages/db/foo.ts",
+      "prisma/schema.prisma",
+      "scripts/foo.ts",
+      "prompts/foo.prompt.md",
+      "skills/foo.skill.md",
+      "docs/foo.md",
+      "e2e/foo.spec.ts",
+      "services/foo.ts",
+      "public/foo.svg",
+    ];
+    const diff = recognized
+      .map(
+        (path) => `diff --git a/${path} b/${path}
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/${path}
+@@ -0,0 +1,1 @@
++x
+`,
+      )
+      .join("");
+
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.findings.some((f) => /Unexpected directory/.test(f))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The architecture gate (`runArchitectureGate` in [pre-pr-gates.ts:111-139](apps/web/lib/integrate/pre-pr-gates.ts)) had zero test coverage. Now that the other three gates (security-scan, destructive-ops, dependency-audit) are all covered by [pre-pr-gates.test.ts](apps/web/lib/integrate/pre-pr-gates.test.ts), this was the obvious blind spot — regressions in the deep-relative-import detection or the `ALLOWED_TOP_DIRS` set would land silently.

## Tests added (6, pure additions — no production code changes)

- **warns on a deep relative import** — `+import { bar } from "../../../../packages/db/bar"` triggers the gate
- **passes on a shallow relative import** — `../../../bar` (3 levels) is fine
- **ignores deep relative imports in removed lines** — symmetric with the destructive-ops "removed-line" test
- **warns on an unexpected top-level directory** — `random-dir/foo.ts` triggers the directory finding
- **does not warn on a root-level file** — exercises the `file.includes("/")` guard for `README.md`-style paths
- **smoke-tests every `ALLOWED_TOP_DIRS` entry** — generates one file in each of apps, packages, prisma, scripts, prompts, skills, docs, e2e, services, public, and asserts none produce an "Unexpected directory" finding. If someone removes an entry without realizing portals use it, this fails loudly.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/pre-pr-gates.test.ts` — 16/16 pass
- [x] `pnpm --filter web typecheck`

Signed-off-by: Mark Bodman <markdbodman@gmail.com>