### PR TITLE
feat: add MCP token refresh rotation

### DIFF
--- a/apps/web/app/api/mcp/token/refresh/route.test.ts
+++ b/apps/web/app/api/mcp/token/refresh/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/mcp-api-token", () => ({
+  acknowledgeMcpTokenRefresh: vi.fn(),
+}));
+
+import { acknowledgeMcpTokenRefresh } from "@/lib/auth/mcp-api-token";
+import { POST } from "./route";
+
+const acknowledgeMock = acknowledgeMcpTokenRefresh as unknown as ReturnType<typeof vi.fn>;
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/mcp/token/refresh", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("POST /api/mcp/token/refresh", () => {
+  it("acknowledges a valid replacement token", async () => {
+    acknowledgeMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_new",
+      prefix: "dpfmcp_NEWS",
+      tokenSuffix: "A1B2",
+      scope: "write",
+      capability: "write",
+      scopes: ["backlog_read", "backlog_write"],
+    });
+
+    const response = await POST(makeRequest({ token: "dpfmcp_NEWSECRET" }));
+
+    expect(response.status).toBe(200);
+    expect(acknowledgeMock).toHaveBeenCalledWith("dpfmcp_NEWSECRET");
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      tokenId: "tok_new",
+      prefix: "dpfmcp_NEWS",
+      tokenSuffix: "A1B2",
+      scope: "write",
+      capability: "write",
+      scopes: ["backlog_read", "backlog_write"],
+    });
+  });
+
+  it("rejects missing token values", async () => {
+    const response = await POST(makeRequest({ token: "" }));
+
+    expect(response.status).toBe(400);
+    expect(acknowledgeMock).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "missing_token",
+    });
+  });
+
+  it("rejects invalid replacement tokens", async () => {
+    acknowledgeMock.mockResolvedValue({ ok: false, error: "invalid_token" });
+
+    const response = await POST(makeRequest({ token: "dpfmcp_BAD" }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "invalid_token",
+    });
+  });
+});

--- a/apps/web/app/api/mcp/token/refresh/route.ts
+++ b/apps/web/app/api/mcp/token/refresh/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { acknowledgeMcpTokenRefresh } from "@/lib/auth/mcp-api-token";
+
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "invalid_json" },
+      { status: 400 },
+    );
+  }
+
+  const token =
+    typeof body === "object" && body != null && "token" in body
+      ? String((body as { token?: unknown }).token ?? "").trim()
+      : "";
+  if (!token) {
+    return NextResponse.json(
+      { ok: false, error: "missing_token" },
+      { status: 400 },
+    );
+  }
+
+  const result = await acknowledgeMcpTokenRefresh(token);
+  if (!result.ok) {
+    return NextResponse.json(result, { status: 401 });
+  }
+  return NextResponse.json(result);
+}
+

--- a/apps/web/components/admin/McpTokenManager.test.tsx
+++ b/apps/web/components/admin/McpTokenManager.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/actions/mcp-tokens", () => ({
+  copyMyMcpToken: vi.fn(),
+  issueMyMcpToken: vi.fn(),
+  issueMyWriteMcpToken: vi.fn(),
+  listAvailableMcpScopes: vi.fn(),
+  listMyMcpTokens: vi.fn(),
+  revokeMyMcpToken: vi.fn(),
+  rotateMyMcpToken: vi.fn(),
+  upgradeMyMcpTokenForCodingAgent: vi.fn(),
+}));
+
+import {
+  copyMyMcpToken,
+  listAvailableMcpScopes,
+  listMyMcpTokens,
+  rotateMyMcpToken,
+} from "@/lib/actions/mcp-tokens";
+import { McpTokenManager } from "./McpTokenManager";
+
+const copyMock = copyMyMcpToken as unknown as ReturnType<typeof vi.fn>;
+const scopesMock = listAvailableMcpScopes as unknown as ReturnType<typeof vi.fn>;
+const tokensMock = listMyMcpTokens as unknown as ReturnType<typeof vi.fn>;
+const rotateMock = rotateMyMcpToken as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  scopesMock.mockResolvedValue({
+    scopes: ["backlog_read", "backlog_write", "spec_plan_read"],
+  });
+  tokensMock.mockResolvedValue({
+    ok: true,
+    tokens: [
+      {
+        id: "tok_active",
+        name: "Mark laptop",
+        prefix: "dpfmcp_MAR",
+        tokenSuffix: "A1B2",
+        canCopy: true,
+        capability: "write",
+        scope: "write",
+        scopes: ["backlog_read", "backlog_write"],
+        lastUsedAt: "2026-05-18T12:00:00.000Z",
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: "2026-05-18T10:00:00.000Z",
+      },
+    ],
+  });
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+describe("McpTokenManager", () => {
+  it("shows active token suffix, scope, issued time, last-used time, and lifecycle actions", async () => {
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+
+    expect(await screen.findByText("Mark laptop")).toBeTruthy();
+    expect(screen.getByText("...A1B2")).toBeTruthy();
+    expect(screen.getByText(/backlog_read, backlog_write/)).toBeTruthy();
+    expect(screen.getByText(/Issued:/)).toBeTruthy();
+    expect(screen.getByText(/Last used:/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Copy current token/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Rotate token/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Revoke/i })).toBeTruthy();
+  });
+
+  it("copies a recoverable current token without reissuing it", async () => {
+    copyMock.mockResolvedValue({
+      ok: true,
+      plaintext: "dpfmcp_COPYABLE",
+      prefix: "dpfmcp_COPY",
+      tokenSuffix: "A1B2",
+      setupSnippets: {
+        claudeCode: '{"mcpServers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_COPYABLE"}}}}',
+        codex: '{"mcpServers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_COPYABLE"}}}}',
+        vscode: '{"servers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_COPYABLE"}}}}',
+        syncCommand: ".\\scripts\\seed-worktree-mcp.ps1",
+      },
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    fireEvent.click(await screen.findByRole("button", { name: /Copy current token/i }));
+
+    await waitFor(() => {
+      expect(copyMock).toHaveBeenCalledWith({
+        tokenId: "tok_active",
+        baseUrl: "http://localhost:3000",
+      });
+    });
+    expect(await screen.findByText(/Current token copied/i)).toBeTruthy();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dpfmcp_COPYABLE");
+  });
+
+  it("rotates an active token and presents the replacement token immediately", async () => {
+    rotateMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_new",
+      plaintext: "dpfmcp_ROTATED",
+      prefix: "dpfmcp_ROTA",
+      tokenSuffix: "C3D4",
+      expiresAt: null,
+      setupSnippets: {
+        claudeCode: '{"mcpServers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_ROTATED"}}}}',
+        codex: '{"mcpServers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_ROTATED"}}}}',
+        vscode: '{"servers":{"dpf":{"headers":{"Authorization":"Bearer dpfmcp_ROTATED"}}}}',
+        syncCommand: ".\\scripts\\seed-worktree-mcp.ps1",
+      },
+    });
+
+    render(<McpTokenManager baseUrl="http://localhost:3000" />);
+    fireEvent.click(await screen.findByRole("button", { name: /Rotate token/i }));
+
+    await waitFor(() => {
+      expect(rotateMock).toHaveBeenCalledWith({
+        tokenId: "tok_active",
+        baseUrl: "http://localhost:3000",
+      });
+    });
+    expect(await screen.findByText(/Replacement token issued/i)).toBeTruthy();
+    expect(screen.getByText("dpfmcp_ROTATED")).toBeTruthy();
+  });
+});

--- a/apps/web/components/admin/McpTokenManager.tsx
+++ b/apps/web/components/admin/McpTokenManager.tsx
@@ -1,13 +1,26 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  Copy,
+  KeyRound,
+  Plus,
+  RefreshCw,
+  ShieldCheck,
+  X,
+} from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useState, useTransition } from "react";
 
 import {
+  copyMyMcpToken,
   issueMyMcpToken,
   issueMyWriteMcpToken,
   listAvailableMcpScopes,
   listMyMcpTokens,
   revokeMyMcpToken,
+  rotateMyMcpToken,
   upgradeMyMcpTokenForCodingAgent,
 } from "@/lib/actions/mcp-tokens";
 import {
@@ -23,6 +36,8 @@ type TokenRow = {
   id: string;
   name: string;
   prefix: string;
+  tokenSuffix: string;
+  canCopy: boolean;
   capability: "read" | "write";
   scope: McpTokenScopeTier;
   scopes: string[];
@@ -33,9 +48,11 @@ type TokenRow = {
 };
 
 type Issued = {
+  mode: "issued" | "rotated";
   tokenId: string;
   plaintext: string;
   prefix: string;
+  tokenSuffix: string;
   expiresAt: string | null;
   setupSnippets: { claudeCode: string; codex: string; vscode: string; syncCommand: string };
 };
@@ -45,18 +62,50 @@ type View =
   | { kind: "form"; error: string | null }
   | { kind: "issued"; payload: Issued };
 
+type Notice = { kind: "success" | "error"; message: string } | null;
+
+function formatDate(value: string | null): string {
+  if (!value) return "never";
+  return new Date(value).toLocaleString();
+}
+
+function isExpired(token: TokenRow): boolean {
+  return token.expiresAt != null && new Date(token.expiresAt).getTime() < Date.now();
+}
+
+function tokenDisplay(token: TokenRow): string {
+  return `...${token.tokenSuffix ?? token.prefix.slice(-4)}`;
+}
+
+function buttonClass(kind: "primary" | "secondary" | "danger" = "secondary"): string {
+  if (kind === "primary") {
+    return "inline-flex items-center gap-1.5 rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50";
+  }
+  if (kind === "danger") {
+    return "inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-2.5 py-1.5 text-xs font-medium text-[var(--dpf-error)] hover:border-[var(--dpf-error)] disabled:opacity-50";
+  }
+  return "inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-2.5 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50";
+}
+
+function iconClass(): string {
+  return "h-3.5 w-3.5";
+}
+
 export function McpTokenManager(props: McpTokenManagerProps) {
   const [tokens, setTokens] = useState<TokenRow[]>([]);
   const [scopes, setScopes] = useState<string[]>([]);
   const [view, setView] = useState<View>({ kind: "idle" });
   const [inlineError, setInlineError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<Notice>(null);
+  const [pendingTokenId, setPendingTokenId] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
-  // Form state
   const [formName, setFormName] = useState("");
   const [formScope, setFormScope] = useState<McpTokenScopeTier>("read");
   const [formScopes, setFormScopes] = useState<Set<string>>(() => new Set());
   const [formExpires, setFormExpires] = useState<string>("90");
+
+  const defaultScopes = useMemo(() => defaultMcpTokenScopes(scopes), [scopes]);
 
   useEffect(() => {
     let cancelled = false;
@@ -96,14 +145,15 @@ export function McpTokenManager(props: McpTokenManagerProps) {
     setFormScope(scope);
     setFormScopes(new Set(defaultMcpTokenScopes(scopes, scope)));
     setFormExpires("90");
+    setNotice(null);
     setView({ kind: "form", error: null });
   }
 
-  function toggleScope(s: string) {
+  function toggleScope(scope: string) {
     setFormScopes((prev) => {
       const next = new Set(prev);
-      if (next.has(s)) next.delete(s);
-      else next.add(s);
+      if (next.has(scope)) next.delete(scope);
+      else next.add(scope);
       return next;
     });
   }
@@ -123,7 +173,37 @@ export function McpTokenManager(props: McpTokenManagerProps) {
         setView({ kind: "form", error: result.message });
         return;
       }
-      setView({ kind: "issued", payload: result });
+      setView({ kind: "issued", payload: { ...result, mode: "issued" } });
+      refresh();
+    });
+  }
+
+  function copyCurrentToken(token: TokenRow) {
+    setNotice(null);
+    setPendingTokenId(token.id);
+    startTransition(async () => {
+      const result = await copyMyMcpToken({ tokenId: token.id, baseUrl: props.baseUrl });
+      setPendingTokenId(null);
+      if (!result.ok) {
+        setNotice({ kind: "error", message: result.message });
+        return;
+      }
+      await navigator.clipboard.writeText(result.plaintext);
+      setNotice({ kind: "success", message: "Current token copied to clipboard." });
+    });
+  }
+
+  function rotateToken(token: TokenRow) {
+    setNotice(null);
+    setPendingTokenId(token.id);
+    startTransition(async () => {
+      const result = await rotateMyMcpToken({ tokenId: token.id, baseUrl: props.baseUrl });
+      setPendingTokenId(null);
+      if (!result.ok) {
+        setNotice({ kind: "error", message: result.message });
+        return;
+      }
+      setView({ kind: "issued", payload: { ...result, mode: "rotated" } });
       refresh();
     });
   }
@@ -138,296 +218,490 @@ export function McpTokenManager(props: McpTokenManagerProps) {
         setInlineError(result.message);
         return;
       }
-      setView({ kind: "issued", payload: result });
+      setView({ kind: "issued", payload: { ...result, mode: "issued" } });
       refresh();
     });
   }
 
   function revoke(tokenId: string) {
-    if (!confirm("Revoke this token? Any client using it will be disconnected on next call.")) {
+    if (!confirm("Revoke this token? Clients using it will fail on their next MCP call.")) {
       return;
     }
+    setNotice(null);
+    setPendingTokenId(tokenId);
     startTransition(async () => {
-      await revokeMyMcpToken({ tokenId, reason: "revoked from admin UI" });
+      const result = await revokeMyMcpToken({ tokenId, reason: "revoked from admin UI" });
+      setPendingTokenId(null);
+      if (!result.ok) {
+        setNotice({ kind: "error", message: result.error ?? "Could not revoke token." });
+        return;
+      }
+      setNotice({ kind: "success", message: "Token revoked." });
       refresh();
     });
   }
 
   function upgradeForCodeIntelligence(tokenId: string) {
+    setNotice(null);
+    setPendingTokenId(tokenId);
     startTransition(async () => {
-      await upgradeMyMcpTokenForCodingAgent({ tokenId });
+      const result = await upgradeMyMcpTokenForCodingAgent({ tokenId });
+      setPendingTokenId(null);
+      if (!result.ok) {
+        setNotice({ kind: "error", message: result.message });
+        return;
+      }
+      setNotice({ kind: "success", message: "Coding-agent scopes enabled." });
       refresh();
     });
   }
 
   return (
-    <section className="mt-6 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold text-[var(--dpf-text)]">External Coding Agent Access</h2>
-          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
-            Personal access tokens for the MCP endpoint at <code>/api/mcp/v1</code>.
-            Use these to point Claude Code, Codex CLI, or VS Code MCP at this DPF install.
+    <section className="mt-6 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+      <div className="flex flex-col gap-3 border-b border-[var(--dpf-border)] p-5 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-[var(--dpf-text)]">MCP access tokens</h2>
+          </div>
+          <p className="mt-1 max-w-2xl text-sm leading-5 text-[var(--dpf-muted)]">
+            External coding-agent access for <code>/api/mcp/v1</code>.
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
           <button
             type="button"
             onClick={issueWriteToken}
             disabled={pending}
-            className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+            className={buttonClass("primary")}
           >
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
             Issue write token
           </button>
           <button
             type="button"
             onClick={() => openForm("read")}
             disabled={pending}
-            className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+            className={buttonClass()}
           >
+            <Plus className={iconClass()} aria-hidden="true" />
             Generate token
           </button>
         </div>
       </div>
 
-      {inlineError && (
-        <div className="mt-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs text-[var(--dpf-accent)]">
-          {inlineError}
-        </div>
-      )}
+      <div className="p-5">
+        {inlineError && (
+          <div className="mb-4 flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-error)]">
+            <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+            <span>{inlineError}</span>
+          </div>
+        )}
 
-      {tokens.length === 0 ? (
-        <p className="mt-4 text-sm text-[var(--dpf-muted)]">No tokens yet.</p>
-      ) : (
-        <ul className="mt-4 space-y-2">
-          {tokens.map((t) => {
-            const revoked = t.revokedAt != null;
-            const expired = t.expiresAt != null && new Date(t.expiresAt).getTime() < Date.now();
-            const missingCodingScopes = defaultMcpTokenScopes(scopes).filter((scope) => !t.scopes.includes(scope));
-            return (
-              <li
-                key={t.id}
-                className="flex items-center justify-between gap-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-[var(--dpf-text)]">{t.name}</span>
-                    <code className="rounded bg-[var(--dpf-surface-1)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
-                      {t.prefix}…
-                    </code>
-                    <span
-                      className={`rounded px-1.5 py-0.5 text-xs ${
-                        t.scope !== "read"
-                          ? "bg-[var(--dpf-accent)] text-white"
-                          : "border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
-                      }`}
-                    >
-                      {t.scope}
-                    </span>
-                    {revoked && (
-                      <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
-                        revoked
-                      </span>
-                    )}
-                    {expired && !revoked && (
-                      <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
-                        expired
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-1 text-xs text-[var(--dpf-muted)]">
-                    Scopes: {t.scopes.join(", ") || "none"} · Last used:{" "}
-                    {t.lastUsedAt ? new Date(t.lastUsedAt).toLocaleString() : "never"} ·
-                    Expires: {t.expiresAt ? new Date(t.expiresAt).toLocaleString() : "never"}
-                  </div>
-                </div>
-                {!revoked && (
-                  <div className="flex shrink-0 items-center gap-2">
-                    {!expired && missingCodingScopes.length > 0 && (
-                      <button
-                        type="button"
-                        onClick={() => upgradeForCodeIntelligence(t.id)}
-                        disabled={pending}
-                        className="rounded border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
-                      >
-                        Enable code intelligence
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => revoke(t.id)}
-                      disabled={pending}
-                      className="rounded border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
-                    >
-                      Revoke
-                    </button>
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+        {notice && (
+          <div
+            className={`mb-4 flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm ${
+              notice.kind === "success" ? "text-[var(--dpf-success)]" : "text-[var(--dpf-error)]"
+            }`}
+          >
+            {notice.kind === "success" ? (
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+            )}
+            <span>{notice.message}</span>
+          </div>
+        )}
+
+        {tokens.length === 0 ? (
+          <div className="rounded-md border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-5 text-sm text-[var(--dpf-muted)]">
+            No MCP tokens have been issued yet.
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {tokens.map((token) => (
+              <TokenListItem
+                key={token.id}
+                token={token}
+                pending={pending || pendingTokenId === token.id}
+                defaultScopes={defaultScopes}
+                onCopy={copyCurrentToken}
+                onRotate={rotateToken}
+                onRevoke={revoke}
+                onUpgrade={upgradeForCodeIntelligence}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
 
       {view.kind === "form" && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          style={{ backgroundColor: "color-mix(in srgb, var(--dpf-text) 55%, transparent)" }}
-          onClick={() => setView({ kind: "idle" })}
-        >
-          <div
-            className="w-full max-w-md rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Generate MCP token</h3>
-
-            <div className="mt-4 space-y-3">
-              <label className="block text-sm">
-                <span className="text-[var(--dpf-text)]">Name</span>
-                <input
-                  type="text"
-                  value={formName}
-                  onChange={(e) => setFormName(e.target.value)}
-                  placeholder="Mark's laptop (Claude Code)"
-                  className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
-                />
-              </label>
-
-              <fieldset className="text-sm">
-                <legend className="text-[var(--dpf-text)]">Token scope</legend>
-                <div className="mt-1 grid grid-cols-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-1">
-                  {(["read", "write", "admin"] as const).map((scope) => (
-                    <label
-                      key={scope}
-                      className={`flex cursor-pointer items-center justify-center rounded px-2 py-1.5 text-xs font-medium ${
-                        formScope === scope
-                          ? "bg-[var(--dpf-accent)] text-white"
-                          : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="scope"
-                        value={scope}
-                        checked={formScope === scope}
-                        onChange={() => applyScopeDefaults(scope)}
-                        className="sr-only"
-                      />
-                      {scope}
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
-
-              <fieldset className="text-sm">
-                <legend className="text-[var(--dpf-text)]">Scopes</legend>
-                <div className="mt-1 grid max-h-40 grid-cols-2 gap-1 overflow-y-auto rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
-                  {scopes.map((s) => (
-                    <label key={s} className="inline-flex items-center gap-1.5 text-xs text-[var(--dpf-text)]">
-                      <input
-                        type="checkbox"
-                        checked={formScopes.has(s)}
-                        onChange={() => toggleScope(s)}
-                      />
-                      {s}
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
-
-              <label className="block text-sm">
-                <span className="text-[var(--dpf-text)]">Expires</span>
-                <select
-                  value={formExpires}
-                  onChange={(e) => setFormExpires(e.target.value)}
-                  className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
-                >
-                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="30">In 30 days</option>
-                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="60">In 60 days</option>
-                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="90">In 90 days</option>
-                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="180">In 180 days</option>
-                  <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="never">Never</option>
-                </select>
-              </label>
-
-              {view.error && (
-                <p className="text-sm text-[var(--dpf-accent)]">{view.error}</p>
-              )}
-            </div>
-
-            <div className="mt-5 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => setView({ kind: "idle" })}
-                className="rounded border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={submit}
-                disabled={pending || !formName.trim() || formScopes.size === 0}
-                className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-              >
-                {pending ? "Generating…" : "Generate"}
-              </button>
-            </div>
-          </div>
-        </div>
+        <TokenFormDialog
+          error={view.error}
+          formExpires={formExpires}
+          formName={formName}
+          formScope={formScope}
+          formScopes={formScopes}
+          pending={pending}
+          scopes={scopes}
+          onCancel={() => setView({ kind: "idle" })}
+          onExpiresChange={setFormExpires}
+          onNameChange={setFormName}
+          onScopeChange={applyScopeDefaults}
+          onSubmit={submit}
+          onToggleScope={toggleScope}
+        />
       )}
 
       {view.kind === "issued" && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          style={{ backgroundColor: "color-mix(in srgb, var(--dpf-text) 55%, transparent)" }}
-        >
-          <div className="w-full max-w-2xl rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
-            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Token issued — copy now</h3>
-            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-              The full secret is shown <strong>once</strong>. After you close this dialog, only the prefix is recoverable.
-            </p>
-
-            <div className="mt-3 break-all rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 font-mono text-xs text-[var(--dpf-text)]">
-              {view.payload.plaintext}
-            </div>
-
-            <div className="mt-5">
-              <p className="mb-1 text-xs font-medium text-[var(--dpf-text)]">
-                Run this command to configure Claude Code automatically:
-              </p>
-              <div className="flex items-start gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-                <code className="flex-1 break-all text-xs text-[var(--dpf-text)]">
-                  {view.payload.setupSnippets.syncCommand}
-                </code>
-                <button
-                  type="button"
-                  onClick={() => navigator.clipboard.writeText(view.payload.setupSnippets.syncCommand)}
-                  className="shrink-0 rounded border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-                >
-                  Copy
-                </button>
-              </div>
-              <p className="mt-2 text-xs text-[var(--dpf-muted)]">
-                Restart Claude Code after running the command for it to pick up the new token.
-              </p>
-            </div>
-
-            <div className="mt-5 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => setView({ kind: "idle" })}
-                className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white"
-              >
-                Done
-              </button>
-            </div>
-          </div>
-        </div>
+        <IssuedTokenDialog
+          baseUrl={props.baseUrl}
+          payload={view.payload}
+          onClose={() => setView({ kind: "idle" })}
+        />
       )}
     </section>
+  );
+}
+
+function TokenListItem(props: {
+  token: TokenRow;
+  pending: boolean;
+  defaultScopes: string[];
+  onCopy: (token: TokenRow) => void;
+  onRotate: (token: TokenRow) => void;
+  onRevoke: (tokenId: string) => void;
+  onUpgrade: (tokenId: string) => void;
+}) {
+  const { token } = props;
+  const revoked = token.revokedAt != null;
+  const expired = isExpired(token);
+  const disabled = props.pending || revoked || expired;
+  const missingCodingScopes = props.defaultScopes.filter((scope) => !token.scopes.includes(scope));
+
+  return (
+    <li className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-[var(--dpf-text)]">{token.name}</span>
+            <code className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 text-xs text-[var(--dpf-text)]">
+              {tokenDisplay(token)}
+            </code>
+            <span
+              className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ${
+                token.scope !== "read"
+                  ? "bg-[var(--dpf-accent)] text-white"
+                  : "border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+              }`}
+            >
+              <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+              {token.scope}
+            </span>
+            {revoked && <StatusPill label="revoked" tone="error" />}
+            {expired && !revoked && <StatusPill label="expired" tone="warning" />}
+          </div>
+
+          <dl className="mt-2 grid gap-1 text-xs text-[var(--dpf-muted)] md:grid-cols-2">
+            <div className="md:col-span-2">
+              <dt className="inline font-medium text-[var(--dpf-text)]">Scope: </dt>
+              <dd className="inline">{token.scopes.join(", ") || "none"}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium text-[var(--dpf-text)]">Issued: </dt>
+              <dd className="inline">{formatDate(token.createdAt)}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium text-[var(--dpf-text)]">Last used: </dt>
+              <dd className="inline">{formatDate(token.lastUsedAt)}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium text-[var(--dpf-text)]">Expires: </dt>
+              <dd className="inline">{formatDate(token.expiresAt)}</dd>
+            </div>
+          </dl>
+        </div>
+
+        {!revoked && (
+          <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+            {!expired && missingCodingScopes.length > 0 && (
+              <button
+                type="button"
+                onClick={() => props.onUpgrade(token.id)}
+                disabled={props.pending}
+                className={buttonClass()}
+              >
+                <ShieldCheck className={iconClass()} aria-hidden="true" />
+                Enable code intelligence
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => props.onCopy(token)}
+              disabled={disabled || !token.canCopy}
+              title={token.canCopy ? "Copy current token" : "Legacy tokens must be rotated before they can be copied"}
+              className={buttonClass()}
+            >
+              <Copy className={iconClass()} aria-hidden="true" />
+              Copy current token
+            </button>
+            <button
+              type="button"
+              onClick={() => props.onRotate(token)}
+              disabled={disabled}
+              className={buttonClass()}
+            >
+              <RefreshCw className={iconClass()} aria-hidden="true" />
+              Rotate token
+            </button>
+            <button
+              type="button"
+              onClick={() => props.onRevoke(token.id)}
+              disabled={props.pending}
+              className={buttonClass("danger")}
+            >
+              <Ban className={iconClass()} aria-hidden="true" />
+              Revoke
+            </button>
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function StatusPill(props: { label: string; tone: "warning" | "error" }) {
+  return (
+    <span
+      className={`rounded-md border border-[var(--dpf-border)] px-2 py-0.5 text-xs font-medium ${
+        props.tone === "warning" ? "text-[var(--dpf-warning)]" : "text-[var(--dpf-error)]"
+      }`}
+    >
+      {props.label}
+    </span>
+  );
+}
+
+function DialogFrame(props: { children: ReactNode; onClose?: () => void }) {
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+      style={{ background: "color-mix(in srgb, var(--dpf-bg) 74%, transparent)" }}
+      onClick={props.onClose}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+function TokenFormDialog(props: {
+  error: string | null;
+  formExpires: string;
+  formName: string;
+  formScope: McpTokenScopeTier;
+  formScopes: Set<string>;
+  pending: boolean;
+  scopes: string[];
+  onCancel: () => void;
+  onExpiresChange: (value: string) => void;
+  onNameChange: (value: string) => void;
+  onScopeChange: (value: McpTokenScopeTier) => void;
+  onSubmit: () => void;
+  onToggleScope: (scope: string) => void;
+}) {
+  return (
+    <DialogFrame onClose={props.onCancel}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-lg rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-base font-semibold text-[var(--dpf-text)]">Generate MCP token</h3>
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">Choose authority, scopes, and expiry for this client.</p>
+          </div>
+          <button type="button" onClick={props.onCancel} className={buttonClass()}>
+            <X className={iconClass()} aria-hidden="true" />
+            Close
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="font-medium text-[var(--dpf-text)]">Name</span>
+            <input
+              type="text"
+              value={props.formName}
+              onChange={(event) => props.onNameChange(event.target.value)}
+              placeholder="Mark laptop"
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)]"
+            />
+          </label>
+
+          <fieldset className="text-sm">
+            <legend className="font-medium text-[var(--dpf-text)]">Scope tier</legend>
+            <div className="mt-2 grid gap-2 sm:grid-cols-3">
+              {(["read", "write", "admin"] as const).map((scope) => (
+                <ScopeTierOption
+                  key={scope}
+                  checked={props.formScope === scope}
+                  label={scope}
+                  value={scope}
+                  onChange={() => props.onScopeChange(scope)}
+                />
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset className="text-sm">
+            <legend className="font-medium text-[var(--dpf-text)]">Scopes</legend>
+            <div className="mt-2 grid max-h-44 grid-cols-1 gap-1 overflow-y-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 sm:grid-cols-2">
+              {props.scopes.map((scope) => (
+                <label key={scope} className="inline-flex items-center gap-2 text-xs text-[var(--dpf-text)]">
+                  <input
+                    type="checkbox"
+                    checked={props.formScopes.has(scope)}
+                    onChange={() => props.onToggleScope(scope)}
+                  />
+                  <span className="break-all">{scope}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="block text-sm">
+            <span className="font-medium text-[var(--dpf-text)]">Expires</span>
+            <select
+              value={props.formExpires}
+              onChange={(event) => props.onExpiresChange(event.target.value)}
+              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
+            >
+              <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="30">In 30 days</option>
+              <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="60">In 60 days</option>
+              <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="90">In 90 days</option>
+              <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="180">In 180 days</option>
+              <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="never">Never</option>
+            </select>
+          </label>
+
+          {props.error && (
+            <p className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-error)]">
+              {props.error}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" onClick={props.onCancel} className={buttonClass()}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={props.onSubmit}
+            disabled={props.pending || !props.formName.trim() || props.formScopes.size === 0}
+            className={buttonClass("primary")}
+          >
+            <KeyRound className="h-4 w-4" aria-hidden="true" />
+            {props.pending ? "Generating..." : "Generate"}
+          </button>
+        </div>
+      </div>
+    </DialogFrame>
+  );
+}
+
+function ScopeTierOption(props: {
+  checked: boolean;
+  label: string;
+  value: McpTokenScopeTier;
+  onChange: () => void;
+}) {
+  return (
+    <label
+      className="flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[var(--dpf-text)]"
+    >
+      <input
+        type="radio"
+        name="scope-tier"
+        value={props.value}
+        checked={props.checked}
+        onChange={props.onChange}
+      />
+      <span className="text-sm">{props.label}</span>
+    </label>
+  );
+}
+
+function IssuedTokenDialog(props: {
+  baseUrl: string;
+  payload: Issued;
+  onClose: () => void;
+}) {
+  const title = props.payload.mode === "rotated" ? "Replacement token issued" : "Token issued";
+  const refreshPayload = JSON.stringify({ token: props.payload.plaintext });
+  const refreshSnippet = `POST ${props.baseUrl}/api/mcp/token/refresh ${refreshPayload}`;
+  const headerSnippet = `Authorization: Bearer ${props.payload.plaintext}`;
+
+  return (
+    <DialogFrame>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-2xl rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-base font-semibold text-[var(--dpf-text)]">{title}</h3>
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              Copy the token or refresh payload before closing.
+            </p>
+          </div>
+          <button type="button" onClick={props.onClose} className={buttonClass()}>
+            <X className={iconClass()} aria-hidden="true" />
+            Close
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <SnippetBlock
+            label="Token"
+            value={props.payload.plaintext}
+          />
+          <SnippetBlock label="Header" value={headerSnippet} />
+          <SnippetBlock label="Refresh endpoint" value={refreshSnippet} />
+          <SnippetBlock label="Claude / Codex config" value={props.payload.setupSnippets.claudeCode} />
+        </div>
+
+        <div className="mt-5 flex justify-end">
+          <button type="button" onClick={props.onClose} className={buttonClass("primary")}>
+            Done
+          </button>
+        </div>
+      </div>
+    </DialogFrame>
+  );
+}
+
+function SnippetBlock(props: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <p className="text-xs font-medium text-[var(--dpf-text)]">{props.label}</p>
+        <button
+          type="button"
+          onClick={() => navigator.clipboard.writeText(props.value)}
+          className={buttonClass()}
+        >
+          <Copy className={iconClass()} aria-hidden="true" />
+          Copy
+        </button>
+      </div>
+      <div className="max-h-32 overflow-auto rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 font-mono text-xs text-[var(--dpf-text)]">
+        <code className="break-all whitespace-pre-wrap">{props.value}</code>
+      </div>
+    </div>
   );
 }

--- a/apps/web/lib/actions/mcp-tokens.test.ts
+++ b/apps/web/lib/actions/mcp-tokens.test.ts
@@ -6,9 +6,11 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/auth/mcp-api-token", () => ({
   addScopesToMcpApiToken: vi.fn(),
+  copyMcpApiTokenPlaintext: vi.fn(),
   issueMcpApiToken: vi.fn(),
   revokeMcpApiToken: vi.fn(),
   listMcpApiTokens: vi.fn(),
+  rotateMcpApiToken: vi.fn(),
 }));
 
 vi.mock("@/lib/tak/agent-grants", () => ({
@@ -18,25 +20,31 @@ vi.mock("@/lib/tak/agent-grants", () => ({
 import { auth } from "@/lib/auth";
 import {
   addScopesToMcpApiToken,
+  copyMcpApiTokenPlaintext,
   issueMcpApiToken,
   listMcpApiTokens,
   revokeMcpApiToken,
+  rotateMcpApiToken,
 } from "@/lib/auth/mcp-api-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 import {
+  copyMyMcpToken,
   issueMyMcpToken,
   issueMyWriteMcpToken,
   listAvailableMcpScopes,
   listMyMcpTokens,
   revokeMyMcpToken,
+  rotateMyMcpToken,
   upgradeMyMcpTokenForCodingAgent,
 } from "./mcp-tokens";
 
 const addScopesMock = addScopesToMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const authMock = auth as unknown as ReturnType<typeof vi.fn>;
+const copyMock = copyMcpApiTokenPlaintext as unknown as ReturnType<typeof vi.fn>;
 const issueMock = issueMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const revokeMock = revokeMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const listMock = listMcpApiTokens as unknown as ReturnType<typeof vi.fn>;
+const rotateMock = rotateMcpApiToken as unknown as ReturnType<typeof vi.fn>;
 const grantMapMock = getToolGrantMapping as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -88,6 +96,8 @@ describe("listMyMcpTokens", () => {
         id: "tok_1",
         name: "Mark's laptop",
         prefix: "dpfmcp_ABC1",
+        tokenSuffix: "9K2M",
+        canCopy: true,
         capability: "read",
         scope: "read",
         scopes: ["backlog_read"],
@@ -102,6 +112,8 @@ describe("listMyMcpTokens", () => {
     expect(result.tokens).toHaveLength(1);
     expect(result.tokens[0]?.lastUsedAt).toBe(now.toISOString());
     expect(result.tokens[0]?.expiresAt).toBeNull();
+    expect(result.tokens[0]?.tokenSuffix).toBe("9K2M");
+    expect(result.tokens[0]?.canCopy).toBe(true);
     expect(listMock).toHaveBeenCalledWith("u1");
   });
 });
@@ -114,6 +126,7 @@ describe("issueMyWriteMcpToken", () => {
       tokenId: "tok_write",
       plaintext: "dpfmcp_WRITE",
       prefix: "dpfmcp_WRIT",
+      tokenSuffix: "W1TE",
       expiresAt: new Date("2026-07-25T00:00:00Z"),
     });
 
@@ -176,6 +189,7 @@ describe("issueMyMcpToken", () => {
       tokenId: "tok_x",
       plaintext: "dpfmcp_SECRET",
       prefix: "dpfmcp_SECR",
+      tokenSuffix: "CRET",
       expiresAt: new Date("2026-07-25T00:00:00Z"),
     });
     const result = await issueMyMcpToken({
@@ -225,6 +239,99 @@ describe("revokeMyMcpToken", () => {
     const result = await revokeMyMcpToken({ tokenId: "tok_x", reason: "leaked" });
     expect(result.ok).toBe(true);
     expect(revokeMock).toHaveBeenCalledWith("tok_x", "leaked");
+  });
+});
+
+describe("copyMyMcpToken", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+
+    const result = await copyMyMcpToken({
+      tokenId: "tok_x",
+      baseUrl: "http://localhost:3000",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("unauthorized");
+    expect(copyMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects copy for tokens not owned by the caller", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([{ id: "tok_owned", name: "x" }]);
+
+    const result = await copyMyMcpToken({
+      tokenId: "tok_other",
+      baseUrl: "http://localhost:3000",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("not_found_or_not_yours");
+    expect(copyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns plaintext and setup snippets for an owned recoverable token", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    listMock.mockResolvedValue([{ id: "tok_x", name: "x", revokedAt: null, expiresAt: null }]);
+    copyMock.mockResolvedValue({
+      ok: true,
+      plaintext: "dpfmcp_SECRET",
+      prefix: "dpfmcp_SECR",
+      tokenSuffix: "A1B2",
+    });
+
+    const result = await copyMyMcpToken({
+      tokenId: "tok_x",
+      baseUrl: "http://localhost:3000",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.plaintext).toBe("dpfmcp_SECRET");
+    expect(result.setupSnippets.claudeCode).toContain("Bearer dpfmcp_SECRET");
+  });
+});
+
+describe("rotateMyMcpToken", () => {
+  it("rejects unauthenticated callers", async () => {
+    authMock.mockResolvedValue(null);
+
+    const result = await rotateMyMcpToken({
+      tokenId: "tok_x",
+      baseUrl: "http://localhost:3000",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toBe("unauthorized");
+    expect(rotateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns replacement plaintext and setup snippets after rotating an owned token", async () => {
+    authMock.mockResolvedValue({ user: { id: "u1" } });
+    rotateMock.mockResolvedValue({
+      ok: true,
+      tokenId: "tok_new",
+      plaintext: "dpfmcp_NEWSECRET",
+      prefix: "dpfmcp_NEWS",
+      tokenSuffix: "C3D4",
+      expiresAt: new Date("2026-08-01T00:00:00Z"),
+      revokedTokenId: "tok_old",
+    });
+
+    const result = await rotateMyMcpToken({
+      tokenId: "tok_old",
+      baseUrl: "http://localhost:3000",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(rotateMock).toHaveBeenCalledWith({ tokenId: "tok_old", userId: "u1" });
+    expect(result.tokenId).toBe("tok_new");
+    expect(result.plaintext).toBe("dpfmcp_NEWSECRET");
+    expect(result.setupSnippets.codex).toContain("Bearer dpfmcp_NEWSECRET");
   });
 });
 

--- a/apps/web/lib/actions/mcp-tokens.ts
+++ b/apps/web/lib/actions/mcp-tokens.ts
@@ -3,12 +3,15 @@
 import { auth } from "@/lib/auth";
 import {
   addScopesToMcpApiToken,
+  copyMcpApiTokenPlaintext,
   issueMcpApiToken,
   listMcpApiTokens,
   revokeMcpApiToken,
+  rotateMcpApiToken,
   type IssueMcpTokenResult,
   type McpTokenCapability,
   type McpTokenScope,
+  type RotateMcpTokenResult,
 } from "@/lib/auth/mcp-api-token";
 import { buildSetupSnippets } from "@/lib/auth/mcp-setup-snippets";
 import { writeMcpJsonToHost } from "@/lib/auth/mcp-host-writer";
@@ -53,6 +56,8 @@ export async function listMyMcpTokens() {
       id: t.id,
       name: t.name,
       prefix: t.prefix,
+      tokenSuffix: t.tokenSuffix,
+      canCopy: t.canCopy,
       capability: t.capability,
       scope: t.scope,
       scopes: t.scopes,
@@ -70,6 +75,7 @@ export type IssueTokenActionResult =
       tokenId: string;
       plaintext: string;
       prefix: string;
+      tokenSuffix: string;
       expiresAt: string | null;
       setupSnippets: {
         claudeCode: string;
@@ -116,6 +122,7 @@ export async function issueMyMcpToken(input: {
     tokenId: result.tokenId,
     plaintext: result.plaintext,
     prefix: result.prefix,
+    tokenSuffix: result.tokenSuffix,
     expiresAt: result.expiresAt?.toISOString() ?? null,
     setupSnippets: buildSetupSnippets(result.plaintext, input.baseUrl),
   };
@@ -149,9 +156,21 @@ export async function issueMyWriteMcpToken(input: {
     tokenId: result.tokenId,
     plaintext: result.plaintext,
     prefix: result.prefix,
+    tokenSuffix: result.tokenSuffix,
     expiresAt: result.expiresAt?.toISOString() ?? null,
     setupSnippets: buildSetupSnippets(result.plaintext, input.baseUrl),
   };
+}
+
+function isOwnedActiveToken(
+  tokens: Awaited<ReturnType<typeof listMcpApiTokens>>,
+  tokenId: string,
+): boolean {
+  const owned = tokens.find((t) => t.id === tokenId);
+  if (!owned) return false;
+  if (owned.revokedAt != null) return false;
+  if (owned.expiresAt != null && owned.expiresAt.getTime() < Date.now()) return false;
+  return true;
 }
 
 export async function revokeMyMcpToken(input: {
@@ -170,6 +189,76 @@ export async function revokeMyMcpToken(input: {
     return { ok: false, error: "not_found_or_not_yours" };
   }
   return revokeMcpApiToken(input.tokenId, input.reason);
+}
+
+export async function copyMyMcpToken(input: {
+  tokenId: string;
+  baseUrl: string;
+}): Promise<IssueTokenActionResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false, error: "unauthorized", message: "Sign in first" };
+  }
+  const tokens = await listMcpApiTokens(session.user.id);
+  if (!isOwnedActiveToken(tokens, input.tokenId)) {
+    return {
+      ok: false,
+      error: "not_found_or_not_yours",
+      message: "Token was not found for the current user.",
+    };
+  }
+
+  const result = await copyMcpApiTokenPlaintext(input.tokenId);
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: result.error,
+      message:
+        result.error === "unavailable"
+          ? "This token was issued before recoverable token storage was enabled. Rotate it to get a copyable replacement."
+          : `Could not copy token: ${result.error}`,
+    };
+  }
+  return {
+    ok: true,
+    tokenId: input.tokenId,
+    plaintext: result.plaintext,
+    prefix: result.prefix,
+    tokenSuffix: result.tokenSuffix,
+    expiresAt: null,
+    setupSnippets: buildSetupSnippets(result.plaintext, input.baseUrl),
+  };
+}
+
+export async function rotateMyMcpToken(input: {
+  tokenId: string;
+  baseUrl: string;
+}): Promise<IssueTokenActionResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { ok: false, error: "unauthorized", message: "Sign in first" };
+  }
+  const result: RotateMcpTokenResult = await rotateMcpApiToken({
+    tokenId: input.tokenId,
+    userId: session.user.id,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: result.error,
+      message: result.message ?? `Could not rotate token: ${result.error}`,
+    };
+  }
+  writeMcpJsonToHost(result.plaintext, input.baseUrl);
+  return {
+    ok: true,
+    tokenId: result.tokenId,
+    plaintext: result.plaintext,
+    prefix: result.prefix,
+    tokenSuffix: result.tokenSuffix,
+    expiresAt: result.expiresAt?.toISOString() ?? null,
+    setupSnippets: buildSetupSnippets(result.plaintext, input.baseUrl),
+  };
 }
 
 export async function upgradeMyMcpTokenForCodingAgent(input: {

--- a/apps/web/lib/auth/mcp-api-token.test.ts
+++ b/apps/web/lib/auth/mcp-api-token.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
+    $transaction: vi.fn(),
     mcpApiToken: {
       create: vi.fn(),
       findUnique: vi.fn(),
@@ -16,11 +17,14 @@ vi.mock("@dpf/db", () => ({
 
 import { prisma } from "@dpf/db";
 import {
+  acknowledgeMcpTokenRefresh,
   addScopesToMcpApiToken,
+  copyMcpApiTokenPlaintext,
   issueMcpApiToken,
   listMcpApiTokens,
   resolveMcpApiToken,
   revokeMcpApiToken,
+  rotateMcpApiToken,
 } from "./mcp-api-token";
 
 const tokenCreate = prisma.mcpApiToken.create as unknown as ReturnType<typeof vi.fn>;
@@ -28,10 +32,13 @@ const tokenFindUnique = prisma.mcpApiToken.findUnique as unknown as ReturnType<t
 const tokenFindMany = prisma.mcpApiToken.findMany as unknown as ReturnType<typeof vi.fn>;
 const tokenUpdate = prisma.mcpApiToken.update as unknown as ReturnType<typeof vi.fn>;
 const cfgFindUnique = prisma.platformDevConfig.findUnique as unknown as ReturnType<typeof vi.fn>;
+const transactionMock = prisma.$transaction as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.resetAllMocks();
   delete process.env.CONTRIBUTION_MODEL_ENABLED;
+  process.env.CREDENTIAL_ENCRYPTION_KEY = "0".repeat(64);
+  transactionMock.mockImplementation(async (fn) => fn(prisma));
   tokenCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
     id: "tok_123",
     createdAt: new Date(),
@@ -46,6 +53,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.resetAllMocks();
   delete process.env.CONTRIBUTION_MODEL_ENABLED;
+  delete process.env.CREDENTIAL_ENCRYPTION_KEY;
 });
 
 describe("issueMcpApiToken — happy path", () => {
@@ -65,6 +73,8 @@ describe("issueMcpApiToken — happy path", () => {
     expect(tokenCreate).toHaveBeenCalledOnce();
     const data = tokenCreate.mock.calls[0]![0].data;
     expect(data.tokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(data.tokenSuffix).toMatch(/^[0-9A-HJKMNP-TV-Z]{4}$/);
+    expect(data.secretEnc).toMatch(/^enc:/);
     expect(data.tokenHash).not.toContain(result.plaintext);
   });
 
@@ -372,6 +382,48 @@ describe("resolveMcpApiToken", () => {
   });
 });
 
+describe("acknowledgeMcpTokenRefresh", () => {
+  it("acknowledges a valid replacement token and marks it used", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_new",
+      userId: "u1",
+      agentId: "AGT-100",
+      scopes: ["backlog_read", "backlog_write"],
+      scope: "write",
+      capability: "write",
+      prefix: "dpfmcp_ABCDE",
+      tokenSuffix: "9K2M",
+      revokedAt: null,
+      expiresAt: null,
+    });
+
+    const result = await acknowledgeMcpTokenRefresh("dpfmcp_GOODTOKEN");
+
+    expect(result).toEqual({
+      ok: true,
+      tokenId: "tok_new",
+      prefix: "dpfmcp_ABCDE",
+      tokenSuffix: "9K2M",
+      scope: "write",
+      capability: "write",
+      scopes: ["backlog_read", "backlog_write"],
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(tokenUpdate).toHaveBeenCalledWith({
+      where: { id: "tok_new" },
+      data: { lastUsedAt: expect.any(Date) },
+    });
+  });
+
+  it("rejects invalid refresh tokens", async () => {
+    tokenFindUnique.mockResolvedValue(null);
+
+    const result = await acknowledgeMcpTokenRefresh("dpfmcp_BAD");
+
+    expect(result).toEqual({ ok: false, error: "invalid_token" });
+  });
+});
+
 describe("revokeMcpApiToken", () => {
   it("returns not_found when token doesn't exist", async () => {
     tokenFindUnique.mockResolvedValue(null);
@@ -395,6 +447,138 @@ describe("revokeMcpApiToken", () => {
       where: { id: "tok_x" },
       data: { revokedAt: expect.any(Date), revokedReason: "leaked" },
     });
+  });
+});
+
+describe("copyMcpApiTokenPlaintext", () => {
+  it("decrypts recoverable token material for copy-current-token actions", async () => {
+    const issued = await issueMcpApiToken({
+      userId: "u1",
+      name: "copyable",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: null,
+    });
+    if (!issued.ok) throw new Error("expected issue ok");
+    const createdData = tokenCreate.mock.calls.at(-1)![0].data;
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_copy",
+      userId: "u1",
+      prefix: issued.prefix,
+      tokenSuffix: createdData.tokenSuffix,
+      secretEnc: createdData.secretEnc,
+      revokedAt: null,
+      expiresAt: null,
+    });
+
+    const result = await copyMcpApiTokenPlaintext("tok_copy");
+
+    expect(result).toEqual({
+      ok: true,
+      plaintext: issued.plaintext,
+      prefix: issued.prefix,
+      tokenSuffix: createdData.tokenSuffix,
+    });
+  });
+
+  it("returns unavailable for legacy hash-only tokens", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_legacy",
+      secretEnc: null,
+      revokedAt: null,
+      expiresAt: null,
+    });
+
+    const result = await copyMcpApiTokenPlaintext("tok_legacy");
+
+    expect(result).toEqual({ ok: false, error: "unavailable" });
+  });
+
+  it("returns decrypt_failed when encrypted token material cannot be opened", async () => {
+    const issued = await issueMcpApiToken({
+      userId: "u1",
+      name: "copyable",
+      capability: "read",
+      scopes: ["backlog_read"],
+      expiresInDays: null,
+    });
+    if (!issued.ok) throw new Error("expected issue ok");
+    const createdData = tokenCreate.mock.calls.at(-1)![0].data;
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_copy",
+      prefix: issued.prefix,
+      tokenSuffix: createdData.tokenSuffix,
+      secretEnc: createdData.secretEnc,
+      revokedAt: null,
+      expiresAt: null,
+    });
+
+    delete process.env.CREDENTIAL_ENCRYPTION_KEY;
+    const result = await copyMcpApiTokenPlaintext("tok_copy");
+
+    expect(result).toEqual({ ok: false, error: "decrypt_failed" });
+  });
+});
+
+describe("rotateMcpApiToken", () => {
+  it("creates a replacement token and revokes the old token in one transaction", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_old",
+      userId: "u1",
+      agentId: "AGT-100",
+      name: "Mark laptop",
+      scope: "write",
+      capability: "write",
+      scopes: ["backlog_read", "backlog_write"],
+      expiresAt: new Date("2026-08-01T00:00:00Z"),
+      revokedAt: null,
+    });
+
+    const result = await rotateMcpApiToken({
+      tokenId: "tok_old",
+      userId: "u1",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.plaintext).toMatch(/^dpfmcp_/);
+    expect(tokenCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: "u1",
+        agentId: "AGT-100",
+        name: "Mark laptop (rotated)",
+        scope: "write",
+        capability: "write",
+        scopes: ["backlog_read", "backlog_write"],
+        expiresAt: new Date("2026-08-01T00:00:00Z"),
+        tokenSuffix: expect.any(String),
+        secretEnc: expect.stringMatching(/^enc:/),
+      }),
+    });
+    expect(tokenUpdate).toHaveBeenCalledWith({
+      where: { id: "tok_old" },
+      data: {
+        revokedAt: expect.any(Date),
+        revokedReason: expect.stringContaining("rotated to"),
+      },
+    });
+  });
+
+  it("refuses to rotate tokens not owned by the user", async () => {
+    tokenFindUnique.mockResolvedValue({
+      id: "tok_old",
+      userId: "someone_else",
+      revokedAt: null,
+    });
+
+    const result = await rotateMcpApiToken({
+      tokenId: "tok_old",
+      userId: "u1",
+    });
+
+    expect(result).toEqual({ ok: false, error: "not_found_or_not_yours" });
+    expect(tokenCreate).not.toHaveBeenCalled();
+    expect(tokenUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -461,6 +645,8 @@ describe("listMcpApiTokens", () => {
         prefix: "dpfmcp_X",
         scope: "admin",
         capability: "write",
+        tokenSuffix: "A1B2",
+        secretEnc: "enc:copyable",
         scopes: ["backlog_read"],
         lastUsedAt: null,
         expiresAt: null,
@@ -473,5 +659,7 @@ describe("listMcpApiTokens", () => {
     expect(list[0]?.id).toBe("tok_1");
     expect(list[0]?.scope).toBe("admin");
     expect(list[0]?.capability).toBe("write");
+    expect(list[0]?.tokenSuffix).toBe("A1B2");
+    expect(list[0]?.canCopy).toBe(true);
   });
 });

--- a/apps/web/lib/auth/mcp-api-token.ts
+++ b/apps/web/lib/auth/mcp-api-token.ts
@@ -1,12 +1,13 @@
 // Personal-access-token model for the external MCP transport at /api/mcp/v1.
 //
-// Issued from the portal admin UI (settings/platform-development), shown to
-// the user exactly once at issuance time, then stored only as sha256(secret).
+// Issued from the portal admin UI (settings/platform-development), stored as
+// sha256(secret) for request lookup plus encrypted plaintext for copy/rotate.
 // Resolution path: client sends Authorization: Bearer <secret>; server hashes
 // and looks up by tokenHash. Lazy lastUsedAt update on success.
 //
 import { createHash, randomBytes } from "crypto";
 import { prisma } from "@dpf/db";
+import { decryptSecret, encryptSecret } from "@/lib/govern/credential-crypto";
 
 export type McpTokenScope = "read" | "write" | "admin";
 export type McpTokenCapability = "read" | "write";
@@ -31,6 +32,7 @@ export type IssueMcpTokenResult =
       tokenId: string;
       plaintext: string;
       prefix: string;
+      tokenSuffix: string;
       expiresAt: Date | null;
     }
   | {
@@ -61,6 +63,54 @@ export type AddMcpTokenScopesResult =
   | {
       ok: false;
       error: "not_found" | "revoked" | "expired";
+    };
+
+export type CopyMcpTokenPlaintextResult =
+  | {
+      ok: true;
+      plaintext: string;
+      prefix: string;
+      tokenSuffix: string;
+    }
+  | {
+      ok: false;
+      error: "not_found" | "revoked" | "expired" | "unavailable" | "decrypt_failed";
+    };
+
+export type RefreshMcpTokenResult =
+  | {
+      ok: true;
+      tokenId: string;
+      prefix: string;
+      tokenSuffix: string;
+      scope: McpTokenScope;
+      capability: McpTokenCapability;
+      scopes: string[];
+    }
+  | {
+      ok: false;
+      error: "invalid_token";
+    };
+
+export type RotateMcpTokenInput = {
+  tokenId: string;
+  userId: string;
+};
+
+export type RotateMcpTokenResult =
+  | {
+      ok: true;
+      tokenId: string;
+      revokedTokenId: string;
+      plaintext: string;
+      prefix: string;
+      tokenSuffix: string;
+      expiresAt: Date | null;
+    }
+  | {
+      ok: false;
+      error: "not_found_or_not_yours" | "revoked" | "expired" | "empty_scopes" | "invalid_capability";
+      message?: string;
     };
 
 const TOKEN_PREFIX = "dpfmcp_";
@@ -97,12 +147,20 @@ function encodeBase32(buf: Buffer): string {
   return out;
 }
 
-function generateToken(): { plaintext: string; hash: string; prefix: string } {
+function generateToken(): {
+  plaintext: string;
+  hash: string;
+  prefix: string;
+  tokenSuffix: string;
+  secretEnc: string;
+} {
   const secret = encodeBase32(randomBytes(SECRET_BYTES));
   const plaintext = `${TOKEN_PREFIX}${secret}`;
   const hash = createHash("sha256").update(plaintext).digest("hex");
   const prefix = plaintext.slice(0, PREFIX_DISPLAY_LENGTH);
-  return { plaintext, hash, prefix };
+  const tokenSuffix = plaintext.slice(-4);
+  const secretEnc = encryptSecret(plaintext);
+  return { plaintext, hash, prefix, tokenSuffix, secretEnc };
 }
 
 function hashSecret(plaintext: string): string {
@@ -157,7 +215,7 @@ export async function issueMcpApiToken(
     };
   }
 
-  const { plaintext, hash, prefix } = generateToken();
+  const { plaintext, hash, prefix, tokenSuffix, secretEnc } = generateToken();
   const expiresAt =
     input.expiresInDays != null
       ? new Date(Date.now() + input.expiresInDays * 24 * 60 * 60 * 1000)
@@ -170,6 +228,8 @@ export async function issueMcpApiToken(
       name,
       tokenHash: hash,
       prefix,
+      tokenSuffix,
+      secretEnc,
       scopes: input.scopes,
       capability: scopeToCapability(scope),
       scope,
@@ -182,7 +242,117 @@ export async function issueMcpApiToken(
     tokenId: row.id,
     plaintext,
     prefix,
+    tokenSuffix,
     expiresAt,
+  };
+}
+
+export async function copyMcpApiTokenPlaintext(
+  tokenId: string,
+): Promise<CopyMcpTokenPlaintextResult> {
+  const row = await prisma.mcpApiToken.findUnique({
+    where: { id: tokenId },
+    select: {
+      prefix: true,
+      tokenSuffix: true,
+      secretEnc: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+  });
+  if (!row) return { ok: false, error: "not_found" };
+  if (row.revokedAt != null) return { ok: false, error: "revoked" };
+  if (row.expiresAt != null && row.expiresAt.getTime() < Date.now()) {
+    return { ok: false, error: "expired" };
+  }
+  if (!row.secretEnc) return { ok: false, error: "unavailable" };
+
+  let plaintext: string | null = null;
+  try {
+    plaintext = decryptSecret(row.secretEnc);
+  } catch {
+    return { ok: false, error: "decrypt_failed" };
+  }
+  if (!plaintext) return { ok: false, error: "decrypt_failed" };
+  return {
+    ok: true,
+    plaintext,
+    prefix: row.prefix,
+    tokenSuffix: row.tokenSuffix ?? plaintext.slice(-4),
+  };
+}
+
+export async function rotateMcpApiToken(
+  input: RotateMcpTokenInput,
+): Promise<RotateMcpTokenResult> {
+  const existing = await prisma.mcpApiToken.findUnique({
+    where: { id: input.tokenId },
+    select: {
+      id: true,
+      userId: true,
+      agentId: true,
+      name: true,
+      capability: true,
+      scope: true,
+      scopes: true,
+      expiresAt: true,
+      revokedAt: true,
+    },
+  });
+  if (!existing || existing.userId !== input.userId) {
+    return { ok: false, error: "not_found_or_not_yours" };
+  }
+  if (existing.revokedAt != null) {
+    return { ok: false, error: "revoked", message: "Revoked tokens cannot be rotated." };
+  }
+  if (existing.expiresAt != null && existing.expiresAt.getTime() < Date.now()) {
+    return { ok: false, error: "expired", message: "Expired tokens cannot be rotated." };
+  }
+  const existingScope = normalizePersistedScope(existing.scope, existing.capability);
+  if (!Array.isArray(existing.scopes) || existing.scopes.length === 0) {
+    return { ok: false, error: "empty_scopes" };
+  }
+
+  const { plaintext, hash, prefix, tokenSuffix, secretEnc } = generateToken();
+  const now = new Date();
+  const replacementName = existing.name.endsWith(" (rotated)")
+    ? existing.name
+    : `${existing.name} (rotated)`;
+
+  const row = await prisma.$transaction(async (tx) => {
+    const created = await tx.mcpApiToken.create({
+      data: {
+        userId: existing.userId,
+        agentId: existing.agentId,
+        name: replacementName,
+        tokenHash: hash,
+        prefix,
+        tokenSuffix,
+        secretEnc,
+        scopes: existing.scopes,
+        capability: scopeToCapability(existingScope),
+        scope: existingScope,
+        expiresAt: existing.expiresAt,
+      },
+    });
+    await tx.mcpApiToken.update({
+      where: { id: existing.id },
+      data: {
+        revokedAt: now,
+        revokedReason: `rotated to ${prefix}...${tokenSuffix}`,
+      },
+    });
+    return created;
+  });
+
+  return {
+    ok: true,
+    tokenId: row.id,
+    revokedTokenId: existing.id,
+    plaintext,
+    prefix,
+    tokenSuffix,
+    expiresAt: row.expiresAt,
   };
 }
 
@@ -266,12 +436,55 @@ export async function resolveMcpApiToken(
   };
 }
 
+export async function acknowledgeMcpTokenRefresh(
+  plaintext: string,
+): Promise<RefreshMcpTokenResult> {
+  if (typeof plaintext !== "string" || !plaintext.startsWith(TOKEN_PREFIX)) {
+    return { ok: false, error: "invalid_token" };
+  }
+  const hash = hashSecret(plaintext);
+  const row = await prisma.mcpApiToken.findUnique({
+    where: { tokenHash: hash },
+    select: {
+      id: true,
+      prefix: true,
+      tokenSuffix: true,
+      scopes: true,
+      capability: true,
+      scope: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+  });
+  if (!row) return { ok: false, error: "invalid_token" };
+  if (row.revokedAt != null) return { ok: false, error: "invalid_token" };
+  if (row.expiresAt != null && row.expiresAt.getTime() < Date.now()) {
+    return { ok: false, error: "invalid_token" };
+  }
+
+  prisma.mcpApiToken
+    .update({ where: { id: row.id }, data: { lastUsedAt: new Date() } })
+    .catch(() => {});
+
+  return {
+    ok: true,
+    tokenId: row.id,
+    prefix: row.prefix,
+    tokenSuffix: row.tokenSuffix ?? plaintext.slice(-4),
+    scope: normalizePersistedScope(row.scope, row.capability),
+    capability: scopeToCapability(normalizePersistedScope(row.scope, row.capability)),
+    scopes: row.scopes,
+  };
+}
+
 export async function listMcpApiTokens(userId: string): Promise<
   Array<{
     id: string;
     name: string;
     prefix: string;
     scope: McpTokenScope;
+    tokenSuffix: string;
+    canCopy: boolean;
     capability: McpTokenCapability;
     scopes: string[];
     lastUsedAt: Date | null;
@@ -287,6 +500,8 @@ export async function listMcpApiTokens(userId: string): Promise<
       id: true,
       name: true,
       prefix: true,
+      tokenSuffix: true,
+      secretEnc: true,
       capability: true,
       scope: true,
       scopes: true,
@@ -300,5 +515,7 @@ export async function listMcpApiTokens(userId: string): Promise<
     ...r,
     scope: normalizePersistedScope(r.scope, r.capability),
     capability: scopeToCapability(normalizePersistedScope(r.scope, r.capability)),
+    tokenSuffix: r.tokenSuffix ?? r.prefix.slice(-4),
+    canCopy: r.secretEnc != null,
   }));
 }

--- a/packages/db/prisma/migrations/20260519000000_mcp_token_recovery/migration.sql
+++ b/packages/db/prisma/migrations/20260519000000_mcp_token_recovery/migration.sql
@@ -1,0 +1,6 @@
+-- Add encrypted recoverable material for MCP API tokens issued after this
+-- migration. Existing hash-only tokens remain valid but cannot be copied.
+ALTER TABLE "McpApiToken"
+  ADD COLUMN "tokenSuffix" TEXT,
+  ADD COLUMN "secretEnc" TEXT;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3651,6 +3651,8 @@ model McpApiToken {
   name          String
   tokenHash     String    @unique
   prefix        String
+  tokenSuffix   String?
+  secretEnc     String?   @db.Text
   scopes        String[]  @default([])
   capability    String    @default("read")
   scope         String    @default("read")


### PR DESCRIPTION
## Summary
- Add recoverable MCP token metadata/storage so current tokens can be copied and rotated from Admin > Platform Development.
- Add POST /api/mcp/token/refresh to acknowledge newly issued tokens and rely on per-request token validation for immediate use.
- Refactor the MCP token manager UI with rotate, copy-current, revoke, token suffix, scope, issued-at, and last-used visibility.
- Fix the schema regression guard so additive schema diffs do not fail when the removed-line grep has no matches.

## Verification
- pnpm --filter @dpf/db generate
- pnpm --filter web exec vitest run lib/auth/mcp-api-token.test.ts lib/actions/mcp-tokens.test.ts app/api/mcp/token/refresh/route.test.ts components/admin/McpTokenManager.test.tsx
- pnpm --filter web typecheck
- pnpm --filter web build
- prisma migrate deploy against disposable Postgres database
- Playwright production-path QA on disposable install: issue write token, refresh endpoint 200, /api/mcp/v1 tools/list 200, copy-current success, rotate token, replacement tools/list 200, old token rejected 401
- Git Bash schema guard command reports no schema regressions for the additive McpApiToken fields

## Notes
- Production build still emits the repo's existing Turbopack/NFT broad trace warnings around discovery/spec-plan modules; no build errors.
- Existing hash-only MCP tokens remain valid but cannot be copied; operators can rotate them to get a copyable recoverable replacement.
