### PR TITLE
fix(edge-node): make the bundled Edge Node actually run on install

### DIFF
--- a/docker-compose.edge.yml
+++ b/docker-compose.edge.yml
@@ -51,12 +51,15 @@
 
 services:
   edge-node:
+    # Compose uses `image` as the local tag; if it can't pull (GHCR auth
+    # denied, offline, dev branch not released yet), `build` runs and tags
+    # the resulting image with the `image` name. Operators don't have to
+    # swap blocks manually for dev vs release.
     image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-edge-node:${DPF_IMAGE_TAG:-latest}
-    # For dev work on unreleased changes, swap the `image:` line above
-    # for a build block. Comment-out + uncomment as needed:
-    # build:
-    #   context: .
-    #   dockerfile: services/edge-node/Dockerfile
+    build:
+      context: .
+      dockerfile: services/edge-node/Dockerfile
+    pull_policy: missing
     restart: unless-stopped
     environment:
       # Authority Core URL — point at the portal service in the same
@@ -142,6 +145,10 @@ services:
     profiles:
       - linux-host-network
     image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-edge-node:${DPF_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: services/edge-node/Dockerfile
+    pull_policy: missing
     restart: unless-stopped
     network_mode: host
     environment:

--- a/scripts/dpf-start.ps1
+++ b/scripts/dpf-start.ps1
@@ -4,7 +4,20 @@ param(
 )
 
 Set-Location $DPF_DIR
-docker compose up -d
+
+# Always bring the Edge Node overlay up alongside the platform so the bundled
+# single-host install includes network discovery. The overlay is harmless
+# when no enrolled node exists yet (edge-node will retry enrollment until the
+# operator wires DPF_BOOTSTRAP_TOKEN via .\scripts\fresh-install.ps1 or the
+# Admin > Platform Development > Edge Nodes UI).
+# See docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md.
+$composeArgs = @("-f", "docker-compose.yml")
+if (Test-Path (Join-Path $DPF_DIR "docker-compose.override.yml")) {
+    $composeArgs += @("-f", "docker-compose.override.yml")
+}
+$composeArgs += @("-f", "docker-compose.edge.yml")
+
+docker compose @composeArgs up -d
 
 # --- Wait for portal health ---------------------------------------------------
 Write-Host "Waiting for portal to be ready..." -ForegroundColor Cyan

--- a/scripts/fresh-install.ps1
+++ b/scripts/fresh-install.ps1
@@ -293,7 +293,107 @@ pnpm --filter @dpf/db seed
 if ($LASTEXITCODE -ne 0) { Write-Fail "Database seed failed" }
 Write-Ok "Base seed complete"
 
-Write-Host "========================================================" 
+Write-Host "========================================================"
+
+# Edge Node bootstrap. Mirror install-dpf.sh's auto-approve flow on Windows
+# so a fresh install brings up an enrolled Edge Node alongside the portal.
+# Spec: docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+#   § Approval policy ("Auto-approve when the bootstrap token is issued by
+#   the local installer for the DPF host's own Edge Node")
+Write-Step "Edge Node bootstrap"
+
+$edgeComposeArgs = @(
+    "-f", "docker-compose.yml",
+    "-f", "docker-compose.override.yml",
+    "-f", "docker-compose.edge.yml"
+)
+
+# Wait for portal /api/health so the token mint can talk to Prisma /
+# Authority. Up to 5 minutes — matches dpf-start.ps1.
+Write-Host "  Waiting for portal /api/health..."
+$portalReady = $false
+for ($i = 0; $i -lt 60; $i++) {
+    try {
+        $resp = Invoke-WebRequest -Uri "http://localhost:3000/api/health" `
+                    -UseBasicParsing -TimeoutSec 3 -ErrorAction SilentlyContinue
+        if ($resp -and $resp.StatusCode -eq 200) { $portalReady = $true; break }
+    } catch {}
+    Start-Sleep -Seconds 5
+}
+if (-not $portalReady) {
+    Write-Warn "Portal did not become healthy in time -- skipping Edge Node bootstrap."
+    Write-Warn "Re-run scripts/fresh-install.ps1 or issue a token from Admin > Platform Development > Edge Nodes."
+} else {
+    # Mint a single-use auto-approve bootstrap token. We run the script
+    # INSIDE the portal container instead of via host pnpm so we get a
+    # Prisma client that matches the just-migrated DB schema regardless of
+    # whether the host's `pnpm install` produced one. This also lets the
+    # consumer install path (no host Node/pnpm) reach the same code path.
+    # Plaintext token is the LAST stdout line; diagnostic output is on stderr.
+    $portalContainer = (docker compose -f "$InstallRoot\docker-compose.yml" `
+                              -f "$InstallRoot\docker-compose.edge.yml" `
+                              ps -q portal 2>$null) -split "`n" | Select-Object -First 1
+    if (-not $portalContainer) { $portalContainer = "dpf-portal-1" }
+
+    $edgeToken = $null
+    try {
+        $tokenOutput = docker exec $portalContainer sh -c `
+            'cd /app/apps/web-src && /app/node_modules/.pnpm/node_modules/.bin/tsx scripts/issue-edge-bootstrap-token.ts --ttl-minutes 30 --auto-approve' 2>$null
+        if ($LASTEXITCODE -eq 0 -and $tokenOutput) {
+            $lines = @($tokenOutput) | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ -ne "" }
+            $candidate = if ($lines.Count -gt 0) { $lines[-1] } else { "" }
+            if ($candidate -match "^dpfboot_") {
+                $edgeToken = $candidate
+            }
+        }
+    } catch {
+        # Captured below by the null check.
+    }
+
+    if (-not $edgeToken) {
+        Write-Warn "Bootstrap token issuance failed -- skipping enrollment wiring."
+        Write-Warn "You can re-issue manually via Admin > Platform Development > Edge Nodes."
+    } else {
+        # Append (or replace) DPF_BOOTSTRAP_TOKEN + DPF_EDGE_NODE_NAME in .env.
+        # Idempotent: re-running the installer overwrites the prior token.
+        $envPath = Join-Path $InstallRoot ".env"
+        $envText = Get-Content $envPath -Raw -ErrorAction SilentlyContinue
+        if ($null -eq $envText) { $envText = "" }
+
+        if ($envText -match "(?m)^DPF_BOOTSTRAP_TOKEN=.*$") {
+            $envText = [System.Text.RegularExpressions.Regex]::Replace(
+                $envText, "(?m)^DPF_BOOTSTRAP_TOKEN=.*$", "DPF_BOOTSTRAP_TOKEN=$edgeToken")
+        } else {
+            if ($envText.Length -gt 0 -and -not $envText.EndsWith("`n")) { $envText += "`n" }
+            $envText += "`n# Edge Node bootstrap token -- installer-issued, auto-approve.`n"
+            $envText += "DPF_BOOTSTRAP_TOKEN=$edgeToken`n"
+        }
+
+        if ($envText -notmatch "(?m)^DPF_EDGE_NODE_NAME=") {
+            $envText += "DPF_EDGE_NODE_NAME=$([System.Net.Dns]::GetHostName())`n"
+        }
+
+        Set-Content -Path $envPath -Value $envText -Encoding UTF8 -NoNewline
+        Write-Ok "Bootstrap token wired into .env (auto-approve)"
+
+        # Force-recreate the edge-node service so it picks up the new env.
+        # --no-deps avoids touching the portal.
+        $oldEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        docker compose @edgeComposeArgs up -d --no-deps --force-recreate edge-node 2>&1 | Out-Null
+        $edgeUpExit = $LASTEXITCODE
+        $ErrorActionPreference = $oldEAP
+
+        if ($edgeUpExit -eq 0) {
+            Write-Ok "Edge Node container started -- enrolls within ~10s"
+        } else {
+            Write-Warn "edge-node container restart failed; node may not have enrolled."
+            Write-Warn "  Inspect: docker compose -f docker-compose.yml -f docker-compose.edge.yml logs edge-node --tail 50"
+        }
+    }
+}
+
+Write-Host "========================================================"
 
 Write-Host ""
 Write-Host "   Fresh install complete!" -ForegroundColor Green

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -154,6 +154,78 @@ step "Seeding database"
 pnpm db:seed
 ok "Database seeded with roles, agents, and default admin user"
 
+# ── Edge Node bootstrap ──────────────────────────────────────────────────────
+# Mirrors install-dpf.sh's auto-approve flow for contributors. Mints a
+# single-use bootstrap token, wires it into .env, force-recreates the
+# edge-node service so it enrolls. Spec § Approval policy permits the local
+# installer to auto-approve the host's own Edge Node.
+#
+# Skip if DPF_SKIP_EDGE_BOOTSTRAP=1 — handy when running setup.sh against a
+# host that already has an enrolled Edge Node and the operator just wants
+# to refresh deps / migrations.
+if [ "${DPF_SKIP_EDGE_BOOTSTRAP:-0}" != "1" ]; then
+  step "Edge Node bootstrap"
+
+  # Bring up the Edge Node container alongside whatever overlay is in use.
+  # docker-compose.yml + docker-compose.edge.yml is the minimum chain.
+  EDGE_COMPOSE_ARGS=("-f" "docker-compose.yml" "-f" "docker-compose.edge.yml")
+
+  # The portal must be reachable for the token mint (Prisma → Postgres) to
+  # succeed. We brought up Postgres/Neo4j/Qdrant above but not the portal,
+  # so do that now (best-effort; warns instead of failing).
+  if docker compose "${EDGE_COMPOSE_ARGS[@]}" up -d portal edge-node >/dev/null 2>&1; then
+    HEALTH_URL="http://localhost:3000/api/health"
+    HEALTH_OK=0
+    for _ in $(seq 1 60); do
+      if curl --silent --max-time 5 --fail "$HEALTH_URL" -o /dev/null 2>/dev/null; then
+        HEALTH_OK=1
+        break
+      fi
+      sleep 5
+    done
+
+    if [ "$HEALTH_OK" = "1" ]; then
+      # Run the token-issuing script inside the portal container instead of
+      # via host pnpm. The container always has a Prisma client that matches
+      # the just-migrated schema, and consumer installs without host Node/pnpm
+      # still reach the same code path.
+      PORTAL_CONTAINER="$(docker compose "${EDGE_COMPOSE_ARGS[@]}" ps -q portal 2>/dev/null | head -1)"
+      if [ -z "$PORTAL_CONTAINER" ]; then PORTAL_CONTAINER="dpf-portal-1"; fi
+      if EDGE_TOKEN="$(docker exec "$PORTAL_CONTAINER" sh -c \
+           'cd /app/apps/web-src && /app/node_modules/.pnpm/node_modules/.bin/tsx scripts/issue-edge-bootstrap-token.ts --ttl-minutes 30 --auto-approve' \
+           2>/dev/null | tail -1)"; then
+        if [ -n "$EDGE_TOKEN" ] && [[ "$EDGE_TOKEN" == dpfboot_* ]]; then
+          if grep -q "^DPF_BOOTSTRAP_TOKEN=" .env 2>/dev/null; then
+            dpf_sed_inplace "s|^DPF_BOOTSTRAP_TOKEN=.*|DPF_BOOTSTRAP_TOKEN=$EDGE_TOKEN|" .env
+          else
+            printf '\n# Edge Node bootstrap token -- installer-issued, auto-approve.\n' >> .env
+            printf 'DPF_BOOTSTRAP_TOKEN=%s\n' "$EDGE_TOKEN" >> .env
+          fi
+          if ! grep -q "^DPF_EDGE_NODE_NAME=" .env 2>/dev/null; then
+            printf 'DPF_EDGE_NODE_NAME=%s\n' "${HOSTNAME:-$(hostname 2>/dev/null || echo edge-node-local)}" >> .env
+          fi
+
+          if docker compose "${EDGE_COMPOSE_ARGS[@]}" up -d --no-deps --force-recreate edge-node >/dev/null 2>&1; then
+            ok "Edge Node bootstrapped (auto-approve token wired into .env)"
+          else
+            warn "edge-node container restart failed; check: docker compose ${EDGE_COMPOSE_ARGS[*]} logs edge-node --tail 50"
+          fi
+        else
+          warn "Bootstrap token output not recognized; skipping Edge Node enrollment."
+          warn "Re-issue via Admin > Platform Development > Edge Nodes."
+        fi
+      else
+        warn "Bootstrap token issuance failed; skipping Edge Node enrollment."
+      fi
+    else
+      warn "Portal did not become healthy within 5 minutes; skipping Edge Node enrollment."
+      warn "Bring it up later: bash scripts/setup.sh (this step is idempotent)."
+    fi
+  else
+    warn "docker compose up -d portal edge-node failed; skipping Edge Node enrollment."
+  fi
+fi
+
 # ── Agent rulebook conformance ───────────────────────────────────────────────
 # Per AGENTS.md: every install must ship the canonical AGENTS.md plus pointer
 # files for each supported AI tool. Fail the install if any are missing or

--- a/services/edge-node/Dockerfile
+++ b/services/edge-node/Dockerfile
@@ -12,7 +12,12 @@
 FROM node:24-alpine AS build
 WORKDIR /app/services/edge-node
 COPY services/edge-node/package.json services/edge-node/tsconfig.json ./
-RUN corepack enable && pnpm install --no-frozen-lockfile
+# pnpm 10 fails the install when transitive deps have ignored postinstall
+# scripts (esbuild ships a native-binary downloader). The edge-node build
+# only needs tsc to produce dist/; esbuild is pulled in by tsx + vitest as
+# devDependencies that the runtime image doesn't consume. Skipping scripts
+# avoids the gate without changing what's actually executed.
+RUN corepack enable && pnpm install --no-frozen-lockfile --ignore-scripts
 COPY services/edge-node/src ./src
 RUN pnpm build
 

--- a/services/edge-node/package.json
+++ b/services/edge-node/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "description": "DPF Edge Node — host-resident agent that enrolls against an Authority Core and submits discovery observations. See docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md.",
-  "type": "module",
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/services/edge-node/tsconfig.json
+++ b/services/edge-node/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    // CommonJS output keeps the existing extensionless imports
+    // (e.g. `import {…} from "./api-client"`) working at runtime under
+    // Node's ESM resolver, which would otherwise refuse them with
+    // ERR_MODULE_NOT_FOUND. tsx (used by the dev/test scripts) handles
+    // either module style, so this only changes what tsc emits to dist/.
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

PR #567 bundled the Edge Node into the single-host install but only half-landed: install scripts never reference the overlay, the published GHCR image isn't reachable yet, the runtime container couldn't start under pnpm 10 + Node 24 ESM, and the host-pnpm token mint fails on any install whose Prisma client has drifted. Result on every fresh install: **zero EdgeNode rows, every DiscoveryRun is the in-portal `dpf_bootstrap` probe, the Infrastructure Topology view shows only Docker subnets** — which is what surfaced this audit.

This closes the loop end-to-end so an install brings up an enrolled Edge Node and starts contributing real discovery submissions.

## What changed

| File | Why |
|---|---|
| [docker-compose.edge.yml](docker-compose.edge.yml) | `build:` fallback + `pull_policy: missing` so dev branches build locally when GHCR is denied/empty, without operators toggling commented blocks. |
| [services/edge-node/Dockerfile](services/edge-node/Dockerfile) | `pnpm install --ignore-scripts` so pnpm 10 doesn't refuse the build on transitive devDeps' postinstall (esbuild). Runtime only runs the compiled dist/. |
| [services/edge-node/tsconfig.json](services/edge-node/tsconfig.json) + [package.json](services/edge-node/package.json) | Emit CommonJS, drop `type:"module"`. Node 24 ESM was rejecting extensionless relative imports in dist/ → ERR_MODULE_NOT_FOUND on every container start. |
| [scripts/dpf-start.ps1](scripts/dpf-start.ps1) | Bring the edge overlay up alongside the platform on every restart. |
| [scripts/fresh-install.ps1](scripts/fresh-install.ps1) | After seed + portal health, mint an auto-approve bootstrap token, write `DPF_BOOTSTRAP_TOKEN` + `DPF_EDGE_NODE_NAME` to `.env`, force-recreate `edge-node`. |
| [scripts/setup.sh](scripts/setup.sh) | Same step for the bash contributor path. |

The token mint runs `scripts/issue-edge-bootstrap-token.ts` **inside the portal container**, not via host pnpm. That:
- works on consumer-mode installs that have no host Node/pnpm,
- works on long-running installs whose host Prisma client has drifted from the current schema (the failure mode this audit hit),
- uses the existing CLI's `--auto-approve` flag (the spec's "local installer auto-approve" path — no Admin click required).

## Test plan

- [x] `pnpm --filter dpf-edge-node typecheck` clean
- [x] `pnpm --filter dpf-edge-node test` — 117 pass / 5 skipped
- [x] Verified live on a long-running install: edge-node enrolls with `trustState=trusted` and submits a `DiscoveryRun` with `edgeNodeId` populated within ~2s of the recreate
  ```
  EdgeNode:    edge_2abb288885694a6a  trustState=trusted  status=active
  DiscoveryRun: edgeNodeId populated, itemCount=2, status=completed
  ```
- [ ] Reviewer to confirm: on a fresh clone, `scripts/fresh-install.ps1` (or `scripts/setup.sh`) ends with an enrolled Edge Node and a populated `DiscoveryRun.edgeNodeId` row

## Out of scope (tracked follow-ups)

1. **install-dpf.ps1 consumer mode** — its embedded compose file doesn't include the edge-node service, and consumer mode has no host pnpm. Same approach (in-container mint + embedded compose entry) but a wider diff; broken out so this PR stays focused.
2. **Real LAN topology fidelity** — even with the edge node enrolled and running, Docker Desktop on Windows/macOS only exposes the VM's network. The fix is the Mode 4 native Go binary ([2026-05-16 ADR](docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md)) and the UniFi/Kasa/Starlink adapters ([2026-05-19 spec](docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md)). Both designed, neither built. This PR is the prerequisite both depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)