### PR TITLE
chore(gitignore): ignore Windows-only `dev/null/` git-lfs hook artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,12 @@ __pycache__/
 
 # Third-party copyrighted reference material is kept outside this repository
 # under D:\DPF_References (Windows) — see ACKNOWLEDGMENTS.md for citations.
+
+# Windows-only git-lfs footgun: when a Windows clone has `core.hookspath`
+# misconfigured (or git-lfs is installed without the hooks dir resolving
+# correctly), the LFS install script writes the four sample hooks
+# (post-checkout / post-commit / post-merge / pre-push) into a literal
+# `dev\null\` directory at the worktree root instead of the intended
+# `.git/hooks/`. Multiple Windows worktrees in this repo have observed it.
+# Without this entry, a `git add -A` would happily commit the stray hooks.
+dev/null/


### PR DESCRIPTION
## Summary

Adds `dev/null/` to `.gitignore` (1 path + 8-line explanatory comment) to defend against a Windows-specific git-lfs footgun that has been observed in multiple worktrees.

## What's happening

git-lfs on Windows occasionally writes its four sample hook scripts (`post-checkout`, `post-commit`, `post-merge`, `pre-push`) into a literal `dev\null\` directory at the worktree root instead of the intended `.git/hooks/`. The trigger is `core.hookspath` being set or resolved to `/dev/null` — on Linux/macOS that's the bit-bucket device, on Windows it's a relative folder name (`dev\null\`).

## Evidence

Observed during the chore-lane sweep this session:

- This worktree (`D:\DPF\.claude\worktrees\recursing-liskov-af0801\dev\null\`) — appeared during initial setup, shown as `?? dev/null/` in every `git status` of the session.
- At least one sibling worktree (`agitated-mendeleev-b846fb`) has the same artifact.
- The `D:\DPF` root clone does **not** have it — so this is intermittent per-clone behavior, not a repo-wide issue.

Before this PR:

```
$ git status --short
?? dev/null/
```

After:

```
$ git status --short
(clean)

$ git check-ignore -v dev/null/post-checkout
.gitignore:86:dev/null/	dev/null/post-checkout
```

## Risk

- One additional `.gitignore` rule scoped to a path that should never legitimately exist.
- Zero impact on Linux/macOS contributors (the path doesn't get created there).
- Defends against a `git add -A` on a future Windows contributor's machine inadvertently committing four stray hook scripts.

## Test plan

- [x] `git check-ignore -v dev/null/post-checkout` — matches the new rule
- [x] `git status --short` — `dev/null/` no longer shown
- [x] DCO sign-off ✓
- [x] Concurrent-PR sweep — no overlap (recent main commits are mobile #877/#879 just merged, and build-pipeline #880; none touch `.gitignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)