### PR TITLE
feat(backup): Slice 2 — restore wizard with typed-RESTORE confirmation

### DIFF
--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -10,11 +10,23 @@ import {
   type BackupRunListItem,
   type BackupRunLog,
 } from "@/lib/actions/backups";
+import {
+  listRestoreRunsAction,
+  previewRestoreAction,
+} from "@/lib/actions/backup-restore";
 import type { ReadinessSummary } from "@/lib/operate/backups/types";
+import type {
+  RestoreImpactPreview,
+  RestoreRunListItem,
+} from "@/lib/operate/backups/restore-types";
+
+import { RestoreConfirmModal } from "./RestoreConfirmModal";
+import { RestoreHistorySection } from "./RestoreHistorySection";
 
 interface Props {
   initialReadiness: ReadinessSummary;
   initialRuns: BackupRunListItem[];
+  initialRestoreRuns: RestoreRunListItem[];
 }
 
 function formatBytes(n: number | null): string {
@@ -59,21 +71,50 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
-export function BackupsClient({ initialReadiness, initialRuns }: Props) {
+export function BackupsClient({
+  initialReadiness,
+  initialRuns,
+  initialRestoreRuns,
+}: Props) {
   const [readiness, setReadiness] = useState(initialReadiness);
   const [runs, setRuns] = useState(initialRuns);
+  const [restoreRuns, setRestoreRuns] = useState(initialRestoreRuns);
   const [pending, startTransition] = useTransition();
   const [openLog, setOpenLog] = useState<{ runId: string; data: BackupRunLog } | null>(null);
   const [loadingLog, setLoadingLog] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [restorePreview, setRestorePreview] = useState<RestoreImpactPreview | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState<string | null>(null);
 
   async function refresh() {
-    const [next, list] = await Promise.all([
+    const [next, list, restores] = await Promise.all([
       getBackupReadinessAction(),
       listBackupRunsAction({ limit: 50 }),
+      listRestoreRunsAction({ limit: 20 }),
     ]);
     setReadiness(next);
     setRuns(list);
+    setRestoreRuns(restores);
+  }
+
+  async function handleOpenRestore(runId: string) {
+    setError(null);
+    setLoadingPreview(runId);
+    try {
+      const preview = await previewRestoreAction(runId);
+      setRestorePreview(preview);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoadingPreview(null);
+    }
+  }
+
+  function handleRestoreConfirmed() {
+    setRestorePreview(null);
+    refresh().catch((e: unknown) =>
+      setError(e instanceof Error ? e.message : String(e)),
+    );
   }
 
   function handleTrigger() {
@@ -253,6 +294,17 @@ export function BackupsClient({ initialReadiness, initialRuns }: Props) {
                     <Td>{formatBytes(r.sizeBytes)}</Td>
                     <Td>{formatDurationMs(r.durationMs)}</Td>
                     <Td className="text-right">
+                      {r.status === "ok" && !r.prunedAt && (
+                        <button
+                          onClick={() => handleOpenRestore(r.id)}
+                          disabled={loadingPreview !== null}
+                          className="mr-3 hover:underline disabled:opacity-50"
+                          style={{ color: "#f87171" }}
+                          title="Restore the database from this backup"
+                        >
+                          {loadingPreview === r.id ? "Loading…" : "Restore…"}
+                        </button>
+                      )}
                       <button
                         onClick={() => handleOpenLog(r.id)}
                         disabled={loadingLog}
@@ -276,6 +328,18 @@ export function BackupsClient({ initialReadiness, initialRuns }: Props) {
           </div>
         )}
       </section>
+
+      {/* ─── Restore history (Slice 2) ──────────────────────────────────── */}
+      <RestoreHistorySection runs={restoreRuns} />
+
+      {/* ─── Restore wizard modal (Slice 2) ─────────────────────────────── */}
+      {restorePreview && (
+        <RestoreConfirmModal
+          preview={restorePreview}
+          onClose={() => setRestorePreview(null)}
+          onConfirmed={handleRestoreConfirmed}
+        />
+      )}
 
       {/* ─── Log drawer ─────────────────────────────────────────────────── */}
       {openLog && (

--- a/apps/web/app/(shell)/admin/backups/RestoreConfirmModal.tsx
+++ b/apps/web/app/(shell)/admin/backups/RestoreConfirmModal.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import {
+  confirmRestoreAction,
+  type ConfirmRestoreResult,
+} from "@/lib/actions/backup-restore";
+import { RESTORE_CONFIRMATION_TEXT } from "@/lib/operate/backups/restore-types";
+import type { RestoreImpactPreview } from "@/lib/operate/backups/restore-types";
+
+interface Props {
+  preview: RestoreImpactPreview;
+  onClose: () => void;
+  onConfirmed: (result: ConfirmRestoreResult) => void;
+}
+
+function formatBytes(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatTimestamp(s: string | null): string {
+  if (!s) return "—";
+  return new Date(s).toLocaleString();
+}
+
+export function RestoreConfirmModal({ preview, onClose, onConfirmed }: Props) {
+  const [confirmation, setConfirmation] = useState("");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const blockedByIntegrity = preview.fileMissing || preview.sha256Mismatch;
+  const confirmationValid = confirmation === RESTORE_CONFIRMATION_TEXT;
+  const canConfirm = !blockedByIntegrity && confirmationValid && !pending;
+
+  function handleConfirm() {
+    setError(null);
+    startTransition(async () => {
+      const result = await confirmRestoreAction(
+        preview.sourceBackupRunId,
+        confirmation,
+      );
+      if (!result.ok) {
+        setError(result.error ?? "Restore failed.");
+        return;
+      }
+      onConfirmed(result);
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={pending ? undefined : onClose}
+      style={{ background: "rgba(0, 0, 0, 0.6)" }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-[640px] max-w-[95vw] rounded p-6 max-h-[90vh] overflow-y-auto"
+        style={{
+          background: "var(--dpf-surface)",
+          border: "1px solid var(--dpf-border)",
+        }}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h2 className="text-lg font-bold text-[var(--dpf-text)]">
+              Restore from backup
+            </h2>
+            <p className="text-xs text-[var(--dpf-muted)] mt-1">
+              This action replaces the current database with the contents of
+              the selected dump.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={pending}
+            className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
+          >
+            Close
+          </button>
+        </div>
+
+        {/* ── Impact summary ───────────────────────────────────────────── */}
+        <div
+          className="rounded p-4 mb-4 text-sm space-y-2"
+          style={{
+            background: "var(--dpf-bg)",
+            border: "1px solid var(--dpf-border)",
+          }}
+        >
+          <div className="flex justify-between gap-3">
+            <span className="text-[var(--dpf-muted)] text-xs uppercase">
+              Source taken
+            </span>
+            <span className="text-[var(--dpf-text)]">
+              {formatTimestamp(preview.sourceFinishedAt)}
+            </span>
+          </div>
+          <div className="flex justify-between gap-3">
+            <span className="text-[var(--dpf-muted)] text-xs uppercase">
+              Size
+            </span>
+            <span className="text-[var(--dpf-text)]">
+              {formatBytes(preview.sourceSizeBytes)}
+            </span>
+          </div>
+          <div className="flex justify-between gap-3">
+            <span className="text-[var(--dpf-muted)] text-xs uppercase">
+              Age
+            </span>
+            <span className="text-[var(--dpf-text)]">
+              {preview.sourceAgeMinutes} minute
+              {preview.sourceAgeMinutes === 1 ? "" : "s"} ago
+            </span>
+          </div>
+          {preview.sourceSha256 && (
+            <div className="flex justify-between gap-3">
+              <span className="text-[var(--dpf-muted)] text-xs uppercase">
+                Checksum
+              </span>
+              <span
+                className="text-[10px] font-mono text-[var(--dpf-muted)]"
+                title={preview.sourceSha256}
+              >
+                {preview.sourceSha256.slice(0, 16)}…
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* ── Impact narrative ─────────────────────────────────────────── */}
+        <div
+          className="rounded p-3 mb-4 text-sm"
+          style={{
+            background: blockedByIntegrity
+              ? "rgba(248, 113, 113, 0.15)"
+              : "rgba(251, 191, 36, 0.12)",
+            color: blockedByIntegrity ? "#f87171" : "var(--dpf-text)",
+            border: `1px solid ${blockedByIntegrity ? "rgba(248, 113, 113, 0.3)" : "rgba(251, 191, 36, 0.3)"}`,
+          }}
+        >
+          {preview.impactSummary}
+        </div>
+
+        {preview.versionWarning && (
+          <div
+            className="rounded p-3 mb-4 text-xs"
+            style={{
+              background: "rgba(251, 191, 36, 0.12)",
+              color: "#fbbf24",
+              border: "1px solid rgba(251, 191, 36, 0.3)",
+            }}
+          >
+            ⚠️ {preview.versionWarning}
+          </div>
+        )}
+
+        {/* ── Typed confirmation ───────────────────────────────────────── */}
+        {!blockedByIntegrity && (
+          <div className="mb-4">
+            <label
+              htmlFor="restore-confirm"
+              className="block text-xs font-medium uppercase mb-2"
+              style={{ color: "var(--dpf-muted)" }}
+            >
+              Type{" "}
+              <span
+                className="font-mono text-[var(--dpf-text)]"
+                style={{ background: "var(--dpf-bg)", padding: "0 4px" }}
+              >
+                {RESTORE_CONFIRMATION_TEXT}
+              </span>{" "}
+              to confirm
+            </label>
+            <input
+              id="restore-confirm"
+              type="text"
+              value={confirmation}
+              onChange={(e) => setConfirmation(e.target.value)}
+              disabled={pending}
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              className="w-full px-3 py-2 rounded font-mono text-sm"
+              style={{
+                background: "var(--dpf-bg)",
+                color: "var(--dpf-text)",
+                border: `1px solid ${
+                  confirmation === "" || confirmationValid
+                    ? "var(--dpf-border)"
+                    : "rgba(248, 113, 113, 0.5)"
+                }`,
+              }}
+              placeholder={RESTORE_CONFIRMATION_TEXT}
+            />
+            {confirmation !== "" && !confirmationValid && (
+              <p
+                className="text-xs mt-1"
+                style={{ color: "#f87171" }}
+              >
+                Confirmation must match exactly (case-sensitive).
+              </p>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <div
+            className="rounded p-3 mb-4 text-sm"
+            style={{
+              background: "rgba(248, 113, 113, 0.15)",
+              color: "#f87171",
+              border: "1px solid rgba(248, 113, 113, 0.3)",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* ── Actions ──────────────────────────────────────────────────── */}
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            onClick={onClose}
+            disabled={pending}
+            className="px-4 py-2 text-sm rounded transition-colors disabled:opacity-50"
+            style={{
+              background: "transparent",
+              color: "var(--dpf-text)",
+              border: "1px solid var(--dpf-border)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            className="px-4 py-2 text-sm font-medium rounded transition-colors"
+            style={{
+              background: canConfirm ? "#f87171" : "var(--dpf-border)",
+              color: canConfirm ? "#fff" : "var(--dpf-muted)",
+              cursor: canConfirm ? "pointer" : "not-allowed",
+            }}
+          >
+            {pending ? "Restoring…" : "Restore"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/admin/backups/RestoreHistorySection.tsx
+++ b/apps/web/app/(shell)/admin/backups/RestoreHistorySection.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { RestoreRunListItem } from "@/lib/operate/backups/restore-types";
+
+interface Props {
+  runs: RestoreRunListItem[];
+}
+
+const STATUS_PILL: Record<string, { bg: string; color: string; label: string }> = {
+  ok: { bg: "rgba(74, 222, 128, 0.15)", color: "#4ade80", label: "OK" },
+  failed: { bg: "rgba(248, 113, 113, 0.15)", color: "#f87171", label: "FAILED" },
+  running: { bg: "rgba(99, 102, 241, 0.15)", color: "#6366f1", label: "RUNNING" },
+};
+
+function StatusPill({ status }: { status: string }) {
+  const style = STATUS_PILL[status] ?? {
+    bg: "rgba(136, 136, 160, 0.15)",
+    color: "#8888a0",
+    label: status.toUpperCase(),
+  };
+  return (
+    <span
+      className="text-[10px] font-bold px-1.5 py-0.5 rounded"
+      style={{ background: style.bg, color: style.color }}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+function formatTimestamp(s: string | null): string {
+  if (!s) return "—";
+  return new Date(s).toLocaleString();
+}
+
+function formatDurationMs(ms: number | null): string {
+  if (ms === null || ms === undefined) return "—";
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60 * 1000) return `${(ms / 1000).toFixed(1)} s`;
+  return `${(ms / 60000).toFixed(1)} min`;
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th
+      className="text-left px-3 py-2 text-[10px] uppercase font-medium"
+      style={{ color: "var(--dpf-muted)" }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title?: string;
+}) {
+  return (
+    <td className="px-3 py-2" style={{ color: "var(--dpf-text)" }} title={title}>
+      {children}
+    </td>
+  );
+}
+
+export function RestoreHistorySection({ runs }: Props) {
+  if (runs.length === 0) {
+    return (
+      <section>
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">
+          Restore history
+        </h2>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          No restores have been performed.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">
+        Restore history
+      </h2>
+      <div
+        className="rounded overflow-hidden"
+        style={{ border: "1px solid var(--dpf-border)" }}
+      >
+        <table className="w-full text-xs">
+          <thead style={{ background: "var(--dpf-bg)" }}>
+            <tr>
+              <Th>Started</Th>
+              <Th>Status</Th>
+              <Th>Source dump</Th>
+              <Th>Safety dump</Th>
+              <Th>Duration</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((r) => (
+              <tr
+                key={r.id}
+                style={{ borderTop: "1px solid var(--dpf-border)" }}
+              >
+                <Td>{formatTimestamp(r.startedAt)}</Td>
+                <Td>
+                  <StatusPill status={r.status} />
+                  {r.errorMessage && (
+                    <span
+                      className="ml-2 text-[10px]"
+                      style={{ color: "#f87171" }}
+                      title={r.errorMessage}
+                    >
+                      ⚠
+                    </span>
+                  )}
+                </Td>
+                <Td title={r.sourceBackupRunId}>
+                  {formatTimestamp(r.sourceFinishedAt)}
+                </Td>
+                <Td title={r.preRestoreBackupRunId ?? undefined}>
+                  {r.preRestoreBackupRunId
+                    ? r.preRestoreBackupRunId.slice(0, 8)
+                    : "—"}
+                </Td>
+                <Td>{formatDurationMs(r.durationMs)}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/(shell)/admin/backups/page.tsx
+++ b/apps/web/app/(shell)/admin/backups/page.tsx
@@ -4,6 +4,7 @@ import {
   getBackupReadinessAction,
   listBackupRunsAction,
 } from "@/lib/actions/backups";
+import { listRestoreRunsAction } from "@/lib/actions/backup-restore";
 
 import { BackupsClient } from "./BackupsClient";
 
@@ -12,16 +13,19 @@ export const dynamic = "force-dynamic";
 /**
  * Admin → Advanced → Backups.
  *
- * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.8
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.8, §4.6
  *
- * Renders the readiness card + history table + manual-trigger button. The
- * operator never sees a CLI here — clicks only — per the
- * never-ask-user-to-run-commands kernel commandment.
+ * Slice 1 renders the readiness card + history table + manual-trigger button.
+ * Slice 2 adds the restore wizard (per-row Restore button + typed-confirmation
+ * modal) and a restore history section below. The operator never sees a CLI
+ * here — clicks only — per the never-ask-user-to-run-commands kernel
+ * commandment.
  */
 export default async function BackupsAdminPage() {
-  const [readiness, runs] = await Promise.all([
+  const [readiness, runs, restoreRuns] = await Promise.all([
     getBackupReadinessAction(),
     listBackupRunsAction({ limit: 50 }),
+    listRestoreRunsAction({ limit: 20 }),
   ]);
 
   return (
@@ -30,13 +34,17 @@ export default async function BackupsAdminPage() {
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Backups</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
           Platform-managed Postgres backups. Daily schedule, automatic
-          retention, manual trigger.
+          retention, manual trigger, restore wizard.
         </p>
       </div>
 
       <AdminTabNav />
 
-      <BackupsClient initialReadiness={readiness} initialRuns={runs} />
+      <BackupsClient
+        initialReadiness={readiness}
+        initialRuns={runs}
+        initialRestoreRuns={restoreRuns}
+      />
     </div>
   );
 }

--- a/apps/web/lib/actions/backup-restore.test.ts
+++ b/apps/web/lib/actions/backup-restore.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the auth + permissions + Prisma + the runner so the unit tests only
+// exercise the server-action contract.
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+vi.mock("@/lib/permissions", () => ({
+  can: vi.fn(),
+}));
+vi.mock("@/lib/operate/backups/restore-preview", () => ({
+  buildRestorePreview: vi.fn(),
+}));
+vi.mock("@/lib/operate/backups/postgres-restore-runner", () => ({
+  runPostgresRestore: vi.fn(),
+  isRestoreInFlight: vi.fn(),
+  RestoreLockedError: class extends Error {
+    constructor(_h: unknown, _s: unknown) {
+      super("locked");
+      this.name = "RestoreLockedError";
+    }
+  },
+  RestoreIntegrityError: class extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "RestoreIntegrityError";
+    }
+  },
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: { backupRestore: { findMany: vi.fn() } },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import {
+  confirmRestoreAction,
+  previewRestoreAction,
+} from "./backup-restore";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { runPostgresRestore } from "@/lib/operate/backups/postgres-restore-runner";
+import { buildRestorePreview } from "@/lib/operate/backups/restore-preview";
+
+const mockedAuth = auth as unknown as ReturnType<typeof vi.fn>;
+const mockedCan = can as unknown as ReturnType<typeof vi.fn>;
+const mockedRunner = runPostgresRestore as unknown as ReturnType<typeof vi.fn>;
+const mockedPreview = buildRestorePreview as unknown as ReturnType<typeof vi.fn>;
+
+describe("confirmRestoreAction (typed-confirmation gate)", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedCan.mockReset();
+    mockedRunner.mockReset();
+  });
+
+  it("rejects when there is no session", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const result = await confirmRestoreAction("src", "RESTORE");
+    expect(result.ok).toBe(false);
+    expect(result.errorClass).toBe("unauthorized");
+    expect(mockedRunner).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the user lacks the manage_provider_connections capability", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "u", isSuperuser: false } });
+    mockedCan.mockReturnValue(false);
+    const result = await confirmRestoreAction("src", "RESTORE");
+    expect(result.ok).toBe(false);
+    expect(result.errorClass).toBe("unauthorized");
+    expect(mockedRunner).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the confirmation text does not exactly equal RESTORE", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "u", isSuperuser: true } });
+    mockedCan.mockReturnValue(true);
+
+    for (const wrong of ["restore", "Restore", "RESTORE ", " RESTORE", "RESTORE!", ""]) {
+      const result = await confirmRestoreAction("src", wrong);
+      expect(result.ok).toBe(false);
+      expect(result.errorClass).toBe("confirmation-required");
+      expect(result.error).toMatch(/RESTORE/);
+    }
+
+    expect(mockedRunner).not.toHaveBeenCalled();
+  });
+
+  it("calls the runner only when confirmation is exactly RESTORE", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "u-1", isSuperuser: true } });
+    mockedCan.mockReturnValue(true);
+    mockedRunner.mockResolvedValue({ restoreId: "BR-x", status: "ok" });
+
+    const result = await confirmRestoreAction("src", "RESTORE");
+    expect(result.ok).toBe(true);
+    expect(result.restoreId).toBe("BR-x");
+    expect(mockedRunner).toHaveBeenCalledWith({
+      sourceBackupRunId: "src",
+      initiatedByUserId: "u-1",
+    });
+  });
+
+  it("surfaces a structured failure when the runner reports status=failed", async () => {
+    mockedAuth.mockResolvedValue({ user: { id: "u", isSuperuser: true } });
+    mockedCan.mockReturnValue(true);
+    mockedRunner.mockResolvedValue({ restoreId: "BR-y", status: "failed" });
+
+    const result = await confirmRestoreAction("src", "RESTORE");
+    expect(result.ok).toBe(false);
+    expect(result.restoreId).toBe("BR-y");
+    expect(result.status).toBe("failed");
+  });
+});
+
+describe("previewRestoreAction", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedCan.mockReset();
+    mockedPreview.mockReset();
+  });
+
+  it("rejects unauthorized callers", async () => {
+    mockedAuth.mockResolvedValue(null);
+    await expect(previewRestoreAction("src")).rejects.toThrow(/Unauthorized/);
+    expect(mockedPreview).not.toHaveBeenCalled();
+  });
+
+  it("returns the impact preview for authorized callers", async () => {
+    mockedAuth.mockResolvedValue({ user: { isSuperuser: true } });
+    mockedCan.mockReturnValue(true);
+    mockedPreview.mockResolvedValue({
+      sourceBackupRunId: "src",
+      sourceFinishedAt: "2026-05-17T22:00:00Z",
+      sourceSizeBytes: 1024,
+      sourceSha256: "deadbeef",
+      sourceAgeMinutes: 5,
+      impactSummary: "summary",
+      fileMissing: false,
+      sha256Mismatch: false,
+      versionWarning: null,
+    });
+
+    const result = await previewRestoreAction("src");
+    expect(result.sourceBackupRunId).toBe("src");
+    expect(mockedPreview).toHaveBeenCalledWith({ sourceBackupRunId: "src" });
+  });
+});

--- a/apps/web/lib/actions/backup-restore.ts
+++ b/apps/web/lib/actions/backup-restore.ts
@@ -1,0 +1,150 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+
+import { buildRestorePreview } from "@/lib/operate/backups/restore-preview";
+import {
+  RESTORE_CONFIRMATION_TEXT,
+  type RestoreImpactPreview,
+  type RestoreRunListItem,
+} from "@/lib/operate/backups/restore-types";
+import {
+  RestoreIntegrityError,
+  RestoreLockedError,
+  isRestoreInFlight,
+  runPostgresRestore,
+} from "@/lib/operate/backups/postgres-restore-runner";
+
+async function requireBackupAdmin(): Promise<string | null> {
+  const session = await auth();
+  const user = session?.user;
+  if (
+    !user ||
+    !can(
+      { platformRole: user.platformRole, isSuperuser: user.isSuperuser },
+      "manage_provider_connections",
+    )
+  ) {
+    throw new Error("Unauthorized");
+  }
+  return user.id ?? null;
+}
+
+export async function previewRestoreAction(
+  sourceBackupRunId: string,
+): Promise<RestoreImpactPreview> {
+  await requireBackupAdmin();
+  return buildRestorePreview({ sourceBackupRunId });
+}
+
+export interface ConfirmRestoreResult {
+  ok: boolean;
+  restoreId?: string;
+  status?: "ok" | "failed";
+  error?: string;
+  errorClass?:
+    | "unauthorized"
+    | "confirmation-required"
+    | "integrity"
+    | "locked"
+    | "unknown";
+}
+
+/**
+ * Confirms and triggers a restore. The wizard's "Restore" button calls this
+ * with the typed confirmation text. We require an exact case-sensitive match
+ * to `RESTORE` — never accept variants. The check is intentionally
+ * server-side AND duplicated on the client (defense in depth).
+ */
+export async function confirmRestoreAction(
+  sourceBackupRunId: string,
+  typedConfirmation: string,
+): Promise<ConfirmRestoreResult> {
+  let userId: string | null = null;
+  try {
+    userId = await requireBackupAdmin();
+  } catch {
+    return {
+      ok: false,
+      error: "You do not have permission to restore backups.",
+      errorClass: "unauthorized",
+    };
+  }
+
+  if (typedConfirmation !== RESTORE_CONFIRMATION_TEXT) {
+    return {
+      ok: false,
+      error: `Confirmation text must be exactly "${RESTORE_CONFIRMATION_TEXT}" to proceed.`,
+      errorClass: "confirmation-required",
+    };
+  }
+
+  try {
+    const result = await runPostgresRestore({
+      sourceBackupRunId,
+      initiatedByUserId: userId,
+    });
+    return {
+      ok: result.status === "ok",
+      restoreId: result.restoreId,
+      status: result.status,
+    };
+  } catch (err) {
+    if (err instanceof RestoreLockedError) {
+      return { ok: false, error: err.message, errorClass: "locked" };
+    }
+    if (err instanceof RestoreIntegrityError) {
+      return { ok: false, error: err.message, errorClass: "integrity" };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message, errorClass: "unknown" };
+  }
+}
+
+export async function listRestoreRunsAction(args?: {
+  limit?: number;
+}): Promise<RestoreRunListItem[]> {
+  await requireBackupAdmin();
+  const limit = Math.min(Math.max(args?.limit ?? 20, 1), 100);
+  const rows = await prisma.backupRestore.findMany({
+    orderBy: { startedAt: "desc" },
+    take: limit,
+    include: {
+      sourceBackup: { select: { finishedAt: true } },
+    },
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    status: r.status,
+    startedAt: r.startedAt.toISOString(),
+    finishedAt: r.finishedAt?.toISOString() ?? null,
+    sourceBackupRunId: r.sourceBackupRunId,
+    sourceFinishedAt: r.sourceBackup.finishedAt?.toISOString() ?? null,
+    preRestoreBackupRunId: r.preRestoreBackupRunId,
+    initiatedByUserId: r.initiatedByUserId,
+    errorMessage: r.errorMessage,
+    durationMs:
+      r.finishedAt && r.startedAt
+        ? r.finishedAt.getTime() - r.startedAt.getTime()
+        : null,
+  }));
+}
+
+export interface RestoreLockStatus {
+  inFlight: boolean;
+  holder: string | null;
+  since: string | null;
+}
+
+export async function getRestoreLockStatusAction(): Promise<RestoreLockStatus> {
+  await requireBackupAdmin();
+  const s = isRestoreInFlight();
+  return {
+    inFlight: s.inFlight,
+    holder: s.holder,
+    since: s.since?.toISOString() ?? null,
+  };
+}

--- a/apps/web/lib/operate/backups/postgres-restore-runner.test.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock prisma + the Slice-1 safety-dump entry point + the metrics module so
+// the unit tests run without a live DB or live runner.
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    backupRun: { findUnique: vi.fn() },
+    backupRestore: { create: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock("./postgres-backup-runner", () => ({
+  runPostgresBackup: vi.fn(),
+}));
+
+vi.mock("@/lib/operate/metrics", () => ({
+  postgresRestoreRunsTotal: { inc: vi.fn() },
+  postgresRestoreDurationSeconds: { observe: vi.fn() },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import {
+  RestoreIntegrityError,
+  RestoreLockedError,
+  __test__,
+  isRestoreInFlight,
+  runPostgresRestore,
+} from "./postgres-restore-runner";
+import { prisma } from "@dpf/db";
+import { runPostgresBackup } from "./postgres-backup-runner";
+
+const mockPrisma = prisma as unknown as {
+  backupRun: { findUnique: ReturnType<typeof vi.fn> };
+  backupRestore: {
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+const mockedSafety = runPostgresBackup as unknown as ReturnType<typeof vi.fn>;
+
+describe("acquireRestoreLock (unit)", () => {
+  beforeEach(() => {
+    __test__.resetLockForTest();
+  });
+
+  it("acquires a lock when none is held", () => {
+    expect(isRestoreInFlight().inFlight).toBe(false);
+    const release = __test__.acquireRestoreLock("holder-1");
+    expect(isRestoreInFlight().inFlight).toBe(true);
+    release();
+    expect(isRestoreInFlight().inFlight).toBe(false);
+  });
+
+  it("throws RestoreLockedError when a second restore tries to acquire", () => {
+    const release = __test__.acquireRestoreLock("holder-a");
+    expect(() => __test__.acquireRestoreLock("holder-b")).toThrow(
+      RestoreLockedError,
+    );
+    release();
+    // After release, a new caller can acquire.
+    const release2 = __test__.acquireRestoreLock("holder-c");
+    release2();
+  });
+});
+
+describe("runPostgresRestore", () => {
+  beforeEach(() => {
+    __test__.resetLockForTest();
+    mockPrisma.backupRun.findUnique.mockReset();
+    mockPrisma.backupRestore.create.mockReset();
+    mockPrisma.backupRestore.update.mockReset();
+    mockedSafety.mockReset();
+  });
+
+  it("throws RestoreIntegrityError when the source BackupRun is missing", async () => {
+    mockPrisma.backupRun.findUnique.mockResolvedValue(null);
+    await expect(
+      runPostgresRestore({ sourceBackupRunId: "missing" }),
+    ).rejects.toThrow(RestoreIntegrityError);
+    // Lock must be released even on failure.
+    expect(isRestoreInFlight().inFlight).toBe(false);
+  });
+
+  it("throws RestoreIntegrityError when the source has been pruned", async () => {
+    mockPrisma.backupRun.findUnique.mockResolvedValue({
+      id: "src",
+      status: "ok",
+      prunedAt: new Date(),
+      storagePath: "postgres/foo",
+      sha256: null,
+    });
+    await expect(
+      runPostgresRestore({ sourceBackupRunId: "src" }),
+    ).rejects.toThrow(/pruned/);
+    expect(isRestoreInFlight().inFlight).toBe(false);
+  });
+
+  it("throws RestoreIntegrityError when source status is failed", async () => {
+    mockPrisma.backupRun.findUnique.mockResolvedValue({
+      id: "src",
+      status: "failed",
+      prunedAt: null,
+      storagePath: "postgres/foo",
+      sha256: null,
+    });
+    await expect(
+      runPostgresRestore({ sourceBackupRunId: "src" }),
+    ).rejects.toThrow(/only successful backups/i);
+  });
+
+  it("throws RestoreIntegrityError when the dump file is missing from disk", async () => {
+    mockPrisma.backupRun.findUnique.mockResolvedValue({
+      id: "src",
+      status: "ok",
+      prunedAt: null,
+      storagePath: "postgres/this-path-does-not-exist-xyz",
+      sha256: null,
+    });
+    await expect(
+      runPostgresRestore({
+        sourceBackupRunId: "src",
+        backupsRoot: "/nonexistent-test-root-9999",
+      }),
+    ).rejects.toThrow(/missing/i);
+    expect(isRestoreInFlight().inFlight).toBe(false);
+    // No BackupRestore row should have been inserted because we never got
+    // past the integrity check.
+    expect(mockPrisma.backupRestore.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/operate/backups/postgres-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.ts
@@ -1,0 +1,322 @@
+/**
+ * Voice Slice 2 — TypeScript orchestrator for the Postgres restore wizard.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6
+ * Plan: docs/superpowers/plans/2026-05-17-postgres-backup-slice-2-restore.md
+ *
+ * Responsibilities:
+ *   1. Acquire the portal-side mutex (single restore at a time).
+ *   2. Verify the source dump's sha256 still matches what was recorded —
+ *      catches on-disk corruption BEFORE pg_restore touches the live DB.
+ *   3. Write a pre-restore safety dump via the Slice 1 runner, labeled
+ *      "pre-restore-safety" so the existing retention pruner treats it
+ *      identically to other successful backups.
+ *   4. Spawn scripts/restore-postgres.sh against the source dump.
+ *   5. Record the BackupRestore audit row (sourceBackupRunId +
+ *      preRestoreBackupRunId + status + duration).
+ *   6. Release the lock in finally.
+ *
+ * Per the never-ask-user-to-run-commands kernel principle, this is only
+ * ever invoked from the admin restore wizard's confirmRestore action with
+ * a typed-RESTORE confirmation already verified.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import {
+  postgresRestoreRunsTotal,
+  postgresRestoreDurationSeconds,
+} from "@/lib/operate/metrics";
+
+import { runPostgresBackup } from "./postgres-backup-runner";
+
+const execFileAsync = promisify(execFile);
+
+const BACKUPS_ROOT = "/backups";
+const RESTORE_SCRIPT_PATH = "/workspace/scripts/restore-postgres.sh";
+const RUNNER_TIMEOUT_MS = 30 * 60 * 1000; // mirror backup runner
+
+/** Module-scoped portal mutex. Single Next.js server = single source of truth. */
+let restoreLockHeld = false;
+let restoreLockHolder: string | null = null;
+let restoreLockAcquiredAt: Date | null = null;
+
+export class RestoreLockedError extends Error {
+  constructor(public readonly heldBy: string | null, public readonly since: Date | null) {
+    super(
+      since
+        ? `A restore is already in progress (started ${since.toISOString()}). Wait for it to complete or fail.`
+        : "A restore is already in progress.",
+    );
+    this.name = "RestoreLockedError";
+  }
+}
+
+export class RestoreIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RestoreIntegrityError";
+  }
+}
+
+export interface RestoreArgs {
+  sourceBackupRunId: string;
+  /** User id who clicked confirm. Stored on BackupRestore for audit. */
+  initiatedByUserId?: string | null;
+  /** Override backups root for tests. */
+  backupsRoot?: string;
+  /** Override restore script path for tests. */
+  scriptPath?: string;
+  /** Inject prisma for tests. */
+  prismaClient?: PrismaLike;
+  /** Inject clock for deterministic tests. */
+  now?: () => Date;
+  /**
+   * Inject a custom safety-backup function for tests. Defaults to the Slice 1
+   * runPostgresBackup with trigger="pre-restore-safety".
+   */
+  takeSafetyBackup?: () => Promise<{ runId: string; status: "ok" | "failed" }>;
+}
+
+type PrismaLike = typeof import("@dpf/db").prisma;
+
+function restoreTraceLog(...parts: unknown[]) {
+  // eslint-disable-next-line no-console
+  console.log("[restore-trace]", ...parts);
+}
+
+async function fileSha256(absolutePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const fileHandle = await fs.open(absolutePath, "r");
+  try {
+    const stream = fileHandle.createReadStream();
+    for await (const chunk of stream) {
+      hash.update(chunk as Buffer);
+    }
+  } finally {
+    await fileHandle.close();
+  }
+  return hash.digest("hex");
+}
+
+interface ScriptOutcome {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runRestoreScript(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<ScriptOutcome> {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env,
+      timeout: RUNNER_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      message?: string;
+    };
+    const exitCode = typeof e.code === "number" ? e.code : -1;
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message ?? String(err),
+      exitCode,
+    };
+  }
+}
+
+function summarizeScriptFailure(outcome: ScriptOutcome): string {
+  const traceLine = outcome.stderr
+    .split("\n")
+    .reverse()
+    .find((l) => l.includes("[restore-trace] failed:"));
+  if (traceLine) {
+    return traceLine.replace(/^.*\[restore-trace\]\s*failed:\s*/, "").trim();
+  }
+  const lastStderr = outcome.stderr.trim().split("\n").pop()?.trim() ?? "";
+  if (lastStderr) return lastStderr.slice(0, 500);
+  if (outcome.exitCode !== 0) return `restore script exited ${outcome.exitCode}`;
+  return "restore failed (no diagnostic captured)";
+}
+
+/**
+ * Acquire the portal mutex. Throws RestoreLockedError if another restore
+ * is already in flight. Returns a release function the caller MUST invoke
+ * in `finally`.
+ */
+function acquireRestoreLock(holder: string): () => void {
+  if (restoreLockHeld) {
+    throw new RestoreLockedError(restoreLockHolder, restoreLockAcquiredAt);
+  }
+  restoreLockHeld = true;
+  restoreLockHolder = holder;
+  restoreLockAcquiredAt = new Date();
+  return () => {
+    restoreLockHeld = false;
+    restoreLockHolder = null;
+    restoreLockAcquiredAt = null;
+  };
+}
+
+/**
+ * Inspect the lock state without acquiring. Used by the readiness card +
+ * server actions that want to surface "restore in progress" to the operator.
+ */
+export function isRestoreInFlight(): {
+  inFlight: boolean;
+  holder: string | null;
+  since: Date | null;
+} {
+  return {
+    inFlight: restoreLockHeld,
+    holder: restoreLockHolder,
+    since: restoreLockAcquiredAt,
+  };
+}
+
+export async function runPostgresRestore(
+  args: RestoreArgs,
+): Promise<{ restoreId: string; status: "ok" | "failed" }> {
+  const now = args.now ?? (() => new Date());
+  const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
+  const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
+  const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
+
+  const release = acquireRestoreLock(args.sourceBackupRunId);
+  const startedAt = now();
+  restoreTraceLog(`acquired lock for source=${args.sourceBackupRunId}`);
+
+  try {
+    // ── 1. Resolve + integrity-check the source dump ──────────────────────
+    const source = await prisma.backupRun.findUnique({
+      where: { id: args.sourceBackupRunId },
+    });
+    if (!source) {
+      throw new RestoreIntegrityError(`Source BackupRun ${args.sourceBackupRunId} not found.`);
+    }
+    if (source.status !== "ok") {
+      throw new RestoreIntegrityError(
+        `Source BackupRun ${args.sourceBackupRunId} status=${source.status}; only successful backups can be restored.`,
+      );
+    }
+    if (source.prunedAt !== null) {
+      throw new RestoreIntegrityError(
+        `Source BackupRun ${args.sourceBackupRunId} has been pruned; its file is no longer on disk.`,
+      );
+    }
+
+    const dumpPath = path.posix.join(backupsRoot, source.storagePath, "dpf.dump");
+    try {
+      await fs.access(dumpPath);
+    } catch {
+      throw new RestoreIntegrityError(`Source dump file is missing at ${dumpPath}.`);
+    }
+
+    if (source.sha256) {
+      const actual = await fileSha256(dumpPath);
+      if (actual !== source.sha256) {
+        throw new RestoreIntegrityError(
+          `Source dump checksum does not match what was recorded when the backup was taken. The file may be corrupted (expected ${source.sha256}, got ${actual}).`,
+        );
+      }
+    }
+
+    // ── 2. Pre-restore safety dump ────────────────────────────────────────
+    restoreTraceLog("writing pre-restore safety dump");
+    const safetyTake = args.takeSafetyBackup
+      ? args.takeSafetyBackup
+      : () =>
+          runPostgresBackup({
+            trigger: "pre-restore-safety",
+            backupsRoot,
+            prismaClient: prisma,
+          });
+    const safety = await safetyTake();
+    if (safety.status !== "ok") {
+      throw new RestoreIntegrityError(
+        "Pre-restore safety dump failed; aborting restore so the current state is not lost.",
+      );
+    }
+    restoreTraceLog(`safety dump ok runId=${safety.runId}`);
+
+    // ── 3. Insert the BackupRestore row in "running" state ────────────────
+    const created = await prisma.backupRestore.create({
+      data: {
+        status: "running",
+        sourceBackupRunId: source.id,
+        preRestoreBackupRunId: safety.runId,
+        initiatedByUserId: args.initiatedByUserId ?? null,
+      },
+      select: { id: true },
+    });
+
+    // ── 4. Run the restore script ─────────────────────────────────────────
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      DUMP_PATH: dumpPath,
+      POSTGRES_USER: process.env.POSTGRES_USER ?? "dpf",
+      POSTGRES_DB: process.env.POSTGRES_DB ?? "dpf",
+      DPF_PRODUCTION_DB_CONTAINER:
+        process.env.DPF_PRODUCTION_DB_CONTAINER ?? "dpf-postgres-1",
+    };
+
+    const outcome = await runRestoreScript(scriptPath, env);
+    const finishedAt = now();
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+    if (outcome.ok) {
+      await prisma.backupRestore.update({
+        where: { id: created.id },
+        data: {
+          status: "ok",
+          finishedAt,
+        },
+      });
+      postgresRestoreRunsTotal.inc({ status: "ok" });
+      postgresRestoreDurationSeconds.observe(durationMs / 1000);
+      restoreTraceLog(`restore ok id=${created.id} duration_ms=${durationMs}`);
+      return { restoreId: created.id, status: "ok" };
+    }
+
+    // Failure path — safety dump is still on disk, operator can retry.
+    const errorMessage = summarizeScriptFailure(outcome);
+    await prisma.backupRestore.update({
+      where: { id: created.id },
+      data: {
+        status: "failed",
+        finishedAt,
+        errorMessage,
+      },
+    });
+    postgresRestoreRunsTotal.inc({ status: "failed" });
+    postgresRestoreDurationSeconds.observe(durationMs / 1000);
+    restoreTraceLog(`restore failed id=${created.id} reason=${errorMessage}`);
+    return { restoreId: created.id, status: "failed" };
+  } finally {
+    release();
+    restoreTraceLog("released lock");
+  }
+}
+
+// Test-only exports
+export const __test__ = {
+  acquireRestoreLock,
+  resetLockForTest: () => {
+    restoreLockHeld = false;
+    restoreLockHolder = null;
+    restoreLockAcquiredAt = null;
+  },
+};

--- a/apps/web/lib/operate/backups/restore-preview.ts
+++ b/apps/web/lib/operate/backups/restore-preview.ts
@@ -1,0 +1,140 @@
+/**
+ * Voice Slice 2 — restore impact preview.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6 step 2.
+ *
+ * Computes the impact preview the wizard renders before the operator types
+ * RESTORE. Reads the BackupRun row, verifies the file exists on disk and
+ * the sha256 matches what was recorded, and emits a human-friendly summary.
+ *
+ * Pure as possible: takes the prisma client + the file system as
+ * dependencies so the unit tests can stub both.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import { prisma as defaultPrisma } from "@dpf/db";
+
+import { type RestoreImpactPreview } from "./restore-types";
+
+const DEFAULT_BACKUPS_ROOT = "/backups";
+
+export interface PreviewArgs {
+  sourceBackupRunId: string;
+  /** Override the backups root for tests. */
+  backupsRoot?: string;
+  /** Inject prisma for tests. */
+  prismaClient?: typeof defaultPrisma;
+  /** Inject clock for deterministic tests. */
+  now?: () => Date;
+  /** Current DPF version (for cross-version warning). Defaults to process.env.DPF_VERSION. */
+  currentDpfVersion?: string | null;
+}
+
+/** Stream the file through sha256 to verify integrity. */
+async function fileSha256(absolutePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const fileHandle = await fs.open(absolutePath, "r");
+  try {
+    const stream = fileHandle.createReadStream();
+    for await (const chunk of stream) {
+      hash.update(chunk as Buffer);
+    }
+  } finally {
+    await fileHandle.close();
+  }
+  return hash.digest("hex");
+}
+
+function describeAge(ageMinutes: number): string {
+  if (ageMinutes < 1) return "less than a minute ago";
+  if (ageMinutes < 60) return `${Math.round(ageMinutes)} minutes ago`;
+  if (ageMinutes < 60 * 24) {
+    const h = Math.round(ageMinutes / 60);
+    return `${h} hour${h === 1 ? "" : "s"} ago`;
+  }
+  const d = Math.round(ageMinutes / (60 * 24));
+  return `${d} day${d === 1 ? "" : "s"} ago`;
+}
+
+export async function buildRestorePreview(
+  args: PreviewArgs,
+): Promise<RestoreImpactPreview> {
+  const prisma = args.prismaClient ?? defaultPrisma;
+  const now = (args.now ?? (() => new Date()))();
+  const backupsRoot = args.backupsRoot ?? DEFAULT_BACKUPS_ROOT;
+  const currentDpfVersion = args.currentDpfVersion ?? process.env.DPF_VERSION ?? null;
+
+  const run = await prisma.backupRun.findUnique({
+    where: { id: args.sourceBackupRunId },
+  });
+  if (!run) {
+    throw new Error(`BackupRun ${args.sourceBackupRunId} not found`);
+  }
+  if (run.status !== "ok") {
+    throw new Error(
+      `BackupRun ${args.sourceBackupRunId} has status="${run.status}"; only successful backups can be restored.`,
+    );
+  }
+  if (run.prunedAt !== null) {
+    throw new Error(
+      `BackupRun ${args.sourceBackupRunId} has been pruned by retention; its file is no longer on disk.`,
+    );
+  }
+
+  const absoluteDir = path.posix.join(backupsRoot, run.storagePath);
+  const dumpPath = path.posix.join(absoluteDir, "dpf.dump");
+
+  let fileMissing = false;
+  let sha256Mismatch = false;
+  try {
+    await fs.access(dumpPath);
+    if (run.sha256) {
+      const actual = await fileSha256(dumpPath);
+      if (actual !== run.sha256) {
+        sha256Mismatch = true;
+      }
+    }
+  } catch {
+    fileMissing = true;
+  }
+
+  const ageMs = run.finishedAt
+    ? now.getTime() - run.finishedAt.getTime()
+    : now.getTime() - run.startedAt.getTime();
+  const ageMinutes = Math.max(0, Math.floor(ageMs / 60_000));
+
+  // Cross-version warning. We never block — operators recovering from a wipe
+  // sometimes need to restore older dumps. We just surface the difference.
+  let versionWarning: string | null = null;
+  if (run.dpfVersion && currentDpfVersion && run.dpfVersion !== currentDpfVersion) {
+    versionWarning = `Source dump was taken from DPF version ${run.dpfVersion.slice(0, 12)}; the install is currently running ${currentDpfVersion.slice(0, 12)}. Schema or behavior may have diverged.`;
+  }
+
+  const impactSummary = fileMissing
+    ? "The dump file is missing from disk. Restore is not possible."
+    : sha256Mismatch
+      ? "The dump file's checksum does not match what was recorded when it was taken. The file may be corrupted. Restore is blocked."
+      : `Restoring this backup will replace ALL platform data created since the dump was taken (${describeAge(
+          ageMinutes,
+        )}). A pre-restore safety dump of the current state will be written first, so a misclick is recoverable.`;
+
+  return {
+    sourceBackupRunId: run.id,
+    sourceFinishedAt: run.finishedAt?.toISOString() ?? null,
+    sourceSizeBytes: run.sizeBytes ? Number(run.sizeBytes) : null,
+    sourceSha256: run.sha256,
+    sourceAgeMinutes: ageMinutes,
+    impactSummary,
+    fileMissing,
+    sha256Mismatch,
+    versionWarning,
+  };
+}
+
+// Test-only exports
+export const __test__ = {
+  describeAge,
+};

--- a/apps/web/lib/operate/backups/restore-types.ts
+++ b/apps/web/lib/operate/backups/restore-types.ts
@@ -1,0 +1,50 @@
+/**
+ * Voice Slice 2 — restore wizard public types.
+ *
+ * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6
+ */
+
+export interface RestoreImpactPreview {
+  /** The BackupRun.id being restored. */
+  sourceBackupRunId: string;
+  /** Source dump's finishedAt timestamp (UTC ISO). */
+  sourceFinishedAt: string | null;
+  /** Source dump size in bytes. */
+  sourceSizeBytes: number | null;
+  /** Recorded sha256 — UI displays for forensic comparison. */
+  sourceSha256: string | null;
+  /** How long ago the source dump was taken, in minutes. */
+  sourceAgeMinutes: number;
+  /**
+   * Free-form human summary of estimated impact. UI renders this verbatim
+   * — keep operator-friendly, no shell terms.
+   */
+  impactSummary: string;
+  /** True when the file is missing from disk (rare — should not happen for non-pruned runs). */
+  fileMissing: boolean;
+  /** True when the on-disk sha256 does not match BackupRun.sha256 (corruption). */
+  sha256Mismatch: boolean;
+  /**
+   * Cross-version warning. Spec §10 open question: dump may have been taken
+   * from a different DPF version. We surface it but do NOT block; operators
+   * recovering from a wipe sometimes need to restore older dumps.
+   */
+  versionWarning: string | null;
+}
+
+export interface RestoreRunListItem {
+  id: string;
+  status: string;
+  startedAt: string;
+  finishedAt: string | null;
+  sourceBackupRunId: string;
+  /** ISO timestamp of the source dump (when it was taken). */
+  sourceFinishedAt: string | null;
+  preRestoreBackupRunId: string | null;
+  initiatedByUserId: string | null;
+  errorMessage: string | null;
+  durationMs: number | null;
+}
+
+/** Confirmation text the operator must type, character-for-character. */
+export const RESTORE_CONFIRMATION_TEXT = "RESTORE";

--- a/apps/web/lib/operate/backups/types.ts
+++ b/apps/web/lib/operate/backups/types.ts
@@ -4,7 +4,15 @@
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
  */
 
-export type BackupTrigger = "scheduled" | "manual";
+/**
+ * Trigger discriminator on BackupRun.
+ *
+ * `scheduled` / `manual` come from Slice 1 (cron + manual button).
+ * `pre-restore-safety` is added by Slice 2: every restore writes a safety
+ * dump first, recorded as a BackupRun row so it shows up in history and is
+ * subject to the same GFS retention as any other successful backup.
+ */
+export type BackupTrigger = "scheduled" | "manual" | "pre-restore-safety";
 export type BackupRunStatus = "running" | "ok" | "failed";
 
 /** GFS retention policy. Tunable via Platform Config in a later slice. */

--- a/apps/web/lib/operate/metrics.ts
+++ b/apps/web/lib/operate/metrics.ts
@@ -176,6 +176,23 @@ export const postgresBackupDurationSeconds = new Histogram({
   registers: [metricsRegistry],
 });
 
+// ─── Postgres Restore (Slice 2) ────────────────────────────────────────────
+// Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6
+
+export const postgresRestoreRunsTotal = new Counter({
+  name: "dpf_postgres_restore_runs_total",
+  help: "Postgres restore runs by status (ok | failed)",
+  labelNames: ["status"] as const,
+  registers: [metricsRegistry],
+});
+
+export const postgresRestoreDurationSeconds = new Histogram({
+  name: "dpf_postgres_restore_duration_seconds",
+  help: "Wall-clock duration of Postgres restore runs (includes pre-restore safety dump)",
+  buckets: [5, 10, 30, 60, 120, 300, 600, 1800],
+  registers: [metricsRegistry],
+});
+
 // ─── Voice Slice 2 — Transcript Cleanup ─────────────────────────────────────
 // Spec: docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md §9
 

--- a/docs/superpowers/plans/2026-05-17-postgres-backup-slice-2-restore.md
+++ b/docs/superpowers/plans/2026-05-17-postgres-backup-slice-2-restore.md
@@ -1,0 +1,283 @@
+# Plan — Postgres Backup, Slice 2: Restore Wizard
+
+> Spec: `docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md` §4.6, §6 Slice 2
+> Slice 1 PR (merged): #715
+> Substrate already in place from Slice 1:
+> - `BackupRun` model with `storagePath`, `sizeBytes`, `sha256`, `pgVersion`, `prunedAt`
+> - `BackupRestore` model with `sourceBackupRunId`, `preRestoreBackupRunId`, `status`,
+>   `initiatedByUserId`, `errorMessage` (created in Slice 1 migration so Slice 2 doesn't
+>   touch ordering)
+> - Host-bound `/backups` mount on portal
+> - GFS retention pruner (which Slice 2 extends to cover pre-restore safety dumps)
+> - `/admin/backups` page with history table and existing per-row "View log" action
+>
+> Goal: ship the typed-confirmation restore wizard so an operator can recover the
+> install from any retained BackupRun without touching shell — closing the loop
+> on the never-ask-user-to-run-commands commandment for the catastrophic-loss
+> case Slice 1 captured.
+
+## Pre-Implementation Gate (binding before Task 1)
+
+1. Spec is APPROVED. Slice 2 lands per spec §4.6 + §6 Slice 2 without further
+   architectural review.
+2. Branch: `feat/backup-restore-wizard` (created off `origin/main` at
+   `c643cf11`).
+3. PR target: `main` via `gh pr create`. DCO `-s` on every commit.
+4. **Zero CLI surfacing in the operator path.** The whole point of this slice
+   is to make recovery a click-only operation. Anything the operator must see
+   in shell form is a spec violation; lint the diff for it before pushing.
+
+## Reality Check (binding context for implementers)
+
+- The portal already mounts `/var/run/docker.sock` and `docker exec`s into
+  `dpf-postgres-1`. Slice 1 proved the pattern with `pg_dump`; Slice 2 mirrors
+  it with `pg_restore`.
+- `pg_restore --clean --if-exists` drops and recreates schema objects in
+  place — no DB drop/recreate needed. The portal stays up; Prisma queries that
+  are mid-flight during the restore window will fail with normal connection
+  errors and recover when the restore finishes.
+- The `BackupRestore` table already exists (Slice 1 migration). Slice 2 only
+  writes to it; no migration in this slice.
+- The portal-side lock is process-local — a single Next.js server. That's
+  enough: there is one portal container per install (single-org-per-install
+  per memory `project_single_org_per_install.md`), so cross-instance locking
+  is not a concern.
+- The Slice 1 retention pruner walks the `BackupRun` table by `target =
+  "postgres"`. Pre-restore safety dumps must be written as `BackupRun` rows
+  with a distinguishing tag so they're (a) visible in history and (b) subject
+  to the same GFS retention. Use `trigger = "pre-restore-safety"` so the
+  existing retention code keeps them per GFS without code changes.
+
+## Scope Check
+
+**In scope (Slice 2).**
+
+1. `scripts/restore-postgres.sh` — POSIX shell, exec'd inside the portal
+   container; takes a dump path, runs `pg_restore --clean --if-exists` against
+   the running `dpf-postgres-1`.
+2. `apps/web/lib/operate/backups/postgres-restore-runner.ts` — TS
+   orchestrator: acquires portal-side lock, writes pre-restore safety dump
+   (reuses the Slice 1 runner), invokes the shell script, records
+   `BackupRestore` row, releases lock.
+3. Server actions: `previewRestore(runId)`, `confirmRestore(runId, typedConfirmation)`,
+   `listRestoreRuns({ limit })`. Admin-gated like the Slice 1 actions.
+4. UI: restore-confirmation modal that opens from the existing per-row
+   "Restore…" button (Slice 1's history table already renders a `[Restore…]`
+   placeholder per spec §4.8; Slice 2 makes it functional). Modal shows
+   impact preview + typed-`RESTORE` input + "Cancel / Restore" buttons.
+5. Restore history section under the existing readiness card, showing recent
+   restores with status + impact (how much pre-restore data they replaced).
+6. Prometheus metrics: `dpf_postgres_restore_runs_total{status}` counter and
+   `dpf_postgres_restore_duration_seconds` histogram.
+7. Tests: lock semantics (mutex behavior), safety-dump invariant (always
+   written before restore touches DB), confirmation gate (wrong text rejects),
+   admin-gated server actions.
+
+**Out of scope (deferred to Phase 5 per spec §4.6).**
+
+- Partial / table-level restore.
+- Restore from a dump that didn't originate in this install.
+- Off-host backup pull-and-restore flow.
+- Encryption-at-rest for the host bind directory.
+
+## Files And Responsibilities
+
+### New
+
+- `scripts/restore-postgres.sh` *(new)* — POSIX shell. Takes `$DUMP_PATH`,
+  exec's `pg_restore --clean --if-exists -U "$POSTGRES_USER" -d "$POSTGRES_DB"`
+  via `docker exec`, streams stdout/stderr to `log.txt` next to the dump.
+- `apps/web/lib/operate/backups/postgres-restore-runner.ts` *(new)* — orchestrator:
+  - Module-scoped `restoreLockHeld: boolean` for portal-side mutex (no
+    concurrent restores).
+  - `runPostgresRestore({ sourceBackupRunId, userId })`:
+    1. Acquire lock or throw `RestoreLockedError`.
+    2. Resolve source `BackupRun`, verify file exists + sha256 matches.
+    3. Trigger a pre-restore safety dump via the Slice 1 runner with a
+       distinguishing trigger label (`pre-restore-safety`).
+    4. Insert `BackupRestore` row with `status: "running"`,
+       `sourceBackupRunId`, `preRestoreBackupRunId`.
+    5. Spawn the restore script.
+    6. On success: mark `BackupRestore.status = "ok"`, finishedAt. Emit
+       Prometheus counter. **No Prisma hot-reload yet** — Prisma client
+       handles dropped/recreated tables transparently because connections
+       reconnect on next query. Future enhancement: `prisma.$disconnect()`
+       then warm-up query.
+    7. On failure: mark `status: "failed"`, errorMessage. Surface to the
+       admin UX so the operator sees the failure with the safety dump still
+       intact.
+    8. Release lock in `finally`.
+- `apps/web/lib/operate/backups/restore-types.ts` *(new)* — shared shape:
+  `RestoreImpactPreview`, `RestoreRunListItem`.
+- `apps/web/lib/operate/backups/restore-preview.ts` *(new)* — pure function
+  + Prisma reads to compute "you will lose all changes since X" — diffs the
+  source `BackupRun.finishedAt` against `Now()` and returns a structured
+  impact preview (timestamp, size, ageMinutes, "estimated rollback window").
+- `apps/web/lib/actions/backup-restore.ts` *(new)* — server actions:
+  `previewRestore`, `confirmRestore`, `listRestoreRuns`. Same auth gate as
+  Slice 1 (`manage_provider_connections`).
+- `apps/web/app/(shell)/admin/backups/RestoreConfirmModal.tsx` *(new)* —
+  client modal: impact preview + typed `RESTORE` input + Cancel/Confirm.
+- `apps/web/app/(shell)/admin/backups/RestoreHistorySection.tsx` *(new)* —
+  client section appended below the existing history table.
+
+### Modified
+
+- `apps/web/app/(shell)/admin/backups/BackupsClient.tsx` — wire `[Restore…]`
+  button to open the new modal; render the new history section.
+- `apps/web/lib/operate/backups/postgres-backup-runner.ts` — add an optional
+  `trigger: "pre-restore-safety"` path (drop-in: just a label). Existing
+  retention treats it the same as any other successful run.
+- `apps/web/lib/operate/metrics.ts` — restore counter + histogram.
+
+### Untouched
+
+- No Prisma schema change (the `BackupRestore` model already exists from
+  Slice 1).
+- No `docker-compose.yml` change.
+- No Inngest function — restore is synchronous, lock-bound, and operator-
+  initiated only; not a background job.
+
+## Chunk 1 — Restore runner
+
+1. Author `scripts/restore-postgres.sh`. POSIX-portable shell. Same
+   `docker exec` pattern as `backup-postgres.sh`. Streams the dump into
+   `docker exec -i dpf-postgres-1 pg_restore --clean --if-exists -U dpf -d dpf`.
+   Exit non-zero on failure with a single `[restore-trace] failed: <reason>`
+   line for the orchestrator to surface.
+2. Smoke-test on the running install AGAINST A TEST DB FIRST (the agent
+   creates a temporary DB, restores the most-recent dump into it, drops it).
+   The script is parameterized for `$POSTGRES_DB` so this is one env-var
+   change. The user never sees a command.
+3. Once smoke green, ready for orchestrator wiring.
+
+**Exit criteria.** Restore script runs against a throwaway DB and emerges
+with the same table count as the source.
+
+## Chunk 2 — TS orchestrator + lock
+
+1. Author `postgres-restore-runner.ts` with the module-scoped mutex.
+2. Reuse the Slice 1 `runPostgresBackup({ trigger: "pre-restore-safety" })`
+   to write the safety dump. Verify retention math treats `"pre-restore-safety"`
+   the same as `"manual"` (already does because retention only inspects
+   `status === "ok"` + `prunedAt`).
+3. Compute sha256 of the source dump file before running `pg_restore`;
+   abort if the file's actual hash doesn't match the stored `BackupRun.sha256`.
+   This is the integrity check spec §4.4 promised.
+4. Author `restore-preview.ts` for the impact computation.
+
+**Exit criteria.** Calling `runPostgresRestore` end-to-end against a test
+run: lock acquired, safety dump written, source restored, BackupRestore row
+inserted with both refs populated.
+
+## Chunk 3 — Server actions
+
+1. Author `apps/web/lib/actions/backup-restore.ts` with admin gate.
+2. `previewRestore(runId)` reads `BackupRun`, computes the impact preview.
+3. `confirmRestore(runId, typedConfirmation)` requires
+   `typedConfirmation === "RESTORE"` (case-sensitive). Anything else throws
+   `Error("Confirmation text required")` with a 4xx posture (no shell
+   surfacing in the message).
+4. `listRestoreRuns({ limit })` returns recent `BackupRestore` rows for the
+   history section.
+5. Unit-test the auth gate + the confirmation-required check.
+
+**Exit criteria.** `confirmRestore("BR-x", "RESTORE")` succeeds against a
+test row; `confirmRestore("BR-x", "restore")` fails with the right error.
+
+## Chunk 4 — UI: restore wizard
+
+1. Build `RestoreConfirmModal.tsx`. Receives `runId` and the impact-preview
+   payload. Renders:
+   - **Impact summary card**: source timestamp, size, age, "this will
+     replace ALL platform data created since `<finishedAt>`. Estimated data
+     loss: `<lastBackup-now diff>` of activity."
+   - **Pre-restore safety dump notice**: "We'll write a safety dump first
+     so this is reversible."
+   - **Typed confirmation**: text input requiring the literal `RESTORE`,
+     case-sensitive. Confirm button disabled until valid.
+   - **Cancel / Confirm buttons.** Confirm calls `confirmRestore`, then
+     polls `listBackupRuns` + `listRestoreRuns` to refresh the page.
+2. Build `RestoreHistorySection.tsx` for the history table directly below
+   the existing backup history (status pill, source backup ts, safety
+   backup id, duration, errorMessage when present).
+3. Wire from `BackupsClient.tsx`:
+   - Replace the Slice-1 placeholder `[Restore…]` button with a real
+     `onClick` that calls `previewRestore(runId)` then opens the modal.
+   - Render `<RestoreHistorySection runs={restoreRuns} />` below the
+     existing history.
+
+**Exit criteria.** Manual click path works in the running install:
+operator clicks Restore, sees impact, types `RESTORE`, clicks Confirm,
+sees the new history row appear.
+
+## Chunk 5 — Tests + telemetry
+
+1. Unit tests for the orchestrator's mutex (concurrent calls throw
+   `RestoreLockedError`).
+2. Unit test for sha256 mismatch path (corrupted dump throws before
+   `pg_restore` runs).
+3. Server-action auth-gate tests.
+4. Architecture test: `confirmRestore` MUST NOT accept anything other than
+   the literal `RESTORE`. Defense against regression.
+5. Prometheus metrics emit on success + failure.
+
+**Exit criteria.** `pnpm --filter web exec vitest run lib/operate/backups
+lib/actions/backup-restore` — all green. `pnpm --filter web typecheck`
+clean. Pre-commit hook green.
+
+## Chunk 6 — Live verification + PR
+
+1. Rebuild the portal image (already merged Slice 1 image, so this just
+   layers Slice 2 source).
+2. Restart portal.
+3. **Self-test the wizard end-to-end** (the agent does this, not the
+   operator). Sequence:
+   - Take a fresh manual backup via the existing button.
+   - Insert a sentinel row in the live DB (`INSERT INTO "BackupRun"
+     (id, status, trigger, "storagePath") VALUES ('sentinel-pre-restore',
+     'ok', 'sentinel', 'test')`).
+   - Navigate (via Chrome MCP) to `/admin/backups`, click Restore on the
+     newest dump, type `RESTORE`, confirm.
+   - Verify post-restore: the sentinel row is GONE (because the dump
+     pre-dates it), but the pre-restore safety dump is now in the history
+     and the new `BackupRestore` row is `ok`.
+   - Confirm the heartbeat row, scheduled cron, and Slice 1 readiness card
+     are all still consistent.
+4. Open PR.
+
+**Exit criteria.** Live install successfully restored a dump end-to-end
+via the wizard. PR opened with the verification log in the body.
+
+## Open Questions Carried Forward
+
+- **Prisma hot-reload after restore.** Slice 2 relies on Prisma client
+  transparently reconnecting on next query. If we observe stale schema
+  cache issues, the follow-up is to call `prisma.$disconnect()` after the
+  restore + a warm-up query. Tracked as a follow-up; current spec §4.6
+  doesn't require it.
+- **Cross-version restore guard.** Source dump may have a different
+  Prisma migration set than the current schema. Slice 2 logs the
+  `pgVersion` + `dpfVersion` from the source manifest and surfaces a
+  warning ("source dump was taken from DPF version X; current is Y"), but
+  does NOT block. Operators recovering from a wipe will sometimes need to
+  restore an older dump; gating the wizard on version match would defeat
+  the use case.
+
+## Recommended Execution Path
+
+1. Chunk 1 → commit `feat(backup): postgres restore shell runner`.
+2. Chunk 2 → commit `feat(backup): restore orchestrator + portal-side lock + sha256 integrity check`.
+3. Chunk 3 → commit `feat(backup): restore server actions with typed-confirmation gate`.
+4. Chunk 4 → commit `feat(backup): admin restore wizard UI + history section`.
+5. Chunk 5 → commit `test(backup): restore lock, integrity, confirmation tests`.
+6. Chunk 6 → live-verify + open PR `feat(backup): Slice 2 — restore wizard with typed confirmation + pre-restore safety dump`.
+
+## What Slice 2 Deliberately Leaves Out
+
+- Partial / table-level restore (spec Phase 5).
+- Restore from off-host / S3 dumps (spec Phase 3).
+- Restore to a different DB / different install (out of single-org-per-install
+  scope).
+- Automated post-restore validation suite (smoke queries; future enhancement).
+- Encryption-at-rest for the host bind directory.

--- a/scripts/restore-postgres.sh
+++ b/scripts/restore-postgres.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# scripts/restore-postgres.sh — platform-managed Postgres restore runner.
+#
+# Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6
+# Plan: docs/superpowers/plans/2026-05-17-postgres-backup-slice-2-restore.md
+#
+# Mirrors scripts/backup-postgres.sh — runs inside the portal container,
+# uses the mounted docker socket to exec into the postgres container, and
+# streams the dump into pg_restore --clean --if-exists.
+#
+# Per the never-ask-user-to-run-commands kernel principle, this is never
+# invoked by the operator. The TS orchestrator
+# (apps/web/lib/operate/backups/postgres-restore-runner.ts) spawns it AFTER
+# acquiring the portal-side mutex AND writing the pre-restore safety dump.
+#
+# Required env:
+#   DUMP_PATH                    absolute path inside the portal container to
+#                                the source .dump file (under /backups/)
+#   POSTGRES_USER                DB role to restore as (default: dpf)
+#   POSTGRES_DB                  target DB (default: dpf)
+#   DPF_PRODUCTION_DB_CONTAINER  postgres container name (default: dpf-postgres-1)
+#
+# Optional env:
+#   LOG_PATH                     where to append stdout/stderr (default: alongside DUMP_PATH)
+#
+# Exit codes:
+#   0  success (pg_restore completed; warnings are normal during --clean)
+#   2  prereq missing
+#   3  pg_restore failed (non-zero exit + no recoverable errors-only path)
+
+set -eu
+
+log() { printf '[restore-trace] %s\n' "$*"; }
+fail() {
+  log "failed: $1"
+  exit "${2:-1}"
+}
+
+DUMP_PATH="${DUMP_PATH:-}"
+POSTGRES_USER="${POSTGRES_USER:-dpf}"
+POSTGRES_DB="${POSTGRES_DB:-dpf}"
+DB_CONTAINER="${DPF_PRODUCTION_DB_CONTAINER:-dpf-postgres-1}"
+LOG_PATH="${LOG_PATH:-${DUMP_PATH}.restore-log.txt}"
+
+[ -n "$DUMP_PATH" ] || fail "DUMP_PATH not set" 2
+[ -r "$DUMP_PATH" ] || fail "dump not readable at $DUMP_PATH" 2
+command -v docker >/dev/null 2>&1 || fail "docker CLI not available in runner image" 2
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+STARTED_EPOCH="$(date +%s)"
+
+SIZE_BYTES="$(wc -c < "$DUMP_PATH" | tr -d ' ')"
+
+log "starting pg_restore container=$DB_CONTAINER user=$POSTGRES_USER db=$POSTGRES_DB dump=$DUMP_PATH size=$SIZE_BYTES"
+
+# Stream the dump into pg_restore --clean --if-exists inside the postgres
+# container. --clean drops objects before recreating them; --if-exists
+# silences "does not exist" warnings on a fresh-state target.
+#
+# Note on warnings: pg_restore frequently emits "warning: errors ignored on
+# restore: N" against a clean target. As long as the exit code is 0, the
+# restore is functionally complete. We surface the full log either way for
+# operator review via the audit row.
+if docker exec -i "$DB_CONTAINER" pg_restore \
+    --clean \
+    --if-exists \
+    --no-owner \
+    --no-privileges \
+    -U "$POSTGRES_USER" \
+    -d "$POSTGRES_DB" \
+    < "$DUMP_PATH" > "$LOG_PATH" 2>&1; then
+  FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  FINISHED_EPOCH="$(date +%s)"
+  DURATION_MS=$(( (FINISHED_EPOCH - STARTED_EPOCH) * 1000 ))
+  log "ok startedAt=$STARTED_AT finishedAt=$FINISHED_AT duration_ms=$DURATION_MS"
+  exit 0
+fi
+
+EXIT=$?
+log "pg_restore exit=$EXIT — tail of log:"
+tail -n 20 "$LOG_PATH" >&2 || true
+fail "pg_restore failed (exit=$EXIT)" 3


### PR DESCRIPTION
## Summary

Postgres backup Slice 2: typed-confirmation restore wizard. Closes the loop on PR #715 — operators can now RECOVER from a backup via the admin UX without ever touching shell.

- **Restore script** \`scripts/restore-postgres.sh\` — POSIX shell, exec's \`pg_restore --clean --if-exists --no-owner --no-privileges\` against the running postgres container (same docker-exec pattern as Slice 1's backup runner).
- **TS orchestrator** with portal-side mutex, sha256 integrity check on the source dump BEFORE pg_restore touches the live DB, automatic pre-restore safety dump via the Slice 1 runner (trigger=\"pre-restore-safety\" — existing GFS retention keeps it), and BackupRestore audit row.
- **Server actions** with admin gate. \`confirmRestoreAction\` requires \`typedConfirmation === \"RESTORE\"\` exactly — wrong text returns \`errorClass: \"confirmation-required\"\` with no other side effects.
- **Restore wizard modal** — impact preview (timestamp, size, age, sha256), narrative (\"will replace ALL platform data since X\"), safety-dump notice, version-mismatch warning when applicable, typed-RESTORE input with inline validation, red destructive styling on the Restore button.
- **Restore history section** below the existing backup history, with status pills, source-dump timestamp, safety-dump id, duration, and inline error indicators on failures.
- **Wired into Slice 1's history table** — \`[Restore…]\` button on every status=ok, not-yet-pruned row.
- **Metrics**: \`dpf_postgres_restore_runs_total{status}\` counter + \`dpf_postgres_restore_duration_seconds\` histogram.

## Spec + plan

- Spec: \`docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md\` §4.6, §6 Slice 2
- Plan: \`docs/superpowers/plans/2026-05-17-postgres-backup-slice-2-restore.md\`

## Test plan

- [x] **Restore script smoke-tested live** against a throwaway DB (\`dpf_restore_smoke\`): restored the 2026-05-17T22-08-39Z dump in 7 s with all 45 epics + 360 BacklogItems present, then dropped the test DB.
- [x] **6 runner tests**: lock acquisition/release, second-acquire throws \`RestoreLockedError\`, missing source / pruned source / failed source / missing file all produce \`RestoreIntegrityError\` without inserting a \`BackupRestore\` row.
- [x] **7 server-action tests**: unauthorized rejection, capability rejection, 6 wrong-confirmation strings (\`restore\`, \`Restore\`, \` RESTORE\`, \`RESTORE \`, \`RESTORE!\`, empty) all rejected, exact \`RESTORE\` succeeds, runner-failure surfaced as \`ok:false\`.
- [x] Slice 1's 12 retention + readiness tests still pass.
- [x] \`pnpm --filter web typecheck\` clean.
- [x] \`pnpm --filter @dpf/db typecheck\` clean.
- [x] Pre-commit hook green.

## Out of scope (Phase 5+)

- Partial / table-level restore.
- Restore from off-host / S3 dumps.
- Automated post-restore validation suite.
- Encryption-at-rest for the host bind directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)