### PR TITLE
feat(skills): add governed evidence search

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
@@ -64,6 +64,8 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+import { getSkillReviewDetail } from "@/lib/actions/skills-observatory";
+
 describe("PlatformAiSkillsPage", () => {
   it("renders catalog, observability, and curator under AI Operations", async () => {
     const { default: PlatformAiSkillsPage } = await import("./page");
@@ -78,5 +80,46 @@ describe("PlatformAiSkillsPage", () => {
     expect(html).toContain("skills-observatory-panel");
     expect(html).toContain("Curator");
     expect(html).toContain("skills-curator-report-panel");
+  });
+
+  it("renders scoped evidence for a focused skill detail", async () => {
+    vi.mocked(getSkillReviewDetail).mockResolvedValueOnce({
+      skillId: "build-page",
+      skillMdContent: "v0",
+      category: "build",
+      proposals: [],
+      revisions: [],
+      seedDrift: {
+        inSync: true,
+        dbBody: "v0",
+        seedBody: "v0",
+        seedPath: "skills/build/build-page.skill.md",
+      },
+      evidence: [
+        {
+          kind: "tool_execution",
+          id: "tool-1",
+          label: "apply_patch failed",
+          summary: "Patch failed after timeout while applying skill guidance.",
+          createdAt: "2026-05-15T12:05:00.000Z",
+          refs: {
+            skillId: "build-page",
+            threadId: "thread-1",
+            taskRunId: "TR-1",
+          },
+        },
+      ],
+    });
+
+    const { default: PlatformAiSkillsPage } = await import("./page");
+    const html = renderToStaticMarkup(
+      await PlatformAiSkillsPage({
+        searchParams: Promise.resolve({ skill: "build-page" }),
+      }),
+    );
+
+    expect(html).toContain("Evidence");
+    expect(html).toContain("apply_patch failed");
+    expect(html).toContain("Patch failed after timeout");
   });
 });

--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -5,6 +5,7 @@ import { SkillProposalsPanel } from "@/components/platform/SkillProposalsPanel";
 import { SkillRevisionHistoryPanel } from "@/components/platform/SkillRevisionHistoryPanel";
 import { SkillCuratorReportPanel } from "@/components/platform/SkillCuratorReportPanel";
 import { SkillLifecycleControls } from "@/components/platform/SkillLifecycleControls";
+import { SkillEvidencePanel } from "@/components/platform/SkillEvidencePanel";
 import {
   getSkillCatalog,
   getSkillCatalogStats,
@@ -24,11 +25,35 @@ import { isSkillLifecycleState } from "@/lib/skills/lifecycle";
 export default async function SkillsObservatoryPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ skill?: string }>;
+  searchParams?: Promise<{
+    skill?: string;
+    evidenceThread?: string;
+    evidenceTaskRun?: string;
+    evidenceRoute?: string;
+    evidenceQuery?: string;
+  }>;
 }) {
   const resolvedParams = (await searchParams) ?? {};
   const focusedSkillId =
     typeof resolvedParams.skill === "string" ? resolvedParams.skill : null;
+  const evidenceScope = {
+    threadId:
+      typeof resolvedParams.evidenceThread === "string"
+        ? resolvedParams.evidenceThread
+        : null,
+    taskRunId:
+      typeof resolvedParams.evidenceTaskRun === "string"
+        ? resolvedParams.evidenceTaskRun
+        : null,
+    routeContext:
+      typeof resolvedParams.evidenceRoute === "string"
+        ? resolvedParams.evidenceRoute
+        : null,
+    query:
+      typeof resolvedParams.evidenceQuery === "string"
+        ? resolvedParams.evidenceQuery
+        : null,
+  };
 
   const [
     catalogSkills,
@@ -49,7 +74,7 @@ export default async function SkillsObservatoryPage({
     getSpecialistExecutions(),
     getSkillsObservatoryStats(),
     getSkillTelemetrySummary(),
-    focusedSkillId ? getSkillReviewDetail(focusedSkillId) : Promise.resolve(null),
+    focusedSkillId ? getSkillReviewDetail(focusedSkillId, evidenceScope) : Promise.resolve(null),
     getLatestSkillCuratorReport(),
     focusedSkillId ? getSkillLifecycleState(focusedSkillId) : Promise.resolve(null),
   ]);
@@ -159,6 +184,12 @@ export default async function SkillsObservatoryPage({
                   installs where the repo isn&rsquo;t checked out next to the app).
                 </div>
               )}
+              <div className="mb-4">
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Evidence
+                </h3>
+                <SkillEvidencePanel evidence={review.evidence} activeScope={evidenceScope} />
+              </div>
               <div className="mb-4">
                 <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
                   Proposals

--- a/apps/web/components/platform/SkillEvidencePanel.test.tsx
+++ b/apps/web/components/platform/SkillEvidencePanel.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SkillEvidencePanel } from "./SkillEvidencePanel";
+import type { SkillEvidenceResult } from "@/lib/skills/evidence-search";
+
+const evidence: SkillEvidenceResult[] = [
+  {
+    kind: "tool_execution",
+    id: "tool-1",
+    label: "apply_patch failed",
+    summary: "Patch failed after timeout while applying skill guidance.",
+    createdAt: "2026-05-15T12:05:00.000Z",
+    refs: {
+      skillId: "build-page",
+      threadId: "thread-1",
+      taskRunId: "TR-1",
+      toolExecutionId: "tool-1",
+    },
+  },
+  {
+    kind: "improvement_proposal",
+    id: "IP-SKL-1",
+    label: "Proposal IP-SKL-1: Tighten retry guidance",
+    summary: "Use clearer retry guidance when patching fails.",
+    createdAt: "2026-05-15T12:10:00.000Z",
+    refs: {
+      skillId: "build-page",
+      proposalId: "IP-SKL-1",
+      threadId: "thread-1",
+    },
+  },
+];
+
+describe("SkillEvidencePanel", () => {
+  it("renders an empty state when no evidence exists", () => {
+    const html = renderToStaticMarkup(<SkillEvidencePanel evidence={[]} />);
+
+    expect(html).toContain("No linked evidence yet");
+  });
+
+  it("renders evidence rows with labels, summaries, and refs", () => {
+    const html = renderToStaticMarkup(
+      <SkillEvidencePanel
+        evidence={evidence}
+        activeScope={{ threadId: "thread-1", query: "timeout" }}
+      />,
+    );
+
+    expect(html).toContain("apply_patch failed");
+    expect(html).toContain("Patch failed after timeout");
+    expect(html).toContain("Proposal IP-SKL-1");
+    expect(html).toContain("thread-1");
+    expect(html).toContain("timeout");
+  });
+
+  it("uses only theme tokens and no hardcoded hex colors", () => {
+    const html = renderToStaticMarkup(<SkillEvidencePanel evidence={evidence} />);
+
+    expect(html).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(html).toContain("var(--dpf-");
+  });
+});

--- a/apps/web/components/platform/SkillEvidencePanel.tsx
+++ b/apps/web/components/platform/SkillEvidencePanel.tsx
@@ -1,0 +1,216 @@
+import type { CSSProperties } from "react";
+
+import type {
+  SkillEvidenceRefs,
+  SkillEvidenceResult,
+} from "@/lib/skills/evidence-search";
+
+type Props = {
+  evidence: SkillEvidenceResult[];
+  activeScope?: {
+    threadId?: string | null;
+    taskRunId?: string | null;
+    routeContext?: string | null;
+    query?: string | null;
+  };
+};
+
+const kindLabels: Record<SkillEvidenceResult["kind"], string> = {
+  skill_usage_event: "Usage",
+  tool_execution: "Tool",
+  task_run: "Run",
+  task_message: "Message",
+  task_artifact: "Artifact",
+  agent_message: "Thread",
+  platform_issue: "Issue",
+  improvement_proposal: "Proposal",
+  skill_revision: "Revision",
+  backlog_activity: "Backlog",
+  external_evidence: "External",
+};
+
+const visibleRefKeys: Array<keyof SkillEvidenceRefs> = [
+  "skillId",
+  "threadId",
+  "taskRunId",
+  "proposalId",
+  "toolExecutionId",
+  "reportId",
+  "artifactId",
+  "messageId",
+  "backlogItemId",
+];
+
+export function SkillEvidencePanel({ evidence, activeScope }: Props) {
+  const scopeEntries = Object.entries(activeScope ?? {}).filter(
+    ([, value]) => typeof value === "string" && value.length > 0,
+  );
+
+  if (evidence.length === 0) {
+    return (
+      <div style={emptyState}>
+        No linked evidence yet
+        {scopeEntries.length > 0 ? (
+          <span style={{ color: "var(--dpf-muted)" }}>
+            {" "}
+            for {scopeEntries.map(([key, value]) => `${key}=${value}`).join(", ")}
+          </span>
+        ) : null}
+        .
+      </div>
+    );
+  }
+
+  return (
+    <div id="skill-evidence" style={rootStyle}>
+      {scopeEntries.length > 0 && (
+        <div style={scopeStyle}>
+          {scopeEntries.map(([key, value]) => (
+            <code key={key} style={scopeTokenStyle}>
+              {key}={value}
+            </code>
+          ))}
+        </div>
+      )}
+      <div role="list" style={listStyle}>
+        {evidence.map((item) => (
+          <EvidenceRow key={`${item.kind}:${item.id}`} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EvidenceRow({ item }: { item: SkillEvidenceResult }) {
+  const refs = visibleRefKeys
+    .map((key) => [key, item.refs[key]] as const)
+    .filter(([, value]) => typeof value === "string" && value.length > 0);
+
+  return (
+    <article role="listitem" style={rowStyle}>
+      <div style={rowHeaderStyle}>
+        <span style={badgeStyle}>{kindLabels[item.kind]}</span>
+        <span style={labelStyle}>{item.label}</span>
+        <time dateTime={item.createdAt} style={timeStyle}>
+          {formatDate(item.createdAt)}
+        </time>
+      </div>
+      <p style={summaryStyle}>{item.summary}</p>
+      {refs.length > 0 && (
+        <div style={refsStyle}>
+          {refs.map(([key, value]) => (
+            <code key={`${key}:${value}`} style={refTokenStyle}>
+              {key}={value}
+            </code>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
+}
+
+const rootStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+};
+
+const scopeStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  alignItems: "center",
+};
+
+const listStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  border: "1px solid var(--dpf-border)",
+  borderRadius: 6,
+  overflow: "hidden",
+  background: "var(--dpf-surface-2)",
+};
+
+const rowStyle: CSSProperties = {
+  padding: "10px 12px",
+  borderTop: "1px solid var(--dpf-border)",
+};
+
+const rowHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  minWidth: 0,
+};
+
+const badgeStyle: CSSProperties = {
+  flex: "0 0 auto",
+  fontSize: 10,
+  padding: "2px 7px",
+  borderRadius: 999,
+  background: "color-mix(in srgb, var(--dpf-accent) 12%, transparent)",
+  color: "var(--dpf-accent)",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: 0,
+};
+
+const labelStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  color: "var(--dpf-text)",
+  fontSize: 13,
+  fontWeight: 600,
+};
+
+const timeStyle: CSSProperties = {
+  flex: "0 0 auto",
+  color: "var(--dpf-muted)",
+  fontSize: 11,
+};
+
+const summaryStyle: CSSProperties = {
+  margin: "6px 0 0 0",
+  color: "var(--dpf-muted)",
+  fontSize: 12,
+  lineHeight: 1.45,
+};
+
+const refsStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  marginTop: 8,
+};
+
+const tokenBase: CSSProperties = {
+  border: "1px solid var(--dpf-border)",
+  background: "var(--dpf-surface-1)",
+  color: "var(--dpf-muted)",
+  borderRadius: 4,
+  fontSize: 11,
+  padding: "2px 5px",
+  overflowWrap: "anywhere",
+};
+
+const refTokenStyle: CSSProperties = tokenBase;
+
+const scopeTokenStyle: CSSProperties = {
+  ...tokenBase,
+  color: "var(--dpf-text)",
+};
+
+const emptyState: CSSProperties = {
+  padding: 12,
+  borderRadius: 6,
+  border: "1px solid var(--dpf-border)",
+  background: "var(--dpf-surface-2)",
+  color: "var(--dpf-muted)",
+  fontSize: 12,
+};

--- a/apps/web/components/platform/SkillProposalsPanel.test.tsx
+++ b/apps/web/components/platform/SkillProposalsPanel.test.tsx
@@ -7,6 +7,12 @@ vi.mock("@/lib/actions/skill-proposal-actions", () => ({
   rollbackSkillAction: vi.fn(),
 }));
 
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
 import { SkillProposalsPanel } from "./SkillProposalsPanel";
 import type { SkillProposalRow } from "@/lib/skills/proposals";
 
@@ -46,6 +52,21 @@ describe("SkillProposalsPanel", () => {
     );
     expect(html).toContain(baseProposal.title);
     expect(html).toContain("Pending");
+  });
+
+  it("links proposal rows to thread-scoped evidence search when thread evidence exists", () => {
+    const html = renderToStaticMarkup(
+      <SkillProposalsPanel
+        skillId="build-page"
+        currentContent="v0 body"
+        proposals={[baseProposal]}
+      />,
+    );
+
+    expect(html).toContain("View evidence");
+    expect(html).toContain(
+      'href="/platform/ai/skills?skill=build-page&amp;evidenceThread=thread-1#skill-evidence"',
+    );
   });
 
   it("uses only theme tokens — no hardcoded hex colors", () => {

--- a/apps/web/components/platform/SkillProposalsPanel.tsx
+++ b/apps/web/components/platform/SkillProposalsPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { CSSProperties } from "react";
 
@@ -117,6 +118,20 @@ function ProposalRow({
         </span>
         <span style={{ fontSize: 11, color: "var(--dpf-muted)" }}>{expanded ? "▲" : "▼"}</span>
       </button>
+
+      {proposal.threadId ? (
+        <div style={evidenceLinkRow}>
+          <Link
+            href={`/platform/ai/skills?skill=${encodeURIComponent(skillId)}&evidenceThread=${encodeURIComponent(proposal.threadId)}#skill-evidence`}
+            style={evidenceLinkStyle}
+          >
+            View evidence
+          </Link>
+          <span style={{ color: "var(--dpf-muted)" }}>
+            thread <code>{proposal.threadId}</code>
+          </span>
+        </div>
+      ) : null}
 
       {expanded && (
         <div style={{ padding: 12, borderTop: "1px solid var(--dpf-border)" }}>
@@ -250,6 +265,20 @@ const primaryBtn: CSSProperties = {
   background: "var(--dpf-accent)",
   color: "white",
   cursor: "pointer",
+};
+
+const evidenceLinkRow: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "0 12px 10px 12px",
+  fontSize: 11,
+};
+
+const evidenceLinkStyle: CSSProperties = {
+  color: "var(--dpf-accent)",
+  textDecoration: "underline",
+  textUnderlineOffset: 2,
 };
 
 const secondaryBtn: CSSProperties = {

--- a/apps/web/lib/actions/skills-observatory.ts
+++ b/apps/web/lib/actions/skills-observatory.ts
@@ -6,6 +6,10 @@
 import { prisma } from "@dpf/db";
 import { ROUTE_CONTEXT_MAP, UNIVERSAL_SKILLS } from "@/lib/tak/route-context-map";
 import { SPECIALIST_AGENT_IDS } from "@/lib/integrate/specialist-prompts";
+import type {
+  SkillEvidenceResult,
+  SkillEvidenceSearchInput,
+} from "@/lib/skills/evidence-search";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -57,6 +61,11 @@ export type SkillTelemetrySummary = {
   /** Period key of the latest SkillMetric row, or null if SkillMetric is empty. */
   latestMetricPeriod: string | null;
 };
+
+export type SkillReviewEvidenceScope = Pick<
+  SkillEvidenceSearchInput,
+  "threadId" | "taskRunId" | "routeContext" | "query" | "limit"
+>;
 
 // ─── Fetchers ───────────────────────────────────────────────────────────────
 
@@ -179,13 +188,17 @@ export async function getSpecialistExecutions(limit = 100): Promise<SkillExecuti
  * proposals/revisions/seed-drift panel. Returns null when the skill does
  * not exist so the caller can render a clean empty state.
  */
-export async function getSkillReviewDetail(skillId: string): Promise<{
+export async function getSkillReviewDetail(
+  skillId: string,
+  evidenceScope: SkillReviewEvidenceScope = {},
+): Promise<{
   skillId: string;
   skillMdContent: string;
   category: string;
   proposals: Awaited<ReturnType<typeof import("@/lib/skills/proposals").listSkillProposals>>;
   revisions: Awaited<ReturnType<typeof import("@/lib/skills/proposals").listSkillRevisions>>;
   seedDrift: Awaited<ReturnType<typeof import("@/lib/skills/seed-parity").getSkillSeedDrift>>;
+  evidence: SkillEvidenceResult[];
 } | null> {
   const skill = await prisma.skillDefinition.findUnique({
     where: { skillId },
@@ -195,10 +208,19 @@ export async function getSkillReviewDetail(skillId: string): Promise<{
 
   const { listSkillProposals, listSkillRevisions } = await import("@/lib/skills/proposals");
   const { getSkillSeedDrift } = await import("@/lib/skills/seed-parity");
-  const [proposals, revisions, seedDrift] = await Promise.all([
+  const { searchSkillEvidence } = await import("@/lib/skills/evidence-search");
+  const [proposals, revisions, seedDrift, evidence] = await Promise.all([
     listSkillProposals(skillId),
     listSkillRevisions(skillId),
     getSkillSeedDrift(skillId),
+    searchSkillEvidence({
+      skillId,
+      threadId: evidenceScope.threadId,
+      taskRunId: evidenceScope.taskRunId,
+      routeContext: evidenceScope.routeContext,
+      query: evidenceScope.query,
+      limit: evidenceScope.limit ?? 25,
+    }),
   ]);
 
   return {
@@ -208,6 +230,7 @@ export async function getSkillReviewDetail(skillId: string): Promise<{
     proposals,
     revisions,
     seedDrift,
+    evidence,
   };
 }
 

--- a/apps/web/lib/skills/evidence-search.test.ts
+++ b/apps/web/lib/skills/evidence-search.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  skillUsageEvent: { findMany: vi.fn() },
+  toolExecution: { findMany: vi.fn() },
+  taskRun: { findMany: vi.fn() },
+  taskMessage: { findMany: vi.fn() },
+  taskArtifact: { findMany: vi.fn() },
+  agentMessage: { findMany: vi.fn() },
+  platformIssueReport: { findMany: vi.fn() },
+  improvementProposal: { findMany: vi.fn() },
+  skillRevision: { findMany: vi.fn() },
+  backlogItemActivity: { findMany: vi.fn() },
+  externalEvidenceRecord: { findMany: vi.fn() },
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: prismaMock,
+}));
+
+import {
+  searchSkillEvidence,
+  summarizeSkillEvidenceForPrompt,
+} from "./evidence-search";
+
+const dt = (iso: string) => new Date(iso);
+
+beforeEach(() => {
+  for (const model of Object.values(prismaMock)) {
+    model.findMany.mockReset();
+    model.findMany.mockResolvedValue([]);
+  }
+});
+
+describe("searchSkillEvidence", () => {
+  it("returns normalized skill evidence newest-first across usage, tools, proposals, and revisions", async () => {
+    prismaMock.skillUsageEvent.findMany.mockResolvedValue([
+      {
+        id: "sue-row-1",
+        eventId: "SUE-1",
+        skillId: "build-page",
+        agentId: "AGT-BUILD",
+        userId: "user-1",
+        threadId: "thread-1",
+        taskRunId: "TR-1",
+        toolExecutionId: "tool-1",
+        routeContext: "/build",
+        phase: "failed",
+        source: "coworker",
+        metadata: { reason: "patch timeout" },
+        createdAt: dt("2026-05-15T12:00:00.000Z"),
+      },
+    ]);
+    prismaMock.toolExecution.findMany.mockResolvedValue([
+      {
+        id: "tool-1",
+        threadId: "thread-1",
+        agentId: "AGT-BUILD",
+        userId: "user-1",
+        toolName: "apply_patch",
+        success: false,
+        executionMode: "governed",
+        routeContext: "/build",
+        durationMs: 1200,
+        taskRunId: "TR-1",
+        skillId: "build-page",
+        summary: "Patch failed after timeout",
+        result: { error: "timeout" },
+        parameters: { files: ["apps/web/page.tsx"] },
+        createdAt: dt("2026-05-15T12:05:00.000Z"),
+      },
+    ]);
+    prismaMock.improvementProposal.findMany.mockResolvedValue([
+      {
+        id: "proposal-row-1",
+        proposalId: "IP-SKL-1",
+        title: "Tighten build-page retry guidance",
+        description: "Use clearer retry guidance when patching fails.",
+        category: "skill",
+        severity: "high",
+        submittedById: "user-1",
+        agentId: "AGT-BUILD",
+        routeContext: "/build",
+        threadId: "thread-1",
+        observedFriction: "Patch timeout was not recovered.",
+        conversationExcerpt: "full proposed skill body",
+        status: "proposed",
+        targetSkillId: "build-page",
+        createdAt: dt("2026-05-15T12:10:00.000Z"),
+      },
+    ]);
+    prismaMock.skillRevision.findMany.mockResolvedValue([
+      {
+        id: "revision-row-1",
+        revisionId: "SREV-1",
+        skillId: "build-page",
+        version: 2,
+        changeReason: "approved proposal IP-SKL-1",
+        changedBy: "reviewer-1",
+        proposalId: "IP-SKL-1",
+        createdAt: dt("2026-05-15T12:15:00.000Z"),
+      },
+    ]);
+
+    const results = await searchSkillEvidence({ skillId: "build-page", limit: 20 });
+
+    expect(results.map((r) => r.kind)).toEqual([
+      "skill_revision",
+      "improvement_proposal",
+      "tool_execution",
+      "skill_usage_event",
+    ]);
+    expect(results[0]).toMatchObject({
+      id: "SREV-1",
+      label: "Skill revision v2",
+      refs: { skillId: "build-page", proposalId: "IP-SKL-1" },
+    });
+    expect(results[2]).toMatchObject({
+      id: "tool-1",
+      label: "apply_patch failed",
+      refs: { skillId: "build-page", threadId: "thread-1", taskRunId: "TR-1" },
+    });
+    expect(prismaMock.skillUsageEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ skillId: "build-page" }),
+      }),
+    );
+  });
+
+  it("maps public TaskRun.taskRunId to TaskRun.id before reading task messages and artifacts", async () => {
+    prismaMock.taskRun.findMany.mockResolvedValue([
+      {
+        id: "task-row-1",
+        taskRunId: "TR-123",
+        title: "Repair build skill",
+        objective: "Use the skill evidence to repair a failed run.",
+        status: "failed",
+        source: "skill",
+        threadId: "thread-7",
+        routeContext: "/build",
+        initiatingAgentId: "AGT-BUILD",
+        currentAgentId: "AGT-BUILD",
+        startedAt: dt("2026-05-15T13:00:00.000Z"),
+        completedAt: dt("2026-05-15T13:10:00.000Z"),
+        createdAt: dt("2026-05-15T13:00:00.000Z"),
+      },
+    ]);
+    prismaMock.taskMessage.findMany.mockResolvedValue([
+      {
+        id: "task-message-row-1",
+        messageId: "MSG-1",
+        taskRunId: "task-row-1",
+        role: "agent",
+        parts: [{ type: "text", text: "Recovered after operator correction." }],
+        metadata: { correction: true },
+        createdAt: dt("2026-05-15T13:04:00.000Z"),
+      },
+    ]);
+    prismaMock.taskArtifact.findMany.mockResolvedValue([
+      {
+        id: "artifact-row-1",
+        artifactId: "ART-1",
+        taskRunId: "task-row-1",
+        name: "verification-notes.md",
+        description: "Focused verification notes",
+        parts: [{ type: "text", text: "timeout reproduced" }],
+        metadata: {},
+        createdAt: dt("2026-05-15T13:05:00.000Z"),
+      },
+    ]);
+
+    const results = await searchSkillEvidence({ taskRunId: "TR-123", limit: 10 });
+
+    const messageCall = prismaMock.taskMessage.findMany.mock.calls[0]?.[0];
+    const artifactCall = prismaMock.taskArtifact.findMany.mock.calls[0]?.[0];
+    expect(messageCall.where.taskRunId.in).toContain("task-row-1");
+    expect(artifactCall.where.taskRunId.in).toContain("task-row-1");
+    expect(results.map((r) => r.kind)).toEqual([
+      "task_artifact",
+      "task_message",
+      "task_run",
+    ]);
+    expect(results[0]).toMatchObject({
+      id: "ART-1",
+      refs: { taskRunId: "TR-123", taskRunRowId: "task-row-1" },
+    });
+  });
+
+  it("filters collected scoped evidence by query without treating memory as evidence", async () => {
+    prismaMock.skillUsageEvent.findMany.mockResolvedValue([
+      {
+        id: "sue-row-1",
+        eventId: "SUE-1",
+        skillId: "build-page",
+        agentId: "AGT-BUILD",
+        userId: null,
+        threadId: "thread-1",
+        taskRunId: null,
+        toolExecutionId: null,
+        routeContext: "/build",
+        phase: "failed",
+        source: "coworker",
+        metadata: { reason: "operator correction after timeout" },
+        createdAt: dt("2026-05-15T12:00:00.000Z"),
+      },
+      {
+        id: "sue-row-2",
+        eventId: "SUE-2",
+        skillId: "build-page",
+        agentId: "AGT-BUILD",
+        userId: null,
+        threadId: "thread-2",
+        taskRunId: null,
+        toolExecutionId: null,
+        routeContext: "/build",
+        phase: "completed",
+        source: "coworker",
+        metadata: { reason: "normal completion" },
+        createdAt: dt("2026-05-15T12:01:00.000Z"),
+      },
+    ]);
+
+    const results = await searchSkillEvidence({
+      skillId: "build-page",
+      query: "operator correction",
+      limit: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      kind: "skill_usage_event",
+      id: "SUE-1",
+    });
+    expect(results[0]?.summary).toContain("operator correction");
+  });
+
+  it("requires an explicit evidence scope", async () => {
+    await expect(searchSkillEvidence({ query: "timeout" })).rejects.toThrow(
+      /requires skillId, threadId, taskRunId, or routeContext/,
+    );
+  });
+
+  it("does not fetch global skill proposals for task-run-only evidence searches", async () => {
+    await searchSkillEvidence({ taskRunId: "TR-DOES-NOT-LINK-PROPOSALS", limit: 10 });
+
+    expect(prismaMock.improvementProposal.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("summarizeSkillEvidenceForPrompt", () => {
+  it("renders bounded prompt context from evidence results", () => {
+    const summary = summarizeSkillEvidenceForPrompt(
+      [
+        {
+          kind: "tool_execution",
+          id: "tool-1",
+          label: "apply_patch failed",
+          summary: "Patch failed after timeout while applying skill guidance.",
+          createdAt: "2026-05-15T12:05:00.000Z",
+          refs: {
+            skillId: "build-page",
+            threadId: "thread-1",
+            taskRunId: "TR-1",
+          },
+        },
+        {
+          kind: "skill_usage_event",
+          id: "SUE-1",
+          label: "Skill build-page failed",
+          summary: "metadata: operator correction after timeout",
+          createdAt: "2026-05-15T12:00:00.000Z",
+          refs: {
+            skillId: "build-page",
+            threadId: "thread-1",
+          },
+        },
+      ],
+      140,
+    );
+
+    expect(summary).toContain("tool_execution");
+    expect(summary).toContain("apply_patch failed");
+    expect(summary.length).toBeLessThanOrEqual(140);
+  });
+});

--- a/apps/web/lib/skills/evidence-search.ts
+++ b/apps/web/lib/skills/evidence-search.ts
@@ -1,0 +1,802 @@
+import { prisma } from "@dpf/db";
+
+export type SkillEvidenceKind =
+  | "skill_usage_event"
+  | "tool_execution"
+  | "task_run"
+  | "task_message"
+  | "task_artifact"
+  | "agent_message"
+  | "platform_issue"
+  | "improvement_proposal"
+  | "skill_revision"
+  | "backlog_activity"
+  | "external_evidence";
+
+export type SkillEvidenceSearchInput = {
+  skillId?: string | null;
+  threadId?: string | null;
+  taskRunId?: string | null;
+  routeContext?: string | null;
+  query?: string | null;
+  limit?: number | null;
+};
+
+export type SkillEvidenceRefs = {
+  skillId?: string | null;
+  threadId?: string | null;
+  taskRunId?: string | null;
+  taskRunRowId?: string | null;
+  toolExecutionId?: string | null;
+  proposalId?: string | null;
+  reportId?: string | null;
+  artifactId?: string | null;
+  messageId?: string | null;
+  backlogItemId?: string | null;
+  routeContext?: string | null;
+  agentId?: string | null;
+  userId?: string | null;
+};
+
+export type SkillEvidenceResult = {
+  kind: SkillEvidenceKind;
+  id: string;
+  label: string;
+  summary: string;
+  createdAt: string;
+  refs: SkillEvidenceRefs;
+};
+
+type NormalizedScope = {
+  skillId?: string;
+  threadId?: string;
+  taskRunId?: string;
+  routeContext?: string;
+  query?: string;
+  limit: number;
+};
+
+type TaskRunEvidenceRow = {
+  id: string;
+  taskRunId: string;
+  title: string;
+  objective: string;
+  status: string;
+  source: string;
+  threadId: string | null;
+  routeContext: string | null;
+  initiatingAgentId: string | null;
+  currentAgentId: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+  createdAt: Date;
+};
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export async function searchSkillEvidence(
+  input: SkillEvidenceSearchInput,
+): Promise<SkillEvidenceResult[]> {
+  const scope = normalizeScope(input);
+  const taskRuns = await loadScopedTaskRuns(scope);
+  const taskRunContext = buildTaskRunContext(scope, taskRuns);
+  const contextualWhere = buildContextualWhere(scope, taskRunContext.businessTaskRunIds);
+
+  const [
+    usageRows,
+    toolRows,
+    proposalRows,
+    revisionRows,
+    agentMessageRows,
+    issueRows,
+    externalEvidenceRows,
+  ] = await Promise.all([
+    loadSkillUsageEvents(scope, contextualWhere),
+    loadToolExecutions(scope, contextualWhere),
+    loadImprovementProposals(scope, contextualWhere),
+    loadSkillRevisions(scope),
+    loadAgentMessages(scope, taskRunContext.allTaskRunRefs),
+    loadPlatformIssues(scope, contextualWhere),
+    loadExternalEvidence(scope),
+  ]);
+
+  const toolExecutionIds = toolRows.map((row) => row.id).filter(Boolean);
+  const [taskMessageRows, taskArtifactRows, backlogActivityRows] = await Promise.all([
+    loadTaskMessages(taskRunContext.rowIds, scope.limit),
+    loadTaskArtifacts(taskRunContext.rowIds, scope.limit),
+    loadBacklogActivities(toolExecutionIds, scope.limit),
+  ]);
+
+  const taskRunByRowId = new Map(taskRuns.map((row) => [row.id, row]));
+
+  const results: SkillEvidenceResult[] = [
+    ...taskRuns.map(mapTaskRun),
+    ...usageRows.map(mapSkillUsageEvent),
+    ...toolRows.map(mapToolExecution),
+    ...proposalRows.map(mapImprovementProposal),
+    ...revisionRows.map(mapSkillRevision),
+    ...agentMessageRows.map(mapAgentMessage),
+    ...issueRows.map(mapPlatformIssue),
+    ...externalEvidenceRows.map(mapExternalEvidence),
+    ...taskMessageRows.map((row) => mapTaskMessage(row, taskRunByRowId, scope)),
+    ...taskArtifactRows.map((row) => mapTaskArtifact(row, taskRunByRowId, scope)),
+    ...backlogActivityRows.map(mapBacklogActivity),
+  ];
+
+  return applyQuery(results, scope.query)
+    .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+    .slice(0, scope.limit);
+}
+
+export function summarizeSkillEvidenceForPrompt(
+  results: SkillEvidenceResult[],
+  maxChars = 2400,
+): string {
+  const boundedMax = Math.max(80, Math.min(12000, Math.floor(maxChars)));
+  const body =
+    results.length === 0
+      ? "No scoped evidence records found."
+      : results
+          .map((result) => {
+            const refs = formatRefs(result.refs);
+            return `- [${result.kind}] ${result.createdAt} ${result.label}${refs ? ` (${refs})` : ""}: ${result.summary}`;
+          })
+          .join("\n");
+
+  if (body.length <= boundedMax) return body;
+  return `${body.slice(0, Math.max(0, boundedMax - 3)).trimEnd()}...`;
+}
+
+function normalizeScope(input: SkillEvidenceSearchInput): NormalizedScope {
+  const scope: NormalizedScope = {
+    skillId: clean(input.skillId),
+    threadId: clean(input.threadId),
+    taskRunId: clean(input.taskRunId),
+    routeContext: clean(input.routeContext),
+    query: clean(input.query),
+    limit: normalizeLimit(input.limit),
+  };
+
+  if (!scope.skillId && !scope.threadId && !scope.taskRunId && !scope.routeContext) {
+    throw new Error(
+      "[skill-evidence] scoped search requires skillId, threadId, taskRunId, or routeContext",
+    );
+  }
+
+  return scope;
+}
+
+function clean(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeLimit(limit: number | null | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(limit)));
+}
+
+async function loadScopedTaskRuns(scope: NormalizedScope): Promise<TaskRunEvidenceRow[]> {
+  const ors: Array<Record<string, unknown>> = [];
+  if (scope.taskRunId) {
+    ors.push({ taskRunId: scope.taskRunId }, { id: scope.taskRunId });
+  }
+  if (scope.threadId) ors.push({ threadId: scope.threadId });
+  if (scope.routeContext) ors.push({ routeContext: scope.routeContext });
+  if (ors.length === 0) return [];
+
+  return prisma.taskRun.findMany({
+    where: { OR: ors },
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      taskRunId: true,
+      title: true,
+      objective: true,
+      status: true,
+      source: true,
+      threadId: true,
+      routeContext: true,
+      initiatingAgentId: true,
+      currentAgentId: true,
+      startedAt: true,
+      completedAt: true,
+      createdAt: true,
+    },
+  });
+}
+
+function buildTaskRunContext(scope: NormalizedScope, taskRuns: TaskRunEvidenceRow[]) {
+  const rowIds = unique(taskRuns.map((row) => row.id));
+  const businessTaskRunIds = unique([
+    ...(scope.taskRunId ? [scope.taskRunId] : []),
+    ...taskRuns.map((row) => row.taskRunId),
+  ]);
+  const allTaskRunRefs = unique([...businessTaskRunIds, ...rowIds]);
+  return { rowIds, businessTaskRunIds, allTaskRunRefs };
+}
+
+function buildContextualWhere(
+  scope: NormalizedScope,
+  businessTaskRunIds: string[],
+): Array<Record<string, unknown>> {
+  const ors: Array<Record<string, unknown>> = [];
+  if (scope.threadId) ors.push({ threadId: scope.threadId });
+  if (businessTaskRunIds.length > 0) ors.push({ taskRunId: { in: businessTaskRunIds } });
+  if (scope.routeContext) ors.push({ routeContext: scope.routeContext });
+  return ors;
+}
+
+function scopedWhere(
+  base: Record<string, unknown>,
+  contextualWhere: Array<Record<string, unknown>>,
+) {
+  if (contextualWhere.length === 0) return base;
+  if (Object.keys(base).length === 0) return { OR: contextualWhere };
+  return { AND: [base, { OR: contextualWhere }] };
+}
+
+async function loadSkillUsageEvents(
+  scope: NormalizedScope,
+  contextualWhere: Array<Record<string, unknown>>,
+) {
+  return prisma.skillUsageEvent.findMany({
+    where: scopedWhere(scope.skillId ? { skillId: scope.skillId } : {}, contextualWhere),
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      eventId: true,
+      skillId: true,
+      agentId: true,
+      userId: true,
+      threadId: true,
+      taskRunId: true,
+      toolExecutionId: true,
+      routeContext: true,
+      phase: true,
+      source: true,
+      metadata: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadToolExecutions(
+  scope: NormalizedScope,
+  contextualWhere: Array<Record<string, unknown>>,
+) {
+  return prisma.toolExecution.findMany({
+    where: scopedWhere(scope.skillId ? { skillId: scope.skillId } : {}, contextualWhere),
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      threadId: true,
+      agentId: true,
+      userId: true,
+      toolName: true,
+      success: true,
+      parameters: true,
+      result: true,
+      executionMode: true,
+      routeContext: true,
+      durationMs: true,
+      createdAt: true,
+      taskRunId: true,
+      skillId: true,
+      summary: true,
+    },
+  });
+}
+
+async function loadImprovementProposals(
+  scope: NormalizedScope,
+  contextualWhere: Array<Record<string, unknown>>,
+) {
+  const proposalContext = contextualWhere.filter(
+    (where) => "threadId" in where || "routeContext" in where,
+  );
+  if (!scope.skillId && proposalContext.length === 0) return [];
+  return prisma.improvementProposal.findMany({
+    where: scopedWhere(
+      {
+        category: "skill",
+        ...(scope.skillId ? { targetSkillId: scope.skillId } : {}),
+      },
+      proposalContext,
+    ),
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      proposalId: true,
+      title: true,
+      description: true,
+      category: true,
+      severity: true,
+      submittedById: true,
+      agentId: true,
+      routeContext: true,
+      threadId: true,
+      conversationExcerpt: true,
+      observedFriction: true,
+      status: true,
+      targetSkillId: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadSkillRevisions(scope: NormalizedScope) {
+  if (!scope.skillId) return [];
+  return prisma.skillRevision.findMany({
+    where: { skillId: scope.skillId },
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      revisionId: true,
+      skillId: true,
+      version: true,
+      changeReason: true,
+      changedBy: true,
+      proposalId: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadAgentMessages(
+  scope: NormalizedScope,
+  allTaskRunRefs: string[],
+) {
+  const ors: Array<Record<string, unknown>> = [];
+  if (scope.threadId) ors.push({ threadId: scope.threadId });
+  if (allTaskRunRefs.length > 0) ors.push({ taskRunId: { in: allTaskRunRefs } });
+  if (scope.routeContext) ors.push({ routeContext: scope.routeContext });
+  if (ors.length === 0) return [];
+  return prisma.agentMessage.findMany({
+    where: { OR: ors },
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      threadId: true,
+      taskRunId: true,
+      role: true,
+      content: true,
+      createdAt: true,
+      agentId: true,
+      routeContext: true,
+    },
+  });
+}
+
+async function loadPlatformIssues(
+  scope: NormalizedScope,
+  contextualWhere: Array<Record<string, unknown>>,
+) {
+  if (contextualWhere.length === 0) return [];
+  return prisma.platformIssueReport.findMany({
+    where: { OR: contextualWhere },
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      reportId: true,
+      type: true,
+      severity: true,
+      status: true,
+      title: true,
+      description: true,
+      routeContext: true,
+      errorStack: true,
+      agentId: true,
+      source: true,
+      threadId: true,
+      taskRunId: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadExternalEvidence(scope: NormalizedScope) {
+  if (!scope.routeContext) return [];
+  return prisma.externalEvidenceRecord.findMany({
+    where: { routeContext: scope.routeContext },
+    orderBy: { createdAt: "desc" },
+    take: scope.limit,
+    select: {
+      id: true,
+      actorUserId: true,
+      routeContext: true,
+      operationType: true,
+      target: true,
+      provider: true,
+      resultSummary: true,
+      details: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadTaskMessages(taskRunRowIds: string[], limit: number) {
+  if (taskRunRowIds.length === 0) return [];
+  return prisma.taskMessage.findMany({
+    where: { taskRunId: { in: taskRunRowIds } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      messageId: true,
+      taskRunId: true,
+      role: true,
+      parts: true,
+      metadata: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadTaskArtifacts(taskRunRowIds: string[], limit: number) {
+  if (taskRunRowIds.length === 0) return [];
+  return prisma.taskArtifact.findMany({
+    where: { taskRunId: { in: taskRunRowIds } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      artifactId: true,
+      taskRunId: true,
+      name: true,
+      description: true,
+      parts: true,
+      metadata: true,
+      createdAt: true,
+    },
+  });
+}
+
+async function loadBacklogActivities(toolExecutionIds: string[], limit: number) {
+  if (toolExecutionIds.length === 0) return [];
+  return prisma.backlogItemActivity.findMany({
+    where: {
+      kind: "evidence",
+      toolExecutionId: { in: toolExecutionIds },
+    },
+    orderBy: { recordedAt: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      backlogItemId: true,
+      kind: true,
+      summary: true,
+      payload: true,
+      recordedAt: true,
+      recordedById: true,
+      recordedByAgentId: true,
+      toolExecutionId: true,
+    },
+  });
+}
+
+function mapTaskRun(row: TaskRunEvidenceRow): SkillEvidenceResult {
+  return {
+    kind: "task_run",
+    id: row.taskRunId,
+    label: `Task run ${row.taskRunId}`,
+    summary: compact(`${row.status} ${row.source}: ${row.title}. ${row.objective}`),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      threadId: row.threadId,
+      taskRunId: row.taskRunId,
+      taskRunRowId: row.id,
+      routeContext: row.routeContext,
+      agentId: row.currentAgentId ?? row.initiatingAgentId,
+    }),
+  };
+}
+
+function mapSkillUsageEvent(row: Record<string, unknown>): SkillEvidenceResult {
+  return {
+    kind: "skill_usage_event",
+    id: asString(row.eventId) ?? asString(row.id) ?? "skill-usage-event",
+    label: `Skill ${asString(row.skillId) ?? "unknown"} ${asString(row.phase) ?? "event"}`,
+    summary: compact(
+      [
+        `phase ${asString(row.phase) ?? "unknown"} from ${asString(row.source) ?? "unknown"}`,
+        preview(row.metadata) ? `metadata: ${preview(row.metadata)}` : null,
+      ]
+        .filter(Boolean)
+        .join("; "),
+    ),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      skillId: asString(row.skillId),
+      threadId: asString(row.threadId),
+      taskRunId: asString(row.taskRunId),
+      toolExecutionId: asString(row.toolExecutionId),
+      routeContext: asString(row.routeContext),
+      agentId: asString(row.agentId),
+      userId: asString(row.userId),
+    }),
+  };
+}
+
+function mapToolExecution(row: Record<string, unknown>): SkillEvidenceResult {
+  const success = row.success === true;
+  const fallbackSummary = success ? preview(row.result) : preview(row.result) || preview(row.parameters);
+  return {
+    kind: "tool_execution",
+    id: asString(row.id) ?? "tool-execution",
+    label: `${asString(row.toolName) ?? "tool"} ${success ? "succeeded" : "failed"}`,
+    summary: compact(asString(row.summary) ?? fallbackSummary ?? "No tool summary recorded."),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      skillId: asString(row.skillId),
+      threadId: asString(row.threadId),
+      taskRunId: asString(row.taskRunId),
+      toolExecutionId: asString(row.id),
+      routeContext: asString(row.routeContext),
+      agentId: asString(row.agentId),
+      userId: asString(row.userId),
+    }),
+  };
+}
+
+function mapImprovementProposal(row: Record<string, unknown>): SkillEvidenceResult {
+  return {
+    kind: "improvement_proposal",
+    id: asString(row.proposalId) ?? asString(row.id) ?? "improvement-proposal",
+    label: `Proposal ${asString(row.proposalId) ?? ""}: ${asString(row.title) ?? "Untitled"}`.trim(),
+    summary: compact(
+      [
+        asString(row.description),
+        asString(row.observedFriction) ? `friction: ${asString(row.observedFriction)}` : null,
+        asString(row.status) ? `status: ${asString(row.status)}` : null,
+      ]
+        .filter(Boolean)
+        .join("; "),
+    ),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      skillId: asString(row.targetSkillId),
+      threadId: asString(row.threadId),
+      proposalId: asString(row.proposalId),
+      routeContext: asString(row.routeContext),
+      agentId: asString(row.agentId),
+      userId: asString(row.submittedById),
+    }),
+  };
+}
+
+function mapSkillRevision(row: Record<string, unknown>): SkillEvidenceResult {
+  const version = typeof row.version === "number" ? row.version : Number(row.version);
+  return {
+    kind: "skill_revision",
+    id: asString(row.revisionId) ?? asString(row.id) ?? "skill-revision",
+    label: `Skill revision v${Number.isFinite(version) ? version : "?"}`,
+    summary: compact(asString(row.changeReason) ?? "Skill revision recorded."),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      skillId: asString(row.skillId),
+      proposalId: asString(row.proposalId),
+      agentId: asString(row.changedBy),
+    }),
+  };
+}
+
+function mapAgentMessage(row: Record<string, unknown>): SkillEvidenceResult {
+  return {
+    kind: "agent_message",
+    id: asString(row.id) ?? "agent-message",
+    label: `Agent message (${asString(row.role) ?? "unknown"})`,
+    summary: compact(asString(row.content) ?? "No message content recorded."),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      threadId: asString(row.threadId),
+      taskRunId: asString(row.taskRunId),
+      routeContext: asString(row.routeContext),
+      agentId: asString(row.agentId),
+      messageId: asString(row.id),
+    }),
+  };
+}
+
+function mapPlatformIssue(row: Record<string, unknown>): SkillEvidenceResult {
+  return {
+    kind: "platform_issue",
+    id: asString(row.reportId) ?? asString(row.id) ?? "platform-issue",
+    label: `${asString(row.severity) ?? "medium"} issue: ${asString(row.title) ?? "Untitled"}`,
+    summary: compact(
+      [
+        asString(row.description),
+        asString(row.errorStack) ? `stack: ${asString(row.errorStack)}` : null,
+        asString(row.status) ? `status: ${asString(row.status)}` : null,
+      ]
+        .filter(Boolean)
+        .join("; "),
+    ),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      threadId: asString(row.threadId),
+      taskRunId: asString(row.taskRunId),
+      routeContext: asString(row.routeContext),
+      agentId: asString(row.agentId),
+      reportId: asString(row.reportId),
+    }),
+  };
+}
+
+function mapExternalEvidence(row: Record<string, unknown>): SkillEvidenceResult {
+  return {
+    kind: "external_evidence",
+    id: asString(row.id) ?? "external-evidence",
+    label: `${asString(row.provider) ?? "provider"} ${asString(row.operationType) ?? "operation"}`,
+    summary: compact(
+      [
+        asString(row.resultSummary),
+        asString(row.target) ? `target: ${asString(row.target)}` : null,
+        preview(row.details) ? `details: ${preview(row.details)}` : null,
+      ]
+        .filter(Boolean)
+        .join("; "),
+    ),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      routeContext: asString(row.routeContext),
+      userId: asString(row.actorUserId),
+    }),
+  };
+}
+
+function mapTaskMessage(
+  row: Record<string, unknown>,
+  taskRunByRowId: Map<string, TaskRunEvidenceRow>,
+  scope: NormalizedScope,
+): SkillEvidenceResult {
+  const taskRunRowId = asString(row.taskRunId);
+  const taskRun = taskRunRowId ? taskRunByRowId.get(taskRunRowId) : undefined;
+  return {
+    kind: "task_message",
+    id: asString(row.messageId) ?? asString(row.id) ?? "task-message",
+    label: `Task message ${asString(row.role) ?? "unknown"}`,
+    summary: compact(partsPreview(row.parts) || preview(row.metadata) || "No task message content recorded."),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      threadId: taskRun?.threadId ?? scope.threadId,
+      taskRunId: taskRun?.taskRunId ?? scope.taskRunId,
+      taskRunRowId,
+      messageId: asString(row.messageId) ?? asString(row.id),
+      routeContext: taskRun?.routeContext ?? scope.routeContext,
+    }),
+  };
+}
+
+function mapTaskArtifact(
+  row: Record<string, unknown>,
+  taskRunByRowId: Map<string, TaskRunEvidenceRow>,
+  scope: NormalizedScope,
+): SkillEvidenceResult {
+  const taskRunRowId = asString(row.taskRunId);
+  const taskRun = taskRunRowId ? taskRunByRowId.get(taskRunRowId) : undefined;
+  return {
+    kind: "task_artifact",
+    id: asString(row.artifactId) ?? asString(row.id) ?? "task-artifact",
+    label: `Task artifact ${asString(row.name) ?? "unnamed"}`,
+    summary: compact(
+      asString(row.description) ?? partsPreview(row.parts) ?? preview(row.metadata) ?? "No artifact summary recorded.",
+    ),
+    createdAt: iso(row.createdAt),
+    refs: cleanRefs({
+      threadId: taskRun?.threadId ?? scope.threadId,
+      taskRunId: taskRun?.taskRunId ?? scope.taskRunId,
+      taskRunRowId,
+      artifactId: asString(row.artifactId) ?? asString(row.id),
+      routeContext: taskRun?.routeContext ?? scope.routeContext,
+    }),
+  };
+}
+
+function mapBacklogActivity(row: Record<string, unknown>): SkillEvidenceResult {
+  return {
+    kind: "backlog_activity",
+    id: asString(row.id) ?? "backlog-activity",
+    label: `Backlog evidence: ${asString(row.summary) ?? "recorded"}`,
+    summary: compact(preview(row.payload) || asString(row.summary) || "Backlog evidence recorded."),
+    createdAt: iso(row.recordedAt),
+    refs: cleanRefs({
+      backlogItemId: asString(row.backlogItemId),
+      toolExecutionId: asString(row.toolExecutionId),
+      agentId: asString(row.recordedByAgentId),
+      userId: asString(row.recordedById),
+    }),
+  };
+}
+
+function applyQuery(
+  results: SkillEvidenceResult[],
+  query: string | undefined,
+): SkillEvidenceResult[] {
+  if (!query) return results;
+  const needle = query.toLowerCase();
+  return results.filter((result) =>
+    [
+      result.kind,
+      result.id,
+      result.label,
+      result.summary,
+      JSON.stringify(result.refs),
+    ]
+      .join(" ")
+      .toLowerCase()
+      .includes(needle),
+  );
+}
+
+function formatRefs(refs: SkillEvidenceRefs): string {
+  return Object.entries(refs)
+    .filter(([, value]) => value !== null && value !== undefined && value !== "")
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
+}
+
+function cleanRefs(refs: SkillEvidenceRefs): SkillEvidenceRefs {
+  return Object.fromEntries(
+    Object.entries(refs).filter(
+      ([, value]) => value !== null && value !== undefined && value !== "",
+    ),
+  ) as SkillEvidenceRefs;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function iso(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+function preview(value: unknown, max = 220): string | null {
+  if (value === null || value === undefined) return null;
+  const raw = typeof value === "string" ? value : JSON.stringify(value);
+  const compacted = compact(raw);
+  if (compacted.length <= max) return compacted;
+  return `${compacted.slice(0, Math.max(0, max - 3)).trimEnd()}...`;
+}
+
+function partsPreview(value: unknown): string | null {
+  if (typeof value === "string") return preview(value);
+  if (Array.isArray(value)) {
+    const text = value
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object" && "text" in part) {
+          const text = (part as { text?: unknown }).text;
+          return typeof text === "string" ? text : null;
+        }
+        return null;
+      })
+      .filter(Boolean)
+      .join(" ");
+    return text ? preview(text) : preview(value);
+  }
+  return preview(value);
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function unique(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))];
+}


### PR DESCRIPTION
## Summary
- add a governed evidence/session search helper over existing skill, thread, task, tool, issue, proposal, revision, backlog, and external evidence records
- wire focused `/platform/ai/skills` detail to show scoped evidence and bounded evidence state
- add proposal-row links into thread-scoped evidence search results

## Verification
- `pnpm --filter web exec vitest run lib/skills/evidence-search.test.ts components/platform/SkillEvidencePanel.test.tsx components/platform/SkillProposalsPanel.test.tsx "app/(shell)/platform/ai/skills/page.test.tsx"`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build` (passes; existing Turbopack broad-file-trace warnings remain)
- Browser UX check on `http://localhost:3100/platform/ai/skills?skill=build-page`: login succeeded, focused skill detail rendered, Evidence heading rendered, empty evidence state rendered