### PR TITLE
feat(FB-409B6ADB): native integration coverage matrix for employee work roles

### DIFF
--- a/apps/web/app/(shell)/platform/tools/integrations/page.test.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/page.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
-const { mockCount } = vi.hoisted(() => ({
+const { mockCount, mockOrgFindFirst, mockGetMatrixByOrg } = vi.hoisted(() => ({
   mockCount: vi.fn(),
+  mockOrgFindFirst: vi.fn(),
+  mockGetMatrixByOrg: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -10,8 +12,20 @@ vi.mock("@dpf/db", () => ({
     integrationCredential: {
       count: mockCount,
     },
+    organization: {
+      findFirst: mockOrgFindFirst,
+    },
   },
 }));
+
+vi.mock("@/lib/actions/integration-coverage", () => ({
+  getMatrixByOrg: mockGetMatrixByOrg,
+}));
+
+beforeEach(() => {
+  mockOrgFindFirst.mockResolvedValue({ id: "org-test" });
+  mockGetMatrixByOrg.mockResolvedValue([]);
+});
 
 describe("EnterpriseIntegrationsPage", () => {
   it("surfaces the Facebook Pages card on the native integrations landing page", async () => {
@@ -56,6 +70,16 @@ describe("EnterpriseIntegrationsPage", () => {
     expect(html).toContain("Instagram Business");
     expect(html).toContain("Local Visual Presence");
     expect(html).toContain("/platform/tools/integrations/instagram-business");
+  });
+
+  it("renders the db-backed integration coverage matrix section", async () => {
+    mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(1);
+
+    const { default: EnterpriseIntegrationsPage } = await import("./page");
+    const html = renderToStaticMarkup(await EnterpriseIntegrationsPage());
+
+    expect(html).toContain("Integration Coverage Matrix");
+    expect(html).toContain("No integration coverage rows configured");
   });
 
   it("surfaces the employee-work integration coverage matrix", async () => {

--- a/apps/web/app/(shell)/platform/tools/integrations/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from "@dpf/db";
 import { PlatformSummaryCard } from "@/components/platform/PlatformSummaryCard";
+import { getMatrixByOrg } from "@/lib/actions/integration-coverage";
 import {
   CSDM_STRUCTURAL_DOMAIN_LABELS,
   EMPLOYEE_WORK_ROLE_LABELS,
@@ -11,6 +12,9 @@ import {
 } from "@/lib/tools/integration-coverage-matrix";
 
 export default async function EnterpriseIntegrationsPage() {
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  const dbCoverageMatrix = org ? await getMatrixByOrg(org.id) : [];
+
   const [configuredIntegrations, errorStates] = await Promise.all([
     prisma.integrationCredential.count({
       where: {
@@ -291,6 +295,44 @@ export default async function EnterpriseIntegrationsPage() {
                   </td>
                 </tr>
               ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">Integration Coverage Matrix</h2>
+        </div>
+        <div className="overflow-x-auto border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[var(--dpf-border)] text-[11px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+              <tr>
+                <th className="px-3 py-2 font-medium">Provider</th>
+                <th className="px-3 py-2 font-medium">Role</th>
+                <th className="px-3 py-2 font-medium">Surface</th>
+                <th className="px-3 py-2 font-medium">Read Posture</th>
+              </tr>
+            </thead>
+            <tbody>
+              {dbCoverageMatrix.map((row) => (
+                <tr
+                  key={`${row.providerKey}-${row.role}-${row.surface}`}
+                  className="border-b border-[var(--dpf-border)] last:border-0"
+                >
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{row.providerKey}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-text)]">{row.role}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-muted)]">{row.surface}</td>
+                  <td className="px-3 py-2 text-[var(--dpf-muted)]">{row.readPosture}</td>
+                </tr>
+              ))}
+              {dbCoverageMatrix.length === 0 ? (
+                <tr>
+                  <td className="px-3 py-3 text-[var(--dpf-muted)]" colSpan={4}>
+                    No integration coverage rows configured.
+                  </td>
+                </tr>
+              ) : null}
             </tbody>
           </table>
         </div>

--- a/apps/web/app/api/v1/integrations/coverage/route.test.ts
+++ b/apps/web/app/api/v1/integrations/coverage/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuthenticateRequest, mockGetMatrixByOrg, mockOrgFindFirst } = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockGetMatrixByOrg: vi.fn(),
+  mockOrgFindFirst: vi.fn(),
+}));
+
+vi.mock("@/lib/api/auth-middleware", () => ({
+  authenticateRequest: mockAuthenticateRequest,
+}));
+
+vi.mock("@/lib/actions/integration-coverage", () => ({
+  getMatrixByOrg: mockGetMatrixByOrg,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: {
+      findFirst: mockOrgFindFirst,
+    },
+  },
+}));
+
+import { GET } from "./route";
+
+function makeRequest() {
+  return new Request("http://test/api/v1/integrations/coverage", {
+    method: "GET",
+  });
+}
+
+beforeEach(() => {
+  mockAuthenticateRequest.mockReset();
+  mockGetMatrixByOrg.mockReset();
+  mockOrgFindFirst.mockReset();
+});
+
+describe("GET /api/v1/integrations/coverage", () => {
+  it("returns 401 when the request is unauthenticated", async () => {
+    mockAuthenticateRequest.mockRejectedValue(new Error("Unauthorized"));
+
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+    expect(mockGetMatrixByOrg).not.toHaveBeenCalled();
+  });
+
+  it("returns a JSON coverage matrix for an authenticated request", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "admin@example.com",
+        type: "admin",
+        platformRole: "owner_operator",
+        isSuperuser: false,
+        organizationId: "org-1",
+      },
+      capabilities: [],
+      authContext: { principalId: null, platformRole: "owner_operator", isSuperuser: false, employeeId: null, managerScope: null, grantedCapabilities: [] },
+    });
+    mockOrgFindFirst.mockResolvedValue({ id: "org-1" });
+    mockGetMatrixByOrg.mockResolvedValue([]);
+
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    await expect(response.json()).resolves.toEqual([]);
+    expect(mockGetMatrixByOrg).toHaveBeenCalledWith("org-1");
+  });
+});

--- a/apps/web/app/api/v1/integrations/coverage/route.ts
+++ b/apps/web/app/api/v1/integrations/coverage/route.ts
@@ -1,0 +1,21 @@
+import { prisma } from "@dpf/db";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { getMatrixByOrg } from "@/lib/actions/integration-coverage";
+import { apiSuccess } from "@/lib/api/response";
+import { apiErrorResponse } from "@/lib/api/error";
+
+export async function GET(request: Request) {
+  try {
+    await authenticateRequest(request);
+  } catch {
+    return apiErrorResponse("UNAUTHENTICATED", "Authentication required", 401);
+  }
+
+  // Single-org install: always fetch the one organization
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return apiErrorResponse("ORG_MISSING", "No organization found", 500);
+  }
+
+  return apiSuccess(await getMatrixByOrg(org.id));
+}

--- a/apps/web/lib/actions/integration-coverage.test.ts
+++ b/apps/web/lib/actions/integration-coverage.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+const roles = [
+  "owner_operator",
+  "bookkeeper_accountant",
+  "sales_bd",
+  "marketer",
+  "service_ops",
+  "customer_support",
+  "hr_payroll_admin",
+  "it_security_compliance",
+  "inventory_procurement_admin",
+] as const;
+
+const coverageRows = ["org-a", "org-b"].flatMap((organizationId) =>
+  roles.map((role) => ({
+    id: `${organizationId}-${role}`,
+    organizationId,
+    providerKey: "quickbooks",
+    role,
+    surface: "core",
+    readPosture: "observe",
+    writeGates: [] as string[],
+    createdAt: new Date(),
+  })),
+);
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    integrationRoleCoverage: {
+      findMany: vi.fn((args?: { where?: { organizationId?: string } }) => {
+        const organizationId = args?.where?.organizationId;
+        return Promise.resolve(
+          organizationId
+            ? coverageRows.filter((row) => row.organizationId === organizationId)
+            : coverageRows,
+        );
+      }),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { getMatrixByOrg } from "./integration-coverage";
+
+describe("getMatrixByOrg", () => {
+  it("returns only org-a integration coverage rows", async () => {
+    const matrix = await getMatrixByOrg("org-a");
+
+    expect(matrix).toHaveLength(roles.length);
+    expect(matrix.every((row) => row.organizationId === "org-a")).toBe(true);
+    expect(matrix.some((row) => row.organizationId === "org-b")).toBe(false);
+    expect(matrix.map((row) => row.role).sort()).toEqual([...roles].sort());
+    expect(prisma.integrationRoleCoverage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ organizationId: "org-a" }),
+      }),
+    );
+  });
+
+  it("returns only org-b integration coverage rows", async () => {
+    const matrix = await getMatrixByOrg("org-b");
+
+    expect(matrix).toHaveLength(roles.length);
+    expect(matrix.every((row) => row.organizationId === "org-b")).toBe(true);
+    expect(matrix.some((row) => row.organizationId === "org-a")).toBe(false);
+    expect(matrix.map((row) => row.role).sort()).toEqual([...roles].sort());
+    expect(prisma.integrationRoleCoverage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ organizationId: "org-b" }),
+      }),
+    );
+  });
+});

--- a/apps/web/lib/actions/integration-coverage.ts
+++ b/apps/web/lib/actions/integration-coverage.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@dpf/db";
+
+export type CoverageRow = {
+  id: string;
+  organizationId: string;
+  providerKey: string;
+  role: string;
+  surface: string;
+  readPosture: string;
+  writeGates: string[];
+  createdAt: Date;
+};
+
+export async function getMatrixByOrg(organizationId: string): Promise<CoverageRow[]> {
+  return prisma.integrationRoleCoverage.findMany({
+    where: { organizationId },
+    orderBy: [{ providerKey: "asc" }, { role: "asc" }, { surface: "asc" }],
+  });
+}

--- a/packages/db/prisma/migrations/20260519000000_add_integration_coverage_matrix/migration.sql
+++ b/packages/db/prisma/migrations/20260519000000_add_integration_coverage_matrix/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "WriteGateRequirement" AS ENUM ('credential_verified', 'read_probe_passed', 'audit_log_enabled', 'approval_binding');
+
+-- CreateTable
+CREATE TABLE "IntegrationCoverageProvider" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "providerKey" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "posture" TEXT NOT NULL,
+    "replacementIntent" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IntegrationCoverageProvider_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "IntegrationRoleCoverage" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "providerKey" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "surface" TEXT NOT NULL,
+    "readPosture" TEXT NOT NULL,
+    "writeGates" "WriteGateRequirement"[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IntegrationRoleCoverage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IntegrationCoverageProvider_organizationId_providerKey_key" ON "IntegrationCoverageProvider"("organizationId", "providerKey");
+
+-- CreateIndex
+CREATE INDEX "IntegrationCoverageProvider_organizationId_idx" ON "IntegrationCoverageProvider"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IntegrationRoleCoverage_organizationId_providerKey_role_surface" ON "IntegrationRoleCoverage"("organizationId", "providerKey", "role", "surface");
+
+-- CreateIndex
+CREATE INDEX "IntegrationRoleCoverage_organizationId_idx" ON "IntegrationRoleCoverage"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "IntegrationCoverageProvider" ADD CONSTRAINT "IntegrationCoverageProvider_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IntegrationRoleCoverage" ADD CONSTRAINT "IntegrationRoleCoverage_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2561,6 +2561,8 @@ model Organization {
   wikiLintFindings              WikiLintFinding[]
   documents                     Document[]
   decisionPerspectiveProfiles   DecisionPerspectiveProfile[]
+  integrationCoverageProviders  IntegrationCoverageProvider[] @relation("OrgToCoverageProviders")
+  integrationRoleCoverages      IntegrationRoleCoverage[]     @relation("OrgToCoverageCells")
 }
 
 model BusinessContext {
@@ -8434,4 +8436,43 @@ model EdgeNodeCapability {
 
   @@unique([edgeNodeId, capability])
   @@index([capability])
+}
+
+// ─── Integration Coverage Matrix ─────────────────────────────────────────────
+
+enum WriteGateRequirement {
+  credential_verified
+  read_probe_passed
+  audit_log_enabled
+  approval_binding
+}
+
+model IntegrationCoverageProvider {
+  id                String       @id @default(cuid())
+  organizationId    String
+  organization      Organization @relation("OrgToCoverageProviders", fields: [organizationId], references: [id])
+  providerKey       String
+  displayName       String
+  posture           String
+  replacementIntent String
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
+
+  @@unique([organizationId, providerKey])
+  @@index([organizationId])
+}
+
+model IntegrationRoleCoverage {
+  id             String                 @id @default(cuid())
+  organizationId String
+  organization   Organization           @relation("OrgToCoverageCells", fields: [organizationId], references: [id])
+  providerKey    String
+  role           String
+  surface        String
+  readPosture    String
+  writeGates     WriteGateRequirement[]
+  createdAt      DateTime               @default(now())
+
+  @@unique([organizationId, providerKey, role, surface])
+  @@index([organizationId])
 }

--- a/packages/db/scripts/seed-integration-coverage.test.ts
+++ b/packages/db/scripts/seed-integration-coverage.test.ts
@@ -1,0 +1,44 @@
+import { prisma, WriteGateRequirement } from "@dpf/db";
+import { afterAll, expect, test, vi } from "vitest";
+import { seedIntegrationCoverage } from "./seed-integration-coverage";
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test("WriteGateRequirement has 4 values", () => {
+  expect(Object.keys(WriteGateRequirement).length).toBe(4);
+});
+
+test("IntegrationCoverageProvider table exists", async () => {
+  await prisma.$executeRawUnsafe('SELECT 1 FROM "IntegrationCoverageProvider" LIMIT 1');
+});
+
+test("IntegrationRoleCoverage table exists", async () => {
+  await prisma.$executeRawUnsafe('SELECT 1 FROM "IntegrationRoleCoverage" LIMIT 1');
+});
+
+test("seedIntegrationCoverage upserts the expected providers", async () => {
+  const upsert = vi.fn().mockResolvedValue(undefined);
+  const mockPrisma = {
+    integrationCoverageProvider: {
+      upsert,
+    },
+  } as never;
+  const orgId = "org_test";
+
+  await seedIntegrationCoverage(mockPrisma, orgId);
+
+  expect(upsert).toHaveBeenCalledTimes(9);
+  expect(upsert.mock.calls.map(([args]) => args.create.providerKey)).toEqual([
+    "adp",
+    "quickbooks",
+    "stripe",
+    "microsoft365",
+    "hubspot",
+    "google-marketing",
+    "google-business-profile",
+    "facebook-lead-ads",
+    "mailchimp",
+  ]);
+});

--- a/packages/db/scripts/seed-integration-coverage.ts
+++ b/packages/db/scripts/seed-integration-coverage.ts
@@ -1,0 +1,119 @@
+import { WriteGateRequirement } from "@dpf/db";
+
+const providers = [
+  { providerKey: "adp", displayName: "ADP Workforce Now", posture: "native", replacementIntent: "augment" },
+  { providerKey: "quickbooks", displayName: "QuickBooks Online", posture: "native", replacementIntent: "augment" },
+  { providerKey: "stripe", displayName: "Stripe Billing & Payments", posture: "native", replacementIntent: "augment" },
+  { providerKey: "microsoft365", displayName: "Microsoft 365 Communications", posture: "native", replacementIntent: "augment" },
+  { providerKey: "hubspot", displayName: "HubSpot CRM & Marketing", posture: "native", replacementIntent: "augment" },
+  { providerKey: "google-marketing", displayName: "Google Marketing Intelligence", posture: "native", replacementIntent: "augment" },
+  { providerKey: "google-business-profile", displayName: "Google Business Profile", posture: "native", replacementIntent: "augment" },
+  { providerKey: "facebook-lead-ads", displayName: "Facebook Lead Ads", posture: "native", replacementIntent: "augment" },
+  { providerKey: "mailchimp", displayName: "Mailchimp Marketing", posture: "native", replacementIntent: "augment" },
+] as const;
+
+const roles = [
+  "owner_operator",
+  "bookkeeper_accountant",
+  "sales_bd",
+  "marketer",
+  "service_ops",
+  "customer_support",
+  "hr_payroll_admin",
+  "it_security_compliance",
+  "inventory_procurement_admin",
+] as const;
+
+type IntegrationCoverageSeedClient = {
+  integrationCoverageProvider: {
+    upsert(args: {
+      where: { organizationId_providerKey: { organizationId: string; providerKey: string } };
+      update: { displayName: string; posture: string; replacementIntent: string };
+      create: {
+        organizationId: string;
+        providerKey: string;
+        displayName: string;
+        posture: string;
+        replacementIntent: string;
+      };
+    }): Promise<unknown>;
+  };
+  integrationRoleCoverage?: {
+    upsert(args: {
+      where: {
+        organizationId_providerKey_role_surface: {
+          organizationId: string;
+          providerKey: string;
+          role: string;
+          surface: string;
+        };
+      };
+      update: { readPosture: string; writeGates: WriteGateRequirement[] };
+      create: {
+        organizationId: string;
+        providerKey: string;
+        role: string;
+        surface: string;
+        readPosture: string;
+        writeGates: WriteGateRequirement[];
+      };
+    }): Promise<unknown>;
+  };
+};
+
+export async function seedIntegrationCoverage(
+  prisma: IntegrationCoverageSeedClient,
+  organizationId: string,
+): Promise<void> {
+  for (const provider of providers) {
+    await prisma.integrationCoverageProvider.upsert({
+      where: {
+        organizationId_providerKey: {
+          organizationId,
+          providerKey: provider.providerKey,
+        },
+      },
+      update: {
+        displayName: provider.displayName,
+        posture: provider.posture,
+        replacementIntent: provider.replacementIntent,
+      },
+      create: {
+        organizationId,
+        providerKey: provider.providerKey,
+        displayName: provider.displayName,
+        posture: provider.posture,
+        replacementIntent: provider.replacementIntent,
+      },
+    });
+
+    if (!prisma.integrationRoleCoverage) {
+      continue;
+    }
+
+    for (const role of roles) {
+      await prisma.integrationRoleCoverage.upsert({
+        where: {
+          organizationId_providerKey_role_surface: {
+            organizationId,
+            providerKey: provider.providerKey,
+            role,
+            surface: "core",
+          },
+        },
+        update: {
+          readPosture: "available",
+          writeGates: [WriteGateRequirement.credential_verified, WriteGateRequirement.approval_binding],
+        },
+        create: {
+          organizationId,
+          providerKey: provider.providerKey,
+          role,
+          surface: "core",
+          readPosture: "available",
+          writeGates: [WriteGateRequirement.credential_verified, WriteGateRequirement.approval_binding],
+        },
+      });
+    }
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@ export { prisma } from "./client";
 // Prisma.DbNull) and a type (for input/output type aliases).
 export { Prisma } from "../generated/client/client";
 export type { PrismaClient } from "../generated/client/client";
+export { WriteGateRequirement } from "../generated/client/client";
 
 export { neo4jSession, closeNeo4j, runCypher } from "./neo4j";
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -34,6 +34,7 @@ import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
+import { seedIntegrationCoverage } from "../scripts/seed-integration-coverage.js";
 import * as crypto from "crypto";
 import bcrypt from "bcryptjs";
 
@@ -2336,7 +2337,8 @@ async function seedWorkQueues(): Promise<void> {
 
 async function main(): Promise<void> {
   console.log("Starting seed...");
-  await ensureBootstrapOrganization();
+  const bootstrapOrganizationId = await ensureBootstrapOrganization();
+  await seedIntegrationCoverage(prisma, bootstrapOrganizationId);
   await seedGeographicData(prisma);
   await seedTaxJurisdictions(prisma);
   await seedLicenseRequirements(prisma);


### PR DESCRIPTION
## Summary

- Adds `WriteGateRequirement` enum, `IntegrationCoverageProvider` and `IntegrationRoleCoverage` models to the Prisma schema (surgical edit on top of current `main` — no existing fields removed)
- Migration `20260519000000_add_integration_coverage_matrix` creates the two new tables + FK constraints
- `seedIntegrationCoverage` seeds 9 native providers × 9 employee work roles per install at first `db:seed`
- `GET /api/v1/integrations/coverage` returns the matrix for the single org; guarded by `authenticateRequest`
- Integrations page renders the DB-backed matrix table alongside the existing static taxonomy section

**Supersedes #775** — that PR had a schema regression (City model missing `nameNormalized` and 15 other fields from a stale sandbox base) and incorrectly committed the generated Prisma client. This PR applies the same feature as a surgical diff on `main`.

## Test plan

- [ ] `pnpm --filter @dpf/db db:seed` completes without errors (new tables created + seeded)
- [ ] `GET /api/v1/integrations/coverage` returns 401 unauthenticated, 200 with array when authenticated
- [ ] `/platform/tools/integrations` page renders "Integration Coverage Matrix" section
- [ ] All unit tests pass (`pnpm --filter web test`)
- [ ] Routing invariants audit passes (seed no longer crashes on `nameNormalized`)

---
License: Apache-2.0 | Signed-off-by: Mark Bodman <markdbodman@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)