### PR TITLE
feat(backup): Slice 3 part A — Neo4j + Qdrant shell runners + spec/plan

### DIFF
--- a/docs/superpowers/plans/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+++ b/docs/superpowers/plans/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
@@ -1,0 +1,178 @@
+# Plan — Backup Slice 3: Neo4j + Qdrant coverage
+
+> Spec: `docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md`
+> Branch: `feat/backup-slice-3-neo4j-qdrant` (off `origin/main`)
+
+## Files
+
+### New scripts
+
+- `scripts/backup-neo4j.sh` — POSIX shell. Stops `dpf-neo4j-1`, runs
+  `neo4j-admin database dump` writing into `/backups/neo4j/<ISO-ts>/`,
+  restarts the container. Emits manifest + sha256 + log mirror of
+  Slice 1's pattern.
+- `scripts/backup-qdrant.sh` — POSIX shell. Hits Qdrant `POST
+  /snapshots` to create a snapshot, downloads it via GET, deletes
+  it from Qdrant's internal storage. Writes the same manifest +
+  sha256 + log shape.
+
+### New TS orchestrators
+
+- `apps/web/lib/operate/backups/neo4j-backup-runner.ts` — mirrors
+  Slice 1's `postgres-backup-runner.ts`. Acquires a per-target lock,
+  spawns the shell script, records `BackupRun` row with
+  `target: "neo4j"`, updates `ScheduledJob` heartbeat for `neo4j-daily-backup`,
+  applies GFS retention scoped to `target: "neo4j"`.
+- `apps/web/lib/operate/backups/qdrant-backup-runner.ts` — same shape,
+  `target: "qdrant"`, heartbeat `qdrant-daily-backup`.
+
+### Modified
+
+- `apps/web/lib/queue/functions/postgres-daily-backup.ts` — rename
+  internally + extend to run all three services on the daily cron
+  fire. The two existing event triggers stay (manual Postgres trigger).
+  Add two more events: `ops/neo4j-backup.requested`,
+  `ops/qdrant-backup.requested`.
+- `apps/web/lib/operate/backups/constants.ts` — add the two new
+  `*_BACKUP_JOB_ID` and event-name constants.
+- `apps/web/lib/operate/backups/types.ts` — extend `BackupTarget`
+  type to include `"neo4j"` and `"qdrant"`.
+- `apps/web/lib/operate/backups/retention.ts` — already target-aware
+  via `BackupRun.target`; verify pruning correctly partitions by
+  target.
+- `apps/web/lib/operate/backups/readiness.ts` — return three
+  `ReadinessSummary` blocks (one per target) instead of one.
+- `apps/web/lib/actions/backups.ts` — extend server actions to accept
+  a `target` parameter; add `triggerNeo4jBackupNowAction`,
+  `triggerQdrantBackupNowAction`.
+- `apps/web/app/(shell)/admin/backups/page.tsx` + `BackupsClient.tsx`
+  — render three readiness sections stacked, each with its own
+  history table.
+- `packages/db/src/seed-platform-backup.ts` — add two more
+  `ScheduledJob` upserts for `neo4j-daily-backup`,
+  `qdrant-daily-backup`.
+- `apps/web/lib/operate/metrics.ts` — add Neo4j + Qdrant counterparts
+  to the postgres backup metrics.
+
+### No schema migration
+
+`BackupRun.target` already exists with `@default("postgres")`. New
+values (`"neo4j"`, `"qdrant"`) are accepted as-is. No migration.
+
+## Chunk 1 — Shell runners
+
+1. Author `scripts/backup-neo4j.sh`:
+   - Stop `${DPF_NEO4J_CONTAINER:-dpf-neo4j-1}` via `docker stop`
+     with a 30 s grace period
+   - Run `docker run --rm -v dpf_neo4jdata:/data -v <host-target>:/dump
+     neo4j:5-community neo4j-admin database dump --to-path=/dump neo4j`
+     (the dump command can run against a stopped database via the
+     volume mount; this is the standard offline-dump pattern)
+   - Start the original container via `docker start`
+   - Verify it returns to healthy before claiming success
+   - Emit manifest + sha256 + log
+2. Author `scripts/backup-qdrant.sh`:
+   - `curl -X POST http://qdrant:6333/snapshots` to create snapshot
+   - Parse the `result.name` from the response JSON
+   - `curl -o /backups/qdrant/.../qdrant.snapshot http://qdrant:6333/snapshots/<name>`
+   - `curl -X DELETE http://qdrant:6333/snapshots/<name>` to clean up
+   - Emit manifest + sha256 + log
+3. Smoke-test each against the live install.
+
+**Exit:** Both scripts produce restorable artifacts on the host bind
+mount with the expected manifest shape.
+
+## Chunk 2 — TS orchestrators
+
+1. Author the two runner files mirroring the Slice 1 pattern.
+2. The orchestrators must:
+   - Use a separate per-target lock (don't share Postgres's lock)
+   - Insert `BackupRun` row in `status: "running"` BEFORE the shell
+     runs (so a failure surfaces in admin UX even if the script
+     hangs)
+   - Update the row on completion / failure
+   - Update the `ScheduledJob` heartbeat
+   - Emit Prometheus metrics
+3. Verify retention works per-target — a Neo4j backup should not
+   prune Postgres backups.
+
+**Exit:** Calling either runner end-to-end produces a `BackupRun`
+row and a file on disk; the admin readiness card sees the run.
+
+## Chunk 3 — Combined Inngest function
+
+1. Replace the single `postgresDailyBackupScheduled` cron with a
+   combined `allBackupsDailyScheduled` that runs all three in
+   sequence.
+2. Keep the existing event-driven `postgresBackupRequested` for
+   backwards compat; add `neo4jBackupRequested` +
+   `qdrantBackupRequested`.
+3. Register the new functions in `apps/web/lib/queue/functions/index.ts`.
+
+**Exit:** Inngest dashboard shows the new functions; firing the new
+events triggers the appropriate runner.
+
+## Chunk 4 — Admin UX
+
+1. Refactor `BackupsClient.tsx` to render three sections by mapping
+   over `[{ target: "postgres", ... }, { target: "neo4j", ... }, ...]`.
+2. Add Neo4j-specific warning copy: "Manual trigger restarts the Neo4j
+   container — expect ~10 s of unavailability."
+3. The "Run backup now" button per section emits the appropriate
+   event.
+4. History table filters by target.
+5. Restore wizard stays Postgres-only for this slice (deferred to
+   Slice 4).
+
+**Exit:** Operator opens `/admin/backups`, sees three sections, can
+manually trigger each.
+
+## Chunk 5 — Seed + heartbeats
+
+1. Extend `seed-platform-backup.ts` to upsert all three
+   `ScheduledJob` rows.
+2. Verify on a fresh seed that all three appear with
+   `schedule: "daily"`.
+
+**Exit:** `pnpm --filter @dpf/db run seed` includes all three
+ScheduledJob upserts; the routing-invariants audit still passes.
+
+## Chunk 6 — FUNCTIONAL verification (per structural ≠ functional)
+
+This is THE GATE. Not "tests pass" — actual end-to-end runs on the
+live install with observable host-disk artifacts.
+
+1. Seed test data into Neo4j (a few labeled nodes) so the dump has
+   non-empty content
+2. Seed a Qdrant collection with a few vectors so the snapshot has
+   non-empty content
+3. Manually trigger Neo4j backup via admin UX:
+   - Observe `BackupRun` row appears with `target: "neo4j"`,
+     `status: "running"`, then `status: "ok"`
+   - Verify `${DPF_HOST_INSTALL_PATH}/backups/neo4j/<ISO-ts>/neo4j.dump`
+     exists, non-zero size, sha256 matches manifest
+   - Verify Neo4j container restarted to healthy
+   - Restore the dump into a throwaway container, verify the labeled
+     nodes are present
+4. Manually trigger Qdrant backup:
+   - Observe `BackupRun` row appears with `target: "qdrant"`
+   - Verify `qdrant/<ISO-ts>/qdrant.snapshot` on host disk
+   - Restore via Qdrant API into a target collection, verify the
+     vectors are present
+5. Capture the verification log in the PR description.
+
+**Exit:** PR has a runnable verification log. Acceptance criteria 1–8
+from the spec all observed.
+
+## Chunk 7 — Open PR
+
+Single PR. Verification log in the body. CI must pass before merge.
+
+## What this slice deliberately leaves out
+
+- Restore wizard for Neo4j + Qdrant (Slice 4)
+- Off-host replication (Phase 3 in original spec)
+- Per-collection Qdrant snapshots
+- PITR / WAL archiving (Phase 4)
+- Cross-service consistency (out of scope; restore is catastrophic-loss
+  recovery, not transactional rollback)

--- a/docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+++ b/docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
@@ -1,0 +1,172 @@
+# Backup — Slice 3: Neo4j + Qdrant coverage
+
+> Status: **APPROVED** — proposed + operator-OK 2026-05-18
+> Amends: `docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md`
+>   §6 Slice 3, §10 Phase 2 — closing both out.
+> Owning kernel principles:
+>   [`consult-specs-first`](../../founder-kernel/wiki/principles/consult-specs-first.md),
+>   [`research-before-implementing`](../../founder-kernel/wiki/principles/research-before-implementing.md),
+>   [`structural-verification-is-not-functional`](../../founder-kernel/wiki/principles/structural-verification-is-not-functional.md),
+>   [`never-ask-user-to-run-commands`](../../founder-kernel/wiki/principles/never-ask-user-to-run-commands.md).
+
+## 1. Goal
+
+Extend the platform-managed backup mechanism (Slices 1 + 2 — already
+shipped) to cover Neo4j and Qdrant. After this slice, **a full-volume
+wipe of any combination of `dpf_pgdata`, `dpf_neo4jdata`, and
+`dpf_qdrant_data` is recoverable from host-bind backups**, not just
+the Postgres volume.
+
+Acceptance is FUNCTIONAL — drive a backup of each service end-to-end
+through the admin UX, observe the dump file lands on the host bind
+mount, restore each into a throwaway target, verify content matches.
+
+## 2. Why both services matter
+
+| Service | What's lost on a volume wipe |
+|---|---|
+| Postgres (`dpf_pgdata`) | Operator state: backlog, providers, employees, governance ledger. **Covered by Slice 1.** |
+| Neo4j (`dpf_neo4jdata`) | Wiki link graph + PPR routing data + EA model topology. Regenerable from Postgres source-of-truth, but ingestion is expensive (~minutes-to-hours on a full re-walk) |
+| Qdrant (`dpf_qdrant_data`) | Vector embeddings for wiki RAG, semantic memory, brand context. Regenerable but every page must be re-embedded — measured in hours on a populated install |
+
+Slice 1 saved the irreplaceable state; Slice 3 saves the regenerable-but-
+expensive state.
+
+## 3. Decision
+
+### 3.1 Per-service backup mechanism
+
+| Service | Tool | Image-bundled? | Operates on running container? |
+|---|---|---|---|
+| Postgres | `pg_dump -Fc` | yes (postgres:16-alpine) | yes |
+| **Neo4j** | `neo4j-admin database dump` | yes (neo4j:5-community) | **no — requires stopping the DB** |
+| **Qdrant** | `POST /snapshots` REST API | yes (qdrant native HTTP) | yes |
+
+Neo4j's offline-only requirement drives the architecture:
+
+- The Slice 3 Neo4j runner must **stop the Neo4j container**, run the
+  dump command (which uses the volume directly, not via Bolt protocol),
+  then **start the container again**. Total downtime: ~5–15 s for the
+  full sequence on a small graph.
+- Qdrant runs entirely online — REST API call, no service interruption.
+- Both are scheduled to run **after** the Postgres backup completes,
+  on the same cron fire. If Postgres backup fails, Neo4j + Qdrant
+  backups still run (independent failure modes).
+
+### 3.2 BackupRun.target — already supports this
+
+The Slice 1 schema (`BackupRun.target String @default("postgres")`)
+already accommodates the discriminator. No migration needed. New target
+values: `"neo4j"`, `"qdrant"`. Retention math is per-target, GFS
+treats each service independently.
+
+### 3.3 Storage layout
+
+```
+<DPF_HOST_INSTALL_PATH>/backups/
+├── postgres/<ISO-ts>/dpf.dump + manifest.json + sha256 + log.txt
+├── neo4j/<ISO-ts>/neo4j.dump + manifest.json + sha256 + log.txt
+└── qdrant/<ISO-ts>/qdrant.snapshot + manifest.json + sha256 + log.txt
+```
+
+### 3.4 Admin UX — extend the existing readiness card
+
+The Slice 1 `/admin/backups` page becomes **three readiness sections
+stacked**: Postgres / Neo4j / Qdrant. Each carries its own:
+- Last run / last success / next run
+- Retention summary
+- Storage path
+- Manual trigger button
+- History table (filtered by target)
+- Restore wizard (Postgres-only for now; Slice 4 = restore-from-snapshot
+  for Neo4j + Qdrant).
+
+### 3.5 Scheduling
+
+Single Inngest function `ops/all-backups-daily-scheduled` fires once
+per day at 03:00 UTC and runs all three in sequence:
+
+```
+1. runPostgresBackup({ trigger: "scheduled" })
+2. runNeo4jBackup({ trigger: "scheduled" })  # stops container + dumps + restarts
+3. runQdrantBackup({ trigger: "scheduled" }) # REST snapshot
+```
+
+Each is independent: a Postgres failure does not abort Neo4j;
+a Neo4j failure does not abort Qdrant. Each writes its own
+`BackupRun` row and updates its own `ScheduledJob` heartbeat:
+`postgres-daily-backup`, `neo4j-daily-backup`, `qdrant-daily-backup`.
+
+Manual triggers also independent — each "Run backup now" button
+emits a target-scoped Inngest event.
+
+## 4. Out of scope
+
+- **Restore wizard for Neo4j + Qdrant.** Slice 4 — same typed-RESTORE
+  confirmation UX as Postgres, per-service runner. Phase 5 in the
+  Slice 1 spec.
+- **Snapshot-API-based Qdrant restore.** Slice 4.
+- **Off-host replication (S3, restic, Backblaze).** Phase 3 in the
+  Slice 1 spec.
+- **Neo4j online backup via `neo4j-admin backup`** (Enterprise-only
+  feature). We use `dump` which works on Community Edition.
+- **Per-collection Qdrant snapshots** instead of full-instance.
+  Phase 5+.
+
+## 5. Acceptance criteria
+
+The slice is complete ONLY when all observed live:
+
+1. Fresh `docker compose up` brings up all three services + the
+   portal. The new `ScheduledJob` rows for `neo4j-daily-backup` and
+   `qdrant-daily-backup` exist with `schedule: "daily"`.
+2. Admin opens `/admin/backups` and sees three readiness sections
+   (Postgres / Neo4j / Qdrant), each showing "never run yet" until
+   the first cron fire or manual trigger.
+3. Clicking "Run backup now" on the Neo4j section:
+   - Stops the Neo4j container
+   - Writes `neo4j/<ISO-ts>/neo4j.dump` to the host bind mount
+   - Restarts the Neo4j container
+   - Inserts a `BackupRun` row with `target: "neo4j"`, `status: "ok"`
+   - Surfaces success in the history table
+4. Clicking "Run backup now" on the Qdrant section:
+   - Calls `POST http://qdrant:6333/snapshots`
+   - Downloads the snapshot file via GET
+   - Writes `qdrant/<ISO-ts>/qdrant.snapshot` to the host bind mount
+   - Inserts a `BackupRun` row with `target: "qdrant"`, `status: "ok"`
+5. The Neo4j dump is restorable into a freshly created Neo4j 5
+   instance (verified by spinning a throwaway container, mounting
+   the dump, running `neo4j-admin database load`, and listing
+   databases).
+6. The Qdrant snapshot is restorable via the Qdrant REST API into a
+   target instance.
+7. When the Neo4j container fails to restart after a dump, the runner
+   surfaces a clear inline error in the readiness card AND keeps
+   trying to restart in background — never leaves Neo4j stopped.
+8. Routing-invariants audit + typecheck + pre-commit hook all pass.
+
+## 6. Open questions
+
+- **Neo4j downtime window**: 5–15 s of unavailability per scheduled
+  backup. Acceptable for daily 03:00 UTC fires; revisit when adding
+  PITR (Phase 4). Documented in the admin card so operator isn't
+  surprised.
+- **Qdrant snapshot cleanup**: Qdrant retains snapshots inside the
+  container's storage until explicitly deleted. The runner deletes
+  the snapshot from Qdrant's storage after downloading it to the
+  host. Otherwise we'd double-store every snapshot.
+- **Cross-service consistency**: Slice 3 does NOT guarantee point-in-
+  time consistency across Postgres + Neo4j + Qdrant. Each is backed
+  up at slightly different timestamps within a single cron fire
+  (~30 s apart). For DPF's use case this is acceptable — restore is
+  catastrophic-loss recovery, not transactional rollback.
+
+## 7. Recommendation
+
+Single PR. Implementation is tactically straightforward:
+- Two new shell runners (`scripts/backup-neo4j.sh`, `scripts/backup-qdrant.sh`)
+- Two new TS orchestrators following the Slice 1 pattern
+- One new combined Inngest function
+- Admin UX extension (three sections instead of one)
+- Two new seed entries for `ScheduledJob` heartbeats
+- Functional verification of each end-to-end on the live install

--- a/scripts/backup-neo4j.sh
+++ b/scripts/backup-neo4j.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# scripts/backup-neo4j.sh — platform-managed Neo4j backup runner.
+#
+# Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+#
+# Neo4j Community Edition only supports OFFLINE dumps via
+# `neo4j-admin database dump`. This script stops the running Neo4j
+# container, runs the dump against the volume mount, and restarts the
+# container.
+#
+# Per the never-ask-user-to-run-commands kernel principle, this is
+# never invoked by the operator. The admin UX warns about the
+# ~10-second unavailability window before invoking.
+#
+# Required env:
+#   TARGET_DIR              absolute path on host where neo4j.dump + manifest + sha256 + log land
+#   DPF_NEO4J_CONTAINER     container name (default: dpf-neo4j-1)
+#   DPF_NEO4J_VOLUME        named volume (default: dpf_neo4jdata)
+#   DPF_NEO4J_DATABASE      database name (default: neo4j)
+#
+# Exit codes:
+#   0 success
+#   2 prereq missing
+#   3 dump failed (Neo4j container restarted regardless)
+#   4 dump succeeded but Neo4j container failed to restart
+
+set -eu
+
+log() { printf '[backup-neo4j-trace] %s\n' "$*"; }
+fail() {
+  log "failed: $1"
+  exit "${2:-1}"
+}
+
+TARGET_DIR="${TARGET_DIR:-}"
+NEO4J_CONTAINER="${DPF_NEO4J_CONTAINER:-dpf-neo4j-1}"
+NEO4J_VOLUME="${DPF_NEO4J_VOLUME:-dpf_neo4jdata}"
+NEO4J_DATABASE="${DPF_NEO4J_DATABASE:-neo4j}"
+DPF_HOST_INSTALL_PATH="${DPF_HOST_INSTALL_PATH:-}"
+
+[ -n "$TARGET_DIR" ] || fail "TARGET_DIR not set" 2
+[ -n "$DPF_HOST_INSTALL_PATH" ] || fail "DPF_HOST_INSTALL_PATH not set — required to translate portal's /backups view to the host path that docker-in-docker bind mounts need" 2
+command -v docker >/dev/null 2>&1 || fail "docker CLI not available" 2
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum not available" 2
+
+mkdir -p "$TARGET_DIR" || fail "could not create $TARGET_DIR" 2
+# Neo4j runs the dump container as user `neo4j` (UID 7474). The host
+# bind mount is created by the portal (root), so without explicit
+# chmod the dump container gets AccessDeniedException writing to
+# /dump. 0777 is safe here because the host-side directory lives
+# under the operator-controlled DPF_HOST_INSTALL_PATH/backups tree.
+chmod 0777 "$TARGET_DIR" || fail "could not chmod $TARGET_DIR" 2
+
+# Translate the portal's view of TARGET_DIR (/backups/neo4j/<ts>) to the
+# host path the docker daemon needs for the dump container's bind
+# mount. Without this translation docker rejects the mount with
+# "invalid path" or silently creates an empty dir, and the dump fails
+# with AccessDeniedException. Same pattern the promoter uses
+# (docker-compose.yml line ~240).
+TARGET_REL="${TARGET_DIR#/backups/}"
+HOST_TARGET_DIR="${DPF_HOST_INSTALL_PATH}/backups/${TARGET_REL}"
+log "host path for dump container: $HOST_TARGET_DIR"
+
+DUMP_FILE="$TARGET_DIR/neo4j.dump"
+SHA_FILE="$TARGET_DIR/neo4j.dump.sha256"
+LOG_FILE="$TARGET_DIR/log.txt"
+MANIFEST_FILE="$TARGET_DIR/manifest.json"
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+STARTED_EPOCH="$(date +%s)"
+
+log "starting offline dump container=$NEO4J_CONTAINER volume=$NEO4J_VOLUME db=$NEO4J_DATABASE"
+
+# Capture the Neo4j image tag so the dump runner uses the same version.
+# Mismatched versions (dump with newer admin against older data) fail.
+NEO4J_IMAGE="$(docker inspect "$NEO4J_CONTAINER" --format='{{.Config.Image}}' 2>/dev/null || echo "neo4j:5-community")"
+log "neo4j_image=$NEO4J_IMAGE"
+
+# Stop the running container so the database is offline for the dump.
+# 30-second grace period gives Neo4j time to flush + checkpoint.
+log "stopping Neo4j container"
+docker stop --timeout=30 "$NEO4J_CONTAINER" > "$LOG_FILE" 2>&1 || fail "could not stop $NEO4J_CONTAINER" 3
+
+# Helper to restart the container on every exit path. Defined before the
+# dump so a dump failure still restarts Neo4j. We track success/fail of
+# the dump separately from the restart.
+restart_neo4j() {
+  log "restarting Neo4j container"
+  if ! docker start "$NEO4J_CONTAINER" >> "$LOG_FILE" 2>&1; then
+    log "WARN could not restart $NEO4J_CONTAINER — operator must check"
+    return 1
+  fi
+  return 0
+}
+
+# Run the dump from a one-shot container mounted on the same volume.
+# Output writes to the host target dir via a bind mount.
+#
+# Don't pass --user — the neo4j image's default user (neo4j, UID 7474)
+# is what owns /data and has dump-write permissions.
+#
+# The bind mount source MUST be the HOST path (HOST_TARGET_DIR), not
+# the portal's view (TARGET_DIR). The docker daemon resolves paths
+# from the host's filesystem.
+DUMP_EXIT=0
+docker run --rm \
+  -v "${NEO4J_VOLUME}:/data" \
+  -v "${HOST_TARGET_DIR}:/dump" \
+  "$NEO4J_IMAGE" \
+  neo4j-admin database dump \
+    --to-path=/dump \
+    --overwrite-destination=true \
+    "$NEO4J_DATABASE" >> "$LOG_FILE" 2>&1 || DUMP_EXIT=$?
+
+# Always restart Neo4j before checking dump exit.
+restart_neo4j
+RESTART_EXIT=$?
+
+if [ "$DUMP_EXIT" -ne 0 ]; then
+  log "dump exit=$DUMP_EXIT — tail of log:"
+  tail -n 20 "$LOG_FILE" >&2 || true
+  fail "neo4j-admin database dump failed (exit=$DUMP_EXIT)" 3
+fi
+
+if [ "$RESTART_EXIT" -ne 0 ]; then
+  fail "Neo4j restart failed AFTER dump — operator must verify container" 4
+fi
+
+# neo4j-admin emits <database>.dump (e.g. neo4j.dump) — normalize the name
+# to a stable "neo4j.dump" regardless of database name so the orchestrator
+# always knows where to find the file.
+ACTUAL_DUMP="$TARGET_DIR/${NEO4J_DATABASE}.dump"
+if [ -f "$ACTUAL_DUMP" ] && [ "$ACTUAL_DUMP" != "$DUMP_FILE" ]; then
+  mv "$ACTUAL_DUMP" "$DUMP_FILE"
+fi
+
+[ -f "$DUMP_FILE" ] || fail "dump file did not appear at $DUMP_FILE" 3
+
+# Checksum + manifest.
+DUMP_SHA="$(sha256sum "$DUMP_FILE" | awk '{print $1}')"
+printf '%s  neo4j.dump\n' "$DUMP_SHA" > "$SHA_FILE"
+
+FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+FINISHED_EPOCH="$(date +%s)"
+SIZE_BYTES="$(wc -c < "$DUMP_FILE" | tr -d ' ')"
+DURATION_MS=$(( (FINISHED_EPOCH - STARTED_EPOCH) * 1000 ))
+
+# Capture the actual neo4j image used for restore parity.
+cat > "$MANIFEST_FILE" <<MANIFEST
+{
+  "schemaVersion": 1,
+  "target": "neo4j",
+  "container": "$NEO4J_CONTAINER",
+  "volume": "$NEO4J_VOLUME",
+  "database": "$NEO4J_DATABASE",
+  "image": "$NEO4J_IMAGE",
+  "startedAt": "$STARTED_AT",
+  "finishedAt": "$FINISHED_AT",
+  "durationMs": $DURATION_MS,
+  "sizeBytes": $SIZE_BYTES,
+  "sha256": "$DUMP_SHA",
+  "dumpFormat": "neo4j-admin database dump"
+}
+MANIFEST
+
+log "ok sha256=$DUMP_SHA size=$SIZE_BYTES duration_ms=$DURATION_MS"
+exit 0

--- a/scripts/backup-qdrant.sh
+++ b/scripts/backup-qdrant.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# scripts/backup-qdrant.sh — platform-managed Qdrant backup runner.
+#
+# Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+#
+# Qdrant supports ONLINE backups via the REST snapshot API. This script
+# triggers a full-instance snapshot, downloads the resulting file, then
+# deletes the in-container copy so Qdrant's storage doesn't bloat.
+#
+# Required env:
+#   TARGET_DIR              absolute host dir for snapshot + manifest + sha256 + log
+#   DPF_QDRANT_URL          internal URL (default: http://qdrant:6333)
+#
+# Exit codes:
+#   0 success
+#   2 prereq missing
+#   3 snapshot create failed
+#   4 download failed
+#   5 cleanup failed (snapshot file downloaded but Qdrant copy not deleted — warning, not fatal)
+
+set -eu
+
+log() { printf '[backup-qdrant-trace] %s\n' "$*"; }
+fail() {
+  log "failed: $1"
+  exit "${2:-1}"
+}
+
+TARGET_DIR="${TARGET_DIR:-}"
+QDRANT_URL="${DPF_QDRANT_URL:-http://qdrant:6333}"
+
+[ -n "$TARGET_DIR" ] || fail "TARGET_DIR not set" 2
+command -v curl >/dev/null 2>&1 || fail "curl not available" 2
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum not available" 2
+
+mkdir -p "$TARGET_DIR" || fail "could not create $TARGET_DIR" 2
+
+DUMP_FILE="$TARGET_DIR/qdrant.snapshot"
+SHA_FILE="$TARGET_DIR/qdrant.snapshot.sha256"
+LOG_FILE="$TARGET_DIR/log.txt"
+MANIFEST_FILE="$TARGET_DIR/manifest.json"
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+STARTED_EPOCH="$(date +%s)"
+
+log "starting snapshot create url=$QDRANT_URL"
+
+# Step 1: create the snapshot on Qdrant's side.
+CREATE_RESPONSE=$(curl -sS -X POST "${QDRANT_URL}/snapshots" 2>>"$LOG_FILE") || fail "snapshot create request failed" 3
+echo "$CREATE_RESPONSE" >> "$LOG_FILE"
+
+# Parse the snapshot name from the JSON response without jq dependency.
+# Response shape: {"result":{"name":"full-snapshot-2026-05-18-04-40-01.snapshot","creation_time":"...","size":N,"checksum":"..."},"status":"ok",...}
+SNAPSHOT_NAME=$(echo "$CREATE_RESPONSE" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p' | head -1)
+[ -n "$SNAPSHOT_NAME" ] || fail "could not parse snapshot name from Qdrant response" 3
+log "snapshot created on Qdrant: $SNAPSHOT_NAME"
+
+# Step 2: download the snapshot file to the host bind mount.
+log "downloading snapshot"
+if ! curl -sSf -o "$DUMP_FILE" "${QDRANT_URL}/snapshots/${SNAPSHOT_NAME}" 2>>"$LOG_FILE"; then
+  fail "snapshot download failed" 4
+fi
+
+[ -s "$DUMP_FILE" ] || fail "downloaded snapshot is empty" 4
+
+# Step 3: delete the snapshot from Qdrant to free storage. Non-fatal —
+# orphaned snapshots inside Qdrant are recoverable next backup; the
+# host-side copy is what matters.
+CLEANUP_EXIT=0
+curl -sS -X DELETE "${QDRANT_URL}/snapshots/${SNAPSHOT_NAME}" >> "$LOG_FILE" 2>&1 || CLEANUP_EXIT=$?
+if [ "$CLEANUP_EXIT" -ne 0 ]; then
+  log "WARN cleanup of in-Qdrant snapshot failed (exit=$CLEANUP_EXIT) — host copy is intact"
+fi
+
+# Checksum + manifest.
+DUMP_SHA="$(sha256sum "$DUMP_FILE" | awk '{print $1}')"
+printf '%s  qdrant.snapshot\n' "$DUMP_SHA" > "$SHA_FILE"
+
+FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+FINISHED_EPOCH="$(date +%s)"
+SIZE_BYTES="$(wc -c < "$DUMP_FILE" | tr -d ' ')"
+DURATION_MS=$(( (FINISHED_EPOCH - STARTED_EPOCH) * 1000 ))
+
+cat > "$MANIFEST_FILE" <<MANIFEST
+{
+  "schemaVersion": 1,
+  "target": "qdrant",
+  "qdrantUrl": "$QDRANT_URL",
+  "snapshotName": "$SNAPSHOT_NAME",
+  "startedAt": "$STARTED_AT",
+  "finishedAt": "$FINISHED_AT",
+  "durationMs": $DURATION_MS,
+  "sizeBytes": $SIZE_BYTES,
+  "sha256": "$DUMP_SHA",
+  "dumpFormat": "qdrant snapshot (full instance)"
+}
+MANIFEST
+
+log "ok sha256=$DUMP_SHA size=$SIZE_BYTES duration_ms=$DURATION_MS"
+exit 0


### PR DESCRIPTION
## Why this exists

Closes out the Slice 1 spec's §10 Phase 2 (\"Neo4j + Qdrant\") at the load-bearing layer. After this PR + Slice 3 part B (admin UX wiring), a full-volume wipe of any combination of \`dpf_pgdata\`, \`dpf_neo4jdata\`, \`dpf_qdrant_data\` is recoverable from host-bind backups.

## What this PR ships

- **\`docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md\`** — spec amendment (3-target scope, neo4j offline-dump strategy, qdrant snapshot API, BackupRun.target discriminator reuse)
- **\`docs/superpowers/plans/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md\`** — implementation plan with explicit functional-acceptance gates
- **\`scripts/backup-neo4j.sh\`** — POSIX shell runner using \`neo4j-admin database dump\` (Community-edition offline only). Stops container, dumps, restarts. Always restarts even on dump failure.
- **\`scripts/backup-qdrant.sh\`** — POSIX shell runner using Qdrant's REST snapshot API. Online, no service interruption.

## Live functional verification (per structural ≠ functional)

### Neo4j (10–15s offline window, then restart)

\`\`\`
$ docker exec dpf-portal-1 sh -c 'DPF_HOST_INSTALL_PATH=d:/DPF \
    DPF_NEO4J_CONTAINER=dpf-neo4j-1 \
    TARGET_DIR=/backups/neo4j/smoke-... /tmp/backup-neo4j.sh'

[backup-neo4j-trace] starting offline dump container=dpf-neo4j-1
[backup-neo4j-trace] neo4j_image=neo4j:5-community
[backup-neo4j-trace] stopping Neo4j container
[backup-neo4j-trace] restarting Neo4j container
[backup-neo4j-trace] ok sha256=f716a613... size=4827711 duration_ms=14000

# On host disk:
-rw-r--r-- 1 root root 4827711 May 17 23:48 neo4j.dump
-rw-r--r-- 1 root root      77 May 17 23:48 neo4j.dump.sha256
-rw-r--r-- 1 root root     411 May 17 23:48 manifest.json
-rw-r--r-- 1 root root    4249 May 17 23:48 log.txt

# Neo4j container after:
running (healthy)
\`\`\`

### Qdrant (online, ~ms)

\`\`\`
$ docker exec dpf-portal-1 sh -c 'DPF_QDRANT_URL=http://qdrant:6333 \
    TARGET_DIR=/backups/qdrant/smoke-... /tmp/backup-qdrant.sh'

[backup-qdrant-trace] starting snapshot create url=http://qdrant:6333
[backup-qdrant-trace] snapshot created on Qdrant: full-snapshot-2026-05-18-04-44-15.snapshot
[backup-qdrant-trace] downloading snapshot
[backup-qdrant-trace] ok sha256=6bd6460c... size=2048 duration_ms=0

# On host disk:
qdrant.snapshot, qdrant.snapshot.sha256, manifest.json, log.txt
\`\`\`

(2 KB because Qdrant has zero collections on this install — verified-empty dump.)

## Important debugging finding: docker-in-docker bind-mount path translation

The Neo4j runner spawns a separate container for the dump. The bind mount source MUST be the HOST path (via \`DPF_HOST_INSTALL_PATH\`), not the portal's view of \`/backups\`. Without translation the docker daemon resolves the path against the host filesystem and the dump fails with \`AccessDeniedException: /dump\`. The Slice 1 Postgres runner doesn't hit this because it shells \`docker exec\` into an existing container; Slice 3 hits it because Neo4j needs a SEPARATE container spawn to dump an offline volume. Same pattern the promoter uses (\`docker-compose.yml\` line ~240, \`\${DPF_HOST_INSTALL_PATH:-.}/backups:/backups\`).

## What's deferred to Slice 3 part B (next PR)

- TS orchestrators (\`neo4j-backup-runner.ts\`, \`qdrant-backup-runner.ts\`) — mirror Slice 1's \`postgres-backup-runner.ts\` pattern
- Combined Inngest cron \`ops/all-backups-daily-scheduled\` + new event-driven manual triggers
- Admin UX: three readiness sections stacked at \`/admin/backups\` (Postgres / Neo4j / Qdrant), per-target history tables, target-aware retention
- \`ScheduledJob\` seed rows for \`neo4j-daily-backup\` + \`qdrant-daily-backup\`
- Dockerfile bundling so the runners ship in the portal image (currently they ship via the source-code volume sync)
- FUNCTIONAL verification through the admin button (this PR verifies via shell)

## Why split into A and B

Part A's mechanism is the load-bearing piece — if either runner doesn't work end-to-end, no UX matters. Verifying that against a live install + landing it as a discrete PR limits blast radius if the wiring needs iteration. Part B is mechanical extension of Slice 1's TS pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)