### PR TITLE
fix(build-studio): create_portal_pr no longer crashes on object-shaped acceptanceMet

### DIFF
--- a/apps/web/lib/integrate/pre-pr-gates.test.ts
+++ b/apps/web/lib/integrate/pre-pr-gates.test.ts
@@ -456,3 +456,30 @@ rename to packages/db/foo.ts
     expect(archGate?.verdict).toBe("pass");
   });
 });
+
+describe("runPrePRGates — BI-E9CD1B92 minimal-diff smoke test", () => {
+  // BI-E9CD1B92 surfaced as "S?.filter is not a function" from create_portal_pr.
+  // Root cause was downstream in mcp-tools.ts acceptance handling, but lock in
+  // that the gate orchestrator itself never throws on a clean single-file token
+  // replacement diff — the exact shape that triggered the original report.
+  it("processes a clean single-file UI token replacement without throwing", () => {
+    const diff = `diff --git a/apps/web/components/my-queue/MyQueue.tsx b/apps/web/components/my-queue/MyQueue.tsx
+index 1111111..2222222 100644
+--- a/apps/web/components/my-queue/MyQueue.tsx
++++ b/apps/web/components/my-queue/MyQueue.tsx
+@@ -10,7 +10,7 @@ export function MyQueue() {
+   return (
+     <div className="my-queue">
+-      <h1>Queue</h1>
++      <h1>My Queue</h1>
+     </div>
+   );
+ }
+`;
+    expect(() => runPrePRGates(diff)).not.toThrow();
+    const result = runPrePRGates(diff);
+    expect(result.canProceed).toBe(true);
+    expect(result.requiresHumanReview).toBe(false);
+    expect(result.gates.every((g) => g.verdict === "pass")).toBe(true);
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7199,9 +7199,15 @@ export async function executeTool(
       const testsPassed = typeof verification?.testsPassed === "number" ? verification.testsPassed : 0;
       const testsFailed = typeof verification?.testsFailed === "number" ? verification.testsFailed : 0;
 
-      const acceptance = build.acceptanceMet as Array<{ criterion: string; met: boolean }> | null;
-      const acMet = acceptance?.filter((a) => a.met).length ?? 0;
-      const acTotal = acceptance?.length ?? 0;
+      // acceptanceMet (Json?) stores either a bare array or {acceptanceCriteria: [...]} — `.filter` must not assume array shape.
+      const rawAcceptance = build.acceptanceMet as unknown;
+      const acceptance: Array<{ met?: boolean }> = Array.isArray(rawAcceptance)
+        ? (rawAcceptance as Array<{ met?: boolean }>)
+        : rawAcceptance && typeof rawAcceptance === "object" && Array.isArray((rawAcceptance as { acceptanceCriteria?: unknown }).acceptanceCriteria)
+          ? ((rawAcceptance as { acceptanceCriteria: Array<{ met?: boolean }> }).acceptanceCriteria)
+          : [];
+      const acMet = acceptance.filter((a) => a?.met === true).length;
+      const acTotal = acceptance.length;
 
       const prBody = [
         `## ${build.title}`,


### PR DESCRIPTION
## Summary

- BI-E9CD1B92 lifecycle run hit `S?.filter is not a function` from `create_portal_pr` via `/api/mcp/call`. The repro path (ship-phase build with a 3007-char single-file diff and an `acceptanceMet` already saved) crashed before opening a PR.
- The bug is not in the pre-PR gates as initially suspected — they're clean. It's at [apps/web/lib/mcp-tools.ts:7202](apps/web/lib/mcp-tools.ts#L7202):
  ```ts
  const acceptance = build.acceptanceMet as Array<{ criterion: string; met: boolean }> | null;
  const acMet = acceptance?.filter((a) => a.met).length ?? 0;
  ```
  `acceptanceMet` is a Prisma `Json?` column, and the build-specialist agent prompt ([prompts/route-persona/build-specialist.prompt.md:87](prompts/route-persona/build-specialist.prompt.md#L87)) saves it as `{ acceptanceCriteria: [{ id, met, evidence }], userOverride? }` — an object, not a bare array. The `as Array<…>` cast lied at runtime, optional chaining didn't short-circuit on the non-null object, and `.filter` on a plain object is `undefined`. V8 threw `acceptance?.filter is not a function`, which minified to `S?.filter is not a function`.
- Every other reader (`ReviewPanel`, `EvidenceSummary`, `contribution-review.ts`, `contribution-pipeline.ts`, `actions/build.ts:454`) already wraps with `Array.isArray`. `create_portal_pr` was the holdout.

## Changes

- [apps/web/lib/mcp-tools.ts](apps/web/lib/mcp-tools.ts) — normalize both documented shapes (bare array, or `{acceptanceCriteria: [...]}`) before calling `.filter`. Falls back to empty array for any other Json value.
- [apps/web/lib/integrate/pre-pr-gates.test.ts](apps/web/lib/integrate/pre-pr-gates.test.ts) — added a BI-E9CD1B92 smoke test that runs `runPrePRGates` on the exact minimal single-file token-replacement diff that triggered the original report and asserts it doesn't throw + all gates pass.

## Why no helper extraction (yet)

The acceptance-shape ambiguity exists at 5+ readers across the codebase. Consolidating to a shared `normalizeAcceptanceMet` helper is the proper architectural fix, but doing it in this PR would balloon the diff and touch unrelated surfaces. Filed as worth a separate sweep — flagging here so it doesn't get forgotten.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/pre-pr-gates.test.ts` — 26/26 pass (25 existing + 1 new)
- [x] `pnpm --filter web exec vitest run` — full apps/web suite: 5750/5750 pass, 14 skipped, 13 todo
- [x] Pre-commit typecheck — clean on changed files
- [ ] CI vitest + typecheck jobs green
- [ ] Manual: re-run BI-E9CD1B92 — ship-phase build with `diffPatch` populated, POST `/api/mcp/call` `{"name":"create_portal_pr"}`, expect PR creation to proceed past the acMet computation