### PR TITLE
fix(portal-context): null-safe candidate.requiredGrantKeys in HiveMindCandidateList

### DIFF
--- a/apps/web/components/portal-context/HiveMindCandidateList.tsx
+++ b/apps/web/components/portal-context/HiveMindCandidateList.tsx
@@ -125,7 +125,11 @@ function CandidateAction({
 
 function disabledReason(candidate: HiveMindCandidate, granted: Set<string>, parentTaskRunId: string | null): string | null {
   if (!parentTaskRunId) return "Needs task";
-  const missing = candidate.requiredGrantKeys.filter((grant) => !granted.has(grant));
+  // Defensive: requiredGrantKeys is typed string[] but stale serialized
+  // portal-context payloads have been observed with missing/undefined arrays,
+  // which crashes the entire /build page render with a minified React error.
+  const requiredKeys = Array.isArray(candidate.requiredGrantKeys) ? candidate.requiredGrantKeys : [];
+  const missing = requiredKeys.filter((grant) => !granted.has(grant));
   if (missing.length > 0) return "Missing grant";
   return null;
 }


### PR DESCRIPTION
## Summary

- `candidate.requiredGrantKeys` is typed `string[]` but stale serialized portal-context envelopes have been observed with the field missing/undefined
- Calling `.filter()` on undefined crashes the entire `/build` page with a minified React error #418
- Operator gets stuck on "Something went wrong" with no recovery path

## Why this matters

Observed 2026-05-20 on FB-F0476EF3 (BI-COST-P1-01). Browser console:
```
TypeError: Cannot read properties of undefined (reading 'filter')
  at Array.map → ev → useMemo
```

The build page error boundary fired, blocking any work on that FB.

## Fix

Wrap the access in `Array.isArray()` so a missing/null value falls through as an empty list. No behavior change for well-formed payloads.

## Test plan
- [x] `components/portal-context` tests pass (2 files / 3 tests)
- [x] Pre-commit typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)