### PR TITLE
feat(edge-node): UniFi adapter Slice B — clients endpoint (/stat/sta)

### DIFF
--- a/docs/edge-node/unifi-adapter.md
+++ b/docs/edge-node/unifi-adapter.md
@@ -1,8 +1,8 @@
 # UniFi Adapter — Operator Setup
 
-The UniFi adapter pulls device-level topology from a local UniFi Network controller and submits it through the same discovery pipeline the rest of the edge node uses. After setup, the topology view shows your real network — gateway → switches → access points — instead of just ARP-discovered hosts.
+The UniFi adapter pulls topology from a local UniFi Network controller and submits it through the same discovery pipeline the rest of the edge node uses. After setup, the topology view shows your real network — gateway → switches → access points — **plus** every connected client (Amazon Echos, Reolink cameras, phones, IoT devices) with vendor labels, all hanging off the AP or switch they're actually connected through.
 
-This page covers Slice A: read-only discovery (no per-port throughput yet). Throughput, LLDP, and the metrics channel land in a follow-up.
+This page covers Slices A + B: read-only discovery of UniFi-managed devices AND the WiFi/wired clients the controller has authenticated. Per-port throughput, LLDP, and the metrics channel land in a follow-up.
 
 ## What you need
 
@@ -81,6 +81,8 @@ docker compose logs edge-node --tail 50
 
 ## What the adapter emits
 
+### UniFi-managed devices (Slice A — `/stat/device`)
+
 | UniFi `type` | DPF `itemType` | OSI layer |
 |---|---|---|
 | `usw` (switch) | `switch` | 2 |
@@ -93,7 +95,21 @@ For every UniFi device:
 - A `SAME_AS` relationship to `arp:<ip>` so the Authority's normalization can collapse the two records into one canonical Configuration Item.
 - A `HOSTS` relationship from each device to its uplink parent (gateway → switch → AP).
 
-The topology view treats these the same way as any other discovered CI, so they show up in the Subnet View, the Network View, and the impact-blast-radius traversal automatically.
+### Connected clients (Slice B — `/stat/sta`)
+
+For every authenticated WiFi or wired client (your phones, laptops, Amazon Echos, Reolink cameras, smart switches, etc.):
+- An `ObservationItem` keyed `arp:<ip>` — same key the local ARP collector uses, so observations dedupe on the Authority side regardless of which collector sees the device first.
+- Display name preference: operator-set name in the UniFi UI ("Mark's iPhone") → DHCP hostname → `<short-vendor> <ip>` (e.g. "Amazon 192.168.0.49") → generic `LAN Host <ip>`.
+- `rawData.vendor` / `vendorOui` / `vendorShort` from the bundled IEEE OUI registry — same enrichment the local ARP collector applies.
+- For WiFi clients: `rawData.apMac`, `essid`, `channel`, `radio`, `signal`, `rssi`, `noise`. Higher confidence (`0.9`) than local ARP entries (`0.7`) because UniFi has authenticated the client, not just learned a kernel neighbor entry.
+- For wired clients: `rawData.swMac`, `swPort`.
+- A `MEMBER_OF` relationship from each client (`arp:<ip>`) to the UniFi-managed device it connects through (`unifi:<ap-or-switch-mac>`) — this is what makes the topology view draw "this Echo hangs off this AP" edges.
+
+### Independent failure handling
+
+The two endpoints are fetched in parallel and their errors are isolated. If `/stat/sta` returns 503 but `/stat/device` succeeds, the device items still flow and only one warning is emitted. Same the other way. A single endpoint failure never blocks the other.
+
+The topology view treats all of these the same way as any other discovered CI, so they show up in the Subnet View, the Network View, and the impact-blast-radius traversal automatically.
 
 ## Troubleshooting
 
@@ -113,7 +129,7 @@ The topology view treats these the same way as any other discovered CI, so they 
 |---|---|
 | Per-port `rx/tx` throughput metrics | The full spec at [`docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md`](../superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md) — needs the `metrics.network` capability + the `/api/v1/edge/metrics` endpoint, neither of which exist yet. |
 | LLDP-derived L2 wiring | Same spec, § 4.2 — separate collector. |
-| WebSocket event-driven sweep on device join | Same spec, § 4.3 — Slice A polls on the regular sweep cadence (5 min). |
+| WebSocket event-driven sweep on client/device join | Same spec, § 4.3 — both slices poll on the regular sweep cadence (5 min). |
 | Cookie-auth for pre-9.0 controllers | If you need this, open an issue with your controller version and we'll add the auth fallback. |
 
 ## Reference

--- a/services/edge-node/src/__tests__/unifi.test.ts
+++ b/services/edge-node/src/__tests__/unifi.test.ts
@@ -32,15 +32,64 @@ function makeConfigAdapter(
   };
 }
 
+type StubResp = {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+  throwErr?: string;
+};
+
+/**
+ * Per-endpoint stub. Test passes responses keyed by the endpoint
+ * substring ("stat/device" or "stat/sta"). Endpoints not in the map
+ * default to an empty `{ data: [] }` success response — so a test
+ * that only cares about device behavior automatically gets a clean
+ * empty-clients response from the parallel /stat/sta fetch the
+ * collector now makes.
+ *
+ * The legacy `makeFetchStub` (single responder, ignores URL) is
+ * preserved as a thin wrapper for older tests that don't need
+ * per-endpoint control.
+ */
+function makeFetchStubByEndpoint(
+  responses: { devices?: StubResp; clients?: StubResp },
+): UnifiAdapter["fetch"] {
+  return async (url) => {
+    let r: StubResp;
+    if (url.includes("/stat/device")) {
+      r = responses.devices ?? {};
+    } else if (url.includes("/stat/sta")) {
+      r = responses.clients ?? {};
+    } else {
+      r = {};
+    }
+    if (r.throwErr) throw new Error(r.throwErr);
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.body ?? { data: [] },
+      text: async () =>
+        typeof r.body === "string" ? r.body : JSON.stringify(r.body ?? {}),
+    };
+  };
+}
+
 function makeFetchStub(
-  responder: (url: string, init: { headers?: Record<string, string> }) => {
-    ok?: boolean;
-    status?: number;
-    body?: unknown;
-    throwErr?: string;
-  },
+  responder: (url: string, init: { headers?: Record<string, string> }) => StubResp,
 ): UnifiAdapter["fetch"] {
   return async (url, init) => {
+    // For backwards-compat: only respond to /stat/device URLs with
+    // the user-supplied responder. /stat/sta defaults to an empty
+    // success response so tests written before Slice B keep working
+    // unchanged.
+    if (!url.includes("/stat/device")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+        text: async () => `{"data":[]}`,
+      };
+    }
     const r = responder(url, init);
     if (r.throwErr) throw new Error(r.throwErr);
     return {
@@ -232,6 +281,274 @@ describe("collectUnifi — controller success", () => {
     };
     const result = await collectUnifi(adapter);
     expect(result.items.map((i) => i.observedKey)).toEqual(["unifi:11:22:33:44:55:66"]);
+  });
+});
+
+// ─── Slice B — clients ────────────────────────────────────────────
+
+const aWifiClient = (overrides: Record<string, unknown> = {}) => ({
+  mac: "fc:a1:83:11:22:33", // Amazon OUI (in bundled IEEE registry)
+  ip: "192.168.0.49",
+  hostname: "echo-dot-bedroom",
+  name: "Echo Dot — Bedroom",
+  is_wired: false,
+  is_guest: false,
+  network: "LAN",
+  ap_mac: "aa:aa:aa:aa:aa:aa",
+  essid: "HomeNet",
+  channel: 36,
+  radio: "na",
+  signal: -50,
+  rssi: 45,
+  noise: -95,
+  first_seen: 1716240000,
+  last_seen: 1716243600,
+  ...overrides,
+});
+
+const aWiredClient = (overrides: Record<string, unknown> = {}) => ({
+  mac: "00:1d:c0:de:fa:ce",
+  ip: "192.168.0.99",
+  hostname: "reolink-cam-driveway",
+  is_wired: true,
+  is_guest: false,
+  network: "LAN",
+  sw_mac: "bb:bb:bb:bb:bb:bb",
+  sw_port: 4,
+  first_seen: 1716200000,
+  last_seen: 1716243600,
+  ...overrides,
+});
+
+describe("collectUnifi — Slice B clients", () => {
+  it("maps a WiFi client to an arp:<ip> ObservationItem with vendor enrichment", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: { body: { data: [aWifiClient()] } },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items).toHaveLength(1);
+    const item = result.items[0]!;
+    expect(item.observedKey).toBe("arp:192.168.0.49");
+    expect(item.itemType).toBe("host");
+    expect(item.confidence).toBe(0.9);
+    // Operator-set name wins over hostname + vendor.
+    expect(item.name).toBe("Echo Dot — Bedroom");
+    // OUI enrichment fired (FC:A1:83 is Amazon).
+    expect(item.rawData.vendor).toMatch(/^Amazon/);
+    expect(item.rawData.vendorOui).toBe("FCA183");
+    expect(item.rawData.vendorShort).toBe("Amazon");
+    // WiFi-only fields populated.
+    expect(item.rawData.isWired).toBe(false);
+    expect(item.rawData.apMac).toBe("aa:aa:aa:aa:aa:aa");
+    expect(item.rawData.essid).toBe("HomeNet");
+    expect(item.rawData.signal).toBe(-50);
+    // Wired-only fields absent (or null) on a WiFi client.
+    expect(item.rawData.swMac).toBeUndefined();
+    expect(item.rawData.swPort).toBeUndefined();
+    // Discovery source records this came from the clients endpoint
+    // specifically, not the local ARP cache.
+    expect(item.rawData.discoveredVia).toBe("unifi_clients_api");
+  });
+
+  it("falls back to vendor-shaped name when no operator name + no hostname", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: {
+          body: {
+            data: [aWifiClient({ name: undefined, hostname: undefined })],
+          },
+        },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items[0]?.name).toBe("Amazon 192.168.0.49");
+  });
+
+  it("falls back to LAN Host shape when no name, no hostname, no OUI match", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: {
+          body: {
+            data: [
+              aWifiClient({
+                mac: "de:ad:be:ef:00:01", // not in IEEE registry
+                name: undefined,
+                hostname: undefined,
+                ip: "192.168.0.77",
+              }),
+            ],
+          },
+        },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items[0]?.name).toBe("LAN Host 192.168.0.77");
+    expect(result.items[0]?.rawData.vendor).toBeUndefined();
+  });
+
+  it("emits a MEMBER_OF link from a WiFi client to its AP", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: { body: { data: [aWifiClient()] } },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    const memberOf = result.relationships.filter((r) => r.relationshipType === "MEMBER_OF");
+    expect(memberOf).toEqual([
+      {
+        fromObservedKey: "arp:192.168.0.49",
+        toObservedKey: "unifi:aa:aa:aa:aa:aa:aa",
+        relationshipType: "MEMBER_OF",
+        rawData: {
+          mechanism: "unifi_wifi_assoc",
+          port: null,
+          essid: "HomeNet",
+        },
+      },
+    ]);
+  });
+
+  it("emits wired-specific MEMBER_OF link from a wired client to its switch+port", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: { body: { data: [aWiredClient()] } },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    const memberOf = result.relationships.filter((r) => r.relationshipType === "MEMBER_OF");
+    expect(memberOf).toEqual([
+      {
+        fromObservedKey: "arp:192.168.0.99",
+        toObservedKey: "unifi:bb:bb:bb:bb:bb:bb",
+        relationshipType: "MEMBER_OF",
+        rawData: {
+          mechanism: "unifi_switch_port",
+          port: 4,
+          essid: null,
+        },
+      },
+    ]);
+
+    // Wired-only fields present on item rawData; WiFi-only absent.
+    const item = result.items[0]!;
+    expect(item.rawData.swMac).toBe("bb:bb:bb:bb:bb:bb");
+    expect(item.rawData.swPort).toBe(4);
+    expect(item.rawData.apMac).toBeUndefined();
+    expect(item.rawData.essid).toBeUndefined();
+  });
+
+  it("skips MEMBER_OF when ap_mac (wifi) or sw_mac (wired) is missing", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: {
+          body: {
+            data: [
+              aWifiClient({ ap_mac: undefined }),
+              aWiredClient({ sw_mac: undefined }),
+            ],
+          },
+        },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items).toHaveLength(2);
+    expect(result.relationships.filter((r) => r.relationshipType === "MEMBER_OF")).toEqual([]);
+  });
+
+  it("drops clients with missing or invalid IP / MAC", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        clients: {
+          body: {
+            data: [
+              aWifiClient({ mac: "not-a-mac" }),
+              aWifiClient({ ip: undefined, mac: "aa:bb:cc:dd:ee:01" }),
+              aWifiClient({ mac: "aa:bb:cc:dd:ee:02", ip: "10.0.0.42" }),
+            ],
+          },
+        },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items.map((i) => i.observedKey)).toEqual(["arp:10.0.0.42"]);
+  });
+
+  it("merges devices + clients into one envelope", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        devices: { body: { data: [aDevice()] } },
+        clients: { body: { data: [aWifiClient()] } },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    const keys = result.items.map((i) => i.observedKey).sort();
+    expect(keys).toEqual([
+      "arp:192.168.0.49",         // the WiFi client
+      "unifi:aa:bb:cc:dd:ee:ff",  // the AP device
+    ]);
+    // Relationships from BOTH endpoints present.
+    const types = result.relationships.map((r) => r.relationshipType).sort();
+    expect(types).toEqual(["MEMBER_OF", "SAME_AS"]);
+  });
+
+  it("isolates errors per endpoint — clients failure doesn't kill devices payload", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        devices: { body: { data: [aDevice()] } },
+        clients: { ok: false, status: 503, body: "service unavailable" },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    // Devices flowed through.
+    expect(result.items.map((i) => i.observedKey)).toEqual(["unifi:aa:bb:cc:dd:ee:ff"]);
+    // Clients failure surfaced as a warning.
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/HTTP 503/);
+  });
+
+  it("isolates errors the other way — devices failure doesn't kill clients payload", async () => {
+    const adapter: UnifiAdapter = {
+      fetch: makeFetchStubByEndpoint({
+        devices: { ok: false, status: 500, body: "down" },
+        clients: { body: { data: [aWifiClient()] } },
+      }),
+      configAdapter: makeConfigAdapter({
+        "/etc/dpf-edge/adapters.json": { contents: VALID_CONFIG, mode: 0o600 },
+      }),
+    };
+    const result = await collectUnifi(adapter);
+    expect(result.items.map((i) => i.observedKey)).toEqual(["arp:192.168.0.49"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/HTTP 500/);
   });
 });
 

--- a/services/edge-node/src/collectors/unifi.ts
+++ b/services/edge-node/src/collectors/unifi.ts
@@ -1,26 +1,37 @@
-// UniFi adapter (Slice A — discovery only).
+// UniFi adapter (Slice A + Slice B — discovery only).
 //
-// Pulls the list of UniFi-managed network devices (switches, access
-// points, gateways) from a local UniFi Network controller and emits
-// them as ObservationItem records. Each device gets a SAME_AS link to
-// the `arp:<ip>` key the ARP collector already produces, so the
-// Authority Core's normalization can collapse the two into a single
-// canonical Configuration Item. Parent-child device topology
-// (gateway → switch → AP) is emitted as HOSTS relationships using the
-// controller's `uplink.uplink_mac` field.
+// Slice A — managed devices (/stat/device):
+//   Pulls the list of UniFi-managed network devices (switches, access
+//   points, gateways) from a local UniFi Network controller and emits
+//   them as ObservationItem records. Each device gets a SAME_AS link
+//   to the `arp:<ip>` key the ARP collector already produces, so the
+//   Authority Core's normalization can collapse the two into a single
+//   canonical Configuration Item. Parent-child device topology
+//   (gateway → switch → AP) is emitted as HOSTS relationships using
+//   the controller's `uplink.uplink_mac` field.
 //
-// What's NOT in this slice (lands in Slice B):
-//   - Per-port throughput telemetry (rx_bytes-r / tx_bytes-r). That
-//     needs the metrics.network capability + /api/v1/edge/metrics
-//     endpoint, neither of which exist yet.
-//   - WebSocket event subscription for instant-on device joins.
+// Slice B — clients (/stat/sta):
+//   Pulls every device the UniFi controller has authenticated — WiFi
+//   clients, wired clients, the works. This is what surfaces Amazon
+//   Echos, Reolink cameras, phones, IoT, etc. when the edge node
+//   itself can't ARP the LAN (the Docker-Desktop-on-Windows case).
+//   Each client emits an ObservationItem keyed `arp:<client-ip>` so
+//   it dedupes with the local ARP collector when both see the same
+//   device, plus a MEMBER_OF relationship to the AP / switch it
+//   connects through (matching the spec's "logical topology" intent).
+//   OUI vendor enrichment is included inline.
+//
+// What's still NOT in this slice (lands in future slices):
+//   - Per-port throughput telemetry (rx_bytes-r / tx_bytes-r). Needs
+//     the metrics.network capability + /api/v1/edge/metrics endpoint.
+//   - WebSocket event subscription for instant-on join events.
 //     5-minute sweep cadence is fine for v1.
 //   - PoE wattage per port.
 //
 // Auth: API-key header (`X-API-KEY`). UniFi Network 9.x+ generates
 // API keys in Settings → System → API. Cookie-session local auth is
-// out of scope for Slice A; if it's needed later, gate on whether
-// config.apiKey is empty and fall through to a /api/auth/login flow.
+// out of scope; if it's needed later, gate on whether config.apiKey
+// is empty and fall through to a /api/auth/login flow.
 //
 // TLS: many home UniFi installs use a self-signed cert. The
 // `tlsInsecure` config flag opts into accepting any cert by swapping
@@ -31,6 +42,7 @@
 
 import { Agent, fetch as undiciFetch } from "undici";
 
+import { lookupOui, shortVendor } from "../lib/mac-oui";
 import {
   resolveAdaptersConfig,
   type AdaptersConfigAdapter,
@@ -63,8 +75,43 @@ type UnifiDevice = {
   state?: number;
   version?: string;
   uplink?: { uplink_mac?: string; uplink_remote_port?: number; type?: string };
-  // Other fields (port_table, stat, last_seen, etc.) are ignored in
-  // Slice A; they'll be consumed by Slice B's metrics path.
+  // Other fields (port_table, stat, etc.) are ignored in Slice A;
+  // they'll be consumed by the metrics path (future slice).
+};
+
+/**
+ * Subset of the UniFi /stat/sta client shape we use. The full
+ * response carries dozens of stat counters per client; we keep the
+ * identity + topology subset and surface a few useful WiFi-only
+ * details (signal strength, AP MAC) in rawData for the topology view.
+ */
+type UnifiClient = {
+  mac: string;
+  ip?: string;
+  hostname?: string;
+  /** Operator-set friendly name in the UniFi UI ("Mark's iPhone"). */
+  name?: string;
+  /** UniFi's own MAC manufacturer lookup. We trust ours over theirs. */
+  oui?: string;
+  /** Unix-second timestamps. */
+  first_seen?: number;
+  last_seen?: number;
+  is_wired?: boolean;
+  is_guest?: boolean;
+  /** Network / VLAN name the controller has the client in. */
+  network?: string;
+  /** WiFi-only — MAC of the AP the client is associated with. */
+  ap_mac?: string;
+  essid?: string;
+  channel?: number;
+  radio?: string;
+  radio_proto?: string;
+  signal?: number;
+  rssi?: number;
+  noise?: number;
+  /** Wired-only — MAC of the switch the client is connected through. */
+  sw_mac?: string;
+  sw_port?: number;
 };
 
 /** Adapter for tests — replaces fetch + the config resolver. */
@@ -171,6 +218,32 @@ async function fetchUnifiDevices(
   adapter: UnifiAdapter,
 ): Promise<{ devices: UnifiDevice[] } | { error: string }> {
   const url = `${unifi.controllerUrl}/proxy/network/api/s/${encodeURIComponent(unifi.site)}/stat/device`;
+  const result = await fetchUnifiJsonArray<UnifiDevice>(url, unifi, adapter);
+  if ("error" in result) return result;
+  return { devices: result.data };
+}
+
+async function fetchUnifiClients(
+  unifi: UnifiAdapterConfig,
+  adapter: UnifiAdapter,
+): Promise<{ clients: UnifiClient[] } | { error: string }> {
+  const url = `${unifi.controllerUrl}/proxy/network/api/s/${encodeURIComponent(unifi.site)}/stat/sta`;
+  const result = await fetchUnifiJsonArray<UnifiClient>(url, unifi, adapter);
+  if ("error" in result) return result;
+  return { clients: result.data };
+}
+
+/**
+ * Common fetch + parse for the two `data: []` endpoints we use. The
+ * wire contract is identical between /stat/device and /stat/sta —
+ * both return `{ data: T[] }`. Each caller wraps with the field name
+ * its API consumers expect.
+ */
+async function fetchUnifiJsonArray<T>(
+  url: string,
+  unifi: UnifiAdapterConfig,
+  adapter: UnifiAdapter,
+): Promise<{ data: T[] } | { error: string }> {
   let resp: Awaited<ReturnType<UnifiAdapter["fetch"]>>;
   try {
     resp = await adapter.fetch(url, {
@@ -206,18 +279,122 @@ async function fetchUnifiDevices(
     return { error: `controller response missing data[] array` };
   }
 
+  return { data: (parsed as { data: T[] }).data };
+}
+
+/**
+ * Map a UniFi client to an ObservationItem. Keyed `arp:<ip>` so it
+ * dedupes with the local ARP collector when both see the same device.
+ * OUI vendor enrichment is included inline so the topology view
+ * shows "Amazon 192.168.0.49" without needing a downstream enricher,
+ * matching the shape the ARP collector emits (per PR #846).
+ *
+ * Returns null for clients without a usable MAC + IP — the wire
+ * contract requires an observedKey, and `arp:<empty>` is meaningless.
+ */
+function buildItemFromClient(client: UnifiClient): ObservationItem | null {
+  const mac = client.mac?.toLowerCase();
+  if (!mac || !/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/.test(mac)) return null;
+  if (!client.ip) return null;
+
+  const oui = lookupOui(mac);
+  const displayName =
+    client.name ||
+    client.hostname ||
+    (oui ? `${shortVendor(oui.vendor)} ${client.ip}` : `LAN Host ${client.ip}`);
+
+  const rawData: Record<string, unknown> = {
+    address: client.ip,
+    mac,
+    osiLayer: 3,
+    osiLayerName: "network",
+    protocolFamily: "ipv4",
+    discoveredVia: "unifi_clients_api",
+    hostname: client.hostname ?? null,
+    operatorName: client.name ?? null,
+    isWired: client.is_wired ?? null,
+    isGuest: client.is_guest ?? null,
+    network: client.network ?? null,
+    firstSeen: client.first_seen ? new Date(client.first_seen * 1000).toISOString() : null,
+    lastSeen: client.last_seen ? new Date(client.last_seen * 1000).toISOString() : null,
+    unifiOui: client.oui ?? null,
+  };
+
+  if (oui) {
+    rawData.vendor = oui.vendor;
+    rawData.vendorOui = oui.oui;
+    rawData.vendorShort = shortVendor(oui.vendor);
+  }
+
+  if (client.is_wired) {
+    rawData.swMac = client.sw_mac ?? null;
+    rawData.swPort = client.sw_port ?? null;
+  } else {
+    rawData.apMac = client.ap_mac ?? null;
+    rawData.essid = client.essid ?? null;
+    rawData.channel = client.channel ?? null;
+    rawData.radio = client.radio ?? null;
+    rawData.radioProto = client.radio_proto ?? null;
+    rawData.signal = client.signal ?? null;
+    rawData.rssi = client.rssi ?? null;
+    rawData.noise = client.noise ?? null;
+  }
+
   return {
-    devices: (parsed as { data: UnifiDevice[] }).data,
+    observedKey: `arp:${client.ip}`,
+    itemType: "host",
+    name: displayName,
+    // Higher confidence than the ARP collector's 0.7: UniFi has
+    // authenticated this client (DHCP lease + auth handshake), not
+    // just learned a kernel neighbor entry.
+    confidence: 0.9,
+    rawData,
   };
 }
 
 /**
- * Run the UniFi adapter once. If no config block is present, returns
- * an empty result with no warnings — the adapter is opt-in.
+ * Build a MEMBER_OF relationship from each client to the UniFi-managed
+ * device it connects through (AP for wifi, switch for wired). Lets
+ * the topology view draw the logical "this phone is hanging off this
+ * AP" edges that operators care about.
  *
- * Errors are converted to warnings (and zero items) rather than
- * thrown, matching the pattern of every other collector: a single
- * adapter failure must never bring down the sweep.
+ * Returns null when the connection device MAC isn't known — that
+ * happens for clients in transitional states the UniFi controller
+ * exposes inconsistently.
+ */
+function buildClientMemberOfLink(client: UnifiClient): UnifiRelationship | null {
+  const mac = client.mac?.toLowerCase();
+  if (!mac || !client.ip) return null;
+
+  const parentMac = client.is_wired
+    ? client.sw_mac?.toLowerCase()
+    : client.ap_mac?.toLowerCase();
+  if (!parentMac) return null;
+
+  return {
+    fromObservedKey: `arp:${client.ip}`,
+    toObservedKey: `unifi:${parentMac}`,
+    relationshipType: "MEMBER_OF",
+    rawData: {
+      mechanism: client.is_wired ? "unifi_switch_port" : "unifi_wifi_assoc",
+      port: client.is_wired ? (client.sw_port ?? null) : null,
+      essid: !client.is_wired ? (client.essid ?? null) : null,
+    },
+  };
+}
+
+/**
+ * Run the UniFi adapter once. Fetches BOTH endpoints in parallel:
+ *   - /stat/device — UniFi-managed gateways/switches/APs (Slice A)
+ *   - /stat/sta    — every authenticated WiFi + wired client (Slice B)
+ *
+ * If no config block is present, returns an empty result with no
+ * warnings — the adapter is opt-in.
+ *
+ * Errors are converted to warnings (and zero items for the failing
+ * endpoint) rather than thrown, matching the pattern of every other
+ * collector. A clients fetch failure doesn't kill the devices
+ * payload, and vice versa — each endpoint is independent.
  */
 export async function collectUnifi(
   adapter?: UnifiAdapter,
@@ -233,26 +410,48 @@ export async function collectUnifi(
   // because the flag lives in the JSON config we just read.
   const effectiveAdapter: UnifiAdapter = adapter ?? buildDefaultAdapter(unifi.tlsInsecure);
 
-  const result = await fetchUnifiDevices(unifi, effectiveAdapter);
-  if ("error" in result) {
-    warnings.push(`unifi: ${result.error}`);
-    return { items: [], relationships: [], warnings };
-  }
+  // Fan out both endpoint calls concurrently. Promise.all is fine
+  // here because the two are independent and we already handle
+  // per-call errors inside each fetch function (they return
+  // {error: string} instead of throwing).
+  const [devicesResult, clientsResult] = await Promise.all([
+    fetchUnifiDevices(unifi, effectiveAdapter),
+    fetchUnifiClients(unifi, effectiveAdapter),
+  ]);
 
   const items: ObservationItem[] = [];
-  const sameAsLinks: UnifiRelationship[] = [];
-  for (const device of result.devices) {
-    const item = buildItemFromDevice(device);
-    if (!item) continue;
-    items.push(item);
-    const link = buildSameAsLink(device);
-    if (link) sameAsLinks.push(link);
+  const relationships: UnifiRelationship[] = [];
+
+  if ("error" in devicesResult) {
+    warnings.push(`unifi: ${devicesResult.error}`);
+  } else {
+    const sameAsLinks: UnifiRelationship[] = [];
+    for (const device of devicesResult.devices) {
+      const item = buildItemFromDevice(device);
+      if (!item) continue;
+      items.push(item);
+      const link = buildSameAsLink(device);
+      if (link) sameAsLinks.push(link);
+    }
+    relationships.push(...sameAsLinks);
+    relationships.push(...buildUplinkLinks(devicesResult.devices));
   }
-  const uplinkLinks = buildUplinkLinks(result.devices);
+
+  if ("error" in clientsResult) {
+    warnings.push(`unifi: ${clientsResult.error}`);
+  } else {
+    for (const client of clientsResult.clients) {
+      const item = buildItemFromClient(client);
+      if (!item) continue;
+      items.push(item);
+      const link = buildClientMemberOfLink(client);
+      if (link) relationships.push(link);
+    }
+  }
 
   return {
     items,
-    relationships: [...sameAsLinks, ...uplinkLinks],
+    relationships,
     warnings,
   };
 }


### PR DESCRIPTION
## Summary

Extends the UniFi adapter to fetch every authenticated WiFi + wired client from the controller alongside the managed devices fetched by Slice A ([#843](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/843)). **This is what surfaces the OTHER devices on the LAN** — Amazon Echos, Reolink cameras, phones, IoT — that the host's local ARP cache can't see when the edge node runs inside Docker Desktop.

Each client lands as an \`ObservationItem\` keyed \`arp:<ip>\` (same key as the local ARP collector so observations dedupe on the Authority side) with OUI vendor enrichment inline so labels match what [#846](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/846)'s ARP enricher produces — \"Amazon 192.168.0.49\", \"Reolink 192.168.0.99\". A \`MEMBER_OF\` relationship from each client to its AP (WiFi) or switch (wired) draws the logical \"which device hangs off which AP\" edges the spec at §4.3 calls out.

## What changed

| File | Role |
|---|---|
| [\`services/edge-node/src/collectors/unifi.ts\`](services/edge-node/src/collectors/unifi.ts) | New \`UnifiClient\` type, \`fetchUnifiClients()\`, \`buildItemFromClient()\` (with OUI enrichment + WiFi-vs-wired \`rawData\` differences), \`buildClientMemberOfLink()\` (mechanism = \`unifi_wifi_assoc\` or \`unifi_switch_port\`). \`collectUnifi()\` now fetches both endpoints in parallel via \`Promise.all\`; per-endpoint errors are isolated (a clients failure doesn't kill the devices payload). |
| [\`services/edge-node/src/__tests__/unifi.test.ts\`](services/edge-node/src/__tests__/unifi.test.ts) | New \`makeFetchStubByEndpoint()\` helper for per-endpoint stub responses. Existing \`makeFetchStub\` upgraded to default \`/stat/sta\` to empty success so all 9 Slice A tests keep working unchanged. 10 new Slice B tests covering item shape, WiFi vs wired \`rawData\`, MEMBER_OF link emission, missing parent skip, invalid input rejection, merged-endpoint envelope, and bidirectional error isolation. |
| [\`docs/edge-node/unifi-adapter.md\`](docs/edge-node/unifi-adapter.md) | Title scope updated to \"Slices A + B\". New \"Connected clients\" section documents the \`arp:<ip>\` key, name fallback chain (operator name → hostname → vendor-prefixed → generic), WiFi-vs-wired \`rawData\` differences, MEMBER_OF topology edges, and the per-endpoint error isolation. |

## Wire-contract details (clients)

- **observedKey**: \`arp:<client-ip>\` — matches the ARP collector for dedup.
- **itemType**: \`host\`.
- **confidence**: \`0.9\` — higher than ARP's \`0.7\` because UniFi has authenticated this client, not just learned a kernel neighbor entry.
- **name preference**: operator-set UniFi UI name (\"Echo Dot — Bedroom\") → DHCP hostname → \`<short-vendor> <ip>\` → generic \`LAN Host <ip>\`.
- **rawData (common)**: \`address\`, \`mac\`, \`osiLayer\`/\`osiLayerName\`, \`protocolFamily\`, \`discoveredVia: \"unifi_clients_api\"\`, \`hostname\`, \`operatorName\`, \`isWired\`, \`isGuest\`, \`network\`, \`firstSeen\`/\`lastSeen\` (RFC 3339), \`unifiOui\`.
- **rawData (when OUI matches)**: \`vendor\`, \`vendorOui\`, \`vendorShort\`.
- **rawData (WiFi-only)**: \`apMac\`, \`essid\`, \`channel\`, \`radio\`, \`radioProto\`, \`signal\`, \`rssi\`, \`noise\`.
- **rawData (wired-only)**: \`swMac\`, \`swPort\`.

## Topology relationship

Each client emits a \`MEMBER_OF\` from \`arp:<client-ip>\` → \`unifi:<ap-or-switch-mac>\`, with \`rawData.mechanism\` set to \`unifi_wifi_assoc\` or \`unifi_switch_port\` and the relevant port/essid. The topology view picks this up and draws \"client → AP/switch\" edges.

## Test plan

- [x] \`pnpm --filter dpf-edge-node typecheck\` clean
- [x] \`pnpm --filter dpf-edge-node test\` — 195 pass / 5 skipped (was 185 pass before; +10 new UniFi clients tests; all 9 prior Slice A tests still pass unchanged)
- [ ] **Live verification deferred** — requires the operator to generate a UniFi API key (Settings → Control Plane → Integrations) and place it in \`/etc/dpf-edge/adapters.json\` per the operator doc. Once configured, the next sweep surfaces every UniFi-authenticated client with vendor labels and topology edges.

## Stacking

Builds on the merged [#843](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/843) (Slice A). Independent of the Mode 4 Go work (#867 stack) — this lands on the TS Mode 1 container that's currently running on operator installs today.

## Out of scope

| Feature | Tracked by |
|---|---|
| Per-port \`rx/tx\` throughput metrics | Parent spec §4.3 — needs the \`metrics.network\` capability + \`/api/v1/edge/metrics\` endpoint, neither of which exist yet. |
| LLDP-derived L2 wiring | Parent spec §4.2 — separate collector. |
| WebSocket event-driven sweep on client/device join | Parent spec §4.3 — both slices poll on the regular sweep cadence (5 min). |
| Cookie-auth for pre-9.0 controllers | If an operator with an older controller needs it, add the \`/api/auth/login\` fallback. |

Spec: [\`docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md\`](docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md) §4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)