### PR TITLE
Fix AI provider runtime routing

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -41,6 +41,7 @@ import { recallWikiContext } from "@/lib/wiki/recall";
 import { getGrantedCapabilities, getDeniedCapabilities } from "@/lib/permissions";
 import { classifyTask } from "@/lib/task-classifier";
 import { getTaskType } from "@/lib/task-types";
+import { applyProviderRouteModelPreference } from "@/lib/ai-provider-route-context";
 import { loadPerformanceProfiles, ensurePerformanceProfile } from "@/lib/agent-router-data";
 import type { RoutingMeta } from "@/lib/process-observer-hook";
 import {
@@ -1060,7 +1061,10 @@ export async function sendMessage(input: {
 
   // EP-AI-WORKFORCE-001: Provider pinning is now via AgentModelConfig.pinnedProviderId
   // (resolved in agentic-loop.ts via agentModelConfig lookup). No need to merge here.
-  const modelReqs = { ...agent.modelRequirements };
+  const modelReqs = applyProviderRouteModelPreference(
+    { ...agent.modelRequirements },
+    input.routeContext,
+  );
 
   // --- Task classification and performance profile injection ---
   // EP-INF-009b: Routing is handled by the agentic loop via routeAndCall().

--- a/apps/web/lib/ai-provider-route-context.test.ts
+++ b/apps/web/lib/ai-provider-route-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyProviderRouteModelPreference,
+  inferProviderIdFromRouteContext,
+} from "./ai-provider-route-context";
+
+describe("AI provider route context", () => {
+  it("extracts the provider id from provider detail routes", () => {
+    expect(inferProviderIdFromRouteContext("/platform/ai/providers/gemini")).toBe("gemini");
+    expect(inferProviderIdFromRouteContext("/platform/ai/providers/anthropic-sub?tab=models")).toBe("anthropic-sub");
+  });
+
+  it("applies the provider detail route as the preferred provider", () => {
+    expect(applyProviderRouteModelPreference({
+      defaultMinimumTier: "strong",
+      defaultBudgetClass: "balanced",
+      preferredProviderId: "anthropic-sub",
+      preferredModelId: "claude-haiku-4-5-20251001",
+    }, "/platform/ai/providers/gemini")).toEqual({
+      defaultMinimumTier: "strong",
+      defaultBudgetClass: "balanced",
+      preferredProviderId: "gemini",
+    });
+  });
+
+  it("leaves non-provider routes unchanged", () => {
+    expect(applyProviderRouteModelPreference({
+      defaultMinimumTier: "strong",
+      preferredProviderId: "anthropic-sub",
+    }, "/platform/ai")).toEqual({
+      defaultMinimumTier: "strong",
+      preferredProviderId: "anthropic-sub",
+    });
+  });
+});

--- a/apps/web/lib/ai-provider-route-context.ts
+++ b/apps/web/lib/ai-provider-route-context.ts
@@ -1,0 +1,25 @@
+export function inferProviderIdFromRouteContext(routeContext?: string | null): string | null {
+  const match = routeContext?.match(/^\/platform\/ai\/providers\/([^/?#]+)/);
+  if (!match?.[1]) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+export function applyProviderRouteModelPreference<T extends Record<string, unknown>>(
+  modelRequirements: T,
+  routeContext?: string | null,
+): T & { preferredProviderId?: string } {
+  const providerId = inferProviderIdFromRouteContext(routeContext);
+  if (!providerId) return { ...modelRequirements };
+
+  const next = {
+    ...modelRequirements,
+    preferredProviderId: providerId,
+  } as T & { preferredProviderId: string; preferredModelId?: string };
+
+  delete next.preferredModelId;
+  return next;
+}

--- a/apps/web/lib/mcp-tools.test.ts
+++ b/apps/web/lib/mcp-tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getAvailableTools, sanitizeToolParams } from "./mcp-tools";
+import {
+  buildEndpointTestRunRequest,
+  getAvailableTools,
+  inferEndpointIdFromRouteContext,
+  sanitizeToolParams,
+} from "./mcp-tools";
 import { getActionsForRoute } from "./agent-action-registry";
 
 describe("mcp tools", () => {
@@ -246,6 +251,44 @@ describe("sanitizeToolParams", () => {
     // All string fields are empty but there's a non-string field — string check still applies
     // to string-typed fields only. Both string fields are empty → stripped.
     expect(result).not.toHaveProperty("proposeNew");
+  });
+});
+
+describe("endpoint test tool scope", () => {
+  it("infers the provider page endpoint and defaults coworker diagnostics to probes only", () => {
+    expect(inferEndpointIdFromRouteContext("/platform/ai/providers/gemini")).toBe("gemini");
+
+    const request = buildEndpointTestRunRequest({}, { routeContext: "/platform/ai/providers/gemini" });
+
+    expect(request).toEqual({
+      endpointId: "gemini",
+      probesOnly: true,
+      allEndpoints: false,
+      allModels: false,
+    });
+  });
+
+  it("requires explicit all-endpoint scope away from a provider route", () => {
+    const request = buildEndpointTestRunRequest({}, { routeContext: "/workspace" });
+
+    expect(request.error).toMatch(/endpointId or allEndpoints/);
+  });
+
+  it("preserves explicit full all-model endpoint test requests", () => {
+    const request = buildEndpointTestRunRequest({
+      endpointId: "gemini",
+      modelId: "gemini-2.5-flash",
+      probesOnly: false,
+      allModels: true,
+    }, { routeContext: "/platform/ai/providers/anthropic-sub" });
+
+    expect(request).toEqual({
+      endpointId: "gemini",
+      modelId: "gemini-2.5-flash",
+      probesOnly: false,
+      allEndpoints: false,
+      allModels: true,
+    });
   });
 });
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -46,6 +46,7 @@ import {
   listCoworkerCapabilityNeeds,
   submitCoworkerSelfAssessment,
 } from "@/lib/coworker-self-assessment/assessment-service";
+import { inferProviderIdFromRouteContext } from "@/lib/ai-provider-route-context";
 import { workCapsuleToolEnums } from "@/lib/work-capsules/mcp-handlers";
 import {
   COWORKER_ASSESSMENT_CONFIDENCE,
@@ -110,6 +111,16 @@ export type ToolDefinition = {
     userId: string;
     params?: Record<string, unknown>;
   }) => Promise<boolean>;
+};
+
+export type EndpointTestRunRequest = {
+  endpointId?: string;
+  modelId?: string;
+  taskType?: string;
+  probesOnly: boolean;
+  allEndpoints: boolean;
+  allModels: boolean;
+  error?: string;
 };
 
 /** Derive tool annotations from existing ToolDefinition fields.
@@ -230,6 +241,69 @@ function codeGraphReadToolResult(
     message,
     data: result,
   };
+}
+
+function cleanEndpointTestString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function inferEndpointIdFromRouteContext(routeContext?: string): string | null {
+  return inferProviderIdFromRouteContext(routeContext);
+}
+
+export function buildEndpointTestRunRequest(
+  params: Record<string, unknown>,
+  context?: { routeContext?: string },
+): EndpointTestRunRequest {
+  const explicitEndpointId = cleanEndpointTestString(params["endpointId"]);
+  const inferredEndpointId = inferEndpointIdFromRouteContext(context?.routeContext) ?? undefined;
+  const endpointId = explicitEndpointId ?? inferredEndpointId;
+  const modelId = cleanEndpointTestString(params["modelId"]);
+  const taskType = cleanEndpointTestString(params["taskType"]);
+  const allEndpoints = endpointId ? false : params["allEndpoints"] === true;
+
+  const base: EndpointTestRunRequest = {
+    probesOnly: params["probesOnly"] === false ? false : true,
+    allEndpoints,
+    allModels: params["allModels"] === true,
+    ...(endpointId ? { endpointId } : {}),
+    ...(modelId ? { modelId } : {}),
+    ...(taskType ? { taskType } : {}),
+  };
+
+  if (!endpointId && !allEndpoints) {
+    return {
+      ...base,
+      error: "run_endpoint_tests requires endpointId or allEndpoints=true when it is not used from a provider detail route.",
+    };
+  }
+
+  return base;
+}
+
+async function resolveRepresentativeEndpointModelId(endpointId: string): Promise<string | undefined> {
+  const orderBy = [
+    { toolFidelity: "desc" as const },
+    { reasoning: "desc" as const },
+    { conversational: "desc" as const },
+    { modelId: "asc" as const },
+  ];
+
+  const toolCapable = await prisma.modelProfile.findFirst({
+    where: { providerId: endpointId, modelStatus: "active", supportsToolUse: true },
+    orderBy,
+    select: { modelId: true },
+  });
+  if (toolCapable?.modelId) return toolCapable.modelId;
+
+  const active = await prisma.modelProfile.findFirst({
+    where: { providerId: endpointId, modelStatus: "active" },
+    orderBy,
+    select: { modelId: true },
+  });
+  return active?.modelId;
 }
 
 function optionalString(value: unknown): string | null {
@@ -2780,13 +2854,16 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   // ─── Endpoint Testing Tools ──────────────────────────────────────────────
   {
     name: "run_endpoint_tests",
-    description: "Run the agent test harness against one or all endpoints. Tests capability probes (instruction compliance, tool calling, output format) and task scenarios. Results feed into endpoint performance scores and update ModelProfile with evidence.",
+    description: "Run the agent test harness against a scoped endpoint. On provider detail routes, omit endpointId to use the current provider and default to quick probes. Set allEndpoints=true or allModels=true only when the user explicitly asks for exhaustive diagnostics.",
     inputSchema: {
       type: "object",
       properties: {
-        endpointId: { type: "string", description: "Test a specific endpoint (default: all active LLM endpoints)" },
+        endpointId: { type: "string", description: "Provider endpoint to test. Defaults to the current /platform/ai/providers/:providerId route when available." },
+        modelId: { type: "string", description: "Optional model profile to test. Defaults to a representative active model for the endpoint." },
         taskType: { type: "string", description: "Run only scenarios for this task type (default: all)" },
-        probesOnly: { type: "boolean", description: "Run only capability probes, skip scenarios (default: false)" },
+        probesOnly: { type: "boolean", description: "Run only capability probes, skip scenarios (default: true for coworker calls)" },
+        allEndpoints: { type: "boolean", description: "Explicitly test every active LLM endpoint. Use only when the user asks for all endpoints." },
+        allModels: { type: "boolean", description: "Test every active model profile for the endpoint. Use only for exhaustive diagnostics." },
       },
     },
     requiredCapability: "manage_capabilities",
@@ -10176,11 +10253,23 @@ export async function executeTool(
 
     case "run_endpoint_tests": {
       const { runEndpointTests } = await import("@/lib/endpoint-test-runner");
+      const request = buildEndpointTestRunRequest(params, context);
+
+      if (request.error) {
+        return { success: false, message: request.error };
+      }
+
+      const modelId = request.modelId ?? (
+        request.endpointId && !request.allModels
+          ? await resolveRepresentativeEndpointModelId(request.endpointId)
+          : undefined
+      );
 
       const results = await runEndpointTests({
-        ...(typeof params.endpointId === "string" ? { endpointId: params.endpointId } : {}),
-        ...(typeof params.taskType === "string" ? { taskType: params.taskType } : {}),
-        probesOnly: params.probesOnly === true,
+        ...(request.endpointId ? { endpointId: request.endpointId } : {}),
+        ...(modelId ? { modelId } : {}),
+        ...(request.taskType ? { taskType: request.taskType } : {}),
+        probesOnly: request.probesOnly,
         triggeredBy: userId,
       });
 
@@ -10207,7 +10296,7 @@ export async function executeTool(
         return lines.join("\n");
       }).join("\n\n");
 
-      return { success: true, message: summary || "No endpoints to test.", data: { results } };
+      return { success: true, message: summary || "No endpoints to test.", data: { results, scope: { ...request, ...(modelId ? { modelId } : {}) } } };
     }
 
       case "search_integrations": {

--- a/apps/web/lib/operate/endpoint-test-runner.ts
+++ b/apps/web/lib/operate/endpoint-test-runner.ts
@@ -79,6 +79,7 @@ export function mapScoresToCodingCapability(
 async function runProbe(
   probe: CapabilityProbe,
   providerId: string,
+  modelId: string,
 ): Promise<ProbeRunResult> {
   try {
     const promptInput: PromptInput = { ...TEST_PROMPT_DEFAULTS, ...probe.promptOverrides };
@@ -90,6 +91,7 @@ async function runProbe(
     const result = await routeAndCall(messages, systemPrompt, promptInput.sensitivity, {
       ...(probeToolsFormatted ? { tools: probeToolsFormatted } : {}),
       preferredProviderId: providerId,
+      ...(modelId !== "default" ? { preferredModelId: modelId } : {}),
     });
 
     // Detect failover — if a different endpoint answered, mark as infrastructure failure
@@ -112,6 +114,7 @@ async function runProbe(
 async function runScenario(
   scenario: TestScenario,
   providerId: string,
+  modelId: string,
 ): Promise<ScenarioRunResult> {
   try {
     const promptInput: PromptInput = { ...TEST_PROMPT_DEFAULTS, ...scenario.promptOverrides };
@@ -123,6 +126,7 @@ async function runScenario(
     const result = await routeAndCall(messages, systemPrompt, promptInput.sensitivity, {
       ...(scenarioToolsFormatted ? { tools: scenarioToolsFormatted } : {}),
       preferredProviderId: providerId,
+      ...(modelId !== "default" ? { preferredModelId: modelId } : {}),
     });
 
     if (result.downgraded) {
@@ -237,7 +241,7 @@ export async function runEndpointTests(opts: {
     // Run probes against this model's provider via V2 routing with preferred provider bias.
     const probeResults: ProbeRunResult[] = [];
     for (const probe of CAPABILITY_PROBES) {
-      const result = await runProbe(probe, providerId);
+      const result = await runProbe(probe, providerId, modelId);
       probeResults.push(result);
     }
 
@@ -255,7 +259,7 @@ export async function runEndpointTests(opts: {
       ).filter((s) => s.requiredProbes.every((rp) => probePassMap[rp]));
 
       for (const scenario of eligibleScenarios) {
-        const result = await runScenario(scenario, providerId);
+        const result = await runScenario(scenario, providerId, modelId);
         scenarioResults.push(result);
 
         // Record TaskEvaluation for scenarios with orchestrator scores

--- a/apps/web/lib/routing/chat-adapter.test.ts
+++ b/apps/web/lib/routing/chat-adapter.test.ts
@@ -446,6 +446,59 @@ describe("chatAdapter", () => {
     expect(sentBody.tools).toEqual([{ code_execution: {} }]);
   });
 
+  it("Gemini: strips unsupported JSON Schema keywords from function declarations", async () => {
+    stubFetchOk({
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 },
+    });
+
+    const req = makeRequest({
+      providerId: "gemini",
+      modelId: "gemini-2.5-flash",
+      plan: makePlan({ providerId: "gemini" }),
+      provider: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        headers: { "Content-Type": "application/json" },
+      },
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "principle_decide",
+            description: "Score candidate options against principles.",
+            parameters: {
+              type: "object",
+              properties: {
+                options: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string" },
+                      features: {
+                        type: "object",
+                        additionalProperties: { type: "number" },
+                      },
+                    },
+                    required: ["id"],
+                  },
+                },
+              },
+              required: ["options"],
+            },
+          },
+        },
+      ],
+    });
+
+    await chatAdapter.execute(req);
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const parameters = sentBody.tools[0].functionDeclarations[0].parameters;
+    expect(JSON.stringify(parameters)).not.toContain("additionalProperties");
+    expect(parameters.properties.options.items.properties.features).toEqual({ type: "object" });
+  });
+
   // ── 8. Gemini: code_execution response parts extracted as text ──
 
   it("Gemini: code_execution response parts extracted as text", async () => {

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -58,6 +58,67 @@ function extractResponsesText(
   return text || outputText || "";
 }
 
+const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
+  "$defs",
+  "$id",
+  "$schema",
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "const",
+  "default",
+  "definitions",
+  "dependencies",
+  "dependentRequired",
+  "dependentSchemas",
+  "deprecated",
+  "else",
+  "examples",
+  "if",
+  "not",
+  "patternProperties",
+  "propertyNames",
+  "readOnly",
+  "then",
+  "unevaluatedProperties",
+  "writeOnly",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeGeminiSchemaNode(value: unknown, propertyMap = false): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeGeminiSchemaNode(item));
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (!propertyMap && GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
+    sanitized[key] = sanitizeGeminiSchemaNode(child, !propertyMap && key === "properties");
+  }
+  return sanitized;
+}
+
+function toGeminiFunctionDeclarations(tools: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return tools
+    .filter((t) => t.type === "function" && t.function)
+    .map((t) => {
+      const fn = t.function as Record<string, unknown>;
+      return {
+        name: fn.name,
+        description: fn.description,
+        parameters: sanitizeGeminiSchemaNode(fn.parameters),
+      };
+    });
+}
+
 // ─── Chat Adapter ────────────────────────────────────────────────────────────
 
 export const chatAdapter: ExecutionAdapterHandler = {
@@ -158,16 +219,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
 
       // Convert OpenAI-format function tools to Gemini functionDeclarations format
       if (tools && tools.length > 0) {
-        const functionDeclarations = tools
-          .filter((t: Record<string, unknown>) => t.type === "function" && t.function)
-          .map((t: Record<string, unknown>) => {
-            const fn = t.function as Record<string, unknown>;
-            return {
-              name: fn.name,
-              description: fn.description,
-              parameters: fn.parameters,
-            };
-          });
+        const functionDeclarations = toGeminiFunctionDeclarations(tools);
         if (functionDeclarations.length > 0) {
           body.tools = [...((body.tools as Array<Record<string, unknown>>) ?? []), { functionDeclarations }];
         }

--- a/apps/web/lib/routing/cli-adapter.test.ts
+++ b/apps/web/lib/routing/cli-adapter.test.ts
@@ -412,7 +412,8 @@ describe("cliAdapter", () => {
       const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
       const mcpWrite = execCalls.find((c) => c.includes("cli-mcp-"));
       expect(mcpWrite).toBeDefined();
-      // chmod 644 so the Claude CLI process (different user) can read the config
+      // chown to node user + chmod 644 so the Claude CLI process can read the config
+      expect(mcpWrite).toContain("chown node:node");
       expect(mcpWrite).toContain("chmod 644");
     });
 

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -448,7 +448,7 @@ export const cliAdapter: ExecutionAdapterHandler = {
         const mcpB64 = Buffer.from(JSON.stringify(mcpConfig)).toString("base64");
         writes.push(
           execAsync(
-            `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${mcpB64}' | base64 -d > ${mcpConfigFile} && chmod 644 ${mcpConfigFile}"`,
+            `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${mcpB64}' | base64 -d > ${mcpConfigFile} && chown node:node ${mcpConfigFile} && chmod 644 ${mcpConfigFile}"`,
             { timeout: 5_000 },
           ),
         );

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -597,6 +597,73 @@ describe("runAgenticLoop", () => {
     );
   });
 
+  it("returns direct conversational provider-status answers without forcing diagnostics", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    const mockExecuteTool = vi.mocked(executeTool);
+
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content: "Yes - I'm active on the anthropic-sub provider and ready to go.",
+        providerId: "anthropic-sub",
+        modelId: "claude-haiku-4-5-20251001",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "Checking endpoint probes.",
+        providerId: "anthropic-sub",
+        modelId: "claude-haiku-4-5-20251001",
+        toolCalls: [
+          {
+            id: "toolu_diagnostics_1",
+            name: "run_endpoint_tests",
+            arguments: { endpointId: "gemini", probesOnly: true },
+          },
+        ],
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content: "Gemini diagnostics are currently failing.",
+        providerId: "anthropic-sub",
+        modelId: "claude-haiku-4-5-20251001",
+      }));
+
+    mockExecuteTool.mockResolvedValueOnce({
+      success: false,
+      message: "Probes 0/8 passed",
+    });
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      chatHistory: [{ role: "user", content: "do you work?" }],
+      routeContext: "/platform/ai/providers/anthropic-sub",
+      agentId: "ai-ops-engineer",
+      taskType: "unknown",
+      tools: [
+        {
+          name: "run_endpoint_tests",
+          description: "Run endpoint diagnostics",
+          inputSchema: {},
+          requiredCapability: null,
+          executionMode: "immediate" as const,
+          sideEffect: false,
+        },
+      ],
+      toolsForProvider: [
+        {
+          type: "function",
+          function: {
+            name: "run_endpoint_tests",
+            description: "Run endpoint diagnostics",
+            parameters: {},
+          },
+        },
+      ],
+    });
+
+    expect(result.content).toBe("Yes - I'm active on the anthropic-sub provider and ready to go.");
+    expect(result.executedTools).toHaveLength(0);
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+    expect(mockRoute).toHaveBeenCalledTimes(1);
+  });
+
   it("returns text-only response when no tool calls (after nudge)", async () => {
     const mockRoute = vi.mocked(routeAndCall);
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -347,6 +347,7 @@ export function shouldNudge(params: {
   responseLength: number;
   responseText?: string;
   hasAuthoritativeToolExecution?: boolean;
+  allowFirstTurnTextOnlyReply?: boolean;
 }): boolean {
   // One nudge maximum. Extra nudges multiply cost — if the model doesn't respond
   // to one targeted nudge, it won't respond to more and will just burn tokens.
@@ -368,7 +369,13 @@ export function shouldNudge(params: {
     const text = params.responseText?.trim() ?? "";
     const isAskingClarification = text.length < 250 && CLARIFYING_QUESTION_PATTERN.test(text);
     const isSubstantiveReply = text.length >= 100 && !COMPLETION_CLAIM_PATTERN.test(text) && !NARRATION_PATTERN.test(text);
-    if (isAskingClarification || isSubstantiveReply) return false;
+    const isAllowedDirectReply = !!params.allowFirstTurnTextOnlyReply
+      && text.length > 0
+      && !COMPLETION_CLAIM_PATTERN.test(text)
+      && !NARRATION_PATTERN.test(text)
+      && !PERMISSION_SEEKING_PATTERN.test(text)
+      && !FRUSTRATION_PATTERN.test(text);
+    if (isAskingClarification || isSubstantiveReply || isAllowedDirectReply) return false;
     return true;
   }
 
@@ -429,6 +436,39 @@ export function detectToolRefusedDespiteAvailability(
 export function phaseRequiresToolCall(phase: string | null | undefined): boolean {
   if (!phase) return false;
   return ["ideate", "plan", "build", "review"].includes(phase);
+}
+
+function latestUserText(messages: ChatMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== "user" || typeof message.content !== "string") continue;
+    return message.content;
+  }
+  return "";
+}
+
+function shouldAllowProviderStatusTextReply(params: {
+  routeContext: string;
+  taskType?: string;
+  providerId: string;
+  messages: ChatMessage[];
+  responseText: string;
+}): boolean {
+  if (!params.routeContext.startsWith("/platform/ai/providers/")) return false;
+  // Provider-detail status questions are often classified as "unknown" or
+  // platform operations because the route carries most of the intent. The
+  // route and status-language checks below are the durable guard here.
+  if (params.providerId === "local") return false;
+
+  const latestUser = latestUserText(params.messages).toLowerCase();
+  const text = params.responseText.toLowerCase();
+  const userAskedProviderStatus =
+    /\b(?:do you work|are you working|can you respond|provider|model|inference|without using tools|no tools|just answer)\b/.test(latestUser);
+  const answerLooksLikeProviderStatus =
+    /\b(?:chat|inference|provider|model|endpoint|gemini|anthropic|openai|claude|codex)\b/.test(text)
+    && /\b(?:operational|working|available|reachable|responding|unavailable|configured|healthy)\b/.test(text);
+
+  return userAskedProviderStatus || answerLooksLikeProviderStatus;
 }
 
 /**
@@ -1134,6 +1174,13 @@ export async function runAgenticLoop(params: {
             (tool) => tool.name === executedTool.name && tool.sideEffect,
           ),
         ),
+        allowFirstTurnTextOnlyReply: shouldAllowProviderStatusTextReply({
+          routeContext,
+          taskType,
+          providerId: result.providerId,
+          messages,
+          responseText: trimmed,
+        }),
       });
 
         if (


### PR DESCRIPTION
## Summary
- Sanitize Gemini function declaration schemas so Gemini does not reject MCP/OpenAI JSON Schema fields such as nested `additionalProperties`.
- Route provider-detail coworker chats to the provider shown on the page, and allow direct provider-status answers without forcing diagnostics.
- Fix Claude CLI native MCP config ownership so the node user can read the generated session config.
- Scope endpoint diagnostics to the provider page by default and pass model pins into endpoint scenario runs.

## Root cause
The provider flow had multiple runtime breaks: Gemini rejected unsupported schema keys, provider detail pages were not consistently preferring the page provider, Claude native MCP config files were written as root with `0600`, and the agentic loop could nudge a valid status reply into unrelated diagnostics.

## Verification
- `pnpm --filter web exec vitest run lib/routing/cli-adapter.test.ts lib/ai-provider-route-context.test.ts lib/routing/chat-adapter.test.ts lib/routing/fallback.test.ts lib/tak/agentic-loop.test.ts lib/mcp-tools.test.ts lib/operate/endpoint-test-runner.test.ts` — 162 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web exec next build` — passed with existing Turbopack tracing warnings.
- `docker compose --env-file D:\DPF\.env -p dpf build --no-cache portal portal-init sandbox` — passed.
- `docker compose --env-file D:\DPF\.env -p dpf up -d portal` plus `http://localhost:3000/api/health` — portal healthy.
- Browser UX check on `/platform/ai/providers/anthropic-sub`: AI Ops Engineer responded directly, server log showed `provider=anthropic-sub`, `mode=native-mcp`, `contentLen=84`, no EACCES, no provider-unavailable fallback, and no diagnostic nudge.

## Notes
Gemini is still disabled in this local database, so Gemini-specific provider-page chat will not pin Gemini until that provider is enabled. The runtime path is fixed for active providers, and Gemini schema rejection is covered by regression tests.