### PR TITLE
fix(routing): classify Gemini 3.x Pro models as strong tier

### DIFF
--- a/apps/web/lib/routing/quality-tiers.test.ts
+++ b/apps/web/lib/routing/quality-tiers.test.ts
@@ -65,6 +65,27 @@ describe("assignTierFromModelId", () => {
     });
   });
 
+  describe("Gemini 3.x tier classification", () => {
+    it("assigns strong to gemini-3-pro-preview", () => {
+      expect(assignTierFromModelId("gemini-3-pro-preview")).toBe("strong");
+    });
+    it("assigns strong to gemini-3-pro-image-preview", () => {
+      expect(assignTierFromModelId("gemini-3-pro-image-preview")).toBe("strong");
+    });
+    it("assigns strong to gemini-3.1-pro-preview", () => {
+      expect(assignTierFromModelId("gemini-3.1-pro-preview")).toBe("strong");
+    });
+    it("assigns strong to gemini-3.1-pro-preview-customtools", () => {
+      expect(assignTierFromModelId("gemini-3.1-pro-preview-customtools")).toBe("strong");
+    });
+    it("assigns adequate to gemini-3-flash-preview (flash stays adequate)", () => {
+      expect(assignTierFromModelId("gemini-3-flash-preview")).toBe("adequate");
+    });
+    it("assigns strong to gemini-2.5-pro (existing)", () => {
+      expect(assignTierFromModelId("gemini-2.5-pro")).toBe("strong");
+    });
+  });
+
   describe("unknown models", () => {
     it("returns adequate as conservative default", () => {
       expect(assignTierFromModelId("some-unknown-model")).toBe("adequate");

--- a/apps/web/lib/routing/quality-tiers.ts
+++ b/apps/web/lib/routing/quality-tiers.ts
@@ -42,7 +42,9 @@ export const FAMILY_TIERS: Record<string, QualityTier> = {
   "o4":               "frontier",
   "gpt-4o":           "strong",
   "gpt-4o-mini":      "adequate",
-  // Google
+  // Google — versioned families, longest prefix wins
+  "gemini-3.1-pro":   "strong",   // Gemini 3.1 Pro: next-gen, matches GPT-4o class
+  "gemini-3-pro":     "strong",   // Gemini 3 Pro: flagship 3.x gen
   "gemini-2.5-pro":   "strong",
   "gemini-2.5-flash": "adequate",
   "gemini-2.0-flash": "adequate",


### PR DESCRIPTION
## Summary

- `gemini-3-pro-preview`, `gemini-3.1-pro-preview` and their variants were falling through to the `adequate` default because `FAMILY_TIERS` had no 3.x entries
- Added `gemini-3-pro` and `gemini-3.1-pro` prefix entries (both `strong`), consistent with `gemini-2.5-pro`
- Flash/lite Gemini 3.x remain `adequate` (unchanged behaviour)

## Test plan

- [x] 6 new tests covering gemini-3-pro-preview, gemini-3-pro-image-preview, gemini-3.1-pro-preview, gemini-3.1-pro-preview-customtools, gemini-3-flash-preview
- [x] All 25 quality-tiers tests pass: `npx vitest run apps/web/lib/routing/quality-tiers.test.ts`
- [ ] Verify in portal: send message from strong-tier coworker and confirm RouteDecisionLog selects a gemini-3.x-pro endpoint (not adequqte-tier flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)