### PR TITLE
fix(build-studio): allow advance to Plan when BusinessBuildBrief is absent

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -375,7 +375,10 @@ export async function advanceBuildPhase(
       where: { featureBuildId: build.id },
       select: { status: true },
     });
-    if (businessBrief?.status !== "accepted") {
+    // null = brief not yet created (governance gap — proceed). Only block on an
+    // explicitly non-accepted brief (draft, rejected, etc.) so builds created
+    // without going through the full intake UI are not permanently deadlocked.
+    if (businessBrief !== null && businessBrief.status !== "accepted") {
       throw new Error("Accept the business build brief before moving into planning.");
     }
   }


### PR DESCRIPTION
## Summary

- The Ideate→Plan gate in `advanceBuildPhase` threw **"Accept the business build brief before moving into planning"** for any build where `BusinessBuildBrief` hadn't been created yet
- Builds created via the direct text input never auto-create a brief; the coworker tool call that would create it (`saveBuildEvidence`) is blocked by the stall-loop bug (FB-3320BCC3), producing a deadlock
- **4 existing builds were permanently stuck**: FB-3320BCC3, FB-1A465165, FB-FB8B2EAA, FB-63E4F3CE

## The fix

One-line logic change in `apps/web/lib/actions/build.ts:378`:

```typescript
// Before — blocks on missing brief (null treated as "not accepted")
if (businessBrief?.status !== "accepted") {

// After — null = not yet created = proceed; only a non-null non-accepted brief blocks
if (businessBrief !== null && businessBrief.status !== "accepted") {
```

The existing `checkPhaseGate` already enforces design-doc + design-review + happy-path intake before planning — the brief gate is redundant when null and the deadlock is unrecoverable without direct DB intervention.

## Test plan

- [ ] Typecheck passes (pre-commit hook confirmed ✓)
- [ ] Advance to Plan works for a build with no `BusinessBuildBrief` record
- [ ] Advance to Plan is still blocked for a build with `businessBrief.status = "draft"` or `"rejected"`
- [ ] Rebuild portal Docker image and verify the 4 stuck builds can now advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)