### PR TITLE
fix(build-studio): guard undefined path in normalizeBuildPlanPaths

### DIFF
--- a/apps/web/lib/integrate/build-plan-paths.ts
+++ b/apps/web/lib/integrate/build-plan-paths.ts
@@ -27,7 +27,8 @@ const LEGACY_BUILD_STUDIO_TEXT_ALIASES: Array<{ from: RegExp; to: string }> = [
   { from: /\bDetailsPreviewPanel\b/g, to: "BuildStudio" },
 ];
 
-function normalizeRelativePath(relativePath: string): string {
+function normalizeRelativePath(relativePath: string | undefined | null): string {
+  if (!relativePath) return "";
   return relativePath.trim().replace(/\\/g, "/").replace(/^\.\//, "");
 }
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6299,6 +6299,20 @@ export async function executeTool(
           };
         }
 
+        // Validate that every fileStructure entry has a path field — missing paths
+        // cause normalizeBuildPlanPaths to crash with "Cannot read properties of
+        // undefined (reading 'trim')".
+        const missingPathEntries = (fileStructure as Array<Record<string, unknown>>)
+          .map((e, i) => ({ i, path: e["path"] }))
+          .filter(({ path }) => !path || typeof path !== "string");
+        if (missingPathEntries.length > 0) {
+          return {
+            success: false,
+            error: "buildPlan fileStructure entries must all have a path field.",
+            message: `REJECTED: ${missingPathEntries.length} fileStructure entries are missing a "path" field (indices: ${missingPathEntries.map(({ i }) => i).join(", ")}). Every entry must have { "path": "apps/web/...", "action": "create"|"modify", "purpose": "..." }.`,
+          };
+        }
+
         const normalizedPlan = normalizeBuildPlanPaths(plan as Parameters<typeof normalizeBuildPlanPaths>[0]);
         if (normalizedPlan.unresolvedModifyPaths.length > 0) {
           return {


### PR DESCRIPTION
## Summary

- **Root cause:** `saveBuildEvidence` was crashing with `Cannot read properties of undefined (reading 'trim')` when an agent submitted a `buildPlan` whose `fileStructure` contained entries without a `path` field. The crash was swallowed as `[executeTool] Uncaught exception` so the agent received no useful feedback and the plan was silently dropped.
- **Impact:** Any build where the planning agent generates a fileStructure entry without a path field (e.g. a header/section entry) results in a permanent stuck state — the plan cannot be saved and the build cannot advance to Build phase.
- **Observed:** FB-78E967D4 (Add Reset Build) failing on every plan-save attempt.

## Fix

1. `normalizeRelativePath()` in `build-plan-paths.ts` — now accepts `undefined | null` and returns `""` for falsy inputs. Makes the normalizer safe regardless of call site.

2. `saveBuildEvidence` validation in `mcp-tools.ts` — explicitly checks every `fileStructure` entry for a non-empty string `path` field before calling `normalizeBuildPlanPaths`. Returns a descriptive `REJECTED` message with the offending indices so agents can fix the plan.

## Test plan

- [x] `pnpm --filter web typecheck` — clean (pre-commit hook confirmed)
- [ ] Verify FB-78E967D4 plan saves successfully after portal self-upgrades with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)