### PR TITLE
fix(integrate): architecture gate now sees the destination path on renames

### DIFF
--- a/apps/web/lib/integrate/pre-pr-gates.test.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.test.ts
@@ -311,3 +311,32 @@ index 0000000..1111111
     expect(archGate?.findings.some((f) => /Unexpected directory/.test(f))).toBe(false);
   });
 });
+
+describe("runPrePRGates — architecture gate (rename detection)", () => {
+  it("warns when a file is RENAMED into an unexpected directory", () => {
+    // Renames have different `a/` and `b/` paths in the `diff --git` header.
+    // The old extractor only captured the `a/` (source) path, so moving a file
+    // from a recognized dir (apps/) to an unrecognized one (random-dir/) was
+    // silently allowed.
+    const diff = `diff --git a/apps/web/lib/foo.ts b/random-dir/foo.ts
+similarity index 100%
+rename from apps/web/lib/foo.ts
+rename to random-dir/foo.ts
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("warn");
+    expect(archGate?.findings.some((f) => /Unexpected directory: random-dir\/foo\.ts/.test(f))).toBe(true);
+  });
+
+  it("does not warn when a file is renamed BETWEEN two recognized directories", () => {
+    const diff = `diff --git a/apps/web/lib/foo.ts b/packages/db/foo.ts
+similarity index 100%
+rename from apps/web/lib/foo.ts
+rename to packages/db/foo.ts
+`;
+    const result = runPrePRGates(diff);
+    const archGate = result.gates.find((g) => g.gate === "architecture");
+    expect(archGate?.verdict).toBe("pass");
+  });
+});

--- a/apps/web/lib/integrate/pre-pr-gates.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.ts
@@ -36,7 +36,16 @@ export interface PrePRGateResult {
 // ─── Diff Helpers ───────────────────────────────────────────────────────────
 
 function extractFilePaths(diff: string): string[] {
-  return [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((m) => m[1]);
+  // Capture both the `a/` (old) and `b/` (new) paths so renames are visible
+  // to gates that care about destination location (e.g. architecture's
+  // unexpected-directory check). For non-renames the two paths are identical
+  // and dedupe via the Set.
+  const paths = new Set<string>();
+  for (const m of diff.matchAll(/^diff --git a\/(.+) b\/(.+)$/gm)) {
+    paths.add(m[1]);
+    paths.add(m[2]);
+  }
+  return [...paths];
 }
 
 function extractDiffLinesForFile(


### PR DESCRIPTION
## Summary

`extractFilePaths` in [pre-pr-gates.ts:38-40](apps/web/lib/integrate/pre-pr-gates.ts) only captured the `a/` (source) side of each `diff --git a/X b/Y` header. For renames where source and destination differ, this meant the architecture gate inspected the OLD location only — a file moved from a recognized directory (`apps/`) to an unrecognized one (`random-dir/`) would silently pass the unexpected-directory check.

## Fix

Extract both `a/` and `b/` paths into a `Set`. For non-renames the two paths are identical and dedupe naturally; for renames both locations are now visible to every gate that walks the file list. No behavioral change for the destructive-ops or dependency-audit gates — those filter on file extensions/locations where renames are not idiomatic.

## Regression test

A rename from `apps/web/lib/foo.ts` to `random-dir/foo.ts` now produces the expected `Unexpected directory: random-dir/foo.ts` finding. Verified the test fails on the unpatched extractor (verdict was `pass` instead of `warn` before the fix). Also added a control test that a rename between two recognized dirs stays `pass`.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/pre-pr-gates.test.ts` — 12/12 pass
- [x] Manual verification: new test fails on unpatched code (1 failed / 1 passed / 10 skipped)
- [x] `pnpm --filter web typecheck`

## Stacking note

Independent of [#595](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/595) (architecture gate test coverage) — both touch the same file but different sections. Whichever lands first, the other rebases trivially.

Signed-off-by: Mark Bodman <markdbodman@gmail.com>