### PR TITLE
fix(test): update BuildStudioHeaderLayout test to match Build Status rename

### DIFF
--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -246,7 +246,7 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Studio Control");
+    expect(html).toContain("Build Status");
     expect(html).toContain("Record Approve Start");
     expect(html).toContain("Review with coworker");
   });


### PR DESCRIPTION
## Summary

- PR #805 renamed `"Studio Control"` → `"Build Status"` in `BuildStudioWorkflowActionCard.tsx` and updated the two matching assertions in `BuildStudioWorkflowActionCard.test.tsx`, but missed the same assertion in `BuildStudioHeaderLayout.test.tsx:249`.
- This caused CI on PR #806 to fail with one test.

## Change

One-line assertion update: `"Studio Control"` → `"Build Status"` in the header layout test.

## Test plan

- [x] `npx vitest run components/build/BuildStudioHeaderLayout.test.tsx` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)