### PR TITLE
test: align MCP token upgrade scope expectation

### DIFF
--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -222,7 +222,7 @@ describe("upgradeMyMcpTokenForCodingAgent", () => {
     expect(addScopesMock).not.toHaveBeenCalled();
   });
 
-  it("adds the default read-only coding-agent scopes to an existing token", async () => {
+  it("adds the default coding-agent scopes to an existing token", async () => {
     authMock.mockResolvedValue({ user: { id: "u1" } });
     listMock.mockResolvedValue([
       {
@@ -241,8 +241,19 @@ describe("upgradeMyMcpTokenForCodingAgent", () => {
         "code_graph_read",
         "file_read",
         "spec_plan_read",
+        "work_capsule_read",
+        "work_capsule_write",
+        "work_capsule_adopt",
       ],
-      addedScopes: ["architecture_read", "code_graph_read", "file_read", "spec_plan_read"],
+      addedScopes: [
+        "architecture_read",
+        "code_graph_read",
+        "file_read",
+        "spec_plan_read",
+        "work_capsule_read",
+        "work_capsule_write",
+        "work_capsule_adopt",
+      ],
     });
 
     const result = await upgradeMyMcpTokenForCodingAgent({ tokenId: "tok_x" });
@@ -254,6 +265,9 @@ describe("upgradeMyMcpTokenForCodingAgent", () => {
       "code_graph_read",
       "file_read",
       "spec_plan_read",
+      "work_capsule_read",
+      "work_capsule_write",
+      "work_capsule_adopt",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Update the existing MCP token upgrade test to expect the Work Capsule scopes added by PR #603.

## Why
PR #603 correctly added Work Capsule scopes to the default coding-agent MCP scope set, but the broader unit suite had a separate test asserting the old five-scope upgrade payload.

## Validation
- `pnpm --filter web exec vitest run lib/actions/mcp-tokens.test.ts lib/mcp-token-scopes.test.ts`
- pre-commit scoped `pnpm --filter web typecheck`