### PR TITLE
feat: add generic epic MCP tools

### DIFF
--- a/apps/web/lib/backlog-enums.test.ts
+++ b/apps/web/lib/backlog-enums.test.ts
@@ -4,6 +4,7 @@ import {
   BACKLOG_SOURCE_VALUES,
   BACKLOG_EFFORT_SIZES,
   BACKLOG_STATUS_VALUES,
+  EPIC_STATUSES,
 } from "@/lib/explore/backlog";
 import { PLATFORM_TOOLS } from "@/lib/mcp-tools";
 
@@ -41,5 +42,13 @@ describe("backlog enum parity between backlog.ts and mcp-tools.ts", () => {
 
   it("query_backlog.status matches shared backlog statuses", () => {
     expect(toolInputEnum("query_backlog", "status")).toEqual([...BACKLOG_STATUS_VALUES]);
+  });
+
+  it("create_epic.status matches shared epic statuses", () => {
+    expect(toolInputEnum("create_epic", "status")).toEqual([...EPIC_STATUSES]);
+  });
+
+  it("update_epic.status matches shared epic statuses", () => {
+    expect(toolInputEnum("update_epic", "status")).toEqual([...EPIC_STATUSES]);
   });
 });

--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -13,6 +13,8 @@ const mockPrisma = {
   },
   epic: {
     create: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
     update: vi.fn(),
   },
   featureBuild: {
@@ -62,6 +64,111 @@ describe("backlog MCP tool execution", () => {
     mockPrisma.$transaction.mockImplementation(async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
       return callback(mockPrisma);
     });
+  });
+
+  it("create_epic creates a generic epic with semantic id and actor attribution", async () => {
+    mockPrisma.epic.findFirst.mockResolvedValue(null);
+    mockPrisma.epic.create.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-WWMD",
+      title: "WWMD Decision Perspective Kernel",
+      status: "open",
+      completedAt: null,
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "create_epic",
+      {
+        epicId: "EP-WWMD",
+        title: "WWMD Decision Perspective Kernel",
+        description: "Governed autonomy gate for ambiguous decisions.",
+        status: "open",
+        source: "feature-gap",
+      },
+      "user-1",
+      { agentId: "AGT-1" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.entityId).toBe("EP-WWMD");
+    expect(mockPrisma.epic.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          epicId: "EP-WWMD",
+          title: "WWMD Decision Perspective Kernel",
+          description: "Governed autonomy gate for ambiguous decisions.",
+          status: "open",
+          submittedById: "user-1",
+          agentId: "AGT-1",
+        }),
+      }),
+    );
+  });
+
+  it("create_epic rejects duplicate semantic ids", async () => {
+    mockPrisma.epic.findFirst.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-WWMD",
+      title: "Existing WWMD",
+      status: "open",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "create_epic",
+      {
+        epicId: "EP-WWMD",
+        title: "WWMD Decision Perspective Kernel",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("duplicate_epicId");
+    expect(mockPrisma.epic.create).not.toHaveBeenCalled();
+  });
+
+  it("update_epic updates editable fields and marks completion when moved to done", async () => {
+    mockPrisma.epic.findFirst.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-WWMD",
+      title: "WWMD Decision Perspective Kernel",
+      description: "Old description",
+      status: "open",
+      completedAt: null,
+    });
+    mockPrisma.epic.update.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-WWMD",
+      title: "WWMD Decision Perspective Kernel",
+      description: "Updated description",
+      status: "done",
+      completedAt: new Date("2026-05-19T12:00:00.000Z"),
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "update_epic",
+      {
+        epicId: "EP-WWMD",
+        description: "Updated description",
+        status: "done",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.epic.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "epic-row-1" },
+        data: expect.objectContaining({
+          description: "Updated description",
+          status: "done",
+          completedAt: expect.any(Date),
+        }),
+      }),
+    );
   });
 
   it("triage_backlog_item persists triage fields and opens a build candidate", async () => {

--- a/apps/web/lib/mcp-tools.test.ts
+++ b/apps/web/lib/mcp-tools.test.ts
@@ -76,6 +76,8 @@ describe("mcp tools", () => {
   it("includes build tools for platform users", async () => {
     const tools = await getAvailableTools(adminUser, { externalAccessEnabled: false });
     const toolNames = tools.map((t) => t.name);
+    expect(toolNames).toContain("create_epic");
+    expect(toolNames).toContain("update_epic");
     expect(toolNames).toContain("update_feature_brief");
     expect(toolNames).toContain("register_digital_product_from_build");
     expect(toolNames).toContain("create_build_epic");

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -4,7 +4,7 @@ import { DISCOVERY_TRIAGE_AGENT_ID, prisma } from "@dpf/db";
 import * as crypto from "crypto";
 import { lazyFs, lazyFsPromises, lazyPath, lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { mergeHappyPathStateIntoPlan, generateBuildId } from "@/lib/feature-build-types";
-import { BACKLOG_STATUS_VALUES } from "@/lib/explore/backlog";
+import { BACKLOG_SOURCE_VALUES, BACKLOG_STATUS_VALUES, EPIC_STATUSES } from "@/lib/explore/backlog";
 import {
   analyzePublicWebsiteBranding,
   fetchPublicWebsiteEvidence,
@@ -815,6 +815,43 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     sideEffect: false,
   },
   // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────────
+  {
+    name: "create_epic",
+    description: "Create a generic backlog epic through the governed MCP surface. Use this for roadmap/recovery/planning epics that are not tied to a live Build Studio build. Rejects duplicate semantic epic IDs; optional source/spec/plan/rationale context is captured by ToolExecution and indexed for discovery.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        epicId: { type: "string", description: "Optional semantic epic id (e.g. EP-WWMD). Auto-generated if omitted." },
+        title: { type: "string", description: "Epic title" },
+        description: { type: "string", description: "Epic description" },
+        status: { type: "string", enum: [...EPIC_STATUSES], description: "Initial epic status (defaults to open)" },
+        source: { type: "string", enum: [...BACKLOG_SOURCE_VALUES], description: "What kind of gap or signal produced this epic" },
+        specPath: { type: "string", description: "Optional related spec path for audit/index context" },
+        planPath: { type: "string", description: "Optional related implementation plan path for audit/index context" },
+        rationale: { type: "string", description: "Optional short rationale for creating the epic" },
+      },
+      required: ["title"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "update_epic",
+    description: "Update a generic backlog epic's editable fields through the governed MCP surface. Use this for title, description, and status changes; status=done stamps completedAt, and reopening clears it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        epicId: { type: "string", description: "Semantic epic id (EP-*) or internal epic row id" },
+        title: { type: "string", description: "New epic title" },
+        description: { type: "string", description: "New epic description" },
+        status: { type: "string", enum: [...EPIC_STATUSES], description: "New epic status" },
+        rationale: { type: "string", description: "Optional short rationale captured by ToolExecution" },
+      },
+      required: ["epicId"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
   {
     name: "list_epics",
     description: "List epics with item-count rollups. Read-only. Filterable by status and whether the epic has open items. Returned epicId is the semantic id (EP-*), not the internal cuid.",
@@ -4534,6 +4571,186 @@ export async function executeTool(
     }
 
     // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────
+    case "create_epic": {
+      const title = String(params["title"] ?? "").trim();
+      if (!title) {
+        return { success: false, error: "missing_title", message: "title is required" };
+      }
+
+      const requestedEpicId = typeof params["epicId"] === "string" && params["epicId"].trim()
+        ? params["epicId"].trim()
+        : null;
+      const epicId = requestedEpicId ?? `EP-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+      if (!epicId.startsWith("EP-")) {
+        return {
+          success: false,
+          error: "invalid_epicId",
+          message: "epicId must use the semantic EP-* format.",
+        };
+      }
+
+      const status = typeof params["status"] === "string" && params["status"].trim()
+        ? params["status"].trim()
+        : "open";
+      if (!(EPIC_STATUSES as readonly string[]).includes(status)) {
+        return {
+          success: false,
+          error: "invalid_status",
+          message: `status must be one of ${EPIC_STATUSES.join("|")}, got ${status}`,
+        };
+      }
+
+      const existing = await prisma.epic.findFirst({
+        where: { epicId },
+        select: { epicId: true, title: true, status: true },
+      });
+      if (existing) {
+        return {
+          success: false,
+          error: "duplicate_epicId",
+          message: `Epic ${epicId} already exists: ${existing.title}`,
+          data: { existingEpic: existing },
+        };
+      }
+
+      const description = typeof params["description"] === "string"
+        ? params["description"].trim()
+        : "";
+      const source = typeof params["source"] === "string" ? params["source"].trim() : null;
+      const specPath = typeof params["specPath"] === "string" ? params["specPath"].trim() : null;
+      const planPath = typeof params["planPath"] === "string" ? params["planPath"].trim() : null;
+      const rationale = typeof params["rationale"] === "string" ? params["rationale"].trim() : null;
+
+      const epic = await prisma.epic.create({
+        data: {
+          epicId,
+          title,
+          status,
+          submittedById: userId,
+          agentId: context?.agentId ?? null,
+          ...(description ? { description } : {}),
+          ...(status === "done" ? { completedAt: new Date() } : {}),
+        },
+      });
+
+      const indexContext = [
+        description,
+        source ? `source: ${source}` : "",
+        specPath ? `specPath: ${specPath}` : "",
+        planPath ? `planPath: ${planPath}` : "",
+        rationale ? `rationale: ${rationale}` : "",
+      ].filter(Boolean).join("\n");
+      import("@/lib/semantic-memory").then(({ storePlatformKnowledge }) =>
+        storePlatformKnowledge({
+          entityId: epic.epicId,
+          entityType: "epic",
+          title,
+          content: indexContext,
+        })
+      ).catch(() => {});
+
+      return {
+        success: true,
+        entityId: epic.epicId,
+        message: `Created epic ${epic.epicId}`,
+        data: {
+          epicId: epic.epicId,
+          title: epic.title,
+          status: epic.status,
+          source,
+          specPath,
+          planPath,
+        },
+      };
+    }
+
+    case "update_epic": {
+      const epicRaw = String(params["epicId"] ?? "").trim();
+      if (!epicRaw) {
+        return { success: false, error: "missing_epicId", message: "epicId is required" };
+      }
+
+      const existing = await prisma.epic.findFirst({
+        where: { OR: [{ epicId: epicRaw }, { id: epicRaw }] },
+        select: {
+          id: true,
+          epicId: true,
+          title: true,
+          description: true,
+          status: true,
+          completedAt: true,
+        },
+      });
+      if (!existing) {
+        return { success: false, error: "not_found", message: `Epic ${epicRaw} not found` };
+      }
+
+      const data: {
+        title?: string;
+        description?: string | null;
+        status?: string;
+        completedAt?: Date | null;
+      } = {};
+      if (typeof params["title"] === "string") {
+        const title = params["title"].trim();
+        if (!title) {
+          return { success: false, error: "missing_title", message: "title cannot be blank" };
+        }
+        data.title = title;
+      }
+      if (typeof params["description"] === "string") {
+        const description = params["description"].trim();
+        data.description = description || null;
+      }
+      if (typeof params["status"] === "string") {
+        const status = params["status"].trim();
+        if (!(EPIC_STATUSES as readonly string[]).includes(status)) {
+          return {
+            success: false,
+            error: "invalid_status",
+            message: `status must be one of ${EPIC_STATUSES.join("|")}, got ${status}`,
+          };
+        }
+        data.status = status;
+        if (status === "done" && existing.status !== "done") {
+          data.completedAt = new Date();
+        }
+        if (status !== "done" && existing.status === "done") {
+          data.completedAt = null;
+        }
+      }
+
+      if (Object.keys(data).length === 0) {
+        return {
+          success: true,
+          entityId: existing.epicId,
+          message: `${existing.epicId} unchanged (no editable fields provided)`,
+          data: {
+            epicId: existing.epicId,
+            title: existing.title,
+            status: existing.status,
+          },
+        };
+      }
+
+      const updated = await prisma.epic.update({
+        where: { id: existing.id },
+        data,
+      });
+
+      return {
+        success: true,
+        entityId: updated.epicId,
+        message: `Updated epic ${updated.epicId}`,
+        data: {
+          epicId: updated.epicId,
+          title: updated.title,
+          status: updated.status,
+          completedAt: updated.completedAt ? updated.completedAt.toISOString() : null,
+        },
+      };
+    }
+
     case "list_epics": {
       const where: Record<string, unknown> = {};
       if (typeof params["status"] === "string") where["status"] = params["status"];

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -253,6 +253,13 @@ describe("TOOL_TO_GRANTS — Tool marketplace entries", () => {
 });
 
 describe("TOOL_TO_GRANTS — Backlog hygiene entries", () => {
+  it("generic epic tools require backlog_write", () => {
+    expect(isToolAllowedByGrants("create_epic", ["backlog_write"])).toBe(true);
+    expect(isToolAllowedByGrants("update_epic", ["backlog_write"])).toBe(true);
+    expect(isToolAllowedByGrants("create_epic", ["backlog_read"])).toBe(false);
+    expect(isToolAllowedByGrants("update_epic", ["backlog_read"])).toBe(false);
+  });
+
   it("retire_backlog_item requires backlog_write without broader triage authority", () => {
     expect(isToolAllowedByGrants("retire_backlog_item", ["backlog_write"])).toBe(true);
     expect(isToolAllowedByGrants("retire_backlog_item", ["backlog_read"])).toBe(false);

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -16,6 +16,8 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   report_quality_issue: ["backlog_write"],
 
   // Governed MCP backlog surface (spec 2026-04-25)
+  create_epic: ["backlog_write"],
+  update_epic: ["backlog_write"],
   list_epics: ["backlog_read"],
   list_backlog_items: ["backlog_read"],
   get_backlog_item: ["backlog_read"],

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -135,6 +135,7 @@
         "create_backlog_item",
         "create_build_epic",
         "create_digital_product",
+        "create_epic",
         "link_backlog_item_to_epic",
         "propose_decomposition",
         "record_execution_evidence",
@@ -148,6 +149,7 @@
         "submit_feedback",
         "update_backlog_item",
         "update_backlog_item_status",
+        "update_epic",
         "update_feature_brief",
         "update_lifecycle"
       ],


### PR DESCRIPTION
## Summary
- add generic `create_epic` and `update_epic` tools to the governed MCP backlog surface
- wire both tools to `backlog_write` grants and the grant catalog
- add regression coverage for tool schemas, grant filtering, duplicate epic rejection, creation attribution, and done-status completion behavior

## Why
WWMD backlog recovery exposed a governed tooling gap: agents could create backlog items and specialized Build Studio epics, but could not create or update ordinary roadmap epics without direct DB fallback.

## Validation
- `pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts lib/mcp-tools.test.ts lib/backlog-enums.test.ts lib/tak/agent-grants.test.ts app/api/mcp/v1/route.test.ts` — 167 passed
- `pnpm --filter web typecheck` — passed
- `pnpm --filter web build` — passed; existing Turbopack broad-trace warnings remain
