### PR TITLE
feat(stall-recovery): Phase F operator UI for stall recovery (BI-4ab6be39)

### DIFF
--- a/apps/web/components/platform/AiOperationsMap.tsx
+++ b/apps/web/components/platform/AiOperationsMap.tsx
@@ -31,6 +31,7 @@ import {
   saveOperationsMapViewPreference,
   type OperationsMapStoredQuickViewId,
 } from "./ai-operations-map-prefs";
+import { StalledTaskRecoveryActions } from "./StalledTaskRecoveryActions";
 
 type SelectedItem =
   | { kind: "station"; id: string }
@@ -2520,6 +2521,15 @@ function ProjectionInspector({ projection }: { projection: OperationsMapProjecti
     projection.links.coworkerHref ? { href: projection.links.coworkerHref, label: "Open coworker" } : null,
   ].filter((item): item is { href: string; label: string } => item !== null);
 
+  // BI-4ab6be39 — detect stalled task-run projections. projectTaskRun
+  // renders summary as "${title} (${status})" — when status is "stalled"
+  // and the projection has a taskRunId in refs, expose the operator
+  // recovery actions (Retry / Abandon / Escalate).
+  const isStalledTaskRun =
+    projection.source === "task-run" &&
+    projection.refs.taskRunId != null &&
+    projection.summary.includes("(stalled)");
+
   return (
     <div className="mt-4 space-y-4">
       <div>
@@ -2535,6 +2545,16 @@ function ProjectionInspector({ projection }: { projection: OperationsMapProjecti
         {projection.refs.threadId ? <InspectorFact label="Thread" value={projection.refs.threadId} /> : null}
         {projection.refs.backlogItemId ? <InspectorFact label="Backlog item" value={projection.refs.backlogItemId} /> : null}
       </dl>
+      {isStalledTaskRun && projection.refs.taskRunId ? (
+        <StalledTaskRecoveryActions
+          taskRunId={projection.refs.taskRunId}
+          // Phase is unknown here — we don't carry it in projection.refs.
+          // The server action will look it up. Passing null disables the
+          // ship-phase confirm branch in the UI (server still enforces
+          // ship_phase_requires_force, so this is safe).
+          phase={null}
+        />
+      ) : null}
       <div className="flex flex-wrap gap-2">
         {linkItems.map((item) => (
           <Link key={item.href} href={item.href} className="text-sm text-[var(--dpf-accent)] hover:underline">

--- a/apps/web/components/platform/StalledTaskRecoveryActions.tsx
+++ b/apps/web/components/platform/StalledTaskRecoveryActions.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  serverTaskrunRetry,
+  serverTaskrunAbandon,
+  serverTaskrunEscalate,
+} from "@/lib/actions/taskrun-recovery-server-actions";
+
+/**
+ * Recovery actions for a stalled TaskRun (BI-4ab6be39 Phase F).
+ *
+ * Renders three buttons — Retry / Abandon / Escalate — that call the
+ * server actions in lib/actions/taskrun-recovery-server-actions.ts.
+ *
+ * Ship-phase Retry is gated behind a confirm dialog per spec §5.5 — the
+ * caller passes `phase`; this component decides the disabled/confirm UX.
+ */
+export function StalledTaskRecoveryActions({
+  taskRunId,
+  phase,
+}: {
+  taskRunId: string;
+  phase: string | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<{ kind: "idle" } | { kind: "error"; message: string } | { kind: "success"; message: string }>({ kind: "idle" });
+
+  const isShipPhase = phase === "ship";
+
+  const onRetry = () => {
+    if (isShipPhase) {
+      const ok = confirm(
+        "Ship-phase Retry can double-publish (resend emails, re-deploy, etc.). Are you sure you want to retry?",
+      );
+      if (!ok) return;
+    }
+    startTransition(async () => {
+      const result = await serverTaskrunRetry(taskRunId, { force: isShipPhase });
+      if (result.ok) {
+        setStatus({ kind: "success", message: `Retried as ${result.newTaskRunId}` });
+        router.refresh();
+      } else {
+        setStatus({ kind: "error", message: result.error });
+      }
+    });
+  };
+
+  const onAbandon = () => {
+    const ok = confirm("Abandon this stalled task? Live child tasks will also be canceled.");
+    if (!ok) return;
+    startTransition(async () => {
+      const result = await serverTaskrunAbandon(taskRunId);
+      if (result.ok) {
+        setStatus({ kind: "success", message: "Task abandoned" });
+        router.refresh();
+      } else {
+        setStatus({ kind: "error", message: result.error });
+      }
+    });
+  };
+
+  const onEscalate = () => {
+    const notes = prompt("Optional note for the escalation:") ?? undefined;
+    startTransition(async () => {
+      const result = await serverTaskrunEscalate(taskRunId, notes);
+      if (result.ok) {
+        setStatus({ kind: "success", message: "Escalated for review" });
+        router.refresh();
+      } else {
+        setStatus({ kind: "error", message: result.error });
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+        Stalled — operator recovery
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={pending}
+          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-accent)] hover:text-white disabled:opacity-50"
+          title={isShipPhase ? "Ship-phase Retry requires confirm (double-publish risk)" : "Spawn a sibling TaskRun and re-dispatch"}
+        >
+          Retry{isShipPhase ? " (ship)" : ""}
+        </button>
+        <button
+          type="button"
+          onClick={onAbandon}
+          disabled={pending}
+          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-error)] hover:text-white disabled:opacity-50"
+          title="Cancel this task and live children"
+        >
+          Abandon
+        </button>
+        <button
+          type="button"
+          onClick={onEscalate}
+          disabled={pending}
+          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-warning)] hover:text-white disabled:opacity-50"
+          title="Park for human review; notifies the accountable owner"
+        >
+          Escalate
+        </button>
+      </div>
+      {status.kind === "success" && (
+        <p className="text-xs text-[var(--dpf-accent)]">{status.message}</p>
+      )}
+      {status.kind === "error" && (
+        <p className="text-xs text-[var(--dpf-error)]">{status.message}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/taskrun-recovery-server-actions.ts
+++ b/apps/web/lib/actions/taskrun-recovery-server-actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { auth } from "@/lib/govern/auth";
+import {
+  taskrunRetry,
+  taskrunAbandon,
+  taskrunEscalate,
+  TaskrunRecoveryError,
+} from "./taskrun-recovery";
+
+type Result<T = void> =
+  | (T extends void ? { ok: true } : { ok: true } & T)
+  | { ok: false; error: string };
+
+/**
+ * Server-action wrappers for Phase F recovery UI. They:
+ *   1. resolve the operator's userId via the auth() session,
+ *   2. call into the pure recovery functions,
+ *   3. normalize errors into a discriminated result the UI can render.
+ *
+ * Errors include the TaskrunRecoveryError code (not_found / not_stalled /
+ * ship_phase_requires_force) when applicable so the client can react
+ * intelligently — e.g. surface a "this isn't stalled anymore" message
+ * after a stale UI click.
+ */
+
+async function operatorUserId(): Promise<string | null> {
+  const session = await auth();
+  return session?.user?.id ?? null;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof TaskrunRecoveryError) {
+    return `${err.code}: ${err.message}`;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+export async function serverTaskrunRetry(
+  taskRunId: string,
+  opts: { force?: boolean } = {},
+): Promise<Result<{ newTaskRunId: string }>> {
+  const userId = await operatorUserId();
+  if (!userId) return { ok: false, error: "Not authenticated" };
+  try {
+    const { newTaskRunId } = await taskrunRetry(taskRunId, userId, opts);
+    return { ok: true, newTaskRunId };
+  } catch (err) {
+    return { ok: false, error: describeError(err) };
+  }
+}
+
+export async function serverTaskrunAbandon(taskRunId: string): Promise<Result> {
+  const userId = await operatorUserId();
+  if (!userId) return { ok: false, error: "Not authenticated" };
+  try {
+    await taskrunAbandon(taskRunId, userId);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: describeError(err) };
+  }
+}
+
+export async function serverTaskrunEscalate(
+  taskRunId: string,
+  notes?: string,
+): Promise<Result> {
+  const userId = await operatorUserId();
+  if (!userId) return { ok: false, error: "Not authenticated" };
+  try {
+    await taskrunEscalate(taskRunId, userId, notes);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: describeError(err) };
+  }
+}

--- a/apps/web/lib/actions/taskrun-recovery.test.ts
+++ b/apps/web/lib/actions/taskrun-recovery.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock prisma at the module boundary so the tests don't need a real DB.
+// Each test installs its own findUnique / findFirst / update / create
+// implementations via the helpers below.
+const {
+  taskRunFindUnique,
+  taskRunFindMany,
+  taskRunUpdate,
+  taskRunCreate,
+  featureBuildFindUnique,
+  stallEventFindFirst,
+  stallEventUpdate,
+  stallEventCreate,
+  notificationCreate,
+  transactionImpl,
+} = vi.hoisted(() => {
+  // Mocks are untyped (any) to keep the test ergonomic — production typing
+  // is enforced by the actual prisma client in lib/actions/taskrun-recovery.ts.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const anyFn = (): any => vi.fn();
+  const taskRunFindUnique = anyFn();
+  const taskRunFindMany = anyFn();
+  const taskRunUpdate = anyFn();
+  const taskRunCreate = anyFn();
+  const featureBuildFindUnique = anyFn();
+  const stallEventFindFirst = anyFn();
+  const stallEventUpdate = anyFn();
+  const stallEventCreate = anyFn();
+  const notificationCreate = anyFn();
+  const transactionImpl = vi.fn(async (fn: (tx: unknown) => unknown) =>
+    fn({
+      taskRun: { update: taskRunUpdate, create: taskRunCreate, findMany: taskRunFindMany },
+      stallEvent: { findFirst: stallEventFindFirst, update: stallEventUpdate, create: stallEventCreate },
+      notification: { create: notificationCreate },
+    }),
+  );
+  return {
+    taskRunFindUnique,
+    taskRunFindMany,
+    taskRunUpdate,
+    taskRunCreate,
+    featureBuildFindUnique,
+    stallEventFindFirst,
+    stallEventUpdate,
+    stallEventCreate,
+    notificationCreate,
+    transactionImpl,
+  };
+});
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: { findUnique: taskRunFindUnique, findMany: taskRunFindMany, update: taskRunUpdate, create: taskRunCreate },
+    featureBuild: { findUnique: featureBuildFindUnique },
+    stallEvent: { findFirst: stallEventFindFirst, update: stallEventUpdate, create: stallEventCreate },
+    notification: { create: notificationCreate },
+    $transaction: transactionImpl,
+  },
+}));
+
+import { taskrunRetry, taskrunAbandon, taskrunEscalate, TaskrunRecoveryError } from "./taskrun-recovery";
+
+function stalledRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cuid-stalled-1",
+    taskRunId: "TR-STALL-1",
+    userId: "user-1",
+    threadId: "thread-1",
+    contextId: "ctx-1",
+    buildId: null,
+    routeContext: "/build",
+    title: "Stalled task",
+    objective: "Do the thing",
+    source: "coworker",
+    status: "stalled",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  taskRunFindUnique.mockReset();
+  taskRunFindMany.mockReset();
+  taskRunFindMany.mockImplementation(async () => []);
+  taskRunUpdate.mockReset();
+  taskRunUpdate.mockImplementation(async () => ({}));
+  taskRunCreate.mockReset();
+  featureBuildFindUnique.mockReset();
+  featureBuildFindUnique.mockImplementation(async () => null);
+  stallEventFindFirst.mockReset();
+  stallEventFindFirst.mockImplementation(async () => null);
+  stallEventUpdate.mockReset();
+  stallEventUpdate.mockImplementation(async () => ({}));
+  stallEventCreate.mockReset();
+  stallEventCreate.mockImplementation(async () => ({}));
+  notificationCreate.mockReset();
+  notificationCreate.mockImplementation(async () => ({}));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("taskrunRetry", () => {
+  it("rejects when the row is not in stalled status", async () => {
+    taskRunFindUnique.mockResolvedValue({ ...stalledRow(), status: "working" });
+    await expect(taskrunRetry("TR-STALL-1", "op-1")).rejects.toBeInstanceOf(TaskrunRecoveryError);
+    await expect(taskrunRetry("TR-STALL-1", "op-1")).rejects.toThrow(/not_stalled|status is working/);
+  });
+
+  it("rejects when the row is not found", async () => {
+    taskRunFindUnique.mockResolvedValue(null);
+    await expect(taskrunRetry("TR-MISSING", "op-1")).rejects.toBeInstanceOf(TaskrunRecoveryError);
+    await expect(taskrunRetry("TR-MISSING", "op-1")).rejects.toThrow(/not_found|not found/);
+  });
+
+  it("rejects ship-phase retry without force:true", async () => {
+    taskRunFindUnique.mockResolvedValue({ ...stalledRow(), buildId: "FB-1" });
+    featureBuildFindUnique.mockResolvedValue({ phase: "ship" });
+    await expect(taskrunRetry("TR-STALL-1", "op-1")).rejects.toThrow(/ship_phase_requires_force|double-publish/);
+  });
+
+  it("permits ship-phase retry with force:true", async () => {
+    taskRunFindUnique.mockResolvedValue({ ...stalledRow(), buildId: "FB-1" });
+    featureBuildFindUnique.mockResolvedValue({ phase: "ship" });
+    taskRunCreate.mockResolvedValue({ taskRunId: "TR-RETRY-X" });
+    const result = await taskrunRetry("TR-STALL-1", "op-1", { force: true });
+    expect(result.newTaskRunId).toBe("TR-RETRY-X");
+  });
+
+  it("spawns a sibling TaskRun with parentTaskRunId set to the stalled row's cuid", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    taskRunCreate.mockResolvedValue({ taskRunId: "TR-RETRY-A" });
+    await taskrunRetry("TR-STALL-1", "op-1");
+    expect(taskRunCreate).toHaveBeenCalledTimes(1);
+    const createArg = taskRunCreate.mock.calls[0]![0] as { data: { parentTaskRunId: string; status: string } };
+    expect(createArg.data.parentTaskRunId).toBe("cuid-stalled-1");
+    expect(createArg.data.status).toBe("submitted");
+  });
+
+  it("closes the most recent open StallEvent as 'retry'", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    stallEventFindFirst.mockResolvedValue({ id: "se-1" });
+    taskRunCreate.mockResolvedValue({ taskRunId: "TR-RETRY-B" });
+    await taskrunRetry("TR-STALL-1", "op-99");
+    expect(stallEventUpdate).toHaveBeenCalledTimes(1);
+    const updateArg = stallEventUpdate.mock.calls[0]![0] as { data: { outcome: string; outcomeBy: string } };
+    expect(updateArg.data.outcome).toBe("retry");
+    expect(updateArg.data.outcomeBy).toBe("op-99");
+  });
+});
+
+describe("taskrunAbandon", () => {
+  it("rejects when the row is not stalled", async () => {
+    taskRunFindUnique.mockResolvedValue({ ...stalledRow(), status: "completed" });
+    await expect(taskrunAbandon("TR-STALL-1", "op-1")).rejects.toThrow(/Cannot recover.*status is completed/);
+  });
+
+  it("transitions the stalled row to canceled", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    await taskrunAbandon("TR-STALL-1", "op-1");
+    const firstUpdate = taskRunUpdate.mock.calls[0]![0] as { data: { status: string } };
+    expect(firstUpdate.data.status).toBe("canceled");
+  });
+
+  it("closes the most recent open StallEvent as 'abandoned'", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    stallEventFindFirst.mockResolvedValue({ id: "se-1" });
+    await taskrunAbandon("TR-STALL-1", "op-1");
+    const updateArg = stallEventUpdate.mock.calls[0]![0] as { data: { outcome: string } };
+    expect(updateArg.data.outcome).toBe("abandoned");
+  });
+
+  it("cascades one level to live children with reason=parent_abandoned", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    taskRunFindMany.mockResolvedValue([
+      { id: "cuid-child-1", taskRunId: "TR-CHILD-1", startedAt: new Date(), buildId: null, lastHeartbeatAt: null },
+      { id: "cuid-child-2", taskRunId: "TR-CHILD-2", startedAt: new Date(), buildId: null, lastHeartbeatAt: null },
+    ]);
+    await taskrunAbandon("TR-STALL-1", "op-1");
+    // 1 update for parent + 2 for children = 3 total
+    expect(taskRunUpdate).toHaveBeenCalledTimes(3);
+    // 2 cascade StallEvent rows
+    expect(stallEventCreate).toHaveBeenCalledTimes(2);
+    const cascadeReasons = stallEventCreate.mock.calls.map(
+      (c: unknown[]) => (c[0] as { data: { reason: string } }).data.reason,
+    );
+    expect(cascadeReasons).toEqual(["parent_abandoned", "parent_abandoned"]);
+  });
+
+  it("does not touch terminal children", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    // findMany filters by status: { in: IN_FLIGHT_STATUSES } so terminal
+    // children would never be returned — the mock simulates that filter by
+    // returning only one live child plus a completed one filtered out.
+    taskRunFindMany.mockResolvedValue([
+      { id: "cuid-child-1", taskRunId: "TR-CHILD-1", startedAt: new Date(), buildId: null, lastHeartbeatAt: null },
+    ]);
+    await taskrunAbandon("TR-STALL-1", "op-1");
+    // 1 parent + 1 live child = 2 updates total
+    expect(taskRunUpdate).toHaveBeenCalledTimes(2);
+    // Verify the findMany call used the in-flight filter
+    const findManyArg = taskRunFindMany.mock.calls[0]![0] as { where: { status: { in: string[] } } };
+    expect(findManyArg.where.status.in).toEqual(["submitted", "working", "input-required", "auth-required"]);
+  });
+});
+
+describe("taskrunEscalate", () => {
+  it("rejects when the row is not stalled", async () => {
+    taskRunFindUnique.mockResolvedValue({ ...stalledRow(), status: "completed" });
+    await expect(taskrunEscalate("TR-STALL-1", "op-1")).rejects.toThrow(/Cannot recover.*status is completed/);
+  });
+
+  it("writes StallEvent.outcome=escalated with notes when provided", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    stallEventFindFirst.mockResolvedValue({ id: "se-1" });
+    await taskrunEscalate("TR-STALL-1", "op-1", "Needs human review");
+    const updateArg = stallEventUpdate.mock.calls[0]![0] as { data: { outcome: string; notes?: string } };
+    expect(updateArg.data.outcome).toBe("escalated");
+    expect(updateArg.data.notes).toBe("Needs human review");
+  });
+
+  it("does NOT transition the TaskRun status — escalation parks the row", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    await taskrunEscalate("TR-STALL-1", "op-1");
+    expect(taskRunUpdate).not.toHaveBeenCalled();
+  });
+
+  it("notifies the build owner when buildId resolves to a FeatureBuild.createdById", async () => {
+    taskRunFindUnique.mockResolvedValue({ ...stalledRow(), buildId: "FB-1" });
+    featureBuildFindUnique.mockResolvedValue({ createdById: "user-owner" });
+    await taskrunEscalate("TR-STALL-1", "op-1");
+    const notifyArg = notificationCreate.mock.calls[0]![0] as { data: { userId: string; type: string } };
+    expect(notifyArg.data.userId).toBe("user-owner");
+    expect(notifyArg.data.type).toBe("taskrun.escalated");
+  });
+
+  it("falls back to the task's userId when no buildId is present", async () => {
+    taskRunFindUnique.mockResolvedValue(stalledRow());
+    await taskrunEscalate("TR-STALL-1", "op-1");
+    const notifyArg = notificationCreate.mock.calls[0]![0] as { data: { userId: string } };
+    expect(notifyArg.data.userId).toBe("user-1");
+  });
+});

--- a/apps/web/lib/actions/taskrun-recovery.ts
+++ b/apps/web/lib/actions/taskrun-recovery.ts
@@ -1,0 +1,296 @@
+/**
+ * Operator-initiated recovery actions for stalled TaskRuns (BI-4ab6be39 Phase F2).
+ *
+ * Three operations the operator UI invokes after the watchdog flags a row:
+ *
+ *   - taskrunRetry: re-dispatch the work. Spawns a sibling TaskRun via
+ *     parentTaskRunId so the audit timeline survives ("Retry #N of build X").
+ *     Per-phase strategy belongs in Phase H — this v1 falls back to a
+ *     uniform "re-dispatch from scratch" for every phase. Ship-phase Retry
+ *     is disabled unless force=true (operator confirmed double-publish risk).
+ *
+ *   - taskrunAbandon: cancel the stalled row and cascade one level to any
+ *     live children (in-flight states). Terminal children are left alone.
+ *     The cascade writes StallEvent rows with reason=parent_abandoned.
+ *
+ *   - taskrunEscalate: park the row in stalled, notify the accountable
+ *     human, write StallEvent.outcome=escalated. The route the notification
+ *     takes resolves to the build owner if a buildId is present.
+ *
+ * See docs/superpowers/specs/2026-05-19-build-studio-stall-detection.md §6.3, §6.5, §6.6
+ * and the corresponding plan file Phase F2.
+ */
+import { prisma } from "@dpf/db";
+
+const IN_FLIGHT_STATUSES = ["submitted", "working", "input-required", "auth-required"];
+
+export class TaskrunRecoveryError extends Error {
+  readonly code: "not_stalled" | "not_found" | "ship_phase_requires_force";
+  constructor(code: TaskrunRecoveryError["code"], message: string) {
+    super(message);
+    this.code = code;
+    this.name = "TaskrunRecoveryError";
+  }
+}
+
+interface StalledRow {
+  id: string;
+  taskRunId: string;
+  userId: string;
+  threadId: string | null;
+  contextId: string | null;
+  buildId: string | null;
+  routeContext: string | null;
+  title: string;
+  objective: string;
+  source: string;
+  phase: string | null;
+}
+
+async function loadStalled(taskRunId: string): Promise<StalledRow> {
+  const row = await prisma.taskRun.findUnique({
+    where: { taskRunId },
+    select: {
+      id: true,
+      taskRunId: true,
+      userId: true,
+      threadId: true,
+      contextId: true,
+      buildId: true,
+      routeContext: true,
+      title: true,
+      objective: true,
+      source: true,
+      status: true,
+    },
+  });
+  if (!row) {
+    throw new TaskrunRecoveryError("not_found", `TaskRun not found: ${taskRunId}`);
+  }
+  if (row.status !== "stalled") {
+    throw new TaskrunRecoveryError(
+      "not_stalled",
+      `Cannot recover TaskRun ${taskRunId}: status is ${row.status}, expected "stalled"`,
+    );
+  }
+  let phase: string | null = null;
+  if (row.buildId) {
+    const fb = await prisma.featureBuild.findUnique({
+      where: { buildId: row.buildId },
+      select: { phase: true },
+    });
+    phase = fb?.phase ?? null;
+  }
+  return {
+    id: row.id,
+    taskRunId: row.taskRunId,
+    userId: row.userId,
+    threadId: row.threadId,
+    contextId: row.contextId,
+    buildId: row.buildId,
+    routeContext: row.routeContext,
+    title: row.title,
+    objective: row.objective,
+    source: row.source,
+    phase,
+  };
+}
+
+/**
+ * Operator clicks Retry on a stalled TaskRun.
+ *
+ * Creates a sibling TaskRun with parentTaskRunId pointing at the stalled
+ * row's cuid id. Re-uses the same threadId/contextId so the UI thread
+ * stays coherent. Updates the most recent open StallEvent's outcome to
+ * "retry". Returns the new business taskRunId so the caller can navigate
+ * the operator to it.
+ *
+ * Ship-phase Retry is gated: callers must pass { force: true } or this
+ * throws ship_phase_requires_force.
+ */
+export async function taskrunRetry(
+  taskRunId: string,
+  operatorUserId: string,
+  opts: { force?: boolean } = {},
+): Promise<{ newTaskRunId: string }> {
+  const stalled = await loadStalled(taskRunId);
+
+  if (stalled.phase === "ship" && !opts.force) {
+    throw new TaskrunRecoveryError(
+      "ship_phase_requires_force",
+      "Ship-phase Retry is disabled by default. Pass force:true to override after confirming the double-publish risk.",
+    );
+  }
+
+  const now = new Date();
+  const newBusinessId = `TR-RETRY-${Math.random().toString(36).slice(2, 10)}`;
+
+  return prisma.$transaction(async (tx) => {
+    const newRun = await tx.taskRun.create({
+      data: {
+        taskRunId: newBusinessId,
+        userId: stalled.userId,
+        threadId: stalled.threadId,
+        contextId: stalled.contextId,
+        buildId: stalled.buildId,
+        parentTaskRunId: stalled.id, // cuid, per the schema FK convention
+        routeContext: stalled.routeContext,
+        title: stalled.title,
+        objective: stalled.objective,
+        source: stalled.source,
+        status: "submitted",
+        startedAt: now,
+      },
+    });
+
+    // Close the most recent open StallEvent on the stalled row as "retry".
+    const openEvent = await tx.stallEvent.findFirst({
+      where: { taskRunId: stalled.id, outcome: null },
+      orderBy: { detectedAt: "desc" },
+    });
+    if (openEvent) {
+      await tx.stallEvent.update({
+        where: { id: openEvent.id },
+        data: {
+          outcome: "retry",
+          outcomeAt: now,
+          outcomeBy: operatorUserId,
+        },
+      });
+    }
+
+    return { newTaskRunId: newRun.taskRunId };
+  });
+}
+
+/**
+ * Operator clicks Abandon on a stalled TaskRun.
+ *
+ * Transitions to canceled. Walks one level of children (parentTaskRunId =
+ * stalled.id) and cancels any that are still in-flight, writing a
+ * StallEvent row of reason="parent_abandoned" for each. Terminal children
+ * (completed/failed/canceled/rejected/archived/stalled) are left alone.
+ */
+export async function taskrunAbandon(
+  taskRunId: string,
+  operatorUserId: string,
+): Promise<void> {
+  const stalled = await loadStalled(taskRunId);
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    // 1. Cancel the stalled row itself.
+    await tx.taskRun.update({
+      where: { taskRunId },
+      data: { status: "canceled", completedAt: now },
+    });
+
+    // 2. Close the most recent open StallEvent as "abandoned".
+    const openEvent = await tx.stallEvent.findFirst({
+      where: { taskRunId: stalled.id, outcome: null },
+      orderBy: { detectedAt: "desc" },
+    });
+    if (openEvent) {
+      await tx.stallEvent.update({
+        where: { id: openEvent.id },
+        data: {
+          outcome: "abandoned",
+          outcomeAt: now,
+          outcomeBy: operatorUserId,
+        },
+      });
+    }
+
+    // 3. Cascade one level: find live children, cancel them, write
+    //    parent_abandoned StallEvent for each.
+    const liveChildren = await tx.taskRun.findMany({
+      where: {
+        parentTaskRunId: stalled.id,
+        status: { in: IN_FLIGHT_STATUSES },
+      },
+      select: { id: true, taskRunId: true, startedAt: true, buildId: true, lastHeartbeatAt: true },
+    });
+
+    for (const child of liveChildren) {
+      await tx.taskRun.update({
+        where: { taskRunId: child.taskRunId },
+        data: { status: "canceled", completedAt: now },
+      });
+      await tx.stallEvent.create({
+        data: {
+          taskRunId: child.id,
+          buildId: child.buildId,
+          phase: stalled.phase,
+          reason: "parent_abandoned",
+          lastHeartbeatAt: child.lastHeartbeatAt,
+          startedAt: child.startedAt,
+          // Thresholds aren't applicable to a cascade event — record 0 as a
+          // sentinel so the audit row remains queryable.
+          thresholdHeartbeatS: 0,
+          thresholdTotalS: 0,
+          outcome: "abandoned",
+          outcomeAt: now,
+          outcomeBy: operatorUserId,
+          notes: `Cancelled via parent abandon: ${taskRunId}`,
+        },
+      });
+    }
+  });
+}
+
+/**
+ * Operator clicks Escalate on a stalled TaskRun.
+ *
+ * Leaves the row in stalled (this is the explicit "park for human review"
+ * outcome). Writes StallEvent.outcome=escalated and notifies the accountable
+ * human — build owner if buildId resolves to a FeatureBuild.createdById,
+ * else the task's userId.
+ */
+export async function taskrunEscalate(
+  taskRunId: string,
+  operatorUserId: string,
+  notes?: string,
+): Promise<void> {
+  const stalled = await loadStalled(taskRunId);
+  const now = new Date();
+
+  // Resolve recipient: build owner > task user.
+  let notifyUserId: string | null = stalled.userId ?? null;
+  if (stalled.buildId) {
+    const fb = await prisma.featureBuild.findUnique({
+      where: { buildId: stalled.buildId },
+      select: { createdById: true },
+    });
+    if (fb?.createdById) notifyUserId = fb.createdById;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const openEvent = await tx.stallEvent.findFirst({
+      where: { taskRunId: stalled.id, outcome: null },
+      orderBy: { detectedAt: "desc" },
+    });
+    if (openEvent) {
+      await tx.stallEvent.update({
+        where: { id: openEvent.id },
+        data: {
+          outcome: "escalated",
+          outcomeAt: now,
+          outcomeBy: operatorUserId,
+          notes,
+        },
+      });
+    }
+
+    if (notifyUserId) {
+      await tx.notification.create({
+        data: {
+          userId: notifyUserId,
+          type: "taskrun.escalated",
+          title: `Stalled task escalated for review`,
+          body: `Stalled task ${taskRunId} (phase ${stalled.phase ?? "unknown"}) escalated by operator. ${notes ?? ""}`.trim(),
+          deepLink: stalled.buildId ? `/build` : `/platform/ai/operations`,
+        },
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Phase F of [BI-4ab6be39](#) (stall detection + recovery) — the operator-facing piece.
After this lands, you can Retry / Abandon / Escalate a stalled TaskRun directly from the AI Operations Map inspector — no SQL, no Docker. Builds on the substrate that shipped in [PR #828](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/828).

## What's in this PR

| Slice | What | Files |
| --- | --- | --- |
| **F2 — Server actions** | \`taskrunRetry\` / \`taskrunAbandon\` / \`taskrunEscalate\`. Sibling-TaskRun retry via \`parentTaskRunId\`, one-level cancel cascade with \`reason=parent_abandoned\`, escalation notification routed to build owner or task user. Discriminated \`TaskrunRecoveryError\` for clean client handling. | \`lib/actions/taskrun-recovery.{ts,test.ts}\`, \`lib/actions/taskrun-recovery-server-actions.ts\` |
| **F1 — Operator UI** | \`StalledTaskRecoveryActions\` client component with three buttons (Retry / Abandon / Escalate). Wired into \`ProjectionInspector\` in \`AiOperationsMap.tsx\` — detects stalled task-run projections and renders the recovery panel. Ship-phase Retry shows a confirm dialog warning about double-publish risk per spec §5.5. | \`components/platform/StalledTaskRecoveryActions.tsx\`, \`components/platform/AiOperationsMap.tsx\` |

## Behavior

- **Retry** → spawns a sibling \`TaskRun\` with \`parentTaskRunId = <stalled cuid>\`, preserving the audit timeline ("Retry #N"). Closes the open \`StallEvent\` as \`outcome=retry\` with the operator's userId.
- **Abandon** → cancels the row; cascades one level to live children (in-flight statuses only), writing a \`StallEvent\` of \`reason=parent_abandoned\` for each. Terminal children are not touched.
- **Escalate** → leaves the row in \`stalled\` (parks for human review). Notifies the build owner if \`buildId\` resolves, else the task user. Writes \`StallEvent.outcome=escalated\`.
- **Ship-phase Retry** → disabled-by-default per §5.5. Operator confirm + \`force:true\` server param needed.

## What's NOT in this PR (next slice)

- **F3** — Build Studio phase panel stalled state + per-build StallEvent history strip.
- **G** — Admin > Build Studio > Stall Thresholds editor.
- **H** — Per-phase Retry dispatcher (sandbox phase resumes via \`runBuildPipeline\` checkpoint; plan resumes from last \`DeliberationRun\`).
- **I** — CI guard preventing new code from writing \`status: "working"\` without the sanctioned helper.

## Test plan

- [x] \`pnpm --filter web typecheck\` — exit 0
- [x] \`npx vitest run lib/actions/taskrun-recovery.test.ts\` — 16/16 pass
- [x] Full sweep: 814 files / 6,529 tests pass / 0 failures
- [x] 16 vitest cases cover: stalled guard, not-found guard, sibling spawn, StallEvent outcome write, ship gating with/without force, cascade live vs terminal children, escalation routing build-owner vs task-user
- [ ] UX: open AI Operations Map → click a stalled task-run projection → confirm three buttons render, each triggers the correct server action and refreshes the projection list

🤖 Generated with [Claude Code](https://claude.com/claude-code)