### PR TITLE
fix(build-studio): gate build→review on releasable sandbox diff (FB-5D6F7000)

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -565,12 +565,14 @@ describe("governed build start approvals", () => {
       acceptanceMet: null,
       uxTestResults: null,
       uxVerificationStatus: null,
+      sandboxId: "dpf-sandbox-1",
       threadId: null,
     });
     mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
       governedBacklogEnabled: true,
     });
     mockPrisma.featureBuild.update.mockResolvedValue({});
+    mockListReleasableSandboxFiles.mockResolvedValue(["apps/web/components/build/BuildStudio.tsx"]);
 
     await advanceBuildPhase("FB-123", "review");
 
@@ -762,6 +764,47 @@ describe("governed build start approvals", () => {
           buildId: "FB-321",
           tool: "record_acceptance",
         }),
+      }),
+    );
+  });
+
+  it("advanceBuildPhase blocks build to review when the sandbox has no releasable source diff (fake-task-complete guard)", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      id: "build-row-fake-1",
+      phase: "build",
+      createdById: "user-1",
+      originatingBacklogItemId: "backlog-row-1",
+      draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+      designDoc: { problemStatement: "Fix overlap" },
+      designReview: { decision: "pass", summary: "ok", issues: [] },
+      plan: null,
+      brief: { acceptanceCriteria: ["Header does not overlap content."] },
+      buildPlan: {
+        fileStructure: [{ path: "apps/web/components/build/BuildStudio.tsx", action: "modify", purpose: "Fix overlap" }],
+        tasks: [{ title: "Fix overlap", testFirst: "Reproduce", implement: "Patch layout", verify: "Run checks" }],
+      },
+      planReview: { decision: "pass", summary: "ok", issues: [] },
+      taskResults: { completedTasks: 1, totalTasks: 1, tasks: [{ title: "Fix overlap", outcome: "DONE" }] },
+      verificationOut: { typecheckPassed: true, testsFailed: 0, testsPassed: 4 },
+      acceptanceMet: [{ criterion: "Header does not overlap content.", met: true }],
+      uxTestResults: [{ step: "Header remains visible", passed: true }],
+      uxVerificationStatus: "complete",
+      sandboxId: "dpf-sandbox-1",
+      threadId: null,
+    });
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({
+      governedBacklogEnabled: true,
+    });
+    mockListReleasableSandboxFiles.mockResolvedValue([]);
+
+    await expect(advanceBuildPhase("FB-123", "review")).rejects.toThrow(
+      "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
+    );
+
+    expect(mockPrisma.featureBuild.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { buildId: "FB-123" },
+        data: expect.objectContaining({ phase: "review" }),
       }),
     );
   });

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -434,6 +434,18 @@ export async function advanceBuildPhase(
     }
   }
 
+  if (currentPhase === "build" && targetPhase === "review") {
+    if (!build.sandboxId) {
+      throw new Error("Build Studio cannot advance to review because the sandbox is no longer available.");
+    }
+    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId);
+    if (releasableFiles.length === 0) {
+      throw new Error(
+        "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
+      );
+    }
+  }
+
   if (currentPhase === "review" && targetPhase === "ship") {
     if (!build.sandboxId) {
       throw new Error("Build Studio cannot continue to release because the sandbox is no longer available.");


### PR DESCRIPTION
## Summary

Add a sandbox-diff check to the build→review phase transition, mirroring the existing review→ship gate. If a build reaches the end of its task list with no releasable source changes in the sandbox, reject the advance with a clear error pointing the operator at Resume Implementation.

## Why

2026-05-20: FB-71FB3A53 (Ollama) reached phase=review with all 9 tasks marked DONE in the UI but `diffPatch=null` and `gitCommitHashes=[]`. The Continue-to-Release click then failed with "No releasable source changes are present". That is the "hallucinated success" anti-pattern — tasks transitioned to DONE based on chat responses alone, with no enforcement that any code was actually written in the sandbox.

This is the narrow first slice of FB-5D6F7000: surface the same emptyness-of-diff check at the earlier gate, so operators see the problem before a fake-complete build accumulates downstream review state.

## Out of scope (follow-ups under the same BI)

- Task-level instrumentation preventing DONE-without-commit at the individual task transition
- Backfill auto-stall for already-broken review-phase FBs

## Test plan
- [x] New unit test: `advanceBuildPhase blocks build to review when the sandbox has no releasable source diff (fake-task-complete guard)` — mirrors existing review→ship empty-diff test
- [x] Existing `enqueues UX verification when moving into review` test updated to model reality (includes sandboxId and a non-empty releasable-files mock)
- [x] Full local suite: 825/825 passing
- [x] Pre-commit typecheck green
- [ ] CI: typecheck + unit tests + production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)