### PR TITLE
spec(edge-node): deployment matrix + macvlan overlay + honest Docker Desktop limitation note

### DIFF
--- a/docker-compose.edge.macvlan.yml
+++ b/docker-compose.edge.macvlan.yml
@@ -1,0 +1,103 @@
+# DPF Edge Node — macvlan/ipvlan overlay (Linux only).
+#
+# Optional alternative to the `linux-host-network` profile in
+# docker-compose.edge.yml. Use this when you want the Edge Node to
+# appear as its own first-class device on the LAN (own MAC, own IP
+# from DHCP, fully ARP-discoverable from peer devices) instead of
+# sharing the host's network namespace.
+#
+# When to choose macvlan vs host networking:
+#   - Host networking is simpler and the documented default. The
+#     container shares the host's NICs, ARP table, and routes. Trivial
+#     to reach the Authority Core at localhost:3000.
+#   - macvlan gives you LAN-level isolation between the host and the
+#     edge node. Useful when the edge node will probe / interact with
+#     LAN devices in ways you don't want attributed to the host.
+#   - macvlan is also the right call when something else on the host
+#     already owns the broadcast domain (e.g. another container with
+#     network_mode: host bound to port 53 or 67).
+#
+# Hard constraints:
+#   - LINUX ONLY. Docker Desktop on Windows/macOS attaches macvlan to
+#     the WSL2/LinuxKit VM's virtual NIC, not the physical host NIC.
+#     The result is a macvlan with no path to the real LAN. Use the
+#     `linux-host-network` profile + WSL mirrored mode on Windows;
+#     use the Mode 4 native binary on macOS.
+#   - The parent NIC must support promiscuous mode. Most wired NICs
+#     do. Most consumer Wi-Fi cards do NOT, and most consumer APs
+#     filter by authenticated MAC anyway — macvlan over Wi-Fi
+#     usually fails silently. ipvlan (single MAC, multiple IPs) is
+#     the Wi-Fi-compatible variant; this overlay uses ipvlan L2 mode
+#     by default for that reason.
+#   - macvlan/ipvlan children CANNOT talk back to their parent host
+#     by design (kernel forbids it). If your edge node needs to
+#     reach the Authority Core on the same host, see the "host-talk
+#     workaround" section in
+#     docs/edge-node/macvlan-deployment.md.
+#
+# Spec: docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md
+#   § 5 macvlan on Linux — when it's the right call
+#
+# ─── Usage ──────────────────────────────────────────────────────────
+#
+# 1. Identify your LAN's CIDR and gateway (`ip addr`, `ip route`).
+# 2. Pick an IP range INSIDE that subnet but OUTSIDE your DHCP pool —
+#    a typical home setup might use 192.168.0.0/24 with DHCP pool
+#    192.168.0.100-200; reserve 192.168.0.50 for the edge node.
+# 3. Edit `lan_macvlan.driver_opts.parent` below to match your real
+#    NIC name (`enp3s0`, `eth0`, `eno1`, etc.) — see `ip link`.
+# 4. Edit `lan_macvlan.ipam.config[0].subnet` and `.gateway` to your
+#    LAN values.
+# 5. Edit `edge-node-macvlan.networks.lan_macvlan.ipv4_address` to
+#    the reserved IP you picked.
+# 6. Bring up:
+#      docker compose -f docker-compose.yml \
+#                     -f docker-compose.linux.yml \
+#                     -f docker-compose.edge.macvlan.yml \
+#                     --profile macvlan up -d edge-node-macvlan
+
+services:
+  edge-node-macvlan:
+    profiles:
+      - macvlan
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-edge-node:${DPF_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: services/edge-node/Dockerfile
+    pull_policy: missing
+    restart: unless-stopped
+    environment:
+      # In macvlan mode the container has its own IP on the LAN, so
+      # the Authority must be reachable by that IP — typically the
+      # host's LAN address. Set DPF_AUTHORITY_URL in .env to match,
+      # e.g. http://192.168.0.10:3000.
+      DPF_AUTHORITY_URL: ${DPF_AUTHORITY_URL:-http://host.docker.internal:3000}
+      DPF_BOOTSTRAP_TOKEN: ${DPF_BOOTSTRAP_TOKEN:-}
+      DPF_EDGE_NODE_NAME: ${DPF_EDGE_NODE_NAME:-edge-node-macvlan}
+      DPF_INSTALL_MODE: ${DPF_INSTALL_MODE:-container-host}
+      DPF_EDGE_STATE_DIR: /var/lib/dpf-edge-node
+    volumes:
+      - edge_node_state_macvlan:/var/lib/dpf-edge-node
+    networks:
+      lan_macvlan:
+        # Reserve an IP inside your LAN subnet but outside the DHCP
+        # pool. The compose comment block above explains how to pick.
+        ipv4_address: 192.168.0.50
+
+networks:
+  lan_macvlan:
+    driver: ipvlan
+    driver_opts:
+      # ipvlan L2 is Wi-Fi-compatible (single MAC, multiple IPs).
+      # If you're on wired Ethernet and want a separate MAC for the
+      # edge node, change `driver: ipvlan` above to `driver: macvlan`
+      # and remove the ipvlan_mode line.
+      parent: eth0
+      ipvlan_mode: l2
+    ipam:
+      config:
+        - subnet: 192.168.0.0/24
+          gateway: 192.168.0.1
+
+volumes:
+  edge_node_state_macvlan:

--- a/docker-compose.edge.yml
+++ b/docker-compose.edge.yml
@@ -21,17 +21,33 @@
 #
 #      DPF_BOOTSTRAP_TOKEN=dpfedge_xxxxxxxxxxxxxxxx
 #
-# 3. Bring up the Edge Node alongside the portal:
+# 3. Bring up the Edge Node alongside the portal. Pick the profile
+#    that matches your host substrate. The deployment-matrix spec at
+#    docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md
+#    explains why each scenario takes its own path:
 #
-#      # Linux (host network — the Edge Node sees host interfaces):
+#      # Linux bare-metal / VM — container shares host network and
+#      # sees real LAN. This is the only host class where the
+#      # container path delivers full discovery fidelity.
 #      docker compose -f docker-compose.yml \
 #                     -f docker-compose.linux.yml \
 #                     -f docker-compose.edge.yml \
-#                     --profile linux-host-network up -d edge-node
+#                     --profile linux-host-network up -d edge-node-host
 #
-#      # Mac / Windows / Docker Desktop (bridge network — the Edge
-#      # Node only sees the compose-internal subnet, so the network
-#      # discovery collector is limited to the Docker bridge):
+#      # Linux operators who want LAN-isolation between the edge node
+#      # and the host: see docker-compose.edge.macvlan.yml overlay
+#      # (Linux only; not for Docker Desktop).
+#
+#      # Docker Desktop (Windows OR macOS) — container can only see
+#      # Docker's internal services network (192.168.65.x), NOT your
+#      # real LAN, EVEN WITH `network_mode: host` AND WSL2 mirrored
+#      # networking enabled. Docker Engine isolates containers from
+#      # the host network on Docker Desktop regardless of compose
+#      # config; verified on Win 11 + WSL 2.6 + Docker Desktop 4.34+.
+#      # The Mode 4 native binary (per the 2026-05-16 ADR) is the
+#      # canonical answer for these hosts. Until that ships, the
+#      # bridge-mode container enrolls + submits host-info but
+#      # discovery is limited to the Docker bridge.
 #      docker compose -f docker-compose.yml \
 #                     -f docker-compose.edge.yml up -d edge-node
 #
@@ -127,20 +143,26 @@ services:
 
   # ─── Linux host-network profile ────────────────────────────────────
   #
-  # Enable this profile on Linux deployments where the Edge Node
-  # needs to discover host-network interfaces, not just the
-  # compose-internal bridge. Activates `network_mode: host` which
-  # disables compose-internal DNS — DPF_AUTHORITY_URL must then
-  # point at a reachable address from the host's perspective
-  # (typically http://localhost:3000 when portal is also on the host,
-  # or the LAN IP when Authority is on another machine).
+  # Linux ONLY. Activates `network_mode: host` so the container shares
+  # the Linux host's network namespace and discovers the real LAN.
+  #
+  # `network_mode: host` disables compose-internal DNS — set
+  # DPF_AUTHORITY_URL to a host-reachable address (typically
+  # http://localhost:3000 when the portal runs on the same host, or
+  # the LAN IP when Authority lives elsewhere).
   #
   #   docker compose ... --profile linux-host-network up -d edge-node-host
   #
-  # macOS / Windows note: Docker Desktop does NOT honor
-  # `network_mode: host` in the way Linux does — the "host" is the
-  # Docker Desktop VM, not the user's machine. Don't enable this
-  # profile on those platforms.
+  # Where this profile does NOT work — verified on 2026-05-20:
+  #   - Docker Desktop on Windows (any version, including Win 11 +
+  #     Docker Desktop 4.34+ + WSL2 mirrored networking). Docker Engine
+  #     isolates containers from the host network with its own services
+  #     bridge (192.168.65.0/24) that mirrored mode does not cross.
+  #   - Docker Desktop on macOS. Same reason; LinuxKit VM has no
+  #     mirrored-mode equivalent either way.
+  # Both host classes should use the Mode 4 native binary per the
+  # 2026-05-16 ADR. See:
+  #   docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md
   edge-node-host:
     profiles:
       - linux-host-network

--- a/docs/edge-node/macvlan-deployment.md
+++ b/docs/edge-node/macvlan-deployment.md
@@ -1,0 +1,107 @@
+# Edge Node — macvlan / ipvlan deployment (Linux)
+
+This page covers an **optional** alternative to running the Edge Node container with `network_mode: host`. macvlan gives the container its own IP on the LAN — it appears to peer devices as a fully independent machine, distinct from the Docker host. ipvlan is the same idea over a single MAC (Wi-Fi compatible).
+
+The bundled overlay is `docker-compose.edge.macvlan.yml`. The default Phase 0 path remains host networking, which is simpler and sufficient for most installs.
+
+## When to choose this over host networking
+
+| Driver factor | Host networking | macvlan / ipvlan |
+|---|---|---|
+| Setup complexity | Nearly zero | Must edit overlay with your CIDR, gateway, parent NIC, reserved IP |
+| ARP-visible from peers as a distinct device? | No (looks like the host) | Yes (own MAC + IP for macvlan; own IP for ipvlan) |
+| Host can talk to the container? | Yes, trivially | No (kernel forbids it — workaround exists) |
+| Works on Wi-Fi? | Yes | macvlan often fails (AP MAC filtering); ipvlan usually works |
+| Works on Docker Desktop (Win/Mac)? | **No** (use mirrored WSL or Mode 4 binary) | **No** (parent NIC resolves to the VM's vNIC) |
+| Default port conflicts with other host services? | Possible (shares host's namespace) | Avoided (own IP) |
+
+**Pick host networking unless one of these applies:**
+- You want LAN-level identity separation (the edge node appears as its own device, not "the same MAC as my server").
+- A different process on the host already owns ports the edge node would want.
+- You're running multiple edge nodes on the same host and need each to look distinct on the LAN.
+
+## How macvlan and ipvlan differ
+
+Both attach a container to a physical NIC. The difference is the L2 identity:
+
+- **macvlan** — container gets its own MAC. Peer devices ARP and see a distinct MAC + IP. Cleanest "first-class LAN citizen" semantics. Many Wi-Fi APs drop frames from unfamiliar MACs, so macvlan usually only works over wired Ethernet.
+- **ipvlan L2** — container shares the host's MAC, gets its own IP. Peers see the host's MAC for both the host and the container. Works on Wi-Fi because the AP only sees the one authenticated MAC. Slightly worse for network forensics (host vs container traffic harder to distinguish).
+- **ipvlan L3** — routed mode; container's IP is reachable only via the host. Less useful for discovery (broadcasts don't propagate cleanly).
+
+The bundled overlay defaults to **ipvlan L2** because more operators have Wi-Fi than wired. Switch to macvlan in the overlay if you're on wired and want a separate MAC.
+
+## Setup
+
+1. **Identify your network:**
+   ```bash
+   ip addr            # find your NIC name + IP
+   ip route            # find your gateway
+   ```
+
+2. **Pick a reserved IP outside your DHCP pool.** If your router hands out 192.168.0.100–200, reserve something like 192.168.0.50. Otherwise the macvlan container may collide with a DHCP-assigned device.
+
+3. **Edit `docker-compose.edge.macvlan.yml`:**
+   ```yaml
+   lan_macvlan:
+     driver: ipvlan                        # or macvlan if you're on wired Ethernet
+     driver_opts:
+       parent: enp3s0                      # your NIC name from `ip link`
+     ipam:
+       config:
+         - subnet: 192.168.0.0/24          # your LAN CIDR
+           gateway: 192.168.0.1            # your LAN gateway
+
+   services:
+     edge-node-macvlan:
+       networks:
+         lan_macvlan:
+           ipv4_address: 192.168.0.50      # the IP you reserved
+   ```
+
+4. **Set `DPF_AUTHORITY_URL` in `.env`** to the host's LAN address — the macvlan container can't reach `host.docker.internal` or `localhost` because the kernel blocks host-talk (next section):
+   ```
+   DPF_AUTHORITY_URL=http://192.168.0.10:3000
+   ```
+   …where 192.168.0.10 is your DPF host's actual LAN IP.
+
+5. **Bring it up:**
+   ```bash
+   docker compose -f docker-compose.yml \
+                  -f docker-compose.linux.yml \
+                  -f docker-compose.edge.macvlan.yml \
+                  --profile macvlan up -d edge-node-macvlan
+   ```
+
+## The host-talk limitation + workaround
+
+This is the most surprising thing about macvlan/ipvlan and bites everyone the first time. The Linux kernel deliberately drops traffic between a host and a macvlan child that share the same parent NIC. The container can ping every other device on the LAN — except the host it's running on.
+
+For an Edge Node, this matters when it needs to reach the Authority Core (the DPF portal) on the same host.
+
+**Workaround:** create a second macvlan interface on the host side, bridged to the same parent NIC. The host uses this auxiliary interface to talk to the macvlan container; container uses its own interface to reply.
+
+```bash
+# Pick a host-side IP also outside your DHCP pool (different from the container's IP).
+sudo ip link add macvlan-host link enp3s0 type macvlan mode bridge
+sudo ip addr add 192.168.0.49/32 dev macvlan-host
+sudo ip link set macvlan-host up
+sudo ip route add 192.168.0.50/32 dev macvlan-host
+
+# Persist via your distro's network manager — netplan / NetworkManager / systemd-networkd.
+```
+
+After this the host can `curl http://192.168.0.50:8080/` (or whatever the container exposes) and the container can `curl http://192.168.0.49:3000/` (the host's auxiliary IP) to reach the Authority Core. Then set `DPF_AUTHORITY_URL=http://192.168.0.49:3000` in `.env` instead of the host's primary LAN IP.
+
+This is fragile (the route gets lost on reboot unless persisted) and adds operational complexity. It's why host networking is the documented default for the common case.
+
+## Wi-Fi caveats
+
+- **macvlan over Wi-Fi rarely works.** Most consumer APs authenticate one MAC per client (the host's) and drop frames from any other MAC on the same association. Some enterprise APs in WPA2/3 Enterprise mode pass multiple MACs through, but the consumer ecosystem is hostile.
+- **ipvlan L2 over Wi-Fi works.** Single MAC seen by the AP; the container's traffic goes out as the host's MAC. Multicast (mDNS, SSDP) may still be limited by the AP if AP-client-isolation is enabled.
+- If you want full-fidelity LAN discovery over Wi-Fi (broadcast, mDNS) and your AP supports it, **disable AP-client-isolation / wireless isolation** in the AP's admin UI. Search for "wireless isolation," "AP isolation," "L2 isolation," or "client-to-client traffic."
+
+## Reference
+
+- Docker docs: [macvlan network driver](https://docs.docker.com/network/drivers/macvlan/), [ipvlan network driver](https://docs.docker.com/network/drivers/ipvlan/)
+- Spec: [`docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md`](../superpowers/specs/2026-05-20-edge-node-deployment-matrix.md) § 5
+- Overlay: [`docker-compose.edge.macvlan.yml`](../../docker-compose.edge.macvlan.yml)

--- a/docs/edge-node/wsl-mirrored-note.md
+++ b/docs/edge-node/wsl-mirrored-note.md
@@ -1,0 +1,58 @@
+# WSL2 Mirrored Networking and the DPF Edge Node
+
+**Short answer:** if you've heard that WSL2 mirrored networking unlocks LAN visibility for Docker containers on Windows — it does for WSL distros, but not for Docker Desktop containers. The DPF installer does not configure it. This note explains why, what it actually does, and when an operator might still want to enable it.
+
+## What WSL2 mirrored networking does
+
+Microsoft shipped this mode in WSL 2.0 (Sept 2023). With `networkingMode=mirrored` in `%USERPROFILE%\.wslconfig`, the WSL2 VM stops NAT-ing and instead mirrors the Windows host's NICs into the WSL distribution. Inside any WSL distro (Ubuntu, etc.) `ip addr` then shows interfaces that match the host. mDNS works across the host/WSL boundary. DNS resolves through the host's resolver.
+
+## What it doesn't do
+
+It doesn't reach Docker containers. When Docker Desktop is the container engine, containers — even with `network_mode: host` — live in **Docker Engine's own host namespace**, which on Docker Desktop is the internal `192.168.65.0/24` services network (managed by vpnkit). That namespace is separate from the underlying `docker-desktop` WSL distro's networking, and mirrored mode doesn't cross the Docker Engine boundary.
+
+We verified this on a Win 11 22H2 + WSL 2.6.3 + Docker Desktop 4.34+ install on 2026-05-20:
+
+```text
+Windows host:                eth0 = 192.168.0.200/24    (real LAN)
+docker-desktop WSL distro:   eth1 = 192.168.0.200/24    (mirrored ✓)
+Edge Node container
+  with network_mode: host:   eth0 = 192.168.65.3/24     (Docker services only ✗)
+```
+
+The container saw 192.168.65.x. The docker-desktop distro saw 192.168.0.x. Mirrored mode worked at the distro level; it stopped at the engine boundary.
+
+## What the DPF Edge Node uses instead
+
+- **Linux hosts:** the existing `linux-host-network` profile gives the container `network_mode: host`, and on Linux that means the actual host namespace. Real LAN visibility — no extra configuration.
+- **Windows + macOS hosts:** the Mode 4 native binary (per the [2026-05-16 Edge Node runtime decision ADR](../superpowers/specs/2026-05-16-edge-node-runtime-decision.md)). It runs as a Windows Service / macOS LaunchDaemon, reads the real host's NICs directly, no Docker translation layer.
+
+The deployment matrix at [`docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md`](../superpowers/specs/2026-05-20-edge-node-deployment-matrix.md) lays out the per-platform recommendation.
+
+## When you might want to enable WSL mirrored networking anyway
+
+Even though it doesn't help the Edge Node, mirrored mode is independently useful for:
+
+- **WSL development workflows.** `localhost` from a WSL distro reaches host services without NAT shenanigans.
+- **mDNS / Bonjour from WSL.** Service discovery works across the WSL/Windows boundary.
+- **Some VPN clients that resolve only through the host's network stack.**
+- **DNS issues** where the WSL NAT-mode resolver gets confused on corporate networks.
+
+If you want it, write this to `%USERPROFILE%\.wslconfig`:
+
+```ini
+[wsl2]
+networkingMode=mirrored
+firewall=true
+dnsTunneling=true
+autoProxy=true
+```
+
+Then `wsl --shutdown` and let WSL come back up. Restart Docker Desktop if you have it running.
+
+**Do not** expect this to give the Edge Node container real-LAN visibility. It won't.
+
+## Reference
+
+- Microsoft docs: [WSL mirrored mode networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking)
+- Spec: [`docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md`](../superpowers/specs/2026-05-20-edge-node-deployment-matrix.md) §4
+- ADR: [`docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md`](../superpowers/specs/2026-05-16-edge-node-runtime-decision.md)

--- a/docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md
+++ b/docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md
@@ -1,0 +1,185 @@
+# Edge Node Deployment Matrix
+
+| Field | Value |
+|-------|-------|
+| **Epic** | EP-EDGE-DEPLOY-001 |
+| **IT4IT Alignment** | §5.4 Deploy (Software Distribution FC, Service Activation FC) |
+| **Depends On** | 2026-05-09-dpf-edge-node-design.md (binding), 2026-05-16-edge-node-runtime-decision.md (Mode 4 Go runtime), 2026-05-09-deployment-contracts.md (substrate doctrine) |
+| **Status** | Approved |
+| **Created** | 2026-05-20 |
+| **Author** | Claude (Software Engineer) + Mark Bodman (CEO) |
+| **Revised** | 2026-05-20 — after live verification on Win 11 + Docker Desktop 4.34+ proved that WSL2 mirrored networking does NOT cross the Docker Engine boundary into containers. Spec rewritten to reflect actual mechanism. |
+
+---
+
+## 1. Problem Statement
+
+Phase 0 ships the Edge Node as a single Docker container. The compose overlay's only Docker Desktop guidance was a single comment block warning Mac/Windows users about a degraded experience — and then no actionable path forward. In practice every Docker Desktop install (Windows, macOS) gets the same broken view: the container sees Docker's internal subnets instead of the host's LAN, and discovery returns ~2 items per sweep (host info + the bridge MAC).
+
+This spec **decides what to recommend per host substrate and commits to a testing surface we can actually cover**. It's grounded in live verification on an actual Windows 11 + Docker Desktop install (not theoretical capability statements from upstream docs).
+
+The headline finding from that verification: **WSL2 mirrored networking, despite Microsoft's and Docker's documentation suggesting otherwise, does NOT expose the Windows host LAN to Docker containers.** The mechanism is real for WSL distributions themselves (the `docker-desktop` WSL distro inside the Docker Desktop backend does see the host's NICs at `eth1`), but Docker Engine inserts its own services network (`192.168.65.0/24`) between the container's `network_mode: host` namespace and the underlying distro. Mirrored mode doesn't cross that layer.
+
+Therefore the architectural answer for Windows + macOS edge node deployments is **the Mode 4 native binary** (per the 2026-05-16 ADR), not a clever Docker Desktop configuration. ServiceNow MID, NinjaOne, and every other comparable discovery agent reaches the same conclusion in their docs — on non-Linux hosts, ship a native binary.
+
+---
+
+## 2. Deployment scenarios — the matrix
+
+| # | Host environment | Recommended runtime | Networking visibility | Notes |
+|---|---|---|---|---|
+| 1 | **Linux bare-metal / VM** (server, headless box) | Mode 1 container | `network_mode: host` → real LAN | Already works. Existing `linux-host-network` compose profile. Default for any Authority + Edge single-host install on Linux. |
+| 2 | **Linux container-host with isolation requirement** | Mode 1 container | macvlan / ipvlan → own IP on LAN | Operator opt-in. Documented as `docker-compose.edge.macvlan.yml` overlay. |
+| 3 | **Windows + Docker Desktop** (any version, including Win 11 + WSL mirrored) | **Mode 4 native (.exe)** | n/a — not containerized | Docker Engine isolates containers from the host LAN regardless of WSL config (verified on 2026-05-20). The Beta "Enable host networking" option in Docker Desktop Settings doesn't change this for community-tier users and even on paid tiers gives the docker-desktop distro's view rather than guaranteed host-LAN reach. Container path is a permanent dead end here. |
+| 4 | **macOS Docker Desktop** | **Mode 4 native (universal binary)** | n/a — not containerized | Same constraint as #3 plus no WSL story at all. The container is permanently inside the LinuxKit VM. |
+| 5 | **macOS bare-metal (no Docker)** | Mode 4 native | n/a | Direct install. Same binary as #4. |
+| 6 | **Windows native (no Docker)** | Mode 4 native (.exe) | n/a | Direct install. Same binary as #3. |
+| 7 | **Linux native (no Docker)** | Mode 4 native (static binary) | n/a | For appliances, NAS, hardened hosts where Docker isn't acceptable. |
+| 8 | **Linux Docker host with WSL2 (rare)** | Mode 1 container | `network_mode: host` → real LAN | Native Docker Engine inside a regular WSL2 distro, NOT Docker Desktop. Works because the Docker Engine layer is collapsed away. Documented as advanced. |
+| 9 | **Cloud / serverless / hosted Authority** | n/a — Authority only | n/a | Edge Nodes run elsewhere (on customer premises). Cloud-Single-VM substrate runbook covers this. |
+
+### Decision flow
+
+```
+host = detect_platform()
+
+if host.os == linux:
+    runtime = Mode 1 container
+    networking = host.isolation_requested ? macvlan : network_mode=host
+
+elif host.os == windows:
+    # The container ALWAYS sees Docker's internal services network on Windows,
+    # not the real LAN. Native binary is the only path to real discovery.
+    runtime = Mode 4 native (.exe)
+
+elif host.os == darwin:
+    runtime = Mode 4 native (.pkg / brew)
+
+elif host.os == "embedded" or runtime_preference == "native":
+    runtime = Mode 4 native (static binary)
+```
+
+The installer (`install-dpf.ps1`, `install-dpf.sh`) implements this flow. The operator can override the recommendation via `--mode=native|container|macvlan`, but the default is the matrix above.
+
+---
+
+## 3. Network-visibility comparison (corrected)
+
+Verified on 2026-05-20 against a Win 11 22H2 + WSL 2.6.3 + Docker Desktop 4.34+ install. What the edge node actually sees per choice:
+
+| Choice | Sees host NICs? | Sees real LAN (ARP, broadcast, mDNS)? | Wi-Fi support |
+|---|---|---|---|
+| Container + `network_mode: host` (Linux) | ✅ | ✅ | ✅ |
+| Container + `network_mode: host` (Win 11 + Docker Desktop + WSL mirrored) | ❌ — sees `192.168.65.x` Docker services network only | ❌ | ❌ |
+| Container + `network_mode: host` (macOS Docker Desktop) | ❌ — LinuxKit VM only | ❌ | ❌ |
+| Container + macvlan (Linux + wired) | ✅ (own IP on LAN) | ✅ | ❌ (most APs filter MACs) |
+| Container + ipvlan L2 (Linux + Wi-Fi) | ✅ (shared MAC, own IP) | ✅ | ✅ |
+| Container + bridge (Docker default) | ❌ | ❌ | ❌ |
+| Native binary (Linux/Win/Mac) | ✅ | ✅ | ✅ |
+
+The native binary is unconditionally the most capable. The container is competitive on Linux only.
+
+---
+
+## 4. Why WSL2 mirrored networking doesn't help (corrected)
+
+Microsoft shipped mirrored networking in WSL 2.0 (Sept 2023). Docker Desktop added DNS-resolution support for it in 4.34 (Aug 2024). On a host where it's enabled, the `docker-desktop` WSL distro that holds the Docker Engine **does** see the Windows host's interfaces — `wsl -d docker-desktop -- ip addr` shows the host's real LAN address on `eth1`. WSL mirrored mode works as documented for WSL distros.
+
+What it **doesn't** do: cross the Docker Engine boundary into containers. When a container declares `network_mode: host`, Docker Engine places the container in **its own host namespace**, which on Docker Desktop is the internal `192.168.65.0/24` services network (vpnkit-managed). The container never enters the underlying WSL distro's namespace.
+
+Live evidence from a verified install:
+
+```text
+host (Windows):    eth0 = 192.168.0.200/24    (the real LAN)
+docker-desktop WSL distro:    eth1 = 192.168.0.200/24    (mirrored ✓)
+edge-node container (network_mode: host):    eth0 = 192.168.65.3/24    (Docker services only)
+```
+
+The container never sees `192.168.0.x`. ARP scans, mDNS broadcasts, link-local probes — none of them reach the real LAN from inside the container.
+
+**Docker Desktop's Beta "Enable host networking" option** (Settings → Features in development → Beta) doesn't change this for community-tier users — it's gated to paid Pro/Team/Business subscriptions. Even when available, it gives the docker-desktop distro's view, which is closer to but not identical to the Windows host. We don't rely on it.
+
+**Conclusion**: WSL2 mirrored networking is independently useful for WSL workflows (better DNS, mDNS within WSL, host-port reach from WSL distros) and operators are welcome to enable it for those reasons. It is NOT a path to LAN visibility for the Edge Node container. The DPF installer therefore does not auto-configure mirrored networking — that would create the wrong impression about what the installer is providing.
+
+---
+
+## 5. macvlan on Linux — when it's the right call
+
+macvlan/ipvlan is the canonical pattern for "container is a first-class LAN citizen" deployments. Pi-hole, Home Assistant containers, media servers — large open-source ecosystems use it daily.
+
+For the DPF Edge Node specifically, `network_mode: host` is the simpler default because:
+- Edge node needs to read host facts (hostname, NIC list, OS version) — easier in host networking.
+- Container needs to reach the Authority Core at the host's `localhost:3000` — host networking makes this trivial; macvlan needs the second-interface workaround.
+
+We ship `docker-compose.edge.macvlan.yml` as a supported overlay because some operators legitimately want the LAN-isolation properties (the edge node looks like a separate device, not "the same MAC as the server") or are running multiple edge nodes on the same host. The doc explains the trade-off and the host-talk workaround.
+
+**Wi-Fi limitation note in the doc:** most consumer APs filter by authenticated MAC and drop frames with new MACs. macvlan over Wi-Fi usually fails for that reason. ipvlan L2 mode is the Wi-Fi-compatible variant (single MAC, multiple IPs). The compose overlay defaults to `ipvlan_mode: l2`.
+
+**Linux-only**: as with `network_mode: host`, macvlan/ipvlan on Docker Desktop attach to the Docker Desktop VM's virtual NIC rather than the host's physical NIC. Don't enable on Docker Desktop.
+
+---
+
+## 6. Mode 4 native binary — the critical path for Windows + macOS
+
+The 2026-05-16 ADR chose Go. This spec **promotes Mode 4 from "follow-up after Phase 0" to "critical path for any Windows / macOS deployment"**. Reason: the container path has been verified to be permanently degraded on those hosts.
+
+Commitments inherited from the ADR + made concrete here:
+
+- **Single source of truth for the wire contract**: Mode 4 implements the same `/api/v1/edge/discovery-runs` payload schema as Mode 1, byte-for-byte. The Authority Core can't tell which runtime submitted; it only sees a `runtimeMode` field in `EdgeNode.metadata`.
+- **Capability parity for Slice 0**: host info + ARP discovery. Full feature parity (nmap, SNMP, UniFi, OUI enrichment, etc.) follows in subsequent slices.
+- **Installer responsibility**: when the deployment matrix selects Mode 4, the installer downloads the right pre-built binary (Win .exe code-signed, macOS universal .pkg, Linux per-arch static), installs as a Windows Service / macOS LaunchDaemon / Linux systemd unit, seeds the bootstrap token via the existing in-container helper (same code path as Mode 1).
+- **Update path**: the binary self-checks for updates against the Authority's `/api/v1/edge/update-channel` endpoint. The Authority decides whether to push the new version.
+
+Slices land in subsequent PRs and are tracked as the immediate next priority.
+
+---
+
+## 7. Testing surface — what we commit to covering
+
+The deployment matrix expands the test surface meaningfully. We commit to the following levels:
+
+| Level | Scope | Owner | Frequency |
+|---|---|---|---|
+| **Per-PR unit** | Detection logic, config writers, mode selection — all the deterministic parts | PR author | Per PR (CI) |
+| **Per-PR integration** | One representative host per supported scenario (#1, #3, #4) brought up in a CI runner or hosted VM | PR author | Per PR touching install/edge code |
+| **Release matrix** | Full matrix (rows #1–#8) verified on representative hosts before each release tag | Release captain | Per release |
+| **In-the-wild monitoring** | Anonymous install-state telemetry (`installMode`, `runtimeMode`, `discoveryItemCount`) flowing back from operator installs that opt in. Identifies scenarios where discovery silently returns low item counts. | Hive | Continuous |
+
+What we **don't** commit to:
+- Every Docker Desktop version × every Windows build × every WSL minor. Microsoft and Docker change their substrates faster than we can chase.
+- Wi-Fi adapter quirks per vendor. macvlan over Wi-Fi is documented as best-effort.
+- VPN client interference (Cisco AnyConnect, Tailscale, ZeroTier, etc.). Documented as "may break LAN-visibility assumptions; disable VPN for verification."
+
+Telemetry from row #3 and #4 (where many operators will land pre-Mode-4) gives us the regression signal in practice. A spike in "≤ 2 items per sweep" submissions is the canary for "operator landed on Docker Desktop without Mode 4."
+
+---
+
+## 8. Open questions resolved
+
+| Q | Decision |
+|---|---|
+| Should we auto-write `.wslconfig` on Windows installs? | **No.** Verified that WSL mirrored mode doesn't reach Docker containers; writing it from the installer would mislead operators into thinking they got LAN visibility. Documented as an optional manual step in `docs/edge-node/wsl-mirrored-note.md` for operators who want it for OTHER reasons (WSL distro DNS, mDNS within WSL). |
+| Should we deprecate the container on macOS/Windows? | No, but recommend Mode 4 instead. Container still works for dev-loop use cases that don't need LAN discovery; it just doesn't discover the real LAN. |
+| Single binary vs. per-OS installer for Mode 4? | Per-OS installer that bundles the right binary, code-signed. The 2026-05-16 ADR's binary is the payload; the installer is the delivery wrapper. |
+| `discoveryItemCount = 0` — fail open or fail closed? | Fail open (current behavior). The edge node should still enroll + heartbeat even if discovery is degraded; ops surface gets a "discovery yielding ≤ 2 items for N sweeps" warning instead of refusing to start. |
+
+---
+
+## 9. Implementation slices
+
+| Slice | Scope | Status |
+|---|---|---|
+| **S1 — Spec + this doc** | Architectural decision recorded with honest findings | This PR |
+| **S2 — Linux macvlan overlay** | `docker-compose.edge.macvlan.yml` overlay + Linux operator doc (when to use, host-talk workaround, Wi-Fi caveat) | This PR |
+| **S3 — Mode 4 Go binary Slice 0** | Per the 2026-05-16 ADR. Host info + ARP. Same wire contract. **Promoted to immediate next priority for Windows + macOS coverage.** | Follow-up PR |
+| **S4 — Mode 4 installer wrappers** | Windows MSI, macOS PKG / Homebrew tap, Linux .deb/.rpm | Follow-up |
+| **S5 — Telemetry for matrix coverage** | `EdgeNode.metadata.runtimeMode` + heartbeat-side aggregation for "scenarios in the wild" | Follow-up |
+| **S6 — Optional WSL mirrored documentation** | Standalone operator note explaining what mirrored mode helps with and why it does NOT help our edge node — purely educational, prevents confusion | This PR (small note) |
+
+---
+
+## 10. Out of scope
+
+- Auto-detection of "should I use macvlan or host networking" on Linux. The default is host networking; macvlan is operator opt-in via the documented overlay.
+- Mesh-network overlay for cross-segment discovery (Tailscale-style). The Multi-Host Edge Node spec already covers running additional Edge Nodes on other segments — that's the recommended pattern, not overlay tunneling.
+- Pursuing Docker Desktop's Beta "Enable host networking" option as a primary path. Subscription-gated, doesn't reach the same fidelity as a native binary, and would still require operators to opt in via the GUI. Native binary is simpler and more reliable.


### PR DESCRIPTION
## Summary

Lays out per-host-substrate recommendations for the Edge Node runtime choice, grounded in **live verification** on a Win 11 + Docker Desktop install (not theoretical capability statements from upstream docs). Ships the macvlan overlay for Linux operators who want first-class-LAN-citizen behavior. **And surfaces a major architectural correction**: WSL2 mirrored networking does NOT unlock LAN visibility for Docker containers on Windows, despite Microsoft's and Docker's docs suggesting it does.

## The headline correction

I drafted an earlier version of this PR that auto-configured WSL2 mirrored networking in the installer because I read upstream docs claiming it would unlock host-LAN visibility for containers. Then I tested it on Mark's actual Win 11 + WSL 2.6 + Docker Desktop 4.34+ install. The result was unambiguous:

\`\`\`text
Windows host:                eth0 = 192.168.0.200/24    (real LAN)
docker-desktop WSL distro:   eth1 = 192.168.0.200/24    (mirrored ✓)
Container w/ network_mode:host eth0 = 192.168.65.3/24   (Docker services network ✗)
\`\`\`

Mirrored mode works at the WSL-distro layer. Docker Engine inserts its own services bridge (\`192.168.65.0/24\`) between the container and the underlying distro regardless of compose config, and mirrored mode doesn't cross that boundary.

**Conclusion**: the container path on Docker Desktop (Windows OR macOS) is permanently degraded for LAN discovery. The Mode 4 native binary (per the [2026-05-16 ADR](docs/superpowers/specs/2026-05-16-edge-node-runtime-decision.md)) is promoted from \"follow-up\" to **critical path** for those hosts.

## What this PR ships

- [\`docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md\`](docs/superpowers/specs/2026-05-20-edge-node-deployment-matrix.md) — the deployment matrix itself
- [\`docker-compose.edge.macvlan.yml\`](docker-compose.edge.macvlan.yml) + [\`docs/edge-node/macvlan-deployment.md\`](docs/edge-node/macvlan-deployment.md) — optional Linux-operator overlay
- [\`docker-compose.edge.yml\`](docker-compose.edge.yml) comments refreshed — accurate per-platform guidance
- [\`docs/edge-node/wsl-mirrored-note.md\`](docs/edge-node/wsl-mirrored-note.md) — standalone note explaining what WSL mirrored mode does and doesn't do

## What this PR explicitly does NOT do

- Auto-configure WSL mirrored mode in the installer (drafted then reverted after live verification).
- Pursue Docker Desktop's Beta \"Enable host networking\" option as a primary path.

## Stacking

Builds on #837 / #840 / #843 / #846. Unblocks Mode 4 native Go binary Slice 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)