### PR TITLE
feat: expose taxonomy commercial market enrichment

### DIFF
--- a/apps/web/components/portfolio/PortfolioNodeEnrichment.test.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeEnrichment.test.tsx
@@ -7,8 +7,16 @@ const empty: EnrichmentView = {
   standards: null,
   patterns: null,
   references: null,
+  sampleServices: null,
+  offeringConsiderations: null,
+  commercialMarket: null,
+  sectorCommercialMarkets: null,
   raw: null,
 };
+
+function view(overrides: Partial<EnrichmentView>): EnrichmentView {
+  return { ...empty, ...overrides };
+}
 
 describe("PortfolioNodeEnrichment", () => {
   it("returns null when all fields are null", () => {
@@ -20,6 +28,10 @@ describe("PortfolioNodeEnrichment", () => {
       standards: [],
       patterns: [],
       references: [],
+      sampleServices: null,
+      offeringConsiderations: null,
+      commercialMarket: null,
+      sectorCommercialMarkets: [],
       raw: null,
     };
     expect(renderToStaticMarkup(<PortfolioNodeEnrichment enrichment={allEmpty} />)).toBe("");
@@ -28,12 +40,9 @@ describe("PortfolioNodeEnrichment", () => {
   it("renders standards list when present", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
+        enrichment={view({
           standards: ["ISO 27001", "NIST CSF"],
-          patterns: null,
-          references: null,
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).toContain(">Enrichment<");
@@ -47,12 +56,9 @@ describe("PortfolioNodeEnrichment", () => {
   it("renders patterns list when present", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
-          standards: null,
+        enrichment={view({
           patterns: ["circuit-breaker", "saga"],
-          references: null,
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).toContain(">Patterns<");
@@ -63,14 +69,11 @@ describe("PortfolioNodeEnrichment", () => {
   it("renders references as anchors with rel/target", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
-          standards: null,
-          patterns: null,
+        enrichment={view({
           references: [
             { label: "ISO 27001 overview", href: "https://example.com/iso27001" },
           ],
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).toContain(">References<");
@@ -80,15 +83,48 @@ describe("PortfolioNodeEnrichment", () => {
     expect(html).toContain('rel="noopener noreferrer"');
   });
 
+  it("renders commercial market guidance with progressive disclosure", () => {
+    const enrichment = {
+      standards: null,
+      patterns: null,
+      references: null,
+      sampleServices: "Capability mapping; Product fit review",
+      offeringConsiderations: "Lightweight advisory vs managed program",
+      commercialMarket: "Representative vendors: ServiceNow SPM; Planview; Jira.",
+      sectorCommercialMarkets: [
+        { sector: "Retail / eCommerce", market: "Shopify; Square; Lightspeed" },
+      ],
+      raw: {
+        industryMarkets: { retail: "Shopify; Square; Lightspeed" },
+        secretKey: "should-not-leak",
+      },
+    };
+
+    const html = renderToStaticMarkup(<PortfolioNodeEnrichment enrichment={enrichment} />);
+
+    expect(html).toContain(">Sample services<");
+    expect(html).toContain("Capability mapping; Product fit review");
+    expect(html).toContain("<details");
+    expect(html).toContain(">Offering considerations<");
+    expect(html).toContain(">Commercial market and products<");
+    expect(html).toContain("Representative vendors: ServiceNow SPM; Planview; Jira.");
+    expect(html).toContain(">Sector market guidance<");
+    expect(html).toContain("Retail / eCommerce");
+    expect(html).toContain("Shopify; Square; Lightspeed");
+    expect(html).not.toContain("industryMarkets");
+    expect(html).not.toContain("secretKey");
+    expect(html).not.toContain("should-not-leak");
+  });
+
   it("does not render raw JSON blob in output", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
+        enrichment={view({
           standards: ["ISO 27001"],
           patterns: ["saga"],
           references: [{ label: "Doc", href: "https://example.com" }],
           raw: { standards: ["ISO 27001"], secretKey: "should-not-leak" },
-        }}
+        })}
       />,
     );
     expect(html).not.toContain('"standards"');
@@ -100,12 +136,10 @@ describe("PortfolioNodeEnrichment", () => {
   it("uses theme tokens only", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
+        enrichment={view({
           standards: ["ISO 27001"],
-          patterns: null,
           references: [{ label: "Doc", href: "https://example.com" }],
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);

--- a/apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
@@ -1,8 +1,8 @@
 // apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
 //
-// Renders the typed enrichment view-model fields (standards, patterns,
-// references) as a full-width band on the portfolio detail page. Task 3.3 of
-// the discovery -> portfolio gap closure plan.
+// Renders the typed enrichment view-model fields as a full-width band on the
+// portfolio detail page. Task 3.3 of the discovery -> portfolio gap closure
+// plan, plus BI-4C166411 commercial market/product guidance.
 //
 // Per spec section 6.4: no nested cards; full-width band with theme tokens
 // only. Each subsection only renders when its source field is non-null and
@@ -15,20 +15,107 @@ type Props = {
   enrichment: EnrichmentView;
 };
 
-function hasItems<T>(arr: T[] | null): arr is T[] {
-  return arr !== null && arr.length > 0;
+function hasItems<T>(arr: T[] | null | undefined): arr is T[] {
+  return arr !== null && arr !== undefined && arr.length > 0;
+}
+
+function hasText(value: string | null | undefined): value is string {
+  return value !== null && value !== undefined && value.trim().length > 0;
+}
+
+function TextBlock({
+  label,
+  value,
+  disclosed = false,
+}: {
+  label: string;
+  value: string;
+  disclosed?: boolean;
+}): ReactElement {
+  if (disclosed) {
+    return (
+      <details className="mb-4 border-l border-[var(--dpf-border)] pl-3">
+        <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-muted)]">
+          {label}
+        </summary>
+        <p className="mt-2 whitespace-pre-line text-sm leading-6 text-[var(--dpf-text)]">
+          {value}
+        </p>
+      </details>
+    );
+  }
+
+  return (
+    <div className="mb-4">
+      <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">{label}</p>
+      <p className="whitespace-pre-line text-sm leading-6 text-[var(--dpf-text)]">{value}</p>
+    </div>
+  );
 }
 
 export function PortfolioNodeEnrichment({ enrichment }: Props): ReactElement | null {
-  const { standards, patterns, references } = enrichment;
+  const {
+    standards,
+    patterns,
+    references,
+    sampleServices,
+    offeringConsiderations,
+    commercialMarket,
+    sectorCommercialMarkets,
+  } = enrichment;
   const showStandards = hasItems(standards);
   const showPatterns = hasItems(patterns);
   const showReferences = hasItems(references);
-  if (!showStandards && !showPatterns && !showReferences) return null;
+  const showSampleServices = hasText(sampleServices);
+  const showOfferingConsiderations = hasText(offeringConsiderations);
+  const showCommercialMarket = hasText(commercialMarket);
+  const showSectorCommercialMarkets = hasItems(sectorCommercialMarkets);
+  if (
+    !showStandards &&
+    !showPatterns &&
+    !showReferences &&
+    !showSampleServices &&
+    !showOfferingConsiderations &&
+    !showCommercialMarket &&
+    !showSectorCommercialMarkets
+  ) {
+    return null;
+  }
 
   return (
     <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
       <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-3">Enrichment</h2>
+
+      {showSampleServices && <TextBlock label="Sample services" value={sampleServices} />}
+
+      {showOfferingConsiderations && (
+        <TextBlock
+          disclosed
+          label="Offering considerations"
+          value={offeringConsiderations}
+        />
+      )}
+
+      {showCommercialMarket && (
+        <TextBlock disclosed label="Commercial market and products" value={commercialMarket} />
+      )}
+
+      {showSectorCommercialMarkets && (
+        <details className="mb-4 border-l border-[var(--dpf-border)] pl-3">
+          <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-muted)]">
+            Sector market guidance
+          </summary>
+          <ul className="mt-2 space-y-2 text-sm text-[var(--dpf-text)]">
+            {sectorCommercialMarkets.map((entry) => (
+              <li key={`${entry.sector}|${entry.market}`}>
+                <span className="font-medium">{entry.sector}</span>
+                <span className="text-[var(--dpf-muted)]"> - </span>
+                <span className="whitespace-pre-line">{entry.market}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
 
       {showStandards && (
         <div className="mb-4">

--- a/apps/web/lib/portfolio/portfolio-node-view-model.test.ts
+++ b/apps/web/lib/portfolio/portfolio-node-view-model.test.ts
@@ -93,6 +93,32 @@ describe("toPortfolioNodeViewModel", () => {
       expect(vm.enrichment.references).toEqual([{ label: "RFC", href: "https://example.com" }]);
     });
 
+    it("projects workbook-derived market and product guidance", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: null,
+        enrichment: {
+          sampleServices: "Capability mapping; Product fit review",
+          offeringConsiderations: "Lightweight advisory vs managed program",
+          commercialMarket: "Representative vendors: ServiceNow SPM; Planview; Jira.",
+          industryMarkets: {
+            retail: "Shopify; Square; Lightspeed",
+            banking: "Fiserv; Temenos",
+          },
+        },
+      });
+
+      expect(vm.enrichment).toMatchObject({
+        sampleServices: "Capability mapping; Product fit review",
+        offeringConsiderations: "Lightweight advisory vs managed program",
+        commercialMarket: "Representative vendors: ServiceNow SPM; Planview; Jira.",
+        sectorCommercialMarkets: [
+          { sector: "retail", market: "Shopify; Square; Lightspeed" },
+          { sector: "banking", market: "Fiserv; Temenos" },
+        ],
+      });
+    });
+
     it("warns and returns null for malformed enrichment shape", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const vm = toPortfolioNodeViewModel({

--- a/apps/web/lib/portfolio/portfolio-node-view-model.ts
+++ b/apps/web/lib/portfolio/portfolio-node-view-model.ts
@@ -32,10 +32,19 @@ export interface EnrichmentReference {
   href: string;
 }
 
+export interface SectorCommercialMarket {
+  sector: string;
+  market: string;
+}
+
 export interface EnrichmentView {
   standards: string[] | null;
   patterns: string[] | null;
   references: EnrichmentReference[] | null;
+  sampleServices: string | null;
+  offeringConsiderations: string | null;
+  commercialMarket: string | null;
+  sectorCommercialMarkets: SectorCommercialMarket[] | null;
   /** Entire JSON for debugging/hover display. JSON-cloned. */
   raw: Record<string, unknown> | null;
 }
@@ -164,18 +173,69 @@ function projectReferences(enrichment: Record<string, unknown>): EnrichmentRefer
   return projected;
 }
 
+function projectTextField(enrichment: Record<string, unknown>, key: string): string | null {
+  if (!(key in enrichment)) return null;
+  const value = enrichment[key];
+  if (typeof value !== "string") {
+    warn(`enrichment.${key} is not a string; ignoring`);
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function projectSectorCommercialMarkets(
+  enrichment: Record<string, unknown>,
+): SectorCommercialMarket[] | null {
+  const source = enrichment.industryMarkets ?? enrichment.sectorCommercialMarkets;
+  if (source === undefined) return null;
+  if (!isPlainObject(source)) {
+    warn("enrichment.industryMarkets is not an object; ignoring");
+    return null;
+  }
+
+  const projected = Object.entries(source)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([sector, market]) => ({ sector, market: market.trim() }))
+    .filter((entry) => entry.sector.trim() !== "" && entry.market !== "");
+
+  return projected.length > 0 ? projected : null;
+}
+
 function projectEnrichment(enrichment: unknown): EnrichmentView {
   if (enrichment === null || enrichment === undefined) {
-    return { standards: null, patterns: null, references: null, raw: null };
+    return {
+      standards: null,
+      patterns: null,
+      references: null,
+      sampleServices: null,
+      offeringConsiderations: null,
+      commercialMarket: null,
+      sectorCommercialMarkets: null,
+      raw: null,
+    };
   }
   if (!isPlainObject(enrichment)) {
     warn("enrichment is not an object; ignoring");
-    return { standards: null, patterns: null, references: null, raw: null };
+    return {
+      standards: null,
+      patterns: null,
+      references: null,
+      sampleServices: null,
+      offeringConsiderations: null,
+      commercialMarket: null,
+      sectorCommercialMarkets: null,
+      raw: null,
+    };
   }
   return {
     standards: projectStandards(enrichment),
     patterns: projectPatterns(enrichment),
     references: projectReferences(enrichment),
+    sampleServices: projectTextField(enrichment, "sampleServices"),
+    offeringConsiderations: projectTextField(enrichment, "offeringConsiderations"),
+    commercialMarket: projectTextField(enrichment, "commercialMarket"),
+    sectorCommercialMarkets: projectSectorCommercialMarkets(enrichment),
     raw: cloneObject(enrichment),
   };
 }


### PR DESCRIPTION
## Summary
- Projects workbook-derived taxonomy enrichment into the portfolio node view model: sample services, offering considerations, commercial market/products, and sector market guidance.
- Renders the enrichment on portfolio taxonomy detail pages with progressive disclosure and theme-token styling.
- Keeps unknown raw enrichment hidden from the UX while preserving it in the view model for internal use.

Backlog: BI-4C166411

## Verification
- `pnpm --filter web test -- lib/portfolio/portfolio-node-view-model.test.ts components/portfolio/PortfolioNodeEnrichment.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (exit 0; existing Turbopack/NFT broad-tracing warnings remain)
- `docker compose build --no-cache portal portal-init sandbox` from `D:\DPF` at commit `cebb7254`
- `docker compose up -d portal-init portal sandbox`
- Playwright against `http://localhost:3000/portfolio/for_employees/develop_and_manage_business_capabilities/manage_sustainability`: confirmed sample services, offering considerations, commercial market/products, sector market guidance, representative vendor text, raw JSON hidden, and CSS-loaded enrichment section (`paddingTop=24px`, `borderTopWidth=1px`).