### PR TITLE
feat: refine generic epic MCP management

### DIFF
--- a/apps/web/lib/backlog-enums.test.ts
+++ b/apps/web/lib/backlog-enums.test.ts
@@ -15,6 +15,12 @@ function toolInputEnum(toolName: string, field: string): readonly string[] {
   return (properties?.[field]?.enum ?? []) as readonly string[];
 }
 
+function toolInputFields(toolName: string): string[] {
+  const tool = PLATFORM_TOOLS.find((t) => t.name === toolName);
+  const properties = (tool?.inputSchema as { properties?: Record<string, unknown> } | undefined)?.properties;
+  return Object.keys(properties ?? {}).sort();
+}
+
 describe("backlog enum parity between backlog.ts and mcp-tools.ts", () => {
   it("triageOutcome matches on triage_backlog_item.outcome", () => {
     expect(toolInputEnum("triage_backlog_item", "outcome")).toEqual([...BACKLOG_TRIAGE_OUTCOMES]);
@@ -50,5 +56,37 @@ describe("backlog enum parity between backlog.ts and mcp-tools.ts", () => {
 
   it("update_epic.status matches shared epic statuses", () => {
     expect(toolInputEnum("update_epic", "status")).toEqual([...EPIC_STATUSES]);
+  });
+
+  it("create_epic exposes the generic epic management fields", () => {
+    expect(toolInputFields("create_epic")).toEqual(
+      expect.arrayContaining([
+        "description",
+        "epicId",
+        "owner",
+        "planPath",
+        "priority",
+        "rationale",
+        "source",
+        "specPath",
+        "status",
+        "title",
+      ]),
+    );
+  });
+
+  it("update_epic exposes priority and spec/plan audit context", () => {
+    expect(toolInputFields("update_epic")).toEqual(
+      expect.arrayContaining([
+        "description",
+        "epicId",
+        "planPath",
+        "priority",
+        "rationale",
+        "specPath",
+        "status",
+        "title",
+      ]),
+    );
   });
 });

--- a/apps/web/lib/backlog/mcp-epic-tools.ts
+++ b/apps/web/lib/backlog/mcp-epic-tools.ts
@@ -1,0 +1,400 @@
+import { prisma } from "@dpf/db";
+import * as crypto from "crypto";
+import { BACKLOG_SOURCE_VALUES, EPIC_STATUSES } from "@/lib/explore/backlog";
+
+type ToolExecutionContext = {
+  agentId?: string;
+  routeContext?: string;
+  taskRunId?: string;
+  threadId?: string;
+};
+
+type ToolResult = {
+  success: boolean;
+  entityId?: string;
+  message: string;
+  error?: string;
+  data?: Record<string, unknown>;
+};
+
+type SimilarEpic = {
+  epicId: string;
+  title: string;
+  status: string;
+  score: number;
+};
+
+type EpicOwner = {
+  id: string;
+  employeeId: string;
+  displayName: string;
+  workEmail: string | null;
+};
+
+const ACTIVE_EPIC_STATUSES = ["open", "in-progress"] as const;
+
+function optionalString(params: Record<string, unknown>, key: string): string | null {
+  const value = params[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseEpicStatus(value: unknown): { ok: true; status: string } | { ok: false; result: ToolResult } {
+  const status = typeof value === "string" && value.trim() ? value.trim() : "open";
+  if (!(EPIC_STATUSES as readonly string[]).includes(status)) {
+    return {
+      ok: false,
+      result: {
+        success: false,
+        error: "invalid_status",
+        message: `status must be one of ${EPIC_STATUSES.join("|")}, got ${status}`,
+      },
+    };
+  }
+  return { ok: true, status };
+}
+
+function parsePriority(value: unknown): { ok: true; priority?: number } | { ok: false; result: ToolResult } {
+  if (value === undefined || value === null || value === "") return { ok: true };
+  const priority = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(priority) || priority < 0 || priority > 999) {
+    return {
+      ok: false,
+      result: {
+        success: false,
+        error: "invalid_priority",
+        message: "priority must be an integer from 0 to 999",
+      },
+    };
+  }
+  return { ok: true, priority };
+}
+
+function parseSource(value: unknown): { ok: true; source: string | null } | { ok: false; result: ToolResult } {
+  if (typeof value !== "string" || !value.trim()) return { ok: true, source: null };
+  const source = value.trim();
+  if (!(BACKLOG_SOURCE_VALUES as readonly string[]).includes(source)) {
+    return {
+      ok: false,
+      result: {
+        success: false,
+        error: "invalid_source",
+        message: `source must be one of ${BACKLOG_SOURCE_VALUES.join("|")}, got ${source}`,
+      },
+    };
+  }
+  return { ok: true, source };
+}
+
+function generateEpicId(): string {
+  return `EP-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function normalizeTitle(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function titleSimilarity(left: string, right: string): number {
+  const a = normalizeTitle(left);
+  const b = normalizeTitle(right);
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  if (a.includes(b) || b.includes(a)) return 0.9;
+  const aTokens = new Set(a.split(" "));
+  const bTokens = new Set(b.split(" "));
+  const intersection = [...aTokens].filter((token) => bTokens.has(token)).length;
+  const union = new Set([...aTokens, ...bTokens]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+async function findSimilarActiveEpics(title: string): Promise<SimilarEpic[]> {
+  const epics = await prisma.epic.findMany({
+    where: { status: { in: [...ACTIVE_EPIC_STATUSES] } },
+    take: 100,
+    orderBy: [{ updatedAt: "desc" }],
+    select: { epicId: true, title: true, status: true },
+  });
+
+  return epics
+    .map((epic) => ({ ...epic, score: titleSimilarity(title, epic.title) }))
+    .filter((epic) => epic.score >= 0.72)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+}
+
+async function resolveOwner(owner: string | null): Promise<
+  | { ok: true; owner: EpicOwner | null }
+  | { ok: false; result: ToolResult }
+> {
+  if (!owner) return { ok: true, owner: null };
+  const employee = await prisma.employeeProfile.findFirst({
+    where: {
+      OR: [
+        { id: owner },
+        { employeeId: owner },
+        { workEmail: { equals: owner, mode: "insensitive" } },
+        { personalEmail: { equals: owner, mode: "insensitive" } },
+        { displayName: { equals: owner, mode: "insensitive" } },
+      ],
+    },
+    select: {
+      id: true,
+      employeeId: true,
+      displayName: true,
+      workEmail: true,
+    },
+  });
+
+  if (!employee) {
+    return {
+      ok: false,
+      result: {
+        success: false,
+        error: "invalid_owner",
+        message: "owner must match an EmployeeProfile id, employeeId, workEmail, personalEmail, or exact displayName",
+      },
+    };
+  }
+  return { ok: true, owner: employee };
+}
+
+function indexEpicContext(input: {
+  epicId: string;
+  title: string;
+  description?: string | null;
+  source?: string | null;
+  specPath?: string | null;
+  planPath?: string | null;
+  rationale?: string | null;
+  priority?: number;
+  owner?: EpicOwner | null;
+}) {
+  const content = [
+    input.description ?? "",
+    input.source ? `source: ${input.source}` : "",
+    input.specPath ? `specPath: ${input.specPath}` : "",
+    input.planPath ? `planPath: ${input.planPath}` : "",
+    input.rationale ? `rationale: ${input.rationale}` : "",
+    input.priority !== undefined ? `priority: ${input.priority}` : "",
+    input.owner ? `owner: ${input.owner.displayName} (${input.owner.employeeId})` : "",
+  ].filter(Boolean).join("\n");
+  if (!content.trim()) return;
+
+  import("@/lib/semantic-memory").then(({ storePlatformKnowledge }) =>
+    storePlatformKnowledge({
+      entityId: input.epicId,
+      entityType: "epic",
+      title: input.title,
+      content,
+    })
+  ).catch(() => {});
+}
+
+function ownerPayload(owner: EpicOwner | null | undefined) {
+  if (!owner) return null;
+  return {
+    employeeId: owner.employeeId,
+    displayName: owner.displayName,
+    workEmail: owner.workEmail,
+  };
+}
+
+export async function createEpicTool(
+  params: Record<string, unknown>,
+  userId: string,
+  context?: ToolExecutionContext,
+): Promise<ToolResult> {
+  const title = String(params["title"] ?? "").trim();
+  if (!title) {
+    return { success: false, error: "missing_title", message: "title is required" };
+  }
+
+  const requestedEpicId = optionalString(params, "epicId");
+  const epicId = requestedEpicId ?? generateEpicId();
+  if (!epicId.startsWith("EP-")) {
+    return {
+      success: false,
+      error: "invalid_epicId",
+      message: "epicId must use the semantic EP-* format.",
+    };
+  }
+
+  const statusResult = parseEpicStatus(params["status"]);
+  if (!statusResult.ok) return statusResult.result;
+  const priorityResult = parsePriority(params["priority"]);
+  if (!priorityResult.ok) return priorityResult.result;
+  const sourceResult = parseSource(params["source"]);
+  if (!sourceResult.ok) return sourceResult.result;
+  const ownerResult = await resolveOwner(optionalString(params, "owner"));
+  if (!ownerResult.ok) return ownerResult.result;
+
+  const existing = await prisma.epic.findFirst({
+    where: { epicId },
+    select: { epicId: true, title: true, status: true },
+  });
+  if (existing) {
+    return {
+      success: false,
+      error: "duplicate_epicId",
+      message: `Epic ${epicId} already exists: ${existing.title}`,
+      data: { existingEpic: existing },
+    };
+  }
+
+  const similarEpics = await findSimilarActiveEpics(title);
+  const warnings = similarEpics.length > 0
+    ? ["A similar active epic already exists; review before linking new backlog work."]
+    : [];
+
+  const description = optionalString(params, "description") ?? "";
+  const specPath = optionalString(params, "specPath");
+  const planPath = optionalString(params, "planPath");
+  const rationale = optionalString(params, "rationale");
+  const priority = priorityResult.priority;
+
+  const epic = await prisma.epic.create({
+    data: {
+      epicId,
+      title,
+      status: statusResult.status,
+      submittedById: userId,
+      agentId: context?.agentId ?? null,
+      ...(description ? { description } : {}),
+      ...(priority !== undefined ? { priority } : {}),
+      ...(ownerResult.owner ? { accountableEmployeeId: ownerResult.owner.id } : {}),
+      ...(statusResult.status === "done" ? { completedAt: new Date() } : {}),
+    },
+    include: {
+      accountableEmployee: {
+        select: {
+          employeeId: true,
+          displayName: true,
+          workEmail: true,
+        },
+      },
+    },
+  });
+
+  indexEpicContext({
+    epicId: epic.epicId,
+    title,
+    description,
+    source: sourceResult.source,
+    specPath,
+    planPath,
+    rationale,
+    priority,
+    owner: ownerResult.owner,
+  });
+
+  return {
+    success: true,
+    entityId: epic.epicId,
+    message: `Created epic ${epic.epicId}`,
+    data: {
+      epicId: epic.epicId,
+      title: epic.title,
+      status: epic.status,
+      priority: epic.priority ?? null,
+      owner: ownerPayload(ownerResult.owner),
+      source: sourceResult.source,
+      specPath,
+      planPath,
+      similarEpics,
+      warnings,
+    },
+  };
+}
+
+export async function updateEpicTool(params: Record<string, unknown>): Promise<ToolResult> {
+  const epicRaw = String(params["epicId"] ?? "").trim();
+  if (!epicRaw) {
+    return { success: false, error: "missing_epicId", message: "epicId is required" };
+  }
+
+  const existing = await prisma.epic.findFirst({
+    where: { OR: [{ epicId: epicRaw }, { id: epicRaw }] },
+    select: {
+      id: true,
+      epicId: true,
+      title: true,
+      description: true,
+      status: true,
+      priority: true,
+      completedAt: true,
+    },
+  });
+  if (!existing) {
+    return { success: false, error: "not_found", message: `Epic ${epicRaw} not found` };
+  }
+
+  const data: Record<string, unknown> = {};
+  if (typeof params["title"] === "string") {
+    const title = params["title"].trim();
+    if (!title) {
+      return { success: false, error: "missing_title", message: "title cannot be blank" };
+    }
+    data["title"] = title;
+  }
+  if (typeof params["description"] === "string") {
+    const description = params["description"].trim();
+    data["description"] = description || null;
+  }
+  if (typeof params["status"] === "string") {
+    const statusResult = parseEpicStatus(params["status"]);
+    if (!statusResult.ok) return statusResult.result;
+    data["status"] = statusResult.status;
+    if (statusResult.status === "done" && existing.status !== "done") {
+      data["completedAt"] = new Date();
+    }
+    if (statusResult.status !== "done" && existing.status === "done") {
+      data["completedAt"] = null;
+    }
+  }
+  const priorityResult = parsePriority(params["priority"]);
+  if (!priorityResult.ok) return priorityResult.result;
+  if (priorityResult.priority !== undefined) {
+    data["priority"] = priorityResult.priority;
+  }
+
+  const specPath = optionalString(params, "specPath");
+  const planPath = optionalString(params, "planPath");
+  const rationale = optionalString(params, "rationale");
+
+  const updated = Object.keys(data).length === 0
+    ? existing
+    : await prisma.epic.update({
+        where: { id: existing.id },
+        data,
+      });
+
+  indexEpicContext({
+    epicId: updated.epicId,
+    title: updated.title,
+    description: typeof data["description"] === "string" ? String(data["description"]) : existing.description,
+    specPath,
+    planPath,
+    rationale,
+    priority: priorityResult.priority,
+  });
+
+  return {
+    success: true,
+    entityId: updated.epicId,
+    message: Object.keys(data).length === 0
+      ? `${updated.epicId} unchanged (no editable fields provided)`
+      : `Updated epic ${updated.epicId}`,
+    data: {
+      epicId: updated.epicId,
+      title: updated.title,
+      status: updated.status,
+      priority: updated.priority ?? null,
+      completedAt: updated.completedAt ? updated.completedAt.toISOString() : null,
+      specPath,
+      planPath,
+    },
+  };
+}

--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -14,8 +14,12 @@ const mockPrisma = {
   epic: {
     create: vi.fn(),
     findFirst: vi.fn(),
+    findMany: vi.fn(),
     findUnique: vi.fn(),
     update: vi.fn(),
+  },
+  employeeProfile: {
+    findFirst: vi.fn(),
   },
   featureBuild: {
     create: vi.fn(),
@@ -60,6 +64,8 @@ describe("backlog MCP tool execution", () => {
       capsuleId: "WC-BUILD-1234",
     });
     mockPrisma.workCapsuleActivity.create.mockResolvedValue({});
+    mockPrisma.epic.findMany.mockResolvedValue([]);
+    mockPrisma.employeeProfile.findFirst.mockResolvedValue(null);
 
     mockPrisma.$transaction.mockImplementation(async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
       return callback(mockPrisma);
@@ -129,6 +135,108 @@ describe("backlog MCP tool execution", () => {
     expect(mockPrisma.epic.create).not.toHaveBeenCalled();
   });
 
+  it("create_epic persists priority and resolves owner to the accountable employee", async () => {
+    mockPrisma.epic.findFirst.mockResolvedValue(null);
+    mockPrisma.employeeProfile.findFirst.mockResolvedValue({
+      id: "employee-row-1",
+      employeeId: "EMP-PLATFORM",
+      displayName: "Platform Owner",
+      workEmail: "owner@dpf.local",
+    });
+    mockPrisma.epic.create.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-MCP",
+      title: "MCP generic epic management",
+      status: "in-progress",
+      priority: 2,
+      accountableEmployeeId: "employee-row-1",
+      accountableEmployee: {
+        employeeId: "EMP-PLATFORM",
+        displayName: "Platform Owner",
+        workEmail: "owner@dpf.local",
+      },
+      completedAt: null,
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "create_epic",
+      {
+        epicId: "EP-MCP",
+        title: "MCP generic epic management",
+        status: "in-progress",
+        priority: 2,
+        owner: "owner@dpf.local",
+        source: "tool-gap",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.employeeProfile.findFirst).toHaveBeenCalled();
+    expect(mockPrisma.epic.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          priority: 2,
+          accountableEmployeeId: "employee-row-1",
+        }),
+      }),
+    );
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        epicId: "EP-MCP",
+        priority: 2,
+        owner: expect.objectContaining({
+          employeeId: "EMP-PLATFORM",
+          displayName: "Platform Owner",
+        }),
+      }),
+    );
+  });
+
+  it("create_epic warns when the title is similar to an active epic", async () => {
+    mockPrisma.epic.findFirst.mockResolvedValue(null);
+    mockPrisma.epic.findMany.mockResolvedValue([
+      {
+        epicId: "EP-MCP",
+        title: "MCP generic epic management",
+        status: "open",
+      },
+    ]);
+    mockPrisma.epic.create.mockResolvedValue({
+      id: "epic-row-2",
+      epicId: "EP-MCP-2",
+      title: "MCP generic epic management tools",
+      status: "open",
+      priority: null,
+      accountableEmployeeId: null,
+      accountableEmployee: null,
+      completedAt: null,
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "create_epic",
+      {
+        epicId: "EP-MCP-2",
+        title: "MCP generic epic management tools",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.similarEpics).toEqual([
+      expect.objectContaining({
+        epicId: "EP-MCP",
+        title: "MCP generic epic management",
+        status: "open",
+      }),
+    ]);
+    expect(result.data?.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining("similar active epic")]),
+    );
+  });
+
   it("update_epic updates editable fields and marks completion when moved to done", async () => {
     mockPrisma.epic.findFirst.mockResolvedValue({
       id: "epic-row-1",
@@ -167,6 +275,57 @@ describe("backlog MCP tool execution", () => {
           status: "done",
           completedAt: expect.any(Date),
         }),
+      }),
+    );
+  });
+
+  it("update_epic updates priority and preserves spec/plan context in the response", async () => {
+    mockPrisma.epic.findFirst.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-WWMD",
+      title: "WWMD Decision Perspective Kernel",
+      description: "Old description",
+      status: "open",
+      priority: null,
+      completedAt: null,
+    });
+    mockPrisma.epic.update.mockResolvedValue({
+      id: "epic-row-1",
+      epicId: "EP-WWMD",
+      title: "WWMD Decision Perspective Kernel",
+      description: "Old description",
+      status: "open",
+      priority: 4,
+      completedAt: null,
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool(
+      "update_epic",
+      {
+        epicId: "EP-WWMD",
+        priority: 4,
+        specPath: "docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md",
+        planPath: "docs/superpowers/plans/2026-05-17-wwmd-decision-perspective-kernel-implementation.md",
+      },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.epic.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "epic-row-1" },
+        data: expect.objectContaining({
+          priority: 4,
+        }),
+      }),
+    );
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        epicId: "EP-WWMD",
+        priority: 4,
+        specPath: "docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md",
+        planPath: "docs/superpowers/plans/2026-05-17-wwmd-decision-perspective-kernel-implementation.md",
       }),
     );
   });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -833,6 +833,8 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         title: { type: "string", description: "Epic title" },
         description: { type: "string", description: "Epic description" },
         status: { type: "string", enum: [...EPIC_STATUSES], description: "Initial epic status (defaults to open)" },
+        priority: { type: "integer", description: "Optional ranked priority for the epic (lower = higher priority)" },
+        owner: { type: "string", description: "Optional accountable employee identifier: EmployeeProfile id, employeeId, workEmail, personalEmail, or exact displayName" },
         source: { type: "string", enum: [...BACKLOG_SOURCE_VALUES], description: "What kind of gap or signal produced this epic" },
         specPath: { type: "string", description: "Optional related spec path for audit/index context" },
         planPath: { type: "string", description: "Optional related implementation plan path for audit/index context" },
@@ -853,6 +855,9 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
         title: { type: "string", description: "New epic title" },
         description: { type: "string", description: "New epic description" },
         status: { type: "string", enum: [...EPIC_STATUSES], description: "New epic status" },
+        priority: { type: "integer", description: "New ranked priority for the epic (lower = higher priority)" },
+        specPath: { type: "string", description: "Optional related spec path for audit/index context" },
+        planPath: { type: "string", description: "Optional related implementation plan path for audit/index context" },
         rationale: { type: "string", description: "Optional short rationale captured by ToolExecution" },
       },
       required: ["epicId"],
@@ -4716,183 +4721,13 @@ export async function executeTool(
 
     // ─── Governed MCP backlog surface (spec 2026-04-25) ─────────────────────
     case "create_epic": {
-      const title = String(params["title"] ?? "").trim();
-      if (!title) {
-        return { success: false, error: "missing_title", message: "title is required" };
-      }
-
-      const requestedEpicId = typeof params["epicId"] === "string" && params["epicId"].trim()
-        ? params["epicId"].trim()
-        : null;
-      const epicId = requestedEpicId ?? `EP-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
-      if (!epicId.startsWith("EP-")) {
-        return {
-          success: false,
-          error: "invalid_epicId",
-          message: "epicId must use the semantic EP-* format.",
-        };
-      }
-
-      const status = typeof params["status"] === "string" && params["status"].trim()
-        ? params["status"].trim()
-        : "open";
-      if (!(EPIC_STATUSES as readonly string[]).includes(status)) {
-        return {
-          success: false,
-          error: "invalid_status",
-          message: `status must be one of ${EPIC_STATUSES.join("|")}, got ${status}`,
-        };
-      }
-
-      const existing = await prisma.epic.findFirst({
-        where: { epicId },
-        select: { epicId: true, title: true, status: true },
-      });
-      if (existing) {
-        return {
-          success: false,
-          error: "duplicate_epicId",
-          message: `Epic ${epicId} already exists: ${existing.title}`,
-          data: { existingEpic: existing },
-        };
-      }
-
-      const description = typeof params["description"] === "string"
-        ? params["description"].trim()
-        : "";
-      const source = typeof params["source"] === "string" ? params["source"].trim() : null;
-      const specPath = typeof params["specPath"] === "string" ? params["specPath"].trim() : null;
-      const planPath = typeof params["planPath"] === "string" ? params["planPath"].trim() : null;
-      const rationale = typeof params["rationale"] === "string" ? params["rationale"].trim() : null;
-
-      const epic = await prisma.epic.create({
-        data: {
-          epicId,
-          title,
-          status,
-          submittedById: userId,
-          agentId: context?.agentId ?? null,
-          ...(description ? { description } : {}),
-          ...(status === "done" ? { completedAt: new Date() } : {}),
-        },
-      });
-
-      const indexContext = [
-        description,
-        source ? `source: ${source}` : "",
-        specPath ? `specPath: ${specPath}` : "",
-        planPath ? `planPath: ${planPath}` : "",
-        rationale ? `rationale: ${rationale}` : "",
-      ].filter(Boolean).join("\n");
-      import("@/lib/semantic-memory").then(({ storePlatformKnowledge }) =>
-        storePlatformKnowledge({
-          entityId: epic.epicId,
-          entityType: "epic",
-          title,
-          content: indexContext,
-        })
-      ).catch(() => {});
-
-      return {
-        success: true,
-        entityId: epic.epicId,
-        message: `Created epic ${epic.epicId}`,
-        data: {
-          epicId: epic.epicId,
-          title: epic.title,
-          status: epic.status,
-          source,
-          specPath,
-          planPath,
-        },
-      };
+      const { createEpicTool } = await import("@/lib/backlog/mcp-epic-tools");
+      return createEpicTool(params, userId, context);
     }
 
     case "update_epic": {
-      const epicRaw = String(params["epicId"] ?? "").trim();
-      if (!epicRaw) {
-        return { success: false, error: "missing_epicId", message: "epicId is required" };
-      }
-
-      const existing = await prisma.epic.findFirst({
-        where: { OR: [{ epicId: epicRaw }, { id: epicRaw }] },
-        select: {
-          id: true,
-          epicId: true,
-          title: true,
-          description: true,
-          status: true,
-          completedAt: true,
-        },
-      });
-      if (!existing) {
-        return { success: false, error: "not_found", message: `Epic ${epicRaw} not found` };
-      }
-
-      const data: {
-        title?: string;
-        description?: string | null;
-        status?: string;
-        completedAt?: Date | null;
-      } = {};
-      if (typeof params["title"] === "string") {
-        const title = params["title"].trim();
-        if (!title) {
-          return { success: false, error: "missing_title", message: "title cannot be blank" };
-        }
-        data.title = title;
-      }
-      if (typeof params["description"] === "string") {
-        const description = params["description"].trim();
-        data.description = description || null;
-      }
-      if (typeof params["status"] === "string") {
-        const status = params["status"].trim();
-        if (!(EPIC_STATUSES as readonly string[]).includes(status)) {
-          return {
-            success: false,
-            error: "invalid_status",
-            message: `status must be one of ${EPIC_STATUSES.join("|")}, got ${status}`,
-          };
-        }
-        data.status = status;
-        if (status === "done" && existing.status !== "done") {
-          data.completedAt = new Date();
-        }
-        if (status !== "done" && existing.status === "done") {
-          data.completedAt = null;
-        }
-      }
-
-      if (Object.keys(data).length === 0) {
-        return {
-          success: true,
-          entityId: existing.epicId,
-          message: `${existing.epicId} unchanged (no editable fields provided)`,
-          data: {
-            epicId: existing.epicId,
-            title: existing.title,
-            status: existing.status,
-          },
-        };
-      }
-
-      const updated = await prisma.epic.update({
-        where: { id: existing.id },
-        data,
-      });
-
-      return {
-        success: true,
-        entityId: updated.epicId,
-        message: `Updated epic ${updated.epicId}`,
-        data: {
-          epicId: updated.epicId,
-          title: updated.title,
-          status: updated.status,
-          completedAt: updated.completedAt ? updated.completedAt.toISOString() : null,
-        },
-      };
+      const { updateEpicTool } = await import("@/lib/backlog/mcp-epic-tools");
+      return updateEpicTool(params);
     }
 
     case "list_epics": {
@@ -4908,6 +4743,7 @@ export async function executeTool(
           epicId: true,
           title: true,
           status: true,
+          priority: true,
           updatedAt: true,
           items: { select: { status: true } },
         },
@@ -4925,6 +4761,7 @@ export async function executeTool(
             epicId: e.epicId,
             title: e.title,
             status: e.status,
+            priority: e.priority,
             itemCount: { total, open, inProgress, done },
             hasSpec: refIndex.specs.has(e.epicId) || refIndex.plans.has(e.epicId),
             updatedAt: e.updatedAt.toISOString(),

--- a/packages/db/prisma/migrations/20260519153000_add_epic_priority/migration.sql
+++ b/packages/db/prisma/migrations/20260519153000_add_epic_priority/migration.sql
@@ -1,0 +1,3 @@
+-- Add a first-class epic priority so MCP generic epic management can rank
+-- roadmap-level epics without overloading backlog item priority.
+ALTER TABLE "Epic" ADD COLUMN "priority" INTEGER;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1128,6 +1128,7 @@ model Epic {
   title                 String
   description           String?
   status                String           @default("open")
+  priority              Int?
   createdAt             DateTime         @default(now())
   updatedAt             DateTime         @updatedAt
   submittedById         String?


### PR DESCRIPTION
## Summary
- add `Epic.priority` with a migration and include priority in `list_epics`
- extract generic epic MCP create/update behavior into `apps/web/lib/backlog/mcp-epic-tools.ts`
- support `create_epic` priority, owner resolution, source validation, duplicate ID rejection, and active-title overlap warnings
- support `update_epic` priority plus spec/plan/rationale context for audit/memory capture

## Verification
- `pnpm --filter web exec vitest run lib/mcp-tools-backlog.test.ts lib/backlog-enums.test.ts lib/mcp-tools.test.ts lib/tak/agent-grants.test.ts app/api/mcp/v1/route.test.ts`
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db exec prisma migrate deploy` against disposable `dpf_mcp_epic_verify_20260519_tip`, then dropped the database
- `pnpm --filter web build`

## Notes
- Production build exits 0 with existing Turbopack broad file-tracing warnings around dynamic filesystem paths.
- The currently running local portal will not expose this refined MCP behavior until this branch is merged and the portal is rebuilt/deployed.
