### PR TITLE
fix(test): update cli-adapter chmod assertion to 644

### DIFF
--- a/apps/web/lib/routing/cli-adapter.test.ts
+++ b/apps/web/lib/routing/cli-adapter.test.ts
@@ -412,8 +412,8 @@ describe("cliAdapter", () => {
       const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
       const mcpWrite = execCalls.find((c) => c.includes("cli-mcp-"));
       expect(mcpWrite).toBeDefined();
-      // The chmod 600 protects the JWT on disk during the call
-      expect(mcpWrite).toContain("chmod 600");
+      // chmod 644 so the Claude CLI process (different user) can read the config
+      expect(mcpWrite).toContain("chmod 644");
     });
 
     it("includes --mcp-config + --strict-mcp-config in the runner script", async () => {


### PR DESCRIPTION
## Summary

- PR #711 changed the MCP config file permission from `chmod 600` to `chmod 644` so the Claude CLI process (running as a different user in the sandbox container) can read it
- The test in `lib/routing/cli-adapter.test.ts` was not updated in the same commit, leaving `expect(mcpWrite).toContain("chmod 600")` on main which breaks the `Unit Tests` CI job

One-line fix: update the assertion comment and the expected string from `600` to `644`.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/routing/cli-adapter.test.ts` — 19/19 pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)