### PR TITLE
fix(code-graph): fail open on dirty-state timeouts

### DIFF
--- a/apps/web/lib/integrate/code-graph-refresh-reconcile.test.ts
+++ b/apps/web/lib/integrate/code-graph-refresh-reconcile.test.ts
@@ -296,6 +296,38 @@ describe("reconcileCodeGraph", () => {
     );
   });
 
+  it("keeps the graph ready when dirty-state detection times out", async () => {
+    vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue({
+      graphKey: CODE_GRAPH_GRAPH_KEY,
+      graphVersion: CODE_GRAPH_PROJECTION_VERSION,
+      lastIndexedHeadSha: "head-2",
+    } as never);
+
+    mockExec.mockImplementation(async (command: string) => {
+      if (command === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
+      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (command === "git status --porcelain") {
+        throw new Error("Command failed: git status --porcelain");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const result = await reconcileCodeGraph({ reason: "scheduled" });
+
+    expect(result.mode).toBe("noop");
+    expect(result.workspaceDirty).toBe(true);
+    expect(prisma.codeGraphIndexState.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          indexStatus: "ready",
+          lastError: null,
+          workspaceDirty: true,
+        }),
+      }),
+    );
+  });
+
   it("performs a full rebuild when the stored graph projection version is stale", async () => {
     vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue({
       graphKey: CODE_GRAPH_GRAPH_KEY,

--- a/apps/web/lib/integrate/code-graph/git-snapshot.ts
+++ b/apps/web/lib/integrate/code-graph/git-snapshot.ts
@@ -6,6 +6,7 @@ import {
 } from "./path-filter";
 
 const exec = lazyExec();
+const GIT_STATUS_TIMEOUT_MS = 2_000;
 
 export function getGitRoot(): string {
   const { resolve } = lazyPath();
@@ -49,8 +50,15 @@ export async function getCurrentBranch(gitRoot: string): Promise<string | null> 
 }
 
 export async function isWorkspaceDirty(gitRoot: string): Promise<boolean> {
-  const { stdout } = await exec("git status --porcelain", { cwd: gitRoot, timeout: 10_000 });
-  return stdout.trim().length > 0;
+  try {
+    const { stdout } = await exec("git status --porcelain", { cwd: gitRoot, timeout: GIT_STATUS_TIMEOUT_MS });
+    return stdout.trim().length > 0;
+  } catch {
+    // Dirty-state detection is advisory telemetry. If Git status is slow on a
+    // host-mounted workspace, keep the graph usable and surface the safer
+    // "possibly stale" warning instead of failing the reconcile job.
+    return true;
+  }
 }
 
 export async function listTrackedFiles(gitRoot: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Keep code graph reconciliation usable when the advisory dirty-workspace check times out or is killed.
- Treat dirty-state detection failures as conservative `workspaceDirty = true` telemetry instead of marking `CodeGraphIndexState` failed.
- Add a regression test for the portal/container failure mode where `git status --porcelain` throws during scheduled reconcile.

## Root Cause

The Build Studio warning came from `CodeGraphIndexState.lastError` after the scheduled code-graph reconcile job ran `git status --porcelain` in `/workspace` inside the portal container. On the Windows bind-mounted repo, that command can exceed the timeout and get killed with SIGTERM. The prior non-git-repo guard did not catch this because `/workspace` is a valid Git worktree: `git rev-parse --is-inside-work-tree` succeeds, but full status still hangs.

The code graph indexes committed tracked files, so dirty-workspace detection is advisory UI telemetry. A telemetry timeout should warn that local changes may not be reflected, not fail the graph.

## Validation

- `pnpm --filter web exec vitest run lib/integrate/code-graph-refresh-reconcile.test.ts lib/integrate/code-graph-access.test.ts components/build/CodeIntelligenceStatusCard.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`

Build completed successfully. Turbopack still reports existing broad file-tracing warnings in `spec-plan-search.ts`, `discovery-fingerprint-catalog.ts`, and `next.config.mjs`; those warnings are unrelated to this code-graph fix.