### PR TITLE
chore(ci): promote Unit Tests to binding merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,9 @@ jobs:
     env:
       DATABASE_URL: postgresql://dpf:ci_test_password@localhost:5432/dpf
       ADMIN_PASSWORD: ci_admin_changeme
-    # Unit Tests runs informationally while the broken-test backlog is drained
-    # (issue #104). It still provisions a CI Postgres database and applies
-    # migrations so Prisma-backed tests fail for product defects, not runner
-    # setup. Typecheck, Production Build, and Routing Tier Contract remain
-    # the binding gates until the full suite is honest again.
-    continue-on-error: true
+    # Unit Tests is now a binding merge gate. The suite reached 0 failures
+    # via #693 (packages/db pool:forks isolation) and #694 (AgentDetailPage
+    # auth mock). All 5 980 tests pass on main as of 2026-05-17.
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Removes `continue-on-error: true` from the `Unit Tests` CI job, making it a binding merge gate alongside Typecheck, Production Build, and Routing Tier Contract.

The suite reached 0 failures on main as of 2026-05-17 through two PRs:
- **#693** — `packages/db/vitest.config.ts` with `pool: "forks"` fixed ECONNREFUSED cross-file Prisma client contamination (5 new test files now green)
- **#694** — `AgentDetailPage` auth + prisma mock fixed the sole remaining failing test

The CI comment tracking the "broken-test backlog" (issue #104) is replaced with a note recording when and how the suite became honest. Per platform policy: no technical debt deferred, no failures left behind.

## Test plan

- [x] `Unit Tests` shows `success` on main at commit `6361b323` (both fixes in place) — confirmed via `gh api` before opening this PR
- [x] No test logic changed — only the CI gate setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)