### PR TITLE
fix(build-studio): clear stale failure breadcrumbs on pipeline state transitions (FB-78E967D4)

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.test.ts
+++ b/apps/web/lib/integrate/build-pipeline.test.ts
@@ -61,4 +61,21 @@ describe("buildFailedState", () => {
     expect(result.error).toBe("Connection refused");
     expect(result.containerId).toBe("abc");
   });
+
+  it("strips completedAt so a prior success cannot leave a completed-yet-failed checkpoint", () => {
+    const base: BuildExecutionState = {
+      step: "complete",
+      retryCount: 0,
+      startedAt: "2026-01-01T00:00:00Z",
+      completedAt: "2026-01-01T00:05:00Z",
+      containerId: "sb-1",
+    };
+    const result = buildFailedState(base, "deps_installed", "brief.targetRoles undefined");
+    expect(result.step).toBe("failed");
+    expect(result.failedAt).toBe("deps_installed");
+    expect(result.error).toBe("brief.targetRoles undefined");
+    // completedAt must be gone -- contradictory state was the FB-78E967D4 root
+    expect(result.completedAt).toBeUndefined();
+    expect(result.containerId).toBe("sb-1");
+  });
 });

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -53,7 +53,12 @@ export function buildFailedState(
   failedAt: string,
   error: string,
 ): BuildExecutionState {
-  return { ...current, step: "failed", failedAt, error };
+  // Strip completedAt so a previous success cannot leave the appearance of a
+  // completed-yet-failed checkpoint. The recovery surfaces (retryBuildExecution,
+  // workflow-action selection) rely on step alone to discriminate states.
+  const { completedAt: _omitCompletedAt, ...rest } = current;
+  void _omitCompletedAt;
+  return { ...rest, step: "failed", failedAt, error };
 }
 
 // ─── Pipeline Orchestration ───────────────────────────────────────────────────
@@ -126,8 +131,13 @@ export async function runBuildPipeline(params: {
     }
   }
 
+  // Strip error/failedAt so a successful resume after a prior failure does
+  // not retain stale failure breadcrumbs on the final completed checkpoint.
+  const { error: _omitError, failedAt: _omitFailedAt, ...stateWithoutFailureFields } = state;
+  void _omitError;
+  void _omitFailedAt;
   const complete: BuildExecutionState = {
-    ...state,
+    ...stateWithoutFailureFields,
     step: "complete",
     completedAt: new Date().toISOString(),
   };


### PR DESCRIPTION
## Summary

`buildFailedState()` and the `runBuildPipeline()` completion writer both spread the previous state via `{ ...current, step: <new> }`, which kept the wrong-outcome breadcrumbs around forever:

- A **success that resumed after a prior failure** kept the previous `error` + `failedAt` on the final "complete" checkpoint
- A **failure that overwrote a previous success** kept the previous `completedAt` on the new "failed" checkpoint

## Why this matters

The "complete + failedAt + error" combo is exactly what stuck **FB-F0476EF3 (BI-COST-P1-01)** on 2026-05-20:

```json
{
  "step": "complete",
  "failedAt": "deps_installed",
  "error": "brief.targetRoles undefined",
  "completedAt": "2026-05-20T06:38:23.171Z"
}
```

The build was unrecoverable through the UX:
- Run Verification Review blocks (verificationOut/acceptanceMet empty)
- Retry Build doesn't render (`state.step !== "failed"`)
- Resume Implementation gated on releasable diff that doesn't exist

## Fix

When a state transitions to `complete`, strip `error`/`failedAt`. When it transitions to `failed`, strip `completedAt`. Each step now owns only the breadcrumbs that match its own outcome.

This is the narrow slice of FB-78E967D4. The broader Reset Build UX affordance (so operators can manually clear a stuck build's state without an engineer touching the DB) remains a follow-up under the same BI.

## Test plan

- [x] Existing `buildFailedState` test untouched
- [x] New test covers the negation: `completedAt` from a prior success must not survive a transition to `failed`
- [x] 10/10 `lib/integrate/build-pipeline` tests pass locally
- [x] Pre-commit typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)