### PR TITLE
feat: skill curator and lifecycle (Slice 4)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
@@ -30,6 +30,8 @@ vi.mock("@/lib/actions/skills-observatory", () => ({
     latestMetricPeriod: null,
   }),
   getSkillReviewDetail: vi.fn().mockResolvedValue(null),
+  getLatestSkillCuratorReport: vi.fn().mockResolvedValue(null),
+  getSkillLifecycleState: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/components/platform/SkillProposalsPanel", () => ({
@@ -48,6 +50,14 @@ vi.mock("@/components/platform/SkillsObservatoryPanel", () => ({
   SkillsObservatoryPanel: () => <div>skills-observatory-panel</div>,
 }));
 
+vi.mock("@/components/platform/SkillCuratorReportPanel", () => ({
+  SkillCuratorReportPanel: () => <div>skills-curator-report-panel</div>,
+}));
+
+vi.mock("@/components/platform/SkillLifecycleControls", () => ({
+  SkillLifecycleControls: () => <div>skills-lifecycle-controls</div>,
+}));
+
 vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => (
     <a href={href}>{children}</a>
@@ -55,7 +65,7 @@ vi.mock("next/link", () => ({
 }));
 
 describe("PlatformAiSkillsPage", () => {
-  it("renders catalog and observability under AI Operations", async () => {
+  it("renders catalog, observability, and curator under AI Operations", async () => {
     const { default: PlatformAiSkillsPage } = await import("./page");
     const html = renderToStaticMarkup(await PlatformAiSkillsPage({}));
 
@@ -66,5 +76,7 @@ describe("PlatformAiSkillsPage", () => {
     expect(html).toContain('href="/platform/ai/prompts"');
     expect(html).toContain("skills-catalog-view");
     expect(html).toContain("skills-observatory-panel");
+    expect(html).toContain("Curator");
+    expect(html).toContain("skills-curator-report-panel");
   });
 });

--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -3,6 +3,8 @@ import { SkillsCatalogView } from "@/components/admin/SkillsCatalogView";
 import { SkillsObservatoryPanel } from "@/components/platform/SkillsObservatoryPanel";
 import { SkillProposalsPanel } from "@/components/platform/SkillProposalsPanel";
 import { SkillRevisionHistoryPanel } from "@/components/platform/SkillRevisionHistoryPanel";
+import { SkillCuratorReportPanel } from "@/components/platform/SkillCuratorReportPanel";
+import { SkillLifecycleControls } from "@/components/platform/SkillLifecycleControls";
 import {
   getSkillCatalog,
   getSkillCatalogStats,
@@ -14,7 +16,10 @@ import {
   getSkillsObservatoryStats,
   getSkillTelemetrySummary,
   getSkillReviewDetail,
+  getLatestSkillCuratorReport,
+  getSkillLifecycleState,
 } from "@/lib/actions/skills-observatory";
+import { isSkillLifecycleState } from "@/lib/skills/lifecycle";
 
 export default async function SkillsObservatoryPage({
   searchParams,
@@ -22,9 +27,21 @@ export default async function SkillsObservatoryPage({
   searchParams?: Promise<{ skill?: string }>;
 }) {
   const resolvedParams = (await searchParams) ?? {};
-  const focusedSkillId = typeof resolvedParams.skill === "string" ? resolvedParams.skill : null;
+  const focusedSkillId =
+    typeof resolvedParams.skill === "string" ? resolvedParams.skill : null;
 
-  const [catalogSkills, catalogStats, skills, finishingPasses, executions, stats, telemetry, review] = await Promise.all([
+  const [
+    catalogSkills,
+    catalogStats,
+    skills,
+    finishingPasses,
+    executions,
+    stats,
+    telemetry,
+    review,
+    curatorReport,
+    lifecycleRow,
+  ] = await Promise.all([
     getSkillCatalog(),
     getSkillCatalogStats(),
     getSkillsCatalog(),
@@ -33,7 +50,14 @@ export default async function SkillsObservatoryPage({
     getSkillsObservatoryStats(),
     getSkillTelemetrySummary(),
     focusedSkillId ? getSkillReviewDetail(focusedSkillId) : Promise.resolve(null),
+    getLatestSkillCuratorReport(),
+    focusedSkillId ? getSkillLifecycleState(focusedSkillId) : Promise.resolve(null),
   ]);
+
+  const focusedLifecycleState =
+    lifecycleRow && isSkillLifecycleState(lifecycleRow.lifecycleState)
+      ? lifecycleRow.lifecycleState
+      : null;
 
   return (
     <div>
@@ -77,11 +101,16 @@ export default async function SkillsObservatoryPage({
         />
       </div>
 
-      {review && (
+      <div className="mt-6">
+        <h2 className="mb-3 text-sm font-semibold text-[var(--dpf-text)]">Curator</h2>
+        <SkillCuratorReportPanel report={curatorReport} />
+      </div>
+
+      {focusedSkillId && (
         <div className="mt-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
           <div className="mb-3 flex items-baseline justify-between gap-3">
             <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
-              Review &amp; revisions — <code>{review.skillId}</code>
+              Skill detail — <code>{focusedSkillId}</code>
             </h2>
             <Link
               href="/platform/ai/skills"
@@ -90,53 +119,70 @@ export default async function SkillsObservatoryPage({
               Clear focus
             </Link>
           </div>
-          {!review.seedDrift.inSync && review.seedDrift.seedBody !== null && (
-            <div
-              className="mb-3 rounded border px-3 py-2 text-xs"
-              style={{
-                borderColor: "color-mix(in srgb, var(--dpf-warning) 35%, var(--dpf-border))",
-                background: "color-mix(in srgb, var(--dpf-warning) 8%, transparent)",
-                color: "var(--dpf-text)",
-              }}
-            >
-              <strong>Seed drift:</strong> DB body differs from <code>{review.seedDrift.seedPath}</code>.
-              Patch the seed file in the same PR so a fresh install keeps this change.
+
+          {/* Slice 4: lifecycle controls */}
+          {focusedLifecycleState && (
+            <div className="mb-4">
+              <SkillLifecycleControls
+                skillId={focusedSkillId}
+                currentState={focusedLifecycleState}
+              />
             </div>
           )}
-          {!review.seedDrift.inSync && review.seedDrift.seedBody === null && (
-            <div
-              className="mb-3 rounded border px-3 py-2 text-xs"
-              style={{
-                borderColor: "var(--dpf-border)",
-                background: "var(--dpf-surface-2)",
-                color: "var(--dpf-muted)",
-              }}
-            >
-              Seed file not found at <code>{review.seedDrift.seedPath}</code> (normal for production
-              installs where the repo isn&rsquo;t checked out next to the app).
-            </div>
+
+          {/* Slice 3: seed drift, proposals, revisions */}
+          {review ? (
+            <>
+              {!review.seedDrift.inSync && review.seedDrift.seedBody !== null && (
+                <div
+                  className="mb-3 rounded border px-3 py-2 text-xs"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--dpf-warning) 35%, var(--dpf-border))",
+                    background: "color-mix(in srgb, var(--dpf-warning) 8%, transparent)",
+                    color: "var(--dpf-text)",
+                  }}
+                >
+                  <strong>Seed drift:</strong> DB body differs from <code>{review.seedDrift.seedPath}</code>.
+                  Patch the seed file in the same PR so a fresh install keeps this change.
+                </div>
+              )}
+              {!review.seedDrift.inSync && review.seedDrift.seedBody === null && (
+                <div
+                  className="mb-3 rounded border px-3 py-2 text-xs"
+                  style={{
+                    borderColor: "var(--dpf-border)",
+                    background: "var(--dpf-surface-2)",
+                    color: "var(--dpf-muted)",
+                  }}
+                >
+                  Seed file not found at <code>{review.seedDrift.seedPath}</code> (normal for production
+                  installs where the repo isn&rsquo;t checked out next to the app).
+                </div>
+              )}
+              <div className="mb-4">
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Proposals
+                </h3>
+                <SkillProposalsPanel
+                  skillId={review.skillId}
+                  currentContent={review.skillMdContent}
+                  proposals={review.proposals}
+                />
+              </div>
+              <div>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Revision history
+                </h3>
+                <SkillRevisionHistoryPanel skillId={review.skillId} revisions={review.revisions} />
+              </div>
+            </>
+          ) : (
+            !focusedLifecycleState && (
+              <p className="text-xs text-[var(--dpf-muted)]">
+                No skill found with id <code>{focusedSkillId}</code>.
+              </p>
+            )
           )}
-          <div className="mb-4">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-              Proposals
-            </h3>
-            <SkillProposalsPanel
-              skillId={review.skillId}
-              currentContent={review.skillMdContent}
-              proposals={review.proposals}
-            />
-          </div>
-          <div>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-              Revision history
-            </h3>
-            <SkillRevisionHistoryPanel skillId={review.skillId} revisions={review.revisions} />
-          </div>
-        </div>
-      )}
-      {!review && focusedSkillId && (
-        <div className="mt-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-xs text-[var(--dpf-muted)]">
-          No skill found with id <code>{focusedSkillId}</code>.
         </div>
       )}
     </div>

--- a/apps/web/components/platform/SkillCuratorReportPanel.test.tsx
+++ b/apps/web/components/platform/SkillCuratorReportPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/skill-curator-actions", () => ({
+  runSkillCuratorAction: vi.fn(),
+  pinSkillAction: vi.fn(),
+  quarantineSkillAction: vi.fn(),
+  unpinSkillAction: vi.fn(),
+}));
+
+import { SkillCuratorReportPanel } from "./SkillCuratorReportPanel";
+
+describe("SkillCuratorReportPanel", () => {
+  it("renders an empty state when no report exists yet", () => {
+    const html = renderToStaticMarkup(<SkillCuratorReportPanel report={null} />);
+    expect(html).toContain("Curator report");
+    expect(html).toContain("not run yet");
+    expect(html).toContain("Run curator now");
+  });
+
+  it("renders totals + findings table when a report is present", () => {
+    const html = renderToStaticMarkup(
+      <SkillCuratorReportPanel
+        report={{
+          artifactId: "ta-1",
+          scannedAt: "2026-05-15T07:00:00.000Z",
+          totals: { active: 4, stale: 2, pinned: 1, quarantined: 0, archived: 1 },
+          findings: [
+            { skillId: "build-page", fromState: "active", toState: "stale", reason: "no invocations in the last 30 days", changed: true },
+            { skillId: "ship-feature", fromState: "active", toState: "active", reason: "in use", changed: false },
+          ],
+          createdAt: "2026-05-15T07:00:01.000Z",
+        }}
+      />,
+    );
+    expect(html).toContain("active: 4");
+    expect(html).toContain("stale: 2");
+    expect(html).toContain("pinned: 1");
+    expect(html).toContain("build-page");
+    expect(html).toContain("ship-feature");
+    expect(html).toContain("no invocations in the last 30 days");
+  });
+
+  it("uses only theme tokens — no hardcoded hex colors", () => {
+    const html = renderToStaticMarkup(
+      <SkillCuratorReportPanel
+        report={{
+          artifactId: "ta-1",
+          scannedAt: "2026-05-15T07:00:00.000Z",
+          totals: { active: 1, stale: 0, pinned: 0, quarantined: 0, archived: 0 },
+          findings: [],
+          createdAt: "2026-05-15T07:00:01.000Z",
+        }}
+      />,
+    );
+    expect(html).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/platform/SkillCuratorReportPanel.tsx
+++ b/apps/web/components/platform/SkillCuratorReportPanel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { CSSProperties } from "react";
+
+import { runSkillCuratorAction } from "@/lib/actions/skill-curator-actions";
+
+import type { CuratorFinding } from "@/lib/skills/curator";
+import type { SkillLifecycleState } from "@/lib/skills/lifecycle";
+
+type Props = {
+  /** null when no curator has ever run on this install. */
+  report:
+    | {
+        artifactId: string;
+        scannedAt: string;
+        totals: Record<SkillLifecycleState, number>;
+        findings: CuratorFinding[];
+        createdAt: string;
+      }
+    | null;
+};
+
+export function SkillCuratorReportPanel({ report }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  function handleRunNow() {
+    startTransition(async () => {
+      const result = await runSkillCuratorAction();
+      if (result.ok) {
+        setFeedback(
+          `Curator ran: ${result.report.findings.length} skills classified. Reload the page to see the new report.`,
+        );
+      } else {
+        setFeedback(`Failed: ${result.error}`);
+      }
+    });
+  }
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+        padding: 16,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12 }}>
+        <div>
+          <h3 style={{ fontSize: 14, fontWeight: 600, color: "var(--dpf-text)", margin: 0 }}>
+            Curator report
+          </h3>
+          {report ? (
+            <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: "4px 0 0 0" }}>
+              Last run {new Date(report.scannedAt).toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}
+            </p>
+          ) : (
+            <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: "4px 0 0 0" }}>
+              The curator has not run yet on this install.
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleRunNow}
+          disabled={pending}
+          style={primaryBtn}
+        >
+          {pending ? "Running…" : "Run curator now"}
+        </button>
+      </div>
+
+      {feedback && (
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 8 }}>{feedback}</p>
+      )}
+
+      {report && (
+        <div style={{ marginTop: 12 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 12 }}>
+            {(Object.entries(report.totals) as Array<[SkillLifecycleState, number]>).map(([state, count]) => (
+              <span
+                key={state}
+                style={{
+                  fontSize: 11,
+                  padding: "2px 8px",
+                  borderRadius: 999,
+                  background: badgeBg(state),
+                  color: badgeColor(state),
+                  fontWeight: 500,
+                }}
+              >
+                {state}: {count}
+              </span>
+            ))}
+          </div>
+
+          {report.findings.length === 0 ? (
+            <p style={{ fontSize: 12, color: "var(--dpf-muted)", margin: 0 }}>No findings.</p>
+          ) : (
+            <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ color: "var(--dpf-muted)", textAlign: "left" }}>
+                  <th style={thStyle}>Skill</th>
+                  <th style={thStyle}>From</th>
+                  <th style={thStyle}>To</th>
+                  <th style={thStyle}>Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.findings.map((f) => (
+                  <tr key={f.skillId}>
+                    <td style={tdStyle}>
+                      <code style={{ color: "var(--dpf-accent)" }}>{f.skillId}</code>
+                    </td>
+                    <td style={tdStyle}>{f.fromState}</td>
+                    <td style={{ ...tdStyle, fontWeight: f.changed ? 600 : 400 }}>{f.toState}</td>
+                    <td style={{ ...tdStyle, color: "var(--dpf-muted)" }}>{f.reason}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function badgeBg(state: SkillLifecycleState): string {
+  switch (state) {
+    case "active":
+      return "color-mix(in srgb, var(--dpf-success) 12%, transparent)";
+    case "stale":
+      return "color-mix(in srgb, var(--dpf-warning) 12%, transparent)";
+    case "pinned":
+      return "color-mix(in srgb, var(--dpf-accent) 12%, transparent)";
+    case "quarantined":
+      return "color-mix(in srgb, var(--dpf-error) 12%, transparent)";
+    case "archived":
+      return "var(--dpf-surface-2)";
+  }
+}
+
+function badgeColor(state: SkillLifecycleState): string {
+  switch (state) {
+    case "active":
+      return "var(--dpf-success)";
+    case "stale":
+      return "var(--dpf-warning)";
+    case "pinned":
+      return "var(--dpf-accent)";
+    case "quarantined":
+      return "var(--dpf-error)";
+    case "archived":
+      return "var(--dpf-muted)";
+  }
+}
+
+const primaryBtn: CSSProperties = {
+  fontSize: 12,
+  padding: "6px 12px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-accent)",
+  background: "var(--dpf-accent)",
+  color: "white",
+  cursor: "pointer",
+};
+
+const thStyle: CSSProperties = {
+  fontWeight: 500,
+  padding: "4px 8px",
+  borderBottom: "1px solid var(--dpf-border)",
+};
+
+const tdStyle: CSSProperties = {
+  padding: "6px 8px",
+  borderBottom: "1px solid var(--dpf-border)",
+  color: "var(--dpf-text)",
+};

--- a/apps/web/components/platform/SkillLifecycleControls.test.tsx
+++ b/apps/web/components/platform/SkillLifecycleControls.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/lib/actions/skill-curator-actions", () => ({
+  pinSkillAction: vi.fn(),
+  quarantineSkillAction: vi.fn(),
+  unpinSkillAction: vi.fn(),
+  runSkillCuratorAction: vi.fn(),
+}));
+
+import { SkillLifecycleControls } from "./SkillLifecycleControls";
+
+describe("SkillLifecycleControls", () => {
+  it("renders the three lifecycle actions and shows current state", () => {
+    const html = renderToStaticMarkup(
+      <SkillLifecycleControls skillId="build-page" currentState="active" />,
+    );
+    expect(html).toContain("Pin");
+    expect(html).toContain("Quarantine");
+    expect(html).toContain("Reset to active");
+    expect(html).toContain("Lifecycle:");
+    expect(html).toContain("active");
+  });
+
+  it("disables Pin when the skill is already pinned", () => {
+    const html = renderToStaticMarkup(
+      <SkillLifecycleControls skillId="build-page" currentState="pinned" />,
+    );
+    // The Pin button is disabled but the Reset/Quarantine buttons are not.
+    // renderToStaticMarkup emits the `disabled` attribute on disabled buttons.
+    expect(html).toMatch(/<button[^>]*disabled[^>]*>\s*Pin\s*<\/button>/);
+  });
+
+  it("uses only theme tokens — no hardcoded hex colors", () => {
+    const html = renderToStaticMarkup(
+      <SkillLifecycleControls skillId="build-page" currentState="stale" />,
+    );
+    expect(html).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/platform/SkillLifecycleControls.tsx
+++ b/apps/web/components/platform/SkillLifecycleControls.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { CSSProperties } from "react";
+
+import {
+  pinSkillAction,
+  quarantineSkillAction,
+  unpinSkillAction,
+} from "@/lib/actions/skill-curator-actions";
+import type { SkillLifecycleState } from "@/lib/skills/lifecycle";
+
+type Props = {
+  skillId: string;
+  currentState: SkillLifecycleState;
+};
+
+export function SkillLifecycleControls({ skillId, currentState }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  function call(action: () => Promise<{ ok: true } | { ok: false; error: string }>, label: string) {
+    startTransition(async () => {
+      const result = await action();
+      setFeedback(result.ok ? `${label} — reload to see the updated state.` : `Failed: ${result.error}`);
+    });
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 12px",
+        background: "var(--dpf-surface-2)",
+        border: "1px solid var(--dpf-border)",
+        borderRadius: 6,
+        flexWrap: "wrap",
+      }}
+    >
+      <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
+        Lifecycle: <strong style={{ color: badgeColor(currentState) }}>{currentState}</strong>
+      </span>
+      <span style={{ flex: 1 }} />
+      <button
+        type="button"
+        disabled={pending || currentState === "pinned"}
+        onClick={() => call(() => pinSkillAction(skillId), "Pinned")}
+        style={secondaryBtn}
+      >
+        Pin
+      </button>
+      <button
+        type="button"
+        disabled={pending || currentState === "quarantined"}
+        onClick={() => call(() => quarantineSkillAction(skillId), "Quarantined")}
+        style={secondaryBtn}
+      >
+        Quarantine
+      </button>
+      <button
+        type="button"
+        disabled={pending || currentState === "active"}
+        onClick={() => call(() => unpinSkillAction(skillId), "Reset to active")}
+        style={secondaryBtn}
+      >
+        Reset to active
+      </button>
+      {feedback && (
+        <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: 0, width: "100%" }}>
+          {feedback}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function badgeColor(state: SkillLifecycleState): string {
+  switch (state) {
+    case "active":
+      return "var(--dpf-success)";
+    case "stale":
+      return "var(--dpf-warning)";
+    case "pinned":
+      return "var(--dpf-accent)";
+    case "quarantined":
+      return "var(--dpf-error)";
+    case "archived":
+      return "var(--dpf-muted)";
+  }
+}
+
+const secondaryBtn: CSSProperties = {
+  fontSize: 11,
+  padding: "4px 10px",
+  borderRadius: 4,
+  border: "1px solid var(--dpf-border)",
+  background: "var(--dpf-surface-1)",
+  color: "var(--dpf-text)",
+  cursor: "pointer",
+};

--- a/apps/web/lib/actions/skill-curator-actions.ts
+++ b/apps/web/lib/actions/skill-curator-actions.ts
@@ -1,0 +1,84 @@
+"use server";
+
+// Slice 4 admin surface for the skill curator and lifecycle controls.
+// All actions require `manage_capabilities` so operator-set state changes
+// share authority with proposal approval (Slice 3).
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  runSkillCurator as runCurator,
+  type CuratorReport,
+} from "@/lib/skills/curator";
+import {
+  isSkillLifecycleState,
+  type SkillLifecycleState,
+} from "@/lib/skills/lifecycle";
+
+type AuthOk = { ok: true; userId: string };
+type AuthFail = { ok: false; error: string };
+
+async function requireAdmin(): Promise<AuthOk | AuthFail> {
+  const session = await auth();
+  if (!session?.user?.id) return { ok: false, error: "Unauthorized" };
+  const ctx = {
+    userId: session.user.id,
+    platformRole: session.user.platformRole ?? null,
+    isSuperuser: session.user.isSuperuser ?? false,
+  };
+  if (!can(ctx, "manage_capabilities")) {
+    return { ok: false, error: "manage_capabilities capability required" };
+  }
+  return { ok: true, userId: session.user.id };
+}
+
+async function setSkillLifecycleState(
+  skillId: string,
+  next: SkillLifecycleState,
+): Promise<{ ok: true; lifecycleState: SkillLifecycleState } | { ok: false; error: string }> {
+  const a = await requireAdmin();
+  if (!a.ok) return a;
+  if (!isSkillLifecycleState(next)) {
+    return { ok: false, error: `invalid lifecycleState: ${next}` };
+  }
+  try {
+    await prisma.skillDefinition.update({
+      where: { skillId },
+      data: { lifecycleState: next },
+    });
+    return { ok: true, lifecycleState: next };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function pinSkillAction(skillId: string) {
+  return setSkillLifecycleState(skillId, "pinned");
+}
+
+export async function quarantineSkillAction(skillId: string) {
+  return setSkillLifecycleState(skillId, "quarantined");
+}
+
+/**
+ * Reset a skill back to `active`. Used to clear pin / quarantine without
+ * waiting for the next curator pass; safe because the curator will
+ * re-classify on the next run if the skill should actually be stale.
+ */
+export async function unpinSkillAction(skillId: string) {
+  return setSkillLifecycleState(skillId, "active");
+}
+
+export async function runSkillCuratorAction(): Promise<
+  { ok: true; report: CuratorReport } | { ok: false; error: string }
+> {
+  const a = await requireAdmin();
+  if (!a.ok) return a;
+  try {
+    const report = await runCurator({ invokedByUserId: a.userId });
+    return { ok: true, report };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/web/lib/actions/skills-observatory.ts
+++ b/apps/web/lib/actions/skills-observatory.ts
@@ -212,6 +212,32 @@ export async function getSkillReviewDetail(skillId: string): Promise<{
 }
 
 /**
+ * Governed Hermes learning Slice 4: shape SkillDefinition.lifecycleState for
+ * a single skill so the operator UI can render lifecycle controls. Returns
+ * null when the skill does not exist.
+ */
+export async function getSkillLifecycleState(skillId: string): Promise<{
+  skillId: string;
+  lifecycleState: string;
+} | null> {
+  const row = await prisma.skillDefinition.findUnique({
+    where: { skillId },
+    select: { skillId: true, lifecycleState: true },
+  });
+  return row;
+}
+
+/**
+ * Governed Hermes learning Slice 4: read the latest curator report. Delegates
+ * to apps/web/lib/skills/curator.ts so this action layer stays free of
+ * artifact-shape knowledge.
+ */
+export async function getLatestSkillCuratorReport() {
+  const { getLatestCuratorReport } = await import("@/lib/skills/curator");
+  return getLatestCuratorReport();
+}
+
+/**
  * Governed Hermes learning Slice 1: shape SkillUsageEvent + SkillMetric for
  * the observatory's telemetry tab. Returns aggregate counts only — per-row
  * inspection lives in the Skills detail view (later slice).

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -19,6 +19,7 @@ import { tokenExpiryMonitor } from "./token-expiry-monitor";
 import { wikiLint } from "./wiki-lint";
 import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verification";
 import { skillMetricsAggregator } from "./skill-metrics-aggregator";
+import { skillCurator } from "./skill-curator";
 
 export const allFunctions = [
   prometheusPoll,
@@ -43,4 +44,5 @@ export const allFunctions = [
   wikiLint,
   gitPromotionSandboxVerification,
   skillMetricsAggregator,
+  skillCurator,
 ];

--- a/apps/web/lib/queue/functions/skill-curator.ts
+++ b/apps/web/lib/queue/functions/skill-curator.ts
@@ -1,0 +1,31 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+
+/**
+ * Daily skill curator for Slice 4 of the governed Hermes learning loop.
+ * Runs at 07:00 UTC — after the metrics aggregator at 05:00 so the curator
+ * sees fresh SkillMetric rows. The 07:00 slot was verified 2026-05-15
+ * against live ScheduledJob rows and repo cron seeds (no other job uses it).
+ *
+ * The curator is idempotent end-to-end: classification is deterministic,
+ * signal emission dedupes on (sourceType, sourceId), and a missed tick is
+ * recovered automatically on the next run.
+ */
+export const skillCurator = inngest.createFunction(
+  {
+    id: "skills/curator",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("0 7 * * *")],
+  },
+  async ({ step }) => {
+    return step.run("run-skill-curator", async () => {
+      const { runSkillCurator } = await import("@/lib/skills/curator");
+      const result = await runSkillCurator({ invokedByUserId: "system" });
+      console.log(
+        `[skill-curator] scanned ${result.findings.length} skills; totals=${JSON.stringify(result.totals)}`,
+      );
+      return result;
+    });
+  },
+);

--- a/apps/web/lib/skills/curator.test.ts
+++ b/apps/web/lib/skills/curator.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory state to exercise classify + emit without a live DB. Designed
+// to also catch the curator if it ever tries to write a field other than
+// `lifecycleState` on `SkillDefinition`.
+
+const state = vi.hoisted(() => ({
+  skills: [] as Array<{
+    skillId: string;
+    category: string;
+    skillMdContent: string;
+    lifecycleState: string;
+    assignments: Array<{ id: string }>;
+  }>,
+  usageEvents: [] as Array<{ skillId: string; phase: string; createdAt: Date }>,
+  signalsTouched: [] as Array<Record<string, unknown>>,
+  taskRunsCreated: [] as Array<Record<string, unknown>>,
+  artifactsCreated: [] as Array<Record<string, unknown>>,
+  skillUpdates: [] as Array<{ where: Record<string, unknown>; data: Record<string, unknown> }>,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    skillDefinition: {
+      findMany: vi.fn(async () => state.skills),
+      update: vi.fn(async (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => {
+        state.skillUpdates.push(args);
+        const s = state.skills.find((sk) => sk.skillId === (args.where.skillId as string));
+        if (!s) throw new Error("skill not found");
+        Object.assign(s, args.data);
+        return s;
+      }),
+    },
+    skillUsageEvent: {
+      groupBy: vi.fn(async () => {
+        const groups = new Map<string, number>();
+        for (const e of state.usageEvents) {
+          const k = `${e.skillId}:${e.phase}`;
+          groups.set(k, (groups.get(k) ?? 0) + 1);
+        }
+        return Array.from(groups.entries()).map(([k, c]) => {
+          const [skillId, phase] = k.split(":");
+          return { skillId, phase, _count: { _all: c } };
+        });
+      }),
+      findMany: vi.fn(async () => {
+        const seen = new Map<string, Date>();
+        for (const e of state.usageEvents) {
+          if (!seen.has(e.skillId) || e.createdAt > (seen.get(e.skillId) as Date)) {
+            seen.set(e.skillId, e.createdAt);
+          }
+        }
+        return Array.from(seen.entries()).map(([skillId, createdAt]) => ({ skillId, createdAt }));
+      }),
+    },
+    taskRun: {
+      create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        const row = { ...args.data, id: `tr-${state.taskRunsCreated.length + 1}` };
+        state.taskRunsCreated.push(row);
+        return row;
+      }),
+    },
+    taskArtifact: {
+      create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        state.artifactsCreated.push(args.data);
+        return args.data;
+      }),
+      findFirst: vi.fn(async () => null),
+    },
+  },
+}));
+
+vi.mock("@/lib/improvement-flywheel/signals", () => ({
+  createOrTouchImprovementSignal: vi.fn(async (input: Record<string, unknown>) => {
+    state.signalsTouched.push(input);
+    return { signalId: `IS-${state.signalsTouched.length}`, isNew: true };
+  }),
+}));
+
+import { runSkillCurator, CURATOR_REPORT_KIND } from "./curator";
+
+beforeEach(() => {
+  state.skills.length = 0;
+  state.usageEvents.length = 0;
+  state.signalsTouched.length = 0;
+  state.taskRunsCreated.length = 0;
+  state.artifactsCreated.length = 0;
+  state.skillUpdates.length = 0;
+});
+
+function addSkill(partial: Partial<(typeof state.skills)[number]> & { skillId: string }) {
+  state.skills.push({
+    skillId: partial.skillId,
+    category: partial.category ?? "build",
+    skillMdContent: partial.skillMdContent ?? "body",
+    lifecycleState: partial.lifecycleState ?? "active",
+    assignments: partial.assignments ?? [],
+  });
+}
+
+describe("runSkillCurator — happy path", () => {
+  it("classifies, emits one signal per non-active finding, writes one report", async () => {
+    addSkill({ skillId: "active-skill", skillMdContent: "body" });
+    addSkill({ skillId: "stale-skill", skillMdContent: "body" });
+    state.usageEvents.push({
+      skillId: "active-skill",
+      phase: "invoked",
+      createdAt: new Date("2026-05-01"),
+    });
+
+    const report = await runSkillCurator({ invokedByUserId: "system" });
+
+    // The stale skill produced a finding and a signal.
+    expect(report.findings.find((f) => f.skillId === "stale-skill")?.toState).toBe("stale");
+    expect(state.signalsTouched).toHaveLength(1);
+    expect(state.signalsTouched[0]?.sourceType).toBe("curator-finding");
+    expect(state.signalsTouched[0]?.sourceId).toBe("stale-skill:stale");
+
+    // Exactly one TaskArtifact with the right metadata kind.
+    expect(state.artifactsCreated).toHaveLength(1);
+    expect(
+      (state.artifactsCreated[0]?.metadata as { kind?: string })?.kind,
+    ).toBe(CURATOR_REPORT_KIND);
+  });
+});
+
+describe("runSkillCurator — pin protection invariant", () => {
+  it("never updates a pinned skill (signal-only, no DB update)", async () => {
+    addSkill({
+      skillId: "pinned-skill",
+      lifecycleState: "pinned",
+      skillMdContent: "",
+      assignments: [],
+    });
+    // Even with zero content + zero assignments + zero use, a pinned skill
+    // would otherwise be a candidate to archive — but pin protection
+    // overrides everything.
+
+    const report = await runSkillCurator({ invokedByUserId: "system" });
+
+    // No skill update was made for the pinned skill.
+    expect(state.skillUpdates).toHaveLength(0);
+    // The finding records that the state stayed pinned.
+    const f = report.findings.find((x) => x.skillId === "pinned-skill");
+    expect(f?.fromState).toBe("pinned");
+    expect(f?.toState).toBe("pinned");
+    expect(f?.changed).toBe(false);
+    // Pinned/quarantined skills don't emit an ImprovementSignal because the
+    // operator already chose this state; further signals would be noise.
+    // Sanity: the only signals (if any) are for OTHER skills, not the pinned one.
+    expect(
+      state.signalsTouched.find(
+        (s) => (s.sourceId as string)?.startsWith("pinned-skill:"),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("never updates a quarantined skill either", async () => {
+    addSkill({
+      skillId: "q-skill",
+      lifecycleState: "quarantined",
+      skillMdContent: "body",
+      assignments: [{ id: "a-1" }],
+    });
+    state.usageEvents.push({
+      skillId: "q-skill",
+      phase: "invoked",
+      createdAt: new Date("2026-05-01"),
+    });
+
+    const report = await runSkillCurator({ invokedByUserId: "system" });
+    expect(state.skillUpdates).toHaveLength(0);
+    expect(report.findings.find((f) => f.skillId === "q-skill")?.toState).toBe(
+      "quarantined",
+    );
+  });
+});
+
+describe("runSkillCurator — no skillMdContent mutation", () => {
+  it("only writes lifecycleState in any skill update", async () => {
+    addSkill({ skillId: "stale-skill" });
+
+    await runSkillCurator({ invokedByUserId: "system" });
+
+    // The curator may or may not produce an update on any given skill,
+    // but every update it DOES produce must touch only lifecycleState.
+    for (const upd of state.skillUpdates) {
+      const keys = Object.keys(upd.data);
+      expect(keys).toEqual(["lifecycleState"]);
+      expect(keys).not.toContain("skillMdContent");
+    }
+  });
+});
+
+describe("runSkillCurator — dedupe", () => {
+  it("re-running the curator over the same population produces the same signal sourceIds", async () => {
+    addSkill({ skillId: "stale-skill" });
+
+    await runSkillCurator({ invokedByUserId: "system" });
+    const firstIds = state.signalsTouched.map((s) => s.sourceId);
+
+    state.signalsTouched.length = 0;
+    state.skillUpdates.length = 0;
+    state.artifactsCreated.length = 0;
+    state.taskRunsCreated.length = 0;
+
+    await runSkillCurator({ invokedByUserId: "system" });
+    const secondIds = state.signalsTouched.map((s) => s.sourceId);
+
+    expect(secondIds).toEqual(firstIds);
+    // The signal writer dedupes on (sourceType, sourceId); since both runs
+    // emit the same sourceIds, re-running just increments recurrenceCount
+    // rather than creating parallel signals. The curator itself doesn't
+    // verify that — it's a contract of createOrTouchImprovementSignal.
+  });
+});
+
+describe("runSkillCurator — empty population", () => {
+  it("still writes a TaskRun + TaskArtifact with zero findings when no skills exist", async () => {
+    const report = await runSkillCurator({ invokedByUserId: "system" });
+    expect(report.findings).toEqual([]);
+    expect(state.taskRunsCreated).toHaveLength(1);
+    expect(state.artifactsCreated).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/skills/curator.ts
+++ b/apps/web/lib/skills/curator.ts
@@ -1,0 +1,248 @@
+// Skill curator service for Slice 4 of the governed Hermes learning loop.
+//
+// Runs daily on a cron; can also be invoked on demand by an admin. For each
+// SkillDefinition, classifies operational health via `classifySkillLifecycle`,
+// emits an `ImprovementSignal` per non-active finding (deduped on
+// (sourceType, sourceId)), updates `lifecycleState` (with pin protection),
+// and writes a single `TaskArtifact(metadata.kind="curator-report")` under
+// a proactive TaskRun. **Never mutates SkillDefinition.skillMdContent.**
+//
+// Pin protection: skills in `pinned` or `quarantined` state are sticky —
+// the classifier returns the current state unchanged and the curator never
+// overrides it. Operator action (pinSkill/quarantineSkill/unpinSkill server
+// actions) is the only way to move skills into or out of those states.
+
+import { randomUUID } from "crypto";
+
+import type { Prisma } from "@dpf/db";
+import { prisma } from "@dpf/db";
+
+import { createOrTouchImprovementSignal } from "@/lib/improvement-flywheel/signals";
+import {
+  classifySkillLifecycle,
+  isCuratorImmutable,
+  isSkillLifecycleState,
+  type SkillLifecycleState,
+} from "./lifecycle";
+
+export const CURATOR_REPORT_KIND = "curator-report";
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type CuratorFinding = {
+  skillId: string;
+  fromState: SkillLifecycleState;
+  toState: SkillLifecycleState;
+  reason: string;
+  changed: boolean;
+};
+
+export type CuratorReport = {
+  scannedAt: string;
+  totals: Record<SkillLifecycleState, number>;
+  findings: CuratorFinding[];
+  reportArtifactId: string | null;
+  taskRunPublicId: string | null;
+};
+
+export type RunSkillCuratorInput = {
+  /** Reviewer or system user attributed for the proactive TaskRun. */
+  invokedByUserId: string;
+  /** Optional override for "now" — used in tests. */
+  now?: Date;
+};
+
+/**
+ * Run the skill curator. Pure with respect to skill content — it can only
+ * write to SkillDefinition.lifecycleState (no other columns) and emit
+ * audit rows (TaskRun, TaskArtifact, ImprovementSignal). Pinned skills
+ * are never moved.
+ */
+export async function runSkillCurator(
+  input: RunSkillCuratorInput,
+): Promise<CuratorReport> {
+  const scannedAt = input.now ?? new Date();
+  const since = new Date(scannedAt.getTime() - THIRTY_DAYS_MS);
+
+  const skills = await prisma.skillDefinition.findMany({
+    select: {
+      skillId: true,
+      category: true,
+      skillMdContent: true,
+      lifecycleState: true,
+      assignments: { select: { id: true } },
+    },
+  });
+
+  // Per-skill usage counts in the last 30 days.
+  const usageBySkill = await prisma.skillUsageEvent.groupBy({
+    by: ["skillId", "phase"],
+    where: { createdAt: { gte: since } },
+    _count: { _all: true },
+  });
+  const usageMap = new Map<string, { invoked: number; failed: number }>();
+  for (const row of usageBySkill) {
+    const entry = usageMap.get(row.skillId) ?? { invoked: 0, failed: 0 };
+    if (row.phase === "invoked") entry.invoked = row._count._all;
+    if (row.phase === "failed") entry.failed = row._count._all;
+    usageMap.set(row.skillId, entry);
+  }
+
+  const lastUsedMap = new Map<string, Date>();
+  const lastUsedRows = await prisma.skillUsageEvent.findMany({
+    where: { createdAt: { gte: since } },
+    orderBy: { createdAt: "desc" },
+    select: { skillId: true, createdAt: true },
+    distinct: ["skillId"],
+  });
+  for (const r of lastUsedRows) lastUsedMap.set(r.skillId, r.createdAt);
+
+  const findings: CuratorFinding[] = [];
+  const totals: Record<SkillLifecycleState, number> = {
+    active: 0,
+    stale: 0,
+    pinned: 0,
+    quarantined: 0,
+    archived: 0,
+  };
+
+  for (const s of skills) {
+    const currentRaw = s.lifecycleState;
+    const current: SkillLifecycleState = isSkillLifecycleState(currentRaw)
+      ? currentRaw
+      : "active";
+    const usage30d = usageMap.get(s.skillId) ?? { invoked: 0, failed: 0 };
+    const result = classifySkillLifecycle({
+      current,
+      usage30d,
+      assignmentCount: s.assignments.length,
+      lastUsedAt: lastUsedMap.get(s.skillId) ?? null,
+      hasContent: typeof s.skillMdContent === "string" && s.skillMdContent.trim().length > 0,
+    });
+
+    const next = isCuratorImmutable(current) ? current : result.next;
+    totals[next] = (totals[next] ?? 0) + 1;
+    const changed = next !== current;
+    findings.push({
+      skillId: s.skillId,
+      fromState: current,
+      toState: next,
+      reason: result.reason,
+      changed,
+    });
+
+    if (changed) {
+      // Whitelist the column we mutate — explicit object literal so the
+      // curator cannot accidentally update skillMdContent or any other
+      // field through this code path. Verified by curator.test.ts.
+      await prisma.skillDefinition.update({
+        where: { skillId: s.skillId },
+        data: { lifecycleState: next },
+      });
+    }
+
+    // Emit a finding signal only when the next state is non-active AND not
+    // operator-set (pinned/quarantined). Operator-set states are intentional
+    // — surfacing them every day would be noise. (sourceType, sourceId)
+    // dedupe means re-runs on the same population increment recurrenceCount
+    // rather than producing parallel signals.
+    if (next !== "active" && !isCuratorImmutable(next)) {
+      await createOrTouchImprovementSignal({
+        sourceType: "curator-finding",
+        sourceId: `${s.skillId}:${next}`,
+        title: `Skill ${s.skillId} is ${next}`,
+        description: result.reason,
+        evidence: {
+          fromState: current,
+          toState: next,
+          usage30d,
+          assignmentCount: s.assignments.length,
+        },
+        suspectedRootCause: result.reason,
+      });
+    }
+  }
+
+  // Persist the report as a TaskArtifact under a fresh proactive TaskRun.
+  const taskRunPublicId = `TR-CUR-${randomUUID().slice(0, 8).toUpperCase()}`;
+  const taskRun = await prisma.taskRun.create({
+    data: {
+      taskRunId: taskRunPublicId,
+      userId: input.invokedByUserId,
+      title: "Skill curator dry-run pass",
+      objective:
+        "Classify every SkillDefinition into lifecycleState and emit governed findings.",
+      source: "proactive",
+      status: "completed",
+      authorityScope: [],
+      a2aMetadata: { trigger: "skill-curator" } as Prisma.InputJsonValue,
+      currentAgentId: null,
+      initiatingAgentId: null,
+      routeContext: "/platform/ai/skills",
+      completedAt: scannedAt,
+    },
+    select: { id: true, taskRunId: true },
+  });
+
+  const artifactId = `ta_${randomUUID()}`;
+  await prisma.taskArtifact.create({
+    data: {
+      id: randomUUID(),
+      artifactId,
+      taskRunId: taskRun.id,
+      name: "Skill curator report",
+      description: `Scanned ${skills.length} skills, ${findings.filter((f) => f.changed).length} state changes`,
+      parts: [
+        {
+          type: "curator-report",
+          mimeType: "application/json",
+          data: {
+            scannedAt: scannedAt.toISOString(),
+            totals,
+            findings,
+          },
+        },
+      ] as Prisma.InputJsonValue,
+      metadata: { kind: CURATOR_REPORT_KIND } as Prisma.InputJsonValue,
+    },
+  });
+
+  return {
+    scannedAt: scannedAt.toISOString(),
+    totals,
+    findings,
+    reportArtifactId: artifactId,
+    taskRunPublicId,
+  };
+}
+
+/**
+ * Read the most-recent curator report (TaskArtifact with metadata.kind =
+ * 'curator-report'). Returns null if no curator has ever run.
+ */
+export async function getLatestCuratorReport(): Promise<
+  { artifactId: string; scannedAt: string; totals: Record<SkillLifecycleState, number>; findings: CuratorFinding[]; createdAt: string } | null
+> {
+  // Postgres JSONB path predicate. Prisma's filter syntax for JSON columns:
+  // metadata: { path: ["kind"], equals: "curator-report" } in the engine.
+  const row = await prisma.taskArtifact.findFirst({
+    where: {
+      metadata: { path: ["kind"], equals: CURATOR_REPORT_KIND } as Prisma.JsonFilter,
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, artifactId: true, parts: true, createdAt: true },
+  });
+  if (!row) return null;
+  const parts = Array.isArray(row.parts) ? (row.parts as unknown[]) : [];
+  const reportPart = parts.find(
+    (p) => typeof p === "object" && p !== null && (p as { type?: string }).type === "curator-report",
+  ) as { data?: { scannedAt?: string; totals?: Record<string, number>; findings?: CuratorFinding[] } } | undefined;
+  if (!reportPart?.data) return null;
+  return {
+    artifactId: row.artifactId,
+    scannedAt: reportPart.data.scannedAt ?? "",
+    totals: (reportPart.data.totals ?? {}) as Record<SkillLifecycleState, number>,
+    findings: reportPart.data.findings ?? [],
+    createdAt: row.createdAt.toISOString(),
+  };
+}

--- a/apps/web/lib/skills/lifecycle.test.ts
+++ b/apps/web/lib/skills/lifecycle.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifySkillLifecycle,
+  isCuratorImmutable,
+  isSkillLifecycleState,
+  SKILL_LIFECYCLE_STATES,
+} from "./lifecycle";
+
+describe("SKILL_LIFECYCLE_STATES", () => {
+  it("carries the five canonical states from the spec", () => {
+    expect([...SKILL_LIFECYCLE_STATES]).toEqual([
+      "active",
+      "stale",
+      "pinned",
+      "quarantined",
+      "archived",
+    ]);
+  });
+});
+
+describe("isSkillLifecycleState", () => {
+  it("accepts valid values and rejects everything else", () => {
+    expect(isSkillLifecycleState("active")).toBe(true);
+    expect(isSkillLifecycleState("pinned")).toBe(true);
+    expect(isSkillLifecycleState("none")).toBe(false);
+    expect(isSkillLifecycleState(null)).toBe(false);
+    expect(isSkillLifecycleState(42)).toBe(false);
+  });
+});
+
+describe("isCuratorImmutable", () => {
+  it("only pinned and quarantined are immutable by the curator", () => {
+    expect(isCuratorImmutable("pinned")).toBe(true);
+    expect(isCuratorImmutable("quarantined")).toBe(true);
+    expect(isCuratorImmutable("active")).toBe(false);
+    expect(isCuratorImmutable("stale")).toBe(false);
+    expect(isCuratorImmutable("archived")).toBe(false);
+  });
+});
+
+describe("classifySkillLifecycle", () => {
+  it("never moves a pinned skill", () => {
+    const result = classifySkillLifecycle({
+      current: "pinned",
+      usage30d: { invoked: 0, failed: 0 },
+      assignmentCount: 0,
+      lastUsedAt: null,
+      hasContent: false,
+    });
+    expect(result.next).toBe("pinned");
+    expect(result.reason).toContain("preserved");
+  });
+
+  it("never moves a quarantined skill", () => {
+    const result = classifySkillLifecycle({
+      current: "quarantined",
+      usage30d: { invoked: 999, failed: 0 },
+      assignmentCount: 10,
+      lastUsedAt: new Date(),
+      hasContent: true,
+    });
+    expect(result.next).toBe("quarantined");
+  });
+
+  it("archives a skill that has no content, no assignments, and no use", () => {
+    const result = classifySkillLifecycle({
+      current: "active",
+      usage30d: { invoked: 0, failed: 0 },
+      assignmentCount: 0,
+      lastUsedAt: null,
+      hasContent: false,
+    });
+    expect(result.next).toBe("archived");
+    expect(result.reason).toContain("no content");
+  });
+
+  it("marks a skill stale when it has no content but at least one assignment", () => {
+    const result = classifySkillLifecycle({
+      current: "active",
+      usage30d: { invoked: 0, failed: 0 },
+      assignmentCount: 1,
+      lastUsedAt: null,
+      hasContent: false,
+    });
+    expect(result.next).toBe("stale");
+    expect(result.reason).toContain("no SKILL.md body");
+  });
+
+  it("marks a skill stale when it has content but no invocations in 30 days", () => {
+    const result = classifySkillLifecycle({
+      current: "active",
+      usage30d: { invoked: 0, failed: 0 },
+      assignmentCount: 3,
+      lastUsedAt: new Date("2026-01-01"),
+      hasContent: true,
+    });
+    expect(result.next).toBe("stale");
+    expect(result.reason).toContain("30 days");
+  });
+
+  it("returns active when the skill has content and invocations", () => {
+    const result = classifySkillLifecycle({
+      current: "active",
+      usage30d: { invoked: 12, failed: 1 },
+      assignmentCount: 4,
+      lastUsedAt: new Date(),
+      hasContent: true,
+    });
+    expect(result.next).toBe("active");
+  });
+
+  it("does NOT archive a stale skill — stale is recoverable", () => {
+    const result = classifySkillLifecycle({
+      current: "stale",
+      usage30d: { invoked: 0, failed: 0 },
+      assignmentCount: 0,
+      lastUsedAt: null,
+      hasContent: true,
+    });
+    // No content + no assignments + no use would archive a never-stale skill,
+    // but a stale-with-content skill stays stale until content disappears
+    // or operator intervenes.
+    expect(result.next).toBe("stale");
+  });
+});

--- a/apps/web/lib/skills/lifecycle.ts
+++ b/apps/web/lib/skills/lifecycle.ts
@@ -1,0 +1,91 @@
+// Skill operational-lifecycle taxonomy for Slice 4 of the governed Hermes
+// learning loop.
+//
+// This axis is **separate** from `SkillDefinition.status` (which carries
+// adoption stage: `discovered | evaluated | approved | installed | active |
+// deprecated`). Lifecycle is operational health — is this skill being used,
+// decaying, intentionally protected, or under quarantine.
+//
+// Both axes coexist on `SkillDefinition`. The curator writes only this one.
+//
+// Spec: docs/superpowers/specs/2026-05-15-governed-hermes-learning-loop-design.md §6.1.1
+
+export const SKILL_LIFECYCLE_STATES = [
+  "active",
+  "stale",
+  "pinned",
+  "quarantined",
+  "archived",
+] as const;
+
+export type SkillLifecycleState = (typeof SKILL_LIFECYCLE_STATES)[number];
+
+export function isSkillLifecycleState(value: unknown): value is SkillLifecycleState {
+  return typeof value === "string" && (SKILL_LIFECYCLE_STATES as readonly string[]).includes(value);
+}
+
+/**
+ * Sticky operator-set states the curator never moves out of. Pin protection
+ * is enforced here so any future curator caller can ask the same question
+ * without duplicating the predicate.
+ */
+export function isCuratorImmutable(state: SkillLifecycleState): boolean {
+  return state === "pinned" || state === "quarantined";
+}
+
+export type ClassifyInput = {
+  /** Current lifecycle state. Sticky states short-circuit. */
+  current: SkillLifecycleState;
+  /** Usage over the last 30 days, grouped by phase. */
+  usage30d: { invoked: number; failed: number };
+  /** Number of coworkers this skill is assigned to. */
+  assignmentCount: number;
+  /** Latest SkillUsageEvent.createdAt for this skill, or null. */
+  lastUsedAt: Date | null;
+  /** True when SkillDefinition.skillMdContent is non-empty. */
+  hasContent: boolean;
+};
+
+export type ClassifyResult = {
+  next: SkillLifecycleState;
+  reason: string;
+};
+
+/**
+ * Decide where a skill should sit on the operational-health axis. Pure
+ * function — no DB I/O — so the curator can call it inside a tight loop
+ * without scaling concerns.
+ *
+ * Rules (top to bottom):
+ *   1. pinned / quarantined are sticky. The curator never moves a skill
+ *      out of them; operator action does. Returning the same state with
+ *      a clear reason keeps the audit trail honest.
+ *   2. Empty SKILL.md content with no assignments and no invocations →
+ *      archived (recoverable; the operator can flip back to active).
+ *   3. Empty content with assignments OR invocations → stale (curator
+ *      asks the operator to either populate or remove).
+ *   4. Zero invocations in 30 days but has assignments → stale.
+ *   5. Otherwise → active.
+ */
+export function classifySkillLifecycle(input: ClassifyInput): ClassifyResult {
+  if (isCuratorImmutable(input.current)) {
+    return {
+      next: input.current,
+      reason: `operator-set state '${input.current}' preserved`,
+    };
+  }
+
+  if (!input.hasContent && input.assignmentCount === 0 && input.usage30d.invoked === 0) {
+    return { next: "archived", reason: "no content, no assignments, no use" };
+  }
+
+  if (!input.hasContent) {
+    return { next: "stale", reason: "skill has no SKILL.md body yet" };
+  }
+
+  if (input.usage30d.invoked === 0) {
+    return { next: "stale", reason: "no invocations in the last 30 days" };
+  }
+
+  return { next: "active", reason: "in use" };
+}

--- a/docs/superpowers/plans/2026-05-15-skill-curator-and-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-15-skill-curator-and-lifecycle.md
@@ -1,0 +1,191 @@
+# Skill Curator and Lifecycle Implementation Plan (Slice 4)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Slice 4 of the governed Hermes-style coworker learning loop. Add `SkillDefinition.lifecycleState` as a separate operational-health axis from the existing adoption-stage `status`; introduce a governed curator that classifies skills into `active | stale | pinned | quarantined | archived`, emits `ImprovementSignal` rows and a `TaskArtifact(metadata.kind="curator-report")` per run, and **never mutates `SkillDefinition.skillMdContent`**. Pin/quarantine controls live on `/platform/ai/skills?skill=<id>`; a pinned skill cannot be archived by the curator (invariant test).
+
+**Architecture decisions.**
+
+- `lifecycleState` is a new column, not a repurposing of `status`. The current `status` enum (`discovered | evaluated | approved | installed | active | deprecated`) describes adoption stage. Lifecycle describes operational health. Both axes are typed enums; the curator only writes `lifecycleState`.
+- The curator emits `ImprovementSignal` rows (Slice 1+2 substrate) and a `TaskArtifact` summary; it does not auto-create `ImprovementProposal` rows. Content proposals come from coworker self-reflection (Slice 2) or operator action (Slice 3). This keeps the curator's job clear: identify candidates, surface them, let humans act.
+- Pin protection is enforced inside the curator: `pinned` skills cannot transition to `archived` regardless of metrics. A dedicated vitest case asserts this.
+- The curator never mutates `skillMdContent` and never deletes a `SkillDefinition`. The strongest action it can take on its own is flipping `lifecycleState` to `archived` (which is reversible) — and even that respects the pin guard.
+
+**Tech Stack:** TypeScript, Next.js 16 App Router, React, Prisma 7, PostgreSQL, Vitest, Inngest crons, pnpm workspaces.
+
+---
+
+## Scope
+
+Implements Slice 4 from `docs/superpowers/specs/2026-05-15-governed-hermes-learning-loop-design.md`.
+
+In scope:
+
+- `SkillDefinition.lifecycleState` column (default `active`) + typed enum + DB-level CHECK constraint via Prisma enum.
+- `apps/web/lib/skills/lifecycle.ts` — typed enum constants and `classifySkillLifecycle(skill, metrics, usage)` helper.
+- `apps/web/lib/skills/curator.ts` — `runSkillCurator()` that iterates every skill, classifies, emits one `ImprovementSignal` per non-trivial finding, persists a `TaskArtifact(metadata.kind="curator-report")` summary, and updates `lifecycleState` (with pin protection).
+- Inngest cron `0 7 * * *` UTC (after the metrics aggregator at 0 5) so the curator sees fresh metrics.
+- Server actions `pinSkillAction(skillId)`, `quarantineSkillAction(skillId)`, `unpinSkillAction(skillId)`, `runSkillCuratorAction()` for the admin UI.
+- UI on `/platform/ai/skills`: lifecycle badge on each row in the executions/skills views; a Curator tab in the Observatory panel showing the latest report and recent findings; pin/quarantine/run-curator controls in the skill detail panel.
+- Vitest covers: classification, pin protection invariant, no content mutation, signal emission, report shape, end-to-end curator run.
+
+Out of scope:
+
+- Evidence / session search — Slice 5.
+- Evolution lab — Slice 6.
+- External skill import — Slice 7.
+- UX consolidation across surfaces — Slice 8.
+- Auto-creating `ImprovementProposal` from curator findings — defer until Slice 3 lands and human review proves needed; for now the curator emits signals only.
+
+## Preconditions
+
+- Worktree base: `feat/skill-curator-and-lifecycle` off `origin/main` after the most-recent merge.
+- `SkillDefinition` already has the Slice 1+2 surface (`skillMdContent`, `usageEvents` relation, `metrics` relation).
+- `ImprovementSignal` already lands via the Slice 1 schema and the curator just calls `createOrTouchImprovementSignal` to emit findings.
+- `TaskArtifact` model already supports `metadata` Json bag.
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+| --- | --- |
+| `packages/db/prisma/migrations/<timestamp>_skill_lifecycle_state/migration.sql` | Add `lifecycleState` column with default `'active'`. |
+| `apps/web/lib/skills/lifecycle.ts` | `SKILL_LIFECYCLE_STATES` enum, type, classify helper. |
+| `apps/web/lib/skills/lifecycle.test.ts` | Classifier tests. |
+| `apps/web/lib/skills/curator.ts` | `runSkillCurator()` + private helpers. |
+| `apps/web/lib/skills/curator.test.ts` | Curator tests including pin invariant. |
+| `apps/web/lib/queue/functions/skill-curator.ts` | Inngest cron. |
+| `apps/web/lib/actions/skill-curator-actions.ts` | Server-action surface for pin/quarantine/unpin/run-now. |
+| `apps/web/components/platform/SkillCuratorReportPanel.tsx` | Latest curator report viewer. |
+| `apps/web/components/platform/SkillCuratorReportPanel.test.tsx` | UI render tests. |
+| `apps/web/components/platform/SkillLifecycleControls.tsx` | Pin / quarantine / unpin buttons in the skill detail panel. |
+| `apps/web/components/platform/SkillLifecycleControls.test.tsx` | UI render tests. |
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `packages/db/prisma/schema.prisma` | Add `lifecycleState` column on `SkillDefinition`. |
+| `apps/web/lib/queue/functions/index.ts` | Register the curator cron. |
+| `apps/web/lib/actions/skills-observatory.ts` | Surface `lifecycleState` on `SkillEntry`-like shapes; new `getLatestCuratorReport()` fetcher. |
+| `apps/web/components/platform/SkillsObservatoryPanel.tsx` | Add Curator tab + lifecycle badge column on executions. |
+| `apps/web/app/(shell)/platform/ai/skills/page.tsx` | Mount the curator panel + lifecycle controls in the per-skill review section. |
+| `apps/web/lib/mcp-tools.ts` | (Optional) only if the curator surface needs an MCP action — skip if not. |
+
+## Chunk 1: Schema + types
+
+### Task 1: lifecycleState column + typed enum
+
+- [ ] `SkillDefinition.lifecycleState`: `String @default("active")` (Postgres TEXT, application-layer typed enum).
+- [ ] Index `@@index([lifecycleState])` for the "show me all stale" query.
+- [ ] Migration ADD COLUMN ... DEFAULT 'active' NOT NULL.
+- [ ] `apps/web/lib/skills/lifecycle.ts`:
+
+```typescript
+export const SKILL_LIFECYCLE_STATES = ["active", "stale", "pinned", "quarantined", "archived"] as const;
+export type SkillLifecycleState = (typeof SKILL_LIFECYCLE_STATES)[number];
+```
+
+- [ ] Classify helper:
+
+```typescript
+export type ClassifyInput = {
+  current: SkillLifecycleState;       // never overridden if pinned/quarantined (caller decides)
+  usage30d: { invoked: number; failed: number };
+  assignmentCount: number;
+  lastUsedAt: Date | null;
+  hasContent: boolean;
+};
+
+export function classifySkillLifecycle(input: ClassifyInput): {
+  next: SkillLifecycleState;
+  reason: string;
+} {
+  // pinned / quarantined are sticky — curator never moves a skill out of them
+  if (input.current === "pinned" || input.current === "quarantined") {
+    return { next: input.current, reason: "operator-set state preserved" };
+  }
+  if (!input.hasContent || input.assignmentCount === 0 && input.usage30d.invoked === 0) {
+    return { next: "archived", reason: "unused with no assignments" };
+  }
+  // 0 invocations in 30d but assignments exist → stale, not archived (recoverable)
+  if (input.usage30d.invoked === 0) return { next: "stale", reason: "no use in 30 days" };
+  // Otherwise active
+  return { next: "active", reason: "in use" };
+}
+```
+
+- [ ] Commit.
+
+## Chunk 2: Curator service
+
+### Task 2: runSkillCurator
+
+- [ ] Reads every `SkillDefinition`, gathers metrics from `SkillMetric` (current period) + `SkillUsageEvent` (last 30 days), gathers assignment counts.
+- [ ] Per skill: call `classifySkillLifecycle`, compute desired `lifecycleState`.
+- [ ] **Pin protection**: if `current === "pinned"`, the result never becomes `archived` or anything else — curator never moves a pinned skill. Same for `quarantined`. The classifier already returns the current state for these inputs; the test asserts the invariant end-to-end (cannot bypass).
+- [ ] **No content mutation**: curator updates `lifecycleState` only. Never touches `skillMdContent`, `description`, etc. Verified by test (mock prisma rejects any update outside the whitelisted fields).
+- [ ] For each non-`active` skill, emit one `ImprovementSignal(sourceType="curator-finding", sourceId=<skillId>:<reason-slug>)` so dedupe means re-runs don't multiply signals.
+- [ ] Persist a single `TaskArtifact` for the run with `metadata.kind="curator-report"`, body containing `{ scannedAt, totals: { active, stale, pinned, quarantined, archived }, findings: [{ skillId, fromState, toState, reason }] }`.
+- [ ] Return the report.
+
+### Task 3: Inngest cron
+
+- [ ] `apps/web/lib/queue/functions/skill-curator.ts`: cron `0 7 * * *` UTC.
+- [ ] Register in `apps/web/lib/queue/functions/index.ts`.
+- [ ] Log `[skill-curator]` prefix.
+
+### Task 4: Server actions
+
+- [ ] `runSkillCuratorAction()` — admin-only (`manage_capabilities`); wraps `runSkillCurator()`.
+- [ ] `pinSkillAction(skillId)`, `unpinSkillAction(skillId)`, `quarantineSkillAction(skillId)` — admin-only; update `lifecycleState` directly. These are explicit operator actions, not curator output.
+
+## Chunk 3: UI
+
+### Task 5: SkillCuratorReportPanel
+
+- [ ] Fetch latest `TaskArtifact(metadata.kind="curator-report")`.
+- [ ] Show: scan time, totals row, findings table (skillId · fromState → toState · reason).
+- [ ] Empty state when no curator has ever run.
+
+### Task 6: SkillLifecycleControls
+
+- [ ] In the existing per-skill review section: pin / unpin / quarantine buttons.
+- [ ] "Run curator now" button → `runSkillCuratorAction()`.
+
+### Task 7: Lifecycle badge
+
+- [ ] In `SkillsObservatoryPanel`'s executions tab, render a small badge per row (only when `lifecycleState !== "active"`). Theme tokens only.
+
+## Chunk 4: Verification + delivery
+
+### Task 8: Verification
+
+- [ ] Focused vitest sweep: `lib/skills/lifecycle.test.ts`, `lib/skills/curator.test.ts`, two new UI tests.
+- [ ] Full vitest stays green.
+- [ ] `pnpm --filter web typecheck` clean.
+- [ ] `pnpm --filter web exec next build` clean.
+
+### Task 9: PR
+
+- [ ] Overlap sweep on `apps/web/lib/skills/*`, `apps/web/lib/actions/skills-observatory.ts`, `apps/web/components/platform/*`, `apps/web/lib/queue/functions/index.ts`, `packages/db/prisma/schema.prisma`.
+- [ ] Push + draft PR with summary, test plan, migration note, DCO note.
+
+## Rollback Plan
+
+If the curator mis-classifies or signal volume spikes:
+
+1. Remove the cron entry from `apps/web/lib/queue/functions/index.ts` and redeploy — the function won't run.
+2. To revert a skill that was archived, the operator clicks "Pin" or directly toggles `lifecycleState` back to `active` via the admin action.
+3. The `lifecycleState` column is additive; no schema rollback needed.
+
+## Definition Of Done
+
+- `SkillDefinition.lifecycleState` column lives with a default value and a typed enum at the application layer; existing rows default to `active`.
+- `runSkillCurator()` emits `ImprovementSignal` rows for non-`active` skills and writes one `TaskArtifact(metadata.kind="curator-report")` per run.
+- A pinned skill cannot be archived by the curator (vitest invariant).
+- The curator never mutates `skillMdContent` (vitest asserts the prisma update payload is restricted).
+- `/platform/ai/skills` shows the latest curator report and per-skill lifecycle controls.
+- Full vitest stays green; typecheck and `next build` clean.
+- PR has no overlap with concurrent open PRs; DCO green before flipping out of draft.

--- a/packages/db/prisma/migrations/20260517000000_skill_lifecycle_state/migration.sql
+++ b/packages/db/prisma/migrations/20260517000000_skill_lifecycle_state/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "SkillDefinition" ADD COLUMN "lifecycleState" TEXT NOT NULL DEFAULT 'active';
+
+-- CreateIndex
+CREATE INDEX "SkillDefinition_lifecycleState_idx" ON "SkillDefinition"("lifecycleState");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6944,6 +6944,15 @@ model SkillDefinition {
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
+  // Governed Hermes learning Slice 4: operational-health axis, separate from
+  // adoption-stage `status`. Typed at the application layer in
+  // apps/web/lib/skills/lifecycle.ts as
+  //   "active" | "stale" | "pinned" | "quarantined" | "archived"
+  // The curator writes this column on its scheduled run; operator pin /
+  // quarantine actions also write it. SkillDefinition.skillMdContent is
+  // never mutated by the curator.
+  lifecycleState String @default("active")
+
   evaluation  ToolEvaluation?   @relation(fields: [evaluationId], references: [id])
   assignments SkillAssignment[]
   metrics     SkillMetric[]
@@ -6953,6 +6962,7 @@ model SkillDefinition {
   @@index([status])
   @@index([category])
   @@index([sourceType])
+  @@index([lifecycleState])
 }
 
 model SkillAssignment {


### PR DESCRIPTION
## Summary

Slice 4 of the governed Hermes-style coworker learning loop. Adds the operational-health axis (`SkillDefinition.lifecycleState`) and a governed curator that classifies every skill on a daily cron, emits findings through the existing flywheel substrate, and never mutates skill content.

**Schema.** `SkillDefinition.lifecycleState String @default("active")` with an index. Values are typed at the application layer (`apps/web/lib/skills/lifecycle.ts`): `active | stale | pinned | quarantined | archived`. Migration is purely additive — every existing skill defaults to `active`.

**Classifier.** `classifySkillLifecycle` is pure (no I/O) so the curator drives it in a tight loop. Rule order: sticky operator states preserved, no-content + no-assignments + no-use → `archived`, no-content → `stale`, no-invocations in 30 days → `stale`, else `active`. Tested across pin, quarantine, archive, stale, and active paths.

**Curator service.** `runSkillCurator()`:
- Iterates every `SkillDefinition`, gathers per-skill usage from the last 30 days via `SkillUsageEvent.groupBy`, computes the target lifecycle state.
- Updates `SkillDefinition.lifecycleState` only — the test asserts `Object.keys(args.data) === ["lifecycleState"]` for every update, so the curator can never touch `skillMdContent` or any other column through this path.
- **Pin protection** (vitest invariant): a pinned or quarantined skill is never touched. The classifier returns the current state for those inputs and the curator skips the prisma update entirely.
- Emits one `ImprovementSignal(sourceType="curator-finding", sourceId="<skillId>:<state>")` per non-active, non-immutable finding. Re-runs over the same population dedupe via the existing `(sourceType, sourceId)` unique on signals.
- Writes a single `TaskArtifact(metadata.kind="curator-report")` under a proactive `TaskRun` capturing scan time, totals by state, and per-skill findings.

**Cron + admin actions.** Inngest cron `0 7 * * *` UTC (after the metrics aggregator at 0 5 — verified free of overlap 2026-05-15). `pinSkillAction`, `quarantineSkillAction`, `unpinSkillAction`, `runSkillCuratorAction` server actions, all gated by `manage_capabilities` so operator-set lifecycle changes share authority with proposal approval (Slice 3).

**UI on `/platform/ai/skills`.** New top-level **Curator** section renders the latest report (totals row + findings table) and a Run-curator-now button. When `?skill=<id>` is set, the per-skill detail panel now stacks lifecycle controls (Pin/Quarantine/Reset) above the Slice 3 review-and-revisions section. All theme-token compliant — verified by hex-regex assertions in panel tests.

Spec: \`docs/superpowers/specs/2026-05-15-governed-hermes-learning-loop-design.md\`  
Plan: \`docs/superpowers/plans/2026-05-15-skill-curator-and-lifecycle.md\`

## Out of scope (deferred per the spec)

- Evidence / session search — Slice 5
- Evolution lab — Slice 6
- External skill import — Slice 7
- UX consolidation across surfaces — Slice 8
- Auto-creating `ImprovementProposal` from curator findings — deferred until the human-review surface (Slice 3, just merged) proves the need; for now the curator emits signals only and the operator uses Slice 3's `propose_skill_improvement` to file content proposals manually.

## Verification

- \`pnpm --filter web typecheck\`: clean
- Full vitest: **714 test files pass, 5,739 tests pass** (14 skipped, 13 todo). Slice 4 adds 26 new tests across 4 files (classifier 10, curator 6, two UI panels 3+4, page integration update 3).
- \`pnpm --filter web exec next build\`: succeeds; 102/102 static pages generated.

## Test plan

- [ ] As a user with `manage_capabilities`, open `/platform/ai/skills` and click **Run curator now**. Verify a Curator report appears with totals row and findings table. Inspect the resulting `TaskArtifact` row — `metadata.kind` is `curator-report` and `parts[0].data.findings` is populated.
- [ ] Visit `/platform/ai/skills?skill=<id>`, click **Pin**. The lifecycle label flips to `pinned` after reload. Trigger the curator again — confirm no signal is emitted for the pinned skill and `lifecycleState` is unchanged.
- [ ] Take a skill with no usage in the last 30 days. Run the curator. Confirm the skill moves to `stale` and a single `ImprovementSignal(sourceType="curator-finding", sourceId="<skillId>:stale")` row exists. Re-run the curator — `recurrenceCount` increments instead of producing a parallel signal.
- [ ] Inspect the `ToolExecution` audit log around an approve cycle to confirm the curator's prisma updates only ever touch `lifecycleState`.

## Migration / DCO

One new migration `20260517000000_skill_lifecycle_state` adds the `lifecycleState` column with default `'active'` and an index. No backfill needed. All commits signed off; DCO is green.