### PR TITLE
test(build): pin C3/C4/C5/C7/C8 acceptance gaps as it.todo placeholders

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.test.ts
+++ b/apps/web/lib/integrate/build-orchestrator.test.ts
@@ -347,6 +347,16 @@ describe("task-scoped Build Studio context", () => {
     expect(scoped).not.toContain("FULL_LIFECYCLE_THREAD");
     expect(scoped).not.toContain("conversation conversation conversation");
   });
+
+  // Pinned acceptance gaps from the rev 4 thread-management design (§13).
+  // Each it.todo names the criterion it will become a regression test for once
+  // the corresponding fast-follow lands. Replacing the todo with a real
+  // assertion is the explicit Definition of Done for that follow-up.
+  it.todo("C3 — decisions slot survives LRU eviction with 20 completed tasks (lands FF-PR-1: decisions ledger wired to DecisionInteraction)");
+  it.todo("C4 — file shapes (exported symbols) for files written by prior tasks appear in scoped context without re-Read (lands BI-FOLLOWUP-SIGNATURE-EXTRACT)");
+  it.todo("C5 — BLOCKED-task retry receives prior attempt's failure context in scoped dispatch (lands FF-PR-3)");
+  it.todo("C7 — taskResults.decisions[] contains only interactionId references, never duplicated rationale/confidence fields (lands FF-PR-1; prohibition test)");
+  it.todo("C8 — scoped context slot order is stable-prefix-first to maximize prompt cache hit rate (lands FF-PR-1; snapshot or position assertion)");
 });
 
 // ─── QA Verification Parsing ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

§13.2 step 3 precursor for the rev 4 thread-management design ([#762](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/762)). Adds five `it.todo` entries to `build-orchestrator.test.ts` inside the existing `"task-scoped Build Studio context"` describe block.

Each `it.todo` pins one uncovered acceptance criterion from the design spec §8 / §13. It does nothing today (vitest treats `it.todo` as a pending marker — appears in test output, does not affect pass/fail). Its job is to make the gap **visible** so the fast-follow PR that closes the gap replaces the `it.todo` with a real assertion, rather than silently shipping a fix without coverage.

## What's pinned

| Todo | Criterion | Lands in |
|---|---|---|
| C3 | Decisions slot survives LRU eviction with 20 completed tasks | FF-PR-1 (decisions ledger wired to `DecisionInteraction`) |
| C4 | File shapes (exported symbols) for files written by prior tasks appear in scoped context without re-Read | BI-FOLLOWUP-SIGNATURE-EXTRACT |
| C5 | `BLOCKED`-task retry receives prior attempt's failure context | FF-PR-3 |
| C7 | `taskResults.decisions[]` contains only `interactionId` references, never duplicated fields (prohibition test) | FF-PR-1 |
| C8 | Scoped context slot order is stable-prefix-first to maximize prompt cache hit rate | FF-PR-1 |

## Why this is its own tiny PR

§13 of the design spec calls out the failure mode this guards against: a fast-follow ships a heuristic that "fixes" a gap, but no regression test was ever written for the criterion, so the next regression goes silently. Pinning the criteria as `it.todo` before the fast-follows start makes the coverage debt visible in CI output every test run.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/build-orchestrator.test.ts` — **49 passed | 5 todo** (the new placeholders)
- [x] `pnpm --filter web typecheck` — pre-commit hook ran scoped typecheck on this file: `[pre-commit] typecheck ok`
- [x] No app code touched — pure test-file scaffolding

## Related

- [PR #762](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/762) — rev 4 design spec defining the criteria
- [PR #756](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/756) — the validated implementation (merged as `538bc685`)
- BI-0789AF6B

🤖 Generated with [Claude Code](https://claude.com/claude-code)