### PR TITLE
feat: complete portal context overlay phase 2

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -108,6 +108,13 @@ export function BuildStudio({
       progressVisibility,
     })
     : null;
+
+  useEffect(() => {
+    if (!activeBuild?.buildId) return;
+    if (initialBuildId === activeBuild.buildId) return;
+    router.replace(buildStudioBuildHref(activeBuild.buildId), { scroll: false });
+  }, [activeBuild?.buildId, initialBuildId, router]);
+
   const refreshActiveBuildState = useCallback(async (buildId: string) => {
     const [freshResult, flowResult, progressResult] = await Promise.allSettled([
       getFeatureBuild(buildId),
@@ -708,6 +715,10 @@ function resolveInitialActiveBuild(
   }
 
   return buildRows.find((build) => build.phase !== "complete" && build.phase !== "failed") ?? null;
+}
+
+function buildStudioBuildHref(buildId: string): string {
+  return `/build?buildId=${encodeURIComponent(buildId)}`;
 }
 
 function BuildFailedBanner({ execState }: { execState: BuildExecutionState | null }) {

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -1,4 +1,7 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { BuildStudio } from "@/components/build/BuildStudio";
 import {
@@ -7,9 +10,15 @@ import {
 } from "@/lib/feature-build-types";
 import type { PortalContextEnvelope } from "@/lib/portal-context";
 
+const routerMocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  replace: vi.fn(),
+}));
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    refresh: vi.fn(),
+    refresh: routerMocks.refresh,
+    replace: routerMocks.replace,
   }),
 }));
 
@@ -167,6 +176,24 @@ describe("BuildStudio active-build header layout", () => {
 
     expect(html).toContain("Backlog launched build");
     expect(html).not.toContain("First build</h2>");
+  });
+
+  it("URL-backs the selected default build when /build has no buildId", async () => {
+    routerMocks.replace.mockClear();
+
+    render(
+      <BuildStudio
+        builds={[makeBuild({ buildId: "FB-DEFAULT", title: "Default build" })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(routerMocks.replace).toHaveBeenCalledWith("/build?buildId=FB-DEFAULT", { scroll: false });
+    });
   });
 
   it("bounds the active-build title so long work names cannot take over the canvas", () => {

--- a/apps/web/components/portal-context/HiveMindCandidateList.tsx
+++ b/apps/web/components/portal-context/HiveMindCandidateList.tsx
@@ -1,23 +1,137 @@
-import type { HiveMindCandidate } from "@/lib/portal-context";
+"use client";
 
-export function HiveMindCandidateList({ candidates }: { candidates: HiveMindCandidate[] }) {
+import { useState, useTransition } from "react";
+import { invokePortalContextHiveCandidate } from "@/lib/actions/portal-context-hive";
+import type { AuthoritySummary, HiveMindCandidate, PortalContextEnvelope } from "@/lib/portal-context";
+
+type Props = {
+  candidates: HiveMindCandidate[];
+  work: PortalContextEnvelope["work"];
+  authority: AuthoritySummary;
+  routeContext: string;
+  envelopeId: string;
+};
+
+export function HiveMindCandidateList({ candidates, work, authority, routeContext, envelopeId }: Props) {
+  const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
+  const [resultMessage, setResultMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
   if (candidates.length === 0) {
     return <p className="text-sm text-[var(--dpf-muted)]">No recommended coworkers</p>;
   }
 
+  const parentTaskRunId = work.taskRun?.taskRunId ?? null;
+  const granted = new Set(authority.grantedToolKeys);
+
+  function invokeCandidate(candidate: HiveMindCandidate) {
+    if (!parentTaskRunId) return;
+    setPendingAgentId(candidate.agentId);
+    setResultMessage(null);
+    startTransition(() => {
+      void (async () => {
+        const result = await invokePortalContextHiveCandidate({
+          parentTaskRunId,
+          contextId: work.taskRun?.contextId ?? null,
+          routeContext,
+          envelopeId,
+          candidate,
+          anchors: {
+            buildId: work.featureBuild?.buildId ?? null,
+            capsuleId: work.capsule?.capsuleId ?? null,
+            backlogItemId: work.backlogItem?.backlogItemId ?? null,
+            epicId: work.epic?.epicId ?? null,
+          },
+        });
+        if (result.ok) {
+          setResultMessage(result.reused ? "Existing hive task reused" : "Hive task queued");
+          if (result.threadId) {
+            document.dispatchEvent(new CustomEvent("open-agent-panel", {
+              detail: { targetThreadId: result.threadId },
+            }));
+          }
+        } else {
+          setResultMessage(result.error);
+        }
+        setPendingAgentId(null);
+      })();
+    });
+  }
+
   return (
-    <ul className="grid gap-2">
-      {candidates.map((candidate) => (
-        <li key={`${candidate.agentId}:${candidate.role}`} className="border-b border-[var(--dpf-border)] pb-2 last:border-b-0 last:pb-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-medium text-[var(--dpf-text)]">{candidate.label}</span>
-            <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
-              {candidate.role}
-            </span>
-          </div>
-          <p className="mt-1 text-sm text-[var(--dpf-muted)]">{candidate.reason}</p>
-        </li>
-      ))}
-    </ul>
+    <div className="grid gap-2">
+      {resultMessage && (
+        <p className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-muted)]">
+          {resultMessage}
+        </p>
+      )}
+      <ul className="grid gap-2">
+        {candidates.map((candidate) => (
+          <li key={`${candidate.agentId}:${candidate.role}`} className="border-b border-[var(--dpf-border)] pb-2 last:border-b-0 last:pb-0">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-[var(--dpf-text)]">{candidate.label}</span>
+                  <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-xs text-[var(--dpf-muted)]">
+                    {candidate.role}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">{candidate.reason}</p>
+              </div>
+              <CandidateAction
+                candidate={candidate}
+                disabledReason={disabledReason(candidate, granted, parentTaskRunId)}
+                pending={isPending && pendingAgentId === candidate.agentId}
+                onInvoke={() => invokeCandidate(candidate)}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
+}
+
+function CandidateAction({
+  candidate,
+  disabledReason,
+  pending,
+  onInvoke,
+}: {
+  candidate: HiveMindCandidate;
+  disabledReason: string | null;
+  pending: boolean;
+  onInvoke: () => void;
+}) {
+  if (disabledReason) {
+    return (
+      <span className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-muted)]">
+        {disabledReason}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onInvoke}
+      disabled={pending}
+      className="inline-flex min-h-9 items-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-accent)] transition-colors hover:border-[var(--dpf-accent)] disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+    >
+      {pending ? "Queuing" : actionLabel(candidate)}
+    </button>
+  );
+}
+
+function disabledReason(candidate: HiveMindCandidate, granted: Set<string>, parentTaskRunId: string | null): string | null {
+  if (!parentTaskRunId) return "Needs task";
+  const missing = candidate.requiredGrantKeys.filter((grant) => !granted.has(grant));
+  if (missing.length > 0) return "Missing grant";
+  return null;
+}
+
+function actionLabel(candidate: HiveMindCandidate): string {
+  if (candidate.activation === "required-before-promotion") return "Ask now";
+  if (candidate.activation === "ask-now") return "Ask now";
+  return "Queue";
 }

--- a/apps/web/components/portal-context/PortalContextOverlayDrawer.tsx
+++ b/apps/web/components/portal-context/PortalContextOverlayDrawer.tsx
@@ -55,7 +55,15 @@ export function PortalContextOverlayDrawer({
             {
               id: "hive",
               label: "Hive",
-              panel: <HiveMindCandidateList candidates={envelope.coworkers} />,
+              panel: (
+                <HiveMindCandidateList
+                  candidates={envelope.coworkers}
+                  work={envelope.work}
+                  authority={envelope.authority}
+                  routeContext={envelope.route.routeContext}
+                  envelopeId={envelope.envelopeId}
+                />
+              ),
             },
             {
               id: "evidence",

--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -85,6 +85,14 @@ vi.mock("@/lib/tak/reflection-triggers", () => ({
   processRuntimeIssueReflection: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/lib/tak/task-records", () => ({
+  createTaskArtifact: vi.fn(),
+}));
+
+vi.mock("@/lib/work-capsules/work-capsule-store", () => ({
+  recordWorkCapsuleEvidence: vi.fn(),
+}));
+
 vi.mock("@/lib/process-observer-hook", () => ({
   observeConversation: vi.fn().mockResolvedValue(undefined),
 }));
@@ -154,6 +162,12 @@ vi.mock("@dpf/db", () => ({
     taskRun: {
       findFirst: vi.fn(),
     },
+    backlogItem: {
+      findUnique: vi.fn(),
+    },
+    backlogItemActivity: {
+      create: vi.fn(),
+    },
     agentActionProposal: {
       create: vi.fn(),
     },
@@ -184,6 +198,8 @@ import { classifyTask } from "@/lib/task-classifier";
 import { executeTool, getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
+import { createTaskArtifact } from "@/lib/tak/task-records";
+import { recordWorkCapsuleEvidence } from "@/lib/work-capsules/work-capsule-store";
 import { prisma } from "@dpf/db";
 import { sendMessage } from "./agent-coworker";
 
@@ -196,6 +212,8 @@ const mockToolsToOpenAIFormat = toolsToOpenAIFormat as ReturnType<typeof vi.fn>;
 const mockExecuteTool = executeTool as ReturnType<typeof vi.fn>;
 const mockGovernedExecuteTool = governedExecuteTool as ReturnType<typeof vi.fn>;
 const mockResolvePortalContextEnvelope = resolvePortalContextEnvelope as ReturnType<typeof vi.fn>;
+const mockCreateTaskArtifact = createTaskArtifact as ReturnType<typeof vi.fn>;
+const mockRecordWorkCapsuleEvidence = recordWorkCapsuleEvidence as ReturnType<typeof vi.fn>;
 const mockPrisma = prisma as any;
 
 describe("agent coworker external access", () => {
@@ -241,12 +259,19 @@ describe("agent coworker external access", () => {
     });
     mockPrisma.agentModelConfig.findUnique.mockResolvedValue(null);
     mockPrisma.toolExecution.create.mockResolvedValue({});
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ id: "backlog-row-1" });
+    mockPrisma.backlogItemActivity.create.mockResolvedValue({ id: "backlog-activity-1" });
+    mockCreateTaskArtifact.mockResolvedValue({ id: "artifact-row-1", artifactId: "ta_123" });
+    mockRecordWorkCapsuleEvidence.mockResolvedValue({ id: "activity-1" });
     mockResolvePortalContextEnvelope.mockResolvedValue({
       promptDigest: "Route: /build\nBuild: FB-123 phase=implement status=active\nCapsule: WC-123 status=claimed executor=codex",
       anchors: [
         { kind: "build", id: "FB-123", label: "Portal context build", href: "/build?buildId=FB-123" },
         { kind: "capsule", id: "WC-123", label: "Portal context capsule", href: "/build/work/WC-123" },
       ],
+      work: {
+        capsule: { capsuleId: "WC-123" },
+      },
     });
     mockClassifyTask.mockReturnValue({
       taskType: "conversation",
@@ -675,6 +700,71 @@ describe("agent coworker external access", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           taskRunId: "run-123",
+        }),
+      }),
+    );
+  });
+
+  it("persists substantive coworker responses as TaskArtifact and Work Capsule evidence", async () => {
+    mockPrisma.taskRun.findFirst.mockResolvedValue({ taskRunId: "run-123" });
+    mockGetAvailableTools.mockReturnValue([]);
+    mockRouteAndCall.mockResolvedValue({
+      content: "I reviewed the anchored capsule and recommend finishing the evidence handoff before promotion.",
+      providerId: "ollama-local",
+      modelId: "llama3.1",
+      inputTokens: 1,
+      outputTokens: 1,
+      toolCalls: [],
+      downgraded: false,
+      downgradeMessage: null,
+      routeDecision: {},
+    });
+    mockResolvePortalContextEnvelope.mockResolvedValueOnce({
+      envelopeId: "env-1",
+      promptDigest: "Route: /build\nBuild: FB-123 phase=implement status=active\nCapsule: WC-123 status=claimed executor=codex",
+      anchors: [
+        { kind: "build", id: "FB-123", label: "Portal context build", href: "/build?buildId=FB-123" },
+        { kind: "capsule", id: "WC-123", label: "Portal context capsule", href: "/build/work/WC-123" },
+        { kind: "backlogItem", id: "BI-123", label: "Portal context backlog", href: "/ops/backlog/BI-123" },
+      ],
+      work: {
+        capsule: { capsuleId: "WC-123" },
+        backlogItem: { backlogItemId: "BI-123" },
+      },
+    });
+
+    await sendMessage({
+      threadId: "thread-1",
+      content: "What should happen next?",
+      routeContext: "/build",
+      buildId: "FB-123",
+    });
+
+    expect(mockCreateTaskArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: "run-123",
+        artifactType: "coworker_response",
+        name: "Coworker response",
+        producerAgentId: "admin-assistant",
+      }),
+    );
+    expect(mockRecordWorkCapsuleEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capsuleId: "WC-123",
+        evidence: expect.objectContaining({
+          kind: "note",
+          summary: "Admin Assistant response captured for the current portal context.",
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "backlog-row-1",
+          kind: "portal-context-coworker-response",
+          summary: "Admin Assistant response captured for the current portal context.",
+          recordedById: "user-1",
+          recordedByAgentId: "admin-assistant",
         }),
       }),
     );

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -32,7 +32,7 @@ import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveRouteContext } from "@/lib/route-context-map";
 import { assembleSystemPrompt } from "@/lib/prompt-assembler";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
-import type { PortalObjectAnchor } from "@/lib/portal-context";
+import type { PortalContextEnvelope, PortalObjectAnchor } from "@/lib/portal-context";
 import {
   extractInvokedSkillId,
   getSkillsForAgent,
@@ -85,7 +85,7 @@ async function buildPortalContextPromptSection(input: {
   routeContext: string;
   threadId: string;
   buildId?: string | null;
-}, userId: string): Promise<string | null> {
+}, userId: string): Promise<{ section: string; envelope: PortalContextEnvelope } | null> {
   const pathname = normalizePortalContextPathname(input.routeContext);
   if (!isPortalContextSupportedPath(pathname)) return null;
 
@@ -103,7 +103,8 @@ async function buildPortalContextPromptSection(input: {
       userId,
     );
 
-    return formatPortalContextPromptSection(envelope.promptDigest, envelope.anchors);
+    const section = formatPortalContextPromptSection(envelope.promptDigest, envelope.anchors);
+    return section ? { section, envelope } : null;
   } catch (error) {
     console.warn("[portal-context] Failed to resolve coworker prompt context", error);
     return null;
@@ -117,6 +118,101 @@ function formatPortalContextPromptSection(promptDigest: string, anchors: PortalO
     : null;
   const lines = ["--- PORTAL CONTEXT ---", digest, anchorLine].filter((line): line is string => Boolean(line));
   return lines.length > 1 ? lines.join("\n") : null;
+}
+
+async function persistCoworkerResponseArtifact(input: {
+  taskRunId: string | null;
+  responseContent: string;
+  routeContext: string;
+  threadId: string;
+  agentId: string;
+  agentName: string;
+  providerId: string | null;
+  modelId: string | null;
+  portalContext: PortalContextEnvelope | null;
+  userId: string;
+}): Promise<void> {
+  if (!input.taskRunId) return;
+  if (!isSubstantiveCoworkerOutput(input.responseContent)) return;
+
+  try {
+    const { createTaskArtifact } = await import("@/lib/tak/task-records");
+    await createTaskArtifact({
+      taskRunId: input.taskRunId,
+      artifactType: "coworker_response",
+      name: "Coworker response",
+      summary: input.responseContent.slice(0, 240),
+      content: {
+        routeContext: input.routeContext,
+        threadId: input.threadId,
+        response: input.responseContent,
+        providerId: input.providerId,
+        modelId: input.modelId,
+        anchors: input.portalContext?.anchors ?? [],
+      },
+      metadata: {
+        kind: "coworker-response",
+        deliveryState: "responded",
+        routeContext: input.routeContext,
+        envelopeId: input.portalContext?.envelopeId ?? null,
+      },
+      producerAgentId: input.agentId,
+    });
+
+    const capsuleId = input.portalContext?.work?.capsule?.capsuleId ?? null;
+    if (capsuleId) {
+      const { recordWorkCapsuleEvidence } = await import("@/lib/work-capsules/work-capsule-store");
+      await recordWorkCapsuleEvidence({
+        db: prisma,
+        capsuleId,
+        evidence: {
+          kind: "note",
+          summary: `${input.agentName} response captured for the current portal context.`,
+          result: {
+            taskRunId: input.taskRunId,
+            threadId: input.threadId,
+            agentId: input.agentId,
+            routeContext: input.routeContext,
+          },
+        },
+        actor: {
+          userId: input.userId,
+          agentId: input.agentId,
+          principalId: input.portalContext?.user?.principalId ?? null,
+        },
+      });
+    }
+
+    const backlogItemId = input.portalContext?.work?.backlogItem?.backlogItemId ?? null;
+    if (backlogItemId) {
+      const { recordPortalContextBacklogEvidence } = await import("@/lib/portal-context/evidence-recording");
+      await recordPortalContextBacklogEvidence({
+        db: prisma,
+        backlogItemId,
+        kind: "portal-context-coworker-response",
+        summary: `${input.agentName} response captured for the current portal context.`,
+        payload: {
+          taskRunId: input.taskRunId,
+          threadId: input.threadId,
+          agentId: input.agentId,
+          routeContext: input.routeContext,
+          envelopeId: input.portalContext?.envelopeId ?? null,
+        },
+        actor: {
+          userId: input.userId,
+          agentId: input.agentId,
+        },
+      });
+    }
+  } catch (error) {
+    console.warn("[portal-context] Failed to persist coworker response artifact", error);
+  }
+}
+
+function isSubstantiveCoworkerOutput(content: string): boolean {
+  const trimmed = content.trim();
+  if (trimmed.length < 40) return false;
+  return !/^(?:ok|yes|no|thanks|thank you|sure|got it|hello|hi|hey)$/i.test(trimmed);
 }
 
 function normalizePortalContextPathname(routeContext: string): string {
@@ -435,7 +531,7 @@ export async function sendMessage(input: {
 
   // Track build ID at function scope — used in both prompt assembly and post-inference research dispatch
   let resolvedBuildId = input.buildId;
-  const portalContextPrompt = await buildPortalContextPromptSection(
+  const portalContextPromptContext = await buildPortalContextPromptSection(
     {
       routeContext: input.routeContext,
       threadId: input.threadId,
@@ -443,6 +539,7 @@ export async function sendMessage(input: {
     },
     user.id!,
   );
+  const portalContextPrompt = portalContextPromptContext?.section ?? null;
 
   // Build inference context: recent window + semantic recall for older context.
   // Build phases need more context (research findings, schema details, tool results)
@@ -1231,6 +1328,8 @@ export async function sendMessage(input: {
           where: { buildId: activeBuild!.buildId, phase: "build" },
           data: { phase: "review" },
         });
+        const { revalidatePortalContextForBuild } = await import("@/lib/portal-context/invalidation");
+        revalidatePortalContextForBuild(activeBuild!.buildId);
       } catch { /* already advanced or concurrent update — fine */ }
 
       const needsReview = (activeBuild!.taskResults as { tasks?: Array<{ outcome: string; title: string }> })?.tasks
@@ -1720,6 +1819,19 @@ export async function sendMessage(input: {
       routeContext: true,
       createdAt: true,
     },
+  });
+
+  await persistCoworkerResponseArtifact({
+    taskRunId: currentTaskRun?.taskRunId ?? null,
+    responseContent,
+    routeContext: input.routeContext,
+    threadId: input.threadId,
+    agentId: agent.agentId,
+    agentName: agent.agentName,
+    providerId: responseProviderId,
+    modelId: responseModelId,
+    portalContext: portalContextPromptContext?.envelope ?? null,
+    userId: user.id!,
   });
 
   const { resolveAIDocForAgent } = await import("@/lib/identity/aidoc-resolver");

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -37,6 +37,7 @@ import {
   attachBuildStudioWorkCapsule,
   type BuildStudioCapsuleDb,
 } from "@/lib/work-capsules/build-studio-attachment";
+import { revalidatePortalContextForBuild } from "@/lib/portal-context/invalidation";
 
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
@@ -446,6 +447,7 @@ export async function advanceBuildPhase(
     where: { buildId },
     data: { phase: targetPhase },
   });
+  revalidatePortalContextForBuild(buildId);
 
   // Notify the UI immediately so progress indicators update without waiting for debounce
   try {
@@ -670,6 +672,7 @@ export async function retryBuildExecution(buildId: string): Promise<void> {
       where: { buildId },
       data: { phase: "build" },
     });
+    revalidatePortalContextForBuild(buildId);
   }
 
   // Fire-and-forget retry — picks up from failed step
@@ -896,6 +899,7 @@ export async function resumeBuildImplementation(buildId: string): Promise<Resume
       },
     },
   });
+  revalidatePortalContextForBuild(buildId);
 
   try {
     if (build.threadId) {
@@ -1297,6 +1301,7 @@ export async function completeBuild(buildId: string): Promise<void> {
     where: { buildId },
     data: { phase: "complete" },
   });
+  revalidatePortalContextForBuild(buildId);
 }
 
 // ─── Create Epic + Backlog Items for a Build ────────────────────────────────

--- a/apps/web/lib/actions/portal-context-hive.test.ts
+++ b/apps/web/lib/actions/portal-context-hive.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+const prismaMocks = vi.hoisted(() => ({
+  taskRun: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  agentThread: {
+    create: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  agentMessage: {
+    create: vi.fn(),
+  },
+  backlogItem: {
+    findUnique: vi.fn(),
+  },
+  backlogItemActivity: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: prismaMocks,
+}));
+
+vi.mock("@/lib/tak/task-records", () => ({
+  createTaskArtifact: vi.fn(),
+}));
+
+vi.mock("@/lib/work-capsules/work-capsule-store", () => ({
+  recordWorkCapsuleEvidence: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/agent-thread-dispatcher", () => ({
+  dispatchAgentThread: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import { createTaskArtifact } from "@/lib/tak/task-records";
+import { recordWorkCapsuleEvidence } from "@/lib/work-capsules/work-capsule-store";
+import { dispatchAgentThread } from "@/lib/actions/agent-thread-dispatcher";
+import { prisma } from "@dpf/db";
+import { invokePortalContextHiveCandidate } from "./portal-context-hive";
+
+const mockAuth = auth as ReturnType<typeof vi.fn>;
+const mockCreateTaskArtifact = createTaskArtifact as ReturnType<typeof vi.fn>;
+const mockRecordWorkCapsuleEvidence = recordWorkCapsuleEvidence as ReturnType<typeof vi.fn>;
+const mockDispatchAgentThread = dispatchAgentThread as ReturnType<typeof vi.fn>;
+const mockPrisma = prisma as unknown as typeof prismaMocks;
+
+describe("invokePortalContextHiveCandidate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: {
+        id: "user-1",
+        platformRole: "HR-000",
+        isSuperuser: true,
+      },
+    });
+    mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof prismaMocks) => Promise<unknown>) => fn(mockPrisma));
+    mockPrisma.taskRun.findUnique.mockResolvedValue({
+      id: "parent-row-1",
+      taskRunId: "TR-PARENT",
+      userId: "user-1",
+      threadId: "thread-parent",
+      contextId: "ctx-build-1",
+      buildId: "FB-1",
+      routeContext: "/build",
+    });
+    mockPrisma.agentThread.create.mockResolvedValue({ id: "thread-child" });
+    mockPrisma.agentThread.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.agentMessage.create.mockResolvedValue({ id: "message-1" });
+    mockPrisma.taskRun.create.mockResolvedValue({
+      id: "child-row-1",
+      taskRunId: "TR-HIVE-NEW",
+      threadId: "thread-child",
+    });
+    mockPrisma.taskRun.update.mockResolvedValue({});
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ id: "backlog-row-1" });
+    mockPrisma.backlogItemActivity.create.mockResolvedValue({ id: "backlog-activity-1" });
+    mockCreateTaskArtifact.mockResolvedValue({ id: "artifact-row-1", artifactId: "ta_123" });
+    mockRecordWorkCapsuleEvidence.mockResolvedValue({ id: "activity-1" });
+    mockDispatchAgentThread.mockResolvedValue(undefined);
+  });
+
+  it("reuses an existing non-terminal child TaskRun for the same parent, context, and hive role", async () => {
+    mockPrisma.taskRun.findFirst.mockResolvedValue({
+      id: "child-row-existing",
+      taskRunId: "TR-HIVE-EXISTING",
+      threadId: "thread-existing",
+      status: "working",
+    });
+
+    const result = await invokePortalContextHiveCandidate(makeInput());
+
+    expect(result).toEqual({
+      ok: true,
+      reused: true,
+      taskRunId: "TR-HIVE-EXISTING",
+      threadId: "thread-existing",
+    });
+    expect(mockPrisma.taskRun.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          parentTaskRunId: "TR-PARENT",
+          contextId: "ctx-build-1",
+          status: expect.objectContaining({
+            notIn: expect.arrayContaining(["completed", "failed", "cancelled", "canceled"]),
+          }),
+          a2aMetadata: {
+            path: ["hiveMindRole"],
+            equals: "architect",
+          },
+        }),
+      }),
+    );
+    expect(mockPrisma.taskRun.create).not.toHaveBeenCalled();
+    expect(mockCreateTaskArtifact).not.toHaveBeenCalled();
+  });
+
+  it("creates a child TaskRun with hive metadata, request artifact, evidence, and dispatch when none exists", async () => {
+    mockPrisma.taskRun.findFirst.mockResolvedValue(null);
+
+    const result = await invokePortalContextHiveCandidate(makeInput());
+
+    expect(result).toEqual({
+      ok: true,
+      reused: false,
+      taskRunId: "TR-HIVE-NEW",
+      threadId: "thread-child",
+    });
+    expect(mockPrisma.taskRun.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+          threadId: "thread-child",
+          contextId: "ctx-build-1",
+          buildId: "FB-1",
+          parentTaskRunId: "TR-PARENT",
+          initiatingAgentId: "AGT-ARCH",
+          currentAgentId: "AGT-ARCH",
+          routeContext: "/build",
+          source: "coworker",
+          status: "submitted",
+          a2aMetadata: expect.objectContaining({
+            trigger: "portal-context-hive",
+            hiveMindContextId: "hive:TR-PARENT:ctx-build-1:architect",
+            hiveMindRole: "architect",
+            buildId: "FB-1",
+            capsuleId: "WC-1",
+            backlogItemId: "BI-1",
+            epicId: "EP-1",
+          }),
+        }),
+        select: { id: true, taskRunId: true, threadId: true },
+      }),
+    );
+    expect(mockCreateTaskArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: "TR-HIVE-NEW",
+        taskRunRecordId: "child-row-1",
+        artifactType: "hive_invocation_request",
+        name: "Portal context hive invocation",
+      }),
+    );
+    expect(mockRecordWorkCapsuleEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capsuleId: "WC-1",
+        evidence: expect.objectContaining({
+          kind: "note",
+          summary: "Architect Review asked to review the current portal context.",
+        }),
+      }),
+    );
+    expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          backlogItemId: "backlog-row-1",
+          kind: "portal-context-hive-invoked",
+          summary: "Architect Review asked to review the current portal context.",
+          recordedById: "user-1",
+          recordedByAgentId: "AGT-ARCH",
+        }),
+      }),
+    );
+    expect(mockDispatchAgentThread).toHaveBeenCalledWith("thread-child", "user-1");
+  });
+});
+
+function makeInput() {
+  return {
+    parentTaskRunId: "TR-PARENT",
+    contextId: "ctx-build-1",
+    routeContext: "/build",
+    envelopeId: "env-1",
+    candidate: {
+      agentId: "AGT-ARCH",
+      label: "Architect Review",
+      role: "architect" as const,
+      reason: "Matches current build context.",
+      taskType: "analysis" as const,
+    },
+    anchors: {
+      buildId: "FB-1",
+      capsuleId: "WC-1",
+      backlogItemId: "BI-1",
+      epicId: "EP-1",
+    },
+  };
+}

--- a/apps/web/lib/actions/portal-context-hive.ts
+++ b/apps/web/lib/actions/portal-context-hive.ts
@@ -1,0 +1,303 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+import { auth } from "@/lib/auth";
+import { prisma, type Prisma } from "@dpf/db";
+import { dispatchAgentThread } from "@/lib/actions/agent-thread-dispatcher";
+import { createTaskArtifact } from "@/lib/tak/task-records";
+import { recordWorkCapsuleEvidence } from "@/lib/work-capsules/work-capsule-store";
+import {
+  revalidatePortalContextForBuild,
+  revalidatePortalContextForTaskRun,
+  revalidatePortalContextForThread,
+} from "@/lib/portal-context/invalidation";
+import { recordPortalContextBacklogEvidence } from "@/lib/portal-context/evidence-recording";
+import type { HiveMindCandidate } from "@/lib/portal-context";
+
+const TERMINAL_TASK_STATES = ["completed", "failed", "cancelled", "canceled", "rejected", "archived"];
+
+export type PortalContextHiveInvocationInput = {
+  parentTaskRunId: string;
+  contextId?: string | null;
+  routeContext: string;
+  envelopeId?: string | null;
+  candidate: Pick<HiveMindCandidate, "agentId" | "label" | "role" | "reason" | "taskType">;
+  anchors?: {
+    buildId?: string | null;
+    capsuleId?: string | null;
+    backlogItemId?: string | null;
+    epicId?: string | null;
+  };
+};
+
+export type PortalContextHiveInvocationResult =
+  | { ok: true; reused: boolean; taskRunId: string; threadId: string | null }
+  | { ok: false; error: string };
+
+type ParentTaskRun = {
+  id: string;
+  taskRunId: string;
+  userId: string;
+  threadId: string | null;
+  contextId: string | null;
+  buildId: string | null;
+  routeContext: string | null;
+};
+
+export async function invokePortalContextHiveCandidate(
+  input: PortalContextHiveInvocationInput,
+): Promise<PortalContextHiveInvocationResult> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) return { ok: false, error: "Unauthorized" };
+
+  const parentTaskRunId = input.parentTaskRunId.trim();
+  if (!parentTaskRunId) return { ok: false, error: "Parent task run is required." };
+
+  const parent = await prisma.taskRun.findUnique({
+    where: { taskRunId: parentTaskRunId },
+    select: {
+      id: true,
+      taskRunId: true,
+      userId: true,
+      threadId: true,
+      contextId: true,
+      buildId: true,
+      routeContext: true,
+    },
+  });
+  if (!parent) return { ok: false, error: "Parent task run was not found." };
+  if (parent.userId !== user.id) return { ok: false, error: "Unauthorized" };
+
+  const contextId = normalizeNullable(input.contextId) ?? parent.contextId;
+  const buildId = normalizeNullable(input.anchors?.buildId) ?? parent.buildId;
+  const hiveMindContextId = createHiveMindContextId(parent.taskRunId, contextId, input.candidate.role);
+
+  const result = await prisma.$transaction(async (tx) => {
+    const existing = await tx.taskRun.findFirst({
+      where: {
+        parentTaskRunId: parent.taskRunId,
+        contextId,
+        status: { notIn: TERMINAL_TASK_STATES },
+        a2aMetadata: {
+          path: ["hiveMindRole"],
+          equals: input.candidate.role,
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        taskRunId: true,
+        threadId: true,
+        status: true,
+      },
+    });
+    if (existing) {
+      return {
+        reused: true,
+        taskRunId: existing.taskRunId,
+        taskRunRecordId: existing.id,
+        threadId: existing.threadId ?? null,
+        created: false,
+      };
+    }
+
+    const childThread = parent.threadId
+      ? await tx.agentThread.create({
+          data: {
+            userId: user.id!,
+            contextKey: `portal-context-hive-${randomUUID()}`,
+            parentThreadId: parent.threadId,
+          },
+          select: { id: true },
+        })
+      : null;
+
+    if (parent.threadId) {
+      await tx.agentThread.updateMany({
+        where: { id: parent.threadId },
+        data: { childCount: { increment: 1 } },
+      });
+    }
+
+    const childTaskRunId = createHiveTaskRunId();
+    const objective = createHiveObjective(input);
+    const created = await tx.taskRun.create({
+      data: {
+        taskRunId: childTaskRunId,
+        userId: user.id!,
+        threadId: childThread?.id ?? parent.threadId,
+        contextId,
+        buildId,
+        initiatingAgentId: input.candidate.agentId,
+        currentAgentId: input.candidate.agentId,
+        parentTaskRunId: parent.taskRunId,
+        routeContext: input.routeContext || parent.routeContext,
+        title: `${input.candidate.label} portal context review`,
+        objective,
+        source: "coworker",
+        status: "submitted",
+        authorityScope: [],
+        a2aMetadata: {
+          trigger: "portal-context-hive",
+          hiveMindContextId,
+          hiveMindRole: input.candidate.role,
+          envelopeId: input.envelopeId ?? null,
+          requestedAgentId: input.candidate.agentId,
+          requestedAgentLabel: input.candidate.label,
+          taskType: input.candidate.taskType,
+          buildId,
+          capsuleId: input.anchors?.capsuleId ?? null,
+          backlogItemId: input.anchors?.backlogItemId ?? null,
+          epicId: input.anchors?.epicId ?? null,
+        } as Prisma.InputJsonValue,
+      },
+      select: { id: true, taskRunId: true, threadId: true },
+    });
+
+    if (childThread?.id) {
+      await tx.agentMessage.create({
+        data: {
+          threadId: childThread.id,
+          taskRunId: created.taskRunId,
+          role: "user",
+          content: objective,
+          agentId: input.candidate.agentId,
+          routeContext: input.routeContext || parent.routeContext,
+        },
+      });
+    }
+
+    return {
+      reused: false,
+      taskRunId: created.taskRunId,
+      taskRunRecordId: created.id,
+      threadId: created.threadId ?? null,
+      created: true,
+    };
+  });
+
+  if (result.created) {
+    await createTaskArtifact({
+      taskRunId: result.taskRunId,
+      taskRunRecordId: result.taskRunRecordId,
+      artifactType: "hive_invocation_request",
+      name: "Portal context hive invocation",
+      summary: createHiveEvidenceSummary(input),
+      content: {
+        routeContext: input.routeContext,
+        envelopeId: input.envelopeId ?? null,
+        hiveMindContextId,
+        candidate: input.candidate,
+        anchors: input.anchors ?? {},
+      },
+      metadata: {
+        kind: "portal-context-hive-invocation",
+        hiveMindContextId,
+        hiveMindRole: input.candidate.role,
+      },
+      producerAgentId: input.candidate.agentId,
+    });
+
+    if (input.anchors?.capsuleId) {
+      await recordWorkCapsuleEvidence({
+        db: prisma,
+        capsuleId: input.anchors.capsuleId,
+        evidence: {
+          kind: "note",
+          summary: createHiveEvidenceSummary(input),
+          result: {
+            taskRunId: result.taskRunId,
+            threadId: result.threadId,
+            hiveMindRole: input.candidate.role,
+            agentId: input.candidate.agentId,
+          },
+        },
+        actor: {
+          userId: user.id,
+          agentId: input.candidate.agentId,
+          principalId: null,
+        },
+      });
+    }
+
+    await recordPortalContextBacklogEvidence({
+      db: prisma,
+      backlogItemId: input.anchors?.backlogItemId,
+      kind: "portal-context-hive-invoked",
+      summary: createHiveEvidenceSummary(input),
+      payload: {
+        taskRunId: result.taskRunId,
+        threadId: result.threadId,
+        routeContext: input.routeContext,
+        envelopeId: input.envelopeId ?? null,
+        hiveMindContextId,
+        hiveMindRole: input.candidate.role,
+        agentId: input.candidate.agentId,
+        anchors: input.anchors ?? {},
+      },
+      actor: {
+        userId: user.id,
+        agentId: input.candidate.agentId,
+      },
+    });
+  }
+
+  if (buildId) revalidatePortalContextForBuild(buildId);
+  if (result.threadId) revalidatePortalContextForThread(result.threadId);
+
+  if (result.created && result.threadId) {
+    try {
+      await dispatchAgentThread(result.threadId, user.id);
+    } catch (error) {
+      await prisma.taskRun.update({
+        where: { taskRunId: result.taskRunId },
+        data: { status: "failed", completedAt: new Date() },
+      });
+      revalidatePortalContextForTaskRun(result.taskRunId, result.threadId);
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : "Failed to dispatch hive coworker.",
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    reused: result.reused,
+    taskRunId: result.taskRunId,
+    threadId: result.threadId,
+  };
+}
+
+function createHiveTaskRunId(): string {
+  return `TR-HIVE-${randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+function createHiveMindContextId(parentTaskRunId: string, contextId: string | null, role: string): string {
+  return `hive:${parentTaskRunId}:${contextId ?? "none"}:${role}`;
+}
+
+function createHiveObjective(input: PortalContextHiveInvocationInput): string {
+  const anchors = [
+    input.anchors?.buildId ? `Build ${input.anchors.buildId}` : null,
+    input.anchors?.capsuleId ? `Capsule ${input.anchors.capsuleId}` : null,
+    input.anchors?.backlogItemId ? `Backlog ${input.anchors.backlogItemId}` : null,
+  ].filter(Boolean).join(", ");
+
+  return [
+    `${input.candidate.label} should review the current portal work context as ${input.candidate.role}.`,
+    input.candidate.reason,
+    anchors ? `Anchors: ${anchors}.` : null,
+    "Return a concise task artifact with risks, recommendation, and next action.",
+  ].filter(Boolean).join("\n");
+}
+
+function createHiveEvidenceSummary(input: PortalContextHiveInvocationInput): string {
+  return `${input.candidate.label} asked to review the current portal context.`;
+}
+
+function normalizeNullable(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/apps/web/lib/portal-context/evidence-recording.ts
+++ b/apps/web/lib/portal-context/evidence-recording.ts
@@ -1,0 +1,54 @@
+import type { Prisma } from "@dpf/db";
+
+type PortalContextEvidenceDb = {
+  backlogItem: {
+    findUnique(args: {
+      where: { itemId: string };
+      select: { id: true };
+    }): Promise<{ id: string } | null>;
+  };
+  backlogItemActivity: {
+    create(args: {
+      data: {
+        backlogItemId: string;
+        kind: string;
+        summary: string;
+        payload: Prisma.InputJsonValue;
+        recordedById: string | null;
+        recordedByAgentId: string | null;
+      };
+    }): Promise<unknown>;
+  };
+};
+
+export async function recordPortalContextBacklogEvidence(args: {
+  db: PortalContextEvidenceDb;
+  backlogItemId: string | null | undefined;
+  kind: string;
+  summary: string;
+  payload: Prisma.InputJsonValue;
+  actor: {
+    userId: string | null;
+    agentId: string | null;
+  };
+}): Promise<void> {
+  const itemId = args.backlogItemId?.trim();
+  if (!itemId) return;
+
+  const backlogItem = await args.db.backlogItem.findUnique({
+    where: { itemId },
+    select: { id: true },
+  });
+  if (!backlogItem) return;
+
+  await args.db.backlogItemActivity.create({
+    data: {
+      backlogItemId: backlogItem.id,
+      kind: args.kind,
+      summary: args.summary.slice(0, 240),
+      payload: args.payload,
+      recordedById: args.actor.userId,
+      recordedByAgentId: args.actor.agentId,
+    },
+  });
+}

--- a/apps/web/lib/portal-context/index.ts
+++ b/apps/web/lib/portal-context/index.ts
@@ -13,14 +13,17 @@ import { resolvePortalEvidence } from "./evidence-resolver";
 import { resolveHiveMindCandidates } from "./hive-mind-resolver";
 import { createPortalContextPromptDigest } from "./prompt-digest";
 import { resolvePortalRoute } from "./route-resolver";
-import { resolvePortalWork } from "./work-resolver";
+import { resolvePortalWork, type WorkResolution } from "./work-resolver";
 import type { AttentionSignal, PortalContextEnvelope, PortalContextInput } from "./types";
 
 type ResolverDeps = {
   db?: PortalContextDb;
   now?: () => Date;
   getRouteDataContext?: (routeContext: string, userId: string) => Promise<string | null>;
+  resolverTimeoutMs?: number;
 };
+
+const DEFAULT_RESOLVER_TIMEOUT_MS = 3_000;
 
 export async function resolvePortalContextEnvelope(
   input: PortalContextInput,
@@ -50,20 +53,49 @@ export async function resolvePortalContextEnvelopeUncached(
   const db = deps.db ?? (prisma as unknown as PortalContextDb);
   const now = deps.now?.() ?? new Date();
   const bucket = bucketPortalContextTimestamp(now);
+  const resolverTimeoutMs = deps.resolverTimeoutMs ?? DEFAULT_RESOLVER_TIMEOUT_MS;
   const routeProjection = resolvePortalRoute(input);
   const attention: AttentionSignal[] = [...routeProjection.attention];
 
-  const [user, principalAlias, organization] = await Promise.all([
-    resolveUser(db, userId),
-    resolvePrincipalAlias(db, userId),
-    resolveOrganization(db),
-    (deps.getRouteDataContext ?? getDefaultRouteDataContext)(input.routeContext, userId).catch(() => null),
+  const [userResult, principalAliasResult, organizationResult, routeDataResult] = await Promise.all([
+    resolveSource("user", resolveUser(db, userId), null, resolverTimeoutMs),
+    resolveSource("principal", resolvePrincipalAlias(db, userId), null, resolverTimeoutMs),
+    resolveSource("organization", resolveOrganization(db), null, resolverTimeoutMs),
+    resolveSource(
+      "route-data",
+      (deps.getRouteDataContext ?? getDefaultRouteDataContext)(input.routeContext, userId),
+      null,
+      resolverTimeoutMs,
+    ),
   ]);
+  attention.push(
+    ...userResult.attention,
+    ...principalAliasResult.attention,
+    ...organizationResult.attention,
+    ...routeDataResult.attention,
+  );
+  const user = userResult.value;
+  const principalAlias = principalAliasResult.value;
+  const organization = organizationResult.value;
 
-  const workProjection = await resolvePortalWork(input, db, now);
+  const workProjectionResult = await resolveSource(
+    "work",
+    resolvePortalWork(input, db, now),
+    emptyWorkResolution(),
+    resolverTimeoutMs,
+  );
+  const workProjection = workProjectionResult.value;
+  attention.push(...workProjectionResult.attention);
   attention.push(...workProjection.attention);
 
-  const evidence = await resolvePortalEvidence(workProjection.work, db);
+  const evidenceResult = await resolveSource(
+    "evidence",
+    resolvePortalEvidence(workProjection.work, db),
+    [],
+    resolverTimeoutMs,
+  );
+  const evidence = evidenceResult.value;
+  attention.push(...evidenceResult.attention);
   if (evidence.some((item) => item.isGap)) {
     attention.push({
       kind: "missing_evidence",
@@ -79,12 +111,19 @@ export async function resolvePortalContextEnvelopeUncached(
     work: workProjection.work,
     domainTools: routeProjection.domainTools,
   });
-  const coworkers = await resolveHiveMindCandidates({
-    routeDomain: routeProjection.route.domain,
-    work: workProjection.work,
-    attention,
-    db,
-  });
+  const coworkersResult = await resolveSource(
+    "hive-mind",
+    resolveHiveMindCandidates({
+      routeDomain: routeProjection.route.domain,
+      work: workProjection.work,
+      attention,
+      db,
+    }),
+    [],
+    resolverTimeoutMs,
+  );
+  const coworkers = coworkersResult.value;
+  attention.push(...coworkersResult.attention);
 
   const baseEnvelope: Omit<PortalContextEnvelope, "promptDigest"> = {
     envelopeId: createPortalContextEnvelopeId(input, userId, bucket),
@@ -163,6 +202,73 @@ async function resolveOrganization(db: PortalContextDb): Promise<OrganizationRow
 
 function platformRoleForUser(user: PortalUserRow | null): string {
   return user?.groups?.[0]?.platformRole?.roleId ?? "none";
+}
+
+class PortalContextResolverTimeoutError extends Error {
+  constructor(source: string) {
+    super(`${source} resolver timed out`);
+    this.name = "PortalContextResolverTimeoutError";
+  }
+}
+
+async function resolveSource<T>(
+  source: string,
+  promise: Promise<T>,
+  fallback: T,
+  timeoutMs: number,
+): Promise<{ value: T; attention: AttentionSignal[] }> {
+  try {
+    return {
+      value: await withTimeout(source, promise, timeoutMs),
+      attention: [],
+    };
+  } catch (error) {
+    const timedOut = error instanceof PortalContextResolverTimeoutError;
+    const attention: AttentionSignal[] = [
+      {
+        kind: "source_unavailable",
+        severity: "warning",
+        message: `Portal context ${source} source is unavailable.`,
+      },
+    ];
+    if (timedOut) {
+      attention.push({
+        kind: "envelope_timeout",
+        severity: "warning",
+        message: `Portal context ${source} source exceeded the soft timeout.`,
+      });
+    }
+    return { value: fallback, attention };
+  }
+}
+
+async function withTimeout<T>(source: string, promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new PortalContextResolverTimeoutError(source)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function emptyWorkResolution(): WorkResolution {
+  return {
+    work: {
+      backlogItem: null,
+      epic: null,
+      capsule: null,
+      featureBuild: null,
+      taskRun: null,
+      agentThread: null,
+      branch: null,
+    },
+    anchors: [],
+    attention: [],
+  };
 }
 
 export type {

--- a/apps/web/lib/portal-context/invalidation.test.ts
+++ b/apps/web/lib/portal-context/invalidation.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}));
+
+import { revalidateTag } from "next/cache";
+import {
+  revalidatePortalContext,
+  revalidatePortalContextForBuild,
+  revalidatePortalContextForTaskRun,
+} from "./invalidation";
+
+const mockRevalidateTag = revalidateTag as ReturnType<typeof vi.fn>;
+
+describe("portal context invalidation", () => {
+  beforeEach(() => {
+    mockRevalidateTag.mockReset();
+  });
+
+  it("falls back to the broad portal context tag when no scoped tag is provided", () => {
+    revalidatePortalContext();
+
+    expect(mockRevalidateTag).toHaveBeenCalledWith("portal-context", "max");
+  });
+
+  it("keeps entity invalidation scoped when a build changes", () => {
+    revalidatePortalContextForBuild("FB-123");
+
+    expect(mockRevalidateTag).toHaveBeenCalledTimes(1);
+    expect(mockRevalidateTag).toHaveBeenCalledWith("portal-context:build:FB-123", "max");
+  });
+
+  it("scopes task-run invalidation to task and thread tags", () => {
+    revalidatePortalContextForTaskRun("thread-1", "thread-1");
+
+    expect(mockRevalidateTag).toHaveBeenCalledTimes(2);
+    expect(mockRevalidateTag).toHaveBeenCalledWith("portal-context:task-run:thread-1", "max");
+    expect(mockRevalidateTag).toHaveBeenCalledWith("portal-context:thread:thread-1", "max");
+  });
+});

--- a/apps/web/lib/portal-context/invalidation.ts
+++ b/apps/web/lib/portal-context/invalidation.ts
@@ -1,9 +1,36 @@
 import { revalidateTag } from "next/cache";
 
-export function revalidatePortalContext(): void {
+export function revalidatePortalContext(tags: string[] = []): void {
+  const scopedTags = tags.map((tag) => tag.trim()).filter(Boolean);
+  const uniqueTags = Array.from(new Set(scopedTags.length > 0 ? scopedTags : ["portal-context"]));
   try {
-    revalidateTag("portal-context", "max");
+    for (const tag of uniqueTags) {
+      revalidateTag(tag, "max");
+    }
   } catch {
     // Revalidation is best-effort outside a Next request/runtime boundary.
   }
+}
+
+export function revalidatePortalContextForBuild(buildId: string): void {
+  revalidatePortalContext([`portal-context:build:${buildId}`]);
+}
+
+export function revalidatePortalContextForCapsule(capsuleId: string): void {
+  revalidatePortalContext([`portal-context:capsule:${capsuleId}`]);
+}
+
+export function revalidatePortalContextForThread(threadId: string): void {
+  revalidatePortalContext([`portal-context:thread:${threadId}`]);
+}
+
+export function revalidatePortalContextForUser(userId: string): void {
+  revalidatePortalContext([`portal-context:user:${userId}`]);
+}
+
+export function revalidatePortalContextForTaskRun(taskRunId: string, threadId?: string | null): void {
+  revalidatePortalContext([
+    `portal-context:task-run:${taskRunId}`,
+    threadId ? `portal-context:thread:${threadId}` : "",
+  ]);
 }

--- a/apps/web/lib/portal-context/portal-context.test.ts
+++ b/apps/web/lib/portal-context/portal-context.test.ts
@@ -41,6 +41,27 @@ describe("portal context cache helpers", () => {
 
     expect(tags).toEqual(["portal-context", "portal-context:user:user-1", "portal-context:build:FB-123"]);
   });
+
+  it("returns entity-specific tags for every anchored work object", () => {
+    const tags = portalContextCacheTags(
+      {
+        pathname: "/build/work/WC-123",
+        routeContext: "/build/work",
+        buildId: "FB-123",
+        capsuleId: "WC-123",
+        threadId: "thread-789",
+      },
+      "user-1",
+    );
+
+    expect(tags).toEqual([
+      "portal-context",
+      "portal-context:user:user-1",
+      "portal-context:build:FB-123",
+      "portal-context:capsule:WC-123",
+      "portal-context:thread:thread-789",
+    ]);
+  });
 });
 
 describe("resolvePortalContextEnvelopeUncached", () => {
@@ -179,6 +200,71 @@ describe("resolvePortalContextEnvelopeUncached", () => {
     expect(db.agent.findMany).toHaveBeenCalled();
     expect(envelope.coworkers.map((candidate) => candidate.agentId)).toContain("AGT-CONTEXT-ARCH");
     expect(envelope.coworkers.map((candidate) => candidate.agentId)).not.toContain("work-context-architect");
+  });
+
+  it("returns a partial envelope with source_unavailable when a sub-resolver fails", async () => {
+    const db = createDbMock({
+      featureBuild: {
+        id: "build-row-1",
+        buildId: "FB-123",
+        title: "Build with offline capsule source",
+        phase: "implement",
+        status: "working",
+      },
+    });
+    db.workCapsule.findFirst.mockRejectedValueOnce(new Error("capsule source offline"));
+
+    const envelope = await resolvePortalContextEnvelopeUncached(
+      { pathname: "/build", routeContext: "/build", buildId: "FB-123" },
+      "user-1",
+      {
+        now: () => new Date("2026-05-17T18:23:41.123Z"),
+        db,
+        getRouteDataContext: vi.fn().mockResolvedValue(null),
+      },
+    );
+
+    expect(envelope.route.routeContext).toBe("/build");
+    expect(envelope.work.featureBuild).toBeNull();
+    expect(envelope.attention).toContainEqual(
+      expect.objectContaining({
+        kind: "source_unavailable",
+        severity: "warning",
+      }),
+    );
+    expect(envelope.promptDigest).toContain("Attention: source_unavailable(warning)");
+  });
+
+  it("returns a partial envelope with envelope_timeout when a sub-resolver exceeds the soft timeout", async () => {
+    const db = createDbMock();
+    db.featureBuild.findUnique.mockImplementationOnce(
+      () => new Promise((resolve) => setTimeout(() => resolve(null), 50)),
+    );
+
+    const envelope = await resolvePortalContextEnvelopeUncached(
+      { pathname: "/build", routeContext: "/build", buildId: "FB-SLOW" },
+      "user-1",
+      {
+        now: () => new Date("2026-05-17T18:23:41.123Z"),
+        db,
+        getRouteDataContext: vi.fn().mockResolvedValue(null),
+        resolverTimeoutMs: 5,
+      },
+    );
+
+    expect(envelope.route.routeContext).toBe("/build");
+    expect(envelope.attention).toContainEqual(
+      expect.objectContaining({
+        kind: "envelope_timeout",
+        severity: "warning",
+      }),
+    );
+    expect(envelope.attention).toContainEqual(
+      expect.objectContaining({
+        kind: "source_unavailable",
+        severity: "warning",
+      }),
+    );
   });
 });
 

--- a/apps/web/lib/portal-context/work-resolver.ts
+++ b/apps/web/lib/portal-context/work-resolver.ts
@@ -20,7 +20,7 @@ import type {
   WorkCapsuleRow,
 } from "./db-types";
 
-type WorkResolution = {
+export type WorkResolution = {
   work: {
     backlogItem: WorkBacklogAnchor | null;
     epic: WorkEpicAnchor | null;

--- a/docs/superpowers/plans/2026-05-17-portal-context-overlay-hive-mind-work-surface-implementation.md
+++ b/docs/superpowers/plans/2026-05-17-portal-context-overlay-hive-mind-work-surface-implementation.md
@@ -59,6 +59,30 @@ Deferred from this slice:
 
 These are now tracked as `BI-3FCA9CB0` under `EP-CAPSULE`.
 
+## Implementation Status - 2026-05-20 Phase 2
+
+Implemented in branch `feat/portal-context-overlay-phase-2`:
+
+- Added explicit Hive tab invocation from the Portal Context overlay. Candidate rows are now grant-aware action rows that either queue/ask the recommended coworker, show `Needs task`, show `Missing grant`, or show the empty state.
+- Added `invokePortalContextHiveCandidate`, a server action that authenticates the caller, verifies parent `TaskRun` ownership, reuses an existing non-terminal child task for the same parent/context/hive role, or creates a new child `TaskRun` with hive metadata, request artifact, anchored build/capsule/backlog/epic IDs, and child thread linkage.
+- Added backlog and Work Capsule evidence recording for hive invocation requests. The action writes a `hive_invocation_request` `TaskArtifact`, Work Capsule evidence when a capsule anchor exists, and `BacklogItemActivity` when a backlog anchor exists.
+- Persisted substantive coworker responses as `TaskArtifact` records and mirrored them to Work Capsule and backlog evidence when the active portal context has those anchors. Short acknowledgements remain chat-only to avoid noisy evidence.
+- Added partial-envelope fallback around user, principal, organization, route-data, work, evidence, and hive candidate sources. Resolver failures now yield a degraded envelope plus `source_unavailable`; soft timeouts also add `envelope_timeout`.
+- Replaced broad-only invalidation with scoped helpers for build, capsule, thread, user, and task-run tags. Generic callers can still invalidate the broad `portal-context` tag, but build/task mutation points now use entity tags.
+- URL-backed default Build Studio selection now replaces `/build` with `/build?buildId=<active>` after hydration, so the server envelope and coworker runtime can anchor the same active build.
+- Added a small shared `recordPortalContextBacklogEvidence` helper so portal-context evidence writes use the same backlog activity shape from hive and coworker paths.
+
+Verified:
+
+- `pnpm --filter web exec vitest run lib/portal-context/portal-context.test.ts lib/portal-context/prompt-digest.test.ts lib/portal-context/invalidation.test.ts components/portal-context/PortalContextOverlayDrawer.test.tsx components/portal-context/PortalContextStrip.test.tsx components/build/BuildStudioHeaderLayout.test.tsx components/build/work-control/WorkControlPanel.test.tsx lib/actions/portal-context-hive.test.ts lib/actions/agent-coworker-external.test.ts lib/work-capsules/work-capsule-store.test.ts lib/actions/build-governed.test.ts` - 11 files, 69 tests passed.
+- `pnpm --filter web typecheck` - passed.
+- `pnpm --filter web build` - passed. Existing Turbopack/NFT broad-trace warnings remain in backlog/spec search and discovery catalog import traces.
+- Disposable Docker UX verification against the phase-2 image on `localhost:3101` passed for `/build`, URL-backed active build selection, Portal Context strip, overlay drawer, Hive tab, and mobile drawer width. Screenshots: `apps/web/output/playwright/phase2-build-overlay-hive.png`, `apps/web/output/playwright/phase2-build-overlay-hive-mobile.png`.
+
+Remaining dependency:
+
+- The hive action calls the existing `dispatchAgentThread` seam after creating or reusing the child task. That dispatcher is still a placeholder in current mainline code, so this slice makes hive participation durable and visible in `TaskRun`/artifact/evidence records, but full autonomous child-thread execution still depends on the A2A/team-orchestration runtime landing behind that seam.
+
 ## File Structure
 
 Create:

--- a/docs/superpowers/specs/2026-05-17-portal-context-overlay-hive-mind-work-surface-design.md
+++ b/docs/superpowers/specs/2026-05-17-portal-context-overlay-hive-mind-work-surface-design.md
@@ -2,13 +2,19 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft for review |
+| Status | Implemented through Phase 2; A2A child execution dependency remains |
 | Date | 2026-05-17 |
 | Backlog | EP-CAPSULE / BI-7529B658 |
 | Author | Codex + Mark Bodman |
 | Primary audience | Platform architecture, Build Studio, coworker runtime, Work Capsule UX |
 | Related repo areas | `apps/web/components/agent/*`, `apps/web/lib/actions/agent-coworker.ts`, `apps/web/lib/tak/*`, `apps/web/lib/work-capsules/*`, `apps/web/app/(shell)/build/*`, `packages/db/prisma/schema.prisma` |
 | Related artifacts | `2026-05-14-portal-work-capsule-control-harness-design.md`, `2026-05-10-ai-coworker-visual-control-surface-design.md`, `2026-04-23-a2a-aligned-coworker-runtime-design.md`, `2026-04-29-coworker-execution-adapter-substrate-design.md`, `2026-04-01-phase-handoff-and-human-authority-engagement-design.md` |
+
+## Implementation Note - 2026-05-20
+
+The first implementation branch delivered the `PortalContextEnvelope` projection, Build Studio/Work Control strip and drawer, prompt digest injection, hive recommendations, and broad Work Capsule invalidation. Phase 2 adds explicit Hive tab invocation, child `TaskRun` dedupe, request artifacts, Work Capsule/backlog evidence writes, substantive coworker response artifacts, resolver timeout/source fallback, scoped cache invalidation helpers, and URL-backed Build Studio active-build selection.
+
+The remaining dependency is not the overlay contract itself. It is the existing child-thread dispatch seam: `dispatchAgentThread` is still a placeholder in mainline, so hive invocation can now create durable task/evidence records and open the child thread context, but autonomous child-agent execution still depends on the A2A/team-orchestration runtime landing behind that dispatcher.
 
 ## 1. Purpose
 


### PR DESCRIPTION
## Summary
- completes Portal Context Overlay phase 2 with explicit Hive tab invocation, child TaskRun dedupe, request artifacts, and Work Capsule/backlog evidence writes
- persists substantive coworker responses as TaskArtifacts and mirrors them into anchored capsule/backlog evidence
- adds partial-envelope source/timeout fallback, scoped portal-context invalidation, and URL-backed Build Studio active-build selection
- updates the implementation plan/spec with shipped scope, verification evidence, and the remaining A2A dispatcher dependency

## Verification
- pnpm --filter web exec vitest run lib/portal-context/portal-context.test.ts lib/portal-context/prompt-digest.test.ts lib/portal-context/invalidation.test.ts components/portal-context/PortalContextOverlayDrawer.test.tsx components/portal-context/PortalContextStrip.test.tsx components/build/BuildStudioHeaderLayout.test.tsx components/build/work-control/WorkControlPanel.test.tsx lib/actions/portal-context-hive.test.ts lib/actions/agent-coworker-external.test.ts lib/work-capsules/work-capsule-store.test.ts lib/actions/build-governed.test.ts
- pnpm --filter web typecheck
- pnpm --filter web build
- git diff --check
- Docker UX smoke: disposable phase-2 image on localhost:3101, login as admin@dpf.local, /build URL-backed to buildId, Portal Context drawer opened, Hive tab rendered, mobile drawer had no horizontal overflow

## Notes
- Build still reports the existing Turbopack/NFT broad-tracing warnings in discovery catalog and backlog/spec search import traces.
- Hive invocation now creates durable task/artifact/evidence records and calls the existing dispatch seam; autonomous child-agent execution still depends on the A2A/team-orchestration dispatcher implementation.
- Backlog evidence was recorded through MCP and BI-3FCA9CB0 was marked done.