### PR TITLE
feat(work-capsules): auto-renew leases on capsule writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
     name: ADP Integration Tests
     runs-on: ubuntu-latest
     needs: typecheck
+    env:
+      AUTH_SECRET: ci-placeholder
+      CREDENTIAL_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
     # Brings up the fake-server harness, runs the e2e test suite against it,
     # then tears down. The harness default token matches HARNESS_CONTROL_TOKEN
     # below. No Postgres needed — the credential layer is mocked in the test.

--- a/apps/web/lib/mcp-tools-work-capsules.test.ts
+++ b/apps/web/lib/mcp-tools-work-capsules.test.ts
@@ -51,6 +51,24 @@ describe("work capsule MCP tools", () => {
     ]);
   });
 
+  it("get_work_capsule does not renew leases for read-only hydration", async () => {
+    mockPrisma.workCapsule.findUnique.mockResolvedValue({
+      id: "row-1",
+      capsuleId: "WC-READ",
+      title: "Read only",
+      activities: [],
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("get_work_capsule", { capsuleId: "WC-READ" }, "user-1", {
+      agentId: "codex",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.workCapsule.update).not.toHaveBeenCalled();
+    expect(mockPrisma.workCapsuleActivity.create).not.toHaveBeenCalled();
+  });
+
   it("create_work_capsule requires idempotencyKey", async () => {
     const { executeTool } = await import("./mcp-tools");
     const result = await executeTool(
@@ -73,8 +91,46 @@ describe("work capsule MCP tools", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(mockPrisma.workCapsule.update).toHaveBeenCalledTimes(1);
     expect(mockPrisma.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
       where: { capsuleId: "WC-1" },
+    }));
+    expect(mockPrisma.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "lease-renewed", recordedByAgentId: "codex" }),
+    }));
+  });
+
+  it("record_capsule_evidence auto-renews the lease after a capsule-scoped write", async () => {
+    mockPrisma.workCapsule.findUnique.mockResolvedValue({ id: "row-1", capsuleId: "WC-EVIDENCE" });
+    mockPrisma.workCapsule.update.mockResolvedValue({ id: "row-1", capsuleId: "WC-EVIDENCE" });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "record_capsule_evidence",
+      {
+        capsuleId: "WC-EVIDENCE",
+        kind: "test",
+        summary: "Focused MCP lease-renewal test passed.",
+        command: "pnpm --filter web exec vitest run lib/mcp-tools-work-capsules.test.ts",
+      },
+      "user-1",
+      { agentId: "codex" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "evidence-recorded", recordedByAgentId: "codex" }),
+    }));
+    expect(mockPrisma.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { capsuleId: "WC-EVIDENCE" },
+      data: expect.objectContaining({
+        leaseHolderPrincipalId: "principal-agent",
+        leaseExpiresAt: expect.any(Date),
+      }),
+    }));
+    expect(mockPrisma.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "lease-renewed", recordedByAgentId: "codex" }),
     }));
   });
 

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -27,6 +27,7 @@ import {
   recordWorkCapsuleEvidence,
   updateWorkCapsuleStatus,
   type CapsuleDb,
+  type WorkCapsuleActor,
 } from "./work-capsule-store";
 import { listLocalBranches } from "./git-scanner";
 
@@ -80,6 +81,25 @@ function numberParam(params: Record<string, unknown>, key: string): number | nul
 
 function workCapsuleDb(): CapsuleDb {
   return prisma as unknown as CapsuleDb;
+}
+
+async function renewLeaseAfterCapsuleWrite(capsuleId: string, currentActor: WorkCapsuleActor) {
+  return heartbeatWorkCapsule({
+    db: workCapsuleDb(),
+    capsuleId,
+    actor: currentActor,
+  });
+}
+
+async function runAutoRenewedCapsuleWrite(args: {
+  capsuleId: string;
+  userId: string;
+  context: ToolContext;
+  write: (currentActor: WorkCapsuleActor) => Promise<unknown>;
+}) {
+  const currentActor = await actor(args.userId, args.context);
+  await args.write(currentActor);
+  return renewLeaseAfterCapsuleWrite(args.capsuleId, currentActor);
 }
 
 const SCOPE_KINDS = new Set<ScopeClaim["kind"]>(["path", "module", "package", "route", "skill", "prompt"]);
@@ -260,18 +280,24 @@ export async function claimCapsuleScopeTool(
     };
   }
 
-  const capsule = await claimWorkCapsuleScope({
-    db: workCapsuleDb(),
+  const db = workCapsuleDb();
+  const renewedCapsule = await runAutoRenewedCapsuleWrite({
     capsuleId,
-    claims,
-    actor: await actor(userId, context),
+    userId,
+    context,
+    write: (currentActor) => claimWorkCapsuleScope({
+      db,
+      capsuleId,
+      claims,
+      actor: currentActor,
+    }),
   });
 
   return {
     success: true,
-    entityId: capsule.capsuleId,
-    message: `Claimed ${claims.length} scope item(s) for ${capsule.capsuleId}.`,
-    data: { capsule },
+    entityId: renewedCapsule.capsuleId,
+    message: `Claimed ${claims.length} scope item(s) for ${renewedCapsule.capsuleId}.`,
+    data: { capsule: renewedCapsule },
   };
 }
 
@@ -291,19 +317,25 @@ export async function updateWorkCapsuleStatusTool(
     };
   }
 
-  const capsule = await updateWorkCapsuleStatus({
-    db: workCapsuleDb(),
+  const db = workCapsuleDb();
+  const renewedCapsule = await runAutoRenewedCapsuleWrite({
     capsuleId,
-    status,
-    reason,
-    actor: await actor(userId, context),
+    userId,
+    context,
+    write: (currentActor) => updateWorkCapsuleStatus({
+      db,
+      capsuleId,
+      status,
+      reason,
+      actor: currentActor,
+    }),
   });
 
   return {
     success: true,
-    entityId: capsule.capsuleId,
-    message: `Updated ${capsule.capsuleId} status to ${status}.`,
-    data: { capsule },
+    entityId: renewedCapsule.capsuleId,
+    message: `Updated ${renewedCapsule.capsuleId} status to ${status}.`,
+    data: { capsule: renewedCapsule },
   };
 }
 
@@ -322,18 +354,24 @@ export async function releaseCapsuleScopeTool(
     };
   }
 
-  const capsule = await releaseWorkCapsuleScope({
-    db: workCapsuleDb(),
+  const db = workCapsuleDb();
+  const renewedCapsule = await runAutoRenewedCapsuleWrite({
     capsuleId,
-    claims,
-    actor: await actor(userId, context),
+    userId,
+    context,
+    write: (currentActor) => releaseWorkCapsuleScope({
+      db,
+      capsuleId,
+      claims,
+      actor: currentActor,
+    }),
   });
 
   return {
     success: true,
-    entityId: capsule.capsuleId,
-    message: `Released ${claims.length} scope item(s) for ${capsule.capsuleId}.`,
-    data: { capsule },
+    entityId: renewedCapsule.capsuleId,
+    message: `Released ${claims.length} scope item(s) for ${renewedCapsule.capsuleId}.`,
+    data: { capsule: renewedCapsule },
   };
 }
 
@@ -512,16 +550,23 @@ export async function recordCapsuleEvidenceTool(
   if (url) evidence.url = url;
   if (Object.prototype.hasOwnProperty.call(params, "result")) evidence.result = params.result;
 
-  await recordWorkCapsuleEvidence({
-    db: workCapsuleDb(),
+  const db = workCapsuleDb();
+  const renewedCapsule = await runAutoRenewedCapsuleWrite({
     capsuleId,
-    evidence,
-    actor: await actor(userId, context),
+    userId,
+    context,
+    write: (currentActor) => recordWorkCapsuleEvidence({
+      db,
+      capsuleId,
+      evidence,
+      actor: currentActor,
+    }),
   });
 
   return {
     success: true,
-    entityId: capsuleId,
-    message: `Recorded evidence for ${capsuleId}.`,
+    entityId: renewedCapsule.capsuleId,
+    message: `Recorded evidence for ${renewedCapsule.capsuleId}.`,
+    data: { capsule: renewedCapsule },
   };
 }

--- a/docs/superpowers/plans/2026-05-16-portal-work-capsule-control-harness-phase-2.md
+++ b/docs/superpowers/plans/2026-05-16-portal-work-capsule-control-harness-phase-2.md
@@ -1,5 +1,7 @@
 # Portal Work Capsule Control Harness Phase 2 Implementation Plan
 
+> **Status (2026-05-17):** Shipped and merged to `main` via PR #675. The plan remains as the durable record of the Phase 2 display-and-record architecture, scope narrowing, and verification expectations.
+
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development if the harness offers subagents; otherwise use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Ship governed-creation planning so the portal generates deterministic branch + worktree allocations for new Work Capsules, displays the exact commands the operator runs on the host, blocks the root clone from becoming an active workspace, and records initial scope — without the portal itself mutating the host filesystem.

--- a/docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md
+++ b/docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md
@@ -1,0 +1,54 @@
+# Portal Work Capsule Control Harness Phase 3 Implementation Plan
+
+> **Status (2026-05-17):** First Phase 3 slice in progress on `feat/work-capsule-phase-3`. This plan tracks the executor-attachment phase without pretending the whole phase lands in one PR.
+
+## Goal
+
+Ship the next durable executor-attachment slice after Phase 2: capsule-scoped MCP write tools keep external executor leases alive, read tools stay idempotent, and the remaining Phase 3 executor-attachment work remains explicitly deferred.
+
+## Grounding
+
+- Phase 1 landed the Work Capsule schema, MCP surface, scanner, adoption UI, and explicit `heartbeat_capsule` renewal path.
+- Phase 2 landed governed creation as display-and-record: deterministic branch/worktree planning, operator-paste launch commands, and root-clone refusal. It merged to `main` via PR #675.
+- Spec section 9.5 requires Phase 3 lease auto-renewal on capsule-scoped write tools while forbidding renewal from `list_work_capsules` and `get_work_capsule`.
+
+## Slice 1 Scope
+
+In scope:
+
+- Add a handler-level helper that renews a lease after successful existing-capsule MCP writes.
+- Cover `claim_capsule_scope`, `record_capsule_evidence`, `update_work_capsule_status`, and `release_capsule_scope`.
+- Keep `heartbeat_capsule` as the explicit single-renewal path.
+- Keep `create_work_capsule` and `adopt_worktree` as initial lease-issue paths for external executor attach.
+- Add tests proving a write renews, a read does not renew, and heartbeat renews once.
+- Update the design spec status and Phase 3 verification notes.
+
+Out of scope for this slice:
+
+- Build Studio build-to-capsule attachment.
+- Codex/Claude desktop attachment UX beyond the existing MCP tools.
+- Codex CLI / Claude Code CLI sandbox executor sessions.
+- Collision-warning UI or cross-capsule overlap queries.
+- `executor-changed` handoff activity.
+- DCO commit trailer and PR-body `DPF-Capsule:` enforcement.
+
+## File Touches
+
+- `apps/web/lib/work-capsules/mcp-handlers.ts`
+- `apps/web/lib/mcp-tools-work-capsules.test.ts`
+- `docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md`
+- `docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md`
+
+## Verification
+
+Required before handoff:
+
+- `pnpm --filter web exec vitest run lib/mcp-tools-work-capsules.test.ts`
+- `pnpm --filter web typecheck`
+- `pnpm --filter web build`
+
+This slice has no migration and no user-facing UI change, so UX verification is limited to the MCP handler contract exercised by the focused test.
+
+## Next Phase 3 Slice
+
+After this PR lands, the next smallest Phase 3 slice is executor handoff: add the `executor-changed` write path, record every transition as activity, and surface the current executor in capsule detail without introducing promotion behavior.

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -2,13 +2,14 @@
 
 | Field | Value |
 |---|---|
-| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied); 2026-05-16 (Phase 2 display-and-record scope applied) |
-| Status | Phase 1 merged to `main` via PR #602; Phase 2 implements display-and-record governed creation pending verification/PR; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
+| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied); 2026-05-16 (Phase 2 display-and-record scope applied); 2026-05-17 (Phase 2 merged and Phase 3 lease auto-renewal slice applied) |
+| Status | Phase 1 merged to `main` via PR #602; Phase 2 merged to `main` via PR #675; Phase 3 first slice implements lease auto-renewal for existing-capsule MCP writes while broader executor attachment remains open; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
 | Author | Codex + Mark Bodman; chief-architect review by Claude (Opus 4.7) |
 | Scope | Portal-coordinated work capsules for Build Studio, external Claude/Codex desktop sessions, manual worktrees, sandbox promotion, and portal self-update governance |
 | Depends On | `2026-04-05-db-github-delivery-sync-design.md`, `2026-04-20-ship-phase-fork-redesign-design.md`, `2026-04-21-backlog-triage-build-studio-design.md`, `2026-04-23-build-studio-governed-backlog-delivery-design.md`, `2026-05-09-build-execution-provider-design.md`, `2026-05-09-deployment-contracts.md` |
 | Phase 1 Plan | `docs/superpowers/plans/2026-05-14-portal-work-capsule-control-harness-phase-1.md` |
 | Phase 2 Plan | `docs/superpowers/plans/2026-05-16-portal-work-capsule-control-harness-phase-2.md` |
+| Phase 3 Plan | `docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md` |
 
 ## 1. Problem Statement
 
@@ -576,6 +577,7 @@ External desktop executors (Codex, Claude, human) cannot be supervised by the po
 
 - On capsule attach (`create_work_capsule` or `adopt_worktree` with an external executor), the server issues a lease: `leaseHolderPrincipalId` is set and `leaseExpiresAt = now() + LEASE_TTL` (default 30 minutes; constant: `LEASE_TTL_MS` in `apps/web/lib/work-capsules.ts`).
 - The executor must call `heartbeat_capsule` before expiry. The MCP middleware MAY auto-heartbeat **only on capsule-scoped *write* tool calls** (`create_work_capsule`, `adopt_worktree`, `claim_capsule_scope`, `record_capsule_evidence`, `heartbeat_capsule`, `update_work_capsule_status`, `release_capsule_scope`). Auto-renewal MUST NOT trigger from read tools (`list_work_capsules`, `get_work_capsule`)  -  a reader checking on a stale capsule should not silently extend that capsule's lease, and read tools must remain idempotent in a way an MCP client can rely on. The auto-heartbeat middleware ships in **Phase 3** alongside external executor attachment; Phase 1 supports only the explicit `heartbeat_capsule` call.
+- The first Phase 3 lease slice (2026-05-17) implements handler-level auto-renewal after successful existing-capsule write tools: `claim_capsule_scope`, `record_capsule_evidence`, `update_work_capsule_status`, and `release_capsule_scope`. `create_work_capsule` and `adopt_worktree` continue to issue the initial external-executor lease during attach, and `heartbeat_capsule` remains the explicit single-renewal path so it does not emit duplicate renewal activities.
 - A capsule whose lease has expired surfaces as `lease-expired` in the daily steward and is eligible for reassignment or abandonment recommendations. Expiry does not change `status`; the work itself may still be sound on disk.
 - Build Studio capsules do not consume the lease; their liveness comes from `FeatureBuild` execution state. The lease applies to `codex-desktop`, `claude-desktop`, `human`, and any future external executor kind.
 
@@ -888,6 +890,7 @@ Execute in this order so fresh installs and existing installs both land cleanly:
 
 ### Phase 3: Executor Attachment
 
+- add handler-level lease auto-renewal for existing-capsule MCP write tools while preserving read-tool idempotence
 - attach Build Studio builds to capsules
 - attach Codex/Claude desktop sessions through MCP tools
 - attach Codex CLI and Claude Code CLI sandbox sessions as first-class capsule executors
@@ -958,7 +961,7 @@ Adds:
 
 Adds:
 
-1. Lease auto-renewal middleware tests  -  write tools renew, read tools do not.
+1. Lease auto-renewal middleware tests  -  existing-capsule write tools renew, read tools do not, and explicit `heartbeat_capsule` renews once.
 2. Collision-detection tests for overlapping `(kind, value)` scope claims across active capsules.
 3. External executor handoff tests  -  `executor-changed` activity is written on every transition.
 4. CLI hive tests proving Codex CLI and Claude Code CLI sessions attach as separate executor sessions, record separate evidence, and do not receive raw provider/OAuth secrets.
@@ -1034,7 +1037,7 @@ These decisions close the chief-architect review questions so implementation pla
 
 1. **Lease TTL default.** External executor leases default to 30 minutes (`LEASE_TTL_MS`). Renewal model phases in over two slices:
    - **Phase 1:** `heartbeat_capsule` is the only renewal path. Clients are responsible for calling it before `leaseExpiresAt`.
-   - **Phase 3:** MCP middleware adds auto-renewal on capsule-scoped *write* tool calls (see section 9.5 for the allowlist). Read tools never auto-renew.
+   - **Phase 3:** MCP middleware adds auto-renewal on capsule-scoped *write* tool calls (see section 9.5 for the allowlist). The first delivered slice renews after successful existing-capsule writes; read tools never auto-renew.
 2. **Capsule-to-PR cardinality.** V1 is 1:1: one capsule links to at most one active PR. Split-PR or stacked-PR work is deferred to a later slice after adoption and collision detection are reliable.
 3. **GitPromotionCandidate ordering.** A git webhook first tries to find an existing capsule by `DPF-Capsule:` trailer, PR metadata, or `(repositoryFullName, headBranch)`. If no capsule exists, it creates a capsule with `source = git-promotion`. The deterministic idempotency key is `git-promotion:<repositoryFullName>:<afterSha>`.
 4. **Branch-name allocation.** Portal-created capsules generate `<prefix>/<capsule-slug>` deterministically from branch taxonomy and title. Adopted branches keep their existing names; the portal infers taxonomy and warns when the name does not match AGENTS.md section 4.

--- a/services/integration-test-harness/Dockerfile
+++ b/services/integration-test-harness/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-alpine AS deps
 WORKDIR /app
 COPY services/integration-test-harness/package.json ./
-RUN corepack enable && pnpm install
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && pnpm install
 
 FROM node:24-alpine AS build
 WORKDIR /app
@@ -9,7 +9,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY services/integration-test-harness/package.json services/integration-test-harness/tsconfig.json ./
 COPY services/integration-test-harness/src ./src
 COPY services/integration-test-harness/vendors ./vendors
-RUN corepack enable && pnpm build
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && pnpm build
 
 FROM node:24-alpine AS runner
 WORKDIR /app

--- a/services/integration-test-harness/package.json
+++ b/services/integration-test-harness/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "build": "tsc",
     "start": "node dist/src/harness.js",


### PR DESCRIPTION
## Summary
- Adds Phase 3 handler-level auto-renewal after successful existing-capsule MCP writes.
- Preserves read-tool idempotence and keeps `heartbeat_capsule` as a single explicit renewal path.
- Updates the Work Capsule design docs and adds a Phase 3 implementation plan for this slice.
- Repairs the ADP CI harness job by providing Compose placeholders and pinning the harness image to the repo pnpm version.

## Verification
- [x] `pnpm --filter web exec vitest run lib/mcp-tools-work-capsules.test.ts`
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web build`
- [x] `$env:AUTH_SECRET="ci-placeholder"; $env:CREDENTIAL_ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000"; docker compose --profile integration-test config --services`
- [x] `$env:AUTH_SECRET="ci-placeholder"; $env:CREDENTIAL_ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000"; docker compose --profile integration-test build integration-test-harness`
- [x] Local ADP harness run: `pnpm --filter dpf-adp-mcp test` against `integration-test-harness` returned 9 files / 42 tests passing.

Notes: no schema migration and no user-facing UI change in this slice. The production build still emits existing Turbopack broad file-tracing warnings around `spec-plan-search.ts` / `next.config.mjs`, but exits 0.