### PR TITLE
fix(tests): add missing backupRun.findUnique mock to backup-restore tests

### DIFF
--- a/apps/web/lib/actions/backup-restore.test.ts
+++ b/apps/web/lib/actions/backup-restore.test.ts
@@ -28,7 +28,13 @@ vi.mock("@/lib/operate/backups/postgres-restore-runner", () => ({
   },
 }));
 vi.mock("@dpf/db", () => ({
-  prisma: { backupRestore: { findMany: vi.fn() } },
+  prisma: {
+    // confirmRestoreAction looks up the BackupRun.target to dispatch to the
+    // correct runner (postgres / neo4j / qdrant). Tests default this to
+    // "postgres" so the mocked runPostgresRestore is exercised.
+    backupRun: { findUnique: vi.fn() },
+    backupRestore: { findMany: vi.fn() },
+  },
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -40,17 +46,22 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { runPostgresRestore } from "@/lib/operate/backups/postgres-restore-runner";
 import { buildRestorePreview } from "@/lib/operate/backups/restore-preview";
+import { prisma } from "@dpf/db";
 
 const mockedAuth = auth as unknown as ReturnType<typeof vi.fn>;
 const mockedCan = can as unknown as ReturnType<typeof vi.fn>;
 const mockedRunner = runPostgresRestore as unknown as ReturnType<typeof vi.fn>;
 const mockedPreview = buildRestorePreview as unknown as ReturnType<typeof vi.fn>;
+const mockedFindUnique = prisma.backupRun.findUnique as unknown as ReturnType<typeof vi.fn>;
 
 describe("confirmRestoreAction (typed-confirmation gate)", () => {
   beforeEach(() => {
     mockedAuth.mockReset();
     mockedCan.mockReset();
     mockedRunner.mockReset();
+    mockedFindUnique.mockReset();
+    // Default: run targets postgres — exercises the mocked runPostgresRestore.
+    mockedFindUnique.mockResolvedValue({ target: "postgres" });
   });
 
   it("rejects when there is no session", async () => {


### PR DESCRIPTION
## Summary

- `confirmRestoreAction` was updated in PRs #765/#766 to call `prisma.backupRun.findUnique` before dispatching to the correct runner (postgres / neo4j / qdrant)
- The `@dpf/db` mock in `backup-restore.test.ts` was never updated to include `backupRun.findUnique`, so calls to it returned `undefined`, threw an exception, and the tests received `{ ok: false, errorClass: "unknown" }` instead of their expected results
- These failures pre-existed on `main` before PR #767 (confirmed in CI run for that PR)

## Changes

- Added `backupRun: { findUnique: vi.fn() }` to the `vi.mock("@dpf/db")` factory
- Added `mockedFindUnique` alias for the mock
- Added `mockReset()` + `mockResolvedValue({ target: "postgres" })` to `beforeEach` so the existing `runPostgresRestore` mock is exercised on the happy path

## Test plan

- [ ] CI passes — the 4 previously-failing `confirmRestoreAction` tests now produce their expected results
- [ ] No other test files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)