### PR TITLE
fix(build-studio): null-safe brief.targetRoles + acceptanceCriteria in build context

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -645,8 +645,12 @@ export async function getBuildContextSection(ctx: BuildContext): Promise<string>
     lines.push(`  Title: ${ctx.brief.title}`);
     lines.push(`  Description: ${ctx.brief.description}`);
     lines.push(`  Portfolio: ${ctx.brief.portfolioContext}`);
-    lines.push(`  Target roles: ${ctx.brief.targetRoles.join(", ")}`);
-    lines.push(`  Acceptance criteria: ${ctx.brief.acceptanceCriteria.join("; ")}`);
+    if (Array.isArray(ctx.brief.targetRoles) && ctx.brief.targetRoles.length > 0) {
+      lines.push(`  Target roles: ${ctx.brief.targetRoles.join(", ")}`);
+    }
+    if (Array.isArray(ctx.brief.acceptanceCriteria) && ctx.brief.acceptanceCriteria.length > 0) {
+      lines.push(`  Acceptance criteria: ${ctx.brief.acceptanceCriteria.join("; ")}`);
+    }
   }
 
   if (ctx.designDoc) {


### PR DESCRIPTION
## Summary

- `getBuildContextSection` calls `.join()` on `ctx.brief.targetRoles` and `ctx.brief.acceptanceCriteria` without null-checking
- When either field is `undefined` (common for briefs created without those fields populated), the pipeline crashes at the `deps_installed` step
- The peer file `lib/integrate/coding-agent.ts` already guards this — this brings `build-agent-prompts.ts` to parity

## Why this matters now

This bug stalled FB-F0476EF3 (COST-P1-01) and FB-AD454C98 (Edge Node) during the 2026-05-20 session. `buildExecState` shows the error verbatim: `"brief.targetRoles undefined"` / `"Cannot read properties of null (reading 'title')"`.

## Test plan
- [x] All 21 `lib/integrate/build-agent-prompts` tests pass locally
- [x] Pre-commit typecheck green
- [ ] CI: Typecheck + Unit Tests + Production Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)