### PR TITLE
fix: stale Studio Control assertion in BuildStudioHeaderLayout test

### DIFF
--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -246,7 +246,7 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Studio Control");
+    expect(html).toContain("Build Status");
     expect(html).toContain("Record Approve Start");
     expect(html).toContain("Review with coworker");
   });


### PR DESCRIPTION
## Summary

- PR #805 renamed the workflow action card label from `"Studio Control"` to `"Build Status"` and correctly updated `BuildStudioWorkflowActionCard.test.tsx`, but missed the same assertion in `BuildStudioHeaderLayout.test.tsx:249`
- This caused CI to fail on any PR merging after #805, including PR #807
- One-line fix: `"Studio Control"` → `"Build Status"` to match the current component output

## Test plan

- [ ] `BuildStudioHeaderLayout.test.tsx` — the "renders a studio approval control for backlog-linked builds that are missing start approval" test passes
- [ ] All 10 tests in that file pass
- [ ] No other test files reference `"Studio Control"` in assertions (confirmed — only `build-agent-prompts.ts` has it, as a prompt string, not an assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)