### PR TITLE
chore(deps): override fast-uri to ^3.1.2 (resolves 2 high-severity alerts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "node-forge": "1.4.0",
       "postcss": "^8.5.10",
       "uuid": "^14.0.0",
-      "@opentelemetry/otlp-transformer>protobufjs": "^8.3.0"
+      "@opentelemetry/otlp-transformer>protobufjs": "^8.3.0",
+      "fast-uri": "^3.1.2"
     },
     "onlyBuiltDependencies": [
       "msw",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   postcss: ^8.5.10
   uuid: ^14.0.0
   '@opentelemetry/otlp-transformer>protobufjs': ^8.3.0
+  fast-uri: ^3.1.2
 
 importers:
 
@@ -5195,8 +5196,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -13157,7 +13158,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14743,7 +14744,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides`: `fast-uri: ^3.1.2`.
- Resolves **2 high-severity Dependabot alerts** on the root lockfile.
- The same vulnerable version on `services/adp/pnpm-lock.yaml` is addressed separately — see follow-up PR removing that stale lockfile.

## Alerts closed (root lockfile)

| GHSA | Severity | Summary |
|------|----------|---------|
| GHSA-v39h-62p7-jpjc | high | Host confusion via percent-encoded authority delimiters |
| GHSA-q3j6-qgpj-74h6 | high | Path traversal via percent-encoded dot segments |

Vulnerable range: `<= 3.1.1`. First fully-patched: `3.1.2`.

## Why a bare override is safe

`fast-uri@3.1.0` is pulled in by `ajv@8.18.0`, which requires `fast-uri: ^3.0.1`. `3.1.2` satisfies that range. There is only one `fast-uri` tree in the root lockfile, so no risk of stomping on a v2 or pre-3.0.1 consumer.

## Lockfile delta

`pnpm-lock.yaml`: `fast-uri@3.1.0` → `fast-uri@3.1.2`.

## Test plan

- [x] `pnpm install` succeeds with refreshed lockfile
- [x] Unit tests pass — web (5758) + @dpf/db src/ unit tests (489) + mobile (149) all green
- [ ] CI typecheck + production build + DB-integration tests pass on PR (the 3 packages/db/test/ integration tests added in #650 need a provisioned postgres which CI handles via the workflow's postgres service; my local dev environment has the dpf-postgres-1 container running but without a host port mapping, so they are not runnable locally without a docker-compose change)
- [ ] Dependabot recomputes and closes the 2 root fast-uri alerts

Part of the 2026-05 Dependabot sweep. Next PR (`chore: remove stale services/adp/pnpm-lock.yaml`) closes the remaining 8 services/adp alerts including the 2 fast-uri ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)