### PR TITLE
feat: add bookkeeper accountant work lane

### DIFF
--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -4,19 +4,24 @@ import Link from "next/link";
 import { getFinancialSetupStatus } from "@/lib/actions/financial-setup";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
+import { AccountantWorkLanePanel } from "@/components/finance/AccountantWorkLanePanel";
 import { FinanceSummaryCard } from "@/components/finance/FinanceSummaryCard";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
 
 const STATUS_COLOURS: Record<string, string> = {
-  draft: "#8888a0",
-  sent: "#38bdf8",
-  viewed: "#a78bfa",
-  overdue: "#ef4444",
-  partially_paid: "#fbbf24",
-  paid: "#4ade80",
-  void: "#6b7280",
-  written_off: "#6b7280",
+  draft: "var(--dpf-muted)",
+  sent: "var(--dpf-info)",
+  viewed: "var(--dpf-accent)",
+  overdue: "var(--dpf-error)",
+  partially_paid: "var(--dpf-warning)",
+  paid: "var(--dpf-success)",
+  void: "var(--dpf-muted)",
+  written_off: "var(--dpf-muted)",
 };
+
+const POSITIVE_COLOUR = "var(--dpf-success)";
+const ATTENTION_COLOUR = "var(--dpf-error)";
+const MUTED_COLOUR = "var(--dpf-muted)";
 
 export default async function FinancePage() {
   const now = new Date();
@@ -266,6 +271,8 @@ export default async function FinancePage() {
         />
       </div>
 
+      <AccountantWorkLanePanel />
+
       {/* Row 1: Cash Position + 30-day Forecast + Outstanding + Overdue */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
         {/* Widget 1: Cash Position */}
@@ -287,7 +294,7 @@ export default async function FinancePage() {
             <>
               <p
                 className="text-2xl font-bold"
-                style={{ color: totalCash >= 0 ? "#4ade80" : "#ef4444" }}
+                style={{ color: totalCash >= 0 ? POSITIVE_COLOUR : ATTENTION_COLOUR }}
               >
                 {sym}{formatMoney(totalCash)}
               </p>
@@ -305,7 +312,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: forecastBalance >= totalCash ? "#4ade80" : "#ef4444" }}
+            style={{ color: forecastBalance >= totalCash ? POSITIVE_COLOUR : ATTENTION_COLOUR }}
           >
             {sym}{formatMoney(forecastBalance)}
           </p>
@@ -334,7 +341,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: overdueCount > 0 ? "#ef4444" : "#4ade80" }}
+            style={{ color: overdueCount > 0 ? ATTENTION_COLOUR : POSITIVE_COLOUR }}
           >
             {overdueCount}
           </p>
@@ -373,7 +380,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: moneyOweAmount > 0 ? "#ef4444" : "#4ade80" }}
+            style={{ color: moneyOweAmount > 0 ? ATTENTION_COLOUR : POSITIVE_COLOUR }}
           >
             {sym}{formatMoney(moneyOweAmount)}
           </p>
@@ -389,7 +396,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: activeRecurringCount > 0 ? "#4ade80" : "#8888a0" }}
+            style={{ color: activeRecurringCount > 0 ? POSITIVE_COLOUR : MUTED_COLOUR }}
           >
             {activeRecurringCount}
           </p>
@@ -407,7 +414,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: overdueGt30Amount > 0 ? "#ef4444" : "#4ade80" }}
+            style={{ color: overdueGt30Amount > 0 ? ATTENTION_COLOUR : POSITIVE_COLOUR }}
           >
             {sym}{formatMoney(overdueGt30Amount)}
           </p>
@@ -428,7 +435,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: pendingExpenseCount > 0 ? "#a78bfa" : "#4ade80" }}
+            style={{ color: pendingExpenseCount > 0 ? "var(--dpf-accent)" : POSITIVE_COLOUR }}
           >
             {pendingExpenseCount}
           </p>
@@ -446,7 +453,7 @@ export default async function FinancePage() {
           </p>
           <p
             className="text-2xl font-bold"
-            style={{ color: totalAssetValue > 0 ? "#4ade80" : "#8888a0" }}
+            style={{ color: totalAssetValue > 0 ? POSITIVE_COLOUR : MUTED_COLOUR }}
           >
             {sym}{formatMoney(totalAssetValue)}
           </p>
@@ -638,7 +645,7 @@ export default async function FinancePage() {
               </thead>
               <tbody>
                 {recentInvoices.map((inv) => {
-                  const colour = STATUS_COLOURS[inv.status] ?? "#6b7280";
+                  const colour = STATUS_COLOURS[inv.status] ?? MUTED_COLOUR;
                   return (
                     <tr
                       key={inv.id}
@@ -665,7 +672,7 @@ export default async function FinancePage() {
                           className="text-[9px] px-1.5 py-0.5 rounded-full"
                           style={{
                             color: colour,
-                            backgroundColor: `${colour}20`,
+                            backgroundColor: `color-mix(in srgb, ${colour} 16%, transparent)`,
                           }}
                         >
                           {inv.status.replace("_", " ")}

--- a/apps/web/components/finance/AccountantWorkLanePanel.test.tsx
+++ b/apps/web/components/finance/AccountantWorkLanePanel.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { AccountantWorkLanePanel } from "./AccountantWorkLanePanel";
+
+describe("AccountantWorkLanePanel", () => {
+  it("renders the bookkeeper accountant lane with current DPF finance routes", () => {
+    const html = renderToStaticMarkup(<AccountantWorkLanePanel />);
+
+    expect(html).toContain("Bookkeeper / Accountant");
+    expect(html).toContain("Employee Work Lane");
+    expect(html).toContain('href="/finance/invoices"');
+    expect(html).toContain('href="/finance/bills"');
+    expect(html).toContain('href="/finance/banking"');
+    expect(html).toContain('href="/finance/reports"');
+    expect(html).toContain("for_employees/financial_management");
+  });
+
+  it("renders coworker responsibilities and missing specialist handoff", () => {
+    const html = renderToStaticMarkup(<AccountantWorkLanePanel />);
+
+    expect(html).toContain("finance-agent");
+    expect(html).toContain("finance-controller");
+    expect(html).toContain("Future bookkeeper/accountant specialist");
+    expect(html).toContain("Proposal mode only");
+    expect(html).toContain("Accountant review gates");
+  });
+
+  it("renders QuickBooks, Stripe, missing coverage, and next backlog slices", () => {
+    const html = renderToStaticMarkup(<AccountantWorkLanePanel />);
+
+    expect(html).toContain('href="/platform/tools/integrations/quickbooks"');
+    expect(html).toContain('href="/platform/tools/integrations/stripe"');
+    expect(html).toContain("QuickBooks Online");
+    expect(html).toContain("Stripe Billing &amp; Payments");
+    expect(html).toContain("Vendors");
+    expect(html).toContain("Bank transactions");
+    expect(html).toContain("QuickBooks reconciliation");
+    expect(html).toContain("BI-C61B5202");
+    expect(html).toContain("BI-07D76D6B");
+  });
+});

--- a/apps/web/components/finance/AccountantWorkLanePanel.tsx
+++ b/apps/web/components/finance/AccountantWorkLanePanel.tsx
@@ -1,0 +1,181 @@
+import { ArrowRight, Plug, ShieldCheck, Workflow } from "lucide-react";
+import Link from "next/link";
+import {
+  getBookkeeperAccountantWorkLane,
+  type AccountantProviderBoundary,
+  type AccountantWorkstream,
+} from "@/lib/finance/accountant-work-lane";
+
+const POSTURE_LABELS: Record<AccountantProviderBoundary["posture"], string> = {
+  "read-first": "Read-first",
+  "reconciliation-anchor": "Reconciliation anchor",
+  "not-mapped": "Not mapped",
+};
+
+export function AccountantWorkLanePanel() {
+  const lane = getBookkeeperAccountantWorkLane();
+
+  return (
+    <section className="mb-8 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
+            Employee Work Lane
+          </p>
+          <h2 className="mt-2 text-lg font-semibold text-[var(--dpf-text)]">{lane.roleLabel}</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+            One operating lane for the finance routes, AI coworker handoffs, and provider boundaries
+            a small-business bookkeeper or accountant needs every day.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-[var(--dpf-text)]">
+            {lane.taxonomyNodeId}
+          </span>
+          <span className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-[var(--dpf-text)]">
+            Hybrid posture
+          </span>
+          <span className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-[var(--dpf-text)]">
+            Observe maturity
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+            <Workflow className="h-4 w-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+            Daily finance path
+          </div>
+          <div className="divide-y divide-[var(--dpf-border)] border-y border-[var(--dpf-border)]">
+            {lane.workstreams.map((workstream) => (
+              <WorkstreamRow key={workstream.key} workstream={workstream} />
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+            <ShieldCheck className="h-4 w-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+            Coworker and approval handoffs
+          </div>
+          <div className="divide-y divide-[var(--dpf-border)] border-y border-[var(--dpf-border)]">
+            {lane.handoffs.map((handoff) => (
+              <div key={handoff.actorId} className="py-3">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <p className="text-sm font-medium text-[var(--dpf-text)]">{handoff.label}</p>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+                      {handoff.actorKind.replace("-", " ")}
+                    </p>
+                    <p className="font-mono text-xs text-[var(--dpf-muted)]">{handoff.actorId}</p>
+                  </div>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">{handoff.responsibility}</p>
+                <p className="mt-1 text-xs leading-5 text-[var(--dpf-text)]">{handoff.boundary}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <div className="flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+          <Plug className="h-4 w-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+          Provider boundaries and missing coverage
+        </div>
+        <div className="mt-3 overflow-x-auto">
+          <table className="min-w-[920px] text-left text-sm">
+            <thead className="border-b border-[var(--dpf-border)] text-[11px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+              <tr>
+                <th className="py-3 pr-4 font-medium">Provider</th>
+                <th className="px-4 py-3 font-medium">Current coverage</th>
+                <th className="px-4 py-3 font-medium">Missing coverage</th>
+                <th className="py-3 pl-4 font-medium">Boundary</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--dpf-border)]">
+              {lane.providerBoundaries.map((boundary) => (
+                <tr key={boundary.provider} className="align-top">
+                  <td className="py-4 pr-4">
+                    <Link href={boundary.href} className="font-medium text-[var(--dpf-accent)] hover:underline">
+                      {boundary.label}
+                    </Link>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">{POSTURE_LABELS[boundary.posture]}</p>
+                    <p className="mt-2 font-mono text-xs text-[var(--dpf-text)]">
+                      {boundary.nextBacklogItemId}
+                    </p>
+                  </td>
+                  <td className="px-4 py-4">
+                    <TagList values={boundary.currentCoverage} />
+                  </td>
+                  <td className="px-4 py-4">
+                    <TagList values={boundary.missingCoverage} muted />
+                  </td>
+                  <td className="py-4 pl-4">
+                    <p className="max-w-[320px] text-xs leading-5 text-[var(--dpf-muted)]">
+                      {boundary.writeBoundary}
+                    </p>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-3 border-t border-[var(--dpf-border)] pt-4 lg:flex-row lg:items-center lg:justify-between">
+        <p className="text-sm leading-6 text-[var(--dpf-text)]">{lane.promotionGuardrail}</p>
+        <Link
+          href={lane.nextWorkflow.route}
+          className="inline-flex max-w-full items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90"
+        >
+          <span className="shrink-0">{lane.nextWorkflow.backlogItemId}</span>
+          <span className="min-w-0 truncate">{lane.nextWorkflow.title}</span>
+          <ArrowRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function WorkstreamRow({ workstream }: { workstream: AccountantWorkstream }) {
+  return (
+    <div className="py-4">
+      <p className="text-sm font-medium text-[var(--dpf-text)]">{workstream.label}</p>
+      <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">{workstream.dailyWork}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {workstream.routes.map((route) => (
+          <Link
+            key={route.href}
+            href={route.href}
+            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+          >
+            {route.label}
+          </Link>
+        ))}
+      </div>
+      <p className="mt-3 text-xs leading-5 text-[var(--dpf-text)]">{workstream.handoffRule}</p>
+    </div>
+  );
+}
+
+function TagList({ values, muted = false }: { values: string[]; muted?: boolean }) {
+  return (
+    <div className="flex max-w-[260px] flex-wrap gap-1.5">
+      {values.map((value) => (
+        <span
+          key={value}
+          className={[
+            "rounded-lg border border-[var(--dpf-border)] px-2 py-0.5 text-xs",
+            muted
+              ? "bg-[var(--dpf-bg)] text-[var(--dpf-muted)]"
+              : "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]",
+          ].join(" ")}
+        >
+          {value}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/lib/finance/accountant-work-lane.test.ts
+++ b/apps/web/lib/finance/accountant-work-lane.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAccountantLaneRouteHrefs,
+  getBookkeeperAccountantWorkLane,
+} from "@/lib/finance/accountant-work-lane";
+
+describe("bookkeeper accountant work lane", () => {
+  it("maps the current DPF finance routes into one accountant lane", () => {
+    const lane = getBookkeeperAccountantWorkLane();
+    const routes = getAccountantLaneRouteHrefs(lane);
+
+    expect(lane.roleLabel).toBe("Bookkeeper / Accountant");
+    expect(lane.taxonomyNodeId).toBe("for_employees/financial_management");
+    expect(routes).toEqual(
+      expect.arrayContaining([
+        "/finance/invoices",
+        "/finance/payments",
+        "/finance/bills",
+        "/finance/suppliers",
+        "/finance/expense-claims",
+        "/finance/purchase-orders",
+        "/finance/banking",
+        "/finance/reports",
+        "/finance/close",
+      ]),
+    );
+  });
+
+  it("keeps AI coworker responsibilities explicit without misclassifying employee approvals", () => {
+    const lane = getBookkeeperAccountantWorkLane();
+
+    expect(lane.handoffs.map((handoff) => handoff.actorId)).toEqual(
+      expect.arrayContaining([
+        "finance-agent",
+        "finance-controller",
+        "owner_operator",
+        "future-bookkeeper-accountant-specialist",
+      ]),
+    );
+    expect(lane.handoffs.find((handoff) => handoff.actorId === "finance-agent")?.actorKind).toBe("ai-coworker");
+    expect(lane.handoffs.find((handoff) => handoff.actorId === "owner_operator")?.actorKind).toBe("employee-role");
+    expect(lane.handoffs.find((handoff) => handoff.actorId === "finance-agent")?.boundary).toContain(
+      "Proposal mode only",
+    );
+  });
+
+  it("derives QuickBooks missing entity families from the readiness descriptor", () => {
+    const lane = getBookkeeperAccountantWorkLane();
+    const quickBooks = lane.providerBoundaries.find((boundary) => boundary.provider === "quickbooks");
+
+    expect(quickBooks?.currentCoverage).toEqual(["Company profile", "Customers", "Invoices"]);
+    expect(quickBooks?.missingCoverage).toEqual(
+      expect.arrayContaining([
+        "Vendors",
+        "Bills",
+        "Payments",
+        "Accounts",
+        "Bank transactions",
+        "Reports",
+        "Tax",
+        "Accountant workflow",
+      ]),
+    );
+    expect(quickBooks?.nextBacklogItemId).toBe("BI-C61B5202");
+  });
+
+  it("anchors Stripe and bank feeds as reconciliation dependencies, not replacement claims", () => {
+    const lane = getBookkeeperAccountantWorkLane();
+    const stripe = lane.providerBoundaries.find((boundary) => boundary.provider === "stripe");
+    const bankFeeds = lane.providerBoundaries.find((boundary) => boundary.provider === "bank-feed-provider");
+
+    expect(stripe?.missingCoverage).toContain("QuickBooks reconciliation");
+    expect(stripe?.nextBacklogItemId).toBe("BI-07D76D6B");
+    expect(bankFeeds?.posture).toBe("not-mapped");
+    expect(lane.promotionGuardrail).toContain("dual-run");
+  });
+});

--- a/apps/web/lib/finance/accountant-work-lane.ts
+++ b/apps/web/lib/finance/accountant-work-lane.ts
@@ -1,0 +1,207 @@
+import {
+  buildQuickBooksReadinessDescriptor,
+  type QuickBooksReadinessConnection,
+} from "@/lib/integrate/quickbooks/readiness";
+
+type LaneRoute = {
+  label: string;
+  href: string;
+};
+
+export type AccountantWorkstream = {
+  key: string;
+  label: string;
+  dailyWork: string;
+  routes: LaneRoute[];
+  handoffRule: string;
+};
+
+export type AccountantLaneHandoff = {
+  actorId: string;
+  actorKind: "ai-coworker" | "employee-role" | "missing-coworker";
+  label: string;
+  responsibility: string;
+  boundary: string;
+};
+
+export type AccountantProviderBoundary = {
+  provider: string;
+  label: string;
+  href: string;
+  posture: "read-first" | "reconciliation-anchor" | "not-mapped";
+  currentCoverage: string[];
+  missingCoverage: string[];
+  writeBoundary: string;
+  nextBacklogItemId: string;
+};
+
+export type AccountantWorkLane = {
+  roleId: "bookkeeper_accountant";
+  roleLabel: string;
+  taxonomyNodeId: string;
+  posture: "hybrid";
+  maturityTarget: "observe";
+  workstreams: AccountantWorkstream[];
+  handoffs: AccountantLaneHandoff[];
+  providerBoundaries: AccountantProviderBoundary[];
+  promotionGuardrail: string;
+  nextWorkflow: {
+    backlogItemId: string;
+    title: string;
+    route: string;
+    reason: string;
+  };
+};
+
+const connectedQuickBooks: QuickBooksReadinessConnection = {
+  status: "connected",
+  companyName: "Example company",
+  realmId: "example-realm",
+  lastErrorMsg: null,
+  lastTestedAt: "2026-05-19T00:00:00.000Z",
+  environment: "sandbox",
+};
+
+const quickBooksReadiness = buildQuickBooksReadinessDescriptor({
+  connection: connectedQuickBooks,
+});
+
+const quickBooksReadCoverage = quickBooksReadiness.capabilities
+  .filter((capability) => capability.state === "read")
+  .map((capability) => capability.label);
+
+const quickBooksMissingCoverage = quickBooksReadiness.capabilities
+  .filter((capability) => capability.state !== "read")
+  .map((capability) => capability.label);
+
+export const BOOKKEEPER_ACCOUNTANT_WORK_LANE: AccountantWorkLane = {
+  roleId: "bookkeeper_accountant",
+  roleLabel: "Bookkeeper / Accountant",
+  taxonomyNodeId: "for_employees/financial_management",
+  posture: "hybrid",
+  maturityTarget: "observe",
+  workstreams: [
+    {
+      key: "receivables",
+      label: "Receivables and payments",
+      dailyWork: "Review invoices, customer balances, payment status, and collections pressure.",
+      routes: [
+        { label: "Invoices", href: "/finance/invoices" },
+        { label: "Payments", href: "/finance/payments" },
+        { label: "Revenue hub", href: "/finance/revenue" },
+      ],
+      handoffRule:
+        "Finance Agent can prepare invoice/payment evidence; owner approval is required before any collection or write-back action.",
+    },
+    {
+      key: "payables",
+      label: "Payables, suppliers, and expenses",
+      dailyWork: "Track vendors, bills, expense claims, purchase orders, and payment-run readiness.",
+      routes: [
+        { label: "Bills", href: "/finance/bills" },
+        { label: "Suppliers", href: "/finance/suppliers" },
+        { label: "Expense claims", href: "/finance/expense-claims" },
+        { label: "Purchase orders", href: "/finance/purchase-orders" },
+        { label: "Payment runs", href: "/finance/payment-runs" },
+      ],
+      handoffRule:
+        "Finance Controller owns approval thresholds and exception review; Finance Agent can assemble draft packets.",
+    },
+    {
+      key: "banking-close",
+      label: "Banking, reports, tax, and close",
+      dailyWork: "Check cash position, bank imports, reconciliation candidates, reports, tax exposure, and close tasks.",
+      routes: [
+        { label: "Banking", href: "/finance/banking" },
+        { label: "Bank rules", href: "/finance/banking/rules" },
+        { label: "Reports", href: "/finance/reports" },
+        { label: "VAT summary", href: "/finance/reports/vat-summary" },
+        { label: "Close hub", href: "/finance/close" },
+      ],
+      handoffRule:
+        "Accountant review gates must exist before DPF claims close, tax, or reconciliation authority.",
+    },
+  ],
+  handoffs: [
+    {
+      actorId: "finance-agent",
+      actorKind: "ai-coworker",
+      label: "Finance Agent",
+      responsibility: "Prepare invoice, payment, bill, and report evidence for review.",
+      boundary: "Proposal mode only for accounting-impacting actions until write gates exist.",
+    },
+    {
+      actorId: "finance-controller",
+      actorKind: "ai-coworker",
+      label: "Finance Controller",
+      responsibility: "Own controls, reconciliation posture, approval thresholds, and close readiness.",
+      boundary: "Escalates ambiguous accounting ownership rather than silently promoting records.",
+    },
+    {
+      actorId: "owner_operator",
+      actorKind: "employee-role",
+      label: "Owner / Operator",
+      responsibility: "Approve provider connections, cash-sensitive actions, and DPF-primary promotion decisions.",
+      boundary: "Keeps business authority separate from coworker preparation work.",
+    },
+    {
+      actorId: "future-bookkeeper-accountant-specialist",
+      actorKind: "missing-coworker",
+      label: "Future bookkeeper/accountant specialist",
+      responsibility: "Review accountant evidence packets and provider reconciliation exceptions.",
+      boundary: "Missing coworker; track as a later capability once the lane is visible.",
+    },
+  ],
+  providerBoundaries: [
+    {
+      provider: "quickbooks",
+      label: "QuickBooks Online",
+      href: "/platform/tools/integrations/quickbooks",
+      posture: "read-first",
+      currentCoverage: quickBooksReadCoverage,
+      missingCoverage: quickBooksMissingCoverage,
+      writeBoundary:
+        "No imports, write-back, or DPF-primary accounting ownership until read expansion, staging metadata, reconciliation evidence, and accountant review are proven.",
+      nextBacklogItemId: "BI-C61B5202",
+    },
+    {
+      provider: "stripe",
+      label: "Stripe Billing & Payments",
+      href: "/platform/tools/integrations/stripe",
+      posture: "reconciliation-anchor",
+      currentCoverage: ["Balance", "Customers", "Invoices", "Payment intents"],
+      missingCoverage: ["Fees", "Payout deposits", "Invoice allocation matching", "QuickBooks reconciliation"],
+      writeBoundary:
+        "Stripe remains the payment processor; DPF should reconcile payment evidence before promoting billing records.",
+      nextBacklogItemId: "BI-07D76D6B",
+    },
+    {
+      provider: "bank-feed-provider",
+      label: "Bank-feed provider",
+      href: "/finance/banking",
+      posture: "not-mapped",
+      currentCoverage: ["Manual bank accounts", "CSV import posture"],
+      missingCoverage: ["Direct bank feeds", "Statement source custody", "Automated reconciliation evidence"],
+      writeBoundary:
+        "Bank feeds stay unmapped until DPF chooses provider ownership and proves rollback/export expectations.",
+      nextBacklogItemId: "BI-07D76D6B",
+    },
+  ],
+  promotionGuardrail:
+    "DPF does not become the accounting system of record until read coverage, import staging, reconciliation evidence, rollback/export, and accountant review workflows are proven in dual-run.",
+  nextWorkflow: {
+    backlogItemId: "BI-C61B5202",
+    title: "QuickBooks read expansion for vendors, bills, expenses, payments, accounts, and reports",
+    route: "/platform/tools/integrations/quickbooks",
+    reason:
+      "The accountant lane needs AP, payment, account, report, and tax visibility before import staging or write-back gates.",
+  },
+};
+
+export function getBookkeeperAccountantWorkLane(): AccountantWorkLane {
+  return BOOKKEEPER_ACCOUNTANT_WORK_LANE;
+}
+
+export function getAccountantLaneRouteHrefs(lane = BOOKKEEPER_ACCOUNTANT_WORK_LANE): string[] {
+  return Array.from(new Set(lane.workstreams.flatMap((workstream) => workstream.routes.map((route) => route.href))));
+}


### PR DESCRIPTION
## Summary

- Adds a typed bookkeeper/accountant work-lane model for the employee taxonomy and current DPF finance routes.
- Adds a Finance page panel that maps daily finance work, AI coworker and approval handoffs, QuickBooks/Stripe/bank-feed boundaries, missing provider coverage, and the next QuickBooks backlog slice.
- Refactors touched Finance page status colors to use DPF theme variables instead of hardcoded color literals.

## Backlog

- Implements `BI-80A71362` under `EP-BIZ-CAP`.
- Keeps the posture hybrid/read-first: QuickBooks remains the accounting anchor until read expansion, staging, reconciliation evidence, rollback/export, and accountant review gates are proven.

## Verification

- `pnpm --filter web test -- "lib/finance/accountant-work-lane.test.ts" "components/finance/AccountantWorkLanePanel.test.tsx"` — 2 files / 7 tests passed.
- `pnpm --filter @dpf/db exec prisma generate` — regenerated Prisma client after rebasing across the latest MCP token schema change.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web build` — passed; existing broad Turbopack/NFT warnings remain in `spec-plan-search`, discovery fingerprint catalog, and `next.config.mjs` traces.
- Existing sandbox on `http://localhost:3035/finance` verified with Playwright at desktop 1440x1100 and mobile 390x844: accountant lane text, coworker/approval actor kinds, QuickBooks/Stripe coverage, `BI-C61B5202`, QuickBooks integration link, no compile error, and no document overflow all passed.