### PR TITLE
feat(platform): daily Postgres backup mechanism + admin UX (Slice 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,10 @@ packages/db/generated/
 .playwright-cli/
 .pnpm-store/
 docker-compose.override.yml
-backups/
+# Host-side platform-managed backup dumps (root-anchored so the pattern
+# does NOT match source-tree directories like apps/web/lib/operate/backups/
+# or apps/web/app/(shell)/admin/backups/, which are checked in.)
+/backups/
 
 # Git LFS writes generated hook shims into core.hooksPath=.githooks.
 .githooks/post-checkout

--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import {
+  getBackupReadinessAction,
+  listBackupRunsAction,
+  readBackupRunLogAction,
+  triggerBackupNowAction,
+  type BackupRunListItem,
+  type BackupRunLog,
+} from "@/lib/actions/backups";
+import type { ReadinessSummary } from "@/lib/operate/backups/types";
+
+interface Props {
+  initialReadiness: ReadinessSummary;
+  initialRuns: BackupRunListItem[];
+}
+
+function formatBytes(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDurationMs(ms: number | null): string {
+  if (ms === null || ms === undefined) return "—";
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60 * 1000) return `${(ms / 1000).toFixed(1)} s`;
+  return `${(ms / 60000).toFixed(1)} min`;
+}
+
+function formatTimestamp(s: string | null): string {
+  if (!s) return "—";
+  return new Date(s).toLocaleString();
+}
+
+const STATUS_PILL: Record<string, { bg: string; color: string; label: string }> = {
+  ok: { bg: "rgba(74, 222, 128, 0.15)", color: "#4ade80", label: "OK" },
+  failed: { bg: "rgba(248, 113, 113, 0.15)", color: "#f87171", label: "FAILED" },
+  running: { bg: "rgba(99, 102, 241, 0.15)", color: "#6366f1", label: "RUNNING" },
+};
+
+function StatusPill({ status }: { status: string }) {
+  const style = STATUS_PILL[status] ?? {
+    bg: "rgba(136, 136, 160, 0.15)",
+    color: "#8888a0",
+    label: status.toUpperCase(),
+  };
+  return (
+    <span
+      className="text-[10px] font-bold px-1.5 py-0.5 rounded"
+      style={{ background: style.bg, color: style.color }}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+export function BackupsClient({ initialReadiness, initialRuns }: Props) {
+  const [readiness, setReadiness] = useState(initialReadiness);
+  const [runs, setRuns] = useState(initialRuns);
+  const [pending, startTransition] = useTransition();
+  const [openLog, setOpenLog] = useState<{ runId: string; data: BackupRunLog } | null>(null);
+  const [loadingLog, setLoadingLog] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    const [next, list] = await Promise.all([
+      getBackupReadinessAction(),
+      listBackupRunsAction({ limit: 50 }),
+    ]);
+    setReadiness(next);
+    setRuns(list);
+  }
+
+  function handleTrigger() {
+    setError(null);
+    startTransition(async () => {
+      const result = await triggerBackupNowAction();
+      if (!result.ok) {
+        setError(result.error ?? "Backup request failed.");
+        return;
+      }
+      // Inngest runs asynchronously; give it a moment to mark the row, then refresh.
+      // The cron concurrency limit serializes overlapping triggers.
+      setTimeout(() => {
+        refresh().catch((e: unknown) =>
+          setError(e instanceof Error ? e.message : String(e)),
+        );
+      }, 1500);
+    });
+  }
+
+  async function handleOpenLog(runId: string) {
+    setLoadingLog(true);
+    setError(null);
+    try {
+      const data = await readBackupRunLogAction(runId);
+      setOpenLog({ runId, data });
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoadingLog(false);
+    }
+  }
+
+  const j = readiness.scheduledJob;
+  const lastRun = readiness.lastRun;
+  const overdue = readiness.failuresInLastThreeRuns >= 2;
+
+  return (
+    <div className="max-w-4xl space-y-8">
+      {/* ─── Readiness card ─────────────────────────────────────────────── */}
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+            Readiness
+          </h2>
+          <button
+            onClick={handleTrigger}
+            disabled={pending}
+            className="px-4 py-2 text-sm font-medium rounded transition-colors"
+            style={{
+              background: pending ? "var(--dpf-border)" : "var(--dpf-accent)",
+              color: pending ? "var(--dpf-muted)" : "#fff",
+              cursor: pending ? "not-allowed" : "pointer",
+            }}
+          >
+            {pending ? "Triggering…" : "Run backup now"}
+          </button>
+        </div>
+
+        <div
+          className="rounded p-4 grid gap-3 text-sm"
+          style={{
+            background: "var(--dpf-surface)",
+            border: "1px solid var(--dpf-border)",
+          }}
+        >
+          <ReadinessRow
+            label="Schedule"
+            value={j ? `${j.schedule} (cron 03:00 UTC)` : "—"}
+          />
+          <ReadinessRow
+            label="Last run"
+            value={
+              lastRun
+                ? `${formatTimestamp(lastRun.startedAt)} · ${formatDurationMs(
+                    lastRun.durationMs,
+                  )} · ${formatBytes(lastRun.sizeBytes)}`
+                : "never"
+            }
+            statusBadge={lastRun ? <StatusPill status={lastRun.status} /> : null}
+          />
+          <ReadinessRow
+            label="Last successful run"
+            value={
+              readiness.lastSuccess
+                ? `${formatTimestamp(readiness.lastSuccess.finishedAt)} · ${formatBytes(
+                    readiness.lastSuccess.sizeBytes,
+                  )}`
+                : "never"
+            }
+          />
+          <ReadinessRow
+            label="Next run"
+            value={j?.nextRunAt ? formatTimestamp(j.nextRunAt) : "—"}
+          />
+          <ReadinessRow
+            label="Retention"
+            value={`${readiness.retention.daily} daily · ${readiness.retention.weekly} weekly · ${readiness.retention.monthly} monthly`}
+          />
+          <ReadinessRow
+            label="Retained on disk"
+            value={`${readiness.retainedCount} backup${readiness.retainedCount === 1 ? "" : "s"} · ${formatBytes(
+              readiness.retainedBytes,
+            )}`}
+          />
+          <ReadinessRow label="Storage path" value={readiness.storagePath} />
+        </div>
+
+        {overdue && (
+          <div
+            className="mt-3 p-3 rounded text-sm"
+            style={{
+              background: "rgba(248, 113, 113, 0.15)",
+              color: "#f87171",
+              border: "1px solid rgba(248, 113, 113, 0.3)",
+            }}
+          >
+            Multiple recent backups have failed. Investigate the latest run log
+            for details.
+          </div>
+        )}
+
+        {error && (
+          <div
+            className="mt-3 p-3 rounded text-sm"
+            style={{
+              background: "rgba(248, 113, 113, 0.15)",
+              color: "#f87171",
+              border: "1px solid rgba(248, 113, 113, 0.3)",
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </section>
+
+      {/* ─── History ────────────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">
+          History
+        </h2>
+        {runs.length === 0 ? (
+          <p className="text-xs text-[var(--dpf-muted)]">
+            No backups yet — the first scheduled run will appear here. Click
+            “Run backup now” above to create one immediately.
+          </p>
+        ) : (
+          <div
+            className="rounded overflow-hidden"
+            style={{
+              border: "1px solid var(--dpf-border)",
+            }}
+          >
+            <table className="w-full text-xs">
+              <thead style={{ background: "var(--dpf-bg)" }}>
+                <tr>
+                  <Th>Started</Th>
+                  <Th>Status</Th>
+                  <Th>Trigger</Th>
+                  <Th>Size</Th>
+                  <Th>Duration</Th>
+                  <Th className="text-right">Actions</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => (
+                  <tr
+                    key={r.id}
+                    className={r.prunedAt ? "opacity-60" : ""}
+                    style={{ borderTop: "1px solid var(--dpf-border)" }}
+                  >
+                    <Td>{formatTimestamp(r.startedAt)}</Td>
+                    <Td>
+                      <StatusPill status={r.status} />
+                    </Td>
+                    <Td className="text-[var(--dpf-muted)]">{r.trigger}</Td>
+                    <Td>{formatBytes(r.sizeBytes)}</Td>
+                    <Td>{formatDurationMs(r.durationMs)}</Td>
+                    <Td className="text-right">
+                      <button
+                        onClick={() => handleOpenLog(r.id)}
+                        disabled={loadingLog}
+                        className="text-[var(--dpf-accent)] hover:underline disabled:opacity-50"
+                      >
+                        View log
+                      </button>
+                      {r.prunedAt && (
+                        <span
+                          className="ml-2 text-[10px]"
+                          style={{ color: "var(--dpf-muted)" }}
+                        >
+                          pruned
+                        </span>
+                      )}
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* ─── Log drawer ─────────────────────────────────────────────────── */}
+      {openLog && (
+        <div
+          className="fixed inset-0 z-40 flex justify-end"
+          onClick={() => setOpenLog(null)}
+          style={{ background: "rgba(0, 0, 0, 0.5)" }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="h-full w-[480px] overflow-y-auto p-6"
+            style={{
+              background: "var(--dpf-surface)",
+              borderLeft: "1px solid var(--dpf-border)",
+            }}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold text-[var(--dpf-text)]">
+                Backup run {openLog.runId.slice(0, 8)}
+              </h3>
+              <button
+                onClick={() => setOpenLog(null)}
+                className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+              >
+                Close
+              </button>
+            </div>
+
+            {openLog.data.notFound ? (
+              <p className="text-xs text-[var(--dpf-muted)]">Run not found.</p>
+            ) : (
+              <>
+                <h4 className="text-xs uppercase text-[var(--dpf-muted)] mb-1">
+                  Manifest
+                </h4>
+                <pre
+                  className="text-[11px] p-3 rounded overflow-x-auto whitespace-pre-wrap"
+                  style={{
+                    background: "var(--dpf-bg)",
+                    border: "1px solid var(--dpf-border)",
+                    color: "var(--dpf-text)",
+                  }}
+                >
+                  {openLog.data.manifest
+                    ? JSON.stringify(openLog.data.manifest, null, 2)
+                    : "(manifest unavailable — backup may have failed before completion)"}
+                </pre>
+
+                <h4 className="text-xs uppercase text-[var(--dpf-muted)] mt-4 mb-1">
+                  Log (tail)
+                </h4>
+                <pre
+                  className="text-[11px] p-3 rounded overflow-x-auto whitespace-pre-wrap"
+                  style={{
+                    background: "var(--dpf-bg)",
+                    border: "1px solid var(--dpf-border)",
+                    color: "var(--dpf-text)",
+                  }}
+                >
+                  {openLog.data.logTail ?? "(log empty)"}
+                </pre>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReadinessRow({
+  label,
+  value,
+  statusBadge,
+}: {
+  label: string;
+  value: string;
+  statusBadge?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span
+        className="text-xs uppercase font-medium w-40"
+        style={{ color: "var(--dpf-muted)" }}
+      >
+        {label}
+      </span>
+      <span className="flex-1 text-[var(--dpf-text)]">{value}</span>
+      {statusBadge}
+    </div>
+  );
+}
+
+function Th({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <th
+      className={`text-left px-3 py-2 text-[10px] uppercase font-medium ${className ?? ""}`}
+      style={{ color: "var(--dpf-muted)" }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <td
+      className={`px-3 py-2 ${className ?? ""}`}
+      style={{ color: "var(--dpf-text)" }}
+    >
+      {children}
+    </td>
+  );
+}

--- a/apps/web/app/(shell)/admin/backups/page.tsx
+++ b/apps/web/app/(shell)/admin/backups/page.tsx
@@ -1,0 +1,42 @@
+import { AdminTabNav } from "@/components/admin/AdminTabNav";
+
+import {
+  getBackupReadinessAction,
+  listBackupRunsAction,
+} from "@/lib/actions/backups";
+
+import { BackupsClient } from "./BackupsClient";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Admin → Advanced → Backups.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.8
+ *
+ * Renders the readiness card + history table + manual-trigger button. The
+ * operator never sees a CLI here — clicks only — per the
+ * never-ask-user-to-run-commands kernel commandment.
+ */
+export default async function BackupsAdminPage() {
+  const [readiness, runs] = await Promise.all([
+    getBackupReadinessAction(),
+    listBackupRunsAction({ limit: 50 }),
+  ]);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Backups</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          Platform-managed Postgres backups. Daily schedule, automatic
+          retention, manual trigger.
+        </p>
+      </div>
+
+      <AdminTabNav />
+
+      <BackupsClient initialReadiness={readiness} initialRuns={runs} />
+    </div>
+  );
+}

--- a/apps/web/components/admin/admin-nav.ts
+++ b/apps/web/components/admin/admin-nav.ts
@@ -61,11 +61,13 @@ export const ADMIN_FAMILIES: AdminFamily[] = [
       "/admin/skills",
       "/admin/issue-reports",
       "/admin/diagnostics",
+      "/admin/backups",
     ],
     subItems: [
       { label: "Platform Development", href: "/admin/platform-development" },
       { label: "Issue Reports", href: "/admin/issue-reports" },
       { label: "Diagnostics", href: "/admin/diagnostics" },
+      { label: "Backups", href: "/admin/backups" },
     ],
   },
 ];

--- a/apps/web/lib/actions/backups.ts
+++ b/apps/web/lib/actions/backups.ts
@@ -1,0 +1,167 @@
+"use server";
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { inngest } from "@/lib/queue/inngest-client";
+
+import {
+  POSTGRES_BACKUP_EVENT,
+  POSTGRES_BACKUP_JOB_ID,
+} from "@/lib/operate/backups/constants";
+import { getPostgresBackupReadiness } from "@/lib/operate/backups/readiness";
+import type { ReadinessSummary } from "@/lib/operate/backups/types";
+
+const BACKUPS_ROOT = "/backups";
+const MAX_LOG_BYTES = 64 * 1024;
+
+async function requireBackupAdmin(): Promise<void> {
+  const session = await auth();
+  const user = session?.user;
+  // Permission reuse: managing platform-level backups requires the same
+  // authority as managing provider connections — superuser or
+  // platform-admin role.
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    throw new Error("Unauthorized");
+  }
+}
+
+export async function getBackupReadinessAction(): Promise<ReadinessSummary> {
+  await requireBackupAdmin();
+  return getPostgresBackupReadiness();
+}
+
+export interface BackupRunListItem {
+  id: string;
+  status: string;
+  trigger: string;
+  startedAt: string;
+  finishedAt: string | null;
+  sizeBytes: number | null;
+  durationMs: number | null;
+  sha256: string | null;
+  prunedAt: string | null;
+  errorMessage: string | null;
+}
+
+export async function listBackupRunsAction(args?: {
+  limit?: number;
+}): Promise<BackupRunListItem[]> {
+  await requireBackupAdmin();
+  const rows = await prisma.backupRun.findMany({
+    where: { target: "postgres" },
+    orderBy: { startedAt: "desc" },
+    take: Math.min(Math.max(args?.limit ?? 50, 1), 200),
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    status: r.status,
+    trigger: r.trigger,
+    startedAt: r.startedAt.toISOString(),
+    finishedAt: r.finishedAt?.toISOString() ?? null,
+    sizeBytes: r.sizeBytes ? Number(r.sizeBytes) : null,
+    durationMs: r.durationMs ?? null,
+    sha256: r.sha256,
+    prunedAt: r.prunedAt?.toISOString() ?? null,
+    errorMessage: r.errorMessage,
+  }));
+}
+
+export async function triggerBackupNowAction(): Promise<{
+  ok: boolean;
+  eventIds?: string[];
+  error?: string;
+}> {
+  await requireBackupAdmin();
+  try {
+    const result = await inngest.send({
+      name: POSTGRES_BACKUP_EVENT,
+      data: { trigger: "manual" },
+    });
+    return { ok: true, eventIds: result.ids };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+export interface BackupRunLog {
+  manifest: unknown | null;
+  logTail: string | null;
+  notFound: boolean;
+}
+
+export async function readBackupRunLogAction(runId: string): Promise<BackupRunLog> {
+  await requireBackupAdmin();
+  const row = await prisma.backupRun.findUnique({
+    where: { id: runId },
+    select: { storagePath: true, prunedAt: true },
+  });
+  if (!row) {
+    return { manifest: null, logTail: null, notFound: true };
+  }
+  if (row.prunedAt) {
+    // Files are gone, but we may still have the row.
+    return { manifest: null, logTail: null, notFound: false };
+  }
+
+  const absoluteDir = path.posix.join(BACKUPS_ROOT, row.storagePath);
+  const manifestPath = path.posix.join(absoluteDir, "manifest.json");
+  const logPath = path.posix.join(absoluteDir, "log.txt");
+
+  const [manifest, logTail] = await Promise.all([
+    fs
+      .readFile(manifestPath, "utf-8")
+      .then((raw) => {
+        try {
+          return JSON.parse(raw);
+        } catch {
+          return null;
+        }
+      })
+      .catch(() => null),
+    fs
+      .readFile(logPath, "utf-8")
+      .then((raw) =>
+        raw.length > MAX_LOG_BYTES ? raw.slice(-MAX_LOG_BYTES) : raw,
+      )
+      .catch(() => null),
+  ]);
+
+  return { manifest, logTail, notFound: false };
+}
+
+export async function refreshBackupScheduleHeartbeatAction(): Promise<void> {
+  await requireBackupAdmin();
+  await prisma.scheduledJob.upsert({
+    where: { jobId: POSTGRES_BACKUP_JOB_ID },
+    create: {
+      jobId: POSTGRES_BACKUP_JOB_ID,
+      name: "Postgres daily backup (platform-managed)",
+      schedule: "daily",
+      nextRunAt: nextDailyRunAt(new Date()),
+    },
+    update: {},
+  });
+}
+
+function nextDailyRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(3);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}

--- a/apps/web/lib/operate/backups/constants.ts
+++ b/apps/web/lib/operate/backups/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Backup mechanism identifier constants. Mirrored in
+ * packages/db/src/seed-platform-backup.ts (which seeds the ScheduledJob row);
+ * both files must agree on the jobId or the heartbeat will be orphaned.
+ */
+export const POSTGRES_BACKUP_JOB_ID = "postgres-daily-backup";
+export const POSTGRES_BACKUP_JOB_NAME =
+  "Postgres daily backup (platform-managed)";
+export const POSTGRES_BACKUP_SCHEDULE = "daily";
+
+/** Inngest event the manual-trigger button emits. */
+export const POSTGRES_BACKUP_EVENT = "ops/postgres-backup.requested";
+
+/** Cron expression — 03:00 UTC daily. */
+export const POSTGRES_BACKUP_CRON = "0 3 * * *";

--- a/apps/web/lib/operate/backups/postgres-backup-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-backup-runner.ts
@@ -1,0 +1,383 @@
+/**
+ * TypeScript orchestrator for the Postgres daily backup.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §6 Slice 1
+ * Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+ *
+ * Responsibilities:
+ *   1. Allocate a per-run target directory under /backups/postgres/<ISO-ts>.
+ *   2. Spawn scripts/backup-postgres.sh, which exec's pg_dump into the
+ *      postgres container and writes dpf.dump + sha256 + manifest + log.
+ *   3. Read back the manifest, insert a BackupRun row (status ok/failed).
+ *   4. Update the ScheduledJob heartbeat (jobId: "postgres-daily-backup").
+ *   5. Apply GFS retention — delete file directories for runs the policy
+ *      no longer keeps and mark them prunedAt.
+ *   6. Emit [backup-trace] logs and Prometheus metrics.
+ *
+ * Per the never-ask-user-to-run-commands kernel principle, the operator
+ * never sees any of the shell commands here. Failure is reported through
+ * BackupRun.errorMessage and rendered as a human-readable readiness banner.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  postgresBackupDurationSeconds,
+  postgresBackupLastSuccessSeconds,
+  postgresBackupRunsTotal,
+  postgresBackupStorageBytes,
+} from "@/lib/operate/metrics";
+
+import { POSTGRES_BACKUP_JOB_ID, POSTGRES_BACKUP_SCHEDULE } from "./constants";
+import { partitionForRetention } from "./retention";
+import {
+  DEFAULT_BACKUP_RETENTION,
+  type BackupManifest,
+  type BackupRetentionPolicy,
+  type BackupTrigger,
+} from "./types";
+
+const execFileAsync = promisify(execFile);
+
+const BACKUPS_ROOT = "/backups";
+const POSTGRES_SUBDIR = "postgres";
+const SCRIPT_PATH = "/workspace/scripts/backup-postgres.sh";
+const RUNNER_TIMEOUT_MS = 30 * 60 * 1000; // 30-minute hard cap
+
+export interface RunBackupArgs {
+  trigger: BackupTrigger;
+  /**
+   * Compose project name. Used to derive the postgres container name
+   * (`<project>-postgres-1`) so worktree-isolated stacks back themselves up
+   * independently. Defaults to "dpf".
+   */
+  composeProject?: string;
+  /** Override the GFS retention policy for tests / future config slider. */
+  retention?: BackupRetentionPolicy;
+  /** Override the backup root for tests. */
+  backupsRoot?: string;
+  /** Override script path for tests. */
+  scriptPath?: string;
+  /** Inject the prisma client (for testing without a live DB). */
+  prismaClient?: PrismaLike;
+  /** Inject a clock for deterministic testing. */
+  now?: () => Date;
+}
+
+type PrismaLike = typeof import("@dpf/db").prisma;
+
+interface ScriptOutcome {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function backupTraceLog(...parts: unknown[]) {
+  // eslint-disable-next-line no-console
+  console.log(`[backup-trace]`, ...parts);
+}
+
+function isoTsForDirectory(d: Date): string {
+  // 2026-05-17T03-00-00Z — colons replaced with hyphens for cross-fs safety.
+  return d.toISOString().replace(/:/g, "-").replace(/\.\d+/, "");
+}
+
+async function runScript(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<ScriptOutcome> {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env,
+      timeout: RUNNER_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      signal?: string;
+      message?: string;
+    };
+    const exitCode =
+      typeof e.code === "number" ? e.code : e.code === undefined ? -1 : -1;
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message ?? String(err),
+      exitCode,
+    };
+  }
+}
+
+async function readManifest(targetDir: string): Promise<BackupManifest | null> {
+  try {
+    const raw = await fs.readFile(path.join(targetDir, "manifest.json"), "utf-8");
+    return JSON.parse(raw) as BackupManifest;
+  } catch {
+    return null;
+  }
+}
+
+async function pruneTargetDir(targetDir: string): Promise<void> {
+  try {
+    await fs.rm(targetDir, { recursive: true, force: true });
+  } catch (err) {
+    backupTraceLog("retention: could not delete", targetDir, err);
+  }
+}
+
+async function computeRetainedStorageBytes(
+  prisma: PrismaLike,
+): Promise<number> {
+  const rows = await prisma.backupRun.findMany({
+    where: { status: "ok", prunedAt: null, target: "postgres" },
+    select: { sizeBytes: true },
+  });
+  return rows.reduce(
+    (sum, r) => sum + Number(r.sizeBytes ?? BigInt(0)),
+    0,
+  );
+}
+
+/**
+ * Compute the next 03:00 UTC strictly after `from`. Mirrors the seed helper
+ * so heartbeat math is consistent at every layer.
+ */
+function nextDailyRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(3);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}
+
+/**
+ * Main entrypoint. Idempotent in the sense that each call produces a new
+ * BackupRun row regardless of outcome; concurrent invocations are kept to one
+ * at a time by the Inngest function's `concurrency: { limit: 1 }`.
+ */
+export async function runPostgresBackup(
+  args: RunBackupArgs,
+): Promise<{ runId: string; status: "ok" | "failed" }> {
+  const now = args.now ?? (() => new Date());
+  const startedAt = now();
+  const trigger = args.trigger;
+  const retention = args.retention ?? DEFAULT_BACKUP_RETENTION;
+  const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
+  const scriptPath = args.scriptPath ?? SCRIPT_PATH;
+  const composeProject = args.composeProject ?? process.env.COMPOSE_PROJECT_NAME ?? "dpf";
+  const containerName =
+    process.env.DPF_PRODUCTION_DB_CONTAINER ?? `${composeProject}-postgres-1`;
+
+  // Use the in-process Prisma client unless the caller injected a stub.
+  const prisma =
+    args.prismaClient ?? (await import("@dpf/db")).prisma;
+
+  const tsKey = isoTsForDirectory(startedAt);
+  const relativePath = `${POSTGRES_SUBDIR}/${tsKey}`;
+  const absoluteTargetDir = path.posix.join(backupsRoot, relativePath);
+
+  backupTraceLog(`run start trigger=${trigger} target=${absoluteTargetDir}`);
+
+  // Create the BackupRun row up front in `running` state so the readiness
+  // card surfaces an in-progress dump immediately. The runner has a hard
+  // timeout so this can't sit `running` forever.
+  const created = await prisma.backupRun.create({
+    data: {
+      target: "postgres",
+      status: "running",
+      trigger,
+      schedule: trigger === "scheduled" ? POSTGRES_BACKUP_SCHEDULE : null,
+      storagePath: relativePath,
+      dpfVersion: process.env.DPF_VERSION ?? null,
+    },
+    select: { id: true },
+  });
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: POSTGRES_BACKUP_JOB_ID },
+      data: {
+        lastRunAt: startedAt,
+        lastStatus: "running",
+        lastError: null,
+      },
+    })
+    .catch(() => {
+      // Heartbeat row not present (fresh install before seed ran). Caller's
+      // seed will create it; we don't fail the run on a missing heartbeat row.
+    });
+
+  // Ensure the parent /backups/postgres directory exists. The target itself
+  // is created by the shell script.
+  await fs.mkdir(path.posix.join(backupsRoot, POSTGRES_SUBDIR), {
+    recursive: true,
+  });
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    TARGET_DIR: absoluteTargetDir,
+    DPF_PRODUCTION_DB_CONTAINER: containerName,
+    POSTGRES_USER: process.env.POSTGRES_USER ?? "dpf",
+    POSTGRES_DB: process.env.POSTGRES_DB ?? "dpf",
+  };
+
+  const outcome = await runScript(scriptPath, env);
+  const manifest = outcome.ok ? await readManifest(absoluteTargetDir) : null;
+  const finishedAt = now();
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+  if (outcome.ok && manifest) {
+    await prisma.backupRun.update({
+      where: { id: created.id },
+      data: {
+        status: "ok",
+        finishedAt,
+        sizeBytes: BigInt(manifest.sizeBytes),
+        durationMs,
+        sha256: manifest.sha256,
+        pgVersion: manifest.pgVersion,
+      },
+    });
+
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: POSTGRES_BACKUP_JOB_ID },
+        data: {
+          lastRunAt: startedAt,
+          lastStatus: "ok",
+          lastError: null,
+          nextRunAt: nextDailyRunAt(finishedAt),
+        },
+      })
+      .catch(() => {});
+
+    postgresBackupRunsTotal.inc({ status: "ok", trigger });
+    postgresBackupDurationSeconds.observe({ trigger }, durationMs / 1000);
+    postgresBackupLastSuccessSeconds.set(Math.floor(finishedAt.getTime() / 1000));
+
+    await applyRetention(prisma, retention, backupsRoot);
+
+    const retainedBytes = await computeRetainedStorageBytes(prisma);
+    postgresBackupStorageBytes.set(retainedBytes);
+
+    backupTraceLog(
+      `run ok id=${created.id} size=${manifest.sizeBytes} duration_ms=${durationMs}`,
+    );
+    return { runId: created.id, status: "ok" };
+  }
+
+  // Failure path. Capture as much diagnostic detail as we can without
+  // surfacing CLI bits to the operator.
+  const errorSummary = summarizeFailure(outcome);
+  await prisma.backupRun.update({
+    where: { id: created.id },
+    data: {
+      status: "failed",
+      finishedAt,
+      durationMs,
+      errorMessage: errorSummary,
+    },
+  });
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: POSTGRES_BACKUP_JOB_ID },
+      data: {
+        lastRunAt: startedAt,
+        lastStatus: "failed",
+        lastError: errorSummary,
+        nextRunAt: nextDailyRunAt(finishedAt),
+      },
+    })
+    .catch(() => {});
+
+  postgresBackupRunsTotal.inc({ status: "failed", trigger });
+  postgresBackupDurationSeconds.observe({ trigger }, durationMs / 1000);
+
+  backupTraceLog(`run failed id=${created.id} reason=${errorSummary}`);
+  return { runId: created.id, status: "failed" };
+}
+
+function summarizeFailure(outcome: ScriptOutcome): string {
+  // Prefer the structured [backup-trace] failure line from the shell script
+  // because it's human-curated; fall back to the last stderr line.
+  const traceLine = outcome.stderr
+    .split("\n")
+    .reverse()
+    .find((line) => line.includes("[backup-trace] failed:"));
+  if (traceLine) {
+    return traceLine.replace(/^.*\[backup-trace\]\s*failed:\s*/, "").trim();
+  }
+  const lastStderr = outcome.stderr.trim().split("\n").pop()?.trim() ?? "";
+  if (lastStderr) return lastStderr.slice(0, 500);
+  if (outcome.exitCode !== 0) return `runner exited ${outcome.exitCode}`;
+  return "backup failed (no diagnostic captured)";
+}
+
+async function applyRetention(
+  prisma: PrismaLike,
+  policy: BackupRetentionPolicy,
+  backupsRoot: string,
+): Promise<void> {
+  const runs = await prisma.backupRun.findMany({
+    where: { target: "postgres" },
+    orderBy: { startedAt: "desc" },
+  });
+
+  const partition = partitionForRetention(
+    runs.map((r) => ({
+      id: r.id,
+      status: r.status,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      prunedAt: r.prunedAt,
+    })),
+    policy,
+  );
+
+  // Only the runs that were eligible (ok + not-yet-pruned) but didn't make
+  // the keep set need filesystem deletion. Failed/already-pruned go through
+  // a metadata-only sweep (just to flip prunedAt for failed runs whose files
+  // we never wrote, so the UI can hide them).
+  const eligibleToPrune = partition.prune.filter(
+    (r) => r.status === "ok" && r.prunedAt === null,
+  );
+  const failedSweep = partition.prune.filter(
+    (r) => r.status === "failed" && r.prunedAt === null,
+  );
+
+  for (const run of eligibleToPrune) {
+    const dbRow = runs.find((r) => r.id === run.id);
+    if (!dbRow) continue;
+    const absolute = path.posix.join(backupsRoot, dbRow.storagePath);
+    await pruneTargetDir(absolute);
+  }
+
+  if (eligibleToPrune.length > 0) {
+    await prisma.backupRun.updateMany({
+      where: { id: { in: eligibleToPrune.map((r) => r.id) } },
+      data: { prunedAt: new Date() },
+    });
+  }
+  if (failedSweep.length > 0) {
+    await prisma.backupRun.updateMany({
+      where: { id: { in: failedSweep.map((r) => r.id) } },
+      data: { prunedAt: new Date() },
+    });
+  }
+
+  backupTraceLog(
+    `retention applied kept=${partition.keep.length} pruned=${eligibleToPrune.length} failed_swept=${failedSweep.length}`,
+  );
+}

--- a/apps/web/lib/operate/backups/readiness.ts
+++ b/apps/web/lib/operate/backups/readiness.ts
@@ -1,0 +1,88 @@
+/**
+ * Reads the current state of the Postgres backup mechanism for the admin
+ * readiness card.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.8
+ */
+
+import { prisma } from "@dpf/db";
+
+import { POSTGRES_BACKUP_JOB_ID } from "./constants";
+import { DEFAULT_BACKUP_RETENTION, type ReadinessSummary } from "./types";
+
+const BACKUPS_ROOT = "/backups";
+
+export async function getPostgresBackupReadiness(): Promise<ReadinessSummary> {
+  const [job, lastRun, lastSuccess, retainedRuns, recentFailures] =
+    await Promise.all([
+      prisma.scheduledJob.findUnique({
+        where: { jobId: POSTGRES_BACKUP_JOB_ID },
+      }),
+      prisma.backupRun.findFirst({
+        where: { target: "postgres" },
+        orderBy: { startedAt: "desc" },
+      }),
+      prisma.backupRun.findFirst({
+        where: { target: "postgres", status: "ok", prunedAt: null },
+        orderBy: { finishedAt: "desc" },
+      }),
+      prisma.backupRun.findMany({
+        where: { target: "postgres", status: "ok", prunedAt: null },
+        select: { sizeBytes: true },
+      }),
+      prisma.backupRun.findMany({
+        where: { target: "postgres" },
+        orderBy: { startedAt: "desc" },
+        take: 3,
+        select: { status: true },
+      }),
+    ]);
+
+  const retainedBytes = retainedRuns.reduce(
+    (sum, r) => sum + Number(r.sizeBytes ?? BigInt(0)),
+    0,
+  );
+
+  return {
+    scheduledJob: job
+      ? {
+          jobId: job.jobId,
+          schedule: job.schedule,
+          nextRunAt: job.nextRunAt?.toISOString() ?? null,
+          lastRunAt: job.lastRunAt?.toISOString() ?? null,
+          lastStatus: job.lastStatus,
+          lastError: job.lastError,
+        }
+      : null,
+    lastRun: lastRun
+      ? {
+          id: lastRun.id,
+          status: lastRun.status as ReadinessSummary["lastRun"] extends infer X
+            ? X extends { status: infer S }
+              ? S
+              : never
+            : never,
+          startedAt: lastRun.startedAt.toISOString(),
+          finishedAt: lastRun.finishedAt?.toISOString() ?? null,
+          sizeBytes: lastRun.sizeBytes ? Number(lastRun.sizeBytes) : null,
+          durationMs: lastRun.durationMs,
+          trigger: lastRun.trigger as "scheduled" | "manual",
+        }
+      : null,
+    lastSuccess: lastSuccess
+      ? {
+          id: lastSuccess.id,
+          finishedAt: lastSuccess.finishedAt?.toISOString() ?? null,
+          sizeBytes: lastSuccess.sizeBytes
+            ? Number(lastSuccess.sizeBytes)
+            : null,
+        }
+      : null,
+    retention: DEFAULT_BACKUP_RETENTION,
+    retainedCount: retainedRuns.length,
+    retainedBytes,
+    storagePath: `${BACKUPS_ROOT}/postgres/`,
+    failuresInLastThreeRuns: recentFailures.filter((r) => r.status === "failed")
+      .length,
+  };
+}

--- a/apps/web/lib/operate/backups/retention.test.ts
+++ b/apps/web/lib/operate/backups/retention.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_BACKUP_RETENTION,
+  type BackupRetentionPolicy,
+} from "./types";
+import { isoWeekKey, monthKey, partitionForRetention } from "./retention";
+
+function makeRun(args: {
+  id: string;
+  finishedAt: string | null;
+  status?: string;
+  pruned?: boolean;
+}) {
+  return {
+    id: args.id,
+    status: args.status ?? "ok",
+    startedAt: new Date(args.finishedAt ?? "2026-01-01T00:00:00Z"),
+    finishedAt: args.finishedAt ? new Date(args.finishedAt) : null,
+    prunedAt: args.pruned ? new Date("2026-01-01T00:00:00Z") : null,
+  };
+}
+
+describe("retention/isoWeekKey", () => {
+  it("groups dates within the same ISO week", () => {
+    expect(isoWeekKey(new Date("2026-05-11T00:00:00Z"))).toBe("2026-W20"); // Mon
+    expect(isoWeekKey(new Date("2026-05-17T23:59:59Z"))).toBe("2026-W20"); // Sun
+    expect(isoWeekKey(new Date("2026-05-18T00:00:00Z"))).toBe("2026-W21"); // Mon next
+  });
+
+  it("handles year boundary correctly", () => {
+    // 2025-12-29 = Mon, ISO week 53 (or W01 of 2026 depending on year length).
+    // The algorithm shifts to Thursday, which is 2026-01-01 → 2026-W01.
+    expect(isoWeekKey(new Date("2025-12-29T00:00:00Z"))).toBe("2026-W01");
+  });
+});
+
+describe("retention/monthKey", () => {
+  it("uses UTC calendar month", () => {
+    expect(monthKey(new Date("2026-05-01T00:00:00Z"))).toBe("2026-05");
+    expect(monthKey(new Date("2026-05-31T23:59:59Z"))).toBe("2026-05");
+    expect(monthKey(new Date("2026-06-01T00:00:00Z"))).toBe("2026-06");
+  });
+});
+
+describe("retention/partitionForRetention", () => {
+  it("keeps everything when fewer runs than daily quota", () => {
+    const runs = [
+      makeRun({ id: "r1", finishedAt: "2026-05-17T03:00:00Z" }),
+      makeRun({ id: "r2", finishedAt: "2026-05-16T03:00:00Z" }),
+    ];
+    const partition = partitionForRetention(runs, DEFAULT_BACKUP_RETENTION);
+    expect(partition.keep.map((r) => r.id).sort()).toEqual(["r1", "r2"]);
+    expect(partition.prune).toEqual([]);
+  });
+
+  it("keeps the N most recent daily runs and prunes older ones in the same week", () => {
+    const policy: BackupRetentionPolicy = { daily: 2, weekly: 0, monthly: 0 };
+    const runs = [
+      makeRun({ id: "d1", finishedAt: "2026-05-17T03:00:00Z" }), // Sun
+      makeRun({ id: "d2", finishedAt: "2026-05-16T03:00:00Z" }), // Sat
+      makeRun({ id: "d3", finishedAt: "2026-05-15T03:00:00Z" }), // Fri
+      makeRun({ id: "d4", finishedAt: "2026-05-14T03:00:00Z" }), // Thu
+    ];
+    const partition = partitionForRetention(runs, policy);
+    expect(partition.keep.map((r) => r.id)).toEqual(["d1", "d2"]);
+    expect(partition.prune.map((r) => r.id).sort()).toEqual(["d3", "d4"]);
+  });
+
+  it("retains weekly buckets across multiple ISO weeks", () => {
+    const policy: BackupRetentionPolicy = { daily: 0, weekly: 3, monthly: 0 };
+    const runs = [
+      makeRun({ id: "w20-late", finishedAt: "2026-05-17T03:00:00Z" }), // W20 Sun
+      makeRun({ id: "w20-early", finishedAt: "2026-05-11T03:00:00Z" }), // W20 Mon
+      makeRun({ id: "w19", finishedAt: "2026-05-04T03:00:00Z" }), // W19 Mon
+      makeRun({ id: "w18", finishedAt: "2026-04-27T03:00:00Z" }), // W18 Mon
+      makeRun({ id: "w17", finishedAt: "2026-04-20T03:00:00Z" }), // W17 Mon — over the cap
+    ];
+    const partition = partitionForRetention(runs, policy);
+    // For each week the MOST RECENT successful run is the bucket representative.
+    expect(partition.keep.map((r) => r.id).sort()).toEqual([
+      "w18",
+      "w19",
+      "w20-late",
+    ]);
+    expect(partition.prune.map((r) => r.id).sort()).toEqual([
+      "w17",
+      "w20-early",
+    ]);
+  });
+
+  it("retains monthly buckets — most-recent-wins per calendar month", () => {
+    const policy: BackupRetentionPolicy = { daily: 0, weekly: 0, monthly: 2 };
+    const runs = [
+      makeRun({ id: "may-end", finishedAt: "2026-05-31T03:00:00Z" }),
+      makeRun({ id: "may-start", finishedAt: "2026-05-01T03:00:00Z" }),
+      makeRun({ id: "apr-end", finishedAt: "2026-04-30T03:00:00Z" }),
+      makeRun({ id: "mar-end", finishedAt: "2026-03-31T03:00:00Z" }), // over cap
+    ];
+    const partition = partitionForRetention(runs, policy);
+    expect(partition.keep.map((r) => r.id).sort()).toEqual([
+      "apr-end",
+      "may-end",
+    ]);
+  });
+
+  it("excludes failed runs from keep set entirely", () => {
+    const runs = [
+      makeRun({ id: "r1", finishedAt: "2026-05-17T03:00:00Z", status: "failed" }),
+      makeRun({ id: "r2", finishedAt: "2026-05-16T03:00:00Z" }),
+    ];
+    const partition = partitionForRetention(runs, DEFAULT_BACKUP_RETENTION);
+    expect(partition.keep.map((r) => r.id)).toEqual(["r2"]);
+    expect(partition.prune.map((r) => r.id)).toEqual(["r1"]);
+  });
+
+  it("excludes already-pruned runs from keep set", () => {
+    const runs = [
+      makeRun({ id: "r1", finishedAt: "2026-05-17T03:00:00Z", pruned: true }),
+      makeRun({ id: "r2", finishedAt: "2026-05-16T03:00:00Z" }),
+    ];
+    const partition = partitionForRetention(runs, DEFAULT_BACKUP_RETENTION);
+    expect(partition.keep.map((r) => r.id)).toEqual(["r2"]);
+    expect(partition.prune.map((r) => r.id)).toEqual(["r1"]);
+  });
+
+  it("never prunes the today's-most-recent dump under any sane policy", () => {
+    const runs = Array.from({ length: 30 }, (_, i) => {
+      const d = new Date("2026-05-17T03:00:00Z");
+      d.setUTCDate(d.getUTCDate() - i);
+      return makeRun({ id: `r${i}`, finishedAt: d.toISOString() });
+    });
+    const partition = partitionForRetention(runs, DEFAULT_BACKUP_RETENTION);
+    expect(partition.keep.find((r) => r.id === "r0")).toBeDefined();
+  });
+
+  it("respects the union semantics — a run can satisfy multiple buckets", () => {
+    // A single run for the entire history. It must show up exactly once in keep,
+    // never duplicated.
+    const policy: BackupRetentionPolicy = { daily: 7, weekly: 4, monthly: 12 };
+    const runs = [makeRun({ id: "only", finishedAt: "2026-05-17T03:00:00Z" })];
+    const partition = partitionForRetention(runs, policy);
+    expect(partition.keep.map((r) => r.id)).toEqual(["only"]);
+  });
+
+  it("at 30 daily successful runs, default policy keeps 7 daily + ~5 older bucket reps", () => {
+    // 30 contiguous daily runs span ~5 ISO weeks and ~2 calendar months.
+    // Default policy: 7 daily + 4 weekly + 12 monthly. Weekly buckets that
+    // overlap the daily window are deduped by Set union, so the keep set is
+    // the 7 daily runs plus any older weekly/monthly reps not already counted.
+    const runs = Array.from({ length: 30 }, (_, i) => {
+      const d = new Date("2026-05-17T03:00:00Z");
+      d.setUTCDate(d.getUTCDate() - i);
+      return makeRun({ id: `r${i}`, finishedAt: d.toISOString() });
+    });
+    const partition = partitionForRetention(runs, DEFAULT_BACKUP_RETENTION);
+    // Sanity: keep set ≥ 7 (the daily bucket), ≤ 30, prune is the complement.
+    expect(partition.keep.length).toBeGreaterThanOrEqual(7);
+    expect(partition.keep.length).toBeLessThanOrEqual(30);
+    expect(partition.keep.length + partition.prune.length).toBe(30);
+  });
+});

--- a/apps/web/lib/operate/backups/retention.ts
+++ b/apps/web/lib/operate/backups/retention.ts
@@ -1,0 +1,126 @@
+/**
+ * GFS (Grandfather-Father-Son) retention math for platform-managed backups.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.5
+ *
+ * Pure function — no Prisma, no filesystem. The orchestrator passes in the
+ * candidate runs, this returns the partition. Easy to unit-test in isolation.
+ */
+
+import type { BackupRetentionPolicy } from "./types";
+
+/**
+ * Minimal subset of a BackupRun we need for retention decisions. Keeping this
+ * narrow lets the caller stub it freely in tests and avoids coupling to the
+ * Prisma type.
+ */
+export interface RetainableRun {
+  id: string;
+  status: string;
+  finishedAt: Date | null;
+  startedAt: Date;
+  prunedAt: Date | null;
+}
+
+export interface RetentionPartition<T extends RetainableRun> {
+  keep: T[];
+  prune: T[];
+}
+
+/** ISO-week key (Monday-anchored) of the given date in UTC: "YYYY-Www". */
+function isoWeekKey(d: Date): string {
+  // Algorithm from Postgres ISO 8601: shift to Thursday of the same week,
+  // then compute week-of-year.
+  const tmp = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = (tmp.getUTCDay() + 6) % 7; // Mon=0..Sun=6
+  tmp.setUTCDate(tmp.getUTCDate() - dayNum + 3); // Thursday of this week
+  const firstThursday = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 4));
+  const firstThursdayDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNum + 3);
+  const week =
+    1 +
+    Math.round(
+      (tmp.getTime() - firstThursday.getTime()) / (7 * 24 * 60 * 60 * 1000),
+    );
+  return `${tmp.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+/** Calendar-month key in UTC: "YYYY-MM". */
+function monthKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * Apply GFS retention. Failed runs and already-pruned runs are excluded from
+ * the keep set entirely (a failed dump is not a candidate to retain — its row
+ * stays in the DB for audit but the file is either absent or untrusted).
+ *
+ * Algorithm:
+ *   1. Successful, not-yet-pruned runs are sorted descending by finishedAt.
+ *   2. The N most recent become the daily keep set.
+ *   3. Walking older→newer, take the most recent successful run per ISO week
+ *      until we have `weekly` weekly entries.
+ *   4. Same for calendar months until we have `monthly` monthly entries.
+ *   5. Union of (daily ∪ weekly ∪ monthly) = keep; complement = prune.
+ *
+ * Note: any failed or already-pruned run is left in `prune` so the caller's
+ * disk cleanup is a no-op for them (their files are already gone or never
+ * existed). They stay in the DB for audit.
+ */
+export function partitionForRetention<T extends RetainableRun>(
+  runs: T[],
+  policy: BackupRetentionPolicy,
+): RetentionPartition<T> {
+  const ineligible = runs.filter(
+    (r) => r.status !== "ok" || r.prunedAt !== null || r.finishedAt === null,
+  );
+
+  const eligible = runs
+    .filter(
+      (r) => r.status === "ok" && r.prunedAt === null && r.finishedAt !== null,
+    )
+    .sort((a, b) => b.finishedAt!.getTime() - a.finishedAt!.getTime());
+
+  const keepIds = new Set<string>();
+
+  // Daily bucket: top N by finishedAt.
+  for (let i = 0; i < Math.min(policy.daily, eligible.length); i++) {
+    keepIds.add(eligible[i]!.id);
+  }
+
+  // Weekly bucket: one per ISO week, most-recent-wins.
+  const weeklyPicked = new Map<string, T>();
+  for (const r of eligible) {
+    const key = isoWeekKey(r.finishedAt!);
+    if (!weeklyPicked.has(key)) {
+      weeklyPicked.set(key, r);
+      if (weeklyPicked.size >= policy.weekly) break;
+    }
+  }
+  for (const r of weeklyPicked.values()) keepIds.add(r.id);
+
+  // Monthly bucket: one per calendar month, most-recent-wins.
+  const monthlyPicked = new Map<string, T>();
+  for (const r of eligible) {
+    const key = monthKey(r.finishedAt!);
+    if (!monthlyPicked.has(key)) {
+      monthlyPicked.set(key, r);
+      if (monthlyPicked.size >= policy.monthly) break;
+    }
+  }
+  for (const r of monthlyPicked.values()) keepIds.add(r.id);
+
+  const keep: T[] = [];
+  const prune: T[] = [];
+  for (const r of eligible) {
+    if (keepIds.has(r.id)) keep.push(r);
+    else prune.push(r);
+  }
+  // Ineligible runs (failed / already-pruned) — pruning is a no-op for them
+  // but the caller may want to know they were considered.
+  for (const r of ineligible) prune.push(r);
+
+  return { keep, prune };
+}
+
+export { isoWeekKey, monthKey };

--- a/apps/web/lib/operate/backups/types.ts
+++ b/apps/web/lib/operate/backups/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for the platform-managed backup mechanism.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+ */
+
+export type BackupTrigger = "scheduled" | "manual";
+export type BackupRunStatus = "running" | "ok" | "failed";
+
+/** GFS retention policy. Tunable via Platform Config in a later slice. */
+export interface BackupRetentionPolicy {
+  /** Number of most-recent daily-trigger runs to keep unconditionally. */
+  daily: number;
+  /** Number of weekly bucket entries (one per ISO week, most recent kept). */
+  weekly: number;
+  /** Number of monthly bucket entries (one per calendar month, most recent kept). */
+  monthly: number;
+}
+
+export const DEFAULT_BACKUP_RETENTION: BackupRetentionPolicy = {
+  daily: 7,
+  weekly: 4,
+  monthly: 12,
+};
+
+/**
+ * Sidecar manifest written by scripts/backup-postgres.sh. The TS orchestrator
+ * reads this back to populate the BackupRun row.
+ */
+export interface BackupManifest {
+  schemaVersion: 1;
+  target: "postgres";
+  container: string;
+  postgresUser: string;
+  postgresDb: string;
+  pgVersion: string;
+  dpfVersion: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  sizeBytes: number;
+  sha256: string;
+  dumpFormat: string;
+}
+
+export interface ReadinessSummary {
+  scheduledJob: {
+    jobId: string;
+    schedule: string;
+    nextRunAt: string | null;
+    lastRunAt: string | null;
+    lastStatus: string | null;
+    lastError: string | null;
+  } | null;
+  lastRun: {
+    id: string;
+    status: BackupRunStatus;
+    startedAt: string;
+    finishedAt: string | null;
+    sizeBytes: number | null;
+    durationMs: number | null;
+    trigger: BackupTrigger;
+  } | null;
+  lastSuccess: {
+    id: string;
+    finishedAt: string | null;
+    sizeBytes: number | null;
+  } | null;
+  retention: BackupRetentionPolicy;
+  retainedCount: number;
+  retainedBytes: number;
+  storagePath: string;
+  failuresInLastThreeRuns: number;
+}

--- a/apps/web/lib/operate/metrics.ts
+++ b/apps/web/lib/operate/metrics.ts
@@ -145,3 +145,33 @@ export const utilityInferenceLatency = new Histogram({
   buckets: [0.5, 1, 2, 5, 10],
   registers: [metricsRegistry],
 });
+
+// ─── Postgres Daily Backup (Slice 1) ───────────────────────────────────────
+// Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §8
+
+export const postgresBackupRunsTotal = new Counter({
+  name: "dpf_postgres_backup_runs_total",
+  help: "Postgres backup runs by status and trigger",
+  labelNames: ["status", "trigger"] as const,
+  registers: [metricsRegistry],
+});
+
+export const postgresBackupLastSuccessSeconds = new Gauge({
+  name: "dpf_postgres_backup_last_success_seconds",
+  help: "Epoch seconds at which the last successful Postgres backup finished",
+  registers: [metricsRegistry],
+});
+
+export const postgresBackupStorageBytes = new Gauge({
+  name: "dpf_postgres_backup_storage_bytes",
+  help: "Total bytes used by retained Postgres backup dumps",
+  registers: [metricsRegistry],
+});
+
+export const postgresBackupDurationSeconds = new Histogram({
+  name: "dpf_postgres_backup_duration_seconds",
+  help: "Wall-clock duration of Postgres backup runs",
+  labelNames: ["trigger"] as const,
+  buckets: [1, 2, 5, 10, 30, 60, 300, 900],
+  registers: [metricsRegistry],
+});

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -20,6 +20,10 @@ import { wikiLint } from "./wiki-lint";
 import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verification";
 import { skillMetricsAggregator } from "./skill-metrics-aggregator";
 import { skillCurator } from "./skill-curator";
+import {
+  postgresDailyBackupScheduled,
+  postgresBackupRequested,
+} from "./postgres-daily-backup";
 
 export const allFunctions = [
   prometheusPoll,
@@ -45,4 +49,6 @@ export const allFunctions = [
   gitPromotionSandboxVerification,
   skillMetricsAggregator,
   skillCurator,
+  postgresDailyBackupScheduled,
+  postgresBackupRequested,
 ];

--- a/apps/web/lib/queue/functions/postgres-daily-backup.ts
+++ b/apps/web/lib/queue/functions/postgres-daily-backup.ts
@@ -1,0 +1,52 @@
+/**
+ * Inngest functions for the platform-managed Postgres backup mechanism.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.2
+ * Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+ *
+ * Two surfaces, one runner:
+ *   - postgresDailyBackupScheduled: cron at 03:00 UTC daily, trigger="scheduled".
+ *   - postgresBackupRequested: event-driven from the admin "Run backup now"
+ *                              button, trigger="manual".
+ *
+ * Both call the same `runPostgresBackup` to keep behavior identical.
+ * `concurrency: { limit: 1, scope: "fn" }` per function ensures the cron
+ * fire and a near-simultaneous manual click serialize rather than collide.
+ */
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { POSTGRES_BACKUP_CRON, POSTGRES_BACKUP_EVENT } from "@/lib/operate/backups/constants";
+
+export const postgresDailyBackupScheduled = inngest.createFunction(
+  {
+    id: "ops/postgres-daily-backup-scheduled",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(POSTGRES_BACKUP_CRON)],
+  },
+  async ({ step }) => {
+    return step.run("run-postgres-backup-scheduled", async () => {
+      const { runPostgresBackup } = await import(
+        "@/lib/operate/backups/postgres-backup-runner"
+      );
+      return runPostgresBackup({ trigger: "scheduled" });
+    });
+  },
+);
+
+export const postgresBackupRequested = inngest.createFunction(
+  {
+    id: "ops/postgres-backup-requested",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [{ event: POSTGRES_BACKUP_EVENT }],
+  },
+  async ({ step }) => {
+    return step.run("run-postgres-backup-manual", async () => {
+      const { runPostgresBackup } = await import(
+        "@/lib/operate/backups/postgres-backup-runner"
+      );
+      return runPostgresBackup({ trigger: "manual" });
+    });
+  },
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,12 @@ services:
       # them through /api/build/<buildId>/evidence/<fileName> (auth-gated).
       # Read-only from the portal's side — only browser-use should write.
       - browser_evidence:/evidence:ro
+      # Platform-managed backups (daily Postgres + future Neo4j/Qdrant).
+      # Host bind mount (NOT a Docker volume) so `docker compose down -v`,
+      # `docker volume rm`, or worktree-induced compose re-labelling cannot
+      # destroy backups. Same path the promoter writes pre-promote dumps to.
+      # See docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md.
+      - ${DPF_HOST_INSTALL_PATH:-.}/backups:/backups
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://dpf:dpf_dev@postgres:5432/dpf}
       AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET must be set - run scripts/setup.ps1 or scripts/setup.sh first}

--- a/docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+++ b/docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
@@ -1,0 +1,246 @@
+# Plan — Postgres Daily Backup, Slice 1
+
+> Spec: `docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md`
+> Goal of this slice: ship the scheduled-daily-Postgres-backup pipeline +
+> manual trigger + admin readiness UX (history table, log drawer).
+> Restore wizard, Neo4j/Qdrant coverage, off-host replication, and PITR
+> are explicit follow-up slices in the spec (§6 Slices 2–5).
+
+## Pre-Implementation Gate (binding before Task 1)
+
+1. Spec is APPROVED. Until then the plan is committed but no
+   implementation tasks fire.
+2. Branch name: `feat/postgres-backup-mechanism` (already created off
+   `origin/main` at HEAD `2576da75`).
+3. PR target: `main` via `gh pr create`. DCO `-s` on every commit
+   (memory: `feedback_dco_signoff_required.md`).
+4. **No CLI surfacing to the operator anywhere in the diff.** Verify
+   by grepping the final diff for shell snippets directed at the user
+   in MD / TSX. Permitted: internal `child_process.spawn` calls, shell
+   scripts the platform itself executes.
+
+## Reality Check (binding context for implementers)
+
+- The promoter container already runs `docker exec dpf-postgres-1
+  pg_dump -U dpf -Fc dpf` and writes the result to a host-bound
+  `/backups` directory (`scripts/promote.sh:157`,
+  `docker-compose.yml:240`). Re-use this proven pattern, do not invent
+  a new one.
+- The portal container already mounts `/var/run/docker.sock` and
+  routinely shells out via `docker exec` for sandbox lifecycle ops
+  (`apps/web/lib/integrate/sandbox/*`). Same pattern applies.
+- `ScheduledJob` model is the existing heartbeat substrate (see
+  `infra-prune.ts` for the canonical pattern: cron, run, upsert
+  heartbeat with `computeNextRunAt`).
+- The `name: ${COMPOSE_PROJECT_NAME:-dpf}` top-level setting in
+  `docker-compose.yml` (PR #709) means we can rely on container names
+  being `dpf-postgres-1` and `dpf-portal-1` in the standard install.
+  Worktree-based dev installs override `COMPOSE_PROJECT_NAME` and get
+  their own isolated stack — backups happen there independently, which
+  is the desired behavior.
+- Postgres image is `postgres:16-alpine`; `pg_dump`/`pg_restore` are
+  available inside the postgres container — we exec into it.
+- Inngest functions are registered in `apps/web/lib/queue/functions/index.ts`.
+- Admin pages use `AdminTabNav` driven by `admin-nav.ts`; the
+  `advanced` family is the right home for Backups (alongside
+  Diagnostics, Issue Reports).
+
+## Scope Check
+
+In: scheduled daily backup, manual trigger, history table, view-log
+drawer, retention pruner, BackupRun/BackupRestore data model, admin
+nav entry, telemetry, tests.
+
+Out (deferred to Slices 2–5):
+
+- Restore wizard (Slice 2)
+- Neo4j + Qdrant coverage (Slice 3)
+- Off-host replication (Slice 4)
+- PITR (Slice 5)
+- Migrating promoter pre-promote dumps into BackupRun rows
+
+## Files And Responsibilities
+
+### Schema + migration
+
+- `packages/db/prisma/schema.prisma` — add `BackupRun` and `BackupRestore` models per spec §4.7.
+- `packages/db/prisma/migrations/<ts>_postgres_backup/migration.sql` — generated.
+- `packages/db/src/seed-platform-backup.ts` *(new)* — idempotent: upsert `ScheduledJob` row `jobId: "postgres-daily-backup"`. Schedule `"daily"`. Wired into the seed orchestrator.
+- `packages/db/src/seed.ts` (or equivalent orchestrator) — call the new seed.
+
+### Backup runner
+
+- `scripts/backup-postgres.sh` *(new)* — POSIX shell:
+  1. Take `$TARGET_DIR` arg; create it.
+  2. `docker exec` the postgres container (variable: container name from `DPF_PRODUCTION_DB_CONTAINER`, default `dpf-postgres-1`).
+  3. `pg_dump -U "$POSTGRES_USER" -Fc -d "$POSTGRES_DB"` redirect to `$TARGET_DIR/dpf.dump`.
+  4. `sha256sum dpf.dump > dpf.dump.sha256`.
+  5. Emit `manifest.json` with start/end/size/checksum/pgVersion.
+  6. Append stdout/stderr to `log.txt`.
+  Exit non-zero on failure with structured stderr line `[backup-trace] failed: <reason>`.
+- `apps/web/lib/operate/backups/postgres-backup-runner.ts` *(new)* — TS orchestrator:
+  - Compute target directory (`/backups/postgres/<ISO-ts>/`).
+  - `child_process.spawn` the shell script.
+  - On success: insert `BackupRun` row with `status: "ok"`, store manifest fields.
+  - On failure: insert `BackupRun` row with `status: "failed"`, errorMessage.
+  - Call retention pruner.
+  - Update `ScheduledJob` heartbeat.
+  - Emit `[backup-trace]` log lines and Prometheus metric updates.
+- `apps/web/lib/operate/backups/retention.ts` *(new)* — pure function `computeRetained(runs: BackupRun[], policy: { daily, weekly, monthly }): { keep: BackupRun[]; prune: BackupRun[] }`. GFS algorithm:
+  - Daily bucket = last N successful daily-trigger runs.
+  - Weekly bucket = most recent successful run per ISO week, last M weeks.
+  - Monthly bucket = most recent successful run per calendar month, last P months.
+  - Union = keep set; complement = prune set.
+- `apps/web/lib/operate/backups/readiness.ts` *(new)* — `getBackupReadiness()` returns `{ schedule, nextRunAt, lastRun: BackupRun | null, lastSuccess: BackupRun | null, retention, storagePath, retainedCount, retainedBytes, failuresInLastThreeRuns: number }`.
+
+### Inngest function
+
+- `apps/web/lib/queue/functions/postgres-daily-backup.ts` *(new)* — `cron("0 3 * * *")` trigger AND `event("ops/postgres-backup.requested")` trigger; `concurrency: { limit: 1, scope: "fn" }`; calls runner.
+- `apps/web/lib/queue/functions/index.ts` — register.
+
+### Server actions
+
+- `apps/web/lib/actions/backups.ts` *(new)* — `triggerBackupNow()`, `listBackupRuns({ limit })`, `getBackupRun(id)`, `getBackupReadiness()`, `readBackupLog(id)`. Auth-gated to admin role only.
+
+### Admin UX
+
+- `apps/web/app/(shell)/admin/backups/page.tsx` *(new)* — readiness card + history table + "Run backup now" button + per-row log drawer trigger.
+- `apps/web/app/(shell)/admin/backups/BackupHistoryTable.tsx` *(new)* — client component, sortable table with row actions.
+- `apps/web/app/(shell)/admin/backups/BackupLogDrawer.tsx` *(new)* — side drawer for `manifest.json` + `log.txt`.
+- `apps/web/components/admin/admin-nav.ts` — add `{ label: "Backups", href: "/admin/backups" }` to the `advanced` family and to the `matchPrefixes` array.
+
+### Compose + env
+
+- `docker-compose.yml` — add `- ${DPF_HOST_INSTALL_PATH:-.}/backups:/backups` to the `portal` service's volumes block. (The promoter already mounts the same path; this just gives the portal r/w access.)
+- `.env.docker.example` — document `DPF_BACKUP_PATH` is **derived from** `DPF_HOST_INSTALL_PATH/backups` and does not need a separate env var; mention the daily-backup mechanism uses this path.
+
+### Tests
+
+- `apps/web/lib/operate/backups/retention.test.ts` — unit tests for GFS math: 30 daily runs reduce to 7+4+12 = 23 (or fewer if collisions); 0 successful runs prune nothing; failed runs never count toward retention; today's run is always kept.
+- `apps/web/lib/operate/backups/postgres-backup-runner.test.ts` — integration with mocked `spawn`; verifies `BackupRun` row on success/failure paths, heartbeat updated.
+- `apps/web/lib/queue/functions/postgres-daily-backup.test.ts` — Inngest function shape (matches discovery-poll test conventions).
+- `apps/web/lib/actions/backups.test.ts` — server-action auth gates.
+
+### Telemetry
+
+- `apps/web/lib/operate/backups/metrics.ts` *(new)* — emit:
+  - `dpf_postgres_backup_last_success_seconds` (gauge)
+  - `dpf_postgres_backup_runs_total{status}` (counter)
+  - `dpf_postgres_backup_storage_bytes` (gauge, sum of retained run sizes)
+  - `dpf_postgres_backup_duration_seconds` (histogram)
+- `monitoring/prometheus/alerts.yml` — alert: `BackupOverdue` if `time() - dpf_postgres_backup_last_success_seconds > 36*3600`.
+
+## Chunk 1 — Schema + Seed
+
+1. Add `BackupRun`, `BackupRestore` to `schema.prisma`.
+2. `pnpm --filter @dpf/db exec prisma migrate dev --name postgres_backup`.
+3. Add `seed-platform-backup.ts` upserting the `ScheduledJob` row.
+4. Wire it into the seed orchestrator (find the equivalent of
+   `seed-discovery-triage.ts`/`seed-hive-scout.ts` registration).
+5. Verify on a fresh install: row present with `schedule: "daily"`,
+   `nextRunAt` ~24 h out.
+
+**Exit criteria.** `pnpm --filter @dpf/db build` clean; `prisma
+generate` clean; seed runs idempotently twice without errors.
+
+## Chunk 2 — Runner + Script
+
+1. Author `scripts/backup-postgres.sh` (POSIX shell). Test it
+   standalone first against the live `dpf-postgres-1` container by
+   the runner (NOT by the operator — per the kernel commandment, the
+   agent runs verification, the operator never sees the command).
+2. Author `postgres-backup-runner.ts`. Use `child_process.spawn` with
+   an absolute path. Pipe stdout/stderr into the structured logger.
+3. Author `retention.ts` with the GFS pruner.
+4. Author `readiness.ts`.
+5. Author `metrics.ts`.
+6. Unit-test retention math.
+
+**Exit criteria.** Runner can be invoked manually from a test
+harness; produces a valid dump + manifest + sha256; row inserted;
+heartbeat updated; old dumps pruned.
+
+## Chunk 3 — Inngest Wiring
+
+1. Author `postgres-daily-backup.ts` with both cron and event
+   triggers.
+2. Register in `functions/index.ts`.
+3. Verify via the Inngest dev UI (the agent verifies, not the
+   operator) that the function is registered at the expected cron
+   schedule.
+
+**Exit criteria.** A manually emitted `ops/postgres-backup.requested`
+event produces a BackupRun row visible in the DB.
+
+## Chunk 4 — Admin Surface
+
+1. Author server actions in `apps/web/lib/actions/backups.ts`.
+2. Author `admin/backups/page.tsx` + history table + log drawer.
+3. Update `admin-nav.ts`.
+4. Verify the admin nav shows "Backups" under Advanced; the page
+   renders the readiness card and history table; the "Run backup
+   now" button triggers a fresh backup that appears in the table
+   after refresh.
+5. Verify failure path: stop the postgres container, click "Run
+   backup now", confirm the readiness card surfaces the failure with
+   a non-actionable reason (no shell to copy).
+
+**Exit criteria.** End-to-end click-only operator path works. Zero
+CLI surfacing in any operator-visible string.
+
+## Chunk 5 — Compose + Bind Mount
+
+1. Add the `/backups` bind mount to the `portal` service in
+   `docker-compose.yml`.
+2. Document in `.env.docker.example` next to `DPF_HOST_INSTALL_PATH`
+   that the daily backup path is derived from it.
+3. Rebuild the portal image. Verify the mount appears inside the
+   container at `/backups` and is writable.
+
+**Exit criteria.** Portal container can write to `/backups/`; host
+sees the file.
+
+## Chunk 6 — Tests + Telemetry
+
+1. All unit and integration tests pass.
+2. `pnpm --filter @dpf/web typecheck` clean.
+3. `pnpm --filter @dpf/web test` clean.
+4. Pre-commit hooks pass (no `--no-verify`).
+5. Prometheus scrape shows the new metrics.
+6. Alert rule lints (`promtool check rules` — the agent runs this,
+   not the operator).
+
+**Exit criteria.** CI green. Backup metrics visible in Prometheus.
+
+## Open Questions Carried Forward (do not block Slice 1)
+
+- Should we expose retention as a Platform Config slider in Slice 1
+  or wait for operator demand? Defaulting to 7/4/12 hardcoded is
+  fine for Slice 1; surface as config when an operator asks.
+- Should pre-promote dumps from the promoter be back-filled into
+  `BackupRun` rows? Spec §9 defers.
+- Should we add a "verify dump" job that runs `pg_restore --list`
+  against the latest dump nightly? Tracked as Slice 4 enhancement
+  but cheap enough that it might fit into Slice 1 if disk I/O
+  permits — decide after profiling first runs.
+
+## Recommended Execution Path
+
+1. Chunk 1 → commit `recovery(platform): postgres backup schema + seed`.
+2. Chunk 2 + Chunk 3 → commit `feat(platform): postgres daily backup runner + inngest cron`.
+3. Chunk 4 → commit `feat(platform): admin backups UX (readiness + history + manual trigger)`.
+4. Chunk 5 → commit `chore(compose): bind-mount /backups into portal`.
+5. Chunk 6 → commit `test(platform): postgres backup retention + runner coverage`.
+6. Open PR `feat(platform): daily Postgres backup mechanism + admin UX`.
+7. After merge, monitor the first scheduled fire at 03:00 the next
+   morning; agent verifies, no operator action required.
+
+## What Slice 1 Deliberately Leaves Out
+
+- Restore wizard (Slice 2 — gated on Slice 1 merge + first scheduled
+  run observed working).
+- Neo4j + Qdrant.
+- S3 / off-host replication.
+- PITR.
+- Backup-of-backups verification job.
+- Encryption-at-rest for the host bind directory.

--- a/docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+++ b/docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
@@ -1,0 +1,456 @@
+# Postgres Daily Backup — In-Platform Schedule + Admin UX
+
+> Status: **PROPOSED** — drafted 2026-05-17
+> Owner: platform / data-substrate
+> Related kernel principles: `never-ask-user-to-run-commands`
+> (`docs/founder-kernel/wiki/principles/never-ask-user-to-run-commands.md`),
+> `agent-as-work-conduit`, `actionable-coworker-responses`.
+> Sibling worktree-hardening commit that prevents the orphan-volume-recreation
+> bug: PR #709 (`fix(dev): isolate compose harness project state`).
+> Trigger: the 2026-05-17T04:35:45Z `dpf_pgdata` volume wipe destroyed all
+> user-created backlog data. Reconstruction took a full session of forensic
+> recovery from PRs / specs / plans / worktrees because no backup existed.
+> This spec closes the gap.
+
+## 1. Problem statement
+
+DPF's substrate today is **single-volume-survivable, not single-volume-recoverable**.
+
+- All authoritative state lives in the `dpf_pgdata` named Docker volume
+  (43 epics + 280 BacklogItems at restore time, plus DigitalProduct,
+  Org, OAuth provider state, brand context, governance ledger, scheduled
+  job heartbeats, ScheduledTask cron registrations, employee directory,
+  Inngest queue state, etc.).
+- The volume is destroyed by any of: `docker compose down -v`,
+  `docker volume rm dpf_pgdata`, a worktree-induced compose project
+  re-label (root cause of the 2026-05-17 wipe, fixed by PR #709), or
+  manual operator action.
+- The only existing backup is **the pre-promote dump the promoter writes
+  before a Build Studio promotion** (`scripts/promote.sh:157`). That dump
+  is:
+  - **Tied to promotion events, not to time.** A user who runs the
+    platform for weeks without a promotion has zero backups.
+  - **Mounted at `${DPF_HOST_INSTALL_PATH}/backups/` on the host** — i.e.
+    it survives a volume wipe, but **only if the promoter has run**.
+  - **Not exposed to the operator.** There is no UI, no readiness
+    surface, no manual trigger, no restore wizard. The recovery
+    procedure is a hand-written runbook (`D:\Backups\RESTORE.md`) that
+    requires shell access to run `pg_restore`.
+- DPF's product thesis is **non-technical operators run real businesses
+  on AI coworkers** (kernel principle `never-ask-user-to-run-commands`).
+  A backup mechanism that requires the operator to know `docker exec`,
+  `pg_dump`, or `pg_restore` is a thesis violation.
+
+Resilience cost of the gap: 6+ hours of catastrophic recovery work and
+~99.4% (not 100%) reconstruction accuracy from secondary sources after
+the May-17 wipe. With a daily backup in place, the same wipe would have
+been recovered in minutes from the previous night's dump.
+
+## 2. Goals and non-goals
+
+**Goals.**
+
+1. Postgres data is backed up **on a daily schedule** by the platform,
+   with no human action required after install.
+2. Backups are **stored on a path that survives volume destruction**
+   (host bind mount, not a Docker volume).
+3. The operator has an **admin UX** to see backup readiness, last/next
+   run, history with size and duration, and to trigger a manual backup
+   or initiate a restore — all without ever leaving the portal.
+4. Retention is **self-managed**: the platform prunes old backups on a
+   GFS schedule (daily/weekly/monthly tiers) without operator
+   intervention.
+5. The mechanism is **rollback-able in a single revert** and produces
+   an auditable run log (success, failure, duration, size, checksum).
+6. **No CLI is ever surfaced to the operator.** Per the
+   `never-ask-user-to-run-commands` commandment, restore is initiated
+   via a typed-confirmation wizard in the UI, executed by the platform.
+
+**Non-goals (this slice).**
+
+1. Neo4j and Qdrant backup. They hold derived/regenerable state and
+   carry less catastrophic loss cost; they are tracked as Phase 2
+   under §10 Future Work.
+2. Sandbox-postgres backup. Build Studio sandboxes are by-design
+   ephemeral; no operator state lives there.
+3. Off-host / cloud / S3 / encrypted-bucket backup. This slice ships
+   host-local backup only. Cloud-replication is Phase 3.
+4. Point-in-time-recovery (WAL archiving / PITR). Phase 4 — daily
+   `pg_dump` covers the catastrophic-loss case this spec exists to
+   prevent. Sub-day RPO is not in scope.
+5. Multi-org backup partitioning. DPF is single-org per install
+   (memory: `project_single_org_per_install.md`); the whole DB is one
+   tenant.
+
+## 3. Current repo grounding
+
+| Surface | File | What it gives us |
+|---|---|---|
+| Existing `pg_dump` invocation | `scripts/promote.sh:157` | `docker exec <db> pg_dump -U <user> -Fc <db>` shape, proven in production by promotion flow |
+| Backup directory convention | `docker-compose.yml:240` | Promoter already host-mounts `${DPF_HOST_INSTALL_PATH:-.}/backups:/backups` — reuse this path |
+| Cron scheduling pattern | `apps/web/lib/queue/functions/discovery-poll.ts`, `infra-prune.ts` | Inngest `cron(...)` triggers + `prisma.scheduledJob` heartbeat + `computeNextRunAt` |
+| Schedule registry | `packages/db/prisma/schema.prisma:1515` (`ScheduledJob`) | `jobId`, `name`, `schedule`, `lastRunAt`, `nextRunAt`, `lastStatus`, `lastError` — drop-in |
+| Schedule helpers | `apps/web/lib/inference/ai-provider-types.ts:6,21` | `SCHEDULE_INTERVALS_MS` includes `daily`; `computeNextRunAt(schedule, from)` |
+| Admin tab nav family | `apps/web/components/admin/admin-nav.ts:54` (`advanced`) | Add Backups under Advanced family alongside Diagnostics / Issue Reports |
+| Function registration | `apps/web/lib/queue/functions/index.ts` | Single place to register the new cron function |
+| Postgres client in container | `Dockerfile.promoter:4` (`postgresql16-client`) | We need the same `pg_dump`/`pg_restore` available wherever the runner executes |
+
+What does **not** exist yet:
+
+- `scripts/backup-postgres.sh` (or equivalent runner)
+- Any Prisma model for backup history (we'll add one — `BackupRun`)
+- Any admin route under `/admin/backups`
+- Any server actions for trigger/list/inspect/restore
+- Any retention policy or pruner
+
+## 4. Decision
+
+**Architecture in one sentence:** an Inngest cron function fires once a
+day, asks the portal container to shell out to `pg_dump -Fc` against the
+`postgres` service, writes the dump file + manifest to a host-bound
+`/backups/` directory, records a `BackupRun` row, and prunes per a
+GFS retention policy; the admin UX exposes status, history, manual
+trigger, and a strongly-confirmed restore wizard.
+
+### 4.1 Where the work runs
+
+| Option | Pros | Cons | Decision |
+|---|---|---|---|
+| **(A) Portal container shells out via `docker exec`** | No new container; reuses promoter pattern; portal already has `/var/run/docker.sock` mounted | Couples backup runner to Docker socket | **Chosen** — promoter already proves this pattern; isolation isn't worth the cost for daily ops housekeeping |
+| (B) Separate `dpf-backup` one-shot container | Stronger isolation | New image, new lifecycle, new failure mode | Deferred — no current need |
+| (C) Postgres-side `pg_basebackup` cron inside the postgres container | Native | Couples backup logic to the database image; harder to evolve | Rejected |
+
+The portal already exec's into containers for sandbox lifecycle
+operations (`apps/web/lib/integrate/sandbox/*`); this is consistent.
+
+### 4.2 Scheduler
+
+**Inngest cron**, identical pattern to `infra-prune.ts`. One function:
+`ops/postgres-daily-backup`, trigger `0 3 * * *` (03:00 local install
+timezone) with `retries: 2` and `concurrency: { limit: 1 }`. The
+`ScheduledJob` row (`jobId: "postgres-daily-backup"`) is the heartbeat
+record the admin UI reads for "last run / next run / last status".
+
+We don't use the existing generic `ScheduledTask` cron substrate
+because that's user-facing scheduled work (HRIS sync, hive scout
+ingest) — backups are platform plumbing, not user workflows.
+
+### 4.3 Storage layout
+
+```
+<DPF_HOST_INSTALL_PATH>/backups/
+├── postgres/
+│   ├── 2026-05-17T03-00-00Z/
+│   │   ├── dpf.dump            # pg_dump -Fc output, ~tens-of-MB compressed
+│   │   ├── manifest.json       # { runId, startedAt, finishedAt, sizeBytes,
+│   │   │                       #   sha256, pgVersion, dpfVersion, schedule,
+│   │   │                       #   trigger: "scheduled"|"manual", durationMs }
+│   │   └── log.txt             # stdout/stderr from pg_dump
+│   └── 2026-05-16T03-00-00Z/...
+└── pre-promote/                # legacy promoter dumps continue here unchanged
+    └── pre-promote-<buildId>-*.dump
+```
+
+Daily backups live under `postgres/<ISO-ts>/`; the existing promoter
+output stays under `pre-promote/` so we don't disturb that flow.
+
+Host bind mount (added to `docker-compose.yml`):
+
+```yaml
+portal:
+  volumes:
+    - ${DPF_HOST_INSTALL_PATH:-.}/backups:/backups
+```
+
+The path is the same one the promoter already mounts; the portal gets
+read+write access. **Critical**: it's a host bind mount, not a Docker
+volume — so `docker volume rm`, project re-labeling, or `down -v`
+cannot destroy backups.
+
+### 4.4 Dump format
+
+`pg_dump -Fc` (PostgreSQL custom format).
+
+- Compressed by default (zlib level 6).
+- Supports selective restore (`pg_restore --table=`, `--schema=`,
+  `--list`) which we'll need for the Phase B "restore the backlog
+  only" use case Mark explicitly called out 2026-05-17.
+- Already proven by `scripts/promote.sh:157`.
+
+We also write a sidecar `manifest.json` and a `sha256` checksum file
+so the UI can verify integrity without re-reading the whole dump.
+
+### 4.5 Retention (self-managed)
+
+**GFS (Grandfather-Father-Son) — fully automatic.** Defaults configurable
+in `PlatformConfig`:
+
+- Keep **last 7 daily** backups (rolling window).
+- Keep **last 4 weekly** backups (Sundays).
+- Keep **last 12 monthly** backups (first of each month).
+
+Pruner runs at the **end of each successful backup**, so retention
+state is self-healing. Failed runs do not prune.
+
+Worst-case footprint: 7 + 4 + 12 = 23 retained dumps. At ~50 MB
+compressed (current DPF DB scale) → ~1.2 GB. Well within reasonable
+disk budget; documented and surfaced in the admin card.
+
+### 4.6 Restore — strongly gated, never automatic
+
+Restore is **never** triggered by the scheduler, by background jobs,
+or by any agent. It is initiated **only** by an explicit operator
+click in the admin UI, followed by a typed-confirmation step.
+
+Restore wizard flow:
+
+1. Operator opens **Admin → Advanced → Backups → [select a run] →
+   Restore from this backup**.
+2. UI shows an **impact preview**: dump timestamp, dump size, table
+   count, "you will lose all changes since `<lastRunAt>`".
+3. Operator types the literal string `RESTORE` to confirm.
+4. UI calls a `restoreBackupRun` server action which:
+   - Acquires a portal-side lock (no concurrent restores).
+   - Writes a **pre-restore safety dump** to `backups/pre-restore/<ts>/`.
+   - Calls `pg_restore --clean --if-exists` against the `postgres`
+     service.
+   - Records a `BackupRestore` row.
+   - Hot-reloads Prisma state.
+5. The pre-restore safety dump is itself retained per GFS so a
+   misclick is recoverable.
+
+**Out-of-scope for restore**: partial / table-level restore. Phase 5
+work — current scope is whole-DB.
+
+### 4.7 Data model addition
+
+```prisma
+model BackupRun {
+  id            String   @id @default(cuid())
+  startedAt     DateTime @default(now())
+  finishedAt    DateTime?
+  status        String   // "running" | "ok" | "failed"
+  trigger       String   // "scheduled" | "manual"
+  schedule      String?  // "daily" when scheduled
+  sizeBytes     BigInt?
+  durationMs    Int?
+  sha256        String?
+  pgVersion     String?
+  dpfVersion    String?
+  storagePath   String   // absolute path inside /backups/ on host bind
+  errorMessage  String?
+  prunedAt      DateTime?  // set when retention removed this run's files
+  createdAt     DateTime @default(now())
+
+  @@index([startedAt])
+  @@index([status])
+}
+
+model BackupRestore {
+  id                String   @id @default(cuid())
+  startedAt         DateTime @default(now())
+  finishedAt        DateTime?
+  status            String   // "running" | "ok" | "failed"
+  initiatedByUserId String?
+  sourceBackupRunId String
+  preRestoreBackupRunId String?  // safety dump
+  errorMessage      String?
+  createdAt         DateTime @default(now())
+
+  @@index([startedAt])
+}
+```
+
+`ScheduledJob` row `jobId: "postgres-daily-backup"` is the heartbeat;
+`BackupRun` rows are the audit log.
+
+### 4.8 Admin UX surface
+
+**Location**: `/admin/backups`, registered in `admin-nav.ts` under the
+`advanced` family.
+
+**Page layout**:
+
+```
+─ Backups ──────────────────────────────────────────────────────────
+ [ Readiness card ]                                  [ Run backup now ]
+   ✓ Daily backup scheduled at 03:00 (DPF timezone)
+   ✓ Last run: 2026-05-17T03:00 UTC — OK — 47 MB — 8.3s
+   ✓ Next run: 2026-05-18T03:00 UTC
+   ✓ Retention: 7 daily / 4 weekly / 12 monthly (23 dumps, 1.1 GB)
+   ✓ Storage path: <DPF_HOST_INSTALL_PATH>/backups/postgres/
+   ✗ <red banner only if> Last 3 runs failed: <reason>
+
+ [ History table ]
+   Timestamp                Status    Trigger    Size      Duration   Actions
+   2026-05-17T03:00Z        ✓ ok      scheduled  47.2 MB   8.3s       [Restore…] [View log]
+   2026-05-16T03:00Z        ✓ ok      scheduled  47.0 MB   8.1s       [Restore…] [View log]
+   2026-05-15T14:22Z        ✓ ok      manual     46.8 MB   7.9s       [Restore…] [View log]
+   …
+   [pruned rows shown faded with "pruned 2026-05-10"]
+```
+
+**Manual trigger**: button calls `triggerBackupNow()` server action →
+emits Inngest event `ops/postgres-backup.requested` → same function
+handles both scheduled and event-driven invocations.
+
+**Restore wizard**: modal with impact preview + typed-`RESTORE`
+confirmation. No raw SQL, no shell, no command anywhere in the
+operator's view.
+
+**View log**: opens a side drawer showing `manifest.json` +
+truncated `log.txt`. Read-only.
+
+### 4.9 No-CLI-for-the-user proof
+
+Per the commandment principle
+(`docs/founder-kernel/wiki/principles/never-ask-user-to-run-commands.md`),
+this design contains **zero** copy-paste shell. Specifically:
+
+| Operator intent | What they do | What the platform does for them |
+|---|---|---|
+| Verify backup ran today | Open `/admin/backups` | Readiness card shows last run, status, size, duration |
+| Force a fresh backup | Click "Run backup now" | Platform triggers Inngest event, runs `pg_dump`, refreshes UI |
+| Restore from a backup | Click `[Restore…]` → type `RESTORE` | Platform writes safety dump, runs `pg_restore`, hot-reloads, refreshes UI |
+| Investigate a failed backup | Click `[View log]` | Drawer renders stored stdout/stderr |
+| Adjust retention | Edit Platform Config slider | Pruner re-runs on next backup |
+
+Operator never sees `docker exec`, `pg_dump`, `pg_restore`, file paths
+to copy, or SQL.
+
+## 5. Research and benchmarking
+
+Backup design for managed Postgres is well-trodden territory. The
+choices DPF makes here align with the consensus best practices and
+deviate only where DPF's substrate (single-org per install, all-state-in-Postgres,
+operator-is-non-technical) makes a different trade-off correct.
+
+### 5.1 `pg_dump -Fc` vs alternatives
+
+| Approach | RPO | RTO | Op complexity | Choice |
+|---|---|---|---|---|
+| **`pg_dump -Fc` daily** | 24h | minutes (selective restore supported) | **lowest** — single binary, no extra config | **Chosen** for v1 |
+| `pg_basebackup` + WAL archiving (PITR) | seconds | minutes | high — WAL retention, archive_command, recovery.conf | Phase 4 (see §10) |
+| Logical replication to a standby | seconds | seconds | very high — replica lifecycle | Out of scope (one-org-per-install) |
+| Filesystem snapshots (ZFS / LVM) | minutes | seconds | requires non-portable host filesystem | Out of scope |
+
+The Postgres docs' own recommendation
+(<https://www.postgresql.org/docs/16/backup-dump.html>) explicitly calls
+out `pg_dump` as the right tool for small-to-medium DBs with daily-grain
+RPO requirements. DPF fits that bracket comfortably — even at 10×
+current scale we're well under the 100 GB threshold where dump time
+starts to bite.
+
+### 5.2 Schedule library
+
+`infraPrune` and `discoveryPoll` already use Inngest `cron(...)`
+triggers. No new dependency. The DPF install ships Inngest as a first-class
+service (see `docker-compose.yml` `inngest:` block) — using anything
+else would be inconsistent with `feedback_consult_specs_first.md`.
+
+### 5.3 Storage path
+
+Host bind mount under `${DPF_HOST_INSTALL_PATH}/backups/` is already
+proven by the promoter. Using the same path means a single tree the
+operator can back up off-host later (Phase 3) by pointing
+restic/rclone/Backblaze at one directory.
+
+### 5.4 Retention policy (GFS)
+
+7/4/12 GFS is the default in nearly every backup tool that defaults at
+all (restic snapshot policies, BorgBackup, Veeam, pg_basebackup
+tutorials). Defaults configurable via Platform Config so an operator
+on a small VPS can drop monthlies.
+
+## 6. Implementation slices
+
+### Slice 1 — Scheduled daily Postgres backup with admin readiness UX
+
+In scope for the first PR (this spec's plan):
+
+- `BackupRun` and `BackupRestore` Prisma models + migration + seed (idempotent — `ScheduledJob` row created if missing).
+- `scripts/backup-postgres.sh` — pure shell entrypoint that the runner exec's. Takes a target directory, writes `dpf.dump` + `manifest.json` + `log.txt` + `dpf.dump.sha256`.
+- `apps/web/lib/operate/backups/postgres-backup-runner.ts` — TypeScript orchestrator: shells the script via `docker exec dpf-postgres-1`, then records `BackupRun`, then prunes.
+- `apps/web/lib/operate/backups/retention.ts` — GFS pruner.
+- `apps/web/lib/queue/functions/postgres-daily-backup.ts` — Inngest function (cron + event), registered in `functions/index.ts`.
+- Server actions: `triggerBackupNow()`, `listBackupRuns({ limit })`, `getBackupRun(id)`, `getBackupReadiness()`.
+- Admin page: `/admin/backups` with readiness card + history table + "Run backup now" button + per-row "View log" drawer.
+- Nav: register Backups under Admin → Advanced.
+- Docker compose: add `${DPF_HOST_INSTALL_PATH:-.}/backups:/backups` mount to the `portal` service.
+- Tests: unit (retention math, manifest emission), integration (server actions hit a stub backup directory).
+- Telemetry: log every run as `[backup-trace]` and emit a Prometheus metric `dpf_postgres_backup_last_success_seconds`.
+
+### Slice 2 — Restore wizard
+
+- Restore server action with safety-dump + locking.
+- Restore UI with typed-`RESTORE` confirmation.
+- `BackupRestore` history surface.
+- Hot Prisma reload after restore.
+
+### Slice 3 — Neo4j + Qdrant coverage
+
+- Per-service runners (`backup-neo4j.sh` using `neo4j-admin database
+  dump`; `backup-qdrant.sh` using qdrant snapshot API).
+- Unified `BackupRun.targets` array and per-target status.
+
+### Slice 4 — Off-host replication
+
+- Pluggable destination (`local`, `s3`, `restic`).
+- Encryption-at-rest for off-host destinations.
+- Verification job that fetches a daily dump back from off-host and runs `pg_restore --list` against it.
+
+### Slice 5 — Point-in-time recovery (PITR)
+
+- WAL archiving via `archive_command`.
+- Restore-to-point-in-time UI.
+
+## 7. Integration contracts
+
+- Inngest event: `ops/postgres-backup.requested { trigger: "manual" | "scheduled", initiatedByUserId?: string }`.
+- ScheduledJob heartbeat: `jobId = "postgres-daily-backup"`, written on every run start (status `running`) and update (status `ok`/`failed`).
+- BackupRun.storagePath is **relative to the host bind mount** (`/backups/postgres/<iso-ts>`), not absolute — so restoring on a different host path still works.
+
+## 8. Telemetry and evidence
+
+- `[backup-trace]` log lines at start / finish / failure (matches `[tool-trace]` convention from `project_tool_trace_logging.md`).
+- Prometheus gauge `dpf_postgres_backup_last_success_seconds` (epoch seconds of last successful backup). Alert if `time() - dpf_postgres_backup_last_success_seconds > 36*3600` (i.e. >36 h since last success).
+- Prometheus counter `dpf_postgres_backup_runs_total{status}`.
+- Prometheus gauge `dpf_postgres_backup_storage_bytes`.
+
+## 9. Open questions
+
+1. **Encryption-at-rest for the host bind mount.** Defer to Phase 4; for v1, document that backups inherit the security posture of the host filesystem.
+2. **Cross-platform shell.** `backup-postgres.sh` is bash. The portal container is `node:24-alpine` (already has busybox `sh`); we'll write to POSIX-portable shell, not bash-specific. Promoter already does this — same constraint.
+3. **Pre-promote dumps under the new model.** Should `scripts/promote.sh` be migrated to write `BackupRun` rows so all dumps are visible in the admin UX? Defer to follow-up; v1 just keeps `pre-promote/` co-located, admin UX shows them in a separate section labeled "Pre-promotion safety dumps (legacy path)".
+
+## 10. Future work
+
+- **Phase 2**: Neo4j + Qdrant.
+- **Phase 3**: Off-host replication (S3 / restic / Backblaze).
+- **Phase 4**: WAL archiving / PITR.
+- **Phase 5**: Partial / table-level restore.
+- **Phase 6**: Cross-install backup federation (one customer's installs back each other up via the hive mind).
+
+## 11. Acceptance criteria (Slice 1)
+
+1. Fresh install — first daily backup writes `<DPF_HOST_INSTALL_PATH>/backups/postgres/<ISO-ts>/dpf.dump` within 30 s of cron fire, with a `manifest.json` and matching `sha256`.
+2. `/admin/backups` shows readiness card with last run, next run, retention summary; loads <1 s.
+3. "Run backup now" button creates a fresh backup, refreshes the table.
+4. Killing the `postgres` container mid-run causes the function to fail, write a `BackupRun` row with `status: "failed"`, and surface the failure in the readiness card.
+5. After 8 daily runs, exactly 7 daily dumps remain (oldest pruned).
+6. Reverting the PR + running the migration revert leaves no dangling tables, services, or schedule rows.
+7. Zero command-line surfacing in the operator's path. The only operator gestures are clicks and typed confirmation.
+
+## 12. Recommendation
+
+Approve and proceed to plan + Slice 1 implementation. The cost of
+**not** having this mechanism was demonstrated 6 hours ago — the only
+reason DPF recovered from the May-17 wipe was that PRs and specs
+happened to preserve enough breadcrumbs to reconstruct ~99.4% of the
+backlog. The next wipe might land between two recoverable substrates
+(e.g. governance ledger, OAuth provider state, employee directory) and
+there will be no breadcrumbs.
+
+Slice 1 is small, self-contained, and reverts cleanly. Slices 2–5 can
+be sequenced based on operator demand without changing the data model
+introduced here.

--- a/packages/db/prisma/migrations/20260517210000_add_backup_run_and_restore/migration.sql
+++ b/packages/db/prisma/migrations/20260517210000_add_backup_run_and_restore/migration.sql
@@ -1,0 +1,56 @@
+-- Postgres daily backup mechanism (Slice 1).
+-- Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+-- Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+--
+-- BackupRun: per-run audit log surfaced in /admin/backups (history table).
+-- BackupRestore: per-restore audit log (Slice 2 surfaces this in UI; Slice 1
+--                creates the table so the FK from a future restore wizard
+--                doesn't trip a migration ordering issue when Slice 2 lands).
+
+CREATE TABLE "BackupRun" (
+  "id"            TEXT NOT NULL,
+  "target"        TEXT NOT NULL DEFAULT 'postgres',
+  "startedAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "finishedAt"    TIMESTAMP(3),
+  "status"        TEXT NOT NULL,
+  "trigger"       TEXT NOT NULL,
+  "schedule"      TEXT,
+  "sizeBytes"     BIGINT,
+  "durationMs"    INTEGER,
+  "sha256"        TEXT,
+  "pgVersion"     TEXT,
+  "dpfVersion"    TEXT,
+  "storagePath"   TEXT NOT NULL,
+  "errorMessage"  TEXT,
+  "prunedAt"      TIMESTAMP(3),
+  "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "BackupRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "BackupRun_startedAt_idx"        ON "BackupRun" ("startedAt");
+CREATE INDEX "BackupRun_status_idx"           ON "BackupRun" ("status");
+CREATE INDEX "BackupRun_target_status_idx"    ON "BackupRun" ("target", "status");
+
+CREATE TABLE "BackupRestore" (
+  "id"                    TEXT NOT NULL,
+  "startedAt"             TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "finishedAt"            TIMESTAMP(3),
+  "status"                TEXT NOT NULL,
+  "initiatedByUserId"     TEXT,
+  "sourceBackupRunId"     TEXT NOT NULL,
+  "preRestoreBackupRunId" TEXT,
+  "errorMessage"          TEXT,
+  "createdAt"             TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "BackupRestore_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "BackupRestore_sourceBackupRunId_fkey"
+    FOREIGN KEY ("sourceBackupRunId") REFERENCES "BackupRun" ("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "BackupRestore_preRestoreBackupRunId_fkey"
+    FOREIGN KEY ("preRestoreBackupRunId") REFERENCES "BackupRun" ("id")
+    ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE INDEX "BackupRestore_startedAt_idx" ON "BackupRestore" ("startedAt");
+CREATE INDEX "BackupRestore_status_idx"    ON "BackupRestore" ("status");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1525,6 +1525,58 @@ model ScheduledJob {
   updatedAt  DateTime  @updatedAt
 }
 
+// Per-run audit log for platform-managed backups (Postgres in Slice 1; Neo4j/
+// Qdrant in later slices). The ScheduledJob row with jobId
+// "postgres-daily-backup" is the live heartbeat; BackupRun rows are durable
+// history surfaced in the /admin/backups UX.
+// See docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.7.
+model BackupRun {
+  id           String    @id @default(cuid())
+  target       String    @default("postgres")
+  startedAt    DateTime  @default(now())
+  finishedAt   DateTime?
+  status       String
+  trigger      String
+  schedule     String?
+  sizeBytes    BigInt?
+  durationMs   Int?
+  sha256       String?
+  pgVersion    String?
+  dpfVersion   String?
+  storagePath  String
+  errorMessage String?
+  prunedAt     DateTime?
+  createdAt    DateTime  @default(now())
+
+  restoresFrom BackupRestore[] @relation("BackupRestoreSource")
+  safetyFor    BackupRestore[] @relation("BackupRestoreSafety")
+
+  @@index([startedAt])
+  @@index([status])
+  @@index([target, status])
+}
+
+// Audit row for every restore operation. Strongly gated in the UX (typed
+// confirmation); never automatic. Each restore writes a pre-restore safety
+// dump first; preRestoreBackupRunId points at that BackupRun.
+model BackupRestore {
+  id                    String    @id @default(cuid())
+  startedAt             DateTime  @default(now())
+  finishedAt            DateTime?
+  status                String
+  initiatedByUserId     String?
+  sourceBackupRunId     String
+  preRestoreBackupRunId String?
+  errorMessage          String?
+  createdAt             DateTime  @default(now())
+
+  sourceBackup     BackupRun  @relation("BackupRestoreSource", fields: [sourceBackupRunId], references: [id])
+  preRestoreBackup BackupRun? @relation("BackupRestoreSafety", fields: [preRestoreBackupRunId], references: [id])
+
+  @@index([startedAt])
+  @@index([status])
+}
+
 model CodeGraphIndexState {
   graphKey                 String              @id
   graphVersion             Int                 @default(1)

--- a/packages/db/src/seed-platform-backup.ts
+++ b/packages/db/src/seed-platform-backup.ts
@@ -1,0 +1,75 @@
+import type { PrismaClient } from "../generated/client/client";
+
+/**
+ * Schedule + identifier constants for the platform-managed Postgres backup.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+ * Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+ *
+ * The ScheduledJob row is the live heartbeat surfaced in /admin/backups
+ * (lastRunAt, nextRunAt, lastStatus). The actual cron firing is owned by
+ * the Inngest function ops/postgres-daily-backup; this seed only ensures
+ * the heartbeat row exists from a fresh install onward so the readiness
+ * card has something to render before the first run.
+ *
+ * The same identifiers are duplicated (intentionally — packages/db cannot
+ * import from apps/web) in apps/web/lib/operate/backups/constants.ts.
+ * If you change one, change both, or the heartbeat row will be orphaned.
+ */
+export const POSTGRES_BACKUP_JOB_ID = "postgres-daily-backup";
+export const POSTGRES_BACKUP_JOB_NAME =
+  "Postgres daily backup (platform-managed)";
+export const POSTGRES_BACKUP_SCHEDULE = "daily";
+
+type ScheduledJobSeedClient = Pick<PrismaClient, "scheduledJob">;
+
+/** Returns the next 03:00 UTC strictly after `from`. */
+function nextDailyRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(3);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}
+
+/**
+ * Idempotent: create the ScheduledJob heartbeat row if missing; update
+ * name/schedule/nextRunAt on every seed run. Does not clobber lastRunAt /
+ * lastStatus / lastError — those are owned by the runner.
+ */
+export async function ensurePostgresBackupScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const nextRunAt = nextDailyRunAt(now);
+
+  const existing = await prisma.scheduledJob.findUnique({
+    where: { jobId: POSTGRES_BACKUP_JOB_ID },
+    select: { jobId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledJob.update({
+      where: { jobId: POSTGRES_BACKUP_JOB_ID },
+      data: {
+        name: POSTGRES_BACKUP_JOB_NAME,
+        schedule: POSTGRES_BACKUP_SCHEDULE,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+    return { created: false };
+  }
+
+  await prisma.scheduledJob.create({
+    data: {
+      jobId: POSTGRES_BACKUP_JOB_ID,
+      name: POSTGRES_BACKUP_JOB_NAME,
+      schedule: POSTGRES_BACKUP_SCHEDULE,
+      nextRunAt,
+    },
+  });
+  return { created: true };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -28,6 +28,7 @@ import {
 import { seedDeliberationPatterns } from "./seed-deliberation.js";
 import { ensureDiscoveryTriageScheduledTask } from "./seed-discovery-triage.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
+import { ensurePostgresBackupScheduledJob } from "./seed-platform-backup.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
@@ -2130,6 +2131,7 @@ async function main(): Promise<void> {
   await seedDefaultAdminUser();
   await ensureDiscoveryTriageScheduledTask(prisma);
   await ensureHiveScoutScheduledTask(prisma);
+  await ensurePostgresBackupScheduledJob(prisma);
   await seedMcpServers();
   await seedSandboxPool();
   await seedProviderRegistry();

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# scripts/backup-postgres.sh — platform-managed Postgres backup runner.
+#
+# Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+# Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+#
+# The TypeScript orchestrator in apps/web/lib/operate/backups/postgres-backup-runner.ts
+# spawns this script. It runs INSIDE the portal container, where /var/run/docker.sock
+# is mounted so we can exec into the postgres container, and where the host-bound
+# /backups directory is mounted at /backups.
+#
+# Per the never-ask-user-to-run-commands kernel principle, this script is
+# never invoked by the operator. It is platform plumbing.
+#
+# Required env:
+#   TARGET_DIR              absolute path inside the portal container where the
+#                           dump and metadata are written (e.g. /backups/postgres/<iso-ts>)
+#   POSTGRES_USER           DB role to dump as (default: dpf)
+#   POSTGRES_DB             DB to dump (default: dpf)
+#   DPF_PRODUCTION_DB_CONTAINER  postgres container name (default: dpf-postgres-1)
+#
+# Optional env:
+#   DPF_VERSION             value to record in manifest.json (default: empty)
+#
+# Exit codes:
+#   0  success
+#   2  prereq missing (missing tool or env)
+#   3  pg_dump failed
+#   4  checksum failed
+#   5  manifest write failed
+
+set -eu
+
+log() { printf '[backup-trace] %s\n' "$*"; }
+fail() {
+  log "failed: $1"
+  exit "${2:-1}"
+}
+
+TARGET_DIR="${TARGET_DIR:-}"
+POSTGRES_USER="${POSTGRES_USER:-dpf}"
+POSTGRES_DB="${POSTGRES_DB:-dpf}"
+DB_CONTAINER="${DPF_PRODUCTION_DB_CONTAINER:-dpf-postgres-1}"
+DPF_VERSION_VALUE="${DPF_VERSION:-}"
+
+[ -n "$TARGET_DIR" ] || fail "TARGET_DIR not set" 2
+command -v docker >/dev/null 2>&1 || fail "docker CLI not available in runner image" 2
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum not available" 2
+
+mkdir -p "$TARGET_DIR" || fail "could not create target directory $TARGET_DIR" 2
+
+DUMP_FILE="$TARGET_DIR/dpf.dump"
+SHA_FILE="$TARGET_DIR/dpf.dump.sha256"
+LOG_FILE="$TARGET_DIR/log.txt"
+MANIFEST_FILE="$TARGET_DIR/manifest.json"
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+STARTED_EPOCH="$(date +%s)"
+
+log "starting pg_dump container=$DB_CONTAINER user=$POSTGRES_USER db=$POSTGRES_DB target=$TARGET_DIR"
+
+# Capture pg_version BEFORE we exec the dump so a dump failure doesn't deny us
+# the version info for diagnostics.
+PG_VERSION="$(docker exec "$DB_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t -A -c "SHOW server_version" 2>/dev/null || echo "unknown")"
+log "pg_version=$PG_VERSION"
+
+# Run pg_dump inside the postgres container; stream output to a host file.
+# Custom format (-Fc) is compressed, supports selective restore, and is what
+# the existing promoter script uses (scripts/promote.sh:157).
+if docker exec "$DB_CONTAINER" pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB" > "$DUMP_FILE" 2> "$LOG_FILE"; then
+  log "pg_dump succeeded size=$(wc -c < "$DUMP_FILE")"
+else
+  EXIT=$?
+  log "pg_dump exit=$EXIT — tail of log:"
+  tail -n 20 "$LOG_FILE" >&2 || true
+  fail "pg_dump failed (exit=$EXIT)" 3
+fi
+
+# sha256 checksum so the admin UX can verify integrity without re-reading the
+# whole dump. We store the bare hash for easy comparison.
+DUMP_SHA="$(sha256sum "$DUMP_FILE" | awk '{print $1}')" || fail "sha256sum failed" 4
+printf '%s  dpf.dump\n' "$DUMP_SHA" > "$SHA_FILE" || fail "could not write sha256 file" 4
+
+FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+FINISHED_EPOCH="$(date +%s)"
+SIZE_BYTES="$(wc -c < "$DUMP_FILE" | tr -d ' ')"
+DURATION_MS=$(( (FINISHED_EPOCH - STARTED_EPOCH) * 1000 ))
+
+# Manifest. Keep this small and JSON-strict so the TS side can parse it
+# with JSON.parse and not a YAML/TOML library.
+cat > "$MANIFEST_FILE" <<MANIFEST || fail "could not write manifest" 5
+{
+  "schemaVersion": 1,
+  "target": "postgres",
+  "container": "$DB_CONTAINER",
+  "postgresUser": "$POSTGRES_USER",
+  "postgresDb": "$POSTGRES_DB",
+  "pgVersion": "$PG_VERSION",
+  "dpfVersion": "$DPF_VERSION_VALUE",
+  "startedAt": "$STARTED_AT",
+  "finishedAt": "$FINISHED_AT",
+  "durationMs": $DURATION_MS,
+  "sizeBytes": $SIZE_BYTES,
+  "sha256": "$DUMP_SHA",
+  "dumpFormat": "pg_dump -Fc"
+}
+MANIFEST
+
+log "manifest written sha256=$DUMP_SHA size=$SIZE_BYTES duration_ms=$DURATION_MS"
+log "ok"
+exit 0


### PR DESCRIPTION
## Summary

In-platform scheduled Postgres backup with admin UX, closing the gap exposed by the 2026-05-17 \`dpf_pgdata\` wipe (PR #707 recovery).

- **Daily cron** (Inngest, 03:00 UTC) + **manual trigger** button — same runner serves both. Concurrency=1.
- **\`pg_dump -Fc\`** to a **host bind mount** (\`\${DPF_HOST_INSTALL_PATH}/backups/\`), so \`docker compose down -v\`, \`docker volume rm\`, or worktree-induced compose re-labelling cannot destroy backups. Same path the promoter already uses for pre-promote dumps.
- **GFS retention** (7 daily / 4 weekly / 12 monthly), self-managed, applied at the end of every successful run.
- **Admin UX** at \`/admin/backups\`: readiness card (schedule, last run, last success, next run, retention, retained-on-disk, storage path), history table, per-row log drawer, manual-trigger button.
- **Prometheus metrics**: \`dpf_postgres_backup_runs_total{status,trigger}\`, \`dpf_postgres_backup_last_success_seconds\`, \`dpf_postgres_backup_storage_bytes\`, \`dpf_postgres_backup_duration_seconds\`.
- **Zero CLI surfacing** in the operator path. Per the \`never-ask-user-to-run-commands\` kernel commandment (added in PR #707), the operator never sees a shell command. Restore wizard (Slice 2) will keep the same posture (typed \`RESTORE\` confirmation, never automatic).

## Spec + plan

- Spec: \`docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md\`

Slices 2–5 (restore wizard, Neo4j/Qdrant coverage, off-host replication, PITR) are explicit follow-ups — see spec §6 and §10.

## What's in the diff

- New Prisma models \`BackupRun\` + \`BackupRestore\` (migration \`20260517210000\`). Slice 1 only writes BackupRun; BackupRestore is scaffolded so Slice 2 doesn't need a migration ordering dance.
- \`scripts/backup-postgres.sh\` — POSIX shell runner (alpine-compatible, no bashisms). docker exec's pg_dump, writes \`dpf.dump\` + \`dpf.dump.sha256\` + \`manifest.json\` + \`log.txt\` into \`/backups/postgres/<ISO-ts>/\`.
- \`apps/web/lib/operate/backups/\` — TS orchestrator + GFS retention pruner + readiness module + types.
- \`apps/web/lib/queue/functions/postgres-daily-backup.ts\` — Inngest cron + event triggers; registered in \`functions/index.ts\`.
- \`apps/web/lib/actions/backups.ts\` — admin-gated server actions (\`manage_provider_connections\` capability).
- \`apps/web/app/(shell)/admin/backups/\` — readiness card + history table + log drawer + manual trigger.
- \`apps/web/components/admin/admin-nav.ts\` — "Backups" added under Admin → Advanced.
- \`docker-compose.yml\` — portal service gains \`\${DPF_HOST_INSTALL_PATH:-.}/backups:/backups\` mount.
- \`packages/db/src/seed-platform-backup.ts\` — idempotent ScheduledJob heartbeat seed; wired into the seed orchestrator after the discovery-triage / hive-scout block.
- \`.gitignore\` — anchored \`/backups/\` so the pattern stops matching source-tree directories (\`apps/web/lib/operate/backups/\`, \`apps/web/app/(shell)/admin/backups/\`).

## Test plan

- [x] \`pnpm --filter web exec vitest run lib/operate/backups\` — **12/12 retention tests pass** (ISO-week math, monthly buckets, failed-run exclusion, prune semantics, union dedupe).
- [x] \`pnpm --filter web typecheck\` — clean (pre-commit hook ran it on commit).
- [x] **Smoke test on the live install** (agent ran via Bash, not operator): \`TARGET_DIR=… scripts/backup-postgres.sh\` produced a valid 3.2 MB pg_dump custom-format archive. \`pg_restore --list\` against the dump confirmed 342 tables of data, dumped by pg_dump 16.13 against the live \`dpf-postgres-1\`. sha256 + manifest written correctly.
- [ ] **End-to-end Inngest dispatch verification** — requires a portal image rebuild to pick up the new script-path mount and the new Inngest function registration. Per \`feedback_docker_explicit_approval.md\` ("Docker needs explicit go"), this is gated on a Mark-approved \`docker compose build portal && docker compose up -d portal\`. After rebuild: open \`/admin/backups\`, click "Run backup now", confirm the BackupRun row appears with \`status: ok\` and the dump file lands at \`\${DPF_HOST_INSTALL_PATH}/backups/postgres/<ISO-ts>/dpf.dump\`.
- [ ] **First scheduled run** — observable at 03:00 UTC the next morning after merge + rebuild. The heartbeat in \`ScheduledJob\` will update \`lastRunAt\` / \`lastStatus\`; the admin UX will surface the new history row.

## Resilience claim

If this had been live before the 2026-05-17T04:35:45Z \`dpf_pgdata\` wipe, recovery would have been a single button-click restore from the previous night's dump instead of 6+ hours forensic backlog reconstruction from PRs/specs/plans. The wipe trigger itself was permanently fixed by PR #709 (\`COMPOSE_PROJECT_NAME\` isolation), but no fix-it-once can prevent every wipe vector — operator error, host disk corruption, future infra changes. Daily off-volume backups make wipes recoverable instead of catastrophic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)