### PR TITLE
Fix sandbox source-currency probe quoting

### DIFF
--- a/apps/web/lib/integrate/sandbox/sandbox-source-currency.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-source-currency.test.ts
@@ -156,9 +156,10 @@ describe("buildSandboxSourceCurrencyProbeCommand", () => {
     expect(command).toContain("rev-parse HEAD^{tree}");
     expect(command).toContain("rev-parse origin/main^{tree}");
     expect(command).toContain("rev-list --left-right --count HEAD...origin/main");
-    expect(command).toContain("status --porcelain");
+    expect(command).toContain("status --porcelain --untracked-files=all -- .");
     expect(command).toContain("localSourceChangeCount");
     expect(command).toContain(":!**/.next/**");
+    expect(command).toContain(":!.pnpm-store");
   });
 });
 

--- a/apps/web/lib/integrate/sandbox/sandbox-source-currency.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-source-currency.ts
@@ -177,7 +177,7 @@ export function buildSandboxSourceCurrencyProbeCommand(args: {
     `mergeBaseSha=$(git merge-base HEAD ${targetRef} 2>/dev/null || true)`,
     `aheadBehind=$(git rev-list --left-right --count HEAD...${targetRef} 2>/dev/null || true)`,
     `dirty=false`,
-    `if [ -n "$(git status --porcelain --untracked-files=all 2>/dev/null)" ]; then dirty=true; fi`,
+    `if [ -n "$(git status --porcelain --untracked-files=all -- . ${diffExcludes} 2>/dev/null)" ]; then dirty=true; fi`,
     `localSourceChangeCount=`,
     `if [ -n "$mergeBaseSha" ]; then localSourceChangeCount=$(git diff --name-only "$mergeBaseSha"..HEAD -- . ${diffExcludes} 2>/dev/null | wc -l | tr -d ' '); fi`,
     `printf 'branch=%s\\n' "$branch"`,

--- a/apps/web/lib/integrate/sandbox/sandbox.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildSandboxAppsWebCopyCommand,
+  buildDockerExecSandboxCommand,
   buildSandboxDiffForFilesCommand,
   buildSandboxCreateArgs,
   buildSandboxListReleasableFilesCommand,
@@ -107,6 +108,28 @@ describe("prefixSafeWorkspaceCommand", () => {
 
     expect(command).toContain('git config --global --add safe.directory "/workspace"');
     expect(command).toContain("cd /workspace && git status -sb");
+  });
+});
+
+describe("buildDockerExecSandboxCommand", () => {
+  it("single-quotes the sandbox shell command so substitutions execute inside the sandbox", () => {
+    const command = buildDockerExecSandboxCommand(
+      "dpf-sandbox-1",
+      "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true) && printf 'branch=%s\\n' \"$branch\"",
+    );
+
+    expect(command).toContain("docker exec 'dpf-sandbox-1' sh -c '");
+    expect(command).toContain("branch=$(git rev-parse --abbrev-ref HEAD");
+    expect(command).toContain("\"$branch\"");
+    expect(command).not.toContain('sh -c "');
+  });
+
+  it("quotes container names and embedded single quotes without breaking command substitution", () => {
+    const command = buildDockerExecSandboxCommand("sandbox'name", "printf 'x' && target=$(pwd)");
+
+    expect(command).toContain("'sandbox'\"'\"'name'");
+    expect(command).toContain("target=$(pwd)");
+    expect(command).toContain("'\"'\"'");
   });
 });
 

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -108,6 +108,11 @@ function joinQuotedArgs(args: readonly string[]): string {
   return args.map((arg) => quotePosixArg(arg)).join(" ");
 }
 
+export function buildDockerExecSandboxCommand(containerId: string, command: string): string {
+  const safeCommand = prefixSafeWorkspaceCommand(command);
+  return `docker exec ${quotePosixArg(containerId)} sh -c ${quotePosixArg(safeCommand)}`;
+}
+
 export function buildSandboxStageCommand(workspace: string = SANDBOX_WORKSPACE): string {
   // Two-pass staging avoids the exit-code 1 that `git add -A` emits when gitignored
   // untracked directories (.pnpm-store, node_modules, packages/db/generated) are
@@ -316,8 +321,7 @@ export async function initializeSandboxWorkspace(containerId: string): Promise<v
 }
 
 export async function execInSandbox(containerId: string, command: string): Promise<string> {
-  const safeCommand = prefixSafeWorkspaceCommand(command);
-  const { stdout } = await exec(`docker exec ${containerId} sh -c ${JSON.stringify(safeCommand)}`, {
+  const { stdout } = await exec(buildDockerExecSandboxCommand(containerId, command), {
     maxBuffer: 100 * 1024 * 1024,
   });
   return stdout;


### PR DESCRIPTION
## Summary
- preserve sandbox source-currency shell substitutions by single-quoting the inner `sh -c` payload passed through Docker
- keep cache/generated paths out of the source-currency dirty check so sandbox package caches do not block freshness decisions
- add focused tests for the Docker exec command builder and source-currency probe command

## Verification
- `pnpm --filter web exec vitest run lib/integrate/sandbox/sandbox.test.ts lib/integrate/sandbox/sandbox-source-currency.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`

## Backlog
- BI-A09749F3
- FB-7A21E1F6 start_build blocker