### PR TITLE
fix(build): scope coworker context to capsule's linked build on capsule pages

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -715,12 +715,32 @@ export async function sendMessage(input: {
     // Inject Build Studio context — use explicit buildId or auto-resolve on /build route.
     // Exclude `abandoned` so a prior-test abandoned build doesn't shadow the real active build.
     if (!resolvedBuildId && input.routeContext.startsWith("/build")) {
-      const latestBuild = await prisma.featureBuild.findFirst({
-        where: { createdById: user.id!, phase: { notIn: ["complete", "failed", "abandoned"] } },
-        orderBy: { updatedAt: "desc" },
-        select: { buildId: true },
-      });
-      resolvedBuildId = latestBuild?.buildId ?? undefined;
+      // On a capsule page (/build/work/<capsuleId>), resolve from the capsule's linked build.
+      // Falling through to "latest build" would pick whichever build was updated most recently
+      // across ALL user builds — e.g. a blocked Ollama build's 9 tasks bleed into an unrelated
+      // ideate-phase capsule's coworker context.
+      const capsuleMatch = input.routeContext.match(/\/build\/work\/(WC-[A-Z0-9]+)/);
+      if (capsuleMatch) {
+        const capsule = await prisma.workCapsule.findUnique({
+          where: { capsuleId: capsuleMatch[1] },
+          select: { featureBuildId: true },
+        });
+        if (capsule?.featureBuildId) {
+          const build = await prisma.featureBuild.findUnique({
+            where: { id: capsule.featureBuildId },
+            select: { buildId: true },
+          });
+          resolvedBuildId = build?.buildId ?? undefined;
+        }
+        // No linked build → leave resolvedBuildId undefined; no build context injected
+      } else {
+        const latestBuild = await prisma.featureBuild.findFirst({
+          where: { createdById: user.id!, phase: { notIn: ["complete", "failed", "abandoned"] } },
+          orderBy: { updatedAt: "desc" },
+          select: { buildId: true },
+        });
+        resolvedBuildId = latestBuild?.buildId ?? undefined;
+      }
     }
     if (resolvedBuildId) {
       const buildCtx = await getFeatureBuildForContext(resolvedBuildId, user.id!);

--- a/apps/web/lib/tak/route-context.ts
+++ b/apps/web/lib/tak/route-context.ts
@@ -26,6 +26,7 @@ const ROUTE_CONTEXT_PROVIDERS: Record<string, (userId: string, routeContext: str
   "/portfolio": getPortfolioContext,
   "/inventory": getDiscoveryOperationsContext,
   "/employee": getEmployeeContext,
+  "/build/work": getCapsuleBuildContext,
   "/build": getBuildContext,
   "/storefront": getStorefrontMarketingContext,
   "/customer/funnel": getCustomerFunnelContext,
@@ -849,6 +850,45 @@ async function getEmployeeContext(): Promise<string> {
 }
 
 // ─── Build Studio Context ───────────────────────────────────────────────
+
+// Scoped context for a specific work capsule page (/build/work/<capsuleId>).
+// The generic getBuildContext lists all 10 recent builds; on a capsule page
+// that leaks every other active build's tasks into the coworker prompt.
+async function getCapsuleBuildContext(_userId: string, routeContext: string): Promise<string> {
+  const capsuleMatch = routeContext.match(/\/build\/work\/(WC-[A-Z0-9]+)/);
+  if (!capsuleMatch) return "\nPAGE DATA — Work Capsule:\nNo capsule identified in route.";
+
+  const capsuleId = capsuleMatch[1];
+  const capsule = await prisma.workCapsule.findUnique({
+    where: { capsuleId },
+    select: { title: true, status: true, featureBuildId: true },
+  });
+
+  if (!capsule) return `\nPAGE DATA — Work Capsule:\nCapsule ${capsuleId} not found.`;
+
+  const lines = [
+    "\nPAGE DATA — Work Capsule:",
+    `Capsule: ${capsuleId} — ${capsule.title} (status: ${capsule.status})`,
+  ];
+
+  if (capsule.featureBuildId) {
+    const build = await prisma.featureBuild.findUnique({
+      where: { id: capsule.featureBuildId },
+      select: { buildId: true, title: true, phase: true, sandboxPort: true },
+    });
+    if (build) {
+      lines.push(
+        `Linked build: ${build.buildId}: ${build.title} [${build.phase}]${build.sandboxPort ? ` (sandbox: port ${build.sandboxPort})` : ""}`,
+      );
+    } else {
+      lines.push("Linked build record not found.");
+    }
+  } else {
+    lines.push("No build linked to this capsule yet.");
+  }
+
+  return lines.join("\n");
+}
 
 async function getBuildContext(userId: string): Promise<string> {
   const builds = await prisma.featureBuild.findMany({


### PR DESCRIPTION
## Summary

- **Bug:** On `/build/work/WC-xxxxx` pages, the Build Studio coworker received task context from ALL active user builds instead of the build linked to the current capsule. When an unrelated blocked build (e.g. Ollama management FB-71FB3A53 with 9 blocked tasks) had a newer `updatedAt`, its tasks bled into an unrelated ideate-phase capsule's coworker prompt — reporting "0 of 9 tasks, 9 need review" on completely wrong work.
- **BI:** BI-2DAB02B4 (EP-BUILD-STUDIO)
- **Two root causes fixed:**
  1. `agent-coworker.ts` auto-resolve fell through to `findFirst orderBy updatedAt` across ALL user builds when `input.buildId` was absent (capsule pages never set `activeBuildId` so it is never sent)
  2. `route-context.ts` `getBuildContext` listed all 10 recent user builds for every `/build/*` route

## Changes

**`apps/web/lib/actions/agent-coworker.ts`**
- On `/build/work/<capsuleId>` routes, extract the `WC-*` capsule ID, look up `WorkCapsule.featureBuildId`, resolve to `FeatureBuild.buildId`, and scope context to that build
- Only fall through to "latest build" fallback on the plain `/build` listing page
- No linked build → no build context injected (correct — don't guess)

**`apps/web/lib/tak/route-context.ts`**
- Add `/build/work` as a distinct key in `ROUTE_CONTEXT_PROVIDERS` (longer-prefix match wins over `/build`)
- New `getCapsuleBuildContext()` scopes PAGE DATA to the capsule's build only
- `getBuildContext()` (all-builds list) now only reached for the `/build` listing page

## Test plan

- [ ] Open a work capsule page (`/build/work/WC-xxxxx`) whose linked build is in ideate phase with 0 tasks — verify coworker reports 0 tasks, not tasks from another active build
- [ ] Open the `/build` listing page — verify coworker still shows recent builds list (unchanged behaviour)
- [ ] Create a capsule with no linked build — verify coworker does not inject any stale build context

🤖 Generated with [Claude Code](https://claude.com/claude-code)