### PR TITLE
fix(build-pipeline): guard null brief in stepGenerateCode prompts

### DIFF
--- a/apps/web/lib/integrate/coding-agent.test.ts
+++ b/apps/web/lib/integrate/coding-agent.test.ts
@@ -1,0 +1,59 @@
+// apps/web/lib/integrate/coding-agent.test.ts
+// Regression tests for null-brief guard in buildCodeGenPrompt.
+// FB-71FB3A53: builds whose FeatureBuild.brief is null (ideate phase never
+// completed) crashed stepGenerateCode with "Cannot read properties of null
+// (reading 'title')".
+
+import { vi, describe, it, expect } from "vitest";
+import type { FeatureBrief } from "@/lib/feature-build-types";
+
+// Mock server-only dependencies that coding-agent.ts imports at module level
+// so the pure buildCodeGenPrompt function can be exercised in isolation.
+vi.mock("@/lib/sandbox", () => ({ execInSandbox: vi.fn() }));
+vi.mock("@/lib/ai-provider-priority", () => ({ getProviderPriority: vi.fn() }));
+vi.mock("@/lib/routed-inference", () => ({ routeAndCall: vi.fn() }));
+vi.mock("@/lib/agent-event-bus", () => ({
+  agentEventBus: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+const { buildCodeGenPrompt } = await import("./coding-agent");
+
+describe("buildCodeGenPrompt", () => {
+  it("does not throw when brief is null (FB-71FB3A53 regression)", () => {
+    expect(() => buildCodeGenPrompt(null, {})).not.toThrow();
+  });
+
+  it("returns a non-empty prompt when brief is null", () => {
+    const result = buildCodeGenPrompt(null, {});
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("uses fallback placeholders when brief is null", () => {
+    const result = buildCodeGenPrompt(null, {});
+    expect(result).toContain("(no title)");
+    expect(result).toContain("Not specified");
+  });
+
+  it("includes brief fields when brief is provided", () => {
+    const brief: FeatureBrief = {
+      title: "Ollama backend build",
+      description: "Adds Ollama as a local AI provider",
+      portfolioContext: "platform",
+      targetRoles: ["Admin"],
+      inputs: [],
+      dataNeeds: "None",
+      acceptanceCriteria: ["Ollama routes requests", "Health check passes"],
+    };
+    const result = buildCodeGenPrompt(brief, {});
+    expect(result).toContain("Ollama backend build");
+    expect(result).toContain("Adds Ollama as a local AI provider");
+    expect(result).toContain("Ollama routes requests");
+    expect(result).toContain("Health check passes");
+  });
+
+  it("handles an empty plan without throwing", () => {
+    expect(() => buildCodeGenPrompt(null, {})).not.toThrow();
+    expect(() => buildCodeGenPrompt(null, { fileStructure: [], tasks: [] })).not.toThrow();
+  });
+});

--- a/apps/web/lib/integrate/coding-agent.ts
+++ b/apps/web/lib/integrate/coding-agent.ts
@@ -58,20 +58,30 @@ export async function checkCodingReadiness(): Promise<CodingReadiness> {
 
 // ─── Build Prompt ────────────────────────────────────────────────────────────
 
-export function buildCodeGenPrompt(brief: FeatureBrief, plan: Record<string, unknown>, instruction?: string): string {
+export function buildCodeGenPrompt(brief: FeatureBrief | null, plan: Record<string, unknown>, instruction?: string): string {
+  // Guard: brief may be null for builds whose ideate phase never completed
+  // (e.g. builds created before the brief was saved, or pipeline retries on
+  // a build whose brief column is null — FB-71FB3A53).
+  const title = brief?.title ?? "(no title)";
+  const description = brief?.description ?? "";
+  const portfolioContext = brief?.portfolioContext ?? "";
+  const targetRoles = brief?.targetRoles;
+  const dataNeeds = brief?.dataNeeds ?? "None specified";
+  const acceptanceCriteria = brief?.acceptanceCriteria;
+
   const parts = [
     "You are a code generation agent working inside a Next.js 14 App Router project.",
     "The project uses TypeScript, Prisma 5, and TailwindCSS with a dark theme.",
     "",
     "## Feature Brief",
-    `Title: ${brief.title}`,
-    `Description: ${brief.description}`,
-    `Portfolio: ${brief.portfolioContext}`,
-    `Target Roles: ${Array.isArray(brief.targetRoles) ? brief.targetRoles.join(", ") : brief.targetRoles ?? "All"}`,
-    `Data Needs: ${brief.dataNeeds ?? "None specified"}`,
+    `Title: ${title}`,
+    `Description: ${description}`,
+    `Portfolio: ${portfolioContext}`,
+    `Target Roles: ${Array.isArray(targetRoles) ? targetRoles.join(", ") : targetRoles ?? "All"}`,
+    `Data Needs: ${dataNeeds}`,
     "",
     "## Acceptance Criteria",
-    ...(Array.isArray(brief.acceptanceCriteria) ? brief.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`) : [String(brief.acceptanceCriteria ?? "Not specified")]),
+    ...(Array.isArray(acceptanceCriteria) ? acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`) : [String(acceptanceCriteria ?? "Not specified")]),
     "",
     "## Implementation Plan",
     JSON.stringify(plan, null, 2),


### PR DESCRIPTION
## Summary

- **Root cause**: `buildCodeGenPrompt` in `coding-agent.ts` accessed `brief.title`, `brief.description`, etc. without null guards. `FeatureBuild.brief` is a nullable JSON column; builds whose ideate phase never completed (e.g. Ollama backend build `FB-71FB3A53`) have `brief=null`. When `stepGenerateCode` retried from the `deps_installed` checkpoint, the crash reproduced on every retry with `"Cannot read properties of null (reading 'title')"`.
- **Fix**: widened `buildCodeGenPrompt`'s `brief` parameter from `FeatureBrief` to `FeatureBrief | null` and replaced all direct `brief.x` accesses with local variables using optional-chaining + fallback strings — matching the `brief?.title ?? build.title ?? buildId` pattern already present in the `stepGenerateCode` userMessage block.
- **Test**: new `coding-agent.test.ts` with 5 regression tests covering the null-brief path, including the exact `FB-71FB3A53` scenario (`buildCodeGenPrompt(null, {})` must not throw).

## Test plan

- [x] `vitest run coding-agent.test.ts` — 5/5 pass
- [x] `vitest run build-pipeline.test.ts` — 11/11 pass (no regressions)
- [ ] CI typecheck gate (worktree has no node_modules; `DPF_SKIP_TYPECHECK=1` used locally per AGENTS.md §5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)