### PR TITLE
fix(voice): surface STT errors inline + strip shell commands from operator copy

### DIFF
--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -182,17 +182,24 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   } catch (e) {
     // ── 4. Error mapping per spec §7.2 ─────────────────────────────────────
     if (e instanceof NoTranscriptionEndpointError) {
+      // Per the never-ask-user-to-run-commands kernel commandment, the
+      // operator-facing copy must NOT name shell. The admin guides the fix
+      // through Platform Tools > Communications > Speech-to-text.
       return jsonError(
         503,
         "tool-error",
-        "No transcription endpoint configured. Start the STT sidecar (`docker compose --profile stt up dpf-stt`) or configure a hosted provider.",
+        "Speech-to-text isn't ready yet. An admin can enable it in Platform Tools > Communications > Speech-to-text.",
       );
     }
     if (e instanceof InferenceError) {
       // Map InferenceError.code to HTTP status.
       const code = e.code;
       if (code === "network") {
-        return jsonError(503, "tool-error", `STT provider unreachable: ${e.message}`);
+        return jsonError(
+          503,
+          "tool-error",
+          "Speech-to-text service is unreachable. An admin can re-check the sidecar in Platform Tools > Communications.",
+        );
       }
       if (code === "provider_error") {
         return jsonError(502, "tool-error", `STT provider error: ${e.message}`);

--- a/apps/web/components/admin/SpeechToTextCard.test.tsx
+++ b/apps/web/components/admin/SpeechToTextCard.test.tsx
@@ -85,7 +85,7 @@ describe("SpeechToTextCard — unconfigured (fresh install)", () => {
       modelId: null,
       baseUrl: null,
       reason:
-        "No transcription endpoint registered. Start the local STT sidecar via `docker compose --profile stt up dpf-stt` or configure a hosted provider.",
+        "Speech-to-text isn't configured yet. Click Enable to start the local sidecar, or connect a hosted provider in Platform Tools > Communications.",
     });
   });
 
@@ -100,9 +100,10 @@ describe("SpeechToTextCard — unconfigured (fresh install)", () => {
     expect(html.match(/—/g)?.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("renders the actionable reason with the docker command", async () => {
+  it("renders the actionable reason WITHOUT shell commands (kernel commandment)", async () => {
     const html = await renderCard();
-    expect(html).toMatch(/docker compose --profile stt/);
+    expect(html).not.toMatch(/docker compose|docker exec|`docker/);
+    expect(html).toMatch(/Platform Tools|Enable/i);
   });
 
   it("passes readinessIsHealthy=false to the test harness", async () => {

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -98,6 +98,49 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
 
   return (
     <div style={{ borderTop: "1px solid var(--dpf-border)" }}>
+      {/*
+        Voice Slice 2 follow-up: surface voice errors INLINE, not just in the
+        button tooltip. Operators were clicking the mic, getting silent
+        failures (red ring on a small button), and concluding "nothing
+        happened". The error banner shows the failure reason + the next
+        actionable step in plain language.
+      */}
+      {voice.state === "error" && voice.error && (
+        <div
+          role="alert"
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 8,
+            padding: "6px 12px",
+            background: "rgba(211, 51, 51, 0.08)",
+            borderBottom: "1px solid rgba(211, 51, 51, 0.25)",
+            fontSize: 11,
+            color: "var(--dpf-text)",
+          }}
+        >
+          <span style={{ color: "var(--dpf-error, #d33)", fontWeight: 600 }}>
+            Voice input failed
+          </span>
+          <span style={{ flex: 1, color: "var(--dpf-muted)" }}>
+            {voice.error}
+          </span>
+          <button
+            type="button"
+            onClick={voice.reset}
+            style={{
+              background: "none",
+              border: "none",
+              color: "var(--dpf-accent)",
+              cursor: "pointer",
+              fontSize: 11,
+              padding: 0,
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       {pendingFile && (
         <div style={{
           display: "flex",

--- a/apps/web/lib/voice/endpoint-resolution.ts
+++ b/apps/web/lib/voice/endpoint-resolution.ts
@@ -31,8 +31,12 @@ export interface ResolveTranscriptionEndpointInput {
 
 export class NoTranscriptionEndpointError extends Error {
   constructor() {
+    // Operator-facing copy: per the never-ask-user-to-run-commands kernel
+    // commandment, the message must not name shell. The Platform Tools >
+    // Communications > Speech-to-text page guides the admin through enabling
+    // the sidecar without copy-paste shell.
     super(
-      "No transcription endpoint configured. Seed speaches via packages/db/data/providers-registry.json or run `docker compose --profile stt up dpf-stt`.",
+      "Speech-to-text isn't configured yet. Enable it in Platform Tools > Communications > Speech-to-text.",
     );
     this.name = "NoTranscriptionEndpointError";
   }

--- a/apps/web/lib/voice/readiness.test.ts
+++ b/apps/web/lib/voice/readiness.test.ts
@@ -36,7 +36,10 @@ describe("getSpeechToTextReadiness", () => {
     const result = await getSpeechToTextReadiness();
     expect(result.status).toBe("unconfigured");
     expect(result.providerId).toBeNull();
-    expect(result.reason).toMatch(/docker compose --profile stt/);
+    // Per the never-ask-user-to-run-commands kernel commandment, the
+    // operator-facing reason must not name shell.
+    expect(result.reason).not.toMatch(/docker compose|docker exec|`docker/);
+    expect(result.reason).toMatch(/Platform Tools|Enable/i);
   });
 
   it("returns 'healthy' when speaches is seeded + active + unblocked", async () => {

--- a/apps/web/lib/voice/readiness.ts
+++ b/apps/web/lib/voice/readiness.ts
@@ -61,7 +61,10 @@ export async function getSpeechToTextReadiness(): Promise<SpeechToTextReadiness>
       modelId: null,
       baseUrl: null,
       reason:
-        "No transcription endpoint registered. Start the local STT sidecar via `docker compose --profile stt up dpf-stt` or configure a hosted provider.",
+        // Operator-facing copy must not name shell. The admin card uses the
+        // Enable button to drive the sidecar start; the underlying script is
+        // platform plumbing.
+        "Speech-to-text isn't configured yet. Click Enable to start the local sidecar, or connect a hosted provider in Platform Tools > Communications.",
     };
   }
 


### PR DESCRIPTION
## Summary

Live testing the voice mic on the install caught two real UX bugs from PRs #696/#700/#716:

1. **Voice failures hid in a tooltip.** The mic button transitioned to its red error state but the error message lived only in the button's \`title=\` attribute. Operator reported \"the button changes, but what I was saying never appears anywhere.\" Added an inline error banner above the textarea row that surfaces \`voice.error\` with a Dismiss action.

2. **Operator copy named docker commands.** Three places told the operator to run \`docker compose --profile stt up dpf-stt\` — direct violation of the [never-ask-user-to-run-commands](../docs/founder-kernel/wiki/principles/never-ask-user-to-run-commands.md) kernel commandment. Replaced all three with \"Speech-to-text isn't configured yet. Enable it in Platform Tools > Communications > Speech-to-text.\"

## Files changed

- \`apps/web/components/agent/AgentMessageInput.tsx\` — inline error banner
- \`apps/web/app/api/transcribe/route.ts\` — 503 message
- \`apps/web/lib/voice/endpoint-resolution.ts\` — NoTranscriptionEndpointError
- \`apps/web/lib/voice/readiness.ts\` — admin card reason
- \`apps/web/lib/voice/readiness.test.ts\` — flipped to assert NO shell strings
- \`apps/web/components/admin/SpeechToTextCard.test.tsx\` — flipped to assert NO shell strings

## Test plan

- [x] 105/105 voice + card tests pass.
- [x] Typecheck clean.
- [x] Pre-commit hook green.
- [ ] Live verification: operator clicks mic with STT not configured, sees inline error banner pointing to Platform Tools (rather than seeing the button silently turn red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)