### PR TITLE
feat(backup): Slice 3 part B — Neo4j + Qdrant orchestrators + admin UX

### DIFF
--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 
 import {
-  getBackupReadinessAction,
+  getAllBackupReadinessAction,
   listBackupRunsAction,
   readBackupRunLogAction,
   triggerBackupNowAction,
@@ -14,7 +14,7 @@ import {
   listRestoreRunsAction,
   previewRestoreAction,
 } from "@/lib/actions/backup-restore";
-import type { ReadinessSummary } from "@/lib/operate/backups/types";
+import type { BackupTarget, ReadinessSummary } from "@/lib/operate/backups/types";
 import type {
   RestoreImpactPreview,
   RestoreRunListItem,
@@ -23,9 +23,17 @@ import type {
 import { RestoreConfirmModal } from "./RestoreConfirmModal";
 import { RestoreHistorySection } from "./RestoreHistorySection";
 
+interface AllReadiness {
+  postgres: ReadinessSummary;
+  neo4j: ReadinessSummary;
+  qdrant: ReadinessSummary;
+}
+
 interface Props {
-  initialReadiness: ReadinessSummary;
-  initialRuns: BackupRunListItem[];
+  initialReadiness: AllReadiness;
+  initialPgRuns: BackupRunListItem[];
+  initialNeo4jRuns: BackupRunListItem[];
+  initialQdrantRuns: BackupRunListItem[];
   initialRestoreRuns: RestoreRunListItem[];
 }
 
@@ -71,15 +79,34 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
+const TARGET_LABELS: Record<BackupTarget, string> = {
+  postgres: "Postgres",
+  neo4j: "Neo4j",
+  qdrant: "Qdrant",
+};
+
+const TARGET_DESCRIPTIONS: Record<BackupTarget, string> = {
+  postgres: "Full database dump (pg_dump -Fc). All operator state, backlog, config.",
+  neo4j: "Offline dump (neo4j-admin). Wiki link graph, routing data, EA model topology. Requires ~10 s Neo4j restart.",
+  qdrant: "Full-instance snapshot (REST API). Vector embeddings, semantic memory, brand context. No service interruption.",
+};
+
 export function BackupsClient({
   initialReadiness,
-  initialRuns,
+  initialPgRuns,
+  initialNeo4jRuns,
+  initialQdrantRuns,
   initialRestoreRuns,
 }: Props) {
-  const [readiness, setReadiness] = useState(initialReadiness);
-  const [runs, setRuns] = useState(initialRuns);
+  const [readiness, setReadiness] = useState<AllReadiness>(initialReadiness);
+  const [runsByTarget, setRunsByTarget] = useState<Record<BackupTarget, BackupRunListItem[]>>({
+    postgres: initialPgRuns,
+    neo4j: initialNeo4jRuns,
+    qdrant: initialQdrantRuns,
+  });
   const [restoreRuns, setRestoreRuns] = useState(initialRestoreRuns);
-  const [pending, startTransition] = useTransition();
+  const [pendingTarget, setPendingTarget] = useState<BackupTarget | null>(null);
+  const [, startTransition] = useTransition();
   const [openLog, setOpenLog] = useState<{ runId: string; data: BackupRunLog } | null>(null);
   const [loadingLog, setLoadingLog] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -87,13 +114,15 @@ export function BackupsClient({
   const [loadingPreview, setLoadingPreview] = useState<string | null>(null);
 
   async function refresh() {
-    const [next, list, restores] = await Promise.all([
-      getBackupReadinessAction(),
-      listBackupRunsAction({ limit: 50 }),
+    const [next, pgRuns, neo4jRuns, qdrantRuns, restores] = await Promise.all([
+      getAllBackupReadinessAction(),
+      listBackupRunsAction({ limit: 50, target: "postgres" }),
+      listBackupRunsAction({ limit: 50, target: "neo4j" }),
+      listBackupRunsAction({ limit: 50, target: "qdrant" }),
       listRestoreRunsAction({ limit: 20 }),
     ]);
     setReadiness(next);
-    setRuns(list);
+    setRunsByTarget({ postgres: pgRuns, neo4j: neo4jRuns, qdrant: qdrantRuns });
     setRestoreRuns(restores);
   }
 
@@ -117,16 +146,16 @@ export function BackupsClient({
     );
   }
 
-  function handleTrigger() {
+  function handleTrigger(target: BackupTarget) {
     setError(null);
+    setPendingTarget(target);
     startTransition(async () => {
-      const result = await triggerBackupNowAction();
+      const result = await triggerBackupNowAction(target);
+      setPendingTarget(null);
       if (!result.ok) {
         setError(result.error ?? "Backup request failed.");
         return;
       }
-      // Inngest runs asynchronously; give it a moment to mark the row, then refresh.
-      // The cron concurrency limit serializes overlapping triggers.
       setTimeout(() => {
         refresh().catch((e: unknown) =>
           setError(e instanceof Error ? e.message : String(e)),
@@ -148,191 +177,214 @@ export function BackupsClient({
     }
   }
 
-  const j = readiness.scheduledJob;
-  const lastRun = readiness.lastRun;
-  const overdue = readiness.failuresInLastThreeRuns >= 2;
+  const targets: BackupTarget[] = ["postgres", "neo4j", "qdrant"];
 
   return (
-    <div className="max-w-4xl space-y-8">
-      {/* ─── Readiness card ─────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
-            Readiness
-          </h2>
-          <button
-            onClick={handleTrigger}
-            disabled={pending}
-            className="px-4 py-2 text-sm font-medium rounded transition-colors"
-            style={{
-              background: pending ? "var(--dpf-border)" : "var(--dpf-accent)",
-              color: pending ? "var(--dpf-muted)" : "#fff",
-              cursor: pending ? "not-allowed" : "pointer",
-            }}
-          >
-            {pending ? "Triggering…" : "Run backup now"}
-          </button>
-        </div>
-
+    <div className="max-w-4xl space-y-10">
+      {error && (
         <div
-          className="rounded p-4 grid gap-3 text-sm"
+          className="p-3 rounded text-sm"
           style={{
-            background: "var(--dpf-surface)",
-            border: "1px solid var(--dpf-border)",
+            background: "rgba(248, 113, 113, 0.15)",
+            color: "#f87171",
+            border: "1px solid rgba(248, 113, 113, 0.3)",
           }}
         >
-          <ReadinessRow
-            label="Schedule"
-            value={j ? `${j.schedule} (cron 03:00 UTC)` : "—"}
-          />
-          <ReadinessRow
-            label="Last run"
-            value={
-              lastRun
-                ? `${formatTimestamp(lastRun.startedAt)} · ${formatDurationMs(
-                    lastRun.durationMs,
-                  )} · ${formatBytes(lastRun.sizeBytes)}`
-                : "never"
-            }
-            statusBadge={lastRun ? <StatusPill status={lastRun.status} /> : null}
-          />
-          <ReadinessRow
-            label="Last successful run"
-            value={
-              readiness.lastSuccess
-                ? `${formatTimestamp(readiness.lastSuccess.finishedAt)} · ${formatBytes(
-                    readiness.lastSuccess.sizeBytes,
-                  )}`
-                : "never"
-            }
-          />
-          <ReadinessRow
-            label="Next run"
-            value={j?.nextRunAt ? formatTimestamp(j.nextRunAt) : "—"}
-          />
-          <ReadinessRow
-            label="Retention"
-            value={`${readiness.retention.daily} daily · ${readiness.retention.weekly} weekly · ${readiness.retention.monthly} monthly`}
-          />
-          <ReadinessRow
-            label="Retained on disk"
-            value={`${readiness.retainedCount} backup${readiness.retainedCount === 1 ? "" : "s"} · ${formatBytes(
-              readiness.retainedBytes,
-            )}`}
-          />
-          <ReadinessRow label="Storage path" value={readiness.storagePath} />
+          {error}
         </div>
+      )}
 
-        {overdue && (
-          <div
-            className="mt-3 p-3 rounded text-sm"
-            style={{
-              background: "rgba(248, 113, 113, 0.15)",
-              color: "#f87171",
-              border: "1px solid rgba(248, 113, 113, 0.3)",
-            }}
-          >
-            Multiple recent backups have failed. Investigate the latest run log
-            for details.
-          </div>
-        )}
+      {targets.map((target) => {
+        const r = readiness[target];
+        const runs = runsByTarget[target];
+        const j = r.scheduledJob;
+        const lastRun = r.lastRun;
+        const overdue = r.failuresInLastThreeRuns >= 2;
+        const isPending = pendingTarget === target;
 
-        {error && (
-          <div
-            className="mt-3 p-3 rounded text-sm"
-            style={{
-              background: "rgba(248, 113, 113, 0.15)",
-              color: "#f87171",
-              border: "1px solid rgba(248, 113, 113, 0.3)",
-            }}
-          >
-            {error}
-          </div>
-        )}
-      </section>
-
-      {/* ─── History ────────────────────────────────────────────────────── */}
-      <section>
-        <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">
-          History
-        </h2>
-        {runs.length === 0 ? (
-          <p className="text-xs text-[var(--dpf-muted)]">
-            No backups yet — the first scheduled run will appear here. Click
-            “Run backup now” above to create one immediately.
-          </p>
-        ) : (
-          <div
-            className="rounded overflow-hidden"
-            style={{
-              border: "1px solid var(--dpf-border)",
-            }}
-          >
-            <table className="w-full text-xs">
-              <thead style={{ background: "var(--dpf-bg)" }}>
-                <tr>
-                  <Th>Started</Th>
-                  <Th>Status</Th>
-                  <Th>Trigger</Th>
-                  <Th>Size</Th>
-                  <Th>Duration</Th>
-                  <Th className="text-right">Actions</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {runs.map((r) => (
-                  <tr
-                    key={r.id}
-                    className={r.prunedAt ? "opacity-60" : ""}
-                    style={{ borderTop: "1px solid var(--dpf-border)" }}
+        return (
+          <div key={target}>
+            {/* ─── Section header ──────────────────────────────────────── */}
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                  {TARGET_LABELS[target]}
+                </h2>
+                <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+                  {TARGET_DESCRIPTIONS[target]}
+                </p>
+                {target === "neo4j" && (
+                  <p
+                    className="text-xs mt-1 font-medium"
+                    style={{ color: "#fbbf24" }}
                   >
-                    <Td>{formatTimestamp(r.startedAt)}</Td>
-                    <Td>
-                      <StatusPill status={r.status} />
-                    </Td>
-                    <Td className="text-[var(--dpf-muted)]">{r.trigger}</Td>
-                    <Td>{formatBytes(r.sizeBytes)}</Td>
-                    <Td>{formatDurationMs(r.durationMs)}</Td>
-                    <Td className="text-right">
-                      {r.status === "ok" && !r.prunedAt && (
-                        <button
-                          onClick={() => handleOpenRestore(r.id)}
-                          disabled={loadingPreview !== null}
-                          className="mr-3 hover:underline disabled:opacity-50"
-                          style={{ color: "#f87171" }}
-                          title="Restore the database from this backup"
-                        >
-                          {loadingPreview === r.id ? "Loading…" : "Restore…"}
-                        </button>
-                      )}
-                      <button
-                        onClick={() => handleOpenLog(r.id)}
-                        disabled={loadingLog}
-                        className="text-[var(--dpf-accent)] hover:underline disabled:opacity-50"
-                      >
-                        View log
-                      </button>
-                      {r.prunedAt && (
-                        <span
-                          className="ml-2 text-[10px]"
-                          style={{ color: "var(--dpf-muted)" }}
-                        >
-                          pruned
-                        </span>
-                      )}
-                    </Td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
+                    Manual trigger stops the Neo4j container for ~10 s.
+                  </p>
+                )}
+              </div>
+              <button
+                onClick={() => handleTrigger(target)}
+                disabled={isPending || pendingTarget !== null}
+                className="px-4 py-2 text-sm font-medium rounded transition-colors shrink-0 ml-4"
+                style={{
+                  background:
+                    isPending || pendingTarget !== null
+                      ? "var(--dpf-border)"
+                      : "var(--dpf-accent)",
+                  color:
+                    isPending || pendingTarget !== null
+                      ? "var(--dpf-muted)"
+                      : "#fff",
+                  cursor:
+                    isPending || pendingTarget !== null ? "not-allowed" : "pointer",
+                }}
+              >
+                {isPending
+                  ? "Triggering…"
+                  : `Run ${TARGET_LABELS[target]} backup now`}
+              </button>
+            </div>
 
-      {/* ─── Restore history (Slice 2) ──────────────────────────────────── */}
+            {/* ─── Readiness card ──────────────────────────────────────── */}
+            <div
+              className="rounded p-4 grid gap-3 text-sm mb-3"
+              style={{
+                background: "var(--dpf-surface)",
+                border: "1px solid var(--dpf-border)",
+              }}
+            >
+              <ReadinessRow
+                label="Schedule"
+                value={j ? `${j.schedule} (cron 03:00 UTC)` : "—"}
+              />
+              <ReadinessRow
+                label="Last run"
+                value={
+                  lastRun
+                    ? `${formatTimestamp(lastRun.startedAt)} · ${formatDurationMs(
+                        lastRun.durationMs,
+                      )} · ${formatBytes(lastRun.sizeBytes)}`
+                    : "never"
+                }
+                statusBadge={lastRun ? <StatusPill status={lastRun.status} /> : null}
+              />
+              <ReadinessRow
+                label="Last success"
+                value={
+                  r.lastSuccess
+                    ? `${formatTimestamp(r.lastSuccess.finishedAt)} · ${formatBytes(
+                        r.lastSuccess.sizeBytes,
+                      )}`
+                    : "never"
+                }
+              />
+              <ReadinessRow
+                label="Next run"
+                value={j?.nextRunAt ? formatTimestamp(j.nextRunAt) : "—"}
+              />
+              <ReadinessRow
+                label="Retention"
+                value={`${r.retention.daily} daily · ${r.retention.weekly} weekly · ${r.retention.monthly} monthly`}
+              />
+              <ReadinessRow
+                label="Retained on disk"
+                value={`${r.retainedCount} backup${r.retainedCount === 1 ? "" : "s"} · ${formatBytes(r.retainedBytes)}`}
+              />
+              <ReadinessRow label="Storage path" value={r.storagePath} />
+            </div>
+
+            {overdue && (
+              <div
+                className="mb-3 p-3 rounded text-sm"
+                style={{
+                  background: "rgba(248, 113, 113, 0.15)",
+                  color: "#f87171",
+                  border: "1px solid rgba(248, 113, 113, 0.3)",
+                }}
+              >
+                Multiple recent {TARGET_LABELS[target]} backups have failed.
+                Investigate the latest run log for details.
+              </div>
+            )}
+
+            {/* ─── History table ───────────────────────────────────────── */}
+            {runs.length === 0 ? (
+              <p className="text-xs text-[var(--dpf-muted)]">
+                No {TARGET_LABELS[target]} backups yet — click the trigger
+                button above to create one immediately.
+              </p>
+            ) : (
+              <div
+                className="rounded overflow-hidden"
+                style={{ border: "1px solid var(--dpf-border)" }}
+              >
+                <table className="w-full text-xs">
+                  <thead style={{ background: "var(--dpf-bg)" }}>
+                    <tr>
+                      <Th>Started</Th>
+                      <Th>Status</Th>
+                      <Th>Trigger</Th>
+                      <Th>Size</Th>
+                      <Th>Duration</Th>
+                      <Th className="text-right">Actions</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {runs.map((row) => (
+                      <tr
+                        key={row.id}
+                        className={row.prunedAt ? "opacity-60" : ""}
+                        style={{ borderTop: "1px solid var(--dpf-border)" }}
+                      >
+                        <Td>{formatTimestamp(row.startedAt)}</Td>
+                        <Td>
+                          <StatusPill status={row.status} />
+                        </Td>
+                        <Td className="text-[var(--dpf-muted)]">{row.trigger}</Td>
+                        <Td>{formatBytes(row.sizeBytes)}</Td>
+                        <Td>{formatDurationMs(row.durationMs)}</Td>
+                        <Td className="text-right">
+                          {row.status === "ok" && !row.prunedAt && target === "postgres" && (
+                            <button
+                              onClick={() => handleOpenRestore(row.id)}
+                              disabled={loadingPreview !== null}
+                              className="mr-3 hover:underline disabled:opacity-50"
+                              style={{ color: "#f87171" }}
+                              title="Restore the database from this backup"
+                            >
+                              {loadingPreview === row.id ? "Loading…" : "Restore…"}
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleOpenLog(row.id)}
+                            disabled={loadingLog}
+                            className="text-[var(--dpf-accent)] hover:underline disabled:opacity-50"
+                          >
+                            View log
+                          </button>
+                          {row.prunedAt && (
+                            <span
+                              className="ml-2 text-[10px]"
+                              style={{ color: "var(--dpf-muted)" }}
+                            >
+                              pruned
+                            </span>
+                          )}
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* ─── Restore history (Slice 2) ────────────────────────────────────── */}
       <RestoreHistorySection runs={restoreRuns} />
 
-      {/* ─── Restore wizard modal (Slice 2) ─────────────────────────────── */}
+      {/* ─── Restore wizard modal (Slice 2, Postgres only) ───────────────── */}
       {restorePreview && (
         <RestoreConfirmModal
           preview={restorePreview}
@@ -341,7 +393,7 @@ export function BackupsClient({
         />
       )}
 
-      {/* ─── Log drawer ─────────────────────────────────────────────────── */}
+      {/* ─── Log drawer ──────────────────────────────────────────────────── */}
       {openLog && (
         <div
           className="fixed inset-0 z-40 flex justify-end"

--- a/apps/web/app/(shell)/admin/backups/page.tsx
+++ b/apps/web/app/(shell)/admin/backups/page.tsx
@@ -1,7 +1,7 @@
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 
 import {
-  getBackupReadinessAction,
+  getAllBackupReadinessAction,
   listBackupRunsAction,
 } from "@/lib/actions/backups";
 import { listRestoreRunsAction } from "@/lib/actions/backup-restore";
@@ -14,35 +14,39 @@ export const dynamic = "force-dynamic";
  * Admin → Advanced → Backups.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.8, §4.6
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md §3.4
  *
- * Slice 1 renders the readiness card + history table + manual-trigger button.
- * Slice 2 adds the restore wizard (per-row Restore button + typed-confirmation
- * modal) and a restore history section below. The operator never sees a CLI
- * here — clicks only — per the never-ask-user-to-run-commands kernel
- * commandment.
+ * Slice 3 extends the page with three stacked readiness sections — one per
+ * backup target (Postgres, Neo4j, Qdrant). The operator never sees CLI here —
+ * clicks only — per the never-ask-user-to-run-commands kernel commandment.
  */
 export default async function BackupsAdminPage() {
-  const [readiness, runs, restoreRuns] = await Promise.all([
-    getBackupReadinessAction(),
-    listBackupRunsAction({ limit: 50 }),
-    listRestoreRunsAction({ limit: 20 }),
-  ]);
+  const [allReadiness, pgRuns, neo4jRuns, qdrantRuns, restoreRuns] =
+    await Promise.all([
+      getAllBackupReadinessAction(),
+      listBackupRunsAction({ limit: 50, target: "postgres" }),
+      listBackupRunsAction({ limit: 50, target: "neo4j" }),
+      listBackupRunsAction({ limit: 50, target: "qdrant" }),
+      listRestoreRunsAction({ limit: 20 }),
+    ]);
 
   return (
     <div>
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Backups</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          Platform-managed Postgres backups. Daily schedule, automatic
-          retention, manual trigger, restore wizard.
+          Platform-managed backups for Postgres, Neo4j, and Qdrant. Daily
+          schedule, automatic retention, manual trigger, restore wizard.
         </p>
       </div>
 
       <AdminTabNav />
 
       <BackupsClient
-        initialReadiness={readiness}
-        initialRuns={runs}
+        initialReadiness={allReadiness}
+        initialPgRuns={pgRuns}
+        initialNeo4jRuns={neo4jRuns}
+        initialQdrantRuns={qdrantRuns}
         initialRestoreRuns={restoreRuns}
       />
     </div>

--- a/apps/web/lib/actions/backups.ts
+++ b/apps/web/lib/actions/backups.ts
@@ -10,11 +10,13 @@ import { can } from "@/lib/permissions";
 import { inngest } from "@/lib/queue/inngest-client";
 
 import {
+  NEO4J_BACKUP_EVENT,
   POSTGRES_BACKUP_EVENT,
   POSTGRES_BACKUP_JOB_ID,
+  QDRANT_BACKUP_EVENT,
 } from "@/lib/operate/backups/constants";
-import { getPostgresBackupReadiness } from "@/lib/operate/backups/readiness";
-import type { ReadinessSummary } from "@/lib/operate/backups/types";
+import { getAllBackupReadiness, getPostgresBackupReadiness } from "@/lib/operate/backups/readiness";
+import type { BackupTarget, ReadinessSummary } from "@/lib/operate/backups/types";
 
 const BACKUPS_ROOT = "/backups";
 const MAX_LOG_BYTES = 64 * 1024;
@@ -36,13 +38,25 @@ async function requireBackupAdmin(): Promise<void> {
   }
 }
 
+/** Returns readiness for a single target (Postgres only — kept for Slice 2 restore compat). */
 export async function getBackupReadinessAction(): Promise<ReadinessSummary> {
   await requireBackupAdmin();
   return getPostgresBackupReadiness();
 }
 
+/** Returns readiness summaries for all three targets. */
+export async function getAllBackupReadinessAction(): Promise<{
+  postgres: ReadinessSummary;
+  neo4j: ReadinessSummary;
+  qdrant: ReadinessSummary;
+}> {
+  await requireBackupAdmin();
+  return getAllBackupReadiness();
+}
+
 export interface BackupRunListItem {
   id: string;
+  target: string;
   status: string;
   trigger: string;
   startedAt: string;
@@ -56,15 +70,17 @@ export interface BackupRunListItem {
 
 export async function listBackupRunsAction(args?: {
   limit?: number;
+  target?: BackupTarget;
 }): Promise<BackupRunListItem[]> {
   await requireBackupAdmin();
   const rows = await prisma.backupRun.findMany({
-    where: { target: "postgres" },
+    where: args?.target ? { target: args.target } : { target: "postgres" },
     orderBy: { startedAt: "desc" },
     take: Math.min(Math.max(args?.limit ?? 50, 1), 200),
   });
   return rows.map((r) => ({
     id: r.id,
+    target: r.target,
     status: r.status,
     trigger: r.trigger,
     startedAt: r.startedAt.toISOString(),
@@ -77,15 +93,19 @@ export async function listBackupRunsAction(args?: {
   }));
 }
 
-export async function triggerBackupNowAction(): Promise<{
-  ok: boolean;
-  eventIds?: string[];
-  error?: string;
-}> {
+const TARGET_EVENT: Record<BackupTarget, string> = {
+  postgres: POSTGRES_BACKUP_EVENT,
+  neo4j: NEO4J_BACKUP_EVENT,
+  qdrant: QDRANT_BACKUP_EVENT,
+};
+
+export async function triggerBackupNowAction(
+  target: BackupTarget = "postgres",
+): Promise<{ ok: boolean; eventIds?: string[]; error?: string }> {
   await requireBackupAdmin();
   try {
     const result = await inngest.send({
-      name: POSTGRES_BACKUP_EVENT,
+      name: TARGET_EVENT[target],
       data: { trigger: "manual" },
     });
     return { ok: true, eventIds: result.ids };
@@ -111,7 +131,6 @@ export async function readBackupRunLogAction(runId: string): Promise<BackupRunLo
     return { manifest: null, logTail: null, notFound: true };
   }
   if (row.prunedAt) {
-    // Files are gone, but we may still have the row.
     return { manifest: null, logTail: null, notFound: false };
   }
 

--- a/apps/web/lib/operate/backups/constants.ts
+++ b/apps/web/lib/operate/backups/constants.ts
@@ -8,8 +8,20 @@ export const POSTGRES_BACKUP_JOB_NAME =
   "Postgres daily backup (platform-managed)";
 export const POSTGRES_BACKUP_SCHEDULE = "daily";
 
-/** Inngest event the manual-trigger button emits. */
+export const NEO4J_BACKUP_JOB_ID = "neo4j-daily-backup";
+export const NEO4J_BACKUP_JOB_NAME = "Neo4j daily backup (platform-managed)";
+export const NEO4J_BACKUP_SCHEDULE = "daily";
+
+export const QDRANT_BACKUP_JOB_ID = "qdrant-daily-backup";
+export const QDRANT_BACKUP_JOB_NAME = "Qdrant daily backup (platform-managed)";
+export const QDRANT_BACKUP_SCHEDULE = "daily";
+
+/** Inngest events for manual triggers. */
 export const POSTGRES_BACKUP_EVENT = "ops/postgres-backup.requested";
+export const NEO4J_BACKUP_EVENT = "ops/neo4j-backup.requested";
+export const QDRANT_BACKUP_EVENT = "ops/qdrant-backup.requested";
 
 /** Cron expression — 03:00 UTC daily. */
 export const POSTGRES_BACKUP_CRON = "0 3 * * *";
+/** All-services daily backup cron — runs after Postgres (same schedule). */
+export const ALL_BACKUPS_CRON = "0 3 * * *";

--- a/apps/web/lib/operate/backups/neo4j-backup-runner.ts
+++ b/apps/web/lib/operate/backups/neo4j-backup-runner.ts
@@ -1,0 +1,338 @@
+/**
+ * TypeScript orchestrator for the Neo4j daily backup.
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+ * Plan: docs/superpowers/plans/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+ *
+ * Responsibilities:
+ *   1. Allocate a per-run target directory under /backups/neo4j/<ISO-ts>.
+ *   2. Spawn scripts/backup-neo4j.sh, which stops the Neo4j container,
+ *      runs neo4j-admin database dump via a one-shot container, restarts
+ *      Neo4j, and writes neo4j.dump + sha256 + manifest + log.
+ *   3. Read back the manifest, insert a BackupRun row (status ok/failed).
+ *   4. Update the ScheduledJob heartbeat (jobId: "neo4j-daily-backup").
+ *   5. Apply GFS retention — delete file directories for runs the policy
+ *      no longer keeps and mark them prunedAt.
+ *   6. Emit [backup-trace] logs and Prometheus metrics.
+ *
+ * Docker-in-docker gotcha: when the script spawns the neo4j-admin dump
+ * container, the bind mount source must be the HOST path (DPF_HOST_INSTALL_PATH
+ * prefix), not the portal's view of /backups. The script handles this
+ * translation via HOST_TARGET_DIR; we pass DPF_HOST_INSTALL_PATH through env.
+ *
+ * Per the never-ask-user-to-run-commands kernel principle, the operator
+ * never sees any of the shell commands here. Failure is reported through
+ * BackupRun.errorMessage and the admin readiness card.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  neo4jBackupDurationSeconds,
+  neo4jBackupLastSuccessSeconds,
+  neo4jBackupRunsTotal,
+  neo4jBackupStorageBytes,
+} from "@/lib/operate/metrics";
+
+import { NEO4J_BACKUP_JOB_ID, NEO4J_BACKUP_SCHEDULE } from "./constants";
+import { partitionForRetention } from "./retention";
+import {
+  DEFAULT_BACKUP_RETENTION,
+  type Neo4jBackupManifest,
+  type BackupRetentionPolicy,
+  type BackupTrigger,
+} from "./types";
+
+const execFileAsync = promisify(execFile);
+
+const BACKUPS_ROOT = "/backups";
+const NEO4J_SUBDIR = "neo4j";
+const SCRIPT_PATH = "/workspace/scripts/backup-neo4j.sh";
+const RUNNER_TIMEOUT_MS = 10 * 60 * 1000; // 10-minute hard cap (Neo4j stop+dump+start)
+
+export interface RunNeo4jBackupArgs {
+  trigger: BackupTrigger;
+  composeProject?: string;
+  retention?: BackupRetentionPolicy;
+  backupsRoot?: string;
+  scriptPath?: string;
+  prismaClient?: PrismaLike;
+  now?: () => Date;
+}
+
+type PrismaLike = typeof import("@dpf/db").prisma;
+
+interface ScriptOutcome {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function backupTraceLog(...parts: unknown[]) {
+  // eslint-disable-next-line no-console
+  console.log(`[backup-trace][neo4j]`, ...parts);
+}
+
+function isoTsForDirectory(d: Date): string {
+  return d.toISOString().replace(/:/g, "-").replace(/\.\d+/, "");
+}
+
+async function runScript(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<ScriptOutcome> {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env,
+      timeout: RUNNER_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      signal?: string;
+      message?: string;
+    };
+    const exitCode =
+      typeof e.code === "number" ? e.code : -1;
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message ?? String(err),
+      exitCode,
+    };
+  }
+}
+
+async function readManifest(targetDir: string): Promise<Neo4jBackupManifest | null> {
+  try {
+    const raw = await fs.readFile(path.posix.join(targetDir, "manifest.json"), "utf-8");
+    return JSON.parse(raw) as Neo4jBackupManifest;
+  } catch {
+    return null;
+  }
+}
+
+async function pruneTargetDir(targetDir: string): Promise<void> {
+  try {
+    await fs.rm(targetDir, { recursive: true, force: true });
+  } catch (err) {
+    backupTraceLog("retention: could not delete", targetDir, err);
+  }
+}
+
+async function computeRetainedStorageBytes(prisma: PrismaLike): Promise<number> {
+  const rows = await prisma.backupRun.findMany({
+    where: { status: "ok", prunedAt: null, target: NEO4J_SUBDIR },
+    select: { sizeBytes: true },
+  });
+  return rows.reduce((sum, r) => sum + Number(r.sizeBytes ?? BigInt(0)), 0);
+}
+
+function nextDailyRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(3);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}
+
+export async function runNeo4jBackup(
+  args: RunNeo4jBackupArgs,
+): Promise<{ runId: string; status: "ok" | "failed" }> {
+  const now = args.now ?? (() => new Date());
+  const startedAt = now();
+  const trigger = args.trigger;
+  const retention = args.retention ?? DEFAULT_BACKUP_RETENTION;
+  const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
+  const scriptPath = args.scriptPath ?? SCRIPT_PATH;
+  const composeProject = args.composeProject ?? process.env.COMPOSE_PROJECT_NAME ?? "dpf";
+  const containerName =
+    process.env.DPF_NEO4J_CONTAINER ?? `${composeProject}-neo4j-1`;
+
+  const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
+
+  const tsKey = isoTsForDirectory(startedAt);
+  const relativePath = `${NEO4J_SUBDIR}/${tsKey}`;
+  const absoluteTargetDir = path.posix.join(backupsRoot, relativePath);
+
+  backupTraceLog(`run start trigger=${trigger} target=${absoluteTargetDir}`);
+
+  const created = await prisma.backupRun.create({
+    data: {
+      target: "neo4j",
+      status: "running",
+      trigger,
+      schedule: trigger === "scheduled" ? NEO4J_BACKUP_SCHEDULE : null,
+      storagePath: relativePath,
+      dpfVersion: process.env.DPF_VERSION ?? null,
+    },
+    select: { id: true },
+  });
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: NEO4J_BACKUP_JOB_ID },
+      data: { lastRunAt: startedAt, lastStatus: "running", lastError: null },
+    })
+    .catch(() => {});
+
+  await fs.mkdir(path.posix.join(backupsRoot, NEO4J_SUBDIR), { recursive: true });
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    TARGET_DIR: absoluteTargetDir,
+    DPF_NEO4J_CONTAINER: containerName,
+    DPF_NEO4J_VOLUME: process.env.DPF_NEO4J_VOLUME ?? `${composeProject}_neo4jdata`,
+    DPF_NEO4J_DATABASE: process.env.DPF_NEO4J_DATABASE ?? "neo4j",
+    // Required by the script to translate /backups/... to a host path for
+    // docker-in-docker bind mounts. Without this the dump container gets an
+    // "invalid path" error from the Docker daemon.
+    DPF_HOST_INSTALL_PATH: process.env.DPF_HOST_INSTALL_PATH ?? "",
+  };
+
+  const outcome = await runScript(scriptPath, env);
+  const manifest = outcome.ok ? await readManifest(absoluteTargetDir) : null;
+  const finishedAt = now();
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+  if (outcome.ok && manifest) {
+    await prisma.backupRun.update({
+      where: { id: created.id },
+      data: {
+        status: "ok",
+        finishedAt,
+        sizeBytes: BigInt(manifest.sizeBytes),
+        durationMs,
+        sha256: manifest.sha256,
+      },
+    });
+
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: NEO4J_BACKUP_JOB_ID },
+        data: {
+          lastRunAt: startedAt,
+          lastStatus: "ok",
+          lastError: null,
+          nextRunAt: nextDailyRunAt(finishedAt),
+        },
+      })
+      .catch(() => {});
+
+    neo4jBackupRunsTotal.inc({ status: "ok", trigger });
+    neo4jBackupDurationSeconds.observe({ trigger }, durationMs / 1000);
+    neo4jBackupLastSuccessSeconds.set(Math.floor(finishedAt.getTime() / 1000));
+
+    await applyRetention(prisma, retention, backupsRoot);
+
+    const retainedBytes = await computeRetainedStorageBytes(prisma);
+    neo4jBackupStorageBytes.set(retainedBytes);
+
+    backupTraceLog(
+      `run ok id=${created.id} size=${manifest.sizeBytes} duration_ms=${durationMs}`,
+    );
+    return { runId: created.id, status: "ok" };
+  }
+
+  const errorSummary = summarizeFailure(outcome);
+  await prisma.backupRun.update({
+    where: { id: created.id },
+    data: { status: "failed", finishedAt, durationMs, errorMessage: errorSummary },
+  });
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: NEO4J_BACKUP_JOB_ID },
+      data: {
+        lastRunAt: startedAt,
+        lastStatus: "failed",
+        lastError: errorSummary,
+        nextRunAt: nextDailyRunAt(finishedAt),
+      },
+    })
+    .catch(() => {});
+
+  neo4jBackupRunsTotal.inc({ status: "failed", trigger });
+  neo4jBackupDurationSeconds.observe({ trigger }, durationMs / 1000);
+
+  backupTraceLog(`run failed id=${created.id} reason=${errorSummary}`);
+  return { runId: created.id, status: "failed" };
+}
+
+function summarizeFailure(outcome: ScriptOutcome): string {
+  const traceLine = outcome.stderr
+    .split("\n")
+    .reverse()
+    .find((line) => line.includes("[backup-neo4j-trace] failed:"));
+  if (traceLine) {
+    return traceLine.replace(/^.*\[backup-neo4j-trace\]\s*failed:\s*/, "").trim();
+  }
+  const lastStderr = outcome.stderr.trim().split("\n").pop()?.trim() ?? "";
+  if (lastStderr) return lastStderr.slice(0, 500);
+  if (outcome.exitCode !== 0) return `runner exited ${outcome.exitCode}`;
+  return "neo4j backup failed (no diagnostic captured)";
+}
+
+async function applyRetention(
+  prisma: PrismaLike,
+  policy: BackupRetentionPolicy,
+  backupsRoot: string,
+): Promise<void> {
+  const runs = await prisma.backupRun.findMany({
+    where: { target: "neo4j" },
+    orderBy: { startedAt: "desc" },
+  });
+
+  const partition = partitionForRetention(
+    runs.map((r) => ({
+      id: r.id,
+      status: r.status,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      prunedAt: r.prunedAt,
+    })),
+    policy,
+  );
+
+  const eligibleToPrune = partition.prune.filter(
+    (r) => r.status === "ok" && r.prunedAt === null,
+  );
+  const failedSweep = partition.prune.filter(
+    (r) => r.status === "failed" && r.prunedAt === null,
+  );
+
+  for (const run of eligibleToPrune) {
+    const dbRow = runs.find((r) => r.id === run.id);
+    if (!dbRow) continue;
+    const absolute = path.posix.join(backupsRoot, dbRow.storagePath);
+    await pruneTargetDir(absolute);
+  }
+
+  if (eligibleToPrune.length > 0) {
+    await prisma.backupRun.updateMany({
+      where: { id: { in: eligibleToPrune.map((r) => r.id) } },
+      data: { prunedAt: new Date() },
+    });
+  }
+  if (failedSweep.length > 0) {
+    await prisma.backupRun.updateMany({
+      where: { id: { in: failedSweep.map((r) => r.id) } },
+      data: { prunedAt: new Date() },
+    });
+  }
+
+  backupTraceLog(
+    `retention applied kept=${partition.keep.length} pruned=${eligibleToPrune.length} failed_swept=${failedSweep.length}`,
+  );
+}

--- a/apps/web/lib/operate/backups/qdrant-backup-runner.ts
+++ b/apps/web/lib/operate/backups/qdrant-backup-runner.ts
@@ -1,0 +1,321 @@
+/**
+ * TypeScript orchestrator for the Qdrant daily backup.
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+ * Plan: docs/superpowers/plans/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+ *
+ * Responsibilities:
+ *   1. Allocate a per-run target directory under /backups/qdrant/<ISO-ts>.
+ *   2. Spawn scripts/backup-qdrant.sh, which hits the Qdrant REST API to
+ *      create a full-instance snapshot, downloads it, deletes the in-Qdrant
+ *      copy, and writes qdrant.snapshot + sha256 + manifest + log.
+ *   3. Read back the manifest, insert a BackupRun row (status ok/failed).
+ *   4. Update the ScheduledJob heartbeat (jobId: "qdrant-daily-backup").
+ *   5. Apply GFS retention.
+ *   6. Emit [backup-trace] logs and Prometheus metrics.
+ *
+ * Qdrant backup is fully online — no service interruption required.
+ *
+ * Per the never-ask-user-to-run-commands kernel principle, the operator
+ * never sees any of the shell commands here.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  qdrantBackupDurationSeconds,
+  qdrantBackupLastSuccessSeconds,
+  qdrantBackupRunsTotal,
+  qdrantBackupStorageBytes,
+} from "@/lib/operate/metrics";
+
+import { QDRANT_BACKUP_JOB_ID, QDRANT_BACKUP_SCHEDULE } from "./constants";
+import { partitionForRetention } from "./retention";
+import {
+  DEFAULT_BACKUP_RETENTION,
+  type QdrantBackupManifest,
+  type BackupRetentionPolicy,
+  type BackupTrigger,
+} from "./types";
+
+const execFileAsync = promisify(execFile);
+
+const BACKUPS_ROOT = "/backups";
+const QDRANT_SUBDIR = "qdrant";
+const SCRIPT_PATH = "/workspace/scripts/backup-qdrant.sh";
+const RUNNER_TIMEOUT_MS = 30 * 60 * 1000; // 30-minute hard cap
+
+export interface RunQdrantBackupArgs {
+  trigger: BackupTrigger;
+  retention?: BackupRetentionPolicy;
+  backupsRoot?: string;
+  scriptPath?: string;
+  prismaClient?: PrismaLike;
+  now?: () => Date;
+}
+
+type PrismaLike = typeof import("@dpf/db").prisma;
+
+interface ScriptOutcome {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function backupTraceLog(...parts: unknown[]) {
+  // eslint-disable-next-line no-console
+  console.log(`[backup-trace][qdrant]`, ...parts);
+}
+
+function isoTsForDirectory(d: Date): string {
+  return d.toISOString().replace(/:/g, "-").replace(/\.\d+/, "");
+}
+
+async function runScript(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<ScriptOutcome> {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env,
+      timeout: RUNNER_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      message?: string;
+    };
+    const exitCode = typeof e.code === "number" ? e.code : -1;
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message ?? String(err),
+      exitCode,
+    };
+  }
+}
+
+async function readManifest(targetDir: string): Promise<QdrantBackupManifest | null> {
+  try {
+    const raw = await fs.readFile(path.posix.join(targetDir, "manifest.json"), "utf-8");
+    return JSON.parse(raw) as QdrantBackupManifest;
+  } catch {
+    return null;
+  }
+}
+
+async function pruneTargetDir(targetDir: string): Promise<void> {
+  try {
+    await fs.rm(targetDir, { recursive: true, force: true });
+  } catch (err) {
+    backupTraceLog("retention: could not delete", targetDir, err);
+  }
+}
+
+async function computeRetainedStorageBytes(prisma: PrismaLike): Promise<number> {
+  const rows = await prisma.backupRun.findMany({
+    where: { status: "ok", prunedAt: null, target: QDRANT_SUBDIR },
+    select: { sizeBytes: true },
+  });
+  return rows.reduce((sum, r) => sum + Number(r.sizeBytes ?? BigInt(0)), 0);
+}
+
+function nextDailyRunAt(from: Date): Date {
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(3);
+  if (next <= from) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}
+
+export async function runQdrantBackup(
+  args: RunQdrantBackupArgs,
+): Promise<{ runId: string; status: "ok" | "failed" }> {
+  const now = args.now ?? (() => new Date());
+  const startedAt = now();
+  const trigger = args.trigger;
+  const retention = args.retention ?? DEFAULT_BACKUP_RETENTION;
+  const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
+  const scriptPath = args.scriptPath ?? SCRIPT_PATH;
+
+  const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
+
+  const tsKey = isoTsForDirectory(startedAt);
+  const relativePath = `${QDRANT_SUBDIR}/${tsKey}`;
+  const absoluteTargetDir = path.posix.join(backupsRoot, relativePath);
+
+  backupTraceLog(`run start trigger=${trigger} target=${absoluteTargetDir}`);
+
+  const created = await prisma.backupRun.create({
+    data: {
+      target: "qdrant",
+      status: "running",
+      trigger,
+      schedule: trigger === "scheduled" ? QDRANT_BACKUP_SCHEDULE : null,
+      storagePath: relativePath,
+      dpfVersion: process.env.DPF_VERSION ?? null,
+    },
+    select: { id: true },
+  });
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: QDRANT_BACKUP_JOB_ID },
+      data: { lastRunAt: startedAt, lastStatus: "running", lastError: null },
+    })
+    .catch(() => {});
+
+  await fs.mkdir(path.posix.join(backupsRoot, QDRANT_SUBDIR), { recursive: true });
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    TARGET_DIR: absoluteTargetDir,
+    DPF_QDRANT_URL: process.env.DPF_QDRANT_URL ?? "http://qdrant:6333",
+  };
+
+  const outcome = await runScript(scriptPath, env);
+  const manifest = outcome.ok ? await readManifest(absoluteTargetDir) : null;
+  const finishedAt = now();
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+  if (outcome.ok && manifest) {
+    await prisma.backupRun.update({
+      where: { id: created.id },
+      data: {
+        status: "ok",
+        finishedAt,
+        sizeBytes: BigInt(manifest.sizeBytes),
+        durationMs,
+        sha256: manifest.sha256,
+      },
+    });
+
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: QDRANT_BACKUP_JOB_ID },
+        data: {
+          lastRunAt: startedAt,
+          lastStatus: "ok",
+          lastError: null,
+          nextRunAt: nextDailyRunAt(finishedAt),
+        },
+      })
+      .catch(() => {});
+
+    qdrantBackupRunsTotal.inc({ status: "ok", trigger });
+    qdrantBackupDurationSeconds.observe({ trigger }, durationMs / 1000);
+    qdrantBackupLastSuccessSeconds.set(Math.floor(finishedAt.getTime() / 1000));
+
+    await applyRetention(prisma, retention, backupsRoot);
+
+    const retainedBytes = await computeRetainedStorageBytes(prisma);
+    qdrantBackupStorageBytes.set(retainedBytes);
+
+    backupTraceLog(
+      `run ok id=${created.id} size=${manifest.sizeBytes} duration_ms=${durationMs}`,
+    );
+    return { runId: created.id, status: "ok" };
+  }
+
+  const errorSummary = summarizeFailure(outcome);
+  await prisma.backupRun.update({
+    where: { id: created.id },
+    data: { status: "failed", finishedAt, durationMs, errorMessage: errorSummary },
+  });
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: QDRANT_BACKUP_JOB_ID },
+      data: {
+        lastRunAt: startedAt,
+        lastStatus: "failed",
+        lastError: errorSummary,
+        nextRunAt: nextDailyRunAt(finishedAt),
+      },
+    })
+    .catch(() => {});
+
+  qdrantBackupRunsTotal.inc({ status: "failed", trigger });
+  qdrantBackupDurationSeconds.observe({ trigger }, durationMs / 1000);
+
+  backupTraceLog(`run failed id=${created.id} reason=${errorSummary}`);
+  return { runId: created.id, status: "failed" };
+}
+
+function summarizeFailure(outcome: ScriptOutcome): string {
+  const traceLine = outcome.stderr
+    .split("\n")
+    .reverse()
+    .find((line) => line.includes("[backup-qdrant-trace] failed:"));
+  if (traceLine) {
+    return traceLine.replace(/^.*\[backup-qdrant-trace\]\s*failed:\s*/, "").trim();
+  }
+  const lastStderr = outcome.stderr.trim().split("\n").pop()?.trim() ?? "";
+  if (lastStderr) return lastStderr.slice(0, 500);
+  if (outcome.exitCode !== 0) return `runner exited ${outcome.exitCode}`;
+  return "qdrant backup failed (no diagnostic captured)";
+}
+
+async function applyRetention(
+  prisma: PrismaLike,
+  policy: BackupRetentionPolicy,
+  backupsRoot: string,
+): Promise<void> {
+  const runs = await prisma.backupRun.findMany({
+    where: { target: "qdrant" },
+    orderBy: { startedAt: "desc" },
+  });
+
+  const partition = partitionForRetention(
+    runs.map((r) => ({
+      id: r.id,
+      status: r.status,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      prunedAt: r.prunedAt,
+    })),
+    policy,
+  );
+
+  const eligibleToPrune = partition.prune.filter(
+    (r) => r.status === "ok" && r.prunedAt === null,
+  );
+  const failedSweep = partition.prune.filter(
+    (r) => r.status === "failed" && r.prunedAt === null,
+  );
+
+  for (const run of eligibleToPrune) {
+    const dbRow = runs.find((r) => r.id === run.id);
+    if (!dbRow) continue;
+    const absolute = path.posix.join(backupsRoot, dbRow.storagePath);
+    await pruneTargetDir(absolute);
+  }
+
+  if (eligibleToPrune.length > 0) {
+    await prisma.backupRun.updateMany({
+      where: { id: { in: eligibleToPrune.map((r) => r.id) } },
+      data: { prunedAt: new Date() },
+    });
+  }
+  if (failedSweep.length > 0) {
+    await prisma.backupRun.updateMany({
+      where: { id: { in: failedSweep.map((r) => r.id) } },
+      data: { prunedAt: new Date() },
+    });
+  }
+
+  backupTraceLog(
+    `retention applied kept=${partition.keep.length} pruned=${eligibleToPrune.length} failed_swept=${failedSweep.length}`,
+  );
+}

--- a/apps/web/lib/operate/backups/readiness.ts
+++ b/apps/web/lib/operate/backups/readiness.ts
@@ -1,37 +1,42 @@
 /**
- * Reads the current state of the Postgres backup mechanism for the admin
- * readiness card.
+ * Reads the current state of the backup mechanism for the admin readiness card.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.8
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md §3.4
  */
 
 import { prisma } from "@dpf/db";
 
-import { POSTGRES_BACKUP_JOB_ID } from "./constants";
-import { DEFAULT_BACKUP_RETENTION, type ReadinessSummary } from "./types";
+import {
+  NEO4J_BACKUP_JOB_ID,
+  POSTGRES_BACKUP_JOB_ID,
+  QDRANT_BACKUP_JOB_ID,
+} from "./constants";
+import { DEFAULT_BACKUP_RETENTION, type BackupTarget, type ReadinessSummary } from "./types";
 
 const BACKUPS_ROOT = "/backups";
 
-export async function getPostgresBackupReadiness(): Promise<ReadinessSummary> {
+async function getReadinessForTarget(
+  jobId: string,
+  target: BackupTarget,
+): Promise<ReadinessSummary> {
   const [job, lastRun, lastSuccess, retainedRuns, recentFailures] =
     await Promise.all([
-      prisma.scheduledJob.findUnique({
-        where: { jobId: POSTGRES_BACKUP_JOB_ID },
-      }),
+      prisma.scheduledJob.findUnique({ where: { jobId } }),
       prisma.backupRun.findFirst({
-        where: { target: "postgres" },
+        where: { target },
         orderBy: { startedAt: "desc" },
       }),
       prisma.backupRun.findFirst({
-        where: { target: "postgres", status: "ok", prunedAt: null },
+        where: { target, status: "ok", prunedAt: null },
         orderBy: { finishedAt: "desc" },
       }),
       prisma.backupRun.findMany({
-        where: { target: "postgres", status: "ok", prunedAt: null },
+        where: { target, status: "ok", prunedAt: null },
         select: { sizeBytes: true },
       }),
       prisma.backupRun.findMany({
-        where: { target: "postgres" },
+        where: { target },
         orderBy: { startedAt: "desc" },
         take: 3,
         select: { status: true },
@@ -44,6 +49,7 @@ export async function getPostgresBackupReadiness(): Promise<ReadinessSummary> {
   );
 
   return {
+    target,
     scheduledJob: job
       ? {
           jobId: job.jobId,
@@ -73,16 +79,38 @@ export async function getPostgresBackupReadiness(): Promise<ReadinessSummary> {
       ? {
           id: lastSuccess.id,
           finishedAt: lastSuccess.finishedAt?.toISOString() ?? null,
-          sizeBytes: lastSuccess.sizeBytes
-            ? Number(lastSuccess.sizeBytes)
-            : null,
+          sizeBytes: lastSuccess.sizeBytes ? Number(lastSuccess.sizeBytes) : null,
         }
       : null,
     retention: DEFAULT_BACKUP_RETENTION,
     retainedCount: retainedRuns.length,
     retainedBytes,
-    storagePath: `${BACKUPS_ROOT}/postgres/`,
-    failuresInLastThreeRuns: recentFailures.filter((r) => r.status === "failed")
-      .length,
+    storagePath: `${BACKUPS_ROOT}/${target}/`,
+    failuresInLastThreeRuns: recentFailures.filter((r) => r.status === "failed").length,
   };
+}
+
+export async function getPostgresBackupReadiness(): Promise<ReadinessSummary> {
+  return getReadinessForTarget(POSTGRES_BACKUP_JOB_ID, "postgres");
+}
+
+export async function getNeo4jBackupReadiness(): Promise<ReadinessSummary> {
+  return getReadinessForTarget(NEO4J_BACKUP_JOB_ID, "neo4j");
+}
+
+export async function getQdrantBackupReadiness(): Promise<ReadinessSummary> {
+  return getReadinessForTarget(QDRANT_BACKUP_JOB_ID, "qdrant");
+}
+
+export async function getAllBackupReadiness(): Promise<{
+  postgres: ReadinessSummary;
+  neo4j: ReadinessSummary;
+  qdrant: ReadinessSummary;
+}> {
+  const [postgres, neo4j, qdrant] = await Promise.all([
+    getReadinessForTarget(POSTGRES_BACKUP_JOB_ID, "postgres"),
+    getReadinessForTarget(NEO4J_BACKUP_JOB_ID, "neo4j"),
+    getReadinessForTarget(QDRANT_BACKUP_JOB_ID, "qdrant"),
+  ]);
+  return { postgres, neo4j, qdrant };
 }

--- a/apps/web/lib/operate/backups/types.ts
+++ b/apps/web/lib/operate/backups/types.ts
@@ -2,6 +2,7 @@
  * Shared types for the platform-managed backup mechanism.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
  */
 
 /**
@@ -14,6 +15,7 @@
  */
 export type BackupTrigger = "scheduled" | "manual" | "pre-restore-safety";
 export type BackupRunStatus = "running" | "ok" | "failed";
+export type BackupTarget = "postgres" | "neo4j" | "qdrant";
 
 /** GFS retention policy. Tunable via Platform Config in a later slice. */
 export interface BackupRetentionPolicy {
@@ -51,7 +53,38 @@ export interface BackupManifest {
   dumpFormat: string;
 }
 
+/** Sidecar manifest written by scripts/backup-neo4j.sh. */
+export interface Neo4jBackupManifest {
+  schemaVersion: 1;
+  target: "neo4j";
+  container: string;
+  volume: string;
+  database: string;
+  image: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  sizeBytes: number;
+  sha256: string;
+  dumpFormat: string;
+}
+
+/** Sidecar manifest written by scripts/backup-qdrant.sh. */
+export interface QdrantBackupManifest {
+  schemaVersion: 1;
+  target: "qdrant";
+  qdrantUrl: string;
+  snapshotName: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  sizeBytes: number;
+  sha256: string;
+  dumpFormat: string;
+}
+
 export interface ReadinessSummary {
+  target: BackupTarget;
   scheduledJob: {
     jobId: string;
     schedule: string;

--- a/apps/web/lib/operate/metrics.ts
+++ b/apps/web/lib/operate/metrics.ts
@@ -193,6 +193,66 @@ export const postgresRestoreDurationSeconds = new Histogram({
   registers: [metricsRegistry],
 });
 
+// ─── Neo4j Daily Backup (Slice 3) ─────────────────────────────────────────────
+// Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+
+export const neo4jBackupRunsTotal = new Counter({
+  name: "dpf_neo4j_backup_runs_total",
+  help: "Neo4j backup runs by status and trigger",
+  labelNames: ["status", "trigger"] as const,
+  registers: [metricsRegistry],
+});
+
+export const neo4jBackupLastSuccessSeconds = new Gauge({
+  name: "dpf_neo4j_backup_last_success_seconds",
+  help: "Epoch seconds at which the last successful Neo4j backup finished",
+  registers: [metricsRegistry],
+});
+
+export const neo4jBackupStorageBytes = new Gauge({
+  name: "dpf_neo4j_backup_storage_bytes",
+  help: "Total bytes used by retained Neo4j backup dumps",
+  registers: [metricsRegistry],
+});
+
+export const neo4jBackupDurationSeconds = new Histogram({
+  name: "dpf_neo4j_backup_duration_seconds",
+  help: "Wall-clock duration of Neo4j backup runs",
+  labelNames: ["trigger"] as const,
+  buckets: [1, 2, 5, 10, 30, 60, 300, 900],
+  registers: [metricsRegistry],
+});
+
+// ─── Qdrant Daily Backup (Slice 3) ────────────────────────────────────────────
+// Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
+
+export const qdrantBackupRunsTotal = new Counter({
+  name: "dpf_qdrant_backup_runs_total",
+  help: "Qdrant backup runs by status and trigger",
+  labelNames: ["status", "trigger"] as const,
+  registers: [metricsRegistry],
+});
+
+export const qdrantBackupLastSuccessSeconds = new Gauge({
+  name: "dpf_qdrant_backup_last_success_seconds",
+  help: "Epoch seconds at which the last successful Qdrant backup finished",
+  registers: [metricsRegistry],
+});
+
+export const qdrantBackupStorageBytes = new Gauge({
+  name: "dpf_qdrant_backup_storage_bytes",
+  help: "Total bytes used by retained Qdrant backup snapshots",
+  registers: [metricsRegistry],
+});
+
+export const qdrantBackupDurationSeconds = new Histogram({
+  name: "dpf_qdrant_backup_duration_seconds",
+  help: "Wall-clock duration of Qdrant backup runs",
+  labelNames: ["trigger"] as const,
+  buckets: [1, 2, 5, 10, 30, 60, 300, 900],
+  registers: [metricsRegistry],
+});
+
 // ─── Voice Slice 2 — Transcript Cleanup ─────────────────────────────────────
 // Spec: docs/superpowers/specs/2026-05-16-voice-input-and-transcription-design.md §9
 

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -21,8 +21,11 @@ import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verific
 import { skillMetricsAggregator } from "./skill-metrics-aggregator";
 import { skillCurator } from "./skill-curator";
 import {
+  allBackupsDailyScheduled,
   postgresDailyBackupScheduled,
   postgresBackupRequested,
+  neo4jBackupRequested,
+  qdrantBackupRequested,
 } from "./postgres-daily-backup";
 
 export const allFunctions = [
@@ -49,6 +52,9 @@ export const allFunctions = [
   gitPromotionSandboxVerification,
   skillMetricsAggregator,
   skillCurator,
+  allBackupsDailyScheduled,
   postgresDailyBackupScheduled,
   postgresBackupRequested,
+  neo4jBackupRequested,
+  qdrantBackupRequested,
 ];

--- a/apps/web/lib/queue/functions/postgres-daily-backup.ts
+++ b/apps/web/lib/queue/functions/postgres-daily-backup.ts
@@ -1,22 +1,72 @@
 /**
- * Inngest functions for the platform-managed Postgres backup mechanism.
+ * Inngest functions for the platform-managed backup mechanism.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.2
- * Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md §3.5
+ * Plan: docs/superpowers/plans/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md Chunk 3
  *
- * Two surfaces, one runner:
- *   - postgresDailyBackupScheduled: cron at 03:00 UTC daily, trigger="scheduled".
- *   - postgresBackupRequested: event-driven from the admin "Run backup now"
- *                              button, trigger="manual".
+ * Slice 3 extends this module with Neo4j + Qdrant runners. The combined daily
+ * cron fires at 03:00 UTC and runs all three services in sequence. Each service
+ * has its own independent manual-trigger event so the admin "Run backup now"
+ * buttons work independently.
  *
- * Both call the same `runPostgresBackup` to keep behavior identical.
- * `concurrency: { limit: 1, scope: "fn" }` per function ensures the cron
- * fire and a near-simultaneous manual click serialize rather than collide.
+ * Failure of one service does NOT abort the others — each runner catches its
+ * own errors and writes its own BackupRun row.
+ *
+ * `concurrency: { limit: 1, scope: "fn" }` per function prevents overlapping
+ * runs of the same function (cron vs. manual).
  */
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
-import { POSTGRES_BACKUP_CRON, POSTGRES_BACKUP_EVENT } from "@/lib/operate/backups/constants";
+import {
+  ALL_BACKUPS_CRON,
+  NEO4J_BACKUP_EVENT,
+  POSTGRES_BACKUP_CRON,
+  POSTGRES_BACKUP_EVENT,
+  QDRANT_BACKUP_EVENT,
+} from "@/lib/operate/backups/constants";
 
+// ─── Daily cron (all three services) ─────────────────────────────────────────
+
+export const allBackupsDailyScheduled = inngest.createFunction(
+  {
+    id: "ops/all-backups-daily-scheduled",
+    retries: 0, // each sub-runner has its own retry / error handling
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(ALL_BACKUPS_CRON)],
+  },
+  async ({ step }) => {
+    // Postgres first — most critical, longest-running.
+    const pgResult = await step.run("run-postgres-backup-scheduled", async () => {
+      const { runPostgresBackup } = await import(
+        "@/lib/operate/backups/postgres-backup-runner"
+      );
+      return runPostgresBackup({ trigger: "scheduled" });
+    });
+
+    // Neo4j: independent. Runs even if Postgres failed.
+    const neo4jResult = await step.run("run-neo4j-backup-scheduled", async () => {
+      const { runNeo4jBackup } = await import(
+        "@/lib/operate/backups/neo4j-backup-runner"
+      );
+      return runNeo4jBackup({ trigger: "scheduled" });
+    });
+
+    // Qdrant: independent. Runs even if the others failed.
+    const qdrantResult = await step.run("run-qdrant-backup-scheduled", async () => {
+      const { runQdrantBackup } = await import(
+        "@/lib/operate/backups/qdrant-backup-runner"
+      );
+      return runQdrantBackup({ trigger: "scheduled" });
+    });
+
+    return { pgResult, neo4jResult, qdrantResult };
+  },
+);
+
+// ─── Postgres — kept for backwards compat + independent manual trigger ────────
+
+/** @deprecated Use allBackupsDailyScheduled for the daily cron path. Kept for backwards compat with existing event subscribers. */
 export const postgresDailyBackupScheduled = inngest.createFunction(
   {
     id: "ops/postgres-daily-backup-scheduled",
@@ -47,6 +97,44 @@ export const postgresBackupRequested = inngest.createFunction(
         "@/lib/operate/backups/postgres-backup-runner"
       );
       return runPostgresBackup({ trigger: "manual" });
+    });
+  },
+);
+
+// ─── Neo4j — manual trigger ───────────────────────────────────────────────────
+
+export const neo4jBackupRequested = inngest.createFunction(
+  {
+    id: "ops/neo4j-backup-requested",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [{ event: NEO4J_BACKUP_EVENT }],
+  },
+  async ({ step }) => {
+    return step.run("run-neo4j-backup-manual", async () => {
+      const { runNeo4jBackup } = await import(
+        "@/lib/operate/backups/neo4j-backup-runner"
+      );
+      return runNeo4jBackup({ trigger: "manual" });
+    });
+  },
+);
+
+// ─── Qdrant — manual trigger ──────────────────────────────────────────────────
+
+export const qdrantBackupRequested = inngest.createFunction(
+  {
+    id: "ops/qdrant-backup-requested",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [{ event: QDRANT_BACKUP_EVENT }],
+  },
+  async ({ step }) => {
+    return step.run("run-qdrant-backup-manual", async () => {
+      const { runQdrantBackup } = await import(
+        "@/lib/operate/backups/qdrant-backup-runner"
+      );
+      return runQdrantBackup({ trigger: "manual" });
     });
   },
 );

--- a/packages/db/src/seed-platform-backup.ts
+++ b/packages/db/src/seed-platform-backup.ts
@@ -1,17 +1,12 @@
 import type { PrismaClient } from "../generated/client/client";
 
 /**
- * Schedule + identifier constants for the platform-managed Postgres backup.
+ * Schedule + identifier constants for the platform-managed backups.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md
- * Plan: docs/superpowers/plans/2026-05-17-postgres-daily-backup-slice-1.md
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md
  *
- * The ScheduledJob row is the live heartbeat surfaced in /admin/backups
- * (lastRunAt, nextRunAt, lastStatus). The actual cron firing is owned by
- * the Inngest function ops/postgres-daily-backup; this seed only ensures
- * the heartbeat row exists from a fresh install onward so the readiness
- * card has something to render before the first run.
- *
+ * The ScheduledJob rows are live heartbeats surfaced in /admin/backups.
  * The same identifiers are duplicated (intentionally — packages/db cannot
  * import from apps/web) in apps/web/lib/operate/backups/constants.ts.
  * If you change one, change both, or the heartbeat row will be orphaned.
@@ -20,6 +15,14 @@ export const POSTGRES_BACKUP_JOB_ID = "postgres-daily-backup";
 export const POSTGRES_BACKUP_JOB_NAME =
   "Postgres daily backup (platform-managed)";
 export const POSTGRES_BACKUP_SCHEDULE = "daily";
+
+export const NEO4J_BACKUP_JOB_ID = "neo4j-daily-backup";
+export const NEO4J_BACKUP_JOB_NAME = "Neo4j daily backup (platform-managed)";
+export const NEO4J_BACKUP_SCHEDULE = "daily";
+
+export const QDRANT_BACKUP_JOB_ID = "qdrant-daily-backup";
+export const QDRANT_BACKUP_JOB_NAME = "Qdrant daily backup (platform-managed)";
+export const QDRANT_BACKUP_SCHEDULE = "daily";
 
 type ScheduledJobSeedClient = Pick<PrismaClient, "scheduledJob">;
 
@@ -35,28 +38,26 @@ function nextDailyRunAt(from: Date): Date {
   return next;
 }
 
-/**
- * Idempotent: create the ScheduledJob heartbeat row if missing; update
- * name/schedule/nextRunAt on every seed run. Does not clobber lastRunAt /
- * lastStatus / lastError — those are owned by the runner.
- */
-export async function ensurePostgresBackupScheduledJob(
+async function ensureBackupScheduledJob(
   prisma: ScheduledJobSeedClient,
-  now: Date = new Date(),
+  jobId: string,
+  name: string,
+  schedule: string,
+  now: Date,
 ): Promise<{ created: boolean }> {
   const nextRunAt = nextDailyRunAt(now);
 
   const existing = await prisma.scheduledJob.findUnique({
-    where: { jobId: POSTGRES_BACKUP_JOB_ID },
+    where: { jobId },
     select: { jobId: true, nextRunAt: true },
   });
 
   if (existing) {
     await prisma.scheduledJob.update({
-      where: { jobId: POSTGRES_BACKUP_JOB_ID },
+      where: { jobId },
       data: {
-        name: POSTGRES_BACKUP_JOB_NAME,
-        schedule: POSTGRES_BACKUP_SCHEDULE,
+        name,
+        schedule,
         nextRunAt: existing.nextRunAt ?? nextRunAt,
       },
     });
@@ -64,12 +65,64 @@ export async function ensurePostgresBackupScheduledJob(
   }
 
   await prisma.scheduledJob.create({
-    data: {
-      jobId: POSTGRES_BACKUP_JOB_ID,
-      name: POSTGRES_BACKUP_JOB_NAME,
-      schedule: POSTGRES_BACKUP_SCHEDULE,
-      nextRunAt,
-    },
+    data: { jobId, name, schedule, nextRunAt },
   });
   return { created: true };
+}
+
+/**
+ * Idempotent: create the Postgres ScheduledJob heartbeat row if missing;
+ * update name/schedule/nextRunAt on every seed run. Does not clobber
+ * lastRunAt / lastStatus / lastError — those are owned by the runner.
+ */
+export async function ensurePostgresBackupScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  return ensureBackupScheduledJob(
+    prisma,
+    POSTGRES_BACKUP_JOB_ID,
+    POSTGRES_BACKUP_JOB_NAME,
+    POSTGRES_BACKUP_SCHEDULE,
+    now,
+  );
+}
+
+export async function ensureNeo4jBackupScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  return ensureBackupScheduledJob(
+    prisma,
+    NEO4J_BACKUP_JOB_ID,
+    NEO4J_BACKUP_JOB_NAME,
+    NEO4J_BACKUP_SCHEDULE,
+    now,
+  );
+}
+
+export async function ensureQdrantBackupScheduledJob(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  return ensureBackupScheduledJob(
+    prisma,
+    QDRANT_BACKUP_JOB_ID,
+    QDRANT_BACKUP_JOB_NAME,
+    QDRANT_BACKUP_SCHEDULE,
+    now,
+  );
+}
+
+/** Convenience: ensure all three backup scheduled jobs exist in one call. */
+export async function ensureAllBackupScheduledJobs(
+  prisma: ScheduledJobSeedClient,
+  now: Date = new Date(),
+): Promise<{ postgres: { created: boolean }; neo4j: { created: boolean }; qdrant: { created: boolean } }> {
+  const [postgres, neo4j, qdrant] = await Promise.all([
+    ensureBackupScheduledJob(prisma, POSTGRES_BACKUP_JOB_ID, POSTGRES_BACKUP_JOB_NAME, POSTGRES_BACKUP_SCHEDULE, now),
+    ensureBackupScheduledJob(prisma, NEO4J_BACKUP_JOB_ID, NEO4J_BACKUP_JOB_NAME, NEO4J_BACKUP_SCHEDULE, now),
+    ensureBackupScheduledJob(prisma, QDRANT_BACKUP_JOB_ID, QDRANT_BACKUP_JOB_NAME, QDRANT_BACKUP_SCHEDULE, now),
+  ]);
+  return { postgres, neo4j, qdrant };
 }

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -29,7 +29,7 @@ import {
 import { seedDeliberationPatterns } from "./seed-deliberation.js";
 import { ensureDiscoveryTriageScheduledTask } from "./seed-discovery-triage.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
-import { ensurePostgresBackupScheduledJob } from "./seed-platform-backup.js";
+import { ensureAllBackupScheduledJobs } from "./seed-platform-backup.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
@@ -2366,7 +2366,7 @@ async function main(): Promise<void> {
   await seedDefaultAdminUser();
   await ensureDiscoveryTriageScheduledTask(prisma);
   await ensureHiveScoutScheduledTask(prisma);
-  await ensurePostgresBackupScheduledJob(prisma);
+  await ensureAllBackupScheduledJobs(prisma);
   await seedMcpServers();
   await seedSandboxPool();
   await seedRuntimeTargets();


### PR DESCRIPTION
## Summary

Extends the platform-managed backup mechanism (Slices 1+2 — Postgres already shipped) to cover Neo4j and Qdrant. After this slice, a full-volume wipe of any combination of `dpf_pgdata`, `dpf_neo4jdata`, and `dpf_qdrant_data` is recoverable from host-bind backups.

Ref: **BI-93A59628**

## What changed

- **`neo4j-backup-runner.ts`** — TS orchestrator wrapping `scripts/backup-neo4j.sh`. Handles docker-in-docker `HOST_TARGET_DIR` path translation, creates `BackupRun` row, updates `ScheduledJob` heartbeat, applies per-target GFS retention.
- **`qdrant-backup-runner.ts`** — TS orchestrator wrapping `scripts/backup-qdrant.sh`. Online REST snapshot, no service interruption.
- **`postgres-daily-backup.ts`** — adds `allBackupsDailyScheduled` (combined 03:00 UTC cron running all three in sequence), `neo4jBackupRequested` and `qdrantBackupRequested` event-driven functions.
- **`constants.ts`** — adds `NEO4J_*` / `QDRANT_*` job IDs, event names.
- **`types.ts`** — adds `BackupTarget` union, `Neo4jBackupManifest`, `QdrantBackupManifest`; `ReadinessSummary` gains `target` discriminator.
- **`readiness.ts`** — refactored to `getReadinessForTarget(jobId, target)`; `getAllBackupReadiness()` returns all three in parallel.
- **`metrics.ts`** — adds neo4j/qdrant backup counter, gauge, histogram metrics.
- **`actions/backups.ts`** — adds `getAllBackupReadinessAction`; extends `listBackupRunsAction` and `triggerBackupNowAction` to accept `target` param.
- **Admin `page.tsx` + `BackupsClient.tsx`** — three stacked readiness sections with per-target history tables and "Run backup now" buttons. Neo4j section shows the ~10 s container restart warning.
- **`seed-platform-backup.ts`** — adds `ensureNeo4j/QdrantBackupScheduledJob`; `ensureAllBackupScheduledJobs` convenience wrapper.
- **`seed.ts`** — wires in `ensureAllBackupScheduledJobs`.
- **`functions/index.ts`** — registers the three new Inngest functions.

No schema migration — `BackupRun.target` already supports all three values per Slice 1 design.

## Functional verification log

Live install: Portal + Neo4j + Qdrant all healthy before test.

### Neo4j backup

Clicked **"Run Neo4j backup now"** at `http://localhost:3000/admin/backups`.

BackupRun row:
```
id:          cmparksjv003t01o1vtodd1oh
target:      neo4j
status:      ok
trigger:     manual
storagePath: neo4j/2026-05-18T05-29-10Z
sizeBytes:   10966507  (10.5 MB)
durationMs:  16424     (16.4 s — includes Neo4j stop + dump + restart)
sha256:      7361033c6bf1223c2916cabced8b9be391de907f7c6d746bcb3c66386cf5bd6b
```

Host disk (`D:\DPF\backups\neo4j\2026-05-18T05-29-10Z\`):
```
neo4j.dump         10,966,507 bytes
manifest.json           412 bytes
neo4j.dump.sha256        77 bytes  — sha256 matches manifest
log.txt               4,249 bytes
```

manifest.json target=neo4j, container=dpf-neo4j-1, image=neo4j:5-community, dumpFormat=neo4j-admin database dump.

Neo4j container after dump: `running / healthy`

Admin UX after refresh: LAST RUN 12:29:10 AM · 16.4 s · 10.5 MB [OK], NEXT RUN tonight 10 PM, RETAINED 1 backup · 10.5 MB.

### Qdrant backup

Clicked **"Run Qdrant backup now"**.

BackupRun row:
```
id:          cmparmvqh005p01o150bnilsj
target:      qdrant
status:      ok
trigger:     manual
storagePath: qdrant/2026-05-18T05-30-47Z
sizeBytes:   2048
durationMs:  86
sha256:      d8a75378212e9601106bd282a725c16cedea14ecea795c25616fbdb5ddb4ab6b
```

Host disk (`D:\DPF\backups\qdrant\2026-05-18T05-30-47Z\`):
```
qdrant.snapshot         2,048 bytes
manifest.json             398 bytes
qdrant.snapshot.sha256     82 bytes  — sha256 matches manifest
log.txt                   274 bytes
```

manifest.json target=qdrant, snapshotName=full-snapshot-2026-05-18-05-30-47.snapshot, dumpFormat=qdrant snapshot (full instance).

Admin UX after refresh: LAST RUN 12:30:47 AM · 86 ms · 2.0 KB [OK], NEXT RUN tonight 10 PM, RETAINED 1 backup · 2.0 KB.

### Admin page final state

- Postgres: daily (cron 03:00 UTC) — 2 backups · 6.7 MB retained
- Neo4j: daily (cron 03:00 UTC) — 1 backup · 10.5 MB retained — OK
- Qdrant: daily (cron 03:00 UTC) — 1 backup · 2.0 KB retained — OK
- Zero CLI copy in any operator-visible surface
- Neo4j section displays ~10 s restart warning as per spec

## Test plan

- [x] `pnpm --filter web typecheck` clean (pre-commit hook passed)
- [x] Clicked "Run Neo4j backup now" → BackupRun row status=ok → neo4j.dump on host disk, sha256 verified
- [x] Neo4j container restarted to healthy after dump
- [x] Clicked "Run Qdrant backup now" → BackupRun row status=ok → qdrant.snapshot on host disk, sha256 verified
- [x] Admin page renders three stacked readiness sections with correct data post-refresh
- [x] No CLI surfaced in operator UX

Generated with [Claude Code](https://claude.com/claude-code)