### PR TITLE
feat(backup): Slice 4 — Neo4j + Qdrant restore wizard

### DIFF
--- a/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
+++ b/apps/web/app/(shell)/admin/backups/BackupsClient.tsx
@@ -344,13 +344,13 @@ export function BackupsClient({
                         <Td>{formatBytes(row.sizeBytes)}</Td>
                         <Td>{formatDurationMs(row.durationMs)}</Td>
                         <Td className="text-right">
-                          {row.status === "ok" && !row.prunedAt && target === "postgres" && (
+                          {row.status === "ok" && !row.prunedAt && (
                             <button
                               onClick={() => handleOpenRestore(row.id)}
                               disabled={loadingPreview !== null}
                               className="mr-3 hover:underline disabled:opacity-50"
                               style={{ color: "#f87171" }}
-                              title="Restore the database from this backup"
+                              title={`Restore ${TARGET_LABELS[target]} from this backup`}
                             >
                               {loadingPreview === row.id ? "Loading…" : "Restore…"}
                             </button>

--- a/apps/web/app/(shell)/admin/backups/RestoreConfirmModal.tsx
+++ b/apps/web/app/(shell)/admin/backups/RestoreConfirmModal.tsx
@@ -68,11 +68,18 @@ export function RestoreConfirmModal({ preview, onClose, onConfirmed }: Props) {
         <div className="flex items-start justify-between mb-4">
           <div>
             <h2 className="text-lg font-bold text-[var(--dpf-text)]">
-              Restore from backup
+              {preview.target === "neo4j"
+                ? "Restore Neo4j from backup"
+                : preview.target === "qdrant"
+                  ? "Restore Qdrant from backup"
+                  : "Restore Postgres from backup"}
             </h2>
             <p className="text-xs text-[var(--dpf-muted)] mt-1">
-              This action replaces the current database with the contents of
-              the selected dump.
+              {preview.target === "neo4j"
+                ? "This replaces the graph database with the selected dump. Neo4j restarts briefly."
+                : preview.target === "qdrant"
+                  ? "This replaces all Qdrant vector collections with the selected snapshot."
+                  : "This action replaces the current database with the contents of the selected dump."}
             </p>
           </div>
           <button
@@ -145,6 +152,19 @@ export function RestoreConfirmModal({ preview, onClose, onConfirmed }: Props) {
         >
           {preview.impactSummary}
         </div>
+
+        {preview.serviceWarning && (
+          <div
+            className="rounded p-3 mb-4 text-xs"
+            style={{
+              background: "rgba(251, 191, 36, 0.12)",
+              color: "#fbbf24",
+              border: "1px solid rgba(251, 191, 36, 0.3)",
+            }}
+          >
+            {preview.serviceWarning}
+          </div>
+        )}
 
         {preview.versionWarning && (
           <div

--- a/apps/web/lib/actions/backup-restore.ts
+++ b/apps/web/lib/actions/backup-restore.ts
@@ -17,6 +17,8 @@ import {
   isRestoreInFlight,
   runPostgresRestore,
 } from "@/lib/operate/backups/postgres-restore-runner";
+import { runNeo4jRestore } from "@/lib/operate/backups/neo4j-restore-runner";
+import { runQdrantRestore } from "@/lib/operate/backups/qdrant-restore-runner";
 
 async function requireBackupAdmin(): Promise<string | null> {
   const session = await auth();
@@ -54,10 +56,8 @@ export interface ConfirmRestoreResult {
 }
 
 /**
- * Confirms and triggers a restore. The wizard's "Restore" button calls this
- * with the typed confirmation text. We require an exact case-sensitive match
- * to `RESTORE` — never accept variants. The check is intentionally
- * server-side AND duplicated on the client (defense in depth).
+ * Confirms and triggers a restore. Dispatches to the right runner based on
+ * the BackupRun.target field. The confirmation text must match RESTORE exactly.
  */
 export async function confirmRestoreAction(
   sourceBackupRunId: string,
@@ -83,15 +83,25 @@ export async function confirmRestoreAction(
   }
 
   try {
-    const result = await runPostgresRestore({
-      sourceBackupRunId,
-      initiatedByUserId: userId,
+    // Look up the target so we dispatch to the correct runner.
+    const run = await prisma.backupRun.findUnique({
+      where: { id: sourceBackupRunId },
+      select: { target: true },
     });
-    return {
-      ok: result.status === "ok",
-      restoreId: result.restoreId,
-      status: result.status,
-    };
+    if (!run) {
+      return { ok: false, error: `Backup run ${sourceBackupRunId} not found.`, errorClass: "integrity" };
+    }
+
+    let result: { restoreId: string; status: "ok" | "failed" };
+    if (run.target === "neo4j") {
+      result = await runNeo4jRestore({ sourceBackupRunId, initiatedByUserId: userId });
+    } else if (run.target === "qdrant") {
+      result = await runQdrantRestore({ sourceBackupRunId, initiatedByUserId: userId });
+    } else {
+      result = await runPostgresRestore({ sourceBackupRunId, initiatedByUserId: userId });
+    }
+
+    return { ok: result.status === "ok", restoreId: result.restoreId, status: result.status };
   } catch (err) {
     if (err instanceof RestoreLockedError) {
       return { ok: false, error: err.message, errorClass: "locked" };

--- a/apps/web/lib/operate/backups/neo4j-restore-runner.ts
+++ b/apps/web/lib/operate/backups/neo4j-restore-runner.ts
@@ -1,0 +1,203 @@
+/**
+ * TypeScript orchestrator for the Neo4j restore wizard.
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md (Slice 4)
+ *
+ * Mirrors postgres-restore-runner.ts in structure:
+ *   1. Acquire the shared portal-side mutex (one restore at a time, any target).
+ *   2. Verify the source dump exists and sha256 matches.
+ *   3. Write a Neo4j safety backup (trigger="pre-restore-safety").
+ *   4. Spawn scripts/restore-neo4j.sh — stops Neo4j, loads dump, restarts.
+ *   5. Record BackupRestore audit row.
+ *   6. Release lock in finally.
+ *
+ * Neo4j is unavailable for ~15–30 s during the stop+load+restart sequence.
+ * The restore wizard shows this warning before the operator types RESTORE.
+ *
+ * Unlike Postgres, Neo4j's database is NOT wiped by the restore — it replaces
+ * the graph database in-place via neo4j-admin. So audit rows written to
+ * Postgres BEFORE the restore persist normally (no re-insert dance needed).
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import {
+  acquireRestoreLock,
+  RestoreLockedError,
+  RestoreIntegrityError,
+} from "./postgres-restore-runner";
+import { runNeo4jBackup } from "./neo4j-backup-runner";
+
+const execFileAsync = promisify(execFile);
+
+const BACKUPS_ROOT = "/backups";
+const RESTORE_SCRIPT_PATH = "/workspace/scripts/restore-neo4j.sh";
+const RUNNER_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface Neo4jRestoreArgs {
+  sourceBackupRunId: string;
+  initiatedByUserId?: string | null;
+  backupsRoot?: string;
+  scriptPath?: string;
+  prismaClient?: PrismaLike;
+  now?: () => Date;
+  takeSafetyBackup?: () => Promise<{ runId: string; status: "ok" | "failed" }>;
+}
+
+type PrismaLike = typeof import("@dpf/db").prisma;
+
+interface ScriptOutcome {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function restoreTraceLog(...parts: unknown[]) {
+  // eslint-disable-next-line no-console
+  console.log("[restore-trace][neo4j]", ...parts);
+}
+
+async function fileSha256(absolutePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const fh = await fs.open(absolutePath, "r");
+  try {
+    const stream = fh.createReadStream();
+    for await (const chunk of stream) hash.update(chunk as Buffer);
+  } finally {
+    await fh.close();
+  }
+  return hash.digest("hex");
+}
+
+async function runScript(scriptPath: string, env: NodeJS.ProcessEnv): Promise<ScriptOutcome> {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env,
+      timeout: RUNNER_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number | string; message?: string };
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message ?? String(err),
+      exitCode: typeof e.code === "number" ? e.code : -1,
+    };
+  }
+}
+
+function summarizeFailure(outcome: ScriptOutcome): string {
+  const traceLine = outcome.stderr
+    .split("\n")
+    .reverse()
+    .find((l) => l.includes("[restore-neo4j-trace] failed:"));
+  if (traceLine) return traceLine.replace(/^.*\[restore-neo4j-trace\]\s*failed:\s*/, "").trim();
+  const lastStderr = outcome.stderr.trim().split("\n").pop()?.trim() ?? "";
+  if (lastStderr) return lastStderr.slice(0, 500);
+  if (outcome.exitCode !== 0) return `restore script exited ${outcome.exitCode}`;
+  return "neo4j restore failed (no diagnostic captured)";
+}
+
+export async function runNeo4jRestore(
+  args: Neo4jRestoreArgs,
+): Promise<{ restoreId: string; status: "ok" | "failed" }> {
+  const now = args.now ?? (() => new Date());
+  const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
+  const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
+  const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
+
+  const release = acquireRestoreLock(args.sourceBackupRunId);
+  const startedAt = now();
+  restoreTraceLog(`acquired lock for source=${args.sourceBackupRunId}`);
+
+  try {
+    // 1. Resolve + integrity-check the source dump
+    const source = await prisma.backupRun.findUnique({ where: { id: args.sourceBackupRunId } });
+    if (!source) {
+      throw new RestoreIntegrityError(`Source BackupRun ${args.sourceBackupRunId} not found.`);
+    }
+    if (source.status !== "ok") {
+      throw new RestoreIntegrityError(`Source BackupRun status=${source.status}; only successful backups can be restored.`);
+    }
+    if (source.prunedAt !== null) {
+      throw new RestoreIntegrityError(`Source BackupRun ${args.sourceBackupRunId} has been pruned; file is gone.`);
+    }
+    if (source.target !== "neo4j") {
+      throw new RestoreIntegrityError(`BackupRun target=${source.target}; expected neo4j.`);
+    }
+
+    const dumpPath = path.posix.join(backupsRoot, source.storagePath, "neo4j.dump");
+    try {
+      await fs.access(dumpPath);
+    } catch {
+      throw new RestoreIntegrityError(`Source dump file is missing at ${dumpPath}.`);
+    }
+    if (source.sha256) {
+      const actual = await fileSha256(dumpPath);
+      if (actual !== source.sha256) {
+        throw new RestoreIntegrityError(
+          `Source dump checksum mismatch — file may be corrupted (expected ${source.sha256}, got ${actual}).`,
+        );
+      }
+    }
+
+    // 2. Pre-restore safety backup
+    restoreTraceLog("writing pre-restore safety dump");
+    const safetyTake = args.takeSafetyBackup
+      ? args.takeSafetyBackup
+      : () => runNeo4jBackup({ trigger: "pre-restore-safety", backupsRoot, prismaClient: prisma });
+    const safety = await safetyTake();
+    if (safety.status !== "ok") {
+      throw new RestoreIntegrityError("Pre-restore safety dump failed; aborting restore so current state is not lost.");
+    }
+    restoreTraceLog(`safety dump ok runId=${safety.runId}`);
+
+    // 3. Run the restore script
+    const composeProject = process.env.COMPOSE_PROJECT_NAME ?? "dpf";
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      DUMP_PATH: dumpPath,
+      DPF_NEO4J_CONTAINER: process.env.DPF_NEO4J_CONTAINER ?? `${composeProject}-neo4j-1`,
+      DPF_NEO4J_VOLUME: process.env.DPF_NEO4J_VOLUME ?? `${composeProject}_neo4jdata`,
+      DPF_NEO4J_DATABASE: process.env.DPF_NEO4J_DATABASE ?? "neo4j",
+      DPF_HOST_INSTALL_PATH: process.env.DPF_HOST_INSTALL_PATH ?? "",
+    };
+    const outcome = await runScript(scriptPath, env);
+    const finishedAt = now();
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+    // 4. Record audit row (Postgres is unaffected, so rows written before the
+    //    restore still exist — no re-insert dance needed unlike the Postgres runner).
+    const created = await prisma.backupRestore.create({
+      data: {
+        startedAt,
+        finishedAt,
+        status: outcome.ok ? "ok" : "failed",
+        sourceBackupRunId: source.id,
+        preRestoreBackupRunId: safety.runId,
+        initiatedByUserId: args.initiatedByUserId ?? null,
+        errorMessage: outcome.ok ? null : summarizeFailure(outcome),
+      },
+      select: { id: true },
+    });
+
+    if (outcome.ok) {
+      restoreTraceLog(`restore ok id=${created.id} duration_ms=${durationMs}`);
+      return { restoreId: created.id, status: "ok" };
+    }
+    restoreTraceLog(`restore failed id=${created.id} reason=${summarizeFailure(outcome)}`);
+    return { restoreId: created.id, status: "failed" };
+  } finally {
+    release();
+    restoreTraceLog("released lock");
+  }
+}
+
+export { RestoreLockedError, RestoreIntegrityError };

--- a/apps/web/lib/operate/backups/postgres-restore-runner.ts
+++ b/apps/web/lib/operate/backups/postgres-restore-runner.ts
@@ -157,7 +157,7 @@ function summarizeScriptFailure(outcome: ScriptOutcome): string {
  * is already in flight. Returns a release function the caller MUST invoke
  * in `finally`.
  */
-function acquireRestoreLock(holder: string): () => void {
+export function acquireRestoreLock(holder: string): () => void {
   if (restoreLockHeld) {
     throw new RestoreLockedError(restoreLockHolder, restoreLockAcquiredAt);
   }

--- a/apps/web/lib/operate/backups/qdrant-restore-runner.ts
+++ b/apps/web/lib/operate/backups/qdrant-restore-runner.ts
@@ -1,0 +1,197 @@
+/**
+ * TypeScript orchestrator for the Qdrant restore wizard.
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md (Slice 4)
+ *
+ * Uses the Qdrant REST snapshot API for an online restore:
+ *   1. Acquire the shared portal-side mutex.
+ *   2. Verify the source snapshot file exists and sha256 matches.
+ *   3. Write a Qdrant safety backup (trigger="pre-restore-safety").
+ *   4. Spawn scripts/restore-qdrant.sh — POST /snapshots/upload?wait=true.
+ *      Qdrant replaces all collections from the full-instance snapshot.
+ *      No service interruption required.
+ *   5. Record BackupRestore audit row.
+ *   6. Release lock in finally.
+ *
+ * The Qdrant REST API (qdrant/qdrant:latest) accepts POST /snapshots/upload
+ * with a multipart snapshot file and recovers all collections inline.
+ * Postgres is unaffected, so audit rows persist normally.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import {
+  acquireRestoreLock,
+  RestoreLockedError,
+  RestoreIntegrityError,
+} from "./postgres-restore-runner";
+import { runQdrantBackup } from "./qdrant-backup-runner";
+
+const execFileAsync = promisify(execFile);
+
+const BACKUPS_ROOT = "/backups";
+const RESTORE_SCRIPT_PATH = "/workspace/scripts/restore-qdrant.sh";
+const RUNNER_TIMEOUT_MS = 30 * 60 * 1000;
+
+export interface QdrantRestoreArgs {
+  sourceBackupRunId: string;
+  initiatedByUserId?: string | null;
+  backupsRoot?: string;
+  scriptPath?: string;
+  prismaClient?: PrismaLike;
+  now?: () => Date;
+  takeSafetyBackup?: () => Promise<{ runId: string; status: "ok" | "failed" }>;
+}
+
+type PrismaLike = typeof import("@dpf/db").prisma;
+
+interface ScriptOutcome {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function restoreTraceLog(...parts: unknown[]) {
+  // eslint-disable-next-line no-console
+  console.log("[restore-trace][qdrant]", ...parts);
+}
+
+async function fileSha256(absolutePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const fh = await fs.open(absolutePath, "r");
+  try {
+    const stream = fh.createReadStream();
+    for await (const chunk of stream) hash.update(chunk as Buffer);
+  } finally {
+    await fh.close();
+  }
+  return hash.digest("hex");
+}
+
+async function runScript(scriptPath: string, env: NodeJS.ProcessEnv): Promise<ScriptOutcome> {
+  try {
+    const { stdout, stderr } = await execFileAsync(scriptPath, [], {
+      env,
+      timeout: RUNNER_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number | string; message?: string };
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message ?? String(err),
+      exitCode: typeof e.code === "number" ? e.code : -1,
+    };
+  }
+}
+
+function summarizeFailure(outcome: ScriptOutcome): string {
+  const traceLine = outcome.stderr
+    .split("\n")
+    .reverse()
+    .find((l) => l.includes("[restore-qdrant-trace] failed:"));
+  if (traceLine) return traceLine.replace(/^.*\[restore-qdrant-trace\]\s*failed:\s*/, "").trim();
+  const lastStderr = outcome.stderr.trim().split("\n").pop()?.trim() ?? "";
+  if (lastStderr) return lastStderr.slice(0, 500);
+  if (outcome.exitCode !== 0) return `restore script exited ${outcome.exitCode}`;
+  return "qdrant restore failed (no diagnostic captured)";
+}
+
+export async function runQdrantRestore(
+  args: QdrantRestoreArgs,
+): Promise<{ restoreId: string; status: "ok" | "failed" }> {
+  const now = args.now ?? (() => new Date());
+  const backupsRoot = args.backupsRoot ?? BACKUPS_ROOT;
+  const scriptPath = args.scriptPath ?? RESTORE_SCRIPT_PATH;
+  const prisma = args.prismaClient ?? (await import("@dpf/db")).prisma;
+
+  const release = acquireRestoreLock(args.sourceBackupRunId);
+  const startedAt = now();
+  restoreTraceLog(`acquired lock for source=${args.sourceBackupRunId}`);
+
+  try {
+    // 1. Resolve + integrity-check the source snapshot
+    const source = await prisma.backupRun.findUnique({ where: { id: args.sourceBackupRunId } });
+    if (!source) {
+      throw new RestoreIntegrityError(`Source BackupRun ${args.sourceBackupRunId} not found.`);
+    }
+    if (source.status !== "ok") {
+      throw new RestoreIntegrityError(`Source BackupRun status=${source.status}; only successful backups can be restored.`);
+    }
+    if (source.prunedAt !== null) {
+      throw new RestoreIntegrityError(`Source BackupRun ${args.sourceBackupRunId} has been pruned; file is gone.`);
+    }
+    if (source.target !== "qdrant") {
+      throw new RestoreIntegrityError(`BackupRun target=${source.target}; expected qdrant.`);
+    }
+
+    const snapshotPath = path.posix.join(backupsRoot, source.storagePath, "qdrant.snapshot");
+    try {
+      await fs.access(snapshotPath);
+    } catch {
+      throw new RestoreIntegrityError(`Source snapshot file is missing at ${snapshotPath}.`);
+    }
+    if (source.sha256) {
+      const actual = await fileSha256(snapshotPath);
+      if (actual !== source.sha256) {
+        throw new RestoreIntegrityError(
+          `Source snapshot checksum mismatch — file may be corrupted (expected ${source.sha256}, got ${actual}).`,
+        );
+      }
+    }
+
+    // 2. Pre-restore safety backup
+    restoreTraceLog("writing pre-restore safety snapshot");
+    const safetyTake = args.takeSafetyBackup
+      ? args.takeSafetyBackup
+      : () => runQdrantBackup({ trigger: "pre-restore-safety", backupsRoot, prismaClient: prisma });
+    const safety = await safetyTake();
+    if (safety.status !== "ok") {
+      throw new RestoreIntegrityError("Pre-restore safety snapshot failed; aborting restore.");
+    }
+    restoreTraceLog(`safety snapshot ok runId=${safety.runId}`);
+
+    // 3. Run the restore script (POST /snapshots/upload?wait=true)
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      DUMP_PATH: snapshotPath,
+      DPF_QDRANT_URL: process.env.DPF_QDRANT_URL ?? "http://qdrant:6333",
+    };
+    const outcome = await runScript(scriptPath, env);
+    const finishedAt = now();
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+    // 4. Record audit row (Postgres unaffected — no re-insert dance needed)
+    const created = await prisma.backupRestore.create({
+      data: {
+        startedAt,
+        finishedAt,
+        status: outcome.ok ? "ok" : "failed",
+        sourceBackupRunId: source.id,
+        preRestoreBackupRunId: safety.runId,
+        initiatedByUserId: args.initiatedByUserId ?? null,
+        errorMessage: outcome.ok ? null : summarizeFailure(outcome),
+      },
+      select: { id: true },
+    });
+
+    if (outcome.ok) {
+      restoreTraceLog(`restore ok id=${created.id} duration_ms=${durationMs}`);
+      return { restoreId: created.id, status: "ok" };
+    }
+    restoreTraceLog(`restore failed id=${created.id} reason=${summarizeFailure(outcome)}`);
+    return { restoreId: created.id, status: "failed" };
+  } finally {
+    release();
+    restoreTraceLog("released lock");
+  }
+}
+
+export { RestoreLockedError, RestoreIntegrityError };

--- a/apps/web/lib/operate/backups/restore-preview.ts
+++ b/apps/web/lib/operate/backups/restore-preview.ts
@@ -1,14 +1,13 @@
 /**
- * Voice Slice 2 — restore impact preview.
+ * Restore impact preview — target-aware.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6 step 2.
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md (Slice 4)
  *
  * Computes the impact preview the wizard renders before the operator types
- * RESTORE. Reads the BackupRun row, verifies the file exists on disk and
- * the sha256 matches what was recorded, and emits a human-friendly summary.
- *
- * Pure as possible: takes the prisma client + the file system as
- * dependencies so the unit tests can stub both.
+ * RESTORE. Reads the BackupRun row, resolves the dump filename by target,
+ * verifies the file exists and the sha256 matches, and emits a human-friendly
+ * summary with any service-specific warnings.
  */
 
 import { promises as fs } from "node:fs";
@@ -21,27 +20,35 @@ import { type RestoreImpactPreview } from "./restore-types";
 
 const DEFAULT_BACKUPS_ROOT = "/backups";
 
+/** Maps BackupTarget to the artifact filename produced by the backup script. */
+const DUMP_FILENAME: Record<string, string> = {
+  postgres: "dpf.dump",
+  neo4j: "neo4j.dump",
+  qdrant: "qdrant.snapshot",
+};
+
+const SERVICE_WARNINGS: Record<string, string | null> = {
+  postgres: null,
+  neo4j:
+    "Restoring Neo4j stops the graph database container for ~15–30 s while the dump loads. Wiki search, routing, and EA topology will be briefly unavailable.",
+  qdrant:
+    "Restoring Qdrant replaces all vector collections with the snapshot state. Semantic search and brand context will briefly reflect the snapshot until reindexing completes.",
+};
+
 export interface PreviewArgs {
   sourceBackupRunId: string;
-  /** Override the backups root for tests. */
   backupsRoot?: string;
-  /** Inject prisma for tests. */
   prismaClient?: typeof defaultPrisma;
-  /** Inject clock for deterministic tests. */
   now?: () => Date;
-  /** Current DPF version (for cross-version warning). Defaults to process.env.DPF_VERSION. */
   currentDpfVersion?: string | null;
 }
 
-/** Stream the file through sha256 to verify integrity. */
 async function fileSha256(absolutePath: string): Promise<string> {
   const hash = crypto.createHash("sha256");
   const fileHandle = await fs.open(absolutePath, "r");
   try {
     const stream = fileHandle.createReadStream();
-    for await (const chunk of stream) {
-      hash.update(chunk as Buffer);
-    }
+    for await (const chunk of stream) hash.update(chunk as Buffer);
   } finally {
     await fileHandle.close();
   }
@@ -59,6 +66,15 @@ function describeAge(ageMinutes: number): string {
   return `${d} day${d === 1 ? "" : "s"} ago`;
 }
 
+function serviceLabel(target: string): string {
+  const labels: Record<string, string> = {
+    postgres: "Postgres database",
+    neo4j: "Neo4j graph database",
+    qdrant: "Qdrant vector store",
+  };
+  return labels[target] ?? target;
+}
+
 export async function buildRestorePreview(
   args: PreviewArgs,
 ): Promise<RestoreImpactPreview> {
@@ -67,9 +83,7 @@ export async function buildRestorePreview(
   const backupsRoot = args.backupsRoot ?? DEFAULT_BACKUPS_ROOT;
   const currentDpfVersion = args.currentDpfVersion ?? process.env.DPF_VERSION ?? null;
 
-  const run = await prisma.backupRun.findUnique({
-    where: { id: args.sourceBackupRunId },
-  });
+  const run = await prisma.backupRun.findUnique({ where: { id: args.sourceBackupRunId } });
   if (!run) {
     throw new Error(`BackupRun ${args.sourceBackupRunId} not found`);
   }
@@ -84,8 +98,9 @@ export async function buildRestorePreview(
     );
   }
 
+  const dumpFilename = DUMP_FILENAME[run.target] ?? "dpf.dump";
   const absoluteDir = path.posix.join(backupsRoot, run.storagePath);
-  const dumpPath = path.posix.join(absoluteDir, "dpf.dump");
+  const dumpPath = path.posix.join(absoluteDir, dumpFilename);
 
   let fileMissing = false;
   let sha256Mismatch = false;
@@ -93,9 +108,7 @@ export async function buildRestorePreview(
     await fs.access(dumpPath);
     if (run.sha256) {
       const actual = await fileSha256(dumpPath);
-      if (actual !== run.sha256) {
-        sha256Mismatch = true;
-      }
+      if (actual !== run.sha256) sha256Mismatch = true;
     }
   } catch {
     fileMissing = true;
@@ -106,23 +119,23 @@ export async function buildRestorePreview(
     : now.getTime() - run.startedAt.getTime();
   const ageMinutes = Math.max(0, Math.floor(ageMs / 60_000));
 
-  // Cross-version warning. We never block — operators recovering from a wipe
-  // sometimes need to restore older dumps. We just surface the difference.
   let versionWarning: string | null = null;
   if (run.dpfVersion && currentDpfVersion && run.dpfVersion !== currentDpfVersion) {
     versionWarning = `Source dump was taken from DPF version ${run.dpfVersion.slice(0, 12)}; the install is currently running ${currentDpfVersion.slice(0, 12)}. Schema or behavior may have diverged.`;
   }
 
+  const label = serviceLabel(run.target);
   const impactSummary = fileMissing
-    ? "The dump file is missing from disk. Restore is not possible."
+    ? `The ${label} file is missing from disk. Restore is not possible.`
     : sha256Mismatch
-      ? "The dump file's checksum does not match what was recorded when it was taken. The file may be corrupted. Restore is blocked."
-      : `Restoring this backup will replace ALL platform data created since the dump was taken (${describeAge(
+      ? `The ${label} file's checksum does not match what was recorded when it was taken. The file may be corrupted. Restore is blocked.`
+      : `Restoring this backup will replace the ${label} with data from ${describeAge(
           ageMinutes,
-        )}). A pre-restore safety dump of the current state will be written first, so a misclick is recoverable.`;
+        )}. A pre-restore safety backup of the current state will be written first, so a misclick is recoverable.`;
 
   return {
     sourceBackupRunId: run.id,
+    target: run.target as RestoreImpactPreview["target"],
     sourceFinishedAt: run.finishedAt?.toISOString() ?? null,
     sourceSizeBytes: run.sizeBytes ? Number(run.sizeBytes) : null,
     sourceSha256: run.sha256,
@@ -131,10 +144,8 @@ export async function buildRestorePreview(
     fileMissing,
     sha256Mismatch,
     versionWarning,
+    serviceWarning: SERVICE_WARNINGS[run.target] ?? null,
   };
 }
 
-// Test-only exports
-export const __test__ = {
-  describeAge,
-};
+export const __test__ = { describeAge };

--- a/apps/web/lib/operate/backups/restore-types.ts
+++ b/apps/web/lib/operate/backups/restore-types.ts
@@ -1,12 +1,17 @@
 /**
- * Voice Slice 2 — restore wizard public types.
+ * Restore wizard public types.
  *
  * Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §4.6
+ * Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md (Slice 4)
  */
+
+import type { BackupTarget } from "./types";
 
 export interface RestoreImpactPreview {
   /** The BackupRun.id being restored. */
   sourceBackupRunId: string;
+  /** Which service this restore targets. */
+  target: BackupTarget;
   /** Source dump's finishedAt timestamp (UTC ISO). */
   sourceFinishedAt: string | null;
   /** Source dump size in bytes. */
@@ -25,11 +30,17 @@ export interface RestoreImpactPreview {
   /** True when the on-disk sha256 does not match BackupRun.sha256 (corruption). */
   sha256Mismatch: boolean;
   /**
-   * Cross-version warning. Spec §10 open question: dump may have been taken
-   * from a different DPF version. We surface it but do NOT block; operators
-   * recovering from a wipe sometimes need to restore older dumps.
+   * Cross-version warning. Dump may have been taken from a different DPF
+   * version. We surface it but do NOT block — operators recovering from a
+   * wipe sometimes need to restore older dumps.
    */
   versionWarning: string | null;
+  /**
+   * Service-specific warning shown before the confirmation input.
+   * null for Postgres (no extra downtime). Set for Neo4j (brief container
+   * restart) and Qdrant (full-instance replacement).
+   */
+  serviceWarning: string | null;
 }
 
 export interface RestoreRunListItem {

--- a/scripts/restore-neo4j.sh
+++ b/scripts/restore-neo4j.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# scripts/restore-neo4j.sh — platform-managed Neo4j restore runner.
+#
+# Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md (Slice 4)
+#
+# Mirrors the offline dump approach used by backup-neo4j.sh:
+#   1. Stop the running Neo4j container.
+#   2. Run neo4j-admin database load against the volume from a one-shot
+#      container (same image as the running Neo4j to ensure format parity).
+#   3. Restart the original container.
+#
+# Per the never-ask-user-to-run-commands kernel principle, this script
+# is never invoked by the operator. The admin restore wizard calls it
+# after the operator types the typed-RESTORE confirmation.
+#
+# Required env:
+#   DUMP_PATH              absolute path on host to neo4j.dump
+#   DPF_NEO4J_CONTAINER    container name (default: dpf-neo4j-1)
+#   DPF_NEO4J_VOLUME       named volume (default: dpf_neo4jdata)
+#   DPF_NEO4J_DATABASE     database name (default: neo4j)
+#   DPF_HOST_INSTALL_PATH  host install path for docker-in-docker bind translation
+#
+# Exit codes:
+#   0 success
+#   2 prereq missing
+#   3 load failed (Neo4j container restarted regardless)
+#   4 load succeeded but Neo4j container failed to restart
+
+set -eu
+
+log() { printf '[restore-neo4j-trace] %s\n' "$*"; }
+fail() {
+  log "failed: $1"
+  exit "${2:-1}"
+}
+
+DUMP_PATH="${DUMP_PATH:-}"
+NEO4J_CONTAINER="${DPF_NEO4J_CONTAINER:-dpf-neo4j-1}"
+NEO4J_VOLUME="${DPF_NEO4J_VOLUME:-dpf_neo4jdata}"
+NEO4J_DATABASE="${DPF_NEO4J_DATABASE:-neo4j}"
+DPF_HOST_INSTALL_PATH="${DPF_HOST_INSTALL_PATH:-}"
+
+[ -n "$DUMP_PATH" ] || fail "DUMP_PATH not set" 2
+[ -n "$DPF_HOST_INSTALL_PATH" ] || fail "DPF_HOST_INSTALL_PATH not set" 2
+[ -f "$DUMP_PATH" ] || fail "dump file does not exist: $DUMP_PATH" 2
+command -v docker >/dev/null 2>&1 || fail "docker CLI not available" 2
+
+# Translate the portal's /backups/... view to the host path the Docker daemon
+# needs for bind mounts (same pattern as backup-neo4j.sh HOST_TARGET_DIR).
+DUMP_DIR="$(dirname "$DUMP_PATH")"
+DUMP_RELATIVE="${DUMP_DIR#/backups/}"
+HOST_DUMP_DIR="${DPF_HOST_INSTALL_PATH}/backups/${DUMP_RELATIVE}"
+HOST_DUMP_FILE="${HOST_DUMP_DIR}/neo4j.dump"
+log "host dump path for bind mount: $HOST_DUMP_FILE"
+
+# Capture the Neo4j image tag so the load runner uses the same version.
+NEO4J_IMAGE="$(docker inspect "$NEO4J_CONTAINER" --format='{{.Config.Image}}' 2>/dev/null || echo "neo4j:5-community")"
+log "neo4j_image=$NEO4J_IMAGE container=$NEO4J_CONTAINER volume=$NEO4J_VOLUME db=$NEO4J_DATABASE"
+
+LOG_FILE="${DUMP_DIR}/restore-log.txt"
+printf 'restore started %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOG_FILE"
+
+# Stop the running container. 30-second grace gives Neo4j time to flush.
+log "stopping Neo4j container"
+docker stop --timeout=30 "$NEO4J_CONTAINER" >> "$LOG_FILE" 2>&1 || fail "could not stop $NEO4J_CONTAINER" 2
+
+# Always restart the container regardless of load outcome.
+restart_neo4j() {
+  log "restarting Neo4j container"
+  if ! docker start "$NEO4J_CONTAINER" >> "$LOG_FILE" 2>&1; then
+    log "WARN could not restart $NEO4J_CONTAINER — operator must check"
+    return 1
+  fi
+  return 0
+}
+
+# Run the load from a one-shot container mounting the same volume.
+# --overwrite-destination=true drops the existing database before loading.
+LOAD_EXIT=0
+docker run --rm \
+  -v "${NEO4J_VOLUME}:/data" \
+  -v "${HOST_DUMP_DIR}:/dump:ro" \
+  "$NEO4J_IMAGE" \
+  neo4j-admin database load \
+    --from-path=/dump \
+    --overwrite-destination=true \
+    "$NEO4J_DATABASE" >> "$LOG_FILE" 2>&1 || LOAD_EXIT=$?
+
+# Always restart, then check load exit.
+restart_neo4j
+RESTART_EXIT=$?
+
+if [ "$LOAD_EXIT" -ne 0 ]; then
+  log "load exit=$LOAD_EXIT — tail of log:"
+  tail -n 20 "$LOG_FILE" >&2 || true
+  fail "neo4j-admin database load failed (exit=$LOAD_EXIT)" 3
+fi
+
+if [ "$RESTART_EXIT" -ne 0 ]; then
+  fail "Neo4j restart failed AFTER load — operator must verify container" 4
+fi
+
+log "ok load complete database=$NEO4J_DATABASE"
+exit 0

--- a/scripts/restore-qdrant.sh
+++ b/scripts/restore-qdrant.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# scripts/restore-qdrant.sh — platform-managed Qdrant restore runner.
+#
+# Spec: docs/superpowers/specs/2026-05-18-postgres-backup-slice-3-neo4j-qdrant.md (Slice 4)
+#
+# Uses Qdrant's full-instance snapshot REST API to restore:
+#   1. Upload the snapshot file via POST /snapshots/upload?wait=true.
+#      Qdrant processes it and recovers all collections from the snapshot.
+#   2. The running Qdrant instance is NOT stopped — the API handles
+#      the recovery online.
+#
+# Per the never-ask-user-to-run-commands kernel principle, this script
+# is only ever called by the portal's restore runner after the operator
+# types the typed-RESTORE confirmation.
+#
+# Required env:
+#   DUMP_PATH          absolute path inside the portal container to qdrant.snapshot
+#   DPF_QDRANT_URL     internal Qdrant URL (default: http://qdrant:6333)
+#
+# Exit codes:
+#   0 success
+#   2 prereq missing
+#   3 upload or restore failed
+
+set -eu
+
+log() { printf '[restore-qdrant-trace] %s\n' "$*"; }
+fail() {
+  log "failed: $1"
+  exit "${2:-1}"
+}
+
+DUMP_PATH="${DUMP_PATH:-}"
+QDRANT_URL="${DPF_QDRANT_URL:-http://qdrant:6333}"
+
+[ -n "$DUMP_PATH" ] || fail "DUMP_PATH not set" 2
+[ -f "$DUMP_PATH" ] || fail "snapshot file does not exist: $DUMP_PATH" 2
+command -v curl >/dev/null 2>&1 || fail "curl not available" 2
+
+DUMP_DIR="$(dirname "$DUMP_PATH")"
+LOG_FILE="${DUMP_DIR}/restore-log.txt"
+printf 'restore started %s url=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$QDRANT_URL" > "$LOG_FILE"
+
+log "uploading snapshot to Qdrant url=$QDRANT_URL file=$DUMP_PATH"
+
+# Upload the full-instance snapshot. ?wait=true means the request blocks
+# until Qdrant has finished processing the snapshot (all collections restored).
+# Qdrant 1.7+ supports this endpoint for full-instance snapshots.
+HTTP_STATUS=$(curl -sS -o "$LOG_FILE.upload_response" -w "%{http_code}" \
+  -X POST "${QDRANT_URL}/snapshots/upload?wait=true" \
+  -H "Content-Type: multipart/form-data" \
+  -F "snapshot=@${DUMP_PATH}" 2>>"$LOG_FILE") || fail "curl request failed" 3
+
+cat "$LOG_FILE.upload_response" >> "$LOG_FILE" 2>/dev/null || true
+rm -f "$LOG_FILE.upload_response"
+
+log "upload HTTP status=$HTTP_STATUS"
+
+# Qdrant returns 200 on success. 4xx/5xx indicate failure.
+case "$HTTP_STATUS" in
+  200|201|202)
+    log "ok snapshot uploaded and restored"
+    exit 0
+    ;;
+  *)
+    log "unexpected HTTP status=$HTTP_STATUS from Qdrant"
+    fail "Qdrant snapshot upload returned HTTP $HTTP_STATUS — check Qdrant logs for details" 3
+    ;;
+esac


### PR DESCRIPTION
## Summary

Extends the restore wizard (Slice 2 — Postgres-only) to cover Neo4j and Qdrant. The "Restore…" button is now enabled for all three backup targets. Same typed-RESTORE confirmation UX as Postgres, per-service runner.

Ref: **BI-93A59628**

## What changed

- **`scripts/restore-neo4j.sh`** — stop `dpf-neo4j-1`, run `neo4j-admin database load` from a one-shot container mounting the volume, restart. Mirrors the offline dump pattern from `backup-neo4j.sh`.
- **`scripts/restore-qdrant.sh`** — `POST /snapshots/upload?wait=true` to Qdrant's full-instance snapshot restore endpoint; no service stop required.
- **`neo4j-restore-runner.ts`** — portal-side orchestrator: shared mutex + sha256 integrity check + safety backup + script execution + BackupRestore audit row.
- **`qdrant-restore-runner.ts`** — same structure for Qdrant.
- **`postgres-restore-runner.ts`** — export `acquireRestoreLock` so neo4j/qdrant runners share the same portal-level mutex (one restore at a time across all targets).
- **`restore-types.ts`** — adds `target: BackupTarget` to `RestoreImpactPreview`; adds `serviceWarning` field for per-service copy (Neo4j restart warning, Qdrant full-replacement warning).
- **`restore-preview.ts`** — target-aware dump filename map (`dpf.dump` / `neo4j.dump` / `qdrant.snapshot`); target-aware impact summary; populates `serviceWarning`.
- **`backup-restore.ts`** — `confirmRestoreAction` looks up `BackupRun.target` and dispatches to the right runner.
- **`RestoreConfirmModal.tsx`** — target-aware title, subtitle, and `serviceWarning` panel.
- **`BackupsClient.tsx`** — removes the `target === "postgres"` guard so "Restore…" shows for all three targets.

## Functional verification log

Live install: Portal + Neo4j + Qdrant all healthy. Both new restore scripts are in the deployed portal image.

### Qdrant restore

Clicked **Restore…** on the 12:59:29 AM Qdrant backup row.

**Modal showed:**
- Title: "Restore Qdrant from backup"
- Impact: "Restoring this backup will replace the Qdrant vector store with data from 4 minutes ago. A pre-restore safety backup of the current state will be written first, so a misclick is recoverable."
- Service warning: "Restoring Qdrant replaces all vector collections with the snapshot state. Semantic search and brand context will briefly reflect the snapshot until reindexing completes."
- Checksum: `e3830f624743315e…`

Typed `RESTORE`, clicked confirm.

**BackupRestore row:**
```
id:            cmpasu6f200g301r0ho7o4qpj
target:        qdrant
status:        ok
startedAt:     2026-05-18 06:04:27.231
finishedAt:    2026-05-18 06:04:27.517
duration:      286 ms  (REST API upload, no service interruption)
```

Pre-restore safety snapshot visible in Qdrant history: `1:04:27 AM · 107 ms · 168.0 KB [OK]`.

### Neo4j restore

Clicked **Restore…** on the 12:53:10 AM Neo4j backup row.

**Modal showed:**
- Title: "Restore Neo4j from backup"
- Impact: "Restoring this backup will replace the Neo4j graph database with data from 11 minutes ago. A pre-restore safety backup of the current state will be written first, so a misclick is recoverable."
- Service warning: "Restoring Neo4j stops the graph database container for ~15–30 s while the dump loads. Wiki search, routing, and EA topology will be briefly unavailable."
- Checksum: `606d31808fa290b0…`

Typed `RESTORE`, clicked confirm.

**BackupRestore row:**
```
id:            cmpasvjgk00h001r0l6h2oymt
target:        neo4j
status:        ok
startedAt:     2026-05-18 06:05:11.154
finishedAt:    2026-05-18 06:05:31.076
duration:      19.9 s  (safety backup + stop + load 53 files 279.8 MiB + restart)
```

Pre-restore safety dump visible in Neo4j history. Neo4j container state after restore: `running / healthy`.

restore-neo4j.sh log tail confirms: `Done: 53 files, 279.8MiB processed in 0.449 seconds.`

### Admin page final state

- Restore history shows 6 entries — both new OK restores at the top
- Qdrant: `running / healthy`, pre-restore safety backup written
- Neo4j: `running / healthy`, pre-restore safety backup written
- Zero CLI copy surfaced to operator in any part of the wizard

## Test plan

- [x] `pnpm --filter web typecheck` clean (pre-commit hook passed)
- [x] Qdrant restore wizard: modal renders with target-aware title + service warning, typed RESTORE, confirmed → `BackupRestore status=ok` in 286 ms, safety snapshot written, Qdrant healthy
- [x] Neo4j restore wizard: modal renders with target-aware title + downtime warning, typed RESTORE, confirmed → `BackupRestore status=ok` in 19.9 s, safety dump written, Neo4j `running/healthy`
- [x] `acquireRestoreLock` shared across all three runners (one restore at a time enforced)
- [x] `previewRestoreAction` correctly resolves `dpf.dump` / `neo4j.dump` / `qdrant.snapshot` by target
- [x] No CLI surfaced to operator; no Postgres state affected by Neo4j or Qdrant restores

Generated with [Claude Code](https://claude.com/claude-code)