### PR TITLE
fix(test): mock auth + missing prisma delegates in AgentDetailPage test

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -6,6 +6,13 @@ vi.mock("@dpf/db", () => ({
     agent: {
       findFirst: vi.fn(),
     },
+    agentModelConfig: {
+      findUnique: vi.fn().mockResolvedValue(null),
+    },
+    modelProvider: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -17,6 +24,10 @@ vi.mock("next/navigation", () => ({
   notFound: () => {
     throw new Error("notFound");
   },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/identity/principal-linking", () => ({


### PR DESCRIPTION
## Summary

Fixes the sole failing test in the `Unit Tests` CI job — 1 test out of 5,925.

**Root cause:** `AgentDetailPage` calls `auth()` from `@/lib/auth` inside a `Promise.all`. `auth()` calls `headers()` internally (next-auth), which requires a Next.js request scope that vitest does not provide → crashes with `E251: headers was called outside a request scope`.

**Two gaps in the mock:**
1. `@/lib/auth` was not mocked at all — `auth()` called next-auth for real.
2. `prisma.agentModelConfig`, `prisma.modelProvider`, and `prisma.$queryRaw` were missing from the `@dpf/db` mock. These are called in the same `Promise.all`. The `.catch(() => null/[])` wrappers on those calls only handle Promise rejections — a synchronous `TypeError: Cannot read properties of undefined` on `prisma.agentModelConfig.findUnique` escapes them.

**Fix:** Add `vi.mock("@/lib/auth", ...)` returning `auth: vi.fn().mockResolvedValue(null)`, and add the three missing prisma delegates to the existing `@dpf/db` mock.

**Verified:** `vitest run app/(shell)/platform/ai/agent` passes locally (1/1).

## Test plan

- [x] `vitest run app/(shell)/platform/ai/agent` — 1/1 pass locally
- [x] Pre-commit typecheck clean
- [ ] CI `Unit Tests` — expect 0 failed, 5925 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)