### PR TITLE
[codex] Remove duplicate routing symbol tooltip

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -122,6 +122,14 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("priorityIds?: ReadonlySet<string>");
   });
 
+  it("uses the rich symbol detail popover instead of native SVG title tooltips", () => {
+    const source = readFileSync(new URL("./AiOperationsMap.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain("aria-label={`${label}: ${summary}`}");
+    expect(source).toContain("data-symbol-detail-popover");
+    expect(source).not.toContain("<title>{`${label}: ${summary}`}</title>");
+  });
+
   it("shows configured inactive providers as topology nodes even without active routes", () => {
     const source = readFileSync(new URL("./AiOperationsMap.tsx", import.meta.url), "utf8");
 

--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -1770,7 +1770,6 @@ function RouteSymbolBadge({
         </g>
       ) : null}
       <circle r={radius + 6} fill="transparent" pointerEvents="all" />
-      <title>{`${label}: ${summary}`}</title>
     </g>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the native SVG `<title>` tooltip from routing symbol badges so it no longer overlays the richer symbol detail popover.
- Adds a regression check that keeps route symbols on the custom in-app popover path while preserving the accessible `aria-label`.

## Root Cause
Route symbols rendered both the detailed `RoutingSymbolDetail` popover and a browser-native SVG title tooltip. On dense routing maps, the native tooltip could appear on top of the more useful popover and obscure the details.

## Validation
- `pnpm --filter web exec vitest run components/platform/AiOperationsMap.test.tsx` — 8 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web exec next build` — passed; existing Turbopack/NFT warnings remain.
- Local browser QA on the rebuilt portal previously confirmed route symbols expose the rich popover with zero native SVG title tooltips.