### PR TITLE
chore: ignore local agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,15 @@ test-results/
 
 # Local agent / codex caches
 .codex/
+.claude/*.jsonl
+.claude/*.lock
+.claude/autonomous-e2e-progress.md
+.claude/worktrees/
+
+# Local verification and handoff artifacts
+output/
+tmp/
+docs/prompts/
 
 # MCP client configs contain live bearer tokens — must never be committed.
 # .mcp.json (Claude Code CLI) and .vscode/mcp.json (Claude Code VS Code


### PR DESCRIPTION
## Summary
- ignore local Claude session logs, lock files, and nested Claude worktrees
- ignore generated verification output, temporary extraction folders, and local handoff prompt drafts
- keep tracked `.claude/commands`, `.claude/skills`, and `.claude/settings.json` visible to git

## Verification
- `git diff --check`
- `git check-ignore -v -- .claude/autonomous-e2e-progress.md .claude/cli-session-64c.jsonl .claude/scheduled_tasks.lock .claude/worktrees/edge-schema output/ci-unit-tests-75449187087.log tmp/gaid.zip docs/prompts/2026-04-28-eliminate-seed-spec.md`
- `git check-ignore -v -- .claude/settings.json .claude/commands/brainstorming.md .claude/skills/ui-ux-pro-max/SKILL.md` returned no matches