### PR TITLE
feat(wiki): Phase 2.3a — commit step (proposal → DB writes), portal-build verified

### DIFF
--- a/apps/web/lib/wiki/proposal-commit.test.ts
+++ b/apps/web/lib/wiki/proposal-commit.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  commitIngestProposal,
+  type CommitProposalInput,
+} from "./proposal-commit";
+import type {
+  ClaimProposal,
+  HeuristicProposal,
+  StanceProposal,
+  WikiDiffProposal,
+} from "./proposal";
+
+// ─── Mock factory ───────────────────────────────────────────────────────────
+
+type FakePage = {
+  id: string;
+  slug: string;
+  title: string;
+  body: string;
+  pageKind: string;
+  status: string;
+  isKernel: boolean;
+  organizationId: string | null;
+};
+
+function makeMockClient(seed: FakePage[] = []) {
+  const pages = new Map<string, FakePage>();
+  for (const p of seed) pages.set(`${p.organizationId ?? "kernel"}:${p.slug}`, { ...p });
+
+  const revisions: Array<Record<string, unknown>> = [];
+  const links: Array<{ fromPageId: string; toPageId: string }> = [];
+  const sources: Array<{ pageId: string; sourceId: string }> = [];
+  const events: Array<Record<string, unknown>> = [];
+  let nextId = 1;
+  const newId = () => `wp_test_${nextId++}`;
+
+  const findFirst = vi.fn(async (args: { where: Record<string, unknown>; select?: unknown }) => {
+    const w = args.where;
+    if (typeof w.id === "string") {
+      for (const p of pages.values()) if (p.id === w.id) return { ...p };
+      return null;
+    }
+    const orgId = w.organizationId ?? null;
+    const slug = w.slug as string;
+    return pages.get(`${orgId ?? "kernel"}:${slug}`) ?? null;
+  });
+
+  const create = vi.fn(async (args: { data: Record<string, unknown> }) => {
+    const id = newId();
+    const page: FakePage = {
+      id,
+      slug: args.data.slug as string,
+      title: args.data.title as string,
+      body: args.data.body as string,
+      pageKind: args.data.pageKind as string,
+      status: (args.data.status as string) ?? "draft",
+      isKernel: (args.data.isKernel as boolean) ?? false,
+      organizationId: (args.data.organizationId as string | null) ?? null,
+    };
+    pages.set(`${page.organizationId ?? "kernel"}:${page.slug}`, page);
+    return { ...page };
+  });
+
+  const update = vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
+    for (const [key, p] of pages) {
+      if (p.id === args.where.id) {
+        const merged: FakePage = { ...p, ...(args.data as Partial<FakePage>) };
+        pages.set(key, merged);
+        return { ...merged };
+      }
+    }
+    throw new Error(`update: page not found ${args.where.id}`);
+  });
+
+  const wikiPage = { findFirst, create, update, findUnique: vi.fn(), findMany: vi.fn() };
+
+  const revisionCreate = vi.fn(async (args: { data: Record<string, unknown> }) => {
+    revisions.push(args.data);
+    return { id: `rev_${revisions.length}`, ...args.data };
+  });
+  const revisionFindFirst = vi.fn(async () => null);
+  const wikiPageRevision = { create: revisionCreate, findFirst: revisionFindFirst };
+
+  const linkUpsert = vi.fn(async (args: { create: { fromPageId: string; toPageId: string } }) => {
+    links.push(args.create);
+    return args.create;
+  });
+  const wikiPageLink = { upsert: linkUpsert };
+
+  const sourceUpsert = vi.fn(async (args: { create: { pageId: string; sourceId: string } }) => {
+    sources.push(args.create);
+    return args.create;
+  });
+  const wikiPageSource = { upsert: sourceUpsert };
+
+  const rawSource = { upsert: vi.fn() };
+
+  const eventCreate = vi.fn(async (args: { data: Record<string, unknown> }) => {
+    const id = `evt_${events.length + 1}`;
+    events.push({ id, ...args.data });
+    return { id, ...args.data };
+  });
+  const wikiIngestEvent = { create: eventCreate };
+
+  const db = {
+    wikiPage,
+    wikiPageRevision,
+    wikiPageLink,
+    wikiPageSource,
+    rawSource,
+    wikiIngestEvent,
+  };
+  return {
+    db,
+    pages,
+    revisions,
+    links,
+    sources,
+    events,
+    mocks: {
+      findFirst,
+      create,
+      update,
+      revisionCreate,
+      linkUpsert,
+      sourceUpsert,
+      eventCreate,
+    },
+  };
+}
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+function makeInput(
+  proposal: WikiDiffProposal,
+  organizationId: string | null = "org_test",
+): CommitProposalInput {
+  return {
+    rawSourceId: "rs_1",
+    sourceKey: "articles/example",
+    proposal,
+    organizationId,
+    userId: "user_1",
+    kernelVersion: "0.2.1",
+  };
+}
+
+function emptyProposal(): WikiDiffProposal {
+  return {
+    abstract: "abs",
+    claims: [],
+    stances: [],
+    heuristics: [],
+    parseErrors: [],
+  };
+}
+
+const claimSample = (overrides: Partial<ClaimProposal> = {}): ClaimProposal => ({
+  claim: "Digital Product is the unit of organization.",
+  targetSlug: "entities/digital-product",
+  pageKind: "entity",
+  proposeNew: false,
+  confidence: 0.9,
+  supportingExcerpt: "Pick one canonical model.",
+  ...overrides,
+});
+
+const stanceSample = (overrides: Partial<StanceProposal> = {}): StanceProposal => ({
+  statement: "Two-system integration always decays.",
+  targetSlug: "stances/dont-integrate-ea-platform",
+  proposeNew: true,
+  supportingExcerpt: "The two-system pattern fails on reconciliation.",
+  ...overrides,
+});
+
+const heuristicSample = (
+  overrides: Partial<HeuristicProposal> = {},
+): HeuristicProposal => ({
+  rule: "When in doubt, auto-populate.",
+  targetSlug: "heuristics/auto-populate-or-its-wrong",
+  proposeNew: true,
+  supportingExcerpt: "Manual inventory data is already lying to you.",
+  ...overrides,
+});
+
+// ─── Kernel write refusal ───────────────────────────────────────────────────
+
+describe("commitIngestProposal — kernel write refusal", () => {
+  it("refuses to write when organizationId is null and surfaces a typed error", async () => {
+    const { db, mocks, events } = makeMockClient();
+    const result = await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), claims: [claimSample()] }, null),
+    );
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/kernel writes are not allowed/);
+    expect(mocks.create).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+    // Audit event still recorded so the attempt is visible.
+    expect(events).toHaveLength(1);
+    expect(result.eventId).toMatch(/^evt_/);
+  });
+
+  it("refuses to overwrite a kernel page even when scoped to an org overlay", async () => {
+    const { db, mocks } = makeMockClient([
+      {
+        id: "wp_kernel_dp",
+        slug: "entities/digital-product",
+        title: "Digital Product",
+        body: "kernel body",
+        pageKind: "entity",
+        status: "published",
+        isKernel: true,
+        organizationId: "org_test",
+      },
+    ]);
+    const result = await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), claims: [claimSample()] }),
+    );
+    expect(result.errors[0]).toMatch(/kernel page \(kernel pages are PR-only\)/);
+    expect(mocks.create).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Confidence threshold ───────────────────────────────────────────────────
+
+describe("commitIngestProposal — confidence threshold", () => {
+  it("skips claims below acceptThreshold and surfaces them in skippedLowConfidence", async () => {
+    const { db, mocks } = makeMockClient();
+    const low = claimSample({ confidence: 0.4, claim: "Weak signal" });
+    const high = claimSample({ confidence: 0.9, claim: "Strong signal", targetSlug: "entities/portfolio" });
+    const result = await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), claims: [low, high] }),
+    );
+    expect(result.skippedLowConfidence).toEqual([low]);
+    expect(result.createdPageSlugs).toContain("entities/portfolio");
+    expect(mocks.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects an explicit acceptThreshold override", async () => {
+    const { db } = makeMockClient();
+    const result = await commitIngestProposal(db, {
+      ...makeInput({ ...emptyProposal(), claims: [claimSample({ confidence: 0.4 })] }),
+      acceptThreshold: 0.3,
+    });
+    expect(result.skippedLowConfidence).toEqual([]);
+    expect(result.createdPageSlugs).toContain("entities/digital-product");
+  });
+});
+
+// ─── New page creation ──────────────────────────────────────────────────────
+
+describe("commitIngestProposal — creates new pages from templates", () => {
+  it("creates an entity page from a claim with the SCHEMA-compliant section structure", async () => {
+    const { db, mocks, pages } = makeMockClient();
+    await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), claims: [claimSample()] }),
+    );
+    const created = pages.get("org_test:entities/digital-product");
+    expect(created?.status).toBe("draft");
+    expect(created?.body).toMatch(/## Definition/);
+    expect(created?.body).toMatch(/## Properties/);
+    expect(created?.body).toMatch(/## Relationships/);
+    expect(created?.body).toMatch(/## Source-anchored claims/);
+    expect(created?.body).toMatch(/\[\[raw-sources\/articles\/example\]\]/);
+    expect(mocks.revisionCreate).toHaveBeenCalled();
+    expect(mocks.sourceUpsert).toHaveBeenCalled();
+  });
+
+  it("creates a stance page from a stance proposal with the SCHEMA stance structure", async () => {
+    const { db, pages } = makeMockClient();
+    await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), stances: [stanceSample()] }),
+    );
+    const created = pages.get("org_test:stances/dont-integrate-ea-platform");
+    expect(created?.body).toMatch(/## Stance/);
+    expect(created?.body).toMatch(/## Reasoning/);
+    expect(created?.body).toMatch(/## When this applies \/ when it doesn't/);
+    expect(created?.body).toMatch(/Two-system integration always decays/);
+  });
+
+  it("creates a heuristic page from a heuristic proposal with the rule/why/example structure", async () => {
+    const { db, pages } = makeMockClient();
+    await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), heuristics: [heuristicSample()] }),
+    );
+    const created = pages.get("org_test:heuristics/auto-populate-or-its-wrong");
+    expect(created?.body).toMatch(/## Rule/);
+    expect(created?.body).toMatch(/## Why/);
+    expect(created?.body).toMatch(/## Worked example/);
+    expect(created?.body).toMatch(/When in doubt, auto-populate/);
+  });
+
+  it("rejects pass-2 stance/heuristic claims (those come from pass-3)", async () => {
+    const { db, mocks } = makeMockClient();
+    const result = await commitIngestProposal(
+      db,
+      makeInput({
+        ...emptyProposal(),
+        claims: [claimSample({ pageKind: "stance", targetSlug: "stances/foo" })],
+      }),
+    );
+    expect(result.errors[0]).toMatch(/pass-2 cannot create stance\/heuristic/);
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Existing page update + body delta cap ──────────────────────────────────
+
+describe("commitIngestProposal — appends to existing pages within delta cap", () => {
+  it("appends a claim to an existing page body and creates a revision", async () => {
+    const { db, pages, mocks } = makeMockClient([
+      {
+        id: "wp_existing",
+        slug: "entities/portfolio",
+        // Body intentionally large so the append stays comfortably under the
+        // default 30% body-delta cap; the cap behaviour gets its own test.
+        body: `## Definition\n\nA portfolio is a curated set of digital products.\n\n${"existing-content ".repeat(80)}`,
+        title: "Portfolio",
+        pageKind: "entity",
+        status: "published",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    const result = await commitIngestProposal(
+      db,
+      makeInput({
+        ...emptyProposal(),
+        claims: [
+          claimSample({
+            targetSlug: "entities/portfolio",
+            claim: "A portfolio is grouped by management purpose.",
+            supportingExcerpt: "Curated set of digital products grouped for shared management.",
+            confidence: 0.9,
+          }),
+        ],
+      }),
+    );
+    expect(result.updatedPageSlugs).toContain("entities/portfolio");
+    const updated = pages.get("org_test:entities/portfolio");
+    expect(updated?.body).toContain("Additional source-anchored claims (ingested)");
+    expect(updated?.body).toContain("A portfolio is grouped by management purpose.");
+    expect(mocks.revisionCreate).toHaveBeenCalled();
+  });
+
+  it("is idempotent — the same claim re-applied does not duplicate the bullet", async () => {
+    const seedPage: FakePage = {
+      id: "wp_idem",
+      slug: "entities/portfolio",
+      title: "Portfolio",
+      body: `## Definition\n\nA portfolio is a curated set.\n\n${"existing-content ".repeat(80)}`,
+      pageKind: "entity",
+      status: "published",
+      isKernel: false,
+      organizationId: "org_test",
+    };
+    const { db, pages, mocks } = makeMockClient([seedPage]);
+    const claim = claimSample({
+      targetSlug: "entities/portfolio",
+      claim: "Idempotent claim.",
+      supportingExcerpt: "evidence",
+      confidence: 0.9,
+    });
+
+    await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), claims: [claim] }),
+    );
+    const bodyAfterFirst = pages.get("org_test:entities/portfolio")?.body ?? "";
+    const occurrencesFirst = bodyAfterFirst.match(/Idempotent claim/g)?.length ?? 0;
+
+    await commitIngestProposal(
+      db,
+      makeInput({ ...emptyProposal(), claims: [claim] }),
+    );
+    const bodyAfterSecond = pages.get("org_test:entities/portfolio")?.body ?? "";
+    const occurrencesSecond = bodyAfterSecond.match(/Idempotent claim/g)?.length ?? 0;
+
+    expect(occurrencesFirst).toBe(1);
+    expect(occurrencesSecond).toBe(1);
+    // Second pass must not have created a new revision (no body change → upsert no-op).
+    expect(mocks.revisionCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses an append that would exceed maxBodyDeltaRatio and reports it", async () => {
+    const tinyBody = "x"; // 1 char — any append blows past 30%.
+    const { db, pages, mocks } = makeMockClient([
+      {
+        id: "wp_tiny",
+        slug: "entities/portfolio",
+        title: "Portfolio",
+        body: tinyBody,
+        pageKind: "entity",
+        status: "published",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    const result = await commitIngestProposal(
+      db,
+      makeInput({
+        ...emptyProposal(),
+        claims: [claimSample({ targetSlug: "entities/portfolio", confidence: 0.9 })],
+      }),
+    );
+    expect(result.errors[0]).toMatch(/maxBodyDeltaRatio/);
+    expect(pages.get("org_test:entities/portfolio")?.body).toBe(tinyBody);
+    expect(mocks.revisionCreate).not.toHaveBeenCalled();
+  });
+
+  it("respects an explicit maxBodyDeltaRatio override", async () => {
+    const { db, mocks } = makeMockClient([
+      {
+        id: "wp_a",
+        slug: "entities/portfolio",
+        title: "Portfolio",
+        body: "x",
+        pageKind: "entity",
+        status: "published",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    const result = await commitIngestProposal(db, {
+      ...makeInput({
+        ...emptyProposal(),
+        claims: [claimSample({ targetSlug: "entities/portfolio", confidence: 0.9 })],
+      }),
+      // 1000x growth allowed — far above the natural ~180-char append from
+      // a 1-char seed body, so the cap shouldn't fire.
+      maxBodyDeltaRatio: 1000,
+    });
+    expect(result.errors).toEqual([]);
+    expect(mocks.revisionCreate).toHaveBeenCalled();
+  });
+});
+
+// ─── Audit event ────────────────────────────────────────────────────────────
+
+describe("commitIngestProposal — audit event", () => {
+  it("records a single WikiIngestEvent with all touched page ids and attribution", async () => {
+    const { db, events } = makeMockClient();
+    const result = await commitIngestProposal(
+      db,
+      makeInput({
+        ...emptyProposal(),
+        claims: [
+          claimSample({ targetSlug: "entities/portfolio", confidence: 0.9 }),
+          claimSample({ targetSlug: "entities/value-stream", confidence: 0.9 }),
+        ],
+        stances: [stanceSample()],
+        heuristics: [heuristicSample()],
+      }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      sourceId: "rs_1",
+      organizationId: "org_test",
+      userId: "user_1",
+      kernelVersion: "0.2.1",
+    });
+    expect((events[0] as { touchedPageIds: string[] }).touchedPageIds).toHaveLength(4);
+    expect(result.touchedPageIds).toHaveLength(4);
+  });
+
+  it("dedupes touchedPageIds when multiple claims hit the same page", async () => {
+    const { db, events } = makeMockClient([
+      {
+        id: "wp_existing",
+        slug: "entities/portfolio",
+        title: "Portfolio",
+        body: "A".repeat(2000),
+        pageKind: "entity",
+        status: "published",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    const result = await commitIngestProposal(
+      db,
+      makeInput({
+        ...emptyProposal(),
+        claims: [
+          claimSample({ targetSlug: "entities/portfolio", claim: "Claim A", confidence: 0.9 }),
+          claimSample({ targetSlug: "entities/portfolio", claim: "Claim B", confidence: 0.9 }),
+        ],
+      }),
+    );
+    expect(events[0]).toBeDefined();
+    expect((events[0] as { touchedPageIds: string[] }).touchedPageIds).toEqual([
+      "wp_existing",
+    ]);
+    expect(result.touchedPageIds).toEqual(["wp_existing"]);
+  });
+});

--- a/apps/web/lib/wiki/proposal-commit.ts
+++ b/apps/web/lib/wiki/proposal-commit.ts
@@ -1,0 +1,754 @@
+// EP-WIKI-001 Phase 2.3a: turn a `WikiDiffProposal` into real DB writes.
+// Spec: docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md §6
+// Plan: docs/superpowers/plans/2026-05-09-platform-kernel-wiki.md (Phase 2.3)
+//
+// Bridge between Phase 2.2's pure proposal engine (apps/web/lib/wiki/proposal.ts)
+// and the WikiPage / WikiPageRevision / WikiPageSource / WikiIngestEvent
+// storage layer. Two core jobs:
+//
+//   1. Translate ClaimProposal / StanceProposal / HeuristicProposal rows
+//      into wiki page bodies that fit the SCHEMA.md required-section
+//      contract. Templates kept simple — every new page lands as `draft`
+//      so Mark reviews before it appears in the published view.
+//
+//   2. Enforce the spec's runtime guardrails:
+//      - Kernel pages are PR-only — runtime ingest cannot write to
+//        isKernel = true rows. Org overlay writes only.
+//      - Body delta cap (default 30%) on UPDATES — larger rewrites need
+//        human approval and are surfaced as errors rather than auto-
+//        committed.
+//      - Confidence threshold (default 0.5) on claims — low-confidence
+//        rows are skipped so the reviewer's signal-to-noise stays high.
+//
+// Qdrant write is intentionally out of scope here — that's a thin
+// concern wired by the production adapter in Phase 2.3b. This module
+// owns Postgres state only and is exercised under test with mocked
+// Prisma clients.
+
+import {
+  appendRevision,
+  attachSource,
+  getWikiPage,
+  linkPages,
+  recordIngestEvent,
+  upsertWikiPage,
+  type WikiStoreClient,
+} from "@dpf/db/wiki-store";
+import { extractWikilinks } from "@dpf/db/wiki-frontmatter";
+import type {
+  ClaimProposal,
+  HeuristicProposal,
+  StanceProposal,
+  WikiDiffProposal,
+} from "./proposal";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Subset of `WikiStoreClient` this orchestrator needs. */
+type CommitClient = Pick<
+  WikiStoreClient,
+  | "wikiPage"
+  | "wikiPageRevision"
+  | "wikiPageLink"
+  | "wikiPageSource"
+  | "wikiIngestEvent"
+>;
+
+export type CommitProposalInput = {
+  /** RawSource.id from Phase 2.1's `ingestRawSourceFromFile`. */
+  rawSourceId: string;
+  /** `sourceKey` of the RawSource — used to render `[[raw-sources/<key>]]` cites. */
+  sourceKey: string;
+  /** Output of `proposeWikiDiff` (Phase 2.2). */
+  proposal: WikiDiffProposal;
+  /**
+   * Org-scoped commit (overlay rows) when set; kernel-scoped (forbidden
+   * for runtime writes) when null. Per spec, `commitIngestProposal`
+   * REFUSES kernel writes and returns an error instead of throwing — the
+   * caller logs it and surfaces to the reviewer.
+   */
+  organizationId: string | null;
+  agentId?: string | null;
+  userId?: string | null;
+  kernelVersion?: string | null;
+  /**
+   * Minimum confidence a claim must reach to be committed. Default 0.5.
+   * Skipped claims appear in `result.skippedLowConfidence` so the reviewer
+   * can see what the model proposed and didn't make the cut.
+   */
+  acceptThreshold?: number;
+  /**
+   * Cap on body growth per existing page in one ingest cycle, expressed
+   * as a fraction of the existing body length. Default 0.3 (30%) per
+   * spec section 6 ("ingest revisions cannot replace >30% of a page in
+   * one shot — forces human approval"). Pages that would exceed the cap
+   * are surfaced as errors instead of being auto-committed.
+   */
+  maxBodyDeltaRatio?: number;
+};
+
+export type CommitProposalResult = {
+  /** Page ids that got a new revision or were created in this commit. */
+  touchedPageIds: string[];
+  createdPageSlugs: string[];
+  updatedPageSlugs: string[];
+  /** Claims dropped because confidence < acceptThreshold. */
+  skippedLowConfidence: ClaimProposal[];
+  /** Per-row errors (kernel-write attempt, body-cap exceeded, etc.). */
+  errors: string[];
+  /** WikiIngestEvent.id created for this commit. */
+  eventId: string;
+};
+
+// ─── Body templates ─────────────────────────────────────────────────────────
+
+const NEW_PAGE_TEMPLATES: Record<
+  "entity" | "summary" | "decision" | "runbook" | "principle",
+  (args: { title: string; excerpt: string; sourceKey: string }) => string
+> = {
+  entity: ({ title, excerpt, sourceKey }) => `## Definition
+
+${excerpt}
+
+## Properties
+
+(to be authored — Mark)
+
+## Relationships
+
+(to be authored — Mark)
+
+## Source-anchored claims
+
+- ${title}. See [[raw-sources/${sourceKey}]].
+
+## Examples
+
+(to be authored — Mark)
+`,
+  summary: ({ excerpt, sourceKey }) => `## Source
+
+[[raw-sources/${sourceKey}]]
+
+## Key claims
+
+${excerpt
+  .split("\n")
+  .filter((l) => l.trim().length > 0)
+  .map((l) => `- ${l.trim()}`)
+  .join("\n")}
+
+## Stance & heuristics extracted
+
+(to be linked once stance/heuristic pages from this source land)
+`,
+  decision: ({ title, excerpt, sourceKey }) => `## Context
+
+${excerpt}
+
+## Decision
+
+${title}
+
+## Consequences
+
+(to be authored — Mark)
+
+## Alternatives Considered
+
+(to be authored — Mark)
+
+## Source
+
+[[raw-sources/${sourceKey}]]
+`,
+  runbook: ({ title, excerpt, sourceKey }) => `## When to use
+
+${excerpt}
+
+## Prerequisites
+
+(to be authored — Mark)
+
+## Steps
+
+1. ${title}
+
+## Verification
+
+(to be authored — Mark)
+
+## Rollback
+
+(to be authored — Mark)
+
+## Source
+
+[[raw-sources/${sourceKey}]]
+`,
+  // Principle pages have richer required frontmatter (tier, dimensions,
+  // applies-to). Runtime-proposed principles are intentionally light: the
+  // body skeleton lands as a draft, Mark fills the metadata.
+  principle: ({ title, excerpt, sourceKey }) => `## Rule
+
+${title}
+
+## Why
+
+${excerpt}
+
+## Applies To
+
+(to be authored — Mark; set principleAppliesTo in frontmatter)
+
+## How To Apply
+
+(to be authored — Mark)
+
+## Decision Dimensions
+
+(to be authored — Mark; populate principleDimensionVector)
+
+## Examples
+
+(positive + counterexample to be authored)
+
+## Sources
+
+[[raw-sources/${sourceKey}]]
+`,
+};
+
+function newStanceBody(args: {
+  statement: string;
+  excerpt: string;
+  sourceKey: string;
+}): string {
+  return `## Stance
+
+${args.statement}
+
+## Reasoning
+
+${args.excerpt}
+
+## When this applies / when it doesn't
+
+(to be authored — Mark)
+
+## Sources
+
+[[raw-sources/${args.sourceKey}]]
+`;
+}
+
+function newHeuristicBody(args: {
+  rule: string;
+  excerpt: string;
+  sourceKey: string;
+}): string {
+  return `## Rule
+
+${args.rule}
+
+## Why
+
+${args.excerpt}
+
+## Worked example
+
+(to be authored — Mark)
+
+## Counterexamples
+
+(to be authored — Mark)
+
+## Sources
+
+[[raw-sources/${args.sourceKey}]]
+`;
+}
+
+/**
+ * Append a new "Additional source-anchored claims" section to an existing
+ * page body. Idempotent on the section header — re-running with the same
+ * claim does not duplicate the bullet (we check for the exact line).
+ */
+function appendClaimToExistingBody(
+  existingBody: string,
+  claim: ClaimProposal,
+  sourceKey: string,
+): string {
+  const headerLine = "## Additional source-anchored claims (ingested)";
+  const newLine = `- ${claim.claim} — supporting: "${truncateExcerpt(claim.supportingExcerpt)}". See [[raw-sources/${sourceKey}]].`;
+
+  if (existingBody.includes(newLine)) {
+    return existingBody;
+  }
+
+  if (existingBody.includes(headerLine)) {
+    return `${existingBody.trimEnd()}\n${newLine}\n`;
+  }
+
+  return `${existingBody.trimEnd()}\n\n${headerLine}\n\n${newLine}\n`;
+}
+
+function truncateExcerpt(excerpt: string, max = 240): string {
+  const trimmed = excerpt.trim().replace(/\s+/g, " ");
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+}
+
+// ─── Title derivation ───────────────────────────────────────────────────────
+
+function titleFromSlug(slug: string): string {
+  const stem = slug.split("/").pop() ?? slug;
+  return stem
+    .split("-")
+    .map((w) => (w.length > 0 ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
+// ─── Commit one row ─────────────────────────────────────────────────────────
+
+type CommitRowDeps = {
+  db: CommitClient;
+  rawSourceId: string;
+  sourceKey: string;
+  organizationId: string;
+  agentId: string | null;
+  userId: string | null;
+  kernelVersion: string | null;
+  maxBodyDeltaRatio: number;
+};
+
+type CommitRowOutcome =
+  | { kind: "created" | "updated"; pageId: string; slug: string }
+  | { kind: "error"; message: string };
+
+async function commitClaim(
+  deps: CommitRowDeps,
+  claim: ClaimProposal,
+): Promise<CommitRowOutcome> {
+  const { db, rawSourceId, sourceKey, organizationId } = deps;
+  const existing = (await getWikiPage(db, {
+    organizationId,
+    slug: claim.targetSlug,
+  })) as { id: string; body: string; title: string; isKernel: boolean } | null;
+
+  if (existing) {
+    if (existing.isKernel) {
+      return {
+        kind: "error",
+        message: `claim ${claim.targetSlug}: refusing to write — kernel page (kernel pages are PR-only).`,
+      };
+    }
+    const newBody = appendClaimToExistingBody(existing.body, claim, sourceKey);
+    if (newBody === existing.body) {
+      // Idempotent no-op — claim already present.
+      return { kind: "updated", pageId: existing.id, slug: claim.targetSlug };
+    }
+    if (
+      existing.body.length > 0 &&
+      (newBody.length - existing.body.length) / existing.body.length >
+        deps.maxBodyDeltaRatio
+    ) {
+      return {
+        kind: "error",
+        message: `claim ${claim.targetSlug}: refusing to commit — append exceeds maxBodyDeltaRatio (${(((newBody.length - existing.body.length) / existing.body.length) * 100).toFixed(0)}% > ${(deps.maxBodyDeltaRatio * 100).toFixed(0)}%); needs human approval.`,
+      };
+    }
+    await upsertWikiPage(db, {
+      organizationId,
+      slug: claim.targetSlug,
+      title: existing.title,
+      body: newBody,
+      pageKind: claim.pageKind,
+      // Existing rows keep their status; the upsert helper preserves it via
+      // findFirst-then-update path. Body change still triggers a revision.
+    });
+    await appendRevision(db, {
+      pageId: existing.id,
+      title: existing.title,
+      body: newBody,
+      changeKind: "ingest",
+      changeSummary: `Ingest from ${sourceKey}: ${claim.claim.slice(0, 80)}`,
+      createdById: deps.userId,
+      createdByAgentId: deps.agentId,
+    });
+    await attachSource(db, { pageId: existing.id, sourceId: rawSourceId });
+    return { kind: "updated", pageId: existing.id, slug: claim.targetSlug };
+  }
+
+  // New page — only the kinds the spec lets ingest propose. Stance and
+  // heuristic pages from claims would short-circuit pass 3; reject.
+  if (claim.pageKind === "stance" || claim.pageKind === "heuristic") {
+    return {
+      kind: "error",
+      message: `claim ${claim.targetSlug}: pass-2 cannot create stance/heuristic pages directly — those come from pass-3.`,
+    };
+  }
+
+  const template = NEW_PAGE_TEMPLATES[claim.pageKind];
+  if (!template) {
+    return {
+      kind: "error",
+      message: `claim ${claim.targetSlug}: no body template for pageKind ${claim.pageKind}.`,
+    };
+  }
+  const title = titleFromSlug(claim.targetSlug);
+  const body = template({
+    title,
+    excerpt: claim.supportingExcerpt,
+    sourceKey,
+  });
+  const created = (await upsertWikiPage(db, {
+    organizationId,
+    slug: claim.targetSlug,
+    title,
+    body,
+    pageKind: claim.pageKind,
+    status: "draft",
+  })) as { id: string };
+
+  await appendRevision(db, {
+    pageId: created.id,
+    title,
+    body,
+    changeKind: "ingest",
+    changeSummary: `Created from ${sourceKey}: ${claim.claim.slice(0, 80)}`,
+    createdById: deps.userId,
+    createdByAgentId: deps.agentId,
+  });
+  await attachSource(db, { pageId: created.id, sourceId: rawSourceId });
+  return { kind: "created", pageId: created.id, slug: claim.targetSlug };
+}
+
+async function commitStance(
+  deps: CommitRowDeps,
+  stance: StanceProposal,
+): Promise<CommitRowOutcome> {
+  const { db, rawSourceId, sourceKey, organizationId } = deps;
+  const existing = (await getWikiPage(db, {
+    organizationId,
+    slug: stance.targetSlug,
+  })) as { id: string; body: string; title: string; isKernel: boolean } | null;
+
+  if (existing) {
+    if (existing.isKernel) {
+      return {
+        kind: "error",
+        message: `stance ${stance.targetSlug}: refusing to write — kernel page (kernel pages are PR-only).`,
+      };
+    }
+    // Existing stance: append the new statement + excerpt as an additional
+    // source-anchored support paragraph; body delta cap applies.
+    const addition = `\n\n> Additional support from [[raw-sources/${sourceKey}]]: ${stance.statement}\n>\n> "${truncateExcerpt(stance.supportingExcerpt)}"\n`;
+    if (existing.body.includes(addition.trim())) {
+      return { kind: "updated", pageId: existing.id, slug: stance.targetSlug };
+    }
+    const newBody = existing.body.trimEnd() + addition;
+    if (
+      existing.body.length > 0 &&
+      (newBody.length - existing.body.length) / existing.body.length >
+        deps.maxBodyDeltaRatio
+    ) {
+      return {
+        kind: "error",
+        message: `stance ${stance.targetSlug}: refusing to commit — append exceeds maxBodyDeltaRatio.`,
+      };
+    }
+    await upsertWikiPage(db, {
+      organizationId,
+      slug: stance.targetSlug,
+      title: existing.title,
+      body: newBody,
+      pageKind: "stance",
+    });
+    await appendRevision(db, {
+      pageId: existing.id,
+      title: existing.title,
+      body: newBody,
+      changeKind: "ingest",
+      changeSummary: `Ingest stance support from ${sourceKey}`,
+      createdById: deps.userId,
+      createdByAgentId: deps.agentId,
+    });
+    await attachSource(db, { pageId: existing.id, sourceId: rawSourceId });
+    return { kind: "updated", pageId: existing.id, slug: stance.targetSlug };
+  }
+
+  const title = titleFromSlug(stance.targetSlug);
+  const body = newStanceBody({
+    statement: stance.statement,
+    excerpt: stance.supportingExcerpt,
+    sourceKey,
+  });
+  const created = (await upsertWikiPage(db, {
+    organizationId,
+    slug: stance.targetSlug,
+    title,
+    body,
+    pageKind: "stance",
+    status: "draft",
+  })) as { id: string };
+  await appendRevision(db, {
+    pageId: created.id,
+    title,
+    body,
+    changeKind: "ingest",
+    changeSummary: `Created stance from ${sourceKey}`,
+    createdById: deps.userId,
+    createdByAgentId: deps.agentId,
+  });
+  await attachSource(db, { pageId: created.id, sourceId: rawSourceId });
+  return { kind: "created", pageId: created.id, slug: stance.targetSlug };
+}
+
+async function commitHeuristic(
+  deps: CommitRowDeps,
+  heuristic: HeuristicProposal,
+): Promise<CommitRowOutcome> {
+  const { db, rawSourceId, sourceKey, organizationId } = deps;
+  const existing = (await getWikiPage(db, {
+    organizationId,
+    slug: heuristic.targetSlug,
+  })) as { id: string; body: string; title: string; isKernel: boolean } | null;
+
+  if (existing) {
+    if (existing.isKernel) {
+      return {
+        kind: "error",
+        message: `heuristic ${heuristic.targetSlug}: refusing to write — kernel page (kernel pages are PR-only).`,
+      };
+    }
+    const addition = `\n\n> Additional support from [[raw-sources/${sourceKey}]]: ${heuristic.rule}\n>\n> "${truncateExcerpt(heuristic.supportingExcerpt)}"\n`;
+    if (existing.body.includes(addition.trim())) {
+      return {
+        kind: "updated",
+        pageId: existing.id,
+        slug: heuristic.targetSlug,
+      };
+    }
+    const newBody = existing.body.trimEnd() + addition;
+    if (
+      existing.body.length > 0 &&
+      (newBody.length - existing.body.length) / existing.body.length >
+        deps.maxBodyDeltaRatio
+    ) {
+      return {
+        kind: "error",
+        message: `heuristic ${heuristic.targetSlug}: refusing to commit — append exceeds maxBodyDeltaRatio.`,
+      };
+    }
+    await upsertWikiPage(db, {
+      organizationId,
+      slug: heuristic.targetSlug,
+      title: existing.title,
+      body: newBody,
+      pageKind: "heuristic",
+    });
+    await appendRevision(db, {
+      pageId: existing.id,
+      title: existing.title,
+      body: newBody,
+      changeKind: "ingest",
+      changeSummary: `Ingest heuristic support from ${sourceKey}`,
+      createdById: deps.userId,
+      createdByAgentId: deps.agentId,
+    });
+    await attachSource(db, { pageId: existing.id, sourceId: rawSourceId });
+    return { kind: "updated", pageId: existing.id, slug: heuristic.targetSlug };
+  }
+
+  const title = titleFromSlug(heuristic.targetSlug);
+  const body = newHeuristicBody({
+    rule: heuristic.rule,
+    excerpt: heuristic.supportingExcerpt,
+    sourceKey,
+  });
+  const created = (await upsertWikiPage(db, {
+    organizationId,
+    slug: heuristic.targetSlug,
+    title,
+    body,
+    pageKind: "heuristic",
+    status: "draft",
+  })) as { id: string };
+  await appendRevision(db, {
+    pageId: created.id,
+    title,
+    body,
+    changeKind: "ingest",
+    changeSummary: `Created heuristic from ${sourceKey}`,
+    createdById: deps.userId,
+    createdByAgentId: deps.agentId,
+  });
+  await attachSource(db, { pageId: created.id, sourceId: rawSourceId });
+  return { kind: "created", pageId: created.id, slug: heuristic.targetSlug };
+}
+
+// ─── Wikilink graph ─────────────────────────────────────────────────────────
+
+/**
+ * After every page write, scan the new body for `[[wikilinks]]` and
+ * upsert WikiPageLink edges for the ones that resolve to existing pages
+ * in the same scope (org overlay or kernel). Dangling links are not
+ * upserted — the lint detector flags them.
+ */
+async function syncOutLinks(
+  db: CommitClient,
+  fromPageId: string,
+  body: string,
+  organizationId: string,
+): Promise<void> {
+  const slugs = extractWikilinks(body).filter(
+    (s) => !s.startsWith("raw-sources/"),
+  );
+  if (slugs.length === 0) return;
+
+  for (const slug of slugs) {
+    const target = (await getWikiPage(db, {
+      organizationId,
+      slug,
+    })) as { id: string } | null;
+    if (target && target.id !== fromPageId) {
+      await linkPages(db, { fromPageId, toPageId: target.id });
+    }
+  }
+}
+
+// ─── Orchestrator ───────────────────────────────────────────────────────────
+
+/**
+ * Commit a `WikiDiffProposal` against the storage layer. Each row commits
+ * independently — a single bad row does not abort the rest. Errors are
+ * collected on `result.errors` so the reviewer sees the full picture.
+ *
+ * Refuses to write to kernel pages (organizationId = null) entirely; per
+ * spec section 6, kernel pages are PR-only. Org overlays only.
+ *
+ * Idempotent on re-run when the same proposal is committed twice — the
+ * append helper checks for the exact claim line before adding it; existing
+ * stances/heuristics deduplicate on the additional-support paragraph.
+ */
+export async function commitIngestProposal(
+  db: CommitClient,
+  input: CommitProposalInput,
+): Promise<CommitProposalResult> {
+  if (input.organizationId === null) {
+    const event = (await recordIngestEvent(db, {
+      sourceId: input.rawSourceId,
+      organizationId: null,
+      touchedPageIds: [],
+      agentId: input.agentId ?? null,
+      userId: input.userId ?? null,
+      kernelVersion: input.kernelVersion ?? null,
+    })) as { id: string };
+    return {
+      touchedPageIds: [],
+      createdPageSlugs: [],
+      updatedPageSlugs: [],
+      skippedLowConfidence: [],
+      errors: [
+        "commitIngestProposal: organizationId is null — kernel writes are not allowed at runtime (kernel pages are PR-only). Pass an organizationId to write an overlay.",
+      ],
+      eventId: event.id,
+    };
+  }
+
+  const acceptThreshold = input.acceptThreshold ?? 0.5;
+  const maxBodyDeltaRatio = input.maxBodyDeltaRatio ?? 0.3;
+  const deps: CommitRowDeps = {
+    db,
+    rawSourceId: input.rawSourceId,
+    sourceKey: input.sourceKey,
+    organizationId: input.organizationId,
+    agentId: input.agentId ?? null,
+    userId: input.userId ?? null,
+    kernelVersion: input.kernelVersion ?? null,
+    maxBodyDeltaRatio,
+  };
+
+  const errors: string[] = [];
+  const skippedLowConfidence: ClaimProposal[] = [];
+  const touchedPageIds: string[] = [];
+  const createdPageSlugs: string[] = [];
+  const updatedPageSlugs: string[] = [];
+
+  // Process claims first so subsequent stance/heuristic links resolve.
+  for (const claim of input.proposal.claims) {
+    if (claim.confidence < acceptThreshold) {
+      skippedLowConfidence.push(claim);
+      continue;
+    }
+    const outcome = await commitClaim(deps, claim);
+    if (outcome.kind === "error") {
+      errors.push(outcome.message);
+      continue;
+    }
+    touchedPageIds.push(outcome.pageId);
+    if (outcome.kind === "created") createdPageSlugs.push(outcome.slug);
+    else updatedPageSlugs.push(outcome.slug);
+  }
+
+  for (const stance of input.proposal.stances) {
+    const outcome = await commitStance(deps, stance);
+    if (outcome.kind === "error") {
+      errors.push(outcome.message);
+      continue;
+    }
+    touchedPageIds.push(outcome.pageId);
+    if (outcome.kind === "created") createdPageSlugs.push(outcome.slug);
+    else updatedPageSlugs.push(outcome.slug);
+  }
+
+  for (const heuristic of input.proposal.heuristics) {
+    const outcome = await commitHeuristic(deps, heuristic);
+    if (outcome.kind === "error") {
+      errors.push(outcome.message);
+      continue;
+    }
+    touchedPageIds.push(outcome.pageId);
+    if (outcome.kind === "created") createdPageSlugs.push(outcome.slug);
+    else updatedPageSlugs.push(outcome.slug);
+  }
+
+  // Sync the wikilink graph for every page we touched. Body lookup is
+  // best-effort (a page that just had its body rewritten still exists in
+  // the same scope), so any errors here just get appended to result.errors.
+  const uniquePageIds = Array.from(new Set(touchedPageIds));
+  for (const pageId of uniquePageIds) {
+    try {
+      const page = (await db.wikiPage.findFirst({
+        where: { id: pageId },
+        select: { body: true },
+      })) as { body: string } | null;
+      if (page) {
+        await syncOutLinks(db, pageId, page.body, input.organizationId);
+      }
+    } catch (err) {
+      errors.push(
+        `link-sync ${pageId}: ${(err as Error).message ?? String(err)}`,
+      );
+    }
+  }
+
+  const event = (await recordIngestEvent(db, {
+    sourceId: input.rawSourceId,
+    organizationId: input.organizationId,
+    touchedPageIds: uniquePageIds,
+    agentId: input.agentId ?? null,
+    userId: input.userId ?? null,
+    kernelVersion: input.kernelVersion ?? null,
+  })) as { id: string };
+
+  return {
+    touchedPageIds: uniquePageIds,
+    createdPageSlugs,
+    updatedPageSlugs,
+    skippedLowConfidence,
+    errors,
+    eventId: event.id,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2.3a — the commit step that turns a `WikiDiffProposal` (from Phase 2.2) into real `WikiPage` / `WikiPageRevision` / `WikiPageSource` / `WikiIngestEvent` rows. This is the missing link between "the LLM proposed something" and "the operator sees a draft page in the portal."

Two core jobs:

1. **Translate proposal rows into wiki page bodies** that fit the SCHEMA.md required-section contract (Definition / Properties / Relationships for entities; Stance / Reasoning / When-this-applies for stances; Rule / Why / Worked-example for heuristics; etc.). Templates kept simple — every new page lands as `draft` so Mark reviews before it appears on `/wiki`.
2. **Enforce the spec's runtime guardrails:**
   - Kernel pages are PR-only — runtime ingest cannot write to `isKernel=true` rows. Org overlay writes only.
   - Body delta cap (default 30%) on UPDATES — larger rewrites need human approval and surface as errors instead of auto-committing.
   - Confidence threshold (default 0.5) on claims — low-confidence rows are skipped so the reviewer's signal-to-noise stays high.

Qdrant write is intentionally out of scope here — that's wired by the production adapter in Phase 2.3b. This module owns Postgres state only.

## Files

- `apps/web/lib/wiki/proposal-commit.ts` — new. `commitIngestProposal()` orchestrator, per-row commit helpers, body templates, link-graph sync.
- `apps/web/lib/wiki/proposal-commit.test.ts` — new. 14 tests covering kernel-write refusal (both null-org and isKernel-overlay paths), confidence threshold + override, new entity/stance/heuristic creation from templates, pass-2-cannot-create-stance/heuristic guard, append + revision creation, idempotency on re-run, body delta cap enforcement + override, audit event shape + touchedPageIds dedupe.

## Verification — done in a real portal build per `principles/test-in-the-portal-build` (#590)

1. **Postgres 16** stood up locally. Clean DB. Migrations applied.
2. **Seeded the founder kernel** — 23 published pages + 11 raw sources land via `seedWikiKernel`.
3. **Provisioned a real Smoke Org** + real `articles/smoke-test` `RawSource`. Built a synthetic `WikiDiffProposal` with 3 claims (one low-confidence to verify the skip path), 1 stance, 1 heuristic.
4. **Ran `commitIngestProposal` end-to-end against the real DB:**
   ```
   touchedPageIds:        4
   createdPageSlugs:      [entities/observability,
                           entities/experiment-cohort,
                           stances/observability-beats-logging,
                           heuristics/instrument-before-flag-open]
   skippedLowConfidence:  1   (the 0.3-confidence claim)
   errors:                []
   eventId:               evt_<id>
   ```
   DB state after: 4 overlay pages (all `draft`), 4 ingest revisions, 4 source links, 1 ingest event. **No kernel pages mutated.**
5. **Built `apps/web` with `npx next build`** — clean, exit 0.
6. **Started production standalone server**, minted a valid Auth.js JWT for the Smoke Org user, curled:
   - `GET /wiki?status=all` → **HTTP 200, 74,485 bytes**; all 4 new slugs visible in the rendered HTML.
   - `GET /wiki/entities/observability` → **HTTP 200, 31,887 bytes**; title *Observability*, *Definition* + *Source-anchored* sections, `draft` status badge, and the `raw-sources/articles/smoke-test` wikilink all rendered.

That's the full path Phase 2.3a ships: from a `WikiDiffProposal` to a rendered draft page in the portal. Mark sees it on `/wiki?status=all` and flips it to `published` when it passes review.

## Stacking

Branch carries **Phase 2.1 (#574) and Phase 2.2 (#581) as merge commits** because `commitIngestProposal` needs `recordIngestEvent` from #574 and the `WikiDiffProposal` types from #581. Reviewer can land #574 / #581 / this PR in any order — the merge into `main` resolves cleanly because the additive code is the same.

## Out of scope (handled in Phase 2.3b)

- Production `InferenceCallable` adapter (`utilityInfer` for pass 1, `routeAndCall` for passes 2/3)
- `wiki_ingest` MCP tool with `executionMode: "proposal"`
- Agent grants + route-context wiring + admin form
- CLI `--propose` / `--commit` flags on `scripts/wiki-ingest.ts`
- Qdrant point upsert post-commit (silent-degradation pattern)

https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_