### PR TITLE
docs(edge-node): resolve runtime open-question — Go for Modes 2 / 4

### DIFF
--- a/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+++ b/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
@@ -88,6 +88,18 @@
 >   promise the original spec made) is explicitly downgraded to
 >   Phase 1+ — Phase 0 relies on the mode + owner + volume-isolation
 >   controls listed above.
+> - 2026-05-16 — **runtime decision resolved.** The
+>   "Language for the binary" open question is closed by ADR
+>   [`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md):
+>   Modes 2 (macOS native) and 4 (Windows native) ship in Go. Mode 1
+>   (Linux container, TypeScript shipped in #501) is retrofitted to
+>   Go in a separate epic (`BI-EDGE-XP-04-MODE1-GO-RETROFIT`), gated
+>   on Mode 4 verification passing on real Windows hardware. The
+>   interim Mode 1 / Modes 2-4 runtime split is bounded by a new
+>   wire-contract test suite shipping with the first Mode 4 slice.
+>   The "Language for the binary", deployment-modes table, maturity-
+>   gate row, and endpoint-vs-MCP-tool sections are amended in the
+>   same PR.
 >
 > Source plan: `docs/superpowers/plans/2026-05-09-macos-linux-native-support.md`
 > (the "Discovery plane refactor" subsection under Future direction).
@@ -221,8 +233,8 @@ that's compatible with its environment.
 | Platform | Runtime | Notes |
 |---|---|---|
 | Linux native Docker (Mode 1) | Container with `network_mode: host` (scoped first-slice default; see Open question resolutions) | Default for Linux server installs. Phase 0 ships Node.js / TypeScript per [`services/edge-node`](../../../services/edge-node) (PR #501). The first-slice networking choice (`network_mode: host`, observer-only) is resolved in "Open question resolutions" below; `macvlan` is a follow-on slice for LLDP/CDP receive, not Phase 0. |
-| macOS native (Mode 2) | Native LaunchDaemon (or LaunchAgent) | Self-contained binary. The original spec assumed Go or Rust for the native-binary path; Phase 0's Mode 1 actually shipped Node.js / TypeScript (#501). The runtime for Mode 2 is **open**: either re-pack the Node service as a self-contained binary (`bun build --compile`, `pkg`, `nexe`) or revisit the Go choice for the native-binary path. See "Runtime drift — Mode 1 Node.js, Mode 2 TBD" in Open question resolutions. |
-| Windows native (Mode 4) | Native Windows Service | Same runtime decision as Mode 2 — open pending the drift resolution. |
+| macOS native (Mode 2) | Native LaunchDaemon (or LaunchAgent) | Self-contained Go binary per the runtime-decision ADR ([`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md)). Cross-compile target `darwin/arm64` first slice; `darwin/amd64` for Intel Macs. Mode 1 (TypeScript, shipped in #501) is retrofitted to Go in a separate epic (`BI-EDGE-XP-04-MODE1-GO-RETROFIT`) gated on Mode 4 verification. |
+| Windows native (Mode 4) | Native Windows Service | Self-contained Go binary per the runtime-decision ADR ([`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md)). Cross-compile target `windows/amd64` first slice; `windows/arm64` deferred to `BI-EDGE-XP-05-WIN-ARM64`. Windows Service registration via `golang.org/x/sys/windows/svc` (native SCM, no NSSM). |
 | Docker Desktop fallback (Mode 3) | Degraded in-VM container | Sees only the Docker Desktop VM's network; capability set restricted. Acceptable for dev installs that don't need host-LAN visibility. Same Node.js / TypeScript image as Mode 1. |
 | Remote managed host | Native service or container per host class | Same API contract, same auth scope; runtime per the host's mode. |
 
@@ -1059,9 +1071,12 @@ revisit without re-opening the doctrine.
 
 ### Edge Node lifecycle
 
-- **Language for the binary** *(open — drift documented)*:
-  - **Spec's original resolution (durable):** Go. Mature
-    cross-compilation, static linking, ~5 MB binary target,
+- **Language for the binary** *(resolved 2026-05-16 — Go for
+  Modes 2 / 4; Mode 1 retrofit follows. See
+  [`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md)
+  for the full ADR.)*:
+  - **Spec's original resolution (durable, now reaffirmed):** Go.
+    Mature cross-compilation, static linking, ~5 MB binary target,
     well-known signing/notarization toolchains on every platform,
     battle-tested in the comparators (Tailscale, Cloudflare Tunnel
     `cloudflared`, HashiCorp Boundary are Go and closer to what
@@ -1073,32 +1088,28 @@ revisit without re-opening the doctrine.
     `node:24-alpine`. Container image size is ~150 MB (vs Go's
     ~5 MB target). This was a divergence from the spec's resolution
     and was not amended in the spec before merge.
-  - **Status (2026-05-12):** the runtime drift is acknowledged but
-    not resolved. Two acceptable paths forward, both **must** be
-    decided before Mode 2 (macOS native binary) ships:
-    1. **Amend the spec to Node.js + bundling.** Standardize on
-       TypeScript across Modes 1 / 2 / 3 / 4. Use `bun build --compile`
-       (the leading single-file Node bundler in 2026) or `pkg` /
-       `nexe` for the native modes. Trade-offs: larger artifact
-       (~50 MB even bundled), worse cold-start than Go, but uses the
-       team's existing TypeScript fluency end-to-end and avoids a
-       Go/TS impedance mismatch between Mode 1 and Mode 2.
-    2. **Hold the spec's Go decision and rewrite Mode 1.** PR #501's
-       TypeScript service is replaced with a Go service for Mode 1
-       and used as-is for Mode 2 / 4. Trade-offs: smaller artifact,
-       better cold-start, matches the comparators — at the cost of
-       throwing away PR #501's working code and adding a Go
-       toolchain to the build pipeline.
-    The decision must be paired with a Mode 2 binary scaffolding PR.
-    Until then, the Mode 1 service in main is the authoritative
-    runtime and this open-question remains the source of truth on
-    the divergence.
+  - **Resolution (2026-05-16):** Modes 2 (macOS native) and 4
+    (Windows native) ship in Go. Mode 1 continues running the
+    Phase-0 TypeScript service on `main`; a Mode 1 Go retrofit is
+    tracked as `BI-EDGE-XP-04-MODE1-GO-RETROFIT`, gated on Mode 4
+    verification passing on real Windows hardware. The interim
+    period (Mode 1 = TS, Modes 2 / 4 = Go) is bounded by a new
+    wire-contract test suite at
+    `apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts`
+    that ships with the first Mode 4 slice — drift between the two
+    implementations becomes a CI failure, not a runtime surprise.
+    Rationale, trade-off matrix, and validation gates live in
+    [`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md).
   - **Why this matters for security review:** the Phase 0 storage
     downgrade controls (Phase 0 storage downgrade — Linux container
     Mode 1) are scoped to the Node.js container shipped in #501.
-    If the Mode 1 implementation is rewritten in Go, those controls
-    must be re-applied to the Go service before that rewrite ships;
-    they are not transferable for free.
+    The Go retrofit for Mode 1 must re-apply those controls
+    (non-root UID, 0600 perms, owner-UID read-time check, volume
+    isolation, no Docker socket, backup exclusion, log redaction)
+    before it ships; they are not transferable for free. Modes 2 /
+    4 bypass the downgrade entirely — they use Keychain /
+    Credential Manager directly per "Token namespaces and
+    lifecycle" above.
 - **Linux default networking** *(scoped to first slice)*:
   **`network_mode: host`** (observer-only). LLDP/CDP receive and
   segregated scanner roles require `macvlan`; that's a follow-on
@@ -1206,15 +1217,21 @@ revisit without re-opening the doctrine.
 - **Endpoint vs MCP tool** *(durable)*: **REST first
   (`/api/v1/edge/*`), MCP tool follow-up**. Reasoning: the first
   Edge Node populations are non-MCP-aware (the binary itself is a
-  custom HTTP client — currently TypeScript / `undici` per
-  [`services/edge-node`](../../../services/edge-node), not an MCP
-  server) and REST is the straightforward surface. An MCP tool
-  (`submit_discovery_observations`) can wrap the same
+  custom HTTP client) and REST is the straightforward surface. An
+  MCP tool (`submit_discovery_observations`) can wrap the same
   `persistSubmittedDiscoveryRun` function later without changing
-  the contract on the wire. Note: this paragraph previously said
-  "custom Go HTTP client" — that was the pre-#501 expected shape;
-  the runtime drift is documented in "Language for the binary"
-  above and the Mode 1 truth is now TypeScript.
+  the contract on the wire. Per-mode HTTP-client truth:
+  - **Mode 1 (Linux container, Phase 0 shipped):** TypeScript /
+    `undici` per [`services/edge-node`](../../../services/edge-node).
+  - **Modes 2 / 4 (native, planned):** Go's `net/http`, per the
+    runtime-decision ADR
+    ([`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md)).
+  - **Mode 1 Go retrofit:** tracked as `BI-EDGE-XP-04-MODE1-GO-RETROFIT`,
+    gated on Mode 4 verification passing on real Windows hardware.
+  Historical note: the pre-#501 draft of this paragraph said "custom
+  Go HTTP client" — that was the original Go resolution which was
+  drifted from in Phase 0 and is now reaffirmed for Modes 2 / 4 with
+  the Mode 1 retrofit as a follow-on.
 
 ## Research and Benchmarking
 
@@ -1691,11 +1708,13 @@ target misconfiguration.**
       enumerated.
 - [x] Open questions resolved or explicitly deferred — see
       "Open question resolutions" above. **Mode 1 runtime: TypeScript
-      / Node.js (shipped in #501, currently authoritative). Mode 2 /
-      Mode 4 native binary runtime: open** — either repack the
-      TypeScript service via `bun build --compile` / `pkg` / `nexe`,
-      or rewrite for the native path; decision must land before
-      Mode 2 ships. Linux networking locked for first slice
+      / Node.js (Phase 0 shipped in #501; Go retrofit tracked as
+      `BI-EDGE-XP-04-MODE1-GO-RETROFIT`, gated on Mode 4 verification).
+      Modes 2 / 4 native binary runtime: Go** — resolved 2026-05-16
+      in [`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md).
+      The interim period (Mode 1 = TS, Modes 2 / 4 = Go) is bounded by
+      a new wire-contract test suite that ships with the first Mode 4
+      slice. Linux networking locked for first slice
       (`network_mode: host`); binary distribution locked (GitHub
       Release assets); update path locked (installer-driven, no
       in-binary self-updater); macOS scope locked (LaunchDaemon

--- a/docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md
+++ b/docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md
@@ -1,0 +1,163 @@
+# DPF Edge Node — Runtime Decision (ADR)
+
+> Status: **accepted** (2026-05-16). Closes the open question in
+> [`docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`](2026-05-09-dpf-edge-node-design.md)
+> §"Language for the binary" *(open — drift documented)*. The binding
+> spec is amended in this same PR: the "open" status flips to
+> "resolved (Go)" and the maturity-gate row "Mode 1 runtime locked
+> (TypeScript, shipped); Mode 2 / 4 native binary runtime open" flips
+> to "Mode 1 runtime: TypeScript (Phase 0 shipped, Go retrofit
+> tracked as BI-EDGE-XP-04-MODE1-GO-RETROFIT); Modes 2 / 4 native:
+> Go."
+>
+> Date: 2026-05-16.
+>
+> Decider: Mark Bodman (project lead).
+>
+> Decision unblocks: T3 plan (`2026-05-14-edge-node-t3-windows-native.md`),
+> `BI-EDGE-WIN-05-BINARY`, `BI-EDGE-WIN-08-WINSERVICE`, and by
+> extension `BI-EDGE-WIN-09-RETIRE-EXPORTER`.
+
+## Context
+
+The Edge Node spec ([`2026-05-09-dpf-edge-node-design.md`](2026-05-09-dpf-edge-node-design.md))
+originally resolved the binary language as **Go** based on
+comparator analysis (Tailscale, `cloudflared`, HashiCorp Boundary,
+osquery — all native compiled binaries). PR #501 shipped Phase 0 of
+the Mode 1 (Linux container) service in **Node.js / TypeScript**
+against `node:24-alpine`, a divergence from the spec's stated
+resolution that was acknowledged in security-review pass 3 but not
+closed. The binding spec currently lists the runtime as:
+
+> **Mode 1 runtime locked (TypeScript, shipped); Mode 2 / 4 native
+> binary runtime open.**
+
+Two acceptable paths were enumerated in the spec, both pending a
+single decision before Mode 2 ships:
+
+1. **Standardize on TypeScript across Modes 1 / 2 / 3 / 4.** Use
+   `bun build --compile` (or `pkg` / `nexe`) to produce
+   self-contained binaries for the native modes. Reuses the Phase 0
+   investment; preserves a single codebase.
+2. **Hold the Go decision and rewrite Mode 1 in Go.** Replace PR
+   #501's TypeScript service with a Go service for Mode 1, and use
+   the same Go binary for Modes 2 / 4. Discards working code in
+   exchange for runtime parity with comparators.
+
+The spec did not enumerate a third option (split runtime —
+TypeScript stays on Mode 1, Go ships for native modes), because it
+creates the impedance mismatch the spec warned against. This ADR
+considers all three but recommends Option B with explicit
+sequencing.
+
+## Decision
+
+**Adopt Option B — Go for native binary modes. Sequence as Mode 4
+first; treat the Mode 1 Go retrofit as a follow-on epic, not a
+blocker for Mode 4 shipping.**
+
+Mode 4 ships in Go. Mode 1 continues to run the Phase-0 TypeScript
+service on `main` while the retrofit is tracked separately as
+`BI-EDGE-XP-04-MODE1-GO-RETROFIT`. The wire contract between Edge
+Node and Authority Core (the `/api/v1/edge/*` REST surface) is the
+seam that makes this safe: Authority Core does not care whether a
+node's runtime is TypeScript or Go, only that the contract holds.
+Verified contract parity tests (see "Validation gate" below) keep
+the seam honest during the interim period.
+
+## Trade-off matrix
+
+| Axis | Option A (TypeScript bundled) | Option B (Go) — **recommended** | Option C (split — Mode 1 TS, Mode 4 Go) |
+|---|---|---|---|
+| **Artifact size** | ~50 MB (Bun runtime + v8) | ~5 MB (static-linked Go) | matches per-mode |
+| **Cold start** | 100–500 ms (v8 init) | 5–20 ms (Go init) | matches per-mode |
+| **Native syscall access** | FFI required. `ffi-napi` unmaintained; `koffi` works but each platform-specific call multiplies bundling pain. `GetIpNetTable`, `GetAdaptersAddresses`, `wincred`, `svc.Run` all need careful bindings per platform. | First-class via `golang.org/x/sys/windows` and `golang.org/x/sys/unix`. All four Win32 surfaces have community bindings (`danieljoos/wincred`, `gosnmp/gosnmp`, `gopacket/gopacket`). | Mode 4 gets clean syscalls; Mode 1 retains FFI burden if it ever needs them (currently doesn't — `/proc/net/arp` is fs read, `arp -an` is subprocess) |
+| **Code reuse from Phase 0** | High — `services/edge-node` ports forward with bundler config | Low — ~1,500 LOC of TypeScript becomes ~1,800 LOC of Go (rewrite, not transpile) | High for Mode 1, none for Mode 4 |
+| **Comparator alignment** | None of the named comparators (Tailscale, cloudflared, Boundary, osquery, Wazuh agent, Falco, Netbox-Agent) use a bundled Node runtime. Closest analogue is Datadog's Node helpers — not the agent itself. | Direct alignment. Tailscale, cloudflared, Boundary are Go. osquery is C++ but daemon-shaped. windows_exporter (which this work eventually retires) is Go. | Mode 4 aligned; Mode 1 isolated |
+| **Toolchain burden** | Bun (already used in some packages? — verify) + bundler config | Go added to `package.json` peers / Renovate / CI matrix. Mature, low-churn toolchain. | Both |
+| **Cross-compile** | Bun cross-compile: `bun build --compile --target=bun-windows-x64`. Works; arm64 support landed in late 2025. | `GOOS=windows GOARCH=amd64 go build` — no cross-compile complexity. arm64 trivial via `GOARCH=arm64`. | Both |
+| **Code-signing / Authenticode** | Bun binary is signable but the runtime-embed pattern triggers extra SmartScreen scrutiny — every new release looks like a "new application" until reputation builds. | Static Go binary is the standard shape; SmartScreen behavior is well-understood for Go agents (Tailscale's pattern is documented). | Both can sign; Go has fewer footguns |
+| **Windows Service integration** | Requires `node-windows` (third-party) or shell to NSSM. Both work; both add dependency. | `golang.org/x/sys/windows/svc` is native, no NSSM, no third-party. | Mode 4 cleaner |
+| **Credential Manager integration** | Requires FFI to `wincred` or a child-process to `cmdkey.exe`. | `github.com/danieljoos/wincred` is the established pattern. | Mode 4 cleaner |
+| **TPM / Platform Crypto path (Phase 1+)** | Requires deep FFI work; Bun does not expose CNG natively. | `github.com/google/go-tpm` for TPM 2.0; CNG via `golang.org/x/sys/windows`. Standard. | Mode 4 future-ready |
+| **Risk of "snowflake" wrappers per platform** | High — each platform's native bindings drift independently. | Low — Go's `runtime.GOOS` build tags are mature. | High on Mode 1, low on Mode 4 |
+| **Interim impedance mismatch** | None — single runtime | Yes, until Mode 1 retrofit ships. Bounded by wire-contract parity tests. | Yes, permanent unless reversed |
+| **Throws away PR #501 work** | No | Yes, ~1,500 LOC. PR is not lost — it's referenceable for shape — but the running code is replaced. | No |
+| **AGENTS.md §10 "research and use standards"** | No standard for bundled-Node-as-an-agent shape. | The standard *is* Go for this shape. Every comparator agrees. | Half-aligned |
+
+## Consequences
+
+### If accepted (Option B)
+
+**Spec amendments (same PR as this ADR):**
+- `2026-05-09-dpf-edge-node-design.md` §"Language for the binary" header changes from `*(open — drift documented)*` to `*(resolved — Go, see 2026-05-16-edge-node-runtime-decision.md)*`. Retains the historical drift narrative for context.
+- Deployment-modes table rows for Modes 2 / 4 change from "Same runtime decision as Mode 2 — open pending the drift resolution" to "Go" with a cross-reference to this ADR.
+- Maturity-gate row updates as quoted in the frontmatter above.
+- Endpoint-vs-MCP-tool resolution updates: "custom HTTP client (currently TypeScript / undici per `services/edge-node`)" stays as the Phase 0 truth but adds "Modes 2 / 4 use Go's `net/http` per [`2026-05-16-edge-node-runtime-decision.md`](2026-05-16-edge-node-runtime-decision.md); Mode 1 Go retrofit tracked as `BI-EDGE-XP-04-MODE1-GO-RETROFIT`."
+
+**T3 plan (`2026-05-14-edge-node-t3-windows-native.md`, new):**
+- Mode 4 sliced into ~10 PRs per the W1–W11 sketch in the planning conversation.
+- New Go project at `services/edge-node-go/` (or `services/dpf-edge-node/` — naming subdecision).
+- Cross-compile target: `windows/amd64` first slice. `windows/arm64` opens as `BI-EDGE-XP-05-WIN-ARM64` (deferred — small user base).
+- Mode 2 (macOS) slices land in same project tree but verification waits on Mac hardware (per Mark's testing constraint).
+
+**Backlog changes:**
+- `BI-EDGE-WIN-05-BINARY` body updated: "Mode 4 Windows-native Go binary" stays correct; runtime decision now closed.
+- `BI-EDGE-WIN-08-WINSERVICE` body updated: refs `golang.org/x/sys/windows/svc` as the implementation surface (not NSSM, not `sc.exe`).
+- `BI-EDGE-WIN-09-RETIRE-EXPORTER` body unchanged — still gated on Mode 4 capability parity.
+- **New BI:** `BI-EDGE-XP-04-MODE1-GO-RETROFIT` — open, blocked on Mode 4 verification passing. Body: "Rewrite `services/edge-node` (Phase 0 TypeScript) in Go using the same wire contract. Sequenced after Mode 4 verification so the Go codebase is proven on real Windows hardware before it lands on the Linux container path. Scope: the Mode 1 container service only — Modes 2 / 4 are separately tracked. Acceptance: every contract test under `apps/web/app/api/v1/edge/__tests__/` passes against the Go service; `scripts/verify-lifecycle.ts` passes."
+
+**Toolchain:**
+- Go 1.24+ added to CI matrix. Pinned via `go.mod` `go` directive.
+- `golangci-lint` configured at sensible defaults.
+- `gosec` for security linting (matches the spec's "heavy security review" posture for Edge Node code).
+- Renovate config extended to bump Go modules.
+- `go vet` + `go test ./...` added to PR CI before merge.
+
+**Interim wire-contract test (gates the impedance mismatch):**
+A new test suite at `apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts` exercises every `/api/v1/edge/*` route against fixtures that both the TypeScript Mode 1 service and the Go Mode 4 binary produce. Any drift between the two implementations becomes a CI failure, not a runtime surprise. This test ships **with W1** (the first Mode 4 PR), not later.
+
+### If rejected (Option A)
+
+Spec amendment goes the other direction: "open" closes as "TypeScript, with bundling for native modes." Mode 4 ships using `bun build --compile`. T3 plan still gets written but with Bun-bundled artifact, FFI-via-koffi for Win32 calls, and a `node-windows` (or NSSM) wrapper for the service. All four trade-offs in the "Option A" column above land in production.
+
+### If a third path (Option C) is preferred despite the impedance-mismatch warning
+
+This ADR rejects Option C. If Mark wants to override, document why — a permanent runtime split is harder to defend than a bounded one. The Mode 4-first / Mode 1-retrofit sequencing in Option B is structurally identical to Option C in the interim period; the difference is that Option B commits to ending the split, and Option C does not.
+
+## Alternatives considered
+
+### Why not Rust?
+
+Mentioned in the spec's original draft as a peer of Go. Rejected by the spec ("Go for cross-platform reach, mature signing/notarization toolchains") and not revisited here. Rust would be a defensible choice on a greenfield project; given that Go aligns with every named comparator and gets us 80% of Rust's safety story with a flatter learning curve, holding to Go is correct.
+
+### Why not C# (.NET / NativeAOT)?
+
+NativeAOT in .NET 8+ produces small, fast Windows-native binaries with excellent Win32 interop and first-class Windows Service support. **Considered and rejected:** none of the named comparators are .NET, the Edge Node must ship on Linux + macOS too (NativeAOT works there but the operator ecosystem is Windows-centric), and adopting .NET tools adds a third major language to the platform alongside TypeScript and Go.
+
+### Why not "wait and see"?
+
+The spec explicitly says the decision must land before Mode 2 ships. Mark only has Windows for testing, so Mode 4 leapfrogs Mode 2 in real-world verification. Delaying the decision blocks both T3 Mode 4 and the future Mode 2 work simultaneously. The cost of deciding now is one ADR; the cost of waiting is two parallel Mode 2 / Mode 4 prototypes or a full code freeze on T3.
+
+### Why not let each mode pick its own runtime?
+
+The spec's option enumeration was deliberately binary because per-mode runtime choice creates four codebases instead of one, and the only thing that makes a four-codebase architecture work is a stable wire contract — which we have, but every additional codebase doubles the surface area for that contract to drift. Two codebases (the bounded Option-B interim period) is defensible because it has a stated end date. Four is not.
+
+## Validation gate
+
+This decision is **revisited** if any of the following becomes true:
+
+1. **The Go Mode 4 binary cannot reach contract parity with the TypeScript Mode 1 service after the W1–W10 slice plan.** Specifically: if the wire-contract test suite identifies more than 3 distinct contract gaps that require schema or route changes (rather than client implementation fixes) over the W1–W10 work, we re-open this ADR.
+2. **Authenticode signing for Go binaries proves materially harder than the spec assumed.** If we cannot produce a SmartScreen-clean signed Windows binary inside the existing GitHub Actions release workflow with reasonable effort (< 1 week of investigation), we re-open.
+3. **A platform-attested-keys path (Phase 1+) emerges that requires a different runtime.** Unlikely given Go's TPM ecosystem, but flagged.
+
+If none of those triggers fire by the time Mode 4 ships and verification passes on real Windows hardware (verification report at `docs/install/verification-reports/edge-node-mode4-<host>.md`), the decision is **confirmed durable** and `BI-EDGE-XP-04-MODE1-GO-RETROFIT` becomes unblocked.
+
+## Cross-references
+
+- Binding spec (to be amended in same PR): [`docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`](2026-05-09-dpf-edge-node-design.md)
+- Phase 0 roadmap (no edits needed): [`docs/superpowers/plans/2026-05-12-edge-node-phase0-roadmap.md`](../plans/2026-05-12-edge-node-phase0-roadmap.md)
+- T2 plan (references "T3 macOS/Windows" — no edits): [`docs/superpowers/plans/2026-05-12-edge-node-t2-multi-host-lan.md`](../plans/2026-05-12-edge-node-t2-multi-host-lan.md)
+- Phase 1 mTLS plan (refs T3 — no edits): [`docs/superpowers/plans/2026-05-13-edge-node-phase1-mtls-hardening.md`](../plans/2026-05-13-edge-node-phase1-mtls-hardening.md)
+- T3 plan (to be created in follow-on PR after this ADR lands): `docs/superpowers/plans/2026-05-14-edge-node-t3-windows-native.md`
+- Phase 0 service (the code Option B eventually retrofits): [`services/edge-node/`](../../../services/edge-node/)


### PR DESCRIPTION
## Summary

- Adds ADR `docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md` closing the "Language for the binary" open question on the binding Edge Node spec.
- **Decision:** Modes 2 (macOS native) and 4 (Windows native) ship in **Go** per the spec's original resolution. Mode 1 (Linux container, TypeScript shipped in #501) is retrofitted to Go as a follow-on epic — gated on Mode 4 verification on real Windows hardware.
- Amends the binding spec [`docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md) in four places + revision history.

## Why this PR is doc-only

The ADR is load-bearing for every downstream artifact: T3 plan (`2026-05-14-edge-node-t3-windows-native.md`), `BI-EDGE-WIN-05-BINARY`, `BI-EDGE-WIN-08-WINSERVICE`, and the new `BI-EDGE-XP-04-MODE1-GO-RETROFIT`. Landing the decision first means none of those land against a runtime assumption that could shift in review. The Mode 1 retrofit BI, the T3 plan, and the W1–W11 Mode 4 implementation slices all follow once this ADR is on `main`.

## Decision shape

| | Mode 1 (Linux container) | Mode 2 (macOS native) | Mode 3 (Docker Desktop) | Mode 4 (Windows native) |
|---|---|---|---|---|
| Phase 0 runtime | **TypeScript / Node.js** (shipped #501) | n/a | TypeScript (same image as Mode 1) | n/a |
| Target runtime | Go (via retrofit BI) | **Go** | TypeScript (continues) | **Go** |

The interim period — Mode 1 = TypeScript, Modes 2 / 4 = Go — is bounded by a wire-contract test suite at `apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts` that ships with the first Mode 4 slice. Drift between the two implementations becomes a CI failure, not a runtime surprise.

## Why Go (full rationale in the ADR)

- Every named comparator in the spec's R&B section (Tailscale, cloudflared, HashiCorp Boundary, windows_exporter) is Go.
- Win32 surfaces Mode 4 needs (`GetIpNetTable`, `wincred`, `golang.org/x/sys/windows/svc`, future TPM) have first-class Go bindings; from Node they require FFI through unmaintained or fragile shims.
- ~10× smaller artifact, ~10–50× faster cold start, well-understood Authenticode + SmartScreen behaviour.
- Cost (~1,500 LOC of working TypeScript becomes follow-on rewrite work) is addressed by sequencing the Mode 1 retrofit as a separate gated BI rather than blocking Mode 4 on it.

Options A (TypeScript bundled across all modes) and C (permanent split) were considered and rejected. Trade-off matrix is in the ADR.

## Test plan

- [ ] Spec frontmatter status remains "binding" (still true — this PR closes one open question, doesn't change spec status).
- [ ] Spec internal cross-references resolve — `docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md` exists at the linked path.
- [ ] Revision-history entry follows the existing pattern (timestamp, bolded label, paragraph body).
- [ ] Deployment-modes table renders cleanly in GitHub markdown preview.
- [ ] No code paths touched — verified by `git diff --stat` showing only `docs/superpowers/specs/*.md`.
- [ ] DCO sign-off present on the commit.

## Follow-up PRs (NOT in this PR)

1. **T3 plan** — `docs/superpowers/plans/2026-05-14-edge-node-t3-windows-native.md`. Mode 4 sliced into ~10 PRs (W1–W11). Mode 2 slices land in same project tree but verification waits on Mac hardware.
2. **`BI-EDGE-XP-04-MODE1-GO-RETROFIT`** — new BI created. Body per ADR §"Consequences → Backlog changes".
3. **`BI-EDGE-WIN-05-BINARY` / `BI-EDGE-WIN-08-WINSERVICE`** — body refresh to ref Go-specific implementation surfaces.
4. **W1 (first Mode 4 implementation slice)** — Go project scaffold + enroll/heartbeat client + wire-contract test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)