### PR TITLE
fix(build-pipeline): route stepGenerateCode to Anthropic with build-phase tools only

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -338,10 +338,21 @@ async function stepGenerateCode(
   });
   const systemPrompt = `You are an AI coworker building a feature in the sandbox.\n${buildContext}`;
 
-  // Get sandbox tools — use a system-level context with full platform access
+  // Get sandbox tools — scoped to build phase only.
+  // Filtering by buildPhases: ["build"] gives the agent the file-editing surface
+  // (read_sandbox_file, edit_sandbox_file, write_sandbox_file, run_sandbox_command,
+  // run_sandbox_tests, search_sandbox, list_sandbox_files, saveBuildEvidence, …)
+  // without overwhelming it with the 100+ tool surface used by the full coworker.
+  //
+  // Tools with no buildPhases tag (null/undefined) are platform-wide utilities
+  // that are safe to include regardless of phase.
   const adminContext = { userId: "system", platformRole: "HR-000", isSuperuser: true } as Parameters<typeof getAvailableTools>[0];
-  const tools = await getAvailableTools(adminContext, { mode: "act", unifiedMode: true });
+  const allTools = await getAvailableTools(adminContext, { mode: "act", unifiedMode: true });
+  const tools = allTools.filter(
+    (t) => !t.buildPhases || t.buildPhases.includes("build"),
+  );
   const toolsForProvider = toolsToOpenAIFormat(tools);
+  console.log(`[build-pipeline] stepGenerateCode buildId=${buildId} tools=${tools.length} (build-phase filtered from ${allTools.length} total)`);
 
   // Build the initial message from the brief
   const userMessage = [
@@ -374,7 +385,11 @@ async function stepGenerateCode(
     routeContext: `/build/${buildId}`,
     agentId: "build-architect",
     threadId,
-    taskType: "code_generation",
+    // Use "analysis" routing so the request goes to the Anthropic API (Claude),
+    // which supports proper function/tool calling in the agentic loop.
+    // "code_generation" routes to Codex CLI which dispatches single-shot prompts
+    // and cannot call the sandbox file-editing tools iteratively.
+    taskType: "analysis",
     requireTools: true,
     onProgress: (event) => {
       if (thread?.id) agentEventBus.emit(thread.id, event);


### PR DESCRIPTION
## Summary

Fixes the silent failure where Build Studio builds complete the pipeline with `filesChanged=0` — no code is actually written.

**Root cause 1 — Wrong task type:**
`taskType: "code_generation"` routes to Codex CLI, which dispatches single-shot prompts and cannot call MCP tools iteratively. Changed to `"analysis"` which routes to Anthropic (Claude) and supports proper function/tool calling in the agentic loop.

**Root cause 2 — No tool filtering:**
`getAvailableTools(adminContext, { mode: "act" })` returned all 100+ platform tools. The agent called `check_sandbox`/`start_sandbox` (ideate-phase tools) instead of the sandbox file-editing tools, then hit its runtime limit with zero edits.
Now filters to tools tagged `buildPhases: ["build"]` — approximately 12 tools: `read_sandbox_file`, `edit_sandbox_file`, `write_sandbox_file`, `run_sandbox_command`, `run_sandbox_tests`, `search_sandbox`, `list_sandbox_files`, `saveBuildEvidence`, etc.

**Evidence:** Four EP-COST Phase 1 builds (FB-F0476EF3, FB-DDCB33C4, FB-A8D46002, FB-5222FED1) all reached `step: "complete"` with `filesChanged: 0` and `toolsExecuted: ["start_build", "check_sandbox"]` before this fix.

## Test plan

- [ ] Typecheck passes ✓ (pre-commit confirmed)
- [ ] Portal log shows `[build-pipeline] stepGenerateCode ... tools=N (build-phase filtered from M total)` with N ≈ 12
- [ ] Next BS build in `build` phase calls `read_sandbox_file`/`edit_sandbox_file` (visible in portal logs)
- [ ] `taskResults.filesChanged > 0` after a build completes code generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)