### PR TITLE
fix(seed): add missing generatedBy to seedModelProfiles() create call

### DIFF
--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1738,7 +1738,7 @@ async function seedModelProfiles(): Promise<void> {
     if (existing) { skipped++; continue; }
     const { providerId: _pid, modelId: _mid, ...rest } = p;
     try {
-      await prisma.modelProfile.create({ data: { providerId, modelId, ...rest } as never });
+      await prisma.modelProfile.create({ data: { generatedBy: "system:seed", ...rest, providerId, modelId } as never });
       created++;
     } catch { skipped++; }
   }


### PR DESCRIPTION
## Summary

- `ModelProfile.generatedBy` is a required `String` column with no database default
- `seedModelProfiles()` spread JSON from `model-profiles.json` which had no `generatedBy` key, causing Prisma to throw `Argument generatedBy is missing` for every entry (Gemini and others)
- Fix: inject `generatedBy: "system:seed"` before `...rest` in the `create()` call, consistent with every other `ModelProfile.create()` in the seed file

## Root cause

All other create paths (`seedLocalModels`, `seedCodexModels`, `seedChatGPTModels`, `seedSpeachesTranscriptionModel`) explicitly set `generatedBy: "system:seed"`. The generic `seedModelProfiles()` JSON-loader path was the only one missing it.

## Spread order

`{ generatedBy: "system:seed", ...rest, providerId, modelId }`

- Default `"system:seed"` is set first
- `...rest` can override it if a JSON entry ever includes `generatedBy`
- `providerId`/`modelId` are pinned last so they cannot be clobbered by JSON

## Test plan

- [ ] Run `pnpm seed` against a fresh DB — all model-profiles.json entries seed without error
- [ ] Confirm Gemini profiles appear in `ModelProfile` table with `generatedBy = system:seed`
- [ ] Re-run seed — `skipped` count increments, no errors

Generated with [Claude Code](https://claude.com/claude-code)