### PR TITLE
chore(mobile): bump TypeScript 5.9 → 6.0 (Phase 4a of Expo upgrade spec)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -43,6 +43,6 @@
     "msw": "^2.14.5",
     "react-test-renderer": "19.0.6",
     "tailwindcss": "^4.3.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         version: 53.0.14(@babel/core@7.29.0)(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.7(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.6)))(graphql@16.14.0)(react-native@0.79.7(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.6))(react@19.0.6))(jest@29.7.0(@types/node@25.9.1))(react-native@0.79.7(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.6))(react@19.0.6)
       msw:
         specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.9.1)(typescript@5.9.3)
+        version: 2.14.5(@types/node@25.9.1)(typescript@6.0.3)
       react-test-renderer:
         specifier: 19.0.6
         version: 19.0.6(react@19.0.6)
@@ -128,8 +128,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   apps/web:
     dependencies:
@@ -17181,31 +17181,6 @@ snapshots:
       - '@types/node'
     optional: true
 
-  msw@2.14.5(@types/node@25.9.1)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 6.0.12(@types/node@25.9.1)
-      '@mswjs/interceptors': 0.41.8
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.0
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-
   msw@2.14.5(@types/node@25.9.1)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.12(@types/node@25.9.1)
@@ -17230,7 +17205,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   mute-stream@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Brings `apps/mobile` into version-alignment with `apps/web` and `packages/db`, both of which moved to `typescript ^6.0.3` prior to this session. Mobile was the last workspace still on the 5.x line.

This is **Phase 4a** of the [Expo SDK 55 upgrade plan (PR #877 — merged as `3a54f6a6`)](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/877). The spec originally scoped Phase 4 as "jest 30 + typescript 6, orthogonal to the SDK bump." An audit during execution showed that's **half-right**:

| Phase | Concern | Why |
|---|---|---|
| **4a** *(this PR)* | typescript ^5.9.3 → ^6.0.3 | Truly orthogonal — `jest-expo` doesn't depend on `typescript`; mobile catches up to the rest of the workspace |
| **4b** *(deferred)* | jest ^29.7 → ^30 | **Gated on Phase 2** — see below |

## Why jest 30 is gated on Phase 2 (not orthogonal)

`jest-expo@53.0.14` carries direct deps on the jest 29 internal package line:

```json
{
  "@jest/create-cache-key-function": "^29.2.1",
  "@jest/globals": "^29.2.1",
  "babel-jest": "^29.2.1",
  "jest-environment-jsdom": "^29.2.1",
  "jest-snapshot": "^29.2.1"
}
```

Bumping `jest` to 30 without also bumping `jest-expo` (which moves to `^55.x` as part of the Expo SDK 55 jump in Phase 2) would mix jest 29 internals with a jest 30 runner — near-certain runtime breakage. Phase 4b therefore rides Phase 2 once `jest-expo@^55` becomes available.

## Test plan

- [x] `pnpm --filter mobile typecheck` — clean on TS 6.0.3
- [x] `pnpm --filter mobile test` — **24/24 test suites, 149/149 tests passing**
- [x] `pnpm --filter @dpf/db typecheck` — clean (regression-guard for the lockfile shift)
- [x] `pnpm --filter web typecheck` — clean (regression-guard for the lockfile shift)
- [x] DCO sign-off ✓
- [x] Concurrent-PR overlap sweep — clean (no open PRs at push time; recent main commits are all unrelated build-studio fixes)

## Diff

2 files changed, +4 / -30:

```
apps/mobile/package.json |  2 +-
pnpm-lock.yaml           | 32 +++-----------------------------
```

The lockfile shrinks because mobile was the last consumer of `typescript@5.9.x` — pnpm dedupes the 5.9 branch out entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)