### PR TITLE
test(agent-detail): fix test mock for auth and new prisma queries

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -3,9 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
-    agent: {
-      findFirst: vi.fn(),
-    },
+    agent: { findFirst: vi.fn() },
+    agentModelConfig: { findUnique: vi.fn().mockResolvedValue(null) },
+    modelProvider: { findMany: vi.fn().mockResolvedValue([]) },
+    $queryRaw: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -14,13 +15,23 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  notFound: () => {
-    throw new Error("notFound");
-  },
+  notFound: () => { throw new Error("notFound"); },
 }));
 
 vi.mock("@/lib/identity/principal-linking", () => ({
   getAgentGaidMap: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "u1", platformRole: "admin", isSuperuser: true } }),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/components/platform/AgentModelRoutingCard", () => ({
+  AgentModelRoutingCard: () => null,
 }));
 
 import { prisma } from "@dpf/db";


### PR DESCRIPTION
## Summary

Follow-up to #689. The agent detail page now calls `auth()` to derive `canWrite`, which internally calls Next.js `headers()` — this breaks the existing test that renders the server component outside a request scope.

Changes:
- Mock `@/lib/auth` → returns a stubbed admin session
- Mock `@/lib/permissions` → `can()` returns true
- Mock `@/components/platform/AgentModelRoutingCard` → `() => null` (prevents client hook issues in `renderToStaticMarkup`)
- Expand `@dpf/db` mock to cover the three new Prisma calls (`agentModelConfig.findUnique`, `modelProvider.findMany`, `$queryRaw`)

## Test plan

- [ ] CI unit tests pass (this was the only failing test in run #25979537277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)