### PR TITLE
Clarify business capability map refinement plan

### DIFF
--- a/docs/superpowers/plans/2026-05-17-business-capability-map-nested-analytics.md
+++ b/docs/superpowers/plans/2026-05-17-business-capability-map-nested-analytics.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Keep `BusinessCapability` as the stable business architecture construct and keep operational records as trace targets. Add tested read-model helpers for evidence summaries, overlay states, and deterministic map rows before changing the UI. Then refactor the current map component into smaller client-side map, control, tile, and detail components while preserving the existing server actions and schema.
 
-**Tech Stack:** Next.js 16 app routes, React 19, Prisma 7 read model, Vitest, DPF theme tokens, `lucide-react`, existing Business Capability schema and server actions.
+**Tech Stack:** Next.js app routes, React, Prisma read model, Vitest, DPF theme tokens, `lucide-react`, existing Business Capability schema and server actions.
 
 ---
 
@@ -14,9 +14,17 @@
 
 - Active backlog item: `BI-03AD102F` ("Nested Business Capability Map implementation").
 - Approved spec: `docs/superpowers/specs/2026-05-17-business-capability-map-nested-analytics-design.md`.
-- Do not add schema in this slice.
+- Do not add DDL migrations or new Prisma model fields in this slice.
 - Do not conflate `BusinessCapability` and `TaxonomyNode`.
 - Reserve refactoring effort for typed read-model helpers and component boundaries.
+
+The spec's control bar lists five elements. This plan implements two of them: **overlay selector** and **maturity legend**. The following three are explicitly deferred to a subsequent plan:
+
+- IT4IT filter (single-select filter to narrow the map to one value stream).
+- Level visibility toggle (show/hide L3 sub-capabilities globally).
+- Search (filter tiles by capability name or description).
+
+Do not implement stubs or placeholders for the deferred controls. Leave blank space in the control bar or add a `{/* TODO: IT4IT filter, level toggle, search */}` comment so the slot is reserved without shipping dead UI.
 
 ## File Map
 
@@ -53,6 +61,8 @@
 - Test: `apps/web/lib/business-capabilities/data.test.ts`
 
 - [ ] **Step 1: Add failing tests for evidence summaries**
+
+Read `data.test.ts` first to understand existing fixtures and test structure. Do not delete or modify any existing test case. Add new `describe` blocks for the new helpers.
 
 Add assertions to `data.test.ts` using the existing `rows` fixture plus backlog and architecture links:
 
@@ -103,6 +113,8 @@ status?: BacklogTraceStatus;
 
 - [ ] **Step 5: Implement evidence summary**
 
+Before writing any code, read `apps/web/lib/business-capabilities/types.ts` to confirm the shape of `BusinessCapabilityNode` — specifically which field holds grouped trace links. Use the confirmed field name throughout the implementation rather than assuming `node.traceGroups`.
+
 Add:
 
 ```ts
@@ -110,13 +122,13 @@ export type CapabilityEvidenceSummary = {
   taxonomyCount: number;
   productCount: number;
   backlogCount: number;
-  activeBacklogCount: number;
+  activeBacklogCount: number; // links with status "open" or "in-progress"
   architectureCount: number;
-  hasOperationalEvidence: boolean;
+  hasOperationalEvidence: boolean; // true when any count above is > 0
 };
 ```
 
-Then implement `buildCapabilityEvidenceSummary(node)` by reading `node.traceGroups`.
+Then implement `buildCapabilityEvidenceSummary(node)` using the confirmed trace-link field from the node type.
 
 - [ ] **Step 6: Run the targeted test and confirm it passes**
 
@@ -206,7 +218,9 @@ The row helper is intentionally simple in this slice. It creates the tested seam
 
 - [ ] **Step 6: Enrich backlog trace status**
 
-In `toTraceRecord`, select and map `backlogItem.status`. In `getBusinessCapabilityMapData`, update the Prisma include:
+Before writing the select, read the `BacklogItem` model in `prisma/schema.prisma` to confirm the exact field name for status. Common alternatives are `status`, `itemStatus`, or `state`. Use the confirmed name in both the Prisma include and the `toTraceRecord` mapping.
+
+In `toTraceRecord`, select and map the status field. In `getBusinessCapabilityMapData`, update the Prisma include, for example:
 
 ```ts
 backlogItem: { select: { itemId: true, title: true, status: true } },
@@ -214,18 +228,17 @@ backlogItem: { select: { itemId: true, title: true, status: true } },
 
 - [ ] **Step 7: Return `mapRows`**
 
-In `getBusinessCapabilityMapData`, build the tree once, then return:
+In `getBusinessCapabilityMapData`, build the tree once, then return. Do not remove any existing return fields — extend the shape:
 
 ```ts
 const tree = buildCapabilityTree(records);
 return {
-  records,
-  tree,
+  ...existingFields,        // preserve all fields currently returned
   mapRows: buildCapabilityMapRows(tree),
-  summary: summarizeCapabilityMap(records),
-  ...
 };
 ```
+
+Read the current return type annotation (or the call sites in `page.tsx`) before writing the updated return to confirm what "existingFields" contains. Do not guess at field names.
 
 - [ ] **Step 8: Run the targeted test**
 
@@ -267,7 +280,7 @@ const [selectedCapabilityId, setSelectedCapabilityId] = useState<string | null>(
 
 - [ ] **Step 2: Move summary metrics into the client shell**
 
-Preserve the current six metrics, but make the control bar visually primary after the header. Use DPF tokens only.
+Read the current `BusinessCapabilityMap.tsx` to confirm which metrics are rendered before touching anything. Preserve all of them — do not drop or rename any metric during the refactor. Use DPF tokens only for all styling.
 
 - [ ] **Step 3: Add overlay segmented controls**
 
@@ -275,15 +288,49 @@ Render `CAPABILITY_OVERLAY_MODES` as buttons with `aria-pressed`.
 
 - [ ] **Step 4: Create `CapabilityMapTiles.tsx`**
 
-Implement pure presentational components:
+Implement pure presentational components with the following prop contracts:
 
-- `CapabilityMapCanvas`
-- `CapabilityFamilyBand`
-- `CapabilityTile`
-- `CapabilitySubCapabilityTile`
-- `EvidenceChips`
+```ts
+// Top-level canvas — owns nothing beyond layout
+type CapabilityMapCanvasProps = {
+  rows: BusinessCapabilityMapRow[];
+  overlayMode: CapabilityOverlayMode;
+  selectedCapabilityId: string | null;
+  onSelectCapability: (id: string | null) => void;
+};
 
-Inputs should include `overlayMode`, `selectedCapabilityId`, and `onSelectCapability`.
+// One L1 family section
+type CapabilityFamilyBandProps = {
+  family: BusinessCapabilityNode;
+  overlayMode: CapabilityOverlayMode;
+  selectedCapabilityId: string | null;
+  onSelectCapability: (id: string | null) => void;
+};
+
+// One L2 tile (holds L3 tiles as children)
+type CapabilityTileProps = {
+  capability: BusinessCapabilityNode;
+  overlayState: CapabilityOverlayState;
+  evidenceSummary: CapabilityEvidenceSummary;
+  isSelected: boolean;
+  onSelect: () => void;
+};
+
+// One L3 nested chip/tile inside an L2 tile
+type CapabilitySubCapabilityTileProps = {
+  capability: BusinessCapabilityNode;
+  overlayState: CapabilityOverlayState;
+  isSelected: boolean;
+  onSelect: () => void;
+};
+
+// Compact evidence row: icons + counts only
+type EvidenceChipsProps = {
+  summary: CapabilityEvidenceSummary;
+};
+```
+
+Derive `overlayState` and `evidenceSummary` inside `CapabilityFamilyBand` using the helpers from `data.ts` so tile components stay purely presentational.
 
 - [ ] **Step 5: Convert `BusinessCapabilityMap.tsx` to server wrapper**
 
@@ -314,7 +361,22 @@ Expected: pass after imports and props are corrected.
 
 - [ ] **Step 1: Add capability flattening helper in client shell**
 
-Use `useMemo` to flatten `mapRows` into a list for selected lookup. Keep this helper local to the client component unless tests prove it belongs in `data.ts`.
+Use `useMemo` to flatten `mapRows` into a `Map<string, BusinessCapabilityNode>` keyed by capability ID. This gives O(1) lookup when the user selects a tile. Keep this helper local to the client component unless tests prove it belongs in `data.ts`.
+
+```ts
+const capabilityById = useMemo(() => {
+  const map = new Map<string, BusinessCapabilityNode>();
+  for (const row of mapRows) {
+    for (const family of row.families) {
+      // recursive walk: add family and all descendants
+      walkCapabilityTree(family, (node) => map.set(node.id, node));
+    }
+  }
+  return map;
+}, [mapRows]);
+```
+
+Implement `walkCapabilityTree` as a small local helper that visits a node and recurses into its children.
 
 - [ ] **Step 2: Create `CapabilityDetailPanel.tsx`**
 
@@ -437,7 +499,15 @@ Run:
 ```powershell
 git status --short
 git add apps/web/lib/business-capabilities apps/web/components/portfolio/architecture apps/web/app/(shell)/portfolio/architecture/page.tsx docs/superpowers/specs/2026-05-17-business-capability-map-nested-analytics-design.md docs/superpowers/plans/2026-05-17-business-capability-map-nested-analytics.md
-git commit -s -m "feat: refine business capability map analytics"
+git commit -s -m "feat(business-capability-map): nested L1/L2/L3 heat map with overlay modes and detail panel
+
+- Add CapabilityOverlayMode, CapabilityEvidenceSummary, and CapabilityOverlayState types
+- Add buildCapabilityEvidenceSummary, deriveCapabilityOverlayState, buildCapabilityMapRows helpers
+- Enrich backlog trace links with status for planning impact overlay
+- Split BusinessCapabilityMap into server wrapper and client map shell
+- Add CapabilityMapTiles nested band/tile/sub-capability components
+- Add CapabilityDetailPanel with planning prompts and grouped trace links
+- Preserve existing forms, server actions, and schema unchanged"
 git push -u origin feat/business-capability-map-nested-analytics
 ```
 

--- a/docs/superpowers/specs/2026-05-17-business-capability-map-nested-analytics-design.md
+++ b/docs/superpowers/specs/2026-05-17-business-capability-map-nested-analytics-design.md
@@ -214,7 +214,7 @@ The nested map should follow these rules:
 - Each L1 band has a title, optional description, maturity summary, and child count.
 - L2 capabilities render as stable tiles inside the family.
 - L3 sub-capabilities render within their parent L2 tile when space allows; on narrow screens they collapse into a count plus expandable list.
-- Empty L1 and L2 containers are allowed but visibly incomplete.
+- Empty L1 and L2 containers are allowed but visibly incomplete: render a dimmed container with a short inline prompt ("Add a capability") that opens the authoring panel pre-filled with the parent set. Do not hide the container or collapse it into a zero-count row.
 - Tile dimensions should use responsive grid constraints and minimum heights so hover states, labels, chips, and counts do not shift the layout.
 
 The visual target is closer to the user's provided examples: parent containers visibly hold child capability tiles. The UI should not look like unrelated cards separated by page whitespace.
@@ -253,7 +253,14 @@ The detail panel should answer four planning questions without requiring the use
 - What work is planned or active?
 - What gaps remain unsupported by products, architecture, or backlog work?
 
-For the first refinement, these answers can be derived from existing maturity fields and trace links. Later slices may add richer assessment history, ownership, time horizons, or investment measures if usage proves the need.
+For the first refinement, the answers are derived as follows:
+
+- **Target state:** `targetMaturity` label and `maturityRationale` from the capability record.
+- **Supports today:** all trace links grouped by type (taxonomy, products, architecture elements).
+- **Active or planned work:** backlog trace links where status is `open` or `in-progress`.
+- **Unsupported gap:** maturity gap exists (`targetMaturity > currentMaturity`) AND no linked backlog item is `open` or `in-progress`.
+
+Later slices may add richer assessment history, ownership, time horizons, or investment measures if usage proves the need.
 
 ## View-Model Design
 
@@ -262,15 +269,20 @@ No new schema is required for the next refinement. Add view-model helpers around
 Recommended additions:
 
 - `CapabilityOverlayMode = "maturity" | "coverage" | "planning" | "it4it"`.
-- `CapabilityEvidenceSummary` with counts for taxonomy, products, backlog, architecture, active backlog, and missing evidence.
-- `CapabilityOverlayState` with `tone`, `label`, `shortLabel`, `description`, and `sortWeight`.
+- `CapabilityEvidenceSummary` with counts for taxonomy, products, backlog, architecture, active backlog, and missing evidence. `hasOperationalEvidence` is `true` when any of `taxonomyCount`, `productCount`, `backlogCount`, or `architectureCount` is greater than zero.
+- `CapabilityOverlayTone = "aligned" | "watch" | "gap" | "unassessed" | "neutral" | "covered" | "active"`. Each mode maps capabilities to tones as follows:
+  - `maturity`: `unassessed` when either maturity value is null or zero; `aligned` when current ≥ target; `watch` when target exceeds current by 1; `gap` when target exceeds current by 2 or more.
+  - `coverage`: `covered` when `hasOperationalEvidence` is true; `gap` when false.
+  - `planning`: `active` when `activeBacklogCount > 0`; `gap` when a maturity gap exists and `activeBacklogCount === 0`; `aligned` when no maturity gap and no active work required.
+  - `it4it`: `covered` when the capability has at least one value-stream tag; `neutral` when none. When a capability aligns to multiple value streams, `tone` is `covered` and `label` lists all tags separated by commas. The IT4IT overlay does not filter out unaligned capabilities; they remain visible at `neutral`.
+- `CapabilityOverlayState` with `tone`, `label`, `shortLabel`, `description`, and `sortWeight`. `sortWeight` drives ordering within an L1 band when the UI offers a sort-by-overlay option: lower values sort first so critical gaps surface at the top-left of each band.
 - `buildCapabilityEvidenceSummary(node)`.
 - `deriveCapabilityOverlayState(node, mode)`.
-- `buildCapabilityMapRows(tree)` - required for deterministic row grouping; implement as an identity pass if child counts are small, so the nested-map slice has a stable seam and a tested boundary regardless of data volume.
+- `buildCapabilityMapRows(tree)` — for this refinement, implement as a single identity row: `[{ id: "row-1", families: tree }]`. This creates a stable, tested seam for future density-aware row grouping without block-breaking the current slice.
 
-The `getBusinessCapabilityMapData()` query should enrich backlog trace links with status where possible, because planning impact needs to distinguish open/in-progress work from done/deferred work. If the current select shape does not include backlog status, add it as a read-model field only.
+The `getBusinessCapabilityMapData()` query should enrich backlog trace links with status because planning impact needs to distinguish open/in-progress work from done/deferred work. Planning verification on 2026-05-17 confirmed that the current query selects backlog item ID and title but not status. The implementation plan will add status to the Prisma include as a read-model field only; no DDL change is required.
 
-Planning verification on 2026-05-17 confirmed that `getBusinessCapabilityMapData()` currently selects backlog item ID and title but not status. The implementation plan will add status to the read model only; no schema change is required.
+**Clarification on "no new schema":** This constraint means no new tables and no new columns added via Prisma migration. Adding fields to an existing `select` or `include` clause that already exists in the database is permitted.
 
 ## UI Implementation Guidance
 
@@ -300,9 +312,9 @@ Later implementation must follow DPF theme rules:
 - Overlay mode can switch between maturity, operational coverage, planning impact, and IT4IT alignment.
 - Traceability to taxonomy, products, backlog, and architecture is visible as compact map evidence and full detail-panel links.
 - IT4IT alignment uses the existing platform slugs.
-- No new database schema is added for this refinement unless an implementation spike proves a blocker and updates this spec first.
-- Unit tests cover evidence summary and overlay-state derivation.
-- Slice 1 confirms whether `BacklogItem` status is already returned by `getBusinessCapabilityMapData()`; if absent, it is added as a read-model field and this spec is updated to record the decision before planning proceeds.
+- No DDL changes (no new tables, no new columns via migration) are added for this refinement unless an implementation spike proves a blocker and updates this spec first.
+- Unit tests cover evidence summary, all four overlay-state modes, and deterministic map-row grouping.
+- `BacklogItem.status` is included in the `getBusinessCapabilityMapData` read model. This was confirmed absent on 2026-05-17 and is added as a `select` field in the implementation plan.
 - UX verification captures desktop and mobile screenshots of the nested map and selected-capability detail panel.
 
 ## Implementation Slices After Spec Approval


### PR DESCRIPTION
## Summary
- Clarifies the nested capability map plan after review: no DDL/schema-field changes in this slice, no placeholder controls for deferred UX, and stronger read-before-edit guardrails.
- Tightens the spec for empty containers, overlay tone derivation, planning-gap logic, map-row grouping, and backlog status read-model usage.
- Preserves the merged implementation PR #728 as the code delivery artifact while capturing the reviewed spec/plan updates in a follow-up PR.

## Verification
- `git diff --check`
- `git diff --cached --check`
- Doc-only change; production build already passed on merged implementation PR #728.