### PR TITLE
doc(readme): add Cloud Single VM row to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Both modes include the full platform with AI coworkers, Build Studio sandbox, an
 | **Windows 10/11** | `powershell -ExecutionPolicy Bypass -File install-dpf.ps1` | (see below) | **GA** — production usage by real users |
 | **macOS Apple Silicon** | `bash install-dpf.sh` | [docs/install/macos.md](docs/install/macos.md) | **Early access — try it!** |
 | **Linux (native Docker)** | `bash install-dpf.sh` | [docs/install/linux.md](docs/install/linux.md) | **Early access — try it!** |
+| **Cloud Single VM** (AWS / GCP / Azure) | `bash install-dpf.sh --headless --release` *(inside the VM)* | [docs/install/cloud-single-vm.md](docs/install/cloud-single-vm.md) | **Early access — pilots wanted** |
+
+> **Picking the right row:** Cloud Single VM **is** the Linux installer running on a cloud VM. Same command, same lifecycle, same verify wrapper — the dedicated runbook just adds the cloud-specific provisioning, public-URL/TLS, and persistent-storage guidance you'd want for a customer-cloud deployment. Use Linux directly if you're installing on bare-metal or a Linux VM you provisioned yourself.
 
 #### Calling all macOS / Linux early adopters
 


### PR DESCRIPTION
Discoverability fix in the README Quick Start table.

#654 shipped the Cloud Single VM runbook + Phase 0 roadmap and cross-linked the runbook from the architecture section, but didn't add a row to the Quick Start table. The honest answer to "which row do I use for cloud?" — Linux, because Single VM **is** the Linux installer running on a cloud VM — isn't visible until you read the architecture section.

## Change

| Before | After |
|--------|-------|
| 3 rows: Windows / macOS / Linux | 4 rows: + Cloud Single VM (AWS / GCP / Azure) |
| Cloud install paths buried in architecture section | First-class row in Quick Start with a "picking the right row" note |

The note explicitly says Cloud Single VM **is** the Linux installer running on a cloud VM (same command, same lifecycle, same verify wrapper), and that operators provisioning their own VMs should use the Linux row directly. No new install paths.

## Scope

- 1 file: `README.md`
- 3 lines added (1 table row + 1 blockquote + 1 blank line)
- No code changes, no schema changes, no installer changes

## Verification

Diff is minimal; rendered table preview:

| Platform | Install command | Full guide | Status |
|----------|-----------------|------------|--------|
| **Windows 10/11** | `powershell …` | — | **GA** |
| **macOS Apple Silicon** | `bash install-dpf.sh` | `docs/install/macos.md` | Early access |
| **Linux (native Docker)** | `bash install-dpf.sh` | `docs/install/linux.md` | Early access |
| **Cloud Single VM** (AWS / GCP / Azure) | `bash install-dpf.sh --headless --release` *(inside the VM)* | `docs/install/cloud-single-vm.md` | Early access — pilots wanted |

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXsDQ73kc4D1WSZY4TWDjE)_