### PR TITLE
fix(deliberation): parse-error reviewer is absent voter, not dissenting

### DIFF
--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -37,6 +37,10 @@ export type ReviewResult = {
     suggestion?: string;
   }>;
   summary: string;
+  /** True when the LLM response could not be parsed (rate-limited, empty, or
+   *  malformed output). Gates and deliberation treat parse-error branches as
+   *  absent reviewers, not dissenting votes. */
+  parseError?: true;
 };
 
 export type ReusabilityAnalysis = {

--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -90,10 +90,16 @@ describe("parseReviewResponse", () => {
     expect(result.decision).toBe("pass");
   });
 
-  it("returns fail for unparseable response", () => {
+  it("returns fail with parseError:true for unparseable response", () => {
     const result = parseReviewResponse("This is not JSON");
     expect(result.decision).toBe("fail");
     expect(result.issues[0].severity).toBe("critical");
+    expect(result.parseError).toBe(true);
+  });
+
+  it("does not set parseError on a successfully parsed response", () => {
+    const result = parseReviewResponse('{"decision":"pass","issues":[],"summary":"All good"}');
+    expect(result.parseError).toBeUndefined();
   });
 
   it("defaults invalid severity to minor", () => {
@@ -241,6 +247,30 @@ describe("buildReviewBranchArtifacts", () => {
     ];
     const branches = buildReviewBranchArtifacts(inputs);
     expect(branches[0].failureReason).toMatch(/did not produce/i);
+  });
+
+  it("treats a parse-error review as incomplete, not as a dissenting vote", () => {
+    // Reproduces the Codex rate-limit scenario: reviewer-2 response was not
+    // parseable so parseReviewResponse returned parseError:true. The branch
+    // must be marked completed:false so detectConsensusState sees only the
+    // one passing reviewer and returns partial-consensus, not no-consensus.
+    const parseErrorReview: ReviewResult = {
+      decision: "fail",
+      issues: [{ severity: "critical", description: "Review agent returned unparseable response" }],
+      summary: "Review failed — could not parse agent response",
+      parseError: true,
+    };
+    const inputs: ReviewBranchInput[] = [
+      { branchNodeId: "reviewer-1", role: "reviewer", review: { decision: "pass", issues: [], summary: "Looks good" } },
+      { branchNodeId: "reviewer-2", role: "reviewer", review: parseErrorReview },
+    ];
+    const branches = buildReviewBranchArtifacts(inputs);
+    expect(branches).toHaveLength(2);
+    expect(branches[0].completed).toBe(true);
+    expect(branches[0].recommendation).toBe("pass");
+    expect(branches[1].completed).toBe(false);
+    expect(branches[1].failureReason).toMatch(/parse-error/i);
+    expect(branches[1].recommendation).toBeUndefined();
   });
 });
 

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -141,10 +141,11 @@ RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):
  * Summary: joined from both reviewers.
  */
 export function mergeReviews(r1: ReviewResult, r2: ReviewResult): ReviewResult {
-  // A parse failure ("could not parse agent response") is not a real review.
-  // If one reviewer parsed successfully and the other didn't, trust the parsed one.
-  const r1ParseFail = r1.issues.some(i => i.description.includes("unparseable response"));
-  const r2ParseFail = r2.issues.some(i => i.description.includes("unparseable response"));
+  // A parse failure is not a real review — treat it as an absent reviewer.
+  // Use the parseError flag first; fall back to text-matching for results
+  // produced before the flag existed.
+  const r1ParseFail = r1.parseError ?? r1.issues.some(i => i.description.includes("unparseable response"));
+  const r2ParseFail = r2.parseError ?? r2.issues.some(i => i.description.includes("unparseable response"));
   const decision =
     r1ParseFail && !r2ParseFail ? r2.decision :
     r2ParseFail && !r1ParseFail ? r1.decision :
@@ -220,11 +221,11 @@ export function parseReviewResponse(raw: string): ReviewResult {
 
     return { decision, issues, summary };
   } catch {
-    // If parsing fails, return a fail result
     return {
       decision: "fail",
       issues: [{ severity: "critical", description: "Review agent returned unparseable response" }],
       summary: "Review failed — could not parse agent response",
+      parseError: true,
     };
   }
 }
@@ -315,12 +316,17 @@ export function buildReviewBranchArtifacts(
   inputs: ReviewBranchInput[],
 ): BranchArtifact[] {
   return inputs.map((input) => {
-    if (!input.review) {
+    // Treat both null reviews and parse-error results as absent reviewers.
+    // A parse-error branch is not a dissenting vote — it is infra noise and
+    // must not contribute a "fail" recommendation to consensusState detection.
+    if (!input.review || input.review.parseError) {
       return {
         branchNodeId: input.branchNodeId,
         role: input.role,
         completed: false,
-        failureReason: input.failureReason ?? "Reviewer did not produce a parsed response.",
+        failureReason: input.review?.parseError
+          ? "parse-error: reviewer returned unparseable output"
+          : (input.failureReason ?? "Reviewer did not produce a parsed response."),
       };
     }
     const { assertions, objections } = extractClaimsFromReview(input.review);


### PR DESCRIPTION
## Summary

- Adds `parseError?: true` to `ReviewResult` so parse failures are typed, not inferred from magic strings
- `parseReviewResponse` sets the flag in its catch block; previously this returned a structured "fail" that was indistinguishable from a genuine failing review
- `buildReviewBranchArtifacts` checks the flag and marks parse-error branches as `completed: false` — an absent reviewer, not a dissenting vote
- `detectConsensusState` then sees a single completed branch (the passer) and returns `partial-consensus` instead of `no-consensus`
- `mergeReviews` updated to prefer the typed flag over its existing text-match heuristic for the gate decision (backwards-compatible)

## Root cause

When Codex is rate-limited, `routeAndCall` resolves (doesn't reject) but returns unparseable content. `parseReviewResponse` catches the JSON error and returns `{ decision: "fail", parseError: true }`. Before this fix, the parse-error result was treated as a genuine dissenting vote: `buildReviewBranchArtifacts` emitted `completed: true, recommendation: "fail"`, giving two branches with different recommendations → `no-consensus`. The `mergedRecommendation` was "pass" (tiebreak by insertion order), making the deliberation summary contradictory and causing autonomous agents to stall.

**Evidence:** `DeliberationRun` rows 2026-05-19 06:08 and 06:25 both showed `no-consensus` + `mergedRecommendation: pass`. Review summary: "Reviewer 2: Review failed — could not parse agent response".

## Test plan

- [x] `parseReviewResponse("This is not JSON")` → `parseError: true` (new assertion)
- [x] `parseReviewResponse(validJson)` → `parseError` is `undefined` (new assertion)
- [x] `buildReviewBranchArtifacts` with one pass + one parse-error review → second branch is `completed: false, failureReason: /parse-error/` (new test)
- [x] All 25 existing `build-reviewers.test.ts` tests pass
- [x] All 13 existing `synthesizer.test.ts` tests pass
- [x] No TypeScript errors in changed files (verified via main-repo `tsc --noEmit`)

Links: EP-BUILD-65837F (formal deliberation epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)