### PR TITLE
fix: harden Work Capsule verification tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,28 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: dpf
+          POSTGRES_PASSWORD: ci_test_password
+          POSTGRES_DB: dpf
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dpf"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://dpf:ci_test_password@localhost:5432/dpf
+      ADMIN_PASSWORD: ci_admin_changeme
     # Unit Tests runs informationally while the broken-test backlog is drained
-    # (issue #104). Typecheck, Production Build, and Routing Tier Contract
-    # are the binding gates. Flip this back to blocking once the suite is
-    # honest again.
+    # (issue #104). It still provisions a CI Postgres database and applies
+    # migrations so Prisma-backed tests fail for product defects, not runner
+    # setup. Typecheck, Production Build, and Routing Tier Contract remain
+    # the binding gates until the full suite is honest again.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -88,6 +106,9 @@ jobs:
 
       - name: Generate Prisma client
         run: pnpm --filter @dpf/db exec prisma generate
+
+      - name: Apply migrations
+        run: pnpm --filter @dpf/db exec prisma migrate deploy
 
       - name: Run unit tests
         run: pnpm test

--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -54,6 +54,33 @@ vi.mock("@/lib/route-context", () => ({
   getRouteDataContext: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("@/lib/wiki/recall", () => ({
+  recallWikiContext: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/tak/governed-memory", () => ({
+  buildGovernedMemoryContext: vi.fn().mockResolvedValue({
+    factsContext: null,
+    recalledContext: null,
+  }),
+}));
+
+vi.mock("@/lib/semantic-memory", () => ({
+  storeConversationMemory: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/tak/user-facts", () => ({
+  extractAndStoreFacts: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/identity/aidoc-resolver", () => ({
+  resolveAIDocForAgent: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/tak/reflection-triggers", () => ({
+  processRuntimeIssueReflection: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/lib/process-observer-hook", () => ({
   observeConversation: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/lib/mcp-tools-wiki-query.test.ts
+++ b/apps/web/lib/mcp-tools-wiki-query.test.ts
@@ -35,7 +35,7 @@ describe("wiki_query MCP tool", () => {
 
     expect(res.success).toBe(true);
     expect(res.message).toContain("No matching wiki pages found.");
-    expect(res.data).toEqual({ results: [] });
+    expect(res.data).toEqual({ results: [], retrievalMode: "vector" });
   });
 
   it("forwards organization id, query, pageKind, and limit to searchWikiPages", async () => {

--- a/docs/install/verification-runbook.md
+++ b/docs/install/verification-runbook.md
@@ -29,6 +29,7 @@
 
 | Path | What CI proves | What this runbook covers | Status |
 |------|----------------|--------------------------|--------|
+| Repository unit tests | `.github/workflows/ci.yml` runs `pnpm test` with an ephemeral Postgres service and `prisma migrate deploy` before the package tests | Local package-specific repros when a test is tied to host Docker state, platform credentials, or a dirty install | 🧪 **CI informational until issue #104 is drained** |
 | Windows installer | n/a (no CI gate today) | Production usage by real users | ✓ verified |
 | Linux end-to-end install | `install-verification.yml` (ubuntu-latest, dev + release modes) — full compose up, `/api/health=200`, doctor bundle | Distro coverage beyond Ubuntu: Debian 12, Fedora 39. Autostart-after-reboot. | 🙋 **reports wanted** |
 | macOS end-to-end install | dry-run only (`macos-14` can't nest-virt Docker Desktop) | The actual `.dmg` install + Docker Desktop boot + portal up + LaunchAgent reboot survival | 🙋 **reports wanted** |

--- a/docs/superpowers/audits/2026-05-16-work-capsule-verification-refresh.md
+++ b/docs/superpowers/audits/2026-05-16-work-capsule-verification-refresh.md
@@ -1,0 +1,63 @@
+# Work Capsule Verification Refresh
+
+Date: 2026-05-16
+Branch: `fix/work-capsule-verification-docs`
+Scope: Work Capsule Phase 1 verification refresh plus CI unit-test root-cause repair.
+
+## Findings
+
+- The previously referenced worktree `D:\DPF\.worktrees\portal-work-capsule-control-harness` is no longer present. Phase 1 landed through PR #602 and is on `main`.
+- The focused Work Capsule suite passes locally after installing workspace dependencies in a fresh worktree: 9 test files, 100 tests.
+- Prisma schema validation passes locally.
+- The Phase 2 implementation plan landed through PR #665, but Phase 2 code is not implemented on `main`.
+- PR #665's GitHub Unit Tests failure was caused by CI runner setup, not Work Capsule code: `pnpm test` includes `@dpf/db` Prisma tests, but the Unit Tests job did not start Postgres or apply migrations, so database-backed tests failed with `ECONNREFUSED`.
+- After reproducing the workflow shape locally with disposable Postgres, the repository test command surfaced two stale web-test contracts unrelated to Work Capsules: `wiki_query` now returns `retrievalMode` in empty results, and the external-access coworker unit test was allowing production fire-and-forget memory/reflection hooks to run after test teardown.
+
+## Changes Made
+
+- Updated `.github/workflows/ci.yml` so the Unit Tests job provisions `postgres:16-alpine`, sets `DATABASE_URL`, applies Prisma migrations, and then runs `pnpm test`.
+- Updated the Work Capsule design status to reflect that Phase 1 merged via PR #602 and Phase 2 has a merged plan awaiting implementation.
+- Updated the Phase 2 section to match the display-and-record/operator-paste narrowing from the merged Phase 2 plan.
+- Added Phase 2 verification expectations to the design spec.
+- Aligned the stale `wiki_query` assertion with the current retrieval-mode response contract.
+- Isolated the external-access coworker test from semantic-memory, wiki-recall, user-fact, AI-doc, and reflection-trigger background hooks so full-suite runs do not leak production async work into Vitest teardown.
+
+## Verification Evidence
+
+```powershell
+pnpm --filter web exec vitest run lib/work-capsules.test.ts lib/work-capsules/work-capsule-store.test.ts lib/work-capsules/git-scanner.test.ts lib/work-capsules/work-capsule-presenter.test.ts lib/actions/work-capsules.test.ts lib/mcp-tools-work-capsules.test.ts lib/tak/agent-grants.test.ts lib/work-capsules-enum-parity.test.ts components/build/work-control/WorkControlPanel.test.tsx
+```
+
+Result: PASS, 9 files, 100 tests.
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+```
+
+Result: PASS, schema valid.
+
+```powershell
+# With disposable postgres:16-alpine, DATABASE_URL=postgresql://dpf:ci_test_password@localhost:<port>/dpf
+pnpm --filter @dpf/db exec prisma migrate deploy
+pnpm test
+```
+
+Result: PASS. Prisma applied 203 migrations. `pnpm test` passed `web` (722 files passed, 3 skipped; 5,825 tests passed, 14 skipped, 13 todo), `@dpf/db` (71 files, 504 tests), and `mobile` (24 suites, 149 tests).
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Result: PASS. `next typegen` completed and `tsc --noEmit` exited 0.
+
+```powershell
+pnpm --filter web build
+```
+
+Result: PASS. Next.js production build compiled and generated 102 static pages. Turbopack still reports existing broad-trace warnings around `spec-plan-search.ts` / `next.config.mjs`; no build errors.
+
+## Remaining Work
+
+- Implement Phase 2 from `docs/superpowers/plans/2026-05-16-portal-work-capsule-control-harness-phase-2.md`.
+- Watch the GitHub Unit Tests job after this CI workflow change lands to confirm the database-backed package tests no longer fail at runner setup.
+- Complete Docker-served UX verification for `/build/work` when a runtime rebuild is in scope.

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -2,12 +2,13 @@
 
 | Field | Value |
 |---|---|
-| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied) |
-| Status | Phase 1 implemented on branch; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
+| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied) |
+| Status | Phase 1 merged to `main` via PR #602; Phase 2 implementation plan merged via PR #665 and awaits implementation; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
 | Author | Codex + Mark Bodman; chief-architect review by Claude (Opus 4.7) |
 | Scope | Portal-coordinated work capsules for Build Studio, external Claude/Codex desktop sessions, manual worktrees, sandbox promotion, and portal self-update governance |
 | Depends On | `2026-04-05-db-github-delivery-sync-design.md`, `2026-04-20-ship-phase-fork-redesign-design.md`, `2026-04-21-backlog-triage-build-studio-design.md`, `2026-04-23-build-studio-governed-backlog-delivery-design.md`, `2026-05-09-build-execution-provider-design.md`, `2026-05-09-deployment-contracts.md` |
 | Phase 1 Plan | `docs/superpowers/plans/2026-05-14-portal-work-capsule-control-harness-phase-1.md` |
+| Phase 2 Plan | `docs/superpowers/plans/2026-05-16-portal-work-capsule-control-harness-phase-2.md` |
 
 ## 1. Problem Statement
 
@@ -877,9 +878,9 @@ Execute in this order so fresh installs and existing installs both land cleanly:
 
 ### Phase 2: Governed Creation
 
-- create worktree from `origin/main`
-- seed MCP config
-- generate branch/worktree names
+- generate the deterministic `<prefix>/<capsule-slug>` branch and canonical worktree path; persist them on the capsule as `headBranch`, `worktreePath`, and `branchTaxonomy`
+- display the exact `git worktree add ... origin/main` and seed-MCP commands; the operator runs them on the host because production installs mount `dpf-source-code` as a named volume, so in-container worktree creation is invisible to the host
+- defer active in-container worktree creation to a sandbox-runner slice that owns the substrate-mount question
 - record initial scope
 - block root clone active work
 - keep branch push as the in-flight handoff mechanism
@@ -941,6 +942,17 @@ Every phase satisfies the canonical Build Gate (AGENTS.md section 5): unit tests
 5. Authorization tests covering both the human capability gate and the agent grant gate from section 9.3.
 6. UI/data-loader tests that prove `main` is not presented as adoptable work.
 7. UX verification against the Docker-served portal at `AUTH_URL` / `APP_URL`, not `next dev`.
+
+### Phase 2 (Governed Creation)
+
+Adds:
+
+1. Unit tests for deterministic capsule slug, branch-name, and worktree-path helpers.
+2. Scanner tests for local branch-list parsing and collision detection inputs.
+3. Store tests for `planCapsuleWorkspace`: idempotent re-plan, root-clone refusal, branch/worktree collision suffixes, and atomic `workspace-planned` activity creation.
+4. MCP tool tests for `plan_capsule_worktree`, including taxonomy enum parity, human capability gating, and `work_capsule_write` grant gating.
+5. UI tests for the governed-work form and launch panel.
+6. UX verification against the Docker-served portal proving `/build/work` can create a planned capsule, `/build/work/[capsuleId]` renders the operator-paste commands, and already-planned work is not double-listed as adoptable.
 
 ### Phase 3 (Executor Attachment)
 


### PR DESCRIPTION
## Summary
- Add a Postgres service and Prisma migration step to the Unit Tests workflow so `pnpm test` has the database setup it already assumes.
- Align current web-test contracts for `wiki_query` retrieval mode and external-access coworker background hooks.
- Update the Work Capsule spec, install verification runbook, and add a dated verification audit.

## Verification
- `pnpm --filter web exec vitest run lib/work-capsules.test.ts lib/work-capsules/work-capsule-store.test.ts lib/work-capsules/git-scanner.test.ts lib/work-capsules/work-capsule-presenter.test.ts lib/actions/work-capsules.test.ts lib/mcp-tools-work-capsules.test.ts lib/tak/agent-grants.test.ts lib/work-capsules-enum-parity.test.ts components/build/work-control/WorkControlPanel.test.tsx`
- `pnpm --filter @dpf/db exec prisma validate`
- disposable `postgres:16-alpine` + `pnpm --filter @dpf/db exec prisma migrate deploy` + `pnpm test`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`