### PR TITLE
fix(watchdog): skip BuildActivity write on orphan buildId FK (BI-4ab6be39)

### DIFF
--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -137,13 +137,17 @@ export const taskrunWatchdog = inngest.createFunction(
           },
         });
 
-        // 3. BuildActivity row when this stall is tied to a build.
-        if (d.candidate.buildId) {
+        // 3. BuildActivity row when this stall is tied to a build that
+        //    still exists. d.candidate.phase is non-null iff the LEFT JOIN
+        //    matched a FeatureBuild row — use that as the FK-safety check.
+        //    Catches the case where TaskRun.buildId references a deleted
+        //    FeatureBuild (observed in live data 2026-05-20).
+        if (d.candidate.buildId && d.candidate.phase) {
           await tx.buildActivity.create({
             data: {
               buildId: d.candidate.buildId,
               tool: "watchdog:stall",
-              summary: `Watchdog detected stall (${d.reason}) in phase ${d.candidate.phase ?? "—"}`,
+              summary: `Watchdog detected stall (${d.reason}) in phase ${d.candidate.phase}`,
             },
           });
         }


### PR DESCRIPTION
## What this fixes

Continuing the actual live verification of the BI-4ab6be39 watchdog. After PR #836 widened the filter to catch \`active\` rows, I rebuilt the portal and waited a watchdog tick. The watchdog DID detect the 83 stuck rows — and then **crashed** inside the same transaction on \`BuildActivity.create()\`:

\`\`\`
prisma:error
Invalid \`prisma.buildActivity.create()\` invocation:
Foreign key constraint violated on the constraint: \`BuildActivity_buildId_fkey\`
\`\`\`

Of the 83 active \`TaskRun\`s in the live DB, **51 reference a \`buildId\` that no longer exists in \`FeatureBuild\`** (orphan FK). The watchdog's transaction rolled back, so no stall got recorded.

## The fix

Use \`d.candidate.phase\` as the FK-safety check before writing \`BuildActivity\`. \`phase\` comes from the LEFT JOIN to \`FeatureBuild\` in the candidates query, so it's non-null iff the FB row exists. Same pattern catches any future case where the FK is orphaned.

The 51 orphan-buildId stalled rows still get \`StallEvent\` + \`Notification\`. They just don't get a \`BuildActivity\` row (the build they'd attach to is gone anyway — no UI surface to drive it to).

## Expected behavior after merge

The next watchdog tick should flag **all 83 active rows** stalled. 32 with valid FK get the full audit treatment (StallEvent + BuildActivity + Notification). 51 orphans get StallEvent + Notification only.

This is the live-functional verification that was missing from the prior PRs. After this lands and I rebuild + recreate the portal once more, the \`StallEvent\` count should jump from 1 to ~84.

## Test plan

- [x] \`pnpm --filter web typecheck\` — exit 0
- [ ] **Live verification (post-merge):** rebuild portal image, recreate container, wait 90s for the next watchdog tick, query \`SELECT count(*) FROM "StallEvent" WHERE "detectedAt" > now() - interval '5 minutes'\` — expect ~83 new rows. This is the verification that finally proves the watchdog catches real production data.

## Process correction

I should have hit this in PR #836's verification. I observed the inngest \`function.failed\` events at every minute boundary but didn't look at the portal logs for the actual exception until Mark asked again. The \`function.failed\` event was a clear signal to check exception logs — I treated it as ambient noise. Will check exception logs by default on any verification run from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)