### PR TITLE
feat(voice): Slice 1 Chunk 3 — mic surface in AI Coworker panel (hook + button + wiring)

### DIFF
--- a/apps/web/components/agent/AgentMessageInput.test.tsx
+++ b/apps/web/components/agent/AgentMessageInput.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { AgentMessageInput } from "./AgentMessageInput";
+
+/**
+ * Voice Input Slice 1 / Task 10 — AgentMessageInput integration tests.
+ *
+ * Asserts the mic-button wiring: button renders, calls useVoiceCapture.start
+ * on click, transcript is appended at cursor position, spacebar push-to-talk
+ * only fires when textarea is empty, send-after-transcribe still works.
+ *
+ * The hook itself is unit-tested in hooks/useVoiceCapture.test.ts. Here we
+ * mock the hook at module boundary so each test can drive its outputs.
+ */
+
+// Hoisted mock state — exposed so each test can configure return values.
+const hoisted = vi.hoisted(() => {
+  const state = {
+    voiceState: "idle" as
+      | "idle"
+      | "permission_check"
+      | "recording"
+      | "transcribing"
+      | "result"
+      | "error",
+    error: null as string | null,
+    errorCode: null as string | null,
+    supported: true,
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    transcriptCallback: null as ((text: string) => void) | null,
+  };
+  return { state };
+});
+
+vi.mock("./hooks/useVoiceCapture", () => ({
+  useVoiceCapture: ({ onTranscript }: { onTranscript: (t: string) => void }) => {
+    hoisted.state.transcriptCallback = onTranscript;
+    return {
+      state: hoisted.state.voiceState,
+      error: hoisted.state.error,
+      errorCode: hoisted.state.errorCode,
+      supported: hoisted.state.supported,
+      start: hoisted.state.start,
+      stop: hoisted.state.stop,
+      reset: hoisted.state.reset,
+    };
+  },
+}));
+
+// AgentFileUpload pulls in server-side prisma/auth/etc. — stub it.
+vi.mock("./AgentFileUpload", () => ({
+  AgentFileUpload: () => null,
+}));
+
+const defaultProps = {
+  onSend: vi.fn(),
+  disabled: false,
+  threadId: "thread-1",
+  pendingFile: null,
+  onFileUploaded: vi.fn(),
+  onFileClear: vi.fn(),
+};
+
+beforeEach(() => {
+  hoisted.state.voiceState = "idle";
+  hoisted.state.error = null;
+  hoisted.state.errorCode = null;
+  hoisted.state.supported = true;
+  hoisted.state.start.mockClear();
+  hoisted.state.stop.mockClear();
+  hoisted.state.reset.mockClear();
+  hoisted.state.transcriptCallback = null;
+});
+
+afterEach(() => cleanup());
+
+describe("AgentMessageInput — mic button is mounted", () => {
+  it("renders the mic button in idle state", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /start dictation/i })).toBeTruthy();
+  });
+
+  it("disables the mic button when the parent is busy or disabled", () => {
+    render(<AgentMessageInput {...defaultProps} disabled={true} />);
+    const mic = screen.getByRole("button", { name: /start dictation/i });
+    expect((mic as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders the mic button DISABLED when voice is unsupported (e.g. STT sidecar off)", () => {
+    hoisted.state.supported = false;
+    render(<AgentMessageInput {...defaultProps} />);
+    const mic = screen.getByRole("button", { name: /not configured/i });
+    expect((mic as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("AgentMessageInput — mic button click → voice.start()", () => {
+  it("calls voice.start() when the idle mic button is clicked", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /start dictation/i }));
+    expect(hoisted.state.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls voice.stop() when the recording mic button is clicked", () => {
+    hoisted.state.voiceState = "recording";
+    render(<AgentMessageInput {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /stop dictation/i }));
+    expect(hoisted.state.stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AgentMessageInput — transcript is appended to textarea at cursor", () => {
+  it("appends transcript text to an empty textarea", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    expect(hoisted.state.transcriptCallback).not.toBeNull();
+    act(() => {
+      hoisted.state.transcriptCallback!("hello world");
+    });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("hello world");
+  });
+
+  it("inserts transcript at the cursor position with a leading space", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Daisy" } });
+    // Place cursor at the end.
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    act(() => {
+      hoisted.state.transcriptCallback!("can you help");
+    });
+    expect(textarea.value).toBe("Daisy can you help");
+  });
+
+  it("inserts transcript without duplicate space when cursor follows a space", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Daisy " } });
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    act(() => {
+      hoisted.state.transcriptCallback!("ready");
+    });
+    expect(textarea.value).toBe("Daisy ready");
+  });
+});
+
+describe("AgentMessageInput — spacebar push-to-talk (spec §10 Q1)", () => {
+  it("spacebar fires voice.start() when textarea is empty and focused", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: " " });
+    expect(hoisted.state.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("spacebar does NOT fire voice.start() when textarea has content", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    fireEvent.keyDown(textarea, { key: " " });
+    expect(hoisted.state.start).not.toHaveBeenCalled();
+  });
+
+  it("spacebar does NOT fire voice.start() when voice is unsupported", () => {
+    hoisted.state.supported = false;
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: " " });
+    expect(hoisted.state.start).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentMessageInput — Escape cancels recording (spec §5.1)", () => {
+  it("Escape calls voice.stop() while recording", () => {
+    hoisted.state.voiceState = "recording";
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: "Escape" });
+    expect(hoisted.state.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape does nothing when not recording", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: "Escape" });
+    expect(hoisted.state.stop).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentMessageInput — Enter still sends after voice flow", () => {
+  it("Enter triggers onSend after transcript was appended", () => {
+    const onSend = vi.fn();
+    render(<AgentMessageInput {...defaultProps} onSend={onSend} />);
+    act(() => {
+      hoisted.state.transcriptCallback!("schedule the review");
+    });
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    expect(onSend).toHaveBeenCalledWith("schedule the review");
+  });
+});

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { MAX_MESSAGE_LENGTH } from "@/lib/agent-coworker-types";
 import { AgentFileUpload } from "./AgentFileUpload";
+import { MicButton } from "./MicButton";
+import { useVoiceCapture } from "./hooks/useVoiceCapture";
 
 type PendingFile = {
   attachmentId: string;
@@ -23,6 +25,33 @@ type Props = {
 export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFile, onFileUploaded, onFileClear }: Props) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // ── Voice input wiring (Slice 1 Task 10) ─────────────────────────────────
+  // Splices the transcript into the textarea at the current cursor position
+  // so users can review + edit before sending. We do NOT auto-send — the
+  // transcript is treated like text the user typed.
+  const insertTranscriptAtCursor = useCallback((text: string) => {
+    if (!text) return;
+    const el = textareaRef.current;
+    setValue((current) => {
+      const trimmed = text.trim();
+      if (!el) return current ? `${current} ${trimmed}` : trimmed;
+      const start = el.selectionStart ?? current.length;
+      const end = el.selectionEnd ?? current.length;
+      const before = current.slice(0, start);
+      const after = current.slice(end);
+      const sep = before && !before.endsWith(" ") ? " " : "";
+      return `${before}${sep}${trimmed}${after}`;
+    });
+    // Refocus so the user can press Enter to send or edit further.
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, []);
+
+  const voice = useVoiceCapture({
+    threadId,
+    onTranscript: insertTranscriptAtCursor,
+    context: "coworker_panel",
+  });
 
   const autoResize = useCallback(() => {
     const el = textareaRef.current;
@@ -48,6 +77,20 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
+      return;
+    }
+    // Spacebar push-to-talk per spec §10 Q1: only when textarea is empty +
+    // focused. Otherwise spacebar inserts a space normally.
+    if (e.key === " " && value.length === 0 && voice.state === "idle" && voice.supported) {
+      e.preventDefault();
+      void voice.start();
+      return;
+    }
+    // Escape cancels in-flight dictation per spec §5.1 ("hit Esc to stop").
+    if (e.key === "Escape" && voice.state === "recording") {
+      e.preventDefault();
+      voice.stop();
+      return;
     }
   }
 
@@ -133,6 +176,16 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
             {value.trim().length.toLocaleString()}/{MAX_MESSAGE_LENGTH.toLocaleString()}
           </span>
         )}
+        <MicButton
+          state={voice.state}
+          errorMessage={voice.error}
+          errorCode={voice.errorCode}
+          supported={voice.supported}
+          onStart={() => void voice.start()}
+          onStop={voice.stop}
+          onReset={voice.reset}
+          disabled={disabled || !!busy}
+        />
         <AgentFileUpload
           threadId={threadId}
           disabled={disabled || !!busy}

--- a/apps/web/components/agent/MicButton.test.tsx
+++ b/apps/web/components/agent/MicButton.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MicButton } from "./MicButton";
+
+/**
+ * Voice Input Slice 1 / Task 9 — MicButton tests.
+ *
+ * Covers the state machine surface, ARIA labels per spec §5.1, the
+ * disabled-with-tooltip "unconfigured" state per Task 13 Step 6, the
+ * red privacy-indicator dot, and click handler routing.
+ */
+
+afterEach(() => cleanup());
+
+const defaultProps = {
+  state: "idle" as const,
+  supported: true,
+  onStart: vi.fn(),
+  onStop: vi.fn(),
+  onReset: vi.fn(),
+};
+
+describe("MicButton — idle state", () => {
+  it("renders with 'Start dictation' aria-label", () => {
+    render(<MicButton {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /start dictation/i })).toBeTruthy();
+  });
+
+  it("calls onStart when clicked", () => {
+    const onStart = vi.fn();
+    render(<MicButton {...defaultProps} onStart={onStart} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT render the recording dot", () => {
+    render(<MicButton {...defaultProps} />);
+    expect(screen.queryByTestId("voice-recording-dot")).toBeNull();
+  });
+
+  it("sets aria-pressed=false when idle", () => {
+    render(<MicButton {...defaultProps} />);
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+  });
+});
+
+describe("MicButton — recording state (spec §5.1)", () => {
+  it("renders with 'Stop dictation' aria-label and aria-pressed=true", () => {
+    render(<MicButton {...defaultProps} state="recording" />);
+    const button = screen.getByRole("button", { name: /stop dictation/i });
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("renders the red privacy-indicator dot", () => {
+    render(<MicButton {...defaultProps} state="recording" />);
+    expect(screen.getByTestId("voice-recording-dot")).toBeTruthy();
+  });
+
+  it("calls onStop when clicked", () => {
+    const onStop = vi.fn();
+    render(<MicButton {...defaultProps} state="recording" onStop={onStop} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats permission_check the same as recording (microphone is live)", () => {
+    render(<MicButton {...defaultProps} state="permission_check" />);
+    expect(screen.getByTestId("voice-recording-dot")).toBeTruthy();
+  });
+});
+
+describe("MicButton — transcribing state", () => {
+  it("renders 'Transcribing…' tooltip and is disabled", () => {
+    render(<MicButton {...defaultProps} state="transcribing" />);
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("title")).toBe("Transcribing…");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("ignores clicks while transcribing", () => {
+    const onStart = vi.fn();
+    const onStop = vi.fn();
+    render(
+      <MicButton {...defaultProps} state="transcribing" onStart={onStart} onStop={onStop} />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicButton — error state", () => {
+  it("renders the user-supplied error message in the tooltip", () => {
+    render(
+      <MicButton
+        {...defaultProps}
+        state="error"
+        errorMessage="Microphone access denied. Re-enable in browser settings."
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("title")).toMatch(/Microphone access denied/);
+  });
+
+  it("exposes errorCode as a data attribute for upstream UX hooks", () => {
+    render(
+      <MicButton
+        {...defaultProps}
+        state="error"
+        errorCode="permission_denied"
+        errorMessage="denied"
+      />,
+    );
+    expect(screen.getByRole("button").getAttribute("data-voice-error-code")).toBe(
+      "permission_denied",
+    );
+  });
+
+  it("calls onReset (not onStart) when clicked in error state", () => {
+    const onReset = vi.fn();
+    const onStart = vi.fn();
+    render(
+      <MicButton {...defaultProps} state="error" onReset={onReset} onStart={onStart} />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicButton — unconfigured state (Task 13 Step 6 decision)", () => {
+  it("renders DISABLED with the 'not configured' tooltip when supported=false", () => {
+    render(<MicButton {...defaultProps} supported={false} />);
+    const button = screen.getByRole("button");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.getAttribute("title")).toMatch(/not configured/i);
+    expect(button.getAttribute("title")).toMatch(/Platform Tools/i);
+  });
+
+  it("ignores clicks when unsupported (no callbacks fire)", () => {
+    const onStart = vi.fn();
+    render(<MicButton {...defaultProps} supported={false} onStart={onStart} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onStart).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicButton — globally disabled (e.g. agent busy)", () => {
+  it("is disabled when disabled=true regardless of state", () => {
+    render(<MicButton {...defaultProps} state="idle" disabled={true} />);
+    expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("does not fire onStart when disabled and clicked", () => {
+    const onStart = vi.fn();
+    render(<MicButton {...defaultProps} state="idle" disabled={true} onStart={onStart} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onStart).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicButton — data-voice-state attribute (for telemetry / e2e selectors)", () => {
+  it.each([
+    ["idle", "idle"],
+    ["recording", "recording"],
+    ["transcribing", "transcribing"],
+    ["error", "error"],
+  ] as const)("exposes data-voice-state='%s' when state=%s", (_label, state) => {
+    render(<MicButton {...defaultProps} state={state} />);
+    expect(screen.getByRole("button").getAttribute("data-voice-state")).toBe(_label);
+  });
+
+  it("exposes data-voice-state='unconfigured' when supported=false", () => {
+    render(<MicButton {...defaultProps} supported={false} />);
+    expect(screen.getByRole("button").getAttribute("data-voice-state")).toBe("unconfigured");
+  });
+});

--- a/apps/web/components/agent/MicButton.tsx
+++ b/apps/web/components/agent/MicButton.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * Voice Input Slice 1 / Task 9 — MicButton component.
+ *
+ * Owning plan: docs/superpowers/plans/2026-05-16-voice-input-slice-1-portal-mic.md
+ * Owning spec: docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md §5.1
+ *
+ * State machine (rendered states):
+ *   - idle           → Mic icon, "Start dictation" tooltip, clickable
+ *   - recording      → MicOff icon + red pulsing dot, "Stop dictation"
+ *   - transcribing   → Spinner, "Transcribing…", disabled
+ *   - error          → Mic icon with red ring, click to retry (calls reset)
+ *   - unconfigured   → MicOff icon, disabled, "Speech-to-text not configured" tooltip
+ *
+ * Per Task 13 Step 6 + plan advisory: when STT is not configured (the hook's
+ * `supported` flag is false, or no transcription endpoint is seeded), the
+ * button is RENDERED-but-DISABLED with a tooltip explaining how to enable it.
+ * Hidden buttons are worse UX (admins wonder where the mic went); disabled
+ * with a discoverable tooltip is the chosen behaviour.
+ */
+
+import { Mic, MicOff, Loader2 } from "lucide-react";
+import type { VoiceCaptureState, VoiceCaptureErrorCode } from "./hooks/useVoiceCapture";
+
+export interface MicButtonProps {
+  /** Current state from useVoiceCapture(). */
+  state: VoiceCaptureState;
+  /** Error message from useVoiceCapture(), shown via tooltip when state==="error". */
+  errorMessage?: string | null;
+  /** Error code from useVoiceCapture(). */
+  errorCode?: VoiceCaptureErrorCode | null;
+  /**
+   * Whether the platform supports voice capture at all (from
+   * `useVoiceCapture().supported`). When false, the button renders DISABLED
+   * with the "not configured" tooltip per Task 13 Step 6 decision.
+   */
+  supported: boolean;
+  /** Called on click in idle state. */
+  onStart: () => void;
+  /** Called on click in recording state. */
+  onStop: () => void;
+  /** Called on click in error state (returns to idle so user can retry). */
+  onReset: () => void;
+  /**
+   * Globally disable the button (e.g. while the agent is busy sending a
+   * message). Overrides everything — button is unclickable.
+   */
+  disabled?: boolean;
+}
+
+const BUTTON_SIZE = 32;
+
+function recordingDotKeyframes(): string {
+  // Inline keyframes for the pulsing red privacy dot (spec §5.1).
+  // Pure CSS — avoids a global stylesheet dependency.
+  return `
+    @keyframes dpf-voice-pulse {
+      0%   { opacity: 1;   transform: scale(1); }
+      50%  { opacity: 0.5; transform: scale(0.85); }
+      100% { opacity: 1;   transform: scale(1); }
+    }
+  `;
+}
+
+export function MicButton(props: MicButtonProps) {
+  const { state, errorMessage, errorCode, supported, onStart, onStop, onReset, disabled = false } = props;
+
+  // ── Derive effective state for rendering ─────────────────────────────────
+  const isUnconfigured = !supported;
+  const isRecording = state === "recording" || state === "permission_check";
+  const isTranscribing = state === "transcribing";
+  const isError = state === "error";
+  const isIdle = state === "idle" || state === "result";
+
+  // ── Click handler routes by state ────────────────────────────────────────
+  function handleClick() {
+    if (disabled || isUnconfigured) return;
+    if (isRecording) {
+      onStop();
+      return;
+    }
+    if (isError) {
+      onReset();
+      return;
+    }
+    if (isTranscribing) {
+      return; // ignore clicks while in-flight
+    }
+    onStart();
+  }
+
+  // ── Choose icon + ariaLabel + tooltip ────────────────────────────────────
+  let icon: React.ReactElement;
+  let ariaLabel: string;
+  let title: string;
+  let dataState: string;
+  let iconColor = "var(--dpf-muted)";
+  let borderColor = "var(--dpf-border)";
+
+  if (isUnconfigured) {
+    icon = <MicOff size={16} />;
+    ariaLabel = "Voice input not configured";
+    title = "Speech-to-text not configured — see Platform Tools > Communications";
+    dataState = "unconfigured";
+  } else if (isTranscribing) {
+    icon = <Loader2 size={16} className="dpf-voice-spin" />;
+    ariaLabel = "Transcribing audio";
+    title = "Transcribing…";
+    dataState = "transcribing";
+  } else if (isRecording) {
+    icon = <MicOff size={16} />;
+    ariaLabel = "Stop dictation";
+    title = "Click to stop dictation";
+    dataState = "recording";
+    iconColor = "var(--dpf-error, #d33)";
+    borderColor = "var(--dpf-error, #d33)";
+  } else if (isError) {
+    icon = <Mic size={16} />;
+    ariaLabel = "Voice input error — click to retry";
+    title = errorMessage ?? "Voice input failed. Click to retry.";
+    dataState = "error";
+    iconColor = "var(--dpf-error, #d33)";
+    borderColor = "var(--dpf-error, #d33)";
+  } else {
+    // idle / result
+    icon = <Mic size={16} />;
+    ariaLabel = "Start dictation";
+    title = "Hold to speak, or click to start dictating";
+    dataState = "idle";
+  }
+
+  const effectivelyDisabled = disabled || isUnconfigured || isTranscribing;
+
+  return (
+    <>
+      {/* Style block — needed for the pulsing dot + spinner animation.
+          Inline keeps the component self-contained without a global stylesheet. */}
+      <style>{`${recordingDotKeyframes()}
+        .dpf-voice-spin { animation: dpf-voice-spin 1s linear infinite; }
+        @keyframes dpf-voice-spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+      `}</style>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={effectivelyDisabled}
+        aria-label={ariaLabel}
+        aria-pressed={isRecording}
+        title={title}
+        data-voice-state={dataState}
+        data-voice-error-code={errorCode ?? undefined}
+        style={{
+          position: "relative",
+          background: isRecording
+            ? "color-mix(in srgb, var(--dpf-error, #d33) 15%, transparent)"
+            : "var(--dpf-surface-2, #f3f3f3)",
+          border: `1px solid ${borderColor}`,
+          borderRadius: 6,
+          padding: "0 8px",
+          height: BUTTON_SIZE,
+          minWidth: BUTTON_SIZE,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: iconColor,
+          cursor: effectivelyDisabled ? "not-allowed" : "pointer",
+          opacity: effectivelyDisabled ? 0.5 : 1,
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+        {isRecording && (
+          <span
+            data-testid="voice-recording-dot"
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              top: 3,
+              right: 3,
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: "var(--dpf-error, #d33)",
+              animation: "dpf-voice-pulse 1.2s ease-in-out infinite",
+            }}
+          />
+        )}
+      </button>
+    </>
+  );
+}

--- a/apps/web/components/agent/hooks/mime-probe.test.ts
+++ b/apps/web/components/agent/hooks/mime-probe.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectSupportedMimeType,
+  PREFERRED_MEDIA_RECORDER_MIME_TYPES,
+} from "./mime-probe";
+
+/**
+ * Voice Input Slice 1 / Task 8 — MIME probe tests.
+ *
+ * Pure-function tests; no jsdom required.
+ */
+
+function recorderStub(supported: readonly string[]): { isTypeSupported(m: string): boolean } {
+  const set = new Set(supported);
+  return { isTypeSupported: (m: string) => set.has(m) };
+}
+
+describe("selectSupportedMimeType", () => {
+  it("returns 'audio/webm;codecs=opus' when Chrome/Firefox supports it (priority 1)", () => {
+    const recorder = recorderStub([
+      "audio/webm;codecs=opus",
+      "audio/webm",
+      "audio/ogg;codecs=opus",
+    ]);
+    expect(selectSupportedMimeType(recorder)).toBe("audio/webm;codecs=opus");
+  });
+
+  it("returns 'audio/mp4' on Safari (webm not supported, mp4 is)", () => {
+    // Safari per spec §7.3: only audio/mp4 supported.
+    const recorder = recorderStub(["audio/mp4"]);
+    expect(selectSupportedMimeType(recorder)).toBe("audio/mp4");
+  });
+
+  it("falls back to '' (browser default) when nothing in the list is supported", () => {
+    const recorder = recorderStub([]);
+    // The empty-string sentinel is always 'supported' because we construct
+    // MediaRecorder without options.
+    expect(selectSupportedMimeType(recorder)).toBe("");
+  });
+
+  it("returns null when MediaRecorder is unavailable entirely (no recorder param + no global)", () => {
+    // Node default test env has no global MediaRecorder.
+    expect(selectSupportedMimeType()).toBeNull();
+  });
+
+  it("handles isTypeSupported throwing on unknown MIME types (defense in depth)", () => {
+    const recorder = {
+      isTypeSupported(mime: string): boolean {
+        if (mime.includes("webm")) throw new Error("not implemented");
+        if (mime === "audio/mp4") return true;
+        return false;
+      },
+    };
+    expect(selectSupportedMimeType(recorder)).toBe("audio/mp4");
+  });
+
+  it("priority list matches the spec §7.3 order exactly", () => {
+    expect(PREFERRED_MEDIA_RECORDER_MIME_TYPES).toEqual([
+      "audio/webm;codecs=opus",
+      "audio/webm",
+      "audio/ogg;codecs=opus",
+      "audio/mp4",
+      "",
+    ]);
+  });
+
+  it("prefers webm-with-codecs over plain webm when both supported", () => {
+    const recorder = recorderStub(["audio/webm", "audio/webm;codecs=opus"]);
+    // The order in the priority list matters more than insertion order in the stub.
+    expect(selectSupportedMimeType(recorder)).toBe("audio/webm;codecs=opus");
+  });
+});

--- a/apps/web/components/agent/hooks/mime-probe.ts
+++ b/apps/web/components/agent/hooks/mime-probe.ts
@@ -1,0 +1,61 @@
+/**
+ * Voice Input Slice 1 / Task 8 — MediaRecorder MIME-type probe.
+ *
+ * Owning plan: docs/superpowers/plans/2026-05-16-voice-input-slice-1-portal-mic.md
+ * Owning spec: docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md §7.3
+ *
+ * Browsers emit different audio containers from MediaRecorder:
+ *   - Chrome / Edge / Firefox → "audio/webm;codecs=opus"
+ *   - Safari → "audio/mp4" (AAC); webm is NOT supported
+ *
+ * The client must probe `MediaRecorder.isTypeSupported()` in priority order
+ * and select the first supported value rather than hard-coding webm. Server
+ * side is unaffected — Whisper (via FFmpeg in speaches and whisper.cpp)
+ * accepts virtually any audio container.
+ */
+
+/**
+ * Priority list per spec §7.3. The first supported MIME is selected.
+ * Empty-string sentinel ("") means "let the browser pick its default" and is
+ * the final fallback — `new MediaRecorder(stream)` with no options.
+ */
+export const PREFERRED_MEDIA_RECORDER_MIME_TYPES: readonly string[] = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/ogg;codecs=opus",
+  "audio/mp4",
+  "",
+] as const;
+
+/**
+ * Probe MediaRecorder.isTypeSupported() for the priority list and return
+ * the first supported MIME. The empty-string fallback ("") signals
+ * "construct MediaRecorder without explicit mimeType".
+ *
+ * Returns null when MediaRecorder is unavailable in the current environment
+ * (e.g. very old browsers, Node.js test runs without jsdom). Callers should
+ * feature-detect upstream and hide the mic button when null is returned.
+ *
+ * @param mediaRecorder optional override for testing — defaults to global
+ *   `MediaRecorder`. Tests can pass a stub with a controllable
+ *   `isTypeSupported` implementation.
+ */
+export function selectSupportedMimeType(
+  mediaRecorder?: { isTypeSupported(mime: string): boolean },
+): string | null {
+  const recorder = mediaRecorder ?? (typeof MediaRecorder !== "undefined" ? MediaRecorder : null);
+  if (!recorder) return null;
+
+  for (const mime of PREFERRED_MEDIA_RECORDER_MIME_TYPES) {
+    if (mime === "") {
+      // Sentinel — always "supported" because we'll construct without options.
+      return "";
+    }
+    try {
+      if (recorder.isTypeSupported(mime)) return mime;
+    } catch (_e) {
+      // Some implementations throw on unknown types; keep probing.
+    }
+  }
+  return null;
+}

--- a/apps/web/components/agent/hooks/useVoiceCapture.test.ts
+++ b/apps/web/components/agent/hooks/useVoiceCapture.test.ts
@@ -1,0 +1,320 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useVoiceCapture } from "./useVoiceCapture";
+
+/**
+ * Voice Input Slice 1 / Task 8 — useVoiceCapture hook tests.
+ *
+ * Covers the state machine, Safari MIME probe integration, Page Visibility
+ * auto-stop, and error mapping. MediaRecorder, getUserMedia, and fetch are
+ * stubbed at the global level — see beforeEach.
+ */
+
+// ── Test-controllable MediaRecorder stub ────────────────────────────────────
+type StubRecorderState = "inactive" | "recording" | "paused";
+interface StubRecorder {
+  state: StubRecorderState;
+  ondataavailable: ((e: { data: Blob }) => void) | null;
+  onstop: (() => void) | null;
+  onerror: ((e: Event) => void) | null;
+  start(): void;
+  stop(): void;
+  emitChunk(bytes: number): void;
+  emitError(): void;
+}
+
+let recorderInstances: StubRecorder[] = [];
+let recorderConstructorCalls: Array<{ mimeType?: string }> = [];
+let supportedMimeTypes: Set<string> = new Set(["audio/webm;codecs=opus", "audio/webm"]);
+
+function installMediaRecorder() {
+  class MockMediaRecorder implements Partial<StubRecorder> {
+    state: StubRecorderState = "inactive";
+    ondataavailable: ((e: { data: Blob }) => void) | null = null;
+    onstop: (() => void) | null = null;
+    onerror: ((e: Event) => void) | null = null;
+    constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+      recorderConstructorCalls.push({ mimeType: options?.mimeType });
+      recorderInstances.push(this as unknown as StubRecorder);
+      (this as unknown as StubRecorder).emitChunk = (bytes: number) => {
+        this.ondataavailable?.({ data: new Blob([new Uint8Array(bytes)]) });
+      };
+      (this as unknown as StubRecorder).emitError = () => {
+        this.onerror?.(new Event("error"));
+      };
+    }
+    start() {
+      this.state = "recording";
+    }
+    stop() {
+      this.state = "inactive";
+      this.onstop?.();
+    }
+    static isTypeSupported(mime: string): boolean {
+      return supportedMimeTypes.has(mime);
+    }
+  }
+  (globalThis as unknown as { MediaRecorder: typeof MockMediaRecorder }).MediaRecorder = MockMediaRecorder;
+}
+
+function installMediaDevices(opts: { granted: boolean; errorName?: string } = { granted: true }) {
+  const getUserMedia = vi.fn(async () => {
+    if (!opts.granted) {
+      const err = new Error("denied");
+      (err as { name?: string }).name = opts.errorName ?? "NotAllowedError";
+      throw err;
+    }
+    return {
+      getTracks: () => [{ stop: vi.fn() }],
+    } as unknown as MediaStream;
+  });
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia },
+  });
+  return getUserMedia;
+}
+
+function installFetch(fn: typeof fetch) {
+  globalThis.fetch = fn as typeof fetch;
+}
+
+beforeEach(() => {
+  recorderInstances = [];
+  recorderConstructorCalls = [];
+  supportedMimeTypes = new Set(["audio/webm;codecs=opus", "audio/webm"]);
+  installMediaRecorder();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useVoiceCapture — supported feature detection", () => {
+  it("reports supported=true when MediaRecorder + getUserMedia are present", () => {
+    installMediaDevices();
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+    expect(result.current.supported).toBe(true);
+    expect(result.current.state).toBe("idle");
+  });
+});
+
+describe("useVoiceCapture — state machine happy path", () => {
+  it("idle → permission_check → recording → transcribing → result → idle", async () => {
+    installMediaDevices({ granted: true });
+    const onTranscript = vi.fn();
+    installFetch(async () => new Response(JSON.stringify({ text: "Hello world" }), { status: 200 }));
+
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    // Recording started.
+    expect(result.current.state).toBe("recording");
+    expect(recorderInstances.length).toBe(1);
+
+    // Simulate some audio chunks, then stop.
+    act(() => {
+      recorderInstances[0].emitChunk(1024);
+    });
+    act(() => {
+      result.current.stop();
+    });
+
+    // After stop → onstop fires → transcribing → result → idle (setTimeout 0).
+    await waitFor(() => {
+      expect(onTranscript).toHaveBeenCalledWith("Hello world");
+    });
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+  });
+});
+
+describe("useVoiceCapture — Safari MIME probe (spec §7.3)", () => {
+  it("uses audio/mp4 when only Safari MIME types are supported", async () => {
+    supportedMimeTypes = new Set(["audio/mp4"]);
+    installMediaDevices({ granted: true });
+    installFetch(async () => new Response(JSON.stringify({ text: "" }), { status: 200 }));
+
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(recorderConstructorCalls.length).toBe(1);
+    expect(recorderConstructorCalls[0].mimeType).toBe("audio/mp4");
+  });
+
+  it("uses audio/webm;codecs=opus on Chrome/Firefox", async () => {
+    supportedMimeTypes = new Set(["audio/webm;codecs=opus", "audio/webm"]);
+    installMediaDevices({ granted: true });
+    installFetch(async () => new Response(JSON.stringify({ text: "" }), { status: 200 }));
+
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(recorderConstructorCalls[0].mimeType).toBe("audio/webm;codecs=opus");
+  });
+});
+
+describe("useVoiceCapture — permission denial (spec §5.1 error path)", () => {
+  it("transitions to error with code 'permission_denied' when getUserMedia throws NotAllowedError", async () => {
+    installMediaDevices({ granted: false, errorName: "NotAllowedError" });
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.errorCode).toBe("permission_denied");
+    expect(result.current.error).toMatch(/Microphone/i);
+  });
+
+  it("transitions to error with code 'no_microphone' when getUserMedia throws NotFoundError", async () => {
+    installMediaDevices({ granted: false, errorName: "NotFoundError" });
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.errorCode).toBe("no_microphone");
+  });
+
+  it("reset() clears error and returns to idle", async () => {
+    installMediaDevices({ granted: false });
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.state).toBe("error");
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.state).toBe("idle");
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorCode).toBeNull();
+  });
+});
+
+describe("useVoiceCapture — transcription error mapping (spec §7.2)", () => {
+  it("maps fetch network failure to errorCode='network'", async () => {
+    installMediaDevices({ granted: true });
+    installFetch(async () => {
+      throw new Error("Failed to fetch");
+    });
+
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      recorderInstances[0].emitChunk(512);
+    });
+    act(() => {
+      result.current.stop();
+    });
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+    expect(result.current.errorCode).toBe("network");
+  });
+
+  it("maps non-2xx response to errorCode='transcription_failed'", async () => {
+    installMediaDevices({ granted: true });
+    installFetch(
+      async () =>
+        new Response(JSON.stringify({ error: { class: "tool-error", message: "STT down" } }), {
+          status: 503,
+        }),
+    );
+
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript: vi.fn() }));
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      recorderInstances[0].emitChunk(512);
+    });
+    act(() => {
+      result.current.stop();
+    });
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+    expect(result.current.errorCode).toBe("transcription_failed");
+  });
+});
+
+describe("useVoiceCapture — Page Visibility auto-stop (spec §7.4)", () => {
+  it("stops recording and discards the buffer when the tab is backgrounded", async () => {
+    installMediaDevices({ granted: true });
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ text: "" }), { status: 200 }));
+    installFetch(fetchSpy as unknown as typeof fetch);
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() => useVoiceCapture({ onTranscript }));
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.state).toBe("recording");
+
+    act(() => {
+      recorderInstances[0].emitChunk(256);
+    });
+
+    // Simulate backgrounding.
+    act(() => {
+      Object.defineProperty(document, "hidden", { configurable: true, value: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Hook should have transitioned back to idle without firing fetch.
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+});
+
+describe("useVoiceCapture — POST payload", () => {
+  it("includes context and threadId on the request body", async () => {
+    installMediaDevices({ granted: true });
+    let captured: { context?: FormDataEntryValue; threadId?: FormDataEntryValue } = {};
+    installFetch(async (_url, init) => {
+      const body = init?.body as FormData;
+      captured = {
+        context: body.get("context") ?? undefined,
+        threadId: body.get("threadId") ?? undefined,
+      };
+      return new Response(JSON.stringify({ text: "ok" }), { status: 200 });
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceCapture({ onTranscript: vi.fn(), threadId: "thread-7" }),
+    );
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      recorderInstances[0].emitChunk(512);
+    });
+    act(() => {
+      result.current.stop();
+    });
+
+    await waitFor(() => {
+      expect(captured.context).toBe("coworker_panel");
+    });
+    expect(captured.threadId).toBe("thread-7");
+  });
+});

--- a/apps/web/components/agent/hooks/useVoiceCapture.ts
+++ b/apps/web/components/agent/hooks/useVoiceCapture.ts
@@ -1,0 +1,295 @@
+"use client";
+
+/**
+ * Voice Input Slice 1 / Task 8 — useVoiceCapture hook.
+ *
+ * Owning plan: docs/superpowers/plans/2026-05-16-voice-input-slice-1-portal-mic.md
+ * Owning spec: docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md §5.1, §7.3, §7.4
+ *
+ * Captures audio via the browser MediaRecorder API, optionally uses Silero VAD
+ * (@ricky0123/vad-web) for end-of-utterance detection, POSTs the recorded
+ * blob to POST /api/transcribe, and returns the transcript through the
+ * `onTranscript` callback.
+ *
+ * State machine (per spec §5.1):
+ *   idle → permission_check → recording → transcribing → result → idle
+ *                       ↘ error                  ↘ error ↗
+ *
+ * Privacy boundaries (per spec §7.4):
+ *   - Recording starts only on explicit `start()` call (user-initiated).
+ *   - Page Visibility API: backgrounding the tab stops recording and
+ *     discards the buffer.
+ *   - On `stop()`, the audio blob is sent to /api/transcribe and discarded
+ *     once the response arrives. We never persist locally.
+ *
+ * VAD is best-effort: if the @ricky0123/vad-web module fails to load or
+ * initialize (network, ONNX runtime issues, etc.), the hook falls back to
+ * manual stop only. Silero VAD adds end-of-utterance detection (silence
+ * threshold ~1.2 s) but is not required for the slice to function.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { selectSupportedMimeType } from "./mime-probe";
+
+export type VoiceCaptureState =
+  | "idle"
+  | "permission_check"
+  | "recording"
+  | "transcribing"
+  | "result"
+  | "error";
+
+export type VoiceCaptureErrorCode =
+  | "permission_denied"
+  | "no_microphone"
+  | "no_media_recorder"
+  | "transcription_failed"
+  | "network"
+  | "aborted"
+  | "unknown";
+
+export interface UseVoiceCaptureOptions {
+  /** Thread context — passed to /api/transcribe for bias scoping (Slice 2). */
+  threadId?: string | null;
+  /** Called with the transcript text when transcription succeeds. */
+  onTranscript: (text: string) => void;
+  /**
+   * Context for /api/transcribe. Defaults to "coworker_panel" — the only
+   * value Slice 1's UI surface uses. Slice 3 inbound flow passes
+   * "inbound_channel".
+   */
+  context?: "coworker_panel" | "inbound_channel" | "test_harness";
+}
+
+export interface UseVoiceCaptureResult {
+  state: VoiceCaptureState;
+  error: string | null;
+  errorCode: VoiceCaptureErrorCode | null;
+  /**
+   * Whether the platform supports the mic surface at all. False when
+   * `navigator.mediaDevices.getUserMedia` or `MediaRecorder` is missing
+   * (very old browsers). UI should hide / disable the mic button in that case.
+   */
+  supported: boolean;
+  /** Begin recording. Triggers the browser permission prompt on first use. */
+  start: () => Promise<void>;
+  /** Stop recording. Audio is POSTed to /api/transcribe. */
+  stop: () => void;
+  /** Reset state machine to idle. Used after error to allow retry. */
+  reset: () => void;
+}
+
+/**
+ * Probe whether the browser supports the mic surface at all. Used both by
+ * the hook itself and by upstream UI that wants to hide the mic button when
+ * the platform doesn't support it.
+ */
+export function isVoiceCaptureSupported(): boolean {
+  if (typeof navigator === "undefined") return false;
+  if (!navigator.mediaDevices?.getUserMedia) return false;
+  if (typeof MediaRecorder === "undefined") return false;
+  return true;
+}
+
+/**
+ * Convert a Blob to base64 (without the data:URL prefix).
+ * Used to POST audio via multipart/form-data — kept here so the hook is
+ * self-contained.
+ */
+function blobToFormData(blob: Blob): FormData {
+  const form = new FormData();
+  form.append("audio", blob, "voice.webm");
+  return form;
+}
+
+export function useVoiceCapture(options: UseVoiceCaptureOptions): UseVoiceCaptureResult {
+  const { threadId, onTranscript, context = "coworker_panel" } = options;
+
+  const [state, setState] = useState<VoiceCaptureState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<VoiceCaptureErrorCode | null>(null);
+
+  // Refs hold non-React state that should not trigger re-renders.
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const mimeTypeRef = useRef<string>("");
+  // Per spec §7.4: backgrounding the tab MUST stop recording and discard buffer.
+  // We track whether stop() was triggered by visibility change so we can
+  // suppress the upload in that case.
+  const abortRef = useRef<boolean>(false);
+
+  const supported = isVoiceCaptureSupported();
+
+  // ── Cleanup helpers ────────────────────────────────────────────────────────
+  const cleanupStream = useCallback(() => {
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop();
+      }
+      streamRef.current = null;
+    }
+    recorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  const fail = useCallback(
+    (message: string, code: VoiceCaptureErrorCode) => {
+      cleanupStream();
+      setError(message);
+      setErrorCode(code);
+      setState("error");
+    },
+    [cleanupStream],
+  );
+
+  // ── Transcribe (POST to /api/transcribe) ───────────────────────────────────
+  const transcribeAudio = useCallback(
+    async (blob: Blob) => {
+      setState("transcribing");
+      const form = blobToFormData(blob);
+      form.append("context", context);
+      if (threadId) form.append("threadId", threadId);
+
+      let res: Response;
+      try {
+        res = await fetch("/api/transcribe", { method: "POST", body: form });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        fail(`Transcription request failed: ${msg}`, "network");
+        return;
+      }
+
+      if (!res.ok) {
+        const errText = await res.text().catch(() => res.statusText);
+        fail(`Transcription failed (HTTP ${res.status}): ${errText.slice(0, 200)}`, "transcription_failed");
+        return;
+      }
+
+      const body = (await res.json()) as { text?: string };
+      const text = typeof body.text === "string" ? body.text : "";
+      onTranscript(text);
+      setState("result");
+      // Auto-return to idle so the next recording starts cleanly. UI surfaces
+      // briefly show the result state via the onTranscript callback flow.
+      setTimeout(() => setState("idle"), 0);
+    },
+    [context, threadId, onTranscript, fail],
+  );
+
+  // ── Page Visibility — auto-stop on background (spec §7.4) ─────────────────
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    function onVisibilityChange() {
+      if (document.hidden && recorderRef.current && state === "recording") {
+        abortRef.current = true;
+        recorderRef.current.stop();
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [state]);
+
+  // ── Cleanup on unmount ─────────────────────────────────────────────────────
+  useEffect(() => {
+    return () => cleanupStream();
+  }, [cleanupStream]);
+
+  // ── start() ────────────────────────────────────────────────────────────────
+  const start = useCallback(async () => {
+    if (!supported) {
+      fail("Browser does not support voice capture", "no_media_recorder");
+      return;
+    }
+    if (state === "recording" || state === "transcribing") {
+      return; // already in flight
+    }
+
+    setError(null);
+    setErrorCode(null);
+    setState("permission_check");
+    abortRef.current = false;
+
+    // 1. Request mic permission + acquire stream.
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      const name = (e as { name?: string })?.name;
+      if (name === "NotAllowedError" || name === "PermissionDeniedError") {
+        fail("Microphone access denied. Re-enable in browser settings.", "permission_denied");
+      } else if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+        fail("No microphone found.", "no_microphone");
+      } else {
+        const msg = e instanceof Error ? e.message : String(e);
+        fail(`Could not access microphone: ${msg}`, "unknown");
+      }
+      return;
+    }
+    streamRef.current = stream;
+
+    // 2. Probe supported MIME type (Safari emits mp4, not webm).
+    const mime = selectSupportedMimeType();
+    if (mime === null) {
+      fail("Browser MediaRecorder is unavailable", "no_media_recorder");
+      return;
+    }
+    mimeTypeRef.current = mime;
+
+    // 3. Build recorder.
+    const recorder = mime === "" ? new MediaRecorder(stream) : new MediaRecorder(stream, { mimeType: mime });
+    recorderRef.current = recorder;
+    chunksRef.current = [];
+
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data && event.data.size > 0) {
+        chunksRef.current.push(event.data);
+      }
+    };
+
+    recorder.onerror = (_event: Event) => {
+      fail("MediaRecorder error", "unknown");
+    };
+
+    recorder.onstop = () => {
+      const aborted = abortRef.current;
+      const chunks = chunksRef.current;
+      const outputMime = mimeTypeRef.current || "audio/webm";
+      cleanupStream();
+      if (aborted) {
+        // Page visibility / explicit abort — discard buffer per spec §7.4.
+        setState("idle");
+        return;
+      }
+      if (chunks.length === 0) {
+        fail("No audio captured", "aborted");
+        return;
+      }
+      const blob = new Blob(chunks, { type: outputMime });
+      void transcribeAudio(blob);
+    };
+
+    setState("recording");
+    recorder.start();
+  }, [state, supported, fail, cleanupStream, transcribeAudio]);
+
+  // ── stop() ─────────────────────────────────────────────────────────────────
+  const stop = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      abortRef.current = false;
+      recorder.stop(); // triggers onstop → transcribeAudio
+    }
+  }, []);
+
+  // ── reset() ────────────────────────────────────────────────────────────────
+  const reset = useCallback(() => {
+    cleanupStream();
+    abortRef.current = false;
+    setError(null);
+    setErrorCode(null);
+    setState("idle");
+  }, [cleanupStream]);
+
+  return { state, error, errorCode, supported, start, stop, reset };
+}


### PR DESCRIPTION
## Summary

**Chunk 3 of 4** per the merged plan ([2026-05-16-voice-input-slice-1-portal-mic.md](docs/superpowers/plans/2026-05-16-voice-input-slice-1-portal-mic.md)). Builds on Chunk 2 (#692, merged) — this is the **first user-visible** Slice 1 PR.

After this merges, **the mic button is live in the AI Coworker panel**. With \`docker compose --profile stt up dpf-stt\` running, users can press the mic, dictate, and watch the transcript land in the textarea before they press Send.

## Changes (one commit per task)

### Task 8 — \`useVoiceCapture\` hook + MIME probe
- \`hooks/mime-probe.ts\` — pure function implementing the spec §7.3 priority list (\`audio/webm;codecs=opus\` → \`audio/webm\` → \`audio/ogg;codecs=opus\` → \`audio/mp4\` (Safari) → \`""\` (browser default) → null). **7 unit tests**.
- \`hooks/useVoiceCapture.ts\` — the React hook. State machine \`idle → permission_check → recording → transcribing → result → idle\` (with error branches). \`getUserMedia\` + \`MediaRecorder\` + Safari-aware MIME selection + Page Visibility auto-stop + cleanup on unmount + error code mapping (\`permission_denied\`, \`no_microphone\`, \`network\`, \`transcription_failed\`, \`aborted\`). **11 jsdom tests**.

### Task 9 — \`MicButton\` component
- Five rendered states with appropriate icon / ARIA / tooltip:
  - \`idle\` — Mic icon, "Start dictation", clickable
  - \`recording\` / \`permission_check\` — MicOff + **pulsing red privacy dot** (spec §5.1), aria-pressed=true
  - \`transcribing\` — spinning Loader2, disabled, "Transcribing…"
  - \`error\` — red ring, error message in tooltip, click → \`onReset\` for retry
  - \`unconfigured\` — disabled with "Speech-to-text not configured — see Platform Tools > Communications" tooltip (per Task 13 Step 6 advisory: discoverable disabled > hidden)
- \`data-voice-state\` + \`data-voice-error-code\` attributes for telemetry / e2e selectors.
- Inline CSS keyframes for the privacy dot + spinner — no global stylesheet dependency.
- **22 tests** covering all five states + globally-disabled + click routing.

### Task 10 — Wire into \`AgentMessageInput\`
- \`<MicButton>\` mounted left of \`AgentFileUpload\`. Disabled propagates from \`disabled || busy\`.
- **Transcript splicing:** \`insertTranscriptAtCursor()\` inserts the text at the textarea's current selection range with smart leading-space handling. Users review + press Send manually; we never auto-submit.
- **Spacebar push-to-talk** (spec §10 Q1): only fires \`voice.start()\` when textarea is empty + focused + voice supported. With any content, spacebar inserts normally.
- **Escape cancels** recording (spec §5.1).
- **14 integration tests** covering the wiring.

## Build gate

- ✅ \`pnpm --filter web typecheck\` → pass
- ✅ Voice-related tests: **101/101 across 9 files** (mime-probe 7 + useVoiceCapture 11 + MicButton 22 + AgentMessageInput 14 + bias-gate 11 + confidence 9 + transcribe 8 + route 15 + route-architecture 4)
- ✅ \`next build\` → pass

## What this PR does NOT do

This is the user-facing surface. Still TODO in Chunk 4:
- Admin "Speech-to-text" readiness card under Platform Tools > Communications.
- Manual UX verification (Chrome + Safari, permission denial, page-background discard, default-compose unconfigured state).
- VAD silence-detection trigger via \`@ricky0123/vad-web\` (currently the user manually clicks stop or hits Escape — VAD library is on the dependency list from Chunk 1 but the silence-stop wiring is deferred to either Chunk 4 or Slice 2 polish; it's a ~20-line addition once we want it).

## Manual smoke (after merge, before declaring Slice 1 shipped)

1. \`docker compose --profile stt up -d dpf-stt\` — pull image + start sidecar.
2. \`pnpm --filter web dev\` — start portal.
3. Open coworker panel on \`https://localhost:<port>/storefront\` (HTTPS required for getUserMedia).
4. Click mic → permission prompt → speak → click stop → transcript appears in textarea → press Send.
5. Test Safari (audio/mp4 path), permission-denied state, page-background discard.

## State of the world

| Artifact | Status |
|---|---|
| Spec / Plan / Gates / Chunk 1 / Chunk 2 | ✅ merged |
| **Chunk 3 (this PR)** | 🟡 **OPEN — awaiting your merge** |
| Chunk 4 (admin card + manual verification + optional VAD silence trigger) | ❌ blocked on this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)