### PR TITLE
test: harden portal self-upgrade runtime

### DIFF
--- a/apps/web/lib/queue/functions/portal-self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/portal-self-upgrade.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { allFunctions } from "./index";
+import {
+  PORTAL_SELF_UPGRADE_COMPLETION_CRON,
+  PORTAL_SELF_UPGRADE_CRON,
+  PORTAL_SELF_UPGRADE_EVENT,
+  portalSelfUpgradeCompletionSweep,
+  portalSelfUpgradeRequested,
+  portalSelfUpgradeScheduled,
+} from "./portal-self-upgrade";
+
+describe("portal self-upgrade queue functions", () => {
+  it("uses stable cron and event contracts", () => {
+    expect(PORTAL_SELF_UPGRADE_CRON).toBe("0 8 * * *");
+    expect(PORTAL_SELF_UPGRADE_COMPLETION_CRON).toBe("*/15 * * * *");
+    expect(PORTAL_SELF_UPGRADE_EVENT).toBe("portal/self-upgrade.requested");
+  });
+
+  it("registers scheduled, manual, and completion sweep functions", () => {
+    expect(allFunctions).toContain(portalSelfUpgradeScheduled);
+    expect(allFunctions).toContain(portalSelfUpgradeRequested);
+    expect(allFunctions).toContain(portalSelfUpgradeCompletionSweep);
+  });
+});

--- a/apps/web/lib/self-upgrade/completion.test.ts
+++ b/apps/web/lib/self-upgrade/completion.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   buildCompletionEvidence,
+  buildCompletionFailureUpdate,
+  getCompletionAttempts,
+  MAX_COMPLETION_ATTEMPTS,
   resolveBuildHeadCandidates,
   completeMergedShipBuilds,
 } from "./completion";
@@ -33,6 +36,46 @@ describe("buildCompletionEvidence", () => {
       confirmedAt: "2026-05-20T03:00:00.000Z",
       selfUpgradeRunId: "SUR-123",
     });
+  });
+});
+
+describe("completion failure retry state", () => {
+  it("increments completion attempts without failing the run until the cap", () => {
+    const first = buildCompletionFailureUpdate({
+      completionEvidence: { reason: "update-available" },
+      message: "git unavailable",
+      failedAt: new Date("2026-05-20T03:00:00Z"),
+    });
+
+    expect(first.completionAttempts).toBe(1);
+    expect(first.exhausted).toBe(false);
+    expect(first.data).toEqual(expect.objectContaining({
+      status: "completing",
+      reason: "completion-failed",
+      failureLog: "git unavailable",
+      completionEvidence: expect.objectContaining({
+        reason: "update-available",
+        completionAttempts: 1,
+        lastCompletionError: "git unavailable",
+        lastCompletionErrorAt: "2026-05-20T03:00:00.000Z",
+      }),
+    }));
+  });
+
+  it("marks the run failed when completion attempts reach the cap", () => {
+    const final = buildCompletionFailureUpdate({
+      completionEvidence: { completionAttempts: MAX_COMPLETION_ATTEMPTS - 1 },
+      message: "still unavailable",
+      failedAt: new Date("2026-05-20T04:00:00Z"),
+    });
+
+    expect(getCompletionAttempts(final.data.completionEvidence)).toBe(MAX_COMPLETION_ATTEMPTS);
+    expect(final.exhausted).toBe(true);
+    expect(final.data).toEqual(expect.objectContaining({
+      status: "failed",
+      reason: "completion-retries-exhausted",
+      completedAt: new Date("2026-05-20T04:00:00Z"),
+    }));
   });
 });
 

--- a/apps/web/lib/self-upgrade/completion.ts
+++ b/apps/web/lib/self-upgrade/completion.ts
@@ -1,3 +1,14 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+import { Prisma, prisma } from "@dpf/db";
+
+import { loadSelfUpgradeConfig } from "./config";
+import { notifySelfUpgradeEvent } from "./notification";
+
+const execFile = promisify(execFileCb);
+export const MAX_COMPLETION_ATTEMPTS = 4;
+
 type BuildHeadInput = {
   buildBranch?: string | null;
   gitCommitHashes?: string[] | null;
@@ -30,6 +41,46 @@ type CompletionGit = {
   resolveRef(candidate: string): Promise<string | null>;
   isAncestor(candidateSha: string, productionSha: string): Promise<boolean>;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function getCompletionAttempts(completionEvidence: unknown): number {
+  if (!isRecord(completionEvidence)) return 0;
+  const attempts = completionEvidence.completionAttempts;
+  return typeof attempts === "number" && Number.isInteger(attempts) && attempts > 0
+    ? attempts
+    : 0;
+}
+
+export function buildCompletionFailureUpdate(input: {
+  completionEvidence: unknown;
+  message: string;
+  failedAt?: Date;
+}) {
+  const completionAttempts = getCompletionAttempts(input.completionEvidence) + 1;
+  const exhausted = completionAttempts >= MAX_COMPLETION_ATTEMPTS;
+  const failedAt = input.failedAt ?? new Date();
+  const failureEvidence = {
+    ...(isRecord(input.completionEvidence) ? input.completionEvidence : {}),
+    completionAttempts,
+    lastCompletionError: input.message.slice(0, 12000),
+    lastCompletionErrorAt: failedAt.toISOString(),
+  } satisfies Prisma.InputJsonObject;
+
+  return {
+    completionAttempts,
+    exhausted,
+    data: {
+      status: exhausted ? "failed" : "completing",
+      reason: exhausted ? "completion-retries-exhausted" : "completion-failed",
+      failureLog: input.message.slice(0, 12000),
+      completedAt: exhausted ? failedAt : undefined,
+      completionEvidence: failureEvidence,
+    },
+  };
+}
 
 export function resolveBuildHeadCandidates(build: BuildHeadInput): string[] {
   const candidates: string[] = [];
@@ -148,7 +199,13 @@ export async function completeSelfUpgradeRun(runId: string): Promise<{
 }> {
   const run = await prisma.selfUpgradeRun.findUnique({
     where: { runId },
-    select: { runId: true, status: true, targetSha: true, deployedSha: true },
+    select: {
+      runId: true,
+      status: true,
+      targetSha: true,
+      deployedSha: true,
+      completionEvidence: true,
+    },
   });
 
   if (!run) return { completedBuildIds: [], skipped: true, reason: "run-not-found" };
@@ -197,16 +254,26 @@ export async function completeSelfUpgradeRun(runId: string): Promise<{
     return result;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const failure = buildCompletionFailureUpdate({
+      completionEvidence: run.completionEvidence,
+      message,
+    });
     await prisma.selfUpgradeRun.update({
       where: { runId },
-      data: {
-        status: "completing",
-        reason: "completion-failed",
-        failureLog: message.slice(0, 12000),
-      },
+      data: failure.data,
     });
-    await notifySelfUpgradeEvent({ type: "failed", runId, reason: message });
-    throw err;
+    await notifySelfUpgradeEvent({
+      type: "failed",
+      runId,
+      reason: failure.exhausted
+        ? `Completion failed ${failure.completionAttempts} times; self-upgrade marked failed: ${message}`
+        : `Completion attempt ${failure.completionAttempts} failed; will retry on the next sweep: ${message}`,
+    });
+    return {
+      completedBuildIds: [],
+      skipped: true,
+      reason: failure.exhausted ? "completion-retries-exhausted" : "completion-failed",
+    };
   }
 }
 
@@ -228,12 +295,3 @@ export async function completePendingSelfUpgradeRuns(limit = 5): Promise<{
 
   return { processedRunIds };
 }
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
-
-import { Prisma, prisma } from "@dpf/db";
-
-import { loadSelfUpgradeConfig } from "./config";
-import { notifySelfUpgradeEvent } from "./notification";
-
-const execFile = promisify(execFileCb);

--- a/apps/web/lib/self-upgrade/notification.test.ts
+++ b/apps/web/lib/self-upgrade/notification.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformNotification: {
+      create: db.create,
+    },
+  },
+}));
+
+import { notificationMessage, notifySelfUpgradeEvent } from "./notification";
+
+describe("notificationMessage", () => {
+  it("formats start, completion, failure, and skipped messages", () => {
+    expect(
+      notificationMessage({
+        type: "started",
+        runId: "SUR-123",
+        currentSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        targetSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      }),
+    ).toContain("aaaaaaaaaaaa to bbbbbbbbbbbb");
+
+    expect(
+      notificationMessage({
+        type: "completed",
+        runId: "SUR-123",
+        completedBuildIds: ["FB-1", "FB-2"],
+      }),
+    ).toContain("FB-1, FB-2");
+
+    expect(notificationMessage({ type: "failed", runId: "SUR-123", reason: "health failed" }))
+      .toContain("health failed");
+    expect(notificationMessage({ type: "skipped", reason: "up-to-date" })).toContain("up-to-date");
+  });
+});
+
+describe("notifySelfUpgradeEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists warnings only for failed upgrade events", async () => {
+    db.create.mockResolvedValue({});
+
+    await notifySelfUpgradeEvent({ type: "failed", runId: "SUR-123", reason: "health failed" });
+    await notifySelfUpgradeEvent({ type: "completed", runId: "SUR-123", completedBuildIds: [] });
+
+    expect(db.create).toHaveBeenNthCalledWith(1, {
+      data: expect.objectContaining({
+        severity: "warning",
+        category: "self-upgrade",
+        subjectId: "SUR-123",
+      }),
+    });
+    expect(db.create).toHaveBeenNthCalledWith(2, {
+      data: expect.objectContaining({
+        severity: "info",
+        category: "self-upgrade",
+        subjectId: "SUR-123",
+      }),
+    });
+  });
+
+  it("logs notification write failures without throwing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    db.create.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(notifySelfUpgradeEvent({ type: "started", runId: "SUR-123" })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "[self-upgrade] notification write failed:",
+      expect.any(Error),
+    );
+
+    warn.mockRestore();
+  });
+});

--- a/apps/web/lib/self-upgrade/notification.ts
+++ b/apps/web/lib/self-upgrade/notification.ts
@@ -11,7 +11,7 @@ type SelfUpgradeNotification = {
   containerName?: string;
 };
 
-function notificationMessage(event: SelfUpgradeNotification): string {
+export function notificationMessage(event: SelfUpgradeNotification): string {
   if (event.type === "started") {
     return `Portal self-upgrade ${event.runId} started from ${event.currentSha?.slice(0, 12) ?? "unknown"} to ${event.targetSha?.slice(0, 12) ?? "unknown"}.`;
   }
@@ -33,5 +33,8 @@ export async function notifySelfUpgradeEvent(event: SelfUpgradeNotification): Pr
       subjectId: event.runId ?? null,
       message: notificationMessage(event),
     },
-  }).catch(() => undefined);
+  }).catch((err: unknown) => {
+    // Upgrade state is already persisted elsewhere; notification failure must not mask it.
+    console.warn("[self-upgrade] notification write failed:", err);
+  });
 }

--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { buildPromoterDockerArgs } from "./promoter";
+
+const config = {
+  enabled: true,
+  hostInstallPath: "D:/DPF",
+  hostSourceMountPath: "/host-source",
+  composeProject: "dpf",
+  portalContainerName: "dpf-portal-1",
+  dbContainerName: "dpf-postgres-1",
+  repositoryRemote: "origin",
+  repositoryBranch: "main",
+  healthUrl: "http://localhost:3000/api/health",
+};
+
+function envValue(args: string[], name: string): string | undefined {
+  return args.find((arg) => arg.startsWith(`${name}=`));
+}
+
+describe("promoter script contract", () => {
+  it("keeps docker env names aligned with scripts/promote.sh", () => {
+    const args = buildPromoterDockerArgs(
+      config,
+      "SUR-12345678",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    const script = readFileSync(resolve(process.cwd(), "..", "..", "scripts", "promote.sh"), "utf8");
+    const requiredEnvNames = [
+      "SELF_UPGRADE_RUN_ID",
+      "SELF_UPGRADE_TARGET_SHA",
+      "DPF_HOST_SOURCE_PATH",
+      "DPF_COMPOSE_PROJECT",
+      "DPF_PORTAL_CONTAINER",
+      "DPF_PRODUCTION_DB_CONTAINER",
+      "DPF_SELF_UPGRADE_REMOTE",
+      "DPF_SELF_UPGRADE_BRANCH",
+      "DPF_SELF_UPGRADE_HEALTH_URL",
+    ];
+
+    for (const name of requiredEnvNames) {
+      expect(envValue(args, name), `${name} missing from promoter docker args`).toBeTruthy();
+      expect(script, `${name} missing from promote.sh`).toContain(name);
+    }
+    expect(args.at(-1)).toBe("--self-upgrade");
+  });
+});

--- a/apps/web/lib/self-upgrade/store.test.ts
+++ b/apps/web/lib/self-upgrade/store.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  Prisma: {},
+  prisma: {
+    selfUpgradeRun: {
+      create: db.create,
+      update: db.update,
+    },
+  },
+}));
+
+import {
+  createSelfUpgradeRun,
+  generateSelfUpgradeRunId,
+  markSelfUpgradeRunSkipped,
+  markSelfUpgradeRunStarted,
+} from "./store";
+
+const versionState = {
+  currentSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  targetSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  upToDate: false,
+  comparable: true,
+  reason: "behind-target" as const,
+};
+
+describe("generateSelfUpgradeRunId", () => {
+  it("uses the SUR prefix and a short stable token shape", () => {
+    expect(generateSelfUpgradeRunId()).toMatch(/^SUR-[A-F0-9]{8}$/);
+  });
+});
+
+describe("createSelfUpgradeRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists queued runs with version and config evidence", async () => {
+    db.create.mockResolvedValue({});
+
+    const result = await createSelfUpgradeRun({
+      trigger: "manual",
+      config: {
+        composeProject: "dpf",
+        repositoryRemote: "origin",
+        repositoryBranch: "main",
+      },
+      versionState,
+    });
+
+    expect(result.runId).toMatch(/^SUR-[A-F0-9]{8}$/);
+    expect(db.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        runId: result.runId,
+        status: "queued",
+        trigger: "manual",
+        currentSha: versionState.currentSha,
+        targetSha: versionState.targetSha,
+        completionEvidence: expect.objectContaining({
+          reason: "behind-target",
+          comparable: true,
+          composeProject: "dpf",
+          repositoryRemote: "origin",
+          repositoryBranch: "main",
+        }),
+      }),
+    });
+  });
+});
+
+describe("markSelfUpgradeRunSkipped", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records skipped runs with optional version evidence", async () => {
+    db.create.mockResolvedValue({});
+
+    await markSelfUpgradeRunSkipped({
+      trigger: "scheduled",
+      reason: "up-to-date",
+      versionState,
+    });
+
+    expect(db.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        status: "skipped",
+        trigger: "scheduled",
+        reason: "up-to-date",
+        currentSha: versionState.currentSha,
+        targetSha: versionState.targetSha,
+        completedAt: expect.any(Date),
+        completionEvidence: expect.objectContaining({
+          reason: "behind-target",
+          comparable: true,
+        }),
+      }),
+    });
+  });
+});
+
+describe("markSelfUpgradeRunStarted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("moves a queued run to running and stores the promoter container", async () => {
+    db.update.mockResolvedValue({});
+
+    await markSelfUpgradeRunStarted({
+      runId: "SUR-12345678",
+      promoter: { containerName: "dpf-promoter-self-upgrade-SUR-12345678" },
+    });
+
+    expect(db.update).toHaveBeenCalledWith({
+      where: { runId: "SUR-12345678" },
+      data: {
+        status: "running",
+        startedAt: expect.any(Date),
+        promoterContainerName: "dpf-promoter-self-upgrade-SUR-12345678",
+      },
+    });
+  });
+});

--- a/docs/superpowers/plans/2026-05-20-portal-self-upgrade-local.md
+++ b/docs/superpowers/plans/2026-05-20-portal-self-upgrade-local.md
@@ -8,81 +8,183 @@
 
 **Tech Stack:** Next.js server actions, Inngest, Prisma, Docker Compose, POSIX shell, Vitest.
 
+**Backlog:** `BI-CAPSULE-SELFUPGRADE-001`.
+
+---
+
+## Status — 2026-05-20
+
+The first implementation slice landed on `feat/portal-self-upgrade-local` (commit `8c129eb7`). The runtime is operational at the API/DB/script level; structural verification passed (typecheck, focused tests, build). **No functional `/ops/self-upgrade` drive has been completed yet,** and seven test files this plan called for did not ship (see "TDD debt" below).
+
+The file structure that actually shipped diverges from the original plan in several places. The headings under each Task have been updated to reflect actual filenames so the next implementer reads accurate paths. Naming-of-record decisions made during implementation:
+
+- `notification.ts` (singular) over `notifications.ts`
+- `store.ts` over `run-store.ts`
+- `apps/web/components/ops/SelfUpgradePanel.tsx` over `SelfUpgradeClient.tsx`
+- `apps/web/lib/queue/functions/portal-self-upgrade.ts` over `self-upgrade.ts`
+- New `apps/web/lib/actions/self-upgrade.ts` server-action surface, NOT a modification to `apps/web/lib/actions/promotions.ts`. The two surfaces share no code; self-upgrade is its own dispatcher.
+
+### Canonical status enum
+
+`SelfUpgradeRun.status` is one of: `queued | running | succeeded | failed | rolled_back | completing | skipped`. This lives as DB-stored strings and TS literals (no Prisma enum); any new state must update `store.ts`, `completion.ts`, and the dashboard. `completing` is the post-promoter-success-pre-build-reconciliation state; `succeeded` is reached only after `completeSelfUpgradeRun` confirms ancestry.
+
+### Two Inngest functions, not one
+
+The plan originally implied a single scheduled function. Implementation shipped THREE Inngest registrations in `apps/web/lib/queue/functions/portal-self-upgrade.ts`:
+
+1. `portal/self-upgrade-scheduled` — daily cron (`0 8 * * *`), calls `runSelfUpgradeCycle({trigger:"scheduled"})`.
+2. `portal/self-upgrade-requested` — event-triggered by `portal/self-upgrade.requested` (manual button), same cycle.
+3. `portal/self-upgrade-completion-sweep` — separate cron (`*/15 * * * *`), reconciles runs in `completing` state to `succeeded` via `completePendingSelfUpgradeRuns`. Without this third function ship-phase builds never auto-complete.
+
+### Capability gates (operator-facing)
+
+`requireSelfUpgradeOperator(capability)` in `apps/web/lib/actions/self-upgrade.ts` gates two surfaces:
+
+- Dashboard read (`getSelfUpgradeDashboardAction`) → `view_operations`.
+- Manual trigger (`requestPortalSelfUpgradeAction`) → `manage_provider_connections`.
+
+`manage_provider_connections` is the chosen gate because the local self-upgrade surface intentionally reuses the same "operator who manages production-touching infrastructure" capability rather than introducing a new `manage_self_upgrade` permission. If a separate gate is wanted for stricter governance, add the capability and update both this plan and the server action.
+
+### Shell-injection / path-traversal defense
+
+Config inputs flow into `docker run` argv via `execFile` and into `scripts/promote.sh` env vars used in `docker compose` invocations. The defense is:
+
+- `apps/web/lib/self-upgrade/config.ts` enforces `SAFE_NAME_RE = /^[A-Za-z0-9_.:-]+$/` for container/image/branch/remote names and `SAFE_PATH_RE = /^[A-Za-z0-9_./:\\-]+$/` for host paths. Inputs that do not match are rejected at `loadSelfUpgradeConfig` time, before the promoter is ever started.
+- `apps/web/lib/self-upgrade/promoter.ts` builds docker argv arrays (not shell strings) and uses `execFile` (not `exec`). `shellQuote` is exported for the rare cases that need it.
+- `scripts/promote.sh` validates `SELF_UPGRADE_RUN_ID` against `^[a-zA-Z0-9_-]+$` and `TARGET_SHA` against `^[0-9a-fA-F]{40}$` before using either in SQL or docker calls.
+
+Do not relax any of these constraints without re-reviewing the shell-injection surface.
+
+### TDD debt — tests called for in this plan that did NOT ship
+
+The plan declares `REQUIRED: superpowers:test-driven-development`. The following tests were listed under their respective tasks but never landed. They should land before this slice is closed:
+
+- [x] `apps/web/lib/self-upgrade/store.test.ts` — idempotent run lifecycle (queued → running, run-id uniqueness, skipped variants) covered by the local hardening slice.
+- [x] `apps/web/lib/self-upgrade/notification.test.ts` — message formatting per event type, severity mapping, and notification-failure logging covered by the local hardening slice.
+- [x] `apps/web/lib/self-upgrade/promote-script-contract.test.ts` — round-trip: `buildPromoterDockerArgs` emits the env vars `scripts/promote.sh` reads (`SELF_UPGRADE_RUN_ID`, `SELF_UPGRADE_TARGET_SHA`, `DPF_HOST_SOURCE_PATH`, `DPF_COMPOSE_PROJECT`, `DPF_PORTAL_CONTAINER`, `DPF_PRODUCTION_DB_CONTAINER`, `DPF_SELF_UPGRADE_REMOTE`, `DPF_SELF_UPGRADE_BRANCH`, `DPF_SELF_UPGRADE_HEALTH_URL`) covered by the local hardening slice.
+- [x] `apps/web/lib/queue/functions/portal-self-upgrade.test.ts` — function registration plus cron/event constants covered by the local hardening slice.
+- [ ] `apps/web/lib/actions/self-upgrade.test.ts` (corresponds to the plan's `promotions.self-upgrade.test.ts`) — capability gate enforcement: an unauthenticated caller, a `view_operations`-only caller, and a `manage_provider_connections` caller; assert error wording for unauthorized.
+- [ ] `apps/web/components/ops/SelfUpgradePanel.test.tsx` — renders current version, target version, recent runs, disabled state when config disabled, error state when `versionError` is set, manual-trigger button visibility per capability.
+- [ ] `packages/db/src/self-upgrade-config.test.ts` — default PlatformConfig seed preserves operator edits (idempotent), and seed creates the row on a fresh DB.
+
+### Known code-quality issues to address in a follow-up commit
+
+- [x] `apps/web/lib/self-upgrade/completion.ts` had imports at the bottom of the file. Fixed in the local hardening slice.
+- [x] `completeSelfUpgradeRun` retried forever on completion failure. The local hardening slice records `completionAttempts` in `completionEvidence`, caps retries at 4, and transitions exhausted runs to `failed` with `reason: "completion-retries-exhausted"`.
+- [x] `notification.ts:36` swallowed notification errors silently. The local hardening slice logs the failure and keeps the intentional "notification must not break upgrade state" policy explicit in code.
+
+### Files NOT mentioned in the original plan that landed
+
+Add to the canonical file list for future readers:
+
+- `docker-compose.yml` — adds `DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT` env to the portal/worker services and a `${DPF_HOST_INSTALL_PATH}:/host-source:ro` mount.
+- `packages/db/src/table-classification.ts` — classifies the new `SelfUpgradeRun` table.
+- `apps/web/components/ops/OpsTabNav.tsx` — adds the Self-Upgrade tab link.
+- `apps/web/lib/queue/inngest-client.ts` — registers the three functions above.
+
 ---
 
 ### Task 1: Persistence and Config
 
-**Files:**
-- Modify: `packages/db/prisma/schema.prisma`
-- Create: `packages/db/prisma/migrations/20260520030000_self_upgrade_runs/migration.sql`
-- Modify: `packages/db/src/seed.ts`
-- Create: `packages/db/src/self-upgrade-config.test.ts`
-- Create: `apps/web/lib/self-upgrade/config.ts`
-- Create: `apps/web/lib/self-upgrade/config.test.ts`
+**Files (canonical, post-implementation):**
+- Modified: `packages/db/prisma/schema.prisma` (added `SelfUpgradeRun` model)
+- Created: `packages/db/prisma/migrations/20260520030000_self_upgrade_runs/migration.sql`
+- Modified: `packages/db/src/seed.ts` (seeds `self_upgrade` PlatformConfig key)
+- Modified: `packages/db/src/table-classification.ts` (classifies `SelfUpgradeRun`)
+- Created: `apps/web/lib/self-upgrade/config.ts`
+- Created: `apps/web/lib/self-upgrade/config.test.ts`
 
-- [ ] Write failing tests for default PlatformConfig seed and config validation.
-- [ ] Add `SelfUpgradeRun` with status/SHA/log fields.
-- [ ] Seed `self_upgrade` PlatformConfig defaults without overwriting operator edits.
-- [ ] Implement `loadSelfUpgradeConfig`.
+- [x] Add `SelfUpgradeRun` with status/SHA/log fields — landed.
+- [x] Seed `self_upgrade` PlatformConfig defaults without overwriting operator edits — landed.
+- [x] Implement `loadSelfUpgradeConfig` with zod schema + `SAFE_NAME_RE` / `SAFE_PATH_RE` validation — landed.
+- [ ] **TDD debt:** `packages/db/src/self-upgrade-config.test.ts` — seed idempotency. Not yet shipped.
 
 ### Task 2: Version Detection and Promoter Dispatch
 
-**Files:**
-- Create: `apps/web/lib/self-upgrade/version.ts`
-- Create: `apps/web/lib/self-upgrade/version.test.ts`
-- Create: `apps/web/lib/self-upgrade/promoter.ts`
-- Create: `apps/web/lib/self-upgrade/promoter.test.ts`
-- Modify: `scripts/promote.sh`
-- Create: `apps/web/lib/self-upgrade/promote-script-contract.test.ts`
+**Files (canonical, post-implementation):**
+- Created: `apps/web/lib/self-upgrade/version.ts`
+- Created: `apps/web/lib/self-upgrade/version.test.ts`
+- Created: `apps/web/lib/self-upgrade/promoter.ts`
+- Created: `apps/web/lib/self-upgrade/promoter.test.ts`
+- Modified: `scripts/promote.sh` (~150 added lines for `--self-upgrade` branch)
+- Modified: `docker-compose.yml` (host-source mount + env)
 
-- [ ] Write failing tests for SHA comparison and promoter command construction.
-- [ ] Compare `/app/.dpf-image-version` to the host checkout's `origin/main`.
-- [ ] Start `dpf-promoter` with `SELF_UPGRADE=1` and a writable host-source mount.
-- [ ] Extend `promote.sh --self-upgrade` to fetch, verify a clean host tree, build from host source, swap, health-check, and rollback.
+- [x] Compare `/app/.dpf-image-version` to the host checkout's `origin/main` — landed in `version.ts`.
+- [x] Start `dpf-promoter` with `SELF_UPGRADE=1` and a writable host-source mount — `promoter.ts:buildPromoterDockerArgs`.
+- [x] Extend `promote.sh --self-upgrade` to fetch, verify a clean host tree, build from host source, swap, health-check, and rollback — landed.
+- [x] **TDD debt:** `apps/web/lib/self-upgrade/promote-script-contract.test.ts` — round-trip that the env vars `buildPromoterDockerArgs` emits are the same names `scripts/promote.sh` reads. This caught and fixed the `DPF_SELF_UPGRADE_HEALTH_URL` script mismatch.
+
+> **Note on the source mount.** The host-source mount must be writable for the current design because `scripts/promote.sh --self-upgrade` fast-forwards the clean host checkout to the target SHA before building and swapping containers. The guardrail is not read-only mounting; it is the dirty-checkout refusal, target SHA validation, safe config validation, argv-based Docker dispatch, and shell-side run-id/SHA validation.
 
 ### Task 3: Run Store, Completion, and Notifications
 
-**Files:**
-- Create: `apps/web/lib/self-upgrade/run-store.ts`
-- Create: `apps/web/lib/self-upgrade/run-store.test.ts`
-- Create: `apps/web/lib/self-upgrade/completion.ts`
-- Create: `apps/web/lib/self-upgrade/completion.test.ts`
-- Create: `apps/web/lib/self-upgrade/notifications.ts`
-- Create: `apps/web/lib/self-upgrade/notifications.test.ts`
-- Modify: `apps/web/lib/tak/agent-event-bus.ts`
+**Files (canonical, post-implementation):**
+- Created: `apps/web/lib/self-upgrade/store.ts` (was `run-store.ts` in original plan)
+- Created: `apps/web/lib/self-upgrade/completion.ts`
+- Created: `apps/web/lib/self-upgrade/completion.test.ts`
+- Created: `apps/web/lib/self-upgrade/notification.ts` (was `notifications.ts` — singular won)
 
-- [ ] Write failing tests for idempotent run lifecycle, ancestry-based build completion, and notification events.
-- [ ] Persist queued/running/succeeded/failed/rolled_back/completing runs.
-- [ ] Complete only ship-phase FeatureBuilds whose branch/head SHA is an ancestor of the running production SHA.
-- [ ] Emit operator-visible self-upgrade events.
+**Files originally proposed but not used:**
+- `apps/web/lib/tak/agent-event-bus.ts` — NOT touched. Notifications go through `PlatformNotification` rows directly, not the agent event bus. If the agent event bus needs to surface self-upgrade events later, add a subscriber that reads `PlatformNotification` where `category = "self-upgrade"`.
+
+- [x] Persist `queued | running | succeeded | failed | rolled_back | completing | skipped` runs — landed.
+- [x] Complete only ship-phase FeatureBuilds whose branch/head SHA is an ancestor of the running production SHA — landed via `resolveBuildHeadCandidates` + `git merge-base --is-ancestor`.
+- [x] Emit operator-visible self-upgrade events as `PlatformNotification` rows with `category = "self-upgrade"` and `severity = "info" | "warning"` — landed.
+- [x] Idempotent ancestry-based completion test — landed in `completion.test.ts`.
+- [x] **TDD debt:** `apps/web/lib/self-upgrade/store.test.ts` — covers `generateSelfUpgradeRunId`, `createSelfUpgradeRun` evidence, `markSelfUpgradeRunSkipped`, and `markSelfUpgradeRunStarted`.
+- [x] **TDD debt:** `apps/web/lib/self-upgrade/notification.test.ts` — covers `notificationMessage()` per event type, severity mapping (only `"failed"` → `"warning"`), and notification write failure logging.
+- [x] **Completion retry cap (see Status section).** `completeSelfUpgradeRun` now records attempts in `completionEvidence` and marks the run failed after 4 completion failures.
+- [x] **Imports-at-bottom cleanup in `completion.ts`** (see Status section).
 
 ### Task 4: Queue and Operations UI
 
-**Files:**
-- Create: `apps/web/lib/self-upgrade/index.ts`
-- Create: `apps/web/lib/self-upgrade/index.test.ts`
-- Create: `apps/web/lib/queue/functions/self-upgrade.ts`
-- Create: `apps/web/lib/queue/functions/self-upgrade.test.ts`
-- Modify: `apps/web/lib/queue/functions/index.ts`
-- Modify: `apps/web/lib/queue/inngest-client.ts`
-- Modify: `apps/web/lib/actions/promotions.ts`
-- Create: `apps/web/lib/actions/promotions.self-upgrade.test.ts`
-- Create: `apps/web/components/ops/SelfUpgradeClient.tsx`
-- Create: `apps/web/components/ops/SelfUpgradeClient.test.tsx`
-- Modify: `apps/web/components/ops/OpsTabNav.tsx`
-- Create: `apps/web/app/(shell)/ops/self-upgrade/page.tsx`
+**Files (canonical, post-implementation):**
+- Created: `apps/web/lib/self-upgrade/index.ts`
+- Created: `apps/web/lib/self-upgrade/index.test.ts`
+- Created: `apps/web/lib/queue/functions/portal-self-upgrade.ts` (was `self-upgrade.ts` in original plan)
+- Modified: `apps/web/lib/queue/functions/index.ts`
+- Modified: `apps/web/lib/queue/inngest-client.ts`
+- Created: `apps/web/lib/actions/self-upgrade.ts` (NEW server-action surface — original plan said to modify `promotions.ts`; implementation correctly chose a separate file to keep capability gates and revalidation paths distinct)
+- Created: `apps/web/components/ops/SelfUpgradePanel.tsx` (was `SelfUpgradeClient.tsx` in original plan)
+- Modified: `apps/web/components/ops/OpsTabNav.tsx`
+- Created: `apps/web/app/(shell)/ops/self-upgrade/page.tsx`
 
-- [ ] Write failing tests for scheduled/manual upgrade orchestration and UI actions.
-- [ ] Add `portal/self-upgrade` scheduled and manual event handling.
-- [ ] Add `triggerSelfUpgrade` server action.
-- [ ] Add a small Operations tab showing current version, target version, recent runs, and a manual trigger.
+- [x] Add `portal/self-upgrade.requested` event handling + daily scheduled cycle — landed as two Inngest functions in `portal-self-upgrade.ts` (`portal/self-upgrade-scheduled`, `portal/self-upgrade-requested`).
+- [x] Add separate `portal/self-upgrade-completion-sweep` Inngest function on `*/15 * * * *` cron to reconcile `completing` runs (NOT in original plan but architecturally required — see Status).
+- [x] Add `requestPortalSelfUpgradeAction` and `getSelfUpgradeDashboardAction` server actions in `apps/web/lib/actions/self-upgrade.ts` — landed.
+- [x] Capability gates: `view_operations` for dashboard read, `manage_provider_connections` for trigger — landed (see Status for the rationale on `manage_provider_connections`).
+- [x] Add a small Operations tab showing current version, target version, recent runs, and a manual trigger — landed as `SelfUpgradePanel.tsx` rendered from `apps/web/app/(shell)/ops/self-upgrade/page.tsx`.
+- [x] **TDD debt:** `apps/web/lib/queue/functions/portal-self-upgrade.test.ts` — asserts all three functions are registered and that `PORTAL_SELF_UPGRADE_EVENT === "portal/self-upgrade.requested"` plus the cron constants.
+- [ ] **TDD debt:** `apps/web/lib/actions/self-upgrade.test.ts` — three-case capability gate (unauth, view-only, full), error wording for unauthorized, `revalidatePath("/ops/self-upgrade")` is called on success.
+- [ ] **TDD debt:** `apps/web/components/ops/SelfUpgradePanel.test.tsx` — renders current/target versions, recent runs table, disabled state when `config.enabled === false`, error banner when `versionError` is set, manual-trigger button visibility per capability.
 
 ### Verification
 
-- [ ] `pnpm install --frozen-lockfile`
-- [ ] Focused Vitest suites for self-upgrade, promoter, queue, ops UI, and seed config.
-- [ ] `pnpm --filter web typecheck`
-- [ ] `pnpm --filter @dpf/db typecheck`
-- [ ] `pnpm --filter @dpf/db exec prisma validate`
-- [ ] `pnpm --filter web exec next build`
-- [ ] Docker-served portal rebuild from clean worktree and health at configured `APP_URL`/`AUTH_URL` plus `http://localhost:3000`.
+#### Structural (landed in `8c129eb7`)
+
+- [x] `pnpm install --frozen-lockfile`
+- [x] Focused Vitest suites for self-upgrade (`config`, `version`, `promoter`, `completion`, `index`).
+- [x] `pnpm --filter web typecheck`
+- [x] `pnpm --filter @dpf/db typecheck`
+- [x] `pnpm --filter @dpf/db exec prisma validate`
+- [x] `pnpm --filter web exec next build`
+- [x] Docker-served portal rebuild from clean worktree and health at configured `APP_URL` / `AUTH_URL` plus `http://localhost:3000`.
+
+#### Functional drive (REQUIRED before this slice closes — `structural-verification-is-not-functional`)
+
+Structural test passes do not prove the upgrade works. The following live drive against the Docker-served portal must happen on a host where `/host-source` is mounted from a clean checkout that has commits on `origin/main` beyond `/app/.dpf-image-version`:
+
+- [ ] Log in as an operator with `view_operations` + `manage_provider_connections`. Open `/ops/self-upgrade`.
+- [ ] Confirm the dashboard renders: current SHA, target SHA, "behind by N commits" or equivalent state, and an empty (or pre-existing) runs table.
+- [ ] Verify that `getUpgradeVersionState` does NOT throw on the operator-visible path; if a Windows-Git-worktree mount is in play, the `toOperatorVersionError` translator should kick in with the documented hint instead of a raw stack.
+- [ ] Trigger a manual upgrade. Assert:
+  - [ ] A new `SelfUpgradeRun` row appears with `status = queued`, then `running`, then `completing`, then `succeeded`. (Watch via `psql` or by refreshing the dashboard.)
+  - [ ] A `dpf-promoter-self-upgrade-<runId>` container starts, runs to completion, and is removed (`--rm`).
+  - [ ] `/app/.dpf-image-version` inside the new portal container reports the target SHA.
+  - [ ] `/api/health` responds 200 on both `localhost:3000` and the configured `APP_URL`.
+  - [ ] At least one `PlatformNotification` row exists with `category = "self-upgrade"` describing the start and completion.
+- [ ] Confirm completion sweep behavior: create a ship-phase FeatureBuild whose `buildBranch` resolves to a SHA that IS an ancestor of the new production SHA. Wait one `*/15 * * * *` cron tick (or trigger the sweep manually). Assert the build moves to `phase = "complete"` with `acceptanceMet.productionSha` set.
+- [ ] Confirm rollback behavior: deliberately break the new build (e.g., inject a failing healthcheck), trigger upgrade, assert the run reaches `rolled_back` and the old portal container is restored.
+- [ ] Capture screenshots and logs into `output/playwright/` or the active backlog item's evidence.
+
+A live drive that cannot complete (e.g., dev hardware lacks docker-in-docker permissions) must be recorded as a known limitation against `BI-CAPSULE-SELFUPGRADE-001` — not silently skipped.

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -35,6 +35,7 @@ SELF_UPGRADE_TARGET_SHA="${SELF_UPGRADE_TARGET_SHA:-}"
 SELF_UPGRADE_REMOTE="${DPF_SELF_UPGRADE_REMOTE:-origin}"
 SELF_UPGRADE_BRANCH="${DPF_SELF_UPGRADE_BRANCH:-main}"
 SELF_UPGRADE_HOST_SOURCE="${DPF_HOST_SOURCE_PATH:-/host-source}"
+SELF_UPGRADE_HEALTH_URL="${DPF_SELF_UPGRADE_HEALTH_URL:-http://127.0.0.1:3000/api/health}"
 
 log() { echo "[promoter] $(date +%H:%M:%S) $1"; }
 
@@ -212,7 +213,7 @@ run_self_upgrade() {
   HEALTHY=false
   for i in $(seq 1 "$HEALTH_RETRIES"); do
     log "  Health check attempt $i/$HEALTH_RETRIES..."
-    if docker exec "$PORTAL_CONTAINER" wget -qO /dev/null -T 10 http://127.0.0.1:3000/api/health 2>/dev/null; then
+    if docker exec "$PORTAL_CONTAINER" wget -qO /dev/null -T 10 "$SELF_UPGRADE_HEALTH_URL" 2>/dev/null; then
       HEALTHY=true
       break
     fi


### PR DESCRIPTION
## Summary
- adds a completion retry cap for portal self-upgrade runs so a poisoned completion state fails deterministically instead of looping forever
- isolates notification-write failures from persisted run state so completion/failure state is not masked by inbox issues
- makes the promote script health probe configurable with `DPF_SELF_UPGRADE_HEALTH_URL`
- expands local coverage for completion, notification, store persistence, queue entrypoint, and promote-script contract behavior
- updates the local implementation plan with the completed hardening slice and the remaining live-drive checklist

## Verification
- Live PR #781 state checked: merged, merge commit `233164a590aa568df5f7eb4e82d41fb792745eb8`
- Live main checked during acceptance: `b6c0dfb756d480010459d65c78a3e3b8e4129971`; commits after the Docker build were triage docs only
- Root `D:\DPF` was dirty and untouched; Docker acceptance used `D:\DPF\.worktrees\portal-self-upgrade-local` plus Linux-clean source checkout `D:\DPF-clean-main-linux`
- `pnpm --filter web exec vitest run lib/self-upgrade/config.test.ts lib/self-upgrade/version.test.ts lib/self-upgrade/promoter.test.ts lib/self-upgrade/promote-script-contract.test.ts lib/self-upgrade/store.test.ts lib/self-upgrade/notification.test.ts lib/self-upgrade/completion.test.ts lib/self-upgrade/index.test.ts lib/queue/functions/portal-self-upgrade.test.ts lib/queue/functions/index.test.ts` -> 10 files / 28 tests passed
- `pnpm --filter web typecheck` -> passed
- `pnpm --filter @dpf/db typecheck` -> passed
- `pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma` -> passed
- `bash -lc 'sh -n scripts/promote.sh'` -> passed
- `pnpm --filter web exec next build` -> passed, 104 static pages generated
- `docker compose --env-file D:\DPF\.env build --no-cache portal` -> passed after one transient dependency-stage SIGSEGV retry
- `docker compose --env-file D:\DPF\.env build --no-cache portal-init` -> passed after one transient Next TypeScript worker SIGSEGV retry
- `docker compose --env-file D:\DPF\.env build --no-cache sandbox` -> passed
- `docker compose --env-file D:\DPF\.env up -d` -> portal healthy, portal-init exited 0, sandbox running
- `http://localhost:3000/api/health` -> 200
- `http://192.168.0.200:3000/api/health` -> 200
- Docker-served `/ops/self-upgrade` Playwright check -> rendered configured source, running image, target head, Queue Upgrade Check, Recent Runs; status `behind-target`; no page/console errors; no unreadable-source warning

## Evidence recorded
- Runtime target `RT-ROOT-PORTAL` updated by live DB fallback with current image/source metadata because MCP token auth was invalid/expired in-session
- Runtime verifications recorded:
  - `RV-SELF-UPGRADE-HARDENING-20260520-HEALTH`
  - `RV-SELF-UPGRADE-HARDENING-20260520-BUILD`
  - `RV-SELF-UPGRADE-HARDENING-20260520-UX`
- Backlog activity recorded:
  - `BI-CAPSULE-SELFUPGRADE-001`: Docker/build evidence and UI evidence
  - `BI-3DE485DE`: manual check that Phase 3 remains in progress

## Remaining work outside this slice
- live end-to-end self-upgrade drive through queued/running/completing/succeeded
- completion sweep proof and rollback drill
- remaining action/panel/config tests from the plan
- follow-up on Docker/BuildKit/Node SIGSEGV instability seen during no-cache builds
