### PR TITLE
feat(mcp): issue-mcp-token CLI — generate .mcp.json from the command line

### DIFF
--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -9,6 +9,7 @@ import {
   type IssueMcpTokenResult,
   type McpTokenCapability,
 } from "@/lib/auth/mcp-api-token";
+import { buildSetupSnippets } from "@/lib/auth/mcp-setup-snippets";
 import { CODING_AGENT_MCP_TOKEN_SCOPES } from "@/lib/mcp-token-scopes";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 
@@ -76,55 +77,6 @@ export type IssueTokenActionResult =
       message: string;
     };
 
-function buildSetupSnippets(plaintext: string, baseUrl: string): {
-  claudeCode: string;
-  codex: string;
-  vscode: string;
-} {
-  const url = `${baseUrl}/api/mcp/v1`;
-  const claudeCode = JSON.stringify(
-    {
-      mcpServers: {
-        dpf: {
-          type: "http",
-          url,
-          headers: { Authorization: `Bearer ${plaintext}` },
-        },
-      },
-    },
-    null,
-    2,
-  );
-  // Codex CLI uses similar JSON config
-  const codex = JSON.stringify(
-    {
-      mcpServers: {
-        dpf: {
-          type: "http",
-          url,
-          headers: { Authorization: `Bearer ${plaintext}` },
-        },
-      },
-    },
-    null,
-    2,
-  );
-  // VS Code MCP `.vscode/mcp.json`
-  const vscode = JSON.stringify(
-    {
-      servers: {
-        dpf: {
-          type: "http",
-          url,
-          headers: { Authorization: `Bearer ${plaintext}` },
-        },
-      },
-    },
-    null,
-    2,
-  );
-  return { claudeCode, codex, vscode };
-}
 
 export async function issueMyMcpToken(input: {
   name: string;

--- a/apps/web/lib/auth/mcp-setup-snippets.test.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildSetupSnippets } from "./mcp-setup-snippets";
+
+const BASE = "http://localhost:3000";
+const TOKEN = "dpfmcp_TESTTOKEN";
+
+describe("buildSetupSnippets", () => {
+  it("claudeCode has mcpServers.dpf with http type, correct url, and auth header", () => {
+    const { claudeCode } = buildSetupSnippets(TOKEN, BASE);
+    const parsed = JSON.parse(claudeCode) as Record<string, unknown>;
+    const dpf = (parsed.mcpServers as Record<string, unknown>).dpf as Record<string, unknown>;
+    expect(dpf.type).toBe("http");
+    expect(dpf.url).toBe(`${BASE}/api/mcp/v1`);
+    expect((dpf.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("vscode has servers.dpf (not mcpServers) with the same http entry", () => {
+    const { vscode } = buildSetupSnippets(TOKEN, BASE);
+    const parsed = JSON.parse(vscode) as Record<string, unknown>;
+    expect("mcpServers" in parsed).toBe(false);
+    const dpf = (parsed.servers as Record<string, unknown>).dpf as Record<string, unknown>;
+    expect(dpf.type).toBe("http");
+    expect(dpf.url).toBe(`${BASE}/api/mcp/v1`);
+    expect((dpf.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("codex is identical to claudeCode", () => {
+    const { claudeCode, codex } = buildSetupSnippets(TOKEN, BASE);
+    expect(codex).toBe(claudeCode);
+  });
+
+  it("auth header embeds the full plaintext token", () => {
+    const t = "dpfmcp_UNIQUETOKEN";
+    const { claudeCode } = buildSetupSnippets(t, BASE);
+    expect(claudeCode).toContain(t);
+  });
+
+  it("constructs the url from a non-localhost baseUrl", () => {
+    const { claudeCode } = buildSetupSnippets(TOKEN, "https://dpf.example.com");
+    expect(claudeCode).toContain("https://dpf.example.com/api/mcp/v1");
+  });
+
+  it("output is valid JSON for all three formats", () => {
+    const { claudeCode, codex, vscode } = buildSetupSnippets(TOKEN, BASE);
+    expect(() => JSON.parse(claudeCode)).not.toThrow();
+    expect(() => JSON.parse(codex)).not.toThrow();
+    expect(() => JSON.parse(vscode)).not.toThrow();
+  });
+});

--- a/apps/web/lib/auth/mcp-setup-snippets.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.ts
@@ -1,0 +1,27 @@
+// Pure helper — no Next.js server context required.
+// Single source of truth for .mcp.json / .vscode/mcp.json snippet generation.
+// Used by apps/web/lib/actions/mcp-tokens.ts (server action) and
+// apps/web/scripts/issue-mcp-token.ts (CLI).
+
+export type McpSnippetFormat = "claude-code" | "codex" | "vscode" | "raw";
+
+export type McpSetupSnippets = {
+  claudeCode: string;
+  codex: string;
+  vscode: string;
+};
+
+export function buildSetupSnippets(plaintext: string, baseUrl: string): McpSetupSnippets {
+  const url = `${baseUrl}/api/mcp/v1`;
+  const httpEntry = {
+    type: "http",
+    url,
+    headers: { Authorization: `Bearer ${plaintext}` },
+  };
+  // Claude Code and Codex: .mcp.json uses the mcpServers key
+  const claudeCode = JSON.stringify({ mcpServers: { dpf: httpEntry } }, null, 2);
+  const codex = JSON.stringify({ mcpServers: { dpf: httpEntry } }, null, 2);
+  // VS Code: .vscode/mcp.json uses servers (not mcpServers)
+  const vscode = JSON.stringify({ servers: { dpf: httpEntry } }, null, 2);
+  return { claudeCode, codex, vscode };
+}

--- a/apps/web/scripts/issue-mcp-token.ts
+++ b/apps/web/scripts/issue-mcp-token.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env -S pnpm --filter web exec tsx
+// apps/web/scripts/issue-mcp-token.ts
+//
+// One-shot CLI that issues an MCP API token for the local DPF install and
+// prints a ready-to-paste config snippet to stdout. Closes the "had to click
+// through the UI" gap for fresh installs and headless environments.
+//
+// Uses the same business-logic helper as Admin > Platform Development, so the
+// issued token appears in the Admin token list with a full audit trail.
+//
+// Run from the repo root:
+//
+//   pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts
+//
+// Or from apps/web/:
+//
+//   pnpm exec tsx scripts/issue-mcp-token.ts
+//
+// Output:
+//   stdout  — the chosen snippet (pipe-friendly, only this)
+//   stderr  — diagnostic line (prefix, expiry, tokenId, user)
+//
+// Examples:
+//
+//   # Write .mcp.json for Claude Code (default):
+//   pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts > .mcp.json
+//
+//   # Write VS Code mcp.json:
+//   pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format vscode > .vscode/mcp.json
+//
+//   # Get the raw token for scripting:
+//   TOKEN=$(pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format raw)
+//
+// Sibling: apps/web/scripts/issue-edge-bootstrap-token.ts
+
+import { prisma } from "@dpf/db";
+import type { McpTokenCapability } from "../lib/auth/mcp-api-token";
+import type { McpSnippetFormat } from "../lib/auth/mcp-setup-snippets";
+
+const DEFAULT_EMAIL = "admin@dpf.local";
+const DEFAULT_EXPIRES_DAYS = 90;
+
+type Args = {
+  email: string;
+  name: string;
+  capability: McpTokenCapability;
+  scopes: string[] | null; // null → resolved to CODING_AGENT_MCP_TOKEN_SCOPES at runtime
+  expiresDays: number | null;
+  format: McpSnippetFormat;
+  baseUrl: string;
+};
+
+function parseArgs(argv: readonly string[]): Args {
+  let email = DEFAULT_EMAIL;
+  let name = `cli-issued-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  let capability: McpTokenCapability = "read";
+  let scopes: string[] | null = null;
+  let expiresDays: number | null = DEFAULT_EXPIRES_DAYS;
+  let format: McpSnippetFormat = "claude-code";
+  let baseUrl =
+    process.env["AUTH_URL"] ?? process.env["APP_URL"] ?? "http://localhost:3000";
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    const next = (): string => {
+      const v = argv[i + 1];
+      if (!v) fatal(`${arg} requires a value`);
+      i++;
+      return v;
+    };
+
+    switch (arg) {
+      case "--user":
+        email = next();
+        break;
+      case "--name":
+        name = next();
+        break;
+      case "--capability": {
+        const v = next();
+        if (v !== "read" && v !== "write") {
+          fatal(`--capability must be "read" or "write"; got: ${v}`);
+        }
+        capability = v;
+        break;
+      }
+      case "--scopes": {
+        const parsed = next()
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        if (parsed.length === 0) fatal("--scopes produced an empty list after splitting");
+        scopes = parsed;
+        break;
+      }
+      case "--expires-days": {
+        const v = next();
+        if (v === "never") {
+          expiresDays = null;
+        } else {
+          const n = Number(v);
+          if (!Number.isFinite(n) || n <= 0) {
+            fatal(`--expires-days must be a positive number or "never"; got: ${v}`);
+          }
+          expiresDays = Math.floor(n);
+        }
+        break;
+      }
+      case "--format": {
+        const v = next();
+        if (v !== "claude-code" && v !== "codex" && v !== "vscode" && v !== "raw") {
+          fatal(`--format must be claude-code | codex | vscode | raw; got: ${v}`);
+        }
+        format = v;
+        break;
+      }
+      case "--base-url":
+        baseUrl = next().replace(/\/$/, "");
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+      default:
+        fatal(`unknown argument: ${arg}`);
+    }
+  }
+
+  return { email, name, capability, scopes, expiresDays, format, baseUrl };
+}
+
+function printHelp(): void {
+  console.error(
+    [
+      "Usage: pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts [flags]",
+      "",
+      "Issues an MCP API token and prints a ready-to-paste config snippet to stdout.",
+      "The issued token appears in Admin > Platform Development with a full audit trail.",
+      "",
+      "Flags:",
+      "  --user <email>         Admin user to issue the token for",
+      `                         (default: ${DEFAULT_EMAIL})`,
+      "  --name <label>         Token display name (default: cli-issued-<timestamp>)",
+      "  --capability <c>       read | write (default: read)",
+      "                         write requires contribution mode configured in Admin",
+      "  --scopes <csv>         Comma-separated scope list",
+      "                         (default: coding-agent set from mcp-token-scopes.ts)",
+      `  --expires-days N|never Token TTL in days, or "never" (default: ${DEFAULT_EXPIRES_DAYS})`,
+      "  --format <fmt>         claude-code | codex | vscode | raw (default: claude-code)",
+      "  --base-url <url>       Portal base URL",
+      "                         (default: $AUTH_URL / $APP_URL / http://localhost:3000)",
+      "  --help, -h             Show this help",
+      "",
+      "Output (stdout):",
+      "  claude-code  .mcp.json snippet   (mcpServers.dpf, http transport)",
+      "  codex        Same as claude-code",
+      "  vscode       .vscode/mcp.json snippet (servers.dpf)",
+      "  raw          Plaintext token only",
+      "",
+      "Examples:",
+      "  pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts > .mcp.json",
+      "  pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format vscode > .vscode/mcp.json",
+      "  TOKEN=$(pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format raw)",
+    ].join("\n"),
+  );
+}
+
+function fatal(msg: string): never {
+  console.error(`issue-mcp-token: ${msg}`);
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Dynamic imports so tsx resolves path aliases correctly at runtime.
+  const { issueMcpApiToken } = await import("../lib/auth/mcp-api-token");
+  const { buildSetupSnippets } = await import("../lib/auth/mcp-setup-snippets");
+  const { CODING_AGENT_MCP_TOKEN_SCOPES } = await import("../lib/mcp-token-scopes");
+
+  const user = await prisma.user.findFirst({ where: { email: args.email } });
+  if (!user) {
+    fatal(
+      `No user found with email "${args.email}". ` +
+        `Ensure the platform is running and seeded (pnpm dev or docker compose up), ` +
+        `then re-run. Override with --user <email>.`,
+    );
+  }
+
+  const scopes: string[] = args.scopes ?? [...CODING_AGENT_MCP_TOKEN_SCOPES];
+
+  const result = await issueMcpApiToken({
+    userId: user.id,
+    name: args.name,
+    capability: args.capability,
+    scopes,
+    expiresInDays: args.expiresDays,
+  });
+
+  if (!result.ok) {
+    const detail =
+      result.error === "contribution_mode_required"
+        ? `${result.message}\nConfigure contribution mode at Admin > Platform Development, then re-run.`
+        : result.message;
+    fatal(detail);
+  }
+
+  // Diagnostics to stderr — stdout stays pipeable.
+  const expiryStr = result.expiresAt ? result.expiresAt.toISOString() : "never";
+  console.error(
+    `Issued MCP token ${result.prefix}…  expires ${expiryStr}  tokenId=${result.tokenId}  user=${args.email}`,
+  );
+
+  if (args.format === "raw") {
+    console.log(result.plaintext);
+  } else {
+    const snippets = buildSetupSnippets(result.plaintext, args.baseUrl);
+    const snippet =
+      args.format === "vscode"
+        ? snippets.vscode
+        : args.format === "codex"
+          ? snippets.codex
+          : snippets.claudeCode;
+    console.log(snippet);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err: unknown) => {
+  console.error(`issue-mcp-token failed: ${(err as Error).stack ?? err}`);
+  try {
+    await prisma.$disconnect();
+  } catch {
+    // best effort
+  }
+  process.exit(1);
+});

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -359,3 +359,22 @@ report — we'll integrate findings as they arrive.
 - [Installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
 - [Deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md) — the 10 canonical contracts every install path wraps.
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — for contributing back to the platform.
+
+### Connecting Claude Code or VS Code via MCP
+
+Once the platform is running, you can connect Claude Code, Codex CLI, or VS Code to your install's MCP server at `/api/mcp/v1`.
+
+**Option A — CLI (fastest, no browser needed):**
+
+```bash
+pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts > .mcp.json
+```
+
+This issues a read-only token with the coding-agent scope set and writes a ready-to-paste `.mcp.json` in one step. Restart Claude Code to pick up the `dpf` connector.
+
+```bash
+# VS Code instead:
+pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format vscode > .vscode/mcp.json
+```
+
+**Option B — Admin UI:** Log in → Admin > Platform Development > MCP Token Manager → generate a token → paste the displayed snippet into `.mcp.json`.

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -271,3 +271,22 @@ report — we'll integrate findings as they arrive.
 - [Installer-parity roadmap](../superpowers/plans/2026-05-09-macos-linux-native-support.md)
 - [Deployment doctrine](../superpowers/specs/2026-05-09-deployment-contracts.md) — the 10 canonical contracts every install path wraps.
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — for contributing back to the platform.
+
+### Connecting Claude Code or VS Code via MCP
+
+Once the platform is running, you can connect Claude Code, Codex CLI, or VS Code to your install's MCP server at `/api/mcp/v1`.
+
+**Option A — CLI (fastest, no browser needed):**
+
+```bash
+pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts > .mcp.json
+```
+
+This issues a read-only token with the coding-agent scope set and writes a ready-to-paste `.mcp.json` in one step. Restart Claude Code to pick up the `dpf` connector.
+
+```bash
+# VS Code instead:
+pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format vscode > .vscode/mcp.json
+```
+
+**Option B — Admin UI:** Log in → Admin > Platform Development > MCP Token Manager → generate a token → paste the displayed snippet into `.mcp.json`.


### PR DESCRIPTION
## Summary

- Adds `apps/web/scripts/issue-mcp-token.ts` — a one-shot CLI that issues an MCP API token and prints a ready-to-paste `.mcp.json` snippet to stdout, closing the \"had to click through the UI\" gap for fresh installs and headless environments. Mirrors the sibling `issue-edge-bootstrap-token.ts` in structure.
- Extracts `buildSetupSnippets` from the `\"use server\"` `lib/actions/mcp-tokens.ts` into a pure module `lib/auth/mcp-setup-snippets.ts`, making it a single source of truth for both the server action and the CLI. Six vitest tests cover all three snippet formats.
- Adds a \"Connecting Claude Code or VS Code via MCP\" subsection to `docs/install/macos.md` and `docs/install/linux.md` with CLI and Admin UI options.

## Usage

```bash
# Write .mcp.json for Claude Code (default):
pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts > .mcp.json

# VS Code:
pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format vscode > .vscode/mcp.json

# Raw token for scripting:
TOKEN=$(pnpm --filter web exec tsx apps/web/scripts/issue-mcp-token.ts --format raw)
```

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] `vitest run lib/auth/mcp-setup-snippets.test.ts` — 6/6 pass
- [x] `next build` — compiled successfully
- [x] No DB migrations, no UI changes, no seed changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)