### PR TITLE
fix(build-studio): surface retry-build affordance when sandbox fails before task results

### DIFF
--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -393,6 +393,25 @@ export function deriveBuildStudioWorkflowAction({
       });
     }
 
+    // Sandbox launch failed before writing any task results — exec state is
+    // "failed" but there is nothing to resume; only a clean retry will work.
+    const execFailed = build.buildExecState?.step === "failed";
+    const hasNoResults = concernState.taskResults.tasks.length === 0;
+    if (execFailed && hasNoResults) {
+      return {
+        kind: "retry-build",
+        title: "Sandbox Launch Failed",
+        message:
+          "The sandbox container could not be started before any implementation work began. Retry to attempt a fresh sandbox launch.",
+        primaryLabel: "Retry Sandbox Launch",
+        targetPhase: null,
+        disabledReason: null,
+        coworkerLabel: "Diagnose with coworker",
+        coworkerPrompt:
+          "The sandbox failed to start before any tasks ran. Check the last build execution error and tell me whether a plain retry is safe or whether the build plan or sandbox config needs to change first.",
+      };
+    }
+
     return {
       kind: "advance-phase",
       title: "Ready for Verification",


### PR DESCRIPTION
## Summary

- When `autoExecuteBuild` fails at the `pending` step (sandbox container unreachable) before writing any task results, the build stays `phase=build` with `buildExecState.step='failed'`
- Previously `getWorkflowStageGuidance` never checked `buildExecState.step` — it only looked at `hasRecoverableConcern` (non-clean tasks or verification failure)
- This left the operator with no UI path to `retryBuildExecution`; the visible buttons were "Run Verification Review" and "Ask coworker to finish implementation", neither of which invokes the retry action
- Fix: when `phase=build`, `buildExecState.step='failed'`, and zero task results exist, return a `retry-build` action ("Retry Sandbox Launch") that correctly calls `retryBuildExecution` on click

## Test plan

- [ ] Build in `phase=build` with `buildExecState.step='failed'` and no `taskResults` shows "Retry Sandbox Launch" button (not "Run Verification Review")
- [ ] Clicking "Retry Sandbox Launch" calls `retryBuildExecution` → `autoExecuteBuild` → sandbox pipeline
- [ ] Build with non-clean tasks still shows `resume-implementation` (existing path unchanged)
- [ ] Build with clean state still shows `advance-phase` → review (existing path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)