### PR TITLE
fix(ci): packages/db integration tests — add vitest.config.ts with pool=forks

### DIFF
--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import { config as loadEnv } from "dotenv";
+import { resolve } from "path";
+
+// Load DATABASE_URL and other secrets from the repo-root .env for local runs.
+// In CI the job-level env block sets DATABASE_URL directly; this is a no-op there.
+const rootDir = resolve(__dirname, "../..");
+loadEnv({ path: resolve(rootDir, ".env") });
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    // Use forked processes instead of worker threads so each test file gets
+    // its own process and its own Prisma singleton (packages/db/src/client.ts
+    // stores the client on globalThis). Without forks, afterAll($disconnect)
+    // in one file disconnects the shared global client, causing the next
+    // file's first Prisma call to fail with ECONNREFUSED.
+    pool: "forks",
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `packages/db/vitest.config.ts` with `pool: "forks"` so each integration test file runs in its own forked process.
- All three tests in `packages/db/test/` call `prisma.$disconnect()` in `afterAll`. The client is stored on `globalThis` (the singleton pattern in `packages/db/src/client.ts`). With vitest's default thread pool, all test files share the same global — so file 1's `afterAll` disconnects the singleton, and file 2's `beforeEach` immediately calls `prisma.adapterRunTelemetry.deleteMany()` on the now-disconnected client, getting `ECONNREFUSED`.
- With `pool: "forks"`, each file gets its own process, its own `globalThis`, and its own `PrismaClient`. `DATABASE_URL` is inherited from the CI job's process env by all forks. The disconnect in one file cannot affect another.

The `Unit Tests` job already has a Postgres service container and applies migrations — the fix needed was in the test runner isolation, not the CI infrastructure.

Closes BI-7F3BF93C.

## Test plan

- [x] Pre-commit typecheck passed for `packages/db`
- [x] Root cause confirmed: `globalThis` singleton + `$disconnect()` in `afterAll` + same-process sequential execution = ECONNREFUSED in file 2+
- [ ] CI `Unit Tests` job — `packages/db` tests should now pass (verified by this PR's CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)