### PR TITLE
fix(build-studio): bound source-of-truth conflict cluster height with scroll

### DIFF
--- a/apps/web/components/build/BuildProgressOperationalPanel.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.tsx
@@ -55,7 +55,10 @@ export function BuildProgressOperationalPanel({ projection }: Props) {
           </div>
 
           {projection.progress.conflicts.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-2">
+            <div
+              className="mt-3 flex max-h-24 flex-wrap gap-2 overflow-y-auto pr-1"
+              aria-label={`${projection.progress.conflicts.length} source-of-truth conflicts`}
+            >
               {projection.progress.conflicts.map((conflict) => (
                 <TruthSourceBadge
                   key={`${conflict.source}-${conflict.observedAt}`}


### PR DESCRIPTION
## Summary

- Long sequences of source-of-truth conflicts (12+ chips observed on real builds) used to wrap freely and consume ~1/3 of canvas vertical space
- Caps cluster at `max-h-24` with internal `overflow-y-auto` so panel below stays visible
- Adds aria-label announcing the conflict count for assistive tech

Pairs with FB-D3A746B3 (BS UX redesign) which calls out "long lists are unscrollable in practice" — this is the smallest slice of that work that can ship in isolation.

## Test plan
- [x] Existing `BuildProgressOperationalPanel` test passes (1/1)
- [x] Pre-commit typecheck green
- [ ] Visual verification: scroll appears when conflicts > ~4

🤖 Generated with [Claude Code](https://claude.com/claude-code)