### PR TITLE
feat(topology): wire Impact Blast Radius + Dependency Audit views to server actions

### DIFF
--- a/apps/web/components/inventory/TopologyGraph.test.tsx
+++ b/apps/web/components/inventory/TopologyGraph.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { getImpactData } from "@/lib/actions/graph";
+import { TopologyGraph } from "./TopologyGraph";
+
+vi.mock("@/lib/actions/graph", () => ({
+  getImpactData: vi.fn().mockResolvedValue({
+    nodes: [
+      { id: "ci-1", name: "Web Server", label: "InfraCI", color: "#ef4444", size: 10 },
+      { id: "ci-2", name: "Database", label: "InfraCI", color: "#f97316", size: 5 },
+    ],
+    links: [{ source: "ci-1", target: "ci-2", type: "DEPENDS_ON" }],
+  }),
+  getDependencyAuditData: vi.fn().mockResolvedValue({ nodes: [], links: [] }),
+}));
+
+vi.mock("@/lib/graph/use-graph-layout", () => ({
+  useGraphLayout: vi.fn().mockReturnValue(null),
+  shouldApplyLayoutResult: vi.fn().mockReturnValue(true),
+}));
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+
+  global.requestAnimationFrame = vi.fn().mockReturnValue(0);
+  global.cancelAnimationFrame = vi.fn();
+
+  HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    scale: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    strokeStyle: "",
+    fillStyle: "",
+    lineWidth: 0,
+    globalAlpha: 1,
+    font: "",
+    textAlign: "center",
+    textBaseline: "alphabetic",
+  }) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+const emptyData = { nodes: [], links: [] };
+
+describe("TopologyGraph", () => {
+  it("calls getImpactData when impact-blast-radius view is active with a focusNodeId", async () => {
+    render(
+      <TopologyGraph
+        data={emptyData}
+        defaultView="impact-blast-radius"
+        initialFocusNodeId="ci-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getImpactData).toHaveBeenCalledWith("ci-1");
+    });
+  });
+
+  it("re-renders with stub data from getImpactData, showing the canvas", async () => {
+    const { container } = render(
+      <TopologyGraph
+        data={emptyData}
+        defaultView="impact-blast-radius"
+        initialFocusNodeId="ci-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("canvas")).not.toBeNull();
+    });
+  });
+
+  it("shows spinner overlay while isPending is true", () => {
+    vi.spyOn(React, "useTransition").mockReturnValue([true, vi.fn()]);
+
+    const dataWithNodes = {
+      nodes: [{ id: "n1", name: "Server", label: "InfraCI", color: "#ef4444", size: 6 }],
+      links: [],
+    };
+
+    const { container } = render(
+      <TopologyGraph data={dataWithNodes} defaultView="exploration" />,
+    );
+
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/apps/web/components/inventory/TopologyGraph.tsx
+++ b/apps/web/components/inventory/TopologyGraph.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRef, useEffect, useState, useCallback, useMemo } from "react";
-import type { GraphData } from "@/lib/actions/graph";
+import { useRef, useEffect, useState, useCallback, useMemo, useTransition } from "react";
+import { getImpactData, getDependencyAuditData, type GraphData } from "@/lib/actions/graph";
 import { hasSubnetScopeNode } from "@/lib/graph/scope-helpers";
 import type { GraphViewName, PositionedNode, LayoutResult } from "@/lib/graph/types";
 import { VIEW_CONFIGS, resolveViewForTaxonomy } from "@/lib/graph/view-config";
@@ -208,6 +208,9 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
   const [selectedView, setSelectedView] = useState<GraphViewName>(autoView);
   const viewConfig = VIEW_CONFIGS[selectedView];
   const isForceLayout = viewConfig.layout === "force";
+  const [isPending, startTransition] = useTransition();
+  const [dynamicData, setDynamicData] = useState<GraphData | null>(null);
+  const effectiveData = useMemo(() => dynamicData ?? data, [dynamicData, data]);
 
   // Subnet filter (for subnet-topology view)
   const [activeSubnetId, setActiveSubnetId] = useState<string | null>(null);
@@ -216,7 +219,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
   );
   const availableSubnets = useMemo(() => {
     if (selectedView !== "subnet-topology") return [];
-    return data.nodes
+    return effectiveData.nodes
       .filter((n) => {
         const ct = (n as Record<string, unknown>).ciType;
         return ct === "subnet" || ct === "vlan";
@@ -228,15 +231,15 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
         if (aDocker !== bDocker) return aDocker ? 1 : -1;
         return a.name.localeCompare(b.name);
       });
-  }, [data.nodes, selectedView]);
+  }, [effectiveData.nodes, selectedView]);
 
   const scopeState = useMemo(
-    () => resolveSubnetScopeState(data, selectedView, activeSubnetId),
-    [data, selectedView, activeSubnetId],
+    () => resolveSubnetScopeState(effectiveData, selectedView, activeSubnetId),
+    [effectiveData, selectedView, activeSubnetId],
   );
   const filteredData = useMemo(
-    () => resolveDisplayedGraphData(data, selectedView, activeSubnetId, focusNodeId, maxHops),
-    [data, selectedView, activeSubnetId, focusNodeId, maxHops],
+    () => resolveDisplayedGraphData(effectiveData, selectedView, activeSubnetId, focusNodeId, maxHops),
+    [effectiveData, selectedView, activeSubnetId, focusNodeId, maxHops],
   );
 
   // Layout computation
@@ -340,6 +343,22 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
     },
     [applySubnetSelection],
   );
+
+  useEffect(() => {
+    if (selectedView === "impact-blast-radius" && focusNodeId) {
+      startTransition(async () => {
+        const result = await getImpactData(focusNodeId);
+        setDynamicData(result);
+      });
+    } else if (selectedView === "dependency-audit" && focusNodeId) {
+      startTransition(async () => {
+        const result = await getDependencyAuditData(focusNodeId);
+        setDynamicData(result);
+      });
+    } else {
+      setDynamicData(null);
+    }
+  }, [selectedView, focusNodeId]);
 
   // ─── Force simulation (exploration view only) ──────────────────────────
   const simulate = useCallback(() => {
@@ -653,7 +672,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
     isPanningRef.current = false;
   }
 
-  if (data.nodes.length === 0) {
+  if (effectiveData.nodes.length === 0) {
     return (
       <div className="text-center py-8 text-sm text-[var(--dpf-muted)]">
         No graph data available. Discovery runs automatically every 15 minutes.
@@ -786,7 +805,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
       <p className="text-[9px] text-[var(--dpf-muted)] mb-2">{viewConfig.description}</p>
 
       {/* ─── Canvas ──────────────────────────────────────────────────── */}
-      <div style={{ position: "relative" }}>
+      <div className="relative w-full h-full">
         <canvas
           ref={canvasRef}
           width={dimensions.width}
@@ -807,6 +826,11 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
         {!isForceLayout && layoutResult == null && (
           <div className="absolute inset-0 flex items-center justify-center text-xs text-[var(--dpf-muted)]">
             Updating graph...
+          </div>
+        )}
+        {isPending && (
+          <div className="absolute inset-0 flex items-center justify-center bg-[var(--dpf-bg)]/60">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--dpf-accent)] border-t-transparent" />
           </div>
         )}
         <div className="absolute bottom-2 left-2 flex flex-wrap gap-x-3 gap-y-1 text-[9px] text-[var(--dpf-muted)]">


### PR DESCRIPTION
## Summary
- Wire `TopologyGraph.tsx` to call existing `getImpactData` and `getDependencyAuditData` server actions when the user switches to Impact Blast Radius or Dependency Audit views
- Add `useTransition` + `dynamicData` state so the targeted subgraph renders instead of the static full graph
- Show loading overlay while the Neo4j query is in flight

## Build Studio
Build: FB-F50C65D2 | Epic: EP-AI-OPSMAP | Phase: ship

## Test plan
- [ ] Switch topology view to Impact Blast Radius on an InfraCI node → `getImpactData` called, radial subgraph renders within 3s
- [ ] Switch to Dependency Audit → `getDependencyAuditData` called, OSI swimlane renders within 3s
- [ ] Switch back to any other view → base graph restored
- [ ] Typecheck passes: `pnpm --filter web typecheck`
- [ ] Unit tests: `pnpm --filter web test -- TopologyGraph`

🤖 Generated with [Claude Code](https://claude.com/claude-code)