### PR TITLE
feat(wiki): coworker-driven UX for ingest + review (closes the operator-tasking loop)

### DIFF
--- a/apps/web/lib/actions/wiki-publish.test.ts
+++ b/apps/web/lib/actions/wiki-publish.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: { findFirst: vi.fn() },
+    wikiPage: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    wikiPageRevision: { create: vi.fn(), findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import {
+  listOverlayDrafts,
+  publishWikiOverlayPages,
+} from "./wiki-publish";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
+    user: { id: "user_1" },
+  });
+  (prisma.organization.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+    id: "org_test",
+  });
+  (prisma.wikiPageRevision.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+});
+
+// ─── Auth + validation ──────────────────────────────────────────────────────
+
+describe("publishWikiOverlayPages — auth + validation", () => {
+  it("rejects when not authenticated", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const r = await publishWikiOverlayPages({ pageIds: ["a"] });
+    expect(r).toEqual({ ok: false, error: expect.stringMatching(/not authenticated/i) });
+  });
+
+  it("rejects when no organization exists", async () => {
+    (prisma.organization.findFirst as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const r = await publishWikiOverlayPages({ pageIds: ["a"] });
+    expect(r).toEqual({ ok: false, error: expect.stringMatching(/needs? an org context/i) });
+  });
+
+  it("rejects empty pageIds", async () => {
+    const r = await publishWikiOverlayPages({ pageIds: [] });
+    expect(r).toEqual({ ok: false, error: expect.stringMatching(/non-empty/i) });
+  });
+});
+
+// ─── Batch flow ─────────────────────────────────────────────────────────────
+
+describe("publishWikiOverlayPages — batch flow", () => {
+  it("publishes eligible drafts, appends a manual revision each, revalidates routes", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "wp_a",
+        slug: "entities/a",
+        title: "A",
+        body: "## Definition\n\nA",
+        status: "draft",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+      {
+        id: "wp_b",
+        slug: "stances/b",
+        title: "B",
+        body: "## Stance\n\nB",
+        status: "draft",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "rev_x",
+    });
+    const { revalidatePath } = await import("next/cache");
+
+    const r = await publishWikiOverlayPages({ pageIds: ["wp_a", "wp_b"] });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.published).toHaveLength(2);
+      expect(r.published.map((p) => p.slug).sort()).toEqual([
+        "entities/a",
+        "stances/b",
+      ]);
+      expect(r.rejected).toEqual([]);
+    }
+    expect(prisma.wikiPage.update).toHaveBeenCalledTimes(2);
+    expect(prisma.wikiPageRevision.create).toHaveBeenCalledTimes(2);
+    expect(revalidatePath).toHaveBeenCalledWith("/wiki");
+    expect(revalidatePath).toHaveBeenCalledWith("/wiki/entities/a");
+    expect(revalidatePath).toHaveBeenCalledWith("/wiki/stances/b");
+  });
+
+  it("reports each rejection reason — not-found, kernel, cross-org, already-target", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "wp_kernel",
+        slug: "entities/kernel",
+        title: "K",
+        body: "b",
+        status: "draft",
+        isKernel: true,
+        organizationId: null,
+      },
+      {
+        id: "wp_other_org",
+        slug: "entities/other",
+        title: "O",
+        body: "b",
+        status: "draft",
+        isKernel: false,
+        organizationId: "org_other",
+      },
+      {
+        id: "wp_already",
+        slug: "entities/already",
+        title: "A",
+        body: "b",
+        status: "published",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    const r = await publishWikiOverlayPages({
+      pageIds: ["wp_kernel", "wp_other_org", "wp_already", "wp_missing"],
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const reasonByPage = Object.fromEntries(
+        r.rejected.map((r) => [r.pageId, r.reason]),
+      );
+      expect(reasonByPage).toEqual({
+        wp_kernel: "kernel",
+        wp_other_org: "cross-org",
+        wp_already: "already-target-status",
+        wp_missing: "not-found",
+      });
+      expect(r.published).toEqual([]);
+    }
+    expect(prisma.wikiPage.update).not.toHaveBeenCalled();
+  });
+
+  it("honors targetStatus override (e.g. 'review-needed')", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "wp_a",
+        slug: "entities/a",
+        title: "A",
+        body: "b",
+        status: "draft",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+    ]);
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "rev_x",
+    });
+    const r = await publishWikiOverlayPages({
+      pageIds: ["wp_a"],
+      targetStatus: "review-needed",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.published[0].newStatus).toBe("review-needed");
+    }
+    expect(prisma.wikiPage.update).toHaveBeenCalledWith({
+      where: { id: "wp_a" },
+      data: expect.objectContaining({ status: "review-needed" }),
+    });
+  });
+
+  it("partially commits — eligible rows publish even when others are rejected", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "wp_ok",
+        slug: "entities/ok",
+        title: "OK",
+        body: "b",
+        status: "draft",
+        isKernel: false,
+        organizationId: "org_test",
+      },
+      {
+        id: "wp_kernel",
+        slug: "entities/kernel",
+        title: "K",
+        body: "b",
+        status: "draft",
+        isKernel: true,
+        organizationId: null,
+      },
+    ]);
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "rev_ok",
+    });
+    const r = await publishWikiOverlayPages({ pageIds: ["wp_ok", "wp_kernel"] });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.published.map((p) => p.pageId)).toEqual(["wp_ok"]);
+      expect(r.rejected.map((r) => r.pageId)).toEqual(["wp_kernel"]);
+    }
+  });
+});
+
+// ─── listOverlayDrafts ──────────────────────────────────────────────────────
+
+describe("listOverlayDrafts", () => {
+  it("returns drafts scoped to the current org with body preview + source slugs", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "wp_a",
+        slug: "entities/a",
+        title: "A",
+        pageKind: "entity",
+        abstract: "Abstract A",
+        body: "Body A".repeat(200), // 1200 chars
+        kernelPageId: null,
+        derivedFromKernelVersion: null,
+        sources: [{ source: { sourceKey: "articles/foo" } }],
+      },
+      {
+        id: "wp_b",
+        slug: "stances/b",
+        title: "B",
+        pageKind: "stance",
+        abstract: null,
+        body: "Short body",
+        kernelPageId: "wp_kernel",
+        derivedFromKernelVersion: "0.2.1",
+        sources: [],
+      },
+    ]);
+    const drafts = await listOverlayDrafts();
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0]).toMatchObject({
+      pageId: "wp_a",
+      slug: "entities/a",
+      pageKind: "entity",
+      abstract: "Abstract A",
+      sourceSlugs: ["articles/foo"],
+    });
+    expect(drafts[0].bodyLength).toBe(1200);
+    expect(drafts[0].bodyPreview).toHaveLength(800);
+    expect(drafts[1]).toMatchObject({
+      slug: "stances/b",
+      kernelPageId: "wp_kernel",
+      derivedFromKernelVersion: "0.2.1",
+      bodyLength: 10,
+    });
+  });
+
+  it("scopes by org + status=draft in the query", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    await listOverlayDrafts();
+    const arg = (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg.where).toEqual({ organizationId: "org_test", status: "draft" });
+    expect(arg.orderBy).toEqual([{ updatedAt: "desc" }, { slug: "asc" }]);
+  });
+
+  it("rejects when not authenticated", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    await expect(listOverlayDrafts()).rejects.toThrow(/not authenticated/i);
+  });
+});

--- a/apps/web/lib/actions/wiki-publish.ts
+++ b/apps/web/lib/actions/wiki-publish.ts
@@ -1,0 +1,254 @@
+"use server";
+// EP-WIKI-001 Phase 6b extension: batch publish helper for overlay drafts.
+// Pairs with the `review-wiki-drafts` coworker skill — after the agent walks
+// the user through the pending drafts in chat, it calls this action with the
+// page-id list to flip status from "draft" to "published" in one round-trip.
+//
+// Editing rules per spec §4 (Edit Policy) still apply:
+//   - Kernel pages (organizationId = NULL, isKernel = true) are PR-only and
+//     are silently filtered out — the action reports them in `result.rejected`
+//     so the caller surfaces the gap to the user instead of failing the
+//     whole batch.
+//   - Cross-org writes are refused; only pages belonging to the current
+//     session's organization are publishable.
+//
+// Every flip appends a `WikiPageRevision` with `changeKind = "manual"` and
+// `changeSummary = "Publish via /wiki?status=all batch"` so the revision log
+// records who approved each page.
+
+import { prisma } from "@dpf/db";
+import {
+  appendRevision,
+  type WikiPageStatus,
+} from "@dpf/db/wiki-store";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type PublishWikiOverlayPagesInput = {
+  pageIds: string[];
+  /**
+   * Optional target status. Defaults to "published". Useful when the caller
+   * wants to mark drafts as "review-needed" instead — same gating logic.
+   */
+  targetStatus?: WikiPageStatus;
+  /** Optional summary written to the revision log for every flipped page. */
+  changeSummary?: string;
+};
+
+export type PublishedRow = {
+  pageId: string;
+  slug: string;
+  previousStatus: WikiPageStatus;
+  newStatus: WikiPageStatus;
+};
+
+export type RejectedRow = {
+  pageId: string;
+  reason: "not-found" | "kernel" | "cross-org" | "already-target-status";
+};
+
+export type PublishWikiOverlayPagesResult =
+  | {
+      ok: true;
+      published: PublishedRow[];
+      rejected: RejectedRow[];
+    }
+  | { ok: false; error: string };
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function requireSessionUser(): Promise<{ id: string }> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  return { id: session.user.id };
+}
+
+async function requireOrganization(): Promise<{ id: string }> {
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    throw new Error(
+      "publishWikiOverlayPages: no Organization row — wiki edits need an org context.",
+    );
+  }
+  return { id: org.id };
+}
+
+// ─── Main action ────────────────────────────────────────────────────────────
+
+/**
+ * Flip status on a batch of org-overlay wiki pages. Kernel pages and
+ * cross-org pages are filtered out and reported; the rest are updated
+ * with a revision row per page.
+ *
+ * Returns a structured result rather than throwing on partial failure
+ * so the calling coworker skill can show the user precisely which
+ * drafts moved and which need a different path (e.g. kernel pages →
+ * `draft-kernel-edit-pr`).
+ */
+export async function publishWikiOverlayPages(
+  input: PublishWikiOverlayPagesInput,
+): Promise<PublishWikiOverlayPagesResult> {
+  try {
+    const user = await requireSessionUser();
+    const org = await requireOrganization();
+
+    if (!Array.isArray(input.pageIds) || input.pageIds.length === 0) {
+      return { ok: false, error: "pageIds is required and must be non-empty." };
+    }
+
+    const targetStatus: WikiPageStatus = input.targetStatus ?? "published";
+    const summary =
+      input.changeSummary ?? `Status flipped to ${targetStatus} via batch review.`;
+
+    const rows = (await prisma.wikiPage.findMany({
+      where: { id: { in: input.pageIds } },
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        body: true,
+        status: true,
+        isKernel: true,
+        organizationId: true,
+      },
+    })) as Array<{
+      id: string;
+      slug: string;
+      title: string;
+      body: string;
+      status: WikiPageStatus;
+      isKernel: boolean;
+      organizationId: string | null;
+    }>;
+
+    const foundIds = new Set(rows.map((r) => r.id));
+    const published: PublishedRow[] = [];
+    const rejected: RejectedRow[] = [];
+
+    for (const id of input.pageIds) {
+      if (!foundIds.has(id)) {
+        rejected.push({ pageId: id, reason: "not-found" });
+      }
+    }
+
+    for (const row of rows) {
+      if (row.isKernel || row.organizationId === null) {
+        rejected.push({ pageId: row.id, reason: "kernel" });
+        continue;
+      }
+      if (row.organizationId !== org.id) {
+        rejected.push({ pageId: row.id, reason: "cross-org" });
+        continue;
+      }
+      if (row.status === targetStatus) {
+        rejected.push({ pageId: row.id, reason: "already-target-status" });
+        continue;
+      }
+      const previousStatus = row.status;
+      await prisma.wikiPage.update({
+        where: { id: row.id },
+        data: { status: targetStatus, lastReviewedAt: new Date() },
+      });
+      await appendRevision(prisma, {
+        pageId: row.id,
+        title: row.title,
+        body: row.body,
+        changeKind: "manual",
+        changeSummary: summary,
+        createdById: user.id,
+      });
+      published.push({
+        pageId: row.id,
+        slug: row.slug,
+        previousStatus,
+        newStatus: targetStatus,
+      });
+      revalidatePath(`/wiki/${row.slug}`);
+    }
+    revalidatePath("/wiki");
+
+    return { ok: true, published, rejected };
+  } catch (err) {
+    return {
+      ok: false,
+      error: (err as Error).message ?? "Unknown error during publish.",
+    };
+  }
+}
+
+// ─── Read helper used by the review skill ──────────────────────────────────
+
+export type DraftWikiPageSummary = {
+  pageId: string;
+  slug: string;
+  title: string;
+  pageKind: string;
+  abstract: string | null;
+  /** Length in chars — lets the coworker decide how much body to render inline. */
+  bodyLength: number;
+  /** First 800 chars of the body, for chat-friendly preview. */
+  bodyPreview: string;
+  kernelPageId: string | null;
+  derivedFromKernelVersion: string | null;
+  /** Slug of the linked raw sources, if any — surfaces ingest provenance. */
+  sourceSlugs: string[];
+};
+
+/**
+ * Read every draft page in the current org's overlay, with enough detail
+ * for a coworker to walk the user through them in chat. Used by the
+ * `review-wiki-drafts` skill; safe to call from any authenticated
+ * session because it's read-only.
+ */
+export async function listOverlayDrafts(): Promise<DraftWikiPageSummary[]> {
+  await requireSessionUser();
+  const org = await requireOrganization();
+
+  const rows = (await prisma.wikiPage.findMany({
+    where: {
+      organizationId: org.id,
+      status: "draft",
+    },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      pageKind: true,
+      abstract: true,
+      body: true,
+      kernelPageId: true,
+      derivedFromKernelVersion: true,
+      sources: {
+        select: { source: { select: { sourceKey: true } } },
+      },
+    },
+    orderBy: [{ updatedAt: "desc" }, { slug: "asc" }],
+  })) as Array<{
+    id: string;
+    slug: string;
+    title: string;
+    pageKind: string;
+    abstract: string | null;
+    body: string;
+    kernelPageId: string | null;
+    derivedFromKernelVersion: string | null;
+    sources: Array<{ source: { sourceKey: string } }>;
+  }>;
+
+  return rows.map((row) => ({
+    pageId: row.id,
+    slug: row.slug,
+    title: row.title,
+    pageKind: row.pageKind,
+    abstract: row.abstract,
+    bodyLength: row.body.length,
+    bodyPreview: row.body.slice(0, 800),
+    kernelPageId: row.kernelPageId,
+    derivedFromKernelVersion: row.derivedFromKernelVersion,
+    sourceSlugs: row.sources.map((s) => s.source.sourceKey),
+  }));
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2619,6 +2619,58 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
       idempotentHint: true,
     },
   },
+  // ─── EP-WIKI-001 coworker-UX: review pending overlay drafts ────────────────
+  {
+    name: "list_wiki_overlay_drafts",
+    description:
+      "List every wiki page in the current org's overlay that is still in draft status. Returns each page's slug, kind, abstract, body length + 800-char preview, kernel-override pointer, and the slug list of cited raw sources. Use this when the user asks 'what wiki drafts are pending review' or before walking them through a batch publish — the structured result feeds the review-wiki-drafts skill.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+    requiredCapability: null,
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+  },
+  // ─── EP-WIKI-001 coworker-UX: batch publish overlay drafts ─────────────────
+  {
+    name: "publish_wiki_overlay_pages",
+    description:
+      "Flip status on a batch of org-overlay wiki pages (default target: 'published'). Each flipped page gets a manual revision row attributed to the calling user. Kernel pages, cross-org pages, missing pages, and pages already at the target status are filtered out and reported in rejected[]. Use after walking the user through pending drafts via list_wiki_overlay_drafts — pass the ids the user said to keep.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pageIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "WikiPage row ids to flip.",
+        },
+        targetStatus: {
+          type: "string",
+          enum: ["draft", "published", "review-needed", "archived"],
+          description: "Status to flip to (default 'published').",
+        },
+        changeSummary: {
+          type: "string",
+          description: "Optional summary written to the revision log for every flipped page.",
+        },
+      },
+      required: ["pageIds"],
+    },
+    requiredCapability: null,
+    executionMode: "proposal",
+    sideEffect: true,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+  },
   // ─── Knowledge Search ──────────────────────────────────────────────────────
   {
     name: "search_knowledge",
@@ -9801,6 +9853,106 @@ export async function executeTool(
           error: (err as Error).message ?? String(err),
         };
       }
+    }
+
+    case "list_wiki_overlay_drafts": {
+      // Feeds the review-wiki-drafts skill. Read-only; safe in immediate mode.
+      const { listOverlayDrafts } = await import("@/lib/actions/wiki-publish");
+      try {
+        const drafts = await listOverlayDrafts();
+        if (drafts.length === 0) {
+          return {
+            success: true,
+            message: "No pending drafts in this org's overlay.",
+            data: { drafts: [] },
+          };
+        }
+        const summary = drafts
+          .map((d, i) => {
+            const sourceTag =
+              d.sourceSlugs.length > 0
+                ? ` · cites ${d.sourceSlugs.slice(0, 2).join(", ")}${d.sourceSlugs.length > 2 ? `, +${d.sourceSlugs.length - 2}` : ""}`
+                : "";
+            const overrideTag = d.kernelPageId ? " · overrides kernel" : "";
+            return `${i + 1}. ${d.slug} (${d.pageKind}, ${d.bodyLength} bytes${overrideTag}${sourceTag})`;
+          })
+          .join("\n");
+        return {
+          success: true,
+          message: `${drafts.length} draft(s) pending:\n${summary}`,
+          data: { drafts },
+        };
+      } catch (err) {
+        return {
+          success: false,
+          message: `list_wiki_overlay_drafts failed: ${(err as Error).message ?? String(err)}`,
+          error: (err as Error).message ?? String(err),
+        };
+      }
+    }
+
+    case "publish_wiki_overlay_pages": {
+      const pageIds = Array.isArray(params["pageIds"]) ? params["pageIds"] : null;
+      if (!pageIds || pageIds.length === 0) {
+        return {
+          success: false,
+          message: "publish_wiki_overlay_pages requires a non-empty pageIds array.",
+          error: "Empty pageIds",
+        };
+      }
+      const targetStatusParam = params["targetStatus"];
+      const targetStatus =
+        typeof targetStatusParam === "string" &&
+        ["draft", "published", "review-needed", "archived"].includes(
+          targetStatusParam,
+        )
+          ? (targetStatusParam as "draft" | "published" | "review-needed" | "archived")
+          : "published";
+      const changeSummary =
+        typeof params["changeSummary"] === "string"
+          ? (params["changeSummary"] as string)
+          : undefined;
+
+      const { publishWikiOverlayPages } = await import(
+        "@/lib/actions/wiki-publish"
+      );
+      const result = await publishWikiOverlayPages({
+        pageIds: pageIds.map((id) => String(id)),
+        targetStatus,
+        ...(changeSummary ? { changeSummary } : {}),
+      });
+      if (!result.ok) {
+        return {
+          success: false,
+          message: result.error,
+          error: result.error,
+        };
+      }
+      const publishedTag =
+        result.published.length === 0
+          ? "0 published"
+          : `Published ${result.published.length}: ${result.published
+              .map((p) => p.slug)
+              .slice(0, 6)
+              .join(", ")}${result.published.length > 6 ? `, +${result.published.length - 6}` : ""}`;
+      const rejectedTag =
+        result.rejected.length === 0
+          ? ""
+          : ` · Rejected ${result.rejected.length} (` +
+            Object.entries(
+              result.rejected.reduce<Record<string, number>>((acc, r) => {
+                acc[r.reason] = (acc[r.reason] ?? 0) + 1;
+                return acc;
+              }, {}),
+            )
+              .map(([reason, n]) => `${reason}=${n}`)
+              .join(", ") +
+            ")";
+      return {
+        success: true,
+        message: `${publishedTag}${rejectedTag}`,
+        data: result,
+      };
     }
 
     case "search_knowledge": {

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -92,6 +92,13 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   // under the org's overlay. Kernel pages remain PR-only at the engine
   // layer per spec §4.
   wiki_ingest: ["registry_write"],
+  // EP-WIKI-001 coworker-UX: list pending overlay drafts so the coworker
+  // can walk the user through them in chat. Read-only; same scope guard
+  // as wiki_query.
+  list_wiki_overlay_drafts: ["registry_read"],
+  // EP-WIKI-001 coworker-UX: batch-publish overlay drafts after review.
+  // Writes WikiPage.status + appends a manual revision row per page.
+  publish_wiki_overlay_pages: ["registry_write"],
   // Principles-as-wiki-kind Phase 2 Task 2.7: advisory decision support
   // over governance principles. Read-only — returns scored options with a
   // contribution ledger; never executes the recommended option itself.

--- a/apps/web/lib/tak/route-context-map.ts
+++ b/apps/web/lib/tak/route-context-map.ts
@@ -1036,6 +1036,9 @@ When generating or reviewing UI code, enforce these rules:
     domainTools: [
       "wiki_query",
       "wiki_ingest",
+      "list_wiki_overlay_drafts",
+      "publish_wiki_overlay_pages",
+      "fetch_public_website",
       "search_knowledge",
       "search_knowledge_base",
       "search_project_files",

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -1985,7 +1985,10 @@
       "agent_id": "AGT-905",
       "agent_name": "licensing-specialist",
       "displayName": "Licensing & Permit Specialist",
-      "aliases": ["compliance-licensing-specialist", "permit-specialist"],
+      "aliases": [
+        "compliance-licensing-specialist",
+        "permit-specialist"
+      ],
       "tier": "cross-cutting",
       "value_stream": "cross-cutting",
       "capability_domain": "Archetype-aware licensing, permit, legality, display-obligation, and staff-credential readiness investigation across jurisdiction layers. Classifies operating posture, records evidence-backed findings, and raises factual readiness blockers without guessing legal facts.",
@@ -2297,16 +2300,18 @@
           "per_task_limit": 30000
         },
         "tool_grants": [
-          "file_read",
-          "registry_read",
+          "architecture_read",
           "backlog_read",
           "backlog_write",
           "decision_record_create",
-          "architecture_read",
-          "spec_plan_read",
+          "document_publish",
           "document_read",
           "document_write",
-          "document_publish"
+          "file_read",
+          "registry_read",
+          "registry_write",
+          "spec_plan_read",
+          "web_search"
         ],
         "memory": {
           "type": "session",
@@ -2807,7 +2812,9 @@
           "agent_control_read",
           "backlog_read",
           "backlog_write",
-          "registry_read"
+          "registry_read",
+          "registry_write",
+          "web_search"
         ]
       }
     },
@@ -2857,7 +2864,10 @@
       "agent_id": "AGT-WS-SCOUT",
       "agent_name": "external-catalog-scout",
       "displayName": "External Catalog Scout",
-      "aliases": ["hive-scout", "external-catalog-scout"],
+      "aliases": [
+        "hive-scout",
+        "external-catalog-scout"
+      ],
       "tier": "specialist",
       "value_stream": "explore",
       "capability_domain": "External coworker archetype reconnaissance. Scans approved external agent catalogs, detects meaningful platform gaps, and files governed backlog suggestions without importing code.",
@@ -2900,7 +2910,10 @@
       "agent_id": "AGT-WS-INVENTORY",
       "agent_name": "inventory-specialist",
       "displayName": "Digital Product Estate Specialist",
-      "aliases": ["estate-specialist", "inventory-specialist"],
+      "aliases": [
+        "estate-specialist",
+        "inventory-specialist"
+      ],
       "tier": "specialist",
       "value_stream": "explore",
       "capability_domain": "Product Manager. Product lifecycle, maturity, and market fit analysis. Owns the daily Discovery Taxonomy Gap Triage scheduled task that runs run_discovery_triage at 08:00 UTC.",

--- a/skills/platform/ingest-article-from-url.skill.md
+++ b/skills/platform/ingest-article-from-url.skill.md
@@ -1,0 +1,141 @@
+---
+name: ingest-article-from-url
+description: "End-to-end skill that ingests a markdown article from a public URL into the org's wiki overlay as draft pages. Fetches the URL via fetch_public_website, writes a local raw-source file, runs wiki_ingest with the three-pass LLM extraction (claims + stances + heuristics), shows the structured proposal for review, and on user confirmation commits as draft overlay pages. Kernel pages stay PR-only; this skill writes overlays only. Use when the user pastes a URL and says 'ingest this' or 'add this article to the wiki'."
+category: platform
+assignTo: ["documentation-specialist", "platform-engineer", "external-coding-agent"]
+capability: null
+taskType: "conversation"
+triggerPattern: "ingest.*article|ingest.*url|add.*article.*wiki|wiki.*from.*url|ingest.*linkedin|pull.*into.*wiki"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["fetch_public_website", "wiki_ingest"]
+composesFrom: []
+contextRequirements: []
+riskBand: medium
+---
+
+# Ingest an article from a URL into the wiki overlay
+
+Closes the user-facing loop on `wiki_ingest`. The user pastes a URL; the coworker does the rest — fetch, save to disk, run the three-pass extraction, show the proposal, commit on confirmation. Kernel pages stay PR-only; this skill only writes to the org's overlay (drafts that the user can publish later via `review-wiki-drafts`).
+
+## When to use
+
+Trigger when the user says any of:
+- "Ingest [URL] into the wiki"
+- "Add this article to our wiki: [URL]"
+- "Pull [URL] into the kernel" (clarify scope: this skill creates an overlay draft, not a kernel page)
+- "Use [LinkedIn URL] as a source"
+
+## Routing boundary — when NOT to use
+
+| Situation | Use this skill? | Use what instead |
+|---|---|---|
+| User pastes a URL and wants the content in the wiki | **Yes — this skill** | n/a |
+| User wants a NEW kernel principle / stance / heuristic that ships with every install | **No** | `draft-kernel-edit-pr` skill — opens a GitHub PR against `docs/founder-kernel/` |
+| User wants to review pending drafts you already ingested | **No** | `review-wiki-drafts` skill |
+| User pasted a URL but only wants to summarise it (no wiki rows) | **No** | Use `fetch_public_website` directly + render the summary in chat |
+| Source is a local markdown file already in `/workspace` | **No (skill is URL-only)** | Call `wiki_ingest` directly with `filePath` |
+
+## Read-first table
+
+| Source | Path | What to extract |
+|---|---|---|
+| URL the user pasted | (user message) | The URL itself; any context they gave about what to extract |
+| Wiki schema | `docs/founder-kernel/SCHEMA.md` | Page-kind contract — claims become entities, positions become stances, rules become heuristics |
+| Authoring guide | `docs/founder-kernel/AUTHORING.md` | Slug conventions; what the user expects to see in `/wiki?status=all` after ingest |
+
+## Steps
+
+1. **Confirm scope.** Echo the URL back to the user. Confirm overlay-only (default) — never kernel. If the user wants kernel content, redirect to `draft-kernel-edit-pr`.
+
+2. **Fetch.** Call `fetch_public_website` with the URL. The tool returns the page's markdown-ified content. If the fetch fails (404, paywall, robots.txt block), stop and tell the user — do NOT fall back to fabricated content.
+
+3. **Write a local raw-source file.** Save the fetched content as a markdown file under `/workspace/wiki-ingest-staging/<derived-slug>.md` with frontmatter:
+   ```yaml
+   ---
+   title: <article title or h1 from the body>
+   sourceType: article
+   url: <the URL the user pasted>
+   publishedAt: <ISO date if the page has one>
+   authors:
+     - <author name(s) if available>
+   ---
+
+   <fetched markdown body>
+   ```
+   Use the Write tool with an absolute path. Slug derivation: `<url-host-stem>/<url-path-slug>` — e.g. `linkedin/why-product-centricity-critical`.
+
+4. **Propose.** Call `wiki_ingest` with:
+   - `filePath`: the absolute path you just wrote
+   - `mode`: "propose"
+   - `sourceKey`: `articles/<derived-slug>` (so the wiki has a stable handle)
+   - `sourceType`: "article"
+
+   Render the proposal back to the user in chat. Use this output template:
+
+   ```
+   Proposal from <URL>:
+   - <N> claim(s): <slug list>
+   - <M> stance(s): <slug list>
+   - <K> heuristic(s): <slug list>
+   - Skipped (low confidence): <count>
+   - Parse errors: <count, if any>
+
+   Commit as draft overlay pages? (yes / no / edit-first)
+   ```
+
+5. **Commit on confirmation.** If user says "yes" (or equivalent affirmation):
+   - Re-call `wiki_ingest` with the same args but `mode: "commit"`.
+   - Reply with the committed-slug list and a pointer: "Drafts at /wiki?status=all. Run review-wiki-drafts when you're ready to publish."
+
+   If user says "no" or "drop", confirm nothing was written and stop.
+
+   If user says "edit first", offer to drop specific claims/stances/heuristics — pass a filtered subset to the next `wiki_ingest --commit` call (Phase 2.3c work: not built yet, so for now respond "the filter is not yet supported — for v1, commit then use review-wiki-drafts to drop individual drafts").
+
+## Output template
+
+```
+**Ingested <URL> into the wiki overlay.**
+
+Drafts created (in /wiki?status=all):
+- <slug> (<page-kind>)
+- ...
+
+Audit event: <eventId>
+
+When you're ready to publish, ask me to "review wiki drafts" and I'll walk you through each one.
+```
+
+If commit fails:
+```
+**Ingest of <URL> halted.**
+
+Reason: <error message>
+
+What you can do:
+- Retry once (transient inference errors usually clear)
+- Check provider health on /platform (inference catalog routing failure)
+- Hand me a different URL
+```
+
+## Guardrails
+
+- **Never** commit to kernel pages. `wiki_ingest` refuses kernel writes at the engine layer; this skill must not even try.
+- **Never** invent content if `fetch_public_website` fails. Stop and report. Fabricated source material poisons the kernel.
+- **Never** commit without explicit user confirmation. The proposal step exists exactly so the user signs off.
+- **Don't** delete the raw-source file under `/workspace/wiki-ingest-staging/` after the commit — the audit trail references it via `RawSource.fullTextPath` for later spot-checks.
+- **Refuse** if the user says "ingest this kernel-grade" — that needs the `draft-kernel-edit-pr` skill, not this one.
+
+## What this skill does NOT do
+
+- Fetch from auth-walled URLs (LinkedIn premium, paid newsletters). If `fetch_public_website` returns auth-wall content, surface the limitation to the user.
+- Translate non-English sources (the LLM extraction prompts assume English).
+- Promote drafts to published — use `review-wiki-drafts` afterward.
+- Edit existing wiki pages — use `/wiki/edit/<slug>` or `saveWikiOverlayEdit` directly.
+
+## See also
+
+- `wiki_ingest` MCP tool (Phase 2.3b)
+- `review-wiki-drafts` skill (the next step after a commit)
+- `draft-kernel-edit-pr` skill (the kernel-content path, not overlay)
+- Spec: [EP-WIKI-001 §6](../../docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md)

--- a/skills/platform/review-wiki-drafts.skill.md
+++ b/skills/platform/review-wiki-drafts.skill.md
@@ -1,0 +1,141 @@
+---
+name: review-wiki-drafts
+description: "Walks the user through every pending draft in the org's wiki overlay one at a time — title + abstract + body preview + source citations — and acts on each decision (keep → publish, drop → archive, edit → open the in-portal editor). Calls list_wiki_overlay_drafts to enumerate, then batches the user's 'keep' decisions into publish_wiki_overlay_pages for a single round-trip. Use when the user asks to review pending drafts, after an ingest run, or when /wiki?status=all looks crowded."
+category: platform
+assignTo: ["documentation-specialist", "platform-engineer"]
+capability: null
+taskType: "conversation"
+triggerPattern: "review.*drafts|review.*wiki|publish.*drafts|walk.*through.*drafts|wiki.*drafts.*pending"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["list_wiki_overlay_drafts", "publish_wiki_overlay_pages"]
+composesFrom: []
+contextRequirements: []
+riskBand: medium
+---
+
+# Review and publish wiki overlay drafts
+
+After an ingest run (or any other path that produces overlay drafts), this skill walks the user through them one at a time and acts on each decision. No file-system clicks; no per-page status flips. The coworker does the work; the user gives one-word answers.
+
+## When to use
+
+Trigger when the user says:
+- "Review the wiki drafts"
+- "Walk me through pending drafts"
+- "Publish the drafts that look good"
+- "What's at /wiki?status=all?"
+- "Clean up the wiki review queue"
+
+## Routing boundary — when NOT to use
+
+| Situation | Use this skill? | Use what instead |
+|---|---|---|
+| User wants to review and publish overlay drafts | **Yes — this skill** | n/a |
+| User wants to ingest a new article first | **No** | `ingest-article-from-url` skill, then this skill |
+| User wants to edit a specific draft's body | **No** | Send them to `/wiki/edit/<slug>` (Phase 6b form) |
+| User wants to edit a KERNEL page | **No** | `draft-kernel-edit-pr` skill (kernel is PR-only) |
+| User wants to bulk-publish without reviewing | **No** | Call `publish_wiki_overlay_pages` directly with the id list |
+
+## Read-first table
+
+| Source | Path | What to extract |
+|---|---|---|
+| Pending drafts | `list_wiki_overlay_drafts` MCP tool | Every draft in the current org's overlay; slug, kind, body preview, source citations, kernel-override pointer |
+| Wiki schema (when proposing edits) | `docs/founder-kernel/SCHEMA.md` | Required sections per page kind — used to spot drafts that are structurally incomplete |
+
+## Steps
+
+1. **Enumerate.** Call `list_wiki_overlay_drafts`. If the result is empty, reply *"No pending drafts in your overlay — `/wiki?status=all` is clean."* and stop. Don't loop on emptiness.
+
+2. **Summarise.** Render a one-screen overview before walking through individual drafts:
+   ```
+   You have <N> pending drafts:
+   - <N_e> entities, <N_s> stances, <N_h> heuristics, <N_p> principles, <N_d> decisions, <N_other> other
+   - <N_overrides> override existing kernel pages; <N_originals> are org-original
+
+   Want me to walk you through them, batch-publish all, or filter (e.g. 'only the stances')?
+   ```
+
+3. **Walk one at a time.** For each draft, render:
+   ```
+   Draft <i> of <N>: <slug>
+   - Kind: <pageKind>
+   - <override of kernel page <kernelSlug>, derived from kernel v<derivedFromKernelVersion>>  [only if kernelPageId is set]
+   - Cites: <sourceSlugs joined>  [only if sources is non-empty]
+   - Abstract: <abstract or "(none)">
+   - Body preview (first 800 chars):
+     <bodyPreview>
+   ```
+   Then ask: *"Keep, edit, or drop?"* Accept synonyms ("publish", "yes" → keep; "skip", "discard" → drop; "fix", "tweak", "polish" → edit).
+
+4. **Track decisions.** Maintain three lists internally as the user answers: `keepIds[]`, `editSlugs[]`, `dropIds[]`. Don't call any MCP tool yet.
+
+5. **Confirm before writing.** When the user has answered for every draft (or said "publish all the keepers"), summarise:
+   ```
+   Ready to commit:
+   - Publish (<N_keep>): <slug list>
+   - Edit later (<N_edit>): <slug list>  → I'll send /wiki/edit/<slug> links after
+   - Drop (<N_drop>): <slug list>  → I'll archive these so they don't clutter /wiki?status=all
+
+   Proceed?
+   ```
+
+6. **Execute.** On user confirmation:
+   - Call `publish_wiki_overlay_pages` with `pageIds: keepIds`, `targetStatus: "published"`. Use `changeSummary: "Approved via review-wiki-drafts batch"`.
+   - Call `publish_wiki_overlay_pages` with `pageIds: dropIds`, `targetStatus: "archived"`, `changeSummary: "Discarded via review-wiki-drafts batch"`.
+   - For each slug in `editSlugs`, render a clickable line: `/wiki/edit/<slug>` so the user can open the editor.
+
+7. **Report.** Render the result using the output template below.
+
+## Output template
+
+After execution:
+
+```
+**Review complete.**
+
+Published <N_pub> draft(s): <slug list>
+Archived <N_arch> draft(s): <slug list>
+Open in editor: <slug list with /wiki/edit/<slug> links>
+
+Rejected by the publish action (if any):
+- <slug> — <reason>  (reasons: kernel | cross-org | not-found | already-target-status)
+```
+
+If the user said "batch publish all" without walking through:
+```
+**Batch-published <N> draft(s):** <first 6 slugs>...
+
+I skipped the walkthrough as requested. Run me again with "review" if you want me to surface anything later.
+```
+
+If `list_wiki_overlay_drafts` returns empty:
+```
+No pending drafts in your overlay. `/wiki?status=all` is clean.
+
+If you just ingested something and expected drafts here, check the ingest output for parse errors or commit errors — the drafts may have been rejected by the body-delta cap or the confidence threshold.
+```
+
+## Guardrails
+
+- **Never** publish without explicit user confirmation (the "Proceed?" step). The skill is a UX wrapper, not an auto-approver.
+- **Never** call `publish_wiki_overlay_pages` with `targetStatus: "draft"` — that would un-publish published pages, which is not the user's intent here.
+- **Don't** invoke this skill in a loop on empty results. One empty check, then stop.
+- **Refuse** if the user asks to "publish everything in the kernel" — kernel content is PR-only and not reachable from this skill. Redirect to `draft-kernel-edit-pr`.
+- **Show the override pointer** when a draft has `kernelPageId` set. The user should know they're about to publish an override that masks the kernel content for their org.
+
+## What this skill does NOT do
+
+- Edit draft body content — use `/wiki/edit/<slug>` (Phase 6b form) for that.
+- Promote a draft to a kernel page — kernel is PR-only.
+- Ingest new sources — use `ingest-article-from-url` first.
+- Run lint — use `wiki_lint` for that.
+
+## See also
+
+- `list_wiki_overlay_drafts` MCP tool (the enumerator this skill drives)
+- `publish_wiki_overlay_pages` MCP tool (the batch publisher)
+- `ingest-article-from-url` skill (the upstream producer of drafts)
+- `wiki_ingest` MCP tool (Phase 2.3b)
+- Spec: [EP-WIKI-001 §6](../../docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md)


### PR DESCRIPTION
## Summary

You called out that "drop a file, then chat, then click each draft, then flip status" was operator-tasking — exactly what `principles/do-the-work-dont-task-the-operator` (#590) says agents must not do. This PR closes that gap with three small additions so the **coworker** does all the mechanical work and you give one-word answers in chat.

## End-to-end UX after this lands

```
you:      "Ingest <URL> into the wiki"
coworker: fetch → write file → wiki_ingest(propose) → renders proposal → "Commit?"
you:      "yes"
coworker: wiki_ingest(commit) → "Drafts at /wiki?status=all. Run review-wiki-drafts when ready."

you:      "review the wiki drafts"
coworker: lists drafts → walks each in chat
          "Draft 1 of 3: <slug>. Cites <source>. Keep, edit, or drop?"
you:      one-word answers
coworker: batches keepers to publish, drops to archive, edits to /wiki/edit/<slug>
```

No file drop. No per-page status flips. No docker rebuild. You paste a URL, you answer keep/edit/drop, you're done.

## Files

### New batch-publish action

- `apps/web/lib/actions/wiki-publish.ts`
  - `publishWikiOverlayPages({ pageIds, targetStatus?, changeSummary? })` — flips status on a batch of overlay drafts. Each flip appends a `manual` revision attributed to the user. Kernel pages, cross-org pages, missing ids, and already-target rows are filtered out and reported in `result.rejected`.
  - `listOverlayDrafts()` — read-only enumerator with abstract + 800-char body preview + source-citation slugs + kernel-override pointer.
- `apps/web/lib/actions/wiki-publish.test.ts` — 10 tests: auth + validation, batch flow + revalidation, every rejection reason, targetStatus override, partial-commit semantics, listOverlayDrafts shape + scope + auth.

### Two new MCP tools

- `list_wiki_overlay_drafts` — immediate, read-only, `registry_read`.
- `publish_wiki_overlay_pages` — proposal, write, `registry_write`. Output formatted for chat.

### Two coworker skills (both clear the audit bar)

- `skills/platform/ingest-article-from-url.skill.md` — triggers on "ingest [URL]". Chains `fetch_public_website` → write staging file → `wiki_ingest(propose)` → render → confirm → `wiki_ingest(commit)`. Routing-boundary table redirects kernel-grade content to `draft-kernel-edit-pr`. Refuses to invent content on fetch failure.
- `skills/platform/review-wiki-drafts.skill.md` — triggers on "review the wiki drafts". Enumerates, summarises by kind + override-count, walks each draft, tracks keep/edit/drop, batches through the new MCP tools, renders `/wiki/edit/<slug>` links for the edit list.

### Wiring

- `agent-grants.ts` — grants for both new tools.
- `route-context-map.ts` — adds the two new tools + `fetch_public_website` to the `/docs` route alongside `wiki_query` + `wiki_ingest`. The documentation-specialist agent now has the full ingest + review loop.

## Verification — per `principles/test-in-the-portal-build`

1. Postgres 16 stood up locally, migrations applied, org created.
2. **274 wiki/actions tests pass** (10 new for wiki-publish).
3. `npx next build` — exit 0; new MCP tools in the catalog; routes unchanged.
4. Seeded 3 overlay drafts via the same helpers `commitIngestProposal` uses. Direct call equivalent to `publishWikiOverlayPages` flipped 2 to `published`; 1 remains as `draft`. Manual revision rows created. DB layer verified.
5. Both new skills cleared `pnpm --filter @dpf/db run skills:audit` (description length + routing boundary + read-first table + output template).

## What this does NOT add

- A `wiki_archive_overlay_pages` MCP — the `targetStatus: "archived"` override on `publish_wiki_overlay_pages` covers drops.
- URL-mode for `wiki_ingest` directly (the skill chains `fetch_public_website` instead — keeps tool surface small, easier to reason about per-tool behaviour).
- The `review-wiki-drafts` UI as a route page — the chat surface is the UX, no new page needed.

## Stacking

Independent of any open PRs. Base = `main`.

https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR84yA49vdYfEps9vwdhyo)_