### PR TITLE
feat(observability): EP-COST Phase 1 — Anthropic cache telemetry + AgentBudgetEvent schema

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -9,6 +9,8 @@ import {
   aiInferenceTokens,
   aiInferenceErrors,
   aiInferenceCostUsd,
+  aiCacheCreationTokens,
+  aiCacheReadTokens,
 } from "@/lib/metrics";
 import {
   getDecryptedCredential,
@@ -465,6 +467,12 @@ export async function callProvider(
   // 4. Record token and cost metrics
   aiInferenceTokens.inc({ provider: providerId, model: modelId, direction: "input" }, result.usage.inputTokens);
   aiInferenceTokens.inc({ provider: providerId, model: modelId, direction: "output" }, result.usage.outputTokens);
+  if (result.usage.cacheCreationInputTokens) {
+    aiCacheCreationTokens.inc({ provider: providerId, model: modelId }, result.usage.cacheCreationInputTokens);
+  }
+  if (result.usage.cacheReadInputTokens) {
+    aiCacheReadTokens.inc({ provider: providerId, model: modelId }, result.usage.cacheReadInputTokens);
+  }
 
   // Phase A7: success-path telemetry row. Fire-and-forget so a DB outage
   // can't break the user's reply.
@@ -481,6 +489,7 @@ export async function callProvider(
     status: "success",
     inputTokens: result.usage.inputTokens,
     outputTokens: result.usage.outputTokens,
+    cacheCreationInputTokens: result.usage.cacheCreationInputTokens,
     toolCallsTotal: result.toolCalls.length,
     agentId: attribution?.agentId ?? undefined,
     threadId: attribution?.threadId ?? undefined,

--- a/apps/web/lib/operate/metrics.ts
+++ b/apps/web/lib/operate/metrics.ts
@@ -63,6 +63,20 @@ export const aiInferenceCostUsd = new Counter({
   registers: [metricsRegistry],
 });
 
+export const aiCacheCreationTokens = new Counter({
+  name: "dpf_ai_cache_creation_tokens_total",
+  help: "Tokens written into the Anthropic prompt cache (billed at cache-write rate)",
+  labelNames: ["provider", "model"] as const,
+  registers: [metricsRegistry],
+});
+
+export const aiCacheReadTokens = new Counter({
+  name: "dpf_ai_cache_read_tokens_total",
+  help: "Tokens read from the Anthropic prompt cache (billed at cache-read rate)",
+  labelNames: ["provider", "model"] as const,
+  registers: [metricsRegistry],
+});
+
 // ─── Semantic Memory Metrics ────────────────────────────────────────────────
 
 export const semanticMemoryOps = new Counter({

--- a/apps/web/lib/routing/adapter-telemetry-writer.ts
+++ b/apps/web/lib/routing/adapter-telemetry-writer.ts
@@ -55,6 +55,8 @@ export type AdapterTelemetryInput = {
   httpStatus?: number;
   inputTokens?: number;
   cachedInputTokens?: number;
+  /** Tokens written into the Anthropic prompt cache this call. */
+  cacheCreationInputTokens?: number;
   outputTokens?: number;
   reasoningTokens?: number;
   estimatedCostUsd?: number;
@@ -128,6 +130,7 @@ export async function writeAdapterTelemetry(
     if (input.httpStatus !== undefined) data.httpStatus = input.httpStatus;
     if (input.inputTokens !== undefined) data.inputTokens = input.inputTokens;
     if (input.cachedInputTokens !== undefined) data.cachedInputTokens = input.cachedInputTokens;
+    if (input.cacheCreationInputTokens !== undefined) data.cacheCreationInputTokens = input.cacheCreationInputTokens;
     if (input.outputTokens !== undefined) data.outputTokens = input.outputTokens;
     if (input.reasoningTokens !== undefined) data.reasoningTokens = input.reasoningTokens;
     if (input.estimatedCostUsd !== undefined) data.estimatedCostUsd = input.estimatedCostUsd;

--- a/apps/web/lib/routing/adapter-types.ts
+++ b/apps/web/lib/routing/adapter-types.ts
@@ -57,7 +57,14 @@ export interface AdapterRequest {
 export interface AdapterResult {
   text: string;
   toolCalls: ToolCallEntry[];
-  usage: { inputTokens: number; outputTokens: number };
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    /** Tokens written into the Anthropic prompt cache this call (billed at write rate). */
+    cacheCreationInputTokens?: number;
+    /** Tokens read from the Anthropic prompt cache this call (billed at read rate). */
+    cacheReadInputTokens?: number;
+  };
   inferenceMs: number;
   raw?: Record<string, unknown>;
   /** Responses API: the response ID for chaining subsequent calls. */

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -373,6 +373,8 @@ export const chatAdapter: ExecutionAdapterHandler = {
     let toolCalls: ToolCallEntry[] = [];
     let inputTokens: number;
     let outputTokens: number;
+    let cacheCreationInputTokens: number | undefined;
+    let cacheReadInputTokens: number | undefined;
 
     if (isAnthropic(providerId)) {
       // Anthropic response
@@ -383,6 +385,9 @@ export const chatAdapter: ExecutionAdapterHandler = {
       const usage = (data.usage as Record<string, number>) ?? {};
       inputTokens = usage.input_tokens ?? 0;
       outputTokens = usage.output_tokens ?? 0;
+      // Prompt-cache token counts (only present when cache is active; 0 means no cache activity)
+      if ((usage.cache_creation_input_tokens ?? 0) > 0) cacheCreationInputTokens = usage.cache_creation_input_tokens;
+      if ((usage.cache_read_input_tokens ?? 0) > 0) cacheReadInputTokens = usage.cache_read_input_tokens;
 
     } else if (providerId === "gemini") {
       // Gemini response
@@ -482,7 +487,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
     return {
       text,
       toolCalls,
-      usage: { inputTokens, outputTokens },
+      usage: { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens },
       inferenceMs,
     };
   },

--- a/packages/db/prisma/migrations/20260520080000_ep_cost_p1_cache_telemetry_and_budget_event/migration.sql
+++ b/packages/db/prisma/migrations/20260520080000_ep_cost_p1_cache_telemetry_and_budget_event/migration.sql
@@ -1,0 +1,24 @@
+-- EP-COST Phase 1: cache telemetry field + AgentBudgetEvent table
+-- Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §3 Phase 1 & Phase 2 prereq
+--
+-- 1. Add cacheCreationInputTokens to AdapterRunTelemetry
+--    (tokens written into the Anthropic prompt cache — billed at write rate)
+ALTER TABLE "AdapterRunTelemetry" ADD COLUMN "cacheCreationInputTokens" INTEGER;
+
+-- 2. Create AgentBudgetEvent — one row per budget event for Phase 2 gate
+CREATE TABLE "AgentBudgetEvent" (
+    "id"          TEXT NOT NULL,
+    "agentId"     TEXT NOT NULL,
+    "buildRunId"  TEXT,
+    "eventKind"   TEXT NOT NULL,
+    "amountUsd"   DECIMAL(10,6) NOT NULL,
+    "tokensTotal" INTEGER,
+    "modelId"     TEXT,
+    "providerId"  TEXT,
+    "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentBudgetEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AgentBudgetEvent_agentId_createdAt_idx" ON "AgentBudgetEvent"("agentId", "createdAt");
+CREATE INDEX "AgentBudgetEvent_buildRunId_idx" ON "AgentBudgetEvent"("buildRunId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2300,7 +2300,9 @@ model AdapterRunTelemetry {
   errorClass          String?
   inputTokens         Int?
   cachedInputTokens   Int?
+  cacheCreationInputTokens Int?  // tokens written into the Anthropic prompt cache this call
   outputTokens        Int?
+
   reasoningTokens     Int?
   estimatedCostUsd    Decimal?  @db.Decimal(10, 6)
   quotaPoolConsumed   String?   // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
@@ -2319,6 +2321,24 @@ model AdapterRunTelemetry {
   @@index([raceCohortId])
   @@index([threadId, startedAt])
   @@index([agentId, startedAt])
+}
+
+// EP-COST Phase 2 prerequisite — one row per budget event so the
+// budget gate in callProvider can enforce per-agent and per-build spend limits.
+// Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §3 Phase 2
+model AgentBudgetEvent {
+  id          String   @id @default(cuid())
+  agentId     String
+  buildRunId  String?  // FK intentionally soft — build runs may be ephemeral
+  eventKind   String   // "inference" | "tool_call" | "budget_exceeded"
+  amountUsd   Decimal  @db.Decimal(10, 6)
+  tokensTotal Int?
+  modelId     String?
+  providerId  String?
+  createdAt   DateTime @default(now())
+
+  @@index([agentId, createdAt])
+  @@index([buildRunId])
 }
 
 // Voice Slice 2 — Transcript cleanup audit row.


### PR DESCRIPTION
## Summary

Implements all four Phase 1 tasks from EP-COST-001 (AI Cost Governance — Observability Closure). These are the substrate changes that make prompt-cache token counts visible in telemetry and set up the budget event table for Phase 2.

- **P1-01** — Extend `AdapterResult.usage` with `cacheCreationInputTokens?` and `cacheReadInputTokens?`; extract both from Anthropic API responses in `chat-adapter.ts`
- **P1-02** — Add `cacheCreationInputTokens Int?` column to `AdapterRunTelemetry`; wire the field through `adapter-telemetry-writer.ts` and `ai-inference.ts`
- **P1-03** — Export `dpf_ai_cache_creation_tokens_total` and `dpf_ai_cache_read_tokens_total` Prometheus counters from `metrics.ts`; increment on each inference call that carries non-zero cache counts
- **P1-04** — Add `AgentBudgetEvent` Prisma model (prerequisite for Phase 2 budget gate): `agentId`, `buildRunId`, `eventKind`, `amountUsd`, `tokensTotal`, `modelId`, `providerId`

**Migration:** `20260520080000_ep_cost_p1_cache_telemetry_and_budget_event` — adds the column and creates the table; applied to production DB already.

**Related builds:** FB-F0476EF3 (P1-01), FB-DDCB33C4 (P1-02), FB-A8D46002 (P1-03), FB-5222FED1 (P1-04)  
**Epic:** EP-COST-001

## Test plan

- [ ] Typecheck passes (pre-commit hook confirmed ✓)
- [ ] `AdapterRunTelemetry` rows written after an Anthropic cache hit carry non-null `cacheCreationInputTokens`
- [ ] `/metrics` endpoint exposes `dpf_ai_cache_creation_tokens_total` and `dpf_ai_cache_read_tokens_total` with `provider` + `model` labels
- [ ] `AgentBudgetEvent` table exists and accepts rows (Phase 2 will write to it)
- [ ] No regression on existing `inputTokens` / `outputTokens` / `cachedInputTokens` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)