### PR TITLE
fix(wiki): make ingest path derivation OS-independent

### DIFF
--- a/apps/web/lib/wiki/ingest.ts
+++ b/apps/web/lib/wiki/ingest.ts
@@ -14,7 +14,13 @@
 // wiki pages second).
 
 import { readFileSync } from "node:fs";
-import { basename, extname, sep } from "node:path";
+import { basename, extname } from "node:path";
+
+// Split on both POSIX and Windows separators so callers can pass either flavor
+// of path (URL-style "/x/y/z.md" or native "C:\x\y\z.md") and get the same
+// derivation. Using `node:path`'s platform `sep` here drops segments on
+// Windows when the input uses forward slashes — see ingest.test.ts.
+const PATH_SEPARATOR = /[\\/]/;
 // Import via subpaths rather than the bare `@dpf/db` barrel: the apps/web
 // vitest config aliases the bare specifier to `client.ts` (Prisma client
 // only) so tests can mock the barrel cleanly. Subpath specifiers resolve
@@ -87,7 +93,7 @@ export type IngestRawSourceResult = {
  * caller controls.
  */
 export function deriveSourceKeyFromPath(filePath: string): string {
-  const segments = filePath.split(sep).filter(Boolean);
+  const segments = filePath.split(PATH_SEPARATOR).filter(Boolean);
   const file = segments.at(-1) ?? filePath;
   const parent = segments.at(-2);
   const stem = basename(file, extname(file));
@@ -102,7 +108,7 @@ export function deriveSourceKeyFromPath(filePath: string): string {
  * is not recognisable — the caller must supply `sourceType` explicitly.
  */
 export function deriveSourceTypeFromPath(filePath: string): RawSourceType | null {
-  const segments = filePath.split(sep).filter(Boolean);
+  const segments = filePath.split(PATH_SEPARATOR).filter(Boolean);
   const parent = segments.at(-2);
   if (!parent) return null;
   const singular = parent.endsWith("s") ? parent.slice(0, -1) : parent;


### PR DESCRIPTION
## Summary

- `deriveSourceKeyFromPath` and `deriveSourceTypeFromPath` in [apps/web/lib/wiki/ingest.ts](apps/web/lib/wiki/ingest.ts) were splitting on `node:path`'s platform `sep` — which is `\` on Windows.
- Test inputs use POSIX paths (`/tmp/papers/bar.markdown`), so on Windows the whole string came back as a single segment, the parent was undefined, and the derivations collapsed to a bare filename. Three tests in `lib/wiki/ingest.test.ts` failed locally on Windows while Linux CI stayed green.
- Switch to splitting on a `[\/]` regex so either path flavor parses the same way; native Windows paths from `path.join` still work because the regex matches both separators.

## Why it matters

Per the "Run full test suite before push" workflow, Windows contributors need a clean local `pnpm --filter web test` run before pushing. This made that impossible — the wiki suite always reported three failures unrelated to anything they'd touched. Linux CI was unaffected so no shipped behavior changes.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/wiki/ingest.test.ts` on Windows — 14/14 pass
- [x] `pnpm --filter web exec vitest run lib/wiki/` on Windows — 224/224 pass
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [ ] Linux CI green (verify on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)