### PR TITLE
fix(build-studio): truncate contribution PR title to fit GitHub 256-char limit

### DIFF
--- a/apps/web/lib/integrate/contribution-pipeline.test.ts
+++ b/apps/web/lib/integrate/contribution-pipeline.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { formatContributionPrTitle } from "./contribution-pipeline";
+
+describe("formatContributionPrTitle", () => {
+  const buildId = "FB-AD454C98";
+
+  it("returns the full title unchanged when it fits well under the GitHub limit", () => {
+    const title = "Wire conflict-cluster overflow scroll";
+    const formatted = formatContributionPrTitle(title, buildId);
+    expect(formatted).toBe(`feat: ${title} (Build ${buildId})`);
+    expect(formatted.length).toBeLessThan(256);
+  });
+
+  it("truncates the body and appends an ellipsis when the rawTitle exceeds 220 chars", () => {
+    const longTitle =
+      "Extend the DPF Edge Node (TypeScript, services/edge-node/) with network telemetry: " +
+      "(1) SNMP ifTable walk — poll ifHCInOctets/ifHCOutOctets (64-bit counters, OIDs 1.3.6.1.2.1.31.1.1.1.6/.10) " +
+      "on a 10-second interval using the netsnmp shared library and persist into edge_iface_metric.";
+    expect(longTitle.length).toBeGreaterThan(220);
+
+    const formatted = formatContributionPrTitle(longTitle, buildId);
+    expect(formatted.length).toBeLessThanOrEqual(256);
+    expect(formatted.endsWith(`(Build ${buildId})`)).toBe(true);
+    expect(formatted).toContain("…");
+  });
+
+  it("strips trailing whitespace before the ellipsis so the cut never reads as a dangling space", () => {
+    // 218 chars of repeated word + lots of spaces in the middle
+    const padded = "a".repeat(150) + " ".repeat(40) + "b".repeat(40);
+    expect(padded.length).toBeGreaterThan(220);
+    const formatted = formatContributionPrTitle(padded, buildId);
+    const beforeEllipsis = formatted.slice(0, formatted.indexOf("…"));
+    expect(beforeEllipsis.endsWith(" ")).toBe(false);
+  });
+
+  it("treats exactly-220-char rawTitle as fitting and does not truncate", () => {
+    const title = "a".repeat(220);
+    const formatted = formatContributionPrTitle(title, buildId);
+    expect(formatted).toBe(`feat: ${title} (Build ${buildId})`);
+    expect(formatted).not.toContain("…");
+  });
+});

--- a/apps/web/lib/integrate/contribution-pipeline.ts
+++ b/apps/web/lib/integrate/contribution-pipeline.ts
@@ -57,6 +57,21 @@ function generateBranchName(buildId: string, title: string): string {
   return `build/${buildId}/${slugify(title)}`;
 }
 
+/**
+ * Format a PR title that stays within GitHub's 256-char limit.
+ *
+ * The wrapper text (`feat: ` prefix + ` (Build FB-XXXXXXXX)` suffix) consumes
+ * around 25 characters, so we cap the body of the title at 220 to leave
+ * headroom and append a single-character ellipsis when truncation fires.
+ */
+export function formatContributionPrTitle(rawTitle: string, buildId: string): string {
+  const PR_TITLE_BODY_LIMIT = 220;
+  const body = rawTitle.length > PR_TITLE_BODY_LIMIT
+    ? rawTitle.slice(0, PR_TITLE_BODY_LIMIT - 1).trimEnd() + "…"
+    : rawTitle;
+  return `feat: ${body} (Build ${buildId})`;
+}
+
 // ─── PR Body Generation ────────────────────────────────────────────────────
 
 function generatePRBody(input: {
@@ -240,7 +255,7 @@ export async function submitBuildAsPR(
   } catch { /* non-fatal */ }
 
   const branchName = generateBranchName(input.buildId, input.title);
-  const prTitle = `feat: ${input.title} (Build ${input.buildId})`;
+  const prTitle = formatContributionPrTitle(input.title, input.buildId);
 
   const prBody = generatePRBody({
     buildId: input.buildId,


### PR DESCRIPTION
## Summary

- `submitBuildAsPR` was building `prTitle` as ``feat: ${input.title} (Build ${input.buildId})`` without any length cap
- For builds with long backlog-item titles (FB-AD454C98 Edge Node — 700+ chars), GitHub's createPullRequest returned HTTP 422 "title is too long (maximum is 256 characters)"
- In the UI this surfaced only as a generic "AI coworker hit a background error" — the operator had no idea the upstream submission had attempted and bounced

## Fix

Extract `formatContributionPrTitle(rawTitle, buildId)` that:
- Caps the title body at 220 chars (leaves ~36 chars of headroom for `feat: ` prefix + ` (Build FB-XXXXXXXX)` suffix)
- Appends a single ellipsis character when truncation actually fires
- Trims trailing whitespace before the ellipsis

## Test plan

- [x] 4 new vitest cases: unchanged-short, truncated-long, trailing-whitespace-trimmed, exact-220-boundary
- [x] All pass locally (4/4)
- [x] Pre-commit typecheck green

## Discovery

Surfaced while driving FB-AD454C98 (Edge Node) through the Submit Upstream PR action — Mark's "exercise the PR for hive mind / self-promotion" request. The flow itself works; this length-limit bug was the only thing blocking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)