### PR TITLE
fix(build-studio): guard rewriteTaskText against undefined task fields

### DIFF
--- a/apps/web/lib/integrate/build-plan-paths.ts
+++ b/apps/web/lib/integrate/build-plan-paths.ts
@@ -79,7 +79,11 @@ function resolveLegacyAlias(relativePath: string, exists: ExistsFn): string {
   return normalized;
 }
 
-function rewriteTaskText(text: string, rewrites: BuildPlanPathRewrite[]): string {
+function rewriteTaskText(text: string | undefined, rewrites: BuildPlanPathRewrite[]): string {
+  // Guard: task fields like implement/testFirst/verify are optional strings. When rewrites is
+  // empty, Array.reduce returns the initial value unchanged — if text is undefined that propagates
+  // to the second reduce and crashes on .replace(). Return early for falsy inputs.
+  if (!text) return text ?? "";
   const pathRewritten = rewrites.reduce((current, rewrite) => current.split(rewrite.from).join(rewrite.to), text);
   return LEGACY_BUILD_STUDIO_TEXT_ALIASES.reduce(
     (current, rewrite) => current.replace(rewrite.from, rewrite.to),

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -131,6 +131,12 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   saveBuildEvidence: ["backlog_write"],
   reviewDesignDoc: ["architecture_read"],
   reviewBuildPlan: ["build_plan_write"],
+  // Build-progress observation tools added in PR #770 — read-only, require backlog_read
+  get_build_progress_visibility: ["backlog_read"],
+  get_build_sandbox_state:       ["backlog_read"],
+  get_build_dispatch_history:    ["backlog_read"],
+  get_build_scoped_verification: ["backlog_read"],
+  list_build_activity_since:     ["backlog_read"],
 
   // Deploy / Release
   deploy_feature: ["iac_execute"],


### PR DESCRIPTION
## Summary

- `normalizeBuildPlanPaths` calls `rewriteTaskText(task.implement, rewrites)` for each task
- When a task has a missing/undefined field AND `rewrites` is empty, `Array.reduce` returns the initial value (`undefined`) unchanged
- The second reduce then calls `undefined.replace(...)` → `Cannot read properties of undefined (reading 'replace')`
- This crashed `saveBuildEvidence` for any buildPlan where a task omitted `implement`, `testFirst`, or `verify`

## Fix

- Early-return guard in `rewriteTaskText` for falsy input (returns `text ?? ""`)
- Widen parameter type to `string | undefined` to match runtime reality (validation only enforces `title`)

## Test plan

- [ ] CI passes
- [ ] `saveBuildEvidence` with a task missing `implement` no longer crashes
- [ ] Normal plans with all fields present are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)