### PR TITLE
fix: refresh stale unit test contracts

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.test.tsx
+++ b/apps/web/components/platform/AiOperationsMap.test.tsx
@@ -116,7 +116,8 @@ describe("AiOperationsMap", () => {
     expect(source).toContain("ROUTING_LAYOUT");
     expect(source).toContain("width: 1080");
     expect(source).toContain("providerNodeX: 852");
-    expect(source).toContain("routedCoworkerIds");
+    expect(source).toContain("visibleCoworkerIds");
+    expect(source).toContain("visibleProviderIds");
     expect(source).toContain("routedProviderIds");
     expect(source).toContain("prioritizeRoutingNodeIds");
     expect(source).toContain("priorityIds?: ReadonlySet<string>");

--- a/apps/web/lib/mcp-tools.thread.test.ts
+++ b/apps/web/lib/mcp-tools.thread.test.ts
@@ -60,7 +60,7 @@ describe("thread MCP tools", () => {
     expect(mocks.getThreadResult).toHaveBeenCalledWith({ childId: "child-1" }, "user-1");
   });
 
-  it("spawn_work_thread without caller thread context returns the MCP error text", async () => {
+  it("spawn_work_thread without caller thread context returns the MCP error message", async () => {
     const { executeTool } = await import("./mcp-tools");
 
     const result = await executeTool("spawn_work_thread", { objective: "Do X" }, "user-1", {});
@@ -68,9 +68,7 @@ describe("thread MCP tools", () => {
     expect(result).toMatchObject({
       success: false,
       error: "missing_threadId",
-      content: [
-        { type: "text", text: "Error: spawn_work_thread requires caller thread context" },
-      ],
+      message: "Error: spawn_work_thread requires caller thread context",
     });
     expect(mocks.spawnWorkThread).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- update the thread MCP test to assert the current raw executeTool error message shape
- update AI Operations Map source-contract expectations for visible routing node sets after the routing-position stabilization change

## Verification
- pnpm --filter web exec vitest run lib/mcp-tools.thread.test.ts components/platform/AiOperationsMap.test.tsx
- pnpm --filter web test
- pnpm --filter web typecheck