### PR TITLE
fix(deliberation): null-safe branchNodeId prevents ClaimRecord FK violation

### DIFF
--- a/apps/web/lib/deliberation/synthesizer.ts
+++ b/apps/web/lib/deliberation/synthesizer.ts
@@ -31,7 +31,7 @@ import { computeEvidenceBadge } from "./evidence";
 /* -------------------------------------------------------------------------- */
 
 export interface BranchArtifact {
-  branchNodeId: string;
+  branchNodeId: string | null;
   role: string;
   completed: boolean;
   /** Short free-text recommendation / position. Used for consensus detection
@@ -82,7 +82,7 @@ export interface SynthesizedOutcome {
 }
 
 export interface BranchRosterEntry {
-  branchNodeId: string;
+  branchNodeId: string | null;
   role: string;
   completed: boolean;
   failureReason?: string;
@@ -371,7 +371,7 @@ async function persistBranchClaims(
     const created = await prisma.claimRecord.create({
       data: {
         deliberationRunId,
-        branchNodeId: branch.branchNodeId,
+        branchNodeId: branch.branchNodeId ?? null,
         claimText: c.claimText,
         claimType,
         status: "unresolved",

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -322,9 +322,14 @@ export async function runBuildReviewDeliberation(
   // roles the orchestrator materialized. If counts don't match (pattern
   // expanded extra branches we don't have content for), we let the
   // synthesizer count them as incomplete — that's truthful.
+  // IMPORTANT: fall back to null (not art.branchNodeId) when no persisted
+  // node exists. art.branchNodeId may be a placeholder string like
+  // "reviewer-1" that doesn't exist in TaskNode, which causes a FK
+  // violation on ClaimRecord.branchNodeId -> TaskNode(id).
+  // branchNodeId is nullable (ON DELETE SET NULL) so null is safe.
   const alignedArtifacts = branchArtifacts.map((art, idx) => ({
     ...art,
-    branchNodeId: nodesByRole[idx]?.id ?? art.branchNodeId,
+    branchNodeId: nodesByRole[idx]?.id ?? null,
   }));
 
   const synth = await synthesizeDeliberation({


### PR DESCRIPTION
## Root cause

`mcp-tools.ts` populates `ReviewBranchInput.branchNodeId` with placeholder strings `"reviewer-1"` / `"reviewer-2"`. In `build-orchestrator.ts`, these are aligned with real persisted `TaskNode` IDs via a DB lookup:

```ts
branchNodeId: nodesByRole[idx]?.id ?? art.branchNodeId,
```

When `nodesByRole` has no entry (lookup miss), it falls back to `art.branchNodeId` — the literal string `"reviewer-1"`. That string doesn't exist in `TaskNode.id`, so `ClaimRecord.create` fails with:

```
Foreign key constraint violated: ClaimRecord_branchNodeId_fkey
  → REFERENCES TaskNode(id)
```

This silently broke `reviewDesignDoc` and `reviewBuildPlan` for all builds — the deliberation trail could not be recorded, surfaced as `[deliberation] failed to record build review trail` in portal logs.

## Fix

- **`build-orchestrator.ts`**: fall back to `null` instead of `art.branchNodeId`. `ClaimRecord.branchNodeId` is nullable (`ON DELETE SET NULL`), so `null` is safe and doesn't violate the constraint.
- **`synthesizer.ts`**: widen `BranchArtifact.branchNodeId` and `BranchRosterEntry.branchNodeId` to `string | null` to match reality. Pass `branchNodeId ?? null` in `ClaimRecord.create`.

## Test plan

- [x] `reviewDesignDoc` no longer logs FK error on FB-71FB3A53
- [x] ClaimRecord rows saved with `branchNodeId = null` when no persisted TaskNode matches
- [ ] CI typecheck passes (types widened correctly)
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)