### PR TITLE
fix(build-studio): capture sandbox diff + commits in pipeline stepComplete (FB-F0476EF3)

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -45,9 +45,10 @@ const { mockAuth, mockPrisma } = vi.hoisted(() => ({
   },
 }));
 
-const { mockIsSandboxAvailable, mockStartBuildBranch } = vi.hoisted(() => ({
+const { mockIsSandboxAvailable, mockStartBuildBranch, mockGetClientIdentity } = vi.hoisted(() => ({
   mockIsSandboxAvailable: vi.fn(),
   mockStartBuildBranch: vi.fn(),
+  mockGetClientIdentity: vi.fn(),
 }));
 
 const { mockQueueBuildReviewVerification } = vi.hoisted(() => ({
@@ -77,6 +78,7 @@ vi.mock("@dpf/db", () => ({
 vi.mock("@/lib/integrate/sandbox/build-branch", () => ({
   isSandboxAvailable: mockIsSandboxAvailable,
   startBuildBranch: mockStartBuildBranch,
+  getClientIdentity: mockGetClientIdentity,
 }));
 
 vi.mock("@/lib/build-review-verification-trigger", () => ({
@@ -149,6 +151,13 @@ describe("governed build start approvals", () => {
       errors: [],
     });
     mockListReleasableSandboxFiles.mockResolvedValue(["apps/web/components/build/BuildStudio.tsx"]);
+    mockGetClientIdentity.mockResolvedValue({
+      clientId: "test-client-id",
+      gitAgentEmail: "agent-test@hive.dpf",
+      gitAuthorName: "dpf-agent-test",
+      clientBranch: "client/test-client-id",
+      upstreamRemoteUrl: null,
+    });
   });
 
   it("createFeatureBuild attaches a Work Capsule to direct Build Studio work", async () => {
@@ -521,7 +530,10 @@ describe("governed build start approvals", () => {
 
     await resumeBuildImplementation("FB-789");
 
-    expect(mockListReleasableSandboxFiles).toHaveBeenCalledWith("dpf-sandbox-1");
+    expect(mockListReleasableSandboxFiles).toHaveBeenCalledWith(
+      "dpf-sandbox-1",
+      { baseRef: "client/test-client-id" },
+    );
     expect(mockStartBuildBranch).toHaveBeenCalledWith("FB-789");
     expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -438,7 +438,9 @@ export async function advanceBuildPhase(
     if (!build.sandboxId) {
       throw new Error("Build Studio cannot advance to review because the sandbox is no longer available.");
     }
-    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId);
+    const { getClientIdentity } = await import("@/lib/integrate/sandbox/build-branch");
+    const { clientBranch } = await getClientIdentity();
+    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId, { baseRef: clientBranch });
     if (releasableFiles.length === 0) {
       throw new Error(
         "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
@@ -450,7 +452,9 @@ export async function advanceBuildPhase(
     if (!build.sandboxId) {
       throw new Error("Build Studio cannot continue to release because the sandbox is no longer available.");
     }
-    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId);
+    const { getClientIdentity } = await import("@/lib/integrate/sandbox/build-branch");
+    const { clientBranch } = await getClientIdentity();
+    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId, { baseRef: clientBranch });
     if (releasableFiles.length === 0) {
       throw new Error(
         "No releasable source changes are present in the sandbox. Resume implementation and make a real code change before continuing to release.",
@@ -829,7 +833,9 @@ export async function resumeBuildImplementation(buildId: string): Promise<Resume
     if (!build.sandboxId) {
       throw new Error("This release-phase build has no sandbox attached, so implementation cannot be resumed safely.");
     }
-    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId);
+    const { getClientIdentity } = await import("@/lib/integrate/sandbox/build-branch");
+    const { clientBranch } = await getClientIdentity();
+    const releasableFiles = await listReleasableSandboxFiles(build.sandboxId, { baseRef: clientBranch });
     if (releasableFiles.length > 0) {
       throw new Error("This build already has releasable source changes. Continue from the release decisions instead of reopening implementation.");
     }

--- a/apps/web/lib/integrate/build-exec-types.ts
+++ b/apps/web/lib/integrate/build-exec-types.ts
@@ -60,7 +60,11 @@ export const MAX_RETRIES: Record<BuildExecStep, number> = {
   db_ready: 3,
   deps_installed: 2,
   code_generated: 2,
-  tests_run: 0,
+  // tests_run is the dispatch slot that runs stepComplete (the diff/commit
+  // capture step). Diff extraction can fail transiently when the sandbox is
+  // mid-rebuild or the index lock is briefly held — give it retry budget so
+  // a one-off hiccup doesn't strand an otherwise-complete build.
+  tests_run: 2,
   complete: 0,
   failed: 0,
 };

--- a/apps/web/lib/integrate/build-pipeline.test.ts
+++ b/apps/web/lib/integrate/build-pipeline.test.ts
@@ -31,8 +31,17 @@ describe("shouldRetry", () => {
   it("denies retry when count equals max", () => {
     expect(shouldRetry("sandbox_created", 3)).toBe(false);
   });
-  it("never retries tests_run or complete", () => {
-    expect(shouldRetry("tests_run", 0)).toBe(false);
+  it("retries the stepComplete (diff/commit capture) dispatch up to its budget", () => {
+    // The "tests_run" slot dispatches stepComplete, which now extracts the
+    // sandbox diff and commit hashes back onto the FeatureBuild row. A
+    // transient sandbox hiccup (index lock, mid-rebuild) shouldn't strand
+    // an otherwise-complete build — give it retry budget like the other
+    // sandbox-touching steps.
+    expect(shouldRetry("tests_run", 0)).toBe(true);
+    expect(shouldRetry("tests_run", 1)).toBe(true);
+    expect(shouldRetry("tests_run", 2)).toBe(false);
+  });
+  it("never retries the terminal complete step", () => {
     expect(shouldRetry("complete", 0)).toBe(false);
   });
 });

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -80,13 +80,43 @@ export async function runBuildPipeline(params: {
 }): Promise<BuildExecutionState> {
   const { buildId, taskRunId, existingState, updateState, emit } = params;
 
-  const resumeStep = getResumeStep(existingState);
+  // Self-heal: if a prior run reached "complete" with an empty diff capture
+  // (the pre-fix stepComplete was a no-op and stranded any build whose agent
+  // committed work inside the sandbox), re-arm the pipeline to re-run the
+  // capture step. Without this, builds created before the fix landed would
+  // stay blocked at the PR #850 gate forever because the orchestration loop
+  // immediately breaks when state.step === "complete".
+  let effectiveExistingState = existingState;
+  if (existingState?.step === "complete" && existingState.containerId) {
+    const { prisma } = await import("@dpf/db");
+    const fbRow = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: { diffPatch: true },
+    });
+    const hasNoCapture = !fbRow?.diffPatch || fbRow.diffPatch.length === 0;
+    if (hasNoCapture) {
+      console.log(
+        `[build-pipeline] self-heal: ${buildId} is "complete" but has empty diffPatch — rewinding to re-run stepComplete capture`,
+      );
+      // Rewind to "code_generated". getResumeStep then advances to "tests_run",
+      // and the orchestration loop dispatches stepComplete (which is the
+      // diff/commit capture step) without re-running stepRunTests or any
+      // earlier sandbox setup. The capture is idempotent.
+      effectiveExistingState = {
+        ...existingState,
+        step: "code_generated",
+        retryCount: 0,
+      };
+    }
+  }
+
+  const resumeStep = getResumeStep(effectiveExistingState);
 
   // Build the slice of STEP_ORDER we still need to execute.
   const resumeIdx = STEP_ORDER.indexOf(resumeStep);
   const stepsToRun = resumeIdx === -1 ? STEP_ORDER : STEP_ORDER.slice(resumeIdx);
 
-  let state: BuildExecutionState = existingState ?? {
+  let state: BuildExecutionState = effectiveExistingState ?? {
     step: "pending",
     retryCount: 0,
     startedAt: new Date().toISOString(),
@@ -397,9 +427,42 @@ async function stepRunTests(
 }
 
 async function stepComplete(
-  _buildId: string,
+  buildId: string,
   state: BuildExecutionState,
 ): Promise<BuildExecutionState> {
-  // No-op: the pipeline loop handles the "complete" transition.
+  // Capture the sandbox's releasable diff and commit hashes onto the
+  // FeatureBuild row so downstream gates (build→review, review→ship, the
+  // contribution flow, the release decision panel) see the work the agent
+  // actually did. Before this step ran inside the pipeline, the pipeline
+  // would mark itself "complete" with a 5-commit branch in the sandbox but
+  // diffPatch=NULL and gitCommitHashes=[] in the DB — and PR #850's gate
+  // would then reject the build for "no releasable source changes."
+  if (!state.containerId) return state;
+
+  const { prisma } = await import("@dpf/db");
+  const { extractDiff, listSandboxCommitsAheadOfBase } = await import("./sandbox/sandbox");
+  const { getClientIdentity } = await import("./sandbox/build-branch");
+
+  const identity = await getClientIdentity();
+  const baseRef = identity.clientBranch;
+
+  const [fullDiff, commitHashes] = await Promise.all([
+    extractDiff(state.containerId, { baseRef }),
+    listSandboxCommitsAheadOfBase(state.containerId, baseRef),
+  ]);
+
+  await prisma.featureBuild.update({
+    where: { buildId },
+    data: {
+      diffPatch: fullDiff,
+      diffSummary: fullDiff.slice(0, 500),
+      gitCommitHashes: commitHashes,
+    },
+  });
+
+  console.log(
+    `[build-pipeline] stepComplete: captured ${fullDiff.length} bytes diff + ${commitHashes.length} commits for ${buildId}`,
+  );
+
   return state;
 }

--- a/apps/web/lib/integrate/sandbox/sandbox-promotion.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-promotion.ts
@@ -218,7 +218,9 @@ export async function executePromotion(
   let diffPatch = build?.diffPatch as string | null;
   if (!diffPatch && build?.sandboxId) {
     try {
-      const extracted = await extractAndCategorizeDiff(build.sandboxId);
+      const { getClientIdentity } = await import("./build-branch");
+      const { clientBranch } = await getClientIdentity();
+      const extracted = await extractAndCategorizeDiff(build.sandboxId, { baseRef: clientBranch });
       diffPatch = extracted.fullDiff;
 
       // Persist for future reference
@@ -476,14 +478,17 @@ export function detectSchemaRegressions(fullDiff: string): string[] {
   return regressions;
 }
 
-export async function extractAndCategorizeDiff(containerId: string): Promise<{
+export async function extractAndCategorizeDiff(
+  containerId: string,
+  opts?: { baseRef?: string },
+): Promise<{
   fullDiff: string;
   migrationFiles: string[];
   codeFiles: string[];
   hasMigrations: boolean;
   schemaRegressions: string[];
 }> {
-  const fullDiff = await extractDiff(containerId);
+  const fullDiff = await extractDiff(containerId, opts);
 
   // Parse file paths from diff headers: lines like "diff --git a/path/to/file b/path/to/file"
   const filePaths: string[] = [];

--- a/apps/web/lib/integrate/sandbox/sandbox.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.test.ts
@@ -181,6 +181,19 @@ describe("buildSandboxListReleasableFilesCommand", () => {
     expect(command).toContain(":(exclude)**/node_modules/**");
     expect(command).not.toContain("grep -v");
   });
+
+  it("compares the index against baseRef when provided so committed branch work is visible", () => {
+    // Without baseRef, `git diff --cached` only shows index-vs-HEAD (i.e. staged
+    // but uncommitted). Once the build-phase agent has committed onto the
+    // build branch, HEAD already contains those changes and the diff goes
+    // empty — even though the branch is N commits ahead of where it forked.
+    // Passing the client branch as baseRef makes committed + uncommitted work
+    // both appear, which is what the PR #850 gate needs to recognize.
+    const command = buildSandboxListReleasableFilesCommand("/workspace", "client/abc-123");
+
+    expect(command).toContain("git diff --cached 'client/abc-123' --name-only -- .");
+    expect(command).toContain(":(exclude)**/.next/**");
+  });
 });
 
 describe("buildSandboxDiffForFilesCommand", () => {
@@ -193,6 +206,16 @@ describe("buildSandboxDiffForFilesCommand", () => {
     expect(command).toContain("git diff --cached --");
     expect(command).toContain("'apps/web/components/build/BuildStudio.tsx'");
     expect(command).toContain("'apps/web/components/build/O'\"'\"'Malley Panel.tsx'");
+  });
+
+  it("compares against baseRef when provided so the diff body includes committed work", () => {
+    const command = buildSandboxDiffForFilesCommand(
+      ["apps/web/lib/foo.ts"],
+      "/workspace",
+      "client/abc-123",
+    );
+
+    expect(command).toContain("git diff --cached 'client/abc-123' -- 'apps/web/lib/foo.ts'");
   });
 });
 

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -133,15 +133,29 @@ export function buildSandboxStageCommand(workspace: string = SANDBOX_WORKSPACE):
   ].join(" && ");
 }
 
-export function buildSandboxListReleasableFilesCommand(workspace: string = SANDBOX_WORKSPACE): string {
-  return `cd ${workspace} && git diff --cached --name-only -- . ${joinQuotedArgs(SANDBOX_DIFF_EXCLUDES)}`;
+export function buildSandboxListReleasableFilesCommand(
+  workspace: string = SANDBOX_WORKSPACE,
+  baseRef?: string,
+): string {
+  // `git diff --cached` defaults to comparing the index against HEAD, which
+  // only surfaces uncommitted staged work. Once the build-phase agent commits
+  // its changes onto the build branch (`git commit` from generate_code or
+  // direct invocation), HEAD already contains those changes and the cached
+  // diff goes empty — even though the branch is N commits ahead of where it
+  // forked. Passing `baseRef` (typically the client branch tip) compares the
+  // post-stage index against the merge base so committed + uncommitted work
+  // both appear.
+  const base = baseRef ? ` ${quotePosixArg(baseRef)}` : "";
+  return `cd ${workspace} && git diff --cached${base} --name-only -- . ${joinQuotedArgs(SANDBOX_DIFF_EXCLUDES)}`;
 }
 
 export function buildSandboxDiffForFilesCommand(
   files: readonly string[],
   workspace: string = SANDBOX_WORKSPACE,
+  baseRef?: string,
 ): string {
-  return `cd ${workspace} && git diff --cached -- ${files.map((file) => quotePosixArg(file)).join(" ")}`;
+  const base = baseRef ? ` ${quotePosixArg(baseRef)}` : "";
+  return `cd ${workspace} && git diff --cached${base} -- ${files.map((file) => quotePosixArg(file)).join(" ")}`;
 }
 
 export function buildSandboxNextDevReadinessCommand(workspace: string = SANDBOX_WORKSPACE): string {
@@ -209,13 +223,43 @@ async function stageSandboxWorkspaceChanges(containerId: string): Promise<void> 
   await execInSandbox(containerId, buildSandboxStageCommand());
 }
 
-export async function listReleasableSandboxFiles(containerId: string): Promise<string[]> {
+export async function listReleasableSandboxFiles(
+  containerId: string,
+  opts?: { baseRef?: string },
+): Promise<string[]> {
   await stageSandboxWorkspaceChanges(containerId);
   try {
-    const output = await execInSandbox(containerId, buildSandboxListReleasableFilesCommand());
+    const output = await execInSandbox(
+      containerId,
+      buildSandboxListReleasableFilesCommand(SANDBOX_WORKSPACE, opts?.baseRef),
+    );
     return parseSandboxChangedFiles(output);
   } finally {
     await resetSandboxGitIndex(containerId);
+  }
+}
+
+/**
+ * Returns the commit hashes on the sandbox's current HEAD that are ahead of
+ * `baseRef` (typically the client branch tip). Excludes merge commits so the
+ * list maps cleanly to FeatureBuild.gitCommitHashes.
+ *
+ * Returns [] if HEAD == baseRef or if the rev-list command errors (e.g. the
+ * base ref does not exist yet in the sandbox).
+ */
+export async function listSandboxCommitsAheadOfBase(
+  containerId: string,
+  baseRef: string,
+  workspace: string = SANDBOX_WORKSPACE,
+): Promise<string[]> {
+  try {
+    const output = await execInSandbox(
+      containerId,
+      `cd ${workspace} && git rev-list --no-merges ${quotePosixArg(baseRef)}..HEAD`,
+    );
+    return output.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
   }
 }
 
@@ -414,13 +458,22 @@ export async function getSandboxLogs(containerId: string, tail: number = 50): Pr
   return stdout;
 }
 
-export async function extractDiff(containerId: string): Promise<string> {
+export async function extractDiff(
+  containerId: string,
+  opts?: { baseRef?: string },
+): Promise<string> {
   await stageSandboxWorkspaceChanges(containerId);
   try {
-    const changedFiles = await execInSandbox(containerId, buildSandboxListReleasableFilesCommand());
+    const changedFiles = await execInSandbox(
+      containerId,
+      buildSandboxListReleasableFilesCommand(SANDBOX_WORKSPACE, opts?.baseRef),
+    );
     const files = parseSandboxChangedFiles(changedFiles);
     if (files.length === 0) return "";
-    return execInSandbox(containerId, buildSandboxDiffForFilesCommand(files));
+    return execInSandbox(
+      containerId,
+      buildSandboxDiffForFilesCommand(files, SANDBOX_WORKSPACE, opts?.baseRef),
+    );
   } finally {
     await resetSandboxGitIndex(containerId);
   }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7647,9 +7647,15 @@ export async function executeTool(
         };
       }
 
-      // Extract diff from sandbox
+      // Extract diff from sandbox. Pass clientBranch as the diff base so
+      // committed work on the build branch (`git commit` from generate_code)
+      // is captured — without the base ref, `git diff --cached` only sees
+      // staged-but-uncommitted changes and returns empty for any build whose
+      // agent committed before deploy_feature ran.
       const { extractAndCategorizeDiff, scanForDestructiveOps, isNowInWindow } = await import("@/lib/integrate/sandbox/sandbox-promotion");
-      const extracted = await extractAndCategorizeDiff(build.sandboxId);
+      const { getClientIdentity } = await import("@/lib/integrate/sandbox/build-branch");
+      const { clientBranch } = await getClientIdentity();
+      const extracted = await extractAndCategorizeDiff(build.sandboxId, { baseRef: clientBranch });
       if (!extracted.fullDiff.trim()) {
         await prisma.featureBuild.update({
           where: { buildId },
@@ -7693,9 +7699,21 @@ export async function executeTool(
         };
       }
 
+      // Capture commit hashes alongside the diff so the contribution flow
+      // (which pushes build/<buildId> upstream) has the exact list of
+      // commits being submitted. Without this, FB.gitCommitHashes stays
+      // empty for committed-work builds and contribute_to_hive cannot
+      // attribute the PR's commits back to specific FBs.
+      const { listSandboxCommitsAheadOfBase } = await import("@/lib/integrate/sandbox/sandbox");
+      const commitHashes = await listSandboxCommitsAheadOfBase(build.sandboxId, clientBranch);
+
       await prisma.featureBuild.update({
         where: { buildId },
-        data: { diffPatch: extracted.fullDiff, diffSummary: extracted.fullDiff.slice(0, 500) },
+        data: {
+          diffPatch: extracted.fullDiff,
+          diffSummary: extracted.fullDiff.slice(0, 500),
+          gitCommitHashes: commitHashes,
+        },
       });
 
       // Scan migrations for destructive operations


### PR DESCRIPTION
## Summary

Plug the gap between **\"sandbox has commits\"** and **\"FB row has diffPatch + gitCommitHashes.\"**

`stepComplete` in [build-pipeline.ts](apps/web/lib/integrate/build-pipeline.ts) was a no-op (`return state`). Any build whose agent committed work inside the sandbox stranded with clean `buildExecState` (`step:\"complete\"`, `sourceCurrency.aheadBy:5`) but `diffPatch=NULL` and `gitCommitHashes=[]` in the DB — and the [PR #850](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/850) gate at build→review then rejected those builds for \"no releasable source changes.\"

**FB-F0476EF3** is the live test case: 5 sandbox commits ahead of `client/bf3a87ef…`, `sourceCurrency.recommendedAction: \"allow\"`, blocked on this.

## Root cause (two-layered)

1. **`stepComplete` is a no-op.** The pipeline marks itself complete without ever copying the sandbox's work back to the FB row.
2. **`listReleasableSandboxFiles` uses `git diff --cached`.** That only sees staged-but-uncommitted changes. After `git commit`, HEAD already contains the work and the cached diff goes empty — so the PR #850 gate fires false-positive even though real code was written.

## Fix

| File | Change |
| --- | --- |
| [`sandbox.ts`](apps/web/lib/integrate/sandbox/sandbox.ts) | `buildSandboxListReleasableFilesCommand`, `buildSandboxDiffForFilesCommand`, `listReleasableSandboxFiles`, `extractDiff` all accept an optional `baseRef`. When set, `git diff --cached <baseRef>` shows committed + uncommitted work. New `listSandboxCommitsAheadOfBase(containerId, baseRef)`. |
| [`build-pipeline.ts`](apps/web/lib/integrate/build-pipeline.ts) | `stepComplete` resolves the client branch via `getClientIdentity()`, extracts diff + commit hashes against it, writes `diffPatch` / `diffSummary` / `gitCommitHashes` to the FB row. `runBuildPipeline` self-heals stranded builds: if a prior run reached \"complete\" with empty capture, rewind one step and re-dispatch `stepComplete`. |
| [`build-exec-types.ts`](apps/web/lib/integrate/build-exec-types.ts) | `MAX_RETRIES.tests_run`: 0 → 2 (this is the dispatch slot for `stepComplete`). |
| [`build.ts`](apps/web/lib/actions/build.ts) | The build→review gate, review→ship gate, and ship-phase \"resume implementation\" check all pass `baseRef = clientBranch` so committed branch work counts. |
| [`sandbox-promotion.ts`](apps/web/lib/integrate/sandbox/sandbox-promotion.ts) | `extractAndCategorizeDiff` accepts `{ baseRef }` and forwards. Internal recovery in `executePromotion` passes `clientBranch`. |
| [`mcp-tools.ts`](apps/web/lib/mcp-tools.ts) | `deploy_feature` passes `baseRef = clientBranch` AND now writes `gitCommitHashes` so the contribution flow has the exact commit list. |

## Self-heal

Existing stranded builds (FB-F0476EF3 + any others created before this PR) will recover automatically the next time their pipeline runs — `runBuildPipeline` detects `step:\"complete\"` + empty `diffPatch` and rewinds to re-dispatch the now-real `stepComplete`. No SQL backfill needed; the dogfooded UX path drives recovery.

## Test plan

- [x] **New unit tests**:
  - `buildSandboxListReleasableFilesCommand` with `baseRef` produces `git diff --cached '<baseRef>' --name-only`.
  - `buildSandboxDiffForFilesCommand` with `baseRef` produces the matching per-file diff command.
- [x] **Updated unit tests**:
  - `shouldRetry(\"tests_run\", n)` now retries up to budget 2 (was 0), with rationale tying it to `stepComplete` dispatch.
  - `advanceBuildPhase` ship-phase resume assertion expects `{ baseRef: \"client/test-client-id\" }` second arg.
  - `build-branch` mock stubs `getClientIdentity`.
- [x] **Full vitest suite**: 6585/6585 passing locally (3 skipped, 18 todo).
- [x] **Typecheck**: clean.
- [ ] **Live verification** (post-merge after self-upgrade): trigger any action on FB-F0476EF3 → confirm `diffPatch` length > 0 and `gitCommitHashes` has 5 entries; confirm build→review gate now allows the advance.

## Follow-ups (handoff #2-#4)

- **Hive contribution end-to-end** (priority #2 from [handoff doc](docs/triage/2026-05-20-handoff-prompt-next-session.md)): once stranded builds self-heal, walk Submit Upstream PR to see what the next layer surfaces.
- **Production promotion rollback + meta-recovery** (#3, #4): independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)