### PR TITLE
feat(work-capsules): attach Build Studio work

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -22,6 +22,16 @@ const { mockAuth, mockPrisma } = vi.hoisted(() => ({
     buildActivity: {
       create: vi.fn(),
     },
+    backlogItemActivity: {
+      create: vi.fn(),
+    },
+    workCapsule: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    workCapsuleActivity: {
+      create: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -73,7 +83,7 @@ vi.mock("next/cache", () => ({
 }));
 
 import { revalidatePath } from "next/cache";
-import { approveBuildStart, advanceBuildPhase, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief, updateFeatureBrief } from "./build";
+import { approveBuildStart, advanceBuildPhase, createFeatureBuild, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief, updateFeatureBrief } from "./build";
 
 describe("governed build start approvals", () => {
   beforeEach(() => {
@@ -86,6 +96,13 @@ describe("governed build start approvals", () => {
       },
     });
     mockPrisma.buildActivity.create.mockResolvedValue({});
+    mockPrisma.backlogItemActivity.create.mockResolvedValue({});
+    mockPrisma.workCapsule.findUnique.mockResolvedValue(null);
+    mockPrisma.workCapsule.create.mockResolvedValue({
+      id: "capsule-row-direct",
+      capsuleId: "WC-DIRECT1",
+    });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({});
     mockPrisma.$transaction.mockImplementation(async (callback) => callback(mockPrisma));
     mockPrisma.businessBuildBrief.findUnique.mockResolvedValue({ status: "accepted" });
     mockPrisma.businessBuildBrief.upsert.mockResolvedValue({});
@@ -103,6 +120,44 @@ describe("governed build start approvals", () => {
       errors: [],
     });
     mockListReleasableSandboxFiles.mockResolvedValue(["apps/web/components/build/BuildStudio.tsx"]);
+  });
+
+  it("createFeatureBuild attaches a Work Capsule to direct Build Studio work", async () => {
+    mockPrisma.featureBuild.create.mockImplementation(async (args) => ({
+      id: "build-row-direct",
+      buildId: args.data.buildId,
+      title: "Harden portal work capsule routing",
+      description: "Keep portal-started development inside governed work.",
+      phase: "ideate",
+    }));
+
+    const result = await createFeatureBuild({
+      title: "Harden portal work capsule routing",
+      description: "Keep portal-started development inside governed work.",
+    });
+
+    expect(result.buildId).toMatch(/^FB-[A-F0-9]{8}$/);
+    expect(mockPrisma.workCapsule.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          source: "build-studio",
+          executorKind: "build-studio",
+          executorRef: result.buildId,
+          status: "working",
+          featureBuildId: "build-row-direct",
+          backlogItemId: null,
+          epicId: null,
+          idempotencyKey: `build-studio:${result.buildId}`,
+          workspaceState: expect.objectContaining({
+            buildStudio: expect.objectContaining({
+              buildId: result.buildId,
+              phase: "ideate",
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).not.toHaveBeenCalled();
   });
 
   it("updateFeatureBrief writes the legacy brief and backfills the BusinessBuildBrief contract", async () => {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -30,6 +30,10 @@ import {
 import { routeAndCall } from "@/lib/routed-inference";
 import * as crypto from "crypto";
 import { listReleasableSandboxFiles } from "@/lib/integrate/sandbox/sandbox";
+import {
+  attachBuildStudioWorkCapsule,
+  type BuildStudioCapsuleDb,
+} from "@/lib/work-capsules/build-studio-attachment";
 
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
@@ -73,17 +77,33 @@ export async function createFeatureBuild(input: {
 
   const buildId = generateBuildId();
 
-  await prisma.featureBuild.create({
-    data: {
-      buildId,
-      title: input.title.trim(),
-      ...(input.description !== undefined && { description: input.description.trim() || null }),
-      ...(input.portfolioId !== undefined && { portfolioId: input.portfolioId || null }),
-      createdById: userId,
-    },
+  const result = await prisma.$transaction(async (tx) => {
+    const created = await tx.featureBuild.create({
+      data: {
+        buildId,
+        title: input.title.trim(),
+        ...(input.description !== undefined && { description: input.description.trim() || null }),
+        ...(input.portfolioId !== undefined && { portfolioId: input.portfolioId || null }),
+        createdById: userId,
+      },
+    });
+
+    await attachBuildStudioWorkCapsule({
+      db: tx as unknown as BuildStudioCapsuleDb,
+      build: {
+        id: created.id,
+        buildId: created.buildId,
+        title: created.title,
+        description: created.description,
+        phase: created.phase,
+      },
+      actor: { userId, agentId: null, principalId: null },
+    });
+
+    return { buildId: created.buildId };
   });
 
-  return { buildId };
+  return result;
 }
 
 export async function approveBuildStart(buildId: string): Promise<{ approvedAt: Date }> {

--- a/apps/web/lib/governed-backlog-tee-up.test.ts
+++ b/apps/web/lib/governed-backlog-tee-up.test.ts
@@ -18,6 +18,16 @@ const mockPrisma = {
   buildActivity: {
     create: vi.fn(),
   },
+  backlogItemActivity: {
+    create: vi.fn(),
+  },
+  workCapsule: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  workCapsuleActivity: {
+    create: vi.fn(),
+  },
   $transaction: vi.fn(),
 };
 
@@ -34,6 +44,13 @@ describe("governed backlog tee-up", () => {
       governedBacklogEnabled: true,
       backlogTeeUpDailyCap: 2,
     });
+    mockPrisma.backlogItemActivity.create.mockResolvedValue({});
+    mockPrisma.workCapsule.findUnique.mockResolvedValue(null);
+    mockPrisma.workCapsule.create.mockResolvedValue({
+      id: "capsule-row-1",
+      capsuleId: "WC-BUILD01",
+    });
+    mockPrisma.workCapsuleActivity.create.mockResolvedValue({});
 
     mockPrisma.$transaction.mockImplementation(async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
       return callback(mockPrisma);
@@ -248,6 +265,35 @@ describe("governed backlog tee-up", () => {
         }),
       }),
     );
+    expect(mockPrisma.workCapsule.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          source: "build-studio",
+          executorKind: "build-studio",
+          executorRef: "FB-11111111",
+          status: "working",
+          backlogItemId: "backlog-epic",
+          epicId: "epic-1",
+          featureBuildId: "build-row-1",
+          idempotencyKey: "build-studio:FB-11111111",
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "backlog-epic",
+          kind: "build-studio-capsule-attached",
+          recordedById: "user-1",
+          summary: expect.stringContaining("FB-11111111"),
+          payload: expect.objectContaining({
+            buildId: "FB-11111111",
+            capsuleId: "WC-BUILD01",
+            featureBuildId: "build-row-1",
+          }),
+        }),
+      }),
+    );
   });
 
   it("skips processing when governed backlog mode is disabled", async () => {
@@ -306,7 +352,47 @@ describe("governed backlog tee-up", () => {
       });
 
       expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.capsuleId).toBe("WC-BUILD01");
+      }
       expect(mockPrisma.epic.create).not.toHaveBeenCalled();
+      expect(mockPrisma.workCapsule.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            source: "build-studio",
+            executorKind: "build-studio",
+            executorRef: "FB-12345678",
+            status: "working",
+            backlogItemId: "bi-cuid-1",
+            epicId: "epic-cuid-1",
+            featureBuildId: "build-row-1",
+            idempotencyKey: "build-studio:FB-12345678",
+            workspaceState: expect.objectContaining({
+              buildStudio: expect.objectContaining({
+                buildId: "FB-12345678",
+                phase: "ideate",
+              }),
+              backlogItem: expect.objectContaining({
+                itemId: "BI-EPIC-OK",
+              }),
+            }),
+          }),
+        }),
+      );
+      expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            backlogItemId: "bi-cuid-1",
+            kind: "build-studio-capsule-attached",
+            recordedById: "user-1",
+            payload: expect.objectContaining({
+              buildId: "FB-12345678",
+              capsuleId: "WC-BUILD01",
+              featureBuildId: "build-row-1",
+            }),
+          }),
+        }),
+      );
 
       const createCall = mockPrisma.featureBuild.create.mock.calls[0]![0];
       const intake = createCall.data.plan.happyPathState.intake;

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -1,5 +1,9 @@
 import * as crypto from "crypto";
 import { generateBuildId, mergeHappyPathStateIntoPlan } from "@/lib/feature-build-types";
+import {
+  attachBuildStudioWorkCapsule,
+  type BuildStudioCapsuleDb,
+} from "@/lib/work-capsules/build-studio-attachment";
 
 const ELIGIBLE_EFFORT_SIZES = new Set(["small", "medium", "large"]);
 const ACTIVE_EPIC_STATUSES = new Set(["open", "in-progress"]);
@@ -27,12 +31,8 @@ type GovernedBacklogConfig = {
   backlogTeeUpDailyCap: number | null;
 } | null;
 
-type GovernedBacklogTeeUpPrisma = {
-  platformDevConfig: {
-    findUnique(args: any): Promise<any>;
-  };
+type GovernedBacklogTeeUpTx = {
   backlogItem: {
-    findMany(args: any): Promise<any>;
     findUnique(args: any): Promise<any>;
     update(args: any): Promise<any>;
   };
@@ -45,11 +45,32 @@ type GovernedBacklogTeeUpPrisma = {
   buildActivity: {
     create(args: any): Promise<any>;
   };
-  $transaction<T>(callback: (tx: GovernedBacklogTeeUpPrisma) => Promise<T>): Promise<T>;
+  backlogItemActivity: {
+    create(args: any): Promise<any>;
+  };
+  workCapsule: {
+    create(args: any): Promise<any>;
+    findUnique(args: any): Promise<any>;
+    findFirst?(args: any): Promise<any>;
+    update?(args: any): Promise<any>;
+  };
+  workCapsuleActivity: {
+    create(args: any): Promise<any>;
+  };
+};
+
+type GovernedBacklogTeeUpPrisma = GovernedBacklogTeeUpTx & {
+  platformDevConfig: {
+    findUnique(args: any): Promise<any>;
+  };
+  backlogItem: GovernedBacklogTeeUpTx["backlogItem"] & {
+    findMany(args: any): Promise<any>;
+  };
+  $transaction<T>(callback: (tx: GovernedBacklogTeeUpTx) => Promise<T>): Promise<T>;
 };
 
 type PromoteBacklogItemToBuildDraftInput = {
-  tx: GovernedBacklogTeeUpPrisma;
+  tx: GovernedBacklogTeeUpTx;
   itemId: string;
   userId: string;
   governedBacklogEnabled: boolean;
@@ -66,6 +87,7 @@ type PromoteBacklogItemToBuildDraftResult =
     kind: "success";
     build: { id: string; buildId: string };
     backlogItemId: string;
+    capsuleId: string;
   }
   | {
     kind: "error";
@@ -141,6 +163,7 @@ export async function promoteBacklogItemToBuildDraft(
   // BacklogItem isn't linked, mint a solo epic from the item title and link it
   // so the ideate→plan gate clears at promote time.
   let epicSemanticId: string;
+  let epicRowId: string | null = item.epicId ?? null;
   if (item.epicId && item.epic?.epicId) {
     epicSemanticId = item.epic.epicId;
   } else {
@@ -150,6 +173,7 @@ export async function promoteBacklogItemToBuildDraft(
       data: { epicId: epicSemanticId, title: epicTitle, status: "open" },
       select: { id: true, epicId: true },
     });
+    epicRowId = createdEpic.id;
     await tx.backlogItem.update({
       where: { itemId },
       data: { epicId: createdEpic.id },
@@ -193,6 +217,27 @@ export async function promoteBacklogItemToBuildDraft(
     },
   });
 
+  const capsule = await attachBuildStudioWorkCapsule({
+    db: tx as unknown as BuildStudioCapsuleDb,
+    build: {
+      id: created.id,
+      buildId: created.buildId,
+      title: item.title,
+      description: item.body,
+      phase: "ideate",
+    },
+    backlogItem: {
+      id: item.id,
+      itemId: item.itemId,
+      title: item.title,
+      body: item.body,
+      epicId: epicRowId,
+      epicSemanticId,
+      taxonomyNodeId: item.taxonomyNodeId ?? null,
+    },
+    actor: { userId, agentId: null, principalId: null },
+  });
+
   if (activity) {
     await tx.buildActivity.create({
       data: {
@@ -207,6 +252,7 @@ export async function promoteBacklogItemToBuildDraft(
     kind: "success",
     build: created,
     backlogItemId: itemId,
+    capsuleId: capsule.capsuleId,
   };
 }
 

--- a/apps/web/lib/work-capsules/build-studio-attachment.ts
+++ b/apps/web/lib/work-capsules/build-studio-attachment.ts
@@ -1,0 +1,111 @@
+import {
+  createWorkCapsule,
+  type CapsuleDb,
+  type WorkCapsuleActor,
+} from "./work-capsule-store";
+
+type BacklogItemActivityDb = {
+  backlogItemActivity: {
+    create(args: unknown): Promise<unknown>;
+  };
+};
+
+export type BuildStudioCapsuleDb = CapsuleDb & BacklogItemActivityDb;
+
+type BuildStudioCapsuleBuild = {
+  id: string;
+  buildId: string;
+  title?: string | null;
+  description?: string | null;
+  phase?: string | null;
+};
+
+type BuildStudioCapsuleBacklogItem = {
+  id: string;
+  itemId: string;
+  title: string;
+  body: string | null;
+  epicId: string | null;
+  epicSemanticId?: string | null;
+  taxonomyNodeId?: string | null;
+};
+
+function fallbackObjective(buildId: string, title: string): string {
+  return `Govern Build Studio work ${buildId}: ${title}`;
+}
+
+function cleanText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export async function attachBuildStudioWorkCapsule(args: {
+  db: BuildStudioCapsuleDb;
+  build: BuildStudioCapsuleBuild;
+  backlogItem?: BuildStudioCapsuleBacklogItem | null;
+  actor: WorkCapsuleActor;
+}) {
+  const idempotencyKey = `build-studio:${args.build.buildId}`;
+  const existing = await args.db.workCapsule.findUnique({
+    where: { idempotencyKey },
+  });
+  if (existing) return existing;
+
+  const title = cleanText(args.build.title) ?? cleanText(args.backlogItem?.title) ?? args.build.buildId;
+  const objective =
+    cleanText(args.build.description)
+    ?? cleanText(args.backlogItem?.body)
+    ?? fallbackObjective(args.build.buildId, title);
+
+  const capsule = await createWorkCapsule({
+    db: args.db,
+    input: {
+      title,
+      objective,
+      source: "build-studio",
+      idempotencyKey,
+      executorKind: "build-studio",
+      executorRef: args.build.buildId,
+      status: "working",
+      backlogItemId: args.backlogItem?.id ?? null,
+      epicId: args.backlogItem?.epicId ?? null,
+      featureBuildId: args.build.id,
+      workspaceState: {
+        buildStudio: {
+          buildId: args.build.buildId,
+          phase: args.build.phase ?? "ideate",
+        },
+        ...(args.backlogItem
+          ? {
+            backlogItem: {
+              itemId: args.backlogItem.itemId,
+              epicId: args.backlogItem.epicSemanticId ?? null,
+              taxonomyNodeId: args.backlogItem.taxonomyNodeId ?? null,
+            },
+          }
+          : {}),
+      },
+    },
+    actor: args.actor,
+  });
+
+  if (args.backlogItem) {
+    await args.db.backlogItemActivity.create({
+      data: {
+        backlogItemId: args.backlogItem.id,
+        kind: "build-studio-capsule-attached",
+        summary: `Build Studio draft ${args.build.buildId} attached to Work Capsule ${capsule.capsuleId}.`,
+        payload: {
+          buildId: args.build.buildId,
+          capsuleId: capsule.capsuleId,
+          featureBuildId: args.build.id,
+          source: "build-studio",
+        },
+        recordedById: args.actor.userId,
+        recordedByAgentId: args.actor.agentId,
+      },
+    });
+  }
+
+  return capsule;
+}

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -47,6 +47,12 @@ type CapsuleCreateInput = {
   source: WorkCapsuleSource;
   idempotencyKey: string;
   executorKind?: WorkCapsuleExecutorKind | null;
+  executorRef?: string | null;
+  status?: WorkCapsuleStatus;
+  backlogItemId?: string | null;
+  epicId?: string | null;
+  featureBuildId?: string | null;
+  workspaceState?: Record<string, unknown>;
 };
 
 type CapsuleAdoptionInput = {
@@ -132,6 +138,9 @@ export async function createWorkCapsule(args: {
   if (args.input.executorKind && !isWorkCapsuleExecutorKind(args.input.executorKind)) {
     throw new Error("Invalid executor kind");
   }
+  if (args.input.status && !isWorkCapsuleStatus(args.input.status)) {
+    throw new Error("Invalid capsule status");
+  }
 
   const existing = await args.db.workCapsule.findUnique({
     where: { idempotencyKey: args.input.idempotencyKey },
@@ -148,13 +157,18 @@ export async function createWorkCapsule(args: {
           objective: args.input.objective,
           source: args.input.source,
           executorKind: args.input.executorKind ?? null,
+          executorRef: args.input.executorRef ?? null,
+          backlogItemId: args.input.backlogItemId ?? null,
+          epicId: args.input.epicId ?? null,
+          featureBuildId: args.input.featureBuildId ?? null,
+          workspaceState: args.input.workspaceState ?? {},
           idempotencyKey: args.input.idempotencyKey,
           leaseHolderPrincipalId: isExternalLeaseExecutor(args.input.executorKind)
             ? args.actor.principalId
             : null,
           leaseExpiresAt: isExternalLeaseExecutor(args.input.executorKind) ? leaseUntil(now) : null,
           createdByPrincipalId: args.actor.principalId,
-          status: args.input.executorKind ? "ready" : "draft",
+          status: args.input.status ?? (args.input.executorKind ? "ready" : "draft"),
         },
       });
       await recordActivity(tx, {

--- a/docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md
+++ b/docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md
@@ -1,6 +1,6 @@
 # Portal Work Capsule Control Harness Phase 3 Implementation Plan
 
-> **Status (2026-05-17):** Slice 1 implementation committed (`268ea90a`). Three write-tool renewal assertions and one read-tool idempotency assertion are missing before the test contract matches spec §17.3 — add them, then run verification before opening PR.
+> **Status (2026-05-17):** Slice 1 landed as the lease auto-renewal path. Slice 2 is Build Studio attachment: new direct Build Studio builds and backlog-promoted Build Studio drafts create a Work Capsule and, when backlog-linked, write backlog timeline activity. External desktop/CLI executor attachment remains open.
 
 ## Goal
 
@@ -80,6 +80,64 @@ Required before PR:
 
 This slice has no migration and no user-facing UI change, so UX verification is limited to the MCP handler contract exercised by the focused test.
 
+## Slice 2 Scope
+
+In scope:
+
+- Attach newly created direct Build Studio `FeatureBuild` rows to a Work Capsule in the same transaction.
+- Attach backlog-promoted Build Studio drafts to a Work Capsule in the same promotion transaction.
+- Preserve the backlog item row id, epic row id, `FeatureBuild.id`, public `buildId`, and Build Studio phase in capsule linkage/workspace state.
+- Write `BacklogItemActivity` of kind `build-studio-capsule-attached` for backlog-linked builds so the backlog timeline shows that development has started under a capsule.
+- Keep direct Build Studio builds valid without a backlog item while still creating a capsule.
+
+Out of scope for Slice 2:
+
+- Backfilling capsules for pre-existing active `FeatureBuild` rows.
+- External Codex/Claude desktop attachment UX.
+- CLI sandbox executor sessions.
+- `executor-changed` handoff UI.
+- Commit trailer and PR-body `DPF-Capsule:` enforcement.
+
+## Slice 2 Implementation Status
+
+Implemented on `feat/work-capsule-build-studio-attach`:
+
+- Added `attachBuildStudioWorkCapsule` in `apps/web/lib/work-capsules/build-studio-attachment.ts` as the reusable Build Studio-to-capsule policy helper.
+- Extended `createWorkCapsule` input to accept existing linkage fields (`executorRef`, `backlogItemId`, `epicId`, `featureBuildId`, `workspaceState`, and explicit `status`) without changing existing manual/MCP callers.
+- Updated `createFeatureBuild` so direct Build Studio work creates a `source = build-studio`, `executorKind = build-studio`, `status = working` capsule.
+- Updated `promoteBacklogItemToBuildDraft` so backlog-created Build Studio drafts create the same capsule link and write backlog activity.
+
+**Slice 2 test coverage:**
+
+| Assertion | Status |
+|---|---|
+| Direct `createFeatureBuild` creates a Build Studio Work Capsule | explicit in `apps/web/lib/actions/build-governed.test.ts` |
+| Direct `createFeatureBuild` does not write backlog activity without a backlog item | explicit |
+| Backlog tee-up promotion creates a Build Studio Work Capsule | explicit in `apps/web/lib/governed-backlog-tee-up.test.ts` |
+| `promoteBacklogItemToBuildDraft` returns the attached capsule id | explicit |
+| Backlog-linked promotion writes `build-studio-capsule-attached` activity | explicit |
+
+## Slice 2 File Touches
+
+- `apps/web/lib/work-capsules/build-studio-attachment.ts`
+- `apps/web/lib/work-capsules/work-capsule-store.ts`
+- `apps/web/lib/actions/build.ts`
+- `apps/web/lib/governed-backlog-tee-up.ts`
+- `apps/web/lib/actions/build-governed.test.ts`
+- `apps/web/lib/governed-backlog-tee-up.test.ts`
+- `docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md`
+- `docs/superpowers/plans/2026-05-17-portal-work-capsule-control-harness-phase-3.md`
+
+## Slice 2 Verification
+
+Required before PR:
+
+- `pnpm --filter web exec vitest run lib/governed-backlog-tee-up.test.ts lib/actions/build-governed.test.ts`
+- `pnpm --filter web typecheck`
+- `pnpm --filter web build`
+
+This slice has no migration and no UI component change. Runtime UX verification is limited to the server-action/workflow contract unless the branch later adds a visible capsule link in Build Studio.
+
 ## Next Phase 3 Slice
 
-After this PR lands, the next smallest Phase 3 slice is executor handoff: add the `executor-changed` write path, record every transition as activity, and surface the current executor in capsule detail without introducing promotion behavior.
+After Slice 2 lands, the next smallest Phase 3 slice is executor handoff: add the `executor-changed` write path, record every transition as activity, and surface the current executor in capsule detail without introducing promotion behavior.

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |---|---|
-| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied); 2026-05-16 (Phase 2 display-and-record scope applied); 2026-05-17 (Phase 2 merged and Phase 3 lease auto-renewal slice applied); 2026-05-17 (chief-architect review: §9.3 MCP table updated with `plan_capsule_worktree`, §9.5 auto-renewal allowlist corrected, §17.3 per-tool test names added) |
-| Status | Phase 1 merged to `main` via PR #602; Phase 2 merged to `main` via PR #675; Phase 3 first slice implements lease auto-renewal for existing-capsule MCP writes while broader executor attachment remains open; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
+| Date | 2026-05-13 (initial); 2026-05-14 (chief-architect review applied); 2026-05-14 (second chief-architect pass after Phase 1 plan review); 2026-05-14 (branch/PR and scratch-install doctrine applied); 2026-05-16 (Phase 1 merged and verification refresh applied); 2026-05-16 (Phase 2 display-and-record scope applied); 2026-05-17 (Phase 2 merged and Phase 3 lease auto-renewal slice applied); 2026-05-17 (chief-architect review: §9.3 MCP table updated with `plan_capsule_worktree`, §9.5 auto-renewal allowlist corrected, §17.3 per-tool test names added); 2026-05-17 (Phase 3 Build Studio attachment slice applied) |
+| Status | Phase 1 merged to `main` via PR #602; Phase 2 merged to `main` via PR #675; Phase 3 now implements lease auto-renewal for existing-capsule MCP writes and capsule attachment for newly created direct/backlog-promoted Build Studio builds; external desktop/CLI executor attachment remains open; PR opens only when ready to merge; Phase 2/3/5 doctrine tightened |
 | Author | Codex + Mark Bodman; chief-architect review by Claude (Opus 4.7) |
 | Scope | Portal-coordinated work capsules for Build Studio, external Claude/Codex desktop sessions, manual worktrees, sandbox promotion, and portal self-update governance |
 | Depends On | `2026-04-05-db-github-delivery-sync-design.md`, `2026-04-20-ship-phase-fork-redesign-design.md`, `2026-04-21-backlog-triage-build-studio-design.md`, `2026-04-23-build-studio-governed-backlog-delivery-design.md`, `2026-05-09-build-execution-provider-design.md`, `2026-05-09-deployment-contracts.md` |
@@ -891,7 +891,7 @@ Execute in this order so fresh installs and existing installs both land cleanly:
 ### Phase 3: Executor Attachment
 
 - add handler-level lease auto-renewal for existing-capsule MCP write tools while preserving read-tool idempotence
-- attach Build Studio builds to capsules
+- attach newly created Build Studio builds to capsules
 - attach Codex/Claude desktop sessions through MCP tools
 - attach Codex CLI and Claude Code CLI sandbox sessions as first-class capsule executors
 - record external execution evidence
@@ -962,9 +962,10 @@ Adds:
 Adds:
 
 1. Lease auto-renewal middleware tests — one test per tool, named explicitly: `claim_capsule_scope`, `record_capsule_evidence`, `update_work_capsule_status`, and `release_capsule_scope` each assert that `workCapsule.update` is called with `leaseHolderPrincipalId` + `leaseExpiresAt` and that a `lease-renewed` activity is written; `list_work_capsules` and `get_work_capsule` each assert that no update or activity write occurs; `heartbeat_capsule` asserts renewal fires exactly once. A single "proof-of-concept" test covering only one write tool is insufficient because the wrapper is applied per-handler and a misconfigured handler is only caught by its own assertion.
-2. Collision-detection tests for overlapping `(kind, value)` scope claims across active capsules.
-3. External executor handoff tests  -  `executor-changed` activity is written on every transition.
-4. CLI hive tests proving Codex CLI and Claude Code CLI sessions attach as separate executor sessions, record separate evidence, and do not receive raw provider/OAuth secrets.
+2. Build Studio attachment tests proving direct `createFeatureBuild` creates a `source = build-studio` capsule, backlog promotion creates the same capsule link, and backlog-linked promotion writes `BacklogItemActivity.kind = build-studio-capsule-attached`.
+3. Collision-detection tests for overlapping `(kind, value)` scope claims across active capsules.
+4. External executor handoff tests  -  `executor-changed` activity is written on every transition.
+5. CLI hive tests proving Codex CLI and Claude Code CLI sessions attach as separate executor sessions, record separate evidence, and do not receive raw provider/OAuth secrets.
 
 ### Phase 4 (Daily Steward)
 
@@ -990,7 +991,7 @@ Adds:
 The "first enforced from" annotation tells implementers when each invariant becomes testable. Earlier-phase invariants stay in force in every later phase.
 
 1. The root clone is never an active implementation workspace. *(Phase 2.)*
-2. Every active Build Studio build should have or create a Work Capsule. *(Phase 3.)*
+2. Every newly created direct/backlog-promoted Build Studio build should have or create a Work Capsule. Existing active builds are reconciler/backfill work. *(Phase 3.)*
 3. Every external desktop coding session should attach to a Work Capsule before making non-trivial changes. *(Phase 3.)*
 4. Every capsule with production-visible intent must link to verification evidence. *(Phase 5.)*
 5. Portal replacement cannot proceed without backup evidence. *(Phase 5.)*


### PR DESCRIPTION
## Summary

- attach direct Build Studio builds to Work Capsules when `createFeatureBuild` creates a `FeatureBuild`
- attach backlog-promoted Build Studio drafts to Work Capsules and write `build-studio-capsule-attached` backlog activity
- refactor Build Studio capsule policy into `apps/web/lib/work-capsules/build-studio-attachment.ts`
- update the Phase 3 Work Capsule plan/spec to document the implemented slice and remaining executor work

## Validation

- `pnpm --filter web exec vitest run lib/governed-backlog-tee-up.test.ts lib/actions/build-governed.test.ts lib/work-capsules/work-capsule-store.test.ts` — 3 files / 30 tests passed
- `pnpm --filter web typecheck` — passed
- `pnpm --filter web build` — passed; emitted existing Turbopack broad-trace warnings unrelated to this slice

## Backlog

- BI-20E6AC44