### PR TITLE
fix(backup): write restore audit rows AFTER pg_restore

### DIFF
--- a/apps/web/lib/operate/backups/postgres-restore-runner.test.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // the unit tests run without a live DB or live runner.
 vi.mock("@dpf/db", () => ({
   prisma: {
-    backupRun: { findUnique: vi.fn() },
+    backupRun: { findUnique: vi.fn(), upsert: vi.fn() },
     backupRestore: { create: vi.fn(), update: vi.fn() },
   },
 }));
@@ -30,7 +30,10 @@ import { prisma } from "@dpf/db";
 import { runPostgresBackup } from "./postgres-backup-runner";
 
 const mockPrisma = prisma as unknown as {
-  backupRun: { findUnique: ReturnType<typeof vi.fn> };
+  backupRun: {
+    findUnique: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
   backupRestore: {
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
@@ -127,4 +130,5 @@ describe("runPostgresRestore", () => {
     // past the integrity check.
     expect(mockPrisma.backupRestore.create).not.toHaveBeenCalled();
   });
+
 });

--- a/apps/web/lib/operate/backups/postgres-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.ts
@@ -235,6 +235,17 @@ export async function runPostgresRestore(
     }
 
     // ── 2. Pre-restore safety dump ────────────────────────────────────────
+    //
+    // CRITICAL: pg_restore --clean drops + recreates ALL tables, which wipes
+    // any rows we INSERT before running it — including the safety-dump
+    // BackupRun row and our own BackupRestore audit row. So we capture the
+    // safety dump's metadata in MEMORY here, run the restore, then re-insert
+    // both rows AFTER the restore lands. This keeps the audit trail visible
+    // to operators in the admin UX (otherwise the table would always be
+    // empty after a successful restore).
+    //
+    // The safety dump's FILE on disk is unaffected by pg_restore (host bind
+    // mount), so even if the re-insert fails, manual recovery is possible.
     restoreTraceLog("writing pre-restore safety dump");
     const safetyTake = args.takeSafetyBackup
       ? args.takeSafetyBackup
@@ -252,18 +263,20 @@ export async function runPostgresRestore(
     }
     restoreTraceLog(`safety dump ok runId=${safety.runId}`);
 
-    // ── 3. Insert the BackupRestore row in "running" state ────────────────
-    const created = await prisma.backupRestore.create({
-      data: {
-        status: "running",
-        sourceBackupRunId: source.id,
-        preRestoreBackupRunId: safety.runId,
-        initiatedByUserId: args.initiatedByUserId ?? null,
-      },
-      select: { id: true },
+    // Snapshot the safety BackupRun row so we can re-insert it after the
+    // restore wipes the DB. We read it back rather than reconstruct from
+    // memory so the audit captures the exact field values (sizeBytes,
+    // sha256, finishedAt, etc.).
+    const safetyRowSnapshot = await prisma.backupRun.findUnique({
+      where: { id: safety.runId },
     });
+    if (!safetyRowSnapshot) {
+      throw new RestoreIntegrityError(
+        "Safety dump BackupRun row not found after creation; aborting restore.",
+      );
+    }
 
-    // ── 4. Run the restore script ─────────────────────────────────────────
+    // ── 3. Run the restore script ─────────────────────────────────────────
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       DUMP_PATH: dumpPath,
@@ -277,33 +290,62 @@ export async function runPostgresRestore(
     const finishedAt = now();
     const durationMs = finishedAt.getTime() - startedAt.getTime();
 
+    // ── 4. Re-insert audit rows AFTER the restore ─────────────────────────
+    // The DB is now in the source-dump state. The safety BackupRun row is
+    // gone; our BackupRestore row was never inserted. Re-insert both so the
+    // operator sees the restore in history and can find the safety dump.
+    //
+    // We use upsert on BackupRun because the safety dump's id may collide
+    // with whatever the dump contains (extremely unlikely with cuids but
+    // defensive). We use create on BackupRestore because it's fresh.
+    await prisma.backupRun.upsert({
+      where: { id: safetyRowSnapshot.id },
+      update: {}, // if it somehow exists, leave alone
+      create: {
+        id: safetyRowSnapshot.id,
+        target: safetyRowSnapshot.target,
+        startedAt: safetyRowSnapshot.startedAt,
+        finishedAt: safetyRowSnapshot.finishedAt,
+        status: safetyRowSnapshot.status,
+        trigger: safetyRowSnapshot.trigger,
+        schedule: safetyRowSnapshot.schedule,
+        sizeBytes: safetyRowSnapshot.sizeBytes,
+        durationMs: safetyRowSnapshot.durationMs,
+        sha256: safetyRowSnapshot.sha256,
+        pgVersion: safetyRowSnapshot.pgVersion,
+        dpfVersion: safetyRowSnapshot.dpfVersion,
+        storagePath: safetyRowSnapshot.storagePath,
+        errorMessage: safetyRowSnapshot.errorMessage,
+        prunedAt: safetyRowSnapshot.prunedAt,
+        createdAt: safetyRowSnapshot.createdAt,
+      },
+    });
+
+    const created = await prisma.backupRestore.create({
+      data: {
+        startedAt,
+        finishedAt: outcome.ok ? finishedAt : finishedAt,
+        status: outcome.ok ? "ok" : "failed",
+        sourceBackupRunId: source.id,
+        preRestoreBackupRunId: safety.runId,
+        initiatedByUserId: args.initiatedByUserId ?? null,
+        errorMessage: outcome.ok ? null : summarizeScriptFailure(outcome),
+      },
+      select: { id: true },
+    });
+
     if (outcome.ok) {
-      await prisma.backupRestore.update({
-        where: { id: created.id },
-        data: {
-          status: "ok",
-          finishedAt,
-        },
-      });
       postgresRestoreRunsTotal.inc({ status: "ok" });
       postgresRestoreDurationSeconds.observe(durationMs / 1000);
       restoreTraceLog(`restore ok id=${created.id} duration_ms=${durationMs}`);
       return { restoreId: created.id, status: "ok" };
     }
 
-    // Failure path — safety dump is still on disk, operator can retry.
-    const errorMessage = summarizeScriptFailure(outcome);
-    await prisma.backupRestore.update({
-      where: { id: created.id },
-      data: {
-        status: "failed",
-        finishedAt,
-        errorMessage,
-      },
-    });
     postgresRestoreRunsTotal.inc({ status: "failed" });
     postgresRestoreDurationSeconds.observe(durationMs / 1000);
-    restoreTraceLog(`restore failed id=${created.id} reason=${errorMessage}`);
+    restoreTraceLog(
+      `restore failed id=${created.id} reason=${summarizeScriptFailure(outcome)}`,
+    );
     return { restoreId: created.id, status: "failed" };
   } finally {
     release();


### PR DESCRIPTION
## Summary

Live end-to-end verification of PR #741 (restore wizard) on the running install caught a real gap: **\`pg_restore --clean\` wipes the audit rows the orchestrator just wrote**.

The current flow:
1. Take pre-restore safety dump → inserts \`BackupRun\` row
2. Insert \`BackupRestore\` row with \`status=\"running\"\`
3. Run \`pg_restore --clean --if-exists\` → drops + recreates ALL tables, including \`BackupRun\` and \`BackupRestore\`. Rows 1 and 2 are now gone.
4. Update \`BackupRestore\` by id → 0 rows affected. Silent.

Net effect: a successful restore leaves the admin Restore History empty, and the safety-dump BackupRun row also vanishes (even though the safety dump's FILE on disk is intact).

## Fix

Capture the safety-dump's \`BackupRun\` row in memory after step 1 completes. Run \`pg_restore\`. Then **re-insert** both rows after the restore lands:
- \`BackupRun\` via \`upsert\` (defensive against cuid collision with whatever the dump contained)
- \`BackupRestore\` as a fresh \`create\` with the final status (no longer the two-phase \"running\" → \"ok\" insert+update, since the running state can never survive the restore window)

The safety dump's file on the host bind mount is unaffected by pg_restore, so even if the re-insert fails the actual rollback artifact is still present.

## Test plan

- [x] 13/13 unit tests pass (6 runner + 7 server-action).
- [x] Typecheck clean.
- [ ] Live end-to-end: take fresh backup → insert sentinel row → drive restore → confirm sentinel gone AND the safety-dump BackupRun row AND the BackupRestore audit row both visible after the restore. (To be run by the agent after merge + rebuild.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)