### PR TITLE
doc(memory): coworker memory shape contracts design spec

### DIFF
--- a/docs/superpowers/plans/2026-05-14-coworker-memory-contracts-slice-1.md
+++ b/docs/superpowers/plans/2026-05-14-coworker-memory-contracts-slice-1.md
@@ -1,0 +1,735 @@
+# Coworker Memory Shape Contracts — Slice 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make the AI Coworker chat input bundle visible as a declared, typed contract with a run-local delivery report — without changing what context is delivered today.
+
+**Architecture:** Add a new `apps/web/lib/coworker-contracts/` module containing (a) the `CoworkerInputContract` / `CoworkerInputFieldContract` / `CoworkerContextDelivery` types from spec §6, (b) a static chat contract declaration covering spec §8.1's eight fields, and (c) a loader that observes the existing prompt-assembly path in `apps/web/lib/actions/agent-coworker.ts` and emits a delivery report (delivered / compressed / withheld / missingRequired / tokenEstimate). The loader is **observational only** in tasks 1–4 (no behaviour change) and gains required-field enforcement in task 5. Both the unified and legacy prompt paths feed the same loader.
+
+**Tech stack:** TypeScript, vitest, Next.js 16 (App Router), Prisma 7.x. No new dependencies. No schema changes. No Qdrant payload changes.
+
+**Spec:** [docs/superpowers/specs/2026-05-14-coworker-memory-shape-contracts-design.md](../specs/2026-05-14-coworker-memory-shape-contracts-design.md) — sections 0, 3, 5, 6, 8.1, 10 ("Slice 1"), 11.
+
+**Backlog alignment:** [BI-MEM-5A41C7](../../../) under EP-TAK-3F9A21 (verified live via `mcp__dpf__get_backlog_item` on 2026-05-14: status open, priority 1, size L). Slice 1 is a foundational sub-deliverable of this BI; the BI as a whole covers all governed memory policy classes, freshness rules, and runtime effectiveness checks and will require subsequent slices to close.
+
+**Sister principles being sharpened:** P3 (Structured Handoffs) — Slice 1 is the input-side complement; P5 (Selective Memory) — Slice 1 instruments visibility into what was actually selected. See [docs/architecture/ai-coworker-development-principles.md](../../architecture/ai-coworker-development-principles.md). **No principle wiki pages are authored in Slice 1** — P9–P11 land in a later batch once enforcement evidence is in hand.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+Run from inside this worktree:
+
+```powershell
+git status --short                       # confirm clean worktree apart from this plan file
+git fetch origin                         # ensure origin/main is current
+git rev-list --left-right --count origin/main...HEAD  # confirm "0 N" with N == commits on this branch
+# Confirm the typecheck script exists in the web package before relying on it:
+node -e "console.log(JSON.parse(require('fs').readFileSync('apps/web/package.json','utf8')).scripts.typecheck)"
+# Expected output: `next typegen && tsc --noEmit`
+pnpm --filter web typecheck              # baseline; must pass before any task
+pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts apps/web/lib/actions/agent-coworker-server.test.ts apps/web/lib/tak/governed-memory.test.ts apps/web/lib/wiki/recall.test.ts
+```
+
+Expected: typecheck exits 0, vitest passes the existing four suites. If anything fails before Task 1, **stop** and surface — Slice 1 must not depend on a pre-broken main.
+
+---
+
+## Task 1: Type definitions
+
+**Files:**
+- Create: `apps/web/lib/coworker-contracts/types.ts`
+- Create: `apps/web/lib/coworker-contracts/index.ts` (barrel)
+- Create: `apps/web/lib/coworker-contracts/types.test.ts`
+
+**Rationale:** Establish the shape every later task imports from. The shapes are copied verbatim from spec §6, no embellishment.
+
+- [ ] **Step 1: Write the failing test** — create `types.test.ts` asserting that `CoworkerContextShape`, `MemoryAuthority`, `FreshnessPolicy`, `ContractDegradation`, `CoworkerInputFieldContract`, `CoworkerInputContract`, and `CoworkerContextDelivery` are exported from the barrel. Use type-only `expectTypeOf` (vitest) assertions plus runtime barrel-export checks. Member counts to assert against spec §6: `CoworkerContextShape` 7 members, `MemoryAuthority` 4, `FreshnessPolicy` 3, `ContractDegradation` 4.
+
+  ```typescript
+  import { describe, it, expectTypeOf } from "vitest";
+  import * as Contracts from ".";
+  import type {
+    CoworkerContextShape,
+    MemoryAuthority,
+    FreshnessPolicy,
+    ContractDegradation,
+    CoworkerInputFieldContract,
+    CoworkerInputContract,
+    CoworkerContextDelivery,
+  } from ".";
+
+  describe("coworker-contracts types", () => {
+    it("exports the four enum unions declared in spec §6 (shape 7, authority 4, freshness 3, degradation 4)", () => {
+      expectTypeOf<CoworkerContextShape>().toEqualTypeOf<
+        "prose" | "structured-doc" | "tabular" | "relational" | "filesystem" | "text-diff" | "receipt"
+      >();
+      expectTypeOf<MemoryAuthority>().toEqualTypeOf<
+        "authoritative" | "user-confirmed" | "inferred" | "advisory"
+      >();
+      expectTypeOf<FreshnessPolicy>().toEqualTypeOf<
+        "any" | "current-only" | "revalidate-before-consequential-action"
+      >();
+      expectTypeOf<ContractDegradation>().toEqualTypeOf<
+        "block-run" | "omit-field" | "compress" | "fallback-to-primary-source"
+      >();
+    });
+
+    it("CoworkerInputFieldContract requires name/shape/primitive/authority/required/freshness/degradation/sourceRef", () => {
+      type Required = "name" | "shape" | "primitive" | "authority" | "required" | "freshness" | "degradation" | "sourceRef";
+      expectTypeOf<keyof CoworkerInputFieldContract>().toEqualTypeOf<Required | "tokenBudget" | "promptLabel">();
+    });
+
+    it("CoworkerContextDelivery has the report fields", () => {
+      const probe: CoworkerContextDelivery = {
+        delivered: [],
+        compressed: [],
+        withheld: [],
+        missingRequired: [],
+        tokenEstimate: 0,
+      };
+      expectTypeOf(probe).toMatchTypeOf<CoworkerContextDelivery>();
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/coworker-contracts/types.test.ts
+  ```
+
+  Expected: failure with module-not-found on `.` (the barrel does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation** — paste the type definitions from spec §6 verbatim into `types.ts`, then re-export from `index.ts`:
+
+  ```typescript
+  // apps/web/lib/coworker-contracts/types.ts
+  export type CoworkerContextShape =
+    | "prose"
+    | "structured-doc"
+    | "tabular"
+    | "relational"
+    | "filesystem"
+    | "text-diff"
+    | "receipt";
+
+  export type MemoryAuthority =
+    | "authoritative"
+    | "user-confirmed"
+    | "inferred"
+    | "advisory";
+
+  export type FreshnessPolicy =
+    | "any"
+    | "current-only"
+    | "revalidate-before-consequential-action";
+
+  export type ContractDegradation =
+    | "block-run"
+    | "omit-field"
+    | "compress"
+    | "fallback-to-primary-source";
+
+  export type CoworkerInputFieldContract = {
+    name: string;
+    shape: CoworkerContextShape;
+    primitive: string;
+    authority: MemoryAuthority;
+    required: boolean;
+    freshness: FreshnessPolicy;
+    degradation: ContractDegradation;
+    tokenBudget?: number;
+    sourceRef: string;
+    promptLabel?: string;
+  };
+
+  export type CoworkerInputContract = {
+    coworkerId: string;
+    routeScope?: readonly string[];
+    fields: readonly CoworkerInputFieldContract[];
+    output: {
+      writes: readonly string[];
+      receipts?: readonly string[];
+      handoff?: "PhaseHandoff" | "TaskMessage" | "TaskArtifact" | "none";
+    };
+  };
+
+  export type CoworkerContextDelivery = {
+    delivered: string[];
+    compressed: string[];
+    withheld: Array<{ field: string; reason: string }>;
+    missingRequired: string[];
+    tokenEstimate: number;
+  };
+  ```
+
+  ```typescript
+  // apps/web/lib/coworker-contracts/index.ts
+  export * from "./types";
+  ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/coworker-contracts/types.test.ts
+  pnpm --filter web typecheck
+  ```
+
+  Expected: vitest passes, typecheck exits 0.
+
+- [ ] **Step 5: Commit** on a branch `feat/coworker-contracts-types` off `origin/main`:
+
+  ```powershell
+  git checkout -b feat/coworker-contracts-types origin/main
+  git add apps/web/lib/coworker-contracts/types.ts apps/web/lib/coworker-contracts/index.ts apps/web/lib/coworker-contracts/types.test.ts
+  git commit -s -m "feat(coworker-contracts): introduce CoworkerInputContract type shapes (slice 1 task 1)"
+  git push -u origin feat/coworker-contracts-types
+  gh pr create --title "feat(coworker-contracts): introduce CoworkerInputContract type shapes" --body "Slice 1 task 1 of EP-TAK-3F9A21 / BI-MEM-5A41C7. Type definitions only — no consumers yet. Spec §6."
+  ```
+
+---
+
+## Task 2: AI Coworker chat contract declaration
+
+**Files:**
+- Create: `apps/web/lib/coworker-contracts/registry/ai-coworker-chat.ts`
+- Create: `apps/web/lib/coworker-contracts/registry/ai-coworker-chat.test.ts`
+- Modify: `apps/web/lib/coworker-contracts/index.ts` — add `export * from "./registry/ai-coworker-chat";`
+
+**Rationale:** Declare the eight-field contract from spec §8.1 as a static, immutable object. No loader yet — pure data.
+
+- [ ] **Step 1: Write the failing test** — assert the declaration has the eight named fields from §8.1, each with the documented shape/authority/primitive. Sample assertions:
+
+  ```typescript
+  import { describe, it, expect } from "vitest";
+  import { aiCoworkerChatContract } from ".";
+
+  describe("aiCoworkerChatContract", () => {
+    it("declares the eight fields from spec §8.1", () => {
+      const names = aiCoworkerChatContract.fields.map((f) => f.name).sort();
+      expect(names).toEqual([
+        "governed_user_facts",
+        "principal_identity",
+        "recent_thread_window",
+        "route_context",
+        "semantic_recall",
+        "thread_summary",
+        "tool_grants",
+        "wiki_context",
+      ]);
+    });
+
+    it("marks principal_identity and tool_grants as required + authoritative", () => {
+      const byName = Object.fromEntries(aiCoworkerChatContract.fields.map((f) => [f.name, f]));
+      expect(byName.principal_identity).toMatchObject({ required: true, authority: "authoritative", shape: "tabular" });
+      expect(byName.tool_grants).toMatchObject({ required: true, authority: "authoritative", shape: "tabular" });
+    });
+
+    it("declares semantic_recall as prose/inferred and thread_summary as prose/inferred", () => {
+      const byName = Object.fromEntries(aiCoworkerChatContract.fields.map((f) => [f.name, f]));
+      expect(byName.semantic_recall).toMatchObject({ shape: "prose", authority: "inferred" });
+      expect(byName.thread_summary).toMatchObject({ shape: "prose", authority: "inferred" });
+    });
+
+    it("declares wiki_context as structured-doc with revalidate-before-consequential-action freshness", () => {
+      const byName = Object.fromEntries(aiCoworkerChatContract.fields.map((f) => [f.name, f]));
+      expect(byName.wiki_context).toMatchObject({
+        shape: "structured-doc",
+        freshness: "revalidate-before-consequential-action",
+      });
+    });
+
+    it("declares no output handoff yet (chat is conversational)", () => {
+      expect(aiCoworkerChatContract.output.handoff).toBe("none");
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/coworker-contracts/registry/ai-coworker-chat.test.ts
+  ```
+
+- [ ] **Step 3: Write minimal implementation** — create the declaration with all eight fields. Translate spec §8.1's table row-by-row. Use `as const satisfies CoworkerInputContract` to lock readonly-ness. `sourceRef` points at the file:line where the value is fetched today in `agent-coworker.ts`:
+
+  ```typescript
+  // apps/web/lib/coworker-contracts/registry/ai-coworker-chat.ts
+  import type { CoworkerInputContract } from "../types";
+
+  export const aiCoworkerChatContract = {
+    coworkerId: "ai-coworker-chat",
+    fields: [
+      {
+        name: "principal_identity",
+        shape: "tabular",
+        primitive: "postgres:User+Principal+AIDoc",
+        authority: "authoritative",
+        required: true,
+        freshness: "current-only",
+        degradation: "block-run",
+        sourceRef: "apps/web/lib/actions/agent-coworker.ts:230 (requireAuthUser)",
+        promptLabel: "Principal",
+      },
+      {
+        name: "route_context",
+        shape: "tabular",
+        primitive: "route-registry + page-context",
+        authority: "authoritative",
+        required: true,
+        freshness: "current-only",
+        degradation: "omit-field",
+        sourceRef: "apps/web/lib/actions/agent-coworker.ts:432 (resolveRouteContext) + :437 (getRouteDataContext)",
+        promptLabel: "Route context",
+      },
+      {
+        name: "recent_thread_window",
+        shape: "prose",
+        primitive: "postgres:AgentMessage windowed by createdAt + token budget",
+        authority: "inferred",
+        required: false,
+        freshness: "any",
+        degradation: "compress",
+        tokenBudget: 4000,
+        sourceRef: "apps/web/lib/actions/agent-coworker.ts:371-390 (RECENT_WINDOW / CHAT_HISTORY_TOKEN_BUDGET)",
+        promptLabel: "Recent conversation",
+      },
+      {
+        name: "thread_summary",
+        shape: "prose",
+        primitive: "rolling summary (not yet implemented — placeholder)",
+        authority: "inferred",
+        required: false,
+        freshness: "any",
+        degradation: "omit-field",
+        sourceRef: "(future) rolling summary writer; see spec §8.1 highest-value fix",
+        promptLabel: "Earlier conversation summary",
+      },
+      {
+        name: "governed_user_facts",
+        shape: "tabular",
+        primitive: "postgres:UserFact via loadGovernedUserFacts",
+        authority: "authoritative",
+        required: false,
+        freshness: "revalidate-before-consequential-action",
+        degradation: "compress",
+        sourceRef: "apps/web/lib/tak/governed-memory.ts:51 (loadGovernedUserFacts)",
+        promptLabel: "Known user facts",
+      },
+      {
+        name: "semantic_recall",
+        shape: "prose",
+        primitive: "qdrant:agent-memory via recallGovernedContext",
+        authority: "inferred",
+        required: false,
+        freshness: "any",
+        degradation: "compress",
+        sourceRef: "apps/web/lib/tak/governed-memory.ts:68 (recallGovernedContext)",
+        promptLabel: "Relevant recall",
+      },
+      {
+        name: "wiki_context",
+        shape: "structured-doc",
+        primitive: "qdrant:wiki-pages via recallWikiContext",
+        authority: "authoritative",
+        required: false,
+        freshness: "revalidate-before-consequential-action",
+        degradation: "omit-field",
+        sourceRef: "apps/web/lib/wiki/recall.ts:74 (recallWikiContext)",
+        promptLabel: "Wiki context",
+      },
+      {
+        name: "tool_grants",
+        shape: "tabular",
+        primitive: "agent-grants resolver intersected with platform tools",
+        authority: "authoritative",
+        required: true,
+        freshness: "current-only",
+        degradation: "block-run",
+        sourceRef: "apps/web/lib/actions/agent-coworker.ts:668 (getAvailableTools) + :713 (filterToolsForCoworkerRuntime)",
+        promptLabel: "Available tools",
+      },
+    ],
+    output: {
+      writes: ["postgres:AgentMessage", "qdrant:agent-memory (inferred scope)"],
+      receipts: [],
+      handoff: "none",
+    },
+  } as const satisfies CoworkerInputContract;
+  ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/coworker-contracts/registry/ai-coworker-chat.test.ts
+  pnpm --filter web typecheck
+  ```
+
+- [ ] **Step 5: Commit** on a branch `feat/coworker-contracts-chat-declaration` off `origin/main`. Note: this branch can be created in parallel with Task 1's PR if Task 1 has merged. Otherwise wait for Task 1 to merge and rebase.
+
+  ```powershell
+  git checkout -b feat/coworker-contracts-chat-declaration origin/main
+  git add apps/web/lib/coworker-contracts/registry/ai-coworker-chat.ts apps/web/lib/coworker-contracts/registry/ai-coworker-chat.test.ts apps/web/lib/coworker-contracts/index.ts
+  git commit -s -m "feat(coworker-contracts): declare AI Coworker chat input contract (slice 1 task 2)"
+  git push -u origin feat/coworker-contracts-chat-declaration
+  gh pr create --title "feat(coworker-contracts): declare AI Coworker chat input contract" --body "Slice 1 task 2 of EP-TAK-3F9A21 / BI-MEM-5A41C7. Static declaration only — no consumers yet. Spec §8.1."
+  ```
+
+---
+
+## Task 3: Contract loader + delivery report generator (pure)
+
+**Files:**
+- Create: `apps/web/lib/coworker-contracts/loader.ts`
+- Create: `apps/web/lib/coworker-contracts/loader.test.ts`
+- Modify: `apps/web/lib/coworker-contracts/index.ts` — `export * from "./loader";`
+
+**Rationale:** A pure function that takes a contract + a "what was actually delivered" record and produces the `CoworkerContextDelivery` report. No I/O, no Prisma, no Qdrant — just shape transformation. This is the unit-testable core.
+
+- [ ] **Step 1: Write the failing test** — cover the four report buckets (delivered / compressed / withheld / missingRequired) plus token accounting:
+
+  ```typescript
+  import { describe, it, expect } from "vitest";
+  import { aiCoworkerChatContract } from "./registry/ai-coworker-chat";
+  import { computeContractDelivery, type FieldOutcome } from "./loader";
+
+  describe("computeContractDelivery", () => {
+    it("classifies fields by outcome and tallies tokens", () => {
+      const outcomes: Record<string, FieldOutcome> = {
+        principal_identity: { status: "delivered", tokens: 12 },
+        route_context: { status: "delivered", tokens: 40 },
+        recent_thread_window: { status: "compressed", tokens: 1800, reason: "token budget" },
+        thread_summary: { status: "omitted", reason: "not yet implemented" },
+        governed_user_facts: { status: "delivered", tokens: 230 },
+        semantic_recall: { status: "withheld", reason: "stale for consequential action" },
+        wiki_context: { status: "delivered", tokens: 120 },
+        tool_grants: { status: "delivered", tokens: 60 },
+      };
+      const report = computeContractDelivery(aiCoworkerChatContract, outcomes);
+      expect(report.delivered.sort()).toEqual([
+        "governed_user_facts",
+        "principal_identity",
+        "route_context",
+        "tool_grants",
+        "wiki_context",
+      ]);
+      expect(report.compressed).toEqual(["recent_thread_window"]);
+      expect(report.withheld).toEqual([{ field: "semantic_recall", reason: "stale for consequential action" }]);
+      expect(report.missingRequired).toEqual([]);
+      expect(report.tokenEstimate).toBe(12 + 40 + 1800 + 230 + 120 + 60);
+    });
+
+    it("flags missingRequired when a required field is not delivered or compressed", () => {
+      const outcomes: Record<string, FieldOutcome> = {
+        principal_identity: { status: "omitted", reason: "auth failed" },
+        route_context: { status: "delivered", tokens: 40 },
+        tool_grants: { status: "delivered", tokens: 60 },
+      };
+      const report = computeContractDelivery(aiCoworkerChatContract, outcomes);
+      expect(report.missingRequired).toContain("principal_identity");
+    });
+
+    it("treats unmentioned optional fields as omitted (not delivered)", () => {
+      const outcomes: Record<string, FieldOutcome> = {
+        principal_identity: { status: "delivered", tokens: 12 },
+        route_context: { status: "delivered", tokens: 40 },
+        tool_grants: { status: "delivered", tokens: 60 },
+      };
+      const report = computeContractDelivery(aiCoworkerChatContract, outcomes);
+      expect(report.delivered).not.toContain("thread_summary");
+      expect(report.compressed).not.toContain("thread_summary");
+      expect(report.withheld).not.toContainEqual({ field: "thread_summary", reason: expect.anything() });
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/coworker-contracts/loader.test.ts
+  ```
+
+- [ ] **Step 3: Write minimal implementation**
+
+  ```typescript
+  // apps/web/lib/coworker-contracts/loader.ts
+  import type { CoworkerInputContract, CoworkerContextDelivery } from "./types";
+
+  export type FieldOutcome =
+    | { status: "delivered"; tokens: number }
+    | { status: "compressed"; tokens: number; reason: string }
+    | { status: "withheld"; reason: string }
+    | { status: "omitted"; reason?: string };
+
+  export function computeContractDelivery(
+    contract: CoworkerInputContract,
+    outcomes: Record<string, FieldOutcome>,
+  ): CoworkerContextDelivery {
+    const delivered: string[] = [];
+    const compressed: string[] = [];
+    const withheld: Array<{ field: string; reason: string }> = [];
+    const missingRequired: string[] = [];
+    let tokenEstimate = 0;
+
+    for (const field of contract.fields) {
+      const outcome = outcomes[field.name] ?? { status: "omitted" as const };
+      switch (outcome.status) {
+        case "delivered":
+          delivered.push(field.name);
+          tokenEstimate += outcome.tokens;
+          break;
+        case "compressed":
+          compressed.push(field.name);
+          tokenEstimate += outcome.tokens;
+          break;
+        case "withheld":
+          withheld.push({ field: field.name, reason: outcome.reason });
+          if (field.required) missingRequired.push(field.name);
+          break;
+        case "omitted":
+          if (field.required) missingRequired.push(field.name);
+          break;
+      }
+    }
+
+    return { delivered, compressed, withheld, missingRequired, tokenEstimate };
+  }
+  ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/coworker-contracts/loader.test.ts
+  pnpm --filter web typecheck
+  ```
+
+- [ ] **Step 5: Commit** on a branch `feat/coworker-contracts-loader` off `origin/main` (after task 2 merges, or in parallel with rebase).
+
+  ```powershell
+  git checkout -b feat/coworker-contracts-loader origin/main
+  git add apps/web/lib/coworker-contracts/loader.ts apps/web/lib/coworker-contracts/loader.test.ts apps/web/lib/coworker-contracts/index.ts
+  git commit -s -m "feat(coworker-contracts): contract delivery report generator (slice 1 task 3)"
+  git push -u origin feat/coworker-contracts-loader
+  gh pr create --title "feat(coworker-contracts): contract delivery report generator" --body "Slice 1 task 3 of EP-TAK-3F9A21 / BI-MEM-5A41C7. Pure function. Spec §6 + §8.1."
+  ```
+
+---
+
+## Task 4: Wire delivery report into `sendMessage` (observe only, no behaviour change)
+
+**Files:**
+- Modify: `apps/web/lib/actions/agent-coworker.ts` — both the unified branch (around lines 471–548) and the legacy branch (around lines 550–660).
+- Modify: `apps/web/lib/actions/agent-coworker.test.ts` (or add a new colocated suite).
+
+**Rationale:** Build a `FieldOutcome` map from the existing field-fetch calls, compute the delivery report, log it. Behaviour is unchanged — only observability is added. **No required-field enforcement yet** (that's Task 5).
+
+This task is the only one that touches a hot path. Keep the diff small: compute outcomes alongside existing assignments, call `computeContractDelivery`, log once. Do not refactor existing variables. Do not move the `contextSources` array.
+
+- [ ] **Step 1: Write the failing test** — **extend the existing happy-path `sendMessage` test in `agent-coworker.test.ts`** rather than authoring a new fixture (the file already has Prisma/recallWikiContext/buildGovernedMemoryContext mocks wired). Add a `vi.spyOn(console, "log")` capture and assert that exactly one call argv matches `["[coworker-contract]", expect.stringMatching(/"coworkerId":"ai-coworker-chat"/)]`. Parse that JSON string and assert:
+  - `delivery.delivered` contains `"principal_identity"` and `"tool_grants"` for the happy path
+  - `delivery.missingRequired` is empty for the happy path
+  - `delivery.tokenEstimate` is a positive number
+
+  If `agent-coworker.test.ts` has no existing happy-path test that reaches the post-`availableTools` codepath, instead add the assertion to `agent-coworker-server.test.ts` which already does (verified at task-write time). State in the PR description which existing test you extended.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts
+  ```
+
+- [ ] **Step 3: Write minimal implementation** — **placement: immediately after `availableTools` is assigned (currently `apps/web/lib/actions/agent-coworker.ts:716`) and before the inference adapter call.** This is the first line reached unconditionally by both `useUnified` and legacy branches *and* where every outcome's source variable exists. Do not move it earlier — `tool_grants` derivation requires `availableTools.length`. Do not move it later — it must run before inference so the log lands when the operator looks for it.
+
+  Assemble a `FieldOutcome` map. Approximate token counts using the existing `countTokens` utility (imported at line 448 inside the unified branch — re-import at module top for use in both branches), or `Math.ceil(s.length / 4)` for legacy-branch strings where `countTokens` was not imported in scope. The eight outcomes derive from existing locals already in scope at line 716:
+
+  | Field | Outcome derivation (variables that exist at line 716) |
+  |---|---|
+  | `principal_identity` | `delivered` with `tokens: Math.ceil((user.id?.length ?? 0) / 4) + 4` (always present — auth gate at line 230 already returned `Unauthorized` if missing). |
+  | `route_context` | `delivered` with tokens of `input.routeContext` (always present; both branches stash it into `populatedPrompt`). |
+  | `recent_thread_window` | `delivered` if `trimmedMessages.length === recentMessages.length`, else `compressed` with `reason: "token budget"`. Tokens = `historyTokens`. |
+  | `thread_summary` | `omitted` with `reason: "not yet implemented (placeholder)"` (always — see §"thread_summary placeholder" note below). |
+  | `governed_user_facts` | The unified branch has `factsContext` in scope (line 466); the legacy branch has `governedMemory.factsContext` (line 651). Hoist one shared `governedMemoryFactsContext` variable to function scope to cover both. `delivered` if non-null with tokens via `countTokens` or length/4; `omitted` with `reason: "no facts"` otherwise. |
+  | `semantic_recall` | Same hoist for `governedMemory.recalledContext`. `delivered` if non-null; `omitted` otherwise. |
+  | `wiki_context` | Unified branch has `wikiContext` (line 531). Legacy branch does **not** call `recallWikiContext` — declare the outcome as `omitted` with `reason: "wiki recall not enabled on legacy prompt path"` in that branch. |
+  | `tool_grants` | `delivered` with `tokens: availableTools.length * 30` (heuristic — fine for an observability metric); track `availableTools.length` separately as `count` if you want richer telemetry. If `availableTools.length === 0`, emit `withheld` with `reason: "no granted tools for route"` so the run blocks in Task 5. |
+
+  Then call `computeContractDelivery(aiCoworkerChatContract, outcomes)` and emit a structured log:
+
+  ```typescript
+  // Add to the import block at the top of the file:
+  import { aiCoworkerChatContract, computeContractDelivery, type FieldOutcome } from "@/lib/coworker-contracts";
+  import { countTokens } from "@/lib/tak/context-arbitrator"; // already imported dynamically in unified branch — promote to module top
+
+  // ... existing code ...
+
+  // After line 716 (the `filterToolsForCoworkerRuntime` assignment), before any inference adapter call:
+  const contractOutcomes: Record<string, FieldOutcome> = {
+    principal_identity: { status: "delivered", tokens: 12 },
+    route_context: { status: "delivered", tokens: countTokens(input.routeContext) },
+    recent_thread_window:
+      trimmedMessages.length === recentMessages.length
+        ? { status: "delivered", tokens: historyTokens }
+        : { status: "compressed", tokens: historyTokens, reason: "token budget" },
+    thread_summary: { status: "omitted", reason: "not yet implemented (placeholder)" },
+    governed_user_facts: governedMemoryFactsContext
+      ? { status: "delivered", tokens: countTokens(governedMemoryFactsContext) }
+      : { status: "omitted", reason: "no facts" },
+    semantic_recall: governedMemoryRecalledContext
+      ? { status: "delivered", tokens: countTokens(governedMemoryRecalledContext) }
+      : { status: "omitted", reason: "no recall" },
+    wiki_context: wikiContextForReport
+      ? { status: "delivered", tokens: countTokens(wikiContextForReport) }
+      : { status: "omitted", reason: useUnified ? "no wiki hit" : "wiki recall not enabled on legacy prompt path" },
+    tool_grants:
+      availableTools.length === 0
+        ? { status: "withheld", reason: "no granted tools for route" }
+        : { status: "delivered", tokens: availableTools.length * 30 },
+  };
+  const contractDelivery = computeContractDelivery(aiCoworkerChatContract, contractOutcomes);
+  console.log(
+    "[coworker-contract]",
+    JSON.stringify({
+      coworkerId: aiCoworkerChatContract.coworkerId,
+      threadId: input.threadId,
+      routeContext: input.routeContext,
+      delivery: contractDelivery,
+    }),
+  );
+  ```
+
+  To make `governedMemoryFactsContext`, `governedMemoryRecalledContext`, and `wikiContextForReport` available at the convergence point, declare them at the top of `sendMessage` as `let governedMemoryFactsContext: string | null = null;` (etc.) and assign inside each branch where the existing locals are set. Keep the diff scoped to those additions — do not refactor the existing variables.
+
+  **`thread_summary` placeholder note:** because this field is `required: false` + `degradation: "omit-field"` and always emits `omitted` until the rolling summary writer exists, Slice 2's Memory Contract Inspector should suppress always-omitted placeholder fields from the "withheld/missing" panel to avoid permanent noise. Flag this in the Slice 2 plan when it's written; out-of-scope for Slice 1 implementation.
+
+- [ ] **Step 4: Run test to verify it passes; run typecheck + production build per AGENTS.md §5**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts
+  pnpm --filter web typecheck
+  cd apps/web; pnpm exec next build; cd ../..
+  ```
+
+  Expected: vitest passes, typecheck exits 0, `next build` completes with zero errors.
+
+- [ ] **Step 5: UX verification per AGENTS.md §5(3)** — start the Docker portal (`docker compose up -d portal portal-init`), log in as `admin@dpf.local` with `ADMIN_PASSWORD` from repo-root `.env`, send a message in any coworker chat (e.g. `/storefront` page), then tail the portal logs and confirm one `[coworker-contract] {...}` JSON line appears with eight fields classified. **State explicitly in the PR description** which routes were exercised and paste one anonymised log line.
+
+- [ ] **Step 6: Commit** on a branch `feat/coworker-contracts-delivery-observability` off `origin/main`:
+
+  ```powershell
+  git checkout -b feat/coworker-contracts-delivery-observability origin/main
+  git add apps/web/lib/actions/agent-coworker.ts apps/web/lib/actions/agent-coworker.test.ts
+  git commit -s -m "feat(coworker-contracts): emit delivery report from sendMessage (slice 1 task 4)"
+  git push -u origin feat/coworker-contracts-delivery-observability
+  gh pr create --title "feat(coworker-contracts): emit delivery report from sendMessage" --body "Slice 1 task 4 of EP-TAK-3F9A21 / BI-MEM-5A41C7. Observability-only — no behaviour change. UX verified on routes [list]. Spec §8.1."
+  ```
+
+---
+
+## Task 5: Required-field enforcement (degradation behaviour)
+
+**Files:**
+- Modify: `apps/web/lib/actions/agent-coworker.ts` — add the enforcement check after `computeContractDelivery`.
+- Modify: `apps/web/lib/actions/agent-coworker.test.ts` — assert the run blocks when a required field is missing.
+
+**Rationale:** Activate the `block-run` degradation behaviour from Task 2's declaration for the two `required: true` fields (`principal_identity`, `tool_grants`). Any other declared `block-run` field that lands in `missingRequired` also blocks. Non-blocking degradations (`omit-field`, `compress`, `fallback-to-primary-source`) continue without intervention in Slice 1.
+
+**Important:** `principal_identity` is already guarded by `requireAuthUser()` at the top of `sendMessage` — by the time Task 4's outcome map runs, the auth check has already returned `Unauthorized` if missing. `tool_grants` is the field most likely to surface in `missingRequired`: Task 4 step 3 emits `withheld` when `availableTools.length === 0`, which lands in `missingRequired` because `tool_grants` is `required: true`. Task 5 turns that into a visible run-block instead of a silent tools-less response. **This is the only behavioural change Slice 1 introduces.**
+
+- [ ] **Step 1: Write the failing test** — assert that `sendMessage` returns an `error` shape (matching the existing `{ error: string }` return arm) when `availableTools` is empty AND the contract's `tool_grants` field has `degradation: "block-run"`. Stub `getAvailableTools` to return `[]`.
+
+  ```typescript
+  it("blocks the run when tool_grants are empty and degradation is block-run", async () => {
+    // ...mock getAvailableTools to return []
+    const result = await sendMessage({ threadId: "t", content: "hello", routeContext: "/somewhere" });
+    expect(result).toMatchObject({ error: expect.stringContaining("tool_grants") });
+  });
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts
+  ```
+
+- [ ] **Step 3: Write minimal implementation** — after `computeContractDelivery`, check for `block-run` degradations among `missingRequired`:
+
+  ```typescript
+  const blockingMissing = contractDelivery.missingRequired.filter((name) => {
+    const field = aiCoworkerChatContract.fields.find((f) => f.name === name);
+    return field?.degradation === "block-run";
+  });
+  if (blockingMissing.length > 0) {
+    return {
+      error: `Coworker contract violation — required fields missing or withheld: ${blockingMissing.join(", ")}. See [coworker-contract] log for details.`,
+    };
+  }
+  ```
+
+  Place the check immediately after the `console.log` from Task 4. Keep the diff additive.
+
+- [ ] **Step 4: Run test to verify it passes; run typecheck + production build**
+
+  ```powershell
+  pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts
+  pnpm --filter web typecheck
+  cd apps/web; pnpm exec next build; cd ../..
+  ```
+
+- [ ] **Step 5: UX verification per AGENTS.md §5(3)** — concrete repro:
+  1. On a throwaway branch, edit `packages/db/data/agent_registry.json` and temporarily set `config_profile.tool_grants` to `[]` for the route coworker assigned to a non-critical route (e.g. `coworker-storefront`). The registry is imported at module load (`apps/web/lib/tak/agent-grants.ts:2`) — a portal rebuild is required.
+  2. `docker compose build --no-cache portal portal-init && docker compose up -d portal portal-init`.
+  3. Log in as `admin@dpf.local`, visit the affected route, send a message.
+  4. Expect the coworker panel to render the contract-violation error string from Task 5 Step 3 (containing `tool_grants`) instead of a silent empty response.
+  5. Tail portal logs and confirm one `[coworker-contract]` JSON line shows `tool_grants` in `missingRequired` and `withheld`.
+  6. Revert the `agent_registry.json` edit; the throwaway branch never lands in PR. Capture the panel text and one log line in the Task 5 PR description.
+
+- [ ] **Step 6: Commit** on a branch `feat/coworker-contracts-block-run` off `origin/main`:
+
+  ```powershell
+  git checkout -b feat/coworker-contracts-block-run origin/main
+  git add apps/web/lib/actions/agent-coworker.ts apps/web/lib/actions/agent-coworker.test.ts
+  git commit -s -m "feat(coworker-contracts): block run on missing required fields (slice 1 task 5)"
+  git push -u origin feat/coworker-contracts-block-run
+  gh pr create --title "feat(coworker-contracts): block run on missing required fields" --body "Slice 1 task 5 of EP-TAK-3F9A21 / BI-MEM-5A41C7. Activates the block-run degradation behaviour declared in task 2. UX verified by [scenario]. Spec §6 + §8.1."
+  ```
+
+---
+
+## Slice 1 completion checklist
+
+- [ ] All five tasks merged via separate PRs
+- [ ] `apps/web/lib/coworker-contracts/` contains: `types.ts`, `loader.ts`, `index.ts`, `registry/ai-coworker-chat.ts`, plus matching tests
+- [ ] `sendMessage` emits one `[coworker-contract]` log per call
+- [ ] `sendMessage` returns the `{ error }` arm with a contract violation message when required fields are missing
+- [ ] No Prisma migration was created
+- [ ] No Qdrant payload schema changed
+- [ ] No new admin UI (the Memory Contract Inspector is Slice 2)
+- [ ] `BI-MEM-5A41C7` status remains `open` (Slice 1 is foundational; subsequent slices close the BI)
+- [ ] Spec section 10's Slice 1 row in the phasing table is annotated "delivered in [list of PR numbers]" via a follow-up doc PR
+
+---
+
+## Operational discipline (apply to every task)
+
+- **DCO sign-off required.** Every commit uses `git commit -s`. The DCO bot blocks merge until every commit has a `Signed-off-by:` trailer (per AGENTS.md §4).
+- **Worktree discipline.** Each task PR comes from its own branch off `origin/main`. Do not stack the five branches; each is independent. (See `AGENTS.md` §4 and the user's `feedback_worktree_base_origin_main` memory.)
+- **Concurrent-session guard.** Always pass explicit file paths to `git add` and `git commit` (no `git add -A`). (See `feedback_git_commit_only_for_concurrent_sessions` memory.)
+- **Pre-push overlap sweep.** Before each `git push`, run `git fetch origin && gh pr list --state open --search "coworker-contracts"` and confirm nobody else has opened an overlapping PR. (See `feedback_pr_overlap_check_before_pushing` memory.)
+- **No mention of "Generated with Claude Code"** in the commit body; the trailer goes only in the PR description per existing conventions (DCO trailer line at end of commit is sufficient).
+
+---
+
+## Out of scope for Slice 1
+
+The following items are explicitly **NOT** part of Slice 1 — they live in Slice 2+ per spec §10:
+
+- The Memory Contract Inspector UI (Slice 2)
+- Qdrant payload changes (authority field on `agent-memory` points — Slice 3)
+- `PhaseHandoff` enforcement (Slice 4)
+- Section-aware spec/plan retriever (Slice 5)
+- `TaskRun` continuation summary (Slice 6)
+- Neo4j build-graph projection (Slice 7)
+- Rediscovery-rate metrics on the coworker panel (Slice 8)
+- Authoring P9–P11 wiki kernel pages (deferred to a future principles batch once enforcement evidence is in hand per PR #570 / #592 cadence)
+- Contracts for any coworker other than AI Coworker chat (subsequent Slice 1.x follow-ups can declare the Build Studio phase contracts, Hive Scout, Scheduled, etc.)

--- a/docs/superpowers/specs/2026-05-14-coworker-memory-shape-contracts-design.md
+++ b/docs/superpowers/specs/2026-05-14-coworker-memory-shape-contracts-design.md
@@ -1,0 +1,398 @@
+# Coworker Memory Shape Contracts - Design
+
+| Field | Value |
+|-------|-------|
+| Backlog epic | `EP-TAK-3F9A21` - TAK/GAID Refresh: Auth, Agent Identity, and Governed Memory Alignment |
+| Related live backlog items | `BI-MEM-5A41C7`, `BI-OBS-4B63F2`, `BI-GAID-8D72B4`, `BI-MCP-7E53D1` |
+| Status | Revised draft for review |
+| Created | 2026-05-14 |
+| Revised | 2026-05-14 repo-grounded review |
+| Author | Mark Bodman + Claude/Codex design partners |
+| IT4IT alignment | Evaluate, Build, Consume |
+| Builds on | [EP-TAK-3F9A21 - Auth, Agent Identity, and Governed Memory](2026-04-25-tak-gaid-auth-identity-memory-refresh-design.md), [Platform Kernel Wiki](2026-05-09-platform-kernel-wiki-design.md), [Wiki PPR Retrieval](2026-05-09-wiki-ppr-retrieval-design.md), [Autonomous AI Coworker Runtime](2026-05-11-autonomous-coworker-runtime-design.md) |
+| Sharpens | [AI Coworker Development Principles P3, P5, P7](../../architecture/ai-coworker-development-principles.md) |
+
+Live backlog check on 2026-05-14 found an existing open epic for this work: `EP-TAK-3F9A21`. This plan should sharpen that epic and its live items, not create a duplicate `EP-MEM-SHAPE-001` unless the backlog owner explicitly splits it later through the governed MCP workflow.
+
+---
+
+## 0. Review Corrections From This Pass
+
+This revision keeps the original thesis, but corrects the parts that drifted from current repo truth.
+
+| Draft claim | Current repo truth | Plan correction |
+|---|---|---|
+| The plan needs a new proposed epic. | Live backlog already has `EP-TAK-3F9A21` with governed-memory, observability, GAID, and MCP items. | Attach this plan to the existing epic and map slices to live items first. |
+| AI Coworker chat loads `AgentMessage` thread history unbounded. | [`agent-coworker.ts`](../../../apps/web/lib/actions/agent-coworker.ts) already trims prompt history: `/build` gets a larger bounded window, other routes get a smaller one, and older messages are paged separately. | The real gap is not unlimited loading. It is that the windowing policy is implicit, not declared as an input contract, and older turns do not have a durable continuation summary. |
+| Scheduled/autonomous runs need a new `RunHandoff` table. | [`agent-task-scheduler.ts`](../../../apps/web/lib/actions/agent-task-scheduler.ts) already creates a `TaskRun`, `TaskMessage`, and links `ScheduledAgentTask.taskRunId`. | Use `TaskRun` plus a typed continuation summary first. Add a table only if `TaskRun` cannot express the boundary. |
+| Phase handoff is absent. | [`PhaseHandoff`](../../../packages/db/prisma/schema.prisma) exists and Build Studio reads it in some paths. Some advancement routes write handoffs best-effort or skip them. | Enforce `PhaseHandoff` as a mandatory boundary contract for Build Studio phase transitions rather than inventing a parallel primitive. |
+| Wiki PPR and section retrieval are already runtime primitives for specs/plans. | [`spec-plan-search.ts`](../../../apps/web/lib/backlog/spec-plan-search.ts) still uses markdown scanning and substring matching for specs/plans. Wiki vector recall exists, but PPR remains design-direction, not universal runtime truth. | Keep section-aware spec/plan retrieval as a future slice and label it honestly. |
+| Semantic memory already carries the right authority metadata. | [`semantic-memory.ts`](../../../apps/web/lib/inference/semantic-memory.ts) writes route, user, agent, thread, preview, fingerprint, and timestamp metadata, but not authority, memory scope, or promotion status. | Add authority/scope payload hardening after the contract and UI slices prove the shape. |
+
+---
+
+## 1. Intent and Non-Goals
+
+DPF already has memory primitives: Qdrant `agent-memory`, Qdrant `wiki-pages`, `UserFact`, `AgentThread`, `AgentMessage`, `TaskRun`, `TaskMessage`, `TaskArtifact`, `PhaseHandoff`, `ToolExecution`, and `ToolExecutionReceipt`. The problem is that coworkers do not yet have a reviewed, visible contract that states which inputs may enter a run, what authority each input carries, how stale or missing data behaves, and what the coworker must emit at the boundary.
+
+This spec adds a contract layer over existing substrate.
+
+It is not:
+
+- a new memory store
+- a replacement taxonomy for TAK governed memory
+- a parallel run identity model
+- a greenfield RAG platform
+- a permission bypass for direct backlog or database writes
+
+The architectural move is deliberately refactoring-heavy: make the implicit runtime contract explicit, make it observable, and only then harden storage payloads or add schema where the existing primitives cannot carry the contract.
+
+---
+
+## 2. Research and Benchmarking
+
+Every new feature spec needs explicit benchmarking. The useful pattern across current agent-memory systems is not "store more"; it is "separate short-term state, durable memory, structured artifacts, and graph-shaped context so the model is not asked to rediscover its own operating context."
+
+| Reference | Pattern to adopt | Pattern to reject for DPF |
+|---|---|---|
+| [LangGraph memory](https://docs.langchain.com/oss/python/langgraph/memory) and [persistence](https://docs.langchain.com/oss/python/langgraph/persistence) | Treat thread state and persistent memory as different concepts. Persist checkpoints at explicit execution boundaries. | Do not migrate DPF orchestration to LangGraph just to get the terminology. DPF already has `TaskRun`, `PhaseHandoff`, and `ToolExecution`. |
+| [Letta memory blocks](https://docs.letta.com/guides/core-concepts/memory/memory-blocks) | Use small named context blocks with clear read/write rules. DPF can mirror this through declared input fields and read-only authoritative blocks. | Do not allow coworkers to self-edit core identity or governance memory. TAK must stay authoritative. |
+| [LlamaIndex hierarchical parsing](https://docs.llamaindex.ai/en/stable/api_reference/node_parsers/hierarchical/) | Long structured documents should keep section hierarchy during retrieval. Specs and plans should not be flattened into substring snippets. | Do not treat every markdown document as undifferentiated prose. |
+| [Microsoft GraphRAG](https://www.microsoft.com/en-us/research/project/graphrag/) and [GraphRAG docs](https://microsoft.github.io/graphrag/index/overview/) | Relationship-heavy questions benefit from graph-shaped retrieval when the graph exists and is scoped. | Do not put all memory in Neo4j. Use graph retrieval for adjacency questions only. |
+| [Mem0/OpenMemory](https://docs.mem0.ai/openmemory/overview) | Production memory systems expose persistent memory as a managed layer with user, agent, and metadata scope. | Do not add an external memory layer when DPF already owns the governance, audit, and local runtime requirements. |
+
+The benchmarked direction is a hybrid: declare the shape first, route retrieval to the primitive that matches that shape, and expose the delivered context to operators.
+
+---
+
+## 3. Verified Current Repo Truth
+
+| Area | Verified fact | Source |
+|---|---|---|
+| AI Coworker prompt assembly | The send path builds route-aware prompt context from recent messages, governed memory, page context, tool grants, wiki recall, and optional Build Studio handoff context. | [`agent-coworker.ts`](../../../apps/web/lib/actions/agent-coworker.ts) |
+| Chat windowing | Current prompt history is bounded and token-trimmed, but the policy is embedded in code instead of being declared as a reusable coworker contract. | [`agent-coworker.ts`](../../../apps/web/lib/actions/agent-coworker.ts) |
+| Governed memory | `buildGovernedMemoryContext` resolves AIDoc, action risk, user facts, semantic recall, counts, and operating profile fingerprint. | [`governed-memory.ts`](../../../apps/web/lib/tak/governed-memory.ts) |
+| User facts | `UserFact` supports categories, confidence, source metadata, active/superseded status, and freshness states. It does not yet provide a universal injected-fact authority surface across all memory classes. | [`user-facts.ts`](../../../apps/web/lib/tak/user-facts.ts), [`schema.prisma`](../../../packages/db/prisma/schema.prisma) |
+| Semantic memory | `agent-memory` points include user, agent, route, route domain, thread, role, preview, fingerprint, and timestamp payload fields. They do not include authority, memory scope, or promotion state. | [`semantic-memory.ts`](../../../apps/web/lib/inference/semantic-memory.ts), [`qdrant.ts`](../../../packages/db/src/qdrant.ts) |
+| Wiki recall | Wiki page recall is vector-backed and overlay-aware, with organization and kernel fallback. It is not the same thing as spec/plan retrieval. | [`wiki/recall.ts`](../../../apps/web/lib/wiki/recall.ts), [`wiki/embeddings.ts`](../../../apps/web/lib/wiki/embeddings.ts) |
+| Spec/plan search | Backlog-facing spec search still scans markdown files and ranks substring matches. | [`spec-plan-search.ts`](../../../apps/web/lib/backlog/spec-plan-search.ts) |
+| Build handoffs | `PhaseHandoff` exists, `save_phase_handoff` exists, and some build paths read or write handoffs. Some transitions still advance without making the handoff the mandatory input/output boundary. | [`mcp-tools.ts`](../../../apps/web/lib/mcp-tools.ts), [`build.ts`](../../../apps/web/lib/actions/build.ts), [`advance-phase/route.ts`](../../../apps/web/app/api/agent/build/advance-phase/route.ts) |
+| Receipts | `ToolExecution.taskRunId` and `ToolExecutionReceipt` exist, and some sandbox/UX tools write receipts with input fingerprints. | [`schema.prisma`](../../../packages/db/prisma/schema.prisma), [`mcp-governed-execute.ts`](../../../apps/web/lib/mcp-governed-execute.ts), [`build-artifact-provenance.ts`](../../../apps/web/lib/build/build-artifact-provenance.ts) |
+| Scheduled tasks | Scheduled coworkers create `TaskRun` and `TaskMessage` rows and link the scheduled task to `taskRunId`. The missing piece is a deterministic continuation summary for the next run. | [`agent-task-scheduler.ts`](../../../apps/web/lib/actions/agent-task-scheduler.ts) |
+| Neo4j | Neo4j is documented as projection/read-side infrastructure, not authoritative storage. Current coworker memory loaders do not consume it for build/backlog adjacency. | [`neo4j.ts`](../../../packages/db/src/neo4j.ts), [platform overview](../../architecture/platform-overview.md) |
+
+---
+
+## 4. Problem Statement
+
+DPF can remember and retrieve, but coworkers do not yet have an explicit memory shape contract.
+
+The practical consequence is that the same system can be technically capable and still behave inconsistently:
+
+- A coworker can receive route context, facts, wiki snippets, and semantic recall without a visible bundle saying what was delivered.
+- A user can wonder why the coworker re-asked a question without seeing whether the fact was missing, stale, withheld, or never looked up.
+- A downstream Build Studio phase can read a conversation tail even though the architectural contract wants a structured handoff.
+- A scheduled coworker can have a `TaskRun` but still lack a compact, deterministic next-run state.
+- A spec search can return a substring hit from a long design doc even when the right unit of recall is a section.
+
+The design goal is not more memory. It is a reviewed contract for memory entering and leaving a run.
+
+---
+
+## 5. Principles to Add
+
+These principles should be added as kernel wiki pages only after this spec is accepted. They sharpen existing coworker principles rather than replace them.
+
+### P9 - Bundle Declaration Before Run
+
+Every coworker run declares its input bundle before execution: fields, source primitive, shape, authority, freshness expectation, required/optional status, token budget, and degradation behavior. The coworker reads the declared bundle, not an accidental prompt blob.
+
+Sharpens P3, Structured Handoffs. P3 covers the output boundary. P9 covers the input boundary.
+
+### P10 - Retrieval Shape Matches the Work
+
+The retrieval primitive must match the shape of the work:
+
+- prose context uses semantic recall
+- long structured documents use section-aware document retrieval
+- governed facts use typed Postgres views or `UserFact`
+- relationship questions use graph-shaped retrieval
+- workspace state uses filesystem/diff primitives
+- proof of work uses receipts and audit evidence
+
+Sharpens P5, Selective Memory. The hard part is not selecting fewer tokens; it is selecting the right primitive.
+
+### P11 - Provenance and Quarantine on Every Injected Fact
+
+Every fact injected into a coworker prompt carries source, authority, freshness, and scope. Inferred memory stays inferred until a user confirmation, tool receipt, verified outcome, or authoritative record promotes it. Coworkers prefer authoritative and user-confirmed facts because metadata says so, not because a prompt happens to phrase them more strongly.
+
+Sharpens TAK freshness and self-edit boundaries. The principle applies to all memory classes, not only `UserFact`.
+
+---
+
+## 6. Contract Shape
+
+The first implementation should be TypeScript-first and co-located with coworker registration. That keeps the initial slice reviewable and avoids creating another admin-editable domain before the shape has proven itself.
+
+```typescript
+export type CoworkerContextShape =
+  | "prose"
+  | "structured-doc"
+  | "tabular"
+  | "relational"
+  | "filesystem"
+  | "text-diff"
+  | "receipt";
+
+export type MemoryAuthority =
+  | "authoritative"
+  | "user-confirmed"
+  | "inferred"
+  | "advisory";
+
+export type FreshnessPolicy =
+  | "any"
+  | "current-only"
+  | "revalidate-before-consequential-action";
+
+export type ContractDegradation =
+  | "block-run"
+  | "omit-field"
+  | "compress"
+  | "fallback-to-primary-source";
+
+export type CoworkerInputFieldContract = {
+  name: string;
+  shape: CoworkerContextShape;
+  primitive: string;
+  authority: MemoryAuthority;
+  required: boolean;
+  freshness: FreshnessPolicy;
+  degradation: ContractDegradation;
+  tokenBudget?: number;
+  sourceRef: string;
+  promptLabel?: string;
+};
+
+export type CoworkerInputContract = {
+  coworkerId: string;
+  routeScope?: readonly string[];
+  fields: readonly CoworkerInputFieldContract[];
+  output: {
+    writes: readonly string[];
+    receipts?: readonly string[];
+    handoff?: "PhaseHandoff" | "TaskMessage" | "TaskArtifact" | "none";
+  };
+};
+```
+
+The loader should produce a run-local delivery report:
+
+```typescript
+export type CoworkerContractDelivery = {
+  delivered: string[];
+  compressed: string[];
+  withheld: Array<{ field: string; reason: string }>;
+  missingRequired: string[];
+  tokenEstimate: number;
+};
+```
+
+Missing required fields either block the run or fall back to an authoritative primary source, depending on the declared degradation behavior. They should never silently disappear.
+
+---
+
+## 7. Retrieval Shape Routing
+
+| Shape | When to use | Current primitive | Contract behavior |
+|---|---|---|---|
+| `prose` | Conversation snippets, rationale, episodic recall | Qdrant `agent-memory` via semantic recall | Route-scoped first, then global fallback. Always label inferred/user-confirmed authority. |
+| `structured-doc` | Specs, plans, wiki pages, policies | Wiki recall today; future section-aware spec/plan retriever | Preserve heading/section source. Snippets must link back to document and section. |
+| `tabular` | User facts, backlog items, feature builds, tool grants | Prisma/Postgres typed records | Treat database row as primary source. Do not summarize away key IDs or status values. |
+| `relational` | "Which X connects to Y?" | Wiki PPR design for wiki; Neo4j projection for build/backlog adjacency later | Use only for adjacency questions. Do not make graph storage authoritative. |
+| `filesystem` | Workspace state, generated files, artifacts | Sandbox filesystem and git working tree | Include path, branch/worktree, and dirty-state summary. |
+| `text-diff` | Code review, Build Studio review, PR repair | Git diff plus target spec/plan | Keep file paths and changed hunks separate from prose conclusions. |
+| `receipt` | Proof that a tool or verification step already ran | `ToolExecution` and `ToolExecutionReceipt` | Use input fingerprint for idempotency and provenance. |
+
+---
+
+## 8. Per-Coworker Contracts and Fixes
+
+### 8.1 AI Coworker Chat
+
+Current state: the runtime already uses bounded recent message windows, governed memory context, wiki recall, tool grants, route/page data, and optional Build Studio handoff context. The issue is that this bundle is implicit, distributed across code branches, and invisible to the operator.
+
+Initial contract fields:
+
+| Field | Shape | Primitive | Authority | Behavior |
+|---|---|---|---|---|
+| `principal_identity` | `tabular` | Principal/User/AIDoc resolution | `authoritative` | Block consequential actions if missing. |
+| `route_context` | `tabular` | route registry and page context | `authoritative` | Omit optional page details when stale. |
+| `recent_thread_window` | `prose` | `AgentMessage` bounded window | `inferred` | Compress if token budget is exceeded. |
+| `thread_summary` | `prose` | new rolling summary artifact or semantic point | `inferred` | Use for older turns; link to raw messages for audit. |
+| `governed_user_facts` | `tabular` | `UserFact` | `authoritative` or `user-confirmed` | Revalidate before consequential action. |
+| `semantic_recall` | `prose` | Qdrant `agent-memory` | `inferred` or `user-confirmed` | Withhold stale same-profile-sensitive recall when policy requires. |
+| `wiki_context` | `structured-doc` | `recallWikiContext` | `authoritative` or `advisory` | Include source page and section. |
+| `tool_grants` | `tabular` | grant resolver | `authoritative` | Block tool claims when grant is absent. |
+
+Highest-value fix: add the contract declaration and delivery report first, then add a rolling thread summary so older conversation state has a deterministic, compact shape instead of being rediscovered or re-summarized ad hoc.
+
+### 8.2 Build Studio Phases
+
+Current state: Build Studio has `PhaseHandoff`, phase gates, sandbox receipts, and Build Studio-specific context injection, but the phase boundary is not consistently mandatory across all advancement paths.
+
+Initial contract fields:
+
+| Phase | Required inputs | Required outputs |
+|---|---|---|
+| Ideate/Scout | backlog item, route/build context, adjacent specs, prior similar builds if available | `FeatureBuild.scoutFindings`, `PhaseHandoff(ideate -> plan)` |
+| Plan | prior `PhaseHandoff`, target spec sections, affected module context, architecture invariants | spec/plan artifact, `PhaseHandoff(plan -> build)` |
+| Build | plan handoff, workspace state, allowed tools, prior receipts for identical fingerprints | file changes, tool receipts, `PhaseHandoff(build -> review)` |
+| Review | build handoff, target spec sections, diff, verification evidence | severity-tagged findings, `PhaseHandoff(review -> ship)` |
+| Ship | review handoff, DCO/credential state, PR template, contribution mode | PR/contribution record, evidence receipt |
+
+Highest-value fix: make `PhaseHandoff` creation and consumption transactional with phase advancement. A phase transition should either produce the required handoff or fail visibly. Do not add a new handoff table for Build Studio.
+
+### 8.3 Scheduled and Autonomous Coworkers
+
+Current state: scheduled tasks now create a `TaskRun`, write `TaskMessage` rows, invoke the agentic loop with `taskRunId`, and link the scheduled task to the latest run.
+
+Initial contract fields:
+
+| Field | Shape | Primitive | Authority | Behavior |
+|---|---|---|---|---|
+| `schedule_definition` | `tabular` | `ScheduledAgentTask` | `authoritative` | Block run if inactive or malformed. |
+| `prior_run_summary` | `structured-doc` | `TaskArtifact` or typed `TaskMessage` metadata | `authoritative` | Use for continuation instead of replaying the thread. |
+| `delta_since_last_run` | `tabular` | typed Postgres query bounded by `lastRunAt` | `authoritative` | Recompute from primary records, not prior prose. |
+| `tool_grants` | `tabular` | grant resolver | `authoritative` | Block tool claims when grant is absent. |
+
+Highest-value fix: write a deterministic `run-continuation-summary` at the end of each scheduled run. Prefer `TaskArtifact` if downstream runs need deterministic lookup; use typed `TaskMessage` metadata only if the summary is primarily part of the conversation projection.
+
+### 8.4 Hive Scout and Backlog Contribution Flows
+
+Current state: the platform already has the right concept of governed backlog interaction and submitter attribution. The memory contract here should prevent duplicate ingestion and preserve provenance.
+
+Initial contract fields:
+
+| Field | Shape | Primitive | Authority | Behavior |
+|---|---|---|---|---|
+| `upstream_catalog_snapshot` | `structured-doc` | fetched catalog plus ETag/hash | `authoritative` | Skip if unchanged. |
+| `existing_backlog_dedup_set` | `tabular` | live backlog query through MCP/Postgres | `authoritative` | Block direct write if live query fails. |
+| `submitter_identity` | `tabular` | coworker identity/GAID/AIDoc | `authoritative` | Required for any backlog suggestion. |
+| `prior_receipt` | `receipt` | `ToolExecutionReceipt.inputFingerprint` | `authoritative` | Short-circuit repeated ingestion. |
+
+Highest-value fix: use input fingerprints and submitter attribution for idempotent backlog suggestions. Keep backlog mutation behind MCP tools when available.
+
+---
+
+## 9. Operator UI - Memory Contract Inspector
+
+This design needs a visible operator surface, not just runtime types. Add a read-only first version at `/platform/ai/memory-contracts` or as a first-class tab under the existing AI operations area.
+
+V1 layout:
+
+| Region | Content |
+|---|---|
+| Left rail | Coworker and route list with contract health: ok, missing optional, missing required, stale, withheld. |
+| Main table | Field, shape, primitive, authority, freshness, delivered/missing/withheld, token budget, last delivered time. |
+| Inspector drawer | Source refs, recent delivered examples, withheld reasons, evidence receipts, and prompt-preview excerpt. |
+| Metrics strip | `contract_delivery_rate`, `missing_required_fields`, `stale_or_withheld_fact_count`, `tokens_before_first_useful_tool_call`, `re_asked_questions_count`. |
+| Deep links | `/platform/ai/history`, `/platform/ai/authority`, relevant `TaskRun`, relevant `ToolExecutionReceipt`, source spec/wiki page. |
+
+UI design rules:
+
+- Use DPF theme tokens only: `text-[var(--dpf-text)]`, `text-[var(--dpf-muted)]`, `bg-[var(--dpf-surface-1)]`, `bg-[var(--dpf-surface-2)]`, `border-[var(--dpf-border)]`, and `text-[var(--dpf-accent)]`.
+- Keep the surface dense and operational. This is an operator table, not a landing page.
+- Avoid cards inside cards. Use a full-width page band with a constrained table and a drawer.
+- Use compact badges for shape, authority, and freshness, but make each badge token-backed rather than hardcoded color-backed.
+- Every alert state must offer the nearest evidence link, not just a warning label.
+- The first screen should answer: "What context entered this coworker run, what was withheld, and why?"
+
+---
+
+## 10. Phasing
+
+| Slice | Scope | Backlog alignment | Schema impact |
+|---|---|---|---|
+| 1 | Contract substrate plus AI Coworker chat declaration and delivery report | `BI-MEM-5A41C7` | None expected |
+| 2 | Read-only Memory Contract Inspector with delivery telemetry | `BI-OBS-4B63F2` | None expected if telemetry uses existing run/log records |
+| 3 | Semantic memory payload hardening: authority, memory scope, freshness/source IDs, and Qdrant indexes | `BI-MEM-5A41C7` | Qdrant payload/index update; avoid SQL migration unless `UserFact` UI needs filtering |
+| 4 | Build Studio `PhaseHandoff` enforcement across all phase advancement paths | Also aligns to active Build Studio cycle items | Possible no-schema refactor if current `PhaseHandoff` is sufficient |
+| 5 | Section-aware spec/plan retriever replacing substring-only matching for docs/superpowers | `BI-MEM-5A41C7` or a new MCP-created item | None expected |
+| 6 | Scheduled coworker continuation summary using `TaskRun` plus `TaskArtifact` or typed `TaskMessage` metadata | `BI-MEM-5A41C7` | Prefer no new table |
+| 7 | Neo4j build/backlog adjacency projection for Scout/Plan/Review relational questions | New MCP-created item after graph scope is accepted | Projection only; Postgres remains authoritative |
+| 8 | Rediscovery-rate automation that can propose `CoworkerCapabilityNeed` or backlog suggestions with submitter attribution | `BI-MCP-7E53D1`, `BI-GAID-8D72B4` | Depends on accepted contribution workflow |
+
+Ordering rationale: slices 1 and 2 make the hidden contract visible before schema hardening. That gives the team evidence about which fields are actually missing, stale, over-budget, or redundant before committing to migrations.
+
+---
+
+## 11. Acceptance and Verification
+
+Doc-only acceptance for this plan:
+
+- The document must separate current repo truth from proposed future contracts.
+- All current-state claims must point at live repo primitives rather than seed data or stale design assumptions.
+- Backlog linkage must use live backlog state or explicitly say when MCP/DB fallback was unavailable.
+
+Implementation acceptance for future slices:
+
+- Unit tests for affected contract loaders, memory recall, scheduled continuation, and spec retrieval. Use pinned workspace tooling, for example:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/lib/tak/governed-memory.test.ts apps/web/lib/inference/semantic-memory.test.ts
+pnpm --filter web exec vitest run apps/web/lib/actions/agent-coworker.test.ts apps/web/lib/actions/agent-task-scheduler.test.ts
+pnpm --filter web exec vitest run apps/web/lib/backlog/spec-plan-search.test.ts
+```
+
+- Typecheck:
+
+```powershell
+pnpm --filter web typecheck
+```
+
+- Production build:
+
+```powershell
+cd apps/web
+pnpm exec next build
+```
+
+- UI/UX verification for any inspector or coworker UI change against the Docker-served app URL from `.env`, logging in as `admin@dpf.local` with repo-root `ADMIN_PASSWORD`.
+- For Qdrant payload/index changes, run a dry-run inventory first: count existing points, sample payloads, and verify the backfill labels old memory as inferred/advisory rather than silently promoting it.
+- For Build Studio handoff enforcement, exercise at least one phase transition through the UI and one direct advance route, then confirm the handoff and phase update are committed together.
+
+---
+
+## 12. Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Contract declarations become ceremony. | The loader emits a delivery report and blocks only when required fields are missing. Operators see whether the contract is doing work. |
+| Authority labels collapse into everything being authoritative. | Default semantic memory to inferred/advisory. Promotion requires a user confirmation, authoritative source, or receipt. |
+| The Memory Contract Inspector becomes another abstract AI page. | Make it run-first and evidence-first: field delivery, withheld reasons, source links, and prompt-preview excerpts. |
+| Build Studio handoff enforcement breaks existing flows. | Start by instrumenting missing handoffs, then flip gates per phase once the UI and direct route both write handoffs reliably. |
+| Section-aware retrieval duplicates wiki code. | Reuse the same section parser and metadata conventions where possible; do not fork a second retrieval framework. |
+| Neo4j becomes an attractive nuisance. | Keep it projection-only and limited to adjacency questions. Postgres remains the write authority. |
+| Scheduled continuation summaries lose detail. | Raw `TaskMessage` and `AgentMessage` records remain the audit trail; the summary is a deterministic run input, not a deletion. |
+
+---
+
+## 13. Open Questions
+
+1. Should contracts remain TypeScript-only after V1, or should accepted contracts be seeded into `PromptTemplate`/DB-backed configuration? Recommendation: TypeScript first, DB only after the shape stabilizes.
+2. Is `TaskArtifact` or typed `TaskMessage` metadata the better continuation-summary carrier? Recommendation: `TaskArtifact` if downstream runs need deterministic lookup; `TaskMessage` metadata if the summary is primarily conversation-facing.
+3. Should authority class become a `UserFact` schema field now or start as Qdrant/result metadata? Recommendation: start with recall-result metadata and Qdrant payload hardening, then add SQL only when the UI needs filtering or reporting.
+4. Should the inspector live at `/platform/ai/memory-contracts` or inside the AI Operations Map? Recommendation: make it a route/tab for discoverability, then deep-link from Operations Map nodes.
+5. Should Build Studio handoff enforcement be part of this TAK/GAID epic or the active Build Studio cycle epic? Recommendation: keep the contract design here and implement the Build Studio phase-gate slice under the active Build Studio workstream to avoid mixing concerns in one PR.
+
+---
+
+## 14. Out of Scope
+
+- Replacing the five-class governed memory model.
+- Introducing a new memory database or external memory service.
+- Issuing public GAIDs or changing the GAID trust boundary.
+- Building a personal wiki/openbrain control plane.
+- Direct database edits for backlog creation or status changes.
+- Making Neo4j authoritative for any domain record.


### PR DESCRIPTION
## Summary

Adds design spec at `docs/superpowers/specs/2026-05-14-coworker-memory-shape-contracts-design.md` under **EP-TAK-3F9A21** codifying the input-side memory contract for AI coworkers.

- Sharpens existing [AI Coworker Development Principles](../blob/main/docs/architecture/ai-coworker-development-principles.md) P3 (Structured Handoffs) and P5 (Selective Memory) — adds the declared **input bundle** complement, **retrieval-shape routing rule**, and **provenance/quarantine** discipline as P9–P11 for a future principles batch
- Per-coworker contracts for AI Coworker chat, Build Studio phases, scheduled/autonomous coworkers, hive scout / backlog contribution — each names existing primitives (`TaskRun`, `PhaseHandoff`, `UserFact`, `agent-memory` Qdrant, `wiki-pages` Qdrant, `ToolExecutionReceipt`) and identifies the enforcement gap rather than proposing parallel substrate
- Adds a **Memory Contract Inspector** UI surface at `/platform/ai/memory-contracts` to make the contract operator-visible
- Phases the substrate + inspector ahead of any schema hardening so missing/stale/withheld fields become visible before migrations commit to a shape

Aligns with live backlog items `BI-MEM-5A41C7`, `BI-OBS-4B63F2`, `BI-GAID-8D72B4`, `BI-MCP-7E53D1` under EP-TAK-3F9A21.

## Test plan

- [ ] Review §0 Review Corrections — confirms repo-truth corrections vs. earlier draft
- [ ] Review §3 Verified Current Repo Truth — citations are accurate against current code
- [ ] Review §5 Principles P9–P11 — confirm they sharpen rather than duplicate existing P3/P5/P7
- [ ] Review §8 Per-coworker contracts — confirm each highest-value-fix is the right entry point
- [ ] Review §10 Phasing — confirm inspector-before-hardening ordering is correct
- [ ] Doc-only change; no code/typecheck/build impact

Doc-only; spec only. Implementation follows in slice-scoped plans per §10 phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)