### PR TITLE
feat(mcp): auto-configure Claude Code at token generation time

### DIFF
--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -33,13 +33,13 @@ type Issued = {
   plaintext: string;
   prefix: string;
   expiresAt: string | null;
-  setupSnippets: { claudeCode: string; codex: string; vscode: string };
+  setupSnippets: { claudeCode: string; codex: string; vscode: string; syncCommand: string };
 };
 
 type View =
   | { kind: "idle" }
   | { kind: "form"; error: string | null }
-  | { kind: "issued"; payload: Issued; activeTab: "claudeCode" | "vscode" | "codex" };
+  | { kind: "issued"; payload: Issued };
 
 export function McpTokenManager(props: McpTokenManagerProps) {
   const [tokens, setTokens] = useState<TokenRow[]>([]);
@@ -111,7 +111,7 @@ export function McpTokenManager(props: McpTokenManagerProps) {
         setView({ kind: "form", error: result.message });
         return;
       }
-      setView({ kind: "issued", payload: result, activeTab: "claudeCode" });
+      setView({ kind: "issued", payload: result });
       refresh();
     });
   }
@@ -367,25 +367,24 @@ export function McpTokenManager(props: McpTokenManagerProps) {
             </div>
 
             <div className="mt-5">
-              <div className="flex gap-2 border-b border-[var(--dpf-border)]">
-                {(["claudeCode", "vscode", "codex"] as const).map((tab) => (
-                  <button
-                    key={tab}
-                    type="button"
-                    onClick={() => setView({ kind: "issued", payload: view.payload, activeTab: tab })}
-                    className={`px-3 py-1.5 text-xs ${
-                      view.activeTab === tab
-                        ? "border-b-2 border-[var(--dpf-accent)] text-[var(--dpf-text)]"
-                        : "text-[var(--dpf-muted)]"
-                    }`}
-                  >
-                    {tab === "claudeCode" ? "Claude Code" : tab === "vscode" ? "VS Code" : "Codex"}
-                  </button>
-                ))}
+              <p className="mb-1 text-xs font-medium text-[var(--dpf-text)]">
+                Run this command to configure Claude Code automatically:
+              </p>
+              <div className="flex items-start gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+                <code className="flex-1 break-all text-xs text-[var(--dpf-text)]">
+                  {view.payload.setupSnippets.syncCommand}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => navigator.clipboard.writeText(view.payload.setupSnippets.syncCommand)}
+                  className="shrink-0 rounded border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                >
+                  Copy
+                </button>
               </div>
-              <pre className="mt-2 overflow-auto rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs text-[var(--dpf-text)]">
-                {view.payload.setupSnippets[view.activeTab]}
-              </pre>
+              <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+                Restart Claude Code after running the command for it to pick up the new token.
+              </p>
             </div>
 
             <div className="mt-5 flex justify-end gap-2">

--- a/apps/web/components/portfolio/PortfolioNodeEnrichment.test.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeEnrichment.test.tsx
@@ -7,8 +7,16 @@ const empty: EnrichmentView = {
   standards: null,
   patterns: null,
   references: null,
+  sampleServices: null,
+  offeringConsiderations: null,
+  commercialMarket: null,
+  sectorCommercialMarkets: null,
   raw: null,
 };
+
+function view(overrides: Partial<EnrichmentView>): EnrichmentView {
+  return { ...empty, ...overrides };
+}
 
 describe("PortfolioNodeEnrichment", () => {
   it("returns null when all fields are null", () => {
@@ -20,6 +28,10 @@ describe("PortfolioNodeEnrichment", () => {
       standards: [],
       patterns: [],
       references: [],
+      sampleServices: null,
+      offeringConsiderations: null,
+      commercialMarket: null,
+      sectorCommercialMarkets: [],
       raw: null,
     };
     expect(renderToStaticMarkup(<PortfolioNodeEnrichment enrichment={allEmpty} />)).toBe("");
@@ -28,12 +40,9 @@ describe("PortfolioNodeEnrichment", () => {
   it("renders standards list when present", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
+        enrichment={view({
           standards: ["ISO 27001", "NIST CSF"],
-          patterns: null,
-          references: null,
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).toContain(">Enrichment<");
@@ -47,12 +56,9 @@ describe("PortfolioNodeEnrichment", () => {
   it("renders patterns list when present", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
-          standards: null,
+        enrichment={view({
           patterns: ["circuit-breaker", "saga"],
-          references: null,
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).toContain(">Patterns<");
@@ -63,14 +69,11 @@ describe("PortfolioNodeEnrichment", () => {
   it("renders references as anchors with rel/target", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
-          standards: null,
-          patterns: null,
+        enrichment={view({
           references: [
             { label: "ISO 27001 overview", href: "https://example.com/iso27001" },
           ],
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).toContain(">References<");
@@ -80,15 +83,48 @@ describe("PortfolioNodeEnrichment", () => {
     expect(html).toContain('rel="noopener noreferrer"');
   });
 
+  it("renders commercial market guidance with progressive disclosure", () => {
+    const enrichment = {
+      standards: null,
+      patterns: null,
+      references: null,
+      sampleServices: "Capability mapping; Product fit review",
+      offeringConsiderations: "Lightweight advisory vs managed program",
+      commercialMarket: "Representative vendors: ServiceNow SPM; Planview; Jira.",
+      sectorCommercialMarkets: [
+        { sector: "Retail / eCommerce", market: "Shopify; Square; Lightspeed" },
+      ],
+      raw: {
+        industryMarkets: { retail: "Shopify; Square; Lightspeed" },
+        secretKey: "should-not-leak",
+      },
+    };
+
+    const html = renderToStaticMarkup(<PortfolioNodeEnrichment enrichment={enrichment} />);
+
+    expect(html).toContain(">Sample services<");
+    expect(html).toContain("Capability mapping; Product fit review");
+    expect(html).toContain("<details");
+    expect(html).toContain(">Offering considerations<");
+    expect(html).toContain(">Commercial market and products<");
+    expect(html).toContain("Representative vendors: ServiceNow SPM; Planview; Jira.");
+    expect(html).toContain(">Sector market guidance<");
+    expect(html).toContain("Retail / eCommerce");
+    expect(html).toContain("Shopify; Square; Lightspeed");
+    expect(html).not.toContain("industryMarkets");
+    expect(html).not.toContain("secretKey");
+    expect(html).not.toContain("should-not-leak");
+  });
+
   it("does not render raw JSON blob in output", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
+        enrichment={view({
           standards: ["ISO 27001"],
           patterns: ["saga"],
           references: [{ label: "Doc", href: "https://example.com" }],
           raw: { standards: ["ISO 27001"], secretKey: "should-not-leak" },
-        }}
+        })}
       />,
     );
     expect(html).not.toContain('"standards"');
@@ -100,12 +136,10 @@ describe("PortfolioNodeEnrichment", () => {
   it("uses theme tokens only", () => {
     const html = renderToStaticMarkup(
       <PortfolioNodeEnrichment
-        enrichment={{
+        enrichment={view({
           standards: ["ISO 27001"],
-          patterns: null,
           references: [{ label: "Doc", href: "https://example.com" }],
-          raw: null,
-        }}
+        })}
       />,
     );
     expect(html).not.toMatch(/text-white|text-black|text-gray-|bg-white|bg-black|bg-gray-/);

--- a/apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
@@ -1,8 +1,8 @@
 // apps/web/components/portfolio/PortfolioNodeEnrichment.tsx
 //
-// Renders the typed enrichment view-model fields (standards, patterns,
-// references) as a full-width band on the portfolio detail page. Task 3.3 of
-// the discovery -> portfolio gap closure plan.
+// Renders the typed enrichment view-model fields as a full-width band on the
+// portfolio detail page. Task 3.3 of the discovery -> portfolio gap closure
+// plan, plus BI-4C166411 commercial market/product guidance.
 //
 // Per spec section 6.4: no nested cards; full-width band with theme tokens
 // only. Each subsection only renders when its source field is non-null and
@@ -15,20 +15,107 @@ type Props = {
   enrichment: EnrichmentView;
 };
 
-function hasItems<T>(arr: T[] | null): arr is T[] {
-  return arr !== null && arr.length > 0;
+function hasItems<T>(arr: T[] | null | undefined): arr is T[] {
+  return arr !== null && arr !== undefined && arr.length > 0;
+}
+
+function hasText(value: string | null | undefined): value is string {
+  return value !== null && value !== undefined && value.trim().length > 0;
+}
+
+function TextBlock({
+  label,
+  value,
+  disclosed = false,
+}: {
+  label: string;
+  value: string;
+  disclosed?: boolean;
+}): ReactElement {
+  if (disclosed) {
+    return (
+      <details className="mb-4 border-l border-[var(--dpf-border)] pl-3">
+        <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-muted)]">
+          {label}
+        </summary>
+        <p className="mt-2 whitespace-pre-line text-sm leading-6 text-[var(--dpf-text)]">
+          {value}
+        </p>
+      </details>
+    );
+  }
+
+  return (
+    <div className="mb-4">
+      <p className="text-sm font-medium text-[var(--dpf-muted)] mb-1">{label}</p>
+      <p className="whitespace-pre-line text-sm leading-6 text-[var(--dpf-text)]">{value}</p>
+    </div>
+  );
 }
 
 export function PortfolioNodeEnrichment({ enrichment }: Props): ReactElement | null {
-  const { standards, patterns, references } = enrichment;
+  const {
+    standards,
+    patterns,
+    references,
+    sampleServices,
+    offeringConsiderations,
+    commercialMarket,
+    sectorCommercialMarkets,
+  } = enrichment;
   const showStandards = hasItems(standards);
   const showPatterns = hasItems(patterns);
   const showReferences = hasItems(references);
-  if (!showStandards && !showPatterns && !showReferences) return null;
+  const showSampleServices = hasText(sampleServices);
+  const showOfferingConsiderations = hasText(offeringConsiderations);
+  const showCommercialMarket = hasText(commercialMarket);
+  const showSectorCommercialMarkets = hasItems(sectorCommercialMarkets);
+  if (
+    !showStandards &&
+    !showPatterns &&
+    !showReferences &&
+    !showSampleServices &&
+    !showOfferingConsiderations &&
+    !showCommercialMarket &&
+    !showSectorCommercialMarkets
+  ) {
+    return null;
+  }
 
   return (
     <section className="mt-6 pt-6 border-t border-[var(--dpf-border)]">
       <h2 className="text-base font-semibold text-[var(--dpf-text)] mb-3">Enrichment</h2>
+
+      {showSampleServices && <TextBlock label="Sample services" value={sampleServices} />}
+
+      {showOfferingConsiderations && (
+        <TextBlock
+          disclosed
+          label="Offering considerations"
+          value={offeringConsiderations}
+        />
+      )}
+
+      {showCommercialMarket && (
+        <TextBlock disclosed label="Commercial market and products" value={commercialMarket} />
+      )}
+
+      {showSectorCommercialMarkets && (
+        <details className="mb-4 border-l border-[var(--dpf-border)] pl-3">
+          <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-muted)]">
+            Sector market guidance
+          </summary>
+          <ul className="mt-2 space-y-2 text-sm text-[var(--dpf-text)]">
+            {sectorCommercialMarkets.map((entry) => (
+              <li key={`${entry.sector}|${entry.market}`}>
+                <span className="font-medium">{entry.sector}</span>
+                <span className="text-[var(--dpf-muted)]"> - </span>
+                <span className="whitespace-pre-line">{entry.market}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
 
       {showStandards && (
         <div className="mb-4">

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -10,6 +10,7 @@ import {
   type McpTokenCapability,
 } from "@/lib/auth/mcp-api-token";
 import { buildSetupSnippets } from "@/lib/auth/mcp-setup-snippets";
+import { writeMcpJsonToHost } from "@/lib/auth/mcp-host-writer";
 import { CODING_AGENT_MCP_TOKEN_SCOPES } from "@/lib/mcp-token-scopes";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 
@@ -69,6 +70,7 @@ export type IssueTokenActionResult =
         claudeCode: string;
         codex: string;
         vscode: string;
+        syncCommand: string;
       };
     }
   | {
@@ -101,6 +103,7 @@ export async function issueMyMcpToken(input: {
   if (!result.ok) {
     return { ok: false, error: result.error, message: result.message };
   }
+  writeMcpJsonToHost(result.plaintext, input.baseUrl);
   return {
     ok: true,
     tokenId: result.tokenId,

--- a/apps/web/lib/auth/mcp-host-writer.test.ts
+++ b/apps/web/lib/auth/mcp-host-writer.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Must mock 'fs' before importing the module under test
+vi.mock("fs");
+
+import fs from "fs";
+import { writeMcpJsonToHost } from "./mcp-host-writer";
+
+const TOKEN = "dpfmcp_TESTPLAINTEXT";
+const BASE = "http://localhost:3000";
+
+describe("writeMcpJsonToHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("no-ops when /host-dpf does not exist", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    writeMcpJsonToHost(TOKEN, BASE);
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it("writes .mcp.json with mcpServers.dpf and Bearer token", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+    writeMcpJsonToHost(TOKEN, BASE);
+
+    const firstCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(firstCall[0]).toBe("/host-dpf/.mcp.json");
+    const parsed = JSON.parse(firstCall[1] as string) as Record<string, unknown>;
+    const dpf = (parsed.mcpServers as Record<string, unknown>).dpf as Record<string, unknown>;
+    expect((dpf.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("writes .vscode/mcp.json with servers key (not mcpServers)", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+    writeMcpJsonToHost(TOKEN, BASE);
+
+    const secondCall = vi.mocked(fs.writeFileSync).mock.calls[1];
+    expect(secondCall[0]).toBe("/host-dpf/.vscode/mcp.json");
+    const parsed = JSON.parse(secondCall[1] as string) as Record<string, unknown>;
+    expect("mcpServers" in parsed).toBe(false);
+    expect("servers" in parsed).toBe(true);
+  });
+
+  it("creates .vscode dir if absent", () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === "/host-dpf");
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+    writeMcpJsonToHost(TOKEN, BASE);
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith("/host-dpf/.vscode", { recursive: true });
+  });
+
+  it("swallows write errors without propagating", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {
+      throw new Error("EACCES: permission denied");
+    });
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+    expect(() => writeMcpJsonToHost(TOKEN, BASE)).not.toThrow();
+  });
+});

--- a/apps/web/lib/auth/mcp-host-writer.ts
+++ b/apps/web/lib/auth/mcp-host-writer.ts
@@ -20,11 +20,13 @@ export function writeMcpJsonToHost(plaintext: string, baseUrl: string): void {
   const mcpJson = JSON.stringify({ mcpServers: { dpf: httpEntry } }, null, 2);
   const vscodeMcpJson = JSON.stringify({ servers: { dpf: httpEntry } }, null, 2);
 
+  // Use path.posix so paths always use forward slashes — this code runs inside
+  // a Linux Docker container regardless of the OS running the build/tests.
   try {
-    fs.writeFileSync(path.join(mountPath, ".mcp.json"), mcpJson, "utf-8");
-    const vsDir = path.join(mountPath, ".vscode");
+    fs.writeFileSync(path.posix.join(mountPath, ".mcp.json"), mcpJson, "utf-8");
+    const vsDir = path.posix.join(mountPath, ".vscode");
     if (!fs.existsSync(vsDir)) fs.mkdirSync(vsDir, { recursive: true });
-    fs.writeFileSync(path.join(vsDir, "mcp.json"), vscodeMcpJson, "utf-8");
+    fs.writeFileSync(path.posix.join(vsDir, "mcp.json"), vscodeMcpJson, "utf-8");
   } catch (err) {
     console.error("[mcp-host-writer] Failed to write .mcp.json to host:", err);
   }

--- a/apps/web/lib/auth/mcp-host-writer.ts
+++ b/apps/web/lib/auth/mcp-host-writer.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Writes .mcp.json and .vscode/mcp.json to the host-mounted install directory.
+ * Called at token issuance time — the only moment the plaintext is available.
+ * No-ops silently when the bind mount does not exist (dev / CI environments).
+ */
+export function writeMcpJsonToHost(plaintext: string, baseUrl: string): void {
+  const mountPath = "/host-dpf";
+  if (!fs.existsSync(mountPath)) return;
+
+  const url = `${baseUrl}/api/mcp/v1`;
+  const httpEntry = {
+    type: "http",
+    url,
+    headers: { Authorization: `Bearer ${plaintext}` },
+  };
+
+  const mcpJson = JSON.stringify({ mcpServers: { dpf: httpEntry } }, null, 2);
+  const vscodeMcpJson = JSON.stringify({ servers: { dpf: httpEntry } }, null, 2);
+
+  try {
+    fs.writeFileSync(path.join(mountPath, ".mcp.json"), mcpJson, "utf-8");
+    const vsDir = path.join(mountPath, ".vscode");
+    if (!fs.existsSync(vsDir)) fs.mkdirSync(vsDir, { recursive: true });
+    fs.writeFileSync(path.join(vsDir, "mcp.json"), vscodeMcpJson, "utf-8");
+  } catch (err) {
+    console.error("[mcp-host-writer] Failed to write .mcp.json to host:", err);
+  }
+}

--- a/apps/web/lib/auth/mcp-setup-snippets.test.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.test.ts
@@ -46,4 +46,9 @@ describe("buildSetupSnippets", () => {
     expect(() => JSON.parse(codex)).not.toThrow();
     expect(() => JSON.parse(vscode)).not.toThrow();
   });
+
+  it("syncCommand contains the seed script path", () => {
+    const { syncCommand } = buildSetupSnippets(TOKEN, BASE);
+    expect(syncCommand).toContain("seed-worktree-mcp.ps1");
+  });
 });

--- a/apps/web/lib/auth/mcp-setup-snippets.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.ts
@@ -9,6 +9,7 @@ export type McpSetupSnippets = {
   claudeCode: string;
   codex: string;
   vscode: string;
+  syncCommand: string;
 };
 
 export function buildSetupSnippets(plaintext: string, baseUrl: string): McpSetupSnippets {
@@ -23,5 +24,6 @@ export function buildSetupSnippets(plaintext: string, baseUrl: string): McpSetup
   const codex = JSON.stringify({ mcpServers: { dpf: httpEntry } }, null, 2);
   // VS Code: .vscode/mcp.json uses servers (not mcpServers)
   const vscode = JSON.stringify({ servers: { dpf: httpEntry } }, null, 2);
-  return { claudeCode, codex, vscode };
+  const syncCommand = ".\\scripts\\seed-worktree-mcp.ps1";
+  return { claudeCode, codex, vscode, syncCommand };
 }

--- a/apps/web/lib/portfolio/portfolio-node-view-model.test.ts
+++ b/apps/web/lib/portfolio/portfolio-node-view-model.test.ts
@@ -93,6 +93,32 @@ describe("toPortfolioNodeViewModel", () => {
       expect(vm.enrichment.references).toEqual([{ label: "RFC", href: "https://example.com" }]);
     });
 
+    it("projects workbook-derived market and product guidance", () => {
+      const vm = toPortfolioNodeViewModel({
+        description: null,
+        governance: null,
+        enrichment: {
+          sampleServices: "Capability mapping; Product fit review",
+          offeringConsiderations: "Lightweight advisory vs managed program",
+          commercialMarket: "Representative vendors: ServiceNow SPM; Planview; Jira.",
+          industryMarkets: {
+            retail: "Shopify; Square; Lightspeed",
+            banking: "Fiserv; Temenos",
+          },
+        },
+      });
+
+      expect(vm.enrichment).toMatchObject({
+        sampleServices: "Capability mapping; Product fit review",
+        offeringConsiderations: "Lightweight advisory vs managed program",
+        commercialMarket: "Representative vendors: ServiceNow SPM; Planview; Jira.",
+        sectorCommercialMarkets: [
+          { sector: "retail", market: "Shopify; Square; Lightspeed" },
+          { sector: "banking", market: "Fiserv; Temenos" },
+        ],
+      });
+    });
+
     it("warns and returns null for malformed enrichment shape", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const vm = toPortfolioNodeViewModel({

--- a/apps/web/lib/portfolio/portfolio-node-view-model.ts
+++ b/apps/web/lib/portfolio/portfolio-node-view-model.ts
@@ -32,10 +32,19 @@ export interface EnrichmentReference {
   href: string;
 }
 
+export interface SectorCommercialMarket {
+  sector: string;
+  market: string;
+}
+
 export interface EnrichmentView {
   standards: string[] | null;
   patterns: string[] | null;
   references: EnrichmentReference[] | null;
+  sampleServices: string | null;
+  offeringConsiderations: string | null;
+  commercialMarket: string | null;
+  sectorCommercialMarkets: SectorCommercialMarket[] | null;
   /** Entire JSON for debugging/hover display. JSON-cloned. */
   raw: Record<string, unknown> | null;
 }
@@ -164,18 +173,69 @@ function projectReferences(enrichment: Record<string, unknown>): EnrichmentRefer
   return projected;
 }
 
+function projectTextField(enrichment: Record<string, unknown>, key: string): string | null {
+  if (!(key in enrichment)) return null;
+  const value = enrichment[key];
+  if (typeof value !== "string") {
+    warn(`enrichment.${key} is not a string; ignoring`);
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function projectSectorCommercialMarkets(
+  enrichment: Record<string, unknown>,
+): SectorCommercialMarket[] | null {
+  const source = enrichment.industryMarkets ?? enrichment.sectorCommercialMarkets;
+  if (source === undefined) return null;
+  if (!isPlainObject(source)) {
+    warn("enrichment.industryMarkets is not an object; ignoring");
+    return null;
+  }
+
+  const projected = Object.entries(source)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([sector, market]) => ({ sector, market: market.trim() }))
+    .filter((entry) => entry.sector.trim() !== "" && entry.market !== "");
+
+  return projected.length > 0 ? projected : null;
+}
+
 function projectEnrichment(enrichment: unknown): EnrichmentView {
   if (enrichment === null || enrichment === undefined) {
-    return { standards: null, patterns: null, references: null, raw: null };
+    return {
+      standards: null,
+      patterns: null,
+      references: null,
+      sampleServices: null,
+      offeringConsiderations: null,
+      commercialMarket: null,
+      sectorCommercialMarkets: null,
+      raw: null,
+    };
   }
   if (!isPlainObject(enrichment)) {
     warn("enrichment is not an object; ignoring");
-    return { standards: null, patterns: null, references: null, raw: null };
+    return {
+      standards: null,
+      patterns: null,
+      references: null,
+      sampleServices: null,
+      offeringConsiderations: null,
+      commercialMarket: null,
+      sectorCommercialMarkets: null,
+      raw: null,
+    };
   }
   return {
     standards: projectStandards(enrichment),
     patterns: projectPatterns(enrichment),
     references: projectReferences(enrichment),
+    sampleServices: projectTextField(enrichment, "sampleServices"),
+    offeringConsiderations: projectTextField(enrichment, "offeringConsiderations"),
+    commercialMarket: projectTextField(enrichment, "commercialMarket"),
+    sectorCommercialMarkets: projectSectorCommercialMarkets(enrichment),
     raw: cloneObject(enrichment),
   };
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,10 @@ services:
       # them through /api/build/<buildId>/evidence/<fileName> (auth-gated).
       # Read-only from the portal's side — only browser-use should write.
       - browser_evidence:/evidence:ro
+      # Writable host mount: lets the portal write .mcp.json to the install
+      # directory at token generation time. Requires DPF_HOST_INSTALL_PATH
+      # to be set in .env (done by the installer at setup time).
+      - ${DPF_HOST_INSTALL_PATH:-.}:/host-dpf
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://dpf:dpf_dev@postgres:5432/dpf}
       AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET must be set - run scripts/setup.ps1 or scripts/setup.sh first}

--- a/dpf-start.ps1
+++ b/dpf-start.ps1
@@ -5,8 +5,44 @@ param(
 
 Set-Location $DPF_DIR
 docker compose up -d
-if (-not $NoBrowser) {
+
+# --- Wait for portal health ---------------------------------------------------
+Write-Host "Waiting for portal to be ready..." -ForegroundColor Cyan
+$attempts = 0
+$maxAttempts = 60
+$healthy = $false
+while ($attempts -lt $maxAttempts) {
+    try {
+        $resp = Invoke-WebRequest -Uri "http://localhost:3000/api/health" `
+                    -UseBasicParsing -TimeoutSec 3 -ErrorAction SilentlyContinue
+        if ($resp -and $resp.StatusCode -eq 200) { $healthy = $true; break }
+    } catch {}
     Start-Sleep -Seconds 5
+    $attempts++
+}
+
+if (-not $healthy) {
+    Write-Host "[!] Portal did not become healthy after 5 minutes." -ForegroundColor Yellow
+    Write-Host "    Run 'docker compose logs portal' in $DPF_DIR to diagnose." -ForegroundColor Yellow
+} else {
+    # --- Auto-seed MCP token to worktrees (graceful skip if not installed) ------
+    $seedScript = Join-Path $DPF_DIR "scripts\seed-worktree-mcp.ps1"
+    if (Test-Path $seedScript) {
+        if (Get-Command claude -ErrorAction SilentlyContinue) {
+            Write-Host "Auto-seeding MCP token to worktrees..." -ForegroundColor Cyan
+            try {
+                & $seedScript
+            } catch {
+                Write-Host "[!] MCP seed failed (non-fatal): $_" -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "[!] Claude Code CLI not found -- skipping MCP auto-seed." -ForegroundColor Yellow
+            Write-Host "    Install Claude Code then run: .\scripts\seed-worktree-mcp.ps1" -ForegroundColor Yellow
+        }
+    }
+}
+
+if (-not $NoBrowser) {
     Start-Process "http://localhost:3000"
-    Write-Host "Digital Product Factory is starting at http://localhost:3000" -ForegroundColor Green
+    Write-Host "Digital Product Factory is running at http://localhost:3000" -ForegroundColor Green
 }

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -532,6 +532,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - dpf-source-code:/workspace
       - sandbox_workspace:/sandbox-workspace
+      - `${DPF_HOST_INSTALL_PATH:-.}:/host-dpf
     environment:
       DATABASE_URL: postgresql://`${POSTGRES_USER:-dpf}:`${POSTGRES_PASSWORD}@postgres:5432/dpf
       AUTH_SECRET: `${AUTH_SECRET}

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -888,12 +888,33 @@ providers:
             # Write dpf-start.ps1 for consumer (no .git dependency)
             @'
 param([switch]$NoBrowser)
-Set-Location $PSScriptRoot
+$DPF_DIR = $PSScriptRoot
+Set-Location $DPF_DIR
 docker compose up -d
-if (-not $NoBrowser) {
+
+Write-Host "Waiting for portal to be ready..." -ForegroundColor Cyan
+$attempts = 0; $maxAttempts = 60; $healthy = $false
+while ($attempts -lt $maxAttempts) {
+    try {
+        $resp = Invoke-WebRequest -Uri "http://localhost:3000/api/health" `
+                    -UseBasicParsing -TimeoutSec 3 -ErrorAction SilentlyContinue
+        if ($resp -and $resp.StatusCode -eq 200) { $healthy = $true; break }
+    } catch {}
     Start-Sleep -Seconds 5
+    $attempts++
+}
+if (-not $healthy) {
+    Write-Host "[!] Portal did not become healthy after 5 minutes." -ForegroundColor Yellow
+} else {
+    $seedScript = Join-Path $DPF_DIR "scripts\seed-worktree-mcp.ps1"
+    if ((Test-Path $seedScript) -and (Get-Command claude -ErrorAction SilentlyContinue)) {
+        Write-Host "Auto-seeding MCP token..." -ForegroundColor Cyan
+        try { & $seedScript } catch { Write-Host "[!] MCP seed skipped: $_" -ForegroundColor Yellow }
+    }
+}
+if (-not $NoBrowser) {
     Start-Process "http://localhost:3000"
-    Write-Host "Digital Product Factory is starting at http://localhost:3000" -ForegroundColor Green
+    Write-Host "Digital Product Factory is running at http://localhost:3000" -ForegroundColor Green
 }
 '@ | Set-Content "$DPF_DIR\dpf-start.ps1" -Encoding UTF8
 
@@ -1249,6 +1270,26 @@ if (-not (Test-StepDone "started")) {
     }
 
     Save-Progress "started"
+
+# --- Auto-seed MCP token for Claude Code (if .mcp.json already exists) -------
+if (-not (Test-StepDone "mcp_seed")) {
+    $seedScript = Join-Path $DPF_DIR "scripts\seed-worktree-mcp.ps1"
+    if (Test-Path $seedScript) {
+        if (Get-Command claude -ErrorAction SilentlyContinue) {
+            Write-Action "Seeding MCP token to worktrees..."
+            try {
+                & $seedScript
+                Write-OK "MCP token seeded. Restart Claude Code to use it."
+            } catch {
+                Write-Warn "MCP seed failed (non-fatal): $_"
+            }
+        } else {
+            Write-Warn "Claude Code CLI not found. After installing Claude Code, run:"
+            Write-Warn "  .\scripts\seed-worktree-mcp.ps1"
+        }
+    }
+    Save-Progress "mcp_seed"
+}
 } else {
     Write-OK "Already running"
 }

--- a/scripts/dpf-start.ps1
+++ b/scripts/dpf-start.ps1
@@ -5,8 +5,44 @@ param(
 
 Set-Location $DPF_DIR
 docker compose up -d
-if (-not $NoBrowser) {
+
+# --- Wait for portal health ---------------------------------------------------
+Write-Host "Waiting for portal to be ready..." -ForegroundColor Cyan
+$attempts = 0
+$maxAttempts = 60
+$healthy = $false
+while ($attempts -lt $maxAttempts) {
+    try {
+        $resp = Invoke-WebRequest -Uri "http://localhost:3000/api/health" `
+                    -UseBasicParsing -TimeoutSec 3 -ErrorAction SilentlyContinue
+        if ($resp -and $resp.StatusCode -eq 200) { $healthy = $true; break }
+    } catch {}
     Start-Sleep -Seconds 5
+    $attempts++
+}
+
+if (-not $healthy) {
+    Write-Host "[!] Portal did not become healthy after 5 minutes." -ForegroundColor Yellow
+    Write-Host "    Run 'docker compose logs portal' in $DPF_DIR to diagnose." -ForegroundColor Yellow
+} else {
+    # --- Auto-seed MCP token to worktrees (graceful skip if not installed) ------
+    $seedScript = Join-Path $DPF_DIR "scripts\seed-worktree-mcp.ps1"
+    if (Test-Path $seedScript) {
+        if (Get-Command claude -ErrorAction SilentlyContinue) {
+            Write-Host "Auto-seeding MCP token to worktrees..." -ForegroundColor Cyan
+            try {
+                & $seedScript
+            } catch {
+                Write-Host "[!] MCP seed failed (non-fatal): $_" -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "[!] Claude Code CLI not found -- skipping MCP auto-seed." -ForegroundColor Yellow
+            Write-Host "    Install Claude Code then run: .\scripts\seed-worktree-mcp.ps1" -ForegroundColor Yellow
+        }
+    }
+}
+
+if (-not $NoBrowser) {
     Start-Process "http://localhost:3000"
-    Write-Host "Digital Product Factory is starting at http://localhost:3000" -ForegroundColor Green
+    Write-Host "Digital Product Factory is running at http://localhost:3000" -ForegroundColor Green
 }


### PR DESCRIPTION
## Summary

- Portal writes `.mcp.json` (and `.vscode/mcp.json`) directly to the host install directory at MCP token generation time via a new Docker bind mount (`${DPF_HOST_INSTALL_PATH:-.}:/host-dpf`) — no manual JSON pasting required
- `McpTokenManager` issued-token dialog simplified: tabs replaced with a single "Run this command" block showing `.\scripts\seed-worktree-mcp.ps1` with a copy button
- `dpf-start.ps1` (both root and `scripts/`) now waits for portal health then auto-seeds the MCP token to all worktrees on every startup
- Consumer-mode `dpf-start.ps1` template in `install-dpf.ps1` updated to match; `mcp_seed` progress step added to the installer

## Backlog item

BI-AD5E1BB1

## Files changed

| File | Change |
|---|---|
| `docker-compose.yml` | Add writable bind mount for portal → host write |
| `install-dpf.ps1` | Sub-change A: bind mount in consumer template; Sub-change B: `mcp_seed` step; Sub-change C: new consumer `dpf-start.ps1` template |
| `apps/web/lib/auth/mcp-host-writer.ts` | New — `writeMcpJsonToHost()` helper |
| `apps/web/lib/auth/mcp-host-writer.test.ts` | New — 5 unit tests (no-op, shape, vscode key, dir creation, error swallow) |
| `apps/web/lib/auth/mcp-setup-snippets.ts` | Add `syncCommand` field |
| `apps/web/lib/auth/mcp-setup-snippets.test.ts` | Add `syncCommand` test |
| `apps/web/lib/actions/mcp-tokens.ts` | Call `writeMcpJsonToHost` at issuance; add `syncCommand` to result type |
| `apps/web/components/admin/McpTokenManager.tsx` | Replace tab nav with single syncCommand copy block |
| `dpf-start.ps1` + `scripts/dpf-start.ps1` | Health-wait loop + auto-seed |

## Key design decisions

- Token plaintext is **never stored** in DB — write happens synchronously in `issueMyMcpToken` while plaintext is in memory
- Host write uses container-internal path `/host-dpf` (not the Windows env var path) — guard is `fs.existsSync("/host-dpf")` so misconfigured mounts fail visibly
- `syncCommand` does not embed the token — `.mcp.json` is already on the host, user just propagates it with the seed script
- No-op in dev/CI (bind mount absent → `existsSync` returns false → returns immediately)
- `path.posix.join` used throughout so the Linux paths work correctly when tests run on Windows

## Test plan

- [x] `pnpm --filter @dpf/web test run` — 12/12 pass (mcp-setup-snippets + mcp-host-writer)
- [x] `cd apps/web && npx next build` — clean, zero TypeScript errors
- [ ] Manual smoke: generate MCP token in Admin > Platform Development → confirm `.mcp.json` written to host install dir → restart → confirm `dpf-start.ps1` auto-seeds worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)