### PR TITLE
fix(build-studio): deliver reviewDesignDoc/reviewBuildPlan to build-specialist

### DIFF
--- a/apps/web/lib/mcp-tools.test.ts
+++ b/apps/web/lib/mcp-tools.test.ts
@@ -195,6 +195,28 @@ describe("mcp tools", () => {
     expect(tool!.requiredCapability).toBe("manage_backlog");
     expect(tool!.sideEffect).toBe(true);
   });
+
+  it("exposes reviewDesignDoc and reviewBuildPlan to the build-specialist agent (architecture_read + build_plan_write grants)", async () => {
+    // Regression: mcp-tools.ts was using the sync JSON-backed getAgentToolGrants which
+    // returned stale grants missing architecture_read / build_plan_write. The ideate phase
+    // then could not call reviewDesignDoc (required for Ideate→Plan transition) because the
+    // tool was filtered out. Fix: switched to getAgentToolGrantsAsync (DB-first, JSON fallback).
+    const tools = await getAvailableTools(adminUser, {
+      externalAccessEnabled: false,
+      agentId: "build-specialist",
+    });
+    const toolNames = tools.map((t) => t.name);
+
+    expect(toolNames).toContain("reviewDesignDoc");
+    expect(toolNames).toContain("reviewBuildPlan");
+    expect(toolNames).toContain("saveBuildEvidence");
+    // Ensure sandbox tools are also present (build phase needs them)
+    expect(toolNames).toContain("start_sandbox");
+    expect(toolNames).toContain("run_sandbox_tests");
+    // Ensure the grant filter is actually applied (work_capsule tools are NOT in build-specialist's grants)
+    expect(toolNames).not.toContain("list_work_capsules");
+    expect(toolNames).not.toContain("get_work_capsule");
+  });
 });
 
 describe("sanitizeToolParams", () => {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -3689,11 +3689,13 @@ export async function getAvailableTools(
       && (options?.mode !== "advise" || !tool.sideEffect),
   );
 
-  // Agent-scoped filtering: intersection of user capabilities and agent tool grants
+  // Agent-scoped filtering: intersection of user capabilities and agent tool grants.
+  // EP-AI-WORKFORCE-001: use the async DB-first resolver so grants written via
+  // the DB (e.g. via seed or Admin UI) take precedence over the JSON fallback.
   if (options?.agentId) {
-    const { getAgentToolGrants, isToolAllowedByGrants } = await import("./agent-grants");
-    const agentGrants = getAgentToolGrants(options.agentId);
-    if (agentGrants) {
+    const { getAgentToolGrantsAsync, isToolAllowedByGrants } = await import("./agent-grants");
+    const agentGrants = await getAgentToolGrantsAsync(options.agentId);
+    if (agentGrants.length > 0) {
       platformTools = platformTools.filter((tool) => isToolAllowedByGrants(tool.name, agentGrants));
     }
   }

--- a/apps/web/lib/tak/build-specialist-prompt.test.ts
+++ b/apps/web/lib/tak/build-specialist-prompt.test.ts
@@ -14,8 +14,8 @@ const PROMPT_PATH = join(REPO_ROOT, "prompts", "route-persona", "build-specialis
 const prompt = readFileSync(PROMPT_PATH, "utf-8");
 
 describe("build-specialist.prompt.md (Operator Contract)", () => {
-  it("has frontmatter version 4 (operator contract update)", () => {
-    expect(prompt).toMatch(/^version:\s*4$/m);
+  it("has frontmatter version 5 (ideate tool guidance + describe_model guard)", () => {
+    expect(prompt).toMatch(/^version:\s*5$/m);
   });
 
   it("preserves the role-defining sections", () => {
@@ -39,6 +39,15 @@ describe("build-specialist.prompt.md (Operator Contract)", () => {
 
   it("trusts the runtime tool list explicitly", () => {
     expect(prompt).toMatch(/platform delivers your callable tool list/i);
+  });
+
+  it("gives explicit ideate tool guidance (prevents describe_model loop)", () => {
+    // Regression: without explicit ideate tool guidance the model fell into a
+    // describe_model loop (4× same-args call detected by stuck-loop guard).
+    // The per-phase judgment section now names start_ideate_research and
+    // explicitly disallows describe_model for design-time research.
+    expect(prompt).toMatch(/start_ideate_research/);
+    expect(prompt).toMatch(/describe_model.*build phase/i);
   });
 
   it("references all nine contract clauses by intent", () => {

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2550,17 +2550,19 @@
         },
         "concurrency_limit": 2,
         "tool_grants": [
+          "file_read",
+          "code_graph_read",
           "backlog_read",
           "backlog_write",
-          "code_graph_read",
-          "file_read",
-          "iac_execute",
+          "architecture_read",
+          "build_plan_write",
           "registry_read",
-          "release_gate_create",
           "sandbox_execute",
-          "work_capsule_read",
-          "work_capsule_write",
-          "work_capsule_adopt"
+          "deployment_plan_create",
+          "iac_execute",
+          "release_gate_create",
+          "release_plan_create",
+          "release_plan_read"
         ]
       }
     },

--- a/prompts/route-persona/build-specialist.prompt.md
+++ b/prompts/route-persona/build-specialist.prompt.md
@@ -3,7 +3,7 @@ name: build-specialist
 displayName: Software Engineer
 description: User-facing build coworker. Five phases — Ideate > Plan > Build > Review > Ship. Distinct from AGT-BUILD-* sub-agents.
 category: route-persona
-version: 4
+version: 5
 
 agent_id: AGT-WS-BUILD
 reports_to: HR-200
@@ -116,7 +116,7 @@ If a clarifying question is needed, ask once, then act on whatever the user answ
 
 # Per-phase judgment
 
-When the user is in **Ideate** — surface options, name tradeoffs, narrow. Save designDoc before advancing.
+When the user is in **Ideate** — use `start_ideate_research` (or `search_project_files` / `read_project_file`) to read the relevant codebase context, then draft a `designDoc` and save it with `saveBuildEvidence({ field: "designDoc", value: { summary, files, approach, risks } })`. Do NOT use `describe_model` for design-time research — `describe_model` inspects sandbox DB schemas and is only useful in the Build phase.
 When in **Plan** — decompose, define done, estimate complexity. Save buildPlan, run reviewBuildPlan.
 When in **Build** — direct AGT-BUILD-DA / -SE / -FE; read their output.
 When in **Review** — direct AGT-BUILD-QA; surface the verdict; save verificationOut and acceptanceMet.


### PR DESCRIPTION
## Summary

- **Root cause:** `getAvailableTools` used the sync JSON-backed `getAgentToolGrants` instead of `getAgentToolGrantsAsync` (DB-first). The JSON registry for `build-specialist` was also stale — missing `architecture_read` / `build_plan_write` / `deployment_plan_create` / `release_plan_*` grants — so `reviewDesignDoc` and `reviewBuildPlan` were silently filtered out of the tool list in every build phase.
- **Symptom:** Without `reviewDesignDoc` in the tool list the model could not complete the Ideate→Plan transition. It fell into a `describe_model` loop (4× same-args call, stuck-loop guard fired) and produced wrong output.
- This is infrastructure failure, not model hallucination — the tools weren't delivered.

## Changes

| File | Change |
|------|--------|
| `apps/web/lib/mcp-tools.ts` | `getAgentToolGrants` → `getAgentToolGrantsAsync` (DB-first, JSON fallback) |
| `packages/db/data/agent_registry.json` | Sync `AGT-WS-BUILD` grants to match `seed.ts`: adds `architecture_read`, `build_plan_write`, `deployment_plan_create`, `release_plan_create`, `release_plan_read`; removes stale `work_capsule_*` not in seed |
| `prompts/route-persona/build-specialist.prompt.md` | Add explicit ideate tool guidance: use `start_ideate_research`, guard against `describe_model` misuse (v4→v5) |
| `apps/web/lib/mcp-tools.test.ts` | Regression test: `reviewDesignDoc` + `reviewBuildPlan` visible to `build-specialist` with grant filter applied |
| `apps/web/lib/tak/build-specialist-prompt.test.ts` | v5 version check + ideate tool guidance assertion |

## Test plan

- [x] `lib/mcp-tools.test.ts` — 34/34 passing (new test verifies `reviewDesignDoc`, `reviewBuildPlan`, `start_sandbox`, `run_sandbox_tests` delivered; `list_work_capsules` excluded)
- [x] `lib/tak/build-specialist-prompt.test.ts` — 7/7 passing (new test verifies `start_ideate_research` mentioned, `describe_model` guarded)
- [x] Full suite — 6256/6256 passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)