### PR TITLE
fix(build-studio): null-safe brief in stepGenerateCode userMessage

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -294,11 +294,11 @@ async function stepGenerateCode(
   // Build the initial message from the brief
   const userMessage = [
     `Build the following feature in the sandbox:`,
-    `Title: ${brief.title}`,
-    `Description: ${brief.description}`,
+    `Title: ${brief?.title ?? build.title ?? buildId}`,
+    `Description: ${brief?.description ?? build.description ?? "(no description provided)"}`,
     ``,
     `Acceptance Criteria:`,
-    ...(Array.isArray(brief.acceptanceCriteria) ? brief.acceptanceCriteria.map((c: string, i: number) => `${i + 1}. ${c}`) : []),
+    ...(Array.isArray(brief?.acceptanceCriteria) ? brief.acceptanceCriteria.map((c: string, i: number) => `${i + 1}. ${c}`) : [`(none specified)`]),
     ``,
     `Follow the approved implementation plan. Start by searching the codebase for existing patterns, then generate new files and edit existing ones as needed. Run tests when done.`,
   ].join("\n");


### PR DESCRIPTION
## Summary

- `stepGenerateCode` accesses `brief.title`, `brief.description`, `brief.acceptanceCriteria` directly when building the initial user message for the build phase
- For builds with `brief=null` (FB has title/description but no full structured brief), this throws `Cannot read properties of null (reading 'title')` and crashes `deps_installed`
- Mirrors #854 which fixed the same anti-pattern in `build-agent-prompts.ts` (`brief.targetRoles`)

## Why this matters

Observed 2026-05-20 on FB-AD454C98 (Edge Node). `buildExecState` shows the error verbatim at `failedAt: "deps_installed"`. With #854 + this fix, the COST P1 cluster and Edge Node should be able to progress past `deps_installed` rather than instantly failing.

## Test plan
- [x] All 9 `lib/integrate/build-pipeline` tests pass locally
- [x] Pre-commit typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)