### PR TITLE
fix(sandbox): raise maxBuffer to 100 MB for source-copy tar operations

### DIFF
--- a/apps/web/lib/integrate/sandbox/sandbox-source-strategy.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-source-strategy.ts
@@ -144,17 +144,20 @@ export class LocalSourceStrategy implements SandboxSourceStrategy {
 
     // 2. Copy full source from the active shared workspace when present.
     //    If the portal is running from an image-only bootstrap, fall back to -src paths.
+    //    maxBuffer: 100 MB — tar piping large source trees can produce >1 MB of stderr
+    //    (file-modified warnings, etc.) which exhausts Node's default 1 MB buffer.
+    const LARGE_COPY_OPTS = { timeout: 60_000, maxBuffer: 100 * 1024 * 1024 };
     await exec(
       buildWorkspacePackagesCopyCommand(portalContainer, containerId, sourcePaths.packagesDir),
-      { timeout: 60_000 },
+      LARGE_COPY_OPTS,
     );
     await exec(
       buildWorkspaceAppsWebCopyCommand(portalContainer, containerId, sourcePaths.webAppDir),
-      { timeout: 60_000 },
+      LARGE_COPY_OPTS,
     );
     await exec(
       buildWorkspaceScriptsCopyCommand(portalContainer, containerId, sourcePaths.rootConfigDir),
-      { timeout: 20_000 },
+      { timeout: 20_000, maxBuffer: 100 * 1024 * 1024 },
     ).catch(() => console.log("[source-strategy] scripts/ not found, skipping"));
 
     // 3. Remove app-local generated artifacts before later pipeline steps


### PR DESCRIPTION
## Summary

- `stepInitWorkspace` (the `workspace_initialized` pipeline step) was failing with **"stderr maxBuffer length exceeded"** when copying large source trees into sandbox containers
- Root cause: the three `exec()` calls that pipe `tar` archives between `dpf-portal-1` and the sandbox container were using Node's default **1 MB** maxBuffer — easily exceeded by verbose tar output (file-modified warnings, duplicate hard-link messages, etc.) on a monorepo the size of DPF
- Fix: set `maxBuffer: 100 * 1024 * 1024` on those calls, matching the value already used by `execInSandbox()` for all other in-container commands

## Affected builds

Any build that reaches `stepInitWorkspace` on a full-size source tree can hit this. Confirmed on **FB-5222FED1** (AgentBudgetEvent schema build, `failedAt: workspace_initialized`).

## Test plan

- [x] TypeScript typecheck clean (pre-commit hook)
- [ ] After merge + portal rebuild: trigger a build that previously failed at `workspace_initialized` and confirm it progresses past that step

🤖 Generated with [Claude Code](https://claude.com/claude-code)