### PR TITLE
fix(test): patch backup-restore mock for prisma.backupRun.findUnique

### DIFF
--- a/apps/web/lib/actions/backup-restore.test.ts
+++ b/apps/web/lib/actions/backup-restore.test.ts
@@ -28,7 +28,10 @@ vi.mock("@/lib/operate/backups/postgres-restore-runner", () => ({
   },
 }));
 vi.mock("@dpf/db", () => ({
-  prisma: { backupRestore: { findMany: vi.fn() } },
+  prisma: {
+    backupRestore: { findMany: vi.fn() },
+    backupRun: { findUnique: vi.fn() },
+  },
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -40,17 +43,23 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { runPostgresRestore } from "@/lib/operate/backups/postgres-restore-runner";
 import { buildRestorePreview } from "@/lib/operate/backups/restore-preview";
+import { prisma } from "@dpf/db";
 
 const mockedAuth = auth as unknown as ReturnType<typeof vi.fn>;
 const mockedCan = can as unknown as ReturnType<typeof vi.fn>;
 const mockedRunner = runPostgresRestore as unknown as ReturnType<typeof vi.fn>;
 const mockedPreview = buildRestorePreview as unknown as ReturnType<typeof vi.fn>;
+const mockedBackupRunFindUnique = prisma.backupRun.findUnique as unknown as ReturnType<typeof vi.fn>;
 
 describe("confirmRestoreAction (typed-confirmation gate)", () => {
   beforeEach(() => {
     mockedAuth.mockReset();
     mockedCan.mockReset();
     mockedRunner.mockReset();
+    mockedBackupRunFindUnique.mockReset();
+    // Default to the postgres path so tests that reach the runner stay on the
+    // postgres branch (the only runner mocked in this file).
+    mockedBackupRunFindUnique.mockResolvedValue({ target: "postgres" });
   });
 
   it("rejects when there is no session", async () => {


### PR DESCRIPTION
## Summary

- PR #766 added multi-target dispatch inside `confirmRestoreAction` — it now calls `prisma.backupRun.findUnique` to determine whether the backup is postgres/neo4j/qdrant before calling the matching runner
- The existing test's `@dpf/db` mock only exposed `prisma.backupRestore`, so `prisma.backupRun` was `undefined`; the resulting `TypeError` was silently caught as `errorClass: "unknown"`, returning `ok: false` before the runner was ever called
- Two cases failed: `calls the runner only when confirmation is exactly RESTORE` and `surfaces a structured failure when the runner reports status=failed`

**Fix:** extend the `prisma` mock to include `backupRun: { findUnique: vi.fn() }` and seed it with `{ target: "postgres" }` in `beforeEach` so both failing cases reach and exercise `runPostgresRestore`

## Test plan

- [x] `cd apps/web && npx vitest run lib/actions/backup-restore.test.ts` — all 7 tests pass (was 5 passing, 2 failing before fix)
- [ ] CI typecheck + vitest suite on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)