### PR TITLE
fix(observability): scout-dispatch async + single-flight mutex (BI-6588414f slices 1+2)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1383,6 +1383,7 @@ export async function sendMessage(input: {
         try {
           const { dispatchScoutResearch } = await import("@/lib/integrate/scout-dispatch");
           const scoutResult = await dispatchScoutResearch({
+            buildId: resolvedBuildId,
             featureTitle: buildForScout?.title ?? "",
             featureDescription: buildForScout?.description ?? "",
             externalUrls: (scoutState.scoutUrls as string[] | undefined) ?? [],

--- a/apps/web/lib/integrate/codebase-tools-non-blocking.test.ts
+++ b/apps/web/lib/integrate/codebase-tools-non-blocking.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+// This test enforces the slice-1 architectural invariant: searchProjectFiles
+// MUST NOT use execSync, fs.readdirSync, or fs.readFileSync — synchronous
+// syscalls block the Node main event loop and were the proximate cause of the
+// 2026-05-19 22:37 portal hang (PID 1 wchan=p9_client_rpc, State D).
+//
+// The function must return through the event loop so that even if the
+// underlying subprocess or fs read wedges on 9P, the portal stays responsive
+// to HTTP requests, health checks, and the watchdog cron.
+
+const { mockExecAsync, syncCallSites } = vi.hoisted(() => ({
+  mockExecAsync: vi.fn(async () => ({ stdout: "", stderr: "" })),
+  syncCallSites: { execSync: 0, readdirSync: 0, readFileSync: 0 },
+}));
+
+vi.mock("@/lib/shared/lazy-node", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/shared/lazy-node")>();
+  return {
+    ...actual,
+    // If anything in codebase-tools.ts calls execSync via lazyChildProcess,
+    // the spy counter increments and the test fails.
+    lazyChildProcess: () => ({
+      execSync: (...args: unknown[]) => {
+        syncCallSites.execSync += 1;
+        return "";
+      },
+    }),
+    // Async exec via the existing lazyExec helper — mock it so the test
+    // doesn't actually spawn git.
+    lazyExec: () => mockExecAsync,
+    // fs sync calls are flagged.
+    lazyFs: () => ({
+      existsSync: () => true,
+      readdirSync: (...args: unknown[]) => {
+        syncCallSites.readdirSync += 1;
+        return [];
+      },
+      readFileSync: (...args: unknown[]) => {
+        syncCallSites.readFileSync += 1;
+        return "";
+      },
+      mkdirSync: () => undefined,
+      writeFileSync: () => undefined,
+    }),
+    lazyFsPromises: () => ({
+      readdir: async () => [],
+      readFile: async () => "",
+    }),
+    lazyPath: () => ({
+      resolve: (...args: string[]) => args.join("/"),
+      relative: (from: string, to: string) => to.replace(`${from}/`, ""),
+      isAbsolute: (p: string) => p.startsWith("/") || /^[A-Za-z]:/.test(p),
+      join: (...args: string[]) => args.join("/"),
+      dirname: (p: string) => p.split("/").slice(0, -1).join("/"),
+    }),
+  };
+});
+
+import { searchProjectFiles } from "./codebase-tools";
+
+afterEach(() => {
+  syncCallSites.execSync = 0;
+  syncCallSites.readdirSync = 0;
+  syncCallSites.readFileSync = 0;
+  mockExecAsync.mockReset();
+  mockExecAsync.mockImplementation(async () => ({ stdout: "", stderr: "" }));
+});
+
+describe("searchProjectFiles non-blocking invariant (BI-6588414f slice 1)", () => {
+  it("never uses synchronous syscalls — neither execSync nor fs sync APIs", async () => {
+    mockExecAsync.mockImplementation(async () => ({
+      stdout: "packages/db/src/seed.ts:1:export function seed() {}",
+      stderr: "",
+    }));
+
+    await searchProjectFiles("seed", { glob: "*.ts" });
+
+    expect(syncCallSites.execSync).toBe(0);
+    expect(syncCallSites.readdirSync).toBe(0);
+    expect(syncCallSites.readFileSync).toBe(0);
+  });
+
+  it("uses async exec on the happy path", async () => {
+    mockExecAsync.mockImplementation(async () => ({
+      stdout: "apps/web/lib/foo.ts:42:foo()",
+      stderr: "",
+    }));
+
+    const result = await searchProjectFiles("foo", { glob: "*.ts" });
+
+    expect(mockExecAsync).toHaveBeenCalledTimes(1);
+    expect("results" in result).toBe(true);
+  });
+
+  it("returns a bounded error rather than walking the tree when async exec rejects", async () => {
+    mockExecAsync.mockImplementation(async () => {
+      throw new Error("fatal: not a git repository");
+    });
+
+    const result = await searchProjectFiles("anything", { glob: "*.ts" });
+
+    // We accept either an error envelope or an empty results envelope —
+    // both are non-blocking. What we reject is the old "fall through to a
+    // sync walker" behaviour.
+    if ("results" in result) {
+      expect(result.results).toEqual([]);
+    } else {
+      expect(result.error).toMatch(/git grep|search/i);
+    }
+    expect(syncCallSites.readdirSync).toBe(0);
+    expect(syncCallSites.readFileSync).toBe(0);
+  });
+
+  it("keeps the event loop responsive while a slow subprocess is pending", async () => {
+    // Simulate a 200ms subprocess. The test must be able to run a different
+    // microtask immediately — proves the await yields to the event loop.
+    mockExecAsync.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ stdout: "", stderr: "" }), 200);
+        }),
+    );
+
+    let otherTaskRan = false;
+    const searchPromise = searchProjectFiles("slow", { glob: "*.ts" });
+    queueMicrotask(() => {
+      otherTaskRan = true;
+    });
+    // Give the microtask one tick to fire.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(otherTaskRan).toBe(true); // event loop still alive
+    await searchPromise; // clean up
+  });
+});

--- a/apps/web/lib/integrate/codebase-tools-search.test.ts
+++ b/apps/web/lib/integrate/codebase-tools-search.test.ts
@@ -3,17 +3,15 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockExecSync } = vi.hoisted(() => ({
-  mockExecSync: vi.fn(),
+const { mockExecAsync } = vi.hoisted(() => ({
+  mockExecAsync: vi.fn(),
 }));
 
 vi.mock("@/lib/shared/lazy-node", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/shared/lazy-node")>();
   return {
     ...actual,
-    lazyChildProcess: () => ({
-      execSync: mockExecSync,
-    }),
+    lazyExec: () => mockExecAsync,
   };
 });
 
@@ -36,7 +34,7 @@ describe("searchProjectFiles", () => {
       ].join("\n"),
     );
     process.env.PROJECT_ROOT = projectRoot;
-    mockExecSync.mockImplementation(() => {
+    mockExecAsync.mockImplementation(async () => {
       throw new Error("fatal: not a git repository");
     });
   });
@@ -66,11 +64,14 @@ describe("searchProjectFiles", () => {
   });
 
   it("filters package-store matches from git grep output", async () => {
-    mockExecSync.mockReturnValue([
-      ".pnpm-store/v10/index/noise.json:1:seedCityOnce",
-      "packages/db/generated/client/index.d.ts:1:seedCityOnce",
-      "packages/db/src/seed-geographic-data.ts:1:export async function seedCityOnce() {",
-    ].join("\n"));
+    mockExecAsync.mockResolvedValue({
+      stdout: [
+        ".pnpm-store/v10/index/noise.json:1:seedCityOnce",
+        "packages/db/generated/client/index.d.ts:1:seedCityOnce",
+        "packages/db/src/seed-geographic-data.ts:1:export async function seedCityOnce() {",
+      ].join("\n"),
+      stderr: "",
+    });
 
     const result = await searchProjectFiles("seedCityOnce", {
       glob: "*.ts",
@@ -89,12 +90,13 @@ describe("searchProjectFiles", () => {
   });
 
   it("parses CRLF git grep output from Windows-authored source files", async () => {
-    mockExecSync.mockReturnValue(
-      [
+    mockExecAsync.mockResolvedValue({
+      stdout: [
         "HEAD:packages/db/src/seed-geographic-data.ts:223:export async function seedGeographicData(prisma: PrismaClient): Promise<void> {\r",
         "HEAD:packages/db/src/seed.ts:16:import { seedGeographicData } from \"./seed-geographic-data.js\";\r",
       ].join("\n"),
-    );
+      stderr: "",
+    });
 
     const result = await searchProjectFiles("seedGeographicData", {
       glob: "*.ts",

--- a/apps/web/lib/integrate/codebase-tools.ts
+++ b/apps/web/lib/integrate/codebase-tools.ts
@@ -18,7 +18,12 @@ export function isDevInstance(): boolean {
 
 const DEV_ONLY_ERROR = "Codebase access is only available on dev instances. Production does not have source code.";
 
-import { lazyFs as getFs, lazyPath as getPath, lazyChildProcess } from "@/lib/shared/lazy-node";
+import {
+  lazyFs as getFs,
+  lazyFsPromises as getFsPromises,
+  lazyPath as getPath,
+  lazyExec,
+} from "@/lib/shared/lazy-node";
 
 function getProjectRoot(): string {
   const path = getPath();
@@ -137,21 +142,26 @@ export async function searchProjectFiles(
   const max = options?.maxResults ?? 20;
   const projectRoot = getProjectRoot();
 
+  // Use async exec via lazyExec — the synchronous variant (execSync) blocks
+  // the Node main event loop on subprocess wait, which under a wedged 9P
+  // bind mount parks the whole portal in kernel D state. See BI-6588414f
+  // for the 2026-05-19 incident. The async path lets the event loop keep
+  // serving HTTP, health checks, and the watchdog cron even if `git grep`
+  // is itself stuck.
   try {
-    const { execSync } = lazyChildProcess();
+    const execAsync = lazyExec();
     const globArg = options?.glob ? `-- "${options.glob}"` : "";
-    const output = execSync(
+    const { stdout } = await execAsync(
       `git grep -n --max-count=${max} ${JSON.stringify(query)} HEAD ${globArg}`.trim(),
       {
         cwd: projectRoot,
-        encoding: "utf-8",
         timeout: 10_000,
         maxBuffer: 1024 * 1024,
       },
     );
 
     const results: Array<{ path: string; line: number; text: string }> = [];
-    for (const rawLine of output.split("\n")) {
+    for (const rawLine of stdout.split("\n")) {
       if (results.length >= max) break;
       const line = rawLine.replace(/\r$/, "");
       const match = line.match(/^(?:HEAD:)?(.+?):(\d+):(.*)$/);
@@ -186,23 +196,23 @@ function makeLineMatcher(query: string): (line: string) => boolean {
   }
 }
 
-function fallbackSearchProjectFiles(
+async function fallbackSearchProjectFiles(
   projectRoot: string,
   query: string,
   options?: { glob?: string; maxResults?: number },
-): { results: Array<{ path: string; line: number; text: string }> } {
-  const fs = getFs();
+): Promise<{ results: Array<{ path: string; line: number; text: string }> }> {
+  const fsp = getFsPromises();
   const path = getPath();
   const max = options?.maxResults ?? 20;
   const matchesLine = makeLineMatcher(query);
   const results: Array<{ path: string; line: number; text: string }> = [];
   const skipDirs = new Set([".git", ".next", "node_modules", ".pnpm-store", "generated"]);
 
-  function visit(dir: string): void {
+  async function visit(dir: string): Promise<void> {
     if (results.length >= max) return;
     let entries: import("fs").Dirent[];
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      entries = await fsp.readdir(dir, { withFileTypes: true });
     } catch {
       return;
     }
@@ -213,14 +223,14 @@ function fallbackSearchProjectFiles(
       const relPath = path.relative(projectRoot, fullPath).replace(/\\/g, "/");
       if (!relPath || !isPathAllowedSync(relPath)) continue;
       if (entry.isDirectory()) {
-        if (!skipDirs.has(entry.name)) visit(fullPath);
+        if (!skipDirs.has(entry.name)) await visit(fullPath);
         continue;
       }
       if (!entry.isFile() || !globMatches(relPath, options?.glob)) continue;
 
       let content: string;
       try {
-        content = fs.readFileSync(fullPath, "utf-8");
+        content = await fsp.readFile(fullPath, "utf-8");
       } catch {
         continue;
       }
@@ -233,7 +243,7 @@ function fallbackSearchProjectFiles(
     }
   }
 
-  visit(projectRoot);
+  await visit(projectRoot);
   return { results };
 }
 

--- a/apps/web/lib/integrate/scout-dispatch.test.ts
+++ b/apps/web/lib/integrate/scout-dispatch.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the heavy I/O dependency so tests don't hit the bind-mounted filesystem.
+// Each call returns synchronously-resolved empty results; per-test overrides
+// (delays, throws) install fresh implementations.
+vi.mock("./codebase-tools", () => ({
+  searchProjectFiles: vi.fn(async () => ({ results: [] })),
+}));
+
+import { dispatchScoutResearch, _resetScoutMutexForTests } from "./scout-dispatch";
+import { searchProjectFiles } from "./codebase-tools";
+
+const mockSearch = vi.mocked(searchProjectFiles);
+
+afterEach(() => {
+  _resetScoutMutexForTests();
+  mockSearch.mockReset();
+  mockSearch.mockImplementation(async () => ({ results: [] }));
+});
+
+describe("dispatchScoutResearch single-flight mutex (BI-6588414f slice 2)", () => {
+  it("collapses concurrent calls with the same buildId into one underlying dispatch", async () => {
+    // Slow inner so both callers overlap at the mutex layer.
+    mockSearch.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      return { results: [] };
+    });
+
+    const params = {
+      buildId: "FB-CONCURRENT",
+      featureTitle: "concurrent dispatch keyword material",
+      featureDescription: "",
+    };
+
+    const [a, b] = await Promise.all([
+      dispatchScoutResearch(params),
+      dispatchScoutResearch(params),
+    ]);
+    const callsAfterTwo = mockSearch.mock.calls.length;
+
+    // Run a third dispatch sequentially as the baseline for "one full pass".
+    _resetScoutMutexForTests();
+    mockSearch.mockClear();
+    await dispatchScoutResearch(params);
+    const callsForOnePass = mockSearch.mock.calls.length;
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    // Both callers observe the SAME result object — the second awaited the
+    // first's in-flight promise instead of starting its own dispatch.
+    expect(b.result).toBe(a.result);
+    // And the two concurrent callers together produced exactly one pass'
+    // worth of searchProjectFiles calls — not two.
+    expect(callsAfterTwo).toBe(callsForOnePass);
+  });
+
+  it("runs distinct buildIds in parallel", async () => {
+    let inflight = 0;
+    let maxConcurrent = 0;
+    mockSearch.mockImplementation(async () => {
+      inflight += 1;
+      maxConcurrent = Math.max(maxConcurrent, inflight);
+      await new Promise((r) => setTimeout(r, 20));
+      inflight -= 1;
+      return { results: [] };
+    });
+
+    await Promise.all([
+      dispatchScoutResearch({ buildId: "FB-A", featureTitle: "alpha distinct keyword content", featureDescription: "" }),
+      dispatchScoutResearch({ buildId: "FB-B", featureTitle: "beta different keyword content", featureDescription: "" }),
+    ]);
+
+    // Different keys → no mutex contention → at least two concurrent inner
+    // calls expected.
+    expect(maxConcurrent).toBeGreaterThanOrEqual(2);
+  });
+
+  it("clears the mutex after a successful dispatch so subsequent calls re-execute", async () => {
+    const params = { buildId: "FB-SEQ", featureTitle: "sequential keyword content here", featureDescription: "" };
+
+    const first = await dispatchScoutResearch(params);
+    const callsAfterFirst = mockSearch.mock.calls.length;
+
+    const second = await dispatchScoutResearch(params);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    // Second call genuinely re-executed — not a stale cached promise.
+    expect(mockSearch.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    // And the two result objects are different identities (fresh dispatch).
+    expect(second.result).not.toBe(first.result);
+  });
+
+  it("clears the mutex after a thrown dispatch so subsequent calls re-execute", async () => {
+    // First call throws.
+    mockSearch.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+
+    const params = { buildId: "FB-THROW", featureTitle: "throwing keyword content here", featureDescription: "" };
+    const first = await dispatchScoutResearch(params);
+
+    // dispatchScoutResearch catches internally and returns success:true with
+    // partial results — but the important invariant is the mutex is cleared,
+    // proven by a subsequent call running a new inner pass.
+    const callsAfterFirst = mockSearch.mock.calls.length;
+
+    mockSearch.mockImplementation(async () => ({ results: [] }));
+    const second = await dispatchScoutResearch(params);
+
+    expect(second.success).toBe(true);
+    expect(mockSearch.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    // Confirm no contamination from the throw.
+    expect(first).toBeDefined();
+  });
+});

--- a/apps/web/lib/integrate/scout-dispatch.ts
+++ b/apps/web/lib/integrate/scout-dispatch.ts
@@ -76,15 +76,50 @@ async function fetchAndParseUrl(url: string): Promise<{
   }
 }
 
+type DispatchResult = { success: boolean; result?: ScoutResult; error?: string };
+
+// Per-featureBuild single-flight guard. If a dispatch is already in flight for
+// a given buildId, additional callers await the same promise instead of
+// starting a parallel pass. Cleared on settle (resolve or reject) so the next
+// request after completion runs fresh. See BI-6588414f for context.
+const inflightByBuildId = new Map<string, Promise<DispatchResult>>();
+
+/** Test-only: clears the mutex between cases. Not exported for production use. */
+export function _resetScoutMutexForTests(): void {
+  inflightByBuildId.clear();
+}
+
 /**
  * Main scout dispatch function.
  * Searches codebase and parses external URLs in parallel.
  */
 export async function dispatchScoutResearch(params: {
+  buildId: string;
   featureTitle: string;
   featureDescription: string;
   externalUrls?: string[];
-}): Promise<{ success: boolean; result?: ScoutResult; error?: string }> {
+}): Promise<DispatchResult> {
+  const existing = inflightByBuildId.get(params.buildId);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<DispatchResult> => {
+    try {
+      return await runScoutResearch(params);
+    } finally {
+      inflightByBuildId.delete(params.buildId);
+    }
+  })();
+
+  inflightByBuildId.set(params.buildId, promise);
+  return promise;
+}
+
+async function runScoutResearch(params: {
+  buildId: string;
+  featureTitle: string;
+  featureDescription: string;
+  externalUrls?: string[];
+}): Promise<DispatchResult> {
   const startTime = Date.now();
 
   try {


### PR DESCRIPTION
## Summary

Fixes the 2026-05-19 portal hang (verified twice in production within ~15 min: PID 1 wchan=p9_client_rpc, kernel state D, 43 failing health checks, recoverable only by SIGKILL).

- **Slice 1 — codebase-tools.ts:** `execSync` → `lazyExec` (async); synchronous fallback walker → `fs/promises`. Removes the blocking-event-loop path that wedged the portal when the WSL2 9P bind mount became unresponsive.
- **Slice 2 — scout-dispatch.ts:** single-flight mutex per `featureBuildId`. Concurrent callers share one in-flight promise. Defense in depth — alone would NOT have prevented this specific incident (only one dispatch fired), but closes the multiplication risk if any other code path is added later.

Together, the portal main event loop now stays responsive even when an individual subprocess wedges. Slice 3 (process-level wchan watchdog sidecar) and slice 4 (eliminate bind mount in dev) are tracked on BI-6588414f for follow-up.

## Live verification — PASSED ✅

Rebuilt portal image, recreated container, triggered a Build Studio Ideate cycle (FB-1A4651G5), and watched the portal main thread every 15s for 2.5 min during sustained codebase grep load:

```
[1/10]  wchan=do_epoll_wait state=S http=307/10ms
[2/10]  wchan=do_epoll_wait state=S http=307/9ms
[3/10]  wchan=do_epoll_wait state=S http=307/28ms
[4/10]  wchan=do_epoll_wait state=S http=307/19ms
[5/10]  wchan=do_epoll_wait state=S http=307/9ms
[6/10]  wchan=do_epoll_wait state=S http=307/9ms
[7/10]  wchan=do_epoll_wait state=S http=307/8ms
[8/10]  wchan=do_epoll_wait state=S http=307/8ms
[9/10]  wchan=do_epoll_wait state=S http=307/27ms
[10/10] wchan=do_epoll_wait state=S http=307/8ms
```

- Main thread never entered `p9_client_rpc` (the failure-mode wchan from the incident).
- State stayed `S` (interruptible sleep / normal idle) — never `D` (uninterruptible).
- HTTP responsiveness 7.7-27.9ms across all 10 samples vs HTTP 000 timeout during the incident.

Recorded as `BacklogItemActivity` kind=`verification` on BI-6588414f.

## Context

- Filed via BI-6588414f-9p-scout-hang (priority 1, EP-BUILD-STUDIO) with full root-cause analysis + 4-slice plan recorded as `BacklogItemActivity`.
- Distinct from BI-4ab6be39 (stall-detection symptom layer) — addresses the upstream architecture flaw that lets one bad codebase grep wedge the whole portal. Cross-linked on both BIs.
- Built **outside** Build Studio per explicit operator authorization: Build Studio cannot fix Build Studio while wedged. The exception is documented on BI-6588414f.

## Test plan

- [x] `npx vitest run lib/integrate/` — 93 files, 682 tests, all green
- [x] `pnpm --filter web typecheck` — exit 0
- [x] 4 new tests in `codebase-tools-non-blocking.test.ts` enforce the architectural invariant (no execSync, no readdirSync, no readFileSync; microtask-yielding proof of event-loop liveness)
- [x] 4 new tests in `scout-dispatch.test.ts` cover the mutex (concurrent collapse, distinct-buildId parallelism, clears on resolve, clears on reject)
- [x] Existing `codebase-tools-search.test.ts` updated to mock the new `lazyExec` API (same scenarios — empty git grep fallback, pnpm-store filtering, CRLF parsing)
- [x] Live verification: 10 wchan/state/HTTP samples across 2.5 min of sustained Build Studio Ideate; portal main thread never entered p9_client_rpc or state D

🤖 Generated with [Claude Code](https://claude.com/claude-code)