### PR TITLE
feat(edge-node): UniFi adapter — Slice A (read-only discovery)

### DIFF
--- a/docs/edge-node/unifi-adapter.md
+++ b/docs/edge-node/unifi-adapter.md
@@ -1,0 +1,122 @@
+# UniFi Adapter — Operator Setup
+
+The UniFi adapter pulls device-level topology from a local UniFi Network controller and submits it through the same discovery pipeline the rest of the edge node uses. After setup, the topology view shows your real network — gateway → switches → access points — instead of just ARP-discovered hosts.
+
+This page covers Slice A: read-only discovery (no per-port throughput yet). Throughput, LLDP, and the metrics channel land in a follow-up.
+
+## What you need
+
+- An enrolled DPF Edge Node (`docker-compose.edge.yml` overlay running; trustState=trusted in **Admin > Platform Development > Edge Nodes**).
+- A UniFi Network controller reachable from the host the edge node runs on — UDM, UDM-Pro, UDR, UCG, or a hosted Network Application instance.
+- UniFi Network **9.0+** (or UniFi OS **4.0+**). Earlier versions don't expose the API-key surface this adapter uses.
+
+## Step 1 — Generate an API key in the controller
+
+1. Open the UniFi controller UI.
+2. Go to **Settings → Control Plane → Integrations**. On older firmware this is **Settings → System → API**.
+3. Click **Create New** under API Keys. Name it something like `dpf-edge-node`.
+4. Copy the key once — it isn't shown again. Treat it like a password.
+
+The adapter calls `GET /proxy/network/api/s/{site}/stat/device`, so the key needs read access to the Network application. Read-only keys are sufficient.
+
+## Step 2 — Place the adapter config on the host
+
+Create `/etc/dpf-edge/adapters.json` on the host running the edge node container, with mode `0600`:
+
+```json
+{
+  "unifi": {
+    "controllerUrl": "https://192.168.1.1",
+    "apiKey": "PASTE-YOUR-API-KEY-HERE",
+    "site": "default",
+    "tlsInsecure": false
+  }
+}
+```
+
+Fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `controllerUrl` | yes | Full URL to the controller. UDM/UDM-Pro: `https://<gateway-ip>`. Hosted Network: `https://unifi.ui.com` won't work for Slice A — local LAN only. |
+| `apiKey` | yes | From Step 1. |
+| `site` | no | Site slug, default `default`. Multi-site installs: check **Settings → System** for the slug. |
+| `tlsInsecure` | no | Default `false`. Set `true` if your controller uses a self-signed cert (common on UDM-Pro), but only if you trust the local network — TLS verification is skipped when this is on. |
+
+The file must be readable by UID `10001` (the edge-node container user) or the same group. Mode `0600` works if you `chown 10001 /etc/dpf-edge/adapters.json` first; or `0640` with a group the container is in. A world-readable file works too but the edge node will log a warning every sweep.
+
+## Step 3 — Bind-mount the file into the container
+
+Add to your local `.env`:
+
+```bash
+DPF_EDGE_ADAPTERS_CONFIG=/etc/dpf-edge/adapters.json
+```
+
+…or override the path explicitly via env. Either way, the file needs to be inside the edge-node container. The simplest mount is to add a `volumes:` entry to `docker-compose.edge.yml` in a local override:
+
+```yaml
+services:
+  edge-node:
+    volumes:
+      - /etc/dpf-edge:/etc/dpf-edge:ro
+```
+
+Drop that into a `docker-compose.override.yml` next to the main compose file, or paste it directly into `docker-compose.edge.yml` if you don't mind editing the checked-in file.
+
+## Step 4 — Recreate the container
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.edge.yml \
+  up -d --no-deps --force-recreate edge-node
+```
+
+The adapter runs on every sweep tick (default 5 minutes). To verify it picked the config up immediately:
+
+```bash
+docker compose logs edge-node --tail 50
+```
+
+…look for a line like `Discovery run submitted: runKey=<uuid> items=<N>` where `N` is now larger than before. The first sweep after restart submits items but the topology view may take a tick or two to project them into Neo4j.
+
+## What the adapter emits
+
+| UniFi `type` | DPF `itemType` | OSI layer |
+|---|---|---|
+| `usw` (switch) | `switch` | 2 |
+| `uap` (access point) | `access_point` | 2 |
+| `ugw` / `udm` / `udmpro` / `uxg` (gateway) | `gateway` | 3 |
+| anything else | `network_device` | 2 |
+
+For every UniFi device:
+- An `ObservationItem` keyed `unifi:<mac>` with model, IP, firmware, state, etc. in `rawData`.
+- A `SAME_AS` relationship to `arp:<ip>` so the Authority's normalization can collapse the two records into one canonical Configuration Item.
+- A `HOSTS` relationship from each device to its uplink parent (gateway → switch → AP).
+
+The topology view treats these the same way as any other discovered CI, so they show up in the Subnet View, the Network View, and the impact-blast-radius traversal automatically.
+
+## Troubleshooting
+
+**No new items appear after a sweep.** Run `docker compose logs edge-node --tail 100 | grep -i unifi`. Common causes:
+- `network error reaching ...` — the container can't reach the controller. Check `DPF_EDGE_DISCOVERY_SUBNETS` doesn't exclude the controller's subnet, and that the host's network mode permits the call.
+- `HTTP 401` — API key is wrong or revoked. Re-generate in Step 1.
+- `HTTP 404` — the controller version doesn't expose `/proxy/network/api/...`. You're likely on UniFi OS 3.x; upgrade or wait for the cookie-auth slice.
+- `controller response was not JSON` — the controller served the login page. Means the API key isn't being honored; double-check the key wasn't truncated when copying.
+
+**`group/world-readable` warning every sweep.** `chmod 0600 /etc/dpf-edge/adapters.json && chown 10001 /etc/dpf-edge/adapters.json`. The warning is informational only — the adapter still runs.
+
+**TLS warning.** If you intentionally need `tlsInsecure: true`, that's fine for a closed LAN. Don't enable it across the public internet.
+
+## What's NOT in this slice
+
+| Feature | Tracked by |
+|---|---|
+| Per-port `rx/tx` throughput metrics | The full spec at [`docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md`](../superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md) — needs the `metrics.network` capability + the `/api/v1/edge/metrics` endpoint, neither of which exist yet. |
+| LLDP-derived L2 wiring | Same spec, § 4.2 — separate collector. |
+| WebSocket event-driven sweep on device join | Same spec, § 4.3 — Slice A polls on the regular sweep cadence (5 min). |
+| Cookie-auth for pre-9.0 controllers | If you need this, open an issue with your controller version and we'll add the auth fallback. |
+
+## Reference
+
+- Spec: [`docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md`](../superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md) § 4.3
+- Code: [`services/edge-node/src/collectors/unifi.ts`](../../services/edge-node/src/collectors/unifi.ts), [`services/edge-node/src/collectors/adapters-config.ts`](../../services/edge-node/src/collectors/adapters-config.ts)

--- a/services/edge-node/src/__tests__/adapters-config.test.ts
+++ b/services/edge-node/src/__tests__/adapters-config.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAdaptersConfig,
+  type AdaptersConfigAdapter,
+} from "../collectors/adapters-config";
+
+function makeAdapter(
+  files: Record<string, { contents: string; mode: number }>,
+  env: Record<string, string | undefined> = {},
+): AdaptersConfigAdapter {
+  return {
+    env,
+    readFile: (p) => {
+      const entry = files[p];
+      if (!entry) throw new Error(`ENOENT: ${p}`);
+      return entry.contents;
+    },
+    statMode: (p) => {
+      const entry = files[p];
+      if (!entry) throw new Error(`ENOENT: ${p}`);
+      return entry.mode;
+    },
+  };
+}
+
+describe("resolveAdaptersConfig", () => {
+  it("returns empty config + source=none when no file present", () => {
+    const result = resolveAdaptersConfig(makeAdapter({}));
+    expect(result.config).toEqual({});
+    expect(result.warnings).toEqual([]);
+    expect(result.source).toBe("none");
+  });
+
+  it("loads a valid unifi block", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter({
+        "/etc/dpf-edge/adapters.json": {
+          contents: JSON.stringify({
+            unifi: {
+              controllerUrl: "https://192.168.1.1",
+              apiKey: "secret-key",
+              site: "default",
+            },
+          }),
+          mode: 0o600,
+        },
+      }),
+    );
+    expect(result.source).toBe("file");
+    expect(result.warnings).toEqual([]);
+    expect(result.config.unifi).toEqual({
+      controllerUrl: "https://192.168.1.1",
+      apiKey: "secret-key",
+      site: "default",
+      tlsInsecure: false,
+    });
+  });
+
+  it("trims trailing slashes from controllerUrl and defaults site/tlsInsecure", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter({
+        "/etc/dpf-edge/adapters.json": {
+          contents: JSON.stringify({
+            unifi: { controllerUrl: "https://udm.local///", apiKey: "k" },
+          }),
+          mode: 0o600,
+        },
+      }),
+    );
+    expect(result.config.unifi).toEqual({
+      controllerUrl: "https://udm.local",
+      apiKey: "k",
+      site: "default",
+      tlsInsecure: false,
+    });
+  });
+
+  it("honors DPF_EDGE_ADAPTERS_CONFIG override", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter(
+        {
+          "/custom/path.json": {
+            contents: JSON.stringify({
+              unifi: { controllerUrl: "https://h", apiKey: "k" },
+            }),
+            mode: 0o600,
+          },
+        },
+        { DPF_EDGE_ADAPTERS_CONFIG: "/custom/path.json" },
+      ),
+    );
+    expect(result.config.unifi?.apiKey).toBe("k");
+  });
+
+  it("warns on world-readable file but still reads it", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter({
+        "/etc/dpf-edge/adapters.json": {
+          contents: JSON.stringify({
+            unifi: { controllerUrl: "https://h", apiKey: "k" },
+          }),
+          mode: 0o644,
+        },
+      }),
+    );
+    expect(result.warnings[0]).toMatch(/group\/world-readable/);
+    expect(result.config.unifi?.apiKey).toBe("k");
+  });
+
+  it("warns + skips a unifi block missing required fields", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter({
+        "/etc/dpf-edge/adapters.json": {
+          contents: JSON.stringify({ unifi: { controllerUrl: "https://h" } }),
+          mode: 0o600,
+        },
+      }),
+    );
+    expect(result.config.unifi).toBeUndefined();
+    expect(result.warnings.some((w) => w.includes("apiKey"))).toBe(true);
+  });
+
+  it("warns + skips unifi when controllerUrl is not http(s)", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter({
+        "/etc/dpf-edge/adapters.json": {
+          contents: JSON.stringify({
+            unifi: { controllerUrl: "udm.local", apiKey: "k" },
+          }),
+          mode: 0o600,
+        },
+      }),
+    );
+    expect(result.config.unifi).toBeUndefined();
+    expect(result.warnings.some((w) => w.includes("http://"))).toBe(true);
+  });
+
+  it("warns on invalid JSON", () => {
+    const result = resolveAdaptersConfig(
+      makeAdapter({
+        "/etc/dpf-edge/adapters.json": {
+          contents: "{ not json",
+          mode: 0o600,
+        },
+      }),
+    );
+    expect(result.config).toEqual({});
+    expect(result.warnings[0]).toMatch(/not valid JSON/);
+  });
+});

--- a/services/edge-node/src/__tests__/sweep.test.ts
+++ b/services/edge-node/src/__tests__/sweep.test.ts
@@ -94,6 +94,27 @@ function emptySnmpAdapter() {
   };
 }
 
+/**
+ * Default UniFi adapter for sweep tests — no adapters.json present.
+ * The collector returns empty without ever calling fetch, so existing
+ * sweep assertions stay deterministic regardless of the runner's
+ * /etc/dpf-edge/adapters.json contents.
+ */
+function emptyUnifiAdapter() {
+  return {
+    fetch: async () => {
+      throw new Error("emptyUnifiAdapter.fetch must not be called");
+    },
+    configAdapter: {
+      env: {},
+      readFile: () => "",
+      statMode: () => {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+    },
+  };
+}
+
 function makeApi(submit: AuthorityApiClient["submitDiscoveryRun"]): AuthorityApiClient {
   return {
     submitDiscoveryRun: submit,
@@ -118,6 +139,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
       newRunKey: () => `run_${++runKeyCounter}`,
       now: () => new Date("2026-05-12T12:00:00.000Z"),
     });
@@ -149,6 +171,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -170,6 +193,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     expect(submit.mock.calls[0]![0]).toBe("dpfedge_specifictoken");
@@ -195,6 +219,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     // 2 iterations × 1 submit each (no retry of dropped 413) = 2 total.
@@ -222,6 +247,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -251,6 +277,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -275,6 +302,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
       newRunKey: () => `run_${++counter}`,
     });
 
@@ -301,6 +329,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     // 3 iterations, each tries once, drops, no retry. So 3 calls total.
@@ -333,6 +362,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
       newRunKey: () => `run_${++counter}`,
       maxBufferedSubmissions: 2,
       log,
@@ -363,6 +393,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     // 3 iterations means 3 sleeps at the end of each tick.
@@ -399,6 +430,7 @@ describe("runSweepLoop", () => {
       arpAdapter: emptyArpAdapter(),
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     // Iter 1 + 3 submit; iter 2 throws during collect. → 2 submits.
@@ -430,6 +462,7 @@ describe("runSweepLoop", () => {
       arpAdapter: populatedArpAdapter,
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     const envelope = submit.mock.calls[0]![1] as Record<string, unknown>;
@@ -473,6 +506,7 @@ describe("runSweepLoop", () => {
       arpAdapter: failingArpAdapter,
       nmapAdapter: emptyNmapAdapter(),
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     const envelope = submit.mock.calls[0]![1] as Record<string, unknown>;
@@ -522,6 +556,7 @@ describe("runSweepLoop", () => {
       arpAdapter: populatedArpAdapter,
       nmapAdapter: populatedNmapAdapter,
       snmpAdapter: emptySnmpAdapter(),
+      unifiAdapter: emptyUnifiAdapter(),
     });
 
     const envelope = submit.mock.calls[0]![1] as Record<string, unknown>;

--- a/services/edge-node/src/__tests__/unifi.test.ts
+++ b/services/edge-node/src/__tests__/unifi.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { collectUnifi, type UnifiAdapter } from "../collectors/unifi";
+import type { AdaptersConfigAdapter } from "../collectors/adapters-config";
+
+const VALID_CONFIG = JSON.stringify({
+  unifi: {
+    controllerUrl: "https://192.168.1.1",
+    apiKey: "test-key",
+    site: "default",
+  },
+});
+
+const NO_CONFIG_FILE_ENOENT = (p: string) => {
+  throw new Error(`ENOENT: ${p}`);
+};
+
+function makeConfigAdapter(
+  files: Record<string, { contents: string; mode: number }>,
+): AdaptersConfigAdapter {
+  return {
+    env: {},
+    readFile: (p) => {
+      const f = files[p];
+      if (!f) throw new Error(`ENOENT: ${p}`);
+      return f.contents;
+    },
+    statMode: (p) => {
+      const f = files[p];
+      if (!f) throw new Error(`ENOENT: ${p}`);
+      return f.mode;
+    },
+  };
+}
+
+function makeFetchStub(
+  responder: (url: string, init: { headers?: Record<string, string> }) => {
+    ok?: boolean;
+    status?: number;
+    body?: unknown;
+    throwErr?: string;
+  },
+): UnifiAdapter["fetch"] {
+  return async (url, init) => {
+    const r = responder(url, init);
+    if (r.throwErr) throw new Error(r.throwErr);
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.body ?? { data: [] },
+      text: async () =>
+        typeof r.body === "string" ? r.body : JSON.stringify(r.body ?? {}),
+    };
+  };
+}
+
+const aDevice = (overrides: Record<string, unknown> = {}) => ({
+  mac: "aa:bb:cc:dd:ee:ff",
+  ip: "192.168.1.10",
+  name: "Living Room AP",
+  model: "U7PG2",
+  model_name: "UniFi AP-AC-Pro",
+  type: "uap",
+  serial: "ABC123",
+  state: 1,
+  version: "6.6.78",
+  ...overrides,
+});
+
+describe("collectUnifi — adapter not configured", () => {
+  it("is a no-op when adapters.json is absent", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({})),
+      configAdapter: {
+        env: {},
+        readFile: NO_CONFIG_FILE_ENOENT,
+        statMode: NO_CONFIG_FILE_ENOENT,
+      },
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items).toEqual([]);
+    expect(result.relationships).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("collectUnifi — controller success", () => {
+  it("maps an AP device to an access_point ObservationItem and SAME_AS link", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> | undefined;
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub((url, init) => {
+        capturedUrl = url;
+        capturedHeaders = init.headers;
+        return { body: { data: [aDevice()] } };
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+
+    const result = await collectUnifi(adapter);
+
+    expect(capturedUrl).toBe("https://192.168.1.1/proxy/network/api/s/default/stat/device");
+    expect(capturedHeaders?.["X-API-KEY"]).toBe("test-key");
+
+    expect(result.items).toEqual([
+      {
+        observedKey: "unifi:aa:bb:cc:dd:ee:ff",
+        itemType: "access_point",
+        name: "Living Room AP",
+        confidence: 1.0,
+        rawData: expect.objectContaining({
+          mac: "aa:bb:cc:dd:ee:ff",
+          ip: "192.168.1.10",
+          type: "uap",
+          osiLayer: 2,
+          osiLayerName: "data_link",
+          discoveredVia: "unifi_api",
+        }),
+      },
+    ]);
+
+    expect(result.relationships).toEqual([
+      {
+        fromObservedKey: "unifi:aa:bb:cc:dd:ee:ff",
+        toObservedKey: "arp:192.168.1.10",
+        relationshipType: "SAME_AS",
+        rawData: { mechanism: "unifi_controller_arp_correlation" },
+      },
+    ]);
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("maps gateway types (ugw / udm / udmpro) to itemType=gateway with osiLayer=3", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({
+        body: {
+          data: [
+            aDevice({ mac: "11:11:11:11:11:11", type: "udmpro", name: "UDM Pro" }),
+          ],
+        },
+      })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items[0]?.itemType).toBe("gateway");
+    expect(result.items[0]?.rawData.osiLayer).toBe(3);
+    expect(result.items[0]?.rawData.osiLayerName).toBe("network");
+  });
+
+  it("emits HOSTS edges from uplink_mac when the parent is also in the response", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({
+        body: {
+          data: [
+            aDevice({ mac: "aa:aa:aa:aa:aa:aa", type: "udm", name: "Gateway" }),
+            aDevice({
+              mac: "bb:bb:bb:bb:bb:bb",
+              type: "usw",
+              name: "Switch",
+              uplink: { uplink_mac: "aa:aa:aa:aa:aa:aa", uplink_remote_port: 1 },
+            }),
+            aDevice({
+              mac: "cc:cc:cc:cc:cc:cc",
+              type: "uap",
+              name: "AP",
+              uplink: { uplink_mac: "bb:bb:bb:bb:bb:bb", uplink_remote_port: 5 },
+            }),
+          ],
+        },
+      })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+
+    const result = await collectUnifi(adapter);
+    const hosts = result.relationships.filter((r) => r.relationshipType === "HOSTS");
+    expect(hosts).toEqual([
+      {
+        fromObservedKey: "unifi:aa:aa:aa:aa:aa:aa",
+        toObservedKey: "unifi:bb:bb:bb:bb:bb:bb",
+        relationshipType: "HOSTS",
+        rawData: { parentPortIdx: 1, uplinkType: null },
+      },
+      {
+        fromObservedKey: "unifi:bb:bb:bb:bb:bb:bb",
+        toObservedKey: "unifi:cc:cc:cc:cc:cc:cc",
+        relationshipType: "HOSTS",
+        rawData: { parentPortIdx: 5, uplinkType: null },
+      },
+    ]);
+  });
+
+  it("skips HOSTS edges when the parent isn't in the response", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({
+        body: {
+          data: [
+            aDevice({
+              mac: "bb:bb:bb:bb:bb:bb",
+              type: "usw",
+              uplink: { uplink_mac: "99:99:99:99:99:99" }, // dangling parent
+            }),
+          ],
+        },
+      })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.relationships.filter((r) => r.relationshipType === "HOSTS")).toEqual([]);
+  });
+
+  it("drops devices with invalid MACs but doesn't fail the whole run", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({
+        body: {
+          data: [
+            aDevice({ mac: "not-a-mac" }),
+            aDevice({ mac: "11:22:33:44:55:66" }),
+          ],
+        },
+      })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items.map((i) => i.observedKey)).toEqual(["unifi:11:22:33:44:55:66"]);
+  });
+});
+
+describe("collectUnifi — controller failures", () => {
+  it("returns a warning (not throw) on network failure", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({ throwErr: "ECONNREFUSED" })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items).toEqual([]);
+    expect(result.warnings[0]).toMatch(/unifi: network error/);
+  });
+
+  it("returns a warning on non-2xx response", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({ ok: false, status: 401, body: "unauthorized" })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items).toEqual([]);
+    expect(result.warnings[0]).toMatch(/HTTP 401/);
+  });
+
+  it("returns a warning on missing data[] in response", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStub(() => ({ body: { meta: {} } })),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items).toEqual([]);
+    expect(result.warnings[0]).toMatch(/data\[\]/);
+  });
+});

--- a/services/edge-node/src/collectors/adapters-config.ts
+++ b/services/edge-node/src/collectors/adapters-config.ts
@@ -1,0 +1,160 @@
+// Configuration loader for the optional vendor adapter collectors
+// (UniFi, Kasa, Starlink, Home Assistant). Each adapter has its own
+// block in a single JSON file; the absence of a block means "don't
+// run". The file path defaults to /etc/dpf-edge/adapters.json and is
+// overridable via the DPF_EDGE_ADAPTERS_CONFIG env var.
+//
+// The pattern matches snmp-config.ts intentionally — adapters carry
+// secrets (API keys, controller passwords) and a 0600 bind-mounted
+// JSON file is the conventional way to scope secret access to the
+// runtime UID. The collector is opt-in: with no file, every adapter
+// is a no-op and no warning fires.
+//
+// Spec: docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md
+//   § 4.3 UniFi Adapter — Activation
+
+import { readFileSync, statSync } from "node:fs";
+
+export type UnifiAdapterConfig = {
+  controllerUrl: string;
+  apiKey: string;
+  site: string;
+  tlsInsecure: boolean;
+};
+
+export type AdaptersConfig = {
+  unifi?: UnifiAdapterConfig;
+  // Future adapters (kasa, starlink, homeAssistant) will land alongside
+  // UniFi as additional optional fields; each gets its own validator
+  // below and the loader returns whatever was provided.
+};
+
+export type AdaptersConfigResolution = {
+  config: AdaptersConfig;
+  /** Non-fatal config warnings (bad fields, file perms, missing keys). */
+  warnings: string[];
+  /** Where the config came from — "none" when no file was found. */
+  source: "file" | "none";
+};
+
+/** Adapter for tests — replaces fs + env. */
+export type AdaptersConfigAdapter = {
+  env: NodeJS.ProcessEnv;
+  readFile: (path: string) => string;
+  statMode: (path: string) => number;
+};
+
+const DEFAULT_ADAPTER: AdaptersConfigAdapter = {
+  env: process.env,
+  readFile: (p) => readFileSync(p, "utf8"),
+  statMode: (p) => statSync(p).mode & 0o777,
+};
+
+const DEFAULT_CONFIG_PATH = "/etc/dpf-edge/adapters.json";
+
+/**
+ * Resolve the adapters configuration. Pure function modulo the adapter.
+ *
+ * Failure modes (mirrors snmp-config.ts):
+ *   - File missing → empty config, source="none".
+ *   - File present but world-readable → warning + still read.
+ *   - File present but invalid JSON → warning + empty config.
+ *   - Block present but invalid fields → warning + that adapter skipped;
+ *     other adapters still load.
+ */
+export function resolveAdaptersConfig(
+  adapter: AdaptersConfigAdapter = DEFAULT_ADAPTER,
+): AdaptersConfigResolution {
+  const path = adapter.env.DPF_EDGE_ADAPTERS_CONFIG ?? DEFAULT_CONFIG_PATH;
+  const warnings: string[] = [];
+
+  let modeBits: number | null = null;
+  try {
+    modeBits = adapter.statMode(path);
+  } catch {
+    return { config: {}, warnings, source: "none" };
+  }
+
+  if (modeBits !== null && (modeBits & 0o077) !== 0) {
+    warnings.push(
+      `adapters: config file ${path} is group/world-readable (mode 0${modeBits.toString(8).padStart(3, "0")}); ` +
+        `API keys and credentials in it are exposed. Recommend chmod 0600 ${path}.`,
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = adapter.readFile(path);
+  } catch (err) {
+    warnings.push(
+      `adapters: config file ${path} exists but is unreadable: ${(err as Error).message}`,
+    );
+    return { config: {}, warnings, source: "none" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    warnings.push(
+      `adapters: config file ${path} is not valid JSON: ${(err as Error).message}`,
+    );
+    return { config: {}, warnings, source: "file" };
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    warnings.push(`adapters: config file ${path} must be a JSON object`);
+    return { config: {}, warnings, source: "file" };
+  }
+
+  const config: AdaptersConfig = {};
+  const root = parsed as Record<string, unknown>;
+
+  const unifi = validateUnifi(root.unifi, warnings);
+  if (unifi !== null) config.unifi = unifi;
+
+  return { config, warnings, source: "file" };
+}
+
+function validateUnifi(raw: unknown, warnings: string[]): UnifiAdapterConfig | null {
+  if (raw === undefined) return null;
+  if (typeof raw !== "object" || raw === null) {
+    warnings.push(`adapters: "unifi" block must be an object — skipped`);
+    return null;
+  }
+  const t = raw as Record<string, unknown>;
+
+  const controllerUrl = stringField(t, "controllerUrl");
+  if (controllerUrl === null) {
+    warnings.push(`adapters: unifi.controllerUrl is required (e.g. "https://192.168.1.1") — skipped`);
+    return null;
+  }
+  if (!/^https?:\/\//i.test(controllerUrl)) {
+    warnings.push(
+      `adapters: unifi.controllerUrl must start with http:// or https:// — skipped`,
+    );
+    return null;
+  }
+  const trimmedUrl = controllerUrl.replace(/\/+$/, "");
+
+  const apiKey = stringField(t, "apiKey");
+  if (apiKey === null) {
+    warnings.push(`adapters: unifi.apiKey is required — skipped`);
+    return null;
+  }
+
+  const site = stringField(t, "site") ?? "default";
+  const tlsInsecure = booleanField(t, "tlsInsecure") ?? false;
+
+  return { controllerUrl: trimmedUrl, apiKey, site, tlsInsecure };
+}
+
+function stringField(o: Record<string, unknown>, key: string): string | null {
+  const v = o[key];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function booleanField(o: Record<string, unknown>, key: string): boolean | null {
+  const v = o[key];
+  return typeof v === "boolean" ? v : null;
+}

--- a/services/edge-node/src/collectors/unifi.ts
+++ b/services/edge-node/src/collectors/unifi.ts
@@ -1,0 +1,277 @@
+// UniFi adapter (Slice A — discovery only).
+//
+// Pulls the list of UniFi-managed network devices (switches, access
+// points, gateways) from a local UniFi Network controller and emits
+// them as ObservationItem records. Each device gets a SAME_AS link to
+// the `arp:<ip>` key the ARP collector already produces, so the
+// Authority Core's normalization can collapse the two into a single
+// canonical Configuration Item. Parent-child device topology
+// (gateway → switch → AP) is emitted as HOSTS relationships using the
+// controller's `uplink.uplink_mac` field.
+//
+// What's NOT in this slice (lands in Slice B):
+//   - Per-port throughput telemetry (rx_bytes-r / tx_bytes-r). That
+//     needs the metrics.network capability + /api/v1/edge/metrics
+//     endpoint, neither of which exist yet.
+//   - WebSocket event subscription for instant-on device joins.
+//     5-minute sweep cadence is fine for v1.
+//   - PoE wattage per port.
+//
+// Auth: API-key header (`X-API-KEY`). UniFi Network 9.x+ generates
+// API keys in Settings → System → API. Cookie-session local auth is
+// out of scope for Slice A; if it's needed later, gate on whether
+// config.apiKey is empty and fall through to a /api/auth/login flow.
+//
+// TLS: many home UniFi installs use a self-signed cert. The
+// `tlsInsecure` config flag opts into accepting any cert by swapping
+// in an undici Agent. We never silently accept invalid certs.
+//
+// Spec: docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md
+//   § 4.3 UniFi Adapter
+
+import { Agent, fetch as undiciFetch } from "undici";
+
+import {
+  resolveAdaptersConfig,
+  type AdaptersConfigAdapter,
+  type UnifiAdapterConfig,
+} from "./adapters-config";
+import type { ObservationItem } from "./host-info";
+
+export type UnifiRelationship = {
+  fromObservedKey: string;
+  toObservedKey: string;
+  relationshipType: string;
+  rawData?: Record<string, unknown>;
+};
+
+export type UnifiCollectResult = {
+  items: ObservationItem[];
+  relationships: UnifiRelationship[];
+  warnings: string[];
+};
+
+/** Subset of the UniFi controller device shape we actually use. */
+type UnifiDevice = {
+  mac: string;
+  ip?: string;
+  name?: string;
+  model?: string;
+  model_name?: string;
+  type?: string;
+  serial?: string;
+  state?: number;
+  version?: string;
+  uplink?: { uplink_mac?: string; uplink_remote_port?: number; type?: string };
+  // Other fields (port_table, stat, last_seen, etc.) are ignored in
+  // Slice A; they'll be consumed by Slice B's metrics path.
+};
+
+/** Adapter for tests — replaces fetch + the config resolver. */
+export type UnifiAdapter = {
+  /** HTTP fetch. Default uses undici with the tlsInsecure dispatcher. */
+  fetch: (
+    url: string,
+    init: { method?: string; headers?: Record<string, string> },
+  ) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }>;
+  /** Config source (defaults to file + env). */
+  configAdapter?: AdaptersConfigAdapter;
+};
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// itemType map — keeps the OSI-layer-aware shape the topology view
+// already understands. The "ugw" / "udm" / "udmpro" types all collapse
+// to "gateway"; UniFi distinguishes them by model_name which we keep
+// in rawData for the icon lookup.
+const TYPE_TO_ITEM_TYPE: Record<string, string> = {
+  usw: "switch",
+  uap: "access_point",
+  ugw: "gateway",
+  udm: "gateway",
+  udmpro: "gateway",
+  uxg: "gateway",
+};
+
+// UniFi `state` enum (from controller API):
+//   0 = disconnected, 1 = connected (managed), 2 = pending,
+//   4 = upgrading, 5 = provisioning, 6 = unreachable, etc.
+// We expose this verbatim in rawData; the Authority side maps it to
+// the canonical OperationalStatus.
+function buildItemFromDevice(device: UnifiDevice): ObservationItem | null {
+  const mac = device.mac?.toLowerCase();
+  if (!mac || !/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/.test(mac)) return null;
+
+  const itemType = TYPE_TO_ITEM_TYPE[device.type ?? ""] ?? "network_device";
+
+  return {
+    observedKey: `unifi:${mac}`,
+    itemType,
+    name: device.name || device.model_name || device.model || `UniFi ${mac}`,
+    confidence: 1.0,
+    rawData: {
+      mac,
+      ip: device.ip ?? null,
+      model: device.model ?? null,
+      modelName: device.model_name ?? null,
+      type: device.type ?? null,
+      serial: device.serial ?? null,
+      state: device.state ?? null,
+      version: device.version ?? null,
+      vendorIconModel: device.model ?? null,
+      discoveredVia: "unifi_api",
+      osiLayer: itemType === "access_point" ? 2 : itemType === "gateway" ? 3 : 2,
+      osiLayerName: itemType === "gateway" ? "network" : "data_link",
+    },
+  };
+}
+
+function buildSameAsLink(device: UnifiDevice): UnifiRelationship | null {
+  if (!device.ip || !device.mac) return null;
+  const mac = device.mac.toLowerCase();
+  return {
+    fromObservedKey: `unifi:${mac}`,
+    toObservedKey: `arp:${device.ip}`,
+    relationshipType: "SAME_AS",
+    rawData: { mechanism: "unifi_controller_arp_correlation" },
+  };
+}
+
+function buildUplinkLinks(devices: UnifiDevice[]): UnifiRelationship[] {
+  // Index by MAC for fast lookup. The uplink_mac field references
+  // another UniFi device; if that device isn't in this sweep's
+  // response (e.g. unreachable), we silently skip the relationship —
+  // the next sweep will catch it.
+  const byMac = new Map<string, UnifiDevice>();
+  for (const d of devices) {
+    if (d.mac) byMac.set(d.mac.toLowerCase(), d);
+  }
+
+  const links: UnifiRelationship[] = [];
+  for (const d of devices) {
+    const childMac = d.mac?.toLowerCase();
+    const parentMac = d.uplink?.uplink_mac?.toLowerCase();
+    if (!childMac || !parentMac) continue;
+    if (!byMac.has(parentMac)) continue;
+    links.push({
+      fromObservedKey: `unifi:${parentMac}`,
+      toObservedKey: `unifi:${childMac}`,
+      relationshipType: "HOSTS",
+      rawData: {
+        parentPortIdx: d.uplink?.uplink_remote_port ?? null,
+        uplinkType: d.uplink?.type ?? null,
+      },
+    });
+  }
+  return links;
+}
+
+async function fetchUnifiDevices(
+  unifi: UnifiAdapterConfig,
+  adapter: UnifiAdapter,
+): Promise<{ devices: UnifiDevice[] } | { error: string }> {
+  const url = `${unifi.controllerUrl}/proxy/network/api/s/${encodeURIComponent(unifi.site)}/stat/device`;
+  let resp: Awaited<ReturnType<UnifiAdapter["fetch"]>>;
+  try {
+    resp = await adapter.fetch(url, {
+      method: "GET",
+      headers: {
+        "X-API-KEY": unifi.apiKey,
+        Accept: "application/json",
+      },
+    });
+  } catch (err) {
+    return { error: `network error reaching ${url}: ${(err as Error).message}` };
+  }
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    return {
+      error: `controller returned HTTP ${resp.status} for ${url}: ${body.slice(0, 200)}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await resp.json();
+  } catch (err) {
+    return { error: `controller response was not JSON: ${(err as Error).message}` };
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !Array.isArray((parsed as { data?: unknown }).data)
+  ) {
+    return { error: `controller response missing data[] array` };
+  }
+
+  return {
+    devices: (parsed as { data: UnifiDevice[] }).data,
+  };
+}
+
+/**
+ * Run the UniFi adapter once. If no config block is present, returns
+ * an empty result with no warnings — the adapter is opt-in.
+ *
+ * Errors are converted to warnings (and zero items) rather than
+ * thrown, matching the pattern of every other collector: a single
+ * adapter failure must never bring down the sweep.
+ */
+export async function collectUnifi(
+  adapter?: UnifiAdapter,
+): Promise<UnifiCollectResult> {
+  const configResolution = resolveAdaptersConfig(adapter?.configAdapter);
+  const warnings = [...configResolution.warnings];
+  const unifi = configResolution.config.unifi;
+  if (!unifi) return { items: [], relationships: [], warnings };
+
+  // Tests always pass a concrete adapter; production builds the
+  // default once we know whether tlsInsecure should be honored. The
+  // dispatcher selection has to happen here (not at module init)
+  // because the flag lives in the JSON config we just read.
+  const effectiveAdapter: UnifiAdapter = adapter ?? buildDefaultAdapter(unifi.tlsInsecure);
+
+  const result = await fetchUnifiDevices(unifi, effectiveAdapter);
+  if ("error" in result) {
+    warnings.push(`unifi: ${result.error}`);
+    return { items: [], relationships: [], warnings };
+  }
+
+  const items: ObservationItem[] = [];
+  const sameAsLinks: UnifiRelationship[] = [];
+  for (const device of result.devices) {
+    const item = buildItemFromDevice(device);
+    if (!item) continue;
+    items.push(item);
+    const link = buildSameAsLink(device);
+    if (link) sameAsLinks.push(link);
+  }
+  const uplinkLinks = buildUplinkLinks(result.devices);
+
+  return {
+    items,
+    relationships: [...sameAsLinks, ...uplinkLinks],
+    warnings,
+  };
+}
+
+function buildDefaultAdapter(tlsInsecure: boolean): UnifiAdapter {
+  const dispatcher = new Agent({
+    headersTimeout: DEFAULT_TIMEOUT_MS,
+    bodyTimeout: DEFAULT_TIMEOUT_MS,
+    connect: { rejectUnauthorized: !tlsInsecure },
+  });
+  return {
+    fetch: async (url, init) => {
+      const resp = await undiciFetch(url, { ...init, dispatcher });
+      return {
+        ok: resp.ok,
+        status: resp.status,
+        json: () => resp.json() as Promise<unknown>,
+        text: () => resp.text(),
+      };
+    },
+  };
+}

--- a/services/edge-node/src/sweep.ts
+++ b/services/edge-node/src/sweep.ts
@@ -49,17 +49,23 @@ import {
   type SnmpPollAdapter,
   type SnmpRelationship,
 } from "./collectors/snmp-poll";
+import {
+  collectUnifi,
+  type UnifiAdapter,
+  type UnifiRelationship,
+} from "./collectors/unifi";
 import type { EdgeNodeConfig } from "./config";
 import type { EdgeNodeState } from "./state";
 
 /**
- * Unified relationship shape carried in the submission envelope. Both
- * the nmap-sweep and snmp-poll collectors produce the same field set,
- * so we widen at the envelope level to accept either.
+ * Unified relationship shape carried in the submission envelope. All
+ * of the nmap-sweep, snmp-poll, and unifi collectors produce the same
+ * field set, so we widen at the envelope level to accept any of them.
  */
 export type SubmissionRelationship =
   | NmapSweepRelationship
-  | SnmpRelationship;
+  | SnmpRelationship
+  | UnifiRelationship;
 
 const PHASE_0_CAPABILITY = "discovery.network";
 
@@ -97,6 +103,8 @@ export type SweepRunnerOptions = {
   nmapAdapter?: NmapSweepAdapter;
   /** Override the SNMP-poll adapter (test seam). */
   snmpAdapter?: SnmpPollAdapter;
+  /** Override the UniFi adapter (test seam). */
+  unifiAdapter?: UnifiAdapter;
   /** Override runKey generation (test seam). */
   newRunKey?: () => string;
   /** Override the wall-clock used for observedAt (test seam). */
@@ -132,6 +140,7 @@ export async function runSweepLoop(opts: SweepRunnerOptions): Promise<void> {
   const arpAdapter = opts.arpAdapter;
   const nmapAdapter = opts.nmapAdapter;
   const snmpAdapter = opts.snmpAdapter;
+  const unifiAdapter = opts.unifiAdapter;
   const maxBuffer = opts.maxBufferedSubmissions ?? 1000;
   const { config, api, state } = opts;
 
@@ -166,21 +175,30 @@ export async function runSweepLoop(opts: SweepRunnerOptions): Promise<void> {
       const arp = await collectArpNeighbors(arpAdapter);
       const nmap = await collectNmapSweep(nmapAdapter);
       const snmp = await collectSnmpPoll(snmpAdapter);
+      // UniFi adapter runs last so its `arp:<ip>` SAME_AS targets line
+      // up with whatever the ARP collector emitted earlier in the same
+      // envelope — gives the Authority's normalization layer the best
+      // chance to collapse `unifi:<mac>` and `arp:<ip>` in one pass.
+      // Opt-in: zero-output no-op when adapters.json is absent.
+      const unifi = await collectUnifi(unifiAdapter);
 
       const items: ObservationItem[] = [
         ...host.items,
         ...arp.items,
         ...nmap.items,
         ...snmp.items,
+        ...unifi.items,
       ];
       const relationships: SubmissionRelationship[] = [
         ...nmap.relationships,
         ...snmp.relationships,
+        ...unifi.relationships,
       ];
       const warnings: string[] = [
         ...arp.warnings,
         ...nmap.warnings,
         ...snmp.warnings,
+        ...unifi.warnings,
       ];
 
       envelope = {


### PR DESCRIPTION
Pulls UniFi-managed network devices (switches, access points, gateways) from a local UniFi Network controller and emits them as ObservationItem records on the existing /api/v1/edge/discovery-runs wire contract. Closes the topology-fidelity gap that's been the real "why doesn't the DPF view match UniFi" question: instead of just ARP-discovered hosts, the topology now shows the gateway → switch → AP tree that UniFi sees.

Pieces:

- `services/edge-node/src/collectors/adapters-config.ts` — JSON config loader for the vendor adapter set, mirroring `snmp-config.ts`. Reads /etc/dpf-edge/adapters.json (DPF_EDGE_ADAPTERS_CONFIG-overridable), validates per-adapter blocks, returns warnings without failing the collector. UniFi is the first block; Kasa / Starlink / HA blocks land alongside in follow-ups.

- `services/edge-node/src/collectors/unifi.ts` — the collector. API-key auth via X-API-KEY header (UniFi Network 9+); honors tlsInsecure for self-signed UDM certs via undici Agent. Maps `type` to itemType (usw → switch, uap → access_point, ugw/udm/udmpro → gateway), drops invalid MACs, emits SAME_AS to `arp:<ip>` for normalization, emits HOSTS edges from uplink_mac → device.mac when the parent is in the same response. All controller failures convert to warnings rather than throws.

- `services/edge-node/src/sweep.ts` — wired UniFi into the existing collector chain, last in order so its SAME_AS targets line up with the ARP items already in the same envelope.

- `services/edge-node/src/__tests__/sweep.test.ts` — added an emptyUnifiAdapter() helper and threaded it through all 14 existing sweep tests so they stay deterministic regardless of the runner's /etc/dpf-edge/adapters.json state.

- `docs/edge-node/unifi-adapter.md` — operator setup: generate API key, place adapters.json at mode 0600, bind-mount into the container, recreate. Troubleshooting for the common 401 / TLS / unreachable failure modes.

Out of scope (Slice B+):
- Per-port rx/tx throughput metrics — needs the metrics.network capability + /api/v1/edge/metrics endpoint from the parent spec.
- LLDP-derived L2 port wiring.
- WebSocket events for instant device joins.
- Cookie-session auth for pre-9.0 controllers — add when needed.

Verified:
- 134 / 5-skipped vitests pass (+17 over baseline: 7 adapters-config
  + 9 unifi + 1 sweep merge regression check).
- `pnpm --filter dpf-edge-node typecheck` clean.

Spec: docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md § 4.3

## Summary

<!-- One paragraph: what does this change do and why? -->

## Changes

<!-- Bullet list of concrete changes. Keep them skimmable. -->

-
-

## Test plan

<!-- How did you verify this works? Include commands and manual steps. -->

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm --filter web build`
- [ ] Manual verification (describe below)

## Related issues

<!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

## Notes for the reviewer

<!-- Flag anything non-obvious: migrations, config changes, breaking behavior, follow-up work. -->
