### PR TITLE
chore(deps): override protobufjs to ^8.3.0 (resolves 7 Dependabot alerts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "dompurify": "3.4.0",
       "node-forge": "1.4.0",
       "postcss": "^8.5.10",
-      "uuid": "^14.0.0"
+      "uuid": "^14.0.0",
+      "@opentelemetry/otlp-transformer>protobufjs": "^8.3.0"
     },
     "onlyBuiltDependencies": [
       "msw",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   node-forge: 1.4.0
   postcss: ^8.5.10
   uuid: ^14.0.0
+  '@opentelemetry/otlp-transformer>protobufjs': ^8.3.0
 
 importers:
 
@@ -7480,8 +7481,8 @@ packages:
     resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@8.3.0:
+    resolution: {integrity: sha512-JpJpFaR7yKNb6WqKvJJ1MLbiuIQWQnbUUb06nDtf2/i8YWYYLEfP6xf9BwSJoJQg1wAy61EQB8dssQg64oX4aA==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -11589,7 +11590,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.1
+      protobufjs: 8.3.0
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -17542,19 +17543,8 @@ snapshots:
       '@types/node': 25.6.2
       long: 5.3.2
 
-  protobufjs@8.0.1:
+  protobufjs@8.3.0:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.6.2
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
## Summary

- Adds a parent-scoped `pnpm.overrides` entry: `@opentelemetry/otlp-transformer>protobufjs: ^8.3.0`.
- Resolves **7 Dependabot alerts** on the v8 line of `protobufjs` (3 high, 4 moderate).
- Leaves the unaffected `protobufjs@7.5.7` tree under `@grpc/proto-loader` on v7 (gRPC requires `^7.5.5`).

## Alerts closed

| GHSA | Severity | Summary |
|------|----------|---------|
| GHSA-66ff-xgx4-vchm | high | Code injection through bytes field defaults in generated toObject code |
| GHSA-75px-5xx7-5xc7 | high | Code generation gadget after prototype pollution |
| GHSA-jvwf-75h9-cwgg | high | Process-wide denial of service through unsafe option paths |
| GHSA-685m-2w69-288q | high | Denial of service through unbounded protobuf recursion |
| GHSA-2pr8-phx7-x9h3 | medium | Denial of service from crafted field names in generated code |
| GHSA-fx83-v9x8-x52w | medium | Prototype injection in generated message constructors |
| GHSA-q6x5-8v7m-xcrf | medium | Overlong UTF-8 decoding |

Vulnerable range: `>= 8.0.0, <= 8.0.1`. First patched: `8.0.2`. Pinning to `^8.3.0` (current latest in the v8 line).

## Why parent-scoped

`protobufjs@8.0.1` is pinned exactly by `@opentelemetry/otlp-transformer@0.217.0`. A bare `protobufjs` override would also rewrite the `protobufjs@7.5.7` tree under `@grpc/proto-loader`, breaking gRPC (it requires `^7.5.5`). The parent-scoped form `@opentelemetry/otlp-transformer>protobufjs` only touches the otlp transitive.

## Lockfile delta

`pnpm-lock.yaml`: `protobufjs@8.0.1` → `protobufjs@8.3.0`. The `protobufjs@7.5.7` resolution under `@grpc/proto-loader@0.8.1` is unchanged.

## Test plan

- [x] `pnpm install` succeeds with refreshed lockfile
- [x] `pnpm test` — full vitest suite: web (5758 passed, 14 skipped, 13 todo) + @dpf/db (489 passed) + mobile (149 passed) — all green
- [ ] CI typecheck + build pass on PR
- [ ] Dependabot recomputes alerts and closes the 7 protobufjs entries

Part of the 2026-05 Dependabot sweep (26 open alerts → 5 PRs by package family). Triage at `dev/dependabot-triage.md` (kept local to the sweep worktree; not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)