### PR TITLE
doc: network topology fidelity specs — edge telemetry + view throughp…

### DIFF
--- a/docs/superpowers/plans/2026-05-19-edge-node-network-telemetry-adapters-plan.md
+++ b/docs/superpowers/plans/2026-05-19-edge-node-network-telemetry-adapters-plan.md
@@ -1,0 +1,471 @@
+# Edge Node — Network Telemetry & Adapter Collectors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Extend the Phase 0 edge node with per-interface throughput metrics, L2 LLDP topology, and optional vendor adapter collectors (UniFi, Kasa, Starlink, Home Assistant).
+
+**Architecture:** Two channels extend the existing sweep loop: `discovery.lldp` submits LLDP-derived L2 topology via the existing `/api/v1/edge/discovery-runs` endpoint; `metrics.network` runs a separate faster loop and POSTs `InterfaceMetric[]` to a new `/api/v1/edge/metrics` endpoint. Adapter collectors (UniFi, Kasa, Starlink, HA) are optional plugins activated by `adapters.json`; each maps vendor data to the shared `ObservationItem` shape. The portal holds metrics in an in-memory singleton cache (`apps/web/lib/edge/metrics-cache.ts`) and fans out to browser clients via WebSocket.
+
+**Tech Stack:** TypeScript (Mode 1, `services/edge-node/`); `net-snmp` npm package for SNMP table walks; `@grpc/grpc-js` + `@grpc/proto-loader` for Starlink; `tplink-smarthome-api` for Kasa; `home-assistant-js-websocket` for HA; Next.js App Router for portal routes.
+
+---
+
+## Phase 1 — SNMP ifTable, LLDP Walk, Metrics Channel
+
+### Task 1: Extend `RESERVED_CAPABILITIES` and heartbeat/enroll responses
+
+**Files:**
+- Modify: `packages/db/src/edge-node-types.ts:71-80`
+- Modify: `apps/web/app/api/v1/edge/heartbeat/route.ts:166-175`
+- Modify: `apps/web/app/api/v1/edge/enroll/route.ts` (response body)
+- Modify: `services/edge-node/src/api-client.ts:36-42` (HeartbeatResponse + EnrollResponse types)
+- Test: `apps/web/app/api/v1/edge/heartbeat/route.test.ts`
+- Test: `apps/web/app/api/v1/edge/enroll/route.test.ts`
+
+- [ ] **Step 1:** In `packages/db/src/edge-node-types.ts`, add `"discovery.lldp"` and `"metrics.network"` to `RESERVED_CAPABILITIES` array (after `"discovery.software"` and `"metrics.host"` respectively). Keep alphabetical within each group.
+- [ ] **Step 2:** In `services/edge-node/src/api-client.ts`, add `metricsIntervalSec: number` to both `HeartbeatResponse` and `EnrollResponse` types. Default 30 (not optional — always returned).
+- [ ] **Step 3:** Write a failing test in `heartbeat/route.test.ts`: POST heartbeat → response body includes `metricsIntervalSec` field as a number ≥ 0.
+- [ ] **Step 4:** Run `npx vitest run apps/web/app/api/v1/edge/heartbeat/route.test.ts` — confirm it fails.
+- [ ] **Step 5:** In `apps/web/app/api/v1/edge/heartbeat/route.ts` (line 166-175), add `metricsIntervalSec: 30` to the JSON response body alongside the existing fields. Hardcode 30 as the default — no DB column yet; operator overrides come in a later task.
+- [ ] **Step 6:** Similarly add `metricsIntervalSec: 30` to the enroll route's response body.
+- [ ] **Step 7:** Run `npx vitest run apps/web/app/api/v1/edge/heartbeat/route.test.ts` — confirm it passes.
+- [ ] **Step 8:** Run `pnpm --filter web typecheck` — fix any errors.
+- [ ] **Step 9:** Commit with `-s`: `feat(edge): add discovery.lldp, metrics.network capabilities; metricsIntervalSec in heartbeat+enroll responses`
+
+---
+
+### Task 2: Add `net-snmp` package and SNMP ifTable walk
+
+**Files:**
+- Modify: `services/edge-node/package.json`
+- Create: `services/edge-node/src/collectors/snmp-iftable.ts`
+- Test: `services/edge-node/src/collectors/snmp-iftable.test.ts`
+
+The existing `snmp-poll.ts` shells out to the `snmpget` binary one OID at a time. Table walks require `getBulk`. Add `net-snmp` npm package to replace the subprocess approach for the new ifTable + LLDP walks. The existing `snmpget` subprocess path in `snmp-poll.ts` stays unchanged for now — YAGNI.
+
+- [ ] **Step 1:** In `services/edge-node/package.json`, add to `dependencies`: `"net-snmp": "^3.11.4"`. Run `pnpm install` inside `services/edge-node/`.
+- [ ] **Step 2:** Create `services/edge-node/src/collectors/snmp-iftable.ts`. Define and export:
+
+```typescript
+export interface IfTableEntry {
+  ifIndex: number;
+  ifDescr: string;        // OID 1.3.6.1.2.1.2.2.1.2
+  ifAlias: string;        // OID 1.3.6.1.2.1.31.1.1.1.18
+  ifOperStatus: 1 | 2 | 3; // 1=up 2=down 3=testing
+  ifHighSpeed: number;    // Mbps, OID 1.3.6.1.2.1.31.1.1.1.15
+  ifHCInOctets: bigint;   // OID 1.3.6.1.2.1.31.1.1.1.6  (64-bit, stored as decimal string in JSON)
+  ifHCOutOctets: bigint;  // OID 1.3.6.1.2.1.31.1.1.1.10
+}
+
+// Walks the ifTable using net-snmp getBulk. Returns [] on error.
+export async function walkIfTable(
+  host: string,
+  community: string,
+  port: number,
+  timeoutMs: number,
+): Promise<IfTableEntry[]>
+```
+
+- [ ] **Step 3:** Write failing tests in `snmp-iftable.test.ts`:
+  - `walkIfTable` with a mock SNMP session returns `IfTableEntry[]` with correct types
+  - BigInt fields (`ifHCInOctets`, `ifHCOutOctets`) are `bigint`, not `number`
+  - An unreachable host returns `[]` with no throw
+- [ ] **Step 4:** Run tests — confirm they fail.
+- [ ] **Step 5:** Implement `walkIfTable` using `net-snmp`'s `session.getBulk()` or `session.subtree()` for each ifTable OID range. Use `Promise`-wrapping of the callback API. Parse each varbind: for 64-bit `Counter64` type, read `.value` as a Buffer and convert via `BigInt('0x' + buf.toString('hex'))` or use the `Integer64` helper from net-snmp.
+- [ ] **Step 6:** Run tests — confirm they pass.
+- [ ] **Step 7:** Run `pnpm --filter dpf-edge-node typecheck`.
+- [ ] **Step 8:** Commit: `feat(edge): add snmp-iftable walker using net-snmp getBulk`
+
+---
+
+### Task 3: Counter snapshot persistence (stateful delta computation)
+
+**Files:**
+- Create: `services/edge-node/src/collectors/snmp-counters.ts`
+- Test: `services/edge-node/src/collectors/snmp-counters.test.ts`
+
+BigInt cannot be JSON-serialised directly. Counters are persisted as decimal strings.
+
+- [ ] **Step 1:** Create `snmp-counters.ts`. Define and export:
+
+```typescript
+export interface CounterRecord {
+  inOctets: string;   // decimal string representation of bigint
+  outOctets: string;  // decimal string representation of bigint
+  sampledAt: number;  // epoch ms
+}
+
+export interface CounterSnapshot {
+  [deviceKey: string]: {
+    [ifIndex: number]: CounterRecord;
+  };
+}
+
+// Load from disk. Returns {} if file missing or parse error.
+export function loadCounters(stateDir: string): CounterSnapshot
+
+// Persist to disk atomically (write tmp, rename).
+export function saveCounters(stateDir: string, snapshot: CounterSnapshot): void
+
+// Compute bps rate between two readings.
+// Returns undefined if prev is undefined (first poll) or counter wrapped.
+export function computeRate(
+  now: CounterRecord,
+  prev: CounterRecord | undefined,
+): { rxBps: number; txBps: number } | undefined
+```
+
+- [ ] **Step 2:** Write failing tests:
+  - `loadCounters` returns `{}` when file is missing
+  - `saveCounters` writes JSON with decimal strings, `loadCounters` reads them back
+  - `computeRate` returns `undefined` when `prev` is `undefined`
+  - `computeRate` computes correct bps: prev `inOctets="1000"`, now `inOctets="9000"`, elapsed 1000ms → rxBps = 8000 * 8 / 1 = 64000 bits/s... wait: `(9000-1000)*8 / (1000/1000) = 64000 bps`. ✓
+  - `computeRate` returns `undefined` when `now.inOctets < prev.inOctets` (counter wrap detection)
+- [ ] **Step 3:** Run — confirm fail.
+- [ ] **Step 4:** Implement. For wrap detection: `BigInt(now.inOctets) < BigInt(prev.inOctets)`. For rate: `Number((BigInt(now.inOctets) - BigInt(prev.inOctets)) * 8n) / ((now.sampledAt - prev.sampledAt) / 1000)`.
+- [ ] **Step 5:** Run — confirm pass.
+- [ ] **Step 6:** Commit: `feat(edge): snmp counter snapshot persistence with bigint decimal strings`
+
+---
+
+### Task 4: Integrate ifTable walk into sweep — produce `InterfaceMetric[]`
+
+**Files:**
+- Modify: `services/edge-node/src/sweep.ts`
+- Create: `services/edge-node/src/metrics-loop.ts`
+- Modify: `services/edge-node/src/api-client.ts`
+- Test: `services/edge-node/src/metrics-loop.test.ts`
+
+The metrics loop is separate from the discovery sweep. It runs at `metricsIntervalSec` cadence and calls SNMP ifTable walk + any active adapter collectors, then POSTs to `/api/v1/edge/metrics`.
+
+- [ ] **Step 1:** In `api-client.ts`, add `MetricsEnvelope` type (matching spec §6.1) and `submitMetrics(nodeToken, body): Promise<void>` method. Pattern identical to `submitDiscoveryRun`.
+
+```typescript
+export type InterfaceMetric = {
+  deviceKey: string;
+  ifIndex?: number;
+  ifName: string;
+  rxBps: number;
+  txBps: number;
+  rxErrors?: number;
+  txErrors?: number;
+  operStatus: "up" | "down" | "unknown";
+  speedMbps?: number;
+  rawData?: Record<string, unknown>;
+};
+
+export type MetricsEnvelope = {
+  runKey: string;
+  observedAt: string;
+  metricsVersion: "1";
+  interfaces: InterfaceMetric[];
+};
+```
+
+- [ ] **Step 2:** Create `services/edge-node/src/metrics-loop.ts`. Export `runMetricsLoop(opts)`. It should:
+  1. Sleep `metricsIntervalSec` seconds between ticks (read from `state`)
+  2. Per tick: call `collectSnmpIfTableMetrics(snmpTargets, stateDir)` which walks ifTable + computes delta using counter snapshots, returns `InterfaceMetric[]`
+  3. Build `MetricsEnvelope` with fresh `runKey`
+  4. POST via `api.submitMetrics(state.nodeToken, envelope)`
+  5. On error: log warning, do not crash the loop
+
+- [ ] **Step 3:** Write failing tests for `metrics-loop.ts`:
+  - Loop runs exactly N times when `maxIterations: N` provided
+  - `submitMetrics` is called with a valid `MetricsEnvelope`
+  - Empty interfaces list still submits (no metrics yet = valid first run)
+  - Loop continues after a POST error (does not throw)
+- [ ] **Step 4:** Run — fail.
+- [ ] **Step 5:** Implement `runMetricsLoop` following the same structural pattern as `runSweepLoop` in `sweep.ts` (test seam for sleep, maxIterations, api adapter).
+- [ ] **Step 6:** In `services/edge-node/src/index.ts`, launch `runMetricsLoop` alongside `runSweepLoop` and `runHeartbeatLoop` using `Promise.race`. `metricsIntervalSec` comes from `state.metricsIntervalSec`. **Wire the population path**: in `services/edge-node/src/state.ts` (or wherever `state` is updated from enroll/heartbeat responses), add `metricsIntervalSec: number` to the `EdgeNodeState` type and populate it from the enroll response (Task 1 added `metricsIntervalSec` to `EnrollResponse`) and update it on each heartbeat response (same field added to `HeartbeatResponse`). Default to `30` if not present for backward compat with old portal versions.
+- [ ] **Step 7:** Run all edge-node tests: `pnpm --filter dpf-edge-node test`.
+- [ ] **Step 8:** Commit: `feat(edge): metrics loop, InterfaceMetric type, submitMetrics client method`
+
+---
+
+### Task 5: Portal — `/api/v1/edge/metrics` endpoint + in-memory cache
+
+**Files:**
+- Create: `apps/web/lib/edge/metrics-cache.ts`
+- Create: `apps/web/app/api/v1/edge/metrics/route.ts`
+- Create: `apps/web/app/api/v1/edge/metrics/route.test.ts`
+
+- [ ] **Step 1:** Create `apps/web/lib/edge/metrics-cache.ts`:
+
+```typescript
+// Singleton in-memory cache. TTL: 90 seconds.
+// Key: `${nodeId}::${deviceKey}::${ifName}`
+
+export interface CachedMetric {
+  metric: InterfaceMetric;
+  expiresAt: number;  // epoch ms
+}
+
+const cache = new Map<string, CachedMetric>();
+const TTL_MS = 90_000;
+
+export function writeMetrics(nodeId: string, interfaces: InterfaceMetric[]): void
+export function getLatestMetricsForEdge(
+  sourceDeviceKey: string,
+  targetDeviceKey: string,
+): InterfaceMetric | undefined
+export function getAllMetrics(nodeId: string): InterfaceMetric[]
+export function pruneExpired(): void  // call on each write to keep Map bounded
+```
+
+- [ ] **Step 2:** Write failing tests for `metrics-cache.ts`:
+  - `writeMetrics` stores entries; `getAllMetrics` retrieves them
+  - Entries expire after 90 seconds (use fake `Date.now`)
+  - `pruneExpired` removes stale entries; Map size stays bounded
+  - `getLatestMetricsForEdge` returns `undefined` when no match
+- [ ] **Step 3:** Run — fail.
+- [ ] **Step 4:** Implement `metrics-cache.ts`. `getLatestMetricsForEdge` should match by `deviceKey` prefix against the cache keys — both `source` and `target` device keys are checked; first match wins (approximation sufficient for Phase 1).
+- [ ] **Step 5:** Create `apps/web/app/api/v1/edge/metrics/route.ts`. Follow the same pattern as `discovery-runs/route.ts`:
+  1. `resolveEdgeNodeAuth` — same auth as other edge routes
+  2. `checkEdgeRateLimit("edge.metrics", edgeNodeId)` — min 1 request per 5 seconds
+  3. Parse body: validate `metricsVersion: "1"`, body ≤ 64 KB, `observedAt` within 5 minutes
+  4. `writeMetrics(authResult.nodeId, body.interfaces)` — write to cache
+  5. **WebSocket fanout (spec §6.2)**: After `writeMetrics`, fan out to browser clients subscribed to topology updates. Look in `apps/web/lib/` for an existing broadcast utility (search for `broadcast`, `socket`, or `realtime`). If no utility exists yet, add a stub `broadcastTopologyMetrics(orgId, payload)` that is a no-op — it will be wired when the portal WebSocket infrastructure lands. Call it here: `broadcastTopologyMetrics(authResult.organizationId, { type: "topology:metrics:update", payload: { interfaces: body.interfaces, observedAt: body.observedAt, nodeId: authResult.nodeId } })`.
+  6. `writeEdgeNodeAudit(...)` — same audit pattern
+  7. Return `{ ok: true }` with status 200
+- [ ] **Step 6:** Write failing tests in `route.test.ts`:
+  - Missing auth → 401
+  - Valid body → 200 + `{ ok: true }`
+  - Body > 64 KB → 413
+  - `observedAt` more than 5 minutes old → 422
+  - `metricsVersion` not `"1"` → 400
+- [ ] **Step 7:** Run — fail. Implement. Run — pass.
+- [ ] **Step 8:** Run `pnpm --filter web typecheck`.
+- [ ] **Step 9:** Commit: `feat(portal): /api/v1/edge/metrics endpoint + in-memory metrics cache`
+
+---
+
+### Task 6: LLDP-MIB walk collector
+
+**Files:**
+- Create: `services/edge-node/src/collectors/lldp-walk.ts`
+- Test: `services/edge-node/src/collectors/lldp-walk.test.ts`
+- Modify: `services/edge-node/src/sweep.ts` (add lldp results to discovery envelope)
+
+- [ ] **Step 1:** Create `lldp-walk.ts`. Define `LldpNeighbor`:
+
+```typescript
+export interface LldpNeighbor {
+  localIfIndex: number;
+  localIfDesc: string;
+  remoteChassisId: string;   // lldpRemChassisId (usually MAC)
+  remoteSysName: string;     // lldpRemSysName
+  remotePortDesc: string;    // lldpRemPortDesc
+}
+
+export async function walkLldpNeighbors(
+  host: string, community: string, port: number, timeoutMs: number,
+): Promise<LldpNeighbor[]>
+```
+
+Walk OID subtree `1.0.8802.1.1.2.1.4.1.1` (lldpRemTable) using `net-snmp`. Map index `localPortNum` to `ifIndex` by also walking `lldpLocPortTable` (`1.0.8802.1.1.2.1.3.7.1.3`). Return `[]` on any error.
+
+- [ ] **Step 2:** Write failing tests — mock SNMP session, verify correct OID parsing, verify empty return on error.
+- [ ] **Step 3:** Run — fail. Implement. Run — pass.
+- [ ] **Step 4:** Create `services/edge-node/src/collectors/lldp-walk-collector.ts`. Export `collectLldpWalk(targets, arpTable)`. For each SNMP target, calls `walkLldpNeighbors`, then:
+  - Emits `ObservationItem` per discovered port: `observedKey: "snmp:<ip>/port/<ifIndex>"`, **`itemType: "switch_port"` (underscore — not "switch-port" with a hyphen; the spec §4.2 body uses a hyphen but the §4.2 naming note is authoritative: use underscore to match `network_device`, `wireless_ap`, etc.)**, `osiLayer: 2`
+  - Emits `SubmissionRelationship` of type `PEER_OF` from `snmp:<ip>/port/<ifIndex>` to `arp:<resolved-ip>` (resolve via ARP table lookup on `remoteSysName` or `remoteChassisId`)
+- [ ] **Step 5:** In `sweep.ts`, after `collectSnmpPoll`, call `collectLldpWalk(snmpTargets, arpItemsFromC1)`. Merge items + relationships into the discovery envelope. Add `"discovery.lldp"` to capabilities when LLDP results are non-empty.
+- [ ] **Step 6:** Run `pnpm --filter dpf-edge-node test`.
+- [ ] **Step 7:** Commit: `feat(edge): LLDP-MIB walk collector, switch_port items, PEER_OF relationships`
+
+---
+
+## Phase 2 — Adapter Collectors
+
+### Task 7: Adapters config loader
+
+**Files:**
+- Create: `services/edge-node/src/collectors/adapters-config.ts`
+- Test: `services/edge-node/src/collectors/adapters-config.test.ts`
+
+- [ ] **Step 1:** Create `adapters-config.ts`. Define Zod schema matching spec §10. Export `resolveAdaptersConfig(stateDir): AdaptersConfig`. Path: `${stateDir}/adapters.json` (co-located with `snmp.json` pattern; env override `DPF_EDGE_ADAPTER_DIR`). Return `{}` if file missing. Warn (do not throw) if file is world-readable (same pattern as `snmp-config.ts`).
+- [ ] **Step 2:** Write failing tests — missing file returns `{}`, valid JSON parses correctly, extra keys are stripped by Zod.
+- [ ] **Step 3:** Run — fail. Implement. Run — pass.
+- [ ] **Step 4:** Commit: `feat(edge): adapters.json config loader`
+
+---
+
+### Task 8: UniFi adapter collector
+
+**Files:**
+- Create: `services/edge-node/src/collectors/unifi.ts`
+- Test: `services/edge-node/src/collectors/unifi.test.ts`
+
+- [ ] **Step 1:** Create `unifi.ts`. Export `collectUnifi(config: UnifiConfig): Promise<{ items, relationships, metrics, warnings }>`. If `config` is undefined, return empty immediately.
+
+Data flow (per spec §4.3):
+1. `GET ${controllerUrl}/proxy/network/api/s/${site}/stat/device` with header `X-API-KEY: ${apiKey}`. If `tlsInsecure`, skip cert verification.
+2. For each device in response: emit one `ObservationItem` (key `unifi:<device.mac>`) + one `SAME_AS` relationship to `arp:<device.ip>`.
+3. For each device's `port_table[]`: if `rx_bytes-r` and `tx_bytes-r` are present, emit an `InterfaceMetric`.
+4. Build `HOSTS` relationships from `uplink.mac` / `downlink_table`.
+
+UniFi type map (add as constant):
+```typescript
+const UNIFI_TYPE_MAP: Record<string, { itemType: string; osiLayer: number }> = {
+  usw: { itemType: "switch", osiLayer: 2 },
+  uap: { itemType: "wireless_ap", osiLayer: 2 },
+  ugw: { itemType: "gateway", osiLayer: 3 },
+  udm: { itemType: "gateway", osiLayer: 3 },
+};
+```
+
+- [ ] **Step 2:** Write failing tests with mocked `fetch`:
+  - No config → `{ items: [], relationships: [], metrics: [], warnings: [] }`
+  - Valid response → items contain one entry per device with correct `observedKey` and `itemType`
+  - Port with `rx_bytes-r: 1250, tx_bytes-r: 3400` → `InterfaceMetric` with `rxBps: 10000, txBps: 27200` (bytes × 8)
+  - Non-2xx response → empty items, one warning
+- [ ] **Step 3:** Run — fail. Implement using `undici.request` (already a dependency). For `tlsInsecure`, pass `{ connect: { rejectUnauthorized: false } }` to undici.
+- [ ] **Step 4:** Run — pass.
+- [ ] **Step 5:** Wire UniFi WebSocket reconnect in a separate exported function `subscribeUnifiEvents(config, onEvent)`. Uses Node.js `ws` package (add to package.json: `"ws": "^8.18.0"`). On `EVT_SW_*` / `EVT_AP_*` events, call `onEvent()`. Reconnect with 1s→2s→4s→8s→30s backoff.
+- [ ] **Step 6:** In `metrics-loop.ts`, if `adaptersConfig.unifi` is set, call `collectUnifi` and merge `metrics` into the `MetricsEnvelope`. In `sweep.ts`, merge `items` and `relationships` into the discovery envelope.
+- [ ] **Step 7:** Commit: `feat(edge): UniFi adapter collector (discovery + metrics + WS events)`
+
+---
+
+### Task 9: TP-Link Kasa adapter
+
+**Files:**
+- Create: `services/edge-node/src/collectors/kasa.ts`
+- Test: `services/edge-node/src/collectors/kasa.test.ts`
+- Modify: `services/edge-node/package.json`
+
+- [ ] **Step 1:** Add `"tplink-smarthome-api": "^6.1.1"` to dependencies. Run `pnpm install`.
+- [ ] **Step 2:** Create `kasa.ts`. Export `collectKasa(config?: KasaConfig): Promise<{ items, metrics, warnings }>`.
+
+If `config?.disabled === true`, return empty immediately.
+
+Discovery:
+1. `const client = new Client()` from `tplink-smarthome-api`
+2. `await client.startDiscovery({ discoveryTimeout: config?.discoveryTimeoutMs ?? 5000 })` — collect `device-new` events into array
+3. For each device: call `device.getSysInfo()`, classify by model prefix:
+   - HS105, EP25, KP115 → `itemType: "smart_plug"`
+   - HS200, HS210, KS200M → `itemType: "smart_switch"`
+   - Default → `smart_plug`
+4. If plug has emeter: call `plug.emeter.getRealtime()` for energy data
+
+- [ ] **Step 3:** Write failing tests using mocked `tplink-smarthome-api` Client:
+  - `disabled: true` → empty result immediately
+  - Device with model `"HS200"` → `itemType: "smart_switch"`
+  - Device with model `"HS105"` → `itemType: "smart_plug"`, `emeter` in rawData
+  - Emeter-capable device → `InterfaceMetric` with `operStatus: "up"` when `is_on === true`
+- [ ] **Step 4:** Run — fail. Implement. Run — pass.
+- [ ] **Step 5:** Commit: `feat(edge): TP-Link Kasa adapter (auto-discover smart plugs/switches)`
+
+---
+
+### Task 10: Starlink gRPC adapter
+
+**Files:**
+- Create: `services/edge-node/src/collectors/starlink.ts`
+- Create: `services/edge-node/src/collectors/starlink-protos/` (vendored proto files)
+- Test: `services/edge-node/src/collectors/starlink.test.ts`
+- Modify: `services/edge-node/package.json`
+
+- [ ] **Step 1:** Add dependencies: `"@grpc/grpc-js": "^1.13.4"`, `"@grpc/proto-loader": "^0.7.15"`. Run `pnpm install`.
+- [ ] **Step 2:** Vendor the Starlink proto files. Download `spacex/api/device/device.proto` and related from `github.com/sparky8512/starlink-grpc-tools` at commit `HEAD` as of today. Place in `services/edge-node/src/collectors/starlink-protos/`. Add a `PROTO_SOURCE.md` noting the commit hash.
+- [ ] **Step 3:** Create `starlink.ts`. Export `collectStarlink(config?: StarlinkConfig): Promise<{ item, metric, warnings } | null>`.
+
+Auto-detect: attempt gRPC connect to `${config?.host ?? "192.168.100.1"}:${config?.port ?? 9200}`. Set connect deadline of 2 seconds. If `DEADLINE_EXCEEDED` or `UNAVAILABLE` → return `null` silently.
+
+On success:
+1. Call `GetStatus` → extract `state`, `uptime_s`, `downlink_throughput_bps`, `uplink_throughput_bps`, `pop_ping_latency_ms`, `pop_ping_drop_rate`
+2. Call `GetDeviceInfo` → extract `id` (serial)
+3. Emit one `ObservationItem` (key `starlink:<serial>`, type `satellite_internet`, osiLayer 3)
+4. Emit one `InterfaceMetric` with `rxBps: downlink_throughput_bps`, `txBps: uplink_throughput_bps`
+
+- [ ] **Step 4:** Write failing tests with mocked gRPC client. Verify: unreachable host returns `null`; connected host returns item + metric with correct rxBps/txBps.
+- [ ] **Step 5:** Run — fail. Implement. Run — pass.
+- [ ] **Step 6:** Commit: `feat(edge): Starlink gRPC adapter (auto-detect satellite throughput)`
+
+---
+
+### Task 11: Home Assistant bridge
+
+**Files:**
+- Create: `services/edge-node/src/collectors/home-assistant.ts`
+- Test: `services/edge-node/src/collectors/home-assistant.test.ts`
+- Modify: `services/edge-node/package.json`
+
+- [ ] **Step 1:** Add `"home-assistant-js-websocket": "^9.4.0"`. Run `pnpm install`.
+- [ ] **Step 2:** Create `home-assistant.ts`. Export `collectHomeAssistant(config: HaConfig, arpTable: Map<string, string>): Promise<{ items, relationships, warnings }>`.
+
+If no config, return empty. Connect via WebSocket:
+1. Send `config/device_registry/list` → get all devices
+2. For each device:
+   - `observedKey: "ha:<device.id>"`
+   - `itemType`: derived from integration domain (kasa→smart_plug, zha/z_wave_js→smart_plug, media_player→"media_device", default→"smart_device")
+   - `name: device.name`
+   - `rawData: { manufacturer, model, swVersion, areaId, haIntegration, vendorIconModel: "${manufacturer}/${model}" }`
+   - If `device.connections` contains a MAC tuple: emit `SAME_AS` to `arp:<ip>` (look up IP in arpTable by MAC)
+- [ ] **Step 3:** Write failing tests with mocked HA WebSocket client. Verify: device with Kasa integration → `itemType: "smart_plug"`; device with MAC in connections → `SAME_AS` relationship to correct `arp:<ip>`.
+- [ ] **Step 4:** Run — fail. Implement. Run — pass.
+- [ ] **Step 5:** Commit: `feat(edge): Home Assistant bridge (device registry as inventory source)`
+
+---
+
+### Task 12: Wire all adapters into sweep and metrics loops
+
+**Files:**
+- Modify: `services/edge-node/src/sweep.ts`
+- Modify: `services/edge-node/src/metrics-loop.ts`
+- Modify: `services/edge-node/src/index.ts`
+
+- [ ] **Step 1:** In `sweep.ts`, after existing collectors, call:
+  - `collectUnifi(adaptersConfig.unifi)` — merge items + relationships
+  - `collectKasa(adaptersConfig.kasa)` — merge items
+  - `collectStarlink(adaptersConfig.starlink)` — merge item if non-null
+  - `collectHomeAssistant(adaptersConfig.homeAssistant, arpIpMap)` — merge items + relationships
+- [ ] **Step 2:** In `metrics-loop.ts`, collect metrics from:
+  - SNMP ifTable walk (with counter delta)
+  - `collectUnifi(...)` `.metrics`
+  - `collectKasa(...)` `.metrics` (emeter only)
+  - `collectStarlink(...)` `.metric` if non-null
+- [ ] **Step 3:** In `index.ts`, load `adaptersConfig` from `resolveAdaptersConfig(config.stateDir)` and pass to sweep + metrics opts.
+- [ ] **Step 4:** Run full test suite: `pnpm --filter dpf-edge-node test`. Fix any failures.
+- [ ] **Step 5:** Run `pnpm --filter dpf-edge-node typecheck`.
+- [ ] **Step 6:** Commit: `feat(edge): wire all adapter collectors into sweep + metrics loops`
+
+---
+
+### Task 13: Normalization — SAME_AS collapse in Authority Core
+
+**Files:**
+- Modify: `apps/web/lib/discovery-data.ts` (or wherever normalization runs)
+- Modify: `apps/web/app/api/v1/edge/discovery-runs/route.ts` (trigger normalization after insert)
+- Test: add unit test for normalization logic
+
+The normalization pipeline collapses multiple items for the same physical device (linked by `SAME_AS`) into one canonical `InventoryEntity` with merged rawData. Priority order: UniFi (1.0) > SNMP (0.95) = Kasa (0.95) > HA (0.9) > nmap (0.85) > ARP (0.7).
+
+- [ ] **Step 1:** Find the function that processes incoming `ObservationItem[]` from discovery-runs. Run: `grep -r "ObservationItem\|normaliz\|inventoryEntity\|items\.map" apps/web/lib/ apps/web/app/api/v1/edge/discovery-runs/ --include="*.ts" -l` to locate the insert/upsert logic. Read it to understand the current shape.
+- [ ] **Step 2:** Write a failing test: two items with SAME_AS link (confidence 1.0 and 0.7) → normalized entity uses higher-confidence item's `name` and merges both `rawData` blobs; `discoveredVia` is an array with both source slugs.
+- [ ] **Step 3:** Run — fail.
+- [ ] **Step 4:** Implement `normalizeInventoryEntities(items, relationships)` that: walks SAME_AS chains, picks the highest-confidence item as canonical base, merges rawData from all linked items, writes a single upsert to `InventoryEntity` with `rawData.discoveredVia: string[]`.
+- [ ] **Step 5:** Run — pass. Run `pnpm --filter web typecheck`.
+- [ ] **Step 6:** Commit: `feat(portal): SAME_AS normalization — collapse multi-source CI records`
+
+---
+
+## Phase 3 — Mode 4 Go Parity (planned, not implemented here)
+
+Mode 4 Go implementation in `services/edge-node-go/` follows after Mode 1 is verified on real hardware. Wire contract tests at `apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts` gate parity. Tracked as `BI-EDGE-XP-04-MODE1-GO-RETROFIT` in the backlog.
+
+---
+
+## Verification
+
+After all Phase 1 tasks:
+- [ ] Deploy edge node container against a local DPF install with an SNMP-capable switch configured
+- [ ] Verify portal receives metrics at `/api/v1/edge/metrics` (check server logs)
+- [ ] Navigate to inventory topology graph — confirm LLDP `PEER_OF` edges appear as L2 links
+- [ ] Confirm existing Phase 0 discovery items are unchanged
+
+After Phase 2 tasks:
+- [ ] With `adapters.json` containing UniFi config: verify switch devices appear with `itemType: "switch"` and port metrics in cache
+- [ ] With no `adapters.json`: verify Phase 0 behavior unchanged (zero regressions)
+- [ ] Kasa: verify HS200 appears as `smart_switch`, HS105 as `smart_plug` with emeter in rawData
+- [ ] Starlink: verify `satellite_internet` CI created, throughput in metrics cache

--- a/docs/superpowers/plans/2026-05-19-topology-view-throughput-icons-plan.md
+++ b/docs/superpowers/plans/2026-05-19-topology-view-throughput-icons-plan.md
@@ -1,0 +1,574 @@
+# Topology View — Throughput Annotations & Product Icons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make the topology graph show real per-link throughput, product icons, and fully wire the Impact Blast Radius and Dependency Audit views that already have UI but no data.
+
+**Architecture:** Three independent work streams: (1) Phase 1 — wire `TopologyGraph.tsx` to call existing `getImpactData`/`getDependencyAuditData` server actions on view switch using `useTransition`; (2) Phase 2 — extend `GraphData` link/node types with throughput fields, resolve CSS variables for canvas, draw link-width by utilization and bps labels, subscribe to WebSocket metrics updates; (3) Phase 3 — add icon-cache module, bundle UniFi fingerprint DB + generic SVGs, extend canvas node renderer with `drawImage` path. Phase 1 has zero external dependencies and can ship immediately.
+
+**Tech Stack:** Next.js 16 App Router, React 19 (`useTransition`), Canvas 2D API, `apps/web/lib/graph/` modules, `@dpf/db` Neo4j functions (already implemented).
+
+---
+
+## Phase 1 — Wire Impact & Dependency Views (zero dependencies)
+
+### Task 1: Confirm server actions exist and understand current TopologyGraph data flow
+
+**Files:**
+- Read: `apps/web/lib/actions/graph.ts` (lines 256-350 — `getImpactData` and `getDependencyAuditData`)
+- Read: `apps/web/components/inventory/TopologyGraph.tsx` (lines 1-120 — props, state, effects)
+
+- [ ] **Step 1:** Read `apps/web/lib/actions/graph.ts` around line 257. Confirm `getImpactData(ciId)` and `getDependencyAuditData(productId)` are exported async functions returning `Promise<GraphData>`.
+- [ ] **Step 2:** Read `TopologyGraph.tsx` top section. Find: (a) the `Props` type — specifically whether `focusNodeId` or equivalent already exists; (b) how `selectedView` state is managed; (c) where the layout engine fires relative to `data` prop changes.
+- [ ] **Step 3:** Note the exact variable names and line numbers. The plan below uses `focusNodeId` as the prop/state name — adjust every occurrence in Task 2 if the actual name differs. Before starting Task 2, write the correct variable name here as a comment so it is explicit.
+
+*No commit for this task — research only. Do not proceed to Task 2 until you have confirmed the exact names of: (a) the focused-node ID prop/state, (b) the `selectedView` state variable, (c) the canvas redraw trigger function.*
+
+---
+
+### Task 2: Add `dynamicData` state and view-switch data fetching
+
+**Files:**
+- Modify: `apps/web/components/inventory/TopologyGraph.tsx`
+- Test: `apps/web/components/inventory/TopologyGraph.test.tsx` (create if absent)
+
+- [ ] **Step 1:** In `TopologyGraph.tsx`, add imports at the top:
+```typescript
+import { useTransition, useState } from "react";
+import { getImpactData, getDependencyAuditData } from "@/lib/actions/graph";
+```
+
+- [ ] **Step 2:** Inside the component (before the canvas ref), add:
+```typescript
+const [isPending, startTransition] = useTransition();
+const [dynamicData, setDynamicData] = useState<GraphData | null>(null);
+```
+
+- [ ] **Step 3:** Add a `useEffect` that depends on `[selectedView, focusNodeId]` (use actual variable name from Task 1):
+```typescript
+useEffect(() => {
+  if (selectedView === "impact-blast-radius" && focusNodeId) {
+    startTransition(() => {
+      void getImpactData(focusNodeId).then(setDynamicData);
+    });
+  } else if (selectedView === "dependency-audit" && focusNodeId) {
+    startTransition(() => {
+      void getDependencyAuditData(focusNodeId).then(setDynamicData);
+    });
+  } else {
+    setDynamicData(null);
+  }
+}, [selectedView, focusNodeId]);
+```
+
+> **React API note:** `startTransition` takes a synchronous callback. The async call `.then(setDynamicData)` is *outside* the transition — only the state setter fires inside. Do not wrap `async` functions directly.
+
+- [ ] **Step 4:** Find every place in the component that reads the `data` prop for layout or rendering. Replace with:
+```typescript
+const effectiveData = dynamicData ?? data;
+```
+and use `effectiveData` everywhere.
+
+- [ ] **Step 5:** Write a failing test in `TopologyGraph.test.tsx`:
+  - Render with `defaultView="impact-blast-radius"` and a `focusNodeId`
+  - Mock `getImpactData` to return `{ nodes: [{ id: "n1", ... }], links: [] }`
+  - Assert the mocked `getImpactData` was called with the `focusNodeId`
+  - Assert component re-renders with the mock data (check a node label in the DOM or canvas)
+
+- [ ] **Step 6:** Run `npx vitest run apps/web/components/inventory/TopologyGraph.test.tsx` — confirm it fails (expected: `getImpactData` not yet called).
+
+- [ ] **Step 7:** The effect is already written in Step 3. Run the test again — confirm it passes.
+
+- [ ] **Step 8:** Run `pnpm --filter web typecheck`.
+
+- [ ] **Step 9:** Commit: `feat(topology): wire impact blast radius + dependency audit views to server actions`
+
+---
+
+### Task 3: Loading overlay during Neo4j query
+
+**Files:**
+- Modify: `apps/web/components/inventory/TopologyGraph.tsx`
+
+While `isPending` is true (transition in flight), the canvas should show a spinner overlay rather than stale data.
+
+- [ ] **Step 1:** In the JSX return of `TopologyGraph.tsx`, wrap the canvas element with a relative-positioned container:
+
+```tsx
+<div className="relative w-full h-full">
+  <canvas ref={canvasRef} ... />
+  {isPending && (
+    <div className="absolute inset-0 flex items-center justify-center bg-[var(--dpf-bg)]/60">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--dpf-accent)] border-t-transparent" />
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 2:** Run the app (`docker compose up`) and manually navigate to the inventory topology. Click "Analyze Impact" on any InfraCI node. Verify:
+  - Spinner appears while Neo4j query runs
+  - Radial layout renders within 3 seconds
+  - No full-page reload
+
+- [ ] **Step 3:** Commit: `feat(topology): loading overlay during impact/dependency data fetch`
+
+---
+
+## Phase 2 — Throughput Annotations (requires EP-EDGE-TELEM-001 Phase 1 deployed)
+
+### Task 4: Extend `GraphData` types with throughput and icon fields
+
+**Files:**
+- Modify: `apps/web/lib/actions/graph.ts`
+
+- [ ] **Step 1:** In `graph.ts`, extract the inline link type to a named export:
+
+```typescript
+export type GraphDataLink = {
+  source: string;
+  target: string;
+  type: string;
+  // Throughput — optional; undefined when no metrics available
+  rxBps?: number;
+  txBps?: number;
+  speedMbps?: number;
+  operStatus?: "up" | "down" | "unknown";
+  poeWatts?: number;
+};
+
+export type GraphDataNode = {
+  id: string;
+  name: string;
+  label: string;
+  color: string;
+  size: number;
+  osiLayer?: number | null;
+  status?: string | null;
+  ciType?: string | null;
+  // New — from adapter rawData
+  vendorIconModel?: string;   // for icon lookup chain
+  areaId?: string;            // room/zone from HA or manual config
+};
+
+export type GraphData = {
+  nodes: GraphDataNode[];
+  links: GraphDataLink[];
+};
+```
+
+- [ ] **Step 2:** Find `infraCIToGraphNode()` helper in `graph.ts`. Add mapping:
+```typescript
+vendorIconModel: (ci.properties as Record<string, unknown>)?.vendorIconModel as string | undefined,
+areaId: (ci.properties as Record<string, unknown>)?.areaId as string | undefined,
+```
+
+- [ ] **Step 3:** Find `mapEdges()` / inline link construction in `getFullGraphData()` and other actions. Add `rxBps: undefined, txBps: undefined` (no-op for now — enriched in Task 5).
+
+- [ ] **Step 4:** Run `pnpm --filter web typecheck` — fix any type errors from the now-named `GraphDataLink` type. Other files that use `GraphData["links"][0]` may need updating to `GraphDataLink`.
+
+- [ ] **Step 5:** Commit: `refactor(graph): extract GraphDataLink + GraphDataNode types, add throughput + icon fields`
+
+---
+
+### Task 5: `enrichLinksWithMetrics` — merge metrics cache into graph links
+
+**Files:**
+- Modify: `apps/web/lib/actions/graph.ts`
+- Test: `apps/web/lib/actions/graph.test.ts`
+
+- [ ] **Step 1:** **Dependency gate**: Confirm `apps/web/lib/edge/metrics-cache.ts` exists (created in Plan A Task 5). If it does not exist yet, do not proceed with this task — Plan A Task 5 must be merged first. Once confirmed, import:
+```typescript
+import { getLatestMetricsForEdge } from "@/lib/edge/metrics-cache";
+```
+
+- [ ] **Step 2:** Add:
+```typescript
+function enrichLinksWithMetrics(links: GraphDataLink[]): GraphDataLink[] {
+  return links.map((link) => {
+    const metric = getLatestMetricsForEdge(link.source, link.target);
+    if (!metric) return link;
+    return {
+      ...link,
+      rxBps: metric.rxBps,
+      txBps: metric.txBps,
+      speedMbps: metric.speedMbps,
+      operStatus: metric.operStatus,
+    };
+  });
+}
+```
+
+- [ ] **Step 3:** Call `enrichLinksWithMetrics(links)` at the end of `getFullGraphData()`, `getNetworkTopologyData()`, `getImpactData()`, and `getDependencyAuditData()` before returning.
+
+- [ ] **Step 4:** Write a failing test in `graph.test.ts`:
+  - Mock `getLatestMetricsForEdge` to return `{ rxBps: 10000, txBps: 5000, operStatus: "up" }` for a specific pair
+  - Call `getFullGraphData()`
+  - Assert the returned link has `rxBps: 10000, txBps: 5000`
+  - Assert a link with no matching metric has `rxBps: undefined`
+
+- [ ] **Step 5:** Run — fail. The mock is already wired; just run again after Step 3. Pass.
+
+- [ ] **Step 6:** Commit: `feat(graph): enrich graph links with metrics cache data`
+
+---
+
+### Task 6: CSS variable resolution for canvas + `CanvasColors` type
+
+**Files:**
+- Create: `apps/web/lib/graph/canvas-colors.ts`
+- Test: `apps/web/lib/graph/canvas-colors.test.ts`
+
+CSS custom properties do not resolve inside Canvas 2D context. They must be read from a DOM element via `getComputedStyle`.
+
+- [ ] **Step 1:** Create `canvas-colors.ts`:
+
+```typescript
+export interface CanvasColors {
+  error: string;
+  warning: string;
+  border: string;
+  muted: string;
+  success: string;
+}
+
+// Call once after mount with the canvas element.
+export function resolveCanvasColors(el: HTMLElement): CanvasColors {
+  const style = getComputedStyle(el);
+  const get = (v: string, fallback: string) =>
+    style.getPropertyValue(v).trim() || fallback;
+  return {
+    error:   get("--dpf-error",   "#ef4444"),
+    warning: get("--dpf-warning", "#f59e0b"),
+    border:  get("--dpf-border",  "#334155"),
+    muted:   get("--dpf-muted",   "#64748b"),
+    success: get("--dpf-success", "#22c55e"),
+  };
+}
+```
+
+- [ ] **Step 2:** Write failing tests:
+  - `resolveCanvasColors` called with a real DOM element (jsdom) that has `--dpf-error` set to `#ff0000` via inline style → returns `{ error: "#ff0000", ... }`
+  - Missing variable → returns fallback hex
+- [ ] **Step 3:** Run — fail. Implement (it's already written). Run — pass.
+- [ ] **Step 4:** In `TopologyGraph.tsx`, add a `canvasColors` ref:
+
+```typescript
+const canvasColorsRef = useRef<CanvasColors>({
+  error: "#ef4444", warning: "#f59e0b", border: "#334155", muted: "#64748b", success: "#22c55e"
+});
+// Mount effect:
+useEffect(() => {
+  if (canvasRef.current) {
+    canvasColorsRef.current = resolveCanvasColors(canvasRef.current);
+  }
+}, []);
+```
+
+- [ ] **Step 5:** Commit: `feat(graph): resolveCanvasColors for canvas-safe CSS variable resolution`
+
+---
+
+### Task 7: Link-width-by-utilization and status-color canvas rendering
+
+**Files:**
+- Modify: `apps/web/components/inventory/TopologyGraph.tsx`
+- Test: manual visual verification (canvas is not easily unit-testable)
+
+Find the canvas edge-drawing section (look for `ctx.beginPath()`, `ctx.moveTo`, `ctx.lineTo`, `ctx.stroke()`).
+
+- [ ] **Step 1:** Before drawing each edge, compute utilization. Add a `linkMetricsMap` state:
+
+```typescript
+const [linkMetricsMap, setLinkMetricsMap] = useState<Map<string, GraphDataLink>>(new Map());
+```
+
+Populate it from `effectiveData.links` in the layout effect (or render loop): for each link, key = `${link.source}::${link.target}`.
+
+- [ ] **Step 2:** In the edge draw section, replace the existing `ctx.lineWidth = 1` and `ctx.strokeStyle = LINK_COLORS[...]` lines with:
+
+```typescript
+const metric = linkMetricsMap.get(`${link.source}::${link.target}`);
+const utilization = metric?.rxBps && metric?.speedMbps
+  ? Math.max(metric.rxBps, metric.txBps ?? 0) / (metric.speedMbps * 1_000_000)
+  : 0;
+ctx.lineWidth = 1 + Math.min(utilization, 1) * 3;
+
+const colors = canvasColorsRef.current;
+if (metric?.operStatus === "down") {
+  ctx.strokeStyle = colors.error;
+} else if (utilization > 0.8) {
+  ctx.strokeStyle = colors.warning;
+} else {
+  ctx.strokeStyle = LINK_COLORS[link.type] ?? colors.border;
+}
+```
+
+- [ ] **Step 3:** After drawing each edge, add throughput label (when zoom scale > 0.6 — find the existing `scale` variable in the component):
+
+```typescript
+if (scale > 0.6 && metric && (metric.rxBps || metric.txBps)) {
+  const midX = (source.x + target.x) / 2;
+  const midY = (source.y + target.y) / 2;
+  ctx.font = "9px system-ui";
+  ctx.fillStyle = colors.muted;
+  ctx.textAlign = "center";
+  ctx.fillText(
+    `↓${formatBps(metric.rxBps ?? 0)} ↑${formatBps(metric.txBps ?? 0)}`,
+    midX, midY - 4
+  );
+}
+```
+
+Add `formatBps` helper near the top of the file (or in a shared util):
+```typescript
+function formatBps(bps: number): string {
+  if (bps >= 1e9) return `${(bps / 1e9).toFixed(1)} Gbps`;
+  if (bps >= 1e6) return `${(bps / 1e6).toFixed(1)} Mbps`;
+  if (bps >= 1e3) return `${(bps / 1e3).toFixed(1)} Kbps`;
+  return `${bps.toFixed(0)} bps`;
+}
+```
+
+- [ ] **Step 4:** Run `pnpm --filter web typecheck`.
+- [ ] **Step 5:** Run the app. Open topology. Confirm existing links render unchanged (no metrics data yet = default width/color). No regressions.
+- [ ] **Step 6:** Commit: `feat(topology): link-width by utilization + bps labels + status color`
+
+---
+
+### Task 8: WebSocket subscription for live metrics updates
+
+**Files:**
+- Modify: `apps/web/components/inventory/TopologyGraph.tsx`
+
+- [ ] **Step 1:** **Cross-plan dependency**: The WebSocket push path requires Plan A Task 5's `broadcastTopologyMetrics` call to be implemented in the portal metrics endpoint. Confirm Plan A Task 5 is merged before proceeding with WS wiring. Run: `grep -r "broadcastTopologyMetrics\|topology:metrics:update" apps/web/lib/ apps/web/app/ --include="*.ts" -l` to verify the broadcaster exists. Also look for any existing WebSocket utility: `apps/web/lib/socket.ts`, `apps/web/lib/realtime.ts`, `apps/web/app/api/ws/`.
+
+- [ ] **Step 2:** If no portal WebSocket yet: the metrics-cache writes data but there is no push path yet. For Phase 2, use a 10-second polling fallback instead: add a `useEffect` that fetches `getFullGraphData()` every 10 seconds while the topology is mounted, and updates `linkMetricsMap` from the enriched links. This is the correct behavior until the WebSocket infrastructure is built.
+
+- [ ] **Step 3:** Implement the polling fallback:
+```typescript
+useEffect(() => {
+  const interval = setInterval(async () => {
+    const fresh = await getFullGraphData();
+    const map = new Map<string, GraphDataLink>();
+    for (const link of fresh.links) {
+      if (link.rxBps !== undefined || link.txBps !== undefined) {
+        map.set(`${link.source}::${link.target}`, link);
+      }
+    }
+    setLinkMetricsMap(map);
+  }, 10_000);
+  return () => clearInterval(interval);
+}, []);
+```
+
+- [ ] **Step 4:** Run typecheck. Confirm no errors.
+- [ ] **Step 5:** Commit: `feat(topology): 10s metrics polling for live link annotations`
+
+> **Note:** Replace polling with portal WebSocket push when the WebSocket infrastructure is ready. The polling interval should match the edge node's `metricsIntervalSec` — read it from a portal config endpoint if available, default 10s.
+
+---
+
+## Phase 3 — Product Icons (independent of Phases 1 and 2)
+
+### Task 9: Create icon cache module
+
+**Files:**
+- Create: `apps/web/lib/graph/icon-cache.ts`
+- Test: `apps/web/lib/graph/icon-cache.test.ts`
+
+- [ ] **Step 1:** Create `icon-cache.ts`:
+
+```typescript
+const imageCache = new Map<string, HTMLImageElement | null>();
+let onIconLoaded: (() => void) | null = null;
+
+// Call once from TopologyGraph mount effect:
+// setIconLoadCallback(() => requestAnimationFrame(() => redrawCanvas()));
+export function setIconLoadCallback(fn: () => void): void {
+  onIconLoaded = fn;
+}
+
+export function getOrLoadIcon(url: string): HTMLImageElement | null {
+  if (imageCache.has(url)) return imageCache.get(url) ?? null;
+  imageCache.set(url, null);  // mark loading; prevents duplicate fetches
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  img.onload = () => {
+    imageCache.set(url, img);
+    onIconLoaded?.();
+  };
+  // onerror: retain null → symbol fallback; no retry storm
+  img.src = url;
+  return null;
+}
+
+// For testing only:
+export function _clearCache(): void { imageCache.clear(); }
+```
+
+- [ ] **Step 2:** Write failing tests:
+  - `getOrLoadIcon(url)` returns `null` before image loads
+  - After `img.onload` fires (simulate in test), `getOrLoadIcon(url)` returns the element
+  - Calling `getOrLoadIcon` twice with same URL does NOT create two `Image` objects
+  - `onIconLoaded` is called exactly once when image loads
+- [ ] **Step 3:** Run — fail. Implement (already written above). Run — pass.
+- [ ] **Step 4:** Commit: `feat(graph): icon-cache module with dedup loading and canvas redraw callback`
+
+---
+
+### Task 10: Bundle UniFi fingerprint DB and generic SVGs
+
+**Files:**
+- Create: `apps/web/lib/graph/data/unifi-fingerprints.json` (download from source)
+- Create: `apps/web/public/icons/network/` (add SVG subset)
+
+- [ ] **Step 1:** Download `fingerprint-database.json` from `https://raw.githubusercontent.com/CANTI-BOT/UniFi-Icon-Browser/main/fingerprint-database.json`. Save to `apps/web/lib/graph/data/unifi-fingerprints.json`. Add a `DATA_SOURCE.md` in `apps/web/lib/graph/data/` noting the source URL and the date downloaded.
+
+- [ ] **Step 2:** Inspect the JSON structure. The fingerprint DB maps model codes to icon URLs (typically `static.ui.com/...` CDN paths). Confirm the key format (e.g., `"US-8-150W"` → `"https://static.ui.com/fingerprint/ui/icons/..."`).
+
+- [ ] **Step 3:** Download the following SVGs from `https://raw.githubusercontent.com/network-automation/networking-icons/master/` and save to `apps/web/public/icons/network/`:
+  - `router.svg`, `switch.svg`, `access-point.svg`, `server.svg`, `cloud.svg`
+  - Plus create simple SVGs for: `smart-plug.svg`, `smart-switch.svg`, `satellite.svg` (can be simple path-based SVGs if not in the repo)
+
+- [ ] **Step 4:** Commit: `chore(graph): add UniFi fingerprint DB + generic network SVG icons`
+
+---
+
+### Task 11: Icon lookup chain in `device-icons.ts`
+
+**Files:**
+- Modify: `apps/web/lib/graph/device-icons.ts`
+- Test: `apps/web/lib/graph/device-icons.test.ts`
+
+- [ ] **Step 1:** Extend `DeviceVisual` type with `iconUrl?: string`.
+
+- [ ] **Step 2:** Add import at top of `device-icons.ts`:
+```typescript
+import UNIFI_FINGERPRINT_DB from './data/unifi-fingerprints.json';
+```
+
+- [ ] **Step 3:** Add `GENERIC_DEVICE_SVGS` mapping:
+```typescript
+const GENERIC_DEVICE_SVGS: Record<string, string> = {
+  router:           "/icons/network/router.svg",
+  gateway:          "/icons/network/router.svg",
+  switch:           "/icons/network/switch.svg",
+  wireless_ap:      "/icons/network/access-point.svg",
+  smart_plug:       "/icons/network/smart-plug.svg",
+  smart_switch:     "/icons/network/smart-switch.svg",
+  satellite_internet: "/icons/network/satellite.svg",
+  host:             "/icons/network/server.svg",
+  docker_host:      "/icons/network/server.svg",
+};
+```
+
+- [ ] **Step 4:** Add exported function:
+```typescript
+export function getDeviceIconUrl(
+  ciType: string | undefined | null,
+  vendorIconModel: string | undefined | null,
+): string | undefined {
+  if (vendorIconModel) {
+    // 1. UniFi fingerprint DB (model code → CDN URL)
+    const fp = (UNIFI_FINGERPRINT_DB as Record<string, unknown>)[vendorIconModel];
+    if (typeof fp === "string") return fp;
+    if (fp && typeof fp === "object" && "icon" in fp) return (fp as {icon: string}).icon;
+  }
+  // 2. Generic device-type SVG
+  if (ciType) {
+    const generic = GENERIC_DEVICE_SVGS[ciType];
+    if (generic) return generic;
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 5:** Write failing tests:
+  - `getDeviceIconUrl("switch", "US-8-150W")` → returns the URL from the fingerprint DB (mock the import or use actual DB if small enough to load in test)
+  - `getDeviceIconUrl("router", undefined)` → returns `"/icons/network/router.svg"`
+  - `getDeviceIconUrl("unknown_type", undefined)` → returns `undefined`
+  - `getDeviceIconUrl(undefined, undefined)` → returns `undefined`
+- [ ] **Step 6:** Run — fail. Fix any fingerprint DB structure mismatches discovered in Step 2. Run — pass.
+- [ ] **Step 7:** Commit: `feat(graph): getDeviceIconUrl lookup chain — UniFi fingerprint DB + generic SVGs`
+
+---
+
+### Task 12: Canvas renderer — `drawImage` with symbol fallback
+
+**Files:**
+- Modify: `apps/web/components/inventory/TopologyGraph.tsx`
+
+- [ ] **Step 1:** Add imports to `TopologyGraph.tsx`:
+```typescript
+import { getDeviceIconUrl } from "@/lib/graph/device-icons";
+import { getOrLoadIcon, setIconLoadCallback } from "@/lib/graph/icon-cache";
+```
+
+- [ ] **Step 2:** In the mount `useEffect`, register the icon load callback:
+```typescript
+useEffect(() => {
+  setIconLoadCallback(() => {
+    requestAnimationFrame(() => {
+      // Trigger canvas redraw — find the existing redraw function/ref and call it
+      redrawRef.current?.();
+    });
+  });
+}, []);
+```
+> Find the existing pattern used for canvas redraws (look for `requestAnimationFrame` calls or a `drawGraph` / `render` function). Use the same trigger.
+
+- [ ] **Step 3:** Find the existing node-draw section. It currently calls `ctx.fillText(dv.symbol, node.x, node.y)` for `InfraCI` nodes. Replace with:
+
+```typescript
+// Try icon first (uses node.vendorIconModel and node.ciType)
+const iconUrl = getDeviceIconUrl(node.ciType, node.vendorIconModel);
+const img = iconUrl ? getOrLoadIcon(iconUrl) : null;
+
+if (img) {
+  const iconSize = radius * 2;
+  ctx.drawImage(img, node.x - iconSize / 2, node.y - iconSize / 2, iconSize, iconSize);
+} else {
+  // Symbol fallback — existing behavior
+  ctx.fillText(dv.symbol, node.x, node.y);
+}
+```
+
+- [ ] **Step 4:** Run `pnpm --filter web typecheck`. Fix any errors (likely `node.vendorIconModel` being undefined in the existing node type — it's now optional in `GraphDataNode` from Task 4).
+
+- [ ] **Step 5:** Run the app. Open inventory topology.
+  - Verify: nodes without `vendorIconModel` still show Unicode symbols (no regression)
+  - Verify: a node with a known UniFi model code shows the product icon after the image loads
+  - Verify: canvas frame rate stays smooth (no flicker during icon load; symbols show immediately, icons appear on first `onload`)
+
+- [ ] **Step 6:** Commit: `feat(topology): canvas drawImage for product icons with symbol fallback`
+
+---
+
+## Phase 4 — Building Product Health Integration (deferred)
+
+The building product health panel (Starlink uptime, switch utilization, Kasa energy draw) requires Phase 2 data (metrics cache populated) and a product with linked InfraCI items. Plan this as a separate spec once Phase 1 and 2 are verified in production.
+
+Tracked in backlog as follow-on to EP-TOPO-FIDELITY-001.
+
+---
+
+## Full Verification Checklist
+
+After Phase 1:
+- [ ] Navigate to inventory topology, click "Analyze Impact" on any InfraCI node. Radial layout loads within 3 seconds. No full-page reload.
+- [ ] Switch to "Dependency Audit" view while focused on a DigitalProduct node. OSI-layer swimlane layout renders within 3 seconds.
+- [ ] Switch to "Exploration" view. Spinner disappears, base graph renders normally.
+
+After Phase 2:
+- [ ] With SNMP metrics flowing (EP-EDGE-TELEM-001 Phase 1 deployed): verify links show `↓X Kbps ↑Y Kbps` labels when zoomed in.
+- [ ] Verify link width varies by utilization (thin = idle, thick = busy).
+- [ ] Verify an "operStatus: down" link renders in error color (not black).
+- [ ] Zoom out below 0.6x — verify labels disappear but width encoding remains.
+- [ ] Remove edge node metrics source — verify topology renders exactly as before (no undefined errors, links at default width).
+
+After Phase 3:
+- [ ] Verify a UniFi switch in the graph shows the correct product photo from `static.ui.com`.
+- [ ] Verify a `smart_plug` node shows the `smart-plug.svg` generic icon.
+- [ ] Verify a node with no `vendorIconModel` and unknown `ciType` shows the Unicode symbol.
+- [ ] Open Chrome DevTools Performance tab. Record 30 seconds of topology interaction with icons loading. Verify no frame drops below 30fps.
+- [ ] Run `cd apps/web && npx next build` — verify zero TypeScript errors and successful bundle.

--- a/docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md
+++ b/docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md
@@ -1,0 +1,772 @@
+# Edge Node — Network Telemetry & Adapter Collectors
+
+| Field | Value |
+|-------|-------|
+| **Epic** | EP-EDGE-TELEM-001 |
+| **IT4IT Alignment** | §5.7 Operate (Service Monitoring FC, Configuration Management FC, Event Management FC) |
+| **Depends On** | Phase 0 Edge Node (PR #501, `services/edge-node/`), SNMP collector (snmp-poll.ts), `2026-05-09-dpf-edge-node-design.md` (binding), `2026-04-02-multi-layer-topology-graph-design.md` (OSI model) |
+| **Status** | Draft |
+| **Created** | 2026-05-19 |
+| **Author** | Claude (Software Engineer) + Mark Bodman (CEO) |
+
+---
+
+## 1. Problem Statement
+
+The Phase 0 edge node ships `discovery.network` — it discovers *what devices exist* and *how they are
+connected* at OSI layers 3–4. It does not answer:
+
+- **How much traffic is flowing right now?** (per-link throughput, the signature of tools like UniFi
+  and NNMI)
+- **What is the physical Layer 2 topology?** (switch port → device wiring, LLDP neighbors)
+- **What smart-home devices are present?** (TP-Link Kasa switches/plugs, Starlink dishes, devices
+  known to Home Assistant)
+- **What is the identity and model of each device?** (manufacturer, product name, serial — needed for
+  product icons and CMDB accuracy)
+
+These gaps exist because the current SNMP collector reads only six system-identity OIDs and runs on a
+5-minute cadence that is too coarse for telemetry. Closing them requires two additions to the edge
+node:
+
+1. **A richer SNMP walk** — ifTable (throughput counters) + LLDP-MIB (L2 neighbors) — giving
+   per-interface traffic rates and wired-topology edges to any SNMP-capable device, regardless of
+   vendor.
+2. **Optional vendor adapter collectors** — lightweight plugins that activate when a specific platform
+   is present on the LAN (UniFi controller, Kasa devices, Starlink dish, Home Assistant). Each adapter
+   maps vendor-proprietary data onto the same `ObservationItem` + `SubmissionRelationship` shape the
+   SNMP collector already uses, and additionally produces telemetry rate data.
+
+Not everyone has a UniFi controller. The SNMP ifTable walk is the universal baseline; adapters are
+progressive enrichment.
+
+---
+
+## 2. Design Principles
+
+| # | Principle | Rationale |
+|---|-----------|-----------|
+| P1 | **SNMP is the universal baseline** | Works on any managed switch, router, or AP regardless of vendor. Adapters are additive; they do not replace SNMP. |
+| P2 | **Adapters are opt-in, auto-detect where possible** | Kasa and Starlink auto-detect via LAN probes. UniFi and HA require explicit config (credentials). A missing adapter produces no error — it simply does not run. |
+| P3 | **Discovery and telemetry are separate channels** | Discovery runs every 5 minutes (inventory), telemetry runs every 10–30 seconds (metrics). They share the same collector code but submit to different endpoints with different retention semantics. |
+| P4 | **Wire contract is runtime-agnostic** | New endpoints follow the same bearer-token, JSON-body, idempotent-runKey pattern as existing edges. Mode 1 (TypeScript) and Mode 4 Go implement the same contract. |
+| P5 | **Stateful delta only in the edge node** | The portal stores the latest computed rate, not raw counter snapshots. Delta computation (current − previous octets ÷ elapsed seconds) runs in the edge node where both readings are available. |
+| P6 | **IoT devices link to CMDB via MAC** | Every adapter emits a `SAME_AS` relationship from its device key to the `arp:<ip>` item already in the discovery graph. The Authority Core normalization pipeline collapses these into a single canonical CI. |
+| P7 | **The building is a Digital Product** | Smart-home devices discovered by adapters are `cmdb_ci_iot_device` Configuration Items. The DPF portfolio can contain a "Building Management" product whose inventory is all the IoT CIs from the local LAN. |
+
+---
+
+## 3. New Capabilities
+
+Extend the reserved capability namespace in `packages/db/src/edge-node-types.ts`:
+
+```typescript
+// Already reserved — now formally specified
+"metrics.network"   // submits per-interface telemetry via /api/v1/edge/metrics
+"discovery.lldp"    // submits L2 neighbor topology via existing /discovery-runs
+```
+
+The `discovery.lldp` capability is additive to `discovery.network` — both submit to the same
+`/api/v1/edge/discovery-runs` endpoint. `metrics.network` uses the new `/api/v1/edge/metrics`
+endpoint (§6).
+
+The Authority Core's heartbeat response already returns `acceptedCapabilities` — operators enable /
+disable individual capabilities without code changes.
+
+---
+
+## 4. Collector Extensions
+
+### 4.1 SNMP ifTable Walk (universal — all SNMP-capable devices)
+
+Extends the existing `src/collectors/snmp-poll.ts`. Runs against the same configured target list as
+the existing system-identity query, in the same sweep tick, as a second SNMP walk phase.
+
+**New OIDs walked** (per interface, indexed by `ifIndex`):
+
+| OID | Name | Purpose |
+|-----|------|---------|
+| `1.3.6.1.2.1.2.2.1.2.N` | ifDescr | Interface description string ("eth0", "GigabitEthernet0/1") |
+| `1.3.6.1.2.1.31.1.1.1.18.N` | ifAlias | Admin-assigned port label (often the connected device name) |
+| `1.3.6.1.2.1.2.2.1.8.N` | ifOperStatus | 1=up, 2=down, 3=testing |
+| `1.3.6.1.2.1.31.1.1.1.15.N` | ifHighSpeed | Interface speed in Mbps (correct for Gigabit+) |
+| `1.3.6.1.2.1.31.1.1.1.6.N` | **ifHCInOctets** | 64-bit cumulative input bytes (must use; 32-bit wraps in minutes at 10G) |
+| `1.3.6.1.2.1.31.1.1.1.10.N` | **ifHCOutOctets** | 64-bit cumulative output bytes |
+
+**SNMP mechanism**: Use `getBulk` (SNMPv2c/v3) or sequential `getNext` (SNMPv1 fallback) to walk the
+full ifTable. The existing shell-out to `snmpget` is insufficient for table walks; this is the point
+where the edge node should adopt the `net-snmp` npm package for Mode 1 TypeScript, or `gosnmp/gosnmp`
+for Mode 4 Go, replacing the subprocess approach for the new walk phase. The existing system-identity
+queries may remain as subprocesses during the transition.
+
+**Delta computation** (stateful):
+
+```typescript
+// Persisted alongside state.json in $DPF_EDGE_STATE_DIR/snmp-counters.json
+interface SnmpCounterSnapshot {
+  [deviceKey: string]: {
+    [ifIndex: number]: {
+      inOctets: bigint;   // ifHCInOctets
+      outOctets: bigint;  // ifHCOutOctets
+      sampledAt: number;  // epoch ms
+    };
+  };
+}
+```
+
+Rate computation per interface per sweep:
+```
+rxBps = (inOctets_now - inOctets_prev) * 8 / ((sampledAt_now - sampledAt_prev) / 1000)
+txBps = (outOctets_now - outOctets_prev) * 8 / ((sampledAt_now - sampledAt_prev) / 1000)
+```
+
+**First-poll rule**: If no prior snapshot exists for a `(deviceKey, ifIndex)` pair, store the
+current reading and emit **no metric** for that interface on this sweep. A valid rate requires two
+readings. Implementers must guard against `undefined` previous values before computing any delta.
+
+**Counter wrap**: 64-bit counters wrap at 2^64 ≈ 18.4 exabytes — at 100 Gbps sustained this takes
+~18.4 seconds worth of data in the absolute sense but the counter represents cumulative bytes since
+device boot, so wrap takes decades on any real device. Detect by `now_bigint < prev_bigint` (using
+arbitrary-precision comparison) and handle by re-seeding the snapshot without emitting a rate.
+
+**BigInt JSON serialisation**: `JSON.stringify` throws on `BigInt`; `JSON.parse` loses precision
+above 2^53 for numeric values. Persist counter values as **decimal strings** in
+`snmp-counters.json` (e.g., `"inOctets": "18446744073709551615"`) and read back via
+`BigInt(str)`. The `SnmpCounterSnapshot` interface comment must document this convention.
+
+**Output**: Interface metric items are not submitted via `discovery-runs` (they are not topology).
+They are collected during the sweep tick and held in memory until the metrics submission cycle fires
+(§5 — separate cadence).
+
+---
+
+### 4.2 LLDP-MIB Walk (L2 neighbor discovery — all LLDP-capable devices)
+
+New collector: `src/collectors/lldp-walk.ts`. Runs against the same SNMP target list. Walks the
+LLDP-MIB neighbor table to produce `PEER_OF` relationships between switch ports.
+
+> **Note on entity-type naming**: New entity types in §4.2 and §7.2 use underscores (`switch_port`,
+> `smart_plug`, `smart_switch`, `satellite_internet`) to match the convention of existing types
+> (`network_device`, `wireless_ap`). The OSI spec uses `switch-port` (hyphen) — the implementation
+> must normalise to underscore; this spec is the authoritative definition going forward.
+
+**OIDs walked** (lldpRemTable, indexed by `[timeMark, localPortNum, remIndex]`):
+
+| OID | Name | Purpose |
+|-----|------|---------|
+| `1.0.8802.1.1.2.1.4.1.1.5.T.P.N` | lldpRemChassisId | Remote chassis ID (usually MAC address) |
+| `1.0.8802.1.1.2.1.4.1.1.7.T.P.N` | lldpRemPortId | Remote port identifier |
+| `1.0.8802.1.1.2.1.4.1.1.8.T.P.N` | lldpRemPortDesc | Remote port description |
+| `1.0.8802.1.1.2.1.4.1.1.9.T.P.N` | **lldpRemSysName** | Remote device hostname — primary correlation key |
+| `1.0.8802.1.1.2.1.4.1.1.10.T.P.N` | lldpRemSysDesc | Remote system description (often includes firmware) |
+
+The index `localPortNum` (P) corresponds to `lldpLocPortTable` → `lldpLocPortId`, which maps to
+`ifIndex` in the IF-MIB. Cross-referencing with `ifDescr` gives the local port name.
+
+**Output**: Emits `PEER_OF` relationships in the `discovery-runs` submission:
+
+```typescript
+SubmissionRelationship {
+  fromObservedKey: "snmp:<local-ip>/port/<ifIndex>",
+  toObservedKey:   "arp:<resolved-ip>",  // resolved from lldpRemSysName + ARP table
+  relationshipType: "PEER_OF",
+  rawData: {
+    localIfIndex: number,
+    localIfDesc: string,     // "eth0" / "GigabitEthernet0/1"
+    remoteChassisId: string, // MAC
+    remoteSysName: string,
+    remotePortDesc: string,
+  }
+}
+```
+
+Also emits `ObservationItem` entries for discovered ports as `osiLayer: 2` items (`itemType:
+"switch-port"`), keyed `snmp:<ip>/port/<ifIndex>`, enabling the OSI Layer 2 swimlane in the topology
+graph.
+
+---
+
+### 4.3 UniFi Adapter (`src/collectors/unifi.ts`) — optional
+
+**Activation**: Config entry in `$DPF_EDGE_ADAPTER_DIR/adapters.json` (new file, alongside
+`snmp.json`). If the file is absent or has no `unifi` block, the adapter does not run.
+
+```json
+{
+  "unifi": {
+    "controllerUrl": "https://192.168.1.1",
+    "apiKey": "...",
+    "site": "default",
+    "tlsInsecure": false
+  }
+}
+```
+
+**Data flow**:
+
+1. `GET /proxy/network/api/s/{site}/stat/device` (polling every metrics cadence)
+2. For each device: extract `model`, `model_name`, `type`, `serial`, `mac`, `ip`, `name`, `state`
+3. For each device's `port_table[]`: extract `ifname`, `rx_bytes-r`, `tx_bytes-r`, `poe_enable`,
+   `poe_power`, `lldp_system_name`, `lldp_mac`
+4. Build parent-child topology from `uplink.mac` → `downlink_table[].mac`
+5. Open WebSocket `wss://{console}/proxy/network/wss/s/{site}/events` for device join/leave events;
+   trigger immediate sweep on `EVT_SW_*` or `EVT_AP_*` events.
+   **Reconnect policy**: On close or error, reconnect with exponential back-off: 1s → 2s → 4s → 8s
+   → 30s (capped). Log a warning after 3 consecutive failures. A downed event loop does not block
+   the regular 5-minute discovery sweep — it only delays event-triggered sweeps.
+
+**Discovery output** (submitted via `discovery-runs`):
+
+```typescript
+ObservationItem {
+  observedKey: "unifi:<device-mac>",
+  itemType: unifiTypeMap[device.type],  // usw→switch, uap→access_point, ugw→gateway, udm→gateway
+  name: device.name || device.model_name,
+  confidence: 1.0,
+  rawData: {
+    model, model_name, serial, mac, ip, state,
+    vendorIconModel: model,  // for fingerprint DB lookup in the portal
+    osiLayer: typeToOsiLayer[itemType],
+    discoveredVia: "unifi_api"
+  }
+}
+
+// Link to existing ARP-discovered host
+SubmissionRelationship {
+  fromObservedKey: "unifi:<device-mac>",
+  toObservedKey:   "arp:<device-ip>",
+  relationshipType: "SAME_AS"
+}
+
+// Parent-child port topology (HOSTS edges)
+SubmissionRelationship {
+  fromObservedKey: "unifi:<parent-mac>",
+  toObservedKey:   "unifi:<child-mac>",
+  relationshipType: "HOSTS",
+  rawData: { parentPortIdx: number, parentPortName: string }
+}
+```
+
+**Telemetry output** (submitted via `/api/v1/edge/metrics`): Per-port `rx_bytes-r` / `tx_bytes-r`
+are already computed rates from the UniFi controller (bytes/sec). No delta calculation required.
+
+```typescript
+InterfaceMetric {
+  deviceKey: "unifi:<device-mac>",
+  ifIndex: port_table[n].port_idx,
+  ifName: port_table[n].name,
+  rxBps: port_table[n]["rx_bytes-r"] * 8,   // bytes→bits
+  txBps: port_table[n]["tx_bytes-r"] * 8,
+  operStatus: port_table[n].speed > 0 ? "up" : "down",
+  speedMbps: port_table[n].speedmax,
+  poeWatts: port_table[n].poe_power,         // optional, PoE-only
+}
+```
+
+---
+
+### 4.4 TP-Link Kasa Adapter (`src/collectors/kasa.ts`) — optional, auto-detect
+
+**Activation**: Auto-detect via UDP broadcast discovery. If `tplink-smarthome-api` client finds no
+devices, the adapter completes silently with zero items. An explicit `"kasa": { "disabled": true }`
+block in `adapters.json` suppresses even the discovery attempt.
+
+**npm dependency** (Mode 1 only): `tplink-smarthome-api`. Add to `services/edge-node/package.json`.
+Mode 4 Go equivalent: `tplink-kasa-go` or subprocess to the python-kasa CLI.
+
+**Discovery**:
+- `client.startDiscovery({ discoveryTimeout: 5000 })` — UDP broadcast on port 9999
+- Receives `device-new` events with device object
+- Calls `device.getSysInfo()` for: `model`, `alias`, `mac`, `deviceId`, `hw_ver`, `sw_ver`, `rssi`
+- HS105/EP25 (energy-monitoring plugs): also calls `plug.emeter.getRealtime()` for `power_mw`,
+  `voltage_mv`, `current_ma`, `total_kwh`
+
+**Discovery output**:
+
+```typescript
+ObservationItem {
+  observedKey: "kasa:<mac>",
+  itemType: "smart_plug",        // HS105, EP25, KP115 = smart_plug
+  // or: "smart_switch"          // HS200, HS210, KS200M = smart_switch
+  name: device.alias,            // User-set friendly name ("Living Room Lamp")
+  confidence: 0.95,
+  rawData: {
+    model, mac, deviceId, hwVer, swVer, rssi,
+    vendorIconModel: model,
+    osiLayer: 7,                 // L7 — these are application-layer endpoints
+    osiLayerName: "application",
+    discoveredVia: "kasa_lan",
+    emeter: { powerMw, voltageMv, currentMa, totalKwh } | null
+  }
+}
+```
+
+**Telemetry output** (HS105/energy-monitoring models only):
+
+```typescript
+InterfaceMetric {
+  deviceKey: "kasa:<mac>",
+  ifName: "emeter",
+  rxBps: 0,
+  txBps: 0,
+  operStatus: device.is_on ? "up" : "down",
+  // Extra: raw energy data in rawData
+  rawData: { powerMw, voltageMv, currentMa, totalKwh }
+}
+```
+
+---
+
+### 4.5 Starlink Adapter (`src/collectors/starlink.ts`) — optional, auto-detect
+
+**Activation**: Attempt gRPC connect to `192.168.100.1:9200` on startup. If the endpoint is
+unreachable within 2 seconds, the adapter is skipped silently. A `"starlink": { "disabled": true }`
+block in `adapters.json` bypasses the probe.
+
+**npm dependencies** (Mode 1): `@grpc/grpc-js`, `@grpc/proto-loader`. Add to
+`services/edge-node/package.json`.  
+**Proto source**: Community-maintained at `sparky8512/starlink-grpc-tools`. The proto files are
+vendored into `services/edge-node/src/collectors/starlink-protos/` at a pinned commit hash.
+
+**gRPC calls**:
+- `get_status` — returns `state` (CONNECTED/SEARCHING/OFFLINE), `uptime_s`, `downlink_throughput_bps`,
+  `uplink_throughput_bps`, `pop_ping_latency_ms`, `pop_ping_drop_rate`
+- `get_device_info` — returns `id` (dish serial), `hardware_version`, `software_version`
+- Called once per metrics cadence; no streaming subscription (the API does not support it).
+
+**Discovery output**:
+
+```typescript
+ObservationItem {
+  observedKey: "starlink:<dish-serial>",
+  itemType: "satellite_internet",   // new CI type
+  name: "Starlink Dish",
+  confidence: 1.0,
+  rawData: {
+    dishSerial: string,
+    hardwareVersion: string,
+    softwareVersion: string,
+    osiLayer: 3,
+    osiLayerName: "network",
+    discoveredVia: "starlink_grpc",
+    vendorIconModel: "STARLINK_STANDARD_ACTUATED_V3",  // fingerprint DB key
+  }
+}
+
+// Connect to gateway
+SubmissionRelationship {
+  fromObservedKey: "starlink:<dish-serial>",
+  toObservedKey:   "arp:<gateway-ip>",
+  relationshipType: "ROUTES_THROUGH",
+}
+```
+
+**Telemetry output**:
+
+```typescript
+InterfaceMetric {
+  deviceKey: "starlink:<dish-serial>",
+  ifName: "satellite-link",
+  rxBps: get_status.downlink_throughput_bps,
+  txBps: get_status.uplink_throughput_bps,
+  operStatus: get_status.state === "CONNECTED" ? "up" : "down",
+  rawData: {
+    latencyMs: pop_ping_latency_ms,
+    dropRate: pop_ping_drop_rate,
+    uptimeSec: uptime_s,
+  }
+}
+```
+
+---
+
+### 4.6 Home Assistant Bridge (`src/collectors/home-assistant.ts`) — optional
+
+**Activation**: Config entry in `adapters.json`:
+
+```json
+{
+  "homeAssistant": {
+    "url": "http://homeassistant.local:8123",
+    "token": "...",
+    "syncIntervalSec": 300
+  }
+}
+```
+
+**Why HA**: Home Assistant acts as the authoritative smart-device registry for homes where it is
+deployed. Its device registry already has `manufacturer`, `model`, and `area_id` (room/zone) for
+every integrated device. Pulling from HA avoids building individual vendor adapters for every smart
+home protocol (Zigbee, Z-Wave, Tuya, etc.).
+
+**WebSocket API** (official, `home-assistant-js-websocket` npm):
+- Connect to `ws://<url>/api/websocket`, authenticate with token
+- Send `config/device_registry/list` → full device catalog with `id`, `name`, `manufacturer`,
+  `model`, `area_id`, `connections` (includes MAC tuples), `sw_version`
+- Send `get_states` → current entity states (on/off, sensor values)
+- Subscribe to `state_changed` events for live device state updates
+
+**Deduplication via MAC**: The `connections` array on each HA device contains tuples like
+`["mac", "aa:bb:cc:dd:ee:ff"]`. This MAC links to the `arp:<ip>` item already in the graph via a
+`SAME_AS` relationship, collapsing the HA device record and the ARP-discovered host into a single
+canonical CI.
+
+**Discovery output**:
+
+```typescript
+ObservationItem {
+  observedKey: "ha:<ha-device-id>",
+  itemType: classifyHaDevice(device),  // derived from device_class or integration domain
+  name: device.name,
+  confidence: 0.9,
+  rawData: {
+    manufacturer, model, swVersion,
+    areaId,    // room/zone location — maps to brick:isLocatedIn
+    haIntegration: device.config_entries[0],  // e.g., "kasa", "zha", "z_wave_js"
+    vendorIconModel: `${manufacturer}/${model}`,
+    osiLayer: 7,
+    discoveredVia: "home_assistant",
+  }
+}
+
+// Link to ARP-discovered IP host via MAC
+SubmissionRelationship {
+  fromObservedKey: "ha:<ha-device-id>",
+  toObservedKey:   "arp:<resolved-ip>",  // look up from ARP table by MAC
+  relationshipType: "SAME_AS",
+}
+```
+
+**Location enrichment**: The `areaId` is stored in rawData and written to the InfraCI node's
+`properties` in PostgreSQL. The topology view and the product Health tab use `areaId` to group
+devices by room — the first implementation of spatial/Brick-schema alignment without requiring a full
+RDF ontology layer.
+
+---
+
+## 5. Metrics Submission Cadence
+
+Two independent loops in `src/sweep.ts` (or factored into separate modules):
+
+| Loop | Cadence | Produces | Endpoint |
+|------|---------|----------|----------|
+| **Discovery sweep** | 5 min (Authority-decided) | Topology items + LLDP relationships | `/api/v1/edge/discovery-runs` |
+| **Metrics sweep** | 10–30 sec (Authority-decided) | Per-interface throughput rates | `/api/v1/edge/metrics` (new) |
+
+The metrics cadence is returned in the heartbeat response alongside the existing `sweepIntervalSec`.
+Add `metricsIntervalSec` to the `HeartbeatResponse` schema.
+
+**Metrics sweep loop**:
+1. Re-use cached SNMP counter snapshots from the last discovery sweep (no extra SNMP round-trip for
+   identity data)
+2. Poll UniFi `/stat/device` for `rx_bytes-r` / `tx_bytes-r` (already-computed rates — no delta)
+3. Poll Kasa devices for emeter (fast, LAN-local)
+4. Poll Starlink gRPC for throughput
+5. Build `MetricsEnvelope` and POST to `/api/v1/edge/metrics`
+
+For SNMP-only devices, the metrics sweep fires the ifTable walk independently of the discovery sweep
+to collect counter snapshots. Delta is computed between the two most recent snapshots.
+
+---
+
+## 6. New API Endpoint: `/api/v1/edge/metrics`
+
+**Route**: `POST /api/v1/edge/metrics`  
+**Auth**: Node bearer token (`dpfedge_*`), same as existing endpoints  
+**Required capability**: `metrics.network`  
+
+### 6.1 Request Body
+
+```typescript
+interface MetricsEnvelope {
+  runKey: string;                  // UUID idempotency key (same pattern as discovery-runs)
+  nodeId: string;                  // Resolved from token, not trusted from body
+  observedAt: string;              // ISO 8601
+  metricsVersion: "1";
+  interfaces: InterfaceMetric[];
+}
+
+interface InterfaceMetric {
+  deviceKey: string;               // "snmp:<ip>", "unifi:<mac>", "kasa:<mac>", "starlink:<serial>"
+  ifIndex?: number;                // SNMP ifIndex (undefined for non-SNMP devices)
+  ifName: string;                  // Human-readable port/interface name
+  rxBps: number;                   // bits per second received
+  txBps: number;                   // bits per second transmitted
+  rxErrors?: number;
+  txErrors?: number;
+  operStatus: "up" | "down" | "unknown";
+  speedMbps?: number;              // Nominal link speed
+  rawData?: Record<string, unknown>; // Adapter-specific extras (poeWatts, latencyMs, etc.)
+}
+```
+
+### 6.2 Portal Ingestion
+
+- Validate bearer token via `resolveEdgeNodeAuth` (same as discovery-runs)
+- Validate `metricsVersion: "1"`, body size cap (64 KB), `observedAt` freshness (within 5 minutes)
+- **Do not write to PostgreSQL** for every metrics tick — metrics are not CMDB data
+- Write to an **in-memory metrics cache** keyed by `(nodeId, deviceKey, ifName)`, TTL 90 seconds
+  (3× the maximum metrics interval, so stale data self-clears)
+- Emit a **WebSocket event** to all browser clients subscribed to topology updates for this
+  organization (`topology:metrics:update` event with the delta)
+
+### 6.3 Browser WebSocket Push
+
+The existing portal has a WebSocket infrastructure (check `apps/web/lib/` for the push mechanism).
+The metrics endpoint writes to the in-memory cache and then fans out to subscribed browser connections.
+Browser clients subscribed to the topology view receive:
+
+```typescript
+{
+  type: "topology:metrics:update",
+  payload: {
+    interfaces: InterfaceMetric[],
+    observedAt: string,
+    nodeId: string,
+  }
+}
+```
+
+The topology canvas re-renders link annotations on receipt.
+
+---
+
+## 7. Portal Schema Changes
+
+### 7.1 `RESERVED_CAPABILITIES` — wire-contract change (required co-change)
+
+**File: `packages/db/src/edge-node-types.ts`**
+
+Add both new capability strings to the `RESERVED_CAPABILITIES` array:
+
+```typescript
+export const RESERVED_CAPABILITIES = [
+  "discovery.network",
+  "discovery.software",
+  "discovery.lldp",     // NEW — submits LLDP neighbor topology via /discovery-runs
+  "metrics.host",
+  "metrics.network",    // NEW — submits per-interface telemetry via /api/v1/edge/metrics
+  "identity.broker",
+  "mcp.gateway",
+  "a2a.gateway",
+  "policy.enforcement",
+  "tunnel.private-link",
+] as const;
+```
+
+**Also update**: `apps/web/app/api/v1/edge/heartbeat/route.ts` uses `z.enum(RESERVED_CAPABILITIES)`
+to validate `acceptedCapabilities` in the heartbeat request body. This co-change must land in the
+same PR as any code that sends `metrics.network` or `discovery.lldp` — otherwise the heartbeat
+route rejects the capability and the edge node falls back to Phase 0 behaviour.
+
+### 7.2 HeartbeatResponse and EnrollResponse (extend existing)
+
+```typescript
+// apps/web/app/api/v1/edge/heartbeat/route.ts
+interface HeartbeatResponse {
+  // existing
+  heartbeatIntervalSec: number;
+  sweepIntervalSec: number;
+  acceptedCapabilities: string[];
+  trustState: EdgeNodeTrustState;
+  // new
+  metricsIntervalSec: number;  // default 30; 0 = metrics disabled for this node
+}
+```
+
+`metricsIntervalSec` must also appear in `EnrollResponse` so a newly enrolled node knows its
+metrics cadence without waiting for the first heartbeat:
+
+```typescript
+// apps/web/app/api/v1/edge/enroll/route.ts
+interface EnrollResponse {
+  // existing
+  nodeId: string;
+  nodeToken: string;
+  trustState: EdgeNodeTrustState;
+  heartbeatIntervalSec: number;
+  sweepIntervalSec: number;
+  acceptedCapabilities: string[];
+  // new
+  metricsIntervalSec: number;
+}
+```
+
+### 7.3 New entity types
+
+Add to the entity-type vocabulary in the discovery taxonomy (all underscore, matching the existing
+`network_device` / `wireless_ap` convention — the OSI spec's `switch-port` hyphen is corrected here):
+
+- `satellite_internet` — OSI Layer 3, internet-connectivity device
+- `smart_plug` — OSI Layer 7, IoT endpoint with power control (note: assigned L7 because the
+  primary interface is the application protocol; the physical power relay is an implementation detail
+  of the endpoint, not a separate L1 entity in the graph)
+- `smart_switch` — OSI Layer 7, IoT endpoint with circuit-level switching
+- `switch_port` — OSI Layer 2, physical switch port (from LLDP walk)
+
+These join the existing `host`, `subnet`, `gateway`, `router`, `switch`, `wireless_ap`, `container`
+types without schema changes — they are stored as the `entityType` string field on `InventoryEntity`.
+
+### 7.4 Metrics Cache Module
+
+The in-memory metrics cache written by the `POST /api/v1/edge/metrics` handler must be exported
+from a single named module so both the portal endpoint and the graph server actions can import it:
+
+**Canonical path: `apps/web/lib/edge/metrics-cache.ts`**
+
+This module is a singleton (module-level `Map`) and must not be instantiated per-request. The
+graph server actions (Spec B `enrichLinksWithMetrics`) import `getLatestMetricsForEdge` from this
+path. The metrics endpoint route handler imports `writeMetrics` from the same path.
+
+### 7.5 InfraCI `areaId` property
+
+The `areaId` from Home Assistant (and future Brick Schema integration) is stored in the `properties`
+JSON column on `InventoryEntity`. No migration needed — `properties` is already `JsonValue`. The
+topology graph uses `properties.areaId` to group nodes by room in a future "spatial view".
+
+---
+
+## 8. Discovery Pipeline: Normalization of SAME_AS Chains
+
+Phase 0 accumulates multiple items per physical device: `arp:<ip>` (from ARP), `snmp:<ip>` (from
+SNMP), `unifi:<mac>` (from UniFi), `kasa:<mac>` (from Kasa), `ha:<id>` (from HA) — all linked by
+`SAME_AS` relationships to the same physical device.
+
+The normalization pipeline (currently stub in Authority Core) must collapse these into a single
+canonical `InventoryEntity` using the highest-confidence item as the base and merging rawData from
+all sources. Priority:
+
+1. UniFi adapter (confidence 1.0) — takes manufacturer, model, serial, icon model
+2. Kasa adapter (confidence 0.95) — takes friendly name, energy data
+3. Home Assistant bridge (confidence 0.9) — takes manufacturer, model, area, integration
+4. SNMP poll (confidence 0.95) — takes sysName, sysDescr, vendor OID, uptime
+5. nmap sweep (confidence 0.85) — takes IP, hostname
+6. ARP table (confidence 0.7) — takes IP, MAC (base record, lowest confidence)
+
+The normalized entity carries a `discoveredVia` array listing all contributing sources, an
+`iconModel` field for the icon lookup chain (§9), and an `areaId` if HA provided one.
+
+---
+
+## 9. Device Icon Model
+
+Each `InventoryEntity` rawData carries a `vendorIconModel` string that drives the icon lookup chain
+in the portal's topology view. The chain is:
+
+1. **UniFi fingerprint DB** — if `vendorIconModel` is a UniFi model code (e.g., `"US-8-150W"`):
+   look up in `fingerprint-database.json` (bundled static asset, ~5,500 entries, sourced from
+   github.com/CANTI-BOT/UniFi-Icon-Browser). Returns a `static.ui.com` CDN URL.
+2. **NetBox device-type library** — manufacturer slug + model slug maps to a front-panel image in
+   the Apache 2.0 `netbox-community/devicetype-library`. Images are bundled at build time for known
+   vendors.
+3. **Generic device-type SVG** — from `network-automation/networking-icons` (Apache 2.0). Maps CI
+   type (`router`, `switch`, `access_point`, `smart_plug`, etc.) to a vendor-neutral SVG.
+4. **Unicode symbol fallback** — current behavior, always succeeds.
+
+The `vendorIconModel` string is set by each adapter as follows:
+
+| Adapter | `vendorIconModel` value |
+|---------|------------------------|
+| UniFi | `device.model` from API (e.g., `"US-8-150W"`) |
+| Kasa | `"TP-Link/HS200"` or `"TP-Link/HS105"` |
+| Starlink | `"SpaceX/Starlink-Standard-V3"` |
+| HA bridge | `"${manufacturer}/${model}"` (e.g., `"TP-Link/HS200"`) |
+| SNMP | Derived from `sysObjectID` enterprise OID + `sysDescr` model-string parsing |
+
+---
+
+## 10. Adapters Config File Schema
+
+Full schema for `$DPF_EDGE_ADAPTER_DIR/adapters.json` (default path:
+`/etc/dpf-edge/adapters.json`):
+
+```typescript
+interface AdaptersConfig {
+  unifi?: {
+    controllerUrl: string;   // e.g., "https://192.168.1.1"
+    apiKey: string;          // X-API-KEY header value
+    site?: string;           // default "default"
+    tlsInsecure?: boolean;   // default false; warn if true
+  };
+  homeAssistant?: {
+    url: string;             // e.g., "http://homeassistant.local:8123"
+    token: string;           // Long-lived access token
+    syncIntervalSec?: number; // default 300 (5 min)
+  };
+  kasa?: {
+    disabled?: boolean;       // default false; set true to suppress auto-detect
+    discoveryTimeoutMs?: number; // default 5000
+  };
+  starlink?: {
+    disabled?: boolean;       // default false; set true to suppress auto-detect
+    host?: string;            // default "192.168.100.1"
+    port?: number;            // default 9200
+  };
+}
+```
+
+File mode check: warn if world-readable (tokens are sensitive). Same pattern as `snmp.json`.
+
+---
+
+## 11. Security Considerations
+
+| Surface | Risk | Mitigation |
+|---------|------|-----------|
+| `adapters.json` credentials | Token/key leak if file is world-readable | File mode check on startup; warn and continue (not fatal — same as snmp.json) |
+| UniFi API key | Full read access to UniFi network data | API key scope: read-only; document the minimum required permission level |
+| Starlink gRPC | Unauthenticated local endpoint | Only reachable from LAN; no auth to add. Document that Starlink may change this. |
+| Kasa UDP broadcast | Devices respond to any LAN broadcast | LAN-local only; no cross-VLAN leakage risk in typical home setup |
+| HA long-lived token | Full HA API access | Document use of a restricted "Device Registry Read" HA user; HA supports per-user token scopes via custom role |
+| SNMP credentials (v3) | Auth/priv credentials in snmp-counters.json | Protected by existing 0600 file perms on state dir |
+| Metrics endpoint DoS | High-frequency metrics flooding the portal | Portal enforces: per-node rate limit (one request per 5s minimum), body size cap 64 KB, `observedAt` freshness window 5 minutes |
+
+---
+
+## 12. Implementation Phases
+
+### Phase 1: SNMP ifTable + LLDP (Mode 1 TypeScript)
+
+1. Add `net-snmp` npm package to `services/edge-node/package.json`
+2. Extend `snmp-poll.ts` with `getBulk` ifTable walk (ifDescr, ifAlias, ifOperStatus, ifHighSpeed,
+   ifHCInOctets, ifHCOutOctets per interface)
+3. Add `lldp-walk.ts` — walk lldpRemTable, emit `PEER_OF` relationships and `switch-port` items
+4. Add stateful counter snapshot persistence to `snmp-counters.json`
+5. Add delta computation, produce in-memory `InterfaceMetric[]` per sweep
+6. Extend `HeartbeatResponse` schema with `metricsIntervalSec`
+7. Add `metrics.network` to `RESERVED_CAPABILITIES`, implement metrics sweep loop
+8. Implement `POST /api/v1/edge/metrics` portal endpoint with in-memory cache
+9. Add `satellite_internet`, `smart_plug`, `smart_switch`, `switch-port` to entity type vocabulary
+
+### Phase 2: Adapter Collectors (Mode 1 TypeScript)
+
+1. Add adapter config file schema and loader (`adapters.json`)
+2. Implement UniFi adapter (poll + WebSocket events + discovery + telemetry)
+3. Implement Kasa adapter (auto-detect + discovery + emeter telemetry)
+4. Implement Starlink adapter (auto-detect gRPC + discovery + throughput)
+5. Implement Home Assistant bridge (WebSocket + device_registry + state subscriptions)
+6. Implement normalization pipeline SAME_AS collapse in Authority Core
+7. Add `vendorIconModel` field to normalized InventoryEntity properties
+
+### Phase 3: Mode 4 Go Parity
+
+Implement equivalent collectors in the Go binary (`services/edge-node-go/`). Wire contract tests
+at `apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts` gate parity. Go dependencies:
+`gosnmp/gosnmp` (SNMP), `google.golang.org/grpc` + proto (Starlink), `net/http` (UniFi, HA).
+Kasa adapter: subprocess to python-kasa CLI or community Go client.
+
+---
+
+## 13. Success Criteria
+
+1. An edge node with a managed SNMP-capable switch in scope reports per-interface `rxBps`/`txBps`
+   to the portal within 30 seconds of a sustained traffic event
+2. LLDP walk produces `PEER_OF` relationships for every adjacent switch port pair, visible as L2
+   edges in the topology graph
+3. A Kasa HS105 plug is discovered, linked to its ARP host via MAC, and reports energy draw in the
+   device detail panel
+4. A Starlink dish is auto-detected, reported as `satellite_internet` CI, and its throughput appears
+   as the uplink metric on the topology graph
+5. When Home Assistant is configured, every HA device appears in DPF inventory with `manufacturer`,
+   `model`, and `areaId`, deduplicated against the ARP-discovered host
+6. Disabling all adapters leaves the existing Phase 0 discovery behavior unchanged — zero regressions
+7. Mode 4 Go binary passes wire-contract test suite against the same portal endpoints

--- a/docs/superpowers/specs/2026-05-19-topology-view-throughput-icons-design.md
+++ b/docs/superpowers/specs/2026-05-19-topology-view-throughput-icons-design.md
@@ -1,0 +1,551 @@
+# Topology View — Throughput Annotations & Product Icons
+
+| Field | Value |
+|-------|-------|
+| **Epic** | EP-TOPO-FIDELITY-001 |
+| **IT4IT Alignment** | §5.7 Operate (CMDB Workspace, visual management surface), §5.2 Explore (product dependency awareness) |
+| **Depends On** | EP-EDGE-TELEM-001 (`2026-05-19-edge-node-network-telemetry-adapters-design.md`) for metrics data; `2026-04-02-multi-layer-topology-graph-design.md` (OSI model, Phase 2 implemented); `2026-04-03-topology-graph-views-design.md` (named views, implemented) |
+| **Status** | Draft |
+| **Created** | 2026-05-19 |
+| **Author** | Claude (Software Engineer) + Mark Bodman (CEO) |
+
+---
+
+## 1. Problem Statement
+
+The topology graph renders the right *structure* — nodes for devices, edges for relationships, OSI
+layer swimlanes, hierarchical and radial layouts — but it falls short of the visual and operational
+fidelity of tools like Ubiquiti UniFi, OpenText NNMI, and LibreNMS in three concrete ways:
+
+1. **No per-link throughput data.** Every edge looks identical regardless of whether it is carrying
+   1 Gbps or 1 Kbps. There is no visual signal for saturation, degradation, or idle links.
+
+2. **Unicode symbols instead of product icons.** Devices are represented as △ ◇ ○ □ — abstract and
+   indistinguishable from one another at a glance. Commercial tools show actual product photos or
+   vendor-branded SVGs, making device identity immediately obvious.
+
+3. **Impact Blast Radius and Dependency Audit views have no data.** The UI layouts, layout
+   algorithms (radial and ELK.js swimlane), and Neo4j queries all exist and are implemented.
+   The missing piece is the server action wrappers that fetch data from Neo4j and serve it to the
+   component. This gap was documented in `2026-04-03-topology-graph-views-design.md` §2.5 and has
+   not yet been closed.
+
+This spec closes all three gaps. The first is contingent on EP-EDGE-TELEM-001. The second and third
+are independent of any external data source.
+
+---
+
+## 2. Design Principles
+
+| # | Principle | Rationale |
+|---|-----------|-----------|
+| P1 | **Close the spec-documented data gap first** | The impact/dependency server actions are the highest-ROI change: the UI and graph queries already exist. Closing this gap makes two views functional with no new data sources or dependencies. |
+| P2 | **Throughput annotation is additive** | If no metrics data is available (EP-EDGE-TELEM-001 not deployed), the topology renders exactly as today. Metrics data enhances but does not break the base graph. |
+| P3 | **Icon chain degrades gracefully** | Product icon → NetBox image → generic SVG → Unicode symbol. Every device always has a visual. No blank nodes. |
+| P4 | **Canvas performance is non-negotiable** | Icons are pre-loaded into a browser-side image cache (keyed by URL). No per-frame fetch. No image decode during animation. The canvas renderer draws from cache only. |
+| P5 | **Throughput labels match the domain** | Auto-scale to the appropriate unit: < 1 Kbps → bps, < 1 Mbps → Kbps, < 1 Gbps → Mbps, ≥ 1 Gbps → Gbps. Both ↓ (rx) and ↑ (tx) shown, as in UniFi. |
+| P6 | **Link width encodes utilization** | Width proportional to `max(rxBps, txBps) / speedBps`. Zero-traffic links are thin; saturated links are thick and highlighted. This communicates load without text at a distance. |
+| P7 | **Status colors are accessible** | Use CSS custom properties (`var(--dpf-success)`, `var(--dpf-warning)`, `var(--dpf-error)`) for link status coloring. Never hardcode hex. |
+
+---
+
+## 3. Gap 1 — Server Action Wrappers for Impact & Dependency Views
+
+### 3.1 Background
+
+`TopologyGraph.tsx` has fully wired Impact Blast Radius and Dependency Audit views. The view
+switcher renders them. The layout algorithms (radial BFS, ELK.js swimlane) compute positions. The
+canvas renders nodes and edges. What is missing: when these views are selected, the component
+currently uses whatever graph data was passed in from the parent page — which is `getFullGraphData()`
+(the exploration view's all-nodes query). The views need their own targeted queries.
+
+`2026-04-03-topology-graph-views-design.md` §2.5 specifies two server actions:
+- `getImpactData(ciId)` → wraps `getDownstreamImpact(ciId)` from `@dpf/db`
+- `getDependencyAuditData(productId)` → wraps `getLayeredDependencyStack(productId)` from `@dpf/db`
+
+**Both server actions already exist** in `apps/web/lib/actions/graph.ts` (confirmed). Both Neo4j
+functions are implemented. The only remaining gap is **wiring `TopologyGraph.tsx` to call them**
+when the user switches views — the component does not yet invoke these actions or handle their
+async results. Phase 1 work is component-wiring only; do not rewrite the server actions.
+
+### 3.2 Implementation
+
+**Server actions**: Both `getImpactData(ciId)` and `getDependencyAuditData(productId)` already
+exist in `apps/web/lib/actions/graph.ts`. No changes to those files.
+
+**Component wiring** (`TopologyGraph.tsx`):
+
+The component currently receives a static `data: GraphData` prop from the parent page. For impact
+and dependency views, the data must be fetched client-side when the view switches (because `ciId` or
+`productId` is determined by user interaction — which node they click or which product is focused).
+
+Add `const [isPending, startTransition] = useTransition()` and a `dynamicData` state:
+
+```typescript
+const [isPending, startTransition] = useTransition();
+const [dynamicData, setDynamicData] = useState<GraphData | null>(null);
+
+// When selectedView switches to "impact-blast-radius" and a focusNodeId is set:
+useEffect(() => {
+  if (selectedView === "impact-blast-radius" && focusNodeId) {
+    startTransition(() => {
+      // async call is OUTSIDE startTransition; only the state setter goes inside
+      void getImpactData(focusNodeId).then(setDynamicData);
+    });
+  } else if (selectedView === "dependency-audit" && focusNodeId) {
+    startTransition(() => {
+      void getDependencyAuditData(focusNodeId).then(setDynamicData);
+    });
+  } else {
+    setDynamicData(null);  // restore base graph on view switch away
+  }
+}, [selectedView, focusNodeId]);
+
+// Effective data for layout and render:
+const effectiveData = dynamicData ?? data;
+```
+
+> **React API note**: `startTransition` accepts a synchronous callback — the async call must be
+> *outside* the transition; only the resulting `setDynamicData` call is inside. Wrapping an `async`
+> function directly in `startTransition` silently discards the Promise and the state update never
+> fires.
+
+`dynamicData` overrides the static `data` prop when non-null. All downstream layout and render code
+reads `effectiveData`.
+
+**Loading state**: While `isPending` is true, render a semi-transparent overlay with a centred
+spinner on the canvas. The layout engine does not fire until `dynamicData` is available.
+
+---
+
+## 4. Gap 2 — GraphData Link Throughput Extensions
+
+### 4.1 Extend the Link Type
+
+**File: `apps/web/lib/actions/graph.ts`** — extend the `GraphData` type:
+
+```typescript
+export type GraphDataLink = {
+  source: string;
+  target: string;
+  type: string;              // relationship type (HOSTS, MEMBER_OF, etc.)
+  // New — optional throughput fields:
+  rxBps?: number;            // bits per second received (from portal metrics cache)
+  txBps?: number;            // bits per second transmitted
+  speedMbps?: number;        // nominal link speed (from SNMP ifHighSpeed or UniFi)
+  operStatus?: "up" | "down" | "unknown";
+  poeWatts?: number;         // optional — for PoE ports
+};
+```
+
+The `GraphData` type currently uses an inline `links` array type. Extract it to `GraphDataLink` as
+the canonical reference.
+
+### 4.2 Populate from Metrics Cache
+
+**File: `apps/web/lib/actions/graph.ts`** — extend `getFullGraphData()` and the new targeted
+actions to merge throughput data into their returned links:
+
+```typescript
+// Server-side: pull latest metrics from the in-memory metrics cache
+function enrichLinksWithMetrics(links: GraphDataLink[]): GraphDataLink[] {
+  return links.map((link) => {
+    const metric = getLatestMetricsForEdge(link.source, link.target);
+    if (!metric) return link;
+    return {
+      ...link,
+      rxBps: metric.rxBps,
+      txBps: metric.txBps,
+      speedMbps: metric.speedMbps,
+      operStatus: metric.operStatus,
+    };
+  });
+}
+```
+
+`getLatestMetricsForEdge` queries the in-memory metrics cache (written by `POST /api/v1/edge/metrics`
+handler) by matching link endpoints to `deviceKey` + `ifName`. Cache lookups are O(1) — no DB query.
+
+### 4.3 WebSocket Push Updates
+
+When the browser is viewing the topology, it maintains a WebSocket subscription to
+`topology:metrics:update` events (§6.2 of EP-EDGE-TELEM-001). On receipt, the component updates
+its local link-throughput state and triggers a canvas redraw — without refetching the full graph
+structure.
+
+```typescript
+// In TopologyGraph.tsx
+useEffect(() => {
+  const ws = subscribeToTopologyMetrics(organizationId);
+  ws.onmessage = (event) => {
+    const update = JSON.parse(event.data);
+    if (update.type === "topology:metrics:update") {
+      setLinkMetrics(mergeLinkMetrics(linkMetrics, update.payload.interfaces));
+    }
+  };
+  return () => ws.close();
+}, [organizationId]);
+```
+
+The `setLinkMetrics` call merges the new interface metrics into a local `Map<deviceKey+ifName,
+InterfaceMetric>` and triggers a `requestAnimationFrame`-gated canvas redraw.
+
+---
+
+## 5. Gap 3 — Canvas Throughput Rendering
+
+### 5.0 CSS Variable Resolution for Canvas
+
+CSS custom properties (`var(--dpf-*)`) resolve in the CSS cascade and are **not available inside a
+Canvas 2D rendering context**. Assigning `ctx.strokeStyle = "var(--dpf-error)"` silently falls back
+to black. The correct pattern is to resolve the variables once from a DOM element and cache the
+resulting hex strings:
+
+```typescript
+// Call once in a useEffect after mount:
+function resolveCanvasColors(canvasEl: HTMLCanvasElement): CanvasColors {
+  const style = getComputedStyle(canvasEl);
+  return {
+    error:   style.getPropertyValue("--dpf-error").trim()   || "#ef4444",
+    warning: style.getPropertyValue("--dpf-warning").trim() || "#f59e0b",
+    border:  style.getPropertyValue("--dpf-border").trim()  || "#334155",
+    muted:   style.getPropertyValue("--dpf-muted").trim()   || "#64748b",
+  };
+}
+```
+
+Store the result as `canvasColors` in a `useRef` or component state. Re-resolve on system
+theme change (listen for `prefers-color-scheme` media query change). The hardcoded fallback hex
+values are safety nets only; the CSS variable takes precedence in any correctly themed install.
+
+### 5.1 Link Width by Utilization
+
+In the canvas render loop, before drawing each edge, compute utilization:
+
+```typescript
+function drawEdge(ctx, link, source, target, linkMetrics) {
+  const metric = linkMetrics.get(edgeKey(link));
+  const utilization = metric && metric.speedMbps
+    ? Math.max(metric.rxBps, metric.txBps) / (metric.speedMbps * 1_000_000)
+    : 0;
+
+  // Width: 1px (idle) → 4px (saturated)
+  ctx.lineWidth = 1 + Math.min(utilization, 1) * 3;
+
+  // Color by status — CSS custom properties do not resolve inside Canvas 2D context.
+  // Resolve them once at mount time and cache the hex values.
+  // See resolveCanvasColors() below.
+  if (metric?.operStatus === "down") {
+    ctx.strokeStyle = canvasColors.error;
+  } else if (utilization > 0.8) {
+    ctx.strokeStyle = canvasColors.warning;
+  } else {
+    ctx.strokeStyle = LINK_COLORS[link.type] ?? canvasColors.border;
+  }
+
+  // Draw the link
+  ctx.beginPath();
+  ctx.moveTo(source.x, source.y);
+  ctx.lineTo(target.x, target.y);
+  ctx.stroke();
+}
+```
+
+### 5.2 Throughput Label on Links
+
+When zoom level is sufficient (scale > 0.6, to avoid label clutter at low zoom), draw throughput
+labels centered on each edge:
+
+```typescript
+function drawLinkLabel(ctx, link, source, target, metric) {
+  if (!metric || (!metric.rxBps && !metric.txBps)) return;
+
+  const midX = (source.x + target.x) / 2;
+  const midY = (source.y + target.y) / 2;
+
+  const rxLabel = formatBps(metric.rxBps);
+  const txLabel = formatBps(metric.txBps);
+
+  ctx.font = "9px system-ui";
+  ctx.fillStyle = "var(--dpf-muted)";
+  ctx.textAlign = "center";
+  ctx.fillText(`↓${rxLabel} ↑${txLabel}`, midX, midY - 4);
+}
+
+function formatBps(bps: number): string {
+  if (bps >= 1_000_000_000) return `${(bps / 1_000_000_000).toFixed(1)} Gbps`;
+  if (bps >= 1_000_000)     return `${(bps / 1_000_000).toFixed(1)} Mbps`;
+  if (bps >= 1_000)         return `${(bps / 1_000).toFixed(1)} Kbps`;
+  return `${bps.toFixed(0)} bps`;
+}
+```
+
+The label sits slightly above the midpoint of the edge. At low zoom, only edge width and color
+communicate load — labels are hidden to keep the canvas readable.
+
+---
+
+## 6. Gap 3 — Device Product Icons
+
+### 6.1 DeviceVisual Type Extension
+
+**File: `apps/web/lib/graph/device-icons.ts`**
+
+Extend `DeviceVisual` with an optional icon URL:
+
+```typescript
+export type DeviceVisual = {
+  symbol: string;     // Unicode fallback (always set)
+  color: string;
+  size: number;
+  label: string;
+  iconUrl?: string;   // New — resolved at runtime via lookup chain
+};
+```
+
+### 6.2 Icon Lookup Chain
+
+Add `getDeviceIconUrl(ciType, vendorIconModel)`:
+
+```typescript
+export function getDeviceIconUrl(
+  ciType: string | undefined | null,
+  vendorIconModel: string | undefined | null,
+): string | undefined {
+  if (!vendorIconModel) return undefined;
+
+  // 1. UniFi fingerprint DB
+  const unifiIcon = UNIFI_FINGERPRINT_DB[vendorIconModel];
+  if (unifiIcon) return unifiIcon;  // static.ui.com CDN URL
+
+  // 2. NetBox device-type library
+  const netboxIcon = NETBOX_DEVICE_IMAGES[vendorIconModel.toLowerCase()];
+  if (netboxIcon) return netboxIcon;  // /device-images/{vendor}/{model}.svg (bundled)
+
+  // 3. Generic type SVG
+  const genericIcon = GENERIC_DEVICE_SVGS[ciType ?? ""];
+  if (genericIcon) return genericIcon;  // /icons/network/{type}.svg (bundled)
+
+  return undefined;  // → symbol fallback in renderer
+}
+```
+
+### 6.3 Static Asset Bundling
+
+**UniFi fingerprint database**:
+- Source: `fingerprint-database.json` from `github.com/CANTI-BOT/UniFi-Icon-Browser`
+- **Bundle path**: `apps/web/lib/graph/data/unifi-fingerprints.json` — a module-importable path,
+  **not** `public/`. Files in `public/` are HTTP-served assets, not importable as modules.
+- Import in `device-icons.ts` as `import UNIFI_FINGERPRINT_DB from './data/unifi-fingerprints.json'`
+  (Next.js supports JSON imports natively via TypeScript `resolveJsonModule`)
+- Size: ~800 KB uncompressed; Brotli-compressed to ~120 KB on the wire. Acceptable as a module
+  import — it is loaded once at module initialisation, not per-request.
+- Update cadence: Renovate or a periodic sync script (not automated in Phase 1)
+
+**Generic network device SVGs** (Apache 2.0 from `network-automation/networking-icons`):
+- Bundle relevant icons at: `apps/web/public/icons/network/`
+- Subset: router.svg, switch.svg, access-point.svg, smart-plug.svg, smart-switch.svg,
+  satellite.svg, docker-host.svg, server.svg, cloud.svg
+- ~15–25 SVG files; negligible bundle size
+
+**NetBox device-type images**:
+- Too large to bundle fully (~2 GB for all vendors)
+- **Selective approach**: For vendors actually present in DPF inventories (detected from normalized
+  `manufacturer` field), download and cache images on the portal host at startup
+- Or: serve via proxied fetch from `raw.githubusercontent.com/netbox-community/devicetype-library/`
+  with a server-side cache (1-week TTL)
+- Phase 1: defer NetBox images; UniFi fingerprint DB + generic SVGs cover the immediate need
+
+### 6.4 Browser Image Cache (OffscreenCanvas)
+
+**File: `apps/web/lib/graph/icon-cache.ts`** (new):
+
+```typescript
+const imageCache = new Map<string, HTMLImageElement | null>();
+// null = load attempted but failed; prevents retry storm
+
+// Module-level redraw signal — set once by TopologyGraph on mount:
+let onIconLoaded: (() => void) | null = null;
+export function setIconLoadCallback(fn: () => void): void { onIconLoaded = fn; }
+
+export function getOrLoadIcon(url: string): HTMLImageElement | null {
+  if (imageCache.has(url)) return imageCache.get(url) ?? null;
+
+  // Mark as loading (prevents duplicate loads)
+  imageCache.set(url, null);
+
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  img.onload = () => {
+    imageCache.set(url, img);
+    // Signal canvas to request a redraw — component sets this callback on mount
+    onIconLoaded?.();
+  };
+  img.onerror = () => {
+    // Retain null → symbol fallback used until next session
+  };
+  img.src = url;
+  return null;  // Not yet loaded; renderer uses symbol this frame
+}
+// TopologyGraph mount effect:
+//   setIconLoadCallback(() => requestAnimationFrame(() => redrawCanvas()));
+// This fires once per loaded image and queues a single frame redraw —
+// no React state update, no re-render, no memory leak.
+```
+
+### 6.5 Canvas Renderer Icon Drawing
+
+In the node-draw loop in `TopologyGraph.tsx`, replace:
+
+```typescript
+// BEFORE (Unicode symbol):
+ctx.fillText(dv.symbol, node.x, node.y);
+```
+
+With:
+
+```typescript
+// AFTER (icon chain):
+const iconUrl = getDeviceIconUrl(node.ciType, node.vendorIconModel);
+const img = iconUrl ? getOrLoadIcon(iconUrl) : null;
+
+if (img) {
+  const iconSize = radius * 2;
+  ctx.drawImage(img, node.x - iconSize / 2, node.y - iconSize / 2, iconSize, iconSize);
+} else {
+  ctx.fillText(dv.symbol, node.x, node.y);
+}
+```
+
+When an image finishes loading, the `iconLoadCallback` triggers a canvas redraw via
+`requestAnimationFrame`. Subsequent frames use the cached `HTMLImageElement` directly — no reload.
+
+### 6.6 GraphNode Extension
+
+The `GraphData["nodes"][0]` type needs `vendorIconModel` to reach the renderer:
+
+```typescript
+export type GraphDataNode = {
+  id: string;
+  label: string;
+  ciType?: string;
+  osiLayer?: number;
+  status?: string;
+  // New:
+  vendorIconModel?: string;  // set from InventoryEntity rawData.vendorIconModel
+  areaId?: string;           // room/zone from HA or manual config
+};
+```
+
+Populate in `mapNodes()` within `apps/web/lib/actions/graph.ts` from the Neo4j node's `rawData`
+property blob.
+
+---
+
+## 7. Building Management Product Integration
+
+When a DPF user creates a "Building Management" or "Home Infrastructure" Digital Product in the
+portfolio and assigns their LAN devices to it (via the existing taxonomy → product relationship), the
+product's Health tab gains operational meaning:
+
+**Health tab additions** (product detail page, `/portfolio/product/[id]`):
+
+| Metric | Source | Display |
+|--------|--------|---------|
+| Internet uptime | Starlink `operStatus` | Uptime gauge |
+| WAN throughput | Starlink `rxBps` / `txBps` | Sparkline, last 24h |
+| Switch port utilization | SNMP ifTable / UniFi ports | Per-port bar chart |
+| Smart plug energy draw | Kasa HS105 emeter | Watts per outlet, kWh this month |
+| Device count (online / total) | InventoryEntity count by product | "12/14 devices online" |
+| Alert: device offline | `operStatus === "down"` | Red badge |
+
+This is achieved by extending the existing product Health tab data loader to query the metrics cache
+for all `InfraCI` items linked to the product via the Neo4j graph (existing `DEPENDS_ON` /
+`BELONGS_TO` traversal), and merging the latest `InterfaceMetric` for each.
+
+**Room/area grouping**: Devices with `areaId` set (from HA or manual config) can be grouped by
+room in the inventory panel — "Living Room (3 devices)", "Home Office (2 devices)". This uses the
+`SubnetGroupedInventoryPanel` pattern but grouped by `areaId` instead of subnet. The spatial grouping
+is a new view variant, not a replacement.
+
+---
+
+## 8. Open Question: Real-Time Canvas Refresh Rate
+
+At 5-second WebSocket push interval, the canvas redraws at most 5 times per minute for metrics
+changes. This is sufficient for "live-feeling" topology without saturating the browser's main thread.
+
+If the edge node pushes more frequently (10-second interval), the canvas may redraw more often.
+Guard with `requestAnimationFrame` — no more than one redraw per frame, regardless of how many
+WebSocket messages arrive. The renderer already uses `requestAnimationFrame` for the force simulation;
+extend the same gate to metric-triggered redraws.
+
+---
+
+## 9. Implementation Phases
+
+### Phase 1: Server Action Wrappers (zero external dependencies)
+
+1. Add `getImpactData(ciId)` and `getDependencyAuditData(productId)` to
+   `apps/web/lib/actions/graph.ts`
+2. Wire dynamic data fetching in `TopologyGraph.tsx` on view switch
+3. Add loading spinner to canvas during Neo4j query
+4. Verify Impact Blast Radius view shows radial layout of downstream impact from a clicked InfraCI
+5. Verify Dependency Audit view shows OSI-swimlane layout for a selected Digital Product
+
+### Phase 2: Throughput Annotations (requires EP-EDGE-TELEM-001 Phase 1)
+
+1. Extend `GraphDataLink` type with `rxBps`, `txBps`, `speedMbps`, `operStatus`
+2. Extend `GraphDataNode` type with `vendorIconModel`, `areaId`
+3. Extend `mapNodes()` and `mapEdges()` to populate new fields from Neo4j node/edge properties
+4. Implement `enrichLinksWithMetrics()` in graph server actions
+5. Implement `drawEdge()` with utilization-based width and status coloring
+6. Implement `drawLinkLabel()` with formatted bps labels (hidden below zoom threshold)
+7. Implement WebSocket subscription in `TopologyGraph.tsx` for `topology:metrics:update`
+
+### Phase 3: Product Icons (independent of Phases 1 and 2)
+
+1. Create `apps/web/lib/graph/icon-cache.ts` with image pre-loading logic
+2. Bundle `fingerprint-database.json` at `apps/web/public/device-data/unifi-fingerprints.json`
+3. Bundle generic network SVGs at `apps/web/public/icons/network/`
+4. Implement `getDeviceIconUrl()` lookup chain in `device-icons.ts`
+5. Extend canvas node renderer with `drawImage()` path + symbol fallback
+6. Verify icon renders for a UniFi switch, a Kasa plug, a generic host — all with appropriate
+   fallback to symbol when icon not available
+
+### Phase 4: Building Product Health Integration
+
+1. Extend product Health tab data loader to query metrics cache for linked InfraCI items
+2. Add per-device metric rows to Health tab (uptime, throughput, energy)
+3. Add `areaId`-based grouping variant to `SubnetGroupedInventoryPanel`
+
+---
+
+## 10. Non-Goals
+
+| Item | Reason |
+|------|--------|
+| 3D topology visualization | Adds rendering complexity without operational benefit |
+| Historical traffic graphs on the topology canvas | History belongs on the product Health tab, not the live topology map |
+| Automatic device icon scraping from vendor sites | Legal and reliability concerns; static bundled assets are the correct model |
+| L1 physical cable tracking | Requires physical audit or proprietary patch-panel integration; not spec'd |
+| Per-packet deep inspection | Security tooling concern; out of scope for topology management |
+
+---
+
+## 11. Success Criteria
+
+1. Clicking "Analyze Impact" on any InfraCI node switches to the radial Impact Blast Radius view,
+   fetched from Neo4j, rendered within 3 seconds — with no full-page reload
+2. A product's topology view in "Dependency Audit" mode shows its dependency stack in OSI-layer
+   swimlanes, fetched from Neo4j, rendered within 3 seconds
+3. When SNMP ifTable data is available, every graph edge linking two SNMP-discovered devices
+   displays a `↓X Kbps ↑Y Kbps` label and has visual width proportional to utilization
+4. A Kasa HS200 wall switch in the topology shows the TP-Link product icon (from the UniFi
+   fingerprint DB or generic SVG), not a Unicode symbol
+5. A Starlink dish shows a satellite icon and its `↓X Mbps ↑Y Mbps` on the uplink edge
+6. The topology canvas frame rate does not drop below 30fps under WebSocket metric update load
+   (validated with Chrome DevTools performance profile)
+7. Removing all edge nodes and adapter config leaves the topology rendering exactly as before
+   this spec — the `rxBps`/`txBps` fields are undefined, links render at default width and color,
+   and Unicode symbols are used throughout


### PR DESCRIPTION
…ut/icons

Spec A (EP-EDGE-TELEM-001): extends the Phase 0 edge node with a metrics.network capability. Adds SNMP ifTable + LLDP-MIB walks for per-interface throughput rates and L2 neighbor topology. Defines optional vendor adapter collectors (UniFi API, TP-Link Kasa, Starlink gRPC, Home Assistant bridge) that activate when the platform is present on the LAN. Introduces a /api/v1/edge/metrics endpoint for sub-minute telemetry delivery, separate from the 5-minute discovery channel.

Spec B (EP-TOPO-FIDELITY-001): closes the server-action wiring gap for Impact Blast Radius and Dependency Audit views (UI and Neo4j queries exist; component did not call them). Extends GraphData link type with rxBps/txBps/ operStatus for canvas throughput annotations. Specifies the device product icon lookup chain (UniFi fingerprint DB → NetBox images → generic SVGs → Unicode fallback) and the OffscreenCanvas image cache pattern. Covers CSS variable resolution for Canvas 2D context and the React useTransition pattern for client-side view-data fetching.

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
