### PR TITLE
fix(code-graph): skip reconciliation gracefully when not in a git repo

### DIFF
--- a/apps/web/lib/integrate/code-graph-refresh-reconcile.test.ts
+++ b/apps/web/lib/integrate/code-graph-refresh-reconcile.test.ts
@@ -101,6 +101,7 @@ describe("reconcileCodeGraph", () => {
           stderr: "",
         };
       }
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -145,6 +146,7 @@ describe("reconcileCodeGraph", () => {
           stderr: "",
         };
       }
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -195,6 +197,7 @@ describe("reconcileCodeGraph", () => {
           stderr: "",
         };
       }
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -239,6 +242,7 @@ describe("reconcileCodeGraph", () => {
           stderr: "",
         };
       }
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -275,6 +279,7 @@ describe("reconcileCodeGraph", () => {
       if (command === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
       if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
       if (command === "git status --porcelain") return { stdout: " M apps/web/lib/foo.ts\n", stderr: "" };
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -308,6 +313,7 @@ describe("reconcileCodeGraph", () => {
           stderr: "",
         };
       }
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 

--- a/apps/web/lib/integrate/code-graph/git-snapshot.ts
+++ b/apps/web/lib/integrate/code-graph/git-snapshot.ts
@@ -14,6 +14,23 @@ export function getGitRoot(): string {
     : resolve(process.cwd(), "..", "..");
 }
 
+/**
+ * Returns true if gitRoot is inside a real git working tree.
+ * Runs fast (no file scanning) — just asks git whether it recognises the dir.
+ * Returns false in production containers where only the built app is present.
+ */
+export async function isGitRepo(gitRoot: string): Promise<boolean> {
+  try {
+    const { stdout } = await exec(
+      "git rev-parse --is-inside-work-tree",
+      { cwd: gitRoot, timeout: 5_000 },
+    );
+    return stdout.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
 export function normalizeGitOutput(stdout: string): string[] {
   return stdout
     .split("\n")

--- a/apps/web/lib/integrate/code-graph/reconcile.ts
+++ b/apps/web/lib/integrate/code-graph/reconcile.ts
@@ -6,6 +6,7 @@ import {
   getCurrentBranch,
   getCurrentHeadSha,
   getGitRoot,
+  isGitRepo,
   isWorkspaceDirty,
   listTrackedFiles,
 } from "./git-snapshot";
@@ -92,6 +93,21 @@ export async function reconcileCodeGraph(input: ReconcileCodeGraphInput): Promis
   const graphKey = input.graphKey ?? CODE_GRAPH_GRAPH_KEY;
   const gitRoot = getGitRoot();
   const observedAt = new Date();
+
+  // Guard: production containers only ship the compiled app, not the source
+  // git repository. Running git commands in a non-git directory hangs until
+  // the timeout fires (SIGTERM), marking the code graph as failed on every
+  // scheduled run. Skip gracefully instead.
+  if (!(await isGitRepo(gitRoot))) {
+    return {
+      mode: "noop",
+      graphKey,
+      headSha: null,
+      branch: null,
+      workspaceDirty: false,
+      changedFiles: [],
+    };
+  }
   let state = await findCodeGraphIndexState(graphKey);
   let headSha: string | null = null;
   let branch: string | null = null;


### PR DESCRIPTION
The code graph reconciler runs git status --porcelain to check for workspace changes. Inside the production portal container (which ships only the compiled Next.js app), the git root resolves to a directory with no .git — so git hangs until the 10s timeout fires, then gets killed with SIGTERM. This marks the code graph as failed on every scheduled run and surfaces as a persistent error in Build Studio.

Fix: add isGitRepo() using git rev-parse --is-inside-work-tree (fast, no file scanning, 5s timeout) and return a noop result immediately in reconcileCodeGraph() when the git root is not a real repository. The code graph stays in its last known state rather than oscillating between indexing and failed.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
