### PR TITLE
fix(threads): register thread grants in catalog + typed deliberate_on API

### DIFF
--- a/apps/web/lib/mcp-tools-deliberation.ts
+++ b/apps/web/lib/mcp-tools-deliberation.ts
@@ -1,5 +1,10 @@
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import { orchestrateDeliberation } from "@/lib/deliberation/orchestrator";
+import {
+  isDeliberationArtifactType,
+  isDeliberationTriggerSource,
+  isDeliberationStrategyProfile,
+} from "@/lib/deliberation/types";
 
 export const DELIBERATION_TOOLS: ToolDefinition[] = [
   {
@@ -51,23 +56,25 @@ export async function deliberateOnMcpHandler(
     };
   }
 
-  const content = typeof params["content"] === "string" ? params["content"] : "";
-  const options: {
-    userId: string;
-    taskRunId?: string;
-    threadId?: string;
-    routeContext?: string;
-  } = { userId };
-  if (context?.taskRunId) options.taskRunId = context.taskRunId;
-  if (context?.threadId) options.threadId = context.threadId;
-  if (context?.routeContext) options.routeContext = context.routeContext;
+  const rawArtifactType = params["artifactType"];
+  const artifactType = isDeliberationArtifactType(rawArtifactType) ? rawArtifactType : "plan";
+  const rawTriggerSource = params["triggerSource"];
+  const triggerSource = isDeliberationTriggerSource(rawTriggerSource) ? rawTriggerSource : "explicit";
+  const rawStrategyProfile = params["strategyProfile"];
+  const strategyProfile = isDeliberationStrategyProfile(rawStrategyProfile) ? rawStrategyProfile : "balanced";
 
-  const result = await orchestrateDeliberation(
-    "review",
-    content,
-    options,
+  const result = await orchestrateDeliberation({
     buildId,
-  );
+    patternSlug: typeof params["patternSlug"] === "string" ? params["patternSlug"] : "review",
+    artifactType,
+    triggerSource,
+    strategyProfile,
+    diversityMode: "multi-model-same-provider",
+    userId,
+    taskRunId: context?.taskRunId ?? null,
+    threadId: context?.threadId ?? null,
+    routeContext: context?.routeContext ?? null,
+  });
 
   return {
     success: true,

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -379,7 +379,8 @@
       "category": "platform",
       "sensitivity": "internal",
       "honored_by_tools": [
-        "start_deliberation"
+        "start_deliberation",
+        "deliberate_on"
       ],
       "implies": []
     },
@@ -391,6 +392,28 @@
       "honored_by_tools": [
         "get_deliberation_outcome",
         "get_deliberation_status"
+      ],
+      "implies": []
+    },
+    {
+      "key": "thread_read",
+      "description": "Read child thread status and results for specialist subtask delegation.",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "get_thread_result",
+        "get_child_threads"
+      ],
+      "implies": []
+    },
+    {
+      "key": "thread_write",
+      "description": "Spawn or cancel specialist subtask child threads.",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "spawn_work_thread",
+        "cancel_thread"
       ],
       "implies": []
     },


### PR DESCRIPTION
## Summary

Two gaps from PR #787 that merged with an earlier commit before these fixes were pushed.

- **`grant_catalog.json`**: registers `thread_read` (honored by `get_thread_result`, `get_child_threads`) and `thread_write` (honored by `spawn_work_thread`, `cancel_thread`). Also adds `deliberate_on` to `deliberation_create.honored_by_tools`. Without this the Coworker Tool-Grant Audit fails GRANT-003 on any future PR that touches `agent-grants.ts`.
- **`mcp-tools-deliberation.ts`**: switches `deliberateOnMcpHandler` from the legacy 4-arg positional `orchestrateDeliberation()` overload to the typed `OrchestrateDeliberationInput` object API. Fixes the `mcp-tools-deliberation.test.ts` assertion (`toHaveBeenCalledWith(objectContaining({...}))`).

## Test plan
- [ ] `Coworker Tool-Grant Audit` passes — `thread_read`/`thread_write` now in catalog
- [ ] `Unit Tests` passes — `mcp-tools-deliberation.test.ts` assertion aligns with implementation
- [ ] `Typecheck` passes — `OrchestrateDeliberationInput` fields are all present and typed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)