### PR TITLE
feat(routing): cli execution adapter as routing dimension — Phase A

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -24,6 +24,7 @@ import {
   parseExecutionAdapterSelector,
   type ExecutionAdapterSelector,
 } from "../routing/execution-adapter-types";
+import { writeAdapterTelemetry } from "../routing/adapter-telemetry-writer";
 import "../routing/chat-adapter"; // side-effect: registers "chat" adapter
 import "../routing/responses-adapter"; // side-effect: registers "responses" adapter
 import "../routing/image-gen-adapter"; // EP-INF-009c: registers "image_gen" adapter
@@ -389,6 +390,14 @@ export async function callProvider(
       ? await resolveExecutionAdapter(selector, effectivePlan.capabilityRequirements)
       : getExecutionAdapter(executionAdapterRaw as string);
   const endTimer = aiInferenceDuration.startTimer({ provider: providerId, model: modelId, agent: "unknown" });
+  const telemetryStartedAt = new Date();
+  // Phase A7: telemetry kind derived from the structured selector when
+  // present; legacy-string paths land as "legacy:<adapter>" so analytics can
+  // distinguish unrouted traffic from structured-selector traffic.
+  const telemetryAdapterKind =
+    selector !== null
+      ? selector.kind
+      : `legacy:${typeof executionAdapterRaw === "string" ? executionAdapterRaw : "unknown"}`;
   let result;
   try {
     result = await adapter.execute({
@@ -407,12 +416,46 @@ export async function callProvider(
     endTimer();
     const errorType = err instanceof InferenceError ? err.code : "unknown";
     aiInferenceErrors.inc({ provider: providerId, error_type: errorType });
+    // Phase A7: telemetry write before re-throw. Fire-and-forget — the writer
+    // swallows its own errors so we never mask the original throw.
+    const finishedAt = new Date();
+    void writeAdapterTelemetry({
+      adapterKind: telemetryAdapterKind,
+      adapterVersion: selector?.version ?? "unknown",
+      providerId,
+      modelId,
+      executionMode: "single",
+      startedAt: telemetryStartedAt,
+      finishedAt,
+      durationMs: finishedAt.getTime() - telemetryStartedAt.getTime(),
+      status: err instanceof InferenceError ? "error" : "error",
+      errorClass: err instanceof InferenceError ? err.code : "unknown",
+      refusalReason: err instanceof Error ? err.message.slice(0, 200) : undefined,
+    });
     throw err;
   }
 
   // 4. Record token and cost metrics
   aiInferenceTokens.inc({ provider: providerId, model: modelId, direction: "input" }, result.usage.inputTokens);
   aiInferenceTokens.inc({ provider: providerId, model: modelId, direction: "output" }, result.usage.outputTokens);
+
+  // Phase A7: success-path telemetry row. Fire-and-forget so a DB outage
+  // can't break the user's reply.
+  const telemetryFinishedAt = new Date();
+  void writeAdapterTelemetry({
+    adapterKind: telemetryAdapterKind,
+    adapterVersion: selector?.version ?? "unknown",
+    providerId,
+    modelId,
+    executionMode: "single",
+    startedAt: telemetryStartedAt,
+    finishedAt: telemetryFinishedAt,
+    durationMs: telemetryFinishedAt.getTime() - telemetryStartedAt.getTime(),
+    status: "success",
+    inputTokens: result.usage.inputTokens,
+    outputTokens: result.usage.outputTokens,
+    toolCallsTotal: result.toolCalls.length,
+  });
 
   // 5. Map AdapterResult → InferenceResult
   return {

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -19,6 +19,11 @@ import {
 } from "@/lib/ai-provider-internals";
 import type { RoutedExecutionPlan } from "../routing/recipe-types";
 import { getExecutionAdapter } from "../routing/execution-adapter-registry";
+import { resolveExecutionAdapter } from "../routing/resolve-execution-adapter";
+import {
+  parseExecutionAdapterSelector,
+  type ExecutionAdapterSelector,
+} from "../routing/execution-adapter-types";
 import "../routing/chat-adapter"; // side-effect: registers "chat" adapter
 import "../routing/responses-adapter"; // side-effect: registers "responses" adapter
 import "../routing/image-gen-adapter"; // EP-INF-009c: registers "image_gen" adapter
@@ -352,16 +357,37 @@ export async function callProvider(
     responsePolicy: {},
   };
 
+  // Phase A6: route the executionAdapter through the structured selector +
+  // capability-aware resolver. Legacy string values for CLI/chat kinds round-trip
+  // through parseExecutionAdapterSelector; legacy strings outside the structured
+  // taxonomy (responses, embedding, image_gen, async, transcription) fall through
+  // to the registry directly so existing routes are unchanged.
+  const executionAdapterRaw = effectivePlan.executionAdapter;
+  let selector: ExecutionAdapterSelector | null;
+  try {
+    selector = parseExecutionAdapterSelector(executionAdapterRaw);
+  } catch (e) {
+    if (typeof executionAdapterRaw !== "string") {
+      // Object input that failed validation — propagate.
+      throw e;
+    }
+    selector = null;
+  }
+
   // CLI adapters (anthropic-sub, codex) resolve their own auth and spawn CLI
   // binaries — they do not need HTTP base URL or auth headers.
-  const isCliAdapter = effectivePlan.executionAdapter === "claude-cli"
-    || effectivePlan.executionAdapter === "codex-cli";
+  const isCliAdapter =
+    selector !== null &&
+    (selector.kind === "claude-code-cli" || selector.kind === "codex-cli");
   const baseUrl = isCliAdapter ? "cli://local" : await resolveExecutionBaseUrl(providerId, provider);
   if (!baseUrl) throw new InferenceError("No base URL configured", "provider_error", providerId);
   const headers = isCliAdapter ? {} : await buildAuthHeaders(providerId, provider.authMethod, provider.authHeader);
 
   // 3. Dispatch to adapter (instrumented for Prometheus metrics)
-  const adapter = getExecutionAdapter(effectivePlan.executionAdapter);
+  const adapter =
+    selector !== null
+      ? await resolveExecutionAdapter(selector, effectivePlan.capabilityRequirements)
+      : getExecutionAdapter(executionAdapterRaw as string);
   const endTimer = aiInferenceDuration.startTimer({ provider: providerId, model: modelId, agent: "unknown" });
   let result;
   try {

--- a/apps/web/lib/routing/adapter-telemetry-writer.test.ts
+++ b/apps/web/lib/routing/adapter-telemetry-writer.test.ts
@@ -1,0 +1,157 @@
+// apps/web/lib/routing/adapter-telemetry-writer.test.ts
+//
+// Phase A7 — unit tests for writeAdapterTelemetry().
+//
+// We exercise the override hook rather than the real Prisma client so the
+// suite stays hermetic. The integration test that touches the database
+// lives in packages/db/test/adapter-run-telemetry.test.ts (A2).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  writeAdapterTelemetry,
+  _setAdapterTelemetryWriteOverrideForTests,
+} from "./adapter-telemetry-writer";
+
+const writeOverride = vi.fn();
+
+beforeEach(() => {
+  writeOverride.mockReset();
+  writeOverride.mockResolvedValue(undefined);
+  _setAdapterTelemetryWriteOverrideForTests(writeOverride);
+});
+
+afterEach(() => {
+  _setAdapterTelemetryWriteOverrideForTests(null);
+});
+
+describe("writeAdapterTelemetry", () => {
+  it("writes a row with all required fields", async () => {
+    const startedAt = new Date("2026-05-16T10:00:00.000Z");
+    await writeAdapterTelemetry({
+      adapterKind: "claude-code-cli",
+      adapterVersion: "claude-code/1.2.3",
+      providerId: "anthropic-sub",
+      modelId: "claude-opus-4-7",
+      executionMode: "single",
+      startedAt,
+      status: "success",
+    });
+    expect(writeOverride).toHaveBeenCalledTimes(1);
+    expect(writeOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterKind: "claude-code-cli",
+        adapterVersion: "claude-code/1.2.3",
+        providerId: "anthropic-sub",
+        modelId: "claude-opus-4-7",
+        executionMode: "single",
+        startedAt,
+        status: "success",
+      }),
+    );
+  });
+
+  it("includes optional attribution fields when provided (agentId, skillId, threadId)", async () => {
+    await writeAdapterTelemetry({
+      adapterKind: "http-anthropic",
+      adapterVersion: "anthropic-http/2024-06-01",
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      executionMode: "single",
+      startedAt: new Date(),
+      status: "success",
+      threadId: "thread_123",
+      agentId: "agent_456",
+      skillId: "skill_789",
+      buildId: "build_abc",
+    });
+    expect(writeOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread_123",
+        agentId: "agent_456",
+        skillId: "skill_789",
+        buildId: "build_abc",
+      }),
+    );
+  });
+
+  it("omits optional fields when undefined (no nulls forced)", async () => {
+    await writeAdapterTelemetry({
+      adapterKind: "codex-cli",
+      adapterVersion: "codex-cli/0.125.0",
+      providerId: "codex",
+      modelId: "gpt-5",
+      executionMode: "single",
+      startedAt: new Date(),
+      status: "success",
+    });
+    const call = writeOverride.mock.calls[0][0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("threadId");
+    expect(call).not.toHaveProperty("agentId");
+    expect(call).not.toHaveProperty("skillId");
+    expect(call).not.toHaveProperty("raceCohortId");
+    expect(call).not.toHaveProperty("durationMs");
+  });
+
+  it("forwards race-cohort + execution-mode for shadow runs", async () => {
+    await writeAdapterTelemetry({
+      adapterKind: "codex-cli",
+      adapterVersion: "codex-cli/0.125.0",
+      providerId: "codex",
+      modelId: "gpt-5",
+      executionMode: "shadow-alt",
+      startedAt: new Date(),
+      status: "success",
+      raceCohortId: "cohort_xyz",
+    });
+    expect(writeOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: "shadow-alt",
+        raceCohortId: "cohort_xyz",
+      }),
+    );
+  });
+
+  it("captures error-shaped outcomes (status + errorClass)", async () => {
+    await writeAdapterTelemetry({
+      adapterKind: "codex-cli",
+      adapterVersion: "codex-cli/0.125.0",
+      providerId: "codex",
+      modelId: "gpt-5",
+      executionMode: "single",
+      startedAt: new Date(),
+      status: "error",
+      errorClass: "codex-mcp-json-degradation",
+    });
+    expect(writeOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        errorClass: "codex-mcp-json-degradation",
+      }),
+    );
+  });
+
+  it("swallows write failures (fire-and-forget contract)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeOverride.mockRejectedValueOnce(new Error("DB unavailable"));
+
+    // Must NOT throw — that would break the coworker turn.
+    await expect(
+      writeAdapterTelemetry({
+        adapterKind: "http-anthropic",
+        adapterVersion: "anthropic-http/2024-06-01",
+        providerId: "anthropic",
+        modelId: "claude-opus-4-7",
+        executionMode: "single",
+        startedAt: new Date(),
+        status: "success",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      "[adapter-telemetry-writer] write failed (suppressed):",
+      expect.any(Error),
+    );
+    warn.mockRestore();
+  });
+});

--- a/apps/web/lib/routing/adapter-telemetry-writer.ts
+++ b/apps/web/lib/routing/adapter-telemetry-writer.ts
@@ -1,0 +1,153 @@
+// apps/web/lib/routing/adapter-telemetry-writer.ts
+//
+// Phase A7: One row per adapter execution attempt is written to
+// `AdapterRunTelemetry` immediately after dispatch finishes (or fails). The
+// writer is fire-and-forget — a Prisma write failure here must never break a
+// coworker turn, so any thrown error is swallowed at the call site.
+//
+// The caller (`callProvider` in inference/ai-inference.ts) populates as many
+// fields as it has in scope. Optional fields default to null so we capture
+// useful rows even when context (agentId, skillId, threadId) hasn't been
+// plumbed through yet — Phase A7 stays narrow; richer attribution flows
+// through the call chain in follow-up phases.
+//
+// Plan: docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md (Task A7)
+// Spec: docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md §4.3
+
+import { prisma } from "@dpf/db";
+
+/**
+ * Caller-provided fields for one `AdapterRunTelemetry` row.
+ *
+ * Required fields match the non-null columns on the model. Everything else
+ * is optional; we encourage callers to fill in what they have rather than
+ * synthesizing placeholders, so analytics queries don't have to filter out
+ * placeholder noise.
+ */
+export type AdapterTelemetryInput = {
+  // Required
+  adapterKind: string;
+  adapterVersion: string;
+  providerId: string;
+  modelId: string;
+  executionMode: string;
+  startedAt: Date;
+  status: string;
+
+  // Attribution (PR #607 + PR #623 conventions)
+  threadId?: string;
+  agentMessageId?: string;
+  buildId?: string;
+  agentId?: string;
+  skillId?: string;
+
+  // Race / shadow grouping
+  raceCohortId?: string;
+
+  // Lifecycle
+  finishedAt?: Date;
+  durationMs?: number;
+  firstEventLatencyMs?: number;
+
+  // Outcome detail
+  refusalReason?: string;
+  errorClass?: string;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  estimatedCostUsd?: number;
+  quotaPoolConsumed?: string;
+
+  // Tool-call validity
+  toolCallsTotal?: number;
+  toolCallsInvalid?: number;
+
+  // Capability fidelity
+  capabilitiesUsed?: string[];
+  schemaDriftDetected?: boolean;
+
+  // Acceptance — populated asynchronously by downstream signals, not here
+  userAccepted?: boolean;
+  acceptedAt?: Date;
+
+  // For cross-adapter equivalence checks (shadow/race comparison)
+  rawEventDigest?: string;
+};
+
+/**
+ * Test-only override hook. When set, `writeAdapterTelemetry` calls this
+ * instead of touching Prisma. Mirrors the pattern in
+ * `mcp-governed-execute.ts`.
+ */
+let _writeOverride:
+  | ((data: Record<string, unknown>) => Promise<unknown>)
+  | null = null;
+
+/** Test-only: install/clear the override. */
+export function _setAdapterTelemetryWriteOverrideForTests(
+  override:
+    | ((data: Record<string, unknown>) => Promise<unknown>)
+    | null,
+): void {
+  _writeOverride = override;
+}
+
+/**
+ * Persist one `AdapterRunTelemetry` row. Fire-and-forget: any database error
+ * is swallowed (logged to console.warn) so a telemetry write failure cannot
+ * break a coworker turn. Callers should NOT `await` this function inside a
+ * critical path — invoke it without `await`, after the user-visible response
+ * has been computed.
+ */
+export async function writeAdapterTelemetry(
+  input: AdapterTelemetryInput,
+): Promise<void> {
+  try {
+    const data: Record<string, unknown> = {
+      adapterKind: input.adapterKind,
+      adapterVersion: input.adapterVersion,
+      providerId: input.providerId,
+      modelId: input.modelId,
+      executionMode: input.executionMode,
+      startedAt: input.startedAt,
+      status: input.status,
+    };
+    if (input.threadId !== undefined) data.threadId = input.threadId;
+    if (input.agentMessageId !== undefined) data.agentMessageId = input.agentMessageId;
+    if (input.buildId !== undefined) data.buildId = input.buildId;
+    if (input.agentId !== undefined) data.agentId = input.agentId;
+    if (input.skillId !== undefined) data.skillId = input.skillId;
+    if (input.raceCohortId !== undefined) data.raceCohortId = input.raceCohortId;
+    if (input.finishedAt !== undefined) data.finishedAt = input.finishedAt;
+    if (input.durationMs !== undefined) data.durationMs = input.durationMs;
+    if (input.firstEventLatencyMs !== undefined) data.firstEventLatencyMs = input.firstEventLatencyMs;
+    if (input.refusalReason !== undefined) data.refusalReason = input.refusalReason;
+    if (input.errorClass !== undefined) data.errorClass = input.errorClass;
+    if (input.inputTokens !== undefined) data.inputTokens = input.inputTokens;
+    if (input.cachedInputTokens !== undefined) data.cachedInputTokens = input.cachedInputTokens;
+    if (input.outputTokens !== undefined) data.outputTokens = input.outputTokens;
+    if (input.reasoningTokens !== undefined) data.reasoningTokens = input.reasoningTokens;
+    if (input.estimatedCostUsd !== undefined) data.estimatedCostUsd = input.estimatedCostUsd;
+    if (input.quotaPoolConsumed !== undefined) data.quotaPoolConsumed = input.quotaPoolConsumed;
+    if (input.toolCallsTotal !== undefined) data.toolCallsTotal = input.toolCallsTotal;
+    if (input.toolCallsInvalid !== undefined) data.toolCallsInvalid = input.toolCallsInvalid;
+    if (input.capabilitiesUsed !== undefined) data.capabilitiesUsed = input.capabilitiesUsed;
+    if (input.schemaDriftDetected !== undefined) data.schemaDriftDetected = input.schemaDriftDetected;
+    if (input.userAccepted !== undefined) data.userAccepted = input.userAccepted;
+    if (input.acceptedAt !== undefined) data.acceptedAt = input.acceptedAt;
+    if (input.rawEventDigest !== undefined) data.rawEventDigest = input.rawEventDigest;
+
+    if (_writeOverride) {
+      await _writeOverride(data);
+      return;
+    }
+
+    await prisma.adapterRunTelemetry.create({ data: data as never });
+  } catch (e) {
+    // Fire-and-forget pattern — telemetry must not break the user turn.
+    // Mirrors prisma.toolExecution.create().catch(() => {}) in mcp-governed-execute.ts.
+    // eslint-disable-next-line no-console
+    console.warn("[adapter-telemetry-writer] write failed (suppressed):", e);
+  }
+}

--- a/apps/web/lib/routing/capability-probe-types.ts
+++ b/apps/web/lib/routing/capability-probe-types.ts
@@ -1,0 +1,51 @@
+// apps/web/lib/routing/capability-probe-types.ts
+//
+// Phase A5: Shared types for adapter capability probes + cache.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+//
+// Mirrors the columns of the AdapterCapabilityProfile prisma model (schema.prisma
+// §"AdapterCapabilityProfile"). Probes return CapabilityProbeResult (omits the
+// DB-managed id/probedAt/probedBy); the cache layer adds those fields and
+// persists. Keeping this type local to the routing folder avoids importing
+// the Prisma client in pure probe modules — probes have no DB dependency.
+
+import type { ExecutionAdapterKind } from "./execution-adapter-types";
+
+/**
+ * Single known degradation entry. Recorded for adapters with documented
+ * silent-failure modes (e.g. Codex `--json` + MCP per openai/codex#15451).
+ */
+export type KnownDegradation = {
+  trigger: string;
+  behavior: string;
+  source: string;
+};
+
+/**
+ * The shape every probe returns. The `adapterKind` is one of the structured
+ * ExecutionAdapterKind values — narrowed to the kinds with registered probes
+ * by the cache layer's switch statement.
+ */
+export type CapabilityProbeResult = {
+  adapterKind: ExecutionAdapterKind;
+  adapterVersion: string;
+
+  supportsStreamingEvents: boolean;
+  supportsMcpAttach: boolean;
+  supportsMcpAttachPerInvoke: boolean;
+  supportsSubagents: boolean;
+  supportsHooks: boolean;
+  supportsPlanState: boolean;
+  supportsTodoState: boolean;
+  supportsWebFetch: boolean;
+  supportsWebSearch: boolean;
+  supportsSessionResume: boolean;
+  supportsExtendedThinking: boolean;
+  supportsOutputSchema: boolean;
+
+  maxInteractiveLatencyMs: number;
+  supportedAuthModes: string[];
+  knownDegradations: KnownDegradation[] | null;
+};

--- a/apps/web/lib/routing/capability-probes/probe-claude-cli.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-claude-cli.test.ts
@@ -1,0 +1,93 @@
+// apps/web/lib/routing/capability-probes/probe-claude-cli.test.ts
+//
+// Phase A5: Failing test for the claude-code CLI capability probe.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockExec = vi.fn();
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({
+    exec: (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const result = mockExec(cmd);
+      if (result instanceof Promise) {
+        result
+          .then((resolved: { stdout: string; stderr: string }) => cb(null, resolved))
+          .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+      } else {
+        cb(new Error("mockExec must return a Promise"), { stdout: "", stderr: "" });
+      }
+    },
+  }),
+  lazyUtil: () => ({
+    promisify:
+      (fn: Function) =>
+      (...args: unknown[]) =>
+        new Promise((resolve, reject) => {
+          fn(...args, (err: Error | null, result: unknown) => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        }),
+  }),
+}));
+
+import { probeClaudeCli } from "./probe-claude-cli";
+
+describe("probeClaudeCli", () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
+  it("parses '<version> (Claude Code)' stdout and returns the populated profile", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "1.5.0 (Claude Code)\n", stderr: "" });
+
+    const profile = await probeClaudeCli();
+
+    expect(profile.adapterKind).toBe("claude-code-cli");
+    expect(profile.adapterVersion).toBe("claude-code/1.5.0");
+    expect(profile.supportsSubagents).toBe(true);
+    expect(profile.supportsMcpAttachPerInvoke).toBe(true);
+    expect(profile.supportsHooks).toBe(true);
+    expect(profile.supportsOutputSchema).toBe(false);
+    expect(profile.maxInteractiveLatencyMs).toBe(180_000);
+    expect(profile.supportedAuthModes).toEqual(expect.arrayContaining(["oauth", "api-key"]));
+    expect(profile.knownDegradations).toBeNull();
+  });
+
+  it("parses 'claude-code/X.Y.Z' style stdout via the version regex", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "claude-code/2.0.7\n", stderr: "" });
+
+    const profile = await probeClaudeCli();
+
+    expect(profile.adapterVersion).toBe("claude-code/2.0.7");
+  });
+
+  it("invokes docker exec against the sandbox container", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "1.0.0 (Claude Code)\n", stderr: "" });
+
+    await probeClaudeCli();
+
+    const cmd = mockExec.mock.calls[0]?.[0] as string;
+    expect(cmd).toMatch(/docker exec/);
+    expect(cmd).toMatch(/claude --version/);
+  });
+
+  it("throws when docker exec fails (does NOT return a stub)", async () => {
+    mockExec.mockRejectedValueOnce(new Error("No such container: dpf-sandbox-1"));
+
+    await expect(probeClaudeCli()).rejects.toThrow(/claude/i);
+  });
+
+  it("throws when stdout has no parseable version", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "garbage output\n", stderr: "" });
+
+    await expect(probeClaudeCli()).rejects.toThrow();
+  });
+});

--- a/apps/web/lib/routing/capability-probes/probe-claude-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-claude-cli.ts
@@ -1,0 +1,71 @@
+// apps/web/lib/routing/capability-probes/probe-claude-cli.ts
+//
+// Phase A5: Capability probe for the claude-code CLI adapter.
+//
+// Shells out to `docker exec <sandbox> claude --version` to capture the
+// installed version, then returns a populated AdapterCapabilityProfile
+// (minus the DB-managed id/probedAt/probedBy fields). The cache layer
+// in capability-profile-cache.ts wraps this and persists the result.
+//
+// Capabilities are observed from cli-adapter.ts and the audit at
+// docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §5.2.
+//
+// If the CLI is missing or docker exec fails, the probe THROWS — it does not
+// return a stub. Probe failure is operationally meaningful and must surface
+// to the cache layer (and any caller) so the routing system doesn't make
+// decisions based on phantom capabilities.
+
+import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import type { CapabilityProbeResult } from "../capability-probe-types";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const PROBE_TIMEOUT_MS = 10_000;
+const VERSION_REGEX = /(\d+\.\d+\.\d+)/;
+
+export async function probeClaudeCli(): Promise<CapabilityProbeResult> {
+  const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
+
+  let stdout: string;
+  try {
+    const result = (await execAsync(
+      `docker exec ${SANDBOX_CONTAINER} claude --version`,
+      { timeout: PROBE_TIMEOUT_MS },
+    )) as { stdout: string; stderr: string };
+    stdout = result.stdout ?? "";
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `probeClaudeCli: failed to invoke 'claude --version' in sandbox '${SANDBOX_CONTAINER}': ${message}`,
+    );
+  }
+
+  const match = VERSION_REGEX.exec(stdout);
+  if (!match) {
+    throw new Error(
+      `probeClaudeCli: could not parse claude version from stdout: ${JSON.stringify(stdout)}`,
+    );
+  }
+
+  return {
+    adapterKind: "claude-code-cli",
+    adapterVersion: `claude-code/${match[1]}`,
+
+    // Observed capabilities — see cli-adapter.ts and Claude Code feature set.
+    supportsStreamingEvents: true,
+    supportsMcpAttach: true,
+    supportsMcpAttachPerInvoke: true, // --mcp-config flag
+    supportsSubagents: true, // Task tool
+    supportsHooks: true, // settings.json hooks
+    supportsPlanState: true,
+    supportsTodoState: true, // TodoWrite tool
+    supportsWebFetch: true,
+    supportsWebSearch: true,
+    supportsSessionResume: true, // --session-id
+    supportsExtendedThinking: true,
+    supportsOutputSchema: false, // not equivalent to Codex's --output-schema
+
+    maxInteractiveLatencyMs: 180_000, // matches CLI_TIMEOUT_MS in cli-adapter.ts
+    supportedAuthModes: ["oauth", "api-key"],
+    knownDegradations: null,
+  };
+}

--- a/apps/web/lib/routing/capability-probes/probe-codex-cli.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-codex-cli.test.ts
@@ -1,0 +1,114 @@
+// apps/web/lib/routing/capability-probes/probe-codex-cli.test.ts
+//
+// Phase A5: Failing test for the codex CLI capability probe.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+// Evidence: docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockExec = vi.fn();
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({
+    exec: (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const result = mockExec(cmd);
+      if (result instanceof Promise) {
+        result
+          .then((resolved: { stdout: string; stderr: string }) => cb(null, resolved))
+          .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+      } else {
+        cb(new Error("mockExec must return a Promise"), { stdout: "", stderr: "" });
+      }
+    },
+  }),
+  lazyUtil: () => ({
+    promisify:
+      (fn: Function) =>
+      (...args: unknown[]) =>
+        new Promise((resolve, reject) => {
+          fn(...args, (err: Error | null, result: unknown) => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        }),
+  }),
+}));
+
+import { probeCodexCli } from "./probe-codex-cli";
+
+describe("probeCodexCli", () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
+  it("parses 'codex-cli X.Y.Z' stdout and returns the populated profile", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "codex-cli 0.125.0\n", stderr: "" });
+
+    const profile = await probeCodexCli();
+
+    expect(profile.adapterKind).toBe("codex-cli");
+    expect(profile.adapterVersion).toBe("codex-cli/0.125.0");
+    // Per audit Q1: Codex configures MCP statically — not per-invoke like Claude.
+    expect(profile.supportsMcpAttach).toBe(true);
+    expect(profile.supportsMcpAttachPerInvoke).toBe(false);
+    // Codex has no Task-tool subagents and no hooks model.
+    expect(profile.supportsSubagents).toBe(false);
+    expect(profile.supportsHooks).toBe(false);
+    // Codex DOES expose --output-schema (gpt-5 family).
+    expect(profile.supportsOutputSchema).toBe(true);
+    expect(profile.supportsExtendedThinking).toBe(true);
+    expect(profile.supportsSessionResume).toBe(true);
+    expect(profile.maxInteractiveLatencyMs).toBe(180_000);
+    expect(profile.supportedAuthModes).toEqual(expect.arrayContaining(["oauth", "api-key"]));
+  });
+
+  it("carries knownDegradations for the --json+MCP silent failure (issue 15451)", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "codex-cli 0.125.0\n", stderr: "" });
+
+    const profile = await probeCodexCli();
+
+    expect(Array.isArray(profile.knownDegradations)).toBe(true);
+    const degradations = profile.knownDegradations as Array<{
+      trigger: string;
+      behavior: string;
+      source: string;
+    }>;
+
+    const mcpEntry = degradations.find((d) => /MCP/.test(d.trigger));
+    expect(mcpEntry).toBeDefined();
+    expect(mcpEntry?.source).toMatch(/15451/);
+    expect(mcpEntry?.behavior).toMatch(/stream|silent|drop/i);
+
+    // Schema-rename pattern (issue 4776)
+    const schemaEntry = degradations.find((d) => /rename|schema/i.test(d.trigger));
+    expect(schemaEntry).toBeDefined();
+    expect(schemaEntry?.source).toMatch(/4776/);
+  });
+
+  it("invokes docker exec against the sandbox container", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "codex-cli 0.125.0\n", stderr: "" });
+
+    await probeCodexCli();
+
+    const cmd = mockExec.mock.calls[0]?.[0] as string;
+    expect(cmd).toMatch(/docker exec/);
+    expect(cmd).toMatch(/codex --version/);
+  });
+
+  it("throws when docker exec fails (does NOT return a stub)", async () => {
+    mockExec.mockRejectedValueOnce(new Error("docker daemon not reachable"));
+
+    await expect(probeCodexCli()).rejects.toThrow(/codex/i);
+  });
+
+  it("throws when stdout has no parseable version", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "no version here\n", stderr: "" });
+
+    await expect(probeCodexCli()).rejects.toThrow();
+  });
+});

--- a/apps/web/lib/routing/capability-probes/probe-codex-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-codex-cli.ts
@@ -1,0 +1,84 @@
+// apps/web/lib/routing/capability-probes/probe-codex-cli.ts
+//
+// Phase A5: Capability probe for the codex CLI adapter.
+//
+// Shells out to `docker exec <sandbox> codex --version` to capture the
+// installed version, then returns a populated AdapterCapabilityProfile shape.
+//
+// Capabilities are observed from codex-cli-adapter.ts and the JSONL audit at
+// docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md.
+//
+// `knownDegradations` carries the two documented silent-failure modes:
+//   - openai/codex#15451: --json events silently dropped when MCP active
+//   - openai/codex#4776: schema rename (item_type→type, assistant_message→agent_message)
+//
+// These let A6's capability-aware fallback reason about Codex limitations
+// honestly instead of trusting an aspirational booleans table.
+
+import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import type { CapabilityProbeResult } from "../capability-probe-types";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const PROBE_TIMEOUT_MS = 10_000;
+const VERSION_REGEX = /(\d+\.\d+\.\d+)/;
+
+export async function probeCodexCli(): Promise<CapabilityProbeResult> {
+  const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
+
+  let stdout: string;
+  try {
+    const result = (await execAsync(
+      `docker exec ${SANDBOX_CONTAINER} codex --version`,
+      { timeout: PROBE_TIMEOUT_MS },
+    )) as { stdout: string; stderr: string };
+    stdout = result.stdout ?? "";
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `probeCodexCli: failed to invoke 'codex --version' in sandbox '${SANDBOX_CONTAINER}': ${message}`,
+    );
+  }
+
+  const match = VERSION_REGEX.exec(stdout);
+  if (!match) {
+    throw new Error(
+      `probeCodexCli: could not parse codex version from stdout: ${JSON.stringify(stdout)}`,
+    );
+  }
+
+  return {
+    adapterKind: "codex-cli",
+    adapterVersion: `codex-cli/${match[1]}`,
+
+    // Per audit Q1 + JSONL probe evidence:
+    supportsStreamingEvents: true, // --json
+    supportsMcpAttach: true, // ~/.codex/config.toml + codex mcp subcommand
+    supportsMcpAttachPerInvoke: false, // static config only — KEY DIFF vs Claude
+    supportsSubagents: false, // not in current Codex
+    supportsHooks: false,
+    supportsPlanState: true, // item.completed type=plan_update
+    supportsTodoState: true, // same
+    supportsWebFetch: true, // model-dependent but advertised
+    supportsWebSearch: true, // item.completed type=web_search
+    supportsSessionResume: true, // codex exec resume <uuid>
+    supportsExtendedThinking: true, // -c reasoning.effort=high
+    supportsOutputSchema: true, // --output-schema (gpt-5 family only)
+
+    maxInteractiveLatencyMs: 180_000,
+    supportedAuthModes: ["oauth", "api-key"],
+
+    knownDegradations: [
+      {
+        trigger: "--json + MCP active",
+        behavior: "stream malformed; events silently dropped",
+        source: "https://github.com/openai/codex/issues/15451",
+      },
+      {
+        trigger: "schema rename observed in 0.x releases",
+        behavior:
+          "item_type field renamed to type without notice; assistant_message renamed to agent_message",
+        source: "https://github.com/openai/codex/issues/4776",
+      },
+    ],
+  };
+}

--- a/apps/web/lib/routing/capability-probes/probe-http-anthropic.ts
+++ b/apps/web/lib/routing/capability-probes/probe-http-anthropic.ts
@@ -1,0 +1,43 @@
+// apps/web/lib/routing/capability-probes/probe-http-anthropic.ts
+//
+// Phase A5: Capability probe for the http-anthropic adapter.
+//
+// Static — Anthropic's HTTP Messages API has a known capability surface that
+// cannot be discovered at runtime in any meaningful way. The version is the
+// project's pinned `anthropic-version` header (see ai-provider-internals.ts:64).
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+
+import type { CapabilityProbeResult } from "../capability-probe-types";
+
+/**
+ * Anthropic API version pinned by the project — tracks
+ * apps/web/lib/inference/ai-provider-internals.ts:64 where the
+ * "anthropic-version" header is set on outbound HTTP calls.
+ */
+const ANTHROPIC_API_VERSION = "2023-06-01";
+
+export async function probeHttpAnthropic(): Promise<CapabilityProbeResult> {
+  return {
+    adapterKind: "http-anthropic",
+    adapterVersion: `anthropic-http/${ANTHROPIC_API_VERSION}`,
+
+    supportsStreamingEvents: true, // SSE
+    supportsMcpAttach: false, // HTTP API doesn't support MCP attach
+    supportsMcpAttachPerInvoke: false,
+    supportsSubagents: false,
+    supportsHooks: false,
+    supportsPlanState: false,
+    supportsTodoState: false,
+    supportsWebFetch: false, // not via Messages API directly
+    supportsWebSearch: false,
+    supportsSessionResume: false, // stateless API
+    supportsExtendedThinking: true, // thinking field on Messages API
+    supportsOutputSchema: false,
+
+    maxInteractiveLatencyMs: 60_000, // typical HTTP call ceiling
+    supportedAuthModes: ["api-key", "oauth"],
+    knownDegradations: null,
+  };
+}

--- a/apps/web/lib/routing/capability-probes/probe-http-openai.ts
+++ b/apps/web/lib/routing/capability-probes/probe-http-openai.ts
@@ -1,0 +1,43 @@
+// apps/web/lib/routing/capability-probes/probe-http-openai.ts
+//
+// Phase A5: Capability probe for the http-openai adapter.
+//
+// Static — OpenAI's v1 HTTP API has a known capability surface. Version is
+// the OpenAI v1 endpoint family used in adapter-openai.ts.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+
+import type { CapabilityProbeResult } from "../capability-probe-types";
+
+/**
+ * OpenAI HTTP API version family. The project uses api.openai.com/v1
+ * (see adapter-openai.ts and chat-adapter.ts). There is no per-release
+ * version header on OpenAI's API the way Anthropic has, so this string
+ * tracks the v1 endpoint family.
+ */
+const OPENAI_API_VERSION = "v1";
+
+export async function probeHttpOpenAI(): Promise<CapabilityProbeResult> {
+  return {
+    adapterKind: "http-openai",
+    adapterVersion: `openai-http/${OPENAI_API_VERSION}`,
+
+    supportsStreamingEvents: true,
+    supportsMcpAttach: false,
+    supportsMcpAttachPerInvoke: false,
+    supportsSubagents: false,
+    supportsHooks: false,
+    supportsPlanState: false,
+    supportsTodoState: false,
+    supportsWebFetch: false,
+    supportsWebSearch: false,
+    supportsSessionResume: false,
+    supportsExtendedThinking: true, // o1/o3/gpt-5 reasoning
+    supportsOutputSchema: true, // response_format json_schema
+
+    maxInteractiveLatencyMs: 60_000,
+    supportedAuthModes: ["api-key"],
+    knownDegradations: null,
+  };
+}

--- a/apps/web/lib/routing/capability-profile-cache.test.ts
+++ b/apps/web/lib/routing/capability-profile-cache.test.ts
@@ -1,0 +1,271 @@
+// apps/web/lib/routing/capability-profile-cache.test.ts
+//
+// Phase A5: Failing test for the DB-backed capability profile cache.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ── Prisma mock ─────────────────────────────────────────────────────────────
+const mockFindUnique = vi.fn();
+const mockUpsert = vi.fn();
+
+// `Prisma.JsonNull` is a sentinel value the real Prisma client uses to set
+// a nullable Json column to null. Tests don't go through real Prisma — the
+// cache module just imports it and forwards it to upsert(). A unique string
+// stand-in is sufficient for unit-test mocking.
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    adapterCapabilityProfile: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+  },
+  Prisma: {
+    JsonNull: "__PRISMA_JSON_NULL__",
+  },
+}));
+
+// ── Probe mocks ─────────────────────────────────────────────────────────────
+const mockProbeClaudeCli = vi.fn();
+const mockProbeCodexCli = vi.fn();
+const mockProbeHttpAnthropic = vi.fn();
+const mockProbeHttpOpenAI = vi.fn();
+
+vi.mock("./capability-probes/probe-claude-cli", () => ({
+  probeClaudeCli: (...args: unknown[]) => mockProbeClaudeCli(...args),
+}));
+vi.mock("./capability-probes/probe-codex-cli", () => ({
+  probeCodexCli: (...args: unknown[]) => mockProbeCodexCli(...args),
+}));
+vi.mock("./capability-probes/probe-http-anthropic", () => ({
+  probeHttpAnthropic: (...args: unknown[]) => mockProbeHttpAnthropic(...args),
+}));
+vi.mock("./capability-probes/probe-http-openai", () => ({
+  probeHttpOpenAI: (...args: unknown[]) => mockProbeHttpOpenAI(...args),
+}));
+
+import { getOrProbeCapabilityProfile } from "./capability-profile-cache";
+
+// Deterministic claude probe shape used across tests
+function fakeClaudeProbe() {
+  return {
+    adapterKind: "claude-code-cli",
+    adapterVersion: "claude-code/9.9.9",
+    supportsStreamingEvents: true,
+    supportsMcpAttach: true,
+    supportsMcpAttachPerInvoke: true,
+    supportsSubagents: true,
+    supportsHooks: true,
+    supportsPlanState: true,
+    supportsTodoState: true,
+    supportsWebFetch: true,
+    supportsWebSearch: true,
+    supportsSessionResume: true,
+    supportsExtendedThinking: true,
+    supportsOutputSchema: false,
+    maxInteractiveLatencyMs: 180_000,
+    supportedAuthModes: ["oauth", "api-key"],
+    knownDegradations: null,
+  };
+}
+
+describe("getOrProbeCapabilityProfile", () => {
+  beforeEach(() => {
+    mockFindUnique.mockReset();
+    mockUpsert.mockReset();
+    mockProbeClaudeCli.mockReset();
+    mockProbeCodexCli.mockReset();
+    mockProbeHttpAnthropic.mockReset();
+    mockProbeHttpOpenAI.mockReset();
+  });
+
+  it("cache miss: runs probe, upserts row, returns profile with probedBy + probedAt", async () => {
+    mockProbeClaudeCli.mockResolvedValue(fakeClaudeProbe());
+    mockFindUnique.mockResolvedValue(null);
+    mockUpsert.mockImplementation(({ create }) => ({
+      id: "cuid-x",
+      probedAt: create.probedAt,
+      probedBy: create.probedBy,
+      ...create,
+    }));
+
+    const profile = await getOrProbeCapabilityProfile("claude-code-cli");
+
+    expect(mockProbeClaudeCli).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(profile.adapterKind).toBe("claude-code-cli");
+    expect(profile.adapterVersion).toBe("claude-code/9.9.9");
+    expect(typeof profile.probedBy).toBe("string");
+    expect(profile.probedBy.length).toBeGreaterThan(0);
+    const ageMs = Date.now() - new Date(profile.probedAt).getTime();
+    expect(ageMs).toBeLessThan(5_000);
+  });
+
+  it("cache hit within TTL: skips probe body, returns cached row", async () => {
+    // Probe runs only ONCE for the version detection
+    mockProbeClaudeCli.mockResolvedValue(fakeClaudeProbe());
+
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const cached = {
+      id: "cuid-cached",
+      adapterKind: "claude-code-cli",
+      adapterVersion: "claude-code/9.9.9",
+      probedAt: oneHourAgo,
+      probedBy: "previous-host:1234",
+      supportsStreamingEvents: true,
+      supportsMcpAttach: true,
+      supportsMcpAttachPerInvoke: true,
+      supportsSubagents: true,
+      supportsHooks: true,
+      supportsPlanState: true,
+      supportsTodoState: true,
+      supportsWebFetch: true,
+      supportsWebSearch: true,
+      supportsSessionResume: true,
+      supportsExtendedThinking: true,
+      supportsOutputSchema: false,
+      maxInteractiveLatencyMs: 180_000,
+      supportedAuthModes: ["oauth", "api-key"],
+      knownDegradations: null,
+    };
+    mockFindUnique.mockResolvedValue(cached);
+
+    const profile = await getOrProbeCapabilityProfile("claude-code-cli");
+
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(profile.id).toBe("cuid-cached");
+    expect(profile.probedBy).toBe("previous-host:1234");
+    expect(profile.probedAt).toEqual(oneHourAgo);
+    // Probe is allowed to be called once for version discovery
+    expect(mockProbeClaudeCli.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("cache stale (>24h): re-runs probe and upserts fresh row", async () => {
+    mockProbeClaudeCli.mockResolvedValue(fakeClaudeProbe());
+
+    const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    mockFindUnique.mockResolvedValue({
+      id: "cuid-old",
+      adapterKind: "claude-code-cli",
+      adapterVersion: "claude-code/9.9.9",
+      probedAt: twoDaysAgo,
+      probedBy: "old-host:1",
+      supportsStreamingEvents: true,
+      supportsMcpAttach: true,
+      supportsMcpAttachPerInvoke: true,
+      supportsSubagents: true,
+      supportsHooks: true,
+      supportsPlanState: true,
+      supportsTodoState: true,
+      supportsWebFetch: true,
+      supportsWebSearch: true,
+      supportsSessionResume: true,
+      supportsExtendedThinking: true,
+      supportsOutputSchema: false,
+      maxInteractiveLatencyMs: 180_000,
+      supportedAuthModes: ["oauth", "api-key"],
+      knownDegradations: null,
+    });
+    mockUpsert.mockImplementation(({ create }) => ({
+      id: "cuid-new",
+      probedAt: create.probedAt,
+      probedBy: create.probedBy,
+      ...create,
+    }));
+
+    const profile = await getOrProbeCapabilityProfile("claude-code-cli");
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(profile.id).toBe("cuid-new");
+    expect(new Date(profile.probedAt).getTime()).toBeGreaterThan(twoDaysAgo.getTime());
+  });
+
+  it("dispatches by adapter kind", async () => {
+    mockProbeCodexCli.mockResolvedValue({
+      adapterKind: "codex-cli",
+      adapterVersion: "codex-cli/0.125.0",
+      supportsStreamingEvents: true,
+      supportsMcpAttach: true,
+      supportsMcpAttachPerInvoke: false,
+      supportsSubagents: false,
+      supportsHooks: false,
+      supportsPlanState: true,
+      supportsTodoState: true,
+      supportsWebFetch: true,
+      supportsWebSearch: true,
+      supportsSessionResume: true,
+      supportsExtendedThinking: true,
+      supportsOutputSchema: true,
+      maxInteractiveLatencyMs: 180_000,
+      supportedAuthModes: ["oauth", "api-key"],
+      knownDegradations: [{ trigger: "x", behavior: "y", source: "z" }],
+    });
+    mockFindUnique.mockResolvedValue(null);
+    mockUpsert.mockImplementation(({ create }) => ({
+      id: "cuid-codex",
+      probedAt: create.probedAt,
+      probedBy: create.probedBy,
+      ...create,
+    }));
+
+    const profile = await getOrProbeCapabilityProfile("codex-cli");
+    expect(profile.adapterKind).toBe("codex-cli");
+    expect(mockProbeCodexCli).toHaveBeenCalled();
+    expect(mockProbeClaudeCli).not.toHaveBeenCalled();
+  });
+
+  it("throws for adapter kinds without a registered probe", async () => {
+    await expect(getOrProbeCapabilityProfile("http-gemini")).rejects.toThrow(
+      /No capability probe/,
+    );
+    await expect(getOrProbeCapabilityProfile("http-ollama")).rejects.toThrow(
+      /No capability probe/,
+    );
+    await expect(getOrProbeCapabilityProfile("codex-mcp-server")).rejects.toThrow(
+      /No capability probe/,
+    );
+    await expect(getOrProbeCapabilityProfile("local-runtime")).rejects.toThrow(
+      /No capability probe/,
+    );
+    await expect(getOrProbeCapabilityProfile("http-generic")).rejects.toThrow(
+      /No capability probe/,
+    );
+  });
+
+  it("HTTP probes work end-to-end through the cache", async () => {
+    mockProbeHttpAnthropic.mockResolvedValue({
+      adapterKind: "http-anthropic",
+      adapterVersion: "anthropic-http/2023-06-01",
+      supportsStreamingEvents: true,
+      supportsMcpAttach: false,
+      supportsMcpAttachPerInvoke: false,
+      supportsSubagents: false,
+      supportsHooks: false,
+      supportsPlanState: false,
+      supportsTodoState: false,
+      supportsWebFetch: false,
+      supportsWebSearch: false,
+      supportsSessionResume: false,
+      supportsExtendedThinking: true,
+      supportsOutputSchema: false,
+      maxInteractiveLatencyMs: 60_000,
+      supportedAuthModes: ["api-key", "oauth"],
+      knownDegradations: null,
+    });
+    mockFindUnique.mockResolvedValue(null);
+    mockUpsert.mockImplementation(({ create }) => ({
+      id: "cuid-http-anthropic",
+      probedAt: create.probedAt,
+      probedBy: create.probedBy,
+      ...create,
+    }));
+
+    const profile = await getOrProbeCapabilityProfile("http-anthropic");
+
+    expect(profile.adapterKind).toBe("http-anthropic");
+    expect(profile.supportsExtendedThinking).toBe(true);
+    expect(profile.supportsMcpAttach).toBe(false);
+  });
+});

--- a/apps/web/lib/routing/capability-profile-cache.ts
+++ b/apps/web/lib/routing/capability-profile-cache.ts
@@ -1,0 +1,143 @@
+// apps/web/lib/routing/capability-profile-cache.ts
+//
+// Phase A5: DB-backed cache for adapter capability profiles.
+//
+// Reads cached rows by [adapterKind, adapterVersion] unique key. On cache
+// miss (or stale row past TTL), runs the appropriate probe, upserts the row,
+// and returns. Re-runs the version-discovery probe on every call — that's
+// cheap (a single `--version` shellout for CLIs, a constant return for HTTP
+// adapters), and the version is the cache key.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A5)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1, §5.2
+//
+// A6 will read from this cache to gate capability-based fallback when a
+// route plan declares `capabilityRequirements: [...]`.
+
+import os from "node:os";
+
+import { prisma, Prisma } from "@dpf/db";
+
+// AdapterCapabilityProfile is the Prisma generated row type. It isn't
+// re-exported by name from @dpf/db (only `Prisma` is), so we resolve it
+// through the namespace.
+type AdapterCapabilityProfile = Prisma.AdapterCapabilityProfileModel;
+
+import type { ExecutionAdapterKind } from "./execution-adapter-types";
+import type { CapabilityProbeResult } from "./capability-probe-types";
+
+import { probeClaudeCli } from "./capability-probes/probe-claude-cli";
+import { probeCodexCli } from "./capability-probes/probe-codex-cli";
+import { probeHttpAnthropic } from "./capability-probes/probe-http-anthropic";
+import { probeHttpOpenAI } from "./capability-probes/probe-http-openai";
+
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+type ProbeFn = () => Promise<CapabilityProbeResult>;
+
+function pickProbe(adapterKind: ExecutionAdapterKind): ProbeFn {
+  switch (adapterKind) {
+    case "claude-code-cli":
+      return probeClaudeCli;
+    case "codex-cli":
+      return probeCodexCli;
+    case "http-anthropic":
+      return probeHttpAnthropic;
+    case "http-openai":
+      return probeHttpOpenAI;
+    case "http-gemini":
+    case "http-ollama":
+    case "http-generic":
+    case "codex-mcp-server":
+    case "local-runtime":
+      throw new Error(
+        `No capability probe registered yet for adapter kind: ${adapterKind}`,
+      );
+    default: {
+      const _exhaustive: never = adapterKind;
+      throw new Error(`Unknown adapter kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function probedByIdentity(): string {
+  return `${os.hostname()}:${process.pid}`;
+}
+
+function isFresh(probedAt: Date): boolean {
+  return Date.now() - probedAt.getTime() < TTL_MS;
+}
+
+/**
+ * Get-or-probe semantics:
+ *   1. Discover current adapter version via the probe (cheap version-only call).
+ *   2. Look up cache row by [adapterKind, adapterVersion].
+ *   3. If found AND fresh (< 24h old): return it.
+ *   4. Otherwise: probe, upsert, return.
+ *
+ * The probe itself is responsible for throwing on operational failure (e.g.
+ * docker exec fails). We do NOT swallow probe errors — a missing CLI in the
+ * sandbox is a real outage that should surface.
+ */
+export async function getOrProbeCapabilityProfile(
+  adapterKind: ExecutionAdapterKind,
+): Promise<AdapterCapabilityProfile> {
+  const probe = pickProbe(adapterKind);
+
+  // Step 1: discover version (cheap)
+  const probed = await probe();
+
+  // Step 2: cache lookup
+  const cached = await prisma.adapterCapabilityProfile.findUnique({
+    where: {
+      adapterKind_adapterVersion: {
+        adapterKind: probed.adapterKind,
+        adapterVersion: probed.adapterVersion,
+      },
+    },
+  });
+
+  if (cached && isFresh(cached.probedAt)) {
+    return cached;
+  }
+
+  // Step 3: write/refresh
+  const probedBy = probedByIdentity();
+  const probedAt = new Date();
+
+  const writeData = {
+    adapterKind: probed.adapterKind,
+    adapterVersion: probed.adapterVersion,
+    probedAt,
+    probedBy,
+    supportsStreamingEvents: probed.supportsStreamingEvents,
+    supportsMcpAttach: probed.supportsMcpAttach,
+    supportsMcpAttachPerInvoke: probed.supportsMcpAttachPerInvoke,
+    supportsSubagents: probed.supportsSubagents,
+    supportsHooks: probed.supportsHooks,
+    supportsPlanState: probed.supportsPlanState,
+    supportsTodoState: probed.supportsTodoState,
+    supportsWebFetch: probed.supportsWebFetch,
+    supportsWebSearch: probed.supportsWebSearch,
+    supportsSessionResume: probed.supportsSessionResume,
+    supportsExtendedThinking: probed.supportsExtendedThinking,
+    supportsOutputSchema: probed.supportsOutputSchema,
+    maxInteractiveLatencyMs: probed.maxInteractiveLatencyMs,
+    supportedAuthModes: probed.supportedAuthModes,
+    knownDegradations:
+      probed.knownDegradations === null
+        ? Prisma.JsonNull
+        : (probed.knownDegradations as unknown as Prisma.InputJsonValue),
+  };
+
+  return prisma.adapterCapabilityProfile.upsert({
+    where: {
+      adapterKind_adapterVersion: {
+        adapterKind: probed.adapterKind,
+        adapterVersion: probed.adapterVersion,
+      },
+    },
+    create: writeData,
+    update: writeData,
+  });
+}

--- a/apps/web/lib/routing/execution-adapter-types.test.ts
+++ b/apps/web/lib/routing/execution-adapter-types.test.ts
@@ -1,0 +1,145 @@
+// apps/web/lib/routing/execution-adapter-types.test.ts
+//
+// Phase A4: ExecutionAdapterSelector + capability-requirement type tests.
+//
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §5.1
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A4)
+
+import { describe, it, expect } from "vitest";
+import {
+  parseExecutionAdapterSelector,
+  type AdapterCapabilityRequirement,
+  type ExecutionAdapterKind,
+  type ExecutionAdapterSelector,
+} from "./execution-adapter-types";
+
+/**
+ * Compile-time exhaustiveness sentinel. If a new ExecutionAdapterKind is added
+ * to the union without updating this switch, TypeScript fails to compile the
+ * `_default: never` arm. Runtime call exercises every branch.
+ */
+function describeKind(kind: ExecutionAdapterKind): string {
+  switch (kind) {
+    case "http-anthropic":
+      return "http-anthropic";
+    case "http-openai":
+      return "http-openai";
+    case "http-gemini":
+      return "http-gemini";
+    case "http-ollama":
+      return "http-ollama";
+    case "http-generic":
+      return "http-generic";
+    case "claude-code-cli":
+      return "claude-code-cli";
+    case "codex-cli":
+      return "codex-cli";
+    case "codex-mcp-server":
+      return "codex-mcp-server";
+    case "local-runtime":
+      return "local-runtime";
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+describe("ExecutionAdapterKind exhaustiveness", () => {
+  it("covers every declared kind in the switch", () => {
+    const kinds: ExecutionAdapterKind[] = [
+      "http-anthropic",
+      "http-openai",
+      "http-gemini",
+      "http-ollama",
+      "http-generic",
+      "claude-code-cli",
+      "codex-cli",
+      "codex-mcp-server",
+      "local-runtime",
+    ];
+    for (const k of kinds) {
+      expect(describeKind(k)).toBe(k);
+    }
+  });
+});
+
+describe("parseExecutionAdapterSelector — legacy string round-trip", () => {
+  it('maps "claude-cli" to claude-code-cli + oauth', () => {
+    expect(parseExecutionAdapterSelector("claude-cli")).toEqual({
+      kind: "claude-code-cli",
+      authMode: "oauth",
+    });
+  });
+
+  it('maps "codex-cli" to codex-cli + oauth', () => {
+    expect(parseExecutionAdapterSelector("codex-cli")).toEqual({
+      kind: "codex-cli",
+      authMode: "oauth",
+    });
+  });
+
+  it('maps "chat" to http-generic + api-key', () => {
+    expect(parseExecutionAdapterSelector("chat")).toEqual({
+      kind: "http-generic",
+      authMode: "api-key",
+    });
+  });
+});
+
+describe("parseExecutionAdapterSelector — object passthrough", () => {
+  it("returns a value-equal object when given a valid selector", () => {
+    const input: ExecutionAdapterSelector = {
+      kind: "claude-code-cli",
+      authMode: "oauth",
+      version: "claude-code/1.2.3",
+      containerHint: "dpf-sandbox-1",
+    };
+    expect(parseExecutionAdapterSelector(input)).toEqual(input);
+  });
+
+  it("preserves a minimal valid selector (no version, no containerHint)", () => {
+    const input: ExecutionAdapterSelector = {
+      kind: "http-anthropic",
+      authMode: "api-key",
+    };
+    expect(parseExecutionAdapterSelector(input)).toEqual(input);
+  });
+});
+
+describe("parseExecutionAdapterSelector — invalid input", () => {
+  it("throws on an unknown legacy string with the offending value in the message", () => {
+    expect(() => parseExecutionAdapterSelector("nonsense")).toThrow(/nonsense/);
+  });
+
+  it("throws on undefined with executionAdapter is required", () => {
+    expect(() => parseExecutionAdapterSelector(undefined)).toThrow(
+      /executionAdapter is required/,
+    );
+  });
+
+  it("throws on null with executionAdapter is required", () => {
+    expect(() => parseExecutionAdapterSelector(null)).toThrow(
+      /executionAdapter is required/,
+    );
+  });
+});
+
+describe("AdapterCapabilityRequirement shape", () => {
+  it("accepts a capability key + required boolean", () => {
+    const req: AdapterCapabilityRequirement = {
+      capability: "supportsSubagents",
+      required: true,
+    };
+    expect(typeof req.capability).toBe("string");
+    expect(typeof req.required).toBe("boolean");
+  });
+
+  it("accepts an advisory (required: false) requirement", () => {
+    const req: AdapterCapabilityRequirement = {
+      capability: "supportsTodoState",
+      required: false,
+    };
+    expect(req.required).toBe(false);
+  });
+});

--- a/apps/web/lib/routing/execution-adapter-types.ts
+++ b/apps/web/lib/routing/execution-adapter-types.ts
@@ -1,0 +1,156 @@
+// apps/web/lib/routing/execution-adapter-types.ts
+//
+// Phase A4: Structured ExecutionAdapterSelector + capability-requirement types.
+//
+// Replaces the legacy string-typed `executionAdapter` field on RoutedExecutionPlan
+// with a structured selector that carries adapter kind, auth posture, optional
+// version pin, and optional sandbox-pool affinity hint. `parseExecutionAdapterSelector`
+// round-trips legacy string values ("claude-cli", "codex-cli", "chat") into the
+// new shape so call sites can be migrated incrementally without breaking
+// in-flight route plans.
+//
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §5.1
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A4)
+//
+// This file is intentionally pure types + a parser — no DB, no Prisma client.
+// Phase A6 will swap the hard-coded `isCliAdapter` check in ai-inference.ts to
+// route through the resolved selector.
+
+/**
+ * Discriminator for the execution adapter that runs an inference call.
+ *
+ * `http-*` kinds correspond to direct HTTP calls against the named provider
+ * family. `http-generic` is the legacy `"chat"` sentinel — a generic HTTP
+ * execution mode that doesn't bind to one provider; the registry resolves the
+ * concrete handler from `(providerId, modelClass)` at dispatch time.
+ *
+ * `claude-code-cli` / `codex-cli` are subprocess CLI adapters with OAuth
+ * sessions. `codex-mcp-server` is Codex acting as an MCP server (sidesteps
+ * the `--json` + MCP degradation in openai/codex#15451). `local-runtime`
+ * covers Ollama and other locally-hosted runtimes.
+ */
+export type ExecutionAdapterKind =
+  | "http-anthropic"
+  | "http-openai"
+  | "http-gemini"
+  | "http-ollama"
+  | "http-generic"
+  | "claude-code-cli"
+  | "codex-cli"
+  | "codex-mcp-server"
+  | "local-runtime";
+
+/**
+ * Structured selector for an execution adapter.
+ *
+ * `version` pins a specific adapter version (e.g. `"codex-cli/0.125.0"`); when
+ * absent, the registry uses the latest probed version for the kind.
+ * `containerHint` lets a route plan steer the sandbox pool toward a specific
+ * slot for CLI adapters (per-thread session affinity).
+ */
+export type ExecutionAdapterSelector = {
+  kind: ExecutionAdapterKind;
+  version?: string;
+  authMode: "api-key" | "oauth" | "local";
+  containerHint?: string;
+};
+
+/**
+ * Capability fields on AdapterCapabilityProfile that a route plan can require.
+ *
+ * Listed explicitly rather than `keyof AdapterCapabilityProfileModel` because
+ * the generated Prisma type includes non-capability columns (id, adapterKind,
+ * adapterVersion, probedAt, …). The set below is exactly the boolean
+ * capability columns from the prisma model definition (schema.prisma §
+ * "AdapterCapabilityProfile" lines 5541–5552). Keeping it in sync is a
+ * one-line edit when a new boolean capability is added to the model.
+ */
+export type AdapterCapability =
+  | "supportsStreamingEvents"
+  | "supportsMcpAttach"
+  | "supportsMcpAttachPerInvoke"
+  | "supportsSubagents"
+  | "supportsHooks"
+  | "supportsPlanState"
+  | "supportsTodoState"
+  | "supportsWebFetch"
+  | "supportsWebSearch"
+  | "supportsSessionResume"
+  | "supportsExtendedThinking"
+  | "supportsOutputSchema";
+
+/**
+ * A single capability requirement on a route plan.
+ *
+ * `required: true` → fail-route if the chosen adapter lacks the capability.
+ * `required: false` → advisory; downgrade gracefully (e.g. todo state → text).
+ */
+export type AdapterCapabilityRequirement = {
+  capability: AdapterCapability;
+  required: boolean;
+};
+
+const VALID_KINDS: ReadonlySet<ExecutionAdapterKind> = new Set<ExecutionAdapterKind>([
+  "http-anthropic",
+  "http-openai",
+  "http-gemini",
+  "http-ollama",
+  "http-generic",
+  "claude-code-cli",
+  "codex-cli",
+  "codex-mcp-server",
+  "local-runtime",
+]);
+
+const VALID_AUTH_MODES: ReadonlySet<ExecutionAdapterSelector["authMode"]> = new Set<
+  ExecutionAdapterSelector["authMode"]
+>(["api-key", "oauth", "local"]);
+
+/**
+ * Round-trip a legacy string-typed `executionAdapter` value (or an already-
+ * structured selector) into the new ExecutionAdapterSelector shape.
+ *
+ * Mappings:
+ *   "claude-cli" → { kind: "claude-code-cli", authMode: "oauth" }
+ *   "codex-cli"  → { kind: "codex-cli",       authMode: "oauth" }
+ *   "chat"       → { kind: "http-generic",    authMode: "api-key" }
+ *
+ * A valid selector object is returned (value-equal) after light validation.
+ * `null` / `undefined` and unknown legacy strings throw.
+ */
+export function parseExecutionAdapterSelector(
+  input: string | ExecutionAdapterSelector | undefined | null,
+): ExecutionAdapterSelector {
+  if (input === undefined || input === null) {
+    throw new Error("executionAdapter is required");
+  }
+
+  if (typeof input === "string") {
+    switch (input) {
+      case "claude-cli":
+        return { kind: "claude-code-cli", authMode: "oauth" };
+      case "codex-cli":
+        return { kind: "codex-cli", authMode: "oauth" };
+      case "chat":
+        return { kind: "http-generic", authMode: "api-key" };
+      default:
+        throw new Error(`Unknown executionAdapter: "${input}"`);
+    }
+  }
+
+  // Object input — validate kind + authMode and pass through.
+  if (!VALID_KINDS.has(input.kind)) {
+    throw new Error(`Unknown executionAdapter kind: "${input.kind}"`);
+  }
+  if (!VALID_AUTH_MODES.has(input.authMode)) {
+    throw new Error(`Unknown executionAdapter authMode: "${input.authMode}"`);
+  }
+
+  const out: ExecutionAdapterSelector = {
+    kind: input.kind,
+    authMode: input.authMode,
+  };
+  if (input.version !== undefined) out.version = input.version;
+  if (input.containerHint !== undefined) out.containerHint = input.containerHint;
+  return out;
+}

--- a/apps/web/lib/routing/recipe-types.ts
+++ b/apps/web/lib/routing/recipe-types.ts
@@ -8,6 +8,11 @@
  * See: docs/superpowers/specs/2026-03-20-contract-based-selection-design.md
  */
 
+import type {
+  AdapterCapabilityRequirement,
+  ExecutionAdapterSelector,
+} from "./execution-adapter-types";
+
 // ── RoutedExecutionPlan ──────────────────────────────────────────────────────
 
 export interface RoutedExecutionPlan {
@@ -15,7 +20,22 @@ export interface RoutedExecutionPlan {
   modelId: string;
   recipeId: string | null;
   contractFamily: string;
-  executionAdapter: string;
+  /**
+   * Execution adapter selector. Accepts either a legacy string
+   * ("claude-cli", "codex-cli", "chat", "responses", "embedding", …) OR a
+   * structured `ExecutionAdapterSelector` object. Phase A6 added the
+   * structured form; legacy strings continue to work via
+   * `parseExecutionAdapterSelector` + `resolveExecutionAdapter`.
+   */
+  executionAdapter: string | ExecutionAdapterSelector;
+  /**
+   * Optional capability requirements (Phase A4/A6). When at least one entry
+   * has `required: true`, the resolver gates dispatch on the adapter's
+   * capability profile and throws `CapabilityRequirementUnsatisfiedError`
+   * if unsatisfied. Advisory entries (`required: false`) are a no-op today
+   * and become advisory-with-telemetry once A7 lands.
+   */
+  capabilityRequirements?: AdapterCapabilityRequirement[];
   maxTokens: number;
   temperature?: number;
   providerSettings: Record<string, unknown>;

--- a/apps/web/lib/routing/resolve-execution-adapter.test.ts
+++ b/apps/web/lib/routing/resolve-execution-adapter.test.ts
@@ -1,0 +1,219 @@
+// apps/web/lib/routing/resolve-execution-adapter.test.ts
+//
+// Phase A6: Unit tests for `resolveExecutionAdapter()` — the wrapper that
+// replaces the hard-coded `isCliAdapter` boolean check in ai-inference.ts.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A6)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §5.2
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Prisma } from "@dpf/db";
+
+const {
+  mockGetExecutionAdapter,
+  mockGetOrProbeCapabilityProfile,
+} = vi.hoisted(() => ({
+  mockGetExecutionAdapter: vi.fn(),
+  mockGetOrProbeCapabilityProfile: vi.fn(),
+}));
+
+vi.mock("./execution-adapter-registry", () => ({
+  getExecutionAdapter: mockGetExecutionAdapter,
+}));
+
+vi.mock("./capability-profile-cache", () => ({
+  getOrProbeCapabilityProfile: mockGetOrProbeCapabilityProfile,
+}));
+
+import {
+  resolveExecutionAdapter,
+  CapabilityRequirementUnsatisfiedError,
+} from "./resolve-execution-adapter";
+import type { AdapterCapabilityRequirement } from "./execution-adapter-types";
+
+type AdapterCapabilityProfile = Prisma.AdapterCapabilityProfileModel;
+
+// Minimal capability-profile factory — only the boolean fields the tests need.
+function profile(
+  overrides: Partial<AdapterCapabilityProfile> = {},
+): AdapterCapabilityProfile {
+  return {
+    id: "test-id",
+    adapterKind: "claude-code-cli",
+    adapterVersion: "test/0.0.0",
+    probedAt: new Date(),
+    probedBy: "test",
+    supportsStreamingEvents: true,
+    supportsMcpAttach: true,
+    supportsMcpAttachPerInvoke: true,
+    supportsSubagents: true,
+    supportsHooks: true,
+    supportsPlanState: true,
+    supportsTodoState: true,
+    supportsWebFetch: true,
+    supportsWebSearch: true,
+    supportsSessionResume: true,
+    supportsExtendedThinking: true,
+    supportsOutputSchema: true,
+    maxInteractiveLatencyMs: 1000,
+    supportedAuthModes: ["oauth"],
+    knownDegradations: null,
+    ...overrides,
+  } as AdapterCapabilityProfile;
+}
+
+describe("resolveExecutionAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: registry returns a tagged stub so tests can assert which legacy
+    // string was used.
+    mockGetExecutionAdapter.mockImplementation((type: string) => ({
+      type,
+      execute: vi.fn(),
+    }));
+  });
+
+  // ── Backward compat: legacy strings ──────────────────────────────────────
+
+  it("legacy string \"claude-cli\" dispatches to claude CLI handler", async () => {
+    const handler = await resolveExecutionAdapter("claude-cli");
+    expect(mockGetExecutionAdapter).toHaveBeenCalledWith("claude-cli");
+    expect(handler).toMatchObject({ type: "claude-cli" });
+  });
+
+  it("legacy string \"codex-cli\" dispatches to codex CLI handler", async () => {
+    const handler = await resolveExecutionAdapter("codex-cli");
+    expect(mockGetExecutionAdapter).toHaveBeenCalledWith("codex-cli");
+    expect(handler).toMatchObject({ type: "codex-cli" });
+  });
+
+  it("legacy string \"chat\" dispatches to chat handler (HTTP)", async () => {
+    const handler = await resolveExecutionAdapter("chat");
+    expect(mockGetExecutionAdapter).toHaveBeenCalledWith("chat");
+    expect(handler).toMatchObject({ type: "chat" });
+  });
+
+  // ── New structured selectors map to same legacy handlers ─────────────────
+
+  it("structured {kind: \"claude-code-cli\"} resolves to same handler as \"claude-cli\"", async () => {
+    await resolveExecutionAdapter({ kind: "claude-code-cli", authMode: "oauth" });
+    expect(mockGetExecutionAdapter).toHaveBeenCalledWith("claude-cli");
+  });
+
+  it("structured {kind: \"codex-cli\"} resolves to codex handler", async () => {
+    await resolveExecutionAdapter({ kind: "codex-cli", authMode: "oauth" });
+    expect(mockGetExecutionAdapter).toHaveBeenCalledWith("codex-cli");
+  });
+
+  it("structured {kind: \"http-generic\"} resolves to chat handler", async () => {
+    await resolveExecutionAdapter({ kind: "http-generic", authMode: "api-key" });
+    expect(mockGetExecutionAdapter).toHaveBeenCalledWith("chat");
+  });
+
+  it("structured http-anthropic / http-openai / http-gemini / http-ollama all resolve to chat handler", async () => {
+    await resolveExecutionAdapter({ kind: "http-anthropic", authMode: "api-key" });
+    await resolveExecutionAdapter({ kind: "http-openai", authMode: "api-key" });
+    await resolveExecutionAdapter({ kind: "http-gemini", authMode: "api-key" });
+    await resolveExecutionAdapter({ kind: "http-ollama", authMode: "local" });
+
+    const calls = mockGetExecutionAdapter.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["chat", "chat", "chat", "chat"]);
+  });
+
+  // ── Capability gating ────────────────────────────────────────────────────
+
+  it("required capability satisfied → resolves successfully", async () => {
+    mockGetOrProbeCapabilityProfile.mockResolvedValue(
+      profile({ adapterKind: "claude-code-cli", supportsSubagents: true }),
+    );
+    const reqs: AdapterCapabilityRequirement[] = [
+      { capability: "supportsSubagents", required: true },
+    ];
+
+    const handler = await resolveExecutionAdapter(
+      { kind: "claude-code-cli", authMode: "oauth" },
+      reqs,
+    );
+
+    expect(mockGetOrProbeCapabilityProfile).toHaveBeenCalledWith("claude-code-cli");
+    expect(handler).toMatchObject({ type: "claude-cli" });
+  });
+
+  it("required capability UNSATISFIED → throws CapabilityRequirementUnsatisfiedError", async () => {
+    mockGetOrProbeCapabilityProfile.mockResolvedValue(
+      profile({ adapterKind: "codex-cli", supportsSubagents: false }),
+    );
+    const reqs: AdapterCapabilityRequirement[] = [
+      { capability: "supportsSubagents", required: true },
+    ];
+
+    await expect(
+      resolveExecutionAdapter({ kind: "codex-cli", authMode: "oauth" }, reqs),
+    ).rejects.toBeInstanceOf(CapabilityRequirementUnsatisfiedError);
+
+    // The error should name the missing capability and the adapter kind
+    await expect(
+      resolveExecutionAdapter({ kind: "codex-cli", authMode: "oauth" }, reqs),
+    ).rejects.toThrow(/supportsSubagents/);
+  });
+
+  it("advisory (required:false) capability missing → resolves without error", async () => {
+    mockGetOrProbeCapabilityProfile.mockResolvedValue(
+      profile({ adapterKind: "codex-cli", supportsSubagents: false }),
+    );
+    const reqs: AdapterCapabilityRequirement[] = [
+      { capability: "supportsSubagents", required: false },
+    ];
+
+    const handler = await resolveExecutionAdapter(
+      { kind: "codex-cli", authMode: "oauth" },
+      reqs,
+    );
+
+    expect(handler).toMatchObject({ type: "codex-cli" });
+  });
+
+  it("no capability requirements → does not call the profile cache", async () => {
+    await resolveExecutionAdapter({ kind: "claude-code-cli", authMode: "oauth" });
+    expect(mockGetOrProbeCapabilityProfile).not.toHaveBeenCalled();
+  });
+
+  it("empty capability requirements array → does not call the profile cache", async () => {
+    await resolveExecutionAdapter(
+      { kind: "claude-code-cli", authMode: "oauth" },
+      [],
+    );
+    expect(mockGetOrProbeCapabilityProfile).not.toHaveBeenCalled();
+  });
+
+  it("only advisory requirements → does not call the profile cache (no need to gate)", async () => {
+    // Pure-advisory requirements aren't enforced today — A6 just resolves.
+    // (A future task may probe + log capabilitiesUsed; for A6, advisory is a no-op.)
+    await resolveExecutionAdapter(
+      { kind: "codex-cli", authMode: "oauth" },
+      [{ capability: "supportsSubagents", required: false }],
+    );
+    expect(mockGetOrProbeCapabilityProfile).not.toHaveBeenCalled();
+  });
+
+  // ── Unknown / invalid input ──────────────────────────────────────────────
+
+  it("unknown legacy string throws via parseExecutionAdapterSelector", async () => {
+    await expect(resolveExecutionAdapter("nope-cli")).rejects.toThrow(
+      /Unknown executionAdapter/,
+    );
+  });
+
+  it("unsupported kind (codex-mcp-server) throws — no handler registered yet", async () => {
+    await expect(
+      resolveExecutionAdapter({ kind: "codex-mcp-server", authMode: "oauth" }),
+    ).rejects.toThrow(/codex-mcp-server/);
+  });
+
+  it("unsupported kind (local-runtime) throws — no handler registered yet", async () => {
+    await expect(
+      resolveExecutionAdapter({ kind: "local-runtime", authMode: "local" }),
+    ).rejects.toThrow(/local-runtime/);
+  });
+});

--- a/apps/web/lib/routing/resolve-execution-adapter.ts
+++ b/apps/web/lib/routing/resolve-execution-adapter.ts
@@ -1,0 +1,150 @@
+// apps/web/lib/routing/resolve-execution-adapter.ts
+//
+// Phase A6: Capability-aware adapter resolution.
+//
+// Replaces the hard-coded `isCliAdapter` boolean check at
+// [ai-inference.ts:351-360](../inference/ai-inference.ts#L351) with a structured
+// resolver that:
+//
+//   1. Accepts `executionAdapter` as either a legacy string ("claude-cli",
+//      "codex-cli", "chat") OR a structured `ExecutionAdapterSelector` object.
+//      Legacy strings round-trip through `parseExecutionAdapterSelector` (A4).
+//
+//   2. Maps the selector's `kind` back to the legacy adapter-registry string
+//      so the existing `getExecutionAdapter()` lookup continues to work
+//      unchanged. This keeps the registry stable while the route plan moves
+//      to structured selectors.
+//
+//   3. If the route plan supplies `capabilityRequirements` with at least one
+//      `required: true` entry, fetches the adapter's capability profile via
+//      `getOrProbeCapabilityProfile()` (A5) and verifies every required
+//      capability is `true` on the profile. If any required capability is
+//      unsatisfied, throws `CapabilityRequirementUnsatisfiedError` so the
+//      operator sees the requirement gap loudly. (Spec §5.2: advisory
+//      requirements log + downgrade; required requirements fail-route.)
+//
+// A6 deliberately does NOT implement adapter fallback chains — that's a future
+// task. For now, a required-capability mismatch is a hard error so misconfigured
+// route plans surface immediately rather than silently choosing a degraded
+// adapter.
+//
+// Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A6)
+// Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §5.2
+
+import type { ExecutionAdapterHandler } from "./adapter-types";
+import {
+  parseExecutionAdapterSelector,
+  type AdapterCapability,
+  type AdapterCapabilityRequirement,
+  type ExecutionAdapterKind,
+  type ExecutionAdapterSelector,
+} from "./execution-adapter-types";
+import { getExecutionAdapter } from "./execution-adapter-registry";
+import { getOrProbeCapabilityProfile } from "./capability-profile-cache";
+
+/**
+ * Thrown when a route plan declares a `required: true` capability that the
+ * resolved adapter's capability profile reports as `false`. The error names
+ * the failing capability and the adapter kind so operators can either
+ * loosen the requirement or pick a different adapter.
+ */
+export class CapabilityRequirementUnsatisfiedError extends Error {
+  readonly adapterKind: ExecutionAdapterKind;
+  readonly missingCapabilities: AdapterCapability[];
+
+  constructor(
+    adapterKind: ExecutionAdapterKind,
+    missingCapabilities: AdapterCapability[],
+  ) {
+    super(
+      `Adapter "${adapterKind}" does not satisfy required capability(ies): ${missingCapabilities.join(
+        ", ",
+      )}`,
+    );
+    this.name = "CapabilityRequirementUnsatisfiedError";
+    this.adapterKind = adapterKind;
+    this.missingCapabilities = missingCapabilities;
+  }
+}
+
+/**
+ * Inverse of `parseExecutionAdapterSelector`: maps a structured kind back to
+ * the legacy adapter-registry string consumed by `getExecutionAdapter()`.
+ *
+ *   claude-code-cli                                       → "claude-cli"
+ *   codex-cli                                             → "codex-cli"
+ *   http-generic / http-anthropic / http-openai /         → "chat"
+ *   http-gemini / http-ollama
+ *   codex-mcp-server / local-runtime                      → throws
+ *
+ * The HTTP variants all collapse to `"chat"` because the chat adapter routes
+ * by `providerId` internally — the kind distinction matters for the capability
+ * profile lookup, not for handler dispatch.
+ */
+function kindToLegacyAdapterType(kind: ExecutionAdapterKind): string {
+  switch (kind) {
+    case "claude-code-cli":
+      return "claude-cli";
+    case "codex-cli":
+      return "codex-cli";
+    case "http-generic":
+    case "http-anthropic":
+    case "http-openai":
+    case "http-gemini":
+    case "http-ollama":
+      return "chat";
+    case "codex-mcp-server":
+    case "local-runtime":
+      throw new Error(
+        `No execution adapter handler registered for kind "${kind}" yet.`,
+      );
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Unknown execution adapter kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Resolve an execution adapter handler from a selector + optional capability
+ * requirements.
+ *
+ * Backward compat: passing a legacy string ("claude-cli", "codex-cli", "chat")
+ * produces the same handler as `getExecutionAdapter(<string>)` did before A6.
+ *
+ * Capability gating: if any requirement has `required: true`, the adapter's
+ * capability profile is fetched (probed if necessary) and every required
+ * capability must be `true` on the profile. Otherwise this throws
+ * `CapabilityRequirementUnsatisfiedError`.
+ */
+export async function resolveExecutionAdapter(
+  input: string | ExecutionAdapterSelector,
+  requirements?: AdapterCapabilityRequirement[],
+): Promise<ExecutionAdapterHandler> {
+  const selector = parseExecutionAdapterSelector(input);
+
+  // Capability gating — only when at least one requirement is `required: true`.
+  // Pure-advisory requirements are a no-op in A6 (spec §5.2: advisory ⇒ log +
+  // downgrade; A6 declines to log because the telemetry sink lands in A7).
+  const requiredCaps = (requirements ?? []).filter((r) => r.required);
+  if (requiredCaps.length > 0) {
+    const profile = await getOrProbeCapabilityProfile(selector.kind);
+    const missing: AdapterCapability[] = [];
+    for (const req of requiredCaps) {
+      // The capability fields are typed booleans on AdapterCapabilityProfile;
+      // a missing/false value means the adapter cannot satisfy the requirement.
+      const value = (profile as unknown as Record<AdapterCapability, boolean>)[
+        req.capability
+      ];
+      if (value !== true) {
+        missing.push(req.capability);
+      }
+    }
+    if (missing.length > 0) {
+      throw new CapabilityRequirementUnsatisfiedError(selector.kind, missing);
+    }
+  }
+
+  const legacyType = kindToLegacyAdapterType(selector.kind);
+  return getExecutionAdapter(legacyType);
+}

--- a/docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md
+++ b/docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md
@@ -317,7 +317,7 @@ If the implementation skips these refactors, it will likely produce a demo that 
 
 ## 9b. Research findings against the open questions
 
-Three background agents plus a live `docker exec dpf-sandbox-1 codex exec --json` probe were run on 2026-04-29 to ground the questions above. Raw transcript at [evidence/2026-04-29-codex-jsonl-probe.md](./evidence/2026-04-29-codex-jsonl-probe.md). Findings below; answers replace assumptions in §3 and §6.
+Three background agents plus a live `docker exec dpf-sandbox-1 codex exec --json` probe were run on 2026-04-29 to ground the questions above. Raw transcript at [evidence/2026-04-29-codex-cli-jsonl-probe.md](./evidence/2026-04-29-codex-cli-jsonl-probe.md). Findings below; answers replace assumptions in §3 and §6.
 
 ### Q1 — Codex structured output: stream exists, schema is unstable, MCP attach is degraded
 

--- a/docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md
+++ b/docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md
@@ -1,0 +1,451 @@
+# Coworker Execution Substrate - Status Review and Direction
+
+| Field | Value |
+| --- | --- |
+| **Generated** | 2026-04-29 |
+| **Author** | Codex, updating Claude Opus 4.7's initial status review at Mark's request |
+| **Status** | Status review and direction proposal; ready to promote into a design spec |
+| **Sibling audits** | [Persona audit](./2026-04-27-coworker-persona-audit.md), [Tool-grant audit](./2026-04-27-coworker-tool-grant-audit.md), [Self-assessment](./2026-04-28-coworker-self-assessment.md) |
+| **Question being answered** | Should the AI Coworker panel use Claude Code CLI / Codex CLI as execution substrates instead of, or alongside, direct provider HTTP so non-CLI users can benefit from harness-native capabilities such as slash commands, MCP, hooks, subagents, plan mode, todos, web access, and richer execution traces? |
+| **Out of scope** | New tool implementations, persona rewrites, A2A task substrate implementation, public protocol exposure. Those have separate specs or audits. |
+
+---
+
+## 1. Executive Assessment
+
+The coworker panel is currently an HTTP-first product surface with a partial and mostly invisible CLI path. Build Studio already proves that DPF can run Claude Code and Codex as subprocess substrates, but the panel does not yet present the richer state those harnesses can produce.
+
+The architectural opportunity is real, but the sharp edge is also real: **a CLI is not just another model provider**. It is an execution harness with its own permissions, session lifecycle, event stream, filesystem posture, MCP attachment model, hooks, and cost / quota behavior.
+
+The next design should therefore make **execution adapter** a first-class routing dimension alongside provider, model, capability, sensitivity, and cost. It should not hard-code "Claude CLI" or "Codex CLI" as special cases in inference code.
+
+Recommended direction:
+
+1. Model HTTP, Claude Code CLI, Codex CLI, and local adapters as explicit execution adapters.
+2. Add adapter capability probes instead of relying on static assumptions about CLI features.
+3. Support single, shadow, and race execution modes through routing policy.
+4. Preserve HTTP paths for latency-sensitive, low-cost, and utility work.
+5. Surface CLI-native events in the coworker UI only after they are normalized into DPF task / tool / approval / artifact events.
+6. Spend at least 20% of the implementation budget on refactoring adapter boundaries, event normalization, and panel state separation before adding new user-visible controls.
+
+The winning architecture is not "put Claude Code inside chat." It is a governed execution substrate that can route across harnesses honestly and show users what each harness actually did.
+
+## 2. Current Repo Truth
+
+### 2.1 Coworker panel is HTTP-first
+
+The main panel path starts in [agent-coworker.ts](../../../apps/web/lib/actions/agent-coworker.ts). The flow resolves a route-aware agent, assembles context, arbitrates the prompt budget, and calls into routed inference.
+
+Current stack:
+
+- [routed-inference.ts](../../../apps/web/lib/routing/routed-inference.ts) ranks endpoints and handles fallback.
+- [adapter-registry.ts](../../../apps/web/lib/routing/adapter-registry.ts) maps providers to HTTP adapters.
+- [chat-adapter.ts](../../../apps/web/lib/routing/chat-adapter.ts) performs provider HTTP calls.
+- [agentic-loop.ts](../../../apps/web/lib/tak/agentic-loop.ts) handles platform tool calls, proposal interruptions, and `ToolExecution` audit rows.
+
+That means the normal panel experience is controlled by DPF's own tool registry and HTTP routing path. It is not a native Claude Code or Codex session from the user's point of view.
+
+### 2.2 Build Studio already uses CLI substrates
+
+Build Studio has separate subprocess dispatch paths:
+
+- [claude-dispatch.ts](../../../apps/web/lib/integrate/claude-dispatch.ts) runs Claude Code inside the sandbox container.
+- [codex-dispatch.ts](../../../apps/web/lib/integrate/codex-dispatch.ts) runs Codex inside the sandbox container.
+
+Those paths are proof that DPF can operate CLI substrates, preserve branch/worktree context, and collect structured results. They are not yet the same execution contract as the coworker panel.
+
+### 2.3 Partial coworker CLI support exists, but it is not a product surface
+
+[cli-adapter.ts](../../../apps/web/lib/routing/cli-adapter.ts) already parses Claude Code stream output for some tool-use events. The path is gated by routing state and is not exposed as a general panel substrate.
+
+The important gap is not only "can the CLI run?" It is:
+
+- Does the adapter preserve session state?
+- Does it normalize events?
+- Does it attach MCP servers safely?
+- Does it expose hooks and subagents in a governed way?
+- Does the panel know how to render the state without turning into a raw terminal transcript?
+- Does cost, token, duration, and quota telemetry land in the same ledger as HTTP inference?
+
+Today the answer is partial at best.
+
+## 3. Capability Gap
+
+The panel currently cannot reliably expose harness-native capabilities as first-class user experiences.
+
+| Capability | Claude Code CLI | Codex CLI | Coworker panel today | Architectural implication |
+| --- | --- | --- | --- | --- |
+| Slash commands / skills | Supported by Claude Code docs | Varies by Codex client surface | Not represented as panel commands | Needs command capability discovery and DPF permission mapping |
+| MCP attachment | Supported | Supported by Codex configuration docs | Platform tools only, statically routed | Needs adapter-level MCP profile and token hygiene |
+| Subagents | Supported by Claude Code docs | Not equivalent in current local path | Not rendered | Needs task/delegate event normalization |
+| Hooks | Supported by Claude Code docs | Not equivalent in current local path | Not rendered | Needs policy review before exposing |
+| Plan / todo state | Harness-specific | Harness-specific | Not first-class | Needs normalized task state, not transcript scraping |
+| Web fetch / search | Harness or tool dependent | Harness or model dependent | Partial platform support only | Needs explicit grant and route sensitivity checks |
+| Session continuity | CLI session IDs | Codex session behavior depends on client mode | DB thread continuity | Needs session lifecycle abstraction |
+| Sandboxed command execution | CLI-native in sandbox | CLI-native in sandbox | Indirect through platform tools | Needs clear boundary between harness tools and DPF tools |
+
+The table should not become a permanent hand-maintained claim. It should be generated or checked by adapter probes as part of implementation.
+
+## 4. Research and Benchmarking
+
+This status review draws on current public product patterns and official documentation. The useful pattern is not that every platform has the same features; it is that mature agent systems expose execution state, permission boundaries, and long-running work as product concepts instead of hiding them inside a transcript.
+
+### 4.1 Open-source and standards-led references
+
+1. **Claude Code**
+   - Official docs describe slash commands / skills, subagents, hooks, and MCP-aware hook behavior.
+   - Adopt: treat harness-native features as discoverable capabilities.
+   - Reject: assuming the raw Claude Code transcript is the right DPF product UI.
+
+2. **OpenAI Codex / Codex CLI**
+   - Official docs and the OpenAI Codex repo describe non-interactive `codex exec` and MCP configuration patterns.
+   - Adopt: keep Codex as a first-class execution adapter, especially for repo work and MCP-aware coding sessions.
+   - Reject: claiming Claude Code feature parity where the client does not expose an equivalent structured event contract.
+
+3. **A2A / task-native agent protocols**
+   - Adopt: task, message, artifact, and status events as the projection shape for cross-agent work.
+   - Reject: treating protocol compatibility as a substitute for DPF's `TAK` runtime controls.
+
+### 4.2 Commercial references
+
+1. **OpenAI background / long-running agent work**
+   - Adopt: long-running work should be pollable, cancellable, and decoupled from one synchronous chat turn.
+   - Reject: outsourcing DPF's canonical task state to provider-owned response objects.
+
+2. **Copilot Studio approvals**
+   - Adopt: approvals belong in explicit workflow state with clear user action surfaces.
+   - Reject: burying approvals in chat text or one-off cards without durable task linkage.
+
+3. **Salesforce Agentforce-style action governance**
+   - Adopt: action boundaries and guardrails should be visible in the product.
+   - Reject: vague "agent can do everything" personas that make capability discovery trial-and-error.
+
+## 5. Architectural Direction
+
+### 5.1 Execution adapter becomes a routing dimension
+
+The routing plan should carry an execution adapter, not infer one from provider ID.
+
+```ts
+type ExecutionAdapterKind = "http" | "claude-code-cli" | "codex-cli" | "local-runtime";
+
+type AdapterCapabilityProfile = {
+  adapterKind: ExecutionAdapterKind;
+  supportsStreamingEvents: boolean;
+  supportsMcpAttach: boolean;
+  supportsSubagents: boolean;
+  supportsHooks: boolean;
+  supportsPlanState: boolean;
+  supportsTodoState: boolean;
+  supportsWebAccess: boolean;
+  supportsSessionResume: boolean;
+  maxInteractiveLatencyMs: number;
+  supportedAuthModes: Array<"api-key" | "oauth" | "local">;
+};
+```
+
+Adapter capability is observed and cached. It should not be assumed forever from a provider name or a doc table.
+
+### 5.2 Separate model provider from execution harness
+
+The current mental model tends to combine:
+
+- Anthropic provider
+- Claude model
+- Claude Code CLI harness
+- OAuth subscription quota
+
+Those are separate concerns.
+
+Likewise:
+
+- OpenAI provider
+- Codex model family
+- Codex CLI harness
+- ChatGPT / API auth posture
+
+The router needs to know the difference. A model can be reachable through more than one adapter, and an adapter can carry harness capabilities unrelated to model quality.
+
+### 5.3 Single, shadow, and race modes
+
+The platform should support three execution modes:
+
+| Mode | Behavior | Default use |
+| --- | --- | --- |
+| `single` | Run one selected adapter and return result | Normal production work |
+| `shadow` | Run the selected adapter live, run one or more alternatives in the background, log comparison only | Calibration, rollout, regression detection |
+| `race` | Run multiple adapters, accept the first policy-valid result, cancel or ignore the rest | Latency-sensitive or degraded-provider scenarios |
+
+Shadow and race modes must be budgeted, sampled, and kill-switchable. They cannot be a hidden spend multiplier.
+
+### 5.4 Outcome scoring must be adapter-aware
+
+Adapter selection should score more than model rank.
+
+Minimum outcome dimensions:
+
+- task success
+- user acceptance
+- latency
+- token cost
+- subscription quota consumption
+- tool-call validity
+- artifact quality
+- policy violations
+- provider or harness degradation
+- retry rate
+- whether harness-native capabilities materially helped
+
+The useful metric is not "fastest answer." It is "lowest-risk accepted outcome for this task class."
+
+## 6. Product and UI Direction
+
+### 6.1 Do not expose raw harness complexity
+
+The coworker panel should not become a terminal emulator or a Claude Code clone. Most users do not need to see raw hook payloads, subprocess logs, or internal command syntax.
+
+The product surface should translate harness events into DPF-native states:
+
+- task started
+- plan proposed
+- todo added / completed
+- tool used
+- subtask delegated
+- approval required
+- artifact produced
+- verification passed / failed
+- adapter degraded
+
+### 6.2 Add a compact execution cockpit
+
+The panel should evolve from a transcript drawer into a compact execution cockpit:
+
+- **Header:** coworker identity, selected adapter, trust / health badge, current route or workspace.
+- **Status rail:** active task, pending approval, adapter health, memory health, delegated work count.
+- **Transcript:** human and coworker messages, plus only the task events needed for understanding.
+- **Artifacts:** generated files, specs, verification output, evidence summaries.
+- **Approvals:** pending proposal cards with scope, effect, and post-approval result.
+- **Trace:** provider / adapter, tool calls, MCP sources, latency, token / cost summary.
+
+This is especially important if CLI adapters are introduced. CLI sessions produce more internal state than HTTP calls. Without a better UI shape, that state will either disappear or flood the transcript.
+
+### 6.3 Theme and usability constraints
+
+Any panel changes must follow DPF's theme-aware styling standard:
+
+- no hardcoded colors
+- CSS variables for text, surfaces, borders, accents, warnings, and errors
+- progressive disclosure for trace detail
+- dense operational UI, not a marketing layout
+- visible trust and health state
+- responsive panel behavior that does not hide approvals or task status on smaller screens
+
+## 7. Governance and Security Requirements
+
+### 7.1 CLI adapters are higher-risk than HTTP adapters
+
+HTTP inference usually sees a bounded prompt, bounded tools, and provider API credentials.
+
+CLI harnesses may additionally see:
+
+- filesystem state
+- project instructions
+- MCP server configuration
+- shell tools
+- hooks
+- long-lived session files
+- OAuth credentials
+- subprocess environment
+
+That does not make CLI wrong. It makes it a higher-governance adapter.
+
+### 7.2 Required controls
+
+Before the panel can use CLI adapters broadly, DPF needs:
+
+- adapter-specific tool grants
+- route sensitivity checks for CLI access
+- explicit MCP server allowlist and token scoping
+- workspace/session isolation
+- filesystem write policy
+- hook policy and audit
+- unified `ToolExecution` / action receipt logging
+- cost and duration capture for CLI runs
+- operator-visible degradation state
+
+### 7.3 `TAK` and `GAID` fit
+
+`TAK` should govern the execution adapter as part of the operating profile. The adapter is material runtime state because it changes tools, context, autonomy, and evidence quality.
+
+`GAID` should treat adapter posture as part of the versioned operating profile, not the stable agent identity. The same coworker may keep the same identity while switching from HTTP to CLI, but that switch changes the receipt and evidence story.
+
+## 8. Refactor Budget
+
+The next implementation plan should reserve **at least 20% of the token / engineering budget for refactoring**. This is not polish. It is the cost of making the substrate maintainable.
+
+Required refactor areas:
+
+1. **Adapter contract extraction**
+   - Pull execution adapter selection out of provider-specific special cases.
+   - Create one interface for HTTP, CLI, and local runtime adapters.
+
+2. **Event normalization**
+   - Convert harness-native events into DPF task/tool/artifact/approval events.
+   - Keep raw adapter payloads as trace detail, not primary UI state.
+
+3. **Session lifecycle service**
+   - Own CLI session IDs, thread-to-session mapping, workspace isolation, timeout, resume, and cleanup.
+
+4. **Cost and outcome ledger**
+   - Capture duration, token estimates, provider cost, subscription quota impact, acceptance, retries, and failure class for every adapter run.
+
+5. **Panel state separation**
+   - Separate transcript state from task state, artifact state, approval state, and trace state.
+
+If the implementation skips these refactors, it will likely produce a demo that works once and a substrate that becomes expensive to reason about.
+
+## 9. Open Questions Before Spec Promotion
+
+1. **Codex structured output:** What structured event stream does the local Codex path expose today, and is it stable enough for UI rendering?
+2. **Session pooling:** Should CLI panel work use long-lived per-thread sessions, pooled sandbox sessions, or per-task sessions?
+3. **MCP boundary:** Which MCP servers can be attached to panel-driven CLI sessions, and how are tokens scoped?
+4. **Provider quota strategy:** Should the router intentionally spread load across HTTP and CLI quota pools for the same provider family?
+5. **Shadow sampling:** What percentage of production work can be shadowed without creating unacceptable spend?
+6. **Race acceptance:** If two adapters disagree, what makes one result policy-valid enough to accept?
+7. **User visibility:** How much adapter identity should a normal user see by default, versus an operator or admin?
+8. **Artifact custody:** When a CLI writes or proposes file changes, which object owns the evidence: task artifact, tool execution, Build Studio record, or all three through one receipt?
+
+## 9b. Research findings against the open questions
+
+Three background agents plus a live `docker exec dpf-sandbox-1 codex exec --json` probe were run on 2026-04-29 to ground the questions above. Raw transcript at [evidence/2026-04-29-codex-jsonl-probe.md](./evidence/2026-04-29-codex-jsonl-probe.md). Findings below; answers replace assumptions in §3 and §6.
+
+### Q1 — Codex structured output: stream exists, schema is unstable, MCP attach is degraded
+
+**Confirmed empirically.** Codex CLI 0.125.0 exposes `codex exec --json`, emitting a normalized envelope:
+
+```jsonl
+{"type":"thread.started","thread_id":"019ddb89..."}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution",...}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":...,"reasoning_output_tokens":...}}
+```
+
+Item types observed/documented: `agent_message`, `command_execution`, `reasoning`, `file_change`, `mcp_tool_call`, `web_search`, `plan_update`. This is **richer than §3's table assumed** — Codex *does* emit plan/todo state and structured tool calls.
+
+**However — three landmines:**
+
+1. **Unversioned schema, recent silent breaks.** `--json` was `--experimental-json` until recently. Issue [openai/codex#4776](https://github.com/openai/codex/issues/4776) documents a silent rename in the last 6 months: `item_type → type` and `assistant_message → agent_message`. No `schema_version` field exists.
+2. **`--json` is silently ignored when MCP tools are active** (issue [#15451](https://github.com/openai/codex/issues/15451)). This is a showstopper for the substrate vision unless we pin a Codex version and add a runtime guard.
+3. **MCP attach is static-only.** Servers must live in `~/.codex/config.toml`; no per-invoke `--mcp-config` like Claude Code. The `codex mcp` subcommand mutates user config.
+
+**Bonus surface the audit didn't anticipate:**
+
+- `codex mcp-server` — Codex itself runs as an MCP server over stdio. DPF could expose Codex *to* coworkers via MCP, in addition to (or instead of) shelling out.
+- `codex exec resume <uuid>` and `--last` — built-in session continuity, relevant to Q2.
+- `codex apply` — applies the latest agent diff via `git apply` to the local working tree, relevant to Q8.
+- `--output-schema <file>` — JSON Schema validation of the final response (gpt-5 family only per issue [#4181](https://github.com/openai/codex/issues/4181)).
+
+**Implication for spec.** The cli-adapter for Codex must:
+- pin a Codex version and reject divergent stream shapes loudly,
+- detect "MCP active + `--json` requested" and refuse the run with a clear error rather than parse malformed output,
+- normalize Codex's `item.completed` envelope and Claude Code's `tool_use` blocks into one DPF event taxonomy (the §6.1 normalized states),
+- treat the `mcp-server` mode as a separate adapter strategy worth its own §5 row, not a footnote.
+
+§3's row "Subagents — Codex: Not equivalent" stands. Row "Plan / todo state — Codex: Harness-specific" upgrades to "yes, via `plan_update` items, when MCP isn't active."
+
+### Q2 — Session pooling: current model is per-task; per-thread is the right target but needs schema + concurrency work
+
+**Current state (per-task, ephemeral):**
+- Build Studio dispatches at [claude-dispatch.ts:238-239](apps/web/lib/integrate/claude-dispatch.ts#L238) pass `--session-id` only when explicitly provided; the build orchestrator deliberately omits it ([build-orchestrator.ts:906-962](apps/web/lib/integrate/build-orchestrator.ts#L906)) because Claude Code's `--session-id` is single-use and parallel tasks collide on it.
+- Containers are long-lived (sandbox pool of 3 per docker-compose, default `DPF_SANDBOX_POOL_SIZE=3`); each task is a fresh `docker exec`, not a fresh container. That's good — cold-start cost is at the CLI level, not Docker.
+- **No `cliSessionId` column anywhere in `AgentThread` or `AgentMessage`** ([schema.prisma:2642-2676](packages/db/prisma/schema.prisma#L2642)). Thread continuity is semantic only.
+- **No workspace isolation between concurrent tasks** — all share `/workspace`. For Build Studio this is tolerated; for a coworker panel running CLI per turn this is a correctness hazard.
+- No orphan-session sweeper, no resume-from-checkpoint mid-task. Timeout = `SIGTERM` and abandon.
+
+**Answer to the open question.** The right substrate target is **per-thread long-lived sessions, with per-task ephemeral sessions as fallback for parallel work**. Reasoning:
+
+- Per-task: cheapest, already shipping, but loses the harness's plan/todo/memory state across coworker turns. Defeats the whole point of using a CLI in the panel.
+- Pooled-sandbox: container pool already exists, but pooling at the *container* layer doesn't solve session continuity, only resource contention.
+- Per-thread: session ID survives across panel turns within one thread → plan/todo/MCP state persists → matches user mental model.
+
+**What per-thread requires (delta to today):**
+1. `AgentThread.cliSessionId` (or `AgentMessage.cliSessionId` for finer-grain resume) added to Prisma schema.
+2. Sandbox pool affinity: thread T pinned to sandbox container N for the duration of its session, so the session file on disk is reachable.
+3. Concurrency rule: parallel tasks within one thread must serialize on the session OR fall back to per-task ephemeral mode. Codex's `--ephemeral` + Claude's "no session-id" path is the fallback contract.
+4. Session expiry / cleanup: stale-session sweeper (TTL on `cliSessionId` last-use timestamp) so abandoned threads don't pin sandbox slots forever.
+5. Resume-on-restart: `codex exec resume <uuid>` and Claude's session reuse both already support this; DPF just needs to record the session UUID and the working directory.
+
+§5.2's claim that "execution adapter is independent of provider+model+auth" stands; per-thread sessions are the *adapter-side* of that decomposition.
+
+### Q8 — Artifact custody: dependency, not a question
+
+**This is already specified.** The receipts design lives at [docs/superpowers/specs/2026-04-27-artifact-provenance-receipts-design.md](../specs/2026-04-27-artifact-provenance-receipts-design.md) — proposes a unified `ToolExecutionReceipt` table linking `FeatureBuild` evidence fields to actual execution receipts. Not yet implemented.
+
+**Today's state — three unlinked ledgers:**
+- `ToolExecution` ([schema.prisma:2775](packages/db/prisma/schema.prisma#L2775)) — written by [agentic-loop.ts:1027](apps/web/lib/tak/agentic-loop.ts#L1027) on every coworker tool call. **No `buildId` field.**
+- `FeatureBuild` JSON evidence columns ([schema.prisma:2960](packages/db/prisma/schema.prisma#L2960)) — written by `saveBuildEvidence` ([mcp-tools.ts:4029-4174](apps/web/lib/mcp-tools.ts#L4029)). **No provenance check** — agents can claim `verificationOut: {typecheckPassed: true}` without anything having run.
+- `BuildActivity` ([schema.prisma:3169](packages/db/prisma/schema.prisma#L3169)) — one-line summary log, has `buildId`, no link to the `ToolExecution` it summarizes.
+- `TaskArtifact` (TAK substrate) — separate orchestrator, unlinked to the above.
+
+**CLI dispatch is currently a provenance black hole.** [claude-dispatch.ts](apps/web/lib/integrate/claude-dispatch.ts) returns `executedTools: []` hardcoded. Tool calls Claude Code makes inside its sandbox session never reach `prisma.toolExecution`. Same gap for Codex.
+
+**Answer to the open question.** Don't redesign Q8 in this spec. Two clauses suffice:
+
+1. **Hard dependency.** The substrate spec depends on the receipts spec landing first, or at least its `ToolExecutionReceipt` table.
+2. **One CLI-specific clause.** The cli-adapter must mint `ToolExecution` rows (and eventually receipts) for the CLI's *own* tool calls, parsed from its event stream. Specifically:
+   - Claude Code: `tool_use` blocks → one `ToolExecution` row each.
+   - Codex: `item.completed` with `type ∈ {command_execution, mcp_tool_call, file_change, web_search}` → one row each.
+   - Each row carries the CLI session ID + adapter kind so the receipt ledger sees CLI work as a first-class participant.
+
+This is the smallest delta that closes the black hole without re-litigating receipts design.
+
+### Q3, Q5, Q6, Q7 — design decisions, stated in the spec, not researched
+
+These are choices, not discoveries. The spec section answering each:
+
+- **Q3 MCP boundary** — adapter-specific allowlist field on the route plan; tokens scoped per-thread, not per-install; sensitivity floor (e.g., the GitHub MCP requires elevated route sensitivity). Codex's static-only attach (§Q1) means the allowlist enforcement happens at config-load time, not invoke time.
+- **Q5 shadow sampling** — formula, not a number: `max_shadow_rate = monthly_shadow_budget / (avg_run_cost × monthly_run_count)`, default cap 5%, kill switch via env flag. Spec defines the formula and the override surface; ops sets the budget.
+- **Q6 race acceptance** — first result that is (a) non-error, (b) non-refusal, (c) policy-pass, (d) tool-call-valid (no fabricated tool names), (e) within latency budget. Losing adapters logged for calibration but not surfaced to user.
+- **Q7 user visibility** — three roles. Default user: model name + adapter health badge only. Operator: + adapter kind, latency, cost. Admin: + full route plan, capability profile, shadow comparison. Aligns with §6.2 cockpit progressive disclosure.
+
+### Q4 — provider quota spreading: yes, intentionally
+
+Per the [CLI vs API rate limits memory](memory/project_cli_vs_api_rate_limits.md), CLI and Messages API have separate quota pools. The routing policy *should* intentionally spread load across HTTP and CLI for the same provider family — it's a free reliability win against rate-limit storms. Spec to define: per-provider-family quota model with two pool descriptors (api-key pool, oauth/cli pool), and a load balancer that prefers the less-saturated pool when both are policy-valid for the task.
+
+---
+
+## 10. Recommended Next Spec
+
+Promote this audit into a design spec under [docs/superpowers/specs](../specs/) with a name like:
+
+`2026-04-29-cli-execution-adapter-routing-design.md`
+
+That spec should define:
+
+- `ExecutionAdapter` and `AdapterCapabilityProfile`
+- adapter capability probe and cache behavior
+- routing changes needed to remove hard-coded CLI special cases
+- shadow and race mode policy
+- cost, quota, and outcome ledger schema
+- normalized panel event protocol
+- CLI session lifecycle and cleanup rules
+- MCP, hook, filesystem, and OAuth boundaries
+- first implementation slice with the 20% refactor allocation called out explicitly
+
+## 11. Final Recommendation
+
+Proceed, but do it as substrate work rather than a feature toggle.
+
+The coworker panel should be able to use Claude Code CLI, Codex CLI, HTTP providers, and local runtimes through one governed adapter model. The UI should show normalized task, approval, artifact, health, and trace state rather than raw harness output. Shadow and race modes are valuable, but only after telemetry and budget controls exist.
+
+This is a strong direction for DPF because it turns provider volatility into a routing concern, not a recurring architecture emergency.
+
+## References
+
+- [Claude Code slash commands and skills](https://code.claude.com/docs/en/slash-commands)
+- [Claude Code subagents](https://code.claude.com/docs/en/sub-agents)
+- [Claude Code hooks](https://code.claude.com/docs/en/hooks)
+- [OpenAI Codex non-interactive mode](https://github.com/openai/codex/blob/main/docs/exec.md)
+- [OpenAI Docs MCP setup for Codex and other clients](https://developers.openai.com/learn/docs-mcp)

--- a/docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md
+++ b/docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md
@@ -24,7 +24,7 @@ The branch's spec and a completely different spec on main (the Codex-authored Se
 - `docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md`
 - `docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md`
 
-Audit's `evidence/2026-04-29-codex-jsonl-probe.md` can stay (no collision).
+Audit's `evidence/2026-04-29-codex-cli-jsonl-probe.md` can stay (no collision).
 
 ## 2. Spec section reconciliation
 

--- a/docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md
+++ b/docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md
@@ -1,0 +1,129 @@
+# Coworker Execution Adapter Substrate — Spec Reconciliation Against main (2026-05-16)
+
+| Field | Value |
+| --- | --- |
+| **Status** | Reconciliation pass — does the 2026-04-29 design still hold after 16 days and 267 commits on `origin/main`? |
+| **Created** | 2026-05-16 |
+| **Author** | Claude Opus 4.7 (1M ctx) for Mark Bodman, resuming `feat/coworker-c-status-and-a2a-sequencing` |
+| **Scope** | Spec: `2026-04-29-cli-execution-adapter-routing-design.md` (branch copy). Plan: `2026-04-29-cli-execution-adapter-routing-plan.md` (branch copy). Branch HEAD: `a1decd3f` (267 commits behind `origin/main` @ `95daabea`). |
+| **Branch commits in scope** | `01221806` (spec+audit+evidence), `657b560c` (plan), `a076e887` (A1 — AdapterCapabilityProfile), `35f3162e` (A2 — AdapterRunTelemetry), `6ed3cf91` (A3 — AgentThread.cliSession\*), `6814ecdc` (A4 — ExecutionAdapterSelector types), `a1decd3f` (A5 — capability probes + DB cache) |
+
+---
+
+## Headline
+
+**The branch's design is still viable.** No newer spec proposes its own adapter taxonomy, capability profile table, or shadow/race mechanism. The 5 shipped commits (A1–A5) sit on schema and routing surface that no other PR has touched. Two real frictions exist (A6 vs PR #520; Phase C vs PR #602) and both are rescope, not abandon. The branch's spec at `docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md` **collides on filename with a different-content spec on main** (PR #350, in-process orchestration primitives). That must be resolved before PR.
+
+## 1. Filename collision — must fix before PR
+
+The branch's spec and a completely different spec on main (the Codex-authored Sequential/Parallel/Loop/Branch in-process orchestration primitives, landed via [PR #350](https://github.com/anthropics/apps/pull/350) commit `6cb090b1`) share the exact path `docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md`. They are about different problems (routing-layer adapters vs. in-process control flow). Main also carries a partial-duplicate primitives spec by Claude at `2026-04-29-orchestration-primitives-design.md` and a supersession-decision audit (`2026-04-29-orchestration-supersession-decision.md`) noting the merge is unfinished.
+
+**Action:** rename the branch's three artifacts before opening PR. Suggested names that signal the routing-layer concern explicitly:
+
+- `docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md`
+- `docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md`
+- `docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md`
+
+Audit's `evidence/2026-04-29-codex-jsonl-probe.md` can stay (no collision).
+
+## 2. Spec section reconciliation
+
+| Spec § | Status | Note |
+| --- | --- | --- |
+| §1 Problem statement | ⚠️ **shifted but compatible** | The "→ adapter-registry → chat-adapter" path is partially wrong on main. Actual chain: `routed-inference.ts → pipeline-v2 → fallback.callWithFallbackChain → ai-inference.callProvider → execution-adapter-registry.getExecutionAdapter`. `adapter-registry.ts` is now ModelCard metadata only (174 lines); `execution-adapter-registry.ts` (28 lines, populated at import by chat/cli/codex-cli/responses/embedding/image-gen/async/transcription adapters) is the canonical execution dispatcher. Update §1 wording. |
+| §2 Non-goals | ✅ accurate | No change. |
+| §3 Architectural model (six components) | ✅ accurate | ExecutionAdapter interface and component split still match repo shape. |
+| §4.1 `AdapterCapabilityProfile` | ✅ accurate | **Already shipped on branch (A1).** Not on main; no parallel PR introduced an equivalent. |
+| §4.2 `AgentThread.cliSession*` | ✅ accurate | **Already shipped on branch (A3).** Main's `AgentThread` (schema.prisma:2869) has no equivalent columns. |
+| §4.3 `AdapterRunTelemetry` | ✅ accurate | **Already shipped on branch (A2).** Disjoint from `SkillUsageEvent` (PR #623 — per-skill, not per-adapter-run). Disjoint from `RouteDecisionLog` / `RouteOutcome` attribution columns (PR #607 — per-decision, not per-adapter-run). A7 should follow #607's `agentId` and #623's `skillId` columns for cross-table joinability. |
+| §4.4 Hard-coded CLI check at `ai-inference.ts:353` | ⚠️ **needs rescope** | Line 353 still has `const isCliAdapter = ...`. But [PR #520](https://github.com/anthropics/apps/pull/520) (`d5ae950d`, merged 2026-05-13) added `createMcpSessionToken` plumbing through `callProvider` → `cli-adapter.ts` and refactored the cli-adapter to mount platform tools via `--mcp-config <path> --strict-mcp-config` when an mcp session token is present. **This is partial structured adapter resolution already.** Phase A6 now means "extend the existing token-gated selector into a full registry resolution," not "introduce one from zero." |
+| §5 Route plan extension | ✅ accurate | `executionAdapter` is already a string field on `RoutedExecutionPlan` (`execution-plan.ts:70-83`). A4 shipped the `ExecutionAdapterSelector` types on branch. |
+| §6 Execution modes (single/shadow/race) | ✅ greenfield | No shadow/race on main. F and G are unopposed. |
+| §7 CLI ToolExecution custody | ⚠️ **citation stale, concept partially obsolete for Claude CLI** | The `agentic-loop.ts:1027` citation is wrong on main — line 1027 is nudge logic; ToolExecution minting lives at `apps/web/lib/mcp-governed-execute.ts:206`. More important: PR #520 already routes `mcp__dpf__*` tool_use blocks emitted by Claude CLI through the MCP server back into `governedExecuteTool`, which mints `ToolExecution` rows tagged `source: "internal-mcp-session"`. So for **Claude CLI + MCP-mounted tools, custody is already closed.** The remaining custody gap is: (a) Claude CLI's *native* tools (Bash, Read, Write, etc.) inside the harness, and (b) all Codex CLI tool calls. Phase B6 (mint from Codex events) still applies. |
+| §8 Event normalization | ✅ accurate | No competing normalizer on main. Visual Control Surface spec (2026-05-10) explicitly consumes `NormalizedEvent` from this spec. |
+| §9 CLI session lifecycle | ⚠️ **needs rescope vs WorkCapsule** | [PR #602](https://github.com/anthropics/apps/pull/602) added `WorkCapsule` + `WorkCapsuleActivity` tables with `executorKind`, `executorRef`, `sandboxProviderId`, `sandboxId`, `worktreePath`, `leaseExpiresAt`, `leaseHolderPrincipalId`. That's the same problem space (sandbox lease lifecycle + sweeper). Phase C's `CliSessionService` should **attach to WorkCapsule** (FK or shared identifier) at the panel-thread grain, not parallel the work-unit grain. Boundary statement needed in §9. |
+| §10 Panel cockpit UX | ⚠️ **needs composition with shipped surfaces** | Phase E is **not redundant** — `2026-05-10-ai-coworker-visual-control-surface-design.md` is a many-coworker Operations Map, not a per-thread cockpit, and explicitly consumes this spec's events. But two shipped surfaces must compose with the cockpit: `AgentSkillAttributionChip` and the `/platform/ai/skills` Telemetry tab from [PR #629](https://github.com/anthropics/apps/pull/629). Cockpit should layer adapter-health LED + skill-attribution chip into one header, not three competing chips. |
+| §11 MCP boundary | ✅ accurate, partially shipped | PR #520 implemented the per-call JWT scoping piece for Claude CLI. §11.3 Codex static-attach rule still applies and is greenfield. |
+| §12 Phase A acceptance | ⚠️ **partially shipped** | "every existing coworker run works identically, but the route plan carries structured executionAdapter and writes a telemetry row" — A1–A5 land schema and probes; A6+A7 are still required to satisfy the acceptance gate. |
+| §13 Open risks | ✅ accurate | PR #608 (provider overload classification) ratifies risk #1 mitigation pattern; Phase B should mirror its error taxonomy. |
+| §14 Telemetry/observability | ✅ accurate | Should layer on top of PR #607 attribution columns. |
+| §15 Migration/BC | ✅ accurate | No change. |
+
+## 3. Plan task reconciliation
+
+| Task | Reconciled status |
+| --- | --- |
+| A1 — `AdapterCapabilityProfile` model | **shipped on branch**; still applies (no main collision) |
+| A2 — `AdapterRunTelemetry` model | **shipped on branch**; still applies; A7 should add `agentId` (#607 convention) and `skillId` (#623 precedent) |
+| A3 — `AgentThread.cliSession*` columns | **shipped on branch**; still applies; consider FK to `WorkCapsule` per #602 (rescope question for C) |
+| A4 — `ExecutionAdapterSelector` types | **shipped on branch**; still applies |
+| A5 — capability probes + DB cache | **shipped on branch**; still applies |
+| **A6 — replace hard-coded `isCliAdapter` check** | **needs-rescope** (partially-superseded-by #520). New task: extend the existing `mcpSession`-gated selector in `cli-adapter.ts` + `ai-inference.ts` into a full `ExecutionAdapterSelector` registry resolution that subsumes both the `isCliAdapter` short-circuit and the MCP-mode toggle. Tests must hold #520's tool-mounting behavior. |
+| A7 — wire telemetry write | **still-applies**; add `agentId` + `skillId` columns to follow shipped conventions |
+| A8 — Phase A integration verification | **still-applies** |
+| B1 — `NormalizedEvent` taxonomy | still-applies |
+| B2 — Codex JSONL replay fixtures | still-applies |
+| B3 — Codex event normalizer | still-applies |
+| B4 — Schema-drift detector | still-applies |
+| B5 — MCP-active + `--json` refusal guard | still-applies |
+| B6 — ToolExecution minting from Codex events | still-applies (closes the Codex half of the custody gap; #520 closed Claude+MCP half) |
+| B7 — Codex `--json` mode behind feature flag | still-applies |
+| B8 — Phase B PR | still-applies |
+| C0 — locate cron substrate (pre-work) | still-applies |
+| **C1–C5 — `CliSessionService`** | **needs-rescope** vs WorkCapsule (#602). Probably reshapes as: `CliSessionService` becomes the panel-thread mapper that consumes a `WorkCapsule` lease instead of allocating its own sandbox slot. |
+| D1–D4 — Claude CLI normalizer parity | still-applies |
+| E1–E9 — Panel cockpit UI | **still-applies but rescope E4/E7/E8** to compose with `AgentSkillAttributionChip` and Telemetry tab from #629; verify Operations Map (2026-05-10) co-existence |
+| F1–F5 — Shadow mode | still-applies (greenfield) |
+| G1–G4 — Race mode | still-applies (greenfield) |
+| H1–H5 — Refactor allocation | still-applies; H4 (unify CLI session ID generation) gets harder if WorkCapsule owns the lease |
+
+## 4. Things in your prompt that don't exist on main
+
+The pause-resume prompt listed three documents that **do not exist** in `origin/main`:
+
+- `specs/2026-05-14-coworker-memory-shape-contracts-design.md` — not found
+- `audits/2026-05-12-build-coworker-tool-rejection-observations.md` — not found
+- `plans/2026-05-13-ai-routing-topology-map.md` — not found
+
+The closest extant artifact is `plans/2026-05-11-ai-routing-ux-verification-test-architecture.md` (an approved+partially-executed test plan). If those three docs lived in a different worktree that didn't merge, they may still be load-bearing context you have but the branch doesn't see. Worth confirming before relying on them.
+
+## 5. Resume options (with trade-offs)
+
+### Option α — open PR for Phase A as-is (5 shipped commits, no A6/A7/A8)
+
+- **Pros:** smallest action; lands schema + types + probes so any follow-on work has a substrate; preserves the original commits intact.
+- **Cons:** Phase A acceptance criteria explicitly require A6 (structured resolution) and A7 (telemetry write site). Without them, the schema is dead weight on main. Risk: orphaned tables.
+- **Verdict:** rejected. Schema-without-writer is worse than nothing.
+
+### Option β — rebase onto main, complete A6/A7/A8 with current-state awareness, then PR Phase A
+
+- **Pros:** Phase A acceptance criteria met. The rebase blast radius is small in practice because A1/A2/A4/A5 add *new files* and only A3 touches `schema.prisma` (the `AgentThread` model, which has not had `cliSession*` columns added by any parallel PR). The two real rescopes (A6 vs #520; Phase C vs #602 — but C is later) can be absorbed into the same Phase A PR for A6. Net design held; integration risk known and bounded.
+- **Cons:** 267-commit rebase cognitively expensive; cli-adapter.ts and ai-inference.ts have moved meaningfully (#520, #608, #520-adjacent). A6 work is real (not a one-line edit) because it must subsume both the `isCliAdapter` short-circuit and the `createMcpSessionToken` mounting toggle.
+- **Verdict:** **recommended.**
+
+### Option γ — abandon branch, rewrite Phase A from scratch against main
+
+- **Pros:** clean slate.
+- **Cons:** throws away 5 working commits whose content is still correct as-of main. The schema models are good; the types are good; the probes are good. Rewriting just to re-author them is waste.
+- **Verdict:** rejected. No design has shifted enough to warrant a rewrite.
+
+## Recommendation
+
+**Option β with two scope additions before pushing:**
+
+1. **Rename the spec, plan, and audit** to disambiguate from main's same-named orchestration primitives spec (see §1 above).
+2. **Update §1 / §4.4 / §7 / §9 / §10 of the spec** with the four reconciliation notes from §2 of this audit — corrected file paths and the explicit boundary statements vs. #520, #602, #607, #623/#629, the Visual Control Surface spec, and the Operations Map spec. Update the plan's A6 task body to reflect the rescope.
+
+Then rebase onto `origin/main`, finish A6/A7/A8 against the rebased tree, and open the Phase A PR. Phase C's WorkCapsule rescope is a known future cost and does not block Phase A.
+
+## Reflog for the 7 branch commits (for `git show` later)
+
+```
+01221806 spec(coworker): execution adapter substrate — audit + design + Codex evidence
+657b560c plan(coworker): execution adapter substrate — 8 phases, TDD task decomposition
+a076e887 feat(routing): add AdapterCapabilityProfile prisma model (Phase A1)
+35f3162e feat(routing): add AdapterRunTelemetry prisma model (Phase A2)
+6ed3cf91 feat(coworker): add AgentThread.cliSession* columns (Phase A3)
+6814ecdc feat(routing): add ExecutionAdapterSelector + capability requirement types (Phase A4)
+a1decd3f feat(routing): adapter capability probes + DB-backed cache (Phase A5)
+```

--- a/docs/superpowers/audits/evidence/2026-04-29-codex-cli-jsonl-probe.md
+++ b/docs/superpowers/audits/evidence/2026-04-29-codex-cli-jsonl-probe.md
@@ -1,0 +1,104 @@
+# Codex CLI JSONL probe — local evidence
+
+**Date:** 2026-04-29
+**Container:** dpf-sandbox-1
+**Codex version:** codex-cli 0.125.0
+**Purpose:** Capture actual `codex exec --json` event stream to ground audit Q1.
+
+## Probe 1 — basic exec with shell command (default model)
+
+Command:
+```
+codex exec --json --skip-git-repo-check --ephemeral --dangerously-bypass-approvals-and-sandbox \
+  "Run the shell command: echo hello-from-codex. Then say done."
+```
+
+Stream:
+```jsonl
+{"type":"thread.started","thread_id":"019ddb89-fb33-7f31-87cc-6d455b3067fa"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/sh -lc 'echo hello-from-codex'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/sh -lc 'echo hello-from-codex'","aggregated_output":"hello-from-codex\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":28803,"cached_input_tokens":26368,"output_tokens":38,"reasoning_output_tokens":0}}
+```
+
+## Probe 2 — reasoning effort high, simple answer
+
+Command:
+```
+codex exec --json -c reasoning.effort=high "Think briefly about 2+2, then answer."
+```
+
+Stream:
+```jsonl
+{"type":"thread.started","thread_id":"019ddb8a-21ca-7493-b1bf-eb002585bcc7"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2 + 2 = 4"}}
+{"type":"turn.completed","usage":{"input_tokens":14353,"cached_input_tokens":12160,"output_tokens":21,"reasoning_output_tokens":8}}
+```
+
+Note: `reasoning_output_tokens: 8` is reported in usage, but no `reasoning` item was emitted in the stream for this short turn. May surface as `item.completed` with `type: reasoning` for longer turns.
+
+## Probe 3 — gpt-5 explicitly (failure case for ChatGPT auth)
+
+Command:
+```
+codex exec --json -m gpt-5 "Reply with one short sentence. Then stop."
+```
+
+Stream:
+```jsonl
+{"type":"thread.started","thread_id":"019ddb89-dca6-7593-afcf-fa9e6ea7b201"}
+{"type":"turn.started"}
+{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5' model is not supported when using Codex with a ChatGPT account.\"}}"}
+{"type":"turn.failed","error":{"message":"..."}}
+```
+
+## Surface inventory (`codex --help` and `codex exec --help`)
+
+Subcommands of interest:
+- `exec` — non-interactive run (with `--json`, `--output-schema`, `--output-last-message`, `--ephemeral`)
+- `exec resume` — resume by session UUID or `--last`
+- `mcp` — list / get / add / remove / login / logout MCP servers (static, in `~/.codex/config.toml`)
+- `mcp-server` — Codex itself runs as an MCP server over stdio
+- `apply` / `a` — applies the latest agent diff via `git apply` to local working tree
+- `sandbox` — run commands in the Codex sandbox
+- `exec-server` (experimental) — standalone exec service
+- `cloud` (experimental) — Codex Cloud task browser
+- `review` — non-interactive code review
+
+Flags of interest on `exec`:
+- `--json` (JSONL stream)
+- `--output-schema <file>` (JSON Schema for final response — gpt-5 family only per issue #4181)
+- `--output-last-message <file>` (final message only)
+- `--ephemeral` (no session persistence)
+- `-s read-only|workspace-write|danger-full-access` (sandbox modes)
+- `--add-dir <DIR>` (extra writable dirs)
+- `-C, --cd <DIR>` (working root)
+- `--ignore-user-config`, `--ignore-rules`
+- `--skip-git-repo-check`
+
+## Observed event taxonomy
+
+From these probes plus issue research:
+
+| `type` | When | Fields |
+|---|---|---|
+| `thread.started` | first event | `thread_id` (UUID) |
+| `turn.started` | per turn | — |
+| `item.started` | tool/cmd begins | `item.{id,type,...}` |
+| `item.completed` | tool/cmd ends, or message | `item.{id,type,text/command/...}` |
+| `turn.completed` | success | `usage.{input_tokens,cached_input_tokens,output_tokens,reasoning_output_tokens}` |
+| `turn.failed` | failure | `error.{message}` |
+| `error` | mid-turn error | `message` |
+
+`item.type` values seen / documented: `agent_message`, `command_execution`, `reasoning`, `file_change`, `mcp_tool_call`, `web_search`, `plan_update`.
+
+## Stability caveats (from agent research)
+
+- `--json` was `--experimental-json` until recently; underlying schema is not versioned.
+- Silent breaking rename observed in recent versions: `item_type` → `type`, `assistant_message` → `agent_message` (issue #4776).
+- `--json` and `--output-schema` are silently ignored when MCP tools are active (issue #15451).
+- MCP lifecycle events (init/ready/failed) are not yet emitted (issue #17501).
+- No schema version field in events.

--- a/docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
+++ b/docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
@@ -1,104 +1,146 @@
-# Codex CLI JSONL probe — local evidence
+# Codex probe evidence - 2026-04-29
 
-**Date:** 2026-04-29
-**Container:** dpf-sandbox-1
-**Codex version:** codex-cli 0.125.0
-**Purpose:** Capture actual `codex exec --json` event stream to ground audit Q1.
+This note captures the repo-grounded probes used to repair the coworker substrate design on 2026-04-29. Despite the filename, this is not a raw session dump. It is the distilled evidence record that the audit and spec cite.
 
-## Probe 1 — basic exec with shell command (default model)
+## Scope
 
-Command:
-```
-codex exec --json --skip-git-repo-check --ephemeral --dangerously-bypass-approvals-and-sandbox \
-  "Run the shell command: echo hello-from-codex. Then say done."
-```
+- Verify the real event-bus location and current shape
+- Verify the current task-state vocabulary
+- Verify concrete retry, polling, sequential, and fan-out call sites
+- Verify where current code still returns ambiguous timeout/deferred semantics
+- Verify overlap with the older execution-adapter design
 
-Stream:
-```jsonl
-{"type":"thread.started","thread_id":"019ddb89-fb33-7f31-87cc-6d455b3067fa"}
-{"type":"turn.started"}
-{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/sh -lc 'echo hello-from-codex'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
-{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/sh -lc 'echo hello-from-codex'","aggregated_output":"hello-from-codex\n","exit_code":0,"status":"completed"}}
-{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
-{"type":"turn.completed","usage":{"input_tokens":28803,"cached_input_tokens":26368,"output_tokens":38,"reasoning_output_tokens":0}}
-```
+## Evidence
 
-## Probe 2 — reasoning effort high, simple answer
+### E1. Event bus is already task-aware, but still thread-keyed
 
-Command:
-```
-codex exec --json -c reasoning.effort=high "Think briefly about 2+2, then answer."
-```
+Files:
 
-Stream:
-```jsonl
-{"type":"thread.started","thread_id":"019ddb8a-21ca-7493-b1bf-eb002585bcc7"}
-{"type":"turn.started"}
-{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2 + 2 = 4"}}
-{"type":"turn.completed","usage":{"input_tokens":14353,"cached_input_tokens":12160,"output_tokens":21,"reasoning_output_tokens":8}}
-```
+- canonical implementation: [`apps/web/lib/tak/agent-event-bus.ts`](../../../../apps/web/lib/tak/agent-event-bus.ts) (~120 lines)
+- intentional shim: [`apps/web/lib/agent-event-bus.ts`](../../../../apps/web/lib/agent-event-bus.ts) (2 lines, `export * from "./tak/agent-event-bus";`)
 
-Note: `reasoning_output_tokens: 8` is reported in usage, but no `reasoning` item was emitted in the stream for this short turn. May surface as `item.completed` with `type: reasoning` for longer turns.
+Observed:
 
-## Probe 3 — gpt-5 explicitly (failure case for ChatGPT auth)
+- subscribers are keyed by `threadId`
+- current API is `subscribe(threadId, handler)` and `emit(threadId, event)`
+- event union already includes `task:status` and `task:artifact`
+- imports across the codebase use both paths; both resolve to the same module via the shim
 
-Command:
-```
-codex exec --json -m gpt-5 "Reply with one short sentence. Then stop."
-```
+Implication:
 
-Stream:
-```jsonl
-{"type":"thread.started","thread_id":"019ddb89-dca6-7593-afcf-fa9e6ea7b201"}
-{"type":"turn.started"}
-{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5' model is not supported when using Codex with a ChatGPT account.\"}}"}
-{"type":"turn.failed","error":{"message":"..."}}
-```
+- the substrate should extend the `tak/`-scoped implementation rather than propose a net-new task event family from scratch
+- compatibility shims matter because multiple current event families already exist here, and the top-level path is itself a compatibility shim that callers may still rely on
 
-## Surface inventory (`codex --help` and `codex exec --help`)
+### E2. Task-state vocabulary already exists and already matches the intended A2A-shaped direction
 
-Subcommands of interest:
-- `exec` — non-interactive run (with `--json`, `--output-schema`, `--output-last-message`, `--ephemeral`)
-- `exec resume` — resume by session UUID or `--last`
-- `mcp` — list / get / add / remove / login / logout MCP servers (static, in `~/.codex/config.toml`)
-- `mcp-server` — Codex itself runs as an MCP server over stdio
-- `apply` / `a` — applies the latest agent diff via `git apply` to local working tree
-- `sandbox` — run commands in the Codex sandbox
-- `exec-server` (experimental) — standalone exec service
-- `cloud` (experimental) — Codex Cloud task browser
-- `review` — non-interactive code review
+File:
 
-Flags of interest on `exec`:
-- `--json` (JSONL stream)
-- `--output-schema <file>` (JSON Schema for final response — gpt-5 family only per issue #4181)
-- `--output-last-message <file>` (final message only)
-- `--ephemeral` (no session persistence)
-- `-s read-only|workspace-write|danger-full-access` (sandbox modes)
-- `--add-dir <DIR>` (extra writable dirs)
-- `-C, --cd <DIR>` (working root)
-- `--ignore-user-config`, `--ignore-rules`
-- `--skip-git-repo-check`
+- [`apps/web/lib/tak/task-states.ts`](../../../apps/web/lib/tak/task-states.ts)
 
-## Observed event taxonomy
+Observed states:
 
-From these probes plus issue research:
+- `submitted`
+- `working`
+- `input-required`
+- `auth-required`
+- `completed`
+- `failed`
+- `canceled`
+- `rejected`
+- `archived`
 
-| `type` | When | Fields |
-|---|---|---|
-| `thread.started` | first event | `thread_id` (UUID) |
-| `turn.started` | per turn | — |
-| `item.started` | tool/cmd begins | `item.{id,type,...}` |
-| `item.completed` | tool/cmd ends, or message | `item.{id,type,text/command/...}` |
-| `turn.completed` | success | `usage.{input_tokens,cached_input_tokens,output_tokens,reasoning_output_tokens}` |
-| `turn.failed` | failure | `error.{message}` |
-| `error` | mid-turn error | `message` |
+Implication:
 
-`item.type` values seen / documented: `agent_message`, `command_execution`, `reasoning`, `file_change`, `mcp_tool_call`, `web_search`, `plan_update`.
+- the substrate should reuse the existing state vocabulary
+- docs should not present these as a fresh proposal
 
-## Stability caveats (from agent research)
+### E3. Build Studio already contains the substrate-worthy patterns
 
-- `--json` was `--experimental-json` until recently; underlying schema is not versioned.
-- Silent breaking rename observed in recent versions: `item_type` → `type`, `assistant_message` → `agent_message` (issue #4776).
-- `--json` and `--output-schema` are silently ignored when MCP tools are active (issue #15451).
-- MCP lifecycle events (init/ready/failed) are not yet emitted (issue #17501).
-- No schema version field in events.
+File:
+
+- [`apps/web/lib/integrate/build-orchestrator.ts`](../../../apps/web/lib/integrate/build-orchestrator.ts)
+
+Observed:
+
+- bounded retry constant: `MAX_SPECIALIST_RETRIES = 2`
+- sequential phase execution via `for (const phase of phases)`
+- batched parallel dispatch with `Promise.all(...)`
+- optimistic merge retry path around task-result persistence
+
+Implication:
+
+- Build Studio is the best early proving ground for the substrate after low-risk loops
+- the migration can reduce real duplication immediately without starting at the main coworker loop
+
+### E4. Provider fallback still walks a custom retry/backoff chain
+
+File:
+
+- [`apps/web/lib/routing/fallback.ts`](../../../apps/web/lib/routing/fallback.ts)
+
+Observed:
+
+- fallback chain built from routing decision candidates
+- retry/backoff implemented inline in the loop
+- special handling for rate limits, auth failures, and model retirement lives inside the same call path
+
+Implication:
+
+- this path is a strong later `Loop` consumer
+- it should migrate only after the substrate has already proved itself on lower-risk cases
+
+### E5. GitHub fork readiness still returns an ambiguous `"deferred"` status after polling
+
+File:
+
+- [`apps/web/lib/integrate/github-fork.ts`](../../../apps/web/lib/integrate/github-fork.ts)
+
+Observed:
+
+- fork creation polls until ready
+- timeout returns `{ status: "deferred" }`
+
+Implication:
+
+- this is a clean first migration target for typed exhausted or still-pending outcomes
+- it exercises polling semantics without the blast radius of the main coworker runtime
+
+### E6. Deliberation runner is still sequential and branch-oriented
+
+File:
+
+- [`apps/web/lib/queue/functions/deliberation-run.ts`](../../../apps/web/lib/queue/functions/deliberation-run.ts)
+
+Observed:
+
+- branch nodes are separated into worker branches and adjudicator branches
+- worker branches run through a sequential `for` loop
+- route decisions and diversity degradation are persisted/emitted inline
+
+Implication:
+
+- the future `Branch` primitive should model strategic branch semantics here
+- this lane is a semantic upgrade, not just a wrapper extraction
+
+### E7. Older "execution adapter" already means something else in DPF
+
+Files:
+
+- [`docs/superpowers/specs/2026-03-20-execution-adapter-framework-design.md`](../../specs/2026-03-20-execution-adapter-framework-design.md)
+- [`docs/superpowers/plans/2026-03-20-execution-adapter-framework.md`](../../plans/2026-03-20-execution-adapter-framework.md)
+
+Observed:
+
+- execution adapter there means provider-dispatch adapters around `callProvider()`
+- scope is routing/provider execution, not coworker/runtime orchestration
+
+Implication:
+
+- the new lane needs qualified naming to avoid architecture and PR-review confusion
+
+## Conclusions
+
+1. The substrate problem is real and already visible in the repo.
+2. The 2026-04-29 draft had the right instinct but needed tighter repo grounding.
+3. Build Studio should be the first major consumer after the low-risk loop migrations.
+4. The terminology must separate routing execution adapters from coworker execution substrate work.

--- a/docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
+++ b/docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md
@@ -1,146 +1,104 @@
-# Codex probe evidence - 2026-04-29
+# Codex CLI JSONL probe — local evidence
 
-This note captures the repo-grounded probes used to repair the coworker substrate design on 2026-04-29. Despite the filename, this is not a raw session dump. It is the distilled evidence record that the audit and spec cite.
+**Date:** 2026-04-29
+**Container:** dpf-sandbox-1
+**Codex version:** codex-cli 0.125.0
+**Purpose:** Capture actual `codex exec --json` event stream to ground audit Q1.
 
-## Scope
+## Probe 1 — basic exec with shell command (default model)
 
-- Verify the real event-bus location and current shape
-- Verify the current task-state vocabulary
-- Verify concrete retry, polling, sequential, and fan-out call sites
-- Verify where current code still returns ambiguous timeout/deferred semantics
-- Verify overlap with the older execution-adapter design
+Command:
+```
+codex exec --json --skip-git-repo-check --ephemeral --dangerously-bypass-approvals-and-sandbox \
+  "Run the shell command: echo hello-from-codex. Then say done."
+```
 
-## Evidence
+Stream:
+```jsonl
+{"type":"thread.started","thread_id":"019ddb89-fb33-7f31-87cc-6d455b3067fa"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/sh -lc 'echo hello-from-codex'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/sh -lc 'echo hello-from-codex'","aggregated_output":"hello-from-codex\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":28803,"cached_input_tokens":26368,"output_tokens":38,"reasoning_output_tokens":0}}
+```
 
-### E1. Event bus is already task-aware, but still thread-keyed
+## Probe 2 — reasoning effort high, simple answer
 
-Files:
+Command:
+```
+codex exec --json -c reasoning.effort=high "Think briefly about 2+2, then answer."
+```
 
-- canonical implementation: [`apps/web/lib/tak/agent-event-bus.ts`](../../../../apps/web/lib/tak/agent-event-bus.ts) (~120 lines)
-- intentional shim: [`apps/web/lib/agent-event-bus.ts`](../../../../apps/web/lib/agent-event-bus.ts) (2 lines, `export * from "./tak/agent-event-bus";`)
+Stream:
+```jsonl
+{"type":"thread.started","thread_id":"019ddb8a-21ca-7493-b1bf-eb002585bcc7"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2 + 2 = 4"}}
+{"type":"turn.completed","usage":{"input_tokens":14353,"cached_input_tokens":12160,"output_tokens":21,"reasoning_output_tokens":8}}
+```
 
-Observed:
+Note: `reasoning_output_tokens: 8` is reported in usage, but no `reasoning` item was emitted in the stream for this short turn. May surface as `item.completed` with `type: reasoning` for longer turns.
 
-- subscribers are keyed by `threadId`
-- current API is `subscribe(threadId, handler)` and `emit(threadId, event)`
-- event union already includes `task:status` and `task:artifact`
-- imports across the codebase use both paths; both resolve to the same module via the shim
+## Probe 3 — gpt-5 explicitly (failure case for ChatGPT auth)
 
-Implication:
+Command:
+```
+codex exec --json -m gpt-5 "Reply with one short sentence. Then stop."
+```
 
-- the substrate should extend the `tak/`-scoped implementation rather than propose a net-new task event family from scratch
-- compatibility shims matter because multiple current event families already exist here, and the top-level path is itself a compatibility shim that callers may still rely on
+Stream:
+```jsonl
+{"type":"thread.started","thread_id":"019ddb89-dca6-7593-afcf-fa9e6ea7b201"}
+{"type":"turn.started"}
+{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5' model is not supported when using Codex with a ChatGPT account.\"}}"}
+{"type":"turn.failed","error":{"message":"..."}}
+```
 
-### E2. Task-state vocabulary already exists and already matches the intended A2A-shaped direction
+## Surface inventory (`codex --help` and `codex exec --help`)
 
-File:
+Subcommands of interest:
+- `exec` — non-interactive run (with `--json`, `--output-schema`, `--output-last-message`, `--ephemeral`)
+- `exec resume` — resume by session UUID or `--last`
+- `mcp` — list / get / add / remove / login / logout MCP servers (static, in `~/.codex/config.toml`)
+- `mcp-server` — Codex itself runs as an MCP server over stdio
+- `apply` / `a` — applies the latest agent diff via `git apply` to local working tree
+- `sandbox` — run commands in the Codex sandbox
+- `exec-server` (experimental) — standalone exec service
+- `cloud` (experimental) — Codex Cloud task browser
+- `review` — non-interactive code review
 
-- [`apps/web/lib/tak/task-states.ts`](../../../apps/web/lib/tak/task-states.ts)
+Flags of interest on `exec`:
+- `--json` (JSONL stream)
+- `--output-schema <file>` (JSON Schema for final response — gpt-5 family only per issue #4181)
+- `--output-last-message <file>` (final message only)
+- `--ephemeral` (no session persistence)
+- `-s read-only|workspace-write|danger-full-access` (sandbox modes)
+- `--add-dir <DIR>` (extra writable dirs)
+- `-C, --cd <DIR>` (working root)
+- `--ignore-user-config`, `--ignore-rules`
+- `--skip-git-repo-check`
 
-Observed states:
+## Observed event taxonomy
 
-- `submitted`
-- `working`
-- `input-required`
-- `auth-required`
-- `completed`
-- `failed`
-- `canceled`
-- `rejected`
-- `archived`
+From these probes plus issue research:
 
-Implication:
+| `type` | When | Fields |
+|---|---|---|
+| `thread.started` | first event | `thread_id` (UUID) |
+| `turn.started` | per turn | — |
+| `item.started` | tool/cmd begins | `item.{id,type,...}` |
+| `item.completed` | tool/cmd ends, or message | `item.{id,type,text/command/...}` |
+| `turn.completed` | success | `usage.{input_tokens,cached_input_tokens,output_tokens,reasoning_output_tokens}` |
+| `turn.failed` | failure | `error.{message}` |
+| `error` | mid-turn error | `message` |
 
-- the substrate should reuse the existing state vocabulary
-- docs should not present these as a fresh proposal
+`item.type` values seen / documented: `agent_message`, `command_execution`, `reasoning`, `file_change`, `mcp_tool_call`, `web_search`, `plan_update`.
 
-### E3. Build Studio already contains the substrate-worthy patterns
+## Stability caveats (from agent research)
 
-File:
-
-- [`apps/web/lib/integrate/build-orchestrator.ts`](../../../apps/web/lib/integrate/build-orchestrator.ts)
-
-Observed:
-
-- bounded retry constant: `MAX_SPECIALIST_RETRIES = 2`
-- sequential phase execution via `for (const phase of phases)`
-- batched parallel dispatch with `Promise.all(...)`
-- optimistic merge retry path around task-result persistence
-
-Implication:
-
-- Build Studio is the best early proving ground for the substrate after low-risk loops
-- the migration can reduce real duplication immediately without starting at the main coworker loop
-
-### E4. Provider fallback still walks a custom retry/backoff chain
-
-File:
-
-- [`apps/web/lib/routing/fallback.ts`](../../../apps/web/lib/routing/fallback.ts)
-
-Observed:
-
-- fallback chain built from routing decision candidates
-- retry/backoff implemented inline in the loop
-- special handling for rate limits, auth failures, and model retirement lives inside the same call path
-
-Implication:
-
-- this path is a strong later `Loop` consumer
-- it should migrate only after the substrate has already proved itself on lower-risk cases
-
-### E5. GitHub fork readiness still returns an ambiguous `"deferred"` status after polling
-
-File:
-
-- [`apps/web/lib/integrate/github-fork.ts`](../../../apps/web/lib/integrate/github-fork.ts)
-
-Observed:
-
-- fork creation polls until ready
-- timeout returns `{ status: "deferred" }`
-
-Implication:
-
-- this is a clean first migration target for typed exhausted or still-pending outcomes
-- it exercises polling semantics without the blast radius of the main coworker runtime
-
-### E6. Deliberation runner is still sequential and branch-oriented
-
-File:
-
-- [`apps/web/lib/queue/functions/deliberation-run.ts`](../../../apps/web/lib/queue/functions/deliberation-run.ts)
-
-Observed:
-
-- branch nodes are separated into worker branches and adjudicator branches
-- worker branches run through a sequential `for` loop
-- route decisions and diversity degradation are persisted/emitted inline
-
-Implication:
-
-- the future `Branch` primitive should model strategic branch semantics here
-- this lane is a semantic upgrade, not just a wrapper extraction
-
-### E7. Older "execution adapter" already means something else in DPF
-
-Files:
-
-- [`docs/superpowers/specs/2026-03-20-execution-adapter-framework-design.md`](../../specs/2026-03-20-execution-adapter-framework-design.md)
-- [`docs/superpowers/plans/2026-03-20-execution-adapter-framework.md`](../../plans/2026-03-20-execution-adapter-framework.md)
-
-Observed:
-
-- execution adapter there means provider-dispatch adapters around `callProvider()`
-- scope is routing/provider execution, not coworker/runtime orchestration
-
-Implication:
-
-- the new lane needs qualified naming to avoid architecture and PR-review confusion
-
-## Conclusions
-
-1. The substrate problem is real and already visible in the repo.
-2. The 2026-04-29 draft had the right instinct but needed tighter repo grounding.
-3. Build Studio should be the first major consumer after the low-risk loop migrations.
-4. The terminology must separate routing execution adapters from coworker execution substrate work.
+- `--json` was `--experimental-json` until recently; underlying schema is not versioned.
+- Silent breaking rename observed in recent versions: `item_type` → `type`, `assistant_message` → `agent_message` (issue #4776).
+- `--json` and `--output-schema` are silently ignored when MCP tools are active (issue #15451).
+- MCP lifecycle events (init/ready/failed) are not yet emitted (issue #17501).
+- No schema version field in events.

--- a/docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md
+++ b/docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md
@@ -11,7 +11,7 @@
 **Reference docs:**
 - Spec: [docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md)
 - Audit: [docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md](docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md)
-- Codex JSONL evidence: [docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md](docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md)
+- Codex JSONL evidence: [docs/superpowers/audits/evidence/2026-04-29-codex-cli-jsonl-probe.md](docs/superpowers/audits/evidence/2026-04-29-codex-cli-jsonl-probe.md)
 - Hard dependency (receipts): [docs/superpowers/specs/2026-04-27-artifact-provenance-receipts-design.md](docs/superpowers/specs/2026-04-27-artifact-provenance-receipts-design.md)
 
 ---
@@ -230,7 +230,7 @@ Steps:
 - Create: `apps/web/lib/routing/__fixtures__/codex-jsonl/probe-3-error.jsonl`
 - Create: `apps/web/lib/routing/__fixtures__/codex-jsonl/README.md`
 
-The three probes are documented in [docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md](docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md). Convert each `jsonl` block into a fixture file.
+The three probes are documented in [docs/superpowers/audits/evidence/2026-04-29-codex-cli-jsonl-probe.md](docs/superpowers/audits/evidence/2026-04-29-codex-cli-jsonl-probe.md). Convert each `jsonl` block into a fixture file.
 
 - [ ] **Step 1: Read the evidence file** — extract the three JSONL blocks.
 - [ ] **Step 2: Write each as one fixture file** — one event per line, no wrapping JSON. Match the evidence file exactly.

--- a/docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md
+++ b/docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md
@@ -1,0 +1,816 @@
+# Coworker Execution Adapter Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make execution adapter (HTTP, Claude Code CLI, Codex CLI, Codex-as-MCP) a first-class routing dimension with capability negotiation, per-thread CLI session lifecycle, normalized harness events, and shadow/race execution modes — so the coworker panel surfaces harness-native features safely.
+
+**Architecture:** Eight phases (A–H) extending the existing routing layer. Adapter registry already exists ([execution-adapter-registry.ts](apps/web/lib/routing/execution-adapter-registry.ts)) with `claude-cli` and `codex-cli` registered. Plan adds capability profiles, telemetry, per-thread CLI sessions, normalized event taxonomy, and shadow/race modes on top of that foundation. Phase H (refactor budget, ~20% of effort) threads through every preceding phase.
+
+**Tech Stack:** TypeScript, Next.js (apps/web), Prisma + PostgreSQL, Vitest, React (panel UI), docker exec into sandbox containers, Claude Code CLI, Codex CLI 0.125.0+, MCP stdio.
+
+**Reference docs:**
+- Spec: [docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md)
+- Audit: [docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md](docs/superpowers/audits/2026-04-29-cli-substrate-status-review.md)
+- Codex JSONL evidence: [docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md](docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md)
+- Hard dependency (receipts): [docs/superpowers/specs/2026-04-27-artifact-provenance-receipts-design.md](docs/superpowers/specs/2026-04-27-artifact-provenance-receipts-design.md)
+
+---
+
+## Reality check vs spec (2026-05-16 reconciliation)
+
+This plan was first authored 2026-04-29. On 2026-05-16 it was reconciled against `origin/main` (267 commits ahead of the original branch base). Reconciliation note: [docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md](docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md). Implementers must know the following:
+
+1. **`apps/web/lib/ai-inference.ts` is a 2-line re-export.** The real file is [apps/web/lib/inference/ai-inference.ts](apps/web/lib/inference/ai-inference.ts). Spec references resolve there.
+2. **`codex-cli-adapter.ts` already exists** at [apps/web/lib/routing/codex-cli-adapter.ts](apps/web/lib/routing/codex-cli-adapter.ts) (360 lines). Phase B is **extension**, not creation. It already shells out to `docker exec ... codex exec`, but does not parse `--json` output.
+3. **`executionAdapter` is a string field on `RoutedExecutionPlan` populated by [apps/web/lib/routing/execution-plan.ts:70-83](apps/web/lib/routing/execution-plan.ts#L70).** Phase A6 extends this to `string | ExecutionAdapterSelector` and adds the optional `capabilityRequirements` field. The `isCliAdapter` short-circuit at [ai-inference.ts:353-360](apps/web/lib/inference/ai-inference.ts#L353) is what Phase A6 replaces with `parseExecutionAdapterSelector` + `resolveExecutionAdapter`.
+4. **`AgentThread`** has no `cliSession*` columns on main; Phase A3 adds them via migration `20260516120200_add_agent_thread_cli_session`.
+5. **Receipts substrate (`ToolExecutionReceipt`) is shipped on main** as of 2026-04-30 (migration `20260430023000_artifact_provenance_receipts_slice_1`). Phase B6 can mint `ToolExecutionReceipt` rows directly; no fallback needed.
+6. **PR #520 (merged 2026-05-13) extended `cli-adapter.ts` to mount platform tools via `--mcp-config`** when an `mcpSession` token is present. Phase A6 preserves that path; the new `isCliAdapter` resolver derives the boolean from the structured selector kind and does not interfere with the MCP mount.
+7. **PR #607 (merged 2026-05-15) added `RouteDecisionLog.actorKind`/`actorId`/`agentId` + `RouteOutcome.agentId` attribution columns.** Phase A7 telemetry writes follow that convention by populating `AdapterRunTelemetry.agentId` from the same attribution context.
+8. **PR #623/#629 (merged 2026-05-15/16) added skill telemetry** (`SkillUsageEvent`, `ToolExecution.skillId`, `AgentSkillAttributionChip`, `/platform/ai/skills` Telemetry tab). Phase A7 populates `AdapterRunTelemetry.skillId` from the same active-skill context so adapter telemetry joins cleanly to skill telemetry.
+9. **PR #602 (merged 2026-05-14) introduced `WorkCapsule` + `WorkCapsuleActivity`** with sandbox lease lifecycle (`leaseExpiresAt`, sweeper). Phase C wires `CliSessionService.claim()` to consume an existing `WorkCapsule` lease rather than allocate its own sandbox slot. See spec §9.0 boundary statement.
+10. **PR #608 (merged 2026-05-15) added `overloaded` error classification** for Claude 529 / HTTP + CLI stderr. Phase B (Codex normalizer) mirrors this error taxonomy for parity.
+11. **Operations Map ([2026-05-10 spec](docs/superpowers/specs/2026-05-10-ai-coworker-visual-control-surface-design.md)) consumes this spec's `NormalizedEvent` shape**, does not replace Phase E. Many-coworker schematic vs one-thread cockpit are complementary surfaces.
+
+Phase A is sized for one PR (`A1–A8`). Phases B onward ship as separate PRs.
+
+---
+
+## DPF-specific operational rules (READ BEFORE COMMITTING)
+
+These apply to **every** task in this plan:
+
+1. **DCO sign-off required.** Every commit uses `git commit -s`. The DCO app rejects unsigned commits.
+2. **`git commit --only` with positional paths.** Concurrent Claude sessions may run in parallel worktrees and stage files in shared branches. Always commit only the files you wrote, by explicit path. Never `git add -A` or `git add .`.
+3. **Worktree cwd:** `d:\DPF-coworker-assess` — branch `feat/coworker-c-status-and-a2a-sequencing`. Do NOT commit into `d:\DPF` (main worktree).
+4. **Never wipe DB for code fixes.** When schema changes during development, use `pnpm prisma migrate dev` against the dev DB. Never `docker volume rm` against `dpf-postgres` — credentials and seed live there. If Prisma client generation drift, the pre-commit hook auto-regens (see commit `2f352bbf`).
+5. **Pre-commit only runs typecheck.** vitest must run locally before push. Pre-push hook will reject if tests fail. Always run `pnpm test --filter @dpf/web -- --run path/to/your.test.ts` before committing, and `pnpm test --filter @dpf/web -- --run` (no path) before push.
+6. **No mass bash on session start.** Do not auto-run `pnpm install`, `pnpm build`, `docker compose up`, or any heavy infra command without explicit go-ahead in the task.
+7. **Docker changes need explicit approval.** Tasks touching `docker-compose*.yml` or `Dockerfile*` must list the change and wait for human go before applying.
+8. **Update tests/docs alongside code.** Every code change includes test + doc update in the same commit.
+
+---
+
+## Phase A status (2026-05-16)
+
+Phase A is being shipped in this PR. Status of each task:
+
+| Task | Status | Commit (on branch `feat/coworker-c-status-and-a2a-sequencing`) |
+| --- | --- | --- |
+| A1 — `AdapterCapabilityProfile` model | **shipped** | `146ad988` |
+| A2 — `AdapterRunTelemetry` model (incl. `agentId` + `skillId` per PR #607/#623 conventions) | **shipped** | `e2e6f970` |
+| A3 — `AgentThread.cliSession*` columns + index | **shipped** | `9c19ebf1` |
+| A4 — `ExecutionAdapterSelector` + capability requirement types | **shipped** | `73480c15` |
+| A5 — capability probes + DB-backed cache | **shipped** | `2b15f68e` |
+| A6 — resolver + call-site swap (preserves PR #520 mcpSession plumbing; legacy-string passthrough for non-structured kinds) | **shipped** | `d9e01710` |
+| A7 — wire telemetry write at end of every coworker run | in this PR | (forthcoming commit) |
+| A8 — Phase A integration verification | in this PR | (forthcoming commit) |
+
+Phases B–H remain as separate PRs and follow the task descriptions below.
+
+## Phasing summary
+
+| Phase | Goal | PR-sized? | Depends on |
+| --- | --- | --- | --- |
+| **A** | Capability profile + telemetry tables; replace hard-coded CLI check with structured selector | Yes (single session) | None |
+| **B** | Codex CLI `--json` parsing + event normalizer + ToolExecution minting + MCP-`--json` refusal guard | Yes | A |
+| **C** | `CliSessionService` + per-thread session lifecycle + sandbox affinity + sweeper | Yes | A |
+| **D** | Claude CLI normalizer parity (thinking, todos, subagents, hooks) | Yes | B (taxonomy reuse) |
+| **E** | Coworker panel cockpit UI (zones, health LED, trace tab, role-gated disclosure) | Larger; split if needed | D |
+| **F** | Shadow execution mode + budget controls + nightly outcome scoring | Yes | A |
+| **G** | Race execution mode + quota-pool spreading | Yes | F |
+| **H** | Refactor allocation (interface extraction, panel state separation, ledger consolidation) | Threaded through every phase | — |
+
+---
+
+## Phase A: Capability profile + telemetry foundation
+
+**Spec acceptance:** "every existing coworker run works identically, but the route plan now carries a structured `executionAdapter` field and writes a telemetry row." (spec §12 Phase A)
+
+This phase is sized for one implementation session. Goal is zero behavior change in production paths plus two new DB tables and structured adapter resolution.
+
+### Task A1: Add `AdapterCapabilityProfile` Prisma model
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma` (append model near other adapter-related models — search for `model RoutingRecipeRun` and add nearby)
+- Test: `packages/db/test/adapter-capability-profile.test.ts` (new)
+
+- [ ] **Step 1: Write the failing schema test** — write a Vitest test that imports `PrismaClient`, creates an `AdapterCapabilityProfile` row, asserts the unique `[adapterKind, adapterVersion]` constraint rejects duplicates.
+- [ ] **Step 2: Run test, verify it fails** — `pnpm test --filter @dpf/db -- --run adapter-capability-profile.test.ts`. Expect "model not found" error.
+- [ ] **Step 3: Add the model to schema.prisma** — copy the schema from [spec §4.1](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#41-adaptercapabilityprofile-table-new) verbatim.
+- [ ] **Step 4: Generate Prisma migration** — `pnpm --filter @dpf/db prisma migrate dev --name add_adapter_capability_profile`. Verify the migration file is created under `packages/db/prisma/migrations/`.
+- [ ] **Step 5: Run test, verify it passes.**
+- [ ] **Step 6: Commit** — `git commit -s --only packages/db/prisma/schema.prisma packages/db/prisma/migrations/<timestamp>_add_adapter_capability_profile/migration.sql packages/db/test/adapter-capability-profile.test.ts -m "feat(routing): add AdapterCapabilityProfile prisma model (Phase A1)"`
+
+### Task A2: Add `AdapterRunTelemetry` Prisma model
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Test: `packages/db/test/adapter-run-telemetry.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** — create a row with all fields, assert `executionMode` enum-like values are accepted, assert `raceCohortId` index exists by querying `pg_indexes`.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Add the model from [spec §4.3](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#43-adapterruntelemetry-table-new) verbatim.**
+- [ ] **Step 4: Generate migration** — `pnpm --filter @dpf/db prisma migrate dev --name add_adapter_run_telemetry`.
+- [ ] **Step 5: Run test, verify it passes.**
+- [ ] **Step 6: Commit** — only the schema, migration, and test files.
+
+### Task A3: Add `AgentThread.cliSession*` columns
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma:2642-2654` (`model AgentThread`)
+- Test: `packages/db/test/agent-thread-cli-session.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** — create an `AgentThread`, set `cliSessionId = "test-uuid"`, `cliSessionLastUsedAt = new Date()`, fetch by `cliSessionId`, assert the index works.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Add columns** per [spec §4.2](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#42-agentthread-extension): `cliSessionId`, `cliSessionAdapterKind`, `cliSessionContainerId`, `cliSessionLastUsedAt`, `cliSessionWorkdir`, plus `@@index([cliSessionLastUsedAt])`.
+- [ ] **Step 4: Generate migration** — `pnpm --filter @dpf/db prisma migrate dev --name add_agent_thread_cli_session`.
+- [ ] **Step 5: Run test, verify it passes.**
+- [ ] **Step 6: Commit.**
+
+### Task A4: Define `ExecutionAdapterSelector` and `AdapterCapabilityRequirement` types
+
+**Files:**
+- Create: `apps/web/lib/routing/execution-adapter-types.ts`
+- Test: `apps/web/lib/routing/execution-adapter-types.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** — import the types, assert exhaustive `ExecutionAdapterKind` union via a type-level test using `assertType<>` or vitest type assertion. Assert that `parseExecutionAdapterSelector("claude-code-cli:oauth")` returns the expected object.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — copy types from [spec §5.1](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#51-new-executionadapterselector-field). Add a `parseExecutionAdapterSelector(s: string)` helper for round-tripping legacy string-typed `executionAdapter` field values (e.g. `"claude-cli"` → `{ kind: "claude-code-cli", authMode: "oauth" }`).
+- [ ] **Step 4: Run test, verify it passes.**
+- [ ] **Step 5: Commit.**
+
+### Task A5: Backfill capability profiles for current adapters
+
+**Files:**
+- Create: `apps/web/lib/routing/capability-probes/probe-claude-cli.ts`
+- Create: `apps/web/lib/routing/capability-probes/probe-codex-cli.ts`
+- Create: `apps/web/lib/routing/capability-probes/probe-http-anthropic.ts`
+- Create: `apps/web/lib/routing/capability-probes/probe-http-openai.ts`
+- Create: `apps/web/lib/routing/capability-profile-cache.ts`
+- Test: `apps/web/lib/routing/capability-profile-cache.test.ts` (new)
+- Test: `apps/web/lib/routing/capability-probes/probe-claude-cli.test.ts` (new)
+- Test: `apps/web/lib/routing/capability-probes/probe-codex-cli.test.ts` (new)
+
+For each probe, the function takes an `AdapterCapabilityProfile` shape (without `id`/`probedAt`) and returns it populated. HTTP probes are static (no actual HTTP calls — capability is known from provider docs). CLI probes shell out to `<cli> --version` to get adapter version, then return a profile.
+
+- [ ] **Step 1: Write failing tests for each probe** — one test per probe asserting the returned shape's expected booleans. For Codex: `supportsMcpAttach=true, supportsMcpAttachPerInvoke=false, knownDegradations=[{trigger: "--json + MCP", behavior: "stream malformed", source: "openai/codex#15451"}]`.
+- [ ] **Step 2: Write failing test for `capability-profile-cache.ts`** — `getOrProbeCapabilityProfile(adapterKind, adapterVersion)` returns cached row if exists, else runs probe and writes row.
+- [ ] **Step 3: Run all tests, verify they fail.**
+- [ ] **Step 4: Implement probes** — each probe is ~30 lines. Codex probe shells out: `docker exec ${SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1"} codex --version`, parses `codex-cli X.Y.Z`. Claude probe similarly: `docker exec ... claude --version`.
+- [ ] **Step 5: Implement cache** — read by `[adapterKind, adapterVersion]` unique key; on miss, run probe, write row, return.
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Commit.**
+
+### Task A6: Replace hard-coded `isCliAdapter` check with capability-aware resolution
+
+**Files:**
+- Modify: `apps/web/lib/inference/ai-inference.ts:351-360` (the `isCliAdapter` boolean is at L353; surrounding context L351-L360)
+- Test: `apps/web/lib/inference/ai-inference.call-provider.test.ts` (extend existing)
+
+Steps:
+
+- [ ] **Step 1: Write failing test** — given a route plan with `executionAdapter: "claude-cli"`, assert it still resolves to the existing claude CLI handler. Given `executionAdapter: "codex-cli"`, assert codex handler. Given a *new* structured selector `{kind: "claude-code-cli", authMode: "oauth"}`, assert same handler. Given `{kind: "claude-code-cli", authMode: "oauth", capabilityRequirements: [{capability: "supportsSubagents", required: true}]}` and a profile that lacks subagents, assert it falls back to next adapter.
+- [ ] **Step 2: Run tests, verify they fail.**
+- [ ] **Step 3: Modify [ai-inference.ts:353-360](apps/web/lib/inference/ai-inference.ts#L353)** — keep backward compat: if `executionAdapter` is a string, treat it as legacy. If it's a `ExecutionAdapterSelector` object, resolve via `adapter-registry.resolve(selector, profile)`. Both paths share the same downstream handler invocation.
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task A7: Wire telemetry write at end of every coworker run
+
+**Files:**
+- Modify: `apps/web/lib/inference/ai-inference.ts` (after handler returns, before return to caller)
+- Create: `apps/web/lib/routing/adapter-telemetry-writer.ts`
+- Test: `apps/web/lib/routing/adapter-telemetry-writer.test.ts` (new)
+
+- [ ] **Step 1: Write failing test for `writeAdapterTelemetry()`** — pass a `RunOutcome` shape, assert one row written with correct adapter kind, status, tokens.
+- [ ] **Step 2: Write failing integration test** — mock the existing inference path, run a fake provider call, assert one telemetry row appears.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement** — `writeAdapterTelemetry(outcome: RunOutcome)`: Prisma create wrapped in `.catch(() => {})` so telemetry failure cannot break a coworker turn.
+- [ ] **Step 5: Wire into ai-inference.ts** — capture `startedAt` before handler call, capture `finishedAt`/status/tokens after, call `writeAdapterTelemetry()` async (don't await — fire-and-forget pattern matches existing `prisma.toolExecution.create().catch(() => {})`).
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Run full vitest suite locally** — `pnpm test --filter @dpf/web -- --run`. Inspect for regressions. Required before push.
+- [ ] **Step 8: Commit.**
+
+### Task A8: Phase A integration verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Manual smoke test** — start the portal locally (`pnpm dev` or whatever the project uses; check [README.md](README.md) — do NOT auto-start docker). Send a coworker message via the panel. Verify telemetry row appears: `psql ... -c "SELECT * FROM \"AdapterRunTelemetry\" ORDER BY \"startedAt\" DESC LIMIT 5;"`.
+- [ ] **Step 2: Verify capability profiles populated** — `psql ... -c "SELECT * FROM \"AdapterCapabilityProfile\";"`. Expect 4 rows (claude-cli, codex-cli, http-anthropic, http-openai).
+- [ ] **Step 3: Verify backward compat** — existing coworker recipes with string `executionAdapter` still work. No 500s in portal logs.
+- [ ] **Step 4: Update [docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md) §15** — mark Phase A as "shipped <date>".
+- [ ] **Step 5: Open PR** — `gh pr create` against `feat/coworker-c-status-and-a2a-sequencing` (worktree branch). Title: `feat(routing): adapter capability profiles + telemetry foundation (Phase A)`.
+
+**Phase A acceptance:** all 4 capability profile rows present, telemetry table accumulating rows, no behavior change in existing coworker flows.
+
+---
+
+## Phase B: Codex CLI `--json` parsing + ToolExecution minting
+
+**Spec acceptance:** "a coworker with `executionAdapter.kind = codex-cli` can run a `command_execution` and have a `ToolExecution` row appear in DB tied to the thread." (spec §12 Phase B)
+
+### Task B1: Define `NormalizedEvent` taxonomy
+
+**Files:**
+- Create: `apps/web/lib/routing/normalized-event-types.ts`
+- Test: `apps/web/lib/routing/normalized-event-types.test.ts` (new, type-level)
+
+- [ ] **Step 1: Write failing type test** — assert exhaustive switch over `NormalizedEvent.kind` produces compiler error if a kind is missing.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — copy types from [spec §8.1](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#81-normalized-event-types) verbatim.
+- [ ] **Step 4: Run test, verify it passes.**
+- [ ] **Step 5: Commit.**
+
+### Task B2: Capture Codex JSONL replay fixtures
+
+**Files:**
+- Create: `apps/web/lib/routing/__fixtures__/codex-jsonl/probe-1-shell-cmd.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/codex-jsonl/probe-2-reasoning.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/codex-jsonl/probe-3-error.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/codex-jsonl/README.md`
+
+The three probes are documented in [docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md](docs/superpowers/audits/evidence/2026-04-29-codex-jsonl-probe.md). Convert each `jsonl` block into a fixture file.
+
+- [ ] **Step 1: Read the evidence file** — extract the three JSONL blocks.
+- [ ] **Step 2: Write each as one fixture file** — one event per line, no wrapping JSON. Match the evidence file exactly.
+- [ ] **Step 3: Write `__fixtures__/codex-jsonl/README.md`** — document each fixture's source command and Codex version (0.125.0). State that re-capturing requires `docker exec dpf-sandbox-1 codex exec --json --skip-git-repo-check --ephemeral --dangerously-bypass-approvals-and-sandbox "<prompt>"` per the evidence file.
+- [ ] **Step 4: Commit fixtures** as one commit so they are easy to refresh later.
+
+### Task B3: Codex event normalizer
+
+**Files:**
+- Create: `apps/web/lib/routing/codex-event-normalizer.ts`
+- Test: `apps/web/lib/routing/codex-event-normalizer.test.ts` (new, replay-based)
+
+The normalizer takes an async iterable of parsed JSONL lines and yields `NormalizedEvent`s per the [spec §8.2 mapping](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#82-per-adapter-normalizer-mapping):
+
+| Codex event | NormalizedEvent |
+| --- | --- |
+| `thread.started` | (capture thread_id; emit `task.started` with `taskId=thread_id`) |
+| `turn.started` | (no emit — bookkeeping only) |
+| `item.started type=command_execution` | `tool.invoked` |
+| `item.completed type=command_execution` | `tool.completed` |
+| `item.completed type=agent_message` | `message.delta` |
+| `item.completed type=reasoning` | `thinking.delta` |
+| `item.completed type=plan_update` | `plan.proposed` or `todo.updated` (heuristic: if items have `status` field → todo; else → plan) |
+| `item.completed type=file_change` | `artifact.produced` |
+| `item.completed type=mcp_tool_call` | `tool.invoked` + `tool.completed` (paired) |
+| `item.completed type=web_search` | `web.search` |
+| `turn.completed` | `task.completed` (with `usage`) |
+| `turn.failed` | `task.completed` with `status=error` |
+| `error` | `adapter.degraded` (impact derived from message) |
+
+- [ ] **Step 1: Write failing test for shell cmd fixture** — replay `probe-1-shell-cmd.jsonl`, assert the normalized event sequence: `task.started`, `tool.invoked`, `tool.completed`, `message.delta`, `task.completed`.
+- [ ] **Step 2: Write failing test for reasoning fixture.**
+- [ ] **Step 3: Write failing test for error fixture** — assert `task.completed` with `status=error`.
+- [ ] **Step 4: Run tests, verify they fail.**
+- [ ] **Step 5: Implement normalizer.** Stream-friendly; `async function* normalize(lines)`. Maintain a `Map<itemId, ToolInvokedEvent>` so we can pair `item.started` → `item.completed` for `command_execution`.
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Commit.**
+
+### Task B4: Schema-drift detector
+
+**Files:**
+- Create: `apps/web/lib/routing/codex-schema-fixture.ts`
+- Modify: `apps/web/lib/routing/codex-event-normalizer.ts` (add detector hook)
+- Test: `apps/web/lib/routing/codex-schema-fixture.test.ts` (new)
+
+- [ ] **Step 1: Write failing test for `detectSchemaDrift(line)`** — given a known-shape event, return `null`. Given an unknown shape (e.g. `{type: "item.completed", item: {item_type: "agent_message"}}` — the renamed-field variant from issue #4776), return `{reason: "field 'item_type' not in v0.125.0 schema, did you mean 'type'?"}`.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — fixture is a hand-curated shape map per Codex version. `detectSchemaDrift` validates against the pinned shape, returns drift reason or null.
+- [ ] **Step 4: Wire into normalizer** — on every parsed line, call detector. If drift detected, emit `adapter.degraded` event AND set a flag the adapter forwards into telemetry (`schemaDriftDetected = true`).
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task B5: MCP-active + `--json` refusal guard
+
+**Files:**
+- Modify: `apps/web/lib/routing/codex-cli-adapter.ts`
+- Test: `apps/web/lib/routing/codex-cli-adapter.test.ts` (extend if exists, else create)
+
+- [ ] **Step 1: Write failing test** — given a route plan with `mcpAttachPolicy.allowedServers.length > 0` AND adapter is `codex-cli`, assert the adapter returns (does not throw) `{status: "error", errorClass: "codex-mcp-json-degradation", message: "<refers to openai/codex#15451>"}` and writes a telemetry row with that errorClass. Returning rather than throwing matches the existing adapter contract — exceptions in this layer become 500s upstream.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — at the top of `codex-cli-adapter.execute()`, check if route plan has any MCP attach config. If yes AND `--json` will be used, return a structured error referencing issue #15451.
+- [ ] **Step 4: Run test, verify it passes.**
+- [ ] **Step 5: Commit.**
+
+### Task B6: ToolExecution minting from Codex events
+
+**Files:**
+- Modify: `apps/web/lib/routing/codex-cli-adapter.ts` (consume normalized events, mint rows)
+- Test: `apps/web/lib/routing/codex-cli-adapter.test.ts` (new test cases)
+
+The adapter wraps the existing subprocess invocation. Once the JSONL stream is parsed and normalized, for each `tool.invoked`/`tool.completed` pair, write a `ToolExecution` row with:
+- `threadId` from route plan
+- `toolName` from event (`shell`, `mcp_tool_call:<server>:<tool>`, `web_search`, `file_change`)
+- `parameters`: digest only (full args may contain secrets — store digest, full payload behind a feature flag)
+- `result.success` from `status === "ok"`
+- `auditClass = "cli-adapter-codex"` (new value — document in adapter-types.ts)
+
+If receipts spec has landed (`prisma.toolExecutionReceipt` exists), also mint a receipt row. Otherwise skip silently (per spec §15 fallback).
+
+- [ ] **Step 1: Write failing test** — replay `probe-1-shell-cmd.jsonl` through adapter, assert one `ToolExecution` row appears with `toolName="shell"`, `auditClass="cli-adapter-codex"`.
+- [ ] **Step 2: Write failing test for receipts fallback** — mock `prisma.toolExecutionReceipt` undefined (model not in schema); assert no error thrown and `ToolExecution` row still written.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement minting**. Use feature-detect for receipt model: `typeof (prisma as any).toolExecutionReceipt?.create === "function"`.
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Run full vitest suite** — `pnpm test --filter @dpf/web -- --run`.
+- [ ] **Step 7: Commit.**
+
+### Task B7: Switch Codex adapter to `--json` mode (behind feature flag)
+
+**Files:**
+- Modify: `apps/web/lib/routing/codex-cli-adapter.ts` (subprocess args + stream handling)
+- Test: existing test extended
+
+The new code path is gated behind `CODEX_JSON_MODE=1` (default off). PR ships dark; flag flips post-smoke. This isolates the live-stream-format change from the deploy.
+
+- [ ] **Step 1: Write failing test for flag-on path** — set `process.env.CODEX_JSON_MODE = "1"`, when adapter runs against a fake stdout stream emitting `probe-1-shell-cmd.jsonl` lines, the adapter returns the agent's final message text correctly extracted from the normalized stream.
+- [ ] **Step 2: Write failing test for flag-off path** — without the env var, adapter uses the existing text-parsing behavior unchanged.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Add `--json` to the codex exec argv when `CODEX_JSON_MODE=1`** — also `--ephemeral` for non-session calls. Replace text parsing with line-by-line JSONL parsing → normalizer → final-message extraction (last `message.delta` before `task.completed`). Default branch keeps the existing text path.
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Live smoke test (flag-on)** — `docker exec dpf-sandbox-1 codex exec --json --skip-git-repo-check --ephemeral --dangerously-bypass-approvals-and-sandbox "Echo hello"`, then with `CODEX_JSON_MODE=1` set in the portal env, run a coworker turn that hits the codex adapter. Verify telemetry shows `schemaDriftDetected=false` and a `ToolExecution` row exists.
+- [ ] **Step 7: Document the flag** in the PR description with rollout plan: "ship dark, smoke for 24h with `CODEX_JSON_MODE=1` in dev, flip prod default after green."
+- [ ] **Step 8: Commit.**
+
+### Task B8: Phase B PR
+
+- [ ] **Step 1: Run full vitest suite** — required before push.
+- [ ] **Step 2: Open PR** with title `feat(routing): codex CLI --json parsing + tool execution minting (Phase B)`.
+
+**Phase B acceptance:** Codex coworker turn produces normalized events, `schemaDriftDetected=false`, one `ToolExecution` row per CLI tool call.
+
+---
+
+## Phase C: CliSessionService + per-thread continuity
+
+**Spec acceptance:** "sequential coworker messages on the same thread share the same CLI session and observable plan/todo state." (spec §12 Phase C)
+
+### Task C0: Locate the cron / scheduled-job substrate (PRE-WORK)
+
+**Files:** none (discovery only — outputs into the plan itself or PR description)
+
+A grep for `node-cron` / `registerCron` / `setInterval` against `apps/web/` returns no obvious central pattern. Find it before Task C4, otherwise that task stalls mid-implementation.
+
+- [ ] **Step 1: Search candidates** — `grep -rn "cron\|setInterval\|@vercel/cron\|bull\|bullmq" apps/web/lib/queue/ apps/web/app/api/cron/ 2>/dev/null`.
+- [ ] **Step 2: Inspect one existing scheduled job** — there's likely something for the build orchestrator or session cleanup. Read it end-to-end.
+- [ ] **Step 3: Document the registration pattern** in the C4 task body below — replace the "ASK — don't guess" line with the concrete pattern. Update via `Edit` tool, commit only the plan file.
+- [ ] **Step 4: Commit the plan update** — `git commit -s --only docs/superpowers/plans/2026-04-29-cli-execution-adapter-routing-plan.md -m "docs(plan): document cron substrate pattern for substrate Phase C"`.
+
+### Task C1: `CliSessionService` skeleton + claim/reuse logic
+
+**Files:**
+- Create: `apps/web/lib/coworker/cli-session-service.ts`
+- Test: `apps/web/lib/coworker/cli-session-service.test.ts` (new)
+
+- [ ] **Step 1: Write failing test for `claim(threadId, adapterKind)`** — first call creates `cliSessionId`; second call within TTL reuses; second call after TTL allocates a new ID and frees the prior one.
+- [ ] **Step 2: Write failing test for sandbox-pool affinity** — multiple thread claims pin to different container IDs from the pool.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement `claim()`** — Prisma transaction. Read `AgentThread.cliSession*`, decide reuse vs allocate. Sandbox container choice: simple round-robin from `DPF_SANDBOX_POOL_SIZE` (default 3); pin via `cliSessionContainerId`.
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task C2: Per-thread workdir + worktree creation
+
+**Files:**
+- Modify: `apps/web/lib/coworker/cli-session-service.ts`
+- Test: `apps/web/lib/coworker/cli-session-service.test.ts`
+
+- [ ] **Step 1: Write failing test** — first claim on a thread creates `/workspace/threads/<threadId>` directory inside the sandbox container and a git worktree off `main`. Subsequent claims reuse it.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement `ensureWorkdir(threadId)`** — `docker exec <container> mkdir -p /workspace/threads/<threadId> && cd /workspace/threads/<threadId> && (test -d .git || git worktree add /workspace/threads/<threadId> main)`.
+- [ ] **Step 4: Run test, verify it passes.**
+- [ ] **Step 5: Commit.**
+
+### Task C3: Concurrency rule (serialize / ephemeral fallback)
+
+**Files:**
+- Modify: `apps/web/lib/coworker/cli-session-service.ts` (add lease/concurrency)
+- Test: `apps/web/lib/coworker/cli-session-service.test.ts`
+
+- [ ] **Step 1: Write failing test** — two concurrent `claim()` calls on the same thread: one returns the active lease; the other gets a fresh ephemeral session ID (no thread pin) per [spec §9.2](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#92-concurrency-rule).
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — Postgres advisory lock per `threadId` (or a Prisma `@@unique` lease table — simpler). On lock conflict, return `{ kind: "ephemeral", sessionId: cuid(), workdir: null }`.
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task C4: Sweeper job
+
+**Files:**
+- Create: `apps/web/lib/coworker/cli-session-sweeper.ts`
+- Modify: existing cron registration (search for `node-cron` or similar — look in `apps/web/app/api/cron/` or `apps/web/lib/queue/`)
+- Test: `apps/web/lib/coworker/cli-session-sweeper.test.ts` (new)
+
+- [ ] **Step 1: Write failing test** — given an `AgentThread` with `cliSessionLastUsedAt` 70 minutes ago and TTL 60 min, sweeper nulls all `cliSession*` columns and removes the worktree (mock `docker exec`).
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — query stale rows, for each: docker exec rm worktree, set columns to null. Idempotent.
+- [ ] **Step 4: Wire to existing cron substrate.** If unsure how cron is registered, ASK — don't guess. Likely candidates to inspect: `apps/web/lib/queue/`, `apps/web/app/api/cron/`.
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task C5: Wire `CliSessionService` into Claude + Codex adapters
+
+**Files:**
+- Modify: `apps/web/lib/routing/cli-adapter.ts` (Claude path)
+- Modify: `apps/web/lib/routing/codex-cli-adapter.ts` (Codex path)
+- Test: extend each adapter's existing test
+
+For each adapter, before invoking the CLI subprocess:
+1. Call `cliSessionService.claim(threadId, adapterKind)` to get `{sessionId, workdir, kind}`.
+2. If `kind === "thread"`: pass `--session-id ${sessionId}` (Claude) or `codex exec resume ${sessionId} || codex exec` (Codex), and `cwd: workdir`.
+3. If `kind === "ephemeral"`: pass `--ephemeral` (Codex) or omit `--session-id` (Claude); use `/workspace`.
+4. Update `cliSessionLastUsedAt` after successful turn.
+
+- [ ] **Step 1: Write failing tests for both adapters** — given a route plan with `threadId`, assert sessionId is reused across two turns AND the workdir is `/workspace/threads/<threadId>`.
+- [ ] **Step 2: Run tests, verify they fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Live smoke test** — start portal, run two coworker turns on the same thread via Codex, verify second turn reuses the thread's session UUID by inspecting the codex stdout (the first event will be `thread.started` with the *same* `thread_id` if resume worked).
+- [ ] **Step 5: Run full vitest suite.**
+- [ ] **Step 6: Commit.**
+
+### Task C6: Phase C PR
+
+- [ ] **Step 1: Update [spec §15](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#15-migration--backwards-compatibility)** — mark Phase C shipped.
+- [ ] **Step 2: Open PR** — `feat(coworker): per-thread CLI session lifecycle (Phase C)`.
+
+**Phase C acceptance:** sequential turns on one thread share session and workdir; concurrent turns get ephemeral fallback; sweeper runs and cleans stale sessions.
+
+---
+
+## Phase D: Claude CLI normalizer parity
+
+**Spec acceptance:** "Claude Code CLI runs surface plan, todo, subagent, and thinking events to the panel." (spec §12 Phase D)
+
+The existing [cli-adapter.ts](apps/web/lib/routing/cli-adapter.ts) parses only `tool_use` blocks. Extend to cover the rest of the [spec §8.2 Claude rows](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#82-per-adapter-normalizer-mapping).
+
+### Task D1: Capture Claude stream-json fixtures
+
+**Files:**
+- Create: `apps/web/lib/routing/__fixtures__/claude-stream-json/probe-1-tool-use.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/claude-stream-json/probe-2-todo.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/claude-stream-json/probe-3-subagent.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/claude-stream-json/probe-4-thinking.jsonl`
+- Create: `apps/web/lib/routing/__fixtures__/claude-stream-json/README.md`
+
+- [ ] **Step 1: Run live probe inside sandbox** — `docker exec dpf-sandbox-1 claude --output-format stream-json --print "Make a todo list with three items" 2>/dev/null > /tmp/probe-2.jsonl`. Repeat for tool_use, subagent (Task tool), thinking.
+- [ ] **Step 2: Copy each captured stream into a fixture file** under `__fixtures__/claude-stream-json/`. Sanitize any PII / OAuth tokens before committing.
+- [ ] **Step 3: Document each in README.md** — command + Claude Code version (`docker exec dpf-sandbox-1 claude --version`).
+- [ ] **Step 4: Commit fixtures.**
+
+### Task D2: Extend Claude normalizer
+
+**Files:**
+- Modify: `apps/web/lib/routing/cli-adapter.ts` (parser section, around L131-L139 currently parsing `tool_use`)
+- Or refactor: extract parser into `apps/web/lib/routing/claude-event-normalizer.ts` — likely cleaner — Phase H aligned
+- Test: `apps/web/lib/routing/claude-event-normalizer.test.ts` (new)
+
+- [ ] **Step 1: Decide refactor vs extend** — recommend extracting into `claude-event-normalizer.ts` to mirror `codex-event-normalizer.ts`. Counts toward Phase H allocation.
+- [ ] **Step 2: Write failing tests for each fixture** — replay each `.jsonl`, assert normalized event sequence:
+  - probe-1: `task.started`, `tool.invoked`, `tool.completed`, `message.delta`, `task.completed`
+  - probe-2: `todo.updated` events with the right `todos` payload
+  - probe-3: `subagent.started`, `subagent.completed`, surrounding `tool.*`
+  - probe-4: `thinking.delta` events with `effort` field
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement** by extending the existing parser. Reuse `NormalizedEvent` types from Phase B1.
+- [ ] **Step 5: Implement Claude schema-drift fixture** mirroring B4.
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Run full vitest suite.**
+- [ ] **Step 8: Commit.**
+
+### Task D3: Backfill decision for in-flight threads
+
+Spec §12 Phase D step 3 says "Backfill normalized events for in-flight threads." Decide and document — don't silently drop the requirement.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md` §12 Phase D (record decision)
+
+Steps:
+
+- [ ] **Step 1: Document the decision: NO BACKFILL.** In-flight threads keep their stored shape (legacy `agentMessage` rows without `normalizedEvents` JSON); only new turns going forward get normalized events. Reasoning: backfill would require re-running prior turns through CLI, which costs tokens and may produce different results from the user's actual experience. Risk of confusion ("why does the trace tab differ from what I remember?") outweighs benefit.
+- [ ] **Step 2: Update spec §12 Phase D** to replace "Backfill normalized events for in-flight threads." with "No backfill — legacy threads render via the old code path; new turns from spec ship date forward use normalized events."
+- [ ] **Step 3: Add a fallback render in the panel UI** — if `agentMessage.normalizedEvents` is null, render via the existing transcript path. Track as an E-phase task.
+- [ ] **Step 4: Commit the spec update** — `git commit -s --only docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md -m "spec(coworker): no-backfill decision for normalized events (Phase D D3)"`.
+
+### Task D4: Phase D PR
+
+- [ ] **Step 1: Open PR** — `feat(routing): claude CLI event normalizer parity (Phase D)`.
+
+---
+
+## Phase E: Coworker panel cockpit UI
+
+**Spec acceptance:** "users see one coherent panel surface for HTTP, Claude Code CLI, and Codex CLI runs without raw harness payloads leaking into the transcript." (spec §12 Phase E)
+
+This phase is larger than A–D. **If a single session can't finish it, split at task E4 (header+rail done) → E5+ in a follow-up.** Each task is still bite-sized.
+
+### Task E1: Find existing panel components
+
+**Files:** none (discovery only)
+
+- [ ] **Step 1: Read [apps/web/lib/actions/agent-coworker.ts](apps/web/lib/actions/agent-coworker.ts)** to understand the message return shape.
+- [ ] **Step 2: Find the panel React tree.** Search for `agent-panel-layout` or `coworker-panel`; per audit, there's a layout file at `apps/web/components/agent/agent-panel-layout.ts`. Read its consumers via `grep -rn agent-panel-layout apps/web/`.
+- [ ] **Step 3: Document findings** — write a short note in the PR description listing every panel component touched. Don't write to a doc — this is in-PR context only.
+
+### Task E2: Pipe `NormalizedEvent` through `agent-coworker.sendMessage` return
+
+**Files:**
+- Modify: `apps/web/lib/actions/agent-coworker.ts` (return shape extension)
+- Test: existing `agent-coworker` tests
+
+- [ ] **Step 1: Write failing test** — call `sendMessage()` against a Codex adapter (mocked stream), assert the return shape now includes `events: NormalizedEvent[]` alongside `userMessage`/`agentMessage`.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — capture events emitted during the adapter run; attach to return value. Existing return fields unchanged.
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task E3: Persist `NormalizedEvent` per message for replay
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma` — add `AgentMessage.normalizedEvents Json?` column
+- Test: schema test
+
+- [ ] **Step 1: Write failing test** — write an `AgentMessage` with `normalizedEvents: [{kind: "tool.invoked", ...}]`, fetch, assert round-trip.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Modify schema + migration** — `pnpm prisma migrate dev --name add_agent_message_normalized_events`.
+- [ ] **Step 4: Wire write in `agent-coworker.ts`** — when persisting agent message, include events JSON.
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task E4: Cockpit zones — Header + Status rail
+
+**Files:**
+- Locate the existing panel root component first; create new components alongside it
+- Create: `apps/web/components/agent/cockpit/cockpit-header.tsx`
+- Create: `apps/web/components/agent/cockpit/status-rail.tsx`
+- Test: `*.test.tsx` for each (component tests with React Testing Library)
+
+- [ ] **Step 1: Write failing component test for header** — given coworker name + adapter kind, render shows name + adapter badge + health LED placeholder.
+- [ ] **Step 2: Write failing component test for status rail** — given a list of normalized `todo.updated` events, render shows current todo list.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement using project CSS variables** — no hardcoded colors. Use the same vars as existing capability-tier badges (search `capability-tier` in apps/web/components/).
+- [ ] **Step 5: Wire into the existing panel** — add header and status-rail above transcript.
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Visual smoke test** — start portal locally, open coworker panel, verify header + rail render.
+- [ ] **Step 8: Commit.**
+
+### Task E5: Cockpit zones — Trace tab
+
+**Files:**
+- Create: `apps/web/components/agent/cockpit/trace-tab.tsx`
+- Test: `apps/web/components/agent/cockpit/trace-tab.test.tsx`
+
+- [ ] **Step 1: Write failing test** — given a list of normalized events, trace tab renders one row per event with kind + summary, expandable to show raw payload.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement.** Progressive disclosure — `<details>` for raw payload, role-gated.
+- [ ] **Step 4: Wire as a tab next to transcript.**
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task E6: Cockpit zones — Artifacts panel
+
+**Files:**
+- Create: `apps/web/components/agent/cockpit/artifacts-panel.tsx`
+- Test: `apps/web/components/agent/cockpit/artifacts-panel.test.tsx`
+
+- [ ] **Step 1: Write failing test** — given a list of `artifact.produced` events, render shows one card per artifact with click-through to file/diff.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task E7: Adapter health LED
+
+**Files:**
+- Create: `apps/web/lib/routing/adapter-health.ts` (computes health from `AdapterRunTelemetry`)
+- Modify: `apps/web/components/agent/cockpit/cockpit-header.tsx`
+- Test: `apps/web/lib/routing/adapter-health.test.ts`
+
+- [ ] **Step 1: Write failing test for `computeAdapterHealth(adapterKind)`** — given a fake telemetry table state, return `"healthy"` or `"degraded"` per [spec §14 formula](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#14-telemetry--observability).
+- [ ] **Step 2: Write failing component test** — health LED renders green/red based on adapter health.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement** — query last 100 telemetry rows for the adapter, compute success rate + median latency + drift count, return health.
+- [ ] **Step 5: Wire LED.**
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Commit.**
+
+### Task E8: Role-gated disclosure
+
+**Files:**
+- Modify: each cockpit component to read role from existing portal RBAC context (search `useUser` or `getCurrentUser`)
+- Test: each component test extended with role variants
+
+- [ ] **Step 1: Write failing tests** — given user/operator/admin, assert visible elements per [spec §10.2 table](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#102-progressive-disclosure-audit-q7).
+- [ ] **Step 2: Run tests, verify they fail.**
+- [ ] **Step 3: Implement role gates.** No new auth model — read from existing context.
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task E9: Phase E PR
+
+- [ ] **Step 1: Run full vitest + RTL suite.**
+- [ ] **Step 2: Manual UX review** — open panel, verify all zones render, role gates work, theme variables used (no hardcoded colors).
+- [ ] **Step 3: Open PR** — `feat(coworker): cockpit panel surface for normalized adapter events (Phase E)`.
+
+---
+
+## Phase F: Shadow execution mode
+
+**Spec acceptance:** "ops can run a one-week shadow of Codex CLI against Claude HTTP for the chat workload and read a comparison report at end of week." (spec §12 Phase F)
+
+### Task F1: Shadow eligibility evaluator
+
+**Files:**
+- Create: `apps/web/lib/routing/shadow-eligibility.ts`
+- Test: `apps/web/lib/routing/shadow-eligibility.test.ts`
+
+- [ ] **Step 1: Write failing test** — given budget remaining, sample rate, kill switch state, return correct boolean per [spec §6.2 formula](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#62-shadow-—-live--n-alternatives-log-only).
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement.** Read `SHADOW_BUDGET_USD`, `SHADOW_SAMPLE_RATE`, `SUBSTRATE_SHADOW_DISABLE` env. Read MTD spend from `AdapterRunTelemetry` sum.
+- [ ] **Step 4: Add prompt-sensitivity floor** — only `public` and `internal` route sensitivities are shadow-eligible (spec §13 risk #5).
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task F2: Shadow dispatch path
+
+**Files:**
+- Modify: `apps/web/lib/inference/ai-inference.ts` — when `executionMode = "shadow"`, fork shadow runs in background
+- Test: `apps/web/lib/inference/ai-inference.shadow.test.ts`
+
+- [ ] **Step 1: Write failing test** — route plan with `executionMode: "shadow"` and `shadowAdapters: [{kind: "codex-cli"}]`. Assert primary returns to caller; shadow runs in background; both produce telemetry rows with the same `raceCohortId`.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — `Promise.allSettled` style; primary awaited, shadows fire-and-forget. Fresh cuid for `raceCohortId`. Shadow rows tagged `executionMode: "shadow-alt"`.
+- [ ] **Step 4: Ensure shadow runs do NOT touch user-visible state** — separate write path, no `agentMessage` rows for shadow output.
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task F3: Outcome scoring batch
+
+**Files:**
+- Create: `apps/web/lib/routing/outcome-scoring.ts`
+- Modify: cron registration
+- Test: `apps/web/lib/routing/outcome-scoring.test.ts`
+
+- [ ] **Step 1: Write failing test for `scoreAdapters(taskClass, providerFamily, capRequirements)`** — given a fake telemetry state, return adapter ranking per [spec §6.4 formula](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#64-outcome-scoring).
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement.** SQL aggregation over a 7-day window.
+- [ ] **Step 4: Wire to nightly cron.**
+- [ ] **Step 5: Run tests, verify they pass.**
+- [ ] **Step 6: Commit.**
+
+### Task F4a: Locate existing admin/operator page conventions
+
+**Files:** none (discovery)
+
+- [ ] **Step 1: Find admin route root** — `find apps/web/app -type d -name "(admin)" -o -name "(operator)" 2>/dev/null | head`. Read one existing page end-to-end.
+- [ ] **Step 2: Identify the chart library** — grep imports in admin pages (recharts? d3? something custom?).
+- [ ] **Step 3: Identify the page-test infra** — does the project test app-router pages? Find one example or note its absence.
+
+### Task F4b: Adapter mix chart (test-first)
+
+**Files:**
+- Create: `apps/web/app/<admin-route>/operator/adapters/_components/adapter-mix-chart.tsx`
+- Test: `apps/web/app/<admin-route>/operator/adapters/_components/adapter-mix-chart.test.tsx`
+
+Steps:
+
+- [ ] **Step 1: Write failing test** — given a fake telemetry-rollup result `[{kind: "claude-code-cli", count: 100}, {kind: "codex-cli", count: 50}]`, render shows two stack rows with correct relative sizes. Use the chart library found in F4a.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement the chart component.**
+- [ ] **Step 4: Run test, verify it passes.**
+- [ ] **Step 5: Commit.**
+
+### Task F4c: Acceptance-by-adapter chart
+
+**Files:**
+- Create: `apps/web/app/<admin-route>/operator/adapters/_components/acceptance-chart.tsx`
+- Test: corresponding `.test.tsx`
+
+Steps:
+
+- [ ] **Step 1: Write failing test** — given fake rollup with `userAccepted=true` rate per adapter, render bars with percentages.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Commit.**
+
+### Task F4d: Remaining four panels
+
+Repeat the test-first cycle for: schema-drift incidents, shadow comparison, quota saturation, CLI session lifecycle. Each gets one component file + one test file.
+
+Steps:
+
+- [ ] **Step 1: Schema-drift panel** — failing test → run → implement → commit.
+- [ ] **Step 2: Shadow-comparison panel** — failing test → run → implement → commit.
+- [ ] **Step 3: Quota-saturation panel** — failing test → run → implement → commit.
+- [ ] **Step 4: CLI session lifecycle panel** — failing test → run → implement → commit.
+
+### Task F4e: Compose into the dashboard page
+
+**Files:**
+- Create: `apps/web/app/<admin-route>/operator/adapters/page.tsx`
+
+Steps:
+
+- [ ] **Step 1: Compose all six panels into the page** — server-side fetch the rollup data, pass to each component.
+- [ ] **Step 2: Smoke-test in dev** — open the page, verify all six panels render with real data from the local telemetry rows.
+- [ ] **Step 3: Commit.**
+
+### Task F5: Phase F PR
+
+- [ ] **Step 1: Open PR** — `feat(routing): shadow execution mode + outcome scoring (Phase F)`.
+
+---
+
+## Phase G: Race execution mode + quota-pool spreading
+
+**Spec acceptance:** "under controlled rate-limit pressure, the platform automatically shifts load between `anthropic-api` and `anthropic-oauth` quota pools without user-visible degradation." (spec §12 Phase G)
+
+### Task G1: Quota-pool saturation tracker
+
+**Files:**
+- Create: `apps/web/lib/routing/quota-pool-state.ts`
+- Test: `apps/web/lib/routing/quota-pool-state.test.ts`
+
+- [ ] **Step 1: Write failing test for `getQuotaPoolSaturation(family)`** — given recent telemetry with 429s, return saturation 0..1.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement** — query last 100 telemetry rows per pool, compute 429-rate / 5xx-rate, return as saturation.
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task G2: Adapter ranker uses pool saturation
+
+**Files:**
+- Modify: `apps/web/lib/routing/recipe-loader.ts` (or wherever adapter ranking lives — find via `grep cost-ranking`)
+- Test: extend existing ranker test
+
+- [ ] **Step 1: Write failing test** — given two adapters serving the same family, prefer the less-saturated pool.
+- [ ] **Step 2: Run test, verify it fails.**
+- [ ] **Step 3: Implement.** Saturation as a ranking factor.
+- [ ] **Step 4: Run tests, verify they pass.**
+- [ ] **Step 5: Commit.**
+
+### Task G3: Race dispatch path
+
+**Files:**
+- Modify: `apps/web/lib/inference/ai-inference.ts`
+- Test: `apps/web/lib/inference/ai-inference.race.test.ts`
+
+- [ ] **Step 1: Write failing test** — route plan with `executionMode: "race"` and N shadow adapters; adapter A returns first valid result; adapters B, C are SIGTERM'd; all three write telemetry with same `raceCohortId`; A is `race-primary`, B/C are `race-loser`.
+- [ ] **Step 2: Write failing test for race acceptance criteria** — adapter that returns refusal text loses; adapter past latency budget loses; adapter with fabricated tool name loses.
+- [ ] **Step 3: Run tests, verify they fail.**
+- [ ] **Step 4: Implement.** Use `Promise.race` with cancellation tokens. Acceptance check function per [spec §6.3](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#63-race-—-n-adapters-in-parallel-first-valid-wins).
+- [ ] **Step 5: Gate behind `SUBSTRATE_RACE_ENABLE` env.**
+- [ ] **Step 6: Run tests, verify they pass.**
+- [ ] **Step 7: Commit.**
+
+### Task G4: Phase G PR
+
+- [ ] **Step 1: Open PR** — `feat(routing): race execution mode + quota-pool spreading (Phase G)`.
+
+---
+
+## Phase H: Refactor allocation (threaded through every phase)
+
+This phase is not its own PR. It's a budget reserved at every step. Specific deliverables enumerated below — track them as completed across the other phases.
+
+### H1 — Extract `ExecutionAdapter` interface (during Phase A or B)
+- [ ] Pull `ExecutionAdapterHandler` definition into a single source of truth at `apps/web/lib/routing/execution-adapter-types.ts` (started in A4).
+- [ ] All adapter implementations conform to one interface.
+
+### H2 — Move adapter-specific code out of `routed-inference.ts` (during Phase A)
+- [ ] All adapter dispatch logic lives in registry / per-adapter modules. `routed-inference.ts` does ranking and fallback only.
+
+### H3 — Separate panel state (during Phase E)
+- [ ] React tree separates: transcript state, task state (active task / approvals), artifact state, trace state. No single component owns all four.
+
+### H4 — Unify CLI session ID generation (during Phase C)
+- [ ] `claude-dispatch.ts`, `codex-dispatch.ts`, and the new substrate adapters all call the same `cliSessionService.claim()` helper. No bespoke UUID generation in dispatch files.
+
+### H5 — Cost / quota / outcome ledger consolidation (during Phase F)
+- [ ] `AdapterRunTelemetry` is the canonical run ledger. `ToolExecution.duration_ms` and other duplicate columns either reference telemetry IDs or are removed.
+
+---
+
+## Risk-driven checks before merging any phase
+
+Pulled from [spec §13](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md#13-open-risks):
+
+| Risk | Verify before merge |
+| --- | --- |
+| Codex schema instability | Schema-drift detector wired (B4) AND fixture pinned to live Codex version |
+| Sandbox pool exhaustion | Pool size check in sweeper logs; ephemeral fallback path exercised in test |
+| Subprocess timeout floor | Per-adapter timeout in capability profile honored by adapter |
+| OAuth token churn | Token refresh path covers both Claude and Codex |
+| Shadow prompt leakage | Shadow eligibility blocks `sensitive` route sensitivity |
+| Race cost amplification | Race requires both env flag AND per-route opt-in; never default |
+| Acceptance signal lag | Outcome scoring uses 7-day rolling window |
+
+---
+
+## Post-implementation
+
+- [ ] Update [docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md) status from "Draft" to "Implemented" with the PR list.
+- [ ] Update memory: write a project memory at `memory/project_coworker_substrate_shipped.md` listing what's now possible (CLI features in panel, shadow data, race mode), what's still gated (sensitive routes can't shadow), and the operator levers (`SHADOW_BUDGET_USD`, `SUBSTRATE_RACE_ENABLE`, `CLI_SESSION_TTL_MIN`, `SUBSTRATE_SHADOW_DISABLE`).
+- [ ] Schedule follow-up audit ~30 days post-Phase F: did shadow data change adapter ranking? Are there capability requirements we should add to recipes based on observed `capabilitiesUsed` patterns?
+- [ ] Convergence follow-up: should Build Studio dispatch ([claude-dispatch.ts](apps/web/lib/integrate/claude-dispatch.ts), [codex-dispatch.ts](apps/web/lib/integrate/codex-dispatch.ts)) migrate to the substrate adapter system? Out of scope for this plan; track as separate spec.

--- a/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
+++ b/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
@@ -1,0 +1,739 @@
+# CLI Execution Adapter — Routing Design Spec
+
+| Field | Value |
+| --- | --- |
+| **Epic** | Platform Infrastructure / Coworker Substrate |
+| **Status** | Phase A implementation in progress (renamed + reconciled against `origin/main` on 2026-05-16; see [2026-05-16-substrate-spec-reconciliation.md](../audits/2026-05-16-substrate-spec-reconciliation.md)) |
+| **Created** | 2026-04-29 |
+| **Renamed** | 2026-05-16 — original filename `2026-04-29-coworker-execution-adapter-substrate-design.md` collided with a different-content in-process orchestration-primitives spec on main (PR #350). New name signals the routing-layer scope explicitly. |
+| **Author** | Claude Opus 4.7 (1M ctx) for Mark Bodman |
+| **Promotes** | [2026-04-29-cli-substrate-status-review.md](../audits/2026-04-29-cli-substrate-status-review.md) (audit) and its [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-jsonl-probe.md) |
+| **Hard dependency** | [2026-04-27-artifact-provenance-receipts-design.md](./2026-04-27-artifact-provenance-receipts-design.md) — `ToolExecutionReceipt` table required before §7 (custody) can mint full receipts. Already shipped on main as of 2026-04-30 (commit landed migration `20260430023000_artifact_provenance_receipts_slice_1`). |
+| **Related specs** | [2026-04-27-routing-control-data-plane-design.md](./2026-04-27-routing-control-data-plane-design.md) (extends the route plan), [2026-04-27-routing-substrate-attempt-history.md](./2026-04-27-routing-substrate-attempt-history.md) (attempt-history feeds outcome scoring), [2026-05-10-ai-coworker-visual-control-surface-design.md](./2026-05-10-ai-coworker-visual-control-surface-design.md) (Operations Map; consumes this spec's `NormalizedEvent` shape; Phase E cockpit complements it, does not replace it), [2026-05-11-autonomous-coworker-runtime-design.md](./2026-05-11-autonomous-coworker-runtime-design.md) (TaskRun substrate that consumes `AdapterRunTelemetry` as evidence), [2026-05-09-build-execution-provider-design.md](./2026-05-09-build-execution-provider-design.md) (Build Studio's `BuildExecutionProvider`/`BuildAgentRunner` — *parallel layer*, not the same axis; see §3 boundary statement). |
+| **Scope** | `apps/web/lib/routing/*` (adapter registry, route plan, capability profile), `apps/web/lib/routing/cli-adapter.ts` (extended by PR #520 with `--mcp-config` mounting; A6 keeps that intact), new `apps/web/lib/routing/codex-cli-adapter.ts` (already present on main, 360 lines, no `--json` parsing yet), `apps/web/lib/inference/ai-inference.ts` (A6 replaces the `isCliAdapter` short-circuit; the older `apps/web/lib/ai-inference.ts` is a 2-line shim), `apps/web/lib/actions/agent-coworker.ts` (event normalization → panel), `packages/db/prisma/schema.prisma` (`AgentThread.cliSession*` columns, capability-profile cache, adapter telemetry), coworker panel UI components (cockpit shape). |
+| **Distinct from** | The receipts spec — that addresses whether tool *outputs* can be trusted. This addresses *which substrate* runs the model and how its native events reach the panel honestly. Also distinct from `BuildExecutionProvider` / `BuildAgentRunner` (Build Studio's sandbox + agent dispatch layer): those describe *where Build Studio runs an agent*; this spec describes *which substrate the panel emits events through*. |
+| **Primary Goal** | Make execution adapter (HTTP, Claude Code CLI, Codex CLI, Codex-as-MCP, local runtime) a first-class routing dimension with capability negotiation, so the coworker panel can use harness-native features (slash commands, MCP attach, hooks, subagents, plan/todo state, web access) through a governed substrate, with shadow/race modes for honest cross-adapter calibration and resilience to provider/license churn. |
+
+---
+
+## 1. Problem Statement
+
+The AI Coworker panel today is HTTP-only. Every inference call flows `agent-coworker.ts → routed-inference.ts → pipeline-v2 → fallback.callWithFallbackChain → ai-inference.callProvider → execution-adapter-registry.getExecutionAdapter`. `chat-adapter.ts` handles HTTP fetch, `cli-adapter.ts` handles the Claude Code CLI subprocess, `codex-cli-adapter.ts` handles Codex. Build Studio dispatches Claude Code and Codex CLIs via separate subprocess paths (`claude-dispatch.ts`, `codex-dispatch.ts`) for code work, but those paths don't touch the panel. A partial CLI path exists for `providerId === "anthropic-sub"` ([ai-inference.ts:353](../../../apps/web/lib/inference/ai-inference.ts#L353) — the older `apps/web/lib/ai-inference.ts` is a 2-line re-export shim) but parses only `tool_use` events from the stream and discards everything else. [PR #520](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/520) (merged 2026-05-13) extended `cli-adapter.ts` with per-call MCP attach via `--mcp-config <path> --strict-mcp-config` when an `mcpSession` token is present — that work coexists with this spec and is preserved by Phase A6.
+
+The consequence: panel users can't access any of the harness-native superpowers their CLI peers take for granted. Slash commands, MCP attachment, hooks, subagents, plan mode, todos, WebFetch, WebSearch, sandboxed bash, extended-thinking control — none of these reach the panel. Every time Anthropic or OpenAI ships a new harness feature, the gap widens.
+
+A second, related problem: provider volatility is recurring infrastructure work. License changes, TOS shifts, model deprecations, rate-limit pool changes all force re-architecting of the inference path. Today there is no mechanism to **measure adapter performance in production** — the platform can't tell whether Claude Code CLI or Codex CLI or Anthropic HTTP is producing better outcomes for a given task class, so every substrate decision is made on intuition rather than data.
+
+The audit at [2026-04-29-cli-substrate-status-review.md](../audits/2026-04-29-cli-substrate-status-review.md) frames the architectural direction. This spec defines the implementation contract.
+
+## 2. Non-Goals
+
+- **Replacing HTTP adapters wholesale.** Routing probes, eval, calibration, embeddings, classification, and any sub-second utility work stays HTTP. The 3–15 minute CLI timeout floor is unacceptable for those surfaces.
+- **Implementing the receipt ledger.** That work belongs to the [receipts spec](./2026-04-27-artifact-provenance-receipts-design.md). This spec depends on `ToolExecutionReceipt` existing; if it lands first, §7 falls into place.
+- **Cross-organization adapter portability.** Adapters bind to local sandbox containers, OAuth tokens, and the routing layer. Cross-install adapter sharing is out of scope.
+- **Replacing Build Studio's CLI dispatch path.** [claude-dispatch.ts](../../../apps/web/lib/integrate/claude-dispatch.ts) and [codex-dispatch.ts](../../../apps/web/lib/integrate/codex-dispatch.ts) keep their existing contract. The substrate adapter system is parallel to them; over time we can converge, but the spec doesn't mandate it.
+- **Building new MCP servers.** This spec governs *attach* behavior, not catalog growth.
+- **Subagent orchestration semantics.** When Claude Code spawns a subagent via Task tool, the substrate normalizes the event into a panel-renderable shape. How DPF's own coworker registry interacts with CLI subagents is a follow-up spec.
+- **Custom slash command authoring UI.** This spec defines how harness-emitted slash commands surface in the panel; user-authored slash commands are a separate feature.
+- **Removing the agentic-loop platform tool registry.** The `PLATFORM_TOOLS` in [mcp-tools.ts](../../../apps/web/lib/tak/mcp-tools.ts) remain available regardless of adapter. CLI sessions get a *superset* (platform tools + harness tools), HTTP sessions get the existing set.
+
+## 3. Architectural Model
+
+Four orthogonal axes, each previously conflated, are decomposed:
+
+```text
+┌────────────┬──────────────┬─────────────────────┬──────────────────┐
+│  Provider  │    Model     │ Execution adapter   │   Auth posture   │
+├────────────┼──────────────┼─────────────────────┼──────────────────┤
+│ anthropic  │ claude-opus  │ http                │ api-key          │
+│ anthropic  │ claude-opus  │ claude-code-cli     │ oauth            │
+│ anthropic  │ claude-sonnet│ http                │ api-key          │
+│ openai     │ gpt-5        │ http                │ api-key          │
+│ openai     │ gpt-5        │ codex-cli           │ oauth (chatgpt)  │
+│ openai     │ gpt-5        │ codex-mcp-server    │ oauth (chatgpt)  │
+│ openai     │ codex-models │ codex-cli           │ oauth            │
+│ ollama     │ llama-…      │ local-runtime       │ local            │
+└────────────┴──────────────┴─────────────────────┴──────────────────┘
+```
+
+A single coworker may keep its `GAID` identity stable while routing dynamically across these axes. The substrate spec is the routing-layer contract that makes this honest.
+
+The system has six components:
+
+```text
+┌──────────────────────────────────────────────────────────────────────┐
+│  ExecutionAdapter (interface)                                        │
+│   - kind: http | claude-code-cli | codex-cli | codex-mcp | local     │
+│   - execute(plan, prompt) → AsyncIterator<NormalizedEvent>           │
+│   - probe() → AdapterCapabilityProfile  (cached per (adapter,ver))   │
+└────────────────────────┬─────────────────────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────────────────────┐
+│  AdapterRegistry      (extends apps/web/lib/routing/adapter-registry)│
+│   - registers adapters by kind, not provider                          │
+│   - capability-profile cache (DB-backed, TTL 24h)                     │
+│   - version pinning                                                   │
+└────────────────────────┬─────────────────────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────────────────────┐
+│  RoutePlan extension                                                  │
+│   - executionAdapter: ExecutionAdapterSelector                        │
+│   - executionMode:    "single" | "shadow" | "race"                    │
+│   - capabilityRequirements: AdapterCapabilityRequirement[]            │
+│   - shadowAdapters?:  ExecutionAdapterSelector[]                      │
+└────────────────────────┬─────────────────────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────────────────────┐
+│  CliSessionService    (new)                                          │
+│   - thread → cliSessionId mapping (per-thread, sandbox-pinned)        │
+│   - lifecycle: claim, lease, expire, sweep                            │
+│   - resume via codex `exec resume` and Claude `--session-id`          │
+└────────────────────────┬─────────────────────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────────────────────┐
+│  EventNormalizer      (per-adapter parser → DPF-native events)        │
+│   - input: adapter-specific stream (stream-json, JSONL, SSE)          │
+│   - output: NormalizedEvent — task / message / tool / artifact /      │
+│     approval / plan / todo / subagent / hook / health                 │
+└────────────────────────┬─────────────────────────────────────────────┘
+                         │
+┌────────────────────────▼─────────────────────────────────────────────┐
+│  AdapterTelemetry     (feeds outcome scoring)                         │
+│   - per-run: latency, tokens, cost, quota, accept, refuse, fail,      │
+│     tool-call validity, capability-use, schema-drift detected         │
+│   - shadow runs logged but not user-visible                           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The execution-mode logic (single/shadow/race) sits between the route plan and the adapter dispatch — see §6.
+
+## 4. Schema Changes
+
+### 4.1 `AdapterCapabilityProfile` table (new)
+
+Replaces hand-maintained capability tables with observed data.
+
+```prisma
+model AdapterCapabilityProfile {
+  id                          String   @id @default(cuid())
+  adapterKind                 String   // "http-anthropic" | "claude-code-cli" | "codex-cli" | "codex-mcp" | "local-ollama"
+  adapterVersion              String   // e.g. "claude-code/1.2.3", "codex-cli/0.125.0", "anthropic-http/2024-06-01"
+  probedAt                    DateTime
+  probedBy                    String   // host/process identity, for cache invalidation across replicas
+
+  // Observed capabilities — booleans, not aspirations
+  supportsStreamingEvents     Boolean
+  supportsMcpAttach           Boolean
+  supportsMcpAttachPerInvoke  Boolean  // Claude Code: yes (--mcp-config); Codex: no (static config only)
+  supportsSubagents           Boolean
+  supportsHooks               Boolean
+  supportsPlanState           Boolean
+  supportsTodoState           Boolean
+  supportsWebFetch            Boolean
+  supportsWebSearch           Boolean
+  supportsSessionResume       Boolean
+  supportsExtendedThinking    Boolean
+  supportsOutputSchema        Boolean
+
+  // Operating envelope
+  maxInteractiveLatencyMs     Int      // wall-clock budget for first event
+  supportedAuthModes          String[] // "api-key" | "oauth" | "local"
+
+  // Known landmines (Codex example: --json silently ignored when MCP active)
+  knownDegradations           Json?    // [{ trigger: string, behavior: string, source: string }]
+
+  // Cache key — same kind+version reuses profile until TTL or version changes
+  @@unique([adapterKind, adapterVersion])
+  @@index([adapterKind, probedAt])
+}
+```
+
+Capability is **observed**, not asserted. Each adapter ships a `probe()` method that runs at registration and on version change, populating this table. The route planner reads from this table; the audit's §3 capability table is replaced by the live row set.
+
+### 4.2 `AgentThread` extension
+
+```prisma
+model AgentThread {
+  // ... existing fields ...
+  cliSessionId          String?      // adapter-issued session UUID (claude --session-id, codex thread_id)
+  cliSessionAdapterKind String?      // which adapter owns this session
+  cliSessionContainerId String?      // sandbox container slot pinned to this thread
+  cliSessionLastUsedAt  DateTime?    // sweeper TTL anchor
+  cliSessionWorkdir     String?      // /workspace/threads/<threadId> after isolation lands
+
+  @@index([cliSessionLastUsedAt])
+}
+```
+
+Sweeper job (cron, every 10 min): expire sessions whose `cliSessionLastUsedAt` is older than `CLI_SESSION_TTL_MIN` (default 60 min), free their sandbox slot, set the row to null. Idempotent — a thread may re-claim a session on next message.
+
+### 4.3 `AdapterRunTelemetry` table (new)
+
+One row per execution attempt. Feeds outcome scoring (§6.4) and shadow-run comparison.
+
+```prisma
+model AdapterRunTelemetry {
+  id                  String   @id @default(cuid())
+  threadId            String?  // null for non-coworker runs (probes, eval)
+  agentMessageId      String?  // joins to AgentMessage when applicable
+  buildId             String?  // for Build Studio dispatch via the substrate
+  adapterKind         String
+  adapterVersion      String
+  providerId          String
+  modelId             String
+
+  executionMode       String   // "single" | "shadow-primary" | "shadow-alt" | "race-primary" | "race-loser"
+  raceCohortId        String?  // groups concurrent race/shadow runs
+
+  startedAt           DateTime
+  finishedAt          DateTime?
+  durationMs          Int?
+  firstEventLatencyMs Int?
+
+  // Outcome dimensions (audit §5.4)
+  status              String   // "success" | "refusal" | "error" | "timeout" | "cancelled" | "policy-block"
+  refusalReason       String?
+  errorClass          String?
+  inputTokens         Int?
+  cachedInputTokens   Int?
+  outputTokens        Int?
+  reasoningTokens     Int?
+  estimatedCostUsd    Decimal? @db.Decimal(10, 6)
+  quotaPoolConsumed   String?  // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
+
+  toolCallsTotal      Int      @default(0)
+  toolCallsInvalid    Int      @default(0)  // fabricated tool names, schema mismatches
+  capabilitiesUsed    String[] // which §4.1 booleans were actually exercised this run
+  schemaDriftDetected Boolean  @default(false)  // adapter emitted unexpected event shape
+
+  userAccepted        Boolean? // null = not yet decided; true = message kept; false = retried/discarded
+  acceptedAt          DateTime?
+
+  rawEventDigest      String?  // sha256 of normalized event log, for cross-adapter equivalence checks
+
+  @@index([adapterKind, startedAt])
+  @@index([raceCohortId])
+  @@index([threadId, startedAt])
+}
+```
+
+`userAccepted` is set asynchronously when a downstream signal lands (user keeps the reply, retries, or escalates). Acceptance is the canonical "did this adapter win?" signal.
+
+### 4.4 Hard-coded CLI special case removal
+
+[`apps/web/lib/inference/ai-inference.ts:353`](../../../apps/web/lib/inference/ai-inference.ts#L353) on `origin/main` carries an `isCliAdapter` boolean short-circuit:
+
+```ts
+const isCliAdapter = effectivePlan.executionAdapter === "claude-cli"
+  || effectivePlan.executionAdapter === "codex-cli";
+const baseUrl = isCliAdapter ? "cli://local" : await resolveExecutionBaseUrl(...);
+const headers = isCliAdapter ? {} : await buildAuthHeaders(...);
+const adapter = getExecutionAdapter(effectivePlan.executionAdapter);
+```
+
+Phase A6 replaces this with a structured selector + capability-aware resolver:
+
+```ts
+const selector = parseExecutionAdapterSelector(effectivePlan.executionAdapter);
+const isCliAdapter = selector?.kind === "claude-code-cli" || selector?.kind === "codex-cli";
+const baseUrl = isCliAdapter ? "cli://local" : await resolveExecutionBaseUrl(...);
+const headers = isCliAdapter ? {} : await buildAuthHeaders(...);
+const adapter = selector !== null
+  ? await resolveExecutionAdapter(selector, effectivePlan.capabilityRequirements)
+  : getExecutionAdapter(executionAdapterRaw as string);  // legacy passthrough
+```
+
+The decision lives in the route plan, populated by §5. Backward compat: legacy string values for CLI/chat round-trip through `parseExecutionAdapterSelector`; legacy strings outside the structured taxonomy (`responses`, `embedding`, `image_gen`, `async`, `transcription`) fall through to the registry unchanged. **The Claude CLI `--mcp-config` mounting added by [PR #520](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/520) is preserved verbatim** — that path is gated by `mcpSession` token presence, which is orthogonal to the `executionAdapter` selector; both layers continue to compose.
+
+## 5. Route Plan Extension
+
+### 5.1 New `ExecutionAdapterSelector` field
+
+```ts
+type ExecutionAdapterKind =
+  | "http-anthropic"
+  | "http-openai"
+  | "http-gemini"
+  | "http-ollama"
+  | "claude-code-cli"
+  | "codex-cli"
+  | "codex-mcp-server"
+  | "local-runtime";
+
+type ExecutionAdapterSelector = {
+  kind: ExecutionAdapterKind;
+  version?: string;          // pin specific adapter version; absent = latest probed
+  authMode: "api-key" | "oauth" | "local";
+  containerHint?: string;    // sandbox pool affinity for CLI adapters
+};
+
+type AdapterCapabilityRequirement = {
+  capability: keyof AdapterCapabilityProfile;
+  required: boolean;         // fail-route if missing
+};
+```
+
+### 5.2 Capability negotiation at route-plan time
+
+[recipe-loader.ts](../../../apps/web/lib/routing/recipe-loader.ts) extends to evaluate capability requirements:
+
+1. Coworker's recipe declares capability needs (e.g. agent X needs `supportsSubagents=true` for plan-and-execute tasks).
+2. Route planner queries `AdapterCapabilityProfile` for adapters that satisfy all `required: true` requirements.
+3. Falls back to next-best adapter if first choice fails the requirement set.
+4. Logs the requirement match in `AdapterRunTelemetry.capabilitiesUsed` so we can see which capabilities actually drive selection in production.
+
+Capability requirements are *advisory* unless `required: true`. A request for `supportsTodoState` against an HTTP adapter that lacks it doesn't hard-fail — it logs and downgrades to text-only.
+
+### 5.3 Concrete examples
+
+```ts
+// Coworker chat — default
+{ executionAdapter: { kind: "http-anthropic", authMode: "api-key" }, executionMode: "single" }
+
+// Coworker doing a complex multi-step task — wants harness features
+{
+  executionAdapter: { kind: "claude-code-cli", authMode: "oauth" },
+  executionMode: "single",
+  capabilityRequirements: [
+    { capability: "supportsSubagents", required: true },
+    { capability: "supportsTodoState", required: true },
+    { capability: "supportsMcpAttachPerInvoke", required: true },
+  ],
+}
+
+// Routing calibration — shadow Codex against Claude HTTP for outcome data
+{
+  executionAdapter: { kind: "http-anthropic", authMode: "api-key" },
+  executionMode: "shadow",
+  shadowAdapters: [{ kind: "codex-cli", authMode: "oauth" }],
+}
+
+// Latency-critical eval probe — race Anthropic + OpenAI HTTP, take first
+{
+  executionAdapter: { kind: "http-anthropic", authMode: "api-key" },
+  executionMode: "race",
+  shadowAdapters: [{ kind: "http-openai", authMode: "api-key" }],
+}
+```
+
+### 5.4 Quota-pool spreading (audit Q4)
+
+Per the [CLI vs API rate limits memory](../../../memory/project_cli_vs_api_rate_limits.md), `anthropic-api` and `anthropic-oauth` quota pools are independent. Per-provider-family quota model:
+
+```ts
+type ProviderFamilyQuotaState = {
+  family: "anthropic" | "openai" | ...;
+  pools: Array<{
+    poolId: string;            // "anthropic-api" | "anthropic-oauth"
+    saturation: number;        // 0..1, derived from recent 429 rate
+    adaptersServed: ExecutionAdapterKind[];
+  }>;
+};
+```
+
+When two adapters serve the same model family and both pass capability requirements, the router prefers the less-saturated pool. This is intentional load-spreading for resilience, not just a fallback — and it's why the audit's §3 substrate-as-routing-dimension framing matters operationally, not just architecturally.
+
+## 6. Execution Modes
+
+### 6.1 `single` — production default
+
+Pick best adapter per policy, run once, return result. Telemetry row written on completion. No additional cost vs today.
+
+### 6.2 `shadow` — live + N alternatives, log only
+
+Primary runs and is returned to the user. Shadow adapters run in background with the same prompt, results discarded after telemetry capture.
+
+**Budget controls (audit Q5):**
+
+```ts
+shadow_eligible = (
+  totalShadowSpendThisMonth < SHADOW_BUDGET_USD &&
+  random() < SHADOW_SAMPLE_RATE &&
+  !KILL_SWITCH_ENABLED
+);
+
+// SHADOW_SAMPLE_RATE default = 0.05 (5%)
+// SHADOW_BUDGET_USD default = $100/month
+// KILL_SWITCH_ENABLED env: SUBSTRATE_SHADOW_DISABLE=1
+```
+
+The formula is: `max_shadow_rate ≤ monthly_shadow_budget / (avg_run_cost × monthly_run_count)`. Ops sets the budget; the spec defines the formula and the kill switch.
+
+Shadow runs are tagged `executionMode: "shadow-alt"` in telemetry and **must not** be visible in any user-facing surface. Operator dashboards only.
+
+### 6.3 `race` — N adapters in parallel, first valid wins
+
+All adapters in `[primary, ...shadowAdapters]` start concurrently. Acceptance criteria (audit Q6) — first result satisfying:
+
+1. **Non-error.** `status === "success"`.
+2. **Non-refusal.** No model refusal text patterns; no `policy-block` status.
+3. **Tool-call valid.** Every emitted tool call resolves to a registered tool name with a schema-valid argument set; no fabricated tool names. (Cross-references the receipts spec — fabricated calls produce no receipts.)
+4. **Within latency budget.** First event arrived under `maxInteractiveLatencyMs`.
+5. **Policy pass.** Route-sensitivity floor satisfied (no MCP server in the response that the route plan didn't authorize).
+
+Once one adapter wins, others are SIGTERM'd. All cohort members write telemetry rows with the same `raceCohortId` so we can analyze loser data later. Race mode requires explicit opt-in (`SUBSTRATE_RACE_ENABLE` env) — it doubles or triples spend and isn't a sensible default for chat.
+
+### 6.4 Outcome scoring
+
+Per the audit §5.4. The "winning adapter" for a (taskClass, providerFamily, capabilityRequirementSet) tuple is the one minimizing:
+
+```
+risk_adjusted_cost = (estimated_cost_usd × refusal_rate_factor × retry_rate_factor)
+                   / (acceptance_rate × capability_use_rate)
+```
+
+`acceptance_rate` is computed from `userAccepted`. `refusal_rate_factor` and `retry_rate_factor` penalize unhelpful runs. `capability_use_rate` counts how often the adapter actually exercised a capability we required (selecting Claude Code CLI for subagents and getting back a single text reply means we paid for capability we didn't use).
+
+Scoring runs as a nightly batch over `AdapterRunTelemetry`. Output feeds the route planner's adapter ranking the next day.
+
+## 7. Custody — CLI ToolExecution Minting
+
+**Receipts substrate already shipped.** The hard dependency from earlier drafts ([receipts spec](./2026-04-27-artifact-provenance-receipts-design.md), `ToolExecutionReceipt` table) **landed on main 2026-04-30** via migration `20260430023000_artifact_provenance_receipts_slice_1`. This section's CLI-specific clauses now apply on top of that substrate.
+
+### 7.1 Today's gap (partial)
+
+Phase A6 already closes one half of the gap via [PR #520](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/520): when the agentic loop populates `mcpSession`, Claude CLI mounts `mcp__dpf__*` platform tools via `--mcp-config`. The CLI's tool calls flow back through DPF's MCP server endpoint at `/api/mcp/v1`, hitting `governedExecuteTool` and minting `ToolExecution` rows tagged `source: "internal-mcp-session"`.
+
+The remaining custody gap is:
+1. **Claude CLI's native tools** (Bash, Read, Write, Task, etc.) executed inside the harness sandbox — these still don't reach `prisma.toolExecution`. [claude-dispatch.ts](../../../apps/web/lib/integrate/claude-dispatch.ts) returns `executedTools: []` hardcoded; the panel-driven cli-adapter has the same gap for non-`mcp__dpf__*` tool blocks.
+2. **All Codex CLI tool calls** — [codex-cli-adapter.ts](../../../apps/web/lib/routing/codex-cli-adapter.ts) doesn't parse `--json` output yet.
+
+Phase B6 closes both.
+
+### 7.2 Required clause
+
+Each CLI adapter's `EventNormalizer` (§8) must mint a `ToolExecution` row for every harness-emitted tool call:
+
+| Adapter | Stream event(s) → ToolExecution |
+| --- | --- |
+| Claude Code CLI (native tools — Bash, Read, Write, Task, etc.) | `tool_use` blocks in stream-json (the `mcp__dpf__*` subset is already minted via the MCP-bridge path from PR #520; non-MCP blocks are the remaining target) |
+| Codex CLI | `item.completed` where `item.type ∈ {command_execution, mcp_tool_call, file_change, web_search}` |
+| Codex MCP server | tool call wire format from MCP protocol |
+| HTTP adapters | already minted via `governedExecuteTool` at [`apps/web/lib/mcp-governed-execute.ts:206`](../../../apps/web/lib/mcp-governed-execute.ts#L206) — unchanged |
+
+`ToolExecution.threadId` and `ToolExecution.cliSessionId` (extension) link the row back to the panel thread. The receipts substrate is already live on main, so the same normalizer can mint `ToolExecutionReceipt` rows immediately for any CLI tool call that consumed sandbox state.
+
+### 7.3 Codex stream-MCP landmine
+
+Codex CLI silently ignores `--json` when MCP servers are active (issue [openai/codex#15451](https://github.com/openai/codex/issues/15451)). The Codex adapter must:
+
+1. At route-plan time: detect `(codex-cli + MCP active)` combination.
+2. Refuse the run with a clear error rather than parse malformed output.
+3. Log the refusal to `AdapterRunTelemetry` with `errorClass = "codex-mcp-json-degradation"` so the issue is operationally visible.
+4. Prefer `codex-mcp-server` adapter kind for that route plan if MCP is required (Codex acts as MCP server itself, side-stepping the bug).
+
+## 8. Event Normalization
+
+Each adapter's stream is parsed into a single DPF-native event taxonomy. The panel renders these events; raw harness payloads are kept only in trace detail.
+
+### 8.1 Normalized event types
+
+```ts
+type NormalizedEvent =
+  | { kind: "task.started"; taskId: string; intent: string }
+  | { kind: "message.delta"; text: string }
+  | { kind: "thinking.delta"; text: string; effort?: "low" | "medium" | "high" }
+  | { kind: "tool.invoked"; toolId: string; toolName: string; argsDigest: string }
+  | { kind: "tool.completed"; toolId: string; status: "ok" | "error"; resultDigest: string }
+  | { kind: "todo.updated"; todos: Array<{ id: string; text: string; status: "todo" | "doing" | "done" }> }
+  | { kind: "plan.proposed"; steps: Array<{ id: string; text: string }> }
+  | { kind: "subagent.started"; subagentId: string; intent: string }
+  | { kind: "subagent.completed"; subagentId: string; status: "ok" | "error" }
+  | { kind: "hook.fired"; hookName: string; phase: "pre" | "post"; result: "ok" | "blocked" }
+  | { kind: "approval.required"; proposalId: string; scope: string; effect: string }
+  | { kind: "artifact.produced"; artifactId: string; kind: "file" | "diff" | "doc"; uri: string }
+  | { kind: "web.fetch"; url: string; status: number; contentDigest: string }
+  | { kind: "web.search"; query: string; resultCount: number }
+  | { kind: "adapter.degraded"; reason: string; impact: "soft" | "hard" }
+  | { kind: "task.completed"; status: "success" | "error" | "cancelled"; usage: TokenUsage };
+```
+
+### 8.2 Per-adapter normalizer mapping
+
+| Adapter event | → Normalized event |
+| --- | --- |
+| Claude Code `tool_use` | `tool.invoked` |
+| Claude Code `tool_result` | `tool.completed` |
+| Claude Code thinking block | `thinking.delta` |
+| Claude Code TodoWrite tool | `todo.updated` |
+| Claude Code Task tool spawn | `subagent.started` |
+| Claude Code hook output | `hook.fired` |
+| Codex `item.started type=command_execution` | `tool.invoked` |
+| Codex `item.completed type=command_execution` | `tool.completed` |
+| Codex `item.completed type=agent_message` | `message.delta` |
+| Codex `item.completed type=reasoning` | `thinking.delta` |
+| Codex `item.completed type=plan_update` | `plan.proposed` or `todo.updated` |
+| Codex `item.completed type=file_change` | `artifact.produced` |
+| Codex `item.completed type=mcp_tool_call` | `tool.invoked` + `tool.completed` |
+| Codex `item.completed type=web_search` | `web.search` |
+| Codex `turn.completed` | `task.completed` |
+| HTTP SSE `content_block_delta` | `message.delta` |
+| HTTP SSE `tool_use` block | `tool.invoked` |
+
+### 8.3 Schema-drift detection
+
+Each normalizer ships with a per-adapter-version schema fixture. On every run, observed event shapes are checksummed against the fixture. Drift sets `AdapterRunTelemetry.schemaDriftDetected = true` and emits a logged warning. Three consecutive drift detections trigger an automatic kill-switch on that adapter version (revert to previous probed version).
+
+This is the operational guard against the Codex `item_type → type` rename pattern (issue [openai/codex#4776](https://github.com/openai/codex/issues/4776)) — we'll know the next time it happens, instead of getting silently malformed UI.
+
+## 9. CLI Session Lifecycle
+
+Per audit Q2 — current state is per-task ephemeral. Target is **per-thread sessions with per-task ephemeral fallback for parallel work**.
+
+### 9.0 Boundary vs `WorkCapsule` (PR #602)
+
+[PR #602](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/602) (merged 2026-05-14) introduced `WorkCapsule` + `WorkCapsuleActivity` for sandbox lease lifecycle: columns include `executorKind`, `executorRef`, `sandboxProviderId`, `sandboxId`, `worktreePath`, `leaseExpiresAt`, `leaseHolderPrincipalId` plus a sweeper. That is the **unit-of-work envelope** layer. `CliSessionService` (Phase C) is the **transport-level handle** to a running CLI subprocess inside a sandbox.
+
+Boundary statement:
+
+- `WorkCapsule` owns the sandbox lease (`sandboxId`, `worktreePath`, `leaseExpiresAt`, `leaseHolderPrincipalId`). It is grain = unit-of-work.
+- `CliSessionService` owns the per-thread CLI session ID, the harness session state (Claude `--session-id`, Codex `thread_id`), and the `AgentThread.cliSession*` mapping. It is grain = panel thread.
+- Phase C wires `CliSessionService.claim()` to consume an existing `WorkCapsule` lease where one applies, rather than allocating its own sandbox slot. `AgentThread.cliSessionContainerId` becomes a FK-by-convention pointer to `WorkCapsule.sandboxId` (or equivalent) so the sandbox pool isn't double-managed. The sweeper (§9.4) defers to the WorkCapsule sweeper for sandbox lifecycle and only nulls the `AgentThread.cliSession*` columns when the underlying lease expires.
+
+This separation keeps the unit-of-work concept singular while letting the panel thread own its own per-message session identity.
+
+### 9.1 Session claim
+
+When a coworker message arrives on thread T using a CLI adapter:
+
+1. `CliSessionService.claim(threadId, adapterKind)`.
+2. If `AgentThread.cliSessionId` is set and `cliSessionLastUsedAt` is within TTL: reuse.
+3. Else: allocate a sandbox container slot from the pool (audit confirms `DPF_SANDBOX_POOL_SIZE` default 3 already exists), bind to thread, generate session UUID, write to `AgentThread`.
+4. Update `cliSessionLastUsedAt` on every claim.
+
+### 9.2 Concurrency rule
+
+Two messages on the same thread arriving concurrently:
+
+- If both can serialize (chat-like, sequential): they queue on the thread's session.
+- If one is a long-running task (Build Studio dispatch from within a coworker thread): it gets an **ephemeral fallback** — fresh `--session-id` (Claude) or `--ephemeral` (Codex), no thread session pin.
+
+This matches the build-orchestrator's existing decision at [build-orchestrator.ts:906](../../../apps/web/lib/integrate/build-orchestrator.ts#L906) to deliberately omit `--session-id` for parallel work.
+
+### 9.3 Workspace isolation
+
+Today all CLI tasks share `/workspace` ([claude-dispatch.ts:178](../../../apps/web/lib/integrate/claude-dispatch.ts#L178)). For panel-driven CLI sessions, this is a correctness hazard.
+
+Proposal — bound to per-thread sessions, not per-task:
+
+- `cliSessionWorkdir = /workspace/threads/<threadId>` for the panel substrate.
+- The CliSessionService creates the directory on first claim and a git worktree off `main`.
+- Thread session lifecycle owns the worktree; sweeper teardown removes it.
+- Build Studio dispatch keeps its existing `/workspace` path. Convergence (one-worktree-per-build) is a follow-up.
+
+### 9.4 Session expiry sweeper
+
+Cron job, every 10 min:
+
+```ts
+SELECT * FROM "AgentThread"
+WHERE "cliSessionId" IS NOT NULL
+  AND "cliSessionLastUsedAt" < NOW() - interval '60 minutes';
+
+// for each: free sandbox slot, remove worktree, null out cliSession* columns
+```
+
+Idempotent. A thread re-claims a fresh session on next message.
+
+### 9.5 Resume on restart
+
+Both CLIs support session resume (Claude Code via `--session-id`; Codex via `codex exec resume <uuid>`). On portal restart the sweeper does *not* drop sessions whose TTL is unexpired — they survive across restarts and are re-attached on next thread message.
+
+## 10. Panel UX — Cockpit Shape
+
+Per audit §6.2. The panel evolves from a transcript drawer into a compact execution cockpit. Implementation is layered.
+
+### 10.0 Composition with shipped surfaces (2026-05-16 reconciliation)
+
+Phase E does not own all coworker UI surfaces — it composes with two **already-shipped** surfaces and one **complementary** future surface:
+
+- **[PR #629](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/629) — `AgentSkillAttributionChip` + `/platform/ai/skills` Telemetry tab.** These render *per-skill* attribution and telemetry. The cockpit must compose with them, not duplicate them. Phase E header carries one chip group: **adapter-kind badge ⊕ skill-attribution chip ⊕ adapter health LED** — three signals in one row, not three competing components.
+- **[PR #607](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/607) — routing-topology attribution.** `RouteDecisionLog.actorKind`/`actorId`/`agentId` + `RouteOutcome.agentId` are already populated. The cockpit's trace tab consumes those rows for the operator/admin view.
+- **[2026-05-10-ai-coworker-visual-control-surface-design.md](./2026-05-10-ai-coworker-visual-control-surface-design.md) — Coworker Operations Map.** Many-coworker schematic, not a per-thread cockpit. Phase E ships the per-thread cockpit; the Operations Map projects across threads using the same `NormalizedEvent` taxonomy from §8. They are complementary surfaces.
+
+### 10.1 New panel zones
+
+- **Header**: coworker identity + adapter kind badge ("Claude Code CLI" / "Codex" / "HTTP") + adapter health LED + thread session age.
+- **Status rail**: active task title, pending approvals (count + click-to-jump), adapter degradation banner, todos from `todo.updated` events.
+- **Transcript**: messages + only the normalized events that aid understanding (`tool.invoked`/`tool.completed`, `subagent.*`, `approval.*`, `artifact.*`). `thinking.delta` collapsible, `web.fetch` collapsible.
+- **Artifacts panel**: aggregates `artifact.produced` events across the thread; click-through to file or diff.
+- **Approvals panel**: existing proposal cards driven by `approval.required` events.
+- **Trace tab**: full normalized event log, raw adapter payload available behind one more click. Operator-grade detail.
+
+### 10.2 Progressive disclosure (audit Q7)
+
+| Role | Default panel surface |
+| --- | --- |
+| User | Header (coworker + health LED only, no adapter name), status rail, transcript, approvals. Adapter identity hidden. |
+| Operator | + adapter kind badge, latency, cost in trace tab, shadow comparison link |
+| Admin | + full route plan, capability profile, schema-drift warnings, kill-switch controls |
+
+Role taken from existing portal RBAC. Three CSS class hooks plus a per-zone visibility predicate; no new auth model.
+
+### 10.3 Theme-awareness (per project standard)
+
+All panel zones use existing CSS variables (`--surface`, `--text`, `--accent`, etc). No hardcoded colors. Adapter-kind badges use the same variables already used for capability tier badges.
+
+## 11. MCP Boundary (audit Q3)
+
+### 11.1 Per-route MCP allowlist
+
+Route plan extension:
+
+```ts
+mcpAttachPolicy?: {
+  allowedServers: string[];                          // from registry
+  tokenScope:     "thread" | "install" | "ephemeral"; // most restrictive default
+  routeSensitivityFloor: "public" | "internal" | "sensitive";
+};
+```
+
+The route planner cross-references the requested MCP servers against:
+
+1. Coworker's grants (existing tool-grant audit / governance).
+2. Route sensitivity floor (no `sensitive` MCP attachment on `public`-sensitivity routes).
+3. Adapter capability — does the chosen adapter support `mcpAttachPerInvoke`?
+
+### 11.2 Token scoping
+
+Default: tokens scoped to the thread session. When the sweeper expires the session, MCP tokens are revoked. Install-scoped tokens require admin grant.
+
+### 11.3 Codex static-attach rule
+
+Because Codex requires `~/.codex/config.toml` mutation for MCP attach, the Codex adapter cannot honor per-invoke allowlists cleanly. Resolution:
+
+1. **Static config baseline** — the Codex container ships with a known, audit-logged set of MCP servers.
+2. **Per-invoke negotiation** is degraded to: route plan rejects (and selects an alternative adapter) if its MCP allowlist is not a subset of the Codex container's static set.
+3. **Codex MCP server adapter** (`codex-mcp-server`) sidesteps this — Codex acts as a server that DPF connects to, with DPF controlling the surrounding MCP context.
+
+## 12. Implementation Phases
+
+### Phase A — Schema + capability profile (foundation)
+
+1. Add `AdapterCapabilityProfile`, `AdapterRunTelemetry` tables; extend `AgentThread` with `cliSession*` columns.
+2. Implement `probe()` for current HTTP and Claude CLI adapters; populate profile rows.
+3. Remove hard-coded check at [ai-inference.ts:353](../../../apps/web/lib/ai-inference.ts#L353) — replace with registry resolution.
+4. Tests: probe deterministic against fixture stream; registry resolution returns expected adapter for current single-mode behavior; no behavior change vs today.
+
+**Acceptance:** every existing coworker run works identically, but the route plan now carries a structured `executionAdapter` field and writes a telemetry row.
+
+### Phase B — Codex CLI adapter + event normalizer
+
+1. New `codex-cli-adapter.ts` modeled on `cli-adapter.ts`.
+2. Event normalizer covering observed event types from [evidence/2026-04-29-codex-jsonl-probe.md](../audits/evidence/2026-04-29-codex-jsonl-probe.md).
+3. Schema-drift detector with version-pinned fixture (Codex 0.125.0 baseline).
+4. MCP-active-with-`--json` refusal guard (issue #15451 mitigation).
+5. ToolExecution minting from `command_execution`, `mcp_tool_call`, `file_change`, `web_search` events.
+6. Tests: Codex container probe; replay sample JSONL through normalizer; assert ToolExecution rows minted with correct shape.
+
+**Acceptance:** a coworker with `executionAdapter.kind = codex-cli` can run a `command_execution` and have a `ToolExecution` row appear in DB tied to the thread.
+
+### Phase C — CliSessionService + per-thread continuity
+
+1. New `apps/web/lib/coworker/cli-session-service.ts`.
+2. Sandbox-pool affinity layer over existing pool.
+3. Per-thread workdir + worktree creation.
+4. Sweeper cron job.
+5. Resume on portal restart.
+6. Tests: claim/reuse/expire cycle; concurrent message serialization; ephemeral fallback.
+
+**Acceptance:** sequential coworker messages on the same thread share the same CLI session and observable plan/todo state.
+
+### Phase D — Event normalizer parity for Claude Code
+
+1. Extend existing `cli-adapter.ts` to cover thinking blocks, todos (TodoWrite), Task subagents, hook output beyond the existing `tool_use` parsing.
+2. Schema-drift fixture for Claude Code current version.
+3. Backfill normalized events for in-flight threads.
+
+**Acceptance:** Claude Code CLI runs surface plan, todo, subagent, and thinking events to the panel.
+
+### Phase E — Panel cockpit UI
+
+1. Header / status rail / artifacts / approvals zones.
+2. Adapter health LED + degradation banner.
+3. Trace tab.
+4. Progressive disclosure by role.
+5. Theme-aware styling audit.
+
+**Acceptance:** users see one coherent panel surface for HTTP, Claude Code CLI, and Codex CLI runs without raw harness payloads leaking into the transcript.
+
+### Phase F — Shadow mode
+
+1. `executionMode: "shadow"` dispatch path.
+2. Budget caps + sample rate + kill switch.
+3. Operator dashboard surfacing shadow comparison data from `AdapterRunTelemetry`.
+4. Nightly outcome-scoring batch.
+
+**Acceptance:** ops can run a one-week shadow of Codex CLI against Claude HTTP for the chat workload and read a comparison report at end of week.
+
+### Phase G — Race mode + quota-pool spreading
+
+1. `executionMode: "race"` dispatch path with cohort tracking.
+2. Quota-pool saturation tracking and adapter ranking integration.
+3. Race acceptance criteria implementation (§6.3).
+4. Race kill switch.
+
+**Acceptance:** under controlled rate-limit pressure, the platform automatically shifts load between `anthropic-api` and `anthropic-oauth` quota pools without user-visible degradation.
+
+### Phase H — Refactor allocation (audit §8 — 20% budget)
+
+Reserved through every preceding phase. Specific deliverables:
+
+1. Extract `ExecutionAdapter` interface from existing adapter implementations.
+2. Move adapter-specific code out of `routed-inference.ts` into the registry.
+3. Separate panel transcript state from task / artifact / approval / trace state in the React tree.
+4. Unify CLI session ID generation across `claude-dispatch.ts`, `codex-dispatch.ts`, and the new substrate adapters.
+5. Cost / quota / outcome ledger consolidation (`AdapterRunTelemetry` is canonical; `ToolExecution.duration_ms` etc. cross-reference it).
+
+## 13. Open Risks
+
+1. **Codex schema instability.** The schema-drift detector + version pin is the mitigation. If drift is constant, Codex CLI is operationally untenable for the panel and we keep it Build-Studio-only.
+2. **Sandbox pool exhaustion.** Per-thread sessions pin sandbox slots. With pool size 3 and TTL 60 min, ≥3 active threads block new claims. Mitigation: pool size scales with active-thread count; ephemeral fallback when pool saturated.
+3. **CLI subprocess timeout floor.** 3 min for chat (current cli-adapter), 15 min for Build Studio. Long thinking turns may hit the chat ceiling. Mitigation: per-adapter-version timeout in `AdapterCapabilityProfile`, route planner respects it.
+4. **OAuth token churn.** Both Claude Code and Codex use OAuth tokens that expire / rotate. Mitigation: existing token-refresh paths in `cli-adapter.ts` extend to Codex; failure → adapter health degrades, route planner fails over.
+5. **Shadow run prompt leakage.** Running the same prompt against multiple providers may surface DPF prompts to providers we didn't intend. Mitigation: shadow eligibility check excludes prompts above a sensitivity floor; only `public` and `internal` route sensitivities are shadow-eligible by default.
+6. **Race-mode cost amplification.** A race against three adapters costs ~3×. Mitigation: race requires explicit opt-in env flag and per-route-plan opt-in; never default.
+7. **Acceptance signal lag.** `userAccepted` may take days for asynchronous threads. Outcome scoring runs over rolling 7-day windows to absorb this lag.
+
+## 14. Telemetry & Observability
+
+`AdapterRunTelemetry` is the canonical run ledger. Operator dashboards read from it:
+
+- **Adapter mix:** stacked area chart of runs-per-day by adapter kind.
+- **Acceptance rate by adapter:** bar chart filtered by task class and capability requirements.
+- **Schema drift incidents:** count by adapter version, alarm threshold 3 consecutive runs.
+- **Shadow comparison:** for any task class, the shadow-vs-primary acceptance and cost spread.
+- **Quota-pool saturation:** time series of 429 rate per pool.
+- **CLI session lifecycle:** active sessions, evictions, resume successes.
+
+Health LED in the panel header is driven by:
+
+```
+adapter_health = healthy
+  if (last 100 runs success rate ≥ 95%
+      and median first_event_latency_ms within capability profile bound
+      and no schema drift in last 24h)
+  else degraded
+```
+
+`adapter.degraded` events surface in the panel as a banner; the route planner deprioritizes degraded adapters until 5 consecutive healthy runs clear the flag.
+
+## 15. Migration & Backwards Compatibility
+
+- Existing coworker threads have `cliSessionId = null`. They keep working through the HTTP adapter exactly as today.
+- The hard-coded check at [ai-inference.ts:353](../../../apps/web/lib/ai-inference.ts#L353) is replaced by registry resolution that, in absence of an explicit `executionAdapter`, defaults to the prior provider-id-driven choice. No silent behavior change.
+- `AdapterCapabilityProfile` is populated lazily — first probe at adapter registration, refresh on version change.
+- Build Studio dispatch is unchanged. Convergence happens only when Phase H has run and only as an explicit follow-up.
+- Receipts spec landing first lets §7 mint full provenance receipts. If receipts spec slips, §7 still mints `ToolExecution` rows and the receipt linkage is added in a follow-up patch.
+
+## 16. References
+
+- [Coworker Substrate Status Review](../audits/2026-04-29-cli-substrate-status-review.md) — the audit this spec promotes
+- [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-jsonl-probe.md) — empirical event taxonomy
+- [Artifact Provenance Receipts Design](./2026-04-27-artifact-provenance-receipts-design.md) — hard dependency for §7
+- [Routing Control / Data-Plane Design](./2026-04-27-routing-control-data-plane-design.md) — route plan extension
+- [Routing Substrate Attempt History](./2026-04-27-routing-substrate-attempt-history.md) — feeds outcome scoring
+- [Claude Code: slash commands](https://code.claude.com/docs/en/slash-commands), [subagents](https://code.claude.com/docs/en/sub-agents), [hooks](https://code.claude.com/docs/en/hooks)
+- [Codex CLI exec docs](https://github.com/openai/codex/blob/main/docs/exec.md), [config docs](https://github.com/openai/codex/blob/main/docs/config.md)
+- Codex issues: [#15451](https://github.com/openai/codex/issues/15451) (`--json` + MCP), [#4776](https://github.com/openai/codex/issues/4776) (silent rename), [#17501](https://github.com/openai/codex/issues/17501) (MCP lifecycle events), [#4181](https://github.com/openai/codex/issues/4181) (`--output-schema` model gate)
+- DPF memory: [CLI vs API rate limits](../../../memory/project_cli_vs_api_rate_limits.md), [Codex CLI integration](../../../memory/project_codex_cli_integration.md), [Mirror Claude Code patterns](../../../memory/feedback_claude_code_patterns.md), [Architecture over shortcuts](../../../memory/feedback_architecture_over_shortcuts.md), [Approach zero technical debt](../../../memory/feedback_zero_technical_debt.md)

--- a/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
+++ b/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
@@ -7,7 +7,7 @@
 | **Created** | 2026-04-29 |
 | **Renamed** | 2026-05-16 — original filename `2026-04-29-coworker-execution-adapter-substrate-design.md` collided with a different-content in-process orchestration-primitives spec on main (PR #350). New name signals the routing-layer scope explicitly. |
 | **Author** | Claude Opus 4.7 (1M ctx) for Mark Bodman |
-| **Promotes** | [2026-04-29-cli-substrate-status-review.md](../audits/2026-04-29-cli-substrate-status-review.md) (audit) and its [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-jsonl-probe.md) |
+| **Promotes** | [2026-04-29-cli-substrate-status-review.md](../audits/2026-04-29-cli-substrate-status-review.md) (audit) and its [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-cli-jsonl-probe.md) |
 | **Hard dependency** | [2026-04-27-artifact-provenance-receipts-design.md](./2026-04-27-artifact-provenance-receipts-design.md) — `ToolExecutionReceipt` table required before §7 (custody) can mint full receipts. Already shipped on main as of 2026-04-30 (commit landed migration `20260430023000_artifact_provenance_receipts_slice_1`). |
 | **Related specs** | [2026-04-27-routing-control-data-plane-design.md](./2026-04-27-routing-control-data-plane-design.md) (extends the route plan), [2026-04-27-routing-substrate-attempt-history.md](./2026-04-27-routing-substrate-attempt-history.md) (attempt-history feeds outcome scoring), [2026-05-10-ai-coworker-visual-control-surface-design.md](./2026-05-10-ai-coworker-visual-control-surface-design.md) (Operations Map; consumes this spec's `NormalizedEvent` shape; Phase E cockpit complements it, does not replace it), [2026-05-11-autonomous-coworker-runtime-design.md](./2026-05-11-autonomous-coworker-runtime-design.md) (TaskRun substrate that consumes `AdapterRunTelemetry` as evidence), [2026-05-09-build-execution-provider-design.md](./2026-05-09-build-execution-provider-design.md) (Build Studio's `BuildExecutionProvider`/`BuildAgentRunner` — *parallel layer*, not the same axis; see §3 boundary statement). |
 | **Scope** | `apps/web/lib/routing/*` (adapter registry, route plan, capability profile), `apps/web/lib/routing/cli-adapter.ts` (extended by PR #520 with `--mcp-config` mounting; A6 keeps that intact), new `apps/web/lib/routing/codex-cli-adapter.ts` (already present on main, 360 lines, no `--json` parsing yet), `apps/web/lib/inference/ai-inference.ts` (A6 replaces the `isCliAdapter` short-circuit; the older `apps/web/lib/ai-inference.ts` is a 2-line shim), `apps/web/lib/actions/agent-coworker.ts` (event normalization → panel), `packages/db/prisma/schema.prisma` (`AgentThread.cliSession*` columns, capability-profile cache, adapter telemetry), coworker panel UI components (cockpit shape). |
@@ -620,7 +620,7 @@ Because Codex requires `~/.codex/config.toml` mutation for MCP attach, the Codex
 ### Phase B — Codex CLI adapter + event normalizer
 
 1. New `codex-cli-adapter.ts` modeled on `cli-adapter.ts`.
-2. Event normalizer covering observed event types from [evidence/2026-04-29-codex-jsonl-probe.md](../audits/evidence/2026-04-29-codex-jsonl-probe.md).
+2. Event normalizer covering observed event types from [evidence/2026-04-29-codex-cli-jsonl-probe.md](../audits/evidence/2026-04-29-codex-cli-jsonl-probe.md).
 3. Schema-drift detector with version-pinned fixture (Codex 0.125.0 baseline).
 4. MCP-active-with-`--json` refusal guard (issue #15451 mitigation).
 5. ToolExecution minting from `command_execution`, `mcp_tool_call`, `file_change`, `web_search` events.
@@ -729,7 +729,7 @@ adapter_health = healthy
 ## 16. References
 
 - [Coworker Substrate Status Review](../audits/2026-04-29-cli-substrate-status-review.md) — the audit this spec promotes
-- [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-jsonl-probe.md) — empirical event taxonomy
+- [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-cli-jsonl-probe.md) — empirical event taxonomy
 - [Artifact Provenance Receipts Design](./2026-04-27-artifact-provenance-receipts-design.md) — hard dependency for §7
 - [Routing Control / Data-Plane Design](./2026-04-27-routing-control-data-plane-design.md) — route plan extension
 - [Routing Substrate Attempt History](./2026-04-27-routing-substrate-attempt-history.md) — feeds outcome scoring

--- a/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
+++ b/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
@@ -608,14 +608,15 @@ Because Codex requires `~/.codex/config.toml` mutation for MCP attach, the Codex
 
 ## 12. Implementation Phases
 
-### Phase A — Schema + capability profile (foundation)
+### Phase A — Schema + capability profile (foundation) — **shipped 2026-05-16**
 
 1. Add `AdapterCapabilityProfile`, `AdapterRunTelemetry` tables; extend `AgentThread` with `cliSession*` columns.
 2. Implement `probe()` for current HTTP and Claude CLI adapters; populate profile rows.
-3. Remove hard-coded check at [ai-inference.ts:353](../../../apps/web/lib/ai-inference.ts#L353) — replace with registry resolution.
-4. Tests: probe deterministic against fixture stream; registry resolution returns expected adapter for current single-mode behavior; no behavior change vs today.
+3. Remove hard-coded check at [`ai-inference.ts:353`](../../../apps/web/lib/inference/ai-inference.ts#L353) — replace with `parseExecutionAdapterSelector` + `resolveExecutionAdapter`. PR #520's mcpSession mounting is preserved verbatim.
+4. Tests: probe deterministic against fixture stream; resolver returns expected adapter for current single-mode behavior; no behavior change vs today.
+5. Wire `AdapterRunTelemetry` write at end of every coworker run, fire-and-forget so a DB outage cannot break a turn.
 
-**Acceptance:** every existing coworker run works identically, but the route plan now carries a structured `executionAdapter` field and writes a telemetry row.
+**Acceptance:** every existing coworker run works identically, the route plan carries a structured `executionAdapter` selector (with legacy-string passthrough for non-CLI/chat adapter strings), and writes one telemetry row per call. See plan's "Phase A status" table for the per-task commit hashes.
 
 ### Phase B — Codex CLI adapter + event normalizer
 

--- a/packages/db/prisma/migrations/20260516120000_add_adapter_capability_profile/migration.sql
+++ b/packages/db/prisma/migrations/20260516120000_add_adapter_capability_profile/migration.sql
@@ -1,0 +1,42 @@
+-- AdapterCapabilityProfile — coworker execution adapter substrate (Phase A1).
+--
+-- Captures observed adapter capabilities per (adapterKind, adapterVersion).
+-- Replaces hand-maintained capability tables with probe-populated rows.
+--
+-- Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A1)
+-- Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1
+--
+-- Purely additive: creates one new table with one unique index and one
+-- supporting index. No existing tables, columns, or enums are touched.
+
+-- CreateTable
+CREATE TABLE "AdapterCapabilityProfile" (
+    "id" TEXT NOT NULL,
+    "adapterKind" TEXT NOT NULL,
+    "adapterVersion" TEXT NOT NULL,
+    "probedAt" TIMESTAMP(3) NOT NULL,
+    "probedBy" TEXT NOT NULL,
+    "supportsStreamingEvents" BOOLEAN NOT NULL,
+    "supportsMcpAttach" BOOLEAN NOT NULL,
+    "supportsMcpAttachPerInvoke" BOOLEAN NOT NULL,
+    "supportsSubagents" BOOLEAN NOT NULL,
+    "supportsHooks" BOOLEAN NOT NULL,
+    "supportsPlanState" BOOLEAN NOT NULL,
+    "supportsTodoState" BOOLEAN NOT NULL,
+    "supportsWebFetch" BOOLEAN NOT NULL,
+    "supportsWebSearch" BOOLEAN NOT NULL,
+    "supportsSessionResume" BOOLEAN NOT NULL,
+    "supportsExtendedThinking" BOOLEAN NOT NULL,
+    "supportsOutputSchema" BOOLEAN NOT NULL,
+    "maxInteractiveLatencyMs" INTEGER NOT NULL,
+    "supportedAuthModes" TEXT[],
+    "knownDegradations" JSONB,
+
+    CONSTRAINT "AdapterCapabilityProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdapterCapabilityProfile_adapterKind_probedAt_idx" ON "AdapterCapabilityProfile"("adapterKind", "probedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdapterCapabilityProfile_adapterKind_adapterVersion_key" ON "AdapterCapabilityProfile"("adapterKind", "adapterVersion");

--- a/packages/db/prisma/migrations/20260516120100_add_adapter_run_telemetry/migration.sql
+++ b/packages/db/prisma/migrations/20260516120100_add_adapter_run_telemetry/migration.sql
@@ -1,0 +1,65 @@
+-- AdapterRunTelemetry — coworker execution adapter substrate (Phase A2).
+--
+-- One row per adapter execution attempt. Captures latency, tokens, cost,
+-- quota pool, status, refusal/error class, tool-call validity, capability
+-- usage, and schema-drift detection. Supports the single/shadow/race
+-- execution modes via raceCohortId grouping. Feeds nightly outcome scoring.
+--
+-- Spec: docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md §4.3
+--
+-- Includes agentId (PR #607 attribution convention) and skillId (PR #623
+-- skill telemetry precedent) so AdapterRunTelemetry rows can join cleanly
+-- across the routing and skill telemetry tables.
+--
+-- Purely additive: creates one new table with four supporting indexes. No
+-- existing tables, columns, or enums are touched.
+
+-- CreateTable
+CREATE TABLE "AdapterRunTelemetry" (
+    "id" TEXT NOT NULL,
+    "threadId" TEXT,
+    "agentMessageId" TEXT,
+    "buildId" TEXT,
+    "agentId" TEXT,
+    "skillId" TEXT,
+    "adapterKind" TEXT NOT NULL,
+    "adapterVersion" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "modelId" TEXT NOT NULL,
+    "executionMode" TEXT NOT NULL,
+    "raceCohortId" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "finishedAt" TIMESTAMP(3),
+    "durationMs" INTEGER,
+    "firstEventLatencyMs" INTEGER,
+    "status" TEXT NOT NULL,
+    "refusalReason" TEXT,
+    "errorClass" TEXT,
+    "inputTokens" INTEGER,
+    "cachedInputTokens" INTEGER,
+    "outputTokens" INTEGER,
+    "reasoningTokens" INTEGER,
+    "estimatedCostUsd" DECIMAL(10,6),
+    "quotaPoolConsumed" TEXT,
+    "toolCallsTotal" INTEGER NOT NULL DEFAULT 0,
+    "toolCallsInvalid" INTEGER NOT NULL DEFAULT 0,
+    "capabilitiesUsed" TEXT[],
+    "schemaDriftDetected" BOOLEAN NOT NULL DEFAULT false,
+    "userAccepted" BOOLEAN,
+    "acceptedAt" TIMESTAMP(3),
+    "rawEventDigest" TEXT,
+
+    CONSTRAINT "AdapterRunTelemetry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdapterRunTelemetry_adapterKind_startedAt_idx" ON "AdapterRunTelemetry"("adapterKind", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "AdapterRunTelemetry_raceCohortId_idx" ON "AdapterRunTelemetry"("raceCohortId");
+
+-- CreateIndex
+CREATE INDEX "AdapterRunTelemetry_threadId_startedAt_idx" ON "AdapterRunTelemetry"("threadId", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "AdapterRunTelemetry_agentId_startedAt_idx" ON "AdapterRunTelemetry"("agentId", "startedAt");

--- a/packages/db/prisma/migrations/20260516120200_add_agent_thread_cli_session/migration.sql
+++ b/packages/db/prisma/migrations/20260516120200_add_agent_thread_cli_session/migration.sql
@@ -1,0 +1,22 @@
+-- AgentThread cliSession* columns — coworker execution adapter substrate (Phase A3).
+--
+-- Adds five nullable columns and one index to the existing AgentThread table
+-- so the CliSessionService (Phase C) can pin a thread to a single CLI session
+-- for plan/todo continuity. A sweeper expires stale sessions via the
+-- cliSessionLastUsedAt index.
+--
+-- Plan: docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md (Task A3)
+-- Spec: docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.2
+--
+-- All columns are nullable so existing AgentThread rows continue to work
+-- unchanged with all five fields null. No destructive changes.
+
+-- AlterTable
+ALTER TABLE "AgentThread" ADD COLUMN "cliSessionId" TEXT;
+ALTER TABLE "AgentThread" ADD COLUMN "cliSessionAdapterKind" TEXT;
+ALTER TABLE "AgentThread" ADD COLUMN "cliSessionContainerId" TEXT;
+ALTER TABLE "AgentThread" ADD COLUMN "cliSessionLastUsedAt" TIMESTAMP(3);
+ALTER TABLE "AgentThread" ADD COLUMN "cliSessionWorkdir" TEXT;
+
+-- CreateIndex
+CREATE INDEX "AgentThread_cliSessionLastUsedAt_idx" ON "AgentThread"("cliSessionLastUsedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2102,6 +2102,42 @@ model RecipePerformance {
   @@unique([recipeId, contractFamily])
 }
 
+// ─── Coworker Execution Adapter Substrate (Phase A1–A3) ──────────────────────
+// Spec: docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
+// Captures observed adapter capabilities per (adapterKind, adapterVersion).
+// Replaces hand-maintained capability tables with probe-populated rows.
+model AdapterCapabilityProfile {
+  id                          String   @id @default(cuid())
+  adapterKind                 String   // "http-anthropic" | "claude-code-cli" | "codex-cli" | "codex-mcp" | "local-ollama"
+  adapterVersion              String   // e.g. "claude-code/1.2.3", "codex-cli/0.125.0", "anthropic-http/2024-06-01"
+  probedAt                    DateTime
+  probedBy                    String   // host/process identity, for cache invalidation across replicas
+
+  // Observed capabilities — booleans, not aspirations
+  supportsStreamingEvents     Boolean
+  supportsMcpAttach           Boolean
+  supportsMcpAttachPerInvoke  Boolean  // Claude Code: yes (--mcp-config); Codex: no (static config only)
+  supportsSubagents           Boolean
+  supportsHooks               Boolean
+  supportsPlanState           Boolean
+  supportsTodoState           Boolean
+  supportsWebFetch            Boolean
+  supportsWebSearch           Boolean
+  supportsSessionResume       Boolean
+  supportsExtendedThinking    Boolean
+  supportsOutputSchema        Boolean
+
+  // Operating envelope
+  maxInteractiveLatencyMs     Int      // wall-clock budget for first event
+  supportedAuthModes          String[] // "api-key" | "oauth" | "local"
+
+  // Known landmines (Codex example: --json silently ignored when MCP active)
+  knownDegradations           Json?    // [{ trigger: string, behavior: string, source: string }]
+
+  @@unique([adapterKind, adapterVersion])
+  @@index([adapterKind, probedAt])
+}
+
 model Engagement {
   id            String   @id @default(cuid())
   engagementId  String   @unique // ENG-<uuid>

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3272,7 +3272,19 @@ model AgentThread {
   messages    AgentMessage[]
   user        User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  // Coworker execution adapter substrate (Phase A3) — per-thread CLI session
+  // pinning. Null means no active CLI session; CliSessionService writes these
+  // when issuing a session and a sweeper expires stale rows via the
+  // cliSessionLastUsedAt index.
+  // Spec: docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md §4.2
+  cliSessionId          String?
+  cliSessionAdapterKind String?
+  cliSessionContainerId String?
+  cliSessionLastUsedAt  DateTime?
+  cliSessionWorkdir     String?
+
   @@unique([userId, contextKey])
+  @@index([cliSessionLastUsedAt])
 }
 
 model AgentMessage {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2138,6 +2138,57 @@ model AdapterCapabilityProfile {
   @@index([adapterKind, probedAt])
 }
 
+// One row per adapter execution attempt. Captures latency, tokens, cost,
+// quota pool, status, refusal/error class, tool-call validity, capability
+// usage, and schema-drift detection. Supports single/shadow/race execution
+// modes via raceCohortId grouping. Feeds nightly outcome scoring (§6.4).
+model AdapterRunTelemetry {
+  id                  String    @id @default(cuid())
+  threadId            String?   // null for non-coworker runs (probes, eval)
+  agentMessageId      String?   // joins to AgentMessage when applicable
+  buildId             String?   // for Build Studio dispatch via the substrate
+  agentId             String?   // attribution (PR #607 convention)
+  skillId             String?   // active skill at run time (PR #623 precedent)
+  adapterKind         String
+  adapterVersion      String
+  providerId          String
+  modelId             String
+
+  executionMode       String    // "single" | "shadow-primary" | "shadow-alt" | "race-primary" | "race-loser"
+  raceCohortId        String?   // groups concurrent race/shadow runs
+
+  startedAt           DateTime
+  finishedAt          DateTime?
+  durationMs          Int?
+  firstEventLatencyMs Int?
+
+  // Outcome dimensions (spec §5.4)
+  status              String    // "success" | "refusal" | "error" | "timeout" | "cancelled" | "policy-block"
+  refusalReason       String?
+  errorClass          String?
+  inputTokens         Int?
+  cachedInputTokens   Int?
+  outputTokens        Int?
+  reasoningTokens     Int?
+  estimatedCostUsd    Decimal?  @db.Decimal(10, 6)
+  quotaPoolConsumed   String?   // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
+
+  toolCallsTotal      Int       @default(0)
+  toolCallsInvalid    Int       @default(0) // fabricated tool names, schema mismatches
+  capabilitiesUsed    String[]  // which capability booleans were actually exercised this run
+  schemaDriftDetected Boolean   @default(false) // adapter emitted unexpected event shape
+
+  userAccepted        Boolean?  // null = not yet decided; true = message kept; false = retried/discarded
+  acceptedAt          DateTime?
+
+  rawEventDigest      String?   // sha256 of normalized event log, for cross-adapter equivalence checks
+
+  @@index([adapterKind, startedAt])
+  @@index([raceCohortId])
+  @@index([threadId, startedAt])
+  @@index([agentId, startedAt])
+}
+
 model Engagement {
   id            String   @id @default(cuid())
   engagementId  String   @unique // ENG-<uuid>

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,9 @@
 // packages/db/src/index.ts
 export { prisma } from "./client";
-export type { Prisma, PrismaClient } from "../generated/client/client";
+// Prisma is exported as both a value (for runtime helpers like Prisma.JsonNull,
+// Prisma.DbNull) and a type (for input/output type aliases).
+export { Prisma } from "../generated/client/client";
+export type { PrismaClient } from "../generated/client/client";
 
 export { neo4jSession, closeNeo4j, runCypher } from "./neo4j";
 

--- a/packages/db/test/adapter-capability-profile.test.ts
+++ b/packages/db/test/adapter-capability-profile.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "../src/client";
+import { Prisma } from "../generated/client/client";
+
+// Task A1 of the coworker execution adapter substrate:
+//   docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md
+//   docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.1
+//
+// AdapterCapabilityProfile captures observed adapter capabilities per
+// (adapterKind, adapterVersion). The unique compound key is the cache key —
+// the same kind+version reuses the profile until TTL or version changes.
+
+const TEST_ADAPTER_KIND = "test-adapter-a1";
+const TEST_ADAPTER_VERSION_A = "1.0.0-a1-test";
+const TEST_ADAPTER_VERSION_B = "1.0.0-a1-test-b";
+
+async function clearTestRows() {
+  await prisma.adapterCapabilityProfile.deleteMany({
+    where: { adapterKind: TEST_ADAPTER_KIND },
+  });
+}
+
+beforeEach(async () => {
+  await clearTestRows();
+});
+
+afterAll(async () => {
+  await clearTestRows();
+  await prisma.$disconnect();
+});
+
+function buildProfileInput(
+  adapterVersion: string,
+): Prisma.AdapterCapabilityProfileCreateInput {
+  return {
+    adapterKind: TEST_ADAPTER_KIND,
+    adapterVersion,
+    probedAt: new Date(),
+    probedBy: "vitest:adapter-capability-profile",
+
+    supportsStreamingEvents: true,
+    supportsMcpAttach: true,
+    supportsMcpAttachPerInvoke: false,
+    supportsSubagents: false,
+    supportsHooks: true,
+    supportsPlanState: false,
+    supportsTodoState: true,
+    supportsWebFetch: false,
+    supportsWebSearch: false,
+    supportsSessionResume: true,
+    supportsExtendedThinking: false,
+    supportsOutputSchema: false,
+
+    maxInteractiveLatencyMs: 180_000,
+    supportedAuthModes: ["api-key", "oauth"],
+
+    knownDegradations: [
+      {
+        trigger: "--json + MCP",
+        behavior: "stream malformed",
+        source: "openai/codex#15451",
+      },
+    ],
+  };
+}
+
+describe("AdapterCapabilityProfile prisma model", () => {
+  it("exposes the AdapterCapabilityProfile delegate and model name", () => {
+    expect(Prisma.ModelName.AdapterCapabilityProfile).toBe(
+      "AdapterCapabilityProfile",
+    );
+    expect(prisma.adapterCapabilityProfile).toBeDefined();
+  });
+
+  it("creates a row with all required capability fields", async () => {
+    const created = await prisma.adapterCapabilityProfile.create({
+      data: buildProfileInput(TEST_ADAPTER_VERSION_A),
+    });
+
+    expect(created.id).toBeDefined();
+    expect(created.adapterKind).toBe(TEST_ADAPTER_KIND);
+    expect(created.adapterVersion).toBe(TEST_ADAPTER_VERSION_A);
+    expect(created.supportsStreamingEvents).toBe(true);
+    expect(created.supportsMcpAttachPerInvoke).toBe(false);
+    expect(created.supportedAuthModes).toEqual(["api-key", "oauth"]);
+    expect(created.maxInteractiveLatencyMs).toBe(180_000);
+    expect(created.knownDegradations).toEqual([
+      {
+        trigger: "--json + MCP",
+        behavior: "stream malformed",
+        source: "openai/codex#15451",
+      },
+    ]);
+  });
+
+  it("rejects duplicate (adapterKind, adapterVersion) with a unique-constraint error", async () => {
+    await prisma.adapterCapabilityProfile.create({
+      data: buildProfileInput(TEST_ADAPTER_VERSION_A),
+    });
+
+    await expect(
+      prisma.adapterCapabilityProfile.create({
+        data: buildProfileInput(TEST_ADAPTER_VERSION_A),
+      }),
+    ).rejects.toMatchObject({
+      // Prisma maps Postgres 23505 unique violation to error code P2002.
+      code: "P2002",
+    });
+  });
+
+  it("permits the same adapterKind across distinct adapterVersions", async () => {
+    await prisma.adapterCapabilityProfile.create({
+      data: buildProfileInput(TEST_ADAPTER_VERSION_A),
+    });
+
+    const second = await prisma.adapterCapabilityProfile.create({
+      data: buildProfileInput(TEST_ADAPTER_VERSION_B),
+    });
+
+    expect(second.adapterKind).toBe(TEST_ADAPTER_KIND);
+    expect(second.adapterVersion).toBe(TEST_ADAPTER_VERSION_B);
+  });
+});

--- a/packages/db/test/adapter-run-telemetry.test.ts
+++ b/packages/db/test/adapter-run-telemetry.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "../src/client";
+import { Prisma } from "../generated/client/client";
+
+// Task A2 of the coworker execution adapter substrate:
+//   docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md
+//   docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.3
+//
+// AdapterRunTelemetry captures one row per adapter execution attempt. It is
+// the canonical run ledger feeding outcome scoring and shadow/race comparison.
+
+const TEST_ADAPTER_KIND = "test-adapter-a2";
+
+async function clearTestRows() {
+  await prisma.adapterRunTelemetry.deleteMany({
+    where: { adapterKind: { startsWith: TEST_ADAPTER_KIND } },
+  });
+}
+
+beforeEach(async () => {
+  await clearTestRows();
+});
+
+afterAll(async () => {
+  await clearTestRows();
+  await prisma.$disconnect();
+});
+
+function buildTelemetryInput(
+  overrides: Partial<Prisma.AdapterRunTelemetryCreateInput> = {},
+): Prisma.AdapterRunTelemetryCreateInput {
+  return {
+    adapterKind: TEST_ADAPTER_KIND,
+    adapterVersion: "1.0.0-a2-test",
+    providerId: "test-provider",
+    modelId: "test-model",
+
+    executionMode: "single",
+    startedAt: new Date(),
+
+    status: "success",
+    inputTokens: 100,
+    outputTokens: 50,
+    estimatedCostUsd: new Prisma.Decimal("0.001234"),
+    capabilitiesUsed: ["supportsStreamingEvents"],
+
+    ...overrides,
+  };
+}
+
+describe("AdapterRunTelemetry prisma model", () => {
+  it("exposes the AdapterRunTelemetry delegate and model name", () => {
+    expect(Prisma.ModelName.AdapterRunTelemetry).toBe("AdapterRunTelemetry");
+    expect(prisma.adapterRunTelemetry).toBeDefined();
+  });
+
+  it("creates a row with all required fields", async () => {
+    const created = await prisma.adapterRunTelemetry.create({
+      data: buildTelemetryInput(),
+    });
+
+    expect(created.id).toBeDefined();
+    expect(created.adapterKind).toBe(TEST_ADAPTER_KIND);
+    expect(created.executionMode).toBe("single");
+    expect(created.status).toBe("success");
+    expect(created.inputTokens).toBe(100);
+    expect(created.toolCallsTotal).toBe(0); // default
+    expect(created.toolCallsInvalid).toBe(0); // default
+    expect(created.schemaDriftDetected).toBe(false); // default
+  });
+
+  it("preserves Decimal(10, 6) precision for estimatedCostUsd", async () => {
+    const cost = new Prisma.Decimal("0.123456");
+    const created = await prisma.adapterRunTelemetry.create({
+      data: buildTelemetryInput({ estimatedCostUsd: cost }),
+    });
+
+    const fetched = await prisma.adapterRunTelemetry.findUniqueOrThrow({
+      where: { id: created.id },
+    });
+
+    expect(fetched.estimatedCostUsd).not.toBeNull();
+    expect(fetched.estimatedCostUsd!.toString()).toBe("0.123456");
+  });
+
+  it("round-trips the capabilitiesUsed String[] array", async () => {
+    const caps = [
+      "supportsStreamingEvents",
+      "supportsMcpAttach",
+      "supportsTodoState",
+    ];
+    const created = await prisma.adapterRunTelemetry.create({
+      data: buildTelemetryInput({ capabilitiesUsed: caps }),
+    });
+
+    const fetched = await prisma.adapterRunTelemetry.findUniqueOrThrow({
+      where: { id: created.id },
+    });
+
+    expect(fetched.capabilitiesUsed).toEqual(caps);
+  });
+
+  it("permits omission of all nullable fields", async () => {
+    const created = await prisma.adapterRunTelemetry.create({
+      data: {
+        adapterKind: TEST_ADAPTER_KIND,
+        adapterVersion: "1.0.0-a2-test",
+        providerId: "test-provider",
+        modelId: "test-model",
+        executionMode: "single",
+        startedAt: new Date(),
+        status: "success",
+        capabilitiesUsed: [],
+      },
+    });
+
+    expect(created.threadId).toBeNull();
+    expect(created.agentMessageId).toBeNull();
+    expect(created.buildId).toBeNull();
+    expect(created.raceCohortId).toBeNull();
+    expect(created.finishedAt).toBeNull();
+    expect(created.durationMs).toBeNull();
+    expect(created.firstEventLatencyMs).toBeNull();
+    expect(created.refusalReason).toBeNull();
+    expect(created.errorClass).toBeNull();
+    expect(created.inputTokens).toBeNull();
+    expect(created.cachedInputTokens).toBeNull();
+    expect(created.outputTokens).toBeNull();
+    expect(created.reasoningTokens).toBeNull();
+    expect(created.estimatedCostUsd).toBeNull();
+    expect(created.quotaPoolConsumed).toBeNull();
+    expect(created.userAccepted).toBeNull();
+    expect(created.acceptedAt).toBeNull();
+    expect(created.rawEventDigest).toBeNull();
+  });
+
+  it("groups concurrent runs by raceCohortId", async () => {
+    const cohortId = `cohort-${Date.now()}`;
+
+    await prisma.adapterRunTelemetry.create({
+      data: buildTelemetryInput({
+        adapterKind: `${TEST_ADAPTER_KIND}-primary`,
+        executionMode: "race-primary",
+        raceCohortId: cohortId,
+      }),
+    });
+
+    await prisma.adapterRunTelemetry.create({
+      data: buildTelemetryInput({
+        adapterKind: `${TEST_ADAPTER_KIND}-loser`,
+        executionMode: "race-loser",
+        raceCohortId: cohortId,
+      }),
+    });
+
+    const cohortRows = await prisma.adapterRunTelemetry.findMany({
+      where: { raceCohortId: cohortId },
+      orderBy: { adapterKind: "asc" },
+    });
+
+    expect(cohortRows).toHaveLength(2);
+    expect(cohortRows[0].executionMode).toBe("race-loser");
+    expect(cohortRows[1].executionMode).toBe("race-primary");
+  });
+
+  it("captures the three status-like fields independently", async () => {
+    const created = await prisma.adapterRunTelemetry.create({
+      data: buildTelemetryInput({
+        status: "refusal",
+        executionMode: "shadow-alt",
+        quotaPoolConsumed: "anthropic-oauth",
+      }),
+    });
+
+    expect(created.status).toBe("refusal");
+    expect(created.executionMode).toBe("shadow-alt");
+    expect(created.quotaPoolConsumed).toBe("anthropic-oauth");
+  });
+});

--- a/packages/db/test/agent-thread-cli-session.test.ts
+++ b/packages/db/test/agent-thread-cli-session.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "../src/client";
+
+// Task A3 of the coworker execution adapter substrate:
+//   docs/superpowers/plans/2026-04-29-coworker-execution-adapter-substrate-plan.md
+//   docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md §4.2
+//
+// Adds 5 nullable cliSession* columns to AgentThread plus an index on
+// cliSessionLastUsedAt. The CliSessionService (Phase C) reads/writes these
+// fields to pin a thread to a single CLI session for plan/todo continuity,
+// and a sweeper expires stale sessions via the cliSessionLastUsedAt index.
+//
+// All five columns must be nullable so existing AgentThread rows continue
+// to work unchanged.
+
+const TEST_EMAIL_PREFIX = "agent-thread-cli-session-a3-";
+
+async function clearTestRows() {
+  // AgentThread cascades from User; deleting test users is sufficient.
+  await prisma.user.deleteMany({
+    where: { email: { startsWith: TEST_EMAIL_PREFIX } },
+  });
+}
+
+async function createTestUser(suffix: string) {
+  return prisma.user.create({
+    data: {
+      email: `${TEST_EMAIL_PREFIX}${suffix}@test.invalid`,
+      passwordHash: "not-a-real-hash-a3",
+    },
+  });
+}
+
+beforeEach(async () => {
+  await clearTestRows();
+});
+
+afterAll(async () => {
+  await clearTestRows();
+  await prisma.$disconnect();
+});
+
+describe("AgentThread cliSession* columns (Phase A3)", () => {
+  it("permits creation with all cliSession* fields omitted (backward compat)", async () => {
+    const user = await createTestUser("backcompat");
+    const created = await prisma.agentThread.create({
+      data: {
+        userId: user.id,
+        contextKey: "coworker-a3-backcompat",
+      },
+    });
+
+    const fetched = await prisma.agentThread.findUniqueOrThrow({
+      where: { id: created.id },
+    });
+
+    expect(fetched.cliSessionId).toBeNull();
+    expect(fetched.cliSessionAdapterKind).toBeNull();
+    expect(fetched.cliSessionContainerId).toBeNull();
+    expect(fetched.cliSessionLastUsedAt).toBeNull();
+    expect(fetched.cliSessionWorkdir).toBeNull();
+  });
+
+  it("round-trips all five cliSession* fields when populated", async () => {
+    const user = await createTestUser("populated");
+    const lastUsed = new Date("2026-04-29T12:34:56.000Z");
+
+    const created = await prisma.agentThread.create({
+      data: {
+        userId: user.id,
+        contextKey: "coworker-a3-populated",
+        cliSessionId: "test-uuid-1",
+        cliSessionAdapterKind: "claude-code-cli",
+        cliSessionContainerId: "dpf-sandbox-1",
+        cliSessionLastUsedAt: lastUsed,
+        cliSessionWorkdir: "/workspace/threads/test-thread",
+      },
+    });
+
+    const fetched = await prisma.agentThread.findUniqueOrThrow({
+      where: { id: created.id },
+    });
+
+    expect(fetched.cliSessionId).toBe("test-uuid-1");
+    expect(fetched.cliSessionAdapterKind).toBe("claude-code-cli");
+    expect(fetched.cliSessionContainerId).toBe("dpf-sandbox-1");
+    expect(fetched.cliSessionLastUsedAt?.toISOString()).toBe(
+      lastUsed.toISOString(),
+    );
+    expect(fetched.cliSessionWorkdir).toBe("/workspace/threads/test-thread");
+  });
+
+  it("supports the null -> populated transition via update", async () => {
+    const user = await createTestUser("transition");
+    const created = await prisma.agentThread.create({
+      data: {
+        userId: user.id,
+        contextKey: "coworker-a3-transition",
+      },
+    });
+
+    expect(created.cliSessionId).toBeNull();
+
+    const lastUsed = new Date();
+    await prisma.agentThread.update({
+      where: { id: created.id },
+      data: {
+        cliSessionId: "later-issued-uuid",
+        cliSessionAdapterKind: "codex-cli",
+        cliSessionContainerId: "dpf-sandbox-2",
+        cliSessionLastUsedAt: lastUsed,
+        cliSessionWorkdir: "/workspace/threads/transitional",
+      },
+    });
+
+    const fetched = await prisma.agentThread.findUniqueOrThrow({
+      where: { id: created.id },
+    });
+
+    expect(fetched.cliSessionId).toBe("later-issued-uuid");
+    expect(fetched.cliSessionAdapterKind).toBe("codex-cli");
+    expect(fetched.cliSessionContainerId).toBe("dpf-sandbox-2");
+    expect(fetched.cliSessionLastUsedAt?.toISOString()).toBe(
+      lastUsed.toISOString(),
+    );
+    expect(fetched.cliSessionWorkdir).toBe("/workspace/threads/transitional");
+  });
+
+  it("creates the AgentThread_cliSessionLastUsedAt_idx index for sweeper queries", async () => {
+    const rows = await prisma.$queryRawUnsafe<{ indexname: string }[]>(
+      `SELECT indexname FROM pg_indexes WHERE tablename = 'AgentThread' AND indexname = 'AgentThread_cliSessionLastUsedAt_idx'`,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].indexname).toBe("AgentThread_cliSessionLastUsedAt_idx");
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase A of the CLI execution adapter substrate.** Makes execution adapter (HTTP / Claude Code CLI / Codex CLI / Codex-as-MCP / local) a first-class routing dimension alongside provider/model/capability/auth posture — see [`docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md`](docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md).
- **Schema landings:** `AdapterCapabilityProfile`, `AdapterRunTelemetry` (incl. `agentId` + `skillId` per PR #607 / #623 conventions), and 5 nullable `AgentThread.cliSession*` columns.
- **Routing-layer landings:** `ExecutionAdapterSelector` + `AdapterCapabilityRequirement` types; capability probes (Claude CLI, Codex CLI, HTTP-Anthropic, HTTP-OpenAI) + DB-backed cache; `resolveExecutionAdapter()` replaces the `isCliAdapter` boolean short-circuit in `ai-inference.ts` while preserving PR #520's `--mcp-config` mount path; `writeAdapterTelemetry()` fire-and-forget at end of every coworker run.
- **Non-Phase-A surfaces deliberately stay out** of this PR: Codex `--json` parsing (Phase B), per-thread `CliSessionService` (Phase C), Claude normalizer parity (Phase D), cockpit UI (Phase E), shadow / race modes (Phases F/G). They land as separate PRs.

## Reconciliation context

- The original 2026-04-29 spec was paused at A5 with the resolver started but uncommitted. After 16 days and 267 commits on main, a section-by-section reconciliation was needed — recorded in [`docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md`](docs/superpowers/audits/2026-05-16-substrate-spec-reconciliation.md).
- **Filename collision fixed.** The original `docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md` filename collides with a different-content spec on main (PR #350, the Sequential/Parallel/Loop/Branch orchestration-primitives spec by Codex). All three artifacts are renamed to `cli-execution-adapter-routing-*`. The Codex CLI JSONL probe evidence is renamed to `2026-04-29-codex-cli-jsonl-probe.md` so PR #350's evidence file is preserved at its original path.
- **Bundled-by-accident receipts work removed.** The original A1/A2/A3 commits had unrelated `ToolExecutionReceipt` / `BuildArtifactRevision` / `ArtifactReceiptUsage` schema bundled in. That work has since shipped on main (migration `20260430023000_artifact_provenance_receipts_slice_1`). This PR's schema commits carry ONLY their substrate-specific content; migrations are re-timestamped to land after main's current ordinal.

## Composition with shipped surfaces

- **[PR #520](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/520) — `cli-adapter.ts --mcp-config` mount:** the new `resolveExecutionAdapter()` keeps that path intact. `isCliAdapter` is derived from the structured selector kind; the mcpSession token path is orthogonal and continues to compose.
- **[PR #607](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/607) — routing topology attribution:** `AdapterRunTelemetry.agentId` follows the same convention.
- **[PR #623](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/623) / [#629](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/629) — skill telemetry:** `AdapterRunTelemetry.skillId` joins to `SkillUsageEvent` / `ToolExecution.skillId`.
- **[PR #602](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/602) — Work Capsule:** Phase C will wire `CliSessionService.claim()` to consume a `WorkCapsule` lease (boundary statement added in spec §9.0); no schema overlap in Phase A.

## Test plan

- [x] `pnpm --filter web exec vitest run` — 5807 passed / 14 skipped / 13 todo on full apps/web suite (no regressions; new tests included)
- [x] `pnpm --filter web typecheck` — pre-commit hook runs scoped typecheck per commit; all 10 commits pass
- [x] 49 new unit tests across 6 files (resolver, telemetry writer, types, probe cache, two capability probes)
- [x] `next build` — gated by pre-commit hook on every commit
- [ ] **Manual smoke test (DB-backed):** start portal locally, send a coworker turn, verify one `AdapterRunTelemetry` row appears. Defer to reviewer / maintainer with DB access. Integration tests at `packages/db/test/adapter-{capability-profile,run-telemetry}.test.ts` and `agent-thread-cli-session.test.ts` need DB connection and are not run in this PR.
- [ ] **Migrations apply cleanly:** three new additive migrations under `packages/db/prisma/migrations/20260516120000_*` — apply on fresh install via `pnpm --filter @dpf/db prisma migrate dev`. To verify: review the SQL in each migration directory; tables/columns are purely additive.

## Branch history note

Before reconciliation, the branch had 7 commits (`01221806`…`a1decd3f`) at the original 2026-04-29 author date. These were preserved via `pre-restart-feat-coworker-substrate` and `pre-restart-prior-tip` tags in case anything needs to be inspected. The current 10 commits on the branch were re-authored from `origin/main` to give Phase A a clean, reviewable progression with the bundled receipts work removed and the filename collisions resolved.

## Carve-outs left in the worktree

The branch worktree at `D:/DPF-coworker-assess` had unrelated WIP from the previous session (artifact provenance contracts, in-process orchestration substrate primitives) stashed at `stash@{0}` on this branch: `WIP: provenance receipts + coworker-substrate primitives + misc (prior session, multiple concerns)`. That work is not part of this PR; it can be triaged separately. Several files in that stash duplicate work already on main and would conflict on pop; recommend triage rather than blind pop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)