### PR TITLE
fix(providers): auth guard + defensive Neo4j handling on provider detail page

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -1,5 +1,5 @@
 // apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
@@ -21,6 +21,12 @@ import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 type Props = { params: Promise<{ providerId: string }> };
 
 export default async function ProviderDetailPage({ params }: Props) {
+  // Guard: this route has no middleware — data-fetching server actions enforce
+  // requireViewAccess() and will throw if called unauthenticated, crashing the
+  // Server Component render. Redirect early before any data fetching occurs.
+  const earlySession = await auth();
+  if (!earlySession?.user) redirect("/login");
+
   const { providerId } = await params;
   const now = new Date();
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
@@ -50,17 +56,22 @@ export default async function ProviderDetailPage({ params }: Props) {
   const user = session?.user;
   const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
 
-  // Fetch hardware info for Ollama
+  // Fetch hardware info for local providers via Neo4j InfraCI.
+  // Wrapped in try/catch — Neo4j is best-effort; a graph error must never crash the page.
   let hardwareInfo: { gpu: string; vramGb: number | null; modelCount: number } | null = null;
   if (providerId === "local" || providerId === "ollama") {
-    const infraCIs = await getInfraCIs("ai-inference");
-    const ollamaCI = infraCIs.find((ci) => ci.id === "CI-ollama-01");
-    if (ollamaCI?.properties.gpu) {
-      hardwareInfo = {
-        gpu: ollamaCI.properties.gpu as string,
-        vramGb: (ollamaCI.properties.vramGb as number) ?? null,
-        modelCount: (ollamaCI.properties.modelCount as number) ?? 0,
-      };
+    try {
+      const infraCIs = await getInfraCIs("ai-inference");
+      const ollamaCI = infraCIs.find((ci) => ci.id === "CI-ollama-01");
+      if (ollamaCI?.properties.gpu) {
+        hardwareInfo = {
+          gpu: String(ollamaCI.properties.gpu),
+          vramGb: ollamaCI.properties.vramGb != null ? Number(ollamaCI.properties.vramGb) : null,
+          modelCount: ollamaCI.properties.modelCount != null ? Number(ollamaCI.properties.modelCount) : 0,
+        };
+      }
+    } catch {
+      // Neo4j unavailable or returns unexpected data — hardware info degrades gracefully to null
     }
   }
 


### PR DESCRIPTION
## Summary

Two defensive fixes for the recurring Server Components crash on \`/platform/ai/providers/local\` (BI-PIR-4c58a8c4, PIR-OD79P, PIR-RSG7T).

**Root cause investigation:** The production build hides the error message, making the exact line impossible to identify without source maps. Two likely contributors were identified:

1. **No auth guard on this page.** Unlike most shell pages, this route has no Next.js middleware. The data-fetching server actions all call \`requireViewAccess()\` which throws \`"Unauthorized"\` if the session is absent or expired. That exception propagates through the \`Promise.all\` in the Server Component, crashing the render. An unauthenticated direct-URL navigation would trigger this every time.

2. **Unguarded Neo4j call unique to the local/ollama provider.** \`getInfraCIs("ai-inference")\` is called outside the main \`Promise.all\` and is unique to the local provider path. If Neo4j throws (transient connection issue) or returns unexpected data types (e.g. driver Integer instead of JS number), the page crashes. The \`as\` type casts also do not protect against BigInt serialisation failures when Next.js builds the RSC payload.

## Changes

- \`import { redirect }\` added; early \`auth()\` check redirects to \`/login\` before any data fetching
- \`getInfraCIs\` wrapped in \`try/catch\`; hardware info gracefully degrades to \`null\` on any error
- \`as string\`/\`as number\` casts replaced with \`String()\`/\`Number()\` to handle any non-primitive Neo4j driver types

## Test plan
- [ ] Navigate to \`/platform/ai/providers/local\` while logged in — page renders
- [ ] Navigate to \`/platform/ai/providers/local\` without a session — redirects to \`/login\`
- [ ] CI typecheck (note: pre-existing \`backupRun\` errors on main are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)