### PR TITLE
feat(db): add skill telemetry schema foundation

### DIFF
--- a/packages/db/prisma/migrations/20260515210051_skill_telemetry_and_reflection/migration.sql
+++ b/packages/db/prisma/migrations/20260515210051_skill_telemetry_and_reflection/migration.sql
@@ -1,0 +1,103 @@
+-- AlterTable
+ALTER TABLE "ToolExecution" ADD COLUMN "skillId" TEXT;
+
+-- AlterTable
+ALTER TABLE "PlatformIssueReport" ADD COLUMN "threadId" TEXT,
+ADD COLUMN "taskRunId" TEXT;
+
+-- CreateTable
+CREATE TABLE "ImprovementSignal" (
+    "id" TEXT NOT NULL,
+    "signalId" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "evidence" JSONB NOT NULL DEFAULT '{}',
+    "recurrenceCount" INTEGER NOT NULL DEFAULT 1,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "routeContext" TEXT,
+    "agentId" TEXT,
+    "threadId" TEXT,
+    "buildId" TEXT,
+    "providerId" TEXT,
+    "toolName" TEXT,
+    "digitalProductId" TEXT,
+    "portfolioId" TEXT,
+    "suspectedRootCause" TEXT,
+    "objectiveImpactHypothesis" TEXT,
+    "graphNodeRefs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "graphEdgeRefs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ImprovementSignal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SkillUsageEvent" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "skillId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "userId" TEXT,
+    "threadId" TEXT,
+    "taskRunId" TEXT,
+    "toolExecutionId" TEXT,
+    "routeContext" TEXT,
+    "phase" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'coworker',
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SkillUsageEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ImprovementSignal_signalId_key" ON "ImprovementSignal"("signalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ImprovementSignal_sourceType_sourceId_key" ON "ImprovementSignal"("sourceType", "sourceId");
+
+-- CreateIndex
+CREATE INDEX "ImprovementSignal_status_createdAt_idx" ON "ImprovementSignal"("status", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "ImprovementSignal_routeContext_createdAt_idx" ON "ImprovementSignal"("routeContext", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "ImprovementSignal_agentId_createdAt_idx" ON "ImprovementSignal"("agentId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "ImprovementSignal_toolName_createdAt_idx" ON "ImprovementSignal"("toolName", "createdAt" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SkillUsageEvent_eventId_key" ON "SkillUsageEvent"("eventId");
+
+-- CreateIndex
+CREATE INDEX "SkillUsageEvent_skillId_createdAt_idx" ON "SkillUsageEvent"("skillId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "SkillUsageEvent_agentId_createdAt_idx" ON "SkillUsageEvent"("agentId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "SkillUsageEvent_threadId_createdAt_idx" ON "SkillUsageEvent"("threadId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "SkillUsageEvent_taskRunId_createdAt_idx" ON "SkillUsageEvent"("taskRunId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "SkillUsageEvent_phase_createdAt_idx" ON "SkillUsageEvent"("phase", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "PlatformIssueReport_threadId_createdAt_idx" ON "PlatformIssueReport"("threadId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "PlatformIssueReport_taskRunId_idx" ON "PlatformIssueReport"("taskRunId");
+
+-- CreateIndex
+CREATE INDEX "ToolExecution_skillId_createdAt_idx" ON "ToolExecution"("skillId", "createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "SkillUsageEvent" ADD CONSTRAINT "SkillUsageEvent_skillId_fkey" FOREIGN KEY ("skillId") REFERENCES "SkillDefinition"("skillId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3330,6 +3330,8 @@ model ToolExecution {
   // Autonomous coworker runtime Slice 1: nullable parent TaskRun link.
   // Persisted by mcp-governed-execute.ts when context.taskRunId is provided.
   taskRunId     String?
+  // Governed Hermes learning Slice 1: nullable active skill attribution.
+  skillId       String?
   receipt       ToolExecutionReceipt?
   documentLifecycleEvents DocumentLifecycleEvent[]
 
@@ -3341,6 +3343,7 @@ model ToolExecution {
   @@index([capabilityId, createdAt(sort: Desc)])
   @@index([apiTokenId, createdAt(sort: Desc)])
   @@index([taskRunId, createdAt(sort: Desc)])
+  @@index([skillId, createdAt(sort: Desc)])
 }
 
 model ToolExecutionReceipt {
@@ -3754,6 +3757,10 @@ model PlatformIssueReport {
   agentId             String?
   featureBuildId      String?
   source              String        @default("manual")
+  // Governed Hermes learning Slice 1: link runtime issues to the thread/run
+  // that produced them so reflection can avoid route/time-window heuristics.
+  threadId            String?
+  taskRunId           String?
   createdAt           DateTime      @default(now())
   updatedAt           DateTime      @updatedAt
   upstreamIssueNumber Int?
@@ -3763,6 +3770,41 @@ model PlatformIssueReport {
   featureBuild        FeatureBuild? @relation(fields: [featureBuildId], references: [id], onDelete: SetNull)
 
   @@index([featureBuildId])
+  @@index([threadId, createdAt(sort: Desc)])
+  @@index([taskRunId])
+}
+
+model ImprovementSignal {
+  id                        String   @id @default(cuid())
+  signalId                  String   @unique
+  sourceType                String
+  sourceId                  String
+  title                     String
+  description               String?  @db.Text
+  evidence                  Json     @default("{}")
+  recurrenceCount           Int      @default(1)
+  status                    String   @default("open")
+  routeContext              String?
+  agentId                   String?
+  threadId                  String?
+  buildId                   String?
+  providerId                String?
+  toolName                  String?
+  digitalProductId          String?
+  portfolioId               String?
+  suspectedRootCause        String?
+  objectiveImpactHypothesis String?
+  graphNodeRefs             String[] @default([])
+  graphEdgeRefs             String[] @default([])
+  createdAt                 DateTime @default(now())
+  updatedAt                 DateTime @updatedAt
+  lastSeenAt                DateTime @default(now())
+
+  @@unique([sourceType, sourceId])
+  @@index([status, createdAt(sort: Desc)])
+  @@index([routeContext, createdAt(sort: Desc)])
+  @@index([agentId, createdAt(sort: Desc)])
+  @@index([toolName, createdAt(sort: Desc)])
 }
 
 model ExternalEvidenceRecord {
@@ -6900,6 +6942,7 @@ model SkillDefinition {
   evaluation  ToolEvaluation?   @relation(fields: [evaluationId], references: [id])
   assignments SkillAssignment[]
   metrics     SkillMetric[]
+  usageEvents SkillUsageEvent[]
 
   @@index([status])
   @@index([category])
@@ -6941,6 +6984,30 @@ model SkillMetric {
 
   @@unique([skillId, agentId, period])
   @@index([skillId])
+}
+
+model SkillUsageEvent {
+  id              String   @id @default(cuid())
+  eventId         String   @unique
+  skillId         String
+  agentId         String
+  userId          String?
+  threadId        String?
+  taskRunId       String?
+  toolExecutionId String?
+  routeContext    String?
+  phase           String
+  source          String   @default("coworker")
+  metadata        Json     @default("{}")
+  createdAt       DateTime @default(now())
+
+  skill SkillDefinition @relation(fields: [skillId], references: [skillId], onDelete: Cascade)
+
+  @@index([skillId, createdAt(sort: Desc)])
+  @@index([agentId, createdAt(sort: Desc)])
+  @@index([threadId, createdAt(sort: Desc)])
+  @@index([taskRunId, createdAt(sort: Desc)])
+  @@index([phase, createdAt(sort: Desc)])
 }
 
 // ─── EP-DELEG-001: Delegation Chain (Authority Propagation & Chain of Custody) ─


### PR DESCRIPTION
## Summary
- Add the Slice 1 skill telemetry schema foundation for the governed Hermes learning loop.
- Add `SkillUsageEvent`, `ImprovementSignal`, `ToolExecution.skillId`, and `PlatformIssueReport.threadId/taskRunId`.
- Include a narrow migration with no unrelated drops or renames.

## Verification
- `pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma`
- `pnpm --filter @dpf/db exec prisma generate --schema prisma/schema.prisma`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter @dpf/db test` (68 files, 461 tests)
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passed; existing Turbopack broad-file-tracing warnings remain)
- Fresh scratch Postgres `prisma migrate deploy` applied all 195 migrations and verified the two new tables plus three nullable link columns.