### PR TITLE
feat: skill revisions and proposals (Slice 3)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
@@ -29,6 +29,15 @@ vi.mock("@/lib/actions/skills-observatory", () => ({
     activeSkillCount: 0,
     latestMetricPeriod: null,
   }),
+  getSkillReviewDetail: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/components/platform/SkillProposalsPanel", () => ({
+  SkillProposalsPanel: () => <div>skills-proposals-panel</div>,
+}));
+
+vi.mock("@/components/platform/SkillRevisionHistoryPanel", () => ({
+  SkillRevisionHistoryPanel: () => <div>skills-revision-history-panel</div>,
 }));
 
 vi.mock("@/components/admin/SkillsCatalogView", () => ({
@@ -48,7 +57,7 @@ vi.mock("next/link", () => ({
 describe("PlatformAiSkillsPage", () => {
   it("renders catalog and observability under AI Operations", async () => {
     const { default: PlatformAiSkillsPage } = await import("./page");
-    const html = renderToStaticMarkup(await PlatformAiSkillsPage());
+    const html = renderToStaticMarkup(await PlatformAiSkillsPage({}));
 
     expect(html).toContain("AI Operations");
     expect(html).toContain("Catalog");

--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { SkillsCatalogView } from "@/components/admin/SkillsCatalogView";
 import { SkillsObservatoryPanel } from "@/components/platform/SkillsObservatoryPanel";
+import { SkillProposalsPanel } from "@/components/platform/SkillProposalsPanel";
+import { SkillRevisionHistoryPanel } from "@/components/platform/SkillRevisionHistoryPanel";
 import {
   getSkillCatalog,
   getSkillCatalogStats,
@@ -11,10 +13,18 @@ import {
   getSpecialistExecutions,
   getSkillsObservatoryStats,
   getSkillTelemetrySummary,
+  getSkillReviewDetail,
 } from "@/lib/actions/skills-observatory";
 
-export default async function SkillsObservatoryPage() {
-  const [catalogSkills, catalogStats, skills, finishingPasses, executions, stats, telemetry] = await Promise.all([
+export default async function SkillsObservatoryPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ skill?: string }>;
+}) {
+  const resolvedParams = (await searchParams) ?? {};
+  const focusedSkillId = typeof resolvedParams.skill === "string" ? resolvedParams.skill : null;
+
+  const [catalogSkills, catalogStats, skills, finishingPasses, executions, stats, telemetry, review] = await Promise.all([
     getSkillCatalog(),
     getSkillCatalogStats(),
     getSkillsCatalog(),
@@ -22,6 +32,7 @@ export default async function SkillsObservatoryPage() {
     getSpecialistExecutions(),
     getSkillsObservatoryStats(),
     getSkillTelemetrySummary(),
+    focusedSkillId ? getSkillReviewDetail(focusedSkillId) : Promise.resolve(null),
   ]);
 
   return (
@@ -65,6 +76,69 @@ export default async function SkillsObservatoryPage() {
           telemetry={telemetry}
         />
       </div>
+
+      {review && (
+        <div className="mt-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <div className="mb-3 flex items-baseline justify-between gap-3">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+              Review &amp; revisions — <code>{review.skillId}</code>
+            </h2>
+            <Link
+              href="/platform/ai/skills"
+              className="text-xs underline text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            >
+              Clear focus
+            </Link>
+          </div>
+          {!review.seedDrift.inSync && review.seedDrift.seedBody !== null && (
+            <div
+              className="mb-3 rounded border px-3 py-2 text-xs"
+              style={{
+                borderColor: "color-mix(in srgb, var(--dpf-warning) 35%, var(--dpf-border))",
+                background: "color-mix(in srgb, var(--dpf-warning) 8%, transparent)",
+                color: "var(--dpf-text)",
+              }}
+            >
+              <strong>Seed drift:</strong> DB body differs from <code>{review.seedDrift.seedPath}</code>.
+              Patch the seed file in the same PR so a fresh install keeps this change.
+            </div>
+          )}
+          {!review.seedDrift.inSync && review.seedDrift.seedBody === null && (
+            <div
+              className="mb-3 rounded border px-3 py-2 text-xs"
+              style={{
+                borderColor: "var(--dpf-border)",
+                background: "var(--dpf-surface-2)",
+                color: "var(--dpf-muted)",
+              }}
+            >
+              Seed file not found at <code>{review.seedDrift.seedPath}</code> (normal for production
+              installs where the repo isn&rsquo;t checked out next to the app).
+            </div>
+          )}
+          <div className="mb-4">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+              Proposals
+            </h3>
+            <SkillProposalsPanel
+              skillId={review.skillId}
+              currentContent={review.skillMdContent}
+              proposals={review.proposals}
+            />
+          </div>
+          <div>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+              Revision history
+            </h3>
+            <SkillRevisionHistoryPanel skillId={review.skillId} revisions={review.revisions} />
+          </div>
+        </div>
+      )}
+      {!review && focusedSkillId && (
+        <div className="mt-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-xs text-[var(--dpf-muted)]">
+          No skill found with id <code>{focusedSkillId}</code>.
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/platform/SkillProposalsPanel.test.tsx
+++ b/apps/web/components/platform/SkillProposalsPanel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/skill-proposal-actions", () => ({
+  approveSkillProposalAction: vi.fn(),
+  rejectSkillProposalAction: vi.fn(),
+  rollbackSkillAction: vi.fn(),
+}));
+
+import { SkillProposalsPanel } from "./SkillProposalsPanel";
+import type { SkillProposalRow } from "@/lib/skills/proposals";
+
+const baseProposal: SkillProposalRow = {
+  proposalId: "IP-SKL-AB12C",
+  title: "Tighten build-page intro",
+  description: "Replace the rambling intro with two clear sentences.",
+  severity: "medium",
+  submittedById: "user-1",
+  agentId: "AGT-1",
+  threadId: "thread-1",
+  observedFriction: "Users keep asking what the skill is for.",
+  proposedContent: "v1 proposed body",
+  status: "proposed",
+  reviewedById: null,
+  reviewedAt: null,
+  rejectionReason: null,
+  createdAt: "2026-05-15T17:00:00.000Z",
+};
+
+describe("SkillProposalsPanel", () => {
+  it("renders an empty state when there are no proposals", () => {
+    const html = renderToStaticMarkup(
+      <SkillProposalsPanel skillId="build-page" currentContent="v0" proposals={[]} />,
+    );
+    expect(html).toContain("No proposals filed against");
+    expect(html).toContain("build-page");
+  });
+
+  it("renders a row per proposal with a Pending badge for proposed status", () => {
+    const html = renderToStaticMarkup(
+      <SkillProposalsPanel
+        skillId="build-page"
+        currentContent="v0 body"
+        proposals={[baseProposal]}
+      />,
+    );
+    expect(html).toContain(baseProposal.title);
+    expect(html).toContain("Pending");
+  });
+
+  it("uses only theme tokens — no hardcoded hex colors", () => {
+    const html = renderToStaticMarkup(
+      <SkillProposalsPanel
+        skillId="build-page"
+        currentContent="v0"
+        proposals={[baseProposal]}
+      />,
+    );
+    expect(html).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+
+  it("renders a Rejected badge for rejected proposals", () => {
+    const rejected: SkillProposalRow = {
+      ...baseProposal,
+      proposalId: "IP-SKL-REJ",
+      status: "rejected",
+      rejectionReason: "regression risk",
+      reviewedAt: "2026-05-15T18:00:00.000Z",
+      reviewedById: "reviewer-1",
+    };
+    const html = renderToStaticMarkup(
+      <SkillProposalsPanel skillId="build-page" currentContent="v0" proposals={[rejected]} />,
+    );
+    expect(html).toContain("Rejected");
+  });
+});

--- a/apps/web/components/platform/SkillProposalsPanel.tsx
+++ b/apps/web/components/platform/SkillProposalsPanel.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { CSSProperties } from "react";
+
+import type { SkillProposalRow } from "@/lib/skills/proposals";
+import {
+  approveSkillProposalAction,
+  rejectSkillProposalAction,
+} from "@/lib/actions/skill-proposal-actions";
+
+type Props = {
+  skillId: string;
+  currentContent: string;
+  proposals: SkillProposalRow[];
+};
+
+const statusBadge: Record<string, { label: string; color: string; bg: string }> = {
+  proposed: { label: "Pending", color: "var(--dpf-warning)", bg: "color-mix(in srgb, var(--dpf-warning) 12%, transparent)" },
+  reviewed: { label: "Approved", color: "var(--dpf-success)", bg: "color-mix(in srgb, var(--dpf-success) 12%, transparent)" },
+  rejected: { label: "Rejected", color: "var(--dpf-error)", bg: "color-mix(in srgb, var(--dpf-error) 12%, transparent)" },
+};
+
+export function SkillProposalsPanel({ skillId, currentContent, proposals }: Props) {
+  if (proposals.length === 0) {
+    return (
+      <div
+        style={{
+          padding: 12,
+          borderRadius: 6,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-2)",
+          color: "var(--dpf-muted)",
+          fontSize: 12,
+        }}
+      >
+        No proposals filed against <code>{skillId}</code> yet.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {proposals.map((p) => (
+        <ProposalRow key={p.proposalId} skillId={skillId} currentContent={currentContent} proposal={p} />
+      ))}
+    </div>
+  );
+}
+
+function ProposalRow({
+  skillId,
+  currentContent,
+  proposal,
+}: {
+  skillId: string;
+  currentContent: string;
+  proposal: SkillProposalRow;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const badge = statusBadge[proposal.status] ?? {
+    label: proposal.status,
+    color: "var(--dpf-muted)",
+    bg: "var(--dpf-surface-2)",
+  };
+
+  const isActionable = proposal.status === "proposed";
+
+  return (
+    <div
+      style={{
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-2)",
+        padding: 0,
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "10px 12px",
+          background: "transparent",
+          border: "none",
+          width: "100%",
+          textAlign: "left",
+          cursor: "pointer",
+          color: "var(--dpf-text)",
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            padding: "2px 8px",
+            borderRadius: 999,
+            background: badge.bg,
+            color: badge.color,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+          }}
+        >
+          {badge.label}
+        </span>
+        <span style={{ fontSize: 13, fontWeight: 500, flex: 1 }}>{proposal.title}</span>
+        <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
+          {new Date(proposal.createdAt).toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}
+        </span>
+        <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>{expanded ? "▲" : "▼"}</span>
+      </button>
+
+      {expanded && (
+        <div style={{ padding: 12, borderTop: "1px solid var(--dpf-border)" }}>
+          <p style={{ fontSize: 12, color: "var(--dpf-text)", margin: "0 0 8px 0" }}>{proposal.description}</p>
+          {proposal.observedFriction && (
+            <p style={{ fontSize: 12, color: "var(--dpf-muted)", margin: "0 0 8px 0" }}>
+              <strong>Observed friction:</strong> {proposal.observedFriction}
+            </p>
+          )}
+          <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: "0 0 12px 0" }}>
+            Submitted by <code>{proposal.submittedById}</code> via <code>{proposal.agentId}</code>
+            {proposal.threadId ? <> · thread <code>{proposal.threadId}</code></> : null}
+          </p>
+
+          <SimpleDiff current={currentContent} proposed={proposal.proposedContent} />
+
+          {proposal.status === "rejected" && proposal.rejectionReason && (
+            <p
+              style={{
+                fontSize: 12,
+                color: "var(--dpf-error)",
+                marginTop: 12,
+              }}
+            >
+              <strong>Rejected:</strong> {proposal.rejectionReason}
+            </p>
+          )}
+
+          {isActionable && (
+            <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 8 }}>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  type="button"
+                  disabled={pending}
+                  onClick={() =>
+                    startTransition(async () => {
+                      const result = await approveSkillProposalAction(proposal.proposalId);
+                      setFeedback(result.ok ? "Approved." : `Failed: ${result.error}`);
+                    })
+                  }
+                  style={primaryBtn}
+                >
+                  Approve and apply
+                </button>
+                <button
+                  type="button"
+                  disabled={pending || rejectionReason.trim().length === 0}
+                  onClick={() =>
+                    startTransition(async () => {
+                      const result = await rejectSkillProposalAction(
+                        proposal.proposalId,
+                        rejectionReason.trim(),
+                      );
+                      setFeedback(result.ok ? "Rejected." : `Failed: ${result.error}`);
+                    })
+                  }
+                  style={secondaryBtn}
+                >
+                  Reject
+                </button>
+              </div>
+              <textarea
+                value={rejectionReason}
+                onChange={(e) => setRejectionReason(e.target.value)}
+                placeholder="Rejection reason (required when rejecting)"
+                rows={2}
+                style={{
+                  fontSize: 12,
+                  padding: 6,
+                  borderRadius: 4,
+                  border: "1px solid var(--dpf-border)",
+                  background: "var(--dpf-surface-1)",
+                  color: "var(--dpf-text)",
+                  resize: "vertical",
+                }}
+              />
+              {feedback && (
+                <p style={{ fontSize: 12, color: "var(--dpf-muted)", margin: 0 }}>{feedback}</p>
+              )}
+              <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: 0 }}>
+                Refresh the page to see the new revision after approval. Submission of a rejection or
+                approval requires the <code>manage_capabilities</code> role.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SimpleDiff({ current, proposed }: { current: string; proposed: string }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+      <DiffColumn label="Current" body={current} accent="var(--dpf-muted)" />
+      <DiffColumn label="Proposed" body={proposed} accent="var(--dpf-accent)" />
+    </div>
+  );
+}
+
+function DiffColumn({ label, body, accent }: { label: string; body: string; accent: string }) {
+  return (
+    <div>
+      <div style={{ fontSize: 10, fontWeight: 600, color: accent, marginBottom: 4 }}>{label}</div>
+      <pre
+        style={{
+          fontSize: 11,
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          color: "var(--dpf-text)",
+          background: "var(--dpf-surface-1)",
+          border: "1px solid var(--dpf-border)",
+          padding: 8,
+          borderRadius: 4,
+          margin: 0,
+          maxHeight: 240,
+          overflow: "auto",
+          whiteSpace: "pre-wrap",
+        }}
+      >
+        {body}
+      </pre>
+    </div>
+  );
+}
+
+const primaryBtn: CSSProperties = {
+  fontSize: 12,
+  padding: "6px 12px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-accent)",
+  background: "var(--dpf-accent)",
+  color: "white",
+  cursor: "pointer",
+};
+
+const secondaryBtn: CSSProperties = {
+  fontSize: 12,
+  padding: "6px 12px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-border)",
+  background: "var(--dpf-surface-1)",
+  color: "var(--dpf-text)",
+  cursor: "pointer",
+};

--- a/apps/web/components/platform/SkillRevisionHistoryPanel.test.tsx
+++ b/apps/web/components/platform/SkillRevisionHistoryPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/skill-proposal-actions", () => ({
+  approveSkillProposalAction: vi.fn(),
+  rejectSkillProposalAction: vi.fn(),
+  rollbackSkillAction: vi.fn(),
+}));
+
+import { SkillRevisionHistoryPanel } from "./SkillRevisionHistoryPanel";
+import type { SkillRevisionRow } from "@/lib/skills/proposals";
+
+describe("SkillRevisionHistoryPanel", () => {
+  it("renders an empty state when no revisions exist", () => {
+    const html = renderToStaticMarkup(
+      <SkillRevisionHistoryPanel skillId="build-page" revisions={[]} />,
+    );
+    expect(html).toContain("No revisions yet");
+  });
+
+  it("renders rows newest-first with version and changeReason", () => {
+    const revisions: SkillRevisionRow[] = [
+      {
+        revisionId: "SREV-B",
+        version: 2,
+        changeReason: "approved proposal IP-SKL-AB12C",
+        changedBy: "reviewer-1",
+        proposalId: "IP-SKL-AB12C",
+        createdAt: "2026-05-15T18:00:00.000Z",
+      },
+      {
+        revisionId: "SREV-A",
+        version: 1,
+        changeReason: "pre-approval snapshot",
+        changedBy: "reviewer-1",
+        proposalId: null,
+        createdAt: "2026-05-15T17:55:00.000Z",
+      },
+    ];
+    const html = renderToStaticMarkup(
+      <SkillRevisionHistoryPanel skillId="build-page" revisions={revisions} />,
+    );
+    expect(html).toContain("v2");
+    expect(html).toContain("v1");
+    expect(html).toContain("approved proposal");
+    expect(html).toContain("pre-approval snapshot");
+    expect(html).toContain("Roll back here");
+  });
+
+  it("uses only theme tokens — no hardcoded hex colors", () => {
+    const revisions: SkillRevisionRow[] = [
+      {
+        revisionId: "SREV-1",
+        version: 1,
+        changeReason: "snapshot",
+        changedBy: "u",
+        proposalId: null,
+        createdAt: "2026-05-15T17:00:00.000Z",
+      },
+    ];
+    const html = renderToStaticMarkup(
+      <SkillRevisionHistoryPanel skillId="build-page" revisions={revisions} />,
+    );
+    expect(html).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/platform/SkillRevisionHistoryPanel.tsx
+++ b/apps/web/components/platform/SkillRevisionHistoryPanel.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { CSSProperties } from "react";
+
+import type { SkillRevisionRow } from "@/lib/skills/proposals";
+import { rollbackSkillAction } from "@/lib/actions/skill-proposal-actions";
+
+type Props = {
+  skillId: string;
+  revisions: SkillRevisionRow[];
+};
+
+export function SkillRevisionHistoryPanel({ skillId, revisions }: Props) {
+  if (revisions.length === 0) {
+    return (
+      <div
+        style={{
+          padding: 12,
+          borderRadius: 6,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-2)",
+          color: "var(--dpf-muted)",
+          fontSize: 12,
+        }}
+      >
+        No revisions yet — the first approved proposal (or rollback) writes v1.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {revisions.map((r) => (
+        <RevisionRow key={r.revisionId} skillId={skillId} revision={r} />
+      ))}
+    </div>
+  );
+}
+
+function RevisionRow({ skillId, revision }: { skillId: string; revision: SkillRevisionRow }) {
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 12px",
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-2)",
+        fontSize: 12,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          color: "var(--dpf-accent)",
+          minWidth: 40,
+        }}
+      >
+        v{revision.version}
+      </span>
+      <span style={{ flex: 1, color: "var(--dpf-text)" }}>
+        {revision.changeReason ?? "—"}
+        {revision.proposalId ? (
+          <span style={{ color: "var(--dpf-muted)" }}>
+            {" "}
+            (proposal <code>{revision.proposalId}</code>)
+          </span>
+        ) : null}
+      </span>
+      <span style={{ color: "var(--dpf-muted)", fontSize: 11 }}>
+        {revision.changedBy ?? "—"} ·{" "}
+        {new Date(revision.createdAt).toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}
+      </span>
+      {confirming ? (
+        <span style={{ display: "inline-flex", gap: 6 }}>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() =>
+              startTransition(async () => {
+                const result = await rollbackSkillAction(skillId, revision.version);
+                setFeedback(
+                  result.ok ? `Rolled back to v${revision.version}.` : `Failed: ${result.error}`,
+                );
+                setConfirming(false);
+              })
+            }
+            style={dangerBtn}
+          >
+            Confirm rollback
+          </button>
+          <button type="button" onClick={() => setConfirming(false)} style={secondaryBtn}>
+            Cancel
+          </button>
+        </span>
+      ) : (
+        <button type="button" onClick={() => setConfirming(true)} style={ghostBtn}>
+          Roll back here
+        </button>
+      )}
+      {feedback && (
+        <span style={{ color: "var(--dpf-muted)", fontSize: 11 }}>{feedback}</span>
+      )}
+    </div>
+  );
+}
+
+const ghostBtn: CSSProperties = {
+  fontSize: 11,
+  padding: "4px 8px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-border)",
+  background: "transparent",
+  color: "var(--dpf-muted)",
+  cursor: "pointer",
+};
+
+const secondaryBtn: CSSProperties = {
+  fontSize: 11,
+  padding: "4px 8px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-border)",
+  background: "var(--dpf-surface-1)",
+  color: "var(--dpf-text)",
+  cursor: "pointer",
+};
+
+const dangerBtn: CSSProperties = {
+  fontSize: 11,
+  padding: "4px 8px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-error)",
+  background: "var(--dpf-error)",
+  color: "white",
+  cursor: "pointer",
+};

--- a/apps/web/lib/actions/skill-proposal-actions.ts
+++ b/apps/web/lib/actions/skill-proposal-actions.ts
@@ -1,0 +1,80 @@
+"use server";
+
+// Server-action surface for skill proposal review. The pure proposal lifecycle
+// lives in `apps/web/lib/skills/proposals.ts`; this module wraps it with
+// session-aware authentication checks so the UI can call from a "use client"
+// component without leaking the user identity into client code.
+//
+// Capability check: only platform-role users with `manage_capabilities`
+// authority may approve, reject, or roll back skills. (Submit is open per
+// MCP convention — anyone can propose.)
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  approveSkillImprovementProposal as actionApprove,
+  rejectSkillImprovementProposal as actionReject,
+  rollbackSkillToRevision as actionRollback,
+} from "@/lib/skills/proposals";
+
+async function requireReviewer(): Promise<
+  { ok: true; userId: string } | { ok: false; error: string }
+> {
+  const session = await auth();
+  if (!session?.user?.id) return { ok: false, error: "Unauthorized" };
+  const platformRole = session.user.platformRole ?? null;
+  const userCtx = {
+    userId: session.user.id,
+    platformRole,
+    isSuperuser: session.user.isSuperuser ?? false,
+  };
+  if (!can(userCtx, "manage_capabilities")) {
+    return {
+      ok: false,
+      error:
+        "manage_capabilities capability required to approve, reject, or roll back skill changes.",
+    };
+  }
+  return { ok: true, userId: session.user.id };
+}
+
+export async function approveSkillProposalAction(
+  proposalId: string,
+): Promise<{ ok: true; data: Awaited<ReturnType<typeof actionApprove>> } | { ok: false; error: string }> {
+  const auth = await requireReviewer();
+  if (!auth.ok) return auth;
+  try {
+    const data = await actionApprove({ proposalId, reviewerId: auth.userId });
+    return { ok: true, data };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function rejectSkillProposalAction(
+  proposalId: string,
+  rejectionReason: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const auth = await requireReviewer();
+  if (!auth.ok) return auth;
+  try {
+    await actionReject({ proposalId, reviewerId: auth.userId, rejectionReason });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function rollbackSkillAction(
+  skillId: string,
+  targetVersion: number,
+): Promise<{ ok: true; data: Awaited<ReturnType<typeof actionRollback>> } | { ok: false; error: string }> {
+  const auth = await requireReviewer();
+  if (!auth.ok) return auth;
+  try {
+    const data = await actionRollback({ skillId, targetVersion, reviewerId: auth.userId });
+    return { ok: true, data };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/web/lib/actions/skills-observatory.ts
+++ b/apps/web/lib/actions/skills-observatory.ts
@@ -175,6 +175,43 @@ export async function getSpecialistExecutions(limit = 100): Promise<SkillExecuti
 }
 
 /**
+ * Governed Hermes learning Slice 3: per-skill detail bundle for the
+ * proposals/revisions/seed-drift panel. Returns null when the skill does
+ * not exist so the caller can render a clean empty state.
+ */
+export async function getSkillReviewDetail(skillId: string): Promise<{
+  skillId: string;
+  skillMdContent: string;
+  category: string;
+  proposals: Awaited<ReturnType<typeof import("@/lib/skills/proposals").listSkillProposals>>;
+  revisions: Awaited<ReturnType<typeof import("@/lib/skills/proposals").listSkillRevisions>>;
+  seedDrift: Awaited<ReturnType<typeof import("@/lib/skills/seed-parity").getSkillSeedDrift>>;
+} | null> {
+  const skill = await prisma.skillDefinition.findUnique({
+    where: { skillId },
+    select: { skillId: true, skillMdContent: true, category: true },
+  });
+  if (!skill) return null;
+
+  const { listSkillProposals, listSkillRevisions } = await import("@/lib/skills/proposals");
+  const { getSkillSeedDrift } = await import("@/lib/skills/seed-parity");
+  const [proposals, revisions, seedDrift] = await Promise.all([
+    listSkillProposals(skillId),
+    listSkillRevisions(skillId),
+    getSkillSeedDrift(skillId),
+  ]);
+
+  return {
+    skillId: skill.skillId,
+    skillMdContent: skill.skillMdContent,
+    category: skill.category,
+    proposals,
+    revisions,
+    seedDrift,
+  };
+}
+
+/**
  * Governed Hermes learning Slice 1: shape SkillUsageEvent + SkillMetric for
  * the observatory's telemetry tab. Returns aggregate counts only — per-row
  * inspection lives in the Skills detail view (later slice).

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2113,6 +2113,42 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     executionMode: "proposal",
     sideEffect: true,
   },
+  {
+    name: "propose_skill_improvement",
+    description:
+      "Propose a content change to a specific coworker skill (e.g. tightening instructions, fixing a stale " +
+      "reference). Use when you have observed the current skill prompt produce the wrong behavior and you can " +
+      "draft a better version. Submits an ImprovementProposal(category='skill', targetSkillId=…) that a human " +
+      "reviews on /platform/ai/skills.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        skillId: {
+          type: "string",
+          description: "The SkillDefinition.skillId (business id) the proposal targets, e.g. 'build-page'.",
+        },
+        title: { type: "string", description: "Short title for the change (max 100 chars)" },
+        description: { type: "string", description: "Why the change is needed; cite the friction or failure" },
+        proposedContent: {
+          type: "string",
+          description: "Full proposed SKILL.md body (replaces the current content if approved)",
+        },
+        severity: {
+          type: "string",
+          enum: ["low", "medium", "high", "critical"],
+          description: "Impact severity (default: medium)",
+        },
+        observedFriction: {
+          type: "string",
+          description: "What you observed that prompted this change",
+        },
+      },
+      required: ["skillId", "title", "description", "proposedContent"],
+    },
+    requiredCapability: null,
+    executionMode: "proposal",
+    sideEffect: true,
+  },
   // ─── Provider Management ────────────────────────────────────────────────────
   {
     name: "add_provider",
@@ -8761,6 +8797,56 @@ export async function executeTool(
           content: String(params["description"] ?? ""),
         })
       ).catch(() => {});
+    }
+
+    case "propose_skill_improvement": {
+      const skillId = String(params["skillId"] ?? "").trim();
+      const proposedContent = String(params["proposedContent"] ?? "").trim();
+      const title = String(params["title"] ?? "").trim();
+      const description = String(params["description"] ?? "").trim();
+      if (!skillId || !proposedContent || !title || !description) {
+        return {
+          success: false,
+          error: "Missing required fields",
+          message:
+            "propose_skill_improvement requires skillId, title, description, and proposedContent.",
+        };
+      }
+      const sev = String(params["severity"] ?? "medium");
+      const severity = (["low", "medium", "high", "critical"].includes(sev) ? sev : "medium") as
+        | "low"
+        | "medium"
+        | "high"
+        | "critical";
+      const observedFriction =
+        typeof params["observedFriction"] === "string" ? params["observedFriction"] : null;
+      try {
+        const { submitSkillImprovementProposal } = await import("@/lib/skills/proposals");
+        const result = await submitSkillImprovementProposal({
+          skillId,
+          proposedContent,
+          title,
+          description,
+          severity,
+          submittedById: userId,
+          agentId: context?.agentId ?? "unknown",
+          routeContext: context?.routeContext ?? "unknown",
+          threadId: context?.threadId ?? null,
+          observedFriction,
+        });
+        return {
+          success: true,
+          entityId: result.proposalId,
+          message: `Skill proposal ${result.proposalId} created for ${skillId}. A reviewer must approve before it takes effect.`,
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        return {
+          success: false,
+          error: msg,
+          message: `Could not create skill proposal: ${msg}`,
+        };
+      }
     }
 
     case "add_provider": {

--- a/apps/web/lib/skills/proposals.test.ts
+++ b/apps/web/lib/skills/proposals.test.ts
@@ -1,0 +1,466 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory state for the mock transaction so atomicity can be exercised
+// without a live database. Each test resets it via the beforeEach hook.
+const state = vi.hoisted(() => {
+  return {
+    skills: new Map<string, { skillId: string; skillMdContent: string }>(),
+    proposals: new Map<string, Record<string, unknown>>(),
+    revisions: new Map<string, Record<string, unknown>>(),
+    revisionRows: [] as Array<Record<string, unknown>>,
+    // Optional injection hook used by the atomicity test
+    failOnNthCreateRevision: null as number | null,
+    createRevisionCallCount: 0,
+  };
+});
+
+const buildPrismaMock = () => {
+  const skillDefinition = {
+    findUnique: vi.fn(async ({ where, select }: { where: { skillId: string }; select?: Record<string, boolean> }) => {
+      const s = state.skills.get(where.skillId);
+      if (!s) return null;
+      if (select?.skillMdContent) return { ...s };
+      return { skillId: s.skillId };
+    }),
+    update: vi.fn(
+      async ({ where, data }: { where: { skillId: string }; data: { skillMdContent: string } }) => {
+        const s = state.skills.get(where.skillId);
+        if (!s) throw new Error("skill not found");
+        s.skillMdContent = data.skillMdContent;
+        return s;
+      },
+    ),
+  };
+
+  const improvementProposal = {
+    findUnique: vi.fn(async ({ where }: { where: { proposalId: string } }) => {
+      return state.proposals.get(where.proposalId) ?? null;
+    }),
+    create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+      const row = { ...data, createdAt: new Date(), updatedAt: new Date() };
+      state.proposals.set(data.proposalId as string, row);
+      return row;
+    }),
+    update: vi.fn(
+      async ({ where, data }: { where: { proposalId: string }; data: Record<string, unknown> }) => {
+        const p = state.proposals.get(where.proposalId);
+        if (!p) throw new Error("proposal not found");
+        Object.assign(p, data);
+        return p;
+      },
+    ),
+  };
+
+  const skillRevision = {
+    findUnique: vi.fn(
+      async ({
+        where,
+      }: {
+        where: { skillId_version: { skillId: string; version: number } };
+      }) => {
+        return (
+          state.revisionRows.find(
+            (r) =>
+              r.skillId === where.skillId_version.skillId &&
+              r.version === where.skillId_version.version,
+          ) ?? null
+        );
+      },
+    ),
+    findFirst: vi.fn(async ({ where }: { where: { skillId: string } }) => {
+      const rows = state.revisionRows
+        .filter((r) => r.skillId === where.skillId)
+        .sort((a, b) => (b.version as number) - (a.version as number));
+      return rows[0] ?? null;
+    }),
+    findMany: vi.fn(async ({ where }: { where: { skillId: string } }) => {
+      return state.revisionRows
+        .filter((r) => r.skillId === where.skillId)
+        .sort((a, b) => (b.version as number) - (a.version as number));
+    }),
+    create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+      state.createRevisionCallCount++;
+      if (
+        state.failOnNthCreateRevision !== null &&
+        state.createRevisionCallCount === state.failOnNthCreateRevision
+      ) {
+        throw new Error("simulated transient DB failure");
+      }
+      const row = {
+        ...data,
+        createdAt: new Date(),
+      };
+      state.revisions.set(data.revisionId as string, row);
+      state.revisionRows.push(row);
+      return row;
+    }),
+  };
+
+  const prisma = {
+    skillDefinition,
+    improvementProposal,
+    skillRevision,
+    $transaction: vi.fn(async (fn: (tx: typeof prisma) => Promise<unknown>) => {
+      // Naive transaction emulator: snapshot state, call fn(tx); on throw,
+      // restore the snapshot. Adequate for atomicity verification without
+      // a real engine.
+      const snapshot = {
+        skills: new Map(state.skills),
+        proposals: new Map(state.proposals),
+        revisions: new Map(state.revisions),
+        revisionRows: [...state.revisionRows],
+      };
+      try {
+        return await fn(prisma);
+      } catch (err) {
+        state.skills = snapshot.skills;
+        state.proposals = snapshot.proposals;
+        state.revisions = snapshot.revisions;
+        state.revisionRows = snapshot.revisionRows;
+        throw err;
+      }
+    }),
+  };
+
+  return prisma;
+};
+
+const mockPrisma = vi.hoisted(() => ({ value: null as ReturnType<typeof buildPrismaMock> | null }));
+
+vi.mock("@dpf/db", () => ({
+  get prisma() {
+    return mockPrisma.value;
+  },
+}));
+
+import {
+  approveSkillImprovementProposal,
+  listSkillProposals,
+  listSkillRevisions,
+  rejectSkillImprovementProposal,
+  rollbackSkillToRevision,
+  submitSkillImprovementProposal,
+} from "./proposals";
+
+beforeEach(() => {
+  mockPrisma.value = buildPrismaMock();
+  state.skills.clear();
+  state.proposals.clear();
+  state.revisions.clear();
+  state.revisionRows.length = 0;
+  state.failOnNthCreateRevision = null;
+  state.createRevisionCallCount = 0;
+  state.skills.set("build-page", {
+    skillId: "build-page",
+    skillMdContent: "v0 body — original",
+  });
+});
+
+describe("submitSkillImprovementProposal", () => {
+  it("rejects unknown skill id", async () => {
+    await expect(
+      submitSkillImprovementProposal({
+        skillId: "missing",
+        proposedContent: "x",
+        title: "t",
+        description: "d",
+        submittedById: "u",
+        agentId: "a",
+        routeContext: "/r",
+      }),
+    ).rejects.toThrow(/unknown skillId/);
+  });
+
+  it("rejects empty proposed content", async () => {
+    await expect(
+      submitSkillImprovementProposal({
+        skillId: "build-page",
+        proposedContent: "",
+        title: "t",
+        description: "d",
+        submittedById: "u",
+        agentId: "a",
+        routeContext: "/r",
+      }),
+    ).rejects.toThrow(/non-empty string/);
+  });
+
+  it("creates an ImprovementProposal with category=skill and targetSkillId", async () => {
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1 proposed body",
+      title: "Tighten build-page intro",
+      description: "Replace the rambling intro with two clear sentences.",
+      submittedById: "user-1",
+      agentId: "AGT-1",
+      routeContext: "/customer",
+      threadId: "thread-1",
+      observedFriction: "Users repeatedly ask what the skill is for.",
+    });
+
+    const row = state.proposals.get(proposalId);
+    expect(row).toBeDefined();
+    expect(row?.category).toBe("skill");
+    expect(row?.targetSkillId).toBe("build-page");
+    expect(row?.status).toBe("proposed");
+    expect(row?.conversationExcerpt).toBe("v1 proposed body");
+    expect(row?.severity).toBe("medium");
+    expect((proposalId).startsWith("IP-SKL-")).toBe(true);
+  });
+});
+
+describe("approveSkillImprovementProposal — atomicity", () => {
+  it("writes snapshot + applied revisions and updates SkillDefinition atomically", async () => {
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1 proposed body",
+      title: "t",
+      description: "d",
+      submittedById: "user-1",
+      agentId: "AGT-1",
+      routeContext: "/r",
+    });
+
+    const result = await approveSkillImprovementProposal({
+      proposalId,
+      reviewerId: "reviewer-1",
+    });
+
+    expect(result.newVersion).toBe(2);
+
+    // SkillDefinition.skillMdContent is updated to the proposed body.
+    expect(state.skills.get("build-page")?.skillMdContent).toBe("v1 proposed body");
+
+    // Two revisions exist: snapshot (v1, original body) + applied (v2, new body).
+    const revisions = state.revisionRows
+      .filter((r) => r.skillId === "build-page")
+      .sort((a, b) => (a.version as number) - (b.version as number));
+    expect(revisions).toHaveLength(2);
+    expect(revisions[0]?.version).toBe(1);
+    expect(revisions[0]?.content).toBe("v0 body — original");
+    expect(revisions[0]?.changeReason).toBe("pre-approval snapshot");
+    expect(revisions[1]?.version).toBe(2);
+    expect(revisions[1]?.content).toBe("v1 proposed body");
+    expect(revisions[1]?.proposalId).toBe(proposalId);
+
+    // Proposal moves to reviewed + verifiedAt.
+    const p = state.proposals.get(proposalId);
+    expect(p?.status).toBe("reviewed");
+    expect(p?.reviewedById).toBe("reviewer-1");
+    expect(p?.verifiedAt).toBeInstanceOf(Date);
+  });
+
+  it("rolls back the whole transaction when any inner write fails", async () => {
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1 proposed body",
+      title: "t",
+      description: "d",
+      submittedById: "user-1",
+      agentId: "AGT-1",
+      routeContext: "/r",
+    });
+
+    // Fail on the second skillRevision.create (the applied revision) so the
+    // snapshot is already written but the SkillDefinition update has not
+    // happened. The transaction must restore the snapshot.
+    state.failOnNthCreateRevision = 2;
+
+    await expect(
+      approveSkillImprovementProposal({ proposalId, reviewerId: "reviewer-1" }),
+    ).rejects.toThrow(/simulated transient DB failure/);
+
+    // SkillDefinition body must be unchanged.
+    expect(state.skills.get("build-page")?.skillMdContent).toBe("v0 body — original");
+    // No revisions persisted.
+    expect(state.revisionRows.filter((r) => r.skillId === "build-page")).toHaveLength(0);
+    // Proposal status unchanged.
+    expect(state.proposals.get(proposalId)?.status).toBe("proposed");
+  });
+
+  it("refuses to approve a non-skill proposal", async () => {
+    state.proposals.set("IP-OTHER-1", {
+      proposalId: "IP-OTHER-1",
+      category: "ux_friction",
+      status: "proposed",
+      targetSkillId: null,
+    });
+    await expect(
+      approveSkillImprovementProposal({ proposalId: "IP-OTHER-1", reviewerId: "r" }),
+    ).rejects.toThrow(/not category="skill"/);
+  });
+
+  it("refuses to re-approve an already-reviewed proposal", async () => {
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1",
+      title: "t",
+      description: "d",
+      submittedById: "u",
+      agentId: "a",
+      routeContext: "/r",
+    });
+    await approveSkillImprovementProposal({ proposalId, reviewerId: "r" });
+    await expect(
+      approveSkillImprovementProposal({ proposalId, reviewerId: "r" }),
+    ).rejects.toThrow(/is not in status="proposed"/);
+  });
+});
+
+describe("rejectSkillImprovementProposal", () => {
+  it("requires a non-empty rejection reason", async () => {
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1",
+      title: "t",
+      description: "d",
+      submittedById: "u",
+      agentId: "a",
+      routeContext: "/r",
+    });
+    await expect(
+      rejectSkillImprovementProposal({ proposalId, reviewerId: "r", rejectionReason: " " }),
+    ).rejects.toThrow(/required/);
+  });
+
+  it("marks the proposal rejected with reason and creates no revision", async () => {
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1",
+      title: "t",
+      description: "d",
+      submittedById: "u",
+      agentId: "a",
+      routeContext: "/r",
+    });
+    await rejectSkillImprovementProposal({
+      proposalId,
+      reviewerId: "r",
+      rejectionReason: "introduces a regression",
+    });
+    const p = state.proposals.get(proposalId);
+    expect(p?.status).toBe("rejected");
+    expect(p?.rejectionReason).toBe("introduces a regression");
+    expect(state.revisionRows).toHaveLength(0);
+    // SkillDefinition body unchanged.
+    expect(state.skills.get("build-page")?.skillMdContent).toBe("v0 body — original");
+  });
+});
+
+describe("rollbackSkillToRevision", () => {
+  it("writes a NEW revision with the target content and updates SkillDefinition", async () => {
+    // Seed a couple of revisions (simulate an earlier approve cycle).
+    state.revisionRows.push({
+      revisionId: "SREV-1",
+      skillId: "build-page",
+      version: 1,
+      content: "v0 body — original",
+      changeReason: "snapshot",
+    });
+    state.revisionRows.push({
+      revisionId: "SREV-2",
+      skillId: "build-page",
+      version: 2,
+      content: "v1 body",
+      changeReason: "applied",
+    });
+    state.skills.get("build-page")!.skillMdContent = "v1 body";
+
+    const result = await rollbackSkillToRevision({
+      skillId: "build-page",
+      targetVersion: 1,
+      reviewerId: "reviewer-1",
+    });
+
+    expect(result.newVersion).toBe(3);
+    expect(result.restoredFromVersion).toBe(1);
+    expect(state.skills.get("build-page")?.skillMdContent).toBe("v0 body — original");
+    const revs = state.revisionRows.filter((r) => r.skillId === "build-page");
+    expect(revs).toHaveLength(3);
+    expect(revs[2]?.version).toBe(3);
+    expect(revs[2]?.content).toBe("v0 body — original");
+    expect(revs[2]?.changeReason).toBe("rollback to v1");
+  });
+
+  it("rejects rollback to a version that does not exist", async () => {
+    await expect(
+      rollbackSkillToRevision({ skillId: "build-page", targetVersion: 99, reviewerId: "r" }),
+    ).rejects.toThrow(/revision not found/);
+  });
+});
+
+describe("listSkillRevisions / listSkillProposals", () => {
+  it("returns revisions newest-first with serialised createdAt", async () => {
+    state.revisionRows.push({
+      revisionId: "SREV-A",
+      skillId: "build-page",
+      version: 1,
+      content: "x",
+      changeReason: "a",
+      changedBy: "u",
+      proposalId: null,
+      createdAt: new Date("2026-05-10T00:00:00Z"),
+    });
+    state.revisionRows.push({
+      revisionId: "SREV-B",
+      skillId: "build-page",
+      version: 2,
+      content: "y",
+      changeReason: "b",
+      changedBy: "u",
+      proposalId: "IP-SKL-1",
+      createdAt: new Date("2026-05-11T00:00:00Z"),
+    });
+    const out = await listSkillRevisions("build-page");
+    expect(out.map((r) => r.version)).toEqual([2, 1]);
+    expect(out[0]?.proposalId).toBe("IP-SKL-1");
+    expect(typeof out[0]?.createdAt).toBe("string");
+  });
+
+  it("returns proposals filtered by category=skill + targetSkillId", async () => {
+    await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1",
+      title: "t",
+      description: "d",
+      submittedById: "u",
+      agentId: "a",
+      routeContext: "/r",
+    });
+    // Add a non-skill proposal to confirm filtering.
+    state.proposals.set("IP-X", {
+      proposalId: "IP-X",
+      category: "ux_friction",
+      targetSkillId: null,
+      title: "n",
+      description: "n",
+      severity: "low",
+      submittedById: "u",
+      agentId: "a",
+      threadId: null,
+      observedFriction: null,
+      conversationExcerpt: null,
+      status: "proposed",
+      reviewedById: null,
+      reviewedAt: null,
+      rejectionReason: null,
+      createdAt: new Date(),
+    });
+    // The mock's findMany is generic — emulate the where filter the action passes.
+    const findMany = mockPrisma.value!.improvementProposal as unknown as {
+      findMany: ReturnType<typeof vi.fn>;
+    };
+    findMany.findMany = vi.fn(async (args: { where: Record<string, unknown> }) => {
+      const allRows = [...state.proposals.values()];
+      return allRows.filter((r) => {
+        if (args.where.category && r.category !== args.where.category) return false;
+        if (args.where.targetSkillId && r.targetSkillId !== args.where.targetSkillId) return false;
+        return true;
+      });
+    });
+
+    const out = await listSkillProposals("build-page");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.proposedContent).toBe("v1");
+  });
+});

--- a/apps/web/lib/skills/proposals.ts
+++ b/apps/web/lib/skills/proposals.ts
@@ -1,0 +1,432 @@
+// Skill proposal lifecycle (Slice 3 of the governed Hermes learning loop).
+//
+// Reuses ImprovementProposal as the proposal envelope; mirrors PromptRevision
+// for SkillRevision. Approval and rollback run inside a Prisma transaction so
+// the row, the snapshot, and the new SkillDefinition.skillMdContent all move
+// together — partial state cannot persist on a transient DB failure.
+
+import { randomUUID } from "crypto";
+
+import { prisma } from "@dpf/db";
+
+const PROPOSAL_ID_PREFIX = "IP-SKL";
+const REVISION_ID_PREFIX = "SREV";
+
+function makeProposalId(): string {
+  return `${PROPOSAL_ID_PREFIX}-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function makeRevisionId(): string {
+  return `${REVISION_ID_PREFIX}-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+export type SubmitSkillImprovementProposalInput = {
+  /** SkillDefinition.skillId (business id). */
+  skillId: string;
+  /** Full proposed SKILL.md content (no diff format — store the target body). */
+  proposedContent: string;
+  /** Short title summarising the proposal. */
+  title: string;
+  /** Long-form description / rationale. */
+  description: string;
+  /** ImprovementProposal severity. */
+  severity?: "low" | "medium" | "high" | "critical";
+  /** User identity submitting the proposal (existing ImprovementProposal contract). */
+  submittedById: string;
+  /** Agent identity (coworker that authored the proposal). */
+  agentId: string;
+  /** Route context where the proposal was raised. */
+  routeContext: string;
+  /** Optional thread linkage for evidence. */
+  threadId?: string | null;
+  /** Optional conversation excerpt for the human reviewer. */
+  conversationExcerpt?: string | null;
+  /** Optional one-liner describing the friction this proposal addresses. */
+  observedFriction?: string | null;
+};
+
+export type SubmitSkillImprovementProposalResult = {
+  proposalId: string;
+};
+
+/**
+ * Persist a new ImprovementProposal(category="skill", targetSkillId=...) row.
+ * The full proposed content is stored in `conversationExcerpt` because the
+ * existing schema has no diff-shaped column — the spec defers a dedicated
+ * `proposedDiffJson` until the text fields prove insufficient. Approval
+ * reads it back from the same column.
+ */
+export async function submitSkillImprovementProposal(
+  input: SubmitSkillImprovementProposalInput,
+): Promise<SubmitSkillImprovementProposalResult> {
+  const skill = await prisma.skillDefinition.findUnique({
+    where: { skillId: input.skillId },
+    select: { skillId: true },
+  });
+  if (!skill) {
+    throw new Error(`[skill-proposals] unknown skillId: ${input.skillId}`);
+  }
+  if (typeof input.proposedContent !== "string" || input.proposedContent.length === 0) {
+    throw new Error("[skill-proposals] proposedContent must be a non-empty string");
+  }
+
+  const proposalId = makeProposalId();
+  await prisma.improvementProposal.create({
+    data: {
+      proposalId,
+      title: input.title.slice(0, 200),
+      description: input.description,
+      category: "skill",
+      severity: input.severity ?? "medium",
+      submittedById: input.submittedById,
+      agentId: input.agentId,
+      routeContext: input.routeContext,
+      threadId: input.threadId ?? null,
+      conversationExcerpt: input.proposedContent,
+      observedFriction: input.observedFriction ?? null,
+      targetSkillId: input.skillId,
+      status: "proposed",
+    },
+  });
+
+  return { proposalId };
+}
+
+export type ApproveSkillImprovementProposalInput = {
+  proposalId: string;
+  reviewerId: string;
+  /** Optional override of the approval reason recorded on the revision. */
+  changeReason?: string;
+};
+
+export type ApproveSkillImprovementProposalResult = {
+  proposalId: string;
+  skillId: string;
+  snapshotRevisionId: string;
+  appliedRevisionId: string;
+  newVersion: number;
+};
+
+/**
+ * Approve a skill improvement proposal. Atomic — all writes happen inside one
+ * Prisma transaction. The DB never mutates SkillDefinition.skillMdContent in
+ * place: a snapshot revision is written FIRST (capturing the pre-approval
+ * body), then the applied revision and the SkillDefinition update happen
+ * together. Rollback simply restores from any prior revision.
+ */
+export async function approveSkillImprovementProposal(
+  input: ApproveSkillImprovementProposalInput,
+): Promise<ApproveSkillImprovementProposalResult> {
+  return prisma.$transaction(async (tx) => {
+    const proposal = await tx.improvementProposal.findUnique({
+      where: { proposalId: input.proposalId },
+    });
+    if (!proposal) {
+      throw new Error(`[skill-proposals] proposal not found: ${input.proposalId}`);
+    }
+    if (proposal.category !== "skill") {
+      throw new Error(
+        `[skill-proposals] proposal ${input.proposalId} is not category="skill"`,
+      );
+    }
+    if (proposal.status !== "proposed") {
+      throw new Error(
+        `[skill-proposals] proposal ${input.proposalId} is not in status="proposed" (was ${proposal.status})`,
+      );
+    }
+    if (!proposal.targetSkillId) {
+      throw new Error(
+        `[skill-proposals] proposal ${input.proposalId} has no targetSkillId`,
+      );
+    }
+    const proposedContent = proposal.conversationExcerpt;
+    if (!proposedContent) {
+      throw new Error(
+        `[skill-proposals] proposal ${input.proposalId} has no proposed content`,
+      );
+    }
+
+    const skill = await tx.skillDefinition.findUnique({
+      where: { skillId: proposal.targetSkillId },
+      select: { skillId: true, skillMdContent: true },
+    });
+    if (!skill) {
+      throw new Error(
+        `[skill-proposals] proposal targets unknown skill: ${proposal.targetSkillId}`,
+      );
+    }
+
+    const latest = await tx.skillRevision.findFirst({
+      where: { skillId: skill.skillId },
+      orderBy: { version: "desc" },
+      select: { version: true },
+    });
+    const baseVersion = latest?.version ?? 0;
+    const snapshotVersion = baseVersion + 1;
+    const appliedVersion = baseVersion + 2;
+
+    const snapshotRevisionId = makeRevisionId();
+    await tx.skillRevision.create({
+      data: {
+        revisionId: snapshotRevisionId,
+        skillId: skill.skillId,
+        version: snapshotVersion,
+        content: skill.skillMdContent,
+        changeReason: "pre-approval snapshot",
+        changedBy: input.reviewerId,
+      },
+    });
+
+    const appliedRevisionId = makeRevisionId();
+    await tx.skillRevision.create({
+      data: {
+        revisionId: appliedRevisionId,
+        skillId: skill.skillId,
+        version: appliedVersion,
+        content: proposedContent,
+        changeReason: input.changeReason ?? `approved proposal ${proposal.proposalId}`,
+        changedBy: input.reviewerId,
+        proposalId: proposal.proposalId,
+      },
+    });
+
+    await tx.skillDefinition.update({
+      where: { skillId: skill.skillId },
+      data: { skillMdContent: proposedContent },
+    });
+
+    const now = new Date();
+    await tx.improvementProposal.update({
+      where: { proposalId: proposal.proposalId },
+      data: {
+        status: "reviewed",
+        reviewedById: input.reviewerId,
+        reviewedAt: now,
+        verifiedAt: now,
+      },
+    });
+
+    return {
+      proposalId: proposal.proposalId,
+      skillId: skill.skillId,
+      snapshotRevisionId,
+      appliedRevisionId,
+      newVersion: appliedVersion,
+    };
+  });
+}
+
+export type RejectSkillImprovementProposalInput = {
+  proposalId: string;
+  reviewerId: string;
+  rejectionReason: string;
+};
+
+export type RejectSkillImprovementProposalResult = {
+  proposalId: string;
+};
+
+/** Mark a skill proposal rejected. No revision is created. */
+export async function rejectSkillImprovementProposal(
+  input: RejectSkillImprovementProposalInput,
+): Promise<RejectSkillImprovementProposalResult> {
+  const proposal = await prisma.improvementProposal.findUnique({
+    where: { proposalId: input.proposalId },
+    select: { category: true, status: true },
+  });
+  if (!proposal) {
+    throw new Error(`[skill-proposals] proposal not found: ${input.proposalId}`);
+  }
+  if (proposal.category !== "skill") {
+    throw new Error(
+      `[skill-proposals] proposal ${input.proposalId} is not category="skill"`,
+    );
+  }
+  if (proposal.status !== "proposed") {
+    throw new Error(
+      `[skill-proposals] proposal ${input.proposalId} is not in status="proposed" (was ${proposal.status})`,
+    );
+  }
+  if (!input.rejectionReason || input.rejectionReason.trim().length === 0) {
+    throw new Error("[skill-proposals] rejectionReason is required");
+  }
+
+  await prisma.improvementProposal.update({
+    where: { proposalId: input.proposalId },
+    data: {
+      status: "rejected",
+      reviewedById: input.reviewerId,
+      reviewedAt: new Date(),
+      rejectionReason: input.rejectionReason,
+    },
+  });
+
+  return { proposalId: input.proposalId };
+}
+
+export type RollbackSkillToRevisionInput = {
+  skillId: string;
+  /** Version number on SkillRevision the operator wants to restore. */
+  targetVersion: number;
+  reviewerId: string;
+};
+
+export type RollbackSkillToRevisionResult = {
+  skillId: string;
+  newRevisionId: string;
+  newVersion: number;
+  restoredFromVersion: number;
+};
+
+/**
+ * Restore a skill's content from a prior revision. Always writes a NEW
+ * revision (never mutates an existing one); the new row's content is a
+ * direct copy of the target revision's content, and its changeReason
+ * records the rollback intent.
+ */
+export async function rollbackSkillToRevision(
+  input: RollbackSkillToRevisionInput,
+): Promise<RollbackSkillToRevisionResult> {
+  return prisma.$transaction(async (tx) => {
+    const target = await tx.skillRevision.findUnique({
+      where: {
+        skillId_version: { skillId: input.skillId, version: input.targetVersion },
+      },
+      select: { content: true, version: true },
+    });
+    if (!target) {
+      throw new Error(
+        `[skill-proposals] revision not found: ${input.skillId} v${input.targetVersion}`,
+      );
+    }
+
+    const latest = await tx.skillRevision.findFirst({
+      where: { skillId: input.skillId },
+      orderBy: { version: "desc" },
+      select: { version: true },
+    });
+    const newVersion = (latest?.version ?? 0) + 1;
+
+    const newRevisionId = makeRevisionId();
+    await tx.skillRevision.create({
+      data: {
+        revisionId: newRevisionId,
+        skillId: input.skillId,
+        version: newVersion,
+        content: target.content,
+        changeReason: `rollback to v${target.version}`,
+        changedBy: input.reviewerId,
+      },
+    });
+
+    await tx.skillDefinition.update({
+      where: { skillId: input.skillId },
+      data: { skillMdContent: target.content },
+    });
+
+    return {
+      skillId: input.skillId,
+      newRevisionId,
+      newVersion,
+      restoredFromVersion: target.version,
+    };
+  });
+}
+
+export type SkillRevisionRow = {
+  revisionId: string;
+  version: number;
+  changeReason: string | null;
+  changedBy: string | null;
+  proposalId: string | null;
+  createdAt: string;
+};
+
+export async function listSkillRevisions(
+  skillId: string,
+): Promise<SkillRevisionRow[]> {
+  const rows = await prisma.skillRevision.findMany({
+    where: { skillId },
+    orderBy: { version: "desc" },
+    select: {
+      revisionId: true,
+      version: true,
+      changeReason: true,
+      changedBy: true,
+      proposalId: true,
+      createdAt: true,
+    },
+  });
+  return rows.map((r) => ({
+    revisionId: r.revisionId,
+    version: r.version,
+    changeReason: r.changeReason,
+    changedBy: r.changedBy,
+    proposalId: r.proposalId,
+    createdAt: r.createdAt.toISOString(),
+  }));
+}
+
+export type SkillProposalRow = {
+  proposalId: string;
+  title: string;
+  description: string;
+  severity: string;
+  submittedById: string;
+  agentId: string;
+  threadId: string | null;
+  observedFriction: string | null;
+  proposedContent: string;
+  status: string;
+  reviewedById: string | null;
+  reviewedAt: string | null;
+  rejectionReason: string | null;
+  createdAt: string;
+};
+
+/**
+ * Fetch all proposals targeting a given skill, newest first. Includes
+ * proposed/reviewed/rejected so the operator can see the full lifecycle in
+ * the panel.
+ */
+export async function listSkillProposals(
+  skillId: string,
+): Promise<SkillProposalRow[]> {
+  const rows = await prisma.improvementProposal.findMany({
+    where: { category: "skill", targetSkillId: skillId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      proposalId: true,
+      title: true,
+      description: true,
+      severity: true,
+      submittedById: true,
+      agentId: true,
+      threadId: true,
+      observedFriction: true,
+      conversationExcerpt: true,
+      status: true,
+      reviewedById: true,
+      reviewedAt: true,
+      rejectionReason: true,
+      createdAt: true,
+    },
+  });
+  return rows.map((r) => ({
+    proposalId: r.proposalId,
+    title: r.title,
+    description: r.description,
+    severity: r.severity,
+    submittedById: r.submittedById,
+    agentId: r.agentId,
+    threadId: r.threadId,
+    observedFriction: r.observedFriction,
+    proposedContent: r.conversationExcerpt ?? "",
+    status: r.status,
+    reviewedById: r.reviewedById,
+    reviewedAt: r.reviewedAt?.toISOString() ?? null,
+    rejectionReason: r.rejectionReason,
+    createdAt: r.createdAt.toISOString(),
+  }));
+}
+

--- a/apps/web/lib/skills/seed-parity.test.ts
+++ b/apps/web/lib/skills/seed-parity.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { findUnique } = vi.hoisted(() => ({ findUnique: vi.fn() }));
+const { existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    skillDefinition: { findUnique },
+  },
+}));
+
+vi.mock("fs", () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+import { getSkillSeedDrift, resolveSeedPath } from "./seed-parity";
+
+describe("resolveSeedPath", () => {
+  it("derives the seed path from category and skillId", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    const p = resolveSeedPath("build", "build-page");
+    expect(p.replace(/\\/g, "/")).toBe("/repo/skills/build/build-page.skill.md");
+  });
+});
+
+describe("getSkillSeedDrift", () => {
+  it("returns inSync: false when the skill is missing from the DB", async () => {
+    findUnique.mockResolvedValueOnce(null);
+    const result = await getSkillSeedDrift("nonexistent");
+    expect(result.inSync).toBe(false);
+    expect(result.dbBody).toBeNull();
+    expect(result.seedBody).toBeNull();
+  });
+
+  it("returns inSync: true when DB and seed match (after CRLF normalisation)", async () => {
+    findUnique.mockResolvedValueOnce({
+      skillId: "build-page",
+      category: "build",
+      skillMdContent: "# Build a page\n\nDo the thing.\n",
+    });
+    existsSyncMock.mockReturnValueOnce(true);
+    readFileSyncMock.mockReturnValueOnce("# Build a page\r\n\r\nDo the thing.\r\n");
+    const result = await getSkillSeedDrift("build-page");
+    expect(result.inSync).toBe(true);
+    expect(result.dbBody).toContain("Build a page");
+    expect(result.seedBody).toContain("Build a page");
+  });
+
+  it("returns inSync: false when DB has drifted from the seed", async () => {
+    findUnique.mockResolvedValueOnce({
+      skillId: "build-page",
+      category: "build",
+      skillMdContent: "# Build a page\n\nDo the new thing.\n",
+    });
+    existsSyncMock.mockReturnValueOnce(true);
+    readFileSyncMock.mockReturnValueOnce("# Build a page\n\nDo the original thing.\n");
+    const result = await getSkillSeedDrift("build-page");
+    expect(result.inSync).toBe(false);
+    expect(result.dbBody).toContain("new thing");
+    expect(result.seedBody).toContain("original thing");
+  });
+
+  it("returns seedBody: null when the seed file is not present", async () => {
+    findUnique.mockResolvedValueOnce({
+      skillId: "internal-only",
+      category: "build",
+      skillMdContent: "any",
+    });
+    existsSyncMock.mockReturnValueOnce(false);
+    const result = await getSkillSeedDrift("internal-only");
+    expect(result.inSync).toBe(false);
+    expect(result.seedBody).toBeNull();
+    expect(result.dbBody).toBe("any");
+  });
+
+  it("never throws when the seed read errors — returns seedBody: null", async () => {
+    findUnique.mockResolvedValueOnce({
+      skillId: "build-page",
+      category: "build",
+      skillMdContent: "any",
+    });
+    existsSyncMock.mockReturnValueOnce(true);
+    readFileSyncMock.mockImplementationOnce(() => {
+      throw new Error("EACCES");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const result = await getSkillSeedDrift("build-page");
+    expect(result.inSync).toBe(false);
+    expect(result.seedBody).toBeNull();
+  });
+});

--- a/apps/web/lib/skills/seed-parity.ts
+++ b/apps/web/lib/skills/seed-parity.ts
@@ -1,0 +1,96 @@
+// Seed-parity helper for the governed Hermes-style learning loop.
+//
+// "Fix the seed, not the runtime path" (per the standing engineering rule):
+// when an approved proposal mutates SkillDefinition.skillMdContent, the
+// matching seed file under skills/<category>/<name>.skill.md should be
+// updated in the same PR — otherwise a fresh install reverts the change.
+// This helper detects that drift so the UI can flag it and the operator
+// can document the follow-up in the PR.
+//
+// Pure I/O over the local filesystem; the operator surface uses it as a
+// best-effort signal — `seedBody: null` means "we couldn't find the seed",
+// which on a production install (where the repo is not checked out next
+// to the app) is the normal case. The check is meaningful in dev and
+// in CI.
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+import { prisma } from "@dpf/db";
+
+/**
+ * Resolve the on-disk path of the seed file for a skill. The seed loader
+ * uses `skills/<category>/<basename>.skill.md`; basename is derived from
+ * the file (not the skillId), so we have to enumerate candidate filenames.
+ *
+ * Convention seen in skills/build/build-page.skill.md: `name: build-page`
+ * frontmatter exactly matches the basename. Treat that as authoritative
+ * and look for `<skillId>.skill.md` first.
+ */
+export function resolveSeedPath(category: string, skillId: string): string {
+  const repoRoot = process.env.DPF_REPO_ROOT ?? join(process.cwd(), "..", "..");
+  return join(repoRoot, "skills", category, `${skillId}.skill.md`);
+}
+
+export type SkillSeedDrift = {
+  /** True iff the seed body matches SkillDefinition.skillMdContent verbatim. */
+  inSync: boolean;
+  /** SkillDefinition.skillMdContent (or null if the skill is missing). */
+  dbBody: string | null;
+  /** Seed file body, or null if the file could not be located/read. */
+  seedBody: string | null;
+  /** Where the helper looked; useful in logs when seedBody is null. */
+  seedPath: string;
+};
+
+/**
+ * Compare a skill's DB body against its on-disk seed. Normalises CRLF →
+ * LF so Windows-checked-out repos don't false-flag. The helper does NOT
+ * mutate anything; it only reports.
+ */
+export async function getSkillSeedDrift(skillId: string): Promise<SkillSeedDrift> {
+  const skill = await prisma.skillDefinition.findUnique({
+    where: { skillId },
+    select: { skillId: true, category: true, skillMdContent: true },
+  });
+  if (!skill) {
+    return {
+      inSync: false,
+      dbBody: null,
+      seedBody: null,
+      seedPath: "",
+    };
+  }
+
+  const seedPath = resolveSeedPath(skill.category, skill.skillId);
+  let seedBody: string | null = null;
+  try {
+    if (existsSync(seedPath)) {
+      seedBody = readFileSync(seedPath, "utf-8");
+    }
+  } catch (err) {
+    console.warn(
+      `[seed-parity] could not read seed file ${seedPath}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  if (seedBody === null) {
+    return {
+      inSync: false,
+      dbBody: skill.skillMdContent,
+      seedBody: null,
+      seedPath,
+    };
+  }
+
+  const normalise = (s: string) => s.replace(/\r\n/g, "\n").trim();
+  const inSync = normalise(skill.skillMdContent) === normalise(seedBody);
+
+  return {
+    inSync,
+    dbBody: skill.skillMdContent,
+    seedBody,
+    seedPath,
+  };
+}

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -153,6 +153,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   compare_versions: ["file_read"],
   propose_file_change: ["file_read"],
   propose_improvement: ["decision_record_create"],
+  propose_skill_improvement: ["decision_record_create"],
 
   // Code graph (file-level coverage today; symbol-level deferred)
   get_code_graph_freshness: ["code_graph_read"],

--- a/docs/superpowers/plans/2026-05-15-skill-revisions-and-proposals.md
+++ b/docs/superpowers/plans/2026-05-15-skill-revisions-and-proposals.md
@@ -1,0 +1,208 @@
+# Skill Revisions and Proposals Implementation Plan (Slice 3)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Slice 3 of the governed Hermes-style coworker learning loop. Coworkers can propose skill content changes via `ImprovementProposal(category="skill")`; operators can approve, reject, or roll back; approval atomically writes a `SkillRevision` row and updates `SkillDefinition.skillMdContent`; rollback restores from a prior revision without in-place mutation.
+
+**Architecture:** Reuse `ImprovementProposal` as the proposal envelope (no parallel `SkillImprovementProposal` table). Mirror `PromptRevision` shape for `SkillRevision`. Approval and rollback run inside a Prisma transaction so the row and the content move together. A seed-parity helper surfaces drift between the DB and `skills/<category>/<name>.skill.md` so an approved change documents the expectation to patch the seed.
+
+**Tech Stack:** TypeScript, Next.js 16 App Router, React, Prisma 7, PostgreSQL, Vitest, pnpm workspaces.
+
+---
+
+## Scope
+
+This plan implements Slice 3 from `docs/superpowers/specs/2026-05-15-governed-hermes-learning-loop-design.md`.
+
+In scope:
+
+- `SkillRevision` model (mirrors `PromptRevision` shape).
+- `ImprovementProposal.targetSkillId` column (nullable) + `skill` value added to the category enum at the application layer.
+- Server actions: `submitSkillImprovementProposal`, `approveSkillImprovementProposal`, `rejectSkillImprovementProposal`, `rollbackSkillToRevision`.
+- MCP tool `propose_skill_improvement` (coworker-callable) — extends, does not replace, `propose_improvement`.
+- Seed-vs-runtime drift helper: `getSkillSeedDrift(skillId)` reads the matching `skills/<category>/<name>.skill.md` and compares its body against the DB row.
+- UI on `/platform/ai/skills/[skillId]` detail panel (or skills observatory if no detail route exists yet): pending proposals list, diff preview, approve/reject/rollback controls, revision history. Theme-token compliant per AGENTS.md §12.
+
+Out of scope:
+
+- Curator lifecycle states (`lifecycleState`, pinned/stale/archive/quarantined). That is Slice 4.
+- Evidence / session search. Slice 5.
+- Evolution Lab. Slice 6.
+- External skill import. Slice 7.
+- Other proposal categories from the spec (`prompt | memory | tool | convention | code | other`). Slice 3 only adds `skill`; others land when their consumer arrives.
+
+## Preconditions
+
+- Worktree base: `feat/skill-revisions-and-proposals` off `origin/main` after #629 merged.
+- `SkillDefinition` already has `skillMdContent` (live since the catalog landed).
+- `ImprovementProposal` already carries `category` (free-form String today; constrained at the application layer); we add `skill` to that constraint and add a nullable `targetSkillId` column.
+- Seed source files live at `skills/<category>/<name>.skill.md`. The seed loader reads them on fresh install.
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+| --- | --- |
+| `packages/db/prisma/migrations/<timestamp>_skill_revisions_and_proposals/migration.sql` | Adds `SkillRevision`, `ImprovementProposal.targetSkillId`. |
+| `apps/web/lib/skills/proposals.ts` | submit / approve / reject / rollback server actions. |
+| `apps/web/lib/skills/proposals.test.ts` | Unit tests for all four actions including transaction atomicity. |
+| `apps/web/lib/skills/seed-parity.ts` | Drift detection between DB and `skills/<category>/<name>.skill.md`. |
+| `apps/web/lib/skills/seed-parity.test.ts` | Drift detection tests. |
+| `apps/web/components/platform/SkillProposalsPanel.tsx` | List pending proposals for a skill, render diff, approve/reject/rollback controls. |
+| `apps/web/components/platform/SkillRevisionHistoryPanel.tsx` | Revision timeline + rollback action. |
+| `apps/web/components/platform/SkillProposalsPanel.test.tsx` | UI rendering tests. |
+| `apps/web/components/platform/SkillRevisionHistoryPanel.test.tsx` | UI rendering tests. |
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `packages/db/prisma/schema.prisma` | Add `SkillRevision`, `ImprovementProposal.targetSkillId`, `SkillDefinition.revisions` relation. |
+| `apps/web/lib/mcp-tools.ts` | Add `propose_skill_improvement` tool + handler. Extend `propose_improvement` category enum so the existing tool also accepts `skill`. |
+| `apps/web/lib/skills/runtime.ts` | Read latest revision when needed (read path stays on `SkillDefinition.skillMdContent`; this is for revision history). |
+| `apps/web/app/(shell)/platform/ai/skills/page.tsx` | Wire panels into the existing observatory page. |
+| `apps/web/lib/actions/skills-observatory.ts` | `getSkillProposalsAndRevisions(skillId)` data fetcher. |
+
+## Chunk 1: Schema
+
+### Task 1: Add SkillRevision + ImprovementProposal.targetSkillId
+
+- [ ] **Step 1: Schema fields**
+
+`SkillRevision`:
+
+```prisma
+model SkillRevision {
+  id           String   @id @default(cuid())
+  revisionId   String   @unique
+  skillId      String   // SkillDefinition.skillId (business id)
+  version      Int
+  content      String   // snapshot of skillMdContent at this version
+  metadata     Json?
+  changeReason String?
+  changedBy    String?
+  proposalId   String?  // ImprovementProposal.proposalId when approved via proposal
+  createdAt    DateTime @default(now())
+
+  skill SkillDefinition @relation(fields: [skillId], references: [skillId], onDelete: Cascade)
+
+  @@unique([skillId, version])
+  @@index([skillId, createdAt(sort: Desc)])
+  @@index([proposalId])
+}
+```
+
+`SkillDefinition`:
+
+```prisma
+  revisions SkillRevision[]
+```
+
+`ImprovementProposal`:
+
+```prisma
+  targetSkillId String?
+  @@index([targetSkillId])
+```
+
+- [ ] **Step 2: Migration + Prisma generate.**
+- [ ] **Step 3: Commit.**
+
+## Chunk 2: Server actions
+
+### Task 2: submitSkillImprovementProposal
+
+- [ ] Accepts `{ skillId, proposedContent, severity, agentId, threadId?, observedFriction?, conversationExcerpt?, evidenceJson? }`.
+- [ ] Resolves current `SkillDefinition.skillMdContent` into `description` (via diff summary) or stores proposed content in `conversationExcerpt` until a richer payload is justified.
+- [ ] Writes `ImprovementProposal(category="skill", status="proposed", targetSkillId, submittedById=agent user identity, agentId)`.
+- [ ] Returns `{ proposalId }`.
+
+### Task 3: approveSkillImprovementProposal (atomic)
+
+- [ ] Prisma transaction:
+  1. Load proposal (must be `status="proposed"` and `category="skill"` and `targetSkillId` set).
+  2. Load skill, current latest version.
+  3. Snapshot current `skillMdContent` into a new `SkillRevision(version=N+1, changeReason="pre-approval snapshot")`.
+  4. Apply the proposed content: a second `SkillRevision(version=N+2, proposalId, content=proposedContent, changeReason)` AND `SkillDefinition.skillMdContent` update.
+  5. Mark proposal `status="reviewed"`, `reviewedById`, `reviewedAt=now`, `verifiedAt=now`.
+- [ ] All five steps in one transaction so partial state cannot persist.
+
+### Task 4: rejectSkillImprovementProposal
+
+- [ ] Mark proposal `status="rejected"`, `reviewedById`, `reviewedAt`, `rejectionReason`. No revision created.
+
+### Task 5: rollbackSkillToRevision
+
+- [ ] Prisma transaction:
+  1. Load target revision (`{ skillId, version }`).
+  2. Write a new `SkillRevision(version=latest+1, content=target.content, changeReason="rollback to v<target.version>")`.
+  3. Update `SkillDefinition.skillMdContent = target.content`.
+
+## Chunk 3: Seed parity + MCP tool
+
+### Task 6: Seed parity helper
+
+- [ ] `getSkillSeedDrift(skillId)` reads `skills/<category>/<name>.skill.md` (path derived from `SkillDefinition.category` + `skillId`), normalizes line endings, and returns `{ inSync: boolean, dbBody: string, seedBody: string | null }`.
+- [ ] Test: when DB matches seed → `inSync: true`; when DB drifted → `inSync: false`; when seed missing → `seedBody: null, inSync: false`.
+
+### Task 7: MCP tool propose_skill_improvement
+
+- [ ] Add to `apps/web/lib/mcp-tools.ts` registry next to `propose_improvement`.
+- [ ] Input: `{ skillId, proposedContent, severity, observedFriction?, conversationExcerpt? }`.
+- [ ] Handler calls `submitSkillImprovementProposal`.
+- [ ] `requiredCapability: null` (anyone can submit, mirrors `propose_improvement`).
+- [ ] `executionMode: "proposal"` so the human approval path engages.
+- [ ] Also extend the `propose_improvement` `category` enum to include `skill` so calls that pick the generic tool with `category=skill` are routed through the same write path.
+
+## Chunk 4: UI
+
+### Task 8: SkillProposalsPanel
+
+- [ ] Fetch pending proposals via `getSkillProposalsAndRevisions(skillId)`.
+- [ ] Render: list of pending proposals with diff preview (current vs proposed), evidence, agent, submittedAt.
+- [ ] Buttons: approve, reject, link-to-backlog (existing tool).
+- [ ] Theme tokens only (AGENTS.md §12).
+
+### Task 9: SkillRevisionHistoryPanel
+
+- [ ] Render: revisions reverse-chronological with `{ version, changedBy, changeReason, createdAt }`.
+- [ ] Per row: "Roll back to this version" button → confirm → call `rollbackSkillToRevision`.
+
+### Task 10: Wire into /platform/ai/skills page
+
+- [ ] When a skill is selected (existing observatory has detail expand), show the two panels stacked under the existing skill detail.
+- [ ] Show a seed-drift badge on the skill row when `getSkillSeedDrift(skillId).inSync === false`. Caption: "Skill differs from seed — `skills/<category>/<name>.skill.md` needs update to survive fresh install."
+
+## Chunk 5: Verification + delivery
+
+### Task 11: Verification
+
+- [ ] `pnpm --filter web typecheck` clean.
+- [ ] Focused vitest sweep: `lib/skills/proposals.test.ts lib/skills/seed-parity.test.ts components/platform/SkillProposalsPanel.test.tsx components/platform/SkillRevisionHistoryPanel.test.tsx`.
+- [ ] Full vitest run — must stay green.
+- [ ] `pnpm --filter web exec next build` clean.
+
+### Task 12: PR
+
+- [ ] PR-overlap sweep against `apps/web/lib/skills/*`, `apps/web/lib/actions/skills-observatory.ts`, `apps/web/components/platform/*`, `apps/web/lib/mcp-tools.ts`, `packages/db/prisma/schema.prisma`.
+- [ ] Push + open draft PR with summary, test plan, migration note, DCO note.
+
+## Rollback Plan
+
+If approve/rollback produces incorrect skill content:
+
+1. Roll back via `rollbackSkillToRevision` to the latest non-affected `SkillRevision`. (The mechanism is self-rollback aware — every action writes a new immutable revision.)
+2. Disable the MCP tool by removing it from `getAvailableTools` if a bug allows malformed proposals through.
+3. If schema must be reverted, drop `SkillRevision` and remove `targetSkillId` — both are additive, no backfill needed.
+
+## Definition Of Done
+
+- A `propose_skill_improvement` MCP call by an authenticated coworker produces an `ImprovementProposal(category="skill", targetSkillId=…)` row.
+- Approve writes a `SkillRevision(version=N+2)`, snapshot `SkillRevision(version=N+1)`, updates `SkillDefinition.skillMdContent`, and marks the proposal reviewed/verified — all in one transaction.
+- Reject marks proposal `rejected` with `rejectionReason`; no revision created.
+- Rollback writes a new `SkillRevision` with the older content and updates `SkillDefinition.skillMdContent`. The DB never mutates in-place.
+- `getSkillSeedDrift` returns `inSync: false` when the DB has diverged from the seed file, surfaced in UI.
+- Vitest covers atomicity (failure during approve never leaves partial state), rollback, drift detection, and rejection.
+- Full vitest stays green; typecheck and `next build` clean.
+- PR has no overlap with concurrent open PRs; DCO green before flipping out of draft.

--- a/packages/db/prisma/migrations/20260516000000_skill_revisions_and_proposals/migration.sql
+++ b/packages/db/prisma/migrations/20260516000000_skill_revisions_and_proposals/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable
+ALTER TABLE "ImprovementProposal" ADD COLUMN "targetSkillId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ImprovementProposal_targetSkillId_idx" ON "ImprovementProposal"("targetSkillId");
+
+-- CreateTable
+CREATE TABLE "SkillRevision" (
+    "id" TEXT NOT NULL,
+    "revisionId" TEXT NOT NULL,
+    "skillId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "changeReason" TEXT,
+    "changedBy" TEXT,
+    "proposalId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SkillRevision_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SkillRevision_revisionId_key" ON "SkillRevision"("revisionId");
+
+-- CreateIndex
+CREATE INDEX "SkillRevision_skillId_createdAt_idx" ON "SkillRevision"("skillId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "SkillRevision_proposalId_idx" ON "SkillRevision"("proposalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SkillRevision_skillId_version_key" ON "SkillRevision"("skillId", "version");
+
+-- AddForeignKey
+ALTER TABLE "SkillRevision" ADD CONSTRAINT "SkillRevision_skillId_fkey" FOREIGN KEY ("skillId") REFERENCES "SkillDefinition"("skillId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1100,6 +1100,10 @@ model ImprovementProposal {
   rejectionReason     String?
   verifiedAt          DateTime?
   contributionStatus  String    @default("local")
+  // Governed Hermes learning Slice 3: when category="skill", this links the
+  // proposal to the SkillDefinition.skillId it targets. Nullable for the
+  // existing non-skill proposal flow.
+  targetSkillId       String?
   createdAt           DateTime  @default(now())
   updatedAt           DateTime  @updatedAt
   reviewedBy          User?     @relation("ImprovementReviews", fields: [reviewedById], references: [id])
@@ -1107,6 +1111,7 @@ model ImprovementProposal {
 
   @@index([status])
   @@index([submittedById])
+  @@index([targetSkillId])
   @@index([routeContext])
 }
 
@@ -6943,6 +6948,7 @@ model SkillDefinition {
   assignments SkillAssignment[]
   metrics     SkillMetric[]
   usageEvents SkillUsageEvent[]
+  revisions   SkillRevision[]
 
   @@index([status])
   @@index([category])
@@ -7008,6 +7014,30 @@ model SkillUsageEvent {
   @@index([threadId, createdAt(sort: Desc)])
   @@index([taskRunId, createdAt(sort: Desc)])
   @@index([phase, createdAt(sort: Desc)])
+}
+
+// Governed Hermes learning Slice 3: immutable per-version snapshot of a
+// skill's SKILL.md content. Mirrors PromptRevision shape so operators who
+// already know the prompt revision pattern can navigate this without
+// retraining. Every approve and rollback writes a new row; the DB never
+// mutates SkillDefinition.skillMdContent in place without leaving a trail.
+model SkillRevision {
+  id           String   @id @default(cuid())
+  revisionId   String   @unique
+  skillId      String // SkillDefinition.skillId (business id)
+  version      Int
+  content      String // snapshot of skillMdContent at this version
+  metadata     Json?
+  changeReason String?
+  changedBy    String?
+  proposalId   String? // ImprovementProposal.proposalId when approved via proposal
+  createdAt    DateTime @default(now())
+
+  skill SkillDefinition @relation(fields: [skillId], references: [skillId], onDelete: Cascade)
+
+  @@unique([skillId, version])
+  @@index([skillId, createdAt(sort: Desc)])
+  @@index([proposalId])
 }
 
 // ─── EP-DELEG-001: Delegation Chain (Authority Propagation & Chain of Custody) ─


### PR DESCRIPTION
## Summary

Slice 3 of the governed Hermes-style coworker learning loop. Coworkers can propose skill content changes via an `ImprovementProposal(category=\"skill\")` envelope; operators approve, reject, or roll back from `/platform/ai/skills?skill=<id>`. Approval atomically writes a pre-approval `SkillRevision` snapshot, an applied `SkillRevision` (linked back to the proposal), and updates `SkillDefinition.skillMdContent` — all-or-nothing. Rollback restores from any prior revision by writing a NEW revision; the DB never mutates `skillMdContent` in place without leaving a trail.

**Schema.** New `SkillRevision` model (mirrors `PromptRevision` shape: `revisionId, skillId, version, content, metadata, changeReason, changedBy, proposalId, createdAt`, with `@@unique([skillId, version])`). `ImprovementProposal` gains a nullable `targetSkillId` with an index. `SkillDefinition` gains a `revisions` back-relation.

**Server actions.** `apps/web/lib/skills/proposals.ts` exports `submitSkillImprovementProposal`, `approveSkillImprovementProposal` (Prisma transaction), `rejectSkillImprovementProposal`, `rollbackSkillToRevision`, plus `listSkillProposals` / `listSkillRevisions` for the UI. `apps/web/lib/actions/skill-proposal-actions.ts` is the session-aware server-action wrapper that enforces `manage_capabilities` before delegating to approve/reject/rollback.

**MCP tool.** `propose_skill_improvement` accepts `{ skillId, title, description, proposedContent, severity?, observedFriction? }` and delegates to the submit action. `requiredCapability: null` + `executionMode: \"proposal\"` mirrors the existing `propose_improvement` so anyone can submit and the human-review card surfaces in chat.

**Seed parity.** New `getSkillSeedDrift(skillId)` compares the DB body against the matching `skills/<category>/<name>.skill.md` after CRLF normalisation. The Review panel renders a drift banner with the exact seed path so the operator can patch the seed in the same PR — the standing 'fix the seed, not the runtime path' rule. When the seed file is missing entirely (production install), the banner downgrades to a muted note instead of a warning.

**UI.** `SkillProposalsPanel` lists pending/approved/rejected proposals with a current-vs-proposed diff column and Approve/Reject controls. `SkillRevisionHistoryPanel` shows reverse-chronological revisions with a two-step rollback confirm. Both mount on `/platform/ai/skills?skill=<id>` and use only `var(--dpf-*)` theme tokens (verified by a hex regex in tests).

Spec: \`docs/superpowers/specs/2026-05-15-governed-hermes-learning-loop-design.md\`  
Plan: \`docs/superpowers/plans/2026-05-15-skill-revisions-and-proposals.md\`

## Out of scope (deferred per the spec)

- Curator lifecycle states (`lifecycleState`, pinned/stale/archive/quarantined) — Slice 4
- Evidence / session search — Slice 5
- Evolution lab — Slice 6
- External skill import — Slice 7
- Proposal categories beyond `skill` (\`prompt | memory | tool | convention | code | other\`) — added when their consumer arrives

## Verification

- \`pnpm --filter web typecheck\`: clean
- Full vitest suite: **709 test files pass, 5,704 tests pass** (14 skipped, 13 todo). Slice 3 adds 27 new tests across 5 files (proposals atomicity, rollback, rejection, seed-parity drift, two UI panels, page integration).
- \`pnpm --filter web exec next build\`: succeeds; 102/102 static pages generated.

## Test plan

- [ ] Call `propose_skill_improvement` (any coworker route, any role) with a small change to a real skill and confirm an `ImprovementProposal(category=\"skill\", targetSkillId=…)` row is created and surfaces in chat as a proposal card.
- [ ] As a user with `manage_capabilities`, open `/platform/ai/skills?skill=<id>` and approve the proposal. Verify two new `SkillRevision` rows (snapshot vN+1 + applied vN+2), `SkillDefinition.skillMdContent` updated to the proposed body, and the proposal moves to `reviewed` with `verifiedAt`.
- [ ] Open the revision history panel, confirm rollback v1 to vN+1 writes a NEW vN+3 row (no in-place edits) and restores the older body.
- [ ] Reject a fresh proposal with a reason and confirm no `SkillRevision` is created; proposal moves to `rejected` with `rejectionReason`.
- [ ] Manually edit `SkillDefinition.skillMdContent` and reload — the drift banner appears citing the exact seed path. Patch the seed file to match and the banner clears.

## Migration / DCO

One new migration `20260516000000_skill_revisions_and_proposals` adds:
- `SkillRevision` table + indexes + FK to `SkillDefinition.skillId`.
- `ImprovementProposal.targetSkillId` (nullable) + index.

No backfill required. All commits signed off; DCO is green.