### PR TITLE
Fix sandbox baseline ignored-path staging

### DIFF
--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -18,6 +18,15 @@ describe("wrapSandboxGitCommand", () => {
     expect(command).toContain("**/*.tsbuildinfo");
   });
 
+  it("stages baseline files without git add -A so ignored caches do not fail the build start", () => {
+    const command = buildSandboxGitAddCommand();
+
+    expect(command).toContain("git add -u");
+    expect(command).toContain("git ls-files -z --others --exclude-standard -- .");
+    expect(command).toContain("xargs -0 -r git add --");
+    expect(command).not.toContain("git add -A");
+  });
+
   it("prunes previously tracked cache artifacts from the sandbox git index", () => {
     const command = buildSandboxGitPruneTrackedArtifactsCommand();
     expect(command).toContain("git rm -r --cached --ignore-unmatch");

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -69,10 +69,11 @@ function quoteGitPathspec(pathspec: string): string {
 }
 
 export function buildSandboxGitAddCommand(): string {
+  const excludes = SANDBOX_GIT_STAGE_EXCLUDES.map(quoteGitPathspec).join(" ");
   return [
-    "git add -A --",
-    ...SANDBOX_GIT_STAGE_EXCLUDES.map(quoteGitPathspec),
-  ].join(" ");
+    "git add -u",
+    `git ls-files -z --others --exclude-standard -- . ${excludes} | xargs -0 -r git add --`,
+  ].join(" && ");
 }
 
 export function buildSandboxBranchSwitchPrepCommand(workspace: string = WORKSPACE): string {


### PR DESCRIPTION
## Summary
- replace sandbox baseline `git add -A` with two-pass staging (`git add -u` plus `git ls-files --others --exclude-standard`)
- keep cache/generated pathspec excludes on new-file discovery so ignored sandbox caches do not fail build start
- add a regression test that blocks `git add -A` in the baseline staging command

## Verification
- `pnpm --filter web exec vitest run lib/integrate/sandbox/build-branch.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`

## Backlog
- BI-A09749F3
- FB-7A21E1F6 start_build blocker after PR #825