### PR TITLE
chore(deps): override ip-address to ^10.2.0 (resolves 1 Dependabot alert)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "@opentelemetry/otlp-transformer>protobufjs": "^8.3.0",
       "fast-uri": "^3.1.2",
       "hono": "^4.12.19",
-      "mermaid": "^11.15.0"
+      "mermaid": "^11.15.0",
+      "ip-address": "^10.2.0"
     },
     "onlyBuiltDependencies": [
       "msw",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   fast-uri: ^3.1.2
   hono: ^4.12.19
   mermaid: ^11.15.0
+  ip-address: ^10.2.0
 
 importers:
 
@@ -5715,10 +5716,6 @@ packages:
     resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
     peerDependencies:
       fp-ts: ^2.5.0
-
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -14599,7 +14596,7 @@ snapshots:
   express-rate-limit@8.4.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -15261,8 +15258,6 @@ snapshots:
   io-ts@2.2.22(fp-ts@2.16.11):
     dependencies:
       fp-ts: 2.16.11
-
-  ip-address@10.1.0: {}
 
   ip-address@10.2.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides`: `ip-address: ^10.2.0`.
- Resolves **1 medium-severity Dependabot alert** on the root lockfile.
- The matching alert on `services/adp/pnpm-lock.yaml` is closed by #681.

## Alert closed

| GHSA | Severity | Summary |
|------|----------|---------|
| GHSA-v2v4-37r5-5v8g | medium | ip-address has XSS in Address6 HTML-emitting methods |

Vulnerable range: `<= 10.1.0`. First fully-patched: `10.1.1`. Pinning to `^10.2.0` (current latest).

## Why a bare override is safe

`ip-address@10.1.0` is pulled in by `express-rate-limit@8.4.0` (which pins `ip-address: 10.1.0` exactly), itself a transitive of `@modelcontextprotocol/sdk`. The root lockfile already had a clean `ip-address@10.2.0` coexisting under `socks` (via `socks-proxy-agent`), so 10.2.0 is already battle-tested in this tree. The override just collapses both consumers to the patched version.

## Lockfile delta

`pnpm-lock.yaml`: removes the `ip-address@10.1.0` resolution (now only `ip-address@10.2.0` exists).

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm --filter web test` passes (5873 tests)
- [ ] CI green
- [ ] Dependabot closes the root ip-address alert

Last PR in the 2026-05 Dependabot sweep. After this + #681 + #682 + #683 land, all 26 alerts from the 2026-05-15 snapshot are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)