### PR TITLE
fix(portal): three UX hardening fixes from driving FB-C26D5B50 Ideate

### DIFF
--- a/apps/web/app/(shell)/admin/backlog/page.tsx
+++ b/apps/web/app/(shell)/admin/backlog/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminBacklogRedirect() {
+  redirect("/ops");
+}

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -211,15 +211,31 @@ export function BuildStudioWorkflowActionCard({
 
         <div className="flex flex-wrap items-center gap-2">
           {primaryLabel && (
-            <button
-              type="button"
-              onClick={handlePrimaryAction}
-              disabled={!primaryEnabled || pending}
-              className="inline-flex items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            <span
+              title={!primaryEnabled && action.disabledReason ? action.disabledReason : undefined}
+              className="inline-flex"
             >
-              {pending && <span className="h-3 w-3 animate-spin rounded-full border-2 border-white border-t-transparent" />}
-              {primaryLabel}
-            </button>
+              <button
+                type="button"
+                onClick={handlePrimaryAction}
+                disabled={!primaryEnabled || pending}
+                aria-disabled={!primaryEnabled || pending}
+                aria-describedby={!primaryEnabled && action.disabledReason ? `${action.kind}-disabled-reason` : undefined}
+                className="inline-flex items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {pending && <span className="h-3 w-3 animate-spin rounded-full border-2 border-white border-t-transparent" />}
+                {primaryLabel}
+              </button>
+            </span>
+          )}
+          {!primaryEnabled && action.disabledReason && primaryLabel && (
+            <span
+              id={`${action.kind}-disabled-reason`}
+              className="text-[11px] text-[var(--dpf-text-muted)]"
+              role="status"
+            >
+              {action.disabledReason}
+            </span>
           )}
           <button
             type="button"

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -9,6 +9,7 @@ import {
   detectToolRefusedDespiteAvailability,
   phaseRequiresToolCall,
   detectUnsavedEvidence,
+  enrichToolDescriptions,
 } from "./agentic-loop";
 
 vi.mock("@dpf/db", () => ({
@@ -178,6 +179,75 @@ describe("buildRepeatedToolStopMessage", () => {
       routeContext: "/build",
       reasonHint: "",
     })).toContain("Check the build evidence for what was completed.");
+  });
+});
+
+describe("enrichToolDescriptions — review-fail veto on write tool", () => {
+  const baseTools = [
+    { type: "function", name: "saveBuildEvidence", description: "Save evidence", inputSchema: {} },
+    { type: "function", name: "reviewDesignDoc", description: "Review design doc", inputSchema: {} },
+  ];
+
+  it("annotates saveBuildEvidence when reviewDesignDoc returned decision:fail", () => {
+    const enriched = enrichToolDescriptions(baseTools, [
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
+      { name: "reviewDesignDoc", args: {}, result: { success: true, message: "Design review: fail.", data: { review: { decision: "fail", rationale: "Missing codebase research section." } } } },
+    ]);
+    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
+    expect(save.description).toContain("REVIEW REJECTION");
+    expect(save.description).toContain("Missing codebase research section.");
+    expect(save.description).toContain("submitting identical arguments will be rejected");
+  });
+
+  it("clears the veto on a later passing review", () => {
+    const enriched = enrichToolDescriptions(baseTools, [
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
+      { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "fail", rationale: "Missing research." } } } },
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v2" }, result: { success: true, message: "Evidence saved." } },
+      { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "pass" } } } },
+    ]);
+    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
+    expect(save.description).toBe("Save evidence");
+  });
+
+  it("keeps the veto sticky across a subsequent saveBuildEvidence success (intermediate save still rejected)", () => {
+    // This is the FB-C26D5B50 scenario: the next saveBuildEvidence succeeds at
+    // the protocol level but the review veto from the prior failed review
+    // must remain visible until a passing review clears it.
+    const enriched = enrichToolDescriptions(baseTools, [
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
+      { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "fail", rationale: "Missing codebase research." } } } },
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1-again" }, result: { success: true, message: "Evidence saved." } },
+    ]);
+    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
+    expect(save.description).toContain("REVIEW REJECTION");
+    expect(save.description).toContain("Missing codebase research.");
+  });
+
+  it("treats data.blocked=true as a veto even without decision:fail", () => {
+    const enriched = enrichToolDescriptions(baseTools, [
+      { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "pass" }, blocked: true } } },
+    ]);
+    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
+    expect(save.description).toContain("REVIEW REJECTION");
+  });
+
+  it("does nothing when there are no review failures and no tool errors", () => {
+    const enriched = enrichToolDescriptions(baseTools, [
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
+      { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "pass" } } } },
+    ]);
+    expect(enriched.find((t) => t.name === "saveBuildEvidence")!.description).toBe("Save evidence");
+    expect(enriched.find((t) => t.name === "reviewDesignDoc")!.description).toBe("Review design doc");
+  });
+
+  it("preserves the existing error-warning path when a tool itself failed", () => {
+    const enriched = enrichToolDescriptions(baseTools, [
+      { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: false, error: "Network timeout on persistence layer" } },
+    ]);
+    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
+    expect(save.description).toContain("WARNING");
+    expect(save.description).toContain("Network timeout on persistence layer");
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -563,21 +563,62 @@ function getPhaseSpecificNudge(executedTools: Array<{ name: string }>): string {
   return "Check your available tools and call the most relevant one now.";
 }
 
+// Review tools succeed at the protocol level (success=true) but can emit
+// data.review.decision === "fail" — a *content* rejection of the artifact
+// produced by an earlier saveBuildEvidence call. Without surfacing that
+// rejection back to the model, it will retry saveBuildEvidence with identical
+// content and the agentic-loop guard will trip after 3 identical calls.
+// See: docs/.../wwmd-mcp-exposure FB-C26D5B50 Ideate loop, 2026-05-19.
+type ReviewResultShape = {
+  review?: { decision?: string; rationale?: string; summary?: string };
+  blocked?: boolean;
+};
+function reviewFailMessage(t: { name: string; result: { success: boolean; data?: Record<string, unknown>; message?: string } }): string | null {
+  if (t.name !== "reviewDesignDoc" && t.name !== "reviewBuildPlan") return null;
+  if (!t.result.success) return null;
+  const data = t.result.data as ReviewResultShape | undefined;
+  const decision = data?.review?.decision;
+  if (decision !== "fail" && !data?.blocked) return null;
+  const detail =
+    data?.review?.rationale
+    ?? data?.review?.summary
+    ?? t.result.message
+    ?? "review rejected the saved artifact";
+  const artifact = t.name === "reviewDesignDoc" ? "design doc" : "build plan";
+  return `Your previous ${artifact} was REJECTED by ${t.name}. Reason: ${detail.slice(0, 200)}. Regenerate the content addressing this specific gap before calling saveBuildEvidence again — submitting identical arguments will be rejected the same way and the run will be stopped.`;
+}
+
 /**
  * Annotate tool descriptions with session-aware hints based on what the agent
  * has already tried. Inspired by Claude Code's dynamic tool description system.
  * Mutates nothing — returns a new array.
  */
-function enrichToolDescriptions(
+export function enrichToolDescriptions(
   toolsForProvider: Array<Record<string, unknown>>,
-  executedTools: Array<{ name: string; args?: Record<string, unknown>; result: { success: boolean; error?: string } }>,
+  executedTools: Array<{ name: string; args?: Record<string, unknown>; result: { success: boolean; error?: string; data?: Record<string, unknown>; message?: string } }>,
 ): Array<Record<string, unknown>> {
   if (executedTools.length === 0) return toolsForProvider;
 
   // Build failure map: tool name → last error. If a tool succeeded after
   // failing, clear the warning — the tool recovered.
   const failures = new Map<string, string>();
+  // Separate veto map for content-level review rejections that target a
+  // different write tool. Stays sticky across subsequent saveBuildEvidence
+  // tool-level successes until a passing review clears it.
+  const reviewVetoes = new Map<string, string>();
   for (const t of executedTools) {
+    const veto = reviewFailMessage(t);
+    if (veto) {
+      reviewVetoes.set("saveBuildEvidence", veto);
+      continue;
+    }
+    // A passing review clears the veto on the corresponding write tool.
+    if ((t.name === "reviewDesignDoc" || t.name === "reviewBuildPlan") && t.result.success) {
+      const data = t.result.data as ReviewResultShape | undefined;
+      if (data?.review?.decision === "pass" && !data?.blocked) {
+        reviewVetoes.delete("saveBuildEvidence");
+      }
+    }
     if (!t.result.success && t.result.error) {
       failures.set(t.name, t.result.error.slice(0, 150));
     } else if (t.result.success) {
@@ -585,17 +626,21 @@ function enrichToolDescriptions(
     }
   }
 
-  if (failures.size === 0) return toolsForProvider;
+  if (failures.size === 0 && reviewVetoes.size === 0) return toolsForProvider;
 
   return toolsForProvider.map((tool) => {
     const name = tool.name as string;
     const lastError = failures.get(name);
-    if (!lastError) return tool;
+    const veto = reviewVetoes.get(name);
+    if (!lastError && !veto) return tool;
 
     const desc = tool.description as string;
+    const warning = veto
+      ? `[REVIEW REJECTION: ${veto}]`
+      : `[WARNING: This tool failed earlier in this session with: "${lastError}". Consider a different approach or different arguments.]`;
     return {
       ...tool,
-      description: `${desc} [WARNING: This tool failed earlier in this session with: "${lastError}". Consider a different approach or different arguments.]`,
+      description: `${desc} ${warning}`,
     };
   });
 }


### PR DESCRIPTION
## Summary

Three independent portal bug fixes captured today (2026-05-19) while driving the WWMD-MCP Sprint-1 umbrella build (`FB-C26D5B50`) through the portal UI for dogfooding. This is the dogfooding return on the new ["drive the portal UX, don't bypass it"](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/813) standing rule — every UX bug caught is one the portal won't ship with.

1. **`/admin/backlog` 404 → redirect to `/ops`.** New one-liner server `redirect()` page matches the project's existing convention. Closes the bookmark-rot gap.
2. **"Advance to Plan" silent no-op when designDoc missing.** Button had `disabled` prop but no visible affordance (no tooltip, no inline reason) — looked clickable, did nothing on click. Now wraps the button in a `title=` span and adds an inline `role="status"` line with `action.disabledReason`.
3. **saveBuildEvidence retry-loop on review-fail decisions.** The agentic-loop's `enrichToolDescriptions` only annotated tools whose protocol-level call failed. It did NOT annotate the (very common in Build Studio) pattern where `saveBuildEvidence` succeeds but the followup `reviewDesignDoc`/`reviewBuildPlan` returns `data.review.decision === "fail"`. Result: the model retries `saveBuildEvidence` with identical args until `detectRepeatedToolCall` trips. Now cross-links review decisions back onto the write tool as a sticky `[REVIEW REJECTION: ...]` veto carrying the review's rationale; cleared only by a subsequent passing review.

## Why this matters now

Bug #3 is currently blocking the in-flight FB-C26D5B50 Ideate run. The Software Engineer coworker reported being stuck after 6 identical `saveBuildEvidence` calls without seeing the review's rationale on its tool description.

## Test plan

- [x] `vitest run` — 6418 passed / 15 skipped / 18 todo
- [x] `pnpm typecheck` — clean
- [x] Six new test cases for the review-veto behavior in `agentic-loop.test.ts`:
  - Veto set on `decision: "fail"`
  - Veto cleared on later `decision: "pass"`
  - Veto sticky across intermediate `saveBuildEvidence` success (FB-C26D5B50 scenario)
  - `data.blocked === true` treated as veto
  - No-op when no failures present
  - Existing error-warning path for protocol-level failures preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)