### PR TITLE
feat(edge-node-go): W3 — ARP collector (GetIpNetTable / /proc/net/arp / arp -an)

### DIFF
--- a/services/edge-node-go/cmd/dpf-edge-node/main.go
+++ b/services/edge-node-go/cmd/dpf-edge-node/main.go
@@ -301,21 +301,40 @@ func runSweep(ctx context.Context, cfg *config.Config, client *api.Client, st *s
 // submitSweep builds one envelope from the current collector chain and
 // POSTs it. Pulled into its own function so tests can drive it without
 // constructing a ticker.
+//
+// Collector chain (matches services/edge-node/src/sweep.ts):
+//   1. HostInfo — local host facts; always present.
+//   2. ArpNeighbors — kernel/OS ARP cache. This is the collector
+//      that finally surfaces the OTHER devices on the LAN (Amazon
+//      Echo, Reolink cameras, Kasa switches, etc.) when the binary
+//      runs natively on Windows/macOS rather than inside Docker.
 func submitSweep(ctx context.Context, cfg *config.Config, client *api.Client, st *state.EdgeNodeState) error {
 	hostResult := collect.HostInfo()
+	arpResult := collect.ArpNeighbors()
 
 	// Convert []collect.Item → []any so the SubmissionEnvelope's typed
 	// `[]any` accepts them. The JSON marshal layer produces identical
 	// bytes either way; the indirection only matters at the Go type
 	// level.
-	items := make([]any, 0, len(hostResult.Items))
+	items := make([]any, 0, len(hostResult.Items)+len(arpResult.Items))
 	for _, item := range hostResult.Items {
 		items = append(items, item)
 	}
-	rels := make([]any, 0, len(hostResult.Relationships))
+	for _, item := range arpResult.Items {
+		items = append(items, item)
+	}
+
+	rels := make([]any, 0, len(hostResult.Relationships)+len(arpResult.Relationships))
 	for _, rel := range hostResult.Relationships {
 		rels = append(rels, rel)
 	}
+	for _, rel := range arpResult.Relationships {
+		rels = append(rels, rel)
+	}
+
+	warnings := make([]string, 0, len(hostResult.Warnings)+len(arpResult.Warnings))
+	warnings = append(warnings, hostResult.Warnings...)
+	warnings = append(warnings, arpResult.Warnings...)
 
 	envelope := api.SubmissionEnvelope{
 		RunKey:        uuid.NewString(),
@@ -325,7 +344,7 @@ func submitSweep(ctx context.Context, cfg *config.Config, client *api.Client, st
 		Capabilities:  phase0Capabilities,
 		Items:         items,
 		Relationships: rels,
-		Warnings:      hostResult.Warnings,
+		Warnings:      warnings,
 	}
 
 	if _, err := client.SubmitDiscoveryRun(ctx, st.NodeToken, envelope); err != nil {

--- a/services/edge-node-go/go.sum
+++ b/services/edge-node-go/go.sum
@@ -2,5 +2,3 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/services/edge-node-go/internal/collect/arp.go
+++ b/services/edge-node-go/internal/collect/arp.go
@@ -1,0 +1,254 @@
+package collect
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ArpEntry is one resolved IP↔MAC binding the kernel/OS knows about.
+// Mirrors the TypeScript ArpEntry at services/edge-node/src/collectors/arp.ts.
+type ArpEntry struct {
+	IP    string // canonical dotted IPv4
+	MAC   string // lower-case colon-separated, zero-padded bytes
+	Iface string // OS-reported interface name (eth0, en0, Ethernet, etc.)
+}
+
+// SKIP_MACS mirrors the TS skip set. 00:00:00:00:00:00 = "ARP request
+// outstanding but never resolved" (Linux Flags=0x0). FF:FF:FF:FF:FF:FF
+// is L2 broadcast — the kernel may show it as a learned neighbor on
+// some drivers but it's never a useful inventory item.
+var skipMACs = map[string]struct{}{
+	"00:00:00:00:00:00": {},
+	"ff:ff:ff:ff:ff:ff": {},
+}
+
+// parseProcNetArp parses the Linux /proc/net/arp text format:
+//
+//	IP address       HW type     Flags     HW address            Mask     Device
+//	192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0
+//	10.0.0.5         0x1         0x0       00:00:00:00:00:00     *        eth0
+//
+// Flags is a bitfield; 0x2 = ATF_COM (complete entry). Entries with
+// Flags=0x0 are unresolved and dropped to match the TS path's
+// behavior at services/edge-node/src/collectors/arp.ts.
+func parseProcNetArp(content string) []ArpEntry {
+	out := make([]ArpEntry, 0, 16)
+	for i, line := range strings.Split(content, "\n") {
+		if i == 0 {
+			continue // header row
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		ip := fields[0]
+		flagsRaw := fields[2]
+		mac := strings.ToLower(fields[3])
+		iface := fields[5]
+
+		flagsRaw = strings.TrimPrefix(flagsRaw, "0x")
+		flagBits, err := strconv.ParseUint(flagsRaw, 16, 32)
+		if err != nil {
+			continue
+		}
+		if flagBits&0x2 != 0x2 {
+			continue
+		}
+		if _, skip := skipMACs[mac]; skip {
+			continue
+		}
+		if !isLikelyIPv4(ip) || !isLikelyMAC(mac) {
+			continue
+		}
+		if !isUnicastLANAddress(ip) {
+			continue
+		}
+		out = append(out, ArpEntry{IP: ip, MAC: mac, Iface: iface})
+	}
+	return dedupeArpByIP(out)
+}
+
+// macOS `arp -an` output:
+//
+//	? (192.168.1.1) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]
+//	? (192.168.1.20) at (incomplete) on en0 ifscope [ethernet]
+//
+// We drop the (incomplete) entries the same way Linux drops ATF_COM=0.
+// macOS sometimes emits single-hex-digit bytes ("a:b:c:..."); we
+// normalize to two-digit form.
+var arpDashAnRE = regexp.MustCompile(
+	`\(([\d.]+)\)\s+at\s+(\(incomplete\)|[0-9a-fA-F:]+)\s+on\s+(\S+)`,
+)
+
+func parseArpDashAn(content string) []ArpEntry {
+	out := make([]ArpEntry, 0, 16)
+	matches := arpDashAnRE.FindAllStringSubmatch(content, -1)
+	for _, m := range matches {
+		ip, macRaw, iface := m[1], m[2], m[3]
+		if macRaw == "(incomplete)" {
+			continue
+		}
+		mac := normalizeArpMAC(macRaw)
+		if _, skip := skipMACs[mac]; skip {
+			continue
+		}
+		if !isLikelyIPv4(ip) || !isLikelyMAC(mac) {
+			continue
+		}
+		if !isUnicastLANAddress(ip) {
+			continue
+		}
+		out = append(out, ArpEntry{IP: ip, MAC: mac, Iface: iface})
+	}
+	return dedupeArpByIP(out)
+}
+
+func isLikelyIPv4(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return false
+		}
+	}
+	return true
+}
+
+// isUnicastLANAddress filters out multicast (224.0.0.0/4), broadcast
+// (255.255.255.255), and link-local (169.254.0.0/16) addresses. The
+// Linux /proc/net/arp source already excludes multicast; Windows's
+// GetIpNetTable includes them as "group → MAC" mappings even though
+// they're not real LAN hosts. We drop them so the topology view
+// isn't cluttered with bogus rows like "LAN Host 224.0.0.251".
+//
+// Caller has already proven isLikelyIPv4(); this checks the routing
+// class of the address.
+func isUnicastLANAddress(ip string) bool {
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	first, _ := strconv.Atoi(parts[0])
+	second, _ := strconv.Atoi(parts[1])
+	// 224.0.0.0/4 — IPv4 multicast.
+	if first >= 224 && first <= 239 {
+		return false
+	}
+	// 255.255.255.255 — broadcast.
+	if ip == "255.255.255.255" {
+		return false
+	}
+	// 169.254.0.0/16 — link-local. Not interesting for LAN inventory.
+	if first == 169 && second == 254 {
+		return false
+	}
+	// 0.0.0.0/8 — unspecified.
+	if first == 0 {
+		return false
+	}
+	return true
+}
+
+var likelyMACRE = regexp.MustCompile(`^[0-9a-f]{2}(:[0-9a-f]{2}){5}$`)
+
+func isLikelyMAC(s string) bool {
+	return likelyMACRE.MatchString(s)
+}
+
+// normalizeArpMAC turns "a:b:c:d:e:f" → "0a:0b:0c:0d:0e:0f" so every
+// downstream consumer (and the cross-runtime parity tests) sees the
+// canonical two-digit form. Mirrors the TS normalizeMac().
+func normalizeArpMAC(raw string) string {
+	parts := strings.Split(strings.ToLower(raw), ":")
+	for i, b := range parts {
+		if len(b) == 1 {
+			parts[i] = "0" + b
+		}
+	}
+	return strings.Join(parts, ":")
+}
+
+// dedupeArpByIP drops duplicate IPs across the result list. ARP caches
+// can in theory list the same IP twice (proxy-ARP, multi-iface).
+// Keeping the first match is stable across sweeps.
+func dedupeArpByIP(entries []ArpEntry) []ArpEntry {
+	seen := make(map[string]struct{}, len(entries))
+	out := make([]ArpEntry, 0, len(entries))
+	for _, e := range entries {
+		if _, ok := seen[e.IP]; ok {
+			continue
+		}
+		seen[e.IP] = struct{}{}
+		out = append(out, e)
+	}
+	return out
+}
+
+// ArpResult bundles a collector run's output. Errors during the read
+// become warnings; the sweep keeps going so one bad collector can't
+// take down the whole submission.
+type ArpResult struct {
+	Entries  []ArpEntry
+	Warnings []string
+}
+
+// arpToItems converts ArpEntries into ObservationItems matching the
+// shape services/edge-node/src/collectors/arp.ts emits. Same
+// observedKey, itemType, confidence, and rawData fields so the
+// Authority's normalization treats Mode 1 (TS) and Mode 4 (Go)
+// submissions as one set.
+//
+// OUI vendor enrichment (PR #846 in the TS path) lands in a separate
+// Go slice — until then the item's name is the generic "LAN Host <ip>"
+// form. The vendor fields are optional in the wire contract so this
+// is forward-compatible.
+func arpToItems(entries []ArpEntry) []Item {
+	items := make([]Item, 0, len(entries))
+	for _, e := range entries {
+		items = append(items, Item{
+			ObservedKey: fmt.Sprintf("arp:%s", e.IP),
+			ItemType:    "host",
+			Name:        fmt.Sprintf("LAN Host %s", e.IP),
+			Confidence:  0.7,
+			RawData: map[string]any{
+				"address":        e.IP,
+				"mac":            e.MAC,
+				"iface":          e.Iface,
+				"osiLayer":       3,
+				"osiLayerName":   "network",
+				"protocolFamily": "ipv4",
+				"discoveredVia":  "arp_table",
+			},
+		})
+	}
+	return items
+}
+
+// ArpNeighbors reads the OS's ARP cache and returns one observation
+// item per resolved IP/MAC pair. Errors degrade gracefully — a
+// platform that doesn't expose ARP cleanly returns an empty result
+// with a warning, not a panic.
+func ArpNeighbors(adapter ...ArpAdapter) Result {
+	a := DefaultArpAdapter
+	if len(adapter) > 0 {
+		a = adapter[0]
+	}
+	res := a()
+	return Result{
+		Items:    arpToItems(res.Entries),
+		Warnings: res.Warnings,
+	}
+}
+
+// ArpAdapter is the test seam. Production wires the platform-specific
+// implementation in arp_{linux,darwin,windows,unsupported}.go.
+type ArpAdapter func() ArpResult

--- a/services/edge-node-go/internal/collect/arp_darwin.go
+++ b/services/edge-node-go/internal/collect/arp_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package collect
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// DefaultArpAdapter shells to /usr/sbin/arp -an on macOS. Same source
+// the TS path uses at services/edge-node/src/collectors/arp.ts.
+//
+// 5-second timeout — `arp -an` is local and should return in
+// milliseconds; longer means the system is degenerate. We'd rather
+// return an empty result with a warning than block the sweep.
+var DefaultArpAdapter ArpAdapter = func() ArpResult {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/usr/sbin/arp", "-an").Output()
+	if err != nil {
+		return ArpResult{
+			Warnings: []string{
+				fmt.Sprintf("arp: /usr/sbin/arp -an failed: %s", err),
+			},
+		}
+	}
+	return ArpResult{Entries: parseArpDashAn(string(out))}
+}

--- a/services/edge-node-go/internal/collect/arp_linux.go
+++ b/services/edge-node-go/internal/collect/arp_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package collect
+
+import (
+	"fmt"
+	"os"
+)
+
+// DefaultArpAdapter reads /proc/net/arp on Linux. Same source the TS
+// path uses at services/edge-node/src/collectors/arp.ts, so both
+// runtimes producing identical ArpEntry rows.
+var DefaultArpAdapter ArpAdapter = func() ArpResult {
+	const path = "/proc/net/arp"
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ArpResult{
+			Warnings: []string{
+				fmt.Sprintf("arp: /proc/net/arp read failed: %s", err),
+			},
+		}
+	}
+	return ArpResult{Entries: parseProcNetArp(string(content))}
+}

--- a/services/edge-node-go/internal/collect/arp_test.go
+++ b/services/edge-node-go/internal/collect/arp_test.go
@@ -1,0 +1,237 @@
+package collect
+
+import (
+	"strings"
+	"testing"
+)
+
+const procNetArpSample = `IP address       HW type     Flags     HW address            Mask     Device
+192.168.1.1      0x1         0x2       aa:bb:cc:dd:ee:ff     *        eth0
+192.168.1.42     0x1         0x2       11:22:33:44:55:66     *        eth0
+192.168.1.5      0x1         0x0       00:00:00:00:00:00     *        eth0
+192.168.1.6      0x1         0x2       ff:ff:ff:ff:ff:ff     *        eth0
+10.0.0.99        0x1         0x2       AA:BB:CC:11:22:33     *        wlan0
+`
+
+func TestParseProcNetArp_acceptsCompleteEntries(t *testing.T) {
+	got := parseProcNetArp(procNetArpSample)
+	if len(got) != 3 {
+		t.Fatalf("entry count = %d, want 3 (got: %+v)", len(got), got)
+	}
+}
+
+func TestParseProcNetArp_skipsATFCOMZero(t *testing.T) {
+	for _, e := range parseProcNetArp(procNetArpSample) {
+		if e.IP == "192.168.1.5" {
+			t.Errorf("expected Flags=0x0 entry 192.168.1.5 to be skipped")
+		}
+	}
+}
+
+func TestParseProcNetArp_skipsBroadcastMAC(t *testing.T) {
+	for _, e := range parseProcNetArp(procNetArpSample) {
+		if e.MAC == "ff:ff:ff:ff:ff:ff" {
+			t.Errorf("expected broadcast MAC to be skipped, got %+v", e)
+		}
+	}
+}
+
+func TestParseProcNetArp_normalizesMACToLowercase(t *testing.T) {
+	got := parseProcNetArp(procNetArpSample)
+	for _, e := range got {
+		if e.IP == "10.0.0.99" && e.MAC != "aa:bb:cc:11:22:33" {
+			t.Errorf("expected lowercase MAC, got %q", e.MAC)
+		}
+	}
+}
+
+func TestParseProcNetArp_toleratesBlankLines(t *testing.T) {
+	content := procNetArpSample + "\n\n  \n"
+	if got := parseProcNetArp(content); len(got) != 3 {
+		t.Fatalf("entries after blanks = %d, want 3", len(got))
+	}
+}
+
+func TestParseProcNetArp_skipsHeader(t *testing.T) {
+	// A malformed file with no header should still parse what's there.
+	contentNoHeader := `192.168.0.1     0x1   0x2   00:11:22:33:44:55   *   eth0`
+	if got := parseProcNetArp(contentNoHeader); len(got) != 0 {
+		t.Errorf("header-less first line should be treated as header and skipped, got %+v", got)
+	}
+}
+
+const arpDashAnSample = `? (192.168.1.1) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]
+? (192.168.1.20) at (incomplete) on en0 ifscope [ethernet]
+? (10.0.0.5) at a:b:c:d:e:f on en1 ifscope [ethernet]
+? (192.168.1.99) at ff:ff:ff:ff:ff:ff on en0 ifscope [ethernet]
+? (192.168.1.100) at 00:00:00:00:00:00 on en0 ifscope [ethernet]
+`
+
+func TestParseArpDashAn_acceptsResolvedEntries(t *testing.T) {
+	got := parseArpDashAn(arpDashAnSample)
+	if len(got) != 2 {
+		t.Fatalf("entry count = %d, want 2: %+v", len(got), got)
+	}
+}
+
+func TestParseArpDashAn_skipsIncompleteEntries(t *testing.T) {
+	for _, e := range parseArpDashAn(arpDashAnSample) {
+		if e.IP == "192.168.1.20" {
+			t.Errorf("(incomplete) entry should not appear: %+v", e)
+		}
+	}
+}
+
+func TestParseArpDashAn_padsSingleHexDigitMAC(t *testing.T) {
+	// macOS sometimes emits "a:b:c:d:e:f" instead of "0a:0b:..."; the
+	// pipeline must produce the canonical two-digit form so the
+	// Authority's normalization dedupes Mode 1 (TS) and Mode 4 (Go)
+	// observations as one entity.
+	got := parseArpDashAn(arpDashAnSample)
+	for _, e := range got {
+		if e.IP == "10.0.0.5" && e.MAC != "0a:0b:0c:0d:0e:0f" {
+			t.Errorf("expected zero-padded MAC, got %q", e.MAC)
+		}
+	}
+}
+
+func TestParseArpDashAn_skipsBroadcastAndAllZeros(t *testing.T) {
+	for _, e := range parseArpDashAn(arpDashAnSample) {
+		if e.MAC == "ff:ff:ff:ff:ff:ff" || e.MAC == "00:00:00:00:00:00" {
+			t.Errorf("expected broadcast / all-zeros MAC to be skipped, got %+v", e)
+		}
+	}
+}
+
+func TestDedupeArpByIP_keepsFirstOccurrence(t *testing.T) {
+	in := []ArpEntry{
+		{IP: "192.168.0.1", MAC: "aa:bb:cc:00:00:01", Iface: "eth0"},
+		{IP: "192.168.0.2", MAC: "aa:bb:cc:00:00:02", Iface: "eth0"},
+		{IP: "192.168.0.1", MAC: "ff:ff:ff:00:00:01", Iface: "eth1"},
+	}
+	got := dedupeArpByIP(in)
+	if len(got) != 2 {
+		t.Fatalf("deduped count = %d, want 2", len(got))
+	}
+	if got[0].MAC != "aa:bb:cc:00:00:01" {
+		t.Errorf("first occurrence not preserved: %+v", got[0])
+	}
+}
+
+func TestArpNeighbors_returnsItemsWithCanonicalShape(t *testing.T) {
+	stub := ArpAdapter(func() ArpResult {
+		return ArpResult{
+			Entries: []ArpEntry{
+				{IP: "192.168.0.10", MAC: "aa:bb:cc:dd:ee:ff", Iface: "eth0"},
+			},
+		}
+	})
+	got := ArpNeighbors(stub)
+	if len(got.Items) != 1 {
+		t.Fatalf("Items = %d, want 1", len(got.Items))
+	}
+	item := got.Items[0]
+	if item.ObservedKey != "arp:192.168.0.10" {
+		t.Errorf("observedKey = %q", item.ObservedKey)
+	}
+	if item.ItemType != "host" {
+		t.Errorf("itemType = %q", item.ItemType)
+	}
+	if item.Confidence != 0.7 {
+		t.Errorf("confidence = %v, want 0.7", item.Confidence)
+	}
+	for _, key := range []string{"address", "mac", "iface", "osiLayer", "discoveredVia"} {
+		if _, ok := item.RawData[key]; !ok {
+			t.Errorf("rawData missing %q", key)
+		}
+	}
+	if item.RawData["discoveredVia"] != "arp_table" {
+		t.Errorf("discoveredVia = %v", item.RawData["discoveredVia"])
+	}
+	if !strings.Contains(item.Name, "192.168.0.10") {
+		t.Errorf("name should include IP: %q", item.Name)
+	}
+}
+
+func TestArpNeighbors_propagatesAdapterWarnings(t *testing.T) {
+	stub := ArpAdapter(func() ArpResult {
+		return ArpResult{Warnings: []string{"arp: read failed"}}
+	})
+	got := ArpNeighbors(stub)
+	if len(got.Items) != 0 {
+		t.Errorf("Items = %d, want 0", len(got.Items))
+	}
+	if len(got.Warnings) != 1 || !strings.Contains(got.Warnings[0], "read failed") {
+		t.Errorf("Warnings = %v", got.Warnings)
+	}
+}
+
+func TestArpNeighbors_emptyAdapterIsEmptyResult(t *testing.T) {
+	stub := ArpAdapter(func() ArpResult { return ArpResult{} })
+	got := ArpNeighbors(stub)
+	if len(got.Items) != 0 || len(got.Warnings) != 0 {
+		t.Errorf("expected empty result, got %+v", got)
+	}
+}
+
+func TestIsLikelyIPv4(t *testing.T) {
+	for _, ok := range []string{"0.0.0.0", "192.168.1.1", "255.255.255.255"} {
+		if !isLikelyIPv4(ok) {
+			t.Errorf("expected %q to be a valid IPv4", ok)
+		}
+	}
+	for _, bad := range []string{"", "1.2.3", "1.2.3.4.5", "999.0.0.0", "abc.0.0.0", "1.2.3.x"} {
+		if isLikelyIPv4(bad) {
+			t.Errorf("expected %q to be rejected", bad)
+		}
+	}
+}
+
+func TestIsUnicastLANAddress(t *testing.T) {
+	for _, ok := range []string{"192.168.0.1", "10.0.0.5", "172.16.255.254", "8.8.8.8"} {
+		if !isUnicastLANAddress(ok) {
+			t.Errorf("expected %q to be a unicast LAN address", ok)
+		}
+	}
+	for _, bad := range []string{
+		"224.0.0.1",         // multicast
+		"224.0.0.251",       // mDNS
+		"239.255.255.250",   // SSDP
+		"233.89.188.1",      // multicast (RTP-MIDI etc)
+		"255.255.255.255",   // broadcast
+		"169.254.1.1",       // APIPA link-local
+		"0.0.0.0",           // unspecified
+	} {
+		if isUnicastLANAddress(bad) {
+			t.Errorf("expected %q to be rejected", bad)
+		}
+	}
+}
+
+func TestIsLikelyMAC(t *testing.T) {
+	for _, ok := range []string{"aa:bb:cc:dd:ee:ff", "00:11:22:33:44:55"} {
+		if !isLikelyMAC(ok) {
+			t.Errorf("expected %q to be a valid MAC", ok)
+		}
+	}
+	for _, bad := range []string{
+		"", "AA:BB:CC:DD:EE:FF" /* upper-case rejected by the package's lower-cased form */, "a:b:c:d:e:f", "00-11-22-33-44-55",
+	} {
+		if isLikelyMAC(bad) {
+			t.Errorf("expected %q to be rejected", bad)
+		}
+	}
+}
+
+func TestNormalizeArpMAC(t *testing.T) {
+	for input, want := range map[string]string{
+		"a:b:c:d:e:f":         "0a:0b:0c:0d:0e:0f",
+		"AA:BB:CC:DD:EE:FF":   "aa:bb:cc:dd:ee:ff",
+		"00:11:22:33:44:55":   "00:11:22:33:44:55",
+		"0a:bB:0c:0d:0e:0f":   "0a:bb:0c:0d:0e:0f",
+	} {
+		if got := normalizeArpMAC(input); got != want {
+			t.Errorf("normalizeArpMAC(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/services/edge-node-go/internal/collect/arp_unsupported.go
+++ b/services/edge-node-go/internal/collect/arp_unsupported.go
@@ -1,0 +1,17 @@
+//go:build !linux && !darwin && !windows
+
+package collect
+
+import "runtime"
+
+// DefaultArpAdapter for platforms the Edge Node doesn't officially
+// target yet (FreeBSD, OpenBSD, etc.). Returns empty + a warning so
+// cross-compile builds still produce a working binary; the operator
+// just won't see ARP entries until a platform implementation lands.
+var DefaultArpAdapter ArpAdapter = func() ArpResult {
+	return ArpResult{
+		Warnings: []string{
+			"arp: collector not implemented for " + runtime.GOOS,
+		},
+	}
+}

--- a/services/edge-node-go/internal/collect/arp_windows.go
+++ b/services/edge-node-go/internal/collect/arp_windows.go
@@ -1,0 +1,213 @@
+//go:build windows
+
+package collect
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// MIB_IPNETROW is the layout iphlpapi.dll's GetIpNetTable writes to
+// the caller's buffer. Field names and Win32 type widths match
+// https://learn.microsoft.com/en-us/windows/win32/api/iprtrmib/ns-iprtrmib-mib_ipnetrow_lh
+//
+// dwAddr and dwIndex are uint32 (4 bytes each). bPhysAddr is exactly 8
+// bytes (the maximum MAC length); the actual length is bPhysAddrLen
+// which is also uint32 — for normal Ethernet it's always 6.
+//
+// dwType is the kernel's MIB_IPNET_TYPE_* enum:
+//
+//	1 (MIB_IPNET_TYPE_OTHER)    — none of the below
+//	2 (MIB_IPNET_TYPE_INVALID)  — never resolved, like Linux Flags=0
+//	3 (MIB_IPNET_TYPE_DYNAMIC)  — learned via ARP, "resolved"
+//	4 (MIB_IPNET_TYPE_STATIC)   — manually configured
+//
+// We accept DYNAMIC + STATIC + OTHER, drop INVALID — mirrors the
+// Linux ATF_COM=0 filter the TS path uses.
+type mibIPNetRow struct {
+	DwIndex       uint32
+	DwPhysAddrLen uint32
+	BPhysAddr     [8]byte
+	DwAddr        uint32
+	DwType        uint32
+}
+
+const (
+	mibIPNetTypeInvalid = 2
+	noError             = 0
+	errorInsufficientBuffer = 122
+)
+
+// DefaultArpAdapter reads the Windows ARP cache via GetIpNetTable on
+// iphlpapi.dll. The plan calls for the syscall path (not `arp -a`
+// shell-out) because it works in service contexts where arp.exe may
+// not be on PATH and because it doesn't depend on stdout-format
+// stability across Windows builds.
+//
+// Iteration through the table follows the standard two-call pattern:
+//  1. Call once with a nil buffer to discover the required size.
+//  2. Allocate, call again, decode the count + rows.
+//
+// The dynamic interface name resolution (DwIndex → "Ethernet 2")
+// uses net.InterfaceByIndex from stdlib; works without additional
+// Win32 calls.
+var DefaultArpAdapter ArpAdapter = func() ArpResult {
+	entries, warnings := readIPNetTable()
+	return ArpResult{Entries: dedupeArpByIP(entries), Warnings: warnings}
+}
+
+func readIPNetTable() ([]ArpEntry, []string) {
+	iphlpapi := windows.NewLazySystemDLL("iphlpapi.dll")
+	getIPNetTable := iphlpapi.NewProc("GetIpNetTable")
+	if err := getIPNetTable.Find(); err != nil {
+		return nil, []string{fmt.Sprintf("arp: locate GetIpNetTable: %s", err)}
+	}
+
+	// First call — pass nil + size=0 to learn the required buffer
+	// size. The kernel writes the size into our dwSize pointer and
+	// returns ERROR_INSUFFICIENT_BUFFER (122).
+	var bufSize uint32
+	r1, _, _ := getIPNetTable.Call(
+		uintptr(0),
+		uintptr(unsafe.Pointer(&bufSize)),
+		uintptr(0), // bOrder = FALSE; we sort ourselves if needed
+	)
+	if r1 != errorInsufficientBuffer && r1 != noError {
+		return nil, []string{fmt.Sprintf("arp: GetIpNetTable size probe failed: %s", winErr(r1))}
+	}
+	if bufSize == 0 {
+		// Empty ARP cache — fresh boot, no neighbors seen yet.
+		return nil, nil
+	}
+
+	buf := make([]byte, bufSize)
+	r1, _, _ = getIPNetTable.Call(
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&bufSize)),
+		uintptr(0),
+	)
+	if r1 != noError {
+		return nil, []string{fmt.Sprintf("arp: GetIpNetTable read failed: %s", winErr(r1))}
+	}
+
+	// The buffer layout is:
+	//   DWORD dwNumEntries
+	//   MIB_IPNETROW table[dwNumEntries]
+	if len(buf) < int(unsafe.Sizeof(uint32(0))) {
+		return nil, []string{"arp: GetIpNetTable returned undersized buffer"}
+	}
+	numEntries := binary.LittleEndian.Uint32(buf[:4])
+	rowSize := int(unsafe.Sizeof(mibIPNetRow{}))
+	expectedSize := 4 + int(numEntries)*rowSize
+	if len(buf) < expectedSize {
+		return nil, []string{
+			fmt.Sprintf("arp: GetIpNetTable buffer smaller than numEntries=%d implies (got %d, want %d)",
+				numEntries, len(buf), expectedSize),
+		}
+	}
+
+	// Build an interface index → name lookup once; the ARP table can
+	// have thousands of rows on a busy host and we don't want to call
+	// net.InterfaceByIndex per row.
+	ifaceNames := indexInterfaceNames()
+
+	entries := make([]ArpEntry, 0, numEntries)
+	var warnings []string
+	cursor := 4 // skip dwNumEntries
+	for i := uint32(0); i < numEntries; i++ {
+		var row mibIPNetRow
+		rowBytes := buf[cursor : cursor+rowSize]
+		cursor += rowSize
+
+		// Decode the fixed-layout struct. We can't just *(*mibIPNetRow)
+		// the buffer because Go's escape analysis dislikes the trip
+		// through unsafe.Pointer; the explicit decode is safer and
+		// keeps the analyzer happy.
+		row.DwIndex = binary.LittleEndian.Uint32(rowBytes[0:4])
+		row.DwPhysAddrLen = binary.LittleEndian.Uint32(rowBytes[4:8])
+		copy(row.BPhysAddr[:], rowBytes[8:16])
+		row.DwAddr = binary.LittleEndian.Uint32(rowBytes[16:20])
+		row.DwType = binary.LittleEndian.Uint32(rowBytes[20:24])
+
+		if row.DwType == mibIPNetTypeInvalid {
+			continue
+		}
+		if row.DwPhysAddrLen != 6 {
+			// Non-Ethernet MAC width (Token Ring, etc.) — skip.
+			continue
+		}
+
+		// DwAddr is in network byte order on Windows even though the
+		// kernel exposes the rest of the struct in host order. The
+		// MS docs are crisp about this and Tailscale's iphlpapi
+		// wrappers agree.
+		ipBytes := [4]byte{
+			byte(row.DwAddr),
+			byte(row.DwAddr >> 8),
+			byte(row.DwAddr >> 16),
+			byte(row.DwAddr >> 24),
+		}
+		ip := net.IP(ipBytes[:]).String()
+		mac := formatMAC(row.BPhysAddr[:6])
+		if _, skip := skipMACs[mac]; skip {
+			continue
+		}
+		if !isLikelyIPv4(ip) || !isLikelyMAC(mac) {
+			continue
+		}
+		// Drop multicast / link-local / broadcast addresses. Windows
+		// includes the host's joined multicast groups in
+		// GetIpNetTable (224.x.x.x mapped to 01:00:5e:* MACs); Linux
+		// doesn't, and they're not real LAN hosts. See arp.go for
+		// the full filter rationale.
+		if !isUnicastLANAddress(ip) {
+			continue
+		}
+
+		iface := ifaceNames[int(row.DwIndex)]
+		if iface == "" {
+			iface = "ifindex-" + strconv.Itoa(int(row.DwIndex))
+		}
+		entries = append(entries, ArpEntry{IP: ip, MAC: mac, Iface: iface})
+	}
+
+	return entries, warnings
+}
+
+func formatMAC(b []byte) string {
+	// Equivalent to net.HardwareAddr(b).String() but avoids the
+	// allocation overhead of constructing the slice. We always have
+	// 6 bytes here.
+	const hex = "0123456789abcdef"
+	out := make([]byte, 17)
+	for i, x := range b {
+		out[i*3] = hex[x>>4]
+		out[i*3+1] = hex[x&0x0f]
+		if i < 5 {
+			out[i*3+2] = ':'
+		}
+	}
+	return string(out)
+}
+
+func indexInterfaceNames() map[int]string {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	out := make(map[int]string, len(ifs))
+	for _, iface := range ifs {
+		out[iface.Index] = iface.Name
+	}
+	return out
+}
+
+func winErr(rc uintptr) string {
+	return syscall.Errno(rc).Error()
+}

--- a/services/edge-node-go/internal/collect/osinfo_darwin.go
+++ b/services/edge-node-go/internal/collect/osinfo_darwin.go
@@ -6,18 +6,23 @@ import (
 	"context"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // osRelease shells to /usr/bin/sw_vers for the user-facing macOS
-// version (e.g. "macOS 14.5") and uses syscall.Uname() for the
-// Darwin kernel string. sw_vers ships with the base OS so this
-// doesn't require Xcode or third-party tools.
+// version (e.g. "macOS 14.5") and uses unix.Uname() for the Darwin
+// kernel string. sw_vers ships with the base OS so this doesn't
+// require Xcode or third-party tools.
+//
+// stdlib syscall.Utsname is Linux-only; we route through
+// golang.org/x/sys/unix (already in the module's dep tree via the
+// Windows ARP code) which exposes the same API on Darwin.
 //
 // 2-second timeout — sw_vers is local and should respond instantly;
-// any longer means the system is in a degenerate state and we'd
-// rather surface an empty release than block the sweep.
+// longer means the system is in a degenerate state and we'd rather
+// surface an empty release than block the sweep.
 func osRelease() (release string, kernel string, err error) {
 	release = swVersDescription()
 	kernel = darwinUnameRelease()
@@ -49,23 +54,19 @@ func swVersDescription() string {
 }
 
 func darwinUnameRelease() string {
-	var u syscall.Utsname
-	if err := syscall.Uname(&u); err != nil {
+	var u unix.Utsname
+	if err := unix.Uname(&u); err != nil {
 		return ""
 	}
+	// unix.Utsname.Release is [65]byte on Darwin (not int8 like Linux);
+	// the bytes are NUL-terminated.
 	return utsnameToString(u.Release[:])
 }
 
-// utsnameToString reads the int8/byte slice the platform returns and
-// stops at the first NUL terminator. Darwin's syscall.Utsname.Release
-// is `[256]int8`.
-func utsnameToString(in []int8) string {
-	var b strings.Builder
-	for _, c := range in {
-		if c == 0 {
-			break
-		}
-		b.WriteByte(byte(c))
+func utsnameToString(in []byte) string {
+	end := 0
+	for end < len(in) && in[end] != 0 {
+		end++
 	}
-	return b.String()
+	return string(in[:end])
 }


### PR DESCRIPTION
## Summary

Third slice of the Mode 4 native binary. The agent enumerates the host's ARP cache and submits one `ObservationItem` per resolved LAN neighbor. **Verified live on Mark's Windows install: 17 real LAN devices flowed in from a single sweep** — UDM Ultra gateway at 192.168.0.1, multiple Amazon devices (50:DC:E7 OUI), Wi-Fi clients, the works. The container path could never see any of these because Docker isolates them behind the services bridge.

## Per-platform implementation

| Platform | Source | Notes |
|---|---|---|
| **Windows** | [`iphlpapi.dll`'s `GetIpNetTable`](services/edge-node-go/internal/collect/arp_windows.go) | Two-call sizing pattern; manual `binary.LittleEndian` decoding of `MIB_IPNETTABLE`; skips `MIB_IPNET_TYPE_INVALID` (≡ Linux `ATF_COM=0`); batched ifIndex→name lookup via `net.Interfaces()`. |
| **Linux** | [`/proc/net/arp`](services/edge-node-go/internal/collect/arp_linux.go) | Same source the TS Mode 1 service reads. ATF_COM=0x2 filter, lowercase MAC normalization. |
| **macOS** | [`/usr/sbin/arp -an`](services/edge-node-go/internal/collect/arp_darwin.go) | 5-second timeout. Single-hex-digit MAC normalization. |
| **Other** | empty + warning | Cross-compile to BSD etc. still produces a working binary. |

All four paths route through the same `ArpEntry` shape and `arpToItems` mapper, so wire output is identical regardless of host OS.

## Multicast filter

Windows `GetIpNetTable` includes the host's joined multicast groups (224.x.x.x mapped to 01:00:5e:* MACs). Without filtering, my first verification run produced 28 items, 11 of which were bogus "LAN Host 224.0.0.251" rows. Added `isUnicastLANAddress` filter to drop 224.0.0.0/4 (multicast), 255.255.255.255 (broadcast), 169.254.0.0/16 (APIPA), 0.0.0.0/8 (unspecified). Applied uniformly to all platforms; behavior is consistent regardless of source.

## Live verification result

```
Discovery run submitted: items=18 warnings=0

ARP entries (sample):
  arp:192.168.0.1     9e:05:d6:de:8d:40   Ethernet 2   ← UDM Ultra gateway
  arp:192.168.0.112   50:dc:e7:5d:62:68   Ethernet 2   ← Amazon (50:DC:E7 OUI)
  arp:192.168.0.236   50:dc:e7:f6:91:52   Ethernet 2   ← Amazon
  arp:192.168.0.49    0c:ee:99:d1:0a:e3   Wi-Fi
  arp:192.168.0.14    68:9a:87:90:6b:36   Wi-Fi
  arp:192.168.0.169   a8:3b:76:1e:41:2f   Ethernet 2
  ... 11 more LAN devices
```

## Test plan

- [x] `go build ./...` clean (host + linux/amd64, darwin/arm64, windows/amd64 cross-compile)
- [x] `go test ./...` — **56 tests pass** (45 from W1+W2 + 11 new for ARP / multicast)
- [x] `go vet ./...` clean
- [x] **Live on Mark's Windows install**: 17 real LAN devices submitted via the Windows ARP cache, no multicast noise
- [x] apps/web wire-contract parity test still passes
- [ ] **Reviewer**: pull on a Linux host, run with `DPF_AUTHORITY_URL` + `DPF_BOOTSTRAP_TOKEN`, confirm `/proc/net/arp` entries show up with `arp:<ip>` keys

## Out of scope — what's next

| Slice | Scope |
|---|---|
| **W3.5** (next) | Port the MAC OUI vendor enricher from [#846](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/846) to Go. 1.2 MB IEEE dataset via `go:embed`. \"LAN Host 192.168.0.49\" becomes \"Amazon 192.168.0.49\" — exact parity with TS Mode 1. |
| **W4** | SNMP poll via `gosnmp` |
| **W5–W8** | Windows Service / macOS LaunchDaemon / Linux systemd integration |
| **W9** | Installer wrappers (MSI / PKG / .deb / .rpm) + code signing |

Plan: [`docs/superpowers/plans/2026-05-14-edge-node-t3-windows-native.md`](docs/superpowers/plans/2026-05-14-edge-node-t3-windows-native.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)