### PR TITLE
fix(build-studio): guard against sandbox schema regressions at deploy time

### DIFF
--- a/.github/workflows/schema-regression-guard.yml
+++ b/.github/workflows/schema-regression-guard.yml
@@ -1,0 +1,52 @@
+name: Schema Regression Guard
+
+# Last-resort safety net: fail any PR that removes existing fields or model
+# declarations from packages/db/prisma/schema.prisma.
+#
+# The primary defence is deploy_feature's runtime check (which blocks the
+# coworker before the PR is even opened). This CI job catches edge cases:
+# hand-edited branches, manual cherry-picks, or any path that bypasses
+# deploy_feature.
+
+on:
+  pull_request:
+    paths:
+      - "packages/db/prisma/schema.prisma"
+
+jobs:
+  schema-regression-guard:
+    name: Schema regression guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect removed schema fields
+        run: |
+          git fetch origin main --depth=50
+
+          # Lines removed from schema.prisma that look like:
+          #   - Prisma field definitions (2-space indent + identifier)
+          #   - model / enum declarations
+          # "+" lines and diff headers are excluded.
+          REMOVED=$(
+            git diff origin/main...HEAD -- packages/db/prisma/schema.prisma \
+              | grep '^-' \
+              | grep -v '^---' \
+              | grep -E '^\-  [a-zA-Z@]|^\-(model|enum) '
+          )
+
+          if [ -n "$REMOVED" ]; then
+            echo "❌ Schema regression detected."
+            echo ""
+            echo "The following lines were removed from packages/db/prisma/schema.prisma:"
+            echo "$REMOVED"
+            echo ""
+            echo "Existing model fields and enum values must never be removed in a feature PR."
+            echo "If this diff came from a Build Studio sandbox, the sandbox image is likely"
+            echo "stale. Rebuild the sandbox from a fresh portal image and re-run the build."
+            exit 1
+          fi
+
+          echo "✅ No schema regressions detected."

--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -77,3 +77,15 @@ describe("wrapSandboxGitCommand", () => {
     expect(command).toContain("node_modules");
   });
 });
+
+// ─── Sandbox git-add exclusions (generated Prisma client) ────────────────────
+
+describe("buildSandboxGitAddCommand generated-client exclusion", () => {
+  it("excludes the generated Prisma client from sandbox staged changes", () => {
+    const command = buildSandboxGitAddCommand();
+    // The generated Prisma client lives at packages/db/generated/ — it must
+    // never appear in the diff baseline because a stale sandbox image will
+    // produce the wrong types and bloat the patch with conflicts.
+    expect(command).toContain("**/generated/client/**");
+  });
+});

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -31,6 +31,11 @@ const SANDBOX_GIT_STAGE_EXCLUDES = [
   ":!*.tsbuildinfo",
   ":!**/*.tsbuildinfo",
   ":!pnpm-lock*",
+  // Generated Prisma client: regenerated on every `prisma generate` and must
+  // never enter the diff baseline. A stale sandbox image produces wrong types
+  // that bloat the patch and cause schema regressions on main.
+  ":!**/generated/client/**",
+  ":!packages/db/generated/**",
 ] as const;
 const SANDBOX_GIT_CLEAN_EXCLUDES = [
   ":!node_modules",
@@ -125,8 +130,9 @@ async function normalizeSandboxBranchArtifacts(branchName: string): Promise<void
 type ClientIdentity = {
   clientId: string;
   gitAgentEmail: string;
-  gitAuthorName: string; // "dpf-agent-<shortId>" — matches identity-privacy.getPlatformIdentity()
-  clientBranch: string;  // "client/<clientId>"
+  gitAuthorName: string;    // "dpf-agent-<shortId>" — matches identity-privacy.getPlatformIdentity()
+  clientBranch: string;     // "client/<clientId>"
+  upstreamRemoteUrl: string | null; // Canonical repo URL for fetching origin/main
 };
 
 let _cachedIdentity: ClientIdentity | null = null;
@@ -140,7 +146,7 @@ export async function getClientIdentity(): Promise<ClientIdentity> {
 
   const config = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
-    select: { clientId: true, gitAgentEmail: true },
+    select: { clientId: true, gitAgentEmail: true, upstreamRemoteUrl: true },
   });
 
   if (!config?.clientId || !config?.gitAgentEmail) {
@@ -160,6 +166,7 @@ export async function getClientIdentity(): Promise<ClientIdentity> {
     gitAgentEmail: config.gitAgentEmail,
     gitAuthorName: `dpf-agent-${shortId}`,
     clientBranch: `client/${config.clientId}`,
+    upstreamRemoteUrl: config.upstreamRemoteUrl ?? null,
   };
 
   return _cachedIdentity;
@@ -179,7 +186,16 @@ export async function isSandboxAvailable(): Promise<boolean> {
 
 /**
  * Configures git identity and ensures a baseline commit exists.
- * Safe to call multiple times.
+ *
+ * When upstreamRemoteUrl is provided (set during portal OAuth setup), the
+ * sandbox fetches origin/main and resets to it before committing the
+ * baseline. This guarantees the sandbox always starts from current main,
+ * not from the potentially weeks-old portal container image.
+ *
+ * Without a remote URL (offline / unconfigured installs) the behaviour is
+ * unchanged: commit whatever the portal container copied in.
+ *
+ * Safe to call multiple times — skips if a baseline already exists.
  */
 async function ensureGitBaseline(identity: ClientIdentity): Promise<void> {
   // Configure identity first (idempotent)
@@ -194,6 +210,18 @@ async function ensureGitBaseline(identity: ClientIdentity): Promise<void> {
     `git -C ${WORKSPACE} rev-parse --is-inside-work-tree 2>/dev/null && echo yes || echo no`,
   ).catch(() => "no");
 
+  if (isRepo.trim() === "yes") {
+    // Repo already exists — ensure at least one commit, then return.
+    const commitCount = await execSandboxGit(
+      `git -C ${WORKSPACE} rev-list --count HEAD 2>/dev/null || echo 0`,
+    ).catch(() => "0");
+
+    if (commitCount.trim() !== "0") return; // Already has a baseline commit.
+  }
+
+  // --- Fresh baseline ---
+
+  // Step 1: git init if not already a repo
   if (isRepo.trim() !== "yes") {
     await execSandboxGit(
       [
@@ -201,31 +229,53 @@ async function ensureGitBaseline(identity: ClientIdentity): Promise<void> {
         `git init`,
         `git config user.name "${identity.gitAuthorName}"`,
         `git config user.email "${identity.gitAgentEmail}"`,
-        buildSandboxGitPruneTrackedArtifactsCommand(),
-        buildSandboxGitAddCommand(),
-        `git commit -m 'sandbox baseline' --allow-empty`,
-      ].join(" && "),
-    );
-    return;
-  }
-
-  // Ensure at least one commit exists
-  const commitCount = await execSandboxGit(
-    `git -C ${WORKSPACE} rev-list --count HEAD 2>/dev/null || echo 0`,
-  ).catch(() => "0");
-
-  if (commitCount.trim() === "0") {
-    await execSandboxGit(
-      [
-        `cd ${WORKSPACE}`,
-        `git config user.name "${identity.gitAuthorName}"`,
-        `git config user.email "${identity.gitAgentEmail}"`,
-        buildSandboxGitPruneTrackedArtifactsCommand(),
-        buildSandboxGitAddCommand(),
-        `git commit -m 'sandbox baseline' --allow-empty`,
       ].join(" && "),
     );
   }
+
+  // Step 2: If we have an upstream remote URL, fetch origin/main and reset to
+  // it so the baseline always matches current main — not the stale portal image.
+  // This is the key fix: the portal container image may be weeks behind
+  // origin/main; by resetting to origin/main, deploy_feature's diff is always
+  // a clean delta against what will actually land on the portal.
+  if (identity.upstreamRemoteUrl) {
+    const escapedUrl = JSON.stringify(identity.upstreamRemoteUrl);
+    try {
+      await execSandboxGit(
+        [
+          `cd ${WORKSPACE}`,
+          // Add remote if not already configured (idempotent)
+          `git remote get-url origin 2>/dev/null || git remote add origin ${escapedUrl}`,
+          // Shallow fetch is fast; we only need the tip of main for the baseline
+          `git fetch origin main --depth=1 2>&1`,
+          // Reset workspace to current main — source files win over portal image
+          `git reset --hard origin/main`,
+        ].join(" && "),
+      );
+      console.log(`[build-branch] Sandbox baseline reset to origin/main via ${identity.upstreamRemoteUrl}`);
+    } catch (fetchErr) {
+      // Non-fatal: if fetch fails (offline, token expired, etc.) fall through
+      // to the portal-copy baseline. The schema regression guard in
+      // deploy_feature will catch any stale-schema issues downstream.
+      console.warn(
+        `[build-branch] Could not fetch origin/main for baseline reset (falling back to portal copy): ${
+          (fetchErr as Error).message?.slice(0, 200)
+        }`,
+      );
+    }
+  }
+
+  // Step 3: Prune generated/cache artifacts and commit the baseline
+  await execSandboxGit(
+    [
+      `cd ${WORKSPACE}`,
+      `git config user.name "${identity.gitAuthorName}"`,
+      `git config user.email "${identity.gitAgentEmail}"`,
+      buildSandboxGitPruneTrackedArtifactsCommand(),
+      buildSandboxGitAddCommand(),
+      `git commit -m 'sandbox baseline' --allow-empty`,
+    ].join(" && "),
+  );
 }
 
 /**

--- a/apps/web/lib/integrate/sandbox/sandbox-promotion.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-promotion.test.ts
@@ -7,6 +7,7 @@ import {
   scanForDestructiveOps,
   categorizeDiffFiles,
   getRestoreInstructions,
+  detectSchemaRegressions,
 } from "./sandbox-promotion";
 
 // ─── DESTRUCTIVE_PATTERNS ─────────────────────────────────────────────────────
@@ -214,5 +215,84 @@ describe("getRestoreInstructions", () => {
     const result1 = getRestoreInstructions("/backups/backup-a.sql");
     const result2 = getRestoreInstructions("/backups/backup-b.sql");
     expect(result1).not.toBe(result2);
+  });
+});
+
+// ─── detectSchemaRegressions ──────────────────────────────────────────────────
+
+const SCHEMA_FILE = "packages/db/prisma/schema.prisma";
+
+function makeSchemaDiff(removedLines: string[], addedLines: string[] = []): string {
+  const removed = removedLines.map((l) => `-${l}`).join("\n");
+  const added = addedLines.map((l) => `+${l}`).join("\n");
+  return [
+    `diff --git a/${SCHEMA_FILE} b/${SCHEMA_FILE}`,
+    "index abc..def 100644",
+    `--- a/${SCHEMA_FILE}`,
+    `+++ b/${SCHEMA_FILE}`,
+    "@@ -1,5 +1,5 @@",
+    removed,
+    added,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+describe("detectSchemaRegressions", () => {
+  it("returns empty array when schema.prisma is not in the diff", () => {
+    const diff = `diff --git a/apps/web/lib/foo.ts b/apps/web/lib/foo.ts\n+// added line`;
+    expect(detectSchemaRegressions(diff)).toHaveLength(0);
+  });
+
+  it("returns empty array for a pure-addition diff (new model)", () => {
+    const diff = makeSchemaDiff([], [
+      "+model NewThing {",
+      "+  id String @id",
+      "+}",
+    ]);
+    expect(detectSchemaRegressions(diff)).toHaveLength(0);
+  });
+
+  it("detects removal of a model field", () => {
+    const diff = makeSchemaDiff(["  nameNormalized String @default(\"\")"]);
+    const result = detectSchemaRegressions(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain("nameNormalized");
+  });
+
+  it("detects removal of an index definition", () => {
+    const diff = makeSchemaDiff(["  @@index([regionId, nameNormalized])"]);
+    const result = detectSchemaRegressions(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain("@@index");
+  });
+
+  it("detects removal of a model declaration", () => {
+    const diff = makeSchemaDiff(["model City {"]);
+    const result = detectSchemaRegressions(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain("model City");
+  });
+
+  it("does not flag blank removed lines as regressions", () => {
+    const diff = makeSchemaDiff(["  ", ""]);
+    expect(detectSchemaRegressions(diff)).toHaveLength(0);
+  });
+
+  it("does not flag the diff --- header line as a regression", () => {
+    // The raw diff includes "--- a/packages/db/prisma/schema.prisma"
+    const diff = makeSchemaDiff(["  nameNormalized String"]);
+    const result = detectSchemaRegressions(diff);
+    // Only the actual field removal should appear, not the header
+    expect(result.every((l) => !l.startsWith("---"))).toBe(true);
+  });
+
+  it("returns multiple regressions when several fields are removed", () => {
+    const diff = makeSchemaDiff([
+      "  nameNormalized String @default(\"\")",
+      "  localityType   String @default(\"city\")",
+      "  source         String @default(\"seed\")",
+    ]);
+    expect(detectSchemaRegressions(diff)).toHaveLength(3);
   });
 });

--- a/apps/web/lib/integrate/sandbox/sandbox-promotion.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-promotion.ts
@@ -429,11 +429,59 @@ export async function backupProductionDb(
   return { id: record.id, filePath, sizeBytes };
 }
 
+/**
+ * Detects schema regressions in a diff patch by scanning for removed lines
+ * inside model/enum blocks of packages/db/prisma/schema.prisma.
+ *
+ * Returns an array of removed lines (empty = no regression). A regression
+ * means the sandbox was initialized from a stale portal image and the diff
+ * would overwrite main's schema with the older version, silently dropping
+ * fields that main added after the sandbox was created.
+ */
+export function detectSchemaRegressions(fullDiff: string): string[] {
+  const SCHEMA_FILE = "packages/db/prisma/schema.prisma";
+
+  // Find the schema.prisma section of the diff
+  const diffHeaderRegex = /^diff --git a\/(.+) b\/.+$/gm;
+  let schemaSection = "";
+  let match;
+  while ((match = diffHeaderRegex.exec(fullDiff)) !== null) {
+    if (match[1] === SCHEMA_FILE) {
+      // Capture everything from this diff header to the next one (or end)
+      const start = match.index;
+      const remaining = fullDiff.slice(start);
+      const nextHeader = remaining.search(/\ndiff --git /);
+      schemaSection = nextHeader === -1 ? remaining : remaining.slice(0, nextHeader);
+      break;
+    }
+  }
+
+  if (!schemaSection) return []; // schema.prisma not in this diff
+
+  // Extract removed lines (lines starting with "-") that look like Prisma
+  // field/enum/index definitions — 2-space-indented lines inside a model block.
+  // These are the lines that would be dropped from main if the patch landed.
+  const regressions: string[] = [];
+  for (const line of schemaSection.split("\n")) {
+    if (!line.startsWith("-")) continue;
+    if (line.startsWith("---")) continue; // diff header
+
+    const content = line.slice(1); // strip leading "-"
+    // Match field/enum value lines (2-space indent + identifier) and
+    // model/enum declaration lines, but not blank lines or pure comment lines.
+    if (/^  [a-zA-Z@]/.test(content) || /^(?:model|enum) /.test(content)) {
+      regressions.push(line);
+    }
+  }
+  return regressions;
+}
+
 export async function extractAndCategorizeDiff(containerId: string): Promise<{
   fullDiff: string;
   migrationFiles: string[];
   codeFiles: string[];
   hasMigrations: boolean;
+  schemaRegressions: string[];
 }> {
   const fullDiff = await extractDiff(containerId);
 
@@ -446,12 +494,14 @@ export async function extractAndCategorizeDiff(containerId: string): Promise<{
   }
 
   const { migrationFiles, codeFiles } = categorizeDiffFiles(filePaths);
+  const schemaRegressions = detectSchemaRegressions(fullDiff);
 
   return {
     fullDiff,
     migrationFiles,
     codeFiles,
     hasMigrations: migrationFiles.length > 0,
+    schemaRegressions,
   };
 }
 

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -26,6 +26,11 @@ const SANDBOX_STAGE_EXCLUDES = [
   ":!.pnpm-store/**",
   ":!**/*.tsbuildinfo",
   ":!pnpm-lock*",
+  // Never include the generated Prisma client — it is regenerated from schema.prisma
+  // on every `prisma generate` and would bloat the diff with hundreds of KB of
+  // generated type stubs that conflict with main if the sandbox base is stale.
+  ":!**/generated/client/**",
+  ":!packages/db/generated/**",
 ] as const;
 const SANDBOX_DIFF_EXCLUDES = [
   ":(exclude)**/node_modules/**",
@@ -35,6 +40,9 @@ const SANDBOX_DIFF_EXCLUDES = [
   ":(exclude).pnpm-store/**",
   ":(exclude)**/*.tsbuildinfo",
   ":(exclude)pnpm-lock*",
+  // Generated Prisma client — see SANDBOX_STAGE_EXCLUDES comment above.
+  ":(exclude)**/generated/client/**",
+  ":(exclude)packages/db/generated/**",
 ] as const;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7430,6 +7430,31 @@ export async function executeTool(
           },
         };
       }
+
+      // Guard: schema regression check.
+      // If the diff removes existing fields/models from schema.prisma, the sandbox
+      // was initialized from a stale portal image and this diff would silently
+      // regress main's schema. Block deploy and surface the removed lines so the
+      // operator knows what drifted.
+      if (extracted.schemaRegressions.length > 0) {
+        const regressionSample = extracted.schemaRegressions.slice(0, 10).join("\n");
+        const regressionMessage =
+          `Schema regression detected in sandbox diff — ${extracted.schemaRegressions.length} existing field(s) or model declaration(s) would be removed from packages/db/prisma/schema.prisma. ` +
+          `This almost always means the sandbox was initialized from a portal image that predates recent schema changes on main. ` +
+          `Rebuild the sandbox from a fresh image (Admin → Build Studio → Rebuild Sandbox) and re-run the build before deploying.\n\n` +
+          `Removed lines (first 10):\n${regressionSample}`;
+        logBuildActivity(buildId, "deploy_feature", regressionMessage);
+        return {
+          success: false,
+          error: "Schema regression detected.",
+          message: regressionMessage,
+          data: {
+            schemaRegressions: extracted.schemaRegressions,
+            regressionCount: extracted.schemaRegressions.length,
+          },
+        };
+      }
+
       await prisma.featureBuild.update({
         where: { buildId },
         data: { diffPatch: extracted.fullDiff, diffSummary: extracted.fullDiff.slice(0, 500) },


### PR DESCRIPTION
## Summary

Four-layer defence against stale sandbox schema regressions, plus the **root-cause fix**.

**Root cause**: sandboxes copy files from the portal container image at init time, then commit that snapshot as the \`sandbox baseline\`. \`deploy_feature\` diffs HEAD vs this baseline — so if the portal image is weeks old, the diff includes the full stale \`schema.prisma\`, silently overwriting fields that \`origin/main\` added after the image was built.

---

### Commit 1 — Three defensive layers

**Layer 1 — Exclude generated Prisma client from sandbox diff** (`sandbox.ts`, `build-branch.ts`)  
Adds `packages/db/generated/**` to both `SANDBOX_STAGE_EXCLUDES` / `SANDBOX_DIFF_EXCLUDES` and `SANDBOX_GIT_STAGE_EXCLUDES`. The generated client is regenerated on every `prisma generate` and must never be part of a feature diff.

**Layer 2 — Schema regression guard in `deploy_feature`** (`sandbox-promotion.ts`, `mcp-tools.ts`)  
`detectSchemaRegressions()` scans the extracted diff for removed model fields, enum values, and model declarations in `schema.prisma`. If any are found, `deploy_feature` blocks with a clear error and instructs the operator to rebuild the sandbox. Fully unit-tested in `sandbox-promotion.test.ts`.

**Layer 3 — CI schema regression guard** (`.github/workflows/schema-regression-guard.yml`)  
Fails any PR that removes field or model declaration lines from `schema.prisma`. Last-resort gate for hand-edited branches or any path bypassing `deploy_feature`.

---

### Commit 2 — Root cause fix

**`ensureGitBaseline()` resets to `origin/main`** (`build-branch.ts`)  
When `PlatformDevConfig.upstreamRemoteUrl` is set (configured during portal OAuth setup), the sandbox now runs `git fetch origin main --depth=1 && git reset --hard origin/main` before committing the baseline. Source code always starts from current main, not the potentially stale portal image. The portal container is still used for `node_modules`/pnpm-store (for install speed). Falls back to portal-copy behaviour if fetch fails (offline, expired token).

## Test plan

- [ ] Unit tests pass: `pnpm --filter web test` (detectSchemaRegressions + build-branch exclusions)
- [ ] `deploy_feature` returns schema regression error when diff removes a model field
- [ ] `schema-regression-guard.yml` CI job passes on additive-only schema PRs, fails on regressions
- [ ] New sandbox initialisation fetches `origin/main` when `upstreamRemoteUrl` is configured
- [ ] Sandbox initialisation falls back gracefully when fetch fails (offline mode)

---
License: Apache-2.0 | Signed-off-by: Mark Bodman <markdbodman@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)