### PR TITLE
fix: expose Work Capsule scopes to coding agents

### DIFF
--- a/apps/web/lib/mcp-token-scopes.test.ts
+++ b/apps/web/lib/mcp-token-scopes.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./mcp-token-scopes";
 
 describe("defaultMcpTokenScopes", () => {
-  it("selects the read-only scopes coding agents need for repo-grounded work", () => {
+  it("selects the scopes coding agents need for repo-grounded coordinated work", () => {
     const availableScopes = [
       "admin_write",
       "architecture_read",
@@ -14,6 +14,9 @@ describe("defaultMcpTokenScopes", () => {
       "code_graph_read",
       "file_read",
       "spec_plan_read",
+      "work_capsule_adopt",
+      "work_capsule_read",
+      "work_capsule_write",
     ];
 
     expect(defaultMcpTokenScopes(availableScopes)).toEqual([
@@ -22,6 +25,9 @@ describe("defaultMcpTokenScopes", () => {
       "code_graph_read",
       "file_read",
       "spec_plan_read",
+      "work_capsule_read",
+      "work_capsule_write",
+      "work_capsule_adopt",
     ]);
   });
 

--- a/apps/web/lib/mcp-token-scopes.ts
+++ b/apps/web/lib/mcp-token-scopes.ts
@@ -4,6 +4,9 @@ export const CODING_AGENT_MCP_TOKEN_SCOPES = [
   "code_graph_read",
   "file_read",
   "spec_plan_read",
+  "work_capsule_read",
+  "work_capsule_write",
+  "work_capsule_adopt",
 ] as const;
 
 export function defaultMcpTokenScopes(availableScopes: readonly string[]): string[] {


### PR DESCRIPTION
## Summary
- Add Work Capsule read/write/adopt scopes to the default coding-agent MCP token scope set.
- Update the token-scope regression test so future coding-agent tokens keep Work Capsule coordination tools visible.

## Why
PR #602 added the Work Capsule tools and grant mappings, but existing/default coding-agent MCP scopes did not include the new Work Capsule grants. That meant the live `/api/mcp/v1` endpoint could advertise zero Work Capsule tools to external Codex/Claude tokens until the token was manually expanded.

## Validation
- `pnpm --filter web exec vitest run lib/mcp-token-scopes.test.ts lib/work-capsules.test.ts lib/work-capsules/work-capsule-store.test.ts lib/work-capsules/git-scanner.test.ts lib/work-capsules/work-capsule-presenter.test.ts lib/actions/work-capsules.test.ts lib/mcp-tools-work-capsules.test.ts lib/tak/agent-grants.test.ts components/build/work-control/WorkControlPanel.test.tsx`
- `pnpm --filter web typecheck`
- `cd apps/web && pnpm exec next build`
- Live `/api/mcp/v1` `tools/list` after local token upgrade advertises all nine Work Capsule tools.
- Live `/api/mcp/v1` `tools/call` to `list_work_capsules` succeeds.