### PR TITLE
feat(communications): surface channel binding management

### DIFF
--- a/apps/web/app/(shell)/platform/tools/integrations/communications/page.test.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/communications/page.test.tsx
@@ -1,10 +1,64 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import CommunicationsPage from "./page";
+const mocks = vi.hoisted(() => ({
+  listCommunicationChannelBindings: vi.fn(),
+}));
+
+vi.mock("@/lib/communications/channel-binding-store", () => ({
+  listCommunicationChannelBindings: mocks.listCommunicationChannelBindings,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listCommunicationChannelBindings.mockResolvedValue({
+    summary: {
+      total: 2,
+      active: 2,
+      verified: 1,
+      failed: 0,
+      pending: 1,
+    },
+    bindings: [
+      {
+        bindingId: "bind-1",
+        channelType: "teams",
+        providerKey: "microsoft365",
+        providerAccountId: "tenant-1",
+        externalSubject: "user@contoso.com",
+        displayLabel: "Microsoft Teams",
+        verificationStatus: "verified",
+        allowedUrgencies: ["priority", "urgent"],
+        isActive: true,
+        lastTestedAt: "2026-05-15T10:00:00.000Z",
+        lastVerifiedAt: "2026-05-15T10:00:00.000Z",
+        lastError: null,
+        principalDisplayName: "Alex Chen",
+        employeeDisplayName: "Alex C.",
+      },
+      {
+        bindingId: "bind-2",
+        channelType: "whatsapp",
+        providerKey: "meta_whatsapp",
+        providerAccountId: "",
+        externalSubject: "+15551212",
+        displayLabel: "Field WhatsApp",
+        verificationStatus: "pending",
+        allowedUrgencies: ["urgent"],
+        isActive: true,
+        lastTestedAt: null,
+        lastVerifiedAt: null,
+        lastError: "Template not approved",
+        principalDisplayName: "Riley Stone",
+        employeeDisplayName: null,
+      },
+    ],
+  });
+});
 
 describe("CommunicationsPage", () => {
   it("renders provider readiness groups for the communication fabric", async () => {
+    const { default: CommunicationsPage } = await import("./page");
     const html = renderToStaticMarkup(await CommunicationsPage());
 
     expect(html).toContain("Communications");
@@ -13,5 +67,19 @@ describe("CommunicationsPage", () => {
     expect(html).toContain("Field and local messaging");
     expect(html).toContain("Telegram");
     expect(html).toContain("WhatsApp Business");
+  });
+
+  it("renders channel binding summary and recent bindings", async () => {
+    const { default: CommunicationsPage } = await import("./page");
+    const html = renderToStaticMarkup(await CommunicationsPage());
+
+    expect(html).toContain("Channel bindings");
+    expect(html).toContain("2 active");
+    expect(html).toContain("1 verified");
+    expect(html).toContain("1 pending");
+    expect(html).toContain("Microsoft Teams");
+    expect(html).toContain("Alex Chen");
+    expect(html).toContain("Field WhatsApp");
+    expect(html).toContain("Template not approved");
   });
 });

--- a/apps/web/app/(shell)/platform/tools/integrations/communications/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/communications/page.tsx
@@ -1,4 +1,5 @@
 import { Bell, Building2, MessagesSquare } from "lucide-react";
+import { listCommunicationChannelBindings } from "@/lib/communications/channel-binding-store";
 
 const groups = [
   {
@@ -31,6 +32,8 @@ const principles = [
 ];
 
 export default async function CommunicationsPage() {
+  const bindingDashboard = await listCommunicationChannelBindings({ take: 8 });
+
   return (
     <main className="space-y-6">
       <header className="space-y-3">
@@ -99,6 +102,94 @@ export default async function CommunicationsPage() {
           );
         })}
       </section>
+
+      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <header className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--dpf-text)]">Channel bindings</h2>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+              Employee reachability records that provider adapters can use for governed delivery.
+            </p>
+          </div>
+          <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--dpf-text)]">
+            {bindingDashboard.summary.total} total
+          </span>
+        </header>
+
+        <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <BindingMetric label="Active" value={`${bindingDashboard.summary.active} active`} />
+          <BindingMetric label="Verified" value={`${bindingDashboard.summary.verified} verified`} />
+          <BindingMetric label="Pending" value={`${bindingDashboard.summary.pending} pending`} />
+          <BindingMetric label="Failed" value={`${bindingDashboard.summary.failed} failed`} />
+        </dl>
+
+        {bindingDashboard.bindings.length === 0 ? (
+          <p className="mt-4 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm text-[var(--dpf-muted)]">
+            No employee channel bindings are configured yet.
+          </p>
+        ) : (
+          <ul className="mt-4 divide-y divide-[var(--dpf-border)] border-y border-[var(--dpf-border)]">
+            {bindingDashboard.bindings.map((binding) => (
+              <li
+                key={binding.bindingId}
+                className="grid gap-3 py-3 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_auto]"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-[var(--dpf-text)]">
+                    {binding.displayLabel}
+                  </p>
+                  <p className="mt-1 truncate text-xs text-[var(--dpf-muted)]">
+                    {binding.channelType} via {binding.providerKey}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <p className="truncate text-sm text-[var(--dpf-text)]">
+                    {binding.employeeDisplayName ?? binding.principalDisplayName}
+                  </p>
+                  <p className="mt-1 truncate text-xs text-[var(--dpf-muted)]">
+                    {binding.employeeDisplayName
+                      ? `${binding.externalSubject} - ${binding.principalDisplayName}`
+                      : binding.externalSubject}
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+                  <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-xs text-[var(--dpf-text)]">
+                    {binding.verificationStatus}
+                  </span>
+                  <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]">
+                    {binding.allowedUrgencies.join(", ")}
+                  </span>
+                  <span className="text-xs text-[var(--dpf-muted)]">
+                    {binding.lastTestedAt ? `Tested ${formatBindingDate(binding.lastTestedAt)}` : "Not tested"}
+                  </span>
+                  {binding.lastError && (
+                    <span className="basis-full text-xs text-[var(--dpf-muted)] lg:text-right">
+                      {binding.lastError}
+                    </span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </main>
   );
+}
+
+function BindingMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2">
+      <dt className="text-xs font-medium uppercase tracking-wide text-[var(--dpf-muted)]">{label}</dt>
+      <dd className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">{value}</dd>
+    </div>
+  );
+}
+
+function formatBindingDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
 }

--- a/apps/web/lib/communications/channel-binding-store.test.ts
+++ b/apps/web/lib/communications/channel-binding-store.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  bindingFindMany: vi.fn(),
+  bindingCount: vi.fn(),
+  bindingUpsert: vi.fn(),
+  bindingUpdate: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    communicationChannelBinding: {
+      findMany: mocks.bindingFindMany,
+      count: mocks.bindingCount,
+      upsert: mocks.bindingUpsert,
+      update: mocks.bindingUpdate,
+    },
+  },
+}));
+
+import {
+  createCommunicationChannelBinding,
+  listCommunicationChannelBindings,
+  recordCommunicationChannelBindingTest,
+} from "./channel-binding-store";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listCommunicationChannelBindings", () => {
+  it("maps stored channel bindings into dashboard rows and summary counts", async () => {
+    mocks.bindingCount
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1);
+    mocks.bindingFindMany.mockResolvedValue([
+      {
+        bindingId: "bind-1",
+        channelType: "teams",
+        providerKey: "microsoft365",
+        providerAccountId: "tenant-1",
+        externalSubject: "user@contoso.com",
+        displayLabel: null,
+        verificationStatus: "verified",
+        allowedUrgencies: ["priority", "urgent"],
+        isActive: true,
+        lastTestedAt: new Date("2026-05-15T10:00:00.000Z"),
+        lastVerifiedAt: new Date("2026-05-15T10:00:00.000Z"),
+        lastError: null,
+        principal: { displayName: "Alex Chen" },
+        employeeProfile: { displayName: "Alex C." },
+      },
+      {
+        bindingId: "bind-2",
+        channelType: "whatsapp",
+        providerKey: "meta_whatsapp",
+        providerAccountId: "",
+        externalSubject: "+15551212",
+        displayLabel: "Field WhatsApp",
+        verificationStatus: "pending",
+        allowedUrgencies: ["urgent"],
+        isActive: true,
+        lastTestedAt: null,
+        lastVerifiedAt: null,
+        lastError: "Template not approved",
+        principal: { displayName: "Riley Stone" },
+        employeeProfile: null,
+      },
+    ]);
+
+    const dashboard = await listCommunicationChannelBindings({ take: 10 });
+
+    expect(mocks.bindingFindMany).toHaveBeenCalledWith(expect.objectContaining({ take: 10 }));
+    expect(dashboard.summary).toEqual({
+      total: 3,
+      active: 2,
+      verified: 1,
+      failed: 1,
+      pending: 1,
+    });
+    expect(mocks.bindingCount).toHaveBeenCalledWith();
+    expect(mocks.bindingCount).toHaveBeenCalledWith({ where: { isActive: true } });
+    expect(mocks.bindingCount).toHaveBeenCalledWith({ where: { verificationStatus: "verified" } });
+    expect(mocks.bindingCount).toHaveBeenCalledWith({ where: { verificationStatus: "failed" } });
+    expect(mocks.bindingCount).toHaveBeenCalledWith({ where: { verificationStatus: "pending" } });
+    expect(dashboard.bindings[0]).toEqual({
+      bindingId: "bind-1",
+      channelType: "teams",
+      providerKey: "microsoft365",
+      providerAccountId: "tenant-1",
+      externalSubject: "user@contoso.com",
+      displayLabel: "Microsoft365 user@contoso.com",
+      verificationStatus: "verified",
+      allowedUrgencies: ["priority", "urgent"],
+      isActive: true,
+      lastTestedAt: "2026-05-15T10:00:00.000Z",
+      lastVerifiedAt: "2026-05-15T10:00:00.000Z",
+      lastError: null,
+      principalDisplayName: "Alex Chen",
+      employeeDisplayName: "Alex C.",
+    });
+  });
+});
+
+describe("createCommunicationChannelBinding", () => {
+  it("rejects invalid channel input before writing", async () => {
+    const result = await createCommunicationChannelBinding({
+      principalId: "principal-1",
+      channelType: "fax",
+      providerKey: "fax",
+      externalSubject: "555-1212",
+      allowedUrgencies: ["urgent"],
+    });
+
+    expect(result).toEqual({ ok: false, message: "Unsupported channel: fax" });
+    expect(mocks.bindingUpsert).not.toHaveBeenCalled();
+  });
+
+  it("upserts a normalized pending binding", async () => {
+    mocks.bindingUpsert.mockResolvedValue({ bindingId: "bind-1" });
+
+    const result = await createCommunicationChannelBinding({
+      principalId: " principal-1 ",
+      employeeProfileId: " emp-1 ",
+      channelType: "Microsoft Teams",
+      providerKey: " microsoft365 ",
+      providerAccountId: " tenant-1 ",
+      externalSubject: " user@contoso.com ",
+      displayLabel: " Teams ",
+      allowedUrgencies: ["priority", "urgent"],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Communication channel binding saved.",
+      bindingId: "bind-1",
+    });
+    expect(mocks.bindingUpsert).toHaveBeenCalledWith({
+      where: {
+        channelType_providerKey_providerAccountId_externalSubject: {
+          channelType: "teams",
+          providerKey: "microsoft365",
+          providerAccountId: "tenant-1",
+          externalSubject: "user@contoso.com",
+        },
+      },
+      create: expect.objectContaining({
+        principalId: "principal-1",
+        employeeProfileId: "emp-1",
+        channelType: "teams",
+        providerKey: "microsoft365",
+        providerAccountId: "tenant-1",
+        externalSubject: "user@contoso.com",
+        displayLabel: "Teams",
+        verificationStatus: "pending",
+        allowedDirections: ["outbound"],
+        allowedUrgencies: ["priority", "urgent"],
+        isActive: true,
+      }),
+      update: expect.objectContaining({
+        principalId: "principal-1",
+        employeeProfileId: "emp-1",
+        displayLabel: "Teams",
+        allowedUrgencies: ["priority", "urgent"],
+        isActive: true,
+        lastError: null,
+      }),
+      select: { bindingId: true },
+    });
+  });
+
+  it("normalizes provider-wide bindings to the default provider account key", async () => {
+    mocks.bindingUpsert.mockResolvedValue({ bindingId: "bind-default-account" });
+
+    const result = await createCommunicationChannelBinding({
+      principalId: "principal-1",
+      channelType: "in_app",
+      providerKey: "dpf",
+      externalSubject: "principal-1",
+      allowedUrgencies: ["routine"],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Communication channel binding saved.",
+      bindingId: "bind-default-account",
+    });
+    expect(mocks.bindingUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          channelType_providerKey_providerAccountId_externalSubject: {
+            channelType: "in-app",
+            providerKey: "dpf",
+            providerAccountId: "",
+            externalSubject: "principal-1",
+          },
+        },
+        create: expect.objectContaining({
+          providerAccountId: "",
+        }),
+      }),
+    );
+  });
+});
+
+describe("recordCommunicationChannelBindingTest", () => {
+  it("marks a successful binding test as verified", async () => {
+    mocks.bindingUpdate.mockResolvedValue({ bindingId: "bind-1" });
+
+    const result = await recordCommunicationChannelBindingTest({
+      bindingId: "bind-1",
+      ok: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Communication channel binding test recorded.",
+    });
+    expect(mocks.bindingUpdate).toHaveBeenCalledWith({
+      where: { bindingId: "bind-1" },
+      data: expect.objectContaining({
+        verificationStatus: "verified",
+        lastError: null,
+        lastTestedAt: expect.any(Date),
+        lastVerifiedAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("records a failed binding test without marking verified", async () => {
+    mocks.bindingUpdate.mockResolvedValue({ bindingId: "bind-1" });
+
+    await recordCommunicationChannelBindingTest({
+      bindingId: "bind-1",
+      ok: false,
+      errorMessage: "No provider credential.",
+    });
+
+    expect(mocks.bindingUpdate).toHaveBeenCalledWith({
+      where: { bindingId: "bind-1" },
+      data: expect.objectContaining({
+        verificationStatus: "failed",
+        lastError: "No provider credential.",
+        lastTestedAt: expect.any(Date),
+        lastVerifiedAt: null,
+      }),
+    });
+  });
+});

--- a/apps/web/lib/communications/channel-binding-store.ts
+++ b/apps/web/lib/communications/channel-binding-store.ts
@@ -1,0 +1,197 @@
+import { prisma } from "@dpf/db";
+
+import {
+  COMMUNICATION_URGENCIES,
+  type CommunicationUrgency,
+} from "./channel-types";
+import {
+  parseChannelBindingInput,
+  type ChannelBindingInput,
+} from "./channel-bindings";
+
+export interface CommunicationChannelBindingRow {
+  bindingId: string;
+  channelType: string;
+  providerKey: string;
+  providerAccountId: string;
+  externalSubject: string;
+  displayLabel: string;
+  verificationStatus: string;
+  allowedUrgencies: CommunicationUrgency[];
+  isActive: boolean;
+  lastTestedAt: string | null;
+  lastVerifiedAt: string | null;
+  lastError: string | null;
+  principalDisplayName: string;
+  employeeDisplayName: string | null;
+}
+
+export interface CommunicationBindingDashboard {
+  summary: {
+    total: number;
+    active: number;
+    verified: number;
+    failed: number;
+    pending: number;
+  };
+  bindings: CommunicationChannelBindingRow[];
+}
+
+export interface CommunicationBindingActionResult {
+  ok: boolean;
+  message: string;
+  bindingId?: string;
+}
+
+export async function listCommunicationChannelBindings(
+  options: { take?: number } = {},
+): Promise<CommunicationBindingDashboard> {
+  const [rows, total, active, verified, failed, pending] = await Promise.all([
+    prisma.communicationChannelBinding.findMany({
+      take: options.take ?? 25,
+      orderBy: [{ updatedAt: "desc" }],
+      select: {
+        bindingId: true,
+        channelType: true,
+        providerKey: true,
+        providerAccountId: true,
+        externalSubject: true,
+        displayLabel: true,
+        verificationStatus: true,
+        allowedUrgencies: true,
+        isActive: true,
+        lastTestedAt: true,
+        lastVerifiedAt: true,
+        lastError: true,
+        principal: { select: { displayName: true } },
+        employeeProfile: { select: { displayName: true } },
+      },
+    }),
+    prisma.communicationChannelBinding.count(),
+    prisma.communicationChannelBinding.count({ where: { isActive: true } }),
+    prisma.communicationChannelBinding.count({ where: { verificationStatus: "verified" } }),
+    prisma.communicationChannelBinding.count({ where: { verificationStatus: "failed" } }),
+    prisma.communicationChannelBinding.count({ where: { verificationStatus: "pending" } }),
+  ]);
+
+  const bindings = rows.map((row) => ({
+    bindingId: row.bindingId,
+    channelType: row.channelType,
+    providerKey: row.providerKey,
+    providerAccountId: row.providerAccountId,
+    externalSubject: row.externalSubject,
+    displayLabel: row.displayLabel?.trim() || formatBindingLabel(row.providerKey, row.externalSubject),
+    verificationStatus: row.verificationStatus,
+    allowedUrgencies: normalizeUrgencies(row.allowedUrgencies),
+    isActive: row.isActive,
+    lastTestedAt: toIsoString(row.lastTestedAt),
+    lastVerifiedAt: toIsoString(row.lastVerifiedAt),
+    lastError: row.lastError,
+    principalDisplayName: row.principal.displayName,
+    employeeDisplayName: row.employeeProfile?.displayName ?? null,
+  }));
+
+  return {
+    summary: {
+      total,
+      active,
+      verified,
+      failed,
+      pending,
+    },
+    bindings,
+  };
+}
+
+export async function createCommunicationChannelBinding(
+  input: ChannelBindingInput,
+): Promise<CommunicationBindingActionResult> {
+  const parsed = parseChannelBindingInput(input);
+  if (!parsed.ok) {
+    return { ok: false, message: parsed.error };
+  }
+
+  const binding = parsed.value;
+  const providerAccountId = binding.providerAccountId ?? "";
+  const saved = await prisma.communicationChannelBinding.upsert({
+    where: {
+      channelType_providerKey_providerAccountId_externalSubject: {
+        channelType: binding.channelType,
+        providerKey: binding.providerKey,
+        providerAccountId,
+        externalSubject: binding.externalSubject,
+      },
+    },
+    create: {
+      principalId: binding.principalId,
+      employeeProfileId: binding.employeeProfileId ?? null,
+      channelType: binding.channelType,
+      providerKey: binding.providerKey,
+      providerAccountId,
+      externalSubject: binding.externalSubject,
+      displayLabel: binding.displayLabel ?? null,
+      verificationStatus: "pending",
+      allowedDirections: ["outbound"],
+      allowedUrgencies: [...binding.allowedUrgencies],
+      isActive: true,
+    },
+    update: {
+      principalId: binding.principalId,
+      employeeProfileId: binding.employeeProfileId ?? null,
+      displayLabel: binding.displayLabel ?? null,
+      allowedUrgencies: [...binding.allowedUrgencies],
+      isActive: true,
+      lastError: null,
+    },
+    select: { bindingId: true },
+  });
+
+  return {
+    ok: true,
+    message: "Communication channel binding saved.",
+    bindingId: saved.bindingId,
+  };
+}
+
+export async function recordCommunicationChannelBindingTest(input: {
+  bindingId: string;
+  ok: boolean;
+  errorMessage?: string;
+}): Promise<CommunicationBindingActionResult> {
+  const testedAt = new Date();
+
+  await prisma.communicationChannelBinding.update({
+    where: { bindingId: input.bindingId },
+    data: {
+      verificationStatus: input.ok ? "verified" : "failed",
+      lastTestedAt: testedAt,
+      lastVerifiedAt: input.ok ? testedAt : null,
+      lastError: input.ok ? null : input.errorMessage?.trim() || "Channel test failed.",
+    },
+  });
+
+  return {
+    ok: true,
+    message: "Communication channel binding test recorded.",
+  };
+}
+
+function normalizeUrgencies(values: readonly string[]): CommunicationUrgency[] {
+  return values.filter((value): value is CommunicationUrgency =>
+    (COMMUNICATION_URGENCIES as readonly string[]).includes(value),
+  );
+}
+
+function toIsoString(value: Date | null): string | null {
+  return value ? value.toISOString() : null;
+}
+
+function formatBindingLabel(providerKey: string, externalSubject: string): string {
+  const provider = providerKey
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+
+  return `${provider} ${externalSubject}`.trim();
+}

--- a/packages/db/prisma/migrations/20260515202500_communication_provider_account_key/migration.sql
+++ b/packages/db/prisma/migrations/20260515202500_communication_provider_account_key/migration.sql
@@ -1,0 +1,19 @@
+UPDATE "CommunicationChannelBinding"
+SET "providerAccountId" = ''
+WHERE "providerAccountId" IS NULL;
+
+ALTER TABLE "CommunicationChannelBinding"
+ALTER COLUMN "providerAccountId" SET DEFAULT '';
+
+ALTER TABLE "CommunicationChannelBinding"
+ALTER COLUMN "providerAccountId" SET NOT NULL;
+
+UPDATE "CommunicationChannelSession"
+SET "providerAccountId" = ''
+WHERE "providerAccountId" IS NULL;
+
+ALTER TABLE "CommunicationChannelSession"
+ALTER COLUMN "providerAccountId" SET DEFAULT '';
+
+ALTER TABLE "CommunicationChannelSession"
+ALTER COLUMN "providerAccountId" SET NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3645,7 +3645,7 @@ model CommunicationChannelBinding {
   employeeProfileId  String?
   channelType        String
   providerKey        String
-  providerAccountId  String?
+  providerAccountId  String                         @default("")
   externalSubject    String
   displayLabel       String?
   verificationStatus String                         @default("pending")
@@ -3674,7 +3674,7 @@ model CommunicationChannelSession {
   sessionId         String     @unique @default(cuid())
   channelType       String
   providerKey       String
-  providerAccountId String?
+  providerAccountId String     @default("")
   externalPeerId    String
   trustLevel        String     @default("unknown")
   principalId       String?


### PR DESCRIPTION
## Summary

Continues the employee communication fabric from [#619](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/619) (foundation, merged) with the operator-facing channel binding surface and the missing piece needed for upsert to be safe.

- Adds `apps/web/lib/communications/channel-binding-store.ts`: `listCommunicationChannelBindings()` (summary metrics + recent rows with principal/employee labels), `createCommunicationChannelBinding()` (upsert through the compound unique key, validated via `parseChannelBindingInput`), and `recordCommunicationChannelBindingTest()` (verification status writer).
- Wires the binding dashboard into `/platform/tools/integrations/communications`: summary metrics (total/active/verified/pending/failed), recent bindings list with channel, principal/employee, urgency tags, verification status, last-tested timestamp, and any last error.
- Tightens `CommunicationChannelBinding.providerAccountId` and `CommunicationChannelSession.providerAccountId` from nullable to required-with-default-`""`. Postgres treats `NULL` as not-equal-to-`NULL` in unique constraints, so the compound unique key `(channelType, providerKey, providerAccountId, externalSubject)` could not deterministically upsert when no provider account was set. Migration backfills existing rows to `""` before tightening the constraint.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/communications/channel-binding-store.test.ts "app/(shell)/platform/tools/integrations/communications/page.test.tsx"` — 8/8 pass
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web exec vitest run` (full suite) — 5607 passed, 0 failed
- [x] `pnpm --filter web build` — production build clean
- [ ] Apply migration `20260515202500_communication_provider_account_key` to a Postgres instance with existing `CommunicationChannelBinding`/`Session` rows (backfill is inline; verify no rows reject the NOT NULL flip)
- [ ] UX: load `/platform/tools/integrations/communications` and confirm the binding summary card + recent rows render with DPF theme variables