### PR TITLE
feat(macos): extend verify-install-edge.sh with macOS-specific checks

### DIFF
--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -233,26 +233,41 @@ the path from "early access" to "GA" runs through the community.
 If you ran the install above on a real Mac, **please file a quick
 report** — happy paths and failures are equally valuable.
 
-**One-minute report:**
+**One-command report (fastest path):**
 
-1. Open a [new GitHub issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new)
-   titled `Install verification — macOS <version> <arch>`
-   (example: `Install verification — macOS 14.5 arm64 (M2 Pro)`).
-2. Paste the output of:
+```bash
+# Already installed — just run the verifier:
+bash scripts/verify-install-edge.sh
+
+# Fresh host — bootstrap + verify in one shot:
+bash scripts/verify-install-edge.sh --bootstrap
+```
+
+The script captures a `~/.dpf/verify-bundle-<timestamp>.tar.gz` with a
+host fingerprint, portal health, Prometheus targets, Edge Node lifecycle
+log, and a paste-able summary — including macOS-specific checks for
+architecture (arm64), LaunchAgent autostart, and Docker Model Runner.
+
+Open a [new GitHub issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new)
+titled `Install verification — macOS <version> <arch>`
+(example: `Install verification — macOS 14.5 arm64 (M2 Pro)`) and
+attach the tarball. Secrets in the bundle are redacted automatically.
+
+**Manual report (if the verifier itself fails to run):**
+
+1. Paste the output of:
    ```bash
    sw_vers && uname -srm
    docker --version 2>/dev/null
    echo "DPF version: $(grep DPF_INSTALLER_VERSION install-dpf.sh)"
    ```
-3. Note which steps you completed from the
+2. Note which steps you completed from the
    [verification runbook §2](verification-runbook.md#2-macos-apple-silicon-end-to-end-install)
    and which (if any) failed.
-4. Attach the doctor bundle:
+3. Attach the doctor bundle:
    ```bash
    bash install-dpf.sh doctor
-   # Then attach ~/.dpf/doctor-<timestamp>.tar.gz to the issue.
-   # Secrets are redacted automatically; you can review the bundle
-   # before sending.
+   # Attach ~/.dpf/doctor-<timestamp>.tar.gz to the issue.
    ```
 
 The verification runbook also covers:

--- a/scripts/verify-install-edge.sh
+++ b/scripts/verify-install-edge.sh
@@ -2,16 +2,21 @@
 # scripts/verify-install-edge.sh
 #
 # One-command hardware verification for the DPF installer + Edge Node
-# end-to-end path. Produces one tarball + one paste-able summary so an
-# operator can run a single command and file the result against the
-# install_verification.md issue template (.github/ISSUE_TEMPLATE/).
+# end-to-end path on Linux and macOS. Produces one tarball + one
+# paste-able summary so an operator can run a single command and file
+# the result against the install_verification.md issue template.
 #
 # Covers verification ledger rows 1, 2, 3, and 4 in a single sweep:
 #   1. Installer ran successfully (Outcome 1/2: hardware verification)
-#   2. Portal /api/health responds (Outcome 2: Linux end-to-end)
+#   2. Portal /api/health responds (Outcome 2: Linux / macOS end-to-end)
 #   3. Prometheus targets are scrape-healthy (Outcome 3: observability)
 #   4. Edge Node enrolls + heartbeats + submits a discovery run
 #      (Outcome 4: Edge Node end-to-end)
+#
+# On macOS (Darwin) the script additionally checks:
+#   - Architecture (arm64 = Apple Silicon = supported)
+#   - LaunchAgent autostart registration
+#   - Docker Desktop Model Runner reachability
 #
 # Designed to be safe to run on a host that already has DPF installed
 # (default), OR to bootstrap a fresh host first (--bootstrap).
@@ -157,6 +162,56 @@ step "Capturing host fingerprint"
   grep "^DPF_INSTALLER_VERSION" install-dpf.sh 2>&1 || echo "install-dpf.sh not found"
 } > "$WORK_DIR/env-fingerprint.txt" 2>&1
 ok "Fingerprint captured ($(wc -l < "$WORK_DIR/env-fingerprint.txt") lines)"
+
+# ── Step 1b: macOS-specific checks (Darwin only) ──────────────────────────
+if [ "$(uname -s)" = "Darwin" ]; then
+  step "macOS-specific checks"
+
+  # Architecture — Apple Silicon (arm64) is the supported target.
+  ARCH="$(uname -m)"
+  if [ "$ARCH" = "arm64" ]; then
+    ok "Architecture: arm64 (Apple Silicon)"
+    record_step "Architecture (macOS)" "PASS" "arm64 — Apple Silicon"
+  else
+    warn "Architecture: $ARCH — Intel Macs run under Rosetta with a performance penalty"
+    record_step "Architecture (macOS)" "FAIL" "$ARCH — pass --force-unsupported-host to install-dpf.sh if needed"
+  fi
+
+  # LaunchAgent autostart (installed by default; skip with --no-autostart).
+  LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/local.dpf-autostart.plist"
+  if [ -f "$LAUNCH_AGENT_PLIST" ]; then
+    if launchctl list 2>/dev/null | grep -q "local.dpf-autostart"; then
+      ok "LaunchAgent loaded: local.dpf-autostart"
+      record_step "LaunchAgent autostart (macOS)" "PASS" "plist present and loaded by launchctl"
+    else
+      warn "LaunchAgent plist present but not loaded by launchctl"
+      record_step "LaunchAgent autostart (macOS)" "FAIL" "run: launchctl load '$LAUNCH_AGENT_PLIST'"
+    fi
+  else
+    warn "LaunchAgent not found at $LAUNCH_AGENT_PLIST"
+    record_step "LaunchAgent autostart (macOS)" "SKIP" "plist missing — was --no-autostart used?"
+  fi
+
+  # Docker Desktop Model Runner (requires Docker Desktop ≥ 4.40).
+  # SKIP rather than FAIL if unreachable — LLM_BASE_URL may point to an external provider.
+  MODEL_RUNNER_URL="http://model-runner.docker.internal/engines/v1/models"
+  if curl --silent --max-time 5 --fail "$MODEL_RUNNER_URL" -o /dev/null 2>/dev/null; then
+    ok "Docker Model Runner reachable"
+    record_step "Docker Model Runner (macOS)" "PASS"
+  else
+    warn "Docker Model Runner not reachable — OK if LLM_BASE_URL is set to an external provider"
+    record_step "Docker Model Runner (macOS)" "SKIP" "unreachable at $MODEL_RUNNER_URL"
+  fi
+
+  # Note the known bridge-mode limitation in the fingerprint for context.
+  {
+    echo
+    echo "## macOS Edge Node note"
+    echo "Edge Node runs inside Docker Desktop's Linux VM (bridge mode)."
+    echo "Discovery sees VM interfaces (172.x.x.x), not your Mac's real NICs."
+    echo "This is expected until the native macOS Edge Node binary (T3) ships."
+  } >> "$WORK_DIR/env-fingerprint.txt"
+fi
 
 # ── Step 2: optional install ──────────────────────────────────────────────
 if [ "$DPF_VERIFY_BOOTSTRAP" = "1" ]; then


### PR DESCRIPTION
## Summary

- Extends `scripts/verify-install-edge.sh` with a Darwin-only **Step 1b** block covering three macOS-specific checks: architecture (arm64 = Apple Silicon = PASS), LaunchAgent autostart registration, and Docker Desktop Model Runner reachability. Bridge-mode Edge Node limitation is appended to the fingerprint file for context.
- Updates the script header to say "Linux and macOS" to reflect the actual coverage.
- Updates `docs/install/macos.md` § Help us graduate to GA to lead with the one-command path (`bash scripts/verify-install-edge.sh [--bootstrap]`) rather than a manual 4-step process — making it trivially easy for community members to file a verification bundle.

The script was already portable to macOS (Bash 3.2 baseline, Darwin branch in the fingerprint step, all tooling cross-platform). This PR adds the missing Mac-specific gate checks.

## Test plan

- [x] `bash -n scripts/verify-install-edge.sh` — syntax clean
- [x] No TypeScript / DB migrations touched — no typecheck or build needed
- [x] Doc change reviewed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)