### PR TITLE
fix(build-studio): auto-merge existing audit on designDoc revision

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -5653,15 +5653,35 @@ export async function executeTool(
       // Reject design docs that skip codebase research — they lead to builds
       // with wrong auth patterns, wrong field names, and wrong imports.
       // Accept "no existing code found" as valid research for new features.
+      // When updating an existing doc (revising for review feedback), auto-merge
+      // the audit from the saved doc so the coworker doesn't loop retrying.
       if (field === "designDoc") {
         const doc = normalizedValue as Record<string, unknown> | null;
         const audit = String(doc?.existingCodeAudit ?? doc?.existingFunctionalityAudit ?? "");
         if (!audit || audit.length < 20) {
-          return {
-            success: false,
-            error: "Design doc missing codebase research.",
-            message: "REJECTED: existingCodeAudit is empty or too short. Research the codebase first with search_project_files and describe_model. If this is a new feature with no existing code, write 'No existing implementation found. Searched for [terms]. This is a new feature.' — that counts as valid research.",
-          };
+          // Check whether the build already has a valid audit saved — if so,
+          // carry it forward rather than forcing a full re-research on revision.
+          const existing = await prisma.featureBuild.findUnique({
+            where: { buildId },
+            select: { designDoc: true },
+          });
+          const existingDoc = existing?.designDoc as Record<string, unknown> | null;
+          const existingAudit = String(
+            existingDoc?.existingCodeAudit ?? existingDoc?.existingFunctionalityAudit ?? ""
+          );
+          if (existingAudit.length >= 20) {
+            // Carry forward the existing audit so the revision can be saved.
+            normalizedValue = {
+              ...doc,
+              existingFunctionalityAudit: existingAudit,
+            };
+          } else {
+            return {
+              success: false,
+              error: "Design doc missing codebase research.",
+              message: "REJECTED: existingCodeAudit is empty or too short. Research the codebase first with search_project_files and describe_model. If this is a new feature with no existing code, write 'No existing implementation found. Searched for [terms]. This is a new feature.' — that counts as valid research.",
+            };
+          }
         }
       }
 


### PR DESCRIPTION
## Root cause

When a coworker revises a design doc to address review feedback (e.g. add CSRF/SSRF/concurrency sections), the new doc omits the `existingFunctionalityAudit` field — it's long and the coworker focuses only on the changed sections. The `saveBuildEvidence` validator checks the *incoming* doc in isolation and rejects with `"Design doc missing codebase research."` on every retry, causing the coworker to loop calling the same tool with the same arguments.

Reproducer: **FB-71FB3A53** — build-specialist called `saveBuildEvidence` 3 times with identical args after being asked to add CSRF/SSRF/concurrency sections to the design doc. Existing doc had 4,653-char audit in DB; all three saves rejected.

## Fix

Before rejecting, check whether the `buildId` already has a valid audit saved. If it does, carry it forward into the incoming doc automatically. The hard gate still applies on first save (no prior audit) — the guard protects against coworkers skipping research entirely.

## Test plan

- [x] Existing design docs with no prior audit still rejected with clear message
- [x] Revision of a doc that has a prior audit in DB: audit auto-merged, save succeeds
- [ ] CI unit tests pass (no test changes needed — existing guard tests still pass; new behaviour covered by the DB check path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)