### PR TITLE
docs: design portal work capsule harness

### DIFF
--- a/docs/superpowers/plans/2026-05-14-portal-work-capsule-control-harness-phase-1.md
+++ b/docs/superpowers/plans/2026-05-14-portal-work-capsule-control-harness-phase-1.md
@@ -1,0 +1,1928 @@
+# Portal Work Capsule Control Harness Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development if the harness offers subagents; otherwise use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the adoption-first Work Capsule registry so DPF can record, inspect, and attach existing branches/worktrees/PRs to governed portal work before automating new worktree creation or production promotion.
+
+**Architecture:** Add `WorkCapsule` and `WorkCapsuleActivity` as the lifecycle layer above `BacklogItem`, `FeatureBuild`, `TaskRun`, git state, and future promotion candidates. Keep domain behavior in focused `apps/web/lib/work-capsules/*` modules; keep `apps/web/lib/mcp-tools.ts` as registration and dispatch only. The first UI at `/build/work` is read-oriented and adoption-oriented, with no production mutation and no automatic worktree deletion.
+
+**Tech Stack:** Next.js 16 App Router, Prisma 7, PostgreSQL, Vitest, DPF MCP tool surface, lucide-react, PowerShell/Windows local git scanning.
+
+---
+
+## Chunk 1: Grounding And Scope
+
+## Live State Used For This Plan
+
+Re-queried through the DPF MCP surface on 2026-05-14 before writing this plan:
+
+- `list_epics(status=open, hasOpenItems=true)` returned 8 open epics with open work: `EP-DOCS-6B9F2A`, `EP-LIC-C64FC2`, `EP-TAK-3F9A21`, `EP-ARCH-8D4F2A`, `EP-CTRL-5E21A4`, `EP-SITE-7C4D2B`, `EP-LAB-6A91C2`, `EP-INT-2E7C1A`.
+- `list_backlog_items(status=in-progress)` returned 7 in-progress items, including `BI-BUILD-GRAPH-CYCLE-05140137`, `BI-LIC-3621D8`, `BI-CDA96CAA`, and `BI-ec41b330-9a67-436f-a68d-e8a101693a9c`.
+- `list_backlog_items(status=open)` returned active Build Studio/runtime noise under `EP-BUILD-CYCLE-0514`, including `BI-BUILD-PROVENANCE-BYPASS-0514`, `BI-BUILD-FALSE-GREEN-0514`, `BI-BUILD-COWORKER-CHAT-RETRY-0514`, `BI-BUILD-SANDBOX-SOURCE-SYNC-0514`, and many `BI-PIR-*` Server Components render-crash reports.
+- `search_specs_and_plans(query="Work Capsule portal control harness Build Studio external Codex Claude worktree adoption")` returned no overlapping existing spec or plan.
+
+Plan consequence: Phase 1 must be adoption-first and visibility-first. It should not try to solve Build Studio execution quality, provider reconciliation, or portal replacement in the same slice.
+
+## Scope
+
+In scope for Phase 1:
+
+- Schema for `WorkCapsule` and `WorkCapsuleActivity`.
+- Enum constants and validation helpers.
+- A focused Work Capsule service module.
+- Read-only git/worktree scanner for adoptable local work.
+- MCP tools for create, adopt, list, get, evidence, heartbeat, scope claim/release, and status update.
+- Human `requiredCapability` choices, grant catalog, and `TOOL_TO_GRANTS` wiring.
+- Read-oriented `/build/work` UI with active/adoptable capsule views.
+- Link from `/build` to `/build/work`.
+
+Out of scope for Phase 1:
+
+- Automatic worktree creation.
+- Production promotion.
+- `ChangePromotion.kind`.
+- Daily steward scheduling.
+- Automatic deletion, closing, or archiving of historical worktrees.
+- GitHub write operations.
+
+## File Structure
+
+- `packages/db/prisma/schema.prisma`: add `WorkCapsule` and `WorkCapsuleActivity`.
+- `packages/db/prisma/migrations/20260514_add_work_capsules/migration.sql`: migration generated from Prisma and hand-reviewed.
+- `apps/web/lib/work-capsules.ts`: public enum constants, labels, validation helpers, and type guards.
+- `apps/web/lib/work-capsules/work-capsule-store.ts`: server-side domain operations over Prisma.
+- `apps/web/lib/work-capsules/git-scanner.ts`: safe read-only scanner for local git branches/worktrees.
+- `apps/web/lib/work-capsules/work-capsule-presenter.ts`: UI-facing row shaping and status labels.
+- `apps/web/lib/actions/work-capsules.ts`: authenticated server actions/loaders for `/build/work`.
+- `apps/web/components/build/work-control/WorkControlPanel.tsx`: page composition.
+- `apps/web/components/build/work-control/WorkCapsuleTable.tsx`: active capsule table.
+- `apps/web/components/build/work-control/AdoptableWorktreeTable.tsx`: adoptable local work table.
+- `apps/web/app/(shell)/build/work/page.tsx`: Work Control route.
+- `apps/web/components/build/BuildStudio.tsx`: add a compact link to `/build/work`.
+- `apps/web/lib/mcp-tools.ts`: register tool definitions and dispatch to handlers.
+- `apps/web/lib/work-capsules/mcp-handlers.ts`: handler functions called by `executeTool`.
+- `apps/web/lib/tak/agent-grants.ts`: map capsule tools to new grants.
+- `apps/web/components/platform/EffectivePermissionsPanel.tsx`: mirror grant mapping for admin visibility.
+- `apps/web/lib/tak/agent-grants.test.ts`: grant tests.
+- `apps/web/lib/work-capsules/*.test.ts`: unit tests.
+- `apps/web/lib/mcp-tools-work-capsules.test.ts`: MCP tool tests.
+- `apps/web/components/build/work-control/*.test.tsx`: UI component tests.
+- `packages/db/data/grant_catalog.json`: add four grant entries and honored tools.
+- `packages/db/data/agent_registry.json`: grant read/write/adopt to Build Studio and external coding agents only where appropriate.
+
+## Chunk 2: Schema And Domain Foundation
+
+## Task 1: Schema Foundation
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/20260514_add_work_capsules/migration.sql`
+
+- [ ] **Step 1: Add the Prisma models**
+
+Add these models near the task/build governance models in `packages/db/prisma/schema.prisma`:
+
+```prisma
+model WorkCapsule {
+  id                       String                 @id @default(cuid())
+  capsuleId                String                 @unique
+  title                    String
+  objective                String                 @db.Text
+  status                   String                 @default("draft")
+  source                   String
+  executorKind             String?
+  executorRef              String?
+  backlogItemId            String?
+  epicId                   String?
+  featureBuildId           String?
+  taskRunId                String?
+  gitPromotionCandidateId  String?
+  changePromotionId        String?
+  repositoryFullName       String?
+  baseBranch               String?
+  baseSha                  String?
+  headBranch               String?
+  headSha                  String?
+  worktreePath             String?
+  pullRequestUrl           String?
+  pullRequestNumber        Int?
+  sandboxProviderId        String?
+  sandboxId                String?
+  scopeClaims              Json                   @default("[]")
+  workspaceState           Json                   @default("{}")
+  verificationState        Json                   @default("{}")
+  providerRequirements     Json                   @default("[]")
+  promotionPolicy          Json                   @default("{}")
+  contributionMode         String                 @default("private")
+  branchTaxonomy           String?
+  idempotencyKey           String?                @unique
+  leaseHolderPrincipalId   String?
+  leaseExpiresAt           DateTime?
+  createdByPrincipalId     String?
+  createdAt                DateTime               @default(now())
+  updatedAt                DateTime               @updatedAt
+  lastSyncedAt             DateTime?
+  archivedAt               DateTime?
+  activities               WorkCapsuleActivity[]
+
+  @@index([status, updatedAt])
+  @@index([backlogItemId])
+  @@index([featureBuildId])
+  @@index([headBranch])
+  @@index([sandboxId])
+  @@index([leaseExpiresAt])
+}
+
+model WorkCapsuleActivity {
+  id                String       @id @default(cuid())
+  workCapsuleId     String
+  kind              String
+  summary           String
+  payload           Json         @default("{}")
+  recordedAt        DateTime     @default(now())
+  recordedById      String?
+  recordedByAgentId String?
+  toolExecutionId   String?
+  capsule           WorkCapsule  @relation(fields: [workCapsuleId], references: [id], onDelete: Cascade)
+
+  @@index([workCapsuleId, recordedAt(sort: Desc)])
+  @@index([kind, recordedAt(sort: Desc)])
+}
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma migrate dev --name add_work_capsules
+```
+
+Expected:
+
+```text
+Applying migration `20260514_add_work_capsules`
+```
+
+If Prisma generates a timestamped folder with a later minute, keep the generated folder name and update this plan checkbox note during execution.
+
+- [ ] **Step 3: Review generated SQL**
+
+Open the generated `migration.sql` and confirm it contains:
+
+```sql
+CREATE TABLE "WorkCapsule" (
+...
+);
+
+CREATE TABLE "WorkCapsuleActivity" (
+...
+);
+
+CREATE UNIQUE INDEX "WorkCapsule_capsuleId_key" ON "WorkCapsule"("capsuleId");
+CREATE UNIQUE INDEX "WorkCapsule_idempotencyKey_key" ON "WorkCapsule"("idempotencyKey");
+CREATE INDEX "WorkCapsule_status_updatedAt_idx" ON "WorkCapsule"("status", "updatedAt");
+CREATE INDEX "WorkCapsule_leaseExpiresAt_idx" ON "WorkCapsule"("leaseExpiresAt");
+```
+
+- [ ] **Step 4: Generate Prisma client**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db generate
+```
+
+Expected: Prisma Client generated without schema errors.
+
+- [ ] **Step 5: Commit schema slice**
+
+Run:
+
+```powershell
+git add packages/db/prisma/schema.prisma packages/db/prisma/migrations
+git commit -s -m "feat(db): add work capsule registry"
+```
+
+## Task 2: Work Capsule Types and Validation
+
+**Files:**
+- Create: `apps/web/lib/work-capsules.ts`
+- Test: `apps/web/lib/work-capsules.test.ts`
+
+- [ ] **Step 1: Write enum validation tests**
+
+Create `apps/web/lib/work-capsules.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  WORK_CAPSULE_ACTIVITY_KINDS,
+  WORK_CAPSULE_EXECUTOR_KINDS,
+  WORK_CAPSULE_SOURCES,
+  WORK_CAPSULE_STATUSES,
+  isWorkCapsuleStatus,
+  normalizeBranchTaxonomy,
+  parseScopeClaims,
+} from "./work-capsules";
+
+describe("work capsule enums", () => {
+  it("uses hyphenated status values", () => {
+    expect(WORK_CAPSULE_STATUSES).toContain("ready-for-review");
+    expect(WORK_CAPSULE_STATUSES).toContain("ready-for-promotion");
+    expect(WORK_CAPSULE_STATUSES).not.toContain("ready_for_review");
+  });
+
+  it("recognizes valid statuses only", () => {
+    expect(isWorkCapsuleStatus("working")).toBe(true);
+    expect(isWorkCapsuleStatus("in_progress")).toBe(false);
+  });
+
+  it("declares source, executor, and activity enums", () => {
+    expect(WORK_CAPSULE_SOURCES).toContain("external-adoption");
+    expect(WORK_CAPSULE_EXECUTOR_KINDS).toContain("codex-desktop");
+    expect(WORK_CAPSULE_ACTIVITY_KINDS).toContain("evidence-recorded");
+  });
+});
+
+describe("scope claims", () => {
+  it("filters invalid scope claims", () => {
+    const claims = parseScopeClaims([
+      { kind: "path", value: "apps/web/lib/work-capsules.ts", intent: "edit", recordedAt: "2026-05-14T00:00:00.000Z", recordedByPrincipalId: "principal-1" },
+      { kind: "bad", value: "x", intent: "edit" },
+    ]);
+
+    expect(claims).toHaveLength(1);
+    expect(claims[0]?.kind).toBe("path");
+  });
+});
+
+describe("branch taxonomy", () => {
+  it("extracts known branch prefixes", () => {
+    expect(normalizeBranchTaxonomy("feat/work-capsules")).toBe("feat");
+    expect(normalizeBranchTaxonomy("doc/work-capsules")).toBe("doc");
+    expect(normalizeBranchTaxonomy("random")).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules.test.ts
+```
+
+Expected: FAIL because `apps/web/lib/work-capsules.ts` does not exist.
+
+- [ ] **Step 3: Implement constants and helpers**
+
+Create `apps/web/lib/work-capsules.ts`:
+
+```ts
+export const WORK_CAPSULE_STATUSES = [
+  "draft",
+  "ready",
+  "working",
+  "blocked",
+  "verifying",
+  "ready-for-review",
+  "ready-for-promotion",
+  "complete",
+  "abandoned",
+  "archived",
+] as const;
+
+export type WorkCapsuleStatus = (typeof WORK_CAPSULE_STATUSES)[number];
+
+export const WORK_CAPSULE_SOURCES = [
+  "backlog",
+  "build-studio",
+  "external-adoption",
+  "git-promotion",
+  "manual",
+  "scheduled-steward",
+] as const;
+
+export type WorkCapsuleSource = (typeof WORK_CAPSULE_SOURCES)[number];
+
+export const WORK_CAPSULE_EXECUTOR_KINDS = [
+  "build-studio",
+  "codex-desktop",
+  "claude-desktop",
+  "human",
+  "git-webhook",
+  "dpf-native",
+] as const;
+
+export type WorkCapsuleExecutorKind = (typeof WORK_CAPSULE_EXECUTOR_KINDS)[number];
+
+export const WORK_CAPSULE_ACTIVITY_KINDS = [
+  "created",
+  "adopted",
+  "status-changed",
+  "status-override",
+  "executor-changed",
+  "scope-claimed",
+  "scope-released",
+  "evidence-recorded",
+  "pr-linked",
+  "pr-merged",
+  "sandbox-attached",
+  "verification-passed",
+  "verification-failed",
+  "provider-blocked",
+  "provider-unblocked",
+  "lease-renewed",
+  "lease-expired",
+  "promotion-prepared",
+  "promotion-approved",
+  "promotion-rolled-back",
+  "archived",
+  "superseded",
+] as const;
+
+export type WorkCapsuleActivityKind = (typeof WORK_CAPSULE_ACTIVITY_KINDS)[number];
+
+export const WORK_CAPSULE_BRANCH_TAXONOMIES = [
+  "feat",
+  "fix",
+  "chore",
+  "doc",
+  "clean",
+] as const;
+
+export type WorkCapsuleBranchTaxonomy = (typeof WORK_CAPSULE_BRANCH_TAXONOMIES)[number];
+
+export type ScopeClaim = {
+  kind: "path" | "module" | "package" | "route" | "skill" | "prompt";
+  value: string;
+  intent: "edit" | "read";
+  recordedAt: string;
+  recordedByPrincipalId: string;
+};
+
+const STATUS_SET = new Set<string>(WORK_CAPSULE_STATUSES);
+const SOURCE_SET = new Set<string>(WORK_CAPSULE_SOURCES);
+const EXECUTOR_SET = new Set<string>(WORK_CAPSULE_EXECUTOR_KINDS);
+const ACTIVITY_SET = new Set<string>(WORK_CAPSULE_ACTIVITY_KINDS);
+const TAXONOMY_SET = new Set<string>(WORK_CAPSULE_BRANCH_TAXONOMIES);
+const SCOPE_KIND_SET = new Set<ScopeClaim["kind"]>(["path", "module", "package", "route", "skill", "prompt"]);
+const SCOPE_INTENT_SET = new Set<ScopeClaim["intent"]>(["edit", "read"]);
+
+export function isWorkCapsuleStatus(value: unknown): value is WorkCapsuleStatus {
+  return typeof value === "string" && STATUS_SET.has(value);
+}
+
+export function isWorkCapsuleSource(value: unknown): value is WorkCapsuleSource {
+  return typeof value === "string" && SOURCE_SET.has(value);
+}
+
+export function isWorkCapsuleExecutorKind(value: unknown): value is WorkCapsuleExecutorKind {
+  return typeof value === "string" && EXECUTOR_SET.has(value);
+}
+
+export function isWorkCapsuleActivityKind(value: unknown): value is WorkCapsuleActivityKind {
+  return typeof value === "string" && ACTIVITY_SET.has(value);
+}
+
+export function normalizeBranchTaxonomy(branch: string | null | undefined): WorkCapsuleBranchTaxonomy | null {
+  const prefix = branch?.split("/")[0]?.trim();
+  return prefix && TAXONOMY_SET.has(prefix) ? (prefix as WorkCapsuleBranchTaxonomy) : null;
+}
+
+export function parseScopeClaims(value: unknown): ScopeClaim[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is ScopeClaim => {
+    if (!entry || typeof entry !== "object") return false;
+    const candidate = entry as Record<string, unknown>;
+    return (
+      typeof candidate.value === "string" &&
+      candidate.value.trim().length > 0 &&
+      typeof candidate.recordedAt === "string" &&
+      typeof candidate.recordedByPrincipalId === "string" &&
+      SCOPE_KIND_SET.has(candidate.kind as ScopeClaim["kind"]) &&
+      SCOPE_INTENT_SET.has(candidate.intent as ScopeClaim["intent"])
+    );
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit types slice**
+
+Run:
+
+```powershell
+git add apps/web/lib/work-capsules.ts apps/web/lib/work-capsules.test.ts
+git commit -s -m "feat(web): add work capsule enums"
+```
+
+## Task 3: Domain Store
+
+**Files:**
+- Create: `apps/web/lib/work-capsules/work-capsule-store.ts`
+- Test: `apps/web/lib/work-capsules/work-capsule-store.test.ts`
+
+- [ ] **Step 1: Write service tests**
+
+Create `apps/web/lib/work-capsules/work-capsule-store.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  adoptWorktreeCapsule,
+  createWorkCapsule,
+  heartbeatWorkCapsule,
+  recordWorkCapsuleEvidence,
+} from "./work-capsule-store";
+
+const db = {
+  workCapsule: {
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  },
+  workCapsuleActivity: {
+    create: vi.fn(),
+  },
+};
+
+describe("work capsule store", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates a capsule idempotently", async () => {
+    db.workCapsule.upsert.mockResolvedValue({ id: "row-1", capsuleId: "WC-ABC12345", title: "Work control" });
+
+    const result = await createWorkCapsule({
+      db,
+      input: {
+        title: "Work control",
+        objective: "Adopt current worktrees.",
+        source: "manual",
+        idempotencyKey: "manual:work-control",
+      },
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    });
+
+    expect(result.capsuleId).toBe("WC-ABC12345");
+    expect(db.workCapsule.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { idempotencyKey: "manual:work-control" },
+    }));
+  });
+
+  it("adopts an existing worktree by repository and branch", async () => {
+    db.workCapsule.findFirst.mockResolvedValue(null);
+    db.workCapsule.create.mockResolvedValue({ id: "row-1", capsuleId: "WC-ADOPT01" });
+
+    const result = await adoptWorktreeCapsule({
+      db,
+      input: {
+        title: "Adopt feature branch",
+        objective: "Recover work in flight.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "feat/recovery",
+        worktreePath: "D:/DPF-recovery",
+        baseBranch: "main",
+        baseSha: "base",
+        headSha: "head",
+        executorKind: "codex-desktop",
+      },
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+    });
+
+    expect(result.capsuleId).toBe("WC-ADOPT01");
+    expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "adopted" }),
+    }));
+  });
+
+  it("renews a lease on heartbeat", async () => {
+    db.workCapsule.update.mockResolvedValue({ id: "row-1", capsuleId: "WC-LEASE" });
+
+    const result = await heartbeatWorkCapsule({
+      db,
+      capsuleId: "WC-LEASE",
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+      now: new Date("2026-05-14T00:00:00.000Z"),
+    });
+
+    expect(result.capsuleId).toBe("WC-LEASE");
+    expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ leaseHolderPrincipalId: "principal-1" }),
+    }));
+  });
+
+  it("records evidence append-only", async () => {
+    db.workCapsule.findUnique.mockResolvedValue({ id: "row-1", capsuleId: "WC-EVIDENCE" });
+    db.workCapsuleActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    await recordWorkCapsuleEvidence({
+      db,
+      capsuleId: "WC-EVIDENCE",
+      evidence: { kind: "test", summary: "Vitest passed", command: "pnpm --filter web test" },
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    });
+
+    expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        kind: "evidence-recorded",
+        summary: "Vitest passed",
+      }),
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules/work-capsule-store.test.ts
+```
+
+Expected: FAIL because `work-capsule-store.ts` does not exist.
+
+- [ ] **Step 3: Implement the store**
+
+Create `apps/web/lib/work-capsules/work-capsule-store.ts` with the tested functions. Use this implementation shape:
+
+```ts
+import * as crypto from "crypto";
+import {
+  isWorkCapsuleExecutorKind,
+  isWorkCapsuleSource,
+  normalizeBranchTaxonomy,
+  type WorkCapsuleExecutorKind,
+  type WorkCapsuleSource,
+} from "@/lib/work-capsules";
+
+const LEASE_TTL_MS = 30 * 60 * 1000;
+
+type Actor = {
+  userId: string;
+  agentId: string | null;
+  principalId: string | null;
+};
+
+type CapsuleDb = {
+  workCapsule: {
+    create(args: any): Promise<any>;
+    findFirst(args: any): Promise<any>;
+    findUnique(args: any): Promise<any>;
+    update(args: any): Promise<any>;
+    upsert(args: any): Promise<any>;
+  };
+  workCapsuleActivity: {
+    create(args: any): Promise<any>;
+  };
+};
+
+function nextCapsuleId(): string {
+  return `WC-${crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+}
+
+function leaseUntil(now = new Date()): Date {
+  return new Date(now.getTime() + LEASE_TTL_MS);
+}
+
+async function recordActivity(db: CapsuleDb, input: {
+  workCapsuleId: string;
+  kind: string;
+  summary: string;
+  payload?: Record<string, unknown>;
+  actor: Actor;
+}) {
+  return db.workCapsuleActivity.create({
+    data: {
+      workCapsuleId: input.workCapsuleId,
+      kind: input.kind,
+      summary: input.summary,
+      payload: input.payload ?? {},
+      recordedById: input.actor.userId,
+      recordedByAgentId: input.actor.agentId,
+    },
+  });
+}
+
+export async function createWorkCapsule(args: {
+  db: CapsuleDb;
+  input: {
+    title: string;
+    objective: string;
+    source: WorkCapsuleSource;
+    idempotencyKey: string;
+    executorKind?: WorkCapsuleExecutorKind | null;
+  };
+  actor: Actor;
+}) {
+  if (!isWorkCapsuleSource(args.input.source)) throw new Error("Invalid capsule source");
+  if (args.input.executorKind && !isWorkCapsuleExecutorKind(args.input.executorKind)) throw new Error("Invalid executor kind");
+
+  const capsule = await args.db.workCapsule.upsert({
+    where: { idempotencyKey: args.input.idempotencyKey },
+    update: {},
+    create: {
+      capsuleId: nextCapsuleId(),
+      title: args.input.title,
+      objective: args.input.objective,
+      source: args.input.source,
+      executorKind: args.input.executorKind ?? null,
+      idempotencyKey: args.input.idempotencyKey,
+      createdByPrincipalId: args.actor.principalId,
+      status: args.input.executorKind ? "ready" : "draft",
+    },
+  });
+
+  await recordActivity(args.db, {
+    workCapsuleId: capsule.id,
+    kind: "created",
+    summary: `Created Work Capsule ${capsule.capsuleId}`,
+    actor: args.actor,
+  });
+
+  return capsule;
+}
+
+export async function adoptWorktreeCapsule(args: {
+  db: CapsuleDb;
+  input: {
+    title: string;
+    objective: string;
+    repositoryFullName: string;
+    headBranch: string;
+    worktreePath: string;
+    baseBranch?: string | null;
+    baseSha?: string | null;
+    headSha?: string | null;
+    executorKind?: WorkCapsuleExecutorKind | null;
+  };
+  actor: Actor;
+}) {
+  const existing = await args.db.workCapsule.findFirst({
+    where: {
+      repositoryFullName: args.input.repositoryFullName,
+      headBranch: args.input.headBranch,
+      archivedAt: null,
+    },
+  });
+  if (existing) return existing;
+
+  const now = new Date();
+  const capsule = await args.db.workCapsule.create({
+    data: {
+      capsuleId: nextCapsuleId(),
+      title: args.input.title,
+      objective: args.input.objective,
+      source: "external-adoption",
+      status: "ready",
+      executorKind: args.input.executorKind ?? null,
+      repositoryFullName: args.input.repositoryFullName,
+      baseBranch: args.input.baseBranch ?? "main",
+      baseSha: args.input.baseSha ?? null,
+      headBranch: args.input.headBranch,
+      headSha: args.input.headSha ?? null,
+      worktreePath: args.input.worktreePath,
+      branchTaxonomy: normalizeBranchTaxonomy(args.input.headBranch),
+      leaseHolderPrincipalId: args.actor.principalId,
+      leaseExpiresAt: args.input.executorKind ? leaseUntil(now) : null,
+      createdByPrincipalId: args.actor.principalId,
+      lastSyncedAt: now,
+    },
+  });
+
+  await recordActivity(args.db, {
+    workCapsuleId: capsule.id,
+    kind: "adopted",
+    summary: `Adopted ${args.input.headBranch}`,
+    payload: { worktreePath: args.input.worktreePath },
+    actor: args.actor,
+  });
+
+  return capsule;
+}
+
+export async function heartbeatWorkCapsule(args: {
+  db: CapsuleDb;
+  capsuleId: string;
+  actor: Actor;
+  now?: Date;
+}) {
+  const nextLease = leaseUntil(args.now ?? new Date());
+  const capsule = await args.db.workCapsule.update({
+    where: { capsuleId: args.capsuleId },
+    data: {
+      leaseHolderPrincipalId: args.actor.principalId,
+      leaseExpiresAt: nextLease,
+    },
+  });
+  await recordActivity(args.db, {
+    workCapsuleId: capsule.id,
+    kind: "lease-renewed",
+    summary: `Lease renewed until ${nextLease.toISOString()}`,
+    actor: args.actor,
+  });
+  return capsule;
+}
+
+export async function recordWorkCapsuleEvidence(args: {
+  db: CapsuleDb;
+  capsuleId: string;
+  evidence: { kind: string; summary: string; command?: string; url?: string; result?: unknown };
+  actor: Actor;
+}) {
+  const capsule = await args.db.workCapsule.findUnique({ where: { capsuleId: args.capsuleId } });
+  if (!capsule) throw new Error(`Work Capsule ${args.capsuleId} not found`);
+  return recordActivity(args.db, {
+    workCapsuleId: capsule.id,
+    kind: "evidence-recorded",
+    summary: args.evidence.summary,
+    payload: args.evidence,
+    actor: args.actor,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules/work-capsule-store.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit store slice**
+
+Run:
+
+```powershell
+git add apps/web/lib/work-capsules/work-capsule-store.ts apps/web/lib/work-capsules/work-capsule-store.test.ts
+git commit -s -m "feat(web): add work capsule store"
+```
+
+## Chunk 3: Scanner And MCP Surface
+
+## Task 4: Read-Only Git and Worktree Scanner
+
+**Files:**
+- Create: `apps/web/lib/work-capsules/git-scanner.ts`
+- Test: `apps/web/lib/work-capsules/git-scanner.test.ts`
+
+- [ ] **Step 1: Write scanner tests**
+
+Create `apps/web/lib/work-capsules/git-scanner.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  parseGitStatusPorcelain,
+  parsePrUrlFromText,
+  parseWorktreeList,
+  shouldSurfaceAdoptableBranch,
+} from "./git-scanner";
+
+describe("git scanner parsing", () => {
+  it("parses dirty and untracked file counts", () => {
+    const parsed = parseGitStatusPorcelain(" M apps/web/a.ts\n?? tmp/out.txt\nA  docs/new.md\n");
+    expect(parsed.modifiedCount).toBe(2);
+    expect(parsed.untrackedCount).toBe(1);
+  });
+
+  it("parses worktree list porcelain output", () => {
+    const worktrees = parseWorktreeList("worktree D:/DPF\nHEAD abc123\nbranch refs/heads/main\n\nworktree D:/DPF-feature\nHEAD def456\nbranch refs/heads/feat/demo\n");
+    expect(worktrees).toEqual([
+      { path: "D:/DPF", headSha: "abc123", branch: "main" },
+      { path: "D:/DPF-feature", headSha: "def456", branch: "feat/demo" },
+    ]);
+  });
+
+  it("extracts a PR URL from text", () => {
+    expect(parsePrUrlFromText("see https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/596")).toBe("https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/596");
+  });
+
+  it("surfaces dirty worktrees and recent ahead branches", () => {
+    expect(shouldSurfaceAdoptableBranch({ hasOpenPr: false, dirtyCount: 1, aheadCount: 0, lastCommitAt: null, now: new Date("2026-05-14") })).toBe(true);
+    expect(shouldSurfaceAdoptableBranch({ hasOpenPr: false, dirtyCount: 0, aheadCount: 1, lastCommitAt: new Date("2026-05-01"), now: new Date("2026-05-14") })).toBe(true);
+    expect(shouldSurfaceAdoptableBranch({ hasOpenPr: false, dirtyCount: 0, aheadCount: 1, lastCommitAt: new Date("2025-12-01"), now: new Date("2026-05-14") })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run scanner tests to verify failure**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules/git-scanner.test.ts
+```
+
+Expected: FAIL because `git-scanner.ts` does not exist.
+
+- [ ] **Step 3: Implement pure parsing helpers and shell wrapper**
+
+Create `apps/web/lib/work-capsules/git-scanner.ts`:
+
+```ts
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+const RECENT_BRANCH_DAYS = 45;
+
+export type WorktreeInfo = {
+  path: string;
+  headSha: string | null;
+  branch: string | null;
+};
+
+export type GitDirtySummary = {
+  modifiedCount: number;
+  untrackedCount: number;
+};
+
+export type AdoptableBranchDecision = {
+  hasOpenPr: boolean;
+  dirtyCount: number;
+  aheadCount: number;
+  lastCommitAt: Date | null;
+  now: Date;
+};
+
+export function parseGitStatusPorcelain(output: string): GitDirtySummary {
+  let modifiedCount = 0;
+  let untrackedCount = 0;
+  for (const line of output.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    if (line.startsWith("??")) untrackedCount += 1;
+    else modifiedCount += 1;
+  }
+  return { modifiedCount, untrackedCount };
+}
+
+export function parseWorktreeList(output: string): WorktreeInfo[] {
+  const records = output.split(/\r?\n\r?\n/).map((entry) => entry.trim()).filter(Boolean);
+  return records.map((record) => {
+    const row: WorktreeInfo = { path: "", headSha: null, branch: null };
+    for (const line of record.split(/\r?\n/)) {
+      if (line.startsWith("worktree ")) row.path = line.slice("worktree ".length).trim();
+      if (line.startsWith("HEAD ")) row.headSha = line.slice("HEAD ".length).trim();
+      if (line.startsWith("branch refs/heads/")) row.branch = line.slice("branch refs/heads/".length).trim();
+    }
+    return row;
+  }).filter((row) => row.path.length > 0);
+}
+
+export function parsePrUrlFromText(text: string | null | undefined): string | null {
+  const match = text?.match(/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/);
+  return match?.[0] ?? null;
+}
+
+export function shouldSurfaceAdoptableBranch(input: AdoptableBranchDecision): boolean {
+  if (input.hasOpenPr) return true;
+  if (input.dirtyCount > 0) return true;
+  if (input.aheadCount <= 0 || !input.lastCommitAt) return false;
+  const ageMs = input.now.getTime() - input.lastCommitAt.getTime();
+  return ageMs <= RECENT_BRANCH_DAYS * 24 * 60 * 60 * 1000;
+}
+
+export async function scanGitWorktrees(repoRoot: string): Promise<WorktreeInfo[]> {
+  const { stdout } = await execFileAsync("git", ["-C", repoRoot, "worktree", "list", "--porcelain"], {
+    timeout: 5000,
+    windowsHide: true,
+  });
+  return parseWorktreeList(stdout);
+}
+
+export async function getWorktreeDirtySummary(worktreePath: string): Promise<GitDirtySummary> {
+  const { stdout } = await execFileAsync("git", ["-C", worktreePath, "status", "--porcelain"], {
+    timeout: 5000,
+    windowsHide: true,
+  });
+  return parseGitStatusPorcelain(stdout);
+}
+```
+
+- [ ] **Step 4: Run scanner tests to verify pass**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules/git-scanner.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit scanner slice**
+
+Run:
+
+```powershell
+git add apps/web/lib/work-capsules/git-scanner.ts apps/web/lib/work-capsules/git-scanner.test.ts
+git commit -s -m "feat(web): add worktree scanner"
+```
+
+## Task 5: MCP Tools and Grants
+
+**Files:**
+- Modify: `apps/web/lib/mcp-tools.ts`
+- Create: `apps/web/lib/work-capsules/mcp-handlers.ts`
+- Test: `apps/web/lib/mcp-tools-work-capsules.test.ts`
+- Modify: `apps/web/lib/tak/agent-grants.ts`
+- Modify: `apps/web/components/platform/EffectivePermissionsPanel.tsx`
+- Modify: `apps/web/lib/tak/agent-grants.test.ts`
+- Modify: `packages/db/data/grant_catalog.json`
+- Modify: `packages/db/data/agent_registry.json`
+
+- [ ] **Step 1: Write MCP handler tests**
+
+Create `apps/web/lib/mcp-tools-work-capsules.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrisma = {
+  workCapsule: {
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  },
+  workCapsuleActivity: {
+    create: vi.fn(),
+  },
+};
+
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+
+describe("work capsule MCP tools", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("list_work_capsules returns capsule rows", async () => {
+    mockPrisma.workCapsule.findMany.mockResolvedValue([
+      { capsuleId: "WC-1", title: "Adopt work", status: "ready", source: "external-adoption", executorKind: "codex-desktop", updatedAt: new Date("2026-05-14T00:00:00.000Z") },
+    ]);
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("list_work_capsules", { status: "ready" }, "user-1");
+
+    expect(result.success).toBe(true);
+    expect(result.data?.capsules).toEqual([
+      expect.objectContaining({ capsuleId: "WC-1", status: "ready" }),
+    ]);
+  });
+
+  it("create_work_capsule requires idempotencyKey", async () => {
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("create_work_capsule", { title: "No key", objective: "Missing key", source: "manual" }, "user-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("missing_idempotencyKey");
+  });
+
+  it("heartbeat_capsule renews a lease", async () => {
+    mockPrisma.workCapsule.update.mockResolvedValue({ id: "row-1", capsuleId: "WC-1" });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("heartbeat_capsule", { capsuleId: "WC-1" }, "user-1", { agentId: "codex" });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { capsuleId: "WC-1" },
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run MCP tests to verify failure**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp-tools-work-capsules.test.ts
+```
+
+Expected: FAIL because the tools are not registered.
+
+- [ ] **Step 3: Add handler module**
+
+Create `apps/web/lib/work-capsules/mcp-handlers.ts` and delegate to the store:
+
+```ts
+import { prisma } from "@dpf/db";
+import type { ToolResult } from "@/lib/mcp-tools";
+import {
+  WORK_CAPSULE_EXECUTOR_KINDS,
+  WORK_CAPSULE_SOURCES,
+  WORK_CAPSULE_STATUSES,
+  isWorkCapsuleExecutorKind,
+  isWorkCapsuleSource,
+  isWorkCapsuleStatus,
+} from "@/lib/work-capsules";
+import {
+  adoptWorktreeCapsule,
+  createWorkCapsule,
+  heartbeatWorkCapsule,
+  recordWorkCapsuleEvidence,
+} from "./work-capsule-store";
+
+type ToolContext = { routeContext?: string; agentId?: string; threadId?: string; taskRunId?: string } | undefined;
+
+function actor(userId: string, context: ToolContext) {
+  return { userId, agentId: context?.agentId ?? null, principalId: context?.agentId ?? userId };
+}
+
+function stringParam(params: Record<string, unknown>, key: string): string | null {
+  const value = params[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function workCapsuleToolEnums() {
+  return {
+    statuses: [...WORK_CAPSULE_STATUSES],
+    sources: [...WORK_CAPSULE_SOURCES],
+    executors: [...WORK_CAPSULE_EXECUTOR_KINDS],
+  };
+}
+
+export async function listWorkCapsulesTool(params: Record<string, unknown>): Promise<ToolResult> {
+  const status = stringParam(params, "status");
+  const capsules = await prisma.workCapsule.findMany({
+    where: status && isWorkCapsuleStatus(status) ? { status } : {},
+    orderBy: { updatedAt: "desc" },
+    take: typeof params.limit === "number" ? Math.min(Math.max(params.limit, 1), 100) : 50,
+    select: {
+      capsuleId: true,
+      title: true,
+      status: true,
+      source: true,
+      executorKind: true,
+      headBranch: true,
+      worktreePath: true,
+      pullRequestUrl: true,
+      leaseExpiresAt: true,
+      lastSyncedAt: true,
+      updatedAt: true,
+    },
+  });
+  return { success: true, message: `Listed ${capsules.length} work capsule(s).`, data: { capsules } };
+}
+
+export async function getWorkCapsuleTool(params: Record<string, unknown>): Promise<ToolResult> {
+  const capsuleId = stringParam(params, "capsuleId");
+  if (!capsuleId) return { success: false, error: "missing_capsuleId", message: "capsuleId is required." };
+  const capsule = await prisma.workCapsule.findUnique({
+    where: { capsuleId },
+    include: { activities: { orderBy: { recordedAt: "desc" }, take: 25 } },
+  });
+  if (!capsule) return { success: false, error: "not_found", message: `Work Capsule ${capsuleId} not found.` };
+  return { success: true, entityId: capsule.capsuleId, message: `Loaded ${capsule.capsuleId}.`, data: { capsule } };
+}
+
+export async function createWorkCapsuleTool(params: Record<string, unknown>, userId: string, context: ToolContext): Promise<ToolResult> {
+  const idempotencyKey = stringParam(params, "idempotencyKey");
+  const title = stringParam(params, "title");
+  const objective = stringParam(params, "objective");
+  const source = stringParam(params, "source");
+  if (!idempotencyKey) return { success: false, error: "missing_idempotencyKey", message: "idempotencyKey is required." };
+  if (!title || !objective || !source || !isWorkCapsuleSource(source)) return { success: false, error: "invalid_input", message: "title, objective, and valid source are required." };
+  const executorKind = stringParam(params, "executorKind");
+  const capsule = await createWorkCapsule({
+    db: prisma,
+    input: {
+      title,
+      objective,
+      source,
+      idempotencyKey,
+      executorKind: executorKind && isWorkCapsuleExecutorKind(executorKind) ? executorKind : null,
+    },
+    actor: actor(userId, context),
+  });
+  return { success: true, entityId: capsule.capsuleId, message: `Created Work Capsule ${capsule.capsuleId}.`, data: { capsule } };
+}
+
+export async function heartbeatCapsuleTool(params: Record<string, unknown>, userId: string, context: ToolContext): Promise<ToolResult> {
+  const capsuleId = stringParam(params, "capsuleId");
+  if (!capsuleId) return { success: false, error: "missing_capsuleId", message: "capsuleId is required." };
+  const capsule = await heartbeatWorkCapsule({ db: prisma, capsuleId, actor: actor(userId, context) });
+  return { success: true, entityId: capsule.capsuleId, message: `Renewed lease for ${capsule.capsuleId}.`, data: { capsule } };
+}
+
+export async function recordCapsuleEvidenceTool(params: Record<string, unknown>, userId: string, context: ToolContext): Promise<ToolResult> {
+  const capsuleId = stringParam(params, "capsuleId");
+  const summary = stringParam(params, "summary");
+  if (!capsuleId || !summary) return { success: false, error: "invalid_input", message: "capsuleId and summary are required." };
+  await recordWorkCapsuleEvidence({
+    db: prisma,
+    capsuleId,
+    evidence: {
+      kind: stringParam(params, "kind") ?? "note",
+      summary,
+      command: stringParam(params, "command") ?? undefined,
+      url: stringParam(params, "url") ?? undefined,
+      result: params.result,
+    },
+    actor: actor(userId, context),
+  });
+  return { success: true, entityId: capsuleId, message: `Recorded evidence for ${capsuleId}.` };
+}
+```
+
+- [ ] **Step 4: Register tool definitions**
+
+Add Work Capsule tools to `PLATFORM_TOOLS` in `apps/web/lib/mcp-tools.ts` near the backlog/governed work tools. Use `workCapsuleToolEnums()` for enum arrays so the MCP schema mirrors `work-capsules.ts`:
+
+```ts
+import { workCapsuleToolEnums } from "@/lib/work-capsules/mcp-handlers";
+```
+
+Add definitions for:
+
+- `list_work_capsules`
+- `get_work_capsule`
+- `create_work_capsule`
+- `adopt_worktree`
+- `claim_capsule_scope`
+- `record_capsule_evidence`
+- `heartbeat_capsule`
+- `update_work_capsule_status`
+- `release_capsule_scope`
+
+Each definition uses `requiredCapability: "view_platform"`, `sideEffect: false` for reads, and `sideEffect: true` for writes. Use the enum arrays returned by `workCapsuleToolEnums()`.
+
+- [ ] **Step 5: Dispatch tool cases**
+
+Inside `executeTool`, add cases that call the handler module. Keep the switch small:
+
+```ts
+    case "list_work_capsules": {
+      const { listWorkCapsulesTool } = await import("@/lib/work-capsules/mcp-handlers");
+      return listWorkCapsulesTool(params);
+    }
+    case "get_work_capsule": {
+      const { getWorkCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
+      return getWorkCapsuleTool(params);
+    }
+    case "create_work_capsule": {
+      const { createWorkCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
+      return createWorkCapsuleTool(params, userId, context);
+    }
+    case "heartbeat_capsule": {
+      const { heartbeatCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
+      return heartbeatCapsuleTool(params, userId, context);
+    }
+    case "record_capsule_evidence": {
+      const { recordCapsuleEvidenceTool } = await import("@/lib/work-capsules/mcp-handlers");
+      return recordCapsuleEvidenceTool(params, userId, context);
+    }
+```
+
+For `adopt_worktree`, `claim_capsule_scope`, `update_work_capsule_status`, and `release_capsule_scope`, do not register the tool cases until the matching handlers in Task 6 exist. A tool must not be visible through MCP if its final handler is not implemented.
+
+- [ ] **Step 6: Wire grants**
+
+In `apps/web/lib/tak/agent-grants.ts`, add:
+
+```ts
+  list_work_capsules: ["work_capsule_read"],
+  get_work_capsule: ["work_capsule_read"],
+  create_work_capsule: ["work_capsule_write"],
+  adopt_worktree: ["work_capsule_adopt"],
+  claim_capsule_scope: ["work_capsule_write"],
+  record_capsule_evidence: ["work_capsule_write"],
+  heartbeat_capsule: ["work_capsule_write"],
+  update_work_capsule_status: ["work_capsule_write"],
+  release_capsule_scope: ["work_capsule_write"],
+```
+
+Mirror the same mapping in `apps/web/components/platform/EffectivePermissionsPanel.tsx`.
+
+Do not add `work_capsule_*` to `apps/web/lib/govern/permissions.ts` or `apps/web/lib/permissions.ts`. Those files define human platform capabilities. The Work Capsule grant keys are agent tool grants enforced by `TOOL_TO_GRANTS` and the seeded grant catalog.
+
+- [ ] **Step 7: Add grant tests**
+
+Append to `apps/web/lib/tak/agent-grants.test.ts`:
+
+```ts
+describe("TOOL_TO_GRANTS - Work Capsule entries", () => {
+  it("read tools require work_capsule_read", () => {
+    expect(isToolAllowedByGrants("list_work_capsules", ["work_capsule_read"])).toBe(true);
+    expect(isToolAllowedByGrants("get_work_capsule", ["work_capsule_read"])).toBe(true);
+    expect(isToolAllowedByGrants("list_work_capsules", ["backlog_read"])).toBe(false);
+  });
+
+  it("write tools require work_capsule_write", () => {
+    expect(isToolAllowedByGrants("create_work_capsule", ["work_capsule_write"])).toBe(true);
+    expect(isToolAllowedByGrants("record_capsule_evidence", ["work_capsule_write"])).toBe(true);
+    expect(isToolAllowedByGrants("heartbeat_capsule", ["work_capsule_read"])).toBe(false);
+  });
+
+  it("adoption requires work_capsule_adopt", () => {
+    expect(isToolAllowedByGrants("adopt_worktree", ["work_capsule_adopt"])).toBe(true);
+    expect(isToolAllowedByGrants("adopt_worktree", ["work_capsule_write"])).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 8: Update grant catalog and seeded agents**
+
+Add grant catalog entries in `packages/db/data/grant_catalog.json`:
+
+```json
+{
+  "key": "work_capsule_read",
+  "description": "Read Work Capsule coordination records.",
+  "category": "integrate",
+  "sensitivity": "internal",
+  "honored_by_tools": ["list_work_capsules", "get_work_capsule"],
+  "implies": []
+}
+```
+
+Add matching entries for `work_capsule_write`, `work_capsule_adopt`, and `work_capsule_promote`. Do not add `work_capsule_promote` to any agent in Phase 1.
+
+In `packages/db/data/agent_registry.json`, grant `work_capsule_read`, `work_capsule_write`, and `work_capsule_adopt` to Build Studio and coding/external agent profiles that already hold `sandbox_execute` or `build_promote`. Grant `work_capsule_read` only to non-coding coordinator agents.
+
+- [ ] **Step 9: Run focused tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp-tools-work-capsules.test.ts apps/web/lib/tak/agent-grants.test.ts
+```
+
+Expected: PASS for the tools implemented in this task. If any Work Capsule tool case is visible through `executeTool`, it must have a real handler, not a temporary fallback response.
+
+- [ ] **Step 10: Commit MCP slice**
+
+Run:
+
+```powershell
+git add apps/web/lib/mcp-tools.ts apps/web/lib/work-capsules/mcp-handlers.ts apps/web/lib/mcp-tools-work-capsules.test.ts apps/web/lib/tak/agent-grants.ts apps/web/lib/tak/agent-grants.test.ts apps/web/components/platform/EffectivePermissionsPanel.tsx packages/db/data/grant_catalog.json packages/db/data/agent_registry.json
+git commit -s -m "feat(web): expose work capsule MCP tools"
+```
+
+## Task 6: Complete Adoption, Scope, Status, and Evidence Handlers
+
+**Files:**
+- Modify: `apps/web/lib/work-capsules/work-capsule-store.ts`
+- Modify: `apps/web/lib/work-capsules/mcp-handlers.ts`
+- Modify: `apps/web/lib/mcp-tools-work-capsules.test.ts`
+
+- [ ] **Step 1: Add tests for adoption and scope**
+
+Extend `apps/web/lib/mcp-tools-work-capsules.test.ts`:
+
+```ts
+  it("adopt_worktree creates a capsule for a branch/worktree pair", async () => {
+    mockPrisma.workCapsule.findFirst.mockResolvedValue(null);
+    mockPrisma.workCapsule.create.mockResolvedValue({ id: "row-1", capsuleId: "WC-ADOPT" });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("adopt_worktree", {
+      title: "Adopt recovery branch",
+      objective: "Recover useful work.",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      headBranch: "fix/recovery",
+      worktreePath: "D:/DPF-recovery",
+      executorKind: "codex-desktop",
+    }, "user-1", { agentId: "codex" });
+
+    expect(result.success).toBe(true);
+    expect(result.entityId).toBe("WC-ADOPT");
+  });
+
+  it("claim_capsule_scope stores typed scope claims", async () => {
+    mockPrisma.workCapsule.findUnique.mockResolvedValue({ id: "row-1", capsuleId: "WC-SCOPE", scopeClaims: [] });
+    mockPrisma.workCapsule.update.mockResolvedValue({ id: "row-1", capsuleId: "WC-SCOPE" });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("claim_capsule_scope", {
+      capsuleId: "WC-SCOPE",
+      claims: [{ kind: "path", value: "apps/web/lib/work-capsules.ts", intent: "edit" }],
+    }, "user-1");
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.workCapsule.update).toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Implement missing store operations**
+
+Add these exports to `work-capsule-store.ts`:
+
+```ts
+export async function claimWorkCapsuleScope(args: {
+  db: CapsuleDb;
+  capsuleId: string;
+  claims: Array<{ kind: string; value: string; intent: string }>;
+  actor: Actor;
+  now?: Date;
+}) {
+  const capsule = await args.db.workCapsule.findUnique({ where: { capsuleId: args.capsuleId } });
+  if (!capsule) throw new Error(`Work Capsule ${args.capsuleId} not found`);
+  const recordedAt = (args.now ?? new Date()).toISOString();
+  const principalId = args.actor.principalId ?? args.actor.userId;
+  const existing = Array.isArray(capsule.scopeClaims) ? capsule.scopeClaims : [];
+  const nextClaims = args.claims.map((claim) => ({
+    kind: claim.kind,
+    value: claim.value,
+    intent: claim.intent,
+    recordedAt,
+    recordedByPrincipalId: principalId,
+  }));
+  const merged = [...existing, ...nextClaims];
+  const updated = await args.db.workCapsule.update({
+    where: { capsuleId: args.capsuleId },
+    data: { scopeClaims: merged },
+  });
+  await recordActivity(args.db, {
+    workCapsuleId: capsule.id,
+    kind: "scope-claimed",
+    summary: `Claimed ${nextClaims.length} scope item(s)`,
+    payload: { claims: nextClaims },
+    actor: args.actor,
+  });
+  return updated;
+}
+
+export async function updateWorkCapsuleStatus(args: {
+  db: CapsuleDb;
+  capsuleId: string;
+  status: string;
+  reason: string;
+  actor: Actor;
+}) {
+  const updated = await args.db.workCapsule.update({
+    where: { capsuleId: args.capsuleId },
+    data: {
+      status: args.status,
+      workspaceState: {
+        statusOverride: {
+          reason: args.reason,
+          until: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        },
+      },
+    },
+  });
+  await recordActivity(args.db, {
+    workCapsuleId: updated.id,
+    kind: "status-override",
+    summary: args.reason,
+    payload: { status: args.status },
+    actor: args.actor,
+  });
+  return updated;
+}
+```
+
+- [ ] **Step 3: Wire the remaining MCP handlers**
+
+Implement and register `adoptWorktreeTool`, `claimCapsuleScopeTool`, `updateWorkCapsuleStatusTool`, and `releaseCapsuleScopeTool` with explicit parameter validation and calls to the store module. Before committing, search `apps/web/lib/work-capsules/mcp-handlers.ts` and `apps/web/lib/mcp-tools.ts` for temporary fallback responses and remove any that remain.
+
+- [ ] **Step 4: Run MCP tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/mcp-tools-work-capsules.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit handler completion**
+
+Run:
+
+```powershell
+git add apps/web/lib/work-capsules/work-capsule-store.ts apps/web/lib/work-capsules/mcp-handlers.ts apps/web/lib/mcp-tools-work-capsules.test.ts
+git commit -s -m "feat(web): complete work capsule adoption handlers"
+```
+
+## Chunk 4: UI And Verification
+
+## Task 7: Work Control Server Actions and Presenter
+
+**Files:**
+- Create: `apps/web/lib/actions/work-capsules.ts`
+- Create: `apps/web/lib/work-capsules/work-capsule-presenter.ts`
+- Test: `apps/web/lib/work-capsules/work-capsule-presenter.test.ts`
+
+- [ ] **Step 1: Write presenter tests**
+
+Create `apps/web/lib/work-capsules/work-capsule-presenter.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { presentCapsuleRow } from "./work-capsule-presenter";
+
+describe("presentCapsuleRow", () => {
+  it("marks expired leases", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-1",
+      title: "Adopt work",
+      status: "working",
+      source: "external-adoption",
+      executorKind: "codex-desktop",
+      headBranch: "feat/adopt",
+      worktreePath: "D:/DPF-adopt",
+      pullRequestUrl: null,
+      leaseExpiresAt: new Date("2026-05-14T00:00:00.000Z"),
+      lastSyncedAt: new Date("2026-05-14T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-14T00:00:00.000Z"),
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("lease-expired");
+  });
+});
+```
+
+- [ ] **Step 2: Implement presenter**
+
+Create `apps/web/lib/work-capsules/work-capsule-presenter.ts`:
+
+```ts
+type CapsuleRowInput = {
+  capsuleId: string;
+  title: string;
+  status: string;
+  source: string;
+  executorKind: string | null;
+  headBranch: string | null;
+  worktreePath: string | null;
+  pullRequestUrl: string | null;
+  leaseExpiresAt: Date | null;
+  lastSyncedAt: Date | null;
+  updatedAt: Date;
+};
+
+export type PresentedCapsuleRow = ReturnType<typeof presentCapsuleRow>;
+
+export function presentCapsuleRow(row: CapsuleRowInput, now = new Date()) {
+  const leaseExpired = row.leaseExpiresAt != null && row.leaseExpiresAt.getTime() < now.getTime();
+  const staleCache = row.lastSyncedAt != null && now.getTime() - row.lastSyncedAt.getTime() > 30 * 60 * 1000;
+  return {
+    capsuleId: row.capsuleId,
+    title: row.title,
+    status: row.status,
+    source: row.source,
+    executorKind: row.executorKind ?? "unassigned",
+    branch: row.headBranch ?? "no branch",
+    worktreePath: row.worktreePath,
+    pullRequestUrl: row.pullRequestUrl,
+    health: leaseExpired ? "lease-expired" : staleCache ? "stale-cache" : "ok",
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+```
+
+- [ ] **Step 3: Implement server actions**
+
+Create `apps/web/lib/actions/work-capsules.ts`:
+
+```ts
+"use server";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { prisma } from "@dpf/db";
+import { presentCapsuleRow } from "@/lib/work-capsules/work-capsule-presenter";
+
+async function requireBuildAccess(): Promise<string> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")) {
+    throw new Error("Unauthorized");
+  }
+  return user.id!;
+}
+
+export async function getWorkControlData() {
+  await requireBuildAccess();
+  const capsules = await prisma.workCapsule.findMany({
+    orderBy: { updatedAt: "desc" },
+    take: 100,
+    select: {
+      capsuleId: true,
+      title: true,
+      status: true,
+      source: true,
+      executorKind: true,
+      headBranch: true,
+      worktreePath: true,
+      pullRequestUrl: true,
+      leaseExpiresAt: true,
+      lastSyncedAt: true,
+      updatedAt: true,
+    },
+  });
+  return {
+    capsules: capsules.map((row) => presentCapsuleRow(row)),
+    adoptable: [],
+  };
+}
+```
+
+- [ ] **Step 4: Run presenter test**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules/work-capsule-presenter.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit action/presenter slice**
+
+Run:
+
+```powershell
+git add apps/web/lib/actions/work-capsules.ts apps/web/lib/work-capsules/work-capsule-presenter.ts apps/web/lib/work-capsules/work-capsule-presenter.test.ts
+git commit -s -m "feat(web): add work control data loader"
+```
+
+## Task 8: Work Control UI
+
+**Files:**
+- Create: `apps/web/app/(shell)/build/work/page.tsx`
+- Create: `apps/web/components/build/work-control/WorkControlPanel.tsx`
+- Create: `apps/web/components/build/work-control/WorkCapsuleTable.tsx`
+- Create: `apps/web/components/build/work-control/AdoptableWorktreeTable.tsx`
+- Test: `apps/web/components/build/work-control/WorkControlPanel.test.tsx`
+- Modify: `apps/web/components/build/BuildStudio.tsx`
+
+- [ ] **Step 1: Write UI test**
+
+Create `apps/web/components/build/work-control/WorkControlPanel.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { WorkControlPanel } from "./WorkControlPanel";
+
+describe("WorkControlPanel", () => {
+  it("renders active capsule rows", () => {
+    render(
+      <WorkControlPanel
+        capsules={[{
+          capsuleId: "WC-1",
+          title: "Adopt work",
+          status: "working",
+          source: "external-adoption",
+          executorKind: "codex-desktop",
+          branch: "feat/adopt",
+          worktreePath: "D:/DPF-adopt",
+          pullRequestUrl: null,
+          health: "ok",
+          updatedAt: "2026-05-14T00:00:00.000Z",
+        }]}
+        adoptable={[]}
+      />,
+    );
+
+    expect(screen.getByText("Work Control")).toBeInTheDocument();
+    expect(screen.getByText("Adopt work")).toBeInTheDocument();
+    expect(screen.getByText("feat/adopt")).toBeInTheDocument();
+  });
+
+  it("renders empty state", () => {
+    render(<WorkControlPanel capsules={[]} adoptable={[]} />);
+    expect(screen.getByText("No active capsules yet.")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement UI components**
+
+Create `apps/web/components/build/work-control/WorkControlPanel.tsx`:
+
+```tsx
+import { GitBranch, RefreshCcw, ShieldCheck } from "lucide-react";
+import { WorkCapsuleTable, type WorkCapsuleRow } from "./WorkCapsuleTable";
+import { AdoptableWorktreeTable, type AdoptableWorktreeRow } from "./AdoptableWorktreeTable";
+
+export function WorkControlPanel({
+  capsules,
+  adoptable,
+}: {
+  capsules: WorkCapsuleRow[];
+  adoptable: AdoptableWorktreeRow[];
+}) {
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">Work Control</h1>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            Coordinate Build Studio, desktop agents, worktrees, pull requests, and verification evidence.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
+          <ShieldCheck className="h-4 w-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+          <span>Adoption-first, no production mutation</span>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+          <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
+            <GitBranch className="h-4 w-4" aria-hidden="true" />
+            Active capsules
+          </div>
+          <div className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{capsules.length}</div>
+        </div>
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+          <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
+            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+            Adoptable work
+          </div>
+          <div className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{adoptable.length}</div>
+        </div>
+      </div>
+
+      <WorkCapsuleTable capsules={capsules} />
+      <AdoptableWorktreeTable rows={adoptable} />
+    </section>
+  );
+}
+```
+
+Create `WorkCapsuleTable.tsx` with a table, not cards:
+
+```tsx
+export type WorkCapsuleRow = {
+  capsuleId: string;
+  title: string;
+  status: string;
+  source: string;
+  executorKind: string;
+  branch: string;
+  worktreePath: string | null;
+  pullRequestUrl: string | null;
+  health: string;
+  updatedAt: string;
+};
+
+export function WorkCapsuleTable({ capsules }: { capsules: WorkCapsuleRow[] }) {
+  return (
+    <section aria-labelledby="work-capsules-heading" className="space-y-3">
+      <h2 id="work-capsules-heading" className="text-base font-semibold text-[var(--dpf-text)]">
+        Active capsules
+      </h2>
+      {capsules.length === 0 ? (
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+          No active capsules yet.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded border border-[var(--dpf-border)]">
+          <table className="min-w-full text-sm">
+            <thead className="bg-[var(--dpf-surface-2)] text-left text-xs text-[var(--dpf-muted)]">
+              <tr>
+                <th className="px-3 py-2 font-medium">Capsule</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium">Executor</th>
+                <th className="px-3 py-2 font-medium">Branch</th>
+                <th className="px-3 py-2 font-medium">Health</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+              {capsules.map((capsule) => (
+                <tr key={capsule.capsuleId}>
+                  <td className="px-3 py-2">
+                    <div className="font-medium text-[var(--dpf-text)]">{capsule.title}</div>
+                    <div className="font-mono text-xs text-[var(--dpf-muted)]">{capsule.capsuleId}</div>
+                  </td>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{capsule.status}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{capsule.executorKind}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-[var(--dpf-muted)]">{capsule.branch}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{capsule.health}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+Create `AdoptableWorktreeTable.tsx`:
+
+```tsx
+export type AdoptableWorktreeRow = {
+  path: string;
+  branch: string | null;
+  modifiedCount: number;
+  untrackedCount: number;
+};
+
+export function AdoptableWorktreeTable({ rows }: { rows: AdoptableWorktreeRow[] }) {
+  return (
+    <section aria-labelledby="adoptable-work-heading" className="space-y-3">
+      <h2 id="adoptable-work-heading" className="text-base font-semibold text-[var(--dpf-text)]">
+        Adoptable work
+      </h2>
+      {rows.length === 0 ? (
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+          No adoptable local work detected by the read-only scanner.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded border border-[var(--dpf-border)]">
+          <table className="min-w-full text-sm">
+            <thead className="bg-[var(--dpf-surface-2)] text-left text-xs text-[var(--dpf-muted)]">
+              <tr>
+                <th className="px-3 py-2 font-medium">Path</th>
+                <th className="px-3 py-2 font-medium">Branch</th>
+                <th className="px-3 py-2 font-medium">Changed</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+              {rows.map((row) => (
+                <tr key={`${row.path}:${row.branch ?? "detached"}`}>
+                  <td className="px-3 py-2 font-mono text-xs text-[var(--dpf-text)]">{row.path}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-[var(--dpf-muted)]">{row.branch ?? "detached"}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{row.modifiedCount + row.untrackedCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Add route**
+
+Create `apps/web/app/(shell)/build/work/page.tsx`:
+
+```tsx
+import { WorkControlPanel } from "@/components/build/work-control/WorkControlPanel";
+import { getWorkControlData } from "@/lib/actions/work-capsules";
+
+export default async function WorkControlPage() {
+  const data = await getWorkControlData();
+  return <WorkControlPanel capsules={data.capsules} adoptable={data.adoptable} />;
+}
+```
+
+- [ ] **Step 4: Link from Build Studio**
+
+In `apps/web/components/build/BuildStudio.tsx`, add a `Link` import from `next/link` and render a compact link near the top-level Build Studio header area:
+
+```tsx
+<Link
+  href="/build/work"
+  className="inline-flex items-center gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+>
+  Work Control
+</Link>
+```
+
+Place it alongside existing build-level actions, not inside a nested card.
+
+- [ ] **Step 5: Run UI tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/components/build/work-control/WorkControlPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit UI slice**
+
+Run:
+
+```powershell
+git add apps/web/app/(shell)/build/work/page.tsx apps/web/components/build/work-control apps/web/components/build/BuildStudio.tsx
+git commit -s -m "feat(web): add work control surface"
+```
+
+## Task 9: Phase 1 Verification and PR Update
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md` if implementation discovers a spec correction.
+- Modify: this plan only if a concrete command path changes during execution.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/work-capsules.test.ts apps/web/lib/work-capsules/work-capsule-store.test.ts apps/web/lib/work-capsules/git-scanner.test.ts apps/web/lib/work-capsules/work-capsule-presenter.test.ts apps/web/lib/mcp-tools-work-capsules.test.ts apps/web/lib/tak/agent-grants.test.ts apps/web/components/build/work-control/WorkControlPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Prisma validation and generation**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+pnpm --filter @dpf/db generate
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run production build**
+
+Run:
+
+```powershell
+pnpm --filter web build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Run migration apply check**
+
+Use the configured development database for the worktree. Run:
+
+```powershell
+pnpm --filter @dpf/db exec prisma migrate status
+```
+
+Expected: no failed migrations. If the new migration is unapplied in the local DB, run `pnpm --filter @dpf/db exec prisma migrate dev` and confirm it applies.
+
+- [ ] **Step 6: UX verification against Docker-served portal**
+
+Start/rebuild the Docker-served portal if needed:
+
+```powershell
+docker compose build --no-cache portal portal-init sandbox
+docker compose up -d
+```
+
+Then verify:
+
+1. Log in with `admin@dpf.local` and `ADMIN_PASSWORD` from repo-root `.env`.
+2. Open `/build/work`.
+3. Confirm the page renders the Work Control header, active capsule table, and adoptable work area.
+4. Open `/build`.
+5. Confirm the Work Control link is visible and navigates to `/build/work`.
+6. Confirm no hardcoded-color regressions are visible in light/dark/brand override.
+
+- [ ] **Step 7: Commit any verification doc updates**
+
+If verification finds only pre-existing failures, document them in the PR body. If verification requires a code/doc correction, commit it:
+
+```powershell
+git add <corrected-files>
+git commit -s -m "fix: finalize work capsule phase 1"
+```
+
+- [ ] **Step 8: Push and update PR**
+
+Run:
+
+```powershell
+git push
+gh pr comment 596 --body "Phase 1 implementation plan added: docs/superpowers/plans/2026-05-14-portal-work-capsule-control-harness-phase-1.md"
+```
+
+Expected: branch pushed; PR updated with a concise pointer to the plan and verification evidence. Do not replace the PR body with the full implementation plan.
+
+## Implementation Notes
+
+- Do not edit the root `D:\DPF` checkout for implementation. Use the existing clean worktree at `D:\DPF\.worktrees\portal-work-capsule-control-harness`.
+- Do not grant `work_capsule_promote` to any agent in Phase 1.
+- Do not use `npx`; use `pnpm --filter <pkg> exec <tool>`.
+- Keep all new UI theme-aware. No `text-gray-*`, `bg-white`, hardcoded hex, or inline color styles.
+- Keep Work Control dense and operational. Tables are appropriate here; decorative cards and hero layouts are not.
+- Keep all code and docs ASCII unless an existing file requires otherwise.
+- Preserve 20 percent refactor budget by keeping Work Capsule logic out of `mcp-tools.ts` and out of the Build Studio component body.

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -1,0 +1,785 @@
+# Portal Work Capsule Control Harness Design
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-14 |
+| Status | Draft for review |
+| Author | Codex + Mark Bodman |
+| Scope | Portal-coordinated work capsules for Build Studio, external Claude/Codex desktop sessions, manual worktrees, sandbox promotion, and portal self-update governance |
+| Depends On | `2026-04-05-db-github-delivery-sync-design.md`, `2026-04-20-ship-phase-fork-redesign-design.md`, `2026-04-21-backlog-triage-build-studio-design.md`, `2026-04-23-build-studio-governed-backlog-delivery-design.md`, `2026-05-09-build-execution-provider-design.md`, `2026-05-09-deployment-contracts.md` |
+
+## 1. Problem Statement
+
+DPF now has several valid ways to produce work:
+
+1. Build Studio inside the portal.
+2. Codex desktop sessions operating in local worktrees.
+3. Claude desktop sessions operating in local worktrees.
+4. Human/manual edits in VS Code.
+5. Git-triggered sandbox verification after upstream changes.
+
+Each path is useful. The problem is that they are not coordinated by one durable control object. The result is predictable sprawl:
+
+- dirty root clone state
+- branches without a clear backlog owner
+- worktrees that outlive their purpose
+- multiple agents touching overlapping files without visibility
+- Build Studio runs that are better governed than external desktop work
+- provider and OAuth setup repeated by hand during portal rebaselines
+- uncertainty about which sandbox or PR should be trusted for promotion
+
+The portal already owns the backlog, Build Studio, sandbox execution, promotion records, and provider configuration. It should therefore become the control harness for work, but not the only executor of work.
+
+The core design decision is:
+
+**All work should be coordinated by the portal, but execution may still happen inside Build Studio, Codex desktop, Claude desktop, or a human worktree.**
+
+## 2. Current State Snapshot
+
+This design is grounded in the live DPF planning surface and current repo state on 2026-05-14.
+
+Live MCP checks showed:
+
+- no existing spec that directly defines "portal as work-control harness"
+- open Build Studio and integration-adjacent epics remain active
+- in-progress backlog items include Build Studio graph/cycle work and release-decision work
+
+Repo review showed existing primitives that should be reused:
+
+- `BacklogItem` is the business source of truth for work intake.
+- `FeatureBuild` records Build Studio execution and sandbox state.
+- `TaskRun` records governed coworker task execution.
+- `GitPromotionCandidate` records git-triggered sandbox verification candidates.
+- `ChangePromotion` records production-visible promotion decisions.
+- `SandboxSlot` records local sandbox capacity.
+- `ToolExecution` and `BacklogItemActivity` record audit/evidence trails.
+- Build execution provider and agent runner seams already exist under `apps/web/lib/integrate/sandbox`.
+
+Current local git state also exposed the operational failure mode this spec addresses:
+
+- root clone `D:\DPF` was still on `main`, dirty, ahead of and behind `origin/main`
+- multiple Codex and Claude worktrees existed at once
+- some active work was visible only through branch/worktree names, not through a shared portal lifecycle
+
+Design consequence:
+
+DPF does not need a second Build Studio. It needs a small, durable **Work Capsule** layer above backlog, Build Studio, git, worktrees, sandboxes, and promotions.
+
+## 3. Goals
+
+1. Make the portal the authoritative coordinator for all platform work.
+2. Preserve Build Studio as the native in-portal executor.
+3. Allow Codex desktop, Claude desktop, and humans to remain useful external executors.
+4. Ensure every non-trivial work unit has one durable Work Capsule.
+5. Attach branches, worktrees, PRs, sandboxes, builds, verification evidence, and promotion records to that capsule.
+6. Support adoption of existing messy work without losing it.
+7. Prevent new collisions through visible scope claims and stale-state warnings.
+8. Preserve the root clone as a release/merge-only worktree.
+9. Coordinate portal self-update through sandbox verification, backups, and explicit approval.
+10. Reduce manual provider/OAuth rebaseline work without exposing secrets to code agents.
+
+## 4. Non-Goals
+
+1. Replacing Build Studio.
+2. Forcing all coding to happen inside the portal UI.
+3. Building a fully autonomous deployment system in v1.
+4. Letting a sandbox directly mutate or replace production.
+5. Moving provider secrets, OAuth tokens, or API keys into git.
+6. Replacing GitHub PR review or branch protection.
+7. Solving every stale historical worktree in the first implementation slice.
+8. Changing the existing `BacklogItem.status` or `FeatureBuild.phase` vocabulary in this spec.
+
+## 5. Research and Benchmarking
+
+### 5.1 Open Source Systems Reviewed
+
+- [Argo Workflows DAG templates](https://argo-workflows.readthedocs.io/en/latest/walk-through/dag/) model explicit task dependencies and nested workflows. Adopt: visible dependency graph and terminal state per node. Reject: arbitrary DAG authoring as the primary v1 user model.
+- [Temporal documentation](https://docs.temporal.io/) emphasizes durable execution that survives failures and resumes from persisted state. Adopt: durable workflow identity and event history. Reject: adding Temporal as a new runtime dependency.
+- [GitLab deployment approvals](https://docs.gitlab.com/ci/environments/deployment_approvals/) and [deployment safety](https://docs.gitlab.com/ci/environments/deployment_safety/) separate build completion from production deployment. Adopt: protected promotion gate and single production deployment control. Reject: treating CI/CD pipeline status as sufficient business approval.
+
+### 5.2 Commercial Systems Reviewed
+
+- [GitHub pull request issue linking](https://docs.github.com/articles/closing-issues-via-commit-messages) makes issue, branch, PR, and merge state traceable. Adopt: work item to PR linkage. Reject: GitHub issue as the DPF business source of truth.
+- [GitHub Codespaces source control docs](https://docs.github.com/en/codespaces/developing-in-codespaces/using-source-control-in-your-codespace) normalize isolated cloud workspaces that still use normal branches and PRs. Adopt: isolated workspace per work unit. Reject: moving DPF's local/offline install dependency to hosted workspaces.
+- [Linear triage](https://linear.app/docs/triage) keeps incoming work in a reviewable inbox before it joins a team workflow. Adopt: capsule adoption/recovery as an intake stage. Reject: assuming every incoming item is ready for execution.
+- [Cursor Background Agents](https://docs.cursor.com/en/background-agents) provide account-level visibility into background coding agents. Adopt: external agent work should be visible and resumable. Reject: agent account dashboard as the authoritative work record.
+
+### 5.3 Patterns Adopted
+
+1. Durable work identity separate from execution substrate.
+2. Work item first, workspace second.
+3. Explicit branch/worktree/PR linkage.
+4. Sandbox verification before production-visible promotion.
+5. Human approval for protected environments.
+6. Reconciliation jobs that repair drift instead of assuming every event arrives cleanly.
+
+### 5.4 Patterns Rejected
+
+1. Portal-only execution.
+2. External desktop clients operating as untracked work systems.
+3. GitHub-only backlog truth.
+4. Production deployment based only on a green build.
+5. Secret copying as a convenience mechanism.
+
+## 6. Core Concept: Work Capsule
+
+A Work Capsule is the durable coordination record for exactly one concern.
+
+It is not the backlog item, because not all execution details belong in the backlog. It is not the Build Studio `FeatureBuild`, because external Codex/Claude work may not start inside Build Studio. It is not a `TaskRun`, because a capsule may contain several task runs, manual commits, PRs, sandboxes, and promotions over time.
+
+A Work Capsule answers:
+
+- What is the objective?
+- What business record owns it?
+- Which executor is working it?
+- Which branch/worktree/sandbox/PR contains the changes?
+- What scope is claimed?
+- What evidence exists?
+- What is stale, blocked, or conflicting?
+- Is it safe to merge, promote, archive, or rebase?
+
+### 6.1 Capsule Status Values
+
+If persisted as strings, these values become strongly typed enums in `apps/web/lib/work-capsules.ts` and the MCP tool definitions:
+
+| Status | Meaning |
+|---|---|
+| `draft` | Captured but not ready for work |
+| `ready` | Ready to start or assign |
+| `working` | Actively being changed by an executor |
+| `blocked` | Needs user input, provider setup, merge decision, or dependency |
+| `verifying` | Changes exist and checks are running |
+| `ready-for-review` | Ready for PR or human review |
+| `ready-for-promotion` | Sandbox evidence supports production promotion |
+| `complete` | Work merged, promoted, or intentionally finished |
+| `abandoned` | Work stopped but preserved for audit/recovery |
+| `archived` | Historical/no-action record |
+
+Hyphenated values are mandatory. Any enum additions must update the library constants and MCP `enum:` arrays in the same commit.
+
+### 6.2 Capsule Sources
+
+| Source | Meaning |
+|---|---|
+| `backlog` | Created from a backlog item |
+| `build-studio` | Created by Build Studio |
+| `external-adoption` | Adopted from an existing branch/worktree/PR |
+| `git-promotion` | Created from a git-triggered sandbox candidate |
+| `manual` | Created by a human before backlog linkage is known |
+| `scheduled-steward` | Created by daily hygiene automation |
+
+### 6.3 Executor Kinds
+
+| Executor | Meaning |
+|---|---|
+| `build-studio` | Native portal Build Studio execution |
+| `codex-desktop` | Codex desktop session in a governed worktree |
+| `claude-desktop` | Claude desktop session in a governed worktree |
+| `human` | Manual local development |
+| `git-webhook` | Git update event awaiting sandbox verification |
+| `dpf-native` | Future portal-side agent runner |
+
+## 7. Architecture
+
+The portal becomes the coordinator. Executors become participants.
+
+```mermaid
+flowchart TD
+  Backlog["BacklogItem / Epic"] --> Capsule["Work Capsule"]
+  Capsule --> Build["FeatureBuild / Build Studio"]
+  Capsule --> Task["TaskRun / Coworker work"]
+  Capsule --> Git["Branch / Worktree / PR"]
+  Capsule --> Sandbox["Sandbox / BuildExecutionProvider"]
+  Capsule --> Evidence["Verification evidence"]
+  Evidence --> Promotion["ChangePromotion"]
+  Promotion --> Portal["Running portal"]
+
+  Codex["Codex desktop"] --> Capsule
+  Claude["Claude desktop"] --> Capsule
+  Human["Human / VS Code"] --> Capsule
+```
+
+### 7.1 Authority Boundaries
+
+| Surface | Authority |
+|---|---|
+| Platform DB | backlog, capsules, evidence, promotion decisions, provider references |
+| Git | source changes, branches, commits, PR review |
+| Build Studio | native sandbox execution and build-phase evidence |
+| External clients | implementation execution only |
+| Promotion runner | host/container swap after approval |
+| Secret store | provider keys, OAuth tokens, runtime credentials |
+
+External clients can write code, tests, docs, and PRs. They do not own lifecycle truth. They update or attach evidence to a capsule.
+
+### 7.2 Why This Is Not Just TaskRun
+
+`TaskRun` is the right model for a governed coworker task. Work Capsules are broader:
+
+- one capsule can contain several task runs
+- a capsule can begin as an adopted branch with no coworker task
+- a capsule can hold a Build Studio build, GitHub PR, sandbox, and promotion candidate together
+- a capsule remains useful after task execution ends
+
+`TaskRun` should link to Work Capsule, not replace it.
+
+### 7.3 Why This Is Not Just FeatureBuild
+
+`FeatureBuild` is the right model for Build Studio execution. Work Capsules coordinate more paths:
+
+- Codex desktop work
+- Claude desktop work
+- manual worktree recovery
+- git-triggered promotion candidates
+- docs-only branch work
+- portal self-update safety
+
+`FeatureBuild` should link to Work Capsule, not expand into a catch-all delivery model.
+
+## 8. Data Model Stewardship
+
+### 8.1 Existing Models Reused
+
+| Existing model | Reuse |
+|---|---|
+| `BacklogItem` | business origin and lifecycle anchor |
+| `Epic` | portfolio/work grouping |
+| `FeatureBuild` | Build Studio execution record |
+| `TaskRun` | coworker task execution |
+| `GitPromotionCandidate` | git update sandbox candidate |
+| `ChangePromotion` | production-visible promotion |
+| `SandboxSlot` | local sandbox capacity |
+| `ToolExecution` | cross-cutting tool audit |
+| `BacklogItemActivity` | backlog-scoped timeline |
+
+### 8.2 New Model: `WorkCapsule`
+
+Recommended fields:
+
+```prisma
+model WorkCapsule {
+  id                    String    @id @default(cuid())
+  capsuleId             String    @unique
+  title                 String
+  objective             String    @db.Text
+  status                String    @default("draft")
+  source                String
+  executorKind          String?
+  executorRef           String?
+
+  backlogItemId         String?
+  epicId                String?
+  featureBuildId        String?
+  taskRunId             String?
+  gitPromotionCandidateId String?
+  changePromotionId     String?
+
+  repositoryFullName    String?
+  baseBranch            String?
+  baseSha               String?
+  headBranch            String?
+  headSha               String?
+  worktreePath          String?
+  pullRequestUrl        String?
+  pullRequestNumber     Int?
+
+  sandboxProviderId     String?
+  sandboxId             String?
+
+  scopeClaims           Json      @default("[]")
+  workspaceState        Json      @default("{}")
+  verificationState     Json      @default("{}")
+  providerRequirements  Json      @default("[]")
+  promotionPolicy       Json      @default("{}")
+
+  createdById           String?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  lastSyncedAt          DateTime?
+  archivedAt            DateTime?
+  activities            WorkCapsuleActivity[]
+
+  @@index([status, updatedAt])
+  @@index([backlogItemId])
+  @@index([featureBuildId])
+  @@index([headBranch])
+  @@index([sandboxId])
+}
+```
+
+The first slice may use string IDs rather than full Prisma relations for low-risk adoption. Later slices can add relations after the shape proves stable.
+
+### 8.3 New Model: `WorkCapsuleActivity`
+
+Recommended fields:
+
+```prisma
+model WorkCapsuleActivity {
+  id                String   @id @default(cuid())
+  workCapsuleId     String
+  kind              String
+  summary           String
+  payload           Json     @default("{}")
+  recordedAt        DateTime @default(now())
+  recordedById      String?
+  recordedByAgentId String?
+  toolExecutionId   String?
+  capsule           WorkCapsule @relation(fields: [workCapsuleId], references: [id], onDelete: Cascade)
+
+  @@index([workCapsuleId, recordedAt(sort: Desc)])
+  @@index([kind, recordedAt(sort: Desc)])
+}
+```
+
+This mirrors `BacklogItemActivity` and keeps capsule history inspectable without overloading `ToolExecution`.
+
+### 8.4 Refactor Budget
+
+Reserve at least 20 percent of implementation capacity for refactoring existing Build Studio, backlog, and promotion seams touched by this work.
+
+Allowed refactors:
+
+- extracting enum constants to `apps/web/lib/work-capsules.ts`
+- normalizing Build Studio links to reference the capsule where present
+- reducing duplicated git/worktree state formatting
+- centralizing "dirty/stale/behind origin" detection
+- moving promotion-readiness derivation into a reusable helper
+
+Disallowed refactors:
+
+- redesigning Build Studio phases
+- renaming existing backlog statuses
+- replacing `FeatureBuild`
+- replacing `TaskRun`
+- broad route or shell layout rewrites
+
+## 9. Primary Workflows
+
+### 9.1 Adopt Existing Work
+
+This is the most important first workflow because it rescues current sprawl.
+
+1. User opens Work Control in the portal.
+2. Portal scans known worktrees, branches, open PRs, active Build Studio builds, and git promotion candidates.
+3. Portal shows untracked candidates.
+4. User selects a candidate and chooses "Adopt".
+5. Portal reads:
+   - branch name
+   - base branch
+   - base SHA
+   - head SHA
+   - ahead/behind count
+   - dirty files
+   - untracked files
+   - PR URL if present
+   - possible backlog/spec references from branch, commit, PR body, or docs
+6. User links the capsule to a backlog item, epic, spec, or plan.
+7. Portal records scope claims from changed files and declared intent.
+8. Portal recommends one action:
+   - continue
+   - rebase
+   - split
+   - supersede
+   - archive
+   - convert to Build Studio
+
+V1 should not delete branches or worktrees. It records and recommends.
+
+### 9.2 Create New Governed Work
+
+1. User starts from a backlog item, spec, plan, or manual objective.
+2. Portal creates a capsule.
+3. Portal generates branch and worktree names.
+4. Portal creates the worktree from `origin/main`.
+5. Portal runs the repo MCP seed helper for the new worktree.
+6. Portal assigns an executor:
+   - Build Studio
+   - Codex desktop
+   - Claude desktop
+   - human
+7. Portal emits launch instructions or starts the native Build Studio flow.
+8. Executor records progress and evidence back to the capsule.
+
+Creation must refuse to use the root clone as an active worktree.
+
+### 9.3 External Client Attachment
+
+Codex and Claude desktop sessions attach through MCP.
+
+Required MCP tools:
+
+| Tool | Purpose |
+|---|---|
+| `list_work_capsules` | find assigned or open capsules |
+| `get_work_capsule` | hydrate context before acting |
+| `create_work_capsule` | create a governed work unit |
+| `adopt_worktree` | attach an existing path/branch |
+| `claim_capsule_scope` | declare intended files/modules |
+| `record_capsule_evidence` | persist tests, builds, screenshots, notes |
+| `update_work_capsule_status` | move status with validation |
+| `release_capsule_scope` | clear claims when done/abandoned |
+
+Grant categories:
+
+- `work_capsule_read`
+- `work_capsule_write`
+- `work_capsule_adopt`
+- `work_capsule_promote`
+
+External clients should not receive `work_capsule_promote` by default.
+
+### 9.4 Collision Detection
+
+V1 uses soft leases, not hard git locks.
+
+The portal warns when:
+
+- two active capsules touch the same file
+- two active capsules claim the same module
+- a capsule is behind `origin/main` beyond a configured threshold
+- the root clone is dirty
+- a branch has local commits but no PR
+- a worktree has untracked files older than a configured threshold
+- a capsule has no linked backlog item/spec/plan
+
+Soft leases keep work moving while making collisions visible early.
+
+### 9.5 Daily Steward
+
+The daily steward is a scheduled hygiene run. It prepares recommendations but does not delete or deploy in v1.
+
+It checks:
+
+- root clone branch, cleanliness, ahead/behind state
+- all known worktrees
+- untracked branches
+- stale capsules
+- capsules without evidence
+- open PRs without matching capsules
+- active Build Studio builds without matching capsules
+- GitPromotionCandidates awaiting review
+- provider/OAuth readiness required by active capsules
+- promotion candidates without backup evidence
+
+Outputs:
+
+- "safe to continue"
+- "needs rebase"
+- "needs backlog link"
+- "needs provider setup"
+- "ready for PR"
+- "ready for sandbox verification"
+- "ready for promotion approval"
+- "archive candidate"
+
+## 10. Portal Self-Update and Replacement
+
+The portal may coordinate its own replacement, but the sandbox must never replace production directly.
+
+The safe path is:
+
+1. Work Capsule reaches `ready-for-review`.
+2. PR is opened and reviewed.
+3. PR merges to `main`.
+4. Git webhook records or updates a `GitPromotionCandidate`.
+5. Build execution provider creates a fresh sandbox from the target SHA.
+6. Sandbox verification runs:
+   - install/build setup
+   - typecheck
+   - production build
+   - migrations against cloned DB
+   - smoke tests
+   - login check
+   - backlog count invariant
+   - provider configuration presence check
+   - promotion-readiness evidence capture
+7. Portal creates or links a `ChangePromotion`.
+8. Backup is captured:
+   - Postgres
+   - Neo4j
+   - Qdrant
+   - runtime config fingerprint
+   - provider configuration fingerprint without secrets
+9. Human approves promotion.
+10. Promotion runner swaps the running portal.
+11. Post-promotion health checks run.
+12. Failure triggers rollback to previous image and backup.
+
+### 10.1 Production Lock
+
+Only one portal replacement promotion may be `in_progress` at a time.
+
+Other capsules may continue work, but no second production-visible portal swap can start until the active promotion reaches a terminal state.
+
+### 10.2 Emergency Recovery
+
+If the portal is unavailable, a release worktree rescue script must be able to:
+
+- list recent backups
+- list latest promotion attempts
+- restore the previous image/container
+- restore database backups when explicitly confirmed
+
+This rescue path is separate from the normal portal UI and should be documented alongside release scripts.
+
+## 11. Provider and OAuth Policy
+
+Provider configuration is runtime state. Capsules record requirements and evidence, not secrets.
+
+### 11.1 What Capsules Store
+
+Allowed:
+
+- provider kind required by the work
+- model capability class
+- OAuth provider connection ID
+- last verified timestamp
+- redacted health status
+- missing setup steps
+
+Disallowed:
+
+- API keys
+- OAuth refresh tokens
+- raw `.env` values
+- CLI auth files
+- copied provider config blobs
+
+### 11.2 Rebaseline Flow
+
+When a portal rebaseline is needed:
+
+1. Portal captures a backup and provider configuration fingerprint.
+2. Sandbox or new portal verifies required provider rows exist by ID/reference.
+3. User re-authorizes missing providers through the portal UI.
+4. Capsules blocked on providers move from `blocked` to `ready` only after health checks pass.
+
+This removes manual guessing while avoiding secret leakage to coding agents.
+
+## 12. UX Design
+
+The Work Capsule UX should be a quiet operational cockpit, not a marketing page.
+
+Primary surface:
+
+- `/build/work` becomes the Work Control view for active build/development work.
+- `/build/work/[capsuleId]` shows one capsule and its evidence.
+- `/build` links to Work Control from the Build Studio header/chrome when active capsules exist.
+- Operations > Promotions continues to own production promotion review.
+
+Recommended navigation:
+
+| View | Purpose |
+|---|---|
+| Intake | adopt existing work, create capsule, link backlog/spec |
+| Active | see current capsules, executors, branches, dirty state |
+| Review | PR readiness, verification evidence, scope conflicts |
+| Promote | sandbox candidates and promotion prerequisites |
+| Cleanup | stale worktrees, abandoned branches, archive recommendations |
+
+### 12.1 Capsule List Row
+
+Each row shows:
+
+- title
+- status
+- linked backlog item or spec
+- executor
+- branch
+- worktree health
+- PR state
+- verification state
+- conflicts
+- next recommended action
+
+The row should be dense and scannable. It should not use cards inside cards.
+
+### 12.2 Capsule Detail
+
+Sections:
+
+1. Objective and linked records.
+2. Executor and workspace.
+3. Scope claims and detected changed files.
+4. Evidence.
+5. PR and review state.
+6. Sandbox and promotion readiness.
+7. Timeline.
+8. Actions.
+
+Actions should be explicit:
+
+- adopt
+- sync state
+- assign executor
+- open worktree
+- create PR
+- run verification
+- mark blocked
+- archive
+- prepare promotion
+
+### 12.3 Theme and Accessibility
+
+All UI must use DPF theme variables:
+
+- `text-[var(--dpf-text)]`
+- `text-[var(--dpf-muted)]`
+- `bg-[var(--dpf-surface-1)]`
+- `bg-[var(--dpf-surface-2)]`
+- `border-[var(--dpf-border)]`
+- `text-[var(--dpf-accent)]`
+
+No hardcoded colors except `text-white` on accent buttons.
+
+Use icons for compact actions where lucide icons exist. Use tooltips for unfamiliar icon-only controls.
+
+## 13. Error Handling
+
+| Failure | Handling |
+|---|---|
+| root clone dirty | block new work from root; show remediation |
+| branch already exists | offer adopt or choose new branch |
+| worktree path missing | mark workspace stale; keep capsule |
+| worktree dirty with no capsule | offer adopt |
+| capsule behind origin | recommend rebase |
+| changed-file conflict | show overlapping capsule and owner |
+| provider missing | mark blocked with setup link |
+| sandbox verification failed | persist evidence and keep promotion disabled |
+| migration failed on clone | block promotion |
+| backup failed | block promotion |
+| post-promotion health failed | trigger rollback path |
+| MCP unavailable | allow read-only UI and show external-client attach blocked |
+
+## 14. Security and Governance
+
+1. `.mcp.json` and `.vscode/mcp.json` remain ignored credential files.
+2. Capsules never store secrets.
+3. External agents receive only grants appropriate to their role.
+4. Promotion requires `work_capsule_promote` plus existing promotion authority.
+5. Every MCP capsule mutation writes `ToolExecution`.
+6. Every user-visible capsule event writes `WorkCapsuleActivity`.
+7. Production portal replacement requires backup evidence and human approval in v1.
+8. Scope claims are advisory in v1 but audit-visible.
+
+## 15. Implementation Phases
+
+### Phase 0: Spec and Plan
+
+- land this design
+- write implementation plan
+- create backlog items/epic if needed
+
+### Phase 1: Adoption-First Registry
+
+- add `WorkCapsule` and `WorkCapsuleActivity`
+- add enum constants and validation
+- add MCP read/create/adopt/sync tools
+- add scan helpers for branches/worktrees/PRs
+- add read-only Work Control UI for active/adoptable work
+
+### Phase 2: Governed Creation
+
+- create worktree from `origin/main`
+- seed MCP config
+- generate branch/worktree names
+- record initial scope
+- block root clone active work
+
+### Phase 3: Executor Attachment
+
+- attach Build Studio builds to capsules
+- attach Codex/Claude desktop sessions through MCP tools
+- record external execution evidence
+- expose collision warnings
+
+### Phase 4: Daily Steward
+
+- scheduled hygiene job
+- recommendations for rebase/archive/link/provider setup
+- operator review UI
+
+### Phase 5: Portal Self-Update Gate
+
+- link `GitPromotionCandidate` to capsules
+- require sandbox verification evidence
+- require backup evidence
+- require human approval
+- expose rollback/rescue instructions
+
+### Phase 6: Automation Expansion
+
+- allow policy-approved automatic sandbox verification
+- consider policy-approved promotion for low-risk docs/runtime-only changes
+- keep production portal replacement human-approved until evidence supports relaxing it
+
+## 16. First Implementation Slice
+
+The smallest useful slice is:
+
+1. `WorkCapsule` and `WorkCapsuleActivity` schema.
+2. `apps/web/lib/work-capsules.ts` enum constants and validators.
+3. `adopt_worktree`, `list_work_capsules`, `get_work_capsule`, and `record_capsule_evidence` MCP tools.
+4. Git/worktree scanner that returns:
+   - branch
+   - base/head SHA
+   - ahead/behind count
+   - dirty file count
+   - untracked file count
+   - possible PR URL
+5. Work Control intake UI showing adoptable and active capsules.
+6. Unit tests for status validation, adoption, and scanner parsing.
+
+This slice does not create worktrees automatically and does not promote production.
+
+## 17. Verification Plan
+
+Implementation must verify:
+
+1. Unit tests for capsule enum validation.
+2. Unit tests for adopt-worktree parsing.
+3. MCP tool tests for create/adopt/list/get/status/evidence paths.
+4. UI tests for Work Control empty, active, conflict, blocked, and stale states.
+5. Production build.
+6. UX verification against the Docker-served portal.
+7. Migration applies cleanly.
+
+For the self-update phase, verification expands to:
+
+1. sandbox clone/build verification
+2. migration against cloned DB
+3. backup creation
+4. health check before and after swap
+5. rollback rehearsal
+
+## 18. Invariants
+
+1. The root clone is never an active implementation workspace.
+2. Every active Build Studio build should have or create a Work Capsule.
+3. Every external desktop coding session should attach to a Work Capsule before making non-trivial changes.
+4. Every capsule with production-visible intent must link to verification evidence.
+5. Portal replacement cannot proceed without backup evidence.
+6. Provider requirements are references and health checks, not copied secrets.
+7. A capsule may be abandoned, but not silently deleted.
+8. Production promotion requires an explicit terminal decision.
+
+## 19. Resolved V1 Decisions
+
+1. The first UI route is `/build/work`, with capsule detail at `/build/work/[capsuleId]`.
+2. Branch names preserve the existing `feat/`, `fix/`, `doc/`, `chore/`, and `clean/` taxonomy. Capsule identity is stored in `WorkCapsule`, PR body metadata, and optional commit trailers rather than replacing branch taxonomy.
+3. The daily steward produces recommendations only in v1. It does not delete worktrees, close PRs, or create cleanup backlog items automatically.
+4. Scope claims are soft leases in v1. They warn and guide, but they do not block git operations.
+5. Portal replacement remains human-approved in v1 even when sandbox verification is green.
+
+## 20. Recommended Direction
+
+Adopt the hybrid governed execution model:
+
+- portal owns work coordination
+- Build Studio remains native executor
+- Codex and Claude desktop attach as external executors
+- Work Capsules become the missing lifecycle record
+- adoption of existing work comes before full automation
+- portal self-update goes through sandbox, backup, approval, promotion, and rollback
+
+This gives DPF the parallelism the user wants without letting each agent create a separate universe of truth.

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |---|---|
-| Date | 2026-05-14 |
-| Status | Draft for review |
-| Author | Codex + Mark Bodman |
+| Date | 2026-05-14; chief-architect review pass 2026-05-13 |
+| Status | Architect review applied; ready for implementation planning |
+| Author | Codex + Mark Bodman; chief-architect review by Claude (Opus 4.7) |
 | Scope | Portal-coordinated work capsules for Build Studio, external Claude/Codex desktop sessions, manual worktrees, sandbox promotion, and portal self-update governance |
 | Depends On | `2026-04-05-db-github-delivery-sync-design.md`, `2026-04-20-ship-phase-fork-redesign-design.md`, `2026-04-21-backlog-triage-build-studio-design.md`, `2026-04-23-build-studio-governed-backlog-delivery-design.md`, `2026-05-09-build-execution-provider-design.md`, `2026-05-09-deployment-contracts.md` |
 
@@ -36,9 +36,9 @@ The core design decision is:
 
 ## 2. Current State Snapshot
 
-This design is grounded in the live DPF planning surface and current repo state on 2026-05-14.
+This design is grounded in the live DPF planning surface and current repo state on 2026-05-14. Per AGENTS.md section 1, "never fabricate", the implementation plan that follows this spec MUST re-query the live backlog/epic/build state at plan-write time and capture concrete counts and IDs alongside this snapshot, rather than reusing the qualitative observations below.
 
-Live MCP checks showed:
+Live MCP checks at spec-draft time showed:
 
 - no existing spec that directly defines "portal as work-control harness"
 - open Build Studio and integration-adjacent epics remain active
@@ -170,14 +170,35 @@ Hyphenated values are mandatory. Any enum additions must update the library cons
 
 ### 6.3 Executor Kinds
 
-| Executor | Meaning |
+| Executor | Meaning | Maps to (BuildExecutionProvider, BuildAgentRunner) |
+|---|---|---|
+| `build-studio` | Native portal Build Studio execution | provider per substrate (`local-docker`, `k8s`, etc.) x runner per agent (`codex`, `claude`, `dpf-native`) |
+| `codex-desktop` | Codex desktop session in a governed worktree | not applicable; runs outside the portal substrate and attaches via MCP |
+| `claude-desktop` | Claude desktop session in a governed worktree | not applicable; runs outside the portal substrate and attaches via MCP |
+| `human` | Manual local development | not applicable |
+| `git-webhook` | Git update event awaiting sandbox verification | provider per substrate x `dpf-native` runner for verification |
+| `dpf-native` | Portal-side agent runner used by Build Studio | provider per substrate x `dpf-native` runner |
+
+`source` is the *origin* of the capsule and is immutable once set. `executorKind` is *current* ownership and may change across handoffs (e.g., human starts a worktree, then a Codex desktop session adopts it, then Build Studio takes it over for sandbox verification). Every executor handoff writes a `WorkCapsuleActivity` of kind `executor-changed`.
+
+For executors that map to `(BuildExecutionProvider, BuildAgentRunner)` per `2026-05-09-build-execution-provider-design.md`, the capsule records the specific pair in `workspaceState.executor.providerId` / `workspaceState.executor.agentRunnerId`. External desktop executors record session metadata under `workspaceState.executor.session` instead.
+
+### 6.4 Status Projection
+
+To prevent drift between three lifecycles (`BacklogItem.status`, `FeatureBuild.phase`, `WorkCapsule.status`), capsule status is **derived** where the underlying records exist. The reconciler (section 9.6 Daily Steward, plus on-demand sync on tool calls) projects status using the precedence:
+
+| Capsule status | Triggering underlying state |
 |---|---|
-| `build-studio` | Native portal Build Studio execution |
-| `codex-desktop` | Codex desktop session in a governed worktree |
-| `claude-desktop` | Claude desktop session in a governed worktree |
-| `human` | Manual local development |
-| `git-webhook` | Git update event awaiting sandbox verification |
-| `dpf-native` | Future portal-side agent runner |
+| `complete` | `ChangePromotion.status = deployed`, **or** linked `BacklogItem.status = done` with merged PR |
+| `ready-for-promotion` | linked `GitPromotionCandidate` has all required verification evidence captured |
+| `ready-for-review` | `FeatureBuild.phase = ship`, **or** capsule has an open PR with green required checks |
+| `verifying` | sandbox verification active for the linked `FeatureBuild` or `GitPromotionCandidate` |
+| `working` | a `TaskRun` is active, **or** the capsule has commits ahead of base within the last 24h |
+| `blocked` | `providerRequirements` unmet, **or** sandbox verification failed, **or** explicit operator flag |
+| `ready` | adopted/created but no execution recorded yet |
+| `draft` | created without any executor assignment or branch |
+
+Manual override is allowed but writes an activity of kind `status-override` with the operator principal and reason. A capsule's `status` field is therefore write-through with projection: the reconciler sets it on every sync, an operator may override, and the override persists until `workspaceState.statusOverride.until` or until the operator clears it.
 
 ## 7. Architecture
 
@@ -236,6 +257,20 @@ External clients can write code, tests, docs, and PRs. They do not own lifecycle
 
 `FeatureBuild` should link to Work Capsule, not expand into a catch-all delivery model.
 
+### 7.4 Source of Truth Discipline
+
+Capsule fields that mirror external systems are **caches** with a reconciler, not authoritative records. The authority remains:
+
+| Information | Authority | Capsule role |
+|---|---|---|
+| Branch name, base/head SHA, ahead/behind, dirty/untracked | git | cached in `headBranch`/`headSha`/`workspaceState.git`; refreshed by scanner |
+| PR state, required-check results, review approvals | GitHub | cached in `pullRequestUrl`/`pullRequestNumber`/`workspaceState.pr`; refreshed by sync |
+| Sandbox container/pod state | `BuildExecutionProvider` | cached in `sandboxId`/`workspaceState.sandbox`; refreshed by provider polling |
+| Provider/OAuth health | `CredentialEntry`, `ModelProfile`, and provider reconciler | cached in `providerRequirements[].lastVerifiedAt`; never the keys themselves |
+| Promotion outcome | `ChangePromotion` | linked via `changePromotionId`; capsule does not duplicate deployment timestamps or promoted SHA |
+
+`lastSyncedAt` is the freshness witness for every cached field group. UI must visibly indicate when caches are stale beyond a configured threshold.
+
 ## 8. Data Model Stewardship
 
 ### 8.1 Existing Models Reused
@@ -292,7 +327,13 @@ model WorkCapsule {
   providerRequirements  Json      @default("[]")
   promotionPolicy       Json      @default("{}")
 
-  createdById           String?
+  contributionMode      String    @default("private")
+  branchTaxonomy        String?
+  idempotencyKey        String?   @unique
+  leaseHolderPrincipalId String?
+  leaseExpiresAt        DateTime?
+
+  createdByPrincipalId  String?
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
   lastSyncedAt          DateTime?
@@ -304,8 +345,18 @@ model WorkCapsule {
   @@index([featureBuildId])
   @@index([headBranch])
   @@index([sandboxId])
+  @@index([leaseExpiresAt])
 }
 ```
+
+Field notes:
+
+- `createdByPrincipalId` and `leaseHolderPrincipalId` reference the canonical `Principal` per AGENTS.md section 11 (post-2026-05-09 convergence). External desktop sessions identify themselves via `PrincipalAlias` (kind `agent` or `service-account`) that resolves to a Principal.
+- `contributionMode` is `private` (default; PR targets the install's own repo) or `hive-public` (PR targets the public hive fork; goes through `contribute_to_hive` plumbing). The two modes require different DCO/signing surfaces; capsule must declare its mode at creation so downstream tools route correctly.
+- `branchTaxonomy` records the AGENTS.md section 4 prefix (`feat`, `fix`, `chore`, `doc`, `clean`). Capsule creation enforces this; adoption infers it from branch name and warns if absent.
+- `idempotencyKey` allows safe retry of `create_work_capsule` and `adopt_worktree`. Server returns the existing capsule on conflict rather than creating a duplicate.
+- `leaseHolderPrincipalId` + `leaseExpiresAt` implement the external executor heartbeat in section 9.5. Build Studio capsules do not use the lease; they rely on `FeatureBuild` lifecycle directly.
+- Cached git/PR/sandbox fields (`baseSha`, `headSha`, `pullRequestNumber`, `sandboxId`, etc.) follow section 7.4: refresh through the reconciler, never authoritative.
 
 The first slice may use string IDs rather than full Prisma relations for low-risk adoption. Later slices can add relations after the shape proves stable.
 
@@ -333,7 +384,29 @@ model WorkCapsuleActivity {
 
 This mirrors `BacklogItemActivity` and keeps capsule history inspectable without overloading `ToolExecution`.
 
-### 8.4 Refactor Budget
+Per AGENTS.md section 3, `kind` is a strongly-typed string enum sourced from `apps/web/lib/work-capsules.ts` and mirrored in MCP tool `enum:` arrays. Initial values:
+
+`created`, `adopted`, `status-changed`, `status-override`, `executor-changed`, `scope-claimed`, `scope-released`, `evidence-recorded`, `pr-linked`, `pr-merged`, `sandbox-attached`, `verification-passed`, `verification-failed`, `provider-blocked`, `provider-unblocked`, `lease-renewed`, `lease-expired`, `promotion-prepared`, `promotion-approved`, `promotion-rolled-back`, `archived`, `superseded`.
+
+Adding a new kind requires updating `work-capsules.ts` and the MCP tool definition in the same commit, per AGENTS.md section 3.
+
+### 8.4 Scope Claim Schema
+
+`scopeClaims` is a typed JSON array, not a free-form blob. Each entry:
+
+```ts
+type ScopeClaim = {
+  kind: "path" | "module" | "package" | "route" | "skill" | "prompt";
+  value: string;            // glob for path; package name; route prefix; etc.
+  intent: "edit" | "read";  // "edit" warns on collision; "read" does not
+  recordedAt: string;       // ISO timestamp
+  recordedByPrincipalId: string;
+};
+```
+
+Collision detection (section 9.4) joins claims across active capsules where `intent = "edit"`. Read claims are advisory and used for change-impact UI only.
+
+### 8.5 Refactor Budget
 
 Reserve at least 20 percent of implementation capacity for refactoring existing Build Studio, backlog, and promotion seams touched by this work.
 
@@ -408,25 +481,34 @@ Codex and Claude desktop sessions attach through MCP.
 
 Required MCP tools:
 
-| Tool | Purpose |
-|---|---|
-| `list_work_capsules` | find assigned or open capsules |
-| `get_work_capsule` | hydrate context before acting |
-| `create_work_capsule` | create a governed work unit |
-| `adopt_worktree` | attach an existing path/branch |
-| `claim_capsule_scope` | declare intended files/modules |
-| `record_capsule_evidence` | persist tests, builds, screenshots, notes |
-| `update_work_capsule_status` | move status with validation |
-| `release_capsule_scope` | clear claims when done/abandoned |
+| Tool | Purpose | Idempotency |
+|---|---|---|
+| `list_work_capsules` | find assigned or open capsules | read-only |
+| `get_work_capsule` | hydrate context before acting | read-only |
+| `create_work_capsule` | create a governed work unit | `idempotencyKey` required; conflict returns existing capsule |
+| `adopt_worktree` | attach an existing path/branch | natural key `(repositoryFullName, headBranch)` returns existing capsule |
+| `claim_capsule_scope` | declare intended files/modules | merging set on `(capsuleId, kind, value)` |
+| `record_capsule_evidence` | persist tests, builds, screenshots, notes | append-only |
+| `heartbeat_capsule` | renew external executor lease | replaces `leaseExpiresAt` |
+| `update_work_capsule_status` | move status with validation | last-write-wins with reason captured |
+| `release_capsule_scope` | clear claims when done/abandoned | idempotent on removal |
 
-Grant categories:
+Commit and PR contract for any executor writing to a capsule's branch:
 
-- `work_capsule_read`
-- `work_capsule_write`
-- `work_capsule_adopt`
-- `work_capsule_promote`
+- Every commit carries a DCO `Signed-off-by:` trailer (AGENTS.md section 4).
+- Every commit on a capsule branch carries a `DPF-Capsule: <capsuleId>` trailer so reconcilers can link commits back to capsules even when the branch name was renamed.
+- The PR body carries a machine-parseable `DPF-Capsule: <capsuleId>` line. Build Studio and external clients are both responsible for emitting this; the reconciler refuses to link a PR that does not carry it (with a one-click "Adopt this PR into capsule X" remediation in the UI).
 
-External clients should not receive `work_capsule_promote` by default.
+Grant categories and authorization (AGENTS.md section 8):
+
+| Grant | Role minimum | Default holders | Notes |
+|---|---|---|---|
+| `work_capsule_read` | any authenticated user | platform users, Build Studio agent, external MCP tokens | inspection only |
+| `work_capsule_write` | builder | Build Studio agent, Codex/Claude desktop agents | create/update/status/evidence |
+| `work_capsule_adopt` | builder | external desktop agents and humans | gated separately because adoption mutates linkage |
+| `work_capsule_promote` | release operator (human role) | nobody by default | required *in addition to* existing promotion authority; never grant to coding agents |
+
+The `work_capsule_*` values are agent tool-grant keys, not human `CapabilityKey` values. Tool definitions use existing `requiredCapability` values for human role gating, then `TOOL_TO_GRANTS`, `packages/db/data/grant_catalog.json`, and seeded agent grants apply the agent-level grant check. Do not extend `PERMISSIONS` with tool-grant names unless a later slice introduces a separate human-facing capability. External clients should not receive `work_capsule_promote` by default.
 
 ### 9.4 Collision Detection
 
@@ -444,7 +526,18 @@ The portal warns when:
 
 Soft leases keep work moving while making collisions visible early.
 
-### 9.5 Daily Steward
+### 9.5 External Executor Lease and Heartbeat
+
+External desktop executors (Codex, Claude, human) cannot be supervised by the portal directly. The capsule therefore models *liveness* with an explicit lease.
+
+- On capsule attach (`create_work_capsule` or `adopt_worktree` with an external executor), the server issues a lease: `leaseHolderPrincipalId` is set and `leaseExpiresAt = now() + LEASE_TTL` (default 30 minutes).
+- The executor must call `heartbeat_capsule` before expiry. The MCP middleware can auto-heartbeat on any capsule-scoped tool call.
+- A capsule whose lease has expired surfaces as `lease-expired` in the daily steward and is eligible for reassignment or abandonment recommendations. Expiry does not change `status`; the work itself may still be sound on disk.
+- Build Studio capsules do not consume the lease; their liveness comes from `FeatureBuild` execution state. The lease applies to `codex-desktop`, `claude-desktop`, `human`, and any future external executor kind.
+
+The lease is advisory in v1. It generates warnings and recommendations, never silent reassignment.
+
+### 9.6 Daily Steward
 
 The daily steward is a scheduled hygiene run. It prepares recommendations but does not delete or deploy in v1.
 
@@ -507,7 +600,11 @@ The safe path is:
 
 ### 10.1 Production Lock
 
-Only one portal replacement promotion may be `in_progress` at a time.
+Only one portal replacement promotion may be `in_progress` at a time. This is enforced as an architectural invariant, not a UI convention:
+
+- The portal-self-update slice adds `ChangePromotion.kind String @default("feature")` and a migration-level Postgres **partial unique index** on `ChangePromotion (kind, status) WHERE status = 'in_progress' AND kind = 'portal-replacement'`. This makes a second concurrent in-progress portal promotion impossible at the DB layer.
+- The promotion runner acquires a Postgres **advisory lock** (`pg_try_advisory_lock(hashtext('portal-promotion'))`) for the duration of the swap; a crashed runner releases the lock on connection drop, preventing zombie locks.
+- A failed promotion leaves the row in `failed` with `rollbackReason` populated. The DB lock prevents concurrent in-progress swaps; the Operations UI and promotion runner also block starting a new portal-replacement promotion while the latest portal-replacement row is `failed` and lacks rollback evidence.
 
 Other capsules may continue work, but no second production-visible portal swap can start until the active promotion reaches a terminal state.
 
@@ -524,7 +621,7 @@ This rescue path is separate from the normal portal UI and should be documented 
 
 ## 11. Provider and OAuth Policy
 
-Provider configuration is runtime state. Capsules record requirements and evidence, not secrets.
+Provider configuration is runtime state owned by the provider reconciler (`2026-04-05-provider-reconciliation-automation-design.md`). Capsules record requirements and health references, never secrets. The reconciler is the single authority that decides whether `CredentialEntry` and `ModelProfile` state is healthy; the capsule only consults that authority and reflects the result in `providerRequirements[].lastVerifiedAt` and `providerRequirements[].health`.
 
 ### 11.1 What Capsules Store
 
@@ -672,11 +769,15 @@ Use icons for compact actions where lucide icons exist. Use tooltips for unfamil
 
 ### Phase 1: Adoption-First Registry
 
-- add `WorkCapsule` and `WorkCapsuleActivity`
-- add enum constants and validation
-- add MCP read/create/adopt/sync tools
-- add scan helpers for branches/worktrees/PRs
-- add read-only Work Control UI for active/adoptable work
+Execute in this order so fresh installs and existing installs both land cleanly:
+
+1. Prisma migration for `WorkCapsule` + `WorkCapsuleActivity` (with the lease index from section 8.2).
+2. Enum constants and validators in `apps/web/lib/work-capsules.ts` (status, source, executor, activity-kind); same commit as the migration so the parity test passes.
+3. MCP tool registrations in `apps/web/lib/mcp-tools.ts` with `enum:` arrays mirroring `work-capsules.ts`, plus a parity test.
+4. Human `requiredCapability` choices plus `TOOL_TO_GRANTS` entries for the four grant categories in section 9.3.
+5. Bundled-MCP active-by-default seed so admins do not have to register the capsule tools.
+6. Scan helpers for branches/worktrees/PRs (read-only).
+7. Read-only Work Control UI at `/build/work` for active and adoptable capsules.
 
 ### Phase 2: Governed Creation
 
@@ -734,15 +835,15 @@ This slice does not create worktrees automatically and does not promote producti
 
 ## 17. Verification Plan
 
-Implementation must verify:
+Implementation must satisfy the canonical Build Gate (AGENTS.md section 5): unit tests, production build, UX verification, and migration applies cleanly. Capsule-specific verification on top of the Build Gate:
 
-1. Unit tests for capsule enum validation.
-2. Unit tests for adopt-worktree parsing.
-3. MCP tool tests for create/adopt/list/get/status/evidence paths.
-4. UI tests for Work Control empty, active, conflict, blocked, and stale states.
-5. Production build.
-6. UX verification against the Docker-served portal.
-7. Migration applies cleanly.
+1. Unit tests for capsule status, source, executor, and activity-kind enum validation (parity test against `mcp-tools.ts` `enum:` arrays).
+2. Unit tests for adopt-worktree parsing of branch name, PR URL inference, and trailer extraction.
+3. MCP tool tests for create/adopt/list/get/status/evidence/heartbeat/scope paths, including idempotency-key conflict behavior.
+4. Reconciler tests: status projection precedence, lease expiry surfacing, cache freshness markers.
+5. UI tests for Work Control empty, active, conflict, blocked, stale-cache, and lease-expired states.
+6. Authorization tests covering each grant category against the role matrix in section 9.3.
+7. UX verification against the Docker-served portal at `AUTH_URL`/`APP_URL`, not `next dev`.
 
 For the self-update phase, verification expands to:
 
@@ -762,6 +863,11 @@ For the self-update phase, verification expands to:
 6. Provider requirements are references and health checks, not copied secrets.
 7. A capsule may be abandoned, but not silently deleted.
 8. Production promotion requires an explicit terminal decision.
+9. Capsule status is *derived where possible*; any manual override writes a `status-override` activity with operator principal and reason.
+10. Git is authoritative for branches, SHAs, and dirty state; capsule fields mirroring git are caches with `lastSyncedAt` and must be refreshed by the reconciler before being used in a production-visible decision.
+11. External executor capsules carry a lease; an expired lease never silently transfers ownership. It surfaces a recommendation.
+12. Every commit on a capsule branch carries a DCO sign-off and a `DPF-Capsule:` trailer; the PR body carries the same trailer.
+13. At most one `ChangePromotion` of kind `portal-replacement` may be `in_progress`, enforced by a partial unique index added in the portal-self-update slice.
 
 ## 19. Resolved V1 Decisions
 
@@ -783,3 +889,15 @@ Adopt the hybrid governed execution model:
 - portal self-update goes through sandbox, backup, approval, promotion, and rollback
 
 This gives DPF the parallelism the user wants without letting each agent create a separate universe of truth.
+
+## 21. Locked Plan Decisions
+
+These decisions close the chief-architect review questions so implementation planning can proceed without schema ambiguity.
+
+1. **Lease TTL default.** External executor leases default to 30 minutes. Any capsule-scoped MCP tool call renews the lease automatically, and `heartbeat_capsule` exists for long-running clients that need an explicit renewal call.
+2. **Capsule-to-PR cardinality.** V1 is 1:1: one capsule links to at most one active PR. Split-PR or stacked-PR work is deferred to a later slice after adoption and collision detection are reliable.
+3. **GitPromotionCandidate ordering.** A git webhook first tries to find an existing capsule by `DPF-Capsule:` trailer, PR metadata, or `(repositoryFullName, headBranch)`. If no capsule exists, it creates a capsule with `source = git-promotion`. The deterministic idempotency key is `git-promotion:<repositoryFullName>:<afterSha>`.
+4. **Branch-name allocation.** Portal-created capsules generate `<prefix>/<capsule-slug>` deterministically from branch taxonomy and title. Adopted branches keep their existing names; the portal infers taxonomy and warns when the name does not match AGENTS.md section 4.
+5. **Status override TTL.** Manual status overrides last 24 hours by default and are stored in `workspaceState.statusOverride.until`. Operators may clear or extend an override explicitly.
+6. **Bundled MCP service activation.** Work Capsule tools are built into the existing `apps/web/lib/mcp-tools.ts` MCP surface and require no separate admin MCP server registration. The implementation updates tool definitions, human `requiredCapability` values, `TOOL_TO_GRANTS`, grant catalog, and seeded agent grants in one slice.
+7. **Historical adoption cutoff.** V1 surfaces: open PRs of any age, dirty worktrees of any age, branches with commits ahead of `origin/main` from the last 45 days, and any branch/worktree explicitly pasted by path or branch name. Older clean branches without PRs stay hidden until Phase 4 cleanup.


### PR DESCRIPTION
## Summary
- Adds a design spec for a portal-governed Work Capsule control harness.
- Defines how Build Studio, Codex desktop, Claude desktop, manual worktrees, sandbox verification, and portal self-update fit under one lifecycle.
- Makes v1 adoption-first, with human-approved portal replacement and no secret copying.

## Verification
- Searched live DPF MCP planning state for overlapping specs/epics.
- Ran placeholder and non-ASCII scans on the spec.
- Ran `git diff --cached --check` before commit.