### PR TITLE
feat(work-capsules): phase 2 governed creation

### DIFF
--- a/apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
+++ b/apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+
+import { WorkCapsuleLaunchPanel } from "@/components/build/work-control/WorkCapsuleLaunchPanel";
+import { getCapsuleDetail } from "@/lib/actions/work-capsules";
+import { presentLaunchInstructions } from "@/lib/work-capsules/launch-presenter";
+
+export default async function CapsuleDetailPage({
+  params,
+}: {
+  params: Promise<{ capsuleId: string }>;
+}) {
+  const { capsuleId } = await params;
+  const capsule = await getCapsuleDetail(capsuleId);
+  if (!capsule) notFound();
+
+  const steps = presentLaunchInstructions(
+    {
+      capsuleId: capsule.capsuleId,
+      headBranch: capsule.headBranch,
+      worktreePath: capsule.worktreePath,
+      baseBranch: capsule.baseBranch,
+    },
+    process.platform,
+  );
+
+  return (
+    <section className="space-y-4 px-4 py-4">
+      <header className="space-y-1">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">{capsule.title}</h1>
+        <div className="font-mono text-xs text-[var(--dpf-muted)]">{capsule.capsuleId}</div>
+      </header>
+      <WorkCapsuleLaunchPanel steps={steps} />
+    </section>
+  );
+}

--- a/apps/web/app/(shell)/build/work/page.tsx
+++ b/apps/web/app/(shell)/build/work/page.tsx
@@ -1,8 +1,14 @@
 import { WorkControlPanel } from "@/components/build/work-control/WorkControlPanel";
-import { getWorkControlData } from "@/lib/actions/work-capsules";
+import { createGovernedWorkAction, getWorkControlData } from "@/lib/actions/work-capsules";
 
 export default async function WorkControlPage() {
   const data = await getWorkControlData();
 
-  return <WorkControlPanel capsules={data.capsules} adoptable={data.adoptable} />;
+  return (
+    <WorkControlPanel
+      capsules={data.capsules}
+      adoptable={data.adoptable}
+      createAction={createGovernedWorkAction}
+    />
+  );
 }

--- a/apps/web/components/build/work-control/CreateGovernedWorkForm.test.tsx
+++ b/apps/web/components/build/work-control/CreateGovernedWorkForm.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import "../../build-studio/test-setup";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CreateGovernedWorkForm } from "./CreateGovernedWorkForm";
+
+describe("CreateGovernedWorkForm", () => {
+  it("renders title, objective, and taxonomy fields", () => {
+    render(<CreateGovernedWorkForm action={vi.fn()} />);
+
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/objective/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/taxonomy/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /plan governed work/i })).toBeInTheDocument();
+  });
+
+  it("renders the AGENTS.md taxonomy options", () => {
+    render(<CreateGovernedWorkForm action={vi.fn()} />);
+    const select = screen.getByLabelText(/taxonomy/i) as HTMLSelectElement;
+    const values = Array.from(select.options).map((option) => option.value);
+
+    expect(values).toEqual(["feat", "fix", "chore", "doc", "clean"]);
+  });
+});

--- a/apps/web/components/build/work-control/CreateGovernedWorkForm.tsx
+++ b/apps/web/components/build/work-control/CreateGovernedWorkForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { GitBranch } from "lucide-react";
+import { useRef, useState, useTransition } from "react";
+
+type Taxonomy = "feat" | "fix" | "chore" | "doc" | "clean";
+
+export type CreateGovernedWorkAction = (input: {
+  title: string;
+  objective: string;
+  taxonomy: Taxonomy;
+  idempotencyKey: string;
+}) => Promise<{ capsuleId: string; headBranch: string | null; worktreePath: string | null }>;
+
+const TAXONOMY_OPTIONS: Taxonomy[] = ["feat", "fix", "chore", "doc", "clean"];
+
+function nextIdempotencyKey(): string {
+  return `ui:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+}
+
+export function CreateGovernedWorkForm({ action }: { action: CreateGovernedWorkAction }) {
+  const [title, setTitle] = useState("");
+  const [objective, setObjective] = useState("");
+  const [taxonomy, setTaxonomy] = useState<Taxonomy>("feat");
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<Awaited<ReturnType<CreateGovernedWorkAction>> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const idempotencyKeyRef = useRef(nextIdempotencyKey());
+
+  return (
+    <section className="space-y-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-center gap-2">
+        <GitBranch className="h-4 w-4 text-[var(--dpf-muted)]" aria-hidden="true" />
+        <h2 className="text-base font-semibold text-[var(--dpf-text)]">Plan governed work</h2>
+      </div>
+
+      <form
+        className="grid gap-3 md:grid-cols-[minmax(0,1fr)_10rem]"
+        onSubmit={(event) => {
+          event.preventDefault();
+          setError(null);
+          const idempotencyKey = idempotencyKeyRef.current;
+          startTransition(() => {
+            void action({ title, objective, taxonomy, idempotencyKey })
+              .then((out) => {
+                setResult(out);
+                setTitle("");
+                setObjective("");
+                idempotencyKeyRef.current = nextIdempotencyKey();
+              })
+              .catch((reason: unknown) => {
+                setError(reason instanceof Error ? reason.message : "Could not plan governed work.");
+              });
+          });
+        }}
+      >
+        <label className="flex flex-col gap-1 text-xs font-medium text-[var(--dpf-muted)]">
+          <span>Title</span>
+          <input
+            required
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs font-medium text-[var(--dpf-muted)]">
+          <span>Taxonomy</span>
+          <select
+            value={taxonomy}
+            onChange={(event) => setTaxonomy(event.target.value as Taxonomy)}
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
+          >
+            {TAXONOMY_OPTIONS.map((option) => (
+              <option key={option} value={option} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs font-medium text-[var(--dpf-muted)] md:col-span-2">
+          <span>Objective</span>
+          <textarea
+            required
+            rows={3}
+            value={objective}
+            onChange={(event) => setObjective(event.target.value)}
+            className="resize-y rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center gap-3 md:col-span-2">
+          <button
+            type="submit"
+            disabled={pending}
+            className="inline-flex items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-white disabled:opacity-60"
+          >
+            <GitBranch className="h-4 w-4" aria-hidden="true" />
+            {pending ? "Planning" : "Plan governed work"}
+          </button>
+          {result ? (
+            <a
+              href={`/build/work/${result.capsuleId}`}
+              className="text-sm font-medium text-[var(--dpf-accent)] hover:underline"
+            >
+              Planned {result.capsuleId}
+            </a>
+          ) : null}
+          {error ? <span className="text-sm text-[var(--dpf-muted)]">{error}</span> : null}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/components/build/work-control/WorkCapsuleLaunchPanel.test.tsx
+++ b/apps/web/components/build/work-control/WorkCapsuleLaunchPanel.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import "../../build-studio/test-setup";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { WorkCapsuleLaunchPanel } from "./WorkCapsuleLaunchPanel";
+
+describe("WorkCapsuleLaunchPanel", () => {
+  it("renders the planned commands when worktree is set", () => {
+    render(
+      <WorkCapsuleLaunchPanel
+        steps={[
+          {
+            label: "Create the worktree from origin/main",
+            command: 'git worktree add "D:\\DPF-work-control" -b "feat/work-control" "origin/main"',
+          },
+          {
+            label: "Seed local MCP credentials into the new worktree",
+            command: 'pwsh -File scripts\\seed-worktree-mcp.ps1 -Target "D:\\DPF-work-control"',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/Create the worktree from origin\/main/)).toBeInTheDocument();
+    expect(screen.getByText(/git worktree add/)).toBeInTheDocument();
+    expect(screen.getByText(/seed-worktree-mcp\.ps1/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no steps are present", () => {
+    render(<WorkCapsuleLaunchPanel steps={[]} />);
+
+    expect(screen.getByText(/Plan the workspace first/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/build/work-control/WorkCapsuleLaunchPanel.tsx
+++ b/apps/web/components/build/work-control/WorkCapsuleLaunchPanel.tsx
@@ -1,0 +1,30 @@
+import type { LaunchStep } from "@/lib/work-capsules/launch-presenter";
+
+export function WorkCapsuleLaunchPanel({ steps }: { steps: LaunchStep[] }) {
+  if (steps.length === 0) {
+    return (
+      <section className="space-y-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <h2 className="text-base font-semibold text-[var(--dpf-text)]">Launch</h2>
+        <p className="text-sm text-[var(--dpf-muted)]">Plan the workspace first to see the launch commands.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <h2 className="text-base font-semibold text-[var(--dpf-text)]">Launch</h2>
+      <ol className="space-y-3">
+        {steps.map((step, index) => (
+          <li key={`${step.label}-${index}`} className="space-y-1">
+            <div className="text-xs font-medium text-[var(--dpf-muted)]">
+              {index + 1}. {step.label}
+            </div>
+            <pre className="overflow-x-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-xs text-[var(--dpf-text)]">
+              <code>{step.command}</code>
+            </pre>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/components/build/work-control/WorkControlPanel.test.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { WorkControlPanel } from "./WorkControlPanel";
 
@@ -20,6 +20,7 @@ describe("WorkControlPanel", () => {
           updatedAt: "2026-05-14T00:00:00.000Z",
         }]}
         adoptable={[]}
+        createAction={vi.fn()}
       />,
     );
 
@@ -29,9 +30,10 @@ describe("WorkControlPanel", () => {
   });
 
   it("renders empty state", () => {
-    const html = renderToStaticMarkup(<WorkControlPanel capsules={[]} adoptable={[]} />);
+    const html = renderToStaticMarkup(<WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} />);
 
     expect(html).toContain("No active capsules yet.");
+    expect(html).toContain("Plan governed work");
   });
 
   it("renders adoptable worktree rows surfaced by the scanner", () => {
@@ -44,6 +46,7 @@ describe("WorkControlPanel", () => {
           modifiedCount: 3,
           untrackedCount: 1,
         }]}
+        createAction={vi.fn()}
       />,
     );
 

--- a/apps/web/components/build/work-control/WorkControlPanel.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.tsx
@@ -1,14 +1,17 @@
 import { GitBranch, RefreshCcw } from "lucide-react";
 
 import { AdoptableWorktreeTable, type AdoptableWorktreeRow } from "./AdoptableWorktreeTable";
+import { CreateGovernedWorkForm, type CreateGovernedWorkAction } from "./CreateGovernedWorkForm";
 import { WorkCapsuleTable, type WorkCapsuleRow } from "./WorkCapsuleTable";
 
 export function WorkControlPanel({
   capsules,
   adoptable,
+  createAction,
 }: {
   capsules: WorkCapsuleRow[];
   adoptable: AdoptableWorktreeRow[];
+  createAction: CreateGovernedWorkAction;
 }) {
   return (
     <section className="space-y-6 px-4 py-4">
@@ -34,6 +37,8 @@ export function WorkControlPanel({
           <div className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{adoptable.length}</div>
         </div>
       </div>
+
+      <CreateGovernedWorkForm action={createAction} />
 
       <WorkCapsuleTable capsules={capsules} />
       <AdoptableWorktreeTable rows={adoptable} />

--- a/apps/web/components/platform/EffectivePermissionsPanel.tsx
+++ b/apps/web/components/platform/EffectivePermissionsPanel.tsx
@@ -61,6 +61,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   list_work_capsules: ["work_capsule_read"],
   get_work_capsule: ["work_capsule_read"],
   create_work_capsule: ["work_capsule_write"],
+  plan_capsule_worktree: ["work_capsule_write"],
   adopt_worktree: ["work_capsule_adopt"],
   claim_capsule_scope: ["work_capsule_write"],
   record_capsule_evidence: ["work_capsule_write"],

--- a/apps/web/lib/actions/work-capsules.test.ts
+++ b/apps/web/lib/actions/work-capsules.test.ts
@@ -3,16 +3,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockAuth,
   mockCan,
+  mockCreateWorkCapsule,
   mockGetWorktreeDirtySummary,
+  mockListLocalBranches,
+  mockPlanCapsuleWorkspace,
   mockPrisma,
   mockScanGitWorktrees,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockCan: vi.fn(),
+  mockCreateWorkCapsule: vi.fn(),
   mockGetWorktreeDirtySummary: vi.fn(),
+  mockListLocalBranches: vi.fn(),
+  mockPlanCapsuleWorkspace: vi.fn(),
   mockPrisma: {
     workCapsule: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
     },
   },
   mockScanGitWorktrees: vi.fn(),
@@ -23,7 +30,12 @@ vi.mock("@/lib/permissions", () => ({ can: mockCan }));
 vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/work-capsules/git-scanner", () => ({
   getWorktreeDirtySummary: mockGetWorktreeDirtySummary,
+  listLocalBranches: mockListLocalBranches,
   scanGitWorktrees: mockScanGitWorktrees,
+}));
+vi.mock("@/lib/work-capsules/work-capsule-store", () => ({
+  createWorkCapsule: mockCreateWorkCapsule,
+  planCapsuleWorkspace: mockPlanCapsuleWorkspace,
 }));
 
 describe("getWorkControlData", () => {
@@ -97,5 +109,90 @@ describe("getWorkControlData", () => {
       expect.objectContaining({ path: "D:/DPF-feature", branch: "feat/real-work" }),
     ]);
     expect(mockGetWorktreeDirtySummary).not.toHaveBeenCalledWith("D:/DPF");
+  });
+});
+
+describe("createGovernedWorkAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { id: "user-1", platformRole: "HR-100", isSuperuser: true },
+    });
+    mockCan.mockReturnValue(true);
+    mockListLocalBranches.mockResolvedValue(new Set<string>());
+    mockCreateWorkCapsule.mockResolvedValue({
+      id: "row-1",
+      capsuleId: "WC-CREATED",
+      title: "x",
+    });
+    mockPlanCapsuleWorkspace.mockResolvedValue({
+      capsuleId: "WC-CREATED",
+      headBranch: "feat/x",
+      worktreePath: "D:\\DPF-x",
+    });
+  });
+
+  it("rejects an unauthorized caller via the write capability gate", async () => {
+    mockCan.mockReturnValue(false);
+    const { createGovernedWorkAction } = await import("./work-capsules");
+
+    await expect(
+      createGovernedWorkAction({ title: "x", objective: "y", taxonomy: "feat", idempotencyKey: "k" }),
+    ).rejects.toThrow(/unauthorized/i);
+    expect(mockCan).toHaveBeenCalledWith(expect.objectContaining({ platformRole: "HR-100" }), "manage_backlog");
+  });
+
+  it("rejects an invalid taxonomy", async () => {
+    const { createGovernedWorkAction } = await import("./work-capsules");
+
+    await expect(
+      createGovernedWorkAction({ title: "x", objective: "y", taxonomy: "wat" as any, idempotencyKey: "k" }),
+    ).rejects.toThrow(/taxonomy/i);
+  });
+
+  it("creates the capsule then plans the workspace and returns both", async () => {
+    const { createGovernedWorkAction } = await import("./work-capsules");
+    const result = await createGovernedWorkAction({
+      title: "Provider routing tool capability",
+      objective: "Phase 2 verification",
+      taxonomy: "feat",
+      idempotencyKey: "stable-key-1",
+    });
+
+    expect(result.capsuleId).toBe("WC-CREATED");
+    expect(result.headBranch).toBe("feat/x");
+    expect(mockCreateWorkCapsule).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({ idempotencyKey: "stable-key-1" }),
+    }));
+    expect(mockPlanCapsuleWorkspace).toHaveBeenCalledWith(expect.objectContaining({
+      capsuleId: "WC-CREATED",
+      taxonomy: "feat",
+    }));
+  });
+});
+
+describe("getCapsuleDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { id: "user-1", platformRole: "HR-100", isSuperuser: true },
+    });
+    mockCan.mockReturnValue(true);
+  });
+
+  it("loads a capsule and recent activity for the detail route", async () => {
+    mockPrisma.workCapsule.findUnique.mockResolvedValue({
+      capsuleId: "WC-DETAIL",
+      title: "Detail",
+      activities: [],
+    });
+
+    const { getCapsuleDetail } = await import("./work-capsules");
+    const result = await getCapsuleDetail("WC-DETAIL");
+
+    expect(result).toEqual(expect.objectContaining({ capsuleId: "WC-DETAIL" }));
+    expect(mockPrisma.workCapsule.findUnique).toHaveBeenCalledWith(expect.objectContaining({
+      where: { capsuleId: "WC-DETAIL" },
+    }));
   });
 });

--- a/apps/web/lib/actions/work-capsules.ts
+++ b/apps/web/lib/actions/work-capsules.ts
@@ -7,25 +7,47 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import {
+  isWorkCapsuleBranchTaxonomy,
+  type WorkCapsuleBranchTaxonomy,
+} from "@/lib/work-capsules";
+import {
   getWorktreeDirtySummary,
+  listLocalBranches,
   scanGitWorktrees,
   type WorktreeInfo,
 } from "@/lib/work-capsules/git-scanner";
+import {
+  createWorkCapsule,
+  planCapsuleWorkspace,
+  type CapsuleDb,
+} from "@/lib/work-capsules/work-capsule-store";
 import { presentCapsuleRow } from "@/lib/work-capsules/work-capsule-presenter";
 
-async function requireBuildAccess(): Promise<string> {
+async function requireCapability(capability: "view_platform" | "manage_backlog"): Promise<string> {
   const session = await auth();
   const user = session?.user;
-  if (!user?.id || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")) {
+  if (!user?.id || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, capability)) {
     throw new Error("Unauthorized");
   }
   return user.id;
+}
+
+async function requireBuildAccess(): Promise<string> {
+  return requireCapability("view_platform");
+}
+
+async function requireGovernedWorkWriteAccess(): Promise<string> {
+  return requireCapability("manage_backlog");
 }
 
 function resolveRepoRoot(): string {
   const override = process.env.DPF_REPO_ROOT?.trim();
   if (override) return path.resolve(override);
   return process.cwd();
+}
+
+function workCapsuleDb(): CapsuleDb {
+  return prisma as unknown as CapsuleDb;
 }
 
 async function loadAdoptableRows(repoRoot: string, adoptedBranches: Set<string>) {
@@ -90,4 +112,66 @@ export async function getWorkControlData() {
     capsules: capsules.map((row) => presentCapsuleRow(row)),
     adoptable,
   };
+}
+
+export async function createGovernedWorkAction(input: {
+  title: string;
+  objective: string;
+  taxonomy: WorkCapsuleBranchTaxonomy;
+  idempotencyKey: string;
+}) {
+  const userId = await requireGovernedWorkWriteAccess();
+  if (!isWorkCapsuleBranchTaxonomy(input.taxonomy)) {
+    throw new Error("Invalid taxonomy");
+  }
+
+  const actor = { userId, agentId: null, principalId: null };
+  const capsule = await createWorkCapsule({
+    db: workCapsuleDb(),
+    input: {
+      title: input.title,
+      objective: input.objective,
+      source: "manual",
+      idempotencyKey: input.idempotencyKey,
+      executorKind: null,
+    },
+    actor,
+  });
+
+  let existingBranches = new Set<string>();
+  try {
+    existingBranches = await listLocalBranches(resolveRepoRoot());
+  } catch {
+    // Best effort only. The store still checks existing active capsules.
+  }
+
+  const planned = await planCapsuleWorkspace({
+    db: workCapsuleDb(),
+    capsuleId: capsule.capsuleId,
+    taxonomy: input.taxonomy,
+    os: process.platform,
+    home: process.env.HOME ?? process.env.USERPROFILE,
+    existingBranches,
+    releaseOverride: process.env.DPF_RELEASE_WORKTREE_PATH,
+    actor,
+  });
+
+  return {
+    capsuleId: planned.capsuleId,
+    headBranch: planned.headBranch,
+    worktreePath: planned.worktreePath,
+  };
+}
+
+export async function getCapsuleDetail(capsuleId: string) {
+  await requireBuildAccess();
+  return prisma.workCapsule.findUnique({
+    where: { capsuleId },
+    include: {
+      activities: {
+        orderBy: { recordedAt: "desc" },
+        take: 25,
+      },
+    },
+  });
 }

--- a/apps/web/lib/mcp-tools-work-capsules.test.ts
+++ b/apps/web/lib/mcp-tools-work-capsules.test.ts
@@ -135,7 +135,7 @@ describe("work capsule MCP tools", () => {
       data: expect.objectContaining({
         branchTaxonomy: "feat",
         headBranch: "feat/phase-2-mcp-plan",
-        worktreePath: "D:\\DPF-phase-2-mcp-plan",
+        worktreePath: expect.stringContaining("phase-2-mcp-plan"),
       }),
     }));
     expect(mockPrisma.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/web/lib/mcp-tools-work-capsules.test.ts
+++ b/apps/web/lib/mcp-tools-work-capsules.test.ts
@@ -97,6 +97,65 @@ describe("work capsule MCP tools", () => {
     expect(result.entityId).toBe("WC-ADOPT");
   });
 
+  it("plan_capsule_worktree persists the planned workspace", async () => {
+    mockPrisma.workCapsule.findUnique.mockResolvedValue({
+      id: "row-1",
+      capsuleId: "WC-PLANMCP",
+      title: "Phase 2 MCP plan",
+      status: "draft",
+      baseBranch: null,
+      headBranch: null,
+      worktreePath: null,
+    });
+    mockPrisma.workCapsule.findFirst.mockResolvedValue(null);
+    mockPrisma.workCapsule.update.mockResolvedValue({
+      id: "row-1",
+      capsuleId: "WC-PLANMCP",
+      title: "Phase 2 MCP plan",
+      status: "ready",
+      baseBranch: "main",
+      headBranch: "feat/phase-2-mcp-plan",
+      worktreePath: "D:\\DPF-phase-2-mcp-plan",
+      branchTaxonomy: "feat",
+    });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "plan_capsule_worktree",
+      { capsuleId: "WC-PLANMCP", taxonomy: "feat" },
+      "user-1",
+      {},
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.entityId).toBe("WC-PLANMCP");
+    expect(mockPrisma.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { capsuleId: "WC-PLANMCP" },
+      data: expect.objectContaining({
+        branchTaxonomy: "feat",
+        headBranch: "feat/phase-2-mcp-plan",
+        worktreePath: "D:\\DPF-phase-2-mcp-plan",
+      }),
+    }));
+    expect(mockPrisma.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "workspace-planned" }),
+    }));
+  });
+
+  it("plan_capsule_worktree rejects an unknown taxonomy", async () => {
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "plan_capsule_worktree",
+      { capsuleId: "WC-PLANMCP", taxonomy: "wat" },
+      "user-1",
+      {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("invalid_taxonomy");
+  });
+
   it("claim_capsule_scope stores typed scope claims", async () => {
     mockPrisma.workCapsule.findUnique.mockResolvedValue({
       id: "row-1",

--- a/apps/web/lib/mcp-tools.test.ts
+++ b/apps/web/lib/mcp-tools.test.ts
@@ -175,6 +175,20 @@ describe("mcp tools", () => {
     expect(scout!.executionMode).toBe("immediate");
     expect(scout!.sideEffect).toBe(true);
   });
+
+  it("hides plan_capsule_worktree from a view-only platform user", async () => {
+    const tools = await getAvailableTools(inventoryUser, { externalAccessEnabled: false });
+    expect(tools.find((tool) => tool.name === "plan_capsule_worktree")).toBeUndefined();
+  });
+
+  it("exposes plan_capsule_worktree to an admin", async () => {
+    const tools = await getAvailableTools(adminUser, { externalAccessEnabled: false });
+    const tool = tools.find((candidate) => candidate.name === "plan_capsule_worktree");
+
+    expect(tool).toBeDefined();
+    expect(tool!.requiredCapability).toBe("manage_backlog");
+    expect(tool!.sideEffect).toBe(true);
+  });
 });
 
 describe("sanitizeToolParams", () => {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -468,6 +468,21 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "plan_capsule_worktree",
+    description: "Generate and persist the deterministic branch and worktree-path plan for a Work Capsule. Idempotent: re-planning returns the existing plan and refuses to propose the root clone.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capsuleId: { type: "string", description: "Semantic Work Capsule id (WC-*)." },
+        taxonomy: { type: "string", enum: WORK_CAPSULE_TOOL_ENUMS.taxonomies, description: "AGENTS.md branch prefix." },
+      },
+      required: ["capsuleId", "taxonomy"],
+    },
+    requiredCapability: "manage_backlog",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
     name: "adopt_worktree",
     description: "Adopt an existing local branch/worktree pair into a Work Capsule without creating a new worktree.",
     inputSchema: {
@@ -3737,6 +3752,10 @@ export async function executeTool(
     case "create_work_capsule": {
       const { createWorkCapsuleTool } = await import("@/lib/work-capsules/mcp-handlers");
       return createWorkCapsuleTool(params, userId, context);
+    }
+    case "plan_capsule_worktree": {
+      const { planCapsuleWorktreeTool } = await import("@/lib/work-capsules/mcp-handlers");
+      return planCapsuleWorktreeTool(params, userId, context);
     }
     case "adopt_worktree": {
       const { adoptWorktreeTool } = await import("@/lib/work-capsules/mcp-handlers");

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -253,8 +253,10 @@ describe("TOOL_TO_GRANTS - Work Capsule entries", () => {
 
   it("write tools require work_capsule_write", () => {
     expect(isToolAllowedByGrants("create_work_capsule", ["work_capsule_write"])).toBe(true);
+    expect(isToolAllowedByGrants("plan_capsule_worktree", ["work_capsule_write"])).toBe(true);
     expect(isToolAllowedByGrants("record_capsule_evidence", ["work_capsule_write"])).toBe(true);
     expect(isToolAllowedByGrants("heartbeat_capsule", ["work_capsule_read"])).toBe(false);
+    expect(isToolAllowedByGrants("plan_capsule_worktree", ["work_capsule_read"])).toBe(false);
   });
 
   it("adoption requires work_capsule_adopt", () => {

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -31,6 +31,7 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   list_work_capsules: ["work_capsule_read"],
   get_work_capsule: ["work_capsule_read"],
   create_work_capsule: ["work_capsule_write"],
+  plan_capsule_worktree: ["work_capsule_write"],
   adopt_worktree: ["work_capsule_adopt"],
   claim_capsule_scope: ["work_capsule_write"],
   record_capsule_evidence: ["work_capsule_write"],

--- a/apps/web/lib/work-capsules-enum-parity.test.ts
+++ b/apps/web/lib/work-capsules-enum-parity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { PLATFORM_TOOLS } from "./mcp-tools";
 import {
+  WORK_CAPSULE_BRANCH_TAXONOMIES,
   WORK_CAPSULE_EVIDENCE_KINDS,
   WORK_CAPSULE_EXECUTOR_KINDS,
   WORK_CAPSULE_SOURCES,
@@ -34,5 +35,9 @@ describe("work capsule MCP enum parity", () => {
 
   it("update_work_capsule_status.status mirrors WORK_CAPSULE_STATUSES", () => {
     expect(enumOf("update_work_capsule_status", "status")).toEqual([...WORK_CAPSULE_STATUSES]);
+  });
+
+  it("plan_capsule_worktree.taxonomy mirrors WORK_CAPSULE_BRANCH_TAXONOMIES", () => {
+    expect(enumOf("plan_capsule_worktree", "taxonomy")).toEqual([...WORK_CAPSULE_BRANCH_TAXONOMIES]);
   });
 });

--- a/apps/web/lib/work-capsules.test.ts
+++ b/apps/web/lib/work-capsules.test.ts
@@ -6,7 +6,12 @@ import {
   WORK_CAPSULE_EXECUTOR_KINDS,
   WORK_CAPSULE_SOURCES,
   WORK_CAPSULE_STATUSES,
+  RELEASE_WORKTREE_DEFAULTS,
+  buildCapsuleBranchName,
+  buildCapsuleSlug,
+  buildCapsuleWorktreePath,
   isWorkCapsuleStatus,
+  isRootClonePath,
   normalizeBranchTaxonomy,
   parseScopeClaims,
 } from "./work-capsules";
@@ -74,5 +79,70 @@ describe("branch taxonomy", () => {
     expect(normalizeBranchTaxonomy("feat/work-capsules")).toBe("feat");
     expect(normalizeBranchTaxonomy("doc/work-capsules")).toBe("doc");
     expect(normalizeBranchTaxonomy("random")).toBe(null);
+  });
+});
+
+describe("buildCapsuleSlug", () => {
+  it("lowercases, replaces non-alnum with hyphens, trims, and caps length", () => {
+    expect(buildCapsuleSlug("Provider routing tool capability")).toBe("provider-routing-tool-capability");
+    expect(buildCapsuleSlug("  Lots   of    spaces  ")).toBe("lots-of-spaces");
+    expect(buildCapsuleSlug("emoji 🎉 and 中文 mixed!")).toBe("emoji-and-mixed");
+    const longTitle = "a".repeat(120);
+    expect(buildCapsuleSlug(longTitle).length).toBeLessThanOrEqual(48);
+  });
+
+  it("falls back to capsuleId tail when the title slugs to empty", () => {
+    expect(buildCapsuleSlug("...", "WC-ABCD1234")).toBe("wc-abcd1234");
+  });
+});
+
+describe("buildCapsuleBranchName", () => {
+  it("uses the chosen taxonomy as prefix", () => {
+    expect(buildCapsuleBranchName({ taxonomy: "feat", slug: "work-capsule" })).toBe("feat/work-capsule");
+    expect(buildCapsuleBranchName({ taxonomy: "doc", slug: "work-capsule-phase-2" })).toBe(
+      "doc/work-capsule-phase-2",
+    );
+  });
+
+  it("rejects an unknown taxonomy", () => {
+    expect(() => buildCapsuleBranchName({ taxonomy: "wat" as any, slug: "x" })).toThrow(/branch taxonomy/i);
+  });
+});
+
+describe("buildCapsuleWorktreePath", () => {
+  it("emits the Windows convention for win32", () => {
+    expect(buildCapsuleWorktreePath({ os: "win32", slug: "work-capsule" })).toBe("D:\\DPF-work-capsule");
+  });
+
+  it("emits the Unix convention for darwin and linux", () => {
+    expect(buildCapsuleWorktreePath({ os: "darwin", slug: "work-capsule", home: "/Users/mark" })).toBe(
+      "/Users/mark/dpf-worktrees/work-capsule",
+    );
+    expect(buildCapsuleWorktreePath({ os: "linux", slug: "work-capsule", home: "/home/mark" })).toBe(
+      "/home/mark/dpf-worktrees/work-capsule",
+    );
+  });
+
+  it("publishes release-worktree defaults for supported host families", () => {
+    expect(RELEASE_WORKTREE_DEFAULTS.win32).toBe("D:\\DPF");
+    expect(RELEASE_WORKTREE_DEFAULTS.darwin).toBe("{home}/dpf");
+    expect(RELEASE_WORKTREE_DEFAULTS.linux).toBe("{home}/dpf");
+  });
+});
+
+describe("isRootClonePath", () => {
+  it("recognizes the canonical Windows root clone", () => {
+    expect(isRootClonePath("D:\\DPF", "win32")).toBe(true);
+    expect(isRootClonePath("d:/DPF", "win32")).toBe(true);
+    expect(isRootClonePath("D:\\DPF-feature", "win32")).toBe(false);
+  });
+
+  it("recognizes the canonical Unix root clone", () => {
+    expect(isRootClonePath("/Users/mark/dpf", "darwin", "/Users/mark")).toBe(true);
+    expect(isRootClonePath("/home/mark/dpf-worktrees/x", "linux", "/home/mark")).toBe(false);
+  });
+
+  it("respects the DPF_RELEASE_WORKTREE_PATH override when supplied", () => {
+    expect(isRootClonePath("/srv/release", "linux", "/home/x", "/srv/release")).toBe(true);
   });
 });

--- a/apps/web/lib/work-capsules.ts
+++ b/apps/web/lib/work-capsules.ts
@@ -38,6 +38,7 @@ export type WorkCapsuleExecutorKind = (typeof WORK_CAPSULE_EXECUTOR_KINDS)[numbe
 export const WORK_CAPSULE_ACTIVITY_KINDS = [
   "created",
   "adopted",
+  "workspace-planned",
   "status-changed",
   "status-override",
   "executor-changed",
@@ -86,6 +87,12 @@ export type WorkCapsuleEvidenceKind = (typeof WORK_CAPSULE_EVIDENCE_KINDS)[numbe
 export const LEASE_TTL_MS = 30 * 60 * 1000;
 export const STALE_CACHE_MS = 30 * 60 * 1000;
 export const STATUS_OVERRIDE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const RELEASE_WORKTREE_DEFAULTS = {
+  win32: "D:\\DPF",
+  darwin: "{home}/dpf",
+  linux: "{home}/dpf",
+} as const;
 
 export type ScopeClaim = {
   kind: "path" | "module" | "package" | "route" | "skill" | "prompt";
@@ -136,6 +143,73 @@ export function normalizeBranchTaxonomy(
 ): WorkCapsuleBranchTaxonomy | null {
   const prefix = branch?.split("/")[0]?.trim();
   return prefix && TAXONOMY_SET.has(prefix) ? (prefix as WorkCapsuleBranchTaxonomy) : null;
+}
+
+const MAX_SLUG_LENGTH = 48;
+
+export function buildCapsuleSlug(title: string, capsuleIdFallback?: string): string {
+  const slug = title
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+  if (slug.length > 0) return slug;
+  if (!capsuleIdFallback) return "capsule";
+  return capsuleIdFallback
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "capsule";
+}
+
+export function buildCapsuleBranchName(args: {
+  taxonomy: WorkCapsuleBranchTaxonomy;
+  slug: string;
+}): string {
+  if (!TAXONOMY_SET.has(args.taxonomy)) {
+    throw new Error(`Invalid branch taxonomy: ${args.taxonomy}`);
+  }
+  return `${args.taxonomy}/${args.slug}`;
+}
+
+function resolveHome(explicit: string | undefined): string {
+  return explicit ?? process.env.HOME ?? process.env.USERPROFILE ?? "";
+}
+
+export function buildCapsuleWorktreePath(args: {
+  os: NodeJS.Platform;
+  slug: string;
+  home?: string;
+}): string {
+  if (args.os === "win32") return `D:\\DPF-${args.slug}`;
+  const home = resolveHome(args.home).replace(/[\\/]+$/g, "");
+  return `${home}/dpf-worktrees/${args.slug}`;
+}
+
+function normalizeComparablePath(value: string, os: NodeJS.Platform): string {
+  const normalized = value.trim().replace(/\\/g, "/").replace(/\/+$/g, "");
+  return os === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function releaseWorktreePath(os: NodeJS.Platform, home?: string, override?: string): string {
+  if (override?.trim()) return override.trim();
+  if (os === "win32") return RELEASE_WORKTREE_DEFAULTS.win32;
+  const template = os === "darwin" ? RELEASE_WORKTREE_DEFAULTS.darwin : RELEASE_WORKTREE_DEFAULTS.linux;
+  return template.replace("{home}", resolveHome(home).replace(/[\\/]+$/g, ""));
+}
+
+export function isRootClonePath(
+  candidatePath: string,
+  os: NodeJS.Platform,
+  home?: string,
+  releasePathOverride?: string,
+): boolean {
+  return (
+    normalizeComparablePath(candidatePath, os) ===
+    normalizeComparablePath(releaseWorktreePath(os, home, releasePathOverride), os)
+  );
 }
 
 function isIsoTimestamp(value: unknown): value is string {

--- a/apps/web/lib/work-capsules.ts
+++ b/apps/web/lib/work-capsules.ts
@@ -134,6 +134,10 @@ export function isWorkCapsuleActivityKind(value: unknown): value is WorkCapsuleA
   return typeof value === "string" && ACTIVITY_SET.has(value);
 }
 
+export function isWorkCapsuleBranchTaxonomy(value: unknown): value is WorkCapsuleBranchTaxonomy {
+  return typeof value === "string" && TAXONOMY_SET.has(value);
+}
+
 export function isWorkCapsuleEvidenceKind(value: unknown): value is WorkCapsuleEvidenceKind {
   return typeof value === "string" && EVIDENCE_KIND_SET.has(value);
 }

--- a/apps/web/lib/work-capsules/git-scanner.test.ts
+++ b/apps/web/lib/work-capsules/git-scanner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   parseGitStatusPorcelain,
+  parseBranchList,
   parsePrUrlFromText,
   parseWorktreeList,
   shouldSurfaceAdoptableBranch,
@@ -33,6 +34,14 @@ describe("git scanner parsing", () => {
         "see https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/596",
       ),
     ).toBe("https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/596");
+  });
+
+  it("parses local branch names and trims empty lines", () => {
+    expect(parseBranchList("main\nfeat/work-capsule\n  fix/recovery  \n\n")).toEqual([
+      "main",
+      "feat/work-capsule",
+      "fix/recovery",
+    ]);
   });
 
   it("surfaces dirty worktrees and recent ahead branches", () => {

--- a/apps/web/lib/work-capsules/git-scanner.ts
+++ b/apps/web/lib/work-capsules/git-scanner.ts
@@ -57,6 +57,13 @@ export function parseWorktreeList(output: string): WorktreeInfo[] {
     .filter((row) => row.path.length > 0);
 }
 
+export function parseBranchList(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 export function parsePrUrlFromText(text: string | null | undefined): string | null {
   const match = text?.match(/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/);
   return match?.[0] ?? null;
@@ -77,6 +84,14 @@ export async function scanGitWorktrees(repoRoot: string): Promise<WorktreeInfo[]
     windowsHide: true,
   });
   return parseWorktreeList(stdout);
+}
+
+export async function listLocalBranches(repoRoot: string): Promise<Set<string>> {
+  const { stdout } = await execFileAsync("git", ["-C", repoRoot, "branch", "--format=%(refname:short)"], {
+    timeout: 5000,
+    windowsHide: true,
+  });
+  return new Set(parseBranchList(stdout));
 }
 
 export async function getWorktreeDirtySummary(worktreePath: string): Promise<GitDirtySummary> {

--- a/apps/web/lib/work-capsules/launch-presenter.test.ts
+++ b/apps/web/lib/work-capsules/launch-presenter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { presentLaunchInstructions } from "./launch-presenter";
+
+describe("presentLaunchInstructions", () => {
+  it("returns the Windows command sequence", () => {
+    const steps = presentLaunchInstructions(
+      {
+        capsuleId: "WC-LAUNCH01",
+        headBranch: "feat/work-control",
+        worktreePath: "D:\\DPF-work-control",
+        baseBranch: "main",
+      },
+      "win32",
+    );
+
+    expect(steps.length).toBeGreaterThanOrEqual(2);
+    expect(steps[0].command).toContain("git worktree add");
+    expect(steps[0].command).toContain("D:\\DPF-work-control");
+    expect(steps[0].command).toContain("feat/work-control");
+    expect(steps[0].command).toContain("origin/main");
+    expect(steps[1].command).toContain("scripts\\seed-worktree-mcp.ps1");
+    expect(steps[1].command).toContain("-Target");
+  });
+
+  it("returns the Unix command sequence for macOS/Linux", () => {
+    const steps = presentLaunchInstructions(
+      {
+        capsuleId: "WC-LAUNCH02",
+        headBranch: "feat/work-control",
+        worktreePath: "/Users/mark/dpf-worktrees/work-control",
+        baseBranch: "main",
+      },
+      "darwin",
+    );
+
+    expect(steps[0].command).toContain("git worktree add");
+    expect(steps[1].command).toMatch(/scripts\/seed-worktree-mcp\.sh\s+"\/Users\/mark/);
+  });
+
+  it("returns an empty plan when fields are missing", () => {
+    const steps = presentLaunchInstructions(
+      { capsuleId: "WC-UNPLANNED", headBranch: null, worktreePath: null, baseBranch: null },
+      "win32",
+    );
+
+    expect(steps).toEqual([]);
+  });
+});

--- a/apps/web/lib/work-capsules/launch-presenter.ts
+++ b/apps/web/lib/work-capsules/launch-presenter.ts
@@ -1,0 +1,39 @@
+export type LaunchStep = {
+  label: string;
+  command: string;
+};
+
+type LaunchInput = {
+  capsuleId: string;
+  headBranch: string | null;
+  worktreePath: string | null;
+  baseBranch: string | null;
+};
+
+export function presentLaunchInstructions(capsule: LaunchInput, os: NodeJS.Platform): LaunchStep[] {
+  if (!capsule.headBranch || !capsule.worktreePath) return [];
+
+  const base = capsule.baseBranch ?? "main";
+  const createWorktree = {
+    label: `Create the worktree from origin/${base}`,
+    command: `git worktree add "${capsule.worktreePath}" -b "${capsule.headBranch}" "origin/${base}"`,
+  };
+
+  if (os === "win32") {
+    return [
+      createWorktree,
+      {
+        label: "Seed local MCP credentials into the new worktree",
+        command: `pwsh -File scripts\\seed-worktree-mcp.ps1 -Target "${capsule.worktreePath}"`,
+      },
+    ];
+  }
+
+  return [
+    createWorktree,
+    {
+      label: "Seed local MCP credentials into the new worktree",
+      command: `bash scripts/seed-worktree-mcp.sh "${capsule.worktreePath}"`,
+    },
+  ];
+}

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -3,10 +3,12 @@ import { prisma } from "@dpf/db";
 import type { ToolResult } from "@/lib/mcp-tools";
 import {
   WORK_CAPSULE_ACTIVITY_KINDS,
+  WORK_CAPSULE_BRANCH_TAXONOMIES,
   WORK_CAPSULE_EVIDENCE_KINDS,
   WORK_CAPSULE_EXECUTOR_KINDS,
   WORK_CAPSULE_SOURCES,
   WORK_CAPSULE_STATUSES,
+  isWorkCapsuleBranchTaxonomy,
   isWorkCapsuleEvidenceKind,
   isWorkCapsuleExecutorKind,
   isWorkCapsuleSource,
@@ -20,11 +22,13 @@ import {
   claimWorkCapsuleScope,
   createWorkCapsule,
   heartbeatWorkCapsule,
+  planCapsuleWorkspace,
   releaseWorkCapsuleScope,
   recordWorkCapsuleEvidence,
   updateWorkCapsuleStatus,
   type CapsuleDb,
 } from "./work-capsule-store";
+import { listLocalBranches } from "./git-scanner";
 
 type ToolContext = {
   routeContext?: string;
@@ -39,6 +43,7 @@ export function workCapsuleToolEnums() {
     sources: [...WORK_CAPSULE_SOURCES],
     executors: [...WORK_CAPSULE_EXECUTOR_KINDS],
     activityKinds: [...WORK_CAPSULE_ACTIVITY_KINDS],
+    taxonomies: [...WORK_CAPSULE_BRANCH_TAXONOMIES],
     evidenceKinds: [...WORK_CAPSULE_EVIDENCE_KINDS],
   };
 }
@@ -386,6 +391,61 @@ export async function createWorkCapsuleTool(
     message: `Created Work Capsule ${capsule.capsuleId}.`,
     data: { capsule },
   };
+}
+
+export async function planCapsuleWorktreeTool(
+  params: Record<string, unknown>,
+  userId: string,
+  context: ToolContext,
+): Promise<ToolResult> {
+  const capsuleId = stringParam(params, "capsuleId");
+  const taxonomy = stringParam(params, "taxonomy");
+  if (!capsuleId) {
+    return { success: false, error: "missing_capsuleId", message: "capsuleId is required." };
+  }
+  if (!taxonomy || !isWorkCapsuleBranchTaxonomy(taxonomy)) {
+    return {
+      success: false,
+      error: "invalid_taxonomy",
+      message: `taxonomy must be one of: ${WORK_CAPSULE_BRANCH_TAXONOMIES.join(", ")}.`,
+    };
+  }
+
+  let existingBranches = new Set<string>();
+  try {
+    const repoRoot = process.env.DPF_REPO_ROOT?.trim() || process.cwd();
+    existingBranches = await listLocalBranches(repoRoot);
+  } catch {
+    // Best-effort collision signal only. DB collision checks still run below.
+  }
+
+  try {
+    const capsule = await planCapsuleWorkspace({
+      db: workCapsuleDb(),
+      capsuleId,
+      taxonomy,
+      os: process.platform,
+      home: process.env.HOME ?? process.env.USERPROFILE,
+      existingBranches,
+      releaseOverride: process.env.DPF_RELEASE_WORKTREE_PATH,
+      actor: await actor(userId, context),
+    });
+    return {
+      success: true,
+      entityId: capsule.capsuleId,
+      message: `Planned ${capsule.headBranch} at ${capsule.worktreePath}.`,
+      data: { capsule },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown failure";
+    if (/root clone/i.test(message)) {
+      return { success: false, error: "root_clone_refused", message };
+    }
+    if (/branch name/i.test(message)) {
+      return { success: false, error: "branch_allocation_failed", message };
+    }
+    throw error;
+  }
 }
 
 export async function heartbeatCapsuleTool(

--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -4,6 +4,7 @@ import {
   adoptWorktreeCapsule,
   createWorkCapsule,
   heartbeatWorkCapsule,
+  planCapsuleWorkspace,
   recordWorkCapsuleEvidence,
   type CapsuleDb,
 } from "./work-capsule-store";
@@ -147,5 +148,191 @@ describe("work capsule store", () => {
         summary: "Vitest passed",
       }),
     }));
+  });
+
+  describe("planCapsuleWorkspace", () => {
+    it("persists deterministic branch + worktree path on first plan and writes a workspace-planned activity", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0001",
+        title: "Provider routing tool capability",
+        status: "draft",
+        baseBranch: null,
+        headBranch: null,
+        worktreePath: null,
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.update.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0001",
+        headBranch: "feat/provider-routing-tool-capability",
+        worktreePath: "D:\\DPF-provider-routing-tool-capability",
+        branchTaxonomy: "feat",
+      });
+
+      const result = await planCapsuleWorkspace({
+        db: capsuleDb(),
+        capsuleId: "WC-PLAN0001",
+        taxonomy: "feat",
+        os: "win32",
+        home: "/Users/mark",
+        existingBranches: new Set(),
+        actor: { userId: "user-1", agentId: null, principalId: "PRN-1" },
+      });
+
+      expect(result.headBranch).toBe("feat/provider-routing-tool-capability");
+      expect(result.worktreePath).toBe("D:\\DPF-provider-routing-tool-capability");
+      expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          baseBranch: "main",
+          branchTaxonomy: "feat",
+          status: "ready",
+        }),
+      }));
+      expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ kind: "workspace-planned" }),
+        }),
+      );
+    });
+
+    it("returns the existing plan on idempotent re-plan without writing a second activity", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0002",
+        title: "Provider routing tool capability",
+        headBranch: "feat/provider-routing-tool-capability",
+        worktreePath: "D:\\DPF-provider-routing-tool-capability",
+        branchTaxonomy: "feat",
+      });
+
+      const result = await planCapsuleWorkspace({
+        db: capsuleDb(),
+        capsuleId: "WC-PLAN0002",
+        taxonomy: "feat",
+        os: "win32",
+        home: "/Users/mark",
+        existingBranches: new Set(),
+        actor: { userId: "user-1", agentId: null, principalId: "PRN-1" },
+      });
+
+      expect(result.headBranch).toBe("feat/provider-routing-tool-capability");
+      expect(db.workCapsule.update).not.toHaveBeenCalled();
+      expect(db.workCapsuleActivity.create).not.toHaveBeenCalled();
+    });
+
+    it("throws on partial-plan state when only one workspace field is set", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PARTIAL",
+        title: "Half written",
+        headBranch: "feat/half-written",
+        worktreePath: null,
+      });
+
+      await expect(
+        planCapsuleWorkspace({
+          db: capsuleDb(),
+          capsuleId: "WC-PARTIAL",
+          taxonomy: "feat",
+          os: "win32",
+          home: "/Users/mark",
+          existingBranches: new Set(),
+          actor: { userId: "user-1", agentId: null, principalId: "PRN-1" },
+        }),
+      ).rejects.toThrow(/partial-plan state/i);
+    });
+
+    it("refuses to propose the root clone as the worktree path", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0003",
+        title: "Danger",
+        status: "draft",
+        baseBranch: null,
+        headBranch: null,
+        worktreePath: null,
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        planCapsuleWorkspace({
+          db: capsuleDb(),
+          capsuleId: "WC-PLAN0003",
+          taxonomy: "feat",
+          os: "win32",
+          home: "/Users/mark",
+          releaseOverride: "D:\\DPF-danger",
+          existingBranches: new Set(),
+          actor: { userId: "user-1", agentId: null, principalId: "PRN-1" },
+        }),
+      ).rejects.toThrow(/root clone/i);
+    });
+
+    it("appends a numeric suffix when the slug collides with an existing branch", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0004",
+        title: "Work capsule",
+        status: "draft",
+        baseBranch: null,
+        headBranch: null,
+        worktreePath: null,
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.update.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0004",
+        headBranch: "feat/work-capsule-2",
+        worktreePath: "D:\\DPF-work-capsule-2",
+        branchTaxonomy: "feat",
+      });
+
+      const result = await planCapsuleWorkspace({
+        db: capsuleDb(),
+        capsuleId: "WC-PLAN0004",
+        taxonomy: "feat",
+        os: "win32",
+        home: "/Users/mark",
+        existingBranches: new Set(["feat/work-capsule"]),
+        actor: { userId: "user-1", agentId: null, principalId: "PRN-1" },
+      });
+
+      expect(result.headBranch).toBe("feat/work-capsule-2");
+    });
+
+    it("appends a numeric suffix when another active capsule already owns the branch", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0005",
+        title: "Owned elsewhere",
+        status: "draft",
+        baseBranch: null,
+        headBranch: null,
+        worktreePath: null,
+      });
+      db.workCapsule.findFirst
+        .mockResolvedValueOnce({ id: "row-other", capsuleId: "WC-OTHER" })
+        .mockResolvedValueOnce(null);
+      db.workCapsule.update.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-PLAN0005",
+        headBranch: "feat/owned-elsewhere-2",
+        worktreePath: "D:\\DPF-owned-elsewhere-2",
+        branchTaxonomy: "feat",
+      });
+
+      const result = await planCapsuleWorkspace({
+        db: capsuleDb(),
+        capsuleId: "WC-PLAN0005",
+        taxonomy: "feat",
+        os: "win32",
+        home: "/Users/mark",
+        existingBranches: new Set(),
+        actor: { userId: "user-1", agentId: null, principalId: "PRN-1" },
+      });
+
+      expect(result.headBranch).toBe("feat/owned-elsewhere-2");
+    });
   });
 });

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -3,6 +3,10 @@ import { randomUUID } from "node:crypto";
 import {
   LEASE_TTL_MS,
   STATUS_OVERRIDE_TTL_MS,
+  buildCapsuleBranchName,
+  buildCapsuleSlug,
+  buildCapsuleWorktreePath,
+  isRootClonePath,
   isWorkCapsuleEvidenceKind,
   isWorkCapsuleExecutorKind,
   isWorkCapsuleSource,
@@ -11,6 +15,7 @@ import {
   parseScopeClaims,
   type ScopeClaim,
   type WorkCapsuleActivityKind,
+  type WorkCapsuleBranchTaxonomy,
   type WorkCapsuleEvidenceKind,
   type WorkCapsuleExecutorKind,
   type WorkCapsuleSource,
@@ -66,6 +71,15 @@ type CapsuleEvidenceInput = {
 
 type ScopeClaimInput = Pick<ScopeClaim, "kind" | "value" | "intent">;
 type ScopeReleaseInput = Pick<ScopeClaim, "kind" | "value">;
+
+type CapsuleWorkspacePlanInput = {
+  capsuleId: string;
+  taxonomy: WorkCapsuleBranchTaxonomy;
+  os: NodeJS.Platform;
+  home?: string;
+  existingBranches: Set<string>;
+  releaseOverride?: string;
+};
 
 function nextCapsuleId(): string {
   return `WC-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
@@ -228,6 +242,101 @@ export async function adoptWorktreeCapsule(args: {
     }
     throw error;
   }
+}
+
+async function hasWorkspaceCollision(
+  db: CapsuleDb,
+  args: { capsuleId: string; headBranch: string; worktreePath: string },
+): Promise<boolean> {
+  const existing = await db.workCapsule.findFirst({
+    where: {
+      capsuleId: { not: args.capsuleId },
+      archivedAt: null,
+      OR: [
+        { headBranch: args.headBranch },
+        { worktreePath: args.worktreePath },
+      ],
+    },
+    select: { id: true },
+  });
+  return Boolean(existing);
+}
+
+export async function planCapsuleWorkspace(args: {
+  db: CapsuleDb;
+  input?: CapsuleWorkspacePlanInput;
+  capsuleId?: string;
+  taxonomy?: WorkCapsuleBranchTaxonomy;
+  os?: NodeJS.Platform;
+  home?: string;
+  existingBranches?: Set<string>;
+  releaseOverride?: string;
+  actor: WorkCapsuleActor;
+}) {
+  const input: CapsuleWorkspacePlanInput = args.input ?? {
+    capsuleId: args.capsuleId ?? "",
+    taxonomy: args.taxonomy as WorkCapsuleBranchTaxonomy,
+    os: args.os ?? process.platform,
+    home: args.home,
+    existingBranches: args.existingBranches ?? new Set<string>(),
+    releaseOverride: args.releaseOverride,
+  };
+
+  const capsule = await args.db.workCapsule.findUnique({
+    where: { capsuleId: input.capsuleId },
+  });
+  if (!capsule) throw new Error(`Work Capsule ${input.capsuleId} not found`);
+
+  if (capsule.headBranch && capsule.worktreePath) return capsule;
+  if (capsule.headBranch || capsule.worktreePath) {
+    throw new Error(
+      `Work Capsule ${input.capsuleId} is in a partial-plan state ` +
+        `(headBranch=${capsule.headBranch ?? "null"}, worktreePath=${capsule.worktreePath ?? "null"}). ` +
+        "Repair the row before re-planning.",
+    );
+  }
+
+  const baseSlug = buildCapsuleSlug(capsule.title, capsule.capsuleId);
+  let slug = baseSlug;
+  let headBranch = buildCapsuleBranchName({ taxonomy: input.taxonomy, slug });
+  let worktreePath = buildCapsuleWorktreePath({ os: input.os, slug, home: input.home });
+  let suffix = 2;
+
+  while (
+    input.existingBranches.has(headBranch) ||
+    await hasWorkspaceCollision(args.db, { capsuleId: input.capsuleId, headBranch, worktreePath })
+  ) {
+    slug = `${baseSlug}-${suffix}`;
+    headBranch = buildCapsuleBranchName({ taxonomy: input.taxonomy, slug });
+    worktreePath = buildCapsuleWorktreePath({ os: input.os, slug, home: input.home });
+    suffix += 1;
+    if (suffix > 99) throw new Error("Could not allocate a unique branch name within 99 attempts");
+  }
+
+  if (isRootClonePath(worktreePath, input.os, input.home, input.releaseOverride)) {
+    throw new Error("Refusing to plan the root clone as an active workspace");
+  }
+
+  return inTransaction(args.db, async (tx) => {
+    const updated = await tx.workCapsule.update({
+      where: { capsuleId: input.capsuleId },
+      data: {
+        headBranch,
+        worktreePath,
+        branchTaxonomy: input.taxonomy,
+        baseBranch: capsule.baseBranch ?? "main",
+        status: capsule.status === "draft" ? "ready" : capsule.status,
+      },
+    });
+    await recordActivity(tx, {
+      workCapsuleId: capsule.id,
+      kind: "workspace-planned",
+      summary: `Planned ${headBranch} at ${worktreePath}`,
+      payload: { headBranch, worktreePath, branchTaxonomy: input.taxonomy },
+      actor: args.actor,
+    });
+    return updated;
+  });
 }
 
 export async function heartbeatWorkCapsule(args: {

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |---|---|
-| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied) |
-| Status | Phase 1 merged to `main` via PR #602; Phase 2 implementation plan merged via PR #665 and awaits implementation; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
+| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied); 2026-05-16 (Phase 2 display-and-record scope applied) |
+| Status | Phase 1 merged to `main` via PR #602; Phase 2 implements display-and-record governed creation pending verification/PR; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
 | Author | Codex + Mark Bodman; chief-architect review by Claude (Opus 4.7) |
 | Scope | Portal-coordinated work capsules for Build Studio, external Claude/Codex desktop sessions, manual worktrees, sandbox promotion, and portal self-update governance |
 | Depends On | `2026-04-05-db-github-delivery-sync-design.md`, `2026-04-20-ship-phase-fork-redesign-design.md`, `2026-04-21-backlog-triage-build-studio-design.md`, `2026-04-23-build-studio-governed-backlog-delivery-design.md`, `2026-05-09-build-execution-provider-design.md`, `2026-05-09-deployment-contracts.md` |
@@ -418,7 +418,7 @@ This mirrors `BacklogItemActivity` and keeps capsule history inspectable without
 
 Per AGENTS.md section 3, `kind` is a strongly-typed string enum sourced from `apps/web/lib/work-capsules.ts` and mirrored in MCP tool `enum:` arrays. Initial values:
 
-`created`, `adopted`, `status-changed`, `status-override`, `executor-changed`, `scope-claimed`, `scope-released`, `evidence-recorded`, `pr-linked`, `pr-merged`, `sandbox-attached`, `verification-passed`, `verification-failed`, `provider-blocked`, `provider-unblocked`, `lease-renewed`, `lease-expired`, `promotion-prepared`, `promotion-approved`, `promotion-rolled-back`, `archived`, `superseded`.
+`created`, `adopted`, `workspace-planned`, `status-changed`, `status-override`, `executor-changed`, `scope-claimed`, `scope-released`, `evidence-recorded`, `pr-linked`, `pr-merged`, `sandbox-attached`, `verification-passed`, `verification-failed`, `provider-blocked`, `provider-unblocked`, `lease-renewed`, `lease-expired`, `promotion-prepared`, `promotion-approved`, `promotion-rolled-back`, `archived`, `superseded`.
 
 Adding a new kind requires updating `work-capsules.ts` and the MCP tool definition in the same commit, per AGENTS.md section 3.
 
@@ -494,9 +494,9 @@ V1 should not delete branches or worktrees. It records and recommends.
 
 1. User starts from a backlog item, spec, plan, or manual objective.
 2. Portal creates a capsule.
-3. Portal generates branch and worktree names.
-4. Portal creates the worktree from `origin/main`.
-5. Portal runs the repo MCP seed helper for the new worktree.
+3. Portal generates the deterministic branch name and canonical worktree path.
+4. Portal persists `headBranch`, `worktreePath`, and `branchTaxonomy`, and records a `workspace-planned` activity.
+5. Portal displays the exact `git worktree add ... origin/main` and repo MCP seed helper commands for the operator to run on the host.
 6. Portal assigns an executor:
    - Build Studio
    - Codex desktop
@@ -504,10 +504,10 @@ V1 should not delete branches or worktrees. It records and recommends.
    - Codex CLI in a governed sandbox
    - Claude Code CLI in a governed sandbox
    - human
-7. Portal emits launch instructions or starts the native Build Studio flow.
+7. Active in-container worktree creation stays deferred to a sandbox-runner slice that owns substrate-mount behavior.
 8. Executor records progress and evidence back to the capsule.
 
-Creation must refuse to use the root clone as an active worktree.
+Creation must refuse to use the root clone as an active worktree. Production installs mount `dpf-source-code` as a named volume, so Phase 2 is intentionally display-and-record rather than portal-executed host mutation.
 
 ### 9.3 External Client Attachment
 

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -202,6 +202,7 @@
         "claim_capsule_scope",
         "create_work_capsule",
         "heartbeat_capsule",
+        "plan_capsule_worktree",
         "record_capsule_evidence",
         "release_capsule_scope",
         "update_work_capsule_status"


### PR DESCRIPTION
## Summary
- Adds deterministic branch/worktree planning for Work Capsules, including collision handling, root-clone refusal, and workspace-planned activity records.
- Registers `plan_capsule_worktree` across MCP tool definitions, dispatch, enum parity, TAK grants, Effective Permissions UI, and seeded grant catalog.
- Adds the governed-work form on `/build/work`, launch-command presenter/panel, and `/build/work/[capsuleId]` detail route.
- Updates the Work Capsule design spec to reflect Phase 2 display-and-record scope.

## Verification
- `pnpm --filter web exec vitest run lib/work-capsules.test.ts lib/work-capsules/work-capsule-store.test.ts lib/work-capsules/git-scanner.test.ts lib/work-capsules/work-capsule-presenter.test.ts lib/work-capsules/launch-presenter.test.ts lib/actions/work-capsules.test.ts lib/mcp-tools-work-capsules.test.ts lib/tak/agent-grants.test.ts lib/work-capsules-enum-parity.test.ts components/build/work-control/WorkControlPanel.test.tsx components/build/work-control/CreateGovernedWorkForm.test.tsx components/build/work-control/WorkCapsuleLaunchPanel.test.tsx`
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `docker compose --env-file D:\DPF\.env build --no-cache portal portal-init`
- `docker compose --env-file D:\DPF\.env up -d`
- Playwright UX check against `http://localhost:3000/build/work`: created planned capsule `WC-A7B01D02`, opened its detail route, verified `git worktree add` and seed-MCP commands render, and confirmed it did not appear in the adoptable section.
- MCP smoke: `tools/list` advertises `plan_capsule_worktree` with taxonomy enum `feat`, `fix`, `chore`, `doc`, `clean`.

## Notes
- Production build still emits existing Turbopack/NFT broad trace warnings around `spec-plan-search.ts` and `next.config.mjs`; the build exits 0 and the new route is present.