### PR TITLE
fix(test): repair TopologyGraph mocks broken by useTransition (5 failing tests on main)

### DIFF
--- a/apps/web/components/inventory/TopologyGraph.test.tsx
+++ b/apps/web/components/inventory/TopologyGraph.test.tsx
@@ -2,9 +2,25 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
-import * as React from "react";
 import { getImpactData } from "@/lib/actions/graph";
 import { TopologyGraph } from "./TopologyGraph";
+
+// useTransition is mocked at module level so tests can flip `mockIsPending`
+// before render. `vi.spyOn(React, "useTransition")` does not work under ESM —
+// module namespaces are not configurable — so we follow vitest's recommended
+// pattern: vi.mock with importOriginal, exposing a controllable stub.
+let mockIsPending = false;
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useTransition: () =>
+      [mockIsPending, (fn: () => void) => fn()] as readonly [
+        boolean,
+        (fn: () => void) => void,
+      ],
+  };
+});
 
 vi.mock("@/lib/actions/graph", () => ({
   getImpactData: vi.fn().mockResolvedValue({
@@ -37,11 +53,14 @@ beforeEach(() => {
     })),
   });
 
-  global.ResizeObserver = vi.fn().mockImplementation(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
+  // Must be a real constructor (arrow function fails `new ResizeObserver()`
+  // in TopologyGraph.tsx:552). Previously masked by an unrelated spy failure
+  // on the spinner test; surfaced once useTransition mocking was repaired.
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof globalThis.ResizeObserver;
 
   global.requestAnimationFrame = vi.fn().mockReturnValue(0);
   global.cancelAnimationFrame = vi.fn();
@@ -102,7 +121,7 @@ describe("TopologyGraph", () => {
   });
 
   it("shows spinner overlay while isPending is true", () => {
-    vi.spyOn(React, "useTransition").mockReturnValue([true, vi.fn()]);
+    mockIsPending = true;
 
     const dataWithNodes = {
       nodes: [{ id: "n1", name: "Server", label: "InfraCI", color: "#ef4444", size: 6 }],
@@ -119,4 +138,7 @@ describe("TopologyGraph", () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // Module-level mocks (vi.mock) are not reset by restoreAllMocks, so reset
+  // the controllable flag explicitly to keep test isolation.
+  mockIsPending = false;
 });

--- a/apps/web/components/inventory/__tests__/TopologyGraph.subnet.test.tsx
+++ b/apps/web/components/inventory/__tests__/TopologyGraph.subnet.test.tsx
@@ -88,6 +88,11 @@ vi.mock("react", () => ({
   },
   useMemo: <T,>(factory: () => T) => factory(),
   useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
+  // TopologyGraph calls useTransition() to mark async data refreshes; the
+  // synthetic hook harness has no scheduler, so stub it as not-pending with
+  // a synchronous startTransition.
+  useTransition: () =>
+    [false, (fn: () => void) => fn()] as readonly [boolean, (fn: () => void) => void],
 }));
 
 vi.mock("@/lib/graph/scope-helpers", () => ({


### PR DESCRIPTION
## Summary

Repairs 5 failing unit tests on `main` introduced by PR #820 (`feat(topology): wire impact blast radius + dependency audit views to server actions`), which added a `useTransition()` call to `TopologyGraph.tsx:211` without updating the two test files that mock React.

Failures since #820 merged (2026-05-19 23:05 UTC): every CI run on `main` reports `5 failed | 6448 passed` in Unit Tests. Discovered when fixing CI on the just-merged #822 (canonical-URL middleware).

## Root causes and fixes

### `components/inventory/TopologyGraph.test.tsx` — 1 failing test

**Problem A**: `vi.spyOn(React, "useTransition").mockReturnValue(...)` does not work under ESM. The module namespace from `import * as React from "react"` is not configurable, so vitest can't redefine `useTransition`.

> `TypeError: Cannot spy on export "useTransition". Module namespace is not configurable in ESM. See: https://vitest.dev/guide/browser/#limitations`

**Fix A**: Use vitest's recommended `vi.mock("react", async (importOriginal) => {...})` pattern, with a module-scoped `mockIsPending` flag the spinner test toggles before render and `afterEach` resets.

**Problem B** (latent, exposed once A was fixed): `global.ResizeObserver = vi.fn().mockImplementation(() => ({...}))` uses an arrow function and cannot be called with `new`. The component does `new ResizeObserver(...)` inside a `useEffect` (`TopologyGraph.tsx:552`). Previously masked because Problem A short-circuited the spinner test before the canvas useEffect ran.

**Fix B**: Replace with a real class so `new ResizeObserver(...)` succeeds.

### `components/inventory/__tests__/TopologyGraph.subnet.test.tsx` — 4 failing tests

**Problem**: The synthetic React hook harness (`vi.mock("react", () => ({useState, useRef, useEffect, useMemo, useCallback}))`) enumerates the hooks the component uses; it was missing `useTransition`.

> `Error: [vitest] No "useTransition" export is defined on the "react" mock. Did you forget to return it from "vi.mock"?`

**Fix**: Add a not-pending synchronous stub matching the real signature.

## Verification

```
$ pnpm exec vitest run components/inventory/TopologyGraph.test.tsx \
                       components/inventory/__tests__/TopologyGraph.subnet.test.tsx
Test Files  2 passed (2)
Tests      10 passed (10)      (was: 5 failed | 5 passed)

$ pnpm exec vitest run             # full suite
Test Files  802 passed | 4 skipped (806)
Tests      6452 passed | 15 skipped | 18 todo (6485)   (was: 5 failed | 6448 passed)

$ pnpm --filter web typecheck
✓ Types generated successfully
```

## Test plan

- [ ] CI Unit Tests gate goes green on this PR (currently the only red gate on `main` since #820).
- [ ] DCO check passes.