### PR TITLE
doc(principles): re-baseline + consumer-archetype design

### DIFF
--- a/docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md
+++ b/docs/superpowers/plans/2026-05-12-principles-as-wiki-kind.md
@@ -1,229 +1,447 @@
 # Principles as a Wiki Kind - Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Each phase is a separate PR; do not bundle phases.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Phase A is one PR; Phase B is an independent PR; do not bundle.
 
 | Field | Value |
 |-------|-------|
 | **Spec** | [2026-05-12-principles-as-wiki-kind-design.md](../specs/2026-05-12-principles-as-wiki-kind-design.md) |
 | **Spec PR** | [#518](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/518) |
-| **Status** | Phase 0 not started |
+| **Status** | Re-baselined 2026-05-15 — single-phase plan against the actual worktree state |
 | **Created** | 2026-05-12 |
-| **Chief architect review** | Updated 2026-05-12 after repo and live-MCP verification |
-| **Branch base for all phases** | `origin/main`, after Phase -1 verifies whether PR #489 / Principle 9 is present on the implementation base |
+| **Re-baselined** | 2026-05-15 after chief-architect review |
+| **Branch base for all phases** | `origin/main` per `feedback_worktree_base_origin_main.md` |
+| **Backlog linkage** | REQUIRED before any PR opens — see Phase -1 below |
 
-**Goal:** Add `principle` as a first-class `WikiPage.pageKind` with tiered taxonomy, explicit signed decision vectors, advisory decision-support tooling, retrieval integration for in-platform coworkers and external MCP agents, and kernel-markdown-driven public docs.
+**Goal:** Land the remaining consumer-archetype axis on top of the already-shipped `principle` wiki kind, back-fill the 41 existing principle pages, add advisory decision support, wire retrieval and MCP, ship lint with coherence enforcement, deliver tier-first UI with consumer-archetype filter chips, and generate the Jekyll public-docs page. Separately, close the kernel-slug uniqueness gap.
 
-**Architecture:** Extend `WikiPage` with nullable principle-only fields. Constants live in a typed module imported by seed, lint, MCP schemas, and UI. Retrieval splits between Postgres (always-include commandments) and Qdrant (relevance-ranked core/contextual). One advisory MCP tool (`principle_decide`) returns a contribution ledger; one extended MCP tool (`wiki_query`) adds tier/applies-to filters. Public docs are generated from kernel markdown into `docs/principles.md` for the Jekyll site.
+**Architecture:** Spec [`2026-05-12-principles-as-wiki-kind-design.md`](../specs/2026-05-12-principles-as-wiki-kind-design.md) is the authority. This plan is the task breakdown.
 
 **Tech Stack:** Prisma 7, Postgres, Qdrant (`nomic-embed-text`, 768-dim), Next.js (App Router) for portal UI, Jekyll/GitHub Pages for public docs, Vitest, TypeScript, MCP JSON-RPC at `/api/mcp/v1`.
 
 ---
 
-## Build Gate (per `AGENTS.md` section 5, applied at the end of every phase)
+## What This Plan Replaces
 
-All four must pass before opening the phase PR:
+Previous revisions had seven sequential batches (Phase -1 through Phase 6) that assumed the worktree was at zero. Re-baseline against the actual worktree (2026-05-15) shows that Phases 0, 1, 3, and most of 4–5 are already shipped via prior PRs. The remaining work is a single Phase A. The legacy phase numbering is retired; do not reference it.
+
+What's already on this branch and not in scope here:
+
+- `WikiPageKind` includes `principle`; `wiki-taxonomy.ts` exports the tier/applies-to/dimension constants and predicates; `WikiPage` carries `principleTier`/`principleDirection`/`principleWeight`/`principleWeightRationale`/`principleDimensionVector`/`principleDimensions`/`principleAppliesTo`/`principlePublic`/`principlePublicRationale` with indexes on tier and public, via migration `20260513000000_add_principle_fields_to_wikipage`.
+- `docs/founder-kernel/_templates/principle.template.md` exists.
+- `docs/founder-kernel/wiki/principles/` has 41 published kernel principles covering Principles 1–9 from the AI-coworker doc, the AGENTS.md durable-governance promotions, and a first slice of reviewed memory promotions.
+- `docs/founder-kernel/manifest.json` is `kernelVersion: 0.2.1`, `schemaVersion: 0.2.0`, `pageCount: 62`, `sourceCount: 11`.
+- `docs/architecture/ai-coworker-development-principles.md` contains Principles 1–9 including Responsible Capacity Utilization.
+
+If a future reader expects Phases 0/1/3/4/5 from the previous plan — look at git log on `packages/db/src/wiki-taxonomy.ts`, `packages/db/prisma/migrations/20260513000000_add_principle_fields_to_wikipage/`, and `docs/founder-kernel/wiki/principles/` to see where they actually shipped.
+
+---
+
+## Build Gate (per `AGENTS.md` section 5, applied at every PR)
+
+All four must pass before opening any PR:
 
 1. Unit tests — `pnpm --filter <pkg> exec vitest run` for affected files.
 2. Production build — `pnpm --filter web build` with zero errors.
-3. UX verification — exercise affected portal paths against the running Docker stack (Phase 0 onward whenever UI changes ship).
-4. Migration applies cleanly on a fresh DB — Phase 0 only (later phases are additive constants/lint/MCP/content).
+3. UX verification — exercise affected portal paths against the running Docker stack whenever UI changes ship.
+4. Migration applies cleanly on a fresh DB — for the schema PR only; back-fill PR is data-only.
 
-Plus: `git commit -s` on every commit (DCO), positional path args to scope staging (`git add -- <path>`), branch from `origin/main`, run `git branch --show-current` before committing and abort if on `main` or detached, use pinned `pnpm --filter ...` commands rather than `npx`, and run `pnpm --filter web exec vitest run` for the full web suite before pushing (per `feedback_run_full_tests_before_push.md`).
+Plus, per memory feedback:
+
+- `git commit -s` on every commit (DCO required since 2026-04-24 public flip).
+- Positional path args to scope staging (`git add -- <path>`) so concurrent worktree sessions cannot sweep their staged files into your commit.
+- Branch from `origin/main`, not local `main`.
+- Run `git branch --show-current` before committing; abort if on `main` or detached.
+- Use pinned `pnpm --filter ...` commands rather than `npx` or root `pnpm`.
+- Run `pnpm --filter web exec vitest run` for the full web suite before pushing — pre-commit hook only runs typecheck.
+- **Continuous overlap sweep** before EVERY push: `git fetch origin && git log origin/main --oneline -20` and `gh pr list --state open --search "principle wiki"`. Re-sweep before each push, not just at session start (per `feedback_continuous_overlap_check.md`).
 
 ---
 
 ## Refactor Budget
 
-20 percent of every phase is reserved for cleanup, deletions, and consistency fixes per `feedback_zero_technical_debt.md`. If a phase implementation surfaces dead constants, duplicated string literals, or stale comments, that work lands inside the same PR — not deferred. Each phase PR description must name what was retired.
+20 percent of every PR is reserved for cleanup, deletions, and consistency fixes per `feedback_zero_technical_debt.md`. Each PR description must name what was retired.
 
-This is not optional polish. For this plan the first refactor budget is already allocated: centralize wiki kind/status/principle constants, add the missing kernel-slug uniqueness guard, and remove duplicated principle payload names before any retrieval or decision logic lands.
-
----
-
-## Chief Architect Corrections
-
-This plan was reviewed against the target worktree and the live DPF MCP planning surface. The following corrections are now part of the implementation contract:
-
-1. **Run Phase -1 before implementation.** Live `search_specs_and_plans` returned no indexed match for this exact principles/wiki work, while open epic `EP-TAK-3F9A21` still owns governed memory, MCP, and observability alignment. Implementers must record whether this work is linked under that epic or whether a new backlog item is needed before Phase 0 starts.
-2. **Do not trust stale branch assumptions.** The target checkout currently contains Principle 9 and the capacity-continuity spec, even though the design document still describes an older eight-principle branch-local state. Phase -1 reconciles that mismatch and updates the spec/plan pair before content seeding.
-3. **Fix the nullable kernel slug uniqueness gap in Phase 0.** `@@unique([organizationId, slug])` does not protect kernel rows where `organizationId IS NULL`. Add a hand-written partial unique index for kernel `WikiPage.slug` in the same schema phase that adds principle fields.
-4. **Use canonical payload names.** Qdrant and MCP metadata use `principleTier`, `principleAppliesTo`, `principleDimensions`, and `principlePublic`. Do not introduce short aliases such as `tier` / `appliesTo` in runtime payloads, and do not add a separate `principleOnly` or `isPrinciple` flag when `pageKind === "principle"` already carries that meaning.
-5. **Keep local memory out of PR scope.** Reviewed memory can inform candidate principles, but private local memory files are not repo artifacts, are not edited by this plan, and are never bulk-imported. Any promoted principle must be rewritten as product-safe kernel content with public/internal classification.
-6. **Treat UI as architecture.** `/wiki?kind=principle`, principle detail pages, admin lint, and decision-ledger rendering must be theme-aware, compact, filterable, and verified in the running portal. Hidden metadata is not a usable governance layer.
+This plan has one explicit refactor item already carved out: Phase B closes the kernel-slug uniqueness gap as its own small PR rather than coupling it to principle work.
 
 ---
 
-## Cross-Phase Constants (one source of truth)
+## Phase -1 — Implementation Preflight
 
-The following constants live in `packages/db/src/wiki-taxonomy.ts` (created in Phase 0, task 1) and are imported by seed, lint, MCP schemas, retrieval, and UI. `wiki-store.ts` imports and re-exports these types for compatibility. Never duplicate these string arrays.
+**Branch:** same branch as Phase A.
 
-```typescript
-export const WIKI_PAGE_KINDS = [
-  "entity",
-  "summary",
-  "decision",
-  "runbook",
-  "index",
-  "stance",
-  "heuristic",
-  "principle",
-] as const;
-export type WikiPageKind = (typeof WIKI_PAGE_KINDS)[number];
+**Objective:** Make sure the implementation base, spec, plan, backlog, and repo truth all agree before code changes begin.
 
-export const WIKI_PAGE_STATUSES = [
-  "draft",
-  "published",
-  "review-needed",
-  "archived",
-] as const;
-export type WikiPageStatus = (typeof WIKI_PAGE_STATUSES)[number];
+- [ ] **Read `AGENTS.md`** in this worktree end-to-end before any commit. Confirm the active branch is not `main` or detached.
+- [ ] **Verify worktree state:** `git status --short`. List unrelated changes in the PR notes and avoid touching them.
+- [ ] **Query live planning state via DPF MCP:**
+  - `mcp__dpf__search_specs_and_plans` for `principles wiki kind consumer archetype`.
+  - `mcp__dpf__list_epics` for open epics touching wiki, TAK/GAID memory, MCP, or governance.
+  - Record matches in the Phase A PR body per spec §1.2. Linking to an existing epic (likely `EP-TAK-3F9A21` or `EP-DOCS-6B9F2A`) is recommended but not strictly required; the PR title + body must always be self-sufficient for discoverability.
+- [ ] **Sweep recent main + open PRs** per `feedback_pr_overlap_check_before_pushing.md` and `feedback_continuous_overlap_check.md`:
+  - `git fetch origin && git log origin/main --oneline -30`.
+  - `gh pr list --state open --limit 30 --search "wiki principle"`.
+  - Record any overlap and adjust scope accordingly.
+- [ ] **Re-confirm current code anchors are still where the spec says they are:**
+  - `WikiPageKind` in `packages/db/src/wiki-taxonomy.ts`.
+  - `WikiPage` `principle*` columns in `packages/db/prisma/schema.prisma`.
+  - `searchWikiPages` in `apps/web/lib/wiki/embeddings.ts`.
+  - `recallWikiContext` in `apps/web/lib/wiki/recall.ts`.
+  - `wiki_query` in `apps/web/lib/mcp-tools.ts`.
+  - `agent-grants.ts` mappings in `apps/web/lib/tak/agent-grants.ts`.
+  - External MCP route at `apps/web/app/api/mcp/v1/route.ts`.
 
-export const PRINCIPLE_TIERS = ["commandment", "core", "contextual"] as const;
-export type PrincipleTier = (typeof PRINCIPLE_TIERS)[number];
-
-export const PRINCIPLE_APPLIES_TO = [
-  "in_platform_coworker",
-  "external_coding_agent",
-  "human",
-] as const;
-export type PrincipleAppliesTo = (typeof PRINCIPLE_APPLIES_TO)[number];
-
-export const PRINCIPLE_DIMENSIONS = [
-  "long_term_maintainability",
-  "blast_radius",
-  "reusability",
-  "evidence_density",
-  "human_cognitive_load",
-  "capacity_utilization",
-  "governance_compliance",
-  "public_safety",
-  "speed_to_value",
-  "schema_grounding",
-] as const;
-export type PrincipleDimension = (typeof PRINCIPLE_DIMENSIONS)[number];
-
-export const PRINCIPLE_TIER_DEFAULT_WEIGHT: Record<PrincipleTier, number> = {
-  commandment: 1.0,
-  core: 0.4,
-  contextual: 0.1,
-};
-
-export const PRINCIPLE_TIER_CAPS: Record<PrincipleTier, number | null> = {
-  commandment: 10,
-  core: 30,
-  contextual: null,
-};
-
-export const PRINCIPLE_DECIDE_DEFAULTS = {
-  maxPrinciples: 20,
-  tieMargin: 0.2,
-  contextualSimilarityThreshold: 0.75,
-  semanticFallbackWarnRatio: 0.4,
-} as const;
-```
-
-Reverse-mappings (e.g., dimension index, `isWikiPageKind`, `isPrincipleTier`, `isPrincipleAppliesTo`, `isPrincipleDimension`) are added to the same module as needed.
+**Exit criteria:** the spec, plan, target branch, live backlog, and overlap sweep agree. PR description has the backlog ID. No surprise overlap.
 
 ---
 
-## Phase -1 - Implementation Preflight and Backlog Alignment
+## Phase A — Consumer-archetype axis, back-fill, retrieval, MCP, lint, UI, public docs
 
-**Branch:** same branch as the phase being prepared.
+**Branch:** `feat/principles-consumer-archetypes-and-decision-support`
 
-**Objective:** Make sure the implementation base, spec, plan, backlog, and repo truth agree before code changes begin.
-
-- [ ] **Read `AGENTS.md` in the target worktree** and confirm the active branch is not `main` or detached.
-- [ ] **Check worktree state:** `git status --short`. If unrelated changes exist, list them in the PR notes and avoid touching them.
-- [ ] **Query live planning state through DPF MCP:** `search_specs_and_plans` for `principles wiki kind principle_decide`, `list_epics` for open epics, and recommended work under `EP-TAK-3F9A21`. Record the result in the first PR description.
-- [ ] **Reconcile Principle 9 state:** verify whether `docs/architecture/ai-coworker-development-principles.md` contains Principle 9 and whether `docs/superpowers/specs/2026-05-12-ai-capacity-continuity-design.md` exists. If the spec still says "eight branch-local principles" on a branch where nine exist, correct the spec before Phase 3 content seeding.
-- [ ] **Re-check current code anchors:** `WikiPageKind` in `packages/db/src/wiki-store.ts`, `WikiPage` in `schema.prisma`, `searchWikiPages` in `apps/web/lib/wiki/embeddings.ts`, `wiki_query` in `apps/web/lib/mcp-tools.ts`, and external MCP gating in `apps/web/app/api/mcp/v1/route.ts`.
-- [ ] **Decide backlog linkage:** attach the PR to an existing TAK/GAID governed-memory/MCP backlog item if appropriate, or create a narrow new backlog item through MCP. Do not leave the work orphaned from live planning state.
-
-**Exit criteria:** the plan, design spec, target branch, and live backlog reference the same implementation base and principle count.
-
----
-
-## Phase 0 - Schema, Constants, and Authoring Contract
-
-**Branch:** `feat/principles-batch-0-schema`
-
-**Objective:** Land the schema migration, typed constants, authoring contract (templates + SCHEMA.md + AUTHORING.md updates), seed parsing, and base UI rendering for the new `principle` page kind. No business logic yet; principles can be authored as kernel markdown and seeded into Postgres and Qdrant.
+**Objective:** Land the remaining work from spec §15 Phase A as one coherent PR.
 
 **Files to create:**
 
-- `packages/db/src/wiki-taxonomy.ts`
-- `packages/db/src/wiki-taxonomy.test.ts`
-- `packages/db/prisma/migrations/<timestamp>_add_principle_fields_to_wikipage/migration.sql`
-- `docs/founder-kernel/wiki/principles/.gitkeep`
-- `docs/founder-kernel/_templates/principle.template.md`
+- `packages/db/prisma/migrations/<timestamp>_add_principle_consumer_archetype_to_wikipage/migration.sql`
+- `apps/web/lib/wiki/principle-recall.ts` + `.test.ts`
+- `apps/web/lib/wiki/principle-decide.ts` + `.test.ts`
+- `apps/web/lib/wiki/lint/principle-detectors.ts` + `.test.ts` (if not already present from earlier work — check first)
+- `apps/web/lib/wiki/lint/principle-public-safety.ts` + `.test.ts`
+- `apps/web/lib/wiki/lint/principle-coherence.ts` + `.test.ts` (new detector from spec §8A.1 + §14)
+- `apps/web/lib/mcp-tools-wiki-query.test.ts` (if not already present)
+- `apps/web/lib/mcp-tools-principle-decide.test.ts`
+- `scripts/generate-public-principles.mjs` + `.test.mjs`
+- `docs/principles.md` (generated artifact, committed for Jekyll)
 
 **Files to modify:**
 
-- `packages/db/prisma/schema.prisma` (extend `WikiPage` model)
-- `packages/db/src/wiki-store.ts` (import/re-export taxonomy types, principle-aware CRUD)
-- `packages/db/src/wiki-store.test.ts` (principle CRUD fixtures)
-- `packages/db/src/seed-wiki-kernel.ts` (frontmatter parsing for principle fields)
-- `packages/db/src/seed-wiki-kernel.test.ts` (principle seeding fixtures)
-- `apps/web/lib/wiki/embeddings.ts` (Qdrant payload extension - include canonical `principleTier`, `principleAppliesTo`, `principleDimensions`, and `principlePublic` only for principle pages)
-- `apps/web/lib/wiki/embeddings.test.ts`
-- `apps/web/components/wiki/WikiPageKindBadge.tsx` (render `principle` label)
-- `apps/web/components/wiki/WikiPageList.tsx` (group/sort principles by tier when filtered)
-- `apps/web/components/wiki/WikiPageViewer.tsx` (render principle metadata block)
-- `docs/founder-kernel/SCHEMA.md` (add `principle` to page-kind contract)
-- `docs/founder-kernel/AUTHORING.md` (principle authoring rules + folder convention)
-- `docs/founder-kernel/manifest.json` (bump schema version)
+- `packages/db/src/wiki-taxonomy.ts` — add consumer-archetype constants + predicates.
+- `packages/db/src/wiki-taxonomy.test.ts` — extend.
+- `packages/db/prisma/schema.prisma` — `WikiPage` model adds `principleConsumerArchetype` + `principleConsumerContexts` + index.
+- `packages/db/src/wiki-store.ts` + test — pass-through CRUD.
+- `packages/db/src/seed-wiki-kernel.ts` + test — parse new frontmatter keys; back-fill validation.
+- `docs/founder-kernel/wiki/principles/*.md` (all 41 pages) — back-fill frontmatter.
+- `docs/founder-kernel/_templates/principle.template.md` — add new fields.
+- `docs/founder-kernel/SCHEMA.md` — document new fields and coherence matrix.
+- `docs/founder-kernel/AUTHORING.md` — document new authoring rules.
+- `docs/founder-kernel/manifest.json` — bump `schemaVersion` to `0.3.0` (minor — additive).
+- `apps/web/lib/wiki/embeddings.ts` + test — Qdrant payload + `searchWikiPages` filters.
+- `apps/web/lib/wiki/recall.ts` + test — wire `recallPrincipleContext`.
+- `apps/web/lib/mcp-tools.ts` — extend `wiki_query` schema/handler; register `principle_decide`.
+- `apps/web/lib/tak/agent-grants.ts` — map `principle_decide` to `registry_read` (provisional).
+- `apps/web/app/api/mcp/v1/route.test.ts` — confirm visibility.
+- `apps/web/components/wiki/WikiPageList.tsx` + test — tier-first grouping for `kind=principle` with CA filter chips.
+- `apps/web/components/wiki/WikiPageViewer.tsx` + test — metadata panel including consumer archetype + contexts.
+- `apps/web/components/wiki/WikiPageKindBadge.tsx` — already renders `principle`; verify only.
+- `apps/web/app/(shell)/admin/wiki/lint/page.tsx` + test — principle finding filter chips, including coherence detector.
+- `docs/superpowers/specs/2026-05-09-wiki-visual-navigation-design.md` — principle-aware passes per spec §13 + visual-nav §3.1 / §4 / §5 / §6.
+- `AGENTS.md` — add the `wiki_query pageKind='principle'` discovery pointer **only after** external MCP visibility test passes.
+- `docs/index.html`, `docs/README.md`, `docs/_config.yml` (if needed) — link to `/principles/`.
+- Root `package.json` — `docs:principles` script entry.
 
-### Task 0.1: Author the taxonomy constants module
+### Task A.1 — Extend taxonomy constants
 
-**Files:**
-- Create: `packages/db/src/wiki-taxonomy.ts`
-- Test: `packages/db/src/wiki-taxonomy.test.ts`
+**Files:** `packages/db/src/wiki-taxonomy.ts`, `packages/db/src/wiki-taxonomy.test.ts`
 
-- [ ] **Write failing test:** assertions for `WIKI_PAGE_KINDS` including `principle` and preserving the existing seven values, `WIKI_PAGE_STATUSES`, `PRINCIPLE_TIERS` length, `PRINCIPLE_DIMENSIONS` matches the spec section 10 list verbatim, `PRINCIPLE_TIER_DEFAULT_WEIGHT.commandment === 1.0`, and type-narrowing helpers `isWikiPageKind(x)` / `isPrincipleTier(x)` / `isPrincipleAppliesTo(x)` / `isPrincipleDimension(x)` work for valid and invalid inputs.
-- [ ] **Run test, verify it fails:** `pnpm --filter @dpf/db exec vitest run src/wiki-taxonomy.test.ts` - expect "no module found" or assertion failure.
-- [ ] **Implement the module** with the constants block under "Cross-Phase Constants" above, plus the type-narrowing predicates. No external dependencies.
-- [ ] **Run test, verify it passes:** same command.
-- [ ] **Commit:** `feat(db): add wiki taxonomy constants module` with DCO sign-off.
+- [ ] **Write failing tests:** `PRINCIPLE_CONSUMER_ARCHETYPES` length and order; `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES` includes `build-studio`; `isPrincipleConsumerArchetype` / `isPrincipleConsumerContextSlug` narrow correctly for valid and reject invalid values.
+- [ ] **Run tests, verify they fail.**
+- [ ] **Implement** the constants and predicates from spec §8A.
+- [ ] **Run tests, verify they pass.**
+- [ ] **Commit (signed):** `feat(db): add principle consumer-archetype taxonomy constants`.
 
-### Task 0.2: Extend `WikiPageKind` type union
+### Task A.2 — Schema migration
 
-**Files:**
-- Modify: `packages/db/src/wiki-store.ts:43` (replace the local `WikiPageKind` declaration with imports/re-exports from `wiki-taxonomy.ts`)
-- Modify: `packages/db/src/wiki-store.test.ts`
+**Files:** `packages/db/prisma/schema.prisma`, `packages/db/prisma/migrations/<timestamp>_add_principle_consumer_archetype_to_wikipage/migration.sql`, `packages/db/src/wiki-store.test.ts`
 
-- [ ] **Write failing test:** `expect(WIKI_PAGE_KINDS).toContain("principle")` and `expect(WIKI_PAGE_KINDS).toHaveLength(8)`. Also test that the existing seven kinds are unchanged.
+- [ ] **Write failing test** in `wiki-store.test.ts`: create a `WikiPage` with `pageKind: "principle"`, `principleConsumerArchetype: "ai-coworker-universal"`, `principleConsumerContexts: []`. Assert round-trip.
 - [ ] **Run test, verify it fails.**
-- [ ] **Modify `wiki-store.ts`** to import `WikiPageKind` and `WikiPageStatus` from `wiki-taxonomy.ts` and re-export them for existing callers. This is the Phase 0 refactor-budget cleanup that prevents a second enum source from appearing.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(db): add principle to WikiPageKind union`.
-
-### Task 0.3: Add Prisma schema fields and migration
-
-**Files:**
-- Modify: `packages/db/prisma/schema.prisma` (the `WikiPage` model)
-- Create: `packages/db/prisma/migrations/<timestamp>_add_principle_fields_to_wikipage/migration.sql`
-
-- [ ] **Write failing test in `packages/db/src/wiki-store.test.ts`:** create a `WikiPage` with `pageKind: "principle"`, `principleTier: "commandment"`, `principleDirection: "..."`, `principleDimensionVector: { long_term_maintainability: 1.0 }`, `principleDimensions: ["long_term_maintainability"]`, `principleAppliesTo: ["external_coding_agent"]`. Assert all fields round-trip from DB.
-- [ ] **Run test, verify it fails** (schema doesn't have the columns yet).
-- [ ] **Modify `schema.prisma`** — append the principle-only fields to `WikiPage` exactly as in spec §9:
+- [ ] **Modify `schema.prisma`** to add:
 
 ```prisma
-  principleTier             String?
-  principleDirection        String?   @db.Text
-  principleWeight           Float?
-  principleWeightRationale  String?   @db.Text
-  principleDimensionVector  Json?
-  principleDimensions       String[]  @default([])
-  principleAppliesTo        String[]  @default([])
-  principlePublic           Boolean   @default(false)
-  principlePublicRationale  String?   @db.Text
+  principleConsumerArchetype String?
+  principleConsumerContexts  String[] @default([])
 
-  @@index([principleTier])
-  @@index([principlePublic])
+  @@index([principleConsumerArchetype])
 ```
 
-- [ ] **Generate migration:** `pnpm --filter @dpf/db exec prisma migrate dev --name add-principle-fields-to-wikipage --create-only`. Inspect the generated SQL — should be additive `ALTER TABLE WikiPage ADD COLUMN ...` only, no destructive changes.
-- [ ] **Add the kernel slug uniqueness guard in the same migration:** hand-edit the migration to create a partial unique index for kernel rows, because `@@unique([organizationId, slug])` does not prevent duplicate `slug` values when `organizationId IS NULL`.
+- [ ] **Generate migration:** `pnpm --filter @dpf/db exec prisma migrate dev --name add-principle-consumer-archetype-to-wikipage --create-only`. Inspect SQL — additive `ALTER TABLE` only.
+- [ ] **Apply migration:** `pnpm --filter @dpf/db exec prisma migrate dev`.
+- [ ] **Regenerate client:** `pnpm --filter @dpf/db exec prisma generate`.
+- [ ] **Run test, verify it passes.**
+- [ ] **Run full DB workspace tests:** `pnpm --filter @dpf/db exec vitest run` — green.
+- [ ] **Commit (signed):** `feat(db): add principleConsumerArchetype + principleConsumerContexts to WikiPage`.
+
+### Task A.3 — Seed parsing + template + SCHEMA.md + AUTHORING.md
+
+**Files:** `packages/db/src/seed-wiki-kernel.ts` + test, `docs/founder-kernel/_templates/principle.template.md`, `docs/founder-kernel/SCHEMA.md`, `docs/founder-kernel/AUTHORING.md`, `docs/founder-kernel/manifest.json`
+
+- [ ] **Write failing test:** fixture principle markdown with `principleConsumerArchetype: route-domain-specific` + `principleConsumerContexts: [build-studio]` round-trips through seed.
+- [ ] **Run test, verify it fails.**
+- [ ] **Extend the seed walker** to parse the new frontmatter keys, validate via the predicates from Task A.1, reject `route-domain-specific` without ≥1 context with a clear error message (per `feedback_check_tool_signals.md` — no silent skips).
+- [ ] **Write second failing test:** seed rejects a coherence-matrix violation (e.g., `principleConsumerArchetype: ai-coworker-universal` + `principleAppliesTo: [human]`) at seed time. (Belt-and-suspenders alongside lint, because lint runs after seed.)
+- [ ] **Run test, verify it fails, then implement, then verify it passes.**
+- [ ] **Update the principle template** to include `principleConsumerArchetype:` and `principleConsumerContexts:` frontmatter placeholders with the §8A coherence guidance as inline comments.
+- [ ] **Update `SCHEMA.md`** — extend the principle section with the consumer-archetype taxonomy, contexts, and the §8A.1 coherence matrix table.
+- [ ] **Update `AUTHORING.md`** — document the consumer-archetype authoring rule and back-fill expectations.
+- [ ] **Bump `manifest.json`** `schemaVersion` to `0.3.0` (additive minor) and update `description` to mention consumer-archetype awareness.
+- [ ] **Commit (signed):** `feat(db,docs): parse consumer-archetype frontmatter; update SCHEMA + AUTHORING + template`.
+
+### Task A.4 — Back-fill the 41 existing principle pages
+
+**Files:** `docs/founder-kernel/wiki/principles/*.md`
+
+For each existing principle page, add `principleConsumerArchetype` (and `principleConsumerContexts` where applicable) per the §8A.1 coherence matrix. Suggested initial assignments (the implementer reviews each against the actual page body):
+
+- `architecture-over-shortcuts`, `single-source-of-truth`, `live-state-over-seed-data`, `never-fabricate`, `research-and-use-standards`, `principal-convergence`, `trust-the-data-spine` → `universal` (humans + agents everywhere).
+- `specialization-over-generalization`, `orchestrator-worker-pattern`, `structured-handoffs-not-conversation-history`, `diversity-of-thought`, `selective-memory-not-total-recall`, `tools-must-be-self-documenting`, `human-in-the-loop-at-phase-boundaries`, `fail-fast-explain-clearly`, `responsible-capacity-utilization` → `ai-coworker-universal`.
+- `do-the-work-dont-task-the-operator`, `state-results-directly`, `contextualize-before-transforming` → `generalist` (COO/coordinator style).
+- `test-in-the-portal-build`, `release-qa-plan`, `tool-evaluation-pipeline`, `schema-audit-before-features`, `db-fallback-explicit`, `no-hardcoded-colors`, `strongly-typed-string-enums`, `one-data-model` → `specialist` (specialist agent rules).
+- `all-changes-land-via-pr`, `always-push-after-committing`, `branch-guard-before-implementation`, `build-gate-mandatory`, `dco-sign-off-required`, `mention-uncommitted-changes`, `worktree-per-session`, `keep-root-clone-as-merge-worktree`, `check-epic-overlap-before-creating`, `one-concern-per-pr`, `plan-before-install-paths`, `fix-the-seed-not-the-runtime`, `backlog-lives-in-postgresql`, `organization-canonical-identity`, `design-research-required` → review each: pure agent-procedural rules go `ai-coworker-universal`; rules that govern human operators too go `universal`.
+
+For each page:
+
+- [ ] **Add `principleConsumerArchetype:`** to frontmatter (required).
+- [ ] **Add `principleConsumerContexts:`** when archetype is `route-domain-specific` (required when applicable).
+- [ ] **Verify coherence** against §8A.1 — adjust either `principleAppliesTo` or `principleConsumerArchetype` if the seeded page violates the matrix.
+- [ ] **Re-seed:** `pnpm --filter @dpf/db seed`. Seed must not error.
+- [ ] **Commit (signed, batched logically):** e.g., `docs(principles): back-fill consumer-archetype on AI-coworker principles (PRs #566, #570)`, `docs(principles): back-fill consumer-archetype on AGENTS.md commandments (PRs #579, #590)`, `docs(principles): back-fill consumer-archetype on AGENTS.md core promotions (PR #589)`, `docs(principles): back-fill consumer-archetype on AGENTS.md contextual promotions (PR #592)`, `docs(principles): back-fill consumer-archetype on founder-kernel seed commandments (PR #565)`. One commit per logical group keyed to its source PR so reviewers can see provenance.
+
+### Task A.5 — Qdrant payload extension
+
+**Files:** `apps/web/lib/wiki/embeddings.ts`, `apps/web/lib/wiki/embeddings.test.ts`
+
+- [ ] **Write failing test:** when a principle page is upserted to Qdrant, the payload includes `principleConsumerArchetype` and `principleConsumerContexts`. Non-principle pages omit both keys (absence, not null/false).
+- [ ] **Run test, verify it fails.**
+- [ ] **Modify the payload write helper** to include the new keys when `pageKind === "principle"`.
+- [ ] **Run test, verify it passes.**
+- [ ] **Commit (signed):** `feat(wiki): include consumer-archetype keys in principle Qdrant payload`.
+
+### Task A.6 — `searchWikiPages` filters
+
+**Files:** `apps/web/lib/wiki/embeddings.ts`, `apps/web/lib/wiki/embeddings.test.ts`
+
+- [ ] **Write failing test:** `searchWikiPages({ pageKind: "principle", principleTier: "commandment", principleAppliesTo: "external_coding_agent", principleConsumerArchetype: "route-domain-specific", principleConsumerContext: "build-studio", principlePublic: true })` returns only matching principles; array filters honor containment.
+- [ ] **Run test, verify it fails.**
+- [ ] **Extend** `searchWikiPages` to accept and forward the new optional filters. Keep existing API stable.
+- [ ] **Run test, verify it passes.**
+- [ ] **Commit (signed):** `feat(wiki): principle filters in searchWikiPages`.
+
+### Task A.7 — `recallPrincipleContext`
+
+**Files:** `apps/web/lib/wiki/principle-recall.ts`, `apps/web/lib/wiki/principle-recall.test.ts`
+
+Contract per spec §12.1: Postgres-first commandments (cap 10) for the calling population, then Qdrant relevance-ranked core (top 5) and contextual (above threshold 0.75). Filter by consumer archetype before tier weighting. Exclude `route-domain-specific` unless `consumerContext` matches. Format as a distinct `## Governance Principles` block. Graceful degrade when Qdrant is down — return commandments from Postgres.
+
+Implement in test-first sub-tasks for each branch (commandments, Qdrant relevance, contextual threshold, consumer-archetype filtering, route-context gating, formatting, Qdrant-degraded path). One commit per sub-task or one final commit, implementer's choice.
+
+- [ ] **Commit (signed):** `feat(wiki): recallPrincipleContext with consumer-archetype filtering`.
+
+### Task A.8 — Wire principle recall into `recallWikiContext`
+
+**Files:** `apps/web/lib/wiki/recall.ts`, `apps/web/lib/wiki/recall.test.ts`
+
+- [ ] **Write failing test:** `recallWikiContext` returns the existing context plus a `principleContext` block; existing consumers see no regression in the non-principle path.
+- [ ] **Run test, verify it fails.**
+- [ ] **Modify `recallWikiContext`** to invoke `recallPrincipleContext` in parallel, default `callingPopulation` to `human` when not provided, pass route/domain context through when the caller supplies one.
+- [ ] **Run test, verify it passes.**
+- [ ] **Commit (signed):** `feat(wiki): wire recallPrincipleContext into recallWikiContext`.
+
+### Task A.9 — `wiki_query` MCP schema and handler
+
+**Files:** `apps/web/lib/mcp-tools.ts`, `apps/web/lib/mcp-tools-wiki-query.test.ts`
+
+- [ ] **Write failing test:** `wiki_query` accepts and forwards `tier`, `appliesTo`, `consumerArchetype`, `consumerContext`, `publicOnly`. For `pageKind: "principle"`, the response includes full principle metadata.
+- [ ] **Run test, verify it fails.**
+- [ ] **Extend** the input schema (ergonomic short names) and the handler (translate to `searchWikiPages` canonical args).
+- [ ] **Backwards-compat test:** existing `wiki_query` calls without new fields return the same shape.
+- [ ] **Commit (signed):** `feat(mcp): wiki_query principle filters + metadata`.
+
+### Task A.10 — `principle_decide` advisory tool
+
+**Files:** `apps/web/lib/wiki/principle-decide.ts` + test, `apps/web/lib/mcp-tools.ts`, `apps/web/lib/tak/agent-grants.ts`, `apps/web/lib/mcp-tools-principle-decide.test.ts`
+
+Per spec §11. Implement in test-first sub-tasks:
+
+- [ ] `computeStructuredAlignment(option, principle)` — dot product normalized by sum of `abs(weights)`, missing dimensions skipped (treated as 0 on the option side) with coverage tracking.
+- [ ] `computeSemanticAlignment(option, principle)` — embedding cosine fallback when `principleDimensionVector` is empty; mark contributions as `mode: "semantic"`.
+- [ ] `computeComposite(options, principles)` + `pickRecommendation(composites, tieMargin)`.
+- [ ] Assemble the contribution ledger (per-principle id/name/tier/weight/mode/alignmentByOption/contributionByOption/missingDimensions; org-overlay rows labeled per spec §11.6).
+- [ ] Guardrails: low-confidence when margin < tie margin, `commandmentConflict` flag on strong negative top-option contribution, `structuredCoverage: "weak"` on >40% semantic fallback, empty-set path.
+- [ ] Register `principle_decide` in `PLATFORM_TOOLS` (`executionMode: "immediate"`, `sideEffect: false`, `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`).
+- [ ] Map to `registry_read` in `agent-grants.ts` (provisional — spec §11.5).
+- [ ] Description: "Advisory only. Returns a scored recommendation across applicable principles with a contribution ledger. Does not execute the recommended option."
+- [ ] **Commit (signed):** `feat(mcp): principle_decide advisory tool with contribution ledger`.
+
+### Task A.11 — External MCP visibility test
+
+**Files:** `apps/web/app/api/mcp/v1/route.test.ts`
+
+- [ ] **Write failing test:** `tools/list` against `/api/mcp/v1` with a `registry_read` token returns extended `wiki_query` (new fields visible in input schema) and `principle_decide`. A token without `registry_read` does not see them.
+- [ ] **Run test, verify it fails or passes** (the route already gates by scope; this test confirms the contract).
+- [ ] **Patch any gaps.**
+- [ ] **Commit (signed):** `test(mcp): external visibility for wiki_query principle filters and principle_decide`.
+
+### Task A.12 — Lint detectors
+
+**Files:** `apps/web/lib/wiki/lint/principle-detectors.ts` + test, `apps/web/lib/wiki/lint/principle-public-safety.ts` + test, `apps/web/lib/wiki/lint/principle-coherence.ts` + test, `apps/web/lib/wiki/lint/index.ts` + test, `apps/web/lib/wiki/lint/__fixtures__/...`
+
+Implement the detectors from spec §14 that are not already shipped. The coherence detector (`principle-incoherent-archetype-applies-to`) is net-new per spec §8A.1. The public-safety detector is the highest-risk lint — see spec §14 row for what it must catch and what it must NOT catch.
+
+Detectors that depend on Qdrant similarity (`principle-duplicate`, `principle-contradiction-review`) MUST degrade to no-op + info-level finding when Qdrant returns empty (cold start) per spec §12.1. Add a regression test that proves this.
+
+- [ ] **One sub-task per detector, test-first.**
+- [ ] **Register** all detectors in the lint orchestrator. Cross-page detectors (cap-exceeded) get the cross-page hook; per-page detectors get the per-page hook.
+- [ ] **Run lint against the 41 existing principle pages** — must pass after Task A.4 back-fill. If any fail, fix the back-fill (do not loosen the lint).
+- [ ] **Commit (signed):** `feat(wiki-lint): principle detectors including coherence + public-safety`.
+
+### Task A.13 — Admin lint UI filter chips
+
+**Files:** `apps/web/app/(shell)/admin/wiki/lint/page.tsx` + test
+
+- [ ] **Write failing test:** the admin lint page accepts a `?findingKind=principle-*` URL param and shows a "Principles" chip group with one chip per principle finding kind, including the new coherence one. (Test invocation: `pnpm --filter web exec vitest run "app/(shell)/admin/wiki/lint/page.test.tsx"` — quotes required so PowerShell doesn't glob the parens.)
+- [ ] **Run test, verify it fails.**
+- [ ] **Implement** the filter chips using DPF theme tokens; long finding-kind names must wrap.
+- [ ] **Run test, verify it passes.**
+- [ ] **Commit (signed):** `feat(admin-wiki-lint): principle finding filter chips`.
+
+### Task A.14 — Wiki UI: tier-first principle browser with CA filter chips
+
+**Files:** `apps/web/components/wiki/WikiPageList.tsx` + test
+
+Per spec §13.1 (re-baselined): default grouping is **tier-first** (Commandments → Core → Contextual). Consumer-archetype lives as a multi-select filter-chip group above the list. A sort toggle flips to CA-first when the user wants a route/domain audit.
+
+- [ ] **Write failing test:** when the `kind=principle` filter is applied, default grouping is tier-first; the CA filter-chip group renders above the list with all five archetypes selectable; toggling the sort to CA-first reorders. Build Studio rows are sub-grouped under Route / Domain Specific > Build Studio.
+- [ ] **Run test, verify it fails.**
+- [ ] **Implement** using DPF theme tokens, the canonical taxonomy constants for ordering and labels, and stable row heights with wrapping.
+- [ ] **Run test, verify it passes.**
+- [ ] **Commit (signed):** `feat(wiki-ui): tier-first principle browser with consumer-archetype filter chips`.
+
+### Task A.15 — `WikiPageViewer` principle metadata panel
+
+**Files:** `apps/web/components/wiki/WikiPageViewer.tsx` + test
+
+- [ ] **Write failing test:** principle detail page shows consumer-archetype chip, route/domain context chips, tier badge, applies-to chips, weight (defaulted from tier if `principleWeight` is null), source count, dimension-vector table, public/internal badge.
+- [ ] **Run test, verify it fails.**
+- [ ] **Implement** the metadata block; keep body markdown render path unchanged.
+- [ ] **Run test, verify it passes.**
+- [ ] **Commit (signed):** `feat(wiki-ui): principle metadata panel in WikiPageViewer`.
+
+### Task A.16 — Decision breakdown view
+
+**Files:** `apps/web/components/wiki/PrincipleDecideBreakdown.tsx` + test (or co-locate inside an existing decision-support panel)
+
+Per spec §13.3. Surface the `principle_decide` contribution ledger inside Build Studio, coworker chat, or admin tooling.
+
+- [ ] Recommendation first, then a compact contribution table.
+- [ ] Horizontal contribution bar per option with positive/negative segments + text labels.
+- [ ] Commandment conflicts shown via tokenized alert styling (no hardcoded red).
+- [ ] Semantic-fallback warnings shown when option features are missing.
+- [ ] No one-click "execute recommended action" button.
+- [ ] Overlay-sourced contributions labeled per spec §11.6.
+- [ ] **Commit (signed):** `feat(wiki-ui): principle_decide breakdown view`.
+
+### Task A.17 — Visual-navigation spec refresh
+
+**Files:** `docs/superpowers/specs/2026-05-09-wiki-visual-navigation-design.md`
+
+Update the visual-nav spec for principle awareness across all tiers, not only the §5.1/§5.2 retrofit:
+
+- §3.1 (Tier 1 sidebar): elevate `principle` pages above stance/heuristic in the relevant-rows ordering when they match scope.
+- §4 (Tier 2 mini-graph): document principle node behavior and override-edge semantics for overlay principles.
+- §5.3 (time-travel atlas): mention principle promotions and tier changes as the most interesting bi-temporal evolution to visualize.
+- §6.1 (node shapes): assign a shape to `principle` so all eight `WikiPageKind` values have a defined glyph.
+- §6.3 (state outlines): add the principle-specific lint states (`principle-commandment-cap-exceeded`, `principle-public-unsafe-marker`, `principle-incoherent-archetype-applies-to`).
+
+- [ ] **Commit (signed):** `doc(wiki): principle awareness in visual-navigation spec`.
+
+### Task A.18 — Public docs generator + Jekyll integration
+
+**Files:** `scripts/generate-public-principles.mjs` + `.test.mjs`, `docs/principles.md`, `docs/index.html`, `docs/README.md`, `docs/_config.yml` (if needed), root `package.json`
+
+- [ ] **Write failing test** for the generator with a small fixture directory: three principle markdown files (one per tier, all `principlePublic: true`), expected output is a single deterministic `principles.md` matching a stored snapshot.
+- [ ] **Run test, verify it fails.**
+- [ ] **Implement** the generator with a small local YAML-frontmatter parser (no new root dependency). Reads `docs/founder-kernel/wiki/principles/*.md`, filters to `principlePublic: true`, groups by tier (Commandments → Core → Contextual), emits Jekyll frontmatter + intro + tiered sections + per-principle title/direction/rule/why/applies-to/how-to-apply, plus public-safe source citations.
+- [ ] **Run test, verify it passes.**
+- [ ] **Run** `pnpm docs:principles` against the real kernel and commit the resulting `docs/principles.md`.
+- [ ] **Add the snapshot-drift CI test** that runs the generator against the real kernel and asserts byte-for-byte match with the committed output. Anyone editing kernel principles without re-running the generator is caught before merge.
+- [ ] **Add navigation links** from `docs/index.html` and `docs/README.md`.
+- [ ] **Add `docs:principles` and `test:docs:principles` script entries** to root `package.json`.
+- [ ] **Commit (signed):** `feat(docs): generate public principles markdown from kernel with snapshot drift detection`.
+
+### Task A.19 — AGENTS.md discovery pointer
+
+**Files:** `AGENTS.md`
+
+**Gate:** only run after Task A.11 (external MCP visibility) merges or is otherwise verified, per spec §12.3.
+
+- [ ] **Verify** Task A.11 is on `origin/main`: `git log origin/main --oneline -- apps/web/app/api/mcp/v1/`.
+- [ ] **Add a short pointer paragraph** near the top of `AGENTS.md`: "For durable DPF governance principles, query `wiki_query` with `pageKind='principle'` when the MCP connector is available. AGENTS.md remains operationally authoritative when MCP is offline."
+- [ ] **Verify** `AGENTS.md` still reads end-to-end as a standalone agent guide without network access. Operational mechanics (commands, branch rules, verification, worktree, MCP token, local QA) stay inline.
+- [ ] **Commit (signed):** `doc(agents): add wiki principle discovery pointer`.
+
+### Phase A Verification
+
+```powershell
+pnpm --filter @dpf/db exec vitest run src/wiki-store.test.ts src/seed-wiki-kernel.test.ts src/wiki-taxonomy.test.ts
+pnpm --filter web exec vitest run lib/wiki/embeddings.test.ts lib/wiki/recall.test.ts lib/wiki/principle-recall.test.ts lib/wiki/principle-decide.test.ts lib/wiki/lint
+pnpm --filter web exec vitest run lib/mcp-tools-wiki-query.test.ts lib/mcp-tools-principle-decide.test.ts
+pnpm --filter web exec vitest run app/api/mcp/v1
+pnpm --filter web exec vitest run components/wiki "app/(shell)/admin/wiki/lint"
+pnpm --filter web typecheck
+pnpm --filter web build
+pnpm --filter @dpf/db exec prisma migrate status
+pnpm docs:principles
+pnpm test:docs:principles
+pnpm --filter web exec vitest run                    # full web suite before push
+```
+
+**UX verification (rebuilt Docker portal):**
+
+- `/wiki?kind=principle` — default tier-first grouping, CA filter chips work, sort toggle flips to CA-first, Build Studio rows isolated under Route / Domain Specific > Build Studio.
+- A principle detail page — metadata panel shows tier, archetype, contexts, applies-to, weight, sources, dimension table.
+- `/admin/wiki/lint` — principle filter chips work, coherence findings appear when seeded principles violate §8A.1.
+- A coworker chat — system prompt shows `## Governance Principles` block from `recallWikiContext`.
+- In-portal MCP debugger — `principle_decide` returns a contribution ledger on two synthetic options.
+- Jekyll preview — `/principles/` renders, internal-only principles absent, navigation links work.
+- Light + dark mode for all UI changes.
+
+**Exit criteria:**
+
+- All Phase A tests pass; full web build is clean.
+- Migration applies cleanly on a fresh DB.
+- All 41 existing principle pages pass lint with zero blocking findings after back-fill.
+- `wiki_query` accepts the new filters; `principle_decide` returns ledgers with tier/conflict/coverage flags.
+- External MCP `tools/list` exposes both for `registry_read` tokens.
+- Public `docs/principles.md` matches the snapshot test against the kernel.
+- `AGENTS.md` remains usable when MCP is offline.
+
+**PR title:** `feat(principles): consumer archetypes, advisory decision support, retrieval, lint, UI, public docs`.
+
+**PR body** must include:
+
+- Backlog item / epic ID from Phase -1.
+- Overlap-sweep snapshot (recent main + open PRs).
+- Refactor-budget items retired.
+- UX verification screenshots for `/wiki?kind=principle`, principle detail, lint admin, and `/principles/` Jekyll preview.
+- Note that Phase B (kernel-slug uniqueness) is independent and tracked separately.
+
+---
+
+## Phase B — Kernel slug uniqueness (independent refactor PR)
+
+**Branch:** `fix/wikipage-kernel-slug-uniqueness`
+
+**Objective:** Close the wiki-platform correctness gap where `@@unique([organizationId, slug])` does not constrain rows where `organizationId IS NULL`. Not coupled to Phase A — ships independently and can land before, alongside, or after.
+
+**Files to create:** `packages/db/prisma/migrations/<timestamp>_guard_kernel_wikipage_slug_uniqueness/migration.sql`
+
+**Files to modify:** `packages/db/src/wiki-store.test.ts` (regression test).
+
+### Task B.1 — Migration
+
+- [ ] **Write failing regression test** in `wiki-store.test.ts`: inserting two kernel rows (`organizationId IS NULL`) with the same `slug` must fail with a unique-constraint error. Inserting an org overlay (`organizationId = "<id>"`) with the same `slug` as a kernel row remains legal.
+- [ ] **Run test, verify it fails** (current schema allows the duplicate).
+- [ ] **Create the migration:**
 
 ```sql
 CREATE UNIQUE INDEX IF NOT EXISTS "WikiPage_kernel_slug_key"
@@ -231,878 +449,40 @@ CREATE UNIQUE INDEX IF NOT EXISTS "WikiPage_kernel_slug_key"
   WHERE "organizationId" IS NULL;
 ```
 
-- [ ] **Add a regression test** that proves two kernel rows with the same slug cannot both be inserted, while an org overlay with the same slug remains legal. This closes a wiki-platform correctness gap discovered during review; it is not principle-specific.
 - [ ] **Apply migration:** `pnpm --filter @dpf/db exec prisma migrate dev`.
-- [ ] **Regenerate Prisma client:** `pnpm --filter @dpf/db exec prisma generate`.
 - [ ] **Run test, verify it passes.**
-- [ ] **Run full DB workspace tests:** `pnpm --filter @dpf/db exec vitest run` — all green.
-- [ ] **Commit:** `feat(db): add principle-only fields to WikiPage schema` with the migration in the same commit (per `feedback_db_seed_migration_sync.md`).
+- [ ] **Run full DB workspace tests:** all green.
+- [ ] **Commit (signed):** `fix(db): guard kernel WikiPage.slug uniqueness when organizationId is NULL`.
 
-### Task 0.4: Principle-aware CRUD in `wiki-store.ts`
-
-**Files:**
-- Modify: `packages/db/src/wiki-store.ts`
-- Modify: `packages/db/src/wiki-store.test.ts`
-
-- [ ] **Write failing tests:** `upsertWikiPage` accepts a `PrincipleUpsertInput` extension; `getWikiPage` returns principle fields when present; `listWikiPagesByKind("principle")` works; passing `pageKind: "principle"` with `principleTier: "commandment"` but missing `principleDirection` should still succeed at the DB layer (validation lives in lint, not the store).
-- [ ] **Run tests, verify they fail.**
-- [ ] **Implement** the type extension and ensure `upsertWikiPage` / `getWikiPage` pass through the new fields. Add a helper `listPrinciplesByTier(tier, options?)` that filters `pageKind="principle" AND status="published"` and orders by `principleTier` then `title`.
-- [ ] **Run tests, verify they pass.**
-- [ ] **Commit:** `feat(db): principle-aware CRUD in wiki-store`.
-
-### Task 0.5: Seed parsing for principle frontmatter
-
-**Files:**
-- Modify: `packages/db/src/seed-wiki-kernel.ts`
-- Modify: `packages/db/src/seed-wiki-kernel.test.ts`
-
-- [ ] **Refactor for testability if needed:** keep the production default pointed at `docs/founder-kernel`, but allow seed parsing tests to pass a temporary kernel directory or fixture string. Do not create a new ad hoc `__fixtures__` convention unless the package already establishes it.
-- [ ] **Write fixture markdown** matching the principle template (frontmatter has `pageKind: principle`, `principleTier: commandment`, `principleDirection:`, `principleDimensionVector:` block, `principleAppliesTo:` list, `principlePublic: false`). Do not introduce new short aliases. If legacy authoring docs already contain shorter aliases (`tier`, `direction`, `dimensionVector`, `appliesTo`, `public`), map them explicitly to these canonical DB fields in one parser function and test both forms as compatibility only.
-- [ ] **Write failing test:** `seedWikiKernel` reads the fixture, calls `upsertWikiPage`, the resulting row has the correct `principleTier`, `principleDirection`, `principleDimensionVector` (parsed JSON), `principleDimensions` (derived from vector keys), `principleAppliesTo`.
-- [ ] **Run test, verify it fails.**
-- [ ] **Extend the seed walker** to handle the `principle` kind: parse the new frontmatter keys, validate dimension keys against `PRINCIPLE_DIMENSIONS`, validate `principleTier` and `principleAppliesTo` against their constants, derive `principleDimensions` from `Object.keys(principleDimensionVector)`, refuse to seed (throw with a clear message) if a dimension is unknown - per `feedback_check_tool_signals.md`, a silent skip on bad frontmatter is the failure mode to avoid.
-- [ ] **Run test, verify it passes.**
-- [ ] **Add a second test for unknown-dimension rejection:** fixture with `principleDimensionVector.fictional_axis: 1.0`. Seeder must throw an error mentioning `fictional_axis` and the allowed dimensions list.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(db): parse principle frontmatter in seedWikiKernel`.
-
-### Task 0.6: Qdrant payload extension
-
-**Files:**
-- Modify: `apps/web/lib/wiki/embeddings.ts` (the `searchWikiPages` signature stays in Phase 0 - only the payload write path changes for principles)
-- Modify: `apps/web/lib/wiki/embeddings.test.ts`
-
-- [ ] **Write failing test:** when a principle page is upserted to Qdrant, its payload includes `principleTier`, `principleAppliesTo`, `principleDimensions`, and `principlePublic`. Non-principle pages do NOT carry those keys at all (absence, not `false` or `null`) - this avoids a backfill of every existing Qdrant payload and keeps the write path purely additive.
-- [ ] **Run test, verify it fails.**
-- [ ] **Modify the Qdrant write helper** in `embeddings.ts` to include the canonical `principle*` payload keys only when `pageKind === "principle"`. Other page kinds have their existing payload unchanged. No `isPrinciple` or `principleOnly` flag - filters check for `pageKind === "principle"` directly.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): add principle-only Qdrant payload keys`.
-
-### Task 0.7a: UI — `WikiPageKindBadge` for the principle kind
-
-**Files:**
-- Modify: `apps/web/components/wiki/WikiPageKindBadge.tsx`
-- Modify (or create): adjacent `.test.tsx`
-
-- [ ] **Write failing test:** rendering with `pageKind="principle"` produces a badge labeled "Principle" using the existing badge density and DPF theme tokens (`bg-[var(--dpf-surface-2)]`, `text-[var(--dpf-muted)]` or another approved token consistent with nearby badges, `border-[var(--dpf-border)]`) - no hardcoded colors per `AGENTS.md` section 12.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the badge case for `principle`. Keep the props API unchanged.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-ui): render principle kind in WikiPageKindBadge`.
-
-### Task 0.7b: UI — `WikiPageList` tier grouping when filtered to principles
-
-**Files:**
-- Modify: `apps/web/components/wiki/WikiPageList.tsx`
-- Modify (or create): adjacent `.test.tsx`
-
-- [ ] **Write failing test:** when the `kind="principle"` filter is applied, results are grouped by tier in the order Commandments, Core, Contextual, each group labeled with the tier name.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the grouping logic in `WikiPageList`. Use only theme tokens; long titles must wrap without resizing adjacent rows (per spec §13.1).
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-ui): tier-group WikiPageList when filtered to principles`.
-
-### Task 0.8: UI — `WikiPageViewer` principle metadata panel
-
-**Files:**
-- Modify: `apps/web/components/wiki/WikiPageViewer.tsx`
-- Modify (or create): adjacent `.test.tsx`
-
-- [ ] **Write failing test:** viewer for a principle page shows tier badge, applies-to chips, weight (defaulted from tier if `principleWeight` is null), source count, and a dimension-vector table. Public principles also show a `Public` badge; internal-only principles show `Internal`. All theme-tokenized.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the metadata block. Keep the body markdown render path unchanged.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-ui): render principle metadata in WikiPageViewer`.
-
-### Task 0.9: Update `SCHEMA.md` and `AUTHORING.md`
-
-**Files:**
-- Modify: `docs/founder-kernel/SCHEMA.md:13` (page-kind contract section)
-- Modify: `docs/founder-kernel/AUTHORING.md:41` (seed-walker folders + per-kind authoring rules)
-- Modify: `docs/founder-kernel/manifest.json` (bump schema version)
-- Create: `docs/founder-kernel/_templates/principle.template.md`
-- Create: `docs/founder-kernel/wiki/principles/.gitkeep`
-
-- [ ] **Add `principle` to `SCHEMA.md`** under page kinds with the required-sections contract from spec §7.2 (Rule / Why / Applies To / How To Apply / Decision Dimensions / Examples / Sources). Note tier semantics, weight defaults, and that direction + dimension vector are required for commandment/core.
-- [ ] **Add `wiki/principles/` to the `AUTHORING.md` folder walker list** with a one-paragraph "principle authoring" subsection: frontmatter shape, public/internal classification, source-citation requirement (at least one `RawSource`).
-- [ ] **Bump `manifest.json` schema version** (likely a minor bump — additive new kind).
-- [ ] **Create the principle template** at `docs/founder-kernel/_templates/principle.template.md` with frontmatter placeholders for every principle-only field, and a body skeleton with the seven required sections.
-- [ ] **Create empty `wiki/principles/.gitkeep`** so the folder lands in git.
-- [ ] **Verify the manifest version + schema doc + template stay in sync:** add a small assertion in `seed-wiki-kernel.test.ts` that the template file exists and that `manifest.schemaVersion` matches the version listed at the top of `SCHEMA.md`. Run the test.
-- [ ] **Commit:** `docs(founder-kernel): add principle kind to schema, authoring, template`.
-
-### Phase 0 Verification
-
-Run on the principles-spec worktree before opening the PR:
+### Phase B Verification
 
 ```powershell
-pnpm --filter @dpf/db exec vitest run src/wiki-store.test.ts src/seed-wiki-kernel.test.ts src/wiki-taxonomy.test.ts
-pnpm --filter web exec vitest run lib/wiki/embeddings.test.ts components/wiki
-pnpm --filter web typecheck
-pnpm --filter web build
+pnpm --filter @dpf/db exec vitest run src/wiki-store.test.ts
 pnpm --filter @dpf/db exec prisma migrate status
-```
-
-**UX verification:** rebuild the portal container, seed the kernel with the fixture principle page, visit `/wiki?kind=principle`, confirm the badge and grouped list render correctly in light + dark mode. Open the detail page, confirm metadata panel.
-
-**Exit criteria:**
-- Migration applies cleanly on a fresh DB.
-- `WikiPage.pageKind = "principle"` round-trips through `wiki-store`, the seed walker, Qdrant payload writes, and the viewer.
-- `SCHEMA.md`, `AUTHORING.md`, and the template are consistent.
-- No principle content shipped yet — only one fixture used in tests.
-- All Phase 0 tests + the full web workspace typecheck + build pass.
-
-**PR:** open against `main`, title `feat(principles): batch 0 — schema, constants, authoring contract`. Per `feedback_no_manual_prs.md`, this work is governance/platform infrastructure (schema + constants + lint substrate), not customer-facing feature delivery — Claude opens these PRs directly. Build Studio is not the intake for principle-system phases. The same direct-PR posture applies to all subsequent phases of this plan.
-
----
-
-## Phase 1 — Principle Lint and Public Safety
-
-**Branch:** `feat/principles-batch-1-lint`
-
-**Objective:** Land the twelve lint detectors from spec §14 with severity gating, plus the public-safety detector that blocks internal markers from leaking. Extend the admin lint UI so principle findings are filterable. No retrieval or MCP work yet.
-
-**Files to create:**
-
-- `apps/web/lib/wiki/lint/principle-detectors.ts`
-- `apps/web/lib/wiki/lint/principle-detectors.test.ts`
-- `apps/web/lib/wiki/lint/principle-public-safety.ts`
-- `apps/web/lib/wiki/lint/principle-public-safety.test.ts`
-- `apps/web/lib/wiki/lint/__fixtures__/principle-valid-commandment.md`
-- `apps/web/lib/wiki/lint/__fixtures__/principle-missing-direction.md`
-- `apps/web/lib/wiki/lint/__fixtures__/principle-unsafe-public.md`
-- `apps/web/lib/wiki/lint/__fixtures__/principle-cap-exceeded/...` (eleven valid commandment fixtures)
-
-**Files to modify:**
-
-- `apps/web/lib/wiki/lint/index.ts` (register principle detectors with the orchestrator)
-- `apps/web/lib/wiki/lint/index.test.ts`
-- `apps/web/app/(shell)/admin/wiki/lint/page.tsx` (add tier/findingKind filter chips for principles)
-- `apps/web/app/(shell)/admin/wiki/lint/page.test.tsx` (or new component test)
-
-### Task 1.1a: Implement `principle-missing-tier`
-
-**Files:**
-- Create: `apps/web/lib/wiki/lint/principle-detectors.ts`
-- Create: `apps/web/lib/wiki/lint/principle-detectors.test.ts`
-
-- [ ] **Write failing test:** a principle page with `principleTier = null` produces a finding with `findingKind = "principle-missing-tier"`, `severity = "error"`, `blocksPublish = true`.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the detector with shared types pulled from `wiki-taxonomy.ts` constants.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-missing-tier detector`.
-
-### Task 1.1b: Implement `principle-missing-applies-to`
-
-**Files:**
-- Modify: `apps/web/lib/wiki/lint/principle-detectors.ts`
-- Modify: `apps/web/lib/wiki/lint/principle-detectors.test.ts`
-
-- [ ] **Write failing test:** a principle page with empty `principleAppliesTo` produces a finding with `findingKind = "principle-missing-applies-to"`, `severity = "error"`, `blocksPublish = true`.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the detector in the same module.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-missing-applies-to detector`.
-
-### Task 1.2: Implement `principle-missing-direction` (severity by tier)
-
-- [ ] **Write failing test:** commandment principle without `principleDirection` → severity `error`, blocks publish. Core principle without direction → severity `error`, blocks publish. Contextual principle without direction → severity `warn`, does not block.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the detector with tier-gated severity. Reuse the `PRINCIPLE_TIERS` constant.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-missing-direction detector with tier-gated severity`.
-
-### Task 1.3: Implement `principle-missing-vector` and `principle-vector-dimension-mismatch`
-
-- [ ] **Write failing test:** commandment with empty `principleDimensionVector` → `error`, blocks. Core with empty vector → `warn`, does not block. Vector keys that don't match `principleDimensions` array → `principle-vector-dimension-mismatch`, `warn`, does not block.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** both detectors.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle dimension vector consistency detectors`.
-
-### Task 1.4: Implement `principle-unknown-dimension`
-
-- [ ] **Write failing test:** a principle whose `principleDimensions` or `principleDimensionVector` keys contain an out-of-registry value → `error`, blocks publish.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the detector using `PRINCIPLE_DIMENSIONS` as the allowlist.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-unknown-dimension detector`.
-
-### Task 1.5: Implement `principle-tier-weight-mismatch`
-
-- [ ] **Write failing test:** a principle whose `principleWeight` differs from `PRINCIPLE_TIER_DEFAULT_WEIGHT[tier]` with no `principleWeightRationale` → `warn`, does not block. Same divergence with rationale present → no finding.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the detector.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-tier-weight-mismatch detector`.
-
-### Task 1.6: Implement `principle-commandment-cap-exceeded`
-
-- [ ] **Write failing test:** seed 11 published kernel commandments, run lint orchestrator, expect a `principle-commandment-cap-exceeded` finding with `severity = "error"`, `blocksPublish = true`, attached to the 11th commandment by `lastReviewedAt` order.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the detector as a cross-page check inside the orchestrator (each individual page detector is local; this one needs the full set). Reuse `PRINCIPLE_TIER_CAPS.commandment`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-commandment-cap-exceeded cross-page detector`.
-
-### Task 1.7: Implement `principle-public-missing-rationale` and the public-safety detector
-
-**Files:**
-- Create: `apps/web/lib/wiki/lint/principle-public-safety.ts`
-- Create: `apps/web/lib/wiki/lint/principle-public-safety.test.ts`
-
-The public-safety detector is the highest-risk lint in this batch. Scope is *internal-leakage signals*, not personal-name censorship. Founder biographical references like "DPF was founded by Mark Bodman" are product-facing per spec §13.4 and must NOT be blocked. It must catch:
-
-- references to local user paths (`C:\Users\...`, `/home/...`, `/Users/...`)
-- raw memory file paths (`feedback_*.md`, `project_*.md`, `MEMORY.md` filename references)
-- private tokens or secrets (heuristic — strings matching `sk-[A-Za-z0-9]{16,}`, `ghp_[A-Za-z0-9]{20,}`, `dpf_pat_[A-Za-z0-9_-]{16,}`, generic `[A-Za-z0-9_-]{32,}` adjacent to "token" / "key")
-- internal-only agent-instruction phrases (literal string matches against a small allowlist: `Drive 100% means don't ask`, `Claude Code`, `Codex CLI`, `<internal-only>` markers) — narrative references to "Claude", "Codex", or "Mark" as people/products are allowed
-- unreleased PR claims (`PR #N` where `N` exceeds the highest merged PR number known at lint time, fetched once at orchestrator start — surface as `warn`, not `error`)
-
-- [ ] **Write failing tests** (one per category) using fixtures: each fixture is a principle page body that violates one rule. Lint output must include the matching marker and reason.
-- [ ] **Run tests, verify they fail.**
-- [ ] **Implement** the detector with regex-based matchers plus a small allowlist (e.g., "Codex" inside a code block fence is allowed since that's reference material; in narrative prose it's flagged).
-- [ ] **Run tests, verify they pass.**
-- [ ] **Write failing test for `principle-public-missing-rationale`:** `principlePublic = true` AND `principlePublicRationale IS NULL` → `warn`, does not block.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the rationale detector (one line — colocate in the same file).
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle public-safety + public-rationale detectors`.
-
-### Task 1.8: Implement `principle-duplicate` and `principle-contradiction-review`
-
-These both require embedding similarity. They piggyback on the existing Qdrant payloads from Phase 0.
-
-- [ ] **Write failing test for `principle-duplicate`:** seed two principles whose `principleDirection` embeddings cosine > 0.9 and titles share ≥3 stemmed words. Expect a `principle-duplicate` finding on the newer page, `warn`, does not block.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** using `searchWikiPages` with `pageKind: "principle"` and a high `scoreThreshold`, plus a small lexical-overlap check on titles.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test for `principle-contradiction-review`:** seed two principles with overlapping dimension keys but opposing signs (e.g., one favors `speed_to_value: +1`, another favors `speed_to_value: -1`) AND direction embeddings cosine > 0.75. Expect a `principle-contradiction-review` finding on both pages, `warn`, does not block.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** using vector-difference comparison on the shared dimension keys plus the embedding similarity check.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki-lint): principle-duplicate and principle-contradiction-review detectors`.
-
-### Task 1.9: Register principle detectors with the lint orchestrator
-
-**Files:**
-- Modify: `apps/web/lib/wiki/lint/index.ts`
-- Modify: `apps/web/lib/wiki/lint/index.test.ts`
-
-- [ ] **Write failing test:** running the orchestrator over a corpus that includes a principle page invokes every principle detector exactly once per page (or once across the corpus for cross-page detectors).
-- [ ] **Run test, verify it fails.**
-- [ ] **Register** the new detectors in the orchestrator's detector list. Cross-page detectors get a different hook than per-page ones — follow the existing pattern from `kernel-drift` or similar.
-- [ ] **Run test, verify it passes.**
-- [ ] **Run the scheduled-job test** to confirm Inngest scheduling still works.
-- [ ] **Commit:** `feat(wiki-lint): register principle detectors with orchestrator`.
-
-### Task 1.10: Admin lint UI — principle filter chips
-
-**Files:**
-- Modify: `apps/web/app/(shell)/admin/wiki/lint/page.tsx`
-- Modify: `apps/web/app/(shell)/admin/wiki/lint/page.test.tsx` (or component-level test)
-
-- [ ] **Write failing test** at `apps/web/app/(shell)/admin/wiki/lint/page.test.tsx` (target invocation: `pnpm --filter web exec vitest run "app/(shell)/admin/wiki/lint/page.test.tsx"` — note the quotes are required so PowerShell does not glob the parentheses): the admin lint page accepts a `?findingKind=principle-*` URL param and filters findings accordingly; a "Principles" filter chip group is shown with chip per principle finding kind.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the filter chips using DPF theme tokens. Long finding-kind names must wrap.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(admin-wiki-lint): principle finding filter chips`.
-
-### Phase 1 Verification
-
-```powershell
-pnpm --filter web exec vitest run lib/wiki/lint
-pnpm --filter web exec vitest run app/admin/wiki/lint
 pnpm --filter web typecheck
 pnpm --filter web build
 ```
 
-**UX verification:** seed a deliberately-broken principle page (missing tier), open `/admin/wiki/lint`, confirm the finding appears, click the principle filter chip, confirm the list narrows.
-
 **Exit criteria:**
-- All twelve detectors from spec §14 are implemented, tested, and registered.
-- Commandment-cap detector is the only cross-page detector and is correctly invoked once per orchestrator run.
-- Public-safety detector blocks publish for internal-marker leaks.
-- Admin UI exposes per-finding-kind filter.
 
-**PR:** title `feat(principles): batch 1 — lint detectors and public safety`.
+- Two kernel rows cannot share a `slug`.
+- Org overlay rows with the same `slug` as a kernel row remain legal.
+- No existing kernel row pre-violates the new uniqueness — if any do, surface them in the PR and resolve before merge.
 
----
-
-## Phase 2 — Retrieval and MCP Tools
-
-**Branch:** `feat/principles-batch-2-retrieval-mcp`
-
-**Objective:** Extend retrieval so principles are surfaced to in-platform coworkers via passive recall, to in-portal and external agents via `wiki_query` filters, and to anyone via the new `principle_decide` advisory tool. The decision math from spec §11 lands here.
-
-**Files to create:**
-
-- `apps/web/lib/wiki/principle-recall.ts`
-- `apps/web/lib/wiki/principle-recall.test.ts`
-- `apps/web/lib/wiki/principle-search.ts`
-- `apps/web/lib/wiki/principle-search.test.ts`
-- `apps/web/lib/wiki/principle-decide.ts`
-- `apps/web/lib/wiki/principle-decide.test.ts`
-- `apps/web/lib/mcp-tools-wiki-query.test.ts` (if not present)
-- `apps/web/lib/mcp-tools-principle-decide.test.ts`
-
-**Files to modify:**
-
-- `apps/web/lib/wiki/embeddings.ts:56` (extend `searchWikiPages` with `principleTier`, `principleAppliesTo`, and `principlePublic` payload filters)
-- `apps/web/lib/wiki/embeddings.test.ts`
-- `apps/web/lib/wiki/recall.ts:70` (orchestrate the new principle-recall alongside the existing single-search path; principle recall is in addition to existing recall, not a replacement)
-- `apps/web/lib/wiki/recall.test.ts`
-- `apps/web/lib/mcp-tools.ts:1971` (extend `wiki_query` input schema; new `principle_decide` tool)
-- `apps/web/lib/mcp-tools.ts:8431` (extend `wiki_query` handler)
-- `apps/web/lib/tak/agent-grants.ts:67` (map `principle_decide` to `registry_read`)
-- `apps/web/app/api/mcp/v1/route.ts:167` (no code change expected; verify tools/list exposes the new tools for `registry_read` tokens via test)
-
-### Task 2.1: Extend `searchWikiPages` with canonical principle filters
-
-**Files:**
-- Modify: `apps/web/lib/wiki/embeddings.ts`
-- Modify: `apps/web/lib/wiki/embeddings.test.ts`
-
-- [ ] **Write failing test:** `searchWikiPages({ query, pageKind: "principle", principleTier: "commandment", principleAppliesTo: "external_coding_agent", principlePublic: true })` returns only matching principles; `principleAppliesTo` filter respects array containment.
-- [ ] **Run test, verify it fails.**
-- [ ] **Extend** `searchWikiPages` to accept optional `principleTier`, `principleAppliesTo`, and `principlePublic` filter args. Translate to Qdrant filter clauses against the canonical payload keys added in Phase 0 (Task 0.6). Keep the existing API stable - all args are optional.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): principle filters in searchWikiPages`.
-
-### Task 2.2: Implement `recallPrincipleContext`
-
-**Files:**
-- Create: `apps/web/lib/wiki/principle-recall.ts`
-- Create: `apps/web/lib/wiki/principle-recall.test.ts`
-
-The spec §12.1 contract: always inject in-scope commandments (cap 10) from Postgres, then top-N relevant core principles from Qdrant (default N=5), then contextual principles only above `contextualSimilarityThreshold` (default 0.75). Format principles separately from ordinary wiki context so the prompt assembler can distinguish governance from background.
-
-- [ ] **Write failing test for the commandment branch:** when Postgres holds 3 published commandments matching `appliesTo`, `recallPrincipleContext` returns all 3 even if Qdrant is unreachable. Stub Qdrant to throw; commandments still come back.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the Postgres-first branch using `listPrinciplesByTier("commandment")` from Task 0.4. Filter by `principleAppliesTo` array containment via the helper.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test for the Qdrant-relevance branch:** seed 6 core principles, query with a context string that semantically matches 2 of them above the relevance threshold, assert top-2 returned.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the Qdrant relevance branch using `searchWikiPages` with `pageKind: "principle"`, `principleTier: "core"`, top-K=5.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test for the contextual threshold:** seed 3 contextual principles, query with a string that matches one above 0.75 and two below; assert only the above-threshold one is returned.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the threshold gate with `scoreThreshold: contextualSimilarityThreshold`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test for the formatting contract:** the returned context block uses a distinct header (e.g. `## Governance Principles`) so the prompt assembler can split it from background context.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the formatter, then add a tiny snapshot test.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): recallPrincipleContext with tiered Postgres + Qdrant strategy`.
-
-### Task 2.3: Wire principle recall into the existing prompt assembler
-
-**Files:**
-- Modify: `apps/web/lib/wiki/recall.ts:70`
-- Modify: `apps/web/lib/wiki/recall.test.ts`
-
-- [ ] **Write failing test:** the existing `recallWikiContext` invocation now also returns a `principleContext` block (or appends to the existing returned shape with a labeled section). Existing consumers see no regression in the non-principle context block.
-- [ ] **Run test, verify it fails.**
-- [ ] **Modify** `recallWikiContext` to invoke `recallPrincipleContext` in parallel with its existing search, merge results into the returned shape. If `callingPopulation` is not provided, default to `human` (safest) and skip Postgres-first commandments — they only inject when scope matches.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): wire recallPrincipleContext into recallWikiContext`.
-
-### Task 2.4: Extend `wiki_query` MCP schema and handler
-
-**Files:**
-- Modify: `apps/web/lib/mcp-tools.ts:1971` (input schema)
-- Modify: `apps/web/lib/mcp-tools.ts:8431` (handler)
-- Create: `apps/web/lib/mcp-tools-wiki-query.test.ts`
-
-- [ ] **Write failing test:** `wiki_query` called with `{ query, pageKind: "principle", tier: "commandment", appliesTo: "external_coding_agent", publicOnly: true, limit: 5 }` returns matching principle pages with full principle metadata (`principleTier`, `principleDirection`, `principleDimensions`, `principleAppliesTo`, `principlePublic`) in the structured content.
-- [ ] **Run test, verify it fails.**
-- [ ] **Extend** the public MCP input schema with the ergonomic optional fields (`tier`, `appliesTo`, `publicOnly`). Update the handler to translate them to `searchWikiPages` canonical args (`principleTier`, `principleAppliesTo`, `principlePublic`). For `pageKind: "principle"`, the response shape includes canonical principle metadata; for other kinds, the shape is unchanged.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test for backwards compat:** existing `wiki_query` calls without the new fields return the same shape they did before Phase 2.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(mcp): wiki_query principle filters and metadata`.
-
-### Task 2.5a: Implement `computeStructuredAlignment`
-
-**Files:**
-- Create: `apps/web/lib/wiki/principle-decide.ts`
-- Create: `apps/web/lib/wiki/principle-decide.test.ts`
-
-The math contract is in spec §11.2 and the worked example is in §11.4.
-
-- [ ] **Write failing test:** given a principle with `principleDimensionVector = { long_term_maintainability: 1.0, schema_grounding: 0.8, speed_to_value: -0.4 }` and an option with `features = { long_term_maintainability: 0.9, schema_grounding: 0.8, speed_to_value: 0.3 }`, alignment = `((0.9*1.0) + (0.8*0.8) + (0.3*-0.4)) / (|1.0|+|0.8|+|-0.4|) = 1.42 / 2.2 ≈ 0.645`.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** `computeStructuredAlignment(option, principle)` returning the normalized dot product. Skip missing dimensions (treat as 0 on the option side) but track which dimensions were present so the caller can surface coverage warnings.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): computeStructuredAlignment for principle_decide`.
-
-### Task 2.5b: Implement `computeSemanticAlignment` fallback
-
-**Files:**
-- Modify: `apps/web/lib/wiki/principle-decide.ts`
-- Modify: `apps/web/lib/wiki/principle-decide.test.ts`
-
-- [ ] **Write failing test:** a principle with empty `principleDimensionVector` and a query option falls back to embedding cosine. Use a deterministic stub embedding model so the test is reproducible.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** `computeSemanticAlignment(option, principle)` using the existing embedding helper. Mark the contribution as `mode: "semantic"`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): computeSemanticAlignment fallback for principle_decide`.
-
-### Task 2.5c: Implement composite score and argmax
-
-**Files:**
-- Modify: `apps/web/lib/wiki/principle-decide.ts`
-- Modify: `apps/web/lib/wiki/principle-decide.test.ts`
-
-- [ ] **Write failing test:** four principles (two commandments at weight 1.0, one core at 0.4, one contextual at 0.1) and two options, composite score sums correctly per spec §11.4 worked example. Argmax picks the higher composite.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** `computeComposite(options, principles)` and `pickRecommendation(composites, tieMargin)`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): composite score + argmax for principle_decide`.
-
-### Task 2.5d: Assemble the contribution ledger
-
-**Files:**
-- Modify: `apps/web/lib/wiki/principle-decide.ts`
-- Modify: `apps/web/lib/wiki/principle-decide.test.ts`
-
-- [ ] **Write failing test:** the returned shape includes one entry per principle (id, name, tier, weight, mode: structured | semantic, alignmentByOption, contributionByOption, missingDimensions). Sum of contributions per option equals composite.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the ledger assembly.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): contribution ledger assembly for principle_decide`.
-
-### Task 2.6: Guardrails — tie-margin, commandment-conflict, semantic-fallback warnings
-
-**Files:**
-- Modify: `apps/web/lib/wiki/principle-decide.ts`
-- Modify: `apps/web/lib/wiki/principle-decide.test.ts`
-
-- [ ] **Write failing test:** when `recommendation.margin < tieMargin`, `confidence` is `"low"` and the reasoning string explicitly recommends human review.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the tie-margin path.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test:** when a commandment principle has a strong negative contribution toward the top option (e.g., `-0.5` or worse), `commandmentConflict = true` and the principle's id is named.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the commandment-conflict flag.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test:** when more than 40% of contributions are semantic (no structured features available), `structuredCoverage = "weak"`.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the coverage flag using `PRINCIPLE_DECIDE_DEFAULTS.semanticFallbackWarnRatio`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test:** when no applicable principles match (empty retrieval), return `recommendation: null`, `confidence: "low"`, and a clear reasoning string.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the empty-set path.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(wiki): principle_decide guardrails — tie-margin, commandment-conflict, coverage`.
-
-### Task 2.7: Register `principle_decide` as an MCP tool
-
-**Files:**
-- Modify: `apps/web/lib/mcp-tools.ts` (add tool definition)
-- Modify: `apps/web/lib/tak/agent-grants.ts:67` (grant mapping)
-- Create: `apps/web/lib/mcp-tools-principle-decide.test.ts`
-
-- [ ] **Write failing test:** `principle_decide` tool exists in `PLATFORM_TOOLS` with `executionMode: "immediate"`, `sideEffect: false`, annotations `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`. Its grant mapping is `registry_read`.
-- [ ] **Run test, verify it fails.**
-- [ ] **Add the tool definition** with the input schema from spec §11.1 and the output shape from Tasks 2.5–2.6. Description: "Advisory only. Returns a scored recommendation across applicable principles with a contribution ledger. Does not execute the recommended option; the caller retains authority."
-- [ ] **Map** the tool to `registry_read` in `agent-grants.ts`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Write failing test:** `principle_decide` invoked through the in-portal handler returns the contribution ledger shape from Task 2.5. Use a small seeded principle set.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the handler that calls `principle-decide.ts` and serializes the result.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `feat(mcp): principle_decide advisory tool with grant mapping`.
-
-### Task 2.8: External MCP visibility test
-
-**Files:**
-- Create or modify: `apps/web/app/api/mcp/v1/route.test.ts` (route-level test)
-
-- [ ] **Write failing test:** issuing a `tools/list` JSON-RPC call against `/api/mcp/v1` with a token whose scope includes `registry_read` returns both the extended `wiki_query` (with new optional fields visible in the input schema) and `principle_decide` in the tools array. A token without `registry_read` does not see them.
-- [ ] **Run test, verify it fails** (only because the test is new; the route should already gate by scope).
-- [ ] **Verify and patch** any gaps. The expectation per spec §1.1 is that the route already default-denies; this task confirms the new tools are picked up by the existing gating.
-- [ ] **Run test, verify it passes.**
-- [ ] **Commit:** `test(mcp): external visibility for wiki_query principle filters and principle_decide`.
-
-### Phase 2 Verification
-
-```powershell
-pnpm --filter web exec vitest run lib/wiki/embeddings.test.ts lib/wiki/recall.test.ts lib/wiki/principle-recall.test.ts lib/wiki/principle-decide.test.ts lib/mcp-tools-wiki-query.test.ts lib/mcp-tools-principle-decide.test.ts
-pnpm --filter web exec vitest run app/api/mcp/v1
-pnpm --filter web typecheck
-pnpm --filter web build
-```
-
-**UX verification:** open a coworker chat, ask a decision-shaped question, confirm the system prompt includes the `## Governance Principles` block from Task 2.2. Call `principle_decide` via the in-portal MCP debugger with two synthetic options and verify the contribution ledger renders end-to-end.
-
-**Exit criteria:**
-- `searchWikiPages` accepts canonical `principleTier`, `principleAppliesTo`, and `principlePublic` filters.
-- `recallPrincipleContext` returns Postgres-first commandments + Qdrant relevance for core/contextual.
-- `wiki_query` MCP accepts the new filters; metadata returned for principles.
-- `principle_decide` returns a ledger with structured-vs-semantic flags, tie-margin handling, commandment-conflict flag, coverage flag.
-- External MCP tools/list exposes both for `registry_read` tokens.
-
-**PR:** title `feat(principles): batch 2 — retrieval and MCP tools`.
-
----
-
-## Phase 3 - Seed the First Principle Set
-
-**Branch:** `doc/principles-batch-3-seed-first-set`
-
-**Objective:** Author and seed the first kernel principles. Phase -1 determines the exact count on the implementation base. In the reviewed target checkout, Principle 9 and the capacity-continuity spec are already present, so the expected scope is Principles 1-9. The proposed Proactive Engagement principle is not seeded unless the founder explicitly approves canonical text before this phase starts.
-
-**Pre-check:** before starting, grep the local copy of the AI principles doc for Principle 9 content:
-
-```powershell
-Select-String -Path "docs/architecture/ai-coworker-development-principles.md" -Pattern "Principle 9" -Quiet
-```
-
-If the result is `True`, scope to Principles 1-9. If `False`, scope to the branch-local principles that exist in the file and update the design spec's current-state table before seeding. Do NOT rely on commit-message grep; PR #489's commit subject is not guaranteed to contain the string "capacity continuity" and could produce a false negative.
-
-**Files to create:**
-
-- `docs/founder-kernel/wiki/principles/specialization-over-generalization.md`
-- `docs/founder-kernel/wiki/principles/orchestrator-worker-pattern.md`
-- `docs/founder-kernel/wiki/principles/structured-handoffs.md`
-- `docs/founder-kernel/wiki/principles/diversity-of-thought.md`
-- `docs/founder-kernel/wiki/principles/selective-memory.md`
-- `docs/founder-kernel/wiki/principles/tools-must-be-self-documenting.md`
-- `docs/founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md`
-- `docs/founder-kernel/wiki/principles/fail-fast-explain-clearly.md`
-- (if PR #489 in branch) `docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md`
-- (if approved) `docs/founder-kernel/wiki/principles/proactive-engagement.md`
-- For each principle, one or more `docs/founder-kernel/raw-sources/...` markdown files where a stable source citation is needed
-
-**Files to modify:**
-
-- `docs/founder-kernel/manifest.json` (page count + source count)
-- `docs/architecture/ai-coworker-development-principles.md` — after seeding, replace each section body with a one-line pointer to the wiki kernel page; keep the file as a navigational stub. Do not delete it; some external tools and links rely on it.
-
-### Task 3.1: Author Principle 1 — Specialization Over Generalization
-
-- [ ] **Read** `docs/architecture/ai-coworker-development-principles.md` lines 18–40 for the canonical text.
-- [ ] **Write** the kernel page at `docs/founder-kernel/wiki/principles/specialization-over-generalization.md` with frontmatter:
-  - `pageKind: principle`
-  - `slug: specialization-over-generalization`
-  - `title: Specialization Over Generalization`
-  - `principleTier: core` (proposed default - finalize during PR review)
-  - `principleDirection: Prefer specialist agents with focused tool sets over generalists with broad surfaces.`
-  - `principleDimensionVector: { reusability: 0.6, blast_radius: 0.4, human_cognitive_load: -0.3 }` (proposed - finalize during PR review)
-  - `principleAppliesTo: [in_platform_coworker]`
-  - `principlePublic: true`
-  - `principlePublicRationale: Documents DPF's agentic architecture posture for adopters and contributors.`
-- [ ] **Author the body** using the required-sections contract from spec §7.2. Source-cite the architecture principles doc itself plus any external research cited in the original (likely Anthropic's "Building Effective Agents" or similar).
-- [ ] **Create RawSource markdown** at `docs/founder-kernel/raw-sources/anthropic-building-effective-agents.md` if not already present, with locator + abstract.
-- [ ] **Run seed** locally through the package script: `pnpm --filter @dpf/db seed`. Confirm `AUTHORING.md` names the same entry point after Phase 0 updates.
-- [ ] **Run lint tests and portal lint check:** `pnpm --filter web exec vitest run lib/wiki/lint`, then open `/admin/wiki/lint` in the rebuilt portal and expect zero principle-related findings on this page.
-- [ ] **Commit:** `doc(principles): author Principle 1 — Specialization Over Generalization`.
-
-### Task 3.2 through Task 3.8 — repeat the same shape for Principles 2–8
-
-For each of the remaining branch-local principles:
-
-- Source markdown from `docs/architecture/ai-coworker-development-principles.md` at the documented line ranges
-- Author kernel page with proposed `principleTier` + `principleDirection` + `principleDimensionVector` + `principleAppliesTo`
-- Create or cite RawSources as needed
-- Run seed
-- Run lint
-- Commit individually so review can focus on one principle at a time
-
-Per-principle proposed tier (subject to PR review):
-
-- Principle 2 — Orchestrator-Worker Pattern → core
-- Principle 3 — Structured Handoffs → core
-- Principle 4 — Diversity of Thought → core
-- Principle 5 — Selective Memory → core
-- Principle 6 — Tools Self-Documenting → core
-- Principle 7 — Human-in-the-Loop at Phase Boundaries → commandment (high consequence; non-negotiable)
-- Principle 8 — Fail Fast, Explain Clearly → core
-
-### Task 3.9 (conditional): Principle 9 — Responsible Capacity Utilization
-
-Only if the Phase 3 pre-check (`Select-String` for "Principle 9" in `docs/architecture/ai-coworker-development-principles.md`) returned `True`.
-
-- [ ] **Source** the canonical text from the rebased copy of `docs/architecture/ai-coworker-development-principles.md`.
-- [ ] **Author** the kernel page with `principleTier: core`, `principleDimensionVector: { capacity_utilization: 1.0, governance_compliance: 0.7, human_cognitive_load: -0.2 }`, `principleAppliesTo: [in_platform_coworker, external_coding_agent]`, `principlePublic: true`.
-- [ ] **Commit:** `doc(principles): author Principle 9 — Responsible Capacity Utilization`.
-
-### Task 3.10 (conditional): Proactive Engagement principle
-
-If the founder approves the Proactive Engagement principle (currently a conversation artifact, not committed text yet), author it the same way with `principleTier: core`, `principleDimensionVector: { human_cognitive_load: -0.5, evidence_density: 0.5, blast_radius: 0.3 }`, `principleAppliesTo: [in_platform_coworker, external_coding_agent]`. Otherwise defer this principle to Phase 5 or a later iteration.
-
-### Task 3.11: Convert `ai-coworker-development-principles.md` into a stub
-
-**Files:**
-- Modify: `docs/architecture/ai-coworker-development-principles.md`
-
-- [ ] **Replace** each principle section body with one line: `> Promoted to the [Founder Kernel](../founder-kernel/wiki/principles/<slug>.md). See the kernel page for the canonical text.`
-- [ ] **Keep** the file's intro and Application section since external readers may have bookmarks. Add a banner at the top: "Canonical principle text lives in the founder kernel."
-- [ ] **Commit:** `doc(architecture): convert principles doc into kernel-pointer stub`.
-
-### Task 3.12: Update manifest counts
-
-**Files:**
-- Modify: `docs/founder-kernel/manifest.json`
-
-- [ ] **Bump** `pageCount` and `sourceCount` to reflect the seeded principles + raw sources.
-- [ ] **Commit:** `doc(founder-kernel): bump manifest after Phase 3 seed`.
-
-### Phase 3 Verification
-
-```powershell
-pnpm --filter @dpf/db exec vitest run src/seed-wiki-kernel.test.ts
-pnpm --filter web exec vitest run lib/wiki/lint lib/wiki/recall.test.ts lib/wiki/principle-recall.test.ts
-pnpm --filter web typecheck
-pnpm --filter web build
-pnpm --filter @dpf/db seed                                        # local seed run
-pnpm --filter web exec vitest run lib/wiki/lint                   # local lint test pass
-```
-
-**UX verification:** in a freshly-rebuilt portal stack, navigate to `/wiki?kind=principle`, confirm all seeded principles appear grouped by tier. Open each detail page, confirm metadata + body render. Open `/admin/wiki/lint`, confirm zero principle findings.
-
-**Exit criteria:**
-- 8 (or 9, or 10) kernel principle pages exist under `docs/founder-kernel/wiki/principles/`.
-- All seeded principles pass lint with zero blocking findings.
-- `ai-coworker-development-principles.md` is now a stub that points to the kernel.
-- Commandment cap is respected: no tier transition crosses 10 commandments.
-
-**PR:** title `doc(principles): batch 3 — seed first principle set`.
-
----
-
-## Phase 4 — AGENTS.md Governance Pointers
-
-**Branch:** `doc/principles-batch-4-agents-md-pointers`
-
-**Objective:** Selectively promote durable principle prose from `AGENTS.md` into the kernel; replace promoted prose with concise pointers. Keep all operational mechanics (command, branch, verification, worktree, MCP-token, local QA) inline so `AGENTS.md` remains usable for coding agents even when MCP/wiki is unavailable.
-
-**Files to modify:**
-
-- `AGENTS.md` (selective promotion + pointers)
-- `docs/founder-kernel/wiki/principles/*.md` (new pages from the promoted prose)
-- `docs/founder-kernel/manifest.json` (count bump)
-
-### Task 4.1: Inventory promotable governance in `AGENTS.md`
-
-This task lands as its OWN small PR before Phase 4's main promotion PR opens, so the inventory can be reviewed and revised without coupling to the promotion work. Branch: `doc/principles-batch-4-inventory`. After it merges, return to the main Phase 4 branch (`doc/principles-batch-4-agents-md-pointers`) and proceed with Task 4.2.
-
-- [ ] **Read** `AGENTS.md` end to end. List candidate principles. The audit on 2026-05-12 surfaced ~16 candidates (see spec §1.1 and Appendix A): Never fabricate, Research and use standards, Fix the seed not the runtime, Live state over seed data, Single source of truth, Architecture over shortcuts, Plan before acting on install/seed/template paths, All changes via PR against main, DCO sign-off, Build Gate verification, Backlog lives in PostgreSQL, Theme-aware styling, Research before designing, Design research required, Data Model Stewardship, Principal convergence.
-- [ ] **Classify** each candidate as commandment-tier, core-tier, contextual-tier, or "keep inline only" (operational). Commit the inventory as `docs/superpowers/audits/2026-05-12-agents-md-principle-inventory.md`.
-- [ ] **Commit and open PR:** `doc(audit): AGENTS.md principle inventory for Batch 4`. Land before Task 4.2.
-
-### Task 4.2: Promote each approved candidate
-
-For each candidate that survives review:
-
-- [ ] **Author** the kernel page at `docs/founder-kernel/wiki/principles/<slug>.md`.
-- [ ] **Source-cite** `AGENTS.md` at the section line range plus any external standard the rule traces to.
-- [ ] **Run seed + lint** locally.
-- [ ] **Replace** the corresponding `AGENTS.md` prose with a one-line pointer: `> Promoted to [<Principle Name>](docs/founder-kernel/wiki/principles/<slug>.md). See the kernel page for rationale.`
-- [ ] **Keep operational instructions inline** even when an associated principle is promoted. Example: "DCO sign-off required" — the principle goes to the kernel, but the literal `git commit -s` instruction stays in `AGENTS.md`.
-- [ ] **Commit per principle:** `doc(principles): promote <name> from AGENTS.md`.
-
-### Task 4.3: Update `AGENTS.md` preamble
-
-**Files:**
-- Modify: `AGENTS.md` (preamble section)
-
-**Gate:** per spec §12.3, this task only runs *after* Phase 2's external MCP visibility test (Task 2.8) has merged and the external `wiki_query` + `principle_decide` tools are confirmed visible to `registry_read` tokens. Adding the pointer before Phase 2 ships would direct agents to a tool they cannot reach.
-
-- [ ] **Verify** Phase 2 has merged by checking `git log origin/main --oneline -- apps/web/lib/wiki/principle-decide.ts` shows the merged commit.
-- [ ] **Add a short pointer paragraph** near the top: "For durable DPF governance principles, query `wiki_query` with `pageKind='principle'` when the MCP connector is available. AGENTS.md remains operationally authoritative when MCP is offline."
-- [ ] **Verify** the file is still usable as a standalone reference for a coding agent without network access.
-- [ ] **Commit:** `doc(agents): add wiki principle discovery pointer`.
-
-### Task 4.4: Bump manifest
-
-- [ ] **Update** `docs/founder-kernel/manifest.json` page count.
-- [ ] **Commit:** `doc(founder-kernel): bump manifest after Batch 4 promotion`.
-
-### Phase 4 Verification
-
-```powershell
-pnpm --filter @dpf/db exec vitest run src/seed-wiki-kernel.test.ts
-pnpm --filter web exec vitest run lib/wiki/lint
-pnpm --filter web typecheck
-pnpm --filter web build
-pnpm --filter @dpf/db seed
-pnpm --filter web exec vitest run lib/wiki/lint
-```
-
-**UX verification:** confirm `AGENTS.md` still reads end-to-end as a working agent guide (no broken pointer-only sections that leave a coding agent without operational instructions).
-
-**Exit criteria:**
-- Only durable governance was promoted; operational mechanics stayed inline.
-- Promoted prose in `AGENTS.md` was replaced with concise pointers, not deleted into a void.
-- Commandment cap is still ≤10 published commandments.
-
-**PR:** title `doc(principles): batch 4 — AGENTS.md selective governance promotion`.
-
----
-
-## Phase 5 — Reviewed Memory Promotion
-
-**Branch:** `doc/principles-batch-5-memory-promotion`
-
-**Objective:** Promote durable, reviewed, product-safe memory entries to the kernel. Rewrite — do not bulk-import — so private/local content stays out. Episodic, runtime, branch, and stale-state notes stay in memory.
-
-**Files to modify:**
-
-- `docs/founder-kernel/wiki/principles/*.md` (new pages)
-- `docs/founder-kernel/manifest.json`
-
-**Files explicitly not modified by this PR:** local/private memory stores. Entries that inspire a kernel principle may be cleaned up later by the founder or the memory owner, but this repository plan never edits local memory paths and never asks an implementation agent to bulk-read a private memory corpus.
-
-### Task 5.1: Author the memory promotion inventory
-
-- [ ] **Start from a reviewed inventory, not a private-path crawl.** Use memory-derived candidate summaries only when the founder provides them in the thread or when an approved memory-export artifact already exists in the repo. If no reviewed inventory exists, stop and create `docs/superpowers/audits/2026-05-12-memory-principle-inventory.md` from the visible discussion and repo evidence; do not require access to a specific local memory path.
-- [ ] **For each candidate**, judge: durable governance (promote) or operational/situational (keep in memory). Use the spec §8 tier criteria and the audit's headcount budget (commandment ≤10, core ~25, contextual unbounded).
-- [ ] **Commit** the inventory as `docs/superpowers/audits/2026-05-12-memory-principle-inventory.md` for review.
-- [ ] **Commit:** `doc(audit): memory principle inventory for Batch 5`.
-
-### Task 5.2: Promote in three sub-batches, in tier order
-
-Per spec §15 Batch 5, this batch lands as three sub-PRs in this strict order so the commandment cap is enforced at the top before lower tiers expand:
-
-1. **Sub-PR 5.2a** — commandment-tier promotions only. Branch: `doc/principles-batch-5a-memory-commandments`. Lands first because the cap of 10 published commandments is a hard gate and any promotion that exceeds it must be reassigned to core during this PR's review.
-2. **Sub-PR 5.2b** — core-tier promotions only. Branch: `doc/principles-batch-5b-memory-core`. Lands second.
-3. **Sub-PR 5.2c** — contextual-tier promotions only. Branch: `doc/principles-batch-5c-memory-contextual`. Lands last.
-
-Each sub-batch follows the same shape:
-
-For each approved candidate:
-
-- [ ] **Author** the kernel page with a rewritten principle body — do not paste the memory entry verbatim. The memory entry was written for the founder; the kernel page is for product readers.
-- [ ] **Source-cite** the rationale via a public-safe or internal-safe `RawSource`. If the rationale came from a private incident, generalize it: "platform incident in early 2026" rather than naming the dated debugging session, local path, or private memory file.
-- [ ] **Run public-safety lint** (Phase 1, Task 1.7) — any local path, memory filename, or internal marker blocks the commit.
-- [ ] **Commit per principle:** `doc(principles): promote <name> from memory`.
-
-### Task 5.3: Update manifest counts
-
-- [ ] **Bump** `docs/founder-kernel/manifest.json`.
-- [ ] **Commit:** `doc(founder-kernel): bump manifest after Batch 5 promotion`.
-
-### Phase 5 Verification
-
-```powershell
-pnpm --filter @dpf/db exec vitest run src/seed-wiki-kernel.test.ts
-pnpm --filter web exec vitest run lib/wiki/lint
-pnpm --filter web typecheck
-pnpm --filter web build
-pnpm --filter @dpf/db seed
-pnpm --filter web exec vitest run lib/wiki/lint
-```
-
-**Manual audit:** read every newly-promoted kernel page front to back. Any sentence that reads like local environment, founder-specific, or branch-specific commentary should be rewritten before the PR opens.
-
-**Exit criteria:**
-- Public-safety lint passes on every promoted page.
-- No raw memory paths, file names, or local markers leak into kernel content.
-- Commandment cap still ≤10.
-- Memory entries not promoted remain in memory as-is.
-
-**PR(s):** up to three: `doc(principles): batch 5 — memory promotion (commandment tier)`, `... (core tier)`, `... (contextual tier)`.
-
----
-
-## Phase 6 — Public Docs Generation
-
-**Branch:** `feat/principles-batch-6-public-docs`
-
-**Objective:** Generate `docs/principles.md` from kernel principle pages for the Jekyll/GitHub Pages public site. Add a script with snapshot-shaped test so drift is caught.
-
-**Files to create:**
-
-- `scripts/generate-public-principles.mjs`
-- `scripts/generate-public-principles.test.mjs`
-- `docs/principles.md` (the generated output, committed to git so the Jekyll build serves it)
-
-**Files to modify:**
-
-- `docs/_config.yml` (add the new page to navigation if the site uses a manifest; otherwise rely on the default `defaults` block)
-- `docs/index.html` and `docs/README.md` (add a link to `/principles/` so visitors can find it)
-- `package.json` at the workspace root (script entry, e.g., `"docs:principles": "node scripts/generate-public-principles.mjs"` and `"test:docs:principles": "node --test scripts/generate-public-principles.test.mjs"`)
-
-### Task 6.1: Generation script
-
-**Files:**
-- Create: `scripts/generate-public-principles.mjs`
-
-The script reads every markdown file under `docs/founder-kernel/wiki/principles/`, filters to those whose frontmatter has `principlePublic: true`, groups by `principleTier` (commandment / core / contextual), and emits a single `docs/principles.md` with:
-
-- Jekyll front matter
-- An intro paragraph explaining what DPF principles are
-- Tiered sections (Commandments → Core → Contextual)
-- For each principle: title, direction (as hero), rule, why, applies-to chips (as plain text since Jekyll renders to HTML), how-to-apply
-- Source citations at the bottom (only the public-safe locators)
-
-- [ ] **Write failing test** for the script with a small fixture directory: input is three principle markdown files (one per tier, all `principlePublic: true`), expected output is a single deterministic `principles.md` matching a stored snapshot.
-- [ ] **Run test, verify it fails.**
-- [ ] **Implement** the script with a small local YAML-frontmatter parser compatible with the subset already documented in `AUTHORING.md` (top-level scalars, inline arrays, block lists, and safe skipping of nested maps the generator does not need). Do not add a new root dependency and do not rely on root-level `tsx`.
-- [ ] **Run test, verify it passes.**
-- [ ] **Run the script** against the real kernel: `pnpm docs:principles`. Commit the resulting `docs/principles.md`.
-- [ ] **Commit:** `feat(docs): generate public principles markdown from kernel`.
-
-### Task 6.2: Snapshot drift detection
-
-**Files:**
-- Modify: `scripts/generate-public-principles.test.mjs`
-
-- [ ] **Write a CI-friendly test** that runs the generator against the real `docs/founder-kernel/wiki/principles/` and asserts the produced output exactly matches the committed `docs/principles.md`. If anyone edits a kernel principle without re-running the script, this test fails — caught before merge.
-- [ ] **Run test, verify it passes** (committed output matches).
-- [ ] **Commit:** `test(docs): public principles snapshot drift detection`.
-
-### Task 6.3: Public-site navigation
-
-**Files:**
-- Modify: `docs/index.html` and `docs/README.md`
-- Modify (if needed): `docs/_config.yml`
-
-- [ ] **Add a link** to the principles page from the docs index. Use the existing site's link style.
-- [ ] **Add a navigation entry** if `_config.yml` uses a manifest list. Otherwise rely on Jekyll's default link discovery from `index.html`.
-- [ ] **Verify locally** with `bundle exec jekyll serve` or the project's documented preview command. Confirm `/principles/` renders.
-- [ ] **Commit:** `doc(site): add public principles to navigation`.
-
-### Task 6.4: Add the generator to the build
-
-**Files:**
-- Modify: `package.json` (root)
-
-- [ ] **Add** a `docs:principles` script entry.
-- [ ] **Add** the same script to the pre-commit or CI gate that's responsible for catching docs drift. If no such gate exists yet, recommend the snapshot test (Task 6.2) as the safety net and document the manual command in `AUTHORING.md`.
-- [ ] **Commit:** `chore(scripts): wire public principles generator into package.json`.
-
-### Phase 6 Verification
-
-```powershell
-pnpm docs:principles
-pnpm test:docs:principles
-pnpm --filter web typecheck
-pnpm --filter web build
-```
-
-**UX verification:** preview the docs site locally (Jekyll or the project's preview command), confirm `/principles/` renders, that internal-only principles are absent, that links from index/README work.
-
-**Exit criteria:**
-- `docs/principles.md` exists, is generated by the script, and matches the snapshot.
-- Only `principlePublic: true` kernel principles appear on the public site.
-- Navigation links exist from `index.html` and `README.md`.
-- Snapshot drift test is in CI.
-
-**PR:** title `feat(principles): batch 6 — public docs generation`.
+**PR title:** `fix(db): guard kernel WikiPage.slug uniqueness when organizationId is NULL`.
 
 ---
 
 ## Post-Implementation Audit
 
-After Phase 6 merges, run a final consolidation pass:
+After Phase A merges:
 
 - [ ] Confirm no durable principle-shaped rule still lives only in `AGENTS.md`, only in local memory, or only in a spec body. Single-source-of-truth check.
 - [ ] Confirm the commandment cap of 10 published kernel commandments is intact.
-- [ ] Confirm `principle_decide` returns non-empty contribution ledgers for at least three real DPF decisions (test cases: "Take the quick patch vs refactor"; "Should we register this connector under contribute mode"; "Should we ship Phase 6 docs gen as a follow-up or now"). Capture the ledgers in `docs/superpowers/audits/2026-MM-DD-principle-decide-audit.md`.
+- [ ] Confirm `principle_decide` returns non-empty contribution ledgers for at least three real DPF decisions (test cases: "quick patch vs refactor"; "connector under contribute mode"; "ship docs gen now vs follow-up"). Capture the ledgers in `docs/superpowers/audits/2026-MM-DD-principle-decide-audit.md`.
 - [ ] Run the wiki lint orchestrator over the full kernel + portal corpus and confirm zero blocking principle findings.
-- [ ] Update `docs/founder-kernel/manifest.json` to a `1.0.0` schema version if `principle` lands as a stable kind.
+- [ ] Confirm the snapshot-drift test caught at least one synthetic kernel edit (manually mutate a kernel principle, expect the test to fail, then revert).
+- [ ] Decide whether `schemaVersion` graduates from `0.3.0` to `1.0.0` based on Phase A stability.
 
 ---
 
@@ -1110,35 +490,39 @@ After Phase 6 merges, run a final consolidation pass:
 
 | Risk | When it surfaces | Response |
 |------|------------------|----------|
-| Phase 2 retrieval is slow against Qdrant | During Phase 2 UX verification | Profile `searchWikiPages` - index the new canonical payload keys (`principleTier`, `principleAppliesTo`, `principlePublic`) if missing. Do not optimize prematurely; if latency is fine, ship. |
-| Phase 3 lint surfaces a contradiction between two seeded principles | During Phase 3 verification | Expected and healthy. `principle-contradiction-review` is `warn`, not `error`. Add a reviewer note explaining the intentional tension; do not silence the detector. |
-| Phase 4 `AGENTS.md` becomes harder to read after pointers replace prose | During Phase 4 verification | Restore the original prose with a pointer paragraph appended ("This rule has been promoted to the kernel as `<name>` — see the kernel page for the canonical version and source citations.") rather than full replacement. Keep readability. |
-| Phase 5 public-safety lint blocks every promoted memory entry | During Phase 5 verification | Slow down. The blocks are correct — memory was authored for the founder. Rewrite each entry in product-facing language and re-run. Do not loosen the lint. |
-| Phase 6 Jekyll build breaks because the generated markdown has YAML edge cases | During Phase 6 UX verification | Add YAML-safe escaping to the generator (quote any value containing colons or hashes). Re-run the snapshot test. |
-| Commandment cap hits 10 before all batches finish | Anywhere | Block the next promotion that would push past 10. Reassign a candidate to core via PR review. Do not raise the cap silently — the cap is the principle. |
+| Back-fill produces a coherence violation on an existing page | Task A.4 / A.12 | Fix the back-fill (adjust archetype or applies-to). Do not loosen lint. |
+| Phase A retrieval is slow against Qdrant | UX verification | Profile `searchWikiPages` — add a GIN index on the new payload keys only if metrics demand it. Don't pre-optimize. |
+| Lint surfaces a contradiction between two existing principles | Task A.12 | Expected and healthy. `principle-contradiction-review` is `warn`. Add a reviewer note explaining the intentional tension. |
+| Public-safety lint blocks an existing principle page after back-fill | Task A.12 | Slow down. Rewrite the principle text in product-facing language. Don't loosen the lint. |
+| Jekyll build breaks because generated markdown has YAML edge cases | Task A.18 | Add YAML-safe escaping to the generator (quote any value containing colons or hashes). Re-run snapshot test. |
+| Commandment cap hits 10 during back-fill | Task A.4 | Reassign a candidate to core via review. Don't raise the cap silently — the cap is the principle. |
+| External MCP visibility test reveals a route gating bug | Task A.11 | Patch the route, not the test. Block the AGENTS.md pointer until verified. |
+| A concurrent session is editing principle pages in another worktree | Any push | The continuous overlap sweep should catch it. If you push first, leave a PR-body note; if they push first, rebase and re-run lint over the merged set. |
 
 ---
 
-## Out of Scope (deferred to follow-up specs)
+## Out of Scope (deferred)
 
-- Dimension registry curation tooling - deferred until Phase 2 proves which dimensions are actually used by seeded principles and decision ledgers.
-- Org-overlay principles UX (`/wiki?kind=principle&org=<id>`) — spec §18 question 4 recommends yes inside the portal; treat as a Phase 6+1 enhancement.
+- Dimension registry curation tooling — defer until decision ledgers show which dimensions are actually used.
+- Org-overlay principle authoring UX (`/wiki?kind=principle&org=<id>`) — spec §11.6 documents the runtime contract; UX is a follow-up spec.
 - `principle_decide` evidence recording for downstream workflows — spec §18 question 6 recommends not in V1.
-- Commandment recall caching layer (if relevant under load) — optimize only if Phase 2 verification shows it's needed.
+- Commandment recall caching layer — optimize only if Phase A verification shows it's needed.
 - Build Studio principle preview during planning — Build Studio integration is its own future spec.
 - AHP / TOPSIS / weighted-product variants of the decision math — spec Appendix B explicitly notes V1 ships weighted-sum only.
+- Migrating `principle_decide` to a tighter advisory grant — owned by the TAK epic (spec §11.5).
 
 ---
 
 ## Plan Review Checklist (run plan-document-reviewer before committing)
 
-- [ ] Every phase has explicit branch name, file lists, TDD-shaped tasks, verification commands, and exit criteria.
-- [ ] No phase relies on another phase's uncommitted output.
+- [ ] Phase A and Phase B both have explicit branch names, file lists, TDD-shaped tasks, verification commands, and exit criteria.
+- [ ] Phase A does not depend on Phase B and vice versa.
 - [ ] Every code change is preceded by a failing test.
 - [ ] Every test command is a workspace-pinned `pnpm --filter` invocation.
-- [ ] Every batch is independently mergeable (no cross-batch dependencies inside a batch).
-- [ ] The commandment cap of 10 is honored across Phases 3–5.
-- [ ] No internal markers, memory paths, or private content can leak through Phases 3–6 (Phase 1 lint blocks it).
-- [ ] `AGENTS.md` remains operationally authoritative after Phase 4.
-- [ ] Public docs render statically from kernel markdown (Phase 6), not from runtime DB.
-- [ ] The plan references the spec's line-numbered current-state truths (§1.1) and does not assume PR #489 content.
+- [ ] Continuous overlap sweep is required before every push, not only at session start.
+- [ ] The commandment cap of 10 is honored.
+- [ ] Public-safety lint passes on every back-filled page.
+- [ ] `AGENTS.md` remains operationally authoritative after Task A.19.
+- [ ] Public docs render statically from kernel markdown (Task A.18), not from runtime DB.
+- [ ] The plan references the spec's re-baselined §1.1 and does not assume any pre-baseline phase exists.
+- [ ] Backlog item / epic ID is recorded in the PR body for Phase A per spec §1.2.

--- a/docs/superpowers/specs/2026-05-09-wiki-visual-navigation-design.md
+++ b/docs/superpowers/specs/2026-05-09-wiki-visual-navigation-design.md
@@ -7,10 +7,11 @@
 | **Builds on** | [EP-WIKI-004 — PPR Retrieval Over the Wiki-Link Graph](2026-05-09-wiki-ppr-retrieval-design.md) (provides the relevance ranking that powers the in-context sidebar and atlas highlight) |
 | **Reuses** | [Phase EA-2 — EA Graph Canvas (2026-03-12, implemented)](2026-03-12-phase-ea2-canvas-design.md) — React Flow + ELK toolchain, custom node/edge patterns |
 | **Reuses** | [EA Reference Value Stream Projection (2026-03-14, implemented)](2026-03-14-ea-reference-value-stream-projection-design.md) — pattern of materializing a normalized model into a visual view |
-| **Status** | Draft (research follow-up) |
+| **Status** | Draft — principle-aware pass applied 2026-05-15 (chief-architect review) |
 | **Created** | 2026-05-09 |
 | **Author** | Mark Bodman + Claude (design partner) |
 | **Inspiration** | Obsidian graph view; Roam Research bidirectional links; Quartz static-site graph; HippoRAG 2 PPR-weighted subgraph visualization |
+| **Related** | [Principles as a Wiki Kind](2026-05-12-principles-as-wiki-kind-design.md) — adds `principle` as the eighth `WikiPageKind` with tier/applies-to/consumer-archetype/dimension-vector metadata. This spec's tier 1 / tier 2 / tier 3 surfaces all need principle-aware behavior, not only the atlas tabs. |
 
 ---
 
@@ -53,7 +54,7 @@ EP-WIKI-005 specifies three surfaces matched to those three needs.
 |------|-------|---------|-------------|
 | **1 — In-context sidebar** | Any product, portfolio, or domain page | Ranked list (no graph) | "What's relevant here?" |
 | **2 — Page-local mini-graph** | Wiki page detail (`/wiki/[slug]`) | Bounded React Flow graph (≤30 nodes) | "How does this page connect?" |
-| **3 — Kernel atlas** | `/wiki` route | Pageable graph with cluster-by-`pageKind`, table view, and search | "What's the shape of the kernel?" |
+| **3 — Kernel atlas** | `/wiki` route | Pageable graph with cluster-by-`pageKind`, principle consumer view, table view, and search | "What's the shape of the kernel?" |
 
 Each tier is independent. The same data (`WikiPage`, `WikiPageLink`, `WikiPageSource`, kernel/overlay flags) feeds all three through different projections. A user never has to leave their primary task to use tier 1; they go to a wiki page for tier 2; they go to `/wiki` for tier 3.
 
@@ -74,12 +75,13 @@ Top 5–7 wiki pages relevant to the current page, queried via `searchByPPR()` (
 
 Each row shows:
 - **Page title** (linked to `/wiki/[slug]`).
-- **`pageKind` chip** — `stance ★`, `heuristic ⬤`, `decision ◆`, `entity ▢`, `summary ▭`, `runbook ▬`, `index ◇`.
+- **`pageKind` chip** — `principle ⬢`, `stance ★`, `heuristic ⬤`, `decision ◆`, `entity ▢`, `summary ▭`, `runbook ▬`, `index ◇`. (Shape registry in §6.1.)
+- **For `principle` rows additionally**: tier badge (Commandment / Core / Contextual) and a small consumer-archetype glyph so the user can tell at a glance whether the rule governs them.
 - **Kernel/overlay badge** — kernel pages carry a small "K" or founder mark; overlay pages are unbadged.
 - **Provenance count** — "3 sources" with hover-card showing the citing `RawSource` titles.
 - **Freshness state** — amber dot if `validation_state ≠ current` per [TAK §12.5](2026-04-25-tak-gaid-auth-identity-memory-refresh-design.md).
 
-`stance` and `heuristic` rows are **always elevated to the top** regardless of PPR score. The kernel exists to surface judgment, and judgment-flavored pages deserve top billing whenever they're at all relevant.
+**Judgment-page elevation, in order:** `principle` rows that match the caller's scope (`principleAppliesTo` + `principleConsumerArchetype` per the principles spec §12.1) come first, ordered Commandment → Core → Contextual. Then `stance` and `heuristic` rows. Then everything else by PPR score. Principle commandments are the kernel's most-load-bearing judgment — they should never be buried by a higher-scoring entity row. Within the principle group, ordering is tier-first then PPR; commandments always show even when their PPR score is below the row cap.
 
 ### 3.2 Where it goes
 
@@ -121,7 +123,9 @@ ELK `layered` direction:
 
 ### 4.3 Visual encoding
 
-Per §6 below. Stance pages render as filled stars; heuristics as filled circles; entities as rectangles; decisions as diamonds; summaries as light rectangles; runbooks as elongated rectangles; indices as open diamonds. Kernel = dark; overlay = accent. Override edges dashed; source-citation chips faint; reflection-derived edges curly (per [EP-WIKI-003](2026-05-09-wiki-importance-and-reflection-design.md)).
+Per §6 below. Principle pages render as filled hexagons; stance pages as filled stars; heuristics as filled circles; entities as rectangles; decisions as diamonds; summaries as light rectangles; runbooks as elongated rectangles; indices as open diamonds. Kernel = dark; overlay = accent. Override edges dashed; source-citation chips faint; reflection-derived edges curly (per [EP-WIKI-003](2026-05-09-wiki-importance-and-reflection-design.md)).
+
+For principle nodes specifically: the hexagon carries an inner glyph for tier (filled = commandment, half-filled = core, hollow = contextual) so commandments read as visually heavier than contextual rules at a glance. Override edges from an overlay principle to its kernel parent are dashed and labeled `overrides` per [Principles as a Wiki Kind §11.6](2026-05-12-principles-as-wiki-kind-design.md).
 
 ### 4.4 Implementation
 
@@ -141,15 +145,19 @@ The dedicated route for kernel maintainers and visual learners. Single page, thr
 
 Force-directed graph with cluster constraints by `pageKind`. Stances cluster together (top), heuristics next, then entities, decisions, summaries, runbooks, indices. Overlay pages render lighter; kernel pages bolder. Override edges visible but de-emphasized so the kernel structure reads first.
 
+For `pageKind=principle`, the atlas exposes two projections. The **default** is the same load-bearing axis as the principle browser (`/wiki?kind=principle` per the principles spec §13.1) — **tier-first**: a Commandment cluster, then a Core cluster, then a Contextual cluster, with consumer-archetype as a filter-chip group above the canvas. The **secondary** projection groups by consumer archetype first (Universal → AI Coworker Universal → Generalist / COO → Specialists → Route / Domain Specific), with route/domain context sub-clusters under the last group; this is the right view when a maintainer is auditing what governs a specific surface (e.g., "what does Build Studio see?"). A toggle at the top of the canvas swaps projections; neither projection should be the only available view.
+
 ### 5.2 Mode B — Pagekind table
 
-Same data, sortable table grouped by `pageKind`. Columns: title, slug, kernel/overlay, source count, last revision, freshness. For list-thinkers and for the cases where the user already knows the slug.
+Same data, sortable table grouped by `pageKind` by default. When filtered to principles, the table groups by **tier first** (Commandment → Core → Contextual) with consumer archetype shown as a filter-chip group above the table and as a sortable column; the same sort toggle from §5.1 flips grouping to CA-first when the user wants a route/domain audit. Columns: title, slug, tier, consumer archetype, applies-to, contexts, kernel/overlay, source count, last revision, freshness. For list-thinkers and for the cases where the user already knows the slug.
 
 ### 5.3 Mode C — Time-travel atlas
 
 Cluster view with a slider at the top exposing the **bi-temporal `asOf`** parameter from [EP-WIKI-002](2026-05-09-wiki-bi-temporal-revisions-design.md). Sliding back shows the kernel as it was at any prior point — pages that didn't exist yet are absent; pages whose `worldValidTo` has passed at the current `asOf` are shown but greyed; revisions reflect the chosen point in system-time.
 
 This is the surface that delivers on the "what did Mark believe in 2024 vs 2026?" promise.
+
+Principle evolution is the most interesting bi-temporal signal on this surface: tier promotions (contextual → core → commandment), retirements, vector rebalances, and overlay/kernel divergence all show as visible changes across the slider range. A "show principle changes only" filter narrows the canvas to `pageKind=principle` so a kernel maintainer can audit "what did our doctrine actually look like a year ago?" without the noise of unrelated entity edits.
 
 ### 5.4 Search integration
 
@@ -186,6 +194,7 @@ Standardized across tiers 2 and 3.
 
 | `pageKind` | Shape | Why |
 |------------|-------|-----|
+| `principle` | Hexagon ⬢ with tier glyph inside | Governance doctrine — heaviest judgment shape; inner glyph carries tier (filled commandment, half-filled core, hollow contextual) |
 | `stance` | Filled star ★ | Judgment kernel — must be visually distinct |
 | `heuristic` | Filled circle ⬤ | Rules of thumb — solid, decisive feel |
 | `entity` | Rectangle ▢ | Neutral concept page |
@@ -193,6 +202,8 @@ Standardized across tiers 2 and 3.
 | `summary` | Light rectangle ▭ | Lower visual weight than entity to discourage summary-only pages |
 | `runbook` | Elongated rectangle ▬ | Procedural feel |
 | `index` | Open diamond ◇ | Table-of-contents pages |
+
+All eight `WikiPageKind` values now have a defined shape. The hexagon is intentionally the visually heaviest because principles outrank every other kind in governance authority.
 
 ### 6.2 Color by kernel/overlay
 
@@ -206,6 +217,13 @@ Standardized across tiers 2 and 3.
 - **Drift detected** (`kernel-drift` lint finding open): amber outline + small ⚠ icon top-right.
 - **Draft** (`status = "draft"`): dashed node border.
 - **Archived** (`status = "archived"`): 50% opacity, grey monochrome.
+
+Principle-specific state outlines (apply only to `pageKind=principle` nodes):
+
+- **Commandment-cap exceeded** (`principle-commandment-cap-exceeded` lint finding open): red outline + ⚠, because the cap of 10 is a doctrinal invariant per [Principles spec §8](2026-05-12-principles-as-wiki-kind-design.md).
+- **Public-safety violation** (`principle-public-unsafe-marker` lint finding open): red outline + 🔒 — page is marked `principlePublic: true` but lint detected a local marker, secret pattern, or internal-only phrase.
+- **Coherence violation** (`principle-incoherent-archetype-applies-to` lint finding open): amber outline + ⚠ — consumer archetype and applies-to combination violates the §8A.1 coherence matrix.
+- **Contradiction under review** (`principle-contradiction-review` lint finding open): amber outline + ⇄ on both contradicting nodes; click expands to a side panel comparing the two `principleDimensionVector` values.
 
 ### 6.4 Edge types
 

--- a/docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md
+++ b/docs/superpowers/specs/2026-05-12-principles-as-wiki-kind-design.md
@@ -2,20 +2,27 @@
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-05-12 |
-| **Status** | Draft (chief-architect review applied) |
+| **Date** | 2026-05-12 (re-baselined 2026-05-15) |
+| **Status** | Draft — re-baselined after chief-architect review against actual worktree state |
 | **Author** | Claude (design partner) for Mark Bodman |
 | **Purpose** | Make DPF's durable operating principles a first-class, citable wiki kind, retrievable by in-platform coworkers and external coding agents, with inspectable advisory decision support. |
 
 ## 0. Chief Architect Review Summary
 
-The direction is right: DPF needs a durable principle layer that is richer than `AGENTS.md`, more governed than local memory, and more retrievable than scattered specs. The original draft also overreached in three places. This pass corrects those before implementation:
+The direction is right: DPF needs a durable principle layer that is richer than `AGENTS.md`, more governed than local memory, and more retrievable than scattered specs. The 2026-05-15 chief-architect review against the live worktree found that **most of the foundation is already shipped** and the spec/plan baseline was materially stale. This revision narrows the scope to the remaining work:
 
-1. **Current truth and future contract are now separated.** In this branch, `KnowledgeArticle` is still live beside `WikiPage`; `WikiPageKind` does not include `principle`; `wiki_query` only filters by `pageKind`; passive recall performs one vector search; and the public docs site is Jekyll/static, not a runtime DB consumer.
-2. **Decision math is advisory, not authority.** Principles do not "resolve mathematically" in the sense of replacing architecture judgment. The tool produces a scored recommendation with a contribution ledger, missing-data warnings, tie handling, and human override path.
-3. **Structured scoring no longer parses prose.** The previous design inferred dimension polarity from `principleDirection` text. That is brittle. This version adds an explicit signed `principleDimensionVector` and treats prose direction as the human-readable statement.
-4. **Public principles are generated from the kernel source, not live DB rows.** The public site under `docs/` is built statically. The single source of truth is the founder-kernel markdown; runtime `WikiPage` rows are seeded projections.
-5. **The UI surface is part of the architecture.** Principles need a compact governance browser, detail pages, public rendering, admin lint, and decision breakdown views. Otherwise they become hidden metadata that agents may or may not use.
+1. **What's done, on the implementation base of this branch.**
+   - `WikiPage.pageKind="principle"` is the eighth supported kind.
+   - `WikiPage` already carries `principleTier`, `principleDirection`, `principleWeight`, `principleWeightRationale`, `principleDimensionVector`, `principleDimensions`, `principleAppliesTo`, `principlePublic`, `principlePublicRationale`, plus indexes on `principleTier` and `principlePublic` — applied via migration `20260513000000_add_principle_fields_to_wikipage`.
+   - `packages/db/src/wiki-taxonomy.ts` is the single source of truth for `WIKI_PAGE_KINDS`, `WIKI_PAGE_STATUSES`, `PRINCIPLE_TIERS`, `PRINCIPLE_APPLIES_TO`, `PRINCIPLE_DIMENSIONS`, `PRINCIPLE_TIER_DEFAULT_WEIGHT`, `PRINCIPLE_TIER_CAPS`, and `PRINCIPLE_DECIDE_DEFAULTS`, with `isWikiPageKind` / `isPrincipleTier` / `isPrincipleAppliesTo` / `isPrincipleDimension` predicates. `wiki-store.ts` imports and re-exports the types.
+   - `docs/founder-kernel/_templates/principle.template.md` exists. `docs/founder-kernel/wiki/principles/` already contains 41 published principle pages — three founder-kernel seed commandments (PR #565), the AI-coworker eight including Principle 9 / Responsible Capacity Utilization (PRs #566, #570), eight commandment-tier promotions from AGENTS.md (PR #579) plus two additional binding commandments (PR #590), fourteen core-tier promotions from AGENTS.md (PR #589), and six contextual-tier promotions from AGENTS.md (PR #592).
+   - `docs/founder-kernel/manifest.json` is on `schemaVersion: 0.2.0`, `kernelVersion: 0.2.1`, `pageCount: 62`, `sourceCount: 11`, with the description naming the principle kind explicitly.
+   - The AI-coworker principles markdown contains Principles 1–9.
+2. **What this spec now owns.** The remaining net-new work is the **consumer-archetype axis** (§8A), the **back-fill of the 41 existing principle pages**, decision support (`principle_decide`), retrieval integration that respects consumer archetype, lint detectors for the new axis plus public safety and coherence, tier-first UI grouping with consumer-archetype filter chips, the kernel-slug uniqueness gap (a separate small refactor PR), and Jekyll public-docs generation.
+3. **Decision math is advisory, not authority.** Principles do not "resolve mathematically" in the sense of replacing architecture judgment. The tool produces a scored recommendation with a contribution ledger, missing-data warnings, tie handling, and human override path. The `Principles as vectors` memory commitment is preserved as a *contribution-aggregation* model, not an authority model.
+4. **Structured scoring does not parse prose.** Polarity is carried by an explicit signed `principleDimensionVector`. Prose `principleDirection` is the human-readable statement.
+5. **Public principles are generated from the kernel source, not live DB rows.** The public site under `docs/` is built statically by Jekyll. The kernel markdown is the single source of truth; runtime `WikiPage` rows are seeded projections; the public site is a generated artifact from the same kernel source.
+6. **The UI surface is part of the architecture.** Principles need a compact governance browser, detail pages, public rendering, admin lint, and decision breakdown views. The browser defaults to **tier-first** ordering (commandments above core above contextual) with consumer-archetype filter chips — tier is what determines weight, lint severity, retrieval injection, and cap enforcement, while consumer archetype is a filter dimension on top of that.
 
 ## 1. Inputs and Current Repo Truth
 
@@ -28,23 +35,37 @@ This design extends:
 - [`AGENTS.md`](../../../AGENTS.md)
 - Live MCP planning context checked on 2026-05-12
 
-### 1.1 Verified Current State
+### 1.1 Verified Current State (re-baselined 2026-05-15)
 
 | Area | Current repo truth | Why it matters |
 |------|--------------------|----------------|
-| Knowledge model migration | `KnowledgeArticle` remains live (`packages/db/prisma/schema.prisma:6402`) and EP-WIKI Phase 1a explicitly says `KnowledgeArticle` stays beside new wiki models until a later PR (`schema.prisma:6469`). | This spec must not assume `KnowledgeArticle` has already been absorbed into `WikiPage`. Principle work is additive unless the wiki migration lands first. |
-| Wiki model | `WikiPage` exists with `pageKind` as a string convention: `entity | summary | decision | runbook | index | stance | heuristic` (`schema.prisma:6500`, `schema.prisma:6505`). | Adding `principle` requires schema docs, TS union, UI labels, seed parsing, query filters, and lint updates. |
-| Wiki type union | `packages/db/src/wiki-store.ts:43` defines `WikiPageKind`; it does not include `principle`. | The type union is the practical enum for authoring and seeding, even though the DB column is a string. |
-| Qdrant wiki search | `searchWikiPages` supports `query`, `organizationId`, optional `pageKind`, `limit`, and `scoreThreshold` (`apps/web/lib/wiki/embeddings.ts:56`). It filters published rows and does overlay-aware two-pass retrieval (`embeddings.ts:139`). | Tier and applies-to filtering are new work. Commandments cannot be "always included" by the current helper without a DB prepass or a dedicated principle recall helper. |
-| Passive recall | `recallWikiContext` performs a single `searchWikiPages` call and formats the result (`apps/web/lib/wiki/recall.ts:70`). | Principle recall needs a new tier-aware assembler, not only a different query string. |
-| In-portal MCP tool | `wiki_query` exists in `PLATFORM_TOOLS` with only `query`, `pageKind`, and `limit` filters (`apps/web/lib/mcp-tools.ts:1971`). Its handler forwards only those fields (`mcp-tools.ts:8431`). | `tier`, `appliesTo`, `principleOnly`, and principle-specific output are new work. |
-| Tool execution modes | `ToolDefinition.executionMode` is only `"proposal" | "immediate"` (`apps/web/lib/mcp-tools.ts:83`). | `principle_decide` must use `executionMode: "immediate"`, `sideEffect: false`, and advisory semantics in the description. `"advisory"` is not a valid execution mode. |
-| External MCP | `/api/mcp/v1` exposes platform tools through JSON-RPC, gates them by token scope, and default-denies tools without grant mappings (`apps/web/app/api/mcp/v1/route.ts:167`). `wiki_query` maps to `registry_read` (`apps/web/lib/tak/agent-grants.ts:67`). | External agents only see principle tools when the tools are in `PLATFORM_TOOLS`, grant-mapped, and the token has the right scope. The spec cannot assume every external session already has them. |
-| Founder kernel schema | `SCHEMA.md` defines seven current page kinds and no `principle` (`docs/founder-kernel/SCHEMA.md:13`). `AUTHORING.md` says the seed walker only scans `raw-sources/` and `wiki/` (`AUTHORING.md:41`). | Principle pages need new schema, templates, folder convention, authoring rules, and seed support. |
-| Founder kernel content | `docs/founder-kernel/manifest.json` currently has `pageCount: 0`, `sourceCount: 0`; `wiki/index.md` says the index is the first kernel page. | The first content-promotion batch is real seeding, not migration of an existing populated kernel. |
-| Public docs site | `docs/_config.yml` is a Jekyll/GitHub Pages config, excludes `superpowers`, and applies default layout to Markdown pages. | `/principles` on the public site should be a generated `docs/principles.md` artifact, not a Next.js route querying runtime Postgres. |
-| AI principles document | In this branch, `ai-coworker-development-principles.md` contains Principles 1-8 and an Application section. PR #489 exists in other branch history, but its capacity-continuity spec and Principle 9 are not present in this branch's HEAD. | Batch 3 must either promote the eight branch-local principles first or explicitly rebase onto PR #489 before claiming nine principles. |
-| Live planning state | MCP `search_specs_and_plans` returned no live matches for this exact principles/wiki spec. Open epic `EP-TAK-3F9A21` covers TAK/GAID refresh with open memory/MCP/observability items (`BI-MEM-5A41C7`, `BI-MCP-7E53D1`, `BI-OBS-4B63F2`). | This work should align with TAK/GAID governed memory and MCP surfaces rather than create an orphan feature epic. |
+| Wiki page kind union | `packages/db/src/wiki-taxonomy.ts` exports `WIKI_PAGE_KINDS` including `principle`. `wiki-store.ts` re-exports the type. The `WikiPage.pageKind` schema comment lists `entity | summary | decision | runbook | index | stance | heuristic | principle`. | The kind is a shipped fact. Net-new code must extend rather than introduce it. |
+| Schema fields | `packages/db/prisma/schema.prisma` `WikiPage` model (lines ~7075–7117) already carries `principleTier`, `principleDirection`, `principleWeight`, `principleWeightRationale`, `principleDimensionVector`, `principleDimensions`, `principleAppliesTo`, `principlePublic`, `principlePublicRationale`, with `@@index([principleTier])` and `@@index([principlePublic])`. Migration `20260513000000_add_principle_fields_to_wikipage` shipped these. | The schema work is done **except for the consumer-archetype axis** (§8A). The remaining migration adds two columns and one index. |
+| Knowledge model migration | `KnowledgeArticle` remains live beside `WikiPage` per EP-WIKI-001 Phase 1a; absorption is owned by a later EP-WIKI migration PR. | Principle work is additive on top of `WikiPage` and does not touch `KnowledgeArticle`. |
+| Taxonomy constants | `wiki-taxonomy.ts` exports `WIKI_PAGE_KINDS`, `WIKI_PAGE_STATUSES`, `PRINCIPLE_TIERS`, `PRINCIPLE_APPLIES_TO`, `PRINCIPLE_DIMENSIONS`, `PRINCIPLE_TIER_DEFAULT_WEIGHT`, `PRINCIPLE_TIER_CAPS`, `PRINCIPLE_DECIDE_DEFAULTS`, plus `isWikiPageKind` / `isWikiPageStatus` / `isPrincipleTier` / `isPrincipleAppliesTo` / `isPrincipleDimension`. | The remaining constants work is `PRINCIPLE_CONSUMER_ARCHETYPES`, `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES`, and the matching `isPrincipleConsumerArchetype` / `isPrincipleConsumerContextSlug` predicates. |
+| Qdrant wiki search | `searchWikiPages` supports `query`, `organizationId`, optional `pageKind`, `limit`, and `scoreThreshold`. Filters published rows and does overlay-aware two-pass retrieval. | Principle-aware filters (`principleTier`, `principleAppliesTo`, `principleConsumerArchetype`, `principleConsumerContext`, `principlePublic`) are not yet wired. Commandments still need a Postgres-first prepass for "always include" semantics. |
+| Passive recall | `recallWikiContext` performs a single `searchWikiPages` call and formats the result. | A principle-aware `recallPrincipleContext` (Postgres-first commandments + Qdrant relevance for core/contextual, filtered by consumer archetype before tier weighting) is still net-new. |
+| In-portal MCP tool | `wiki_query` exists in `PLATFORM_TOOLS` with `query`, `pageKind`, and `limit` filters. | `tier`, `appliesTo`, `consumerArchetype`, `consumerContext`, `publicOnly`, and principle-specific output are still net-new. |
+| Tool execution modes | `ToolDefinition.executionMode` is `"proposal" | "immediate"`. | `principle_decide` must use `executionMode: "immediate"`, `sideEffect: false`, advisory description. `"advisory"` is not a valid execution mode. |
+| External MCP | `/api/mcp/v1` exposes platform tools through JSON-RPC, gates them by token scope, and default-denies tools without grant mappings. `wiki_query` maps to `registry_read`. | `principle_decide` provisionally maps to `registry_read`; see §11.5 on the future case for a tighter advisory-grant. |
+| Founder kernel schema and authoring | `SCHEMA.md` documents the eight page kinds including `principle`. `AUTHORING.md` documents the principle authoring contract and the `wiki/principles/` folder convention. The principle template exists at `docs/founder-kernel/_templates/principle.template.md`. | Schema and authoring docs are shipped. Updates needed: add consumer-archetype frontmatter shape, coherence rule (§8A), and back-fill guidance. |
+| Founder kernel content | `docs/founder-kernel/manifest.json` is on `kernelVersion: 0.2.1`, `schemaVersion: 0.2.0`, `pageCount: 62`, `sourceCount: 11`. `docs/founder-kernel/wiki/principles/` contains 41 published principle pages: founder-kernel seed commandments (PR #565); AI-coworker Principles 1–9 (PRs #566, #570); ten commandment-tier promotions from AGENTS.md (PRs #579, #590); fourteen core-tier promotions from AGENTS.md (PR #589); six contextual-tier promotions from AGENTS.md (PR #592). | Phases that used to seed these pages from scratch are obsolete. The remaining content work is **back-fill** of consumer archetype + contexts onto the 41 existing pages, plus separately-scoped future memory promotions (Batch 5) and public-docs generation (Batch 6) which have **not** shipped on main. |
+| AI principles document | `docs/architecture/ai-coworker-development-principles.md` contains Principles 1–9 including `## Principle 9: Responsible Capacity Utilization`. The capacity-continuity spec `2026-05-12-ai-capacity-continuity-design.md` is present alongside this spec. | Earlier phase plans that branched on "is Principle 9 here?" are obsolete. The pre-check is redundant; the answer is yes. |
+| Public docs site | `docs/_config.yml` is a Jekyll/GitHub Pages config, excludes `superpowers`, and applies default layout to Markdown pages. | `/principles` on the public site is still a generated `docs/principles.md` artifact, not a Next.js route querying runtime Postgres. Public docs generation is still net-new. |
+| Kernel slug uniqueness | `WikiPage` carries `@@unique([organizationId, slug])`, which does not protect kernel rows where `organizationId IS NULL`. | Two kernel rows can currently collide on `slug`. Closing this is a small refactor-budget PR that does not depend on principle work and should ship independently. |
+| Live planning state | The spec links to a backlog item/epic via `Backlog linkage` in §1.2. Implementation PRs MUST cite that ID rather than treating this work as orphan. | Per the *Verify substrate before proposing new substrate* and *Continuous overlap sweep* feedback, this work must be tied to live planning state before any PR opens. |
+
+### 1.2 Backlog Linkage and Discoverability
+
+Established practice on this substrate is that principle PRs ship via PR alone — the shipped batches (#531, #538, #542/#564, #565, #566, #570, #579, #589, #590, #592) cite no `BI-*` IDs and rely on the PR title + body for discoverability. This spec respects that pattern: a `BI-*` ID is recommended but not strictly required.
+
+What IS required:
+
+1. Before opening the PR, run `mcp__dpf__search_specs_and_plans` for "principles wiki kind consumer archetype" and `mcp__dpf__list_epics` for open epics — record matches in the PR body.
+2. If an existing epic fits (likely `EP-TAK-3F9A21` for governed memory + MCP grants, or `EP-DOCS-6B9F2A` for the public-docs Jekyll piece), attach the PR to it via the PR body. If no epic fits cleanly, the PR body must include a self-contained "Why this exists" paragraph so the work is discoverable from PR search alone.
+3. The PR title MUST name the substantive change (e.g., `feat(principles): consumer archetypes, advisory decision support, retrieval, lint, UI, public docs`) — never a generic `feat(wiki): updates`.
+
+This loosens the earlier "MUST create or attach a backlog item" framing because the actual practice across the shipped batches shows the PR + merge history is the source of truth for principle work, not the backlog table.
 
 ## 2. Research and Benchmarking
 
@@ -199,36 +220,97 @@ Tier inflation is the primary governance failure mode. A commandment requires:
 
 `situational` is intentionally not a wiki tier. Situational notes stay in memory, backlog comments, execution evidence, or dated specs.
 
+## 8A. Consumer Archetype Taxonomy
+
+Tier answers "how strongly should this govern a decision?" It does not answer "who is expected to consume this?" The portal and retrieval paths need a second axis so humans reviewing the wiki and AI coworkers retrieving context do not see Build Studio-specific, specialist-specific, or route-bound material mixed into universal guidance.
+
+Add a principle consumer archetype:
+
+| Consumer archetype | Meaning | Default portal placement | Runtime retrieval posture |
+|--------------------|---------|--------------------------|---------------------------|
+| `universal` | Applies to humans and AI anywhere in DPF. | Universal | Always eligible when `principleAppliesTo` matches the caller. |
+| `ai-coworker-universal` | Applies to all in-platform AI coworkers, regardless of route. | AI Coworker Universal | Eligible for all AI coworker recall; visible to humans reviewing AI governance. |
+| `generalist` | Applies to generalist/orchestrator coworkers such as the COO, especially when coordinating or escalating work. | Generalist / COO | Eligible for generalist agents and coordinator routes; not injected into specialist-only recall by default. |
+| `specialist` | Applies to specialist coworkers as a class. | Specialists | Eligible for specialist agents before route-specific rules are considered. |
+| `route-domain-specific` | Applies only inside a named product surface, route, domain, or workflow. Build Studio principles live here unless they truly apply everywhere. | Route / Domain Specific, grouped by context such as Build Studio | Eligible only when the caller's route/domain context matches, or when the query explicitly asks for that context. |
+
+Use `principleConsumerContexts` for the specific route/domain labels behind `route-domain-specific`, such as `build-studio`, `marketing`, `compliance`, `discovery`, `finance`, `storefront`, or `portfolio`. These are governed slug strings, not a closed enum; route-facing lint can compare them against `apps/web/lib/tak/route-context-map.ts` where a route context exists. A route-specific principle without at least one context is a lint error. Context labels are for consumption routing and human review; they do not create new wiki pages.
+
+### 8A.1 Coherence Matrix (consumer archetype × applies-to)
+
+The two axes are independent in the schema but not in semantics. The coherence rule below is enforced by `principle-incoherent-archetype-applies-to` lint (§14):
+
+| Consumer archetype \ `principleAppliesTo` | `in_platform_coworker` | `external_coding_agent` | `human` |
+|---|---|---|---|
+| `universal` | required (with at least one of external or human) | required (with at least one of in-platform or human) | required (with at least one of in-platform or external) |
+| `ai-coworker-universal` | ✅ valid | ✅ valid | ❌ incoherent — humans are not AI coworkers |
+| `generalist` | ✅ valid | ✅ valid (treats Claude Code, Codex CLI, and similar broad agents as generalists) | ❌ incoherent — "generalist" denotes a generalist agent, not a human role |
+| `specialist` | ✅ valid | ⚠️ rare but valid only when the principle scopes a specialist external agent (e.g., a single-purpose CI bot); lint warns and asks for `principleWeightRationale` | ❌ incoherent |
+| `route-domain-specific` | ✅ valid (most Build Studio coworker rules live here) | ✅ valid (route-specific external-agent rules) | ✅ valid (humans operating inside a specific product surface — e.g., a Storefront-specific human policy) |
+
+Rules:
+
+- `universal` requires at least two `principleAppliesTo` populations. Otherwise it is not universal and should be tightened to `ai-coworker-universal`, `generalist`, `specialist`, or `route-domain-specific`.
+- `ai-coworker-universal`, `generalist`, and `specialist` MUST NOT include `human` in `principleAppliesTo`. These archetypes describe agent classes.
+- `route-domain-specific` MAY include `human`, since route/domain governance often binds humans operating inside that route.
+- `specialist` + `external_coding_agent` is rare (most external agents are generalists). Lint downgrades this to a `warn` and requires `principleWeightRationale` to explain the specialist scope.
+
+Back-fill of the 41 existing principle pages MUST apply this matrix. Lint blocks publish on incoherent combinations.
+
 ## 9. Schema Extension
 
-Add principle-only fields to `WikiPage`. These are nullable or defaulted so existing page kinds are unaffected.
+### 9.1 What is already in the schema
+
+The first principle migration (`20260513000000_add_principle_fields_to_wikipage`) is already applied on this branch. The following fields are live on `WikiPage`:
 
 ```prisma
-model WikiPage {
-  // existing fields...
-
-  principleTier             String?   // commandment | core | contextual
-  principleDirection        String?   @db.Text
-  principleWeight           Float?
-  principleWeightRationale  String?   @db.Text
-  principleDimensionVector  Json?     // Record<dimension, signed weight -1..1>
-  principleDimensions       String[]  @default([]) // derived keys for query/filter/display
-  principleAppliesTo        String[]  @default([]) // in_platform_coworker | external_coding_agent | human
-  principlePublic           Boolean   @default(false)
-  principlePublicRationale  String?   @db.Text
+  principleTier            String?   // commandment | core | contextual
+  principleDirection       String?   @db.Text
+  principleWeight          Float?
+  principleWeightRationale String?   @db.Text
+  principleDimensionVector Json?     // Record<dimension, signed weight -1..1>
+  principleDimensions      String[]  @default([])
+  principleAppliesTo       String[]  @default([])
+  principlePublic          Boolean   @default(false)
+  principlePublicRationale String?   @db.Text
 
   @@index([principleTier])
   @@index([principlePublic])
-}
+```
+
+### 9.2 What this spec still adds (the only remaining schema delta)
+
+Two columns and one index for the consumer-archetype axis:
+
+```prisma
+  principleConsumerArchetype String?  // universal | ai-coworker-universal | generalist | specialist | route-domain-specific
+  principleConsumerContexts  String[] @default([]) // route/domain labels such as build-studio
+
+  @@index([principleConsumerArchetype])
 ```
 
 Notes:
 
-- `principleDimensions` and `principleAppliesTo` default to empty arrays so the migration applies cleanly to existing rows.
-- `principleDimensionVector` is JSON because Prisma cannot express a typed sparse vector map in the schema. Its keys must be validated against the registry.
-- Do not add a normal Prisma index on array containment in V1. If applies-to filtering becomes hot, add a hand-written Postgres GIN index in a later migration.
-- `principlePublic=false` by default. Public exposure is a deliberate promotion decision, not a tier default.
-- Canonical string values live in a small typed module, for example `packages/db/src/wiki-principles.ts`, and are imported by seed, lint, MCP schemas, and UI.
+- The two new fields default to nullable / empty array so the migration applies cleanly to the 41 existing principle rows. Back-fill happens via kernel-markdown frontmatter edits + re-seed, not via DML in the migration.
+- `principleDimensionVector` remains JSON because Prisma cannot express a typed sparse vector map in the schema. Its keys are validated against `PRINCIPLE_DIMENSIONS` by seed parsing and lint.
+- No Prisma GIN index on array containment in V1. If `principleAppliesTo` or `principleConsumerContexts` filtering becomes hot, add a hand-written Postgres GIN index in a later migration with metrics evidence.
+- Canonical consumer-archetype string values live in `packages/db/src/wiki-taxonomy.ts` (added by this spec) and are imported by seed, lint, MCP schemas, retrieval, and UI. Consumer contexts use a shared slug-normalization helper rather than a closed enum.
+
+### 9.3 Adjacent refactor — kernel slug uniqueness gap (separate small PR)
+
+While reading the wiki schema, the chief-architect review surfaced a uniqueness gap that is **not principle-specific** and should not be coupled to this work:
+
+`WikiPage` carries `@@unique([organizationId, slug])`. In Postgres, a unique index over a nullable column treats `NULL` values as distinct — so two kernel rows (`organizationId IS NULL`) can be inserted with the same `slug`. This is a real wiki-platform correctness gap that affects all eight page kinds, not only principles.
+
+Closing this requires a hand-written partial unique index:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS "WikiPage_kernel_slug_key"
+  ON "WikiPage"("slug")
+  WHERE "organizationId" IS NULL;
+```
+
+This ships as its own small PR titled `fix(db): guard kernel WikiPage.slug uniqueness when organizationId is NULL` and is not blocked by, nor blocks, principle work. The plan calls it out as a refactor-budget item.
 
 ## 10. Dimension Registry
 
@@ -295,8 +377,24 @@ Tool metadata:
 - `executionMode: "immediate"`
 - `sideEffect: false`
 - annotations: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`
-- grant: `registry_read`
+- grant: `registry_read` (provisional — see §11.5)
 - response semantics: advisory only
+
+### 11.5 Grant-mapping is provisional
+
+Mapping `principle_decide` to `registry_read` is the right starting point — it inherits an existing scope, requires no new TAK governance surface, and matches the read-only behavior of the tool. But `principle_decide` is decision support, not registry read. A future TAK/GAID refresh (already tracked under the TAK epic referenced by §1.2) may introduce a tighter scope such as `principle_advisory_read` to distinguish "see the principle catalog" from "score options against the catalog." When that refinement lands, `principle_decide` migrates to the tighter scope. Until then, the read-only and side-effect-free annotations are load-bearing.
+
+### 11.6 Org overlay contract
+
+Mark's `Single org per install (no multi-tenancy)` posture means overlay risk is low in practice today, but the underlying data model is multi-tenant via `WikiPage.kernelPageId`. The contract:
+
+- **Retrieval.** `recallPrincipleContext` for a caller in org `X` returns:
+  1. Overlay principles published by org `X` that match scope (always, when `principleTier="commandment"`; subject to Qdrant ranking otherwise).
+  2. Kernel principles NOT shadowed by an org-`X` overlay (matched by `kernelPageId` reference).
+  3. For other orgs, only the kernel set is returned. Overlay rows are org-scoped.
+- **Cap.** The kernel commandment cap of 10 is global to the kernel. Each org carries its own cap (default 10) over its own overlay commandments. Lint enforces both.
+- **Ledger.** `principle_decide` contribution ledger rows include `source: "kernel"` or `source: "overlay:<orgId>"` and, when the row is an overlay, `overrides: "<kernel-slug>"` if applicable. Reviewers can see exactly which principle voted.
+- **Public docs.** `docs/principles.md` is generated from kernel principles only. Overlay principles are never written to the public site.
 
 ### 11.2 Retrieval Procedure
 
@@ -358,13 +456,15 @@ The output should explain that Option B wins because the strongest commandments 
 
 ### 12.1 Passive Recall
 
-Add a principle-aware recall helper rather than overloading the current single-search `recallWikiContext`:
+Add a principle-aware recall helper rather than overloading the current single-search `recallWikiContext`. Lint detectors that depend on Qdrant similarity (`principle-duplicate`, `principle-contradiction-review`) run **after** seed completes; on a cold start without Qdrant content they degrade to no-op and emit an `info`-level finding rather than failing the orchestrator. Lint must remain usable before any embedding exists.
 
 ```typescript
 recallPrincipleContext({
   query,
   organizationId,
   callingPopulation,
+  consumerArchetype,
+  consumerContext,
   limit,
 })
 ```
@@ -374,6 +474,8 @@ It should:
 - inject all in-scope commandments, capped at 10
 - add top relevant core principles, default 5
 - add contextual principles only above a higher threshold, default 0.75
+- filter by consumer archetype before tier weighting: universal first, then caller-specific archetypes, then matching route/domain contexts
+- exclude `route-domain-specific` principles unless `consumerContext` matches or the query explicitly asks for that route/domain
 - format principles separately from ordinary wiki context so system prompts can distinguish governance from background knowledge
 - silently degrade like existing wiki recall if Qdrant is down, but still include commandments from Postgres when DB is available
 
@@ -387,12 +489,14 @@ Extend both in-portal and external MCP tool schema:
   pageKind?: "entity" | "summary" | "decision" | "runbook" | "index" | "stance" | "heuristic" | "principle";
   tier?: "commandment" | "core" | "contextual";
   appliesTo?: "in_platform_coworker" | "external_coding_agent" | "human";
+  consumerArchetype?: "universal" | "ai-coworker-universal" | "generalist" | "specialist" | "route-domain-specific";
+  consumerContext?: string;
   publicOnly?: boolean;
   limit?: number;
 }
 ```
 
-When `pageKind="principle"`, the response should include principle metadata, not only slug/kind/title. For external MCP, verify the tool appears in `/api/mcp/v1` `tools/list` for tokens with `registry_read`.
+When `pageKind="principle"`, the response should include principle metadata, not only slug/kind/title. The metadata includes tier, applies-to, consumer archetype, consumer contexts, public/internal state, and direction. For external MCP, verify the tool appears in `/api/mcp/v1` `tools/list` for tokens with `registry_read`.
 
 ### 12.3 AGENTS.md Discovery
 
@@ -406,11 +510,14 @@ Update `AGENTS.md` only after the external MCP/tooling slice lands:
 
 ### 13.1 Portal Principle Browser
 
-The existing `/wiki` list is a good base, but principle pages need richer scan behavior:
+The existing `/wiki` list is a good base, but principle pages need a governance-first organization. Do not create duplicate wiki pages to solve this; organize the same pages.
 
-- Add a `Principles` tab or `/wiki?kind=principle` filter that groups by tier: Commandments, Core, Contextual.
-- Show compact rows, not large cards: tier badge, title, direction, applies-to chips, public/internal state, source count, last reviewed date.
-- Use DPF tokens only: `text-[var(--dpf-text)]`, `text-[var(--dpf-muted)]`, `bg-[var(--dpf-surface-1)]`, `bg-[var(--dpf-surface-2)]`, `border-[var(--dpf-border)]`, `text-[var(--dpf-accent)]`.
+- The default grouping for `/wiki?kind=principle` is **tier-first**: Commandments → Core → Contextual. Tier is what determines weight, lint severity, retrieval injection, and cap enforcement, so tier is the load-bearing view of governance hierarchy.
+- Consumer archetype is a **filter-chip group** above the list: Universal, AI Coworker Universal, Generalist / COO, Specialists, Route / Domain Specific. Multi-select; default is all-selected. A secondary sort toggle lets a user flip the grouping to **CA-first** when they want a route/domain audit (e.g., "show me everything Build Studio coworkers see").
+- Route / Domain Specific rows show their `principleConsumerContexts` as chips. When the CA filter narrows to Route / Domain Specific, rows further sub-group by context (Build Studio, Marketing, Compliance, …).
+- Compact rows (not large cards): tier badge, title, direction, applies-to chips, consumer archetype chip, route/domain context chips, public/internal state, source count, last reviewed date.
+- `pageKind` is a secondary filter (and a small badge per row). It must not be the primary human-review organization when the user is already inside the principle browser.
+- Use DPF tokens only: `text-[var(--dpf-text)]`, `text-[var(--dpf-muted)]`, `bg-[var(--dpf-surface-1)]`, `bg-[var(--dpf-surface-2)]`, `border-[var(--dpf-border)]`, `text-[var(--dpf-accent)]`. No hardcoded colors.
 - Add a dimension mini-strip using labels and accessible text. Do not rely on color alone.
 - Keep row heights stable; badges and long principle names must wrap without resizing adjacent controls.
 
@@ -457,6 +564,9 @@ Use existing `WikiLintFinding.findingKind` and severity values (`info`, `warn`, 
 | `principle-unknown-dimension` | error | yes | Vector or dimensions include a key outside registry |
 | `principle-vector-dimension-mismatch` | warn | no | `principleDimensions` does not match vector keys |
 | `principle-missing-applies-to` | error | yes | Empty `principleAppliesTo` |
+| `principle-missing-consumer-archetype` | error | yes | Empty or unknown `principleConsumerArchetype` |
+| `principle-route-context-missing` | error | yes | `route-domain-specific` without at least one `principleConsumerContexts` entry |
+| `principle-incoherent-archetype-applies-to` | error / warn | yes for error rows | Violates §8A.1 coherence matrix: `human` paired with `ai-coworker-universal` / `generalist` / `specialist` = `error`; `specialist` + `external_coding_agent` without `principleWeightRationale` = `warn` with required rationale; `universal` with fewer than two `principleAppliesTo` populations = `error` |
 | `principle-tier-weight-mismatch` | warn | no | Weight differs from tier default without rationale |
 | `principle-commandment-cap-exceeded` | error | yes | More than 10 published kernel commandments |
 | `principle-public-missing-rationale` | warn | no | `principlePublic=true` without `principlePublicRationale` |
@@ -468,70 +578,36 @@ The contradiction lint does not auto-resolve. Contradictions can be legitimate; 
 
 ## 15. Migration and Delivery Plan
 
-Each batch should be a separate PR. Branch from current `main` and rebase this spec branch before implementation because the capacity-continuity PR exists outside this branch's HEAD.
+Earlier revisions of this spec described seven sequential batches starting from scratch. After the 2026-05-15 re-baseline, most of that work is already shipped. The remaining delivery is **one focused phase** (consumer-archetype axis + back-fill + decision support + retrieval + lint + UI + public-docs generator) and **two adjacent small PRs** (kernel-slug uniqueness fix; `principle_decide` advisory tool if it cannot fit cleanly in the main PR).
 
-### Batch 0 - Schema, Constants, and Authoring Contract
+The detailed implementation plan lives in [`2026-05-12-principles-as-wiki-kind.md`](../plans/2026-05-12-principles-as-wiki-kind.md). The summary below is intentionally short — read the plan for tasks, files, and verification commands.
 
-- Add principle fields to `WikiPage`.
-- Add `principle` to `WikiPageKind`.
-- Add canonical constants for tiers, applies-to values, dimensions, and defaults.
-- Update `SCHEMA.md`, `AUTHORING.md`, templates, seed frontmatter parsing, and manifest schema version.
-- Update `WikiPageKindBadge`, `WikiPageList`, `WikiPageViewer` to render principle metadata.
-- Tests: `packages/db/src/wiki-store.test.ts`, `packages/db/src/seed-wiki-kernel.test.ts`, wiki component tests where present.
+### Phase A — Consumer-archetype axis and back-fill (main PR)
 
-### Batch 1 - Principle Lint and Public Safety
+- **Schema.** Add `principleConsumerArchetype String?` and `principleConsumerContexts String[] @default([])` to `WikiPage`. Add `@@index([principleConsumerArchetype])`. New migration `<timestamp>_add_principle_consumer_archetype_to_wikipage`.
+- **Taxonomy constants.** Extend `wiki-taxonomy.ts` with `PRINCIPLE_CONSUMER_ARCHETYPES`, `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES`, `isPrincipleConsumerArchetype`, `isPrincipleConsumerContextSlug`. Existing constants stay.
+- **Seed parsing.** Extend `seed-wiki-kernel.ts` to parse `principleConsumerArchetype` and `principleConsumerContexts` from frontmatter. Validate via the new predicates; reject `route-domain-specific` without at least one context.
+- **Back-fill.** Edit the 41 existing principle pages under `docs/founder-kernel/wiki/principles/` to add `principleConsumerArchetype` and (where applicable) `principleConsumerContexts` frontmatter. Defaults per §8A.1 coherence matrix; Build Studio principles use `route-domain-specific` + `[build-studio]`. Re-seed verifies the back-fill.
+- **Qdrant payload.** Extend the wiki-page payload write helper so principle pages also carry `principleConsumerArchetype` and `principleConsumerContexts`. Non-principle pages are unchanged.
+- **Retrieval.** Add `recallPrincipleContext` (Postgres-first commandments + Qdrant relevance for core/contextual) with consumer-archetype filtering ahead of tier weighting. Wire it into `recallWikiContext`. Pass route/domain context through.
+- **MCP.** Extend `wiki_query` schema with `tier`, `appliesTo`, `consumerArchetype`, `consumerContext`, `publicOnly`. Update the handler to forward to `searchWikiPages`. Add `principle_decide` (executionMode: immediate, sideEffect: false, advisory). Map to `registry_read` (see §11.5).
+- **Lint.** Add the principle detectors per §14 (tier/direction/vector/applies-to/consumer-archetype/route-context/incoherent-archetype-applies-to/tier-weight-mismatch/commandment-cap/public-rationale/public-unsafe/duplicate/contradiction). Detectors that depend on Qdrant degrade to no-op + info finding on cold start (§12.1).
+- **UI.** Principle browser at `/wiki?kind=principle`: tier-first default grouping, CA filter chips, contextual sub-grouping for Route / Domain Specific (§13.1). Principle detail page metadata panel (§13.2). Decision breakdown view for `principle_decide` results (§13.3).
+- **AGENTS.md pointer.** Add the short `wiki_query pageKind='principle'` discovery line after external MCP visibility is verified.
+- **Visual-nav spec.** Update [`2026-05-09-wiki-visual-navigation-design.md`](2026-05-09-wiki-visual-navigation-design.md) for principle awareness in Tier 1 (sidebar), Tier 2 (mini-graph node shape), Tier 3 (atlas grouping), §6.1 (shape), §6.3 (state outlines).
+- **Public docs generation.** `scripts/generate-public-principles.mjs` reads kernel principle markdown with `principlePublic: true`, generates `docs/principles.md` grouped by tier, with snapshot-drift test. Link from `docs/index.html` and `docs/README.md`.
 
-- Add principle lint detectors and tests.
-- Add public-safety detection for local/private/internal markers.
-- Extend `/admin/wiki/lint` filters so principle findings are easy to isolate.
-- Add fixture pages for valid/invalid principle cases.
+### Phase B — Adjacent refactor-budget PR (independent)
 
-### Batch 2 - Retrieval and MCP Tools
+`fix(db): guard kernel WikiPage.slug uniqueness when organizationId is NULL` — adds the partial unique index per §9.3. Not coupled to Phase A; can land before, alongside, or after.
 
-- Add `recallPrincipleContext`.
-- Extend `searchWikiPages` or add `searchPrinciples`.
-- Extend `wiki_query` filters and results.
-- Add `principle_decide`.
-- Ensure `/api/mcp/v1` tools/list exposes the new/extended tools for `registry_read` tokens.
-- Tests: `apps/web/lib/wiki/recall.test.ts`, `apps/web/lib/wiki/embeddings.test.ts`, `apps/web/lib/mcp-tools-wiki-query.test.ts`, new `mcp-tools-principle-decide.test.ts`, and `/api/mcp/v1` route tests if the tool visibility contract changes.
+### Phase C — Future durable-promotion follow-ups (out of scope here)
 
-### Batch 3 - Seed the First Principle Set
+The 41 existing principle pages cover most of the AI-coworker, AGENTS.md, and first-slice memory promotions. Any further memory promotions are out of scope for this spec; they ship through normal kernel authoring PRs against the existing `principle` kind, with the same lint and review discipline.
 
-Scope depends on branch base:
+### Phase D — Future grant-mapping refinement (tracked under TAK epic)
 
-- If PR #489/capacity continuity is present after rebase: promote Principles 1-9 plus the approved capacity principle.
-- If not: promote the eight branch-local AI coworker principles first and leave capacity/proactivity as follow-up content.
-
-For each principle:
-
-- author a kernel markdown page under `docs/founder-kernel/wiki/principles/`
-- create or cite public-safe raw sources
-- assign tier, direction, vector, applies-to, public flag, and public rationale
-- run seed and lint
-
-Do not bulk move `AGENTS.md` in this batch.
-
-### Batch 4 - AGENTS.md Governance Pointers
-
-- Identify durable principle prose in `AGENTS.md`.
-- Promote only durable governance, not local operational mechanics.
-- Replace duplicated prose with short pointers where safe.
-- Keep command, branch, verification, worktree, MCP-token, and local QA instructions inline.
-- Add the `wiki_query pageKind='principle'` pointer after MCP tooling is verified.
-
-### Batch 5 - Reviewed Memory Promotion
-
-- Inventory candidate memory-derived principles.
-- Classify as commandment/core/contextual/situational.
-- Promote only reviewed, durable, product-safe principles.
-- Rewrite private memory as authored principles with sources and rationale; do not cite local memory paths in public content.
-- Leave episodic, runtime, branch, and stale-state notes in memory.
-
-### Batch 6 - Public Docs Generation
-
-- Add a script to generate `docs/principles.md` from public kernel principle pages.
-- Add public docs navigation links.
-- Add a doc-generation test or snapshot check to catch drift.
+When TAK/GAID adds a tighter advisory scope (e.g., `principle_advisory_read`), migrate `principle_decide` from `registry_read`. Owned by the TAK epic referenced in §1.2, not by this spec.
 
 ## 16. Verification Plan
 
@@ -548,6 +624,7 @@ pnpm --filter web build
 For UI changes:
 
 - Verify `/wiki`, `/wiki?kind=principle`, a principle detail page, and `/admin/wiki/lint` against the rebuilt Docker-served portal.
+- Verify `/wiki?kind=principle` groups by consumer archetype first and tier second, with Build Studio material isolated under Route / Domain Specific > Build Studio.
 - Verify theme tokens in light and dark mode.
 - Verify long principle names, long dimension labels, and empty-state copy do not overflow.
 - Verify public `docs/principles.md` renders under the Jekyll layout.
@@ -564,14 +641,18 @@ For MCP:
 |------|----------|------------|
 | Principle inflation | High | Hard cap on commandments; lint gate; PR review for tier changes. |
 | Math is trusted as authority | High | Tool is read-only/immediate/advisory; output includes warnings; no execute button; TAK/HITL remains authoritative. |
+| Back-fill produces incoherent archetype/applies-to combos on the 41 existing pages | High | §8A.1 coherence matrix + `principle-incoherent-archetype-applies-to` lint runs against every back-filled page before the migration PR opens. |
 | Prose/vector drift | Medium | Lint checks that dimension keys and prose direction are present; reviewer must approve vector changes. |
-| Public docs drift from runtime | Medium | Generate public docs from kernel markdown, then seed runtime from the same source. |
+| Public docs drift from runtime | Medium | Generate public docs from kernel markdown, then seed runtime from the same source; snapshot-drift test gates CI. |
 | Local memory leaks into product docs | High | No raw memory import; review/redact/rewrite; public-safety lint blocks local paths and private markers. |
-| External agents cannot see principles | High | Extend external MCP `tools/list`; add `AGENTS.md` pointer only after verified; keep core operational rules inline. |
-| Current branch lacks PR #489 content | Medium | Rebase before implementation or scope Batch 3 to eight branch-local principles. |
+| External agents cannot see principles | High | Extend external MCP `tools/list`; add `AGENTS.md` pointer only after visibility is verified; keep core operational rules inline. |
+| `principle_decide` grant is too broad | Medium | `registry_read` is provisional per §11.5; tighter advisory scope tracked under TAK epic; tool stays read-only, sideEffect:false. |
+| Org overlay overrides a kernel commandment in surprising ways | Low today (single-org-per-install) / Medium long-term | §11.6 documents the contract: overlay commandments are scoped to the org, do not count toward the kernel cap of 10, override by `kernelPageId` reference; ledger labels overlay-sourced contributions as such. |
+| Lint blocked on cold start because Qdrant has no embeddings yet | Medium | `principle-duplicate` and `principle-contradiction-review` degrade to no-op + info finding when Qdrant returns empty; per §12.1, lint must work before seed completes. |
 | `KnowledgeArticle` migration collision | Medium | Principle work is additive; do not alter `KnowledgeArticle` unless EP-WIKI migration PR owns it. |
-| Query performance for applies-to arrays | Low in V1 | Start without GIN index; add hand-written index if metrics show need. |
+| Query performance for applies-to / consumer-contexts arrays | Low in V1 | Start without GIN index; add hand-written index if metrics show need. |
 | UI becomes decorative instead of operational | Medium | Compact rows, contribution ledger, filters, source count, and last-reviewed signals are required acceptance criteria. |
+| Concurrent worktrees ship overlapping principle changes | Medium | Per `Continuous overlap sweep` feedback, Phase A preflight includes a recent-main `git log` + `gh pr list --state open` sweep before push; re-sweep before every push, not just at session start. |
 
 ## 18. Open Questions with Recommendations
 
@@ -585,21 +666,28 @@ For MCP:
    Recommendation: public pages should speak as DPF doctrine. Internal pages can reference Mark/local-agent details; public pages should not.
 
 4. **Should org overlays have their own principles?**  
-   Recommendation: yes inside the portal, using the existing overlay mechanism. Public docs remain kernel-only.
+   Resolved: yes inside the portal, using the existing overlay mechanism (`WikiPage.kernelPageId`). Mark's `Single org per install (no multi-tenancy)` posture means this is low-risk in practice today, but the data model is multi-tenant and the contract needs to be explicit:
+   - Overlay principles are scoped to the org and DO NOT count toward the kernel commandment cap of 10. Each org may carry its own commandment set up to its own cap (default 10; per-org overrides via configuration).
+   - When an overlay overrides a kernel principle, `recallPrincipleContext` returns the overlay row only for callers in that org; the kernel row is returned for everyone else.
+   - The `principle_decide` contribution ledger labels overlay-sourced contributions with their org and the kernel page they override (if any), so reviewers can see exactly which principle voted.
+   - Public docs (`docs/principles.md`) remain kernel-only. Overlay principles are never published to the public site.
 
 5. **Should commandment recall bypass Qdrant?**  
-   Recommendation: yes. Use Postgres for in-scope commandments, then Qdrant for relevance-ranked core/contextual principles.
+   Recommendation: yes. Use Postgres for in-scope commandments, then Qdrant for relevance-ranked core/contextual principles. See §12.1 for the cold-start contract.
 
 6. **Should `principle_decide` record evidence?**  
    Recommendation: not in V1. Tool execution logging already captures calls. Add explicit evidence recording only when a downstream workflow consumes decisions as artifacts.
+
+7. **Should the `/wiki?kind=principle` browser default to tier-first or consumer-archetype-first ordering?**  
+   Resolved (re-baseline 2026-05-15): tier-first by default. Tier is what determines weight, lint severity, retrieval injection, and cap enforcement, so the load-bearing governance axis comes first. CA is exposed as a filter-chip group above the list with a sort toggle for CA-first viewing. See §13.1.
 
 ## 19. Success Criteria
 
 - `principle` is accepted by seed, DB, UI, Qdrant payloads, lint, `wiki_query`, and passive recall.
 - Commandment principles are always injected for matching populations.
-- `wiki_query` can filter by `pageKind="principle"`, `tier`, and `appliesTo`.
+- `wiki_query` can filter by `pageKind="principle"`, `tier`, `appliesTo`, `consumerArchetype`, and `consumerContext`.
 - `principle_decide` returns structured contribution ledgers, tie warnings, commandment-conflict flags, and semantic-fallback warnings.
-- `/wiki?kind=principle` and principle detail pages are polished, dense, token-themed, and accessible.
+- `/wiki?kind=principle` and principle detail pages are polished, dense, token-themed, accessible, and organized by consumer archetype for human review.
 - `docs/principles.md` is generated from public kernel principles and linked from the public docs.
 - No durable principle-shaped rule remains duplicated across the AI principles doc, promoted `AGENTS.md` sections, and founder-kernel principles without an intentional pointer.
 - `AGENTS.md` remains usable when MCP/wiki is unavailable.


### PR DESCRIPTION
## Summary

- Re-baseline the principles-as-wiki-kind spec and plan against actual worktree state — Phases 0–4 of the previous draft already shipped on main, leaving only the consumer-archetype axis (§8A), advisory decision support (`principle_decide`), retrieval/MCP/lint/UI propagation, and public-docs generation as net-new.
- Add §8A.1 coherence matrix for `consumerArchetype × appliesTo`, §11.6 org-overlay contract, §11.5 provisional grant-mapping note, §9.3 kernel-slug uniqueness carve-out, §12.1 Qdrant cold-start lint contract; flip §13.1 default to tier-first with consumer-archetype filter chips.
- Refresh the wiki-visual-navigation spec for principle awareness across all three tiers — sidebar elevation, hexagon node shape, atlas tier-first projection, time-travel principle-changes filter, four principle-specific lint state outlines.

## Context

The shipped batches across PRs #531, #538, #542 / #564, #565, #566, #570, #579, #589, #590, #592 already deliver the `principle` wiki kind, schema (minus consumer-archetype), taxonomy module, lint detectors, retrieval, MCP, founder-kernel seed commandments, AI-coworker Principles 1–9, and 30 AGENTS.md durable-governance promotions across commandment/core/contextual tiers.

Worktree state at commit time:

- 41 published kernel principle pages under `docs/founder-kernel/wiki/principles/`
- `WikiPage` schema carries `principleTier`, `principleDirection`, `principleWeight`, `principleWeightRationale`, `principleDimensionVector`, `principleDimensions`, `principleAppliesTo`, `principlePublic`, `principlePublicRationale` (migration `20260513000000_add_principle_fields_to_wikipage`)
- `wiki-taxonomy.ts` exports tier, applies-to, dimension constants + predicates
- `manifest.json` at `kernelVersion: 0.2.1`, `schemaVersion: 0.2.0`, `pageCount: 62`

The earlier draft of this spec claimed all of that was net-new work. This PR corrects the baseline.

## Candidate epic linkages

No existing backlog item fits cleanly; closest open epics:

- **EP-TAK-3F9A21** — TAK/GAID governed memory + MCP grants (covers retrieval + grant-mapping touch points)
- **EP-DOCS-6B9F2A** — Current-State Documentation, README, Public Website Refresh (covers the Phase A.18 Jekyll generator)

Per the updated §1.2, `BI-*` linkage is recommended but not strictly required — none of the shipped principle batches (#531 … #592) cite one. PR title + body must always be self-sufficient for discoverability.

## Overlap sweep

- `gh pr list --state open --search \"principle OR wiki\"` → zero hits at commit time
- Most-recent principle commit on main: #592 (batch 4c contextual promotions)
- Other local worktrees with `principle*` branches (`founder-kernel-commandment-principles`, `principles-batch-2-rest`, `principles-batch-3-seed-first`) have no remote tracking — local-only, no overlap risk

## What lands in this PR vs follow-ups

- **This PR (doc-only):** spec + plan + visual-nav refresh. No code changes.
- **Phase A (next PR):** implements the plan — consumer-archetype taxonomy + migration + back-fill of 41 pages, `recallPrincipleContext`, `principle_decide`, lint coherence detector, tier-first UI, Jekyll docs generator. 19 TDD-shaped tasks against pinned `pnpm --filter` commands.
- **Phase B (independent small PR):** `fix(db): guard kernel WikiPage.slug uniqueness when organizationId IS NULL` — uncoupled refactor surfaced during the chief-architect review.

## Test plan

- [ ] Spec §1.1 attributions match `git log --oneline` for cited PRs (#565, #566, #570, #579, #589, #590, #592)
- [ ] §8A.1 coherence matrix would flag the realistic violations on existing pages (e.g., a `human`-targeted page mistakenly tagged `ai-coworker-universal`)
- [ ] Plan Phase A tasks each pair a failing test with the implementation step
- [ ] Visual-nav spec covers Tier 1 (sidebar §3.1), Tier 2 (mini-graph §4.3), Tier 3 (atlas §5.1/§5.2), §6.1 shapes, §6.3 state outlines — not only the previous §5 retrofit
- [ ] §1.2 wording matches the actual practice of the merged principle PRs (no `BI-*` required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)