### PR TITLE
fix(build-studio): rename 'Topology' tab label to 'Workflow'

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -589,7 +589,7 @@ export function BuildStudio({
                     className="px-3 py-1 rounded-t text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
                     style={getTabStyle(buildView === "topology")}
                   >
-                    Topology
+                    Workflow
                   </button>
                   {/* Details tab — always available so design doc / brief is visible during ideate/plan */}
                   <button

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -239,7 +239,7 @@ describe("BuildStudio active-build header layout", () => {
     );
 
     expect(html).toContain(">Progress<");
-    expect(html).toContain(">Topology<");
+    expect(html).toContain(">Workflow<");
     expect(html).toContain("Loading build progress...");
     expect(html).not.toContain("code-intelligence-status-card");
     expect(html).not.toContain("process-graph");


### PR DESCRIPTION
## Summary

- The build canvas tab labelled "Topology" actually shows the build's workflow / lifecycle process graph, not a network topology
- "Topology" in the rest of the platform refers to network topology (devices, subnets), so this label was misleading
- Renames the visible label only; internal state value `"topology"`, panel id `panel-topology`, and aria-controls reference stay unchanged

## Test plan
- [x] `pnpm --filter web exec vitest run components/build/BuildStudioHeaderLayout` → 11/11 passing
- [x] Pre-commit typecheck green
- [ ] CI vitest + typecheck
- [ ] Visual: confirm Workflow label renders on `/build` and the panel still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)