### PR TITLE
fix(routing): raise CLI adapter timeout to 10 min for large Build Studio prompts

### DIFF
--- a/apps/web/lib/routing/capability-probes/probe-claude-cli.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-claude-cli.test.ts
@@ -56,7 +56,7 @@ describe("probeClaudeCli", () => {
     expect(profile.supportsMcpAttachPerInvoke).toBe(true);
     expect(profile.supportsHooks).toBe(true);
     expect(profile.supportsOutputSchema).toBe(false);
-    expect(profile.maxInteractiveLatencyMs).toBe(180_000);
+    expect(profile.maxInteractiveLatencyMs).toBe(600_000);
     expect(profile.supportedAuthModes).toEqual(expect.arrayContaining(["oauth", "api-key"]));
     expect(profile.knownDegradations).toBeNull();
   });

--- a/apps/web/lib/routing/capability-probes/probe-claude-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-claude-cli.ts
@@ -64,7 +64,7 @@ export async function probeClaudeCli(): Promise<CapabilityProbeResult> {
     supportsExtendedThinking: true,
     supportsOutputSchema: false, // not equivalent to Codex's --output-schema
 
-    maxInteractiveLatencyMs: 180_000, // matches CLI_TIMEOUT_MS in cli-adapter.ts
+    maxInteractiveLatencyMs: 600_000, // matches CLI_TIMEOUT_MS in cli-adapter.ts
     supportedAuthModes: ["oauth", "api-key"],
     knownDegradations: null,
   };

--- a/apps/web/lib/routing/capability-probes/probe-codex-cli.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-codex-cli.test.ts
@@ -63,7 +63,7 @@ describe("probeCodexCli", () => {
     expect(profile.supportsOutputSchema).toBe(true);
     expect(profile.supportsExtendedThinking).toBe(true);
     expect(profile.supportsSessionResume).toBe(true);
-    expect(profile.maxInteractiveLatencyMs).toBe(180_000);
+    expect(profile.maxInteractiveLatencyMs).toBe(600_000);
     expect(profile.supportedAuthModes).toEqual(expect.arrayContaining(["oauth", "api-key"]));
   });
 

--- a/apps/web/lib/routing/capability-probes/probe-codex-cli.ts
+++ b/apps/web/lib/routing/capability-probes/probe-codex-cli.ts
@@ -64,7 +64,7 @@ export async function probeCodexCli(): Promise<CapabilityProbeResult> {
     supportsExtendedThinking: true, // -c reasoning.effort=high
     supportsOutputSchema: true, // --output-schema (gpt-5 family only)
 
-    maxInteractiveLatencyMs: 180_000,
+    maxInteractiveLatencyMs: 600_000, // matches CLI_TIMEOUT_MS in codex-cli-adapter.ts
     supportedAuthModes: ["oauth", "api-key"],
 
     knownDegradations: [

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -26,7 +26,7 @@ import { createMcpSessionToken } from "@/lib/mcp/session-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
-const CLI_TIMEOUT_MS = 180_000; // 3 minutes — matches chat adapter's AbortSignal.timeout
+const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
 
 /** Internal portal URL the sandbox uses to reach `/api/mcp/v1`. The standard
  *  self-host docker bridge resolves `portal` to the portal container; override

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -23,7 +23,7 @@ import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { extractToolCalls as sharedExtractToolCalls } from "./extract-tool-calls";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
-const CLI_TIMEOUT_MS = 180_000; // 3 minutes
+const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
 
 // ─── Container file writer ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Raises `CLI_TIMEOUT_MS` from `180_000` (3 min) to `600_000` (10 min) in both `codex-cli-adapter.ts` and `cli-adapter.ts`.
- Updates the `maxInteractiveLatencyMs` ceiling in the matching capability probes (`probe-codex-cli.ts`, `probe-claude-cli.ts`) and their tests so the published profile continues to mirror the actual adapter SLA.

## Why

Build Studio runs accumulate large prompts — system prompt + accumulated phase context + tool schemas + user prompt — easily exceeding 100K characters. At those sizes the codex/claude CLI takes well over 3 minutes per turn, and both adapters were aborting mid-inference with `Codex CLI timed out after 180s` / `Claude CLI timed out after 180s`. The symptom for the user is a build that goes silent at a phase boundary and never advances.

This is an urgent hotfix to unblock two currently-stuck builds:
- **FB-E6BE8D3B** — specialist subtask thread spawning (7/14 tasks done, 7 blocked on this timeout)
- **FB-6D0D5513** — formal deliberation / diversity of thought (stuck, needs resume)

Both CLI adapters are patched because the issue is identical on the Claude-subscription path; bumping only codex leaves the Anthropic-subscription users with the same latent failure.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` (full vitest suite on apps/web) — 6254 passed, 14 skipped, 13 todo, 0 failed
- [x] Focused tests on the 5 affected files — 46/46 passing
- [ ] Post-merge: rebuild portal, resume FB-E6BE8D3B + FB-6D0D5513, verify they progress past prior stall point

🤖 Generated with [Claude Code](https://claude.com/claude-code)