### PR TITLE
fix(codex-cli): pass prompt to container via stdin to prevent E2BIG

### DIFF
--- a/apps/web/lib/routing/codex-cli-adapter.test.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.test.ts
@@ -1,0 +1,293 @@
+// apps/web/lib/routing/codex-cli-adapter.test.ts
+// Tests for codex-cli-adapter — focusing on the stdin-pipe fix for BI-2685C1E5
+// and E2BIG spawn error classification.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/ai-inference", () => {
+  class InferenceError extends Error {
+    name = "InferenceError";
+    constructor(
+      message: string,
+      public readonly code: string,
+      public readonly providerId: string,
+    ) {
+      super(message);
+    }
+  }
+  return { InferenceError };
+});
+
+vi.mock("@/lib/inference/ai-provider-internals", () => ({
+  getDecryptedCredential: vi.fn(),
+  getProviderBearerToken: vi.fn(),
+}));
+
+vi.mock("./execution-adapter-registry", () => ({
+  registerExecutionAdapter: vi.fn(),
+}));
+
+vi.mock("./extract-tool-calls", () => ({
+  extractToolCalls: vi.fn().mockReturnValue([]),
+}));
+
+// ── Spawn mock infrastructure ─────────────────────────────────────────────────
+
+interface MockProcess extends EventEmitter {
+  stdin: {
+    write: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function makeMockProcess(): MockProcess {
+  const proc = new EventEmitter() as MockProcess;
+  proc.stdin = {
+    write: vi.fn((_data: unknown, cb?: (err?: Error | null) => void) => {
+      cb?.();
+      return true;
+    }),
+    end: vi.fn(),
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  return proc;
+}
+
+const mockSpawn = vi.fn();
+const mockExecAsync = vi.fn();
+
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({
+    exec: (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const result = mockExecAsync(cmd);
+      if (result instanceof Promise) {
+        result
+          .then((resolved: { stdout: string; stderr: string }) => cb(null, resolved))
+          .catch((error: Error) => cb(error, { stdout: "", stderr: "" }));
+      } else {
+        cb(null, { stdout: "", stderr: "" });
+      }
+    },
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+  }),
+  lazyUtil: () => ({
+    promisify:
+      (fn: Function) =>
+      (...args: unknown[]) =>
+        new Promise((resolve, reject) => {
+          fn(...args, (err: Error | null, result: unknown) => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        }),
+  }),
+}));
+
+import { writeContainerFileViaStdin } from "./codex-cli-adapter";
+import type { AdapterRequest } from "./adapter-types";
+import type { RoutedExecutionPlan } from "./recipe-types";
+
+// ── Request factory (mirrors cli-adapter.test.ts pattern) ────────────────────
+
+function makePlan(overrides?: Partial<RoutedExecutionPlan>): RoutedExecutionPlan {
+  return {
+    providerId: "codex",
+    modelId: "gpt-4o",
+    recipeId: null,
+    contractFamily: "conversation",
+    executionAdapter: "codex-cli",
+    maxTokens: 4096,
+    providerSettings: {},
+    toolPolicy: {},
+    responsePolicy: {},
+    ...overrides,
+  };
+}
+
+function makeRequest(overrides?: Partial<AdapterRequest>): AdapterRequest {
+  return {
+    providerId: "codex",
+    modelId: "gpt-4o",
+    plan: makePlan(),
+    provider: { baseUrl: "cli://local", headers: {} },
+    messages: [{ role: "user", content: "hello" }],
+    systemPrompt: "",
+    ...overrides,
+  };
+}
+
+// ── writeContainerFileViaStdin ────────────────────────────────────────────────
+
+describe("writeContainerFileViaStdin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses docker exec -i (stdin pipe) — NOT echo arg injection", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("aGVsbG8=", "/tmp/test.txt");
+    proc.emit("close", 0);
+    await writePromise;
+
+    const [cmd, args] = mockSpawn.mock.calls[0] as [string, string[]];
+    expect(cmd).toBe("docker");
+    // -i flag is required for stdin piping
+    expect(args).toContain("-i");
+    // The base64 payload must NEVER appear in the command arguments —
+    // that is the exact bug BI-2685C1E5: large payloads hit OS ARG_MAX.
+    expect(args.join(" ")).not.toContain("aGVsbG8=");
+  });
+
+  it("sends b64 data through stdin.write, then calls stdin.end", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("aGVsbG8=", "/tmp/test.txt");
+    proc.emit("close", 0);
+    await writePromise;
+
+    expect(proc.stdin.write).toHaveBeenCalledWith("aGVsbG8=", expect.any(Function));
+    expect(proc.stdin.end).toHaveBeenCalled();
+  });
+
+  it("applies the specified chmod mode in the container sh -c command", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("dGVzdA==", "/tmp/run.sh", "755");
+    proc.emit("close", 0);
+    await writePromise;
+
+    const shCmd = (mockSpawn.mock.calls[0] as [string, string[]])[1].join(" ");
+    expect(shCmd).toContain("chmod 755");
+  });
+
+  it("rejects when docker exits with non-zero code", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("dGVzdA==", "/tmp/fail.txt");
+    proc.stderr.emit("data", Buffer.from("permission denied"));
+    proc.emit("close", 1);
+
+    await expect(writePromise).rejects.toThrow("Container file write failed");
+  });
+
+  it("rejects on spawn-level error (e.g. docker not found)", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("dGVzdA==", "/tmp/fail.txt");
+    proc.emit("error", new Error("spawn ENOENT"));
+
+    await expect(writePromise).rejects.toThrow("spawn ENOENT");
+  });
+
+  it("kills the process and rejects after the 10 s write timeout", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("dGVzdA==", "/tmp/slow.txt");
+
+    vi.advanceTimersByTime(11_000);
+
+    await expect(writePromise).rejects.toThrow("timed out");
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("does not double-reject when both timeout and close fire", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const writePromise = writeContainerFileViaStdin("dGVzdA==", "/tmp/double.txt");
+
+    vi.advanceTimersByTime(11_000);
+    // Subsequent close or error must be silently swallowed by the settled flag
+    proc.emit("close", 1);
+
+    await expect(writePromise).rejects.toThrow("timed out");
+  });
+});
+
+// ── E2BIG spawn error classification ─────────────────────────────────────────
+
+describe("codexCliAdapter — E2BIG spawn error classification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Runs execute() with a mock where:
+   *  - auth returns apikey mode (no file write)
+   *  - the first two spawns (prompt + runner file writes) succeed immediately
+   *  - the third spawn (the actual codex exec) emits the given error
+   */
+  async function runAndGetSpawnErrorCode(spawnErrMsg: string): Promise<string> {
+    const { getDecryptedCredential } = await import("@/lib/inference/ai-provider-internals");
+    vi.mocked(getDecryptedCredential).mockResolvedValue({
+      secretRef: "sk-test",
+      cachedToken: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    let spawnCallCount = 0;
+    mockSpawn.mockImplementation(() => {
+      spawnCallCount++;
+      const proc = makeMockProcess();
+      if (spawnCallCount <= 2) {
+        // Prompt + runner file writes — succeed synchronously on nextTick
+        process.nextTick(() => proc.emit("close", 0));
+      } else {
+        // The actual codex exec spawn fails with the given error
+        process.nextTick(() => proc.emit("error", new Error(spawnErrMsg)));
+      }
+      return proc;
+    });
+
+    // execAsync for archive copy and cleanup — succeed silently
+    mockExecAsync.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const { codexCliAdapter } = await import("./codex-cli-adapter");
+    try {
+      await codexCliAdapter.execute(makeRequest());
+      return "no-error";
+    } catch (err: unknown) {
+      return (err as { code?: string }).code ?? "unknown";
+    }
+  }
+
+  it("classifies ENOMEM (typical E2BIG surface) as request_too_large", async () => {
+    expect(await runAndGetSpawnErrorCode("spawn ENOMEM")).toBe("request_too_large");
+  });
+
+  it("classifies 'argument list too long' as request_too_large", async () => {
+    expect(await runAndGetSpawnErrorCode("argument list too long")).toBe("request_too_large");
+  });
+
+  it("classifies ENOENT (docker not found) as network", async () => {
+    expect(await runAndGetSpawnErrorCode("spawn ENOENT")).toBe("network");
+  });
+
+  it("classifies ECONNREFUSED as network", async () => {
+    expect(await runAndGetSpawnErrorCode("spawn ECONNREFUSED")).toBe("network");
+  });
+});

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -25,6 +25,68 @@ import { extractToolCalls as sharedExtractToolCalls } from "./extract-tool-calls
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 180_000; // 3 minutes
 
+// ─── Container file writer ─────────────────────────────────────────────────
+
+/**
+ * Write base64-encoded data to a file inside the sandbox container via stdin.
+ *
+ * Root cause fix for BI-2685C1E5: the old approach —
+ *   docker exec CONTAINER sh -c "echo '${largeB64}' | base64 -d > file"
+ * — passes the entire base64 payload as a shell argument inside the `sh -c`
+ * string, which itself is an argument to `docker exec`. On Linux the combined
+ * size of all arguments + the environment must stay below ARG_MAX (~2 MB).
+ * With 58+ tools each carrying full JSON parameter schemas the base64-encoded
+ * prompt easily exceeds that limit and the OS rejects the spawn with POSIX
+ * E2BIG ("Argument list too long").
+ *
+ * Piping through stdin is unlimited in size. `docker exec -i` connects the
+ * host's stdin to the container's stdin; `base64 -d` reads from stdin when no
+ * file argument is given. The command line for `docker exec` stays short
+ * regardless of payload size.
+ */
+export async function writeContainerFileViaStdin(
+  b64Data: string,
+  destPath: string,
+  mode = "644",
+): Promise<void> {
+  const spawn = lazyChildProcess().spawn;
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(
+      "docker",
+      ["exec", "-i", SANDBOX_CONTAINER, "sh", "-c", `base64 -d > ${destPath} && chmod ${mode} ${destPath}`],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    let stderr = "";
+    let settled = false;
+    const settle = (fn: () => void) => { if (!settled) { settled = true; clearTimeout(writeTimeout); fn(); } };
+
+    // 10 s is generous for any realistic payload over a loopback socket.
+    const writeTimeout = setTimeout(() => {
+      proc.kill("SIGTERM");
+      settle(() => reject(new Error(`Container file write timed out: ${destPath}`)));
+    }, 10_000);
+
+    proc.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+    proc.stdin!.write(b64Data, (writeErr) => {
+      if (writeErr) settle(() => reject(new Error(`Container file write stdin error: ${writeErr.message}`)));
+    });
+    proc.stdin!.end();
+
+    proc.on("close", (code: number | null) => {
+      settle(() => {
+        if (code === 0) resolve();
+        else reject(new Error(`Container file write failed (exit ${code ?? "?"}): ${stderr.slice(0, 200)}`));
+      });
+    });
+
+    proc.on("error", (err: Error) => {
+      settle(() => reject(err));
+    });
+  });
+}
+
 export const TOOL_TRACE_KEYWORD_PATTERN = /\b(read_sandbox_file|write_sandbox_file|edit_sandbox_file|search_sandbox|list_sandbox_files|run_sandbox_command|check_sandbox|start_sandbox|saveBuildEvidence|save_build_notes|save_phase_handoff|reviewDesignDoc|reviewBuildPlan|search_project_files|read_project_file|list_project_directory|get_code_graph_freshness|inspect_build_code_impact|search_code_graph|trace_code_surface|find_related_tests|generate_design_system|search_design_intelligence|describe_model|deploy_feature|execute_promotion)\b/g;
 
 export function extractMentionedPlatformToolNames(text: string): string[] {
@@ -88,11 +150,10 @@ async function injectAuth(providerId: string): Promise<{ mode: "oauth" } | { mod
   });
 
   const execAsync = lazyUtil().promisify(lazyChildProcess().exec);
+  // mkdir is a tiny command — safe to run via execAsync.
+  await execAsync(`docker exec ${SANDBOX_CONTAINER} mkdir -p /root/.codex`, { timeout: 5_000 });
   const authB64 = Buffer.from(authJson).toString("base64");
-  await execAsync(
-    `docker exec ${SANDBOX_CONTAINER} sh -c "mkdir -p /root/.codex && echo '${authB64}' | base64 -d > /root/.codex/auth.json"`,
-    { timeout: 5_000 },
-  );
+  await writeContainerFileViaStdin(authB64, "/root/.codex/auth.json");
 
   return { mode: "oauth" };
 }
@@ -166,11 +227,10 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
     const spawnCb = cp.spawn;
 
     try {
+      // Write prompt via stdin to avoid the POSIX ARG_MAX limit (BI-2685C1E5).
+      // See writeContainerFileViaStdin for full rationale.
       const promptB64 = Buffer.from(prompt).toString("base64");
-      await execAsync(
-        `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${promptB64}' | base64 -d > ${promptFile} && chmod 644 ${promptFile}"`,
-        { timeout: 5_000 },
-      );
+      await writeContainerFileViaStdin(promptB64, promptFile);
 
       // 4. Build runner script
       const modelFlag = modelId ? `-m ${modelId}` : "";
@@ -190,10 +250,7 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
       ].join("\n");
 
       const scriptB64 = Buffer.from(script).toString("base64");
-      await execAsync(
-        `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${scriptB64}' | base64 -d > ${runnerScript} && chmod 755 ${runnerScript}"`,
-        { timeout: 5_000 },
-      );
+      await writeContainerFileViaStdin(scriptB64, runnerScript, "755");
 
       // 5. Spawn the CLI process
       console.log(`[codex-cli-adapter] Dispatching: model=${modelId}, provider=${providerId}, messages=${messages.length}`);
@@ -259,9 +316,16 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
 
         proc.on("error", (err: Error) => {
           clearTimeout(timer);
+          // E2BIG / ENOMEM: combined arg+env exceeded OS ARG_MAX.
+          // After the stdin-pipe fix this should not occur for prompt writes,
+          // but classify correctly if it ever does so the fallback chain can
+          // skip this provider rather than retrying a doomed request.
+          const isArgTooLong =
+            /E2BIG|ENOMEM/i.test(err.message) ||
+            /argument.*too.*long/i.test(err.message);
           reject(new InferenceError(
             `Codex CLI spawn error: ${err.message}`,
-            "network",
+            isArgTooLong ? "request_too_large" : "network",
             providerId,
           ));
         });


### PR DESCRIPTION
## Summary

- **Root cause (BI-2685C1E5):** `docker exec sh -c "echo '${largeB64}' | base64 -d > file"` passes the entire base64-encoded prompt as a shell argument. On Linux, `ARG_MAX` (~2 MB) caps the combined size of all arguments + the environment. With 58+ tools each carrying full JSON parameter schemas the encoded prompt exceeds that limit and the OS rejects the spawn with POSIX `E2BIG` ("Argument list too long").
- **Fix:** New `writeContainerFileViaStdin` helper uses `docker exec -i` and pipes data through stdin — unlimited in size, regardless of payload. Applied to the prompt write, runner-script write, and auth.json injection (all three used the same vulnerable pattern).
- **Error classification:** E2BIG / ENOMEM spawn errors on the codex exec process itself are now classified as `request_too_large` (was `"network"`) so the fallback chain skips to the next provider instead of retrying a doomed request.

## Test plan

- [ ] 11 new unit tests in `codex-cli-adapter.test.ts`:
  - Payload never appears in spawn args (the exact regression guard)
  - `stdin.write` is called with the b64 data; `stdin.end` is called
  - chmod mode is forwarded correctly into the container `sh -c` command
  - Non-zero exit code, spawn-level error, and 10 s write timeout all reject cleanly
  - Double-reject is guarded by a `settled` flag
  - `ENOMEM` / `"argument list too long"` -> `request_too_large`
  - `ENOENT` / `ECONNREFUSED` -> `network`
- [ ] Existing `codex-cli-tool-extract.test.ts` (7 tests) passes unchanged
- [ ] TypeScript typecheck clean (pre-commit hook passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)