### PR TITLE
fix(stall-detection): map 'stalled' to attention severity in projection list (BI-4ab6be39)

### DIFF
--- a/apps/web/lib/ai-operations-map/project-events.ts
+++ b/apps/web/lib/ai-operations-map/project-events.ts
@@ -425,7 +425,14 @@ function resolveTaskRunStationId(row: OperationsMapTaskRun, template: Operations
 
 function severityForTaskRunStatus(status: string): OperationsMapSeverity {
   if (status === "failed" || status === "rejected") return "critical";
-  if (status === "input-required" || status === "auth-required") return "attention";
+  // BI-4ab6be39 — stalled is operator-actionable: surfaces with attention
+  // severity so it filters alongside input-required / auth-required in the
+  // AI Operations Map projection list, and so ProjectionInspector's
+  // StalledTaskRecoveryActions component receives projections with the
+  // right summary suffix. Without this, stalled rows fell through to
+  // "normal" and were invisible to the attention filter (caught in the
+  // F1+F2 UX dogfooding pass, 2026-05-20).
+  if (status === "input-required" || status === "auth-required" || status === "stalled") return "attention";
   return "normal";
 }
 


### PR DESCRIPTION
## What this fixes

Caught by Mark calling out the "Drive the portal UX" principle I'd broken. Driving the actual filter chain in the AI Operations Map surfaced a real bug in <2 min:

- I had 4 stalled \`TaskRun\` rows in the DB (caught by the watchdog).
- Filtered the projection list to **Task run + Attention** → "Showing **0** of 154 activities."

The projection list was using \`severityForTaskRunStatus\` (project-events.ts:422) — a function I hadn't updated in Phase A. I'd updated \`deriveProjectionSeverityFromTaskState\` instead, which feeds a different surface. So stalled rows fell through to \`"normal"\` severity, never appeared in the Attention filter, and the operator could never click into one to see the \`StalledTaskRecoveryActions\` buttons (F1/F2).

F3 (Build Studio phase panel history strip) still worked because it queries \`StallEvent\` directly. F1/F2 was effectively dark — the buttons exist in code but no projection ever rendered them.

## The fix

One line — add \`stalled\` to the attention branch alongside \`input-required\` and \`auth-required\`:

\`\`\`ts
if (status === "input-required" || status === "auth-required" || status === "stalled") return "attention";
\`\`\`

After this lands and the portal is rebuilt, the 4 currently-stalled rows surface in the projection list under the Attention filter. Clicking one opens the inspector with the Retry/Abandon/Escalate buttons that StalledTaskRecoveryActions renders.

## Lesson + apology

This is the SECOND time in this BI's lifecycle I shipped substrate that passed all the tests (typecheck + 6,500 unit tests) but didn't actually work end-to-end. PR #836 had the same shape (active vs working filter). I have a commandment-tier principle in my own memory file:

> "Structural verification ≠ functional verification" (\`structural-verification-is-not-functional\`)

Mark called it out:
> "how can we possibly know if the portal works if you bypass the UX?"

Going to drive the actual UX as the standard verification step from now on, not after the user has to ask.

## Test plan

- [x] \`pnpm --filter web typecheck\` — exit 0
- [ ] **Live UX verification (post-merge):** rebuild portal, navigate to AI Operations Map → Activity projection details → filter to Task run + Attention. Expect ≥4 stalled rows visible. Click one. Expect inspector to show "Stalled — operator recovery" panel with Retry / Abandon / Escalate buttons. Click Retry, confirm a sibling TaskRun is spawned and the StallEvent outcome flips to \`retry\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)