### PR TITLE
fix(inference): harden all external LLM failure modes — transient retry, billing, 413, overload

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -66,7 +66,7 @@ export type InferenceResult = {
 export class InferenceError extends Error {
   constructor(
     message: string,
-    public readonly code: "network" | "auth" | "rate_limit" | "overloaded" | "model_not_found" | "provider_error",
+    public readonly code: "network" | "auth" | "rate_limit" | "overloaded" | "model_not_found" | "provider_error" | "transient" | "billing" | "request_too_large",
     public readonly providerId: string,
     public readonly statusCode?: number,
     public readonly headers?: Record<string, string>,
@@ -102,6 +102,12 @@ export function classifyHttpError(
   if (status === 401 || status === 403) {
     return new InferenceError(`Auth failed for ${providerId}: ${body.slice(0, 200)}`, "auth", providerId, status, headers, body);
   }
+  if (status === 402) {
+    return new InferenceError(`Billing error on ${providerId}: ${body.slice(0, 200)}`, "billing", providerId, status, headers, body);
+  }
+  if (status === 413) {
+    return new InferenceError(`Request too large for ${providerId}: ${body.slice(0, 200)}`, "request_too_large", providerId, status, headers, body);
+  }
   if (status === 429) {
     return new InferenceError(`Rate limited by ${providerId}`, "rate_limit", providerId, status, headers, body);
   }
@@ -110,6 +116,9 @@ export function classifyHttpError(
   }
   if (status === 404) {
     return new InferenceError(`Model not found on ${providerId}: ${body.slice(0, 200)}`, "model_not_found", providerId, status, headers, body);
+  }
+  if (status === 408 || status === 500 || status === 502 || status === 503 || status === 504) {
+    return new InferenceError(`Transient error (${status}) from ${providerId}: ${body.slice(0, 200)}`, "transient", providerId, status, headers, body);
   }
   return new InferenceError(`HTTP ${status} from ${providerId}: ${body.slice(0, 300)}`, "provider_error", providerId, status, headers, body);
 }

--- a/apps/web/lib/routing/fallback.test.ts
+++ b/apps/web/lib/routing/fallback.test.ts
@@ -409,15 +409,104 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
     });
   });
 
-  describe("provider overload (529)", () => {
-    it("degrades the model and schedules recovery without disabling the provider", async () => {
-      const err = new InferenceError(
-        "API Error: 529 Overloaded. This is a server-side issue, usually temporary.",
-        "overloaded",
-        "prov1",
-        529,
+  // ── transient (5xx / 408) ──────────────────────────────────────────────────
+
+  describe("transient errors (500/502/503/504/408)", () => {
+    it("retries the pinned endpoint once after 10 s on transient error then succeeds", async () => {
+      const transientErr = new InferenceError("Transient error (500) from prov1", "transient", "prov1", 500);
+      mockCallProvider
+        .mockRejectedValueOnce(transientErr)
+        .mockResolvedValueOnce({ content: "ok", inputTokens: 10, outputTokens: 5, inferenceMs: 100 });
+
+      const pending = callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
       );
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await pending;
+
+      expect(result.content).toBe("ok");
+      expect(mockCallProvider).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.modelProfile.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("degrades model and schedules recovery after transient retry also fails", async () => {
+      const err = new InferenceError("Transient error (503) from prov1", "transient", "prov1", 503);
       mockCallProvider.mockRejectedValue(err);
+
+      const pending = callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      const rejection = expect(pending).rejects.toThrow("All endpoints failed");
+      await vi.runAllTimersAsync();
+      await rejection;
+
+      expect(mockPrisma.modelProfile.updateMany).toHaveBeenCalledWith({
+        where: { providerId: "prov1", modelId: "model1" },
+        data: { modelStatus: "degraded" },
+      });
+      expect(mockScheduleRecovery).toHaveBeenCalledWith("prov1", "model1");
+      expect(mockPrisma.modelProvider.update).not.toHaveBeenCalled();
+    });
+
+    it("does not retry transient on a fallback endpoint", async () => {
+      const decision: RouteDecision = {
+        selectedEndpoint: "prov1",
+        selectedModelId: "model1",
+        reason: "test",
+        fitnessScore: 1,
+        fallbackChain: ["fallback-prov"],
+        candidates: [
+          { endpointId: "prov1", providerId: "prov1", modelId: "model1",
+            endpointName: "Prov1", fitnessScore: 1, dimensionScores: {},
+            costPerOutputMToken: null, excluded: false },
+          { endpointId: "fallback-prov", providerId: "fallback-prov", modelId: "fb-model",
+            endpointName: "Fallback", fitnessScore: 0.5, dimensionScores: {},
+            costPerOutputMToken: null, excluded: false },
+        ],
+        excludedCount: 0, excludedReasons: [], policyRulesApplied: [],
+        taskType: "test", sensitivity: "internal" as SensitivityLevel, timestamp: new Date(),
+      };
+
+      mockPrisma.modelProvider.findUnique
+        .mockResolvedValueOnce({ providerId: "prov1", name: "Prov1" })
+        .mockResolvedValueOnce({ providerId: "fallback-prov", name: "Fallback" });
+
+      const pinnedErr = new InferenceError("pinned rate limit", "rate_limit", "prov1", 429);
+      const fallbackTransient = new InferenceError("Transient 502 from fallback", "transient", "fallback-prov", 502);
+      // pinned: rate_limit → retry (30s wait) → rate_limit → degrade → fallback: transient (no retry)
+      mockCallProvider
+        .mockRejectedValueOnce(pinnedErr)
+        .mockRejectedValueOnce(pinnedErr)
+        .mockRejectedValueOnce(fallbackTransient);
+
+      const pending = callWithFallbackChain(
+        decision,
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      const rejection = expect(pending).rejects.toThrow("All endpoints failed");
+      await vi.runAllTimersAsync();
+      await rejection;
+
+      // pinned×2 (rate limit + retry) + fallback×1 (no transient retry)
+      expect(mockCallProvider).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // ── billing (402) ──────────────────────────────────────────────────────────
+
+  describe("billing error (402)", () => {
+    function throwBilling() {
+      const err = new InferenceError("Billing error on prov1", "billing", "prov1", 402);
+      mockCallProvider.mockRejectedValue(err);
+    }
+
+    it("disables the entire provider", async () => {
+      throwBilling();
 
       await expect(
         callWithFallbackChain(
@@ -427,12 +516,146 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
         ),
       ).rejects.toThrow();
 
+      expect(mockPrisma.modelProvider.update).toHaveBeenCalledWith({
+        where: { providerId: "prov1" },
+        data: { status: "disabled" },
+      });
+    });
+
+    it("does not degrade the model", async () => {
+      throwBilling();
+
+      await expect(
+        callWithFallbackChain(
+          makeDecision("prov1", "model1"),
+          [{ role: "user", content: "hi" }],
+          "system",
+        ),
+      ).rejects.toThrow();
+
+      expect(mockPrisma.modelProfile.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── request_too_large (413) ────────────────────────────────────────────────
+
+  describe("request_too_large (413)", () => {
+    it("throws immediately without trying fallback endpoints", async () => {
+      const err = new InferenceError("Request too large for prov1", "request_too_large", "prov1", 413);
+      mockCallProvider.mockRejectedValueOnce(err);
+
+      const decision: RouteDecision = {
+        selectedEndpoint: "prov1",
+        selectedModelId: "model1",
+        reason: "test",
+        fitnessScore: 1,
+        fallbackChain: ["fallback-prov"],
+        candidates: [
+          { endpointId: "prov1", providerId: "prov1", modelId: "model1",
+            endpointName: "Prov1", fitnessScore: 1, dimensionScores: {},
+            costPerOutputMToken: null, excluded: false },
+          { endpointId: "fallback-prov", providerId: "fallback-prov", modelId: "fb-model",
+            endpointName: "Fallback", fitnessScore: 0.5, dimensionScores: {},
+            costPerOutputMToken: null, excluded: false },
+        ],
+        excludedCount: 0, excludedReasons: [], policyRulesApplied: [],
+        taskType: "test", sensitivity: "internal" as SensitivityLevel, timestamp: new Date(),
+      };
+
+      await expect(
+        callWithFallbackChain(
+          decision,
+          [{ role: "user", content: "hi" }],
+          "system",
+        ),
+      ).rejects.toThrow("REQUEST_TOO_LARGE");
+
+      expect(mockCallProvider).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── provider overload (529) ────────────────────────────────────────────────
+
+  describe("provider overload (529)", () => {
+    it("degrades model and schedules recovery without disabling provider when retry also fails", async () => {
+      const err = new InferenceError("Provider overloaded on prov1", "overloaded", "prov1", 529);
+      mockCallProvider.mockRejectedValue(err);
+
+      const pending = callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      const rejection = expect(pending).rejects.toThrow("All endpoints failed");
+      await vi.runAllTimersAsync();
+      await rejection;
+
       expect(mockPrisma.modelProfile.updateMany).toHaveBeenCalledWith({
         where: { providerId: "prov1", modelId: "model1" },
         data: { modelStatus: "degraded" },
       });
       expect(mockScheduleRecovery).toHaveBeenCalledWith("prov1", "model1");
       expect(mockPrisma.modelProvider.update).not.toHaveBeenCalled();
+    });
+
+    it("retries the pinned endpoint once after 15 s on overload then succeeds", async () => {
+      const overloadErr = new InferenceError("Provider overloaded on prov1", "overloaded", "prov1", 529);
+      mockCallProvider
+        .mockRejectedValueOnce(overloadErr)
+        .mockResolvedValueOnce({ content: "ok after retry", inputTokens: 10, outputTokens: 5, inferenceMs: 100 });
+
+      const pending = callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await pending;
+
+      expect(result.content).toBe("ok after retry");
+      expect(mockCallProvider).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.modelProfile.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("does not retry overload on a fallback (non-pinned) endpoint", async () => {
+      const decision: RouteDecision = {
+        selectedEndpoint: "prov1",
+        selectedModelId: "model1",
+        reason: "test",
+        fitnessScore: 1,
+        fallbackChain: ["fallback-prov"],
+        candidates: [
+          { endpointId: "prov1", providerId: "prov1", modelId: "model1",
+            endpointName: "Prov1", fitnessScore: 1, dimensionScores: {},
+            costPerOutputMToken: null, excluded: false },
+          { endpointId: "fallback-prov", providerId: "fallback-prov", modelId: "fb-model",
+            endpointName: "Fallback", fitnessScore: 0.5, dimensionScores: {},
+            costPerOutputMToken: null, excluded: false },
+        ],
+        excludedCount: 0, excludedReasons: [], policyRulesApplied: [],
+        taskType: "test", sensitivity: "internal" as SensitivityLevel, timestamp: new Date(),
+      };
+
+      mockPrisma.modelProvider.findUnique
+        .mockResolvedValueOnce({ providerId: "prov1", name: "Prov1" })
+        .mockResolvedValueOnce({ providerId: "fallback-prov", name: "Fallback" });
+
+      const pinnedErr = new InferenceError("pinned auth fail", "auth", "prov1", 401);
+      const overloadErr = new InferenceError("Provider overloaded on fallback", "overloaded", "fallback-prov", 529);
+      mockCallProvider
+        .mockRejectedValueOnce(pinnedErr)
+        .mockRejectedValueOnce(overloadErr);
+
+      const pending = callWithFallbackChain(
+        decision,
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      const rejection = expect(pending).rejects.toThrow("All endpoints failed");
+      await vi.runAllTimersAsync();
+      await rejection;
+
+      expect(mockCallProvider).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -99,6 +99,8 @@ export async function callWithFallbackChain(
 
   const attempts: Array<{ endpointId: string; error: string }> = [];
   let rateLimitRetried = false;
+  let overloadRetried = false;
+  let transientRetried = false;
   const agentId = outcomeAttribution?.agentId?.trim() || mcpSession?.agentId?.trim() || null;
 
   for (let i = 0; i < chain.length; i++) {
@@ -212,11 +214,51 @@ export async function callWithFallbackChain(
           scheduleRecovery(entry.providerId, entry.modelId);
 
         } else if (e.code === "overloaded") {
-          // Claude/Anthropic 529 is provider-side overload, not bad auth or
-          // model retirement. Remove this model from preference briefly and
-          // let fallback continue through the approved chain.
+          // 529 is transient — retry once on the pinned endpoint before degrading.
+          // Overload clears in seconds to minutes; 15 s is a safe conservative wait.
+          if (i === 0 && !overloadRetried) {
+            overloadRetried = true;
+            console.log(`[callWithFallbackChain] Provider ${entry.providerId} overloaded (529). Waiting 15s before retry...`);
+            await new Promise(r => setTimeout(r, 15_000));
+            i--;
+            continue;
+          }
           await markModelDegraded(entry.providerId, entry.modelId, "overload");
           scheduleRecovery(entry.providerId, entry.modelId);
+
+        } else if (e.code === "transient") {
+          // 5xx / 408 are transient server-side errors — retry once on the pinned
+          // endpoint with a shorter wait (10 s) before degrading and falling through.
+          if (i === 0 && !transientRetried) {
+            transientRetried = true;
+            console.log(`[callWithFallbackChain] Transient error (${e.statusCode}) from ${entry.providerId}. Waiting 10s before retry...`);
+            await new Promise(r => setTimeout(r, 10_000));
+            i--;
+            continue;
+          }
+          await markModelDegraded(entry.providerId, entry.modelId, `transient_${e.statusCode ?? "5xx"}`);
+          scheduleRecovery(entry.providerId, entry.modelId);
+
+        } else if (e.code === "billing") {
+          // 402: billing lapse is account-level and permanent until fixed.
+          // Disable the entire provider — same treatment as auth failure.
+          await prisma.modelProvider
+            .update({
+              where: { providerId: entry.providerId },
+              data: { status: "disabled" },
+            })
+            .catch((err) =>
+              console.error(`[callWithFallbackChain] failed to disable ${entry.providerId} after billing error:`, err),
+            );
+
+        } else if (e.code === "request_too_large") {
+          // 413: falling through to the next provider won't help — the same
+          // messages will be sent. Throw immediately so the agentic loop can
+          // surface a specific "start a new thread" message.
+          throw new Error(
+            `REQUEST_TOO_LARGE: ${entry.providerId} rejected the request as too large (413). ` +
+            `Start a new thread to reduce context size.`,
+          );
 
         } else if (e.code === "model_not_found") {
           // EP-INF-004: Retire the specific model, not the provider

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -856,12 +856,32 @@ export async function runAgenticLoop(params: {
 
     // EP-INF-009b: All inference goes through V2 routing pipeline
     inferenceCallCount++;
-    const result = await routeAndCall(
-      compactAgenticMessages(messages),
-      systemPrompt,
-      sensitivity,
-      { ...enrichedRouteOptions, previousResponseId },
-    );
+    let result: RoutedInferenceResult;
+    try {
+      result = await routeAndCall(
+        compactAgenticMessages(messages),
+        systemPrompt,
+        sensitivity,
+        { ...enrichedRouteOptions, previousResponseId },
+      );
+    } catch (routeErr) {
+      const msg = routeErr instanceof Error ? routeErr.message : String(routeErr);
+      console.warn(`[agentic-loop] routeAndCall threw: ${msg}`);
+      const isTooLarge = msg.startsWith("REQUEST_TOO_LARGE:");
+      return {
+        content: isTooLarge
+          ? "Your conversation is too long for this AI provider. Please start a new thread to continue."
+          : "The AI provider is temporarily unavailable. Please try again in about 30 seconds.",
+        providerId: "unknown",
+        modelId: "unknown",
+        downgraded: false,
+        downgradeMessage: null,
+        totalInputTokens,
+        totalOutputTokens,
+        executedTools,
+        proposal: null,
+      };
+    }
     // Track response ID for conversation chaining (Responses API)
     if (result.responseId) {
       previousResponseId = result.responseId;


### PR DESCRIPTION
## Summary

Audit of HTTP status codes returned by Anthropic, OpenAI, and local (Ollama/Docker Model Runner) found five gaps where errors were mis-classified as generic \`provider_error\` and silently fell through to weaker fallback models. This PR addresses all of them.

**New error codes in \`classifyHttpError\`:**
- \`transient\` — 408/500/502/503/504: server-side errors that clear on their own
- \`billing\` — 402: account billing lapse, permanent until resolved
- \`request_too_large\` — 413: context exceeds provider limit, cannot be retried with same context

**New behaviors in \`callWithFallbackChain\`:**
- \`transient\`: retry once on pinned endpoint after 10 s, then degrade + fall through
- \`overloaded\` (529): retry once on pinned endpoint after 15 s, then degrade + fall through (previously fell through immediately)
- \`billing\`: disable provider immediately (same as auth 401/403)
- \`request_too_large\`: throw immediately — fallback won't help with same context; surfaces specific user message

**Agentic loop \`routeAndCall\` wrapped in try/catch:**
- \`REQUEST_TOO_LARGE\` → "Your conversation is too long. Please start a new thread."
- Any other routing failure → "The AI provider is temporarily unavailable. Please try again in about 30 seconds."

## What was broken before

| Error | Old behavior | New behavior |
|---|---|---|
| 500/502/503/504 from any provider | Falls immediately to local model | Retries same endpoint after 10 s |
| 529 from Anthropic | Marks model degraded immediately | Retries same endpoint after 15 s |
| 402 from Anthropic | Treated as unknown error | Disables provider |
| 413 from any provider | Falls to next provider (same context fails again) | Fails fast with clear user message |
| All-providers-fail | Generic "I ran into a limit" or unhandled throw | Provider-specific actionable message |

## Test plan
- [ ] \`pnpm vitest run apps/web/lib/routing/fallback.test.ts\` — all pass including new suites for transient/billing/request_too_large/overload retry
- [ ] CI typecheck gate
- [ ] Manual: confirm 529 and 5xx retry log lines appear in portal container logs on error injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)