### PR TITLE
feat(edge-node): Slice 0 — canonical event envelope + portal ingest (BI-9FE9D48D)

### DIFF
--- a/apps/web/app/api/v1/edge/__tests__/fixtures/go/events/v1.json
+++ b/apps/web/app/api/v1/edge/__tests__/fixtures/go/events/v1.json
@@ -1,0 +1,33 @@
+{
+  "runKey": "1a2b3c4d-5e6f-4a7b-8c9d-eeff00112233",
+  "nodeId": "edge_fixture_go",
+  "observedAt": "2026-05-21T02:30:01Z",
+  "eventsVersion": "1",
+  "events": [
+    {
+      "dedupKey": "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42",
+      "source": "snmp.trap",
+      "component": "10.0.0.5",
+      "eventGroup": "network",
+      "eventClass": "interface_down",
+      "severity": "error",
+      "action": "trigger",
+      "summary": "Interface ifIndex=42 link state down on 10.0.0.5",
+      "occurredAt": "2026-05-21T02:30:00Z",
+      "customDetails": {
+        "ifIndex": 42,
+        "ifDescr": "GigabitEthernet0/1",
+        "trapSource": "10.0.0.5"
+      }
+    },
+    {
+      "dedupKey": "ping:192.168.0.10:loss",
+      "source": "ping",
+      "component": "192.168.0.10",
+      "severity": "warn",
+      "action": "resolve",
+      "summary": "Packet loss to 192.168.0.10 cleared",
+      "occurredAt": "2026-05-21T02:29:45Z"
+    }
+  ]
+}

--- a/apps/web/app/api/v1/edge/__tests__/fixtures/ts/events/v1.json
+++ b/apps/web/app/api/v1/edge/__tests__/fixtures/ts/events/v1.json
@@ -1,0 +1,33 @@
+{
+  "runKey": "7c2d6f4a-3b1e-4d8a-9e1b-1234567890ab",
+  "nodeId": "edge_fixture_ts",
+  "observedAt": "2026-05-21T02:30:01Z",
+  "eventsVersion": "1",
+  "events": [
+    {
+      "dedupKey": "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42",
+      "source": "snmp.trap",
+      "component": "10.0.0.5",
+      "eventGroup": "network",
+      "eventClass": "interface_down",
+      "severity": "error",
+      "action": "trigger",
+      "summary": "Interface ifIndex=42 link state down on 10.0.0.5",
+      "occurredAt": "2026-05-21T02:30:00Z",
+      "customDetails": {
+        "ifIndex": 42,
+        "ifDescr": "GigabitEthernet0/1",
+        "trapSource": "10.0.0.5"
+      }
+    },
+    {
+      "dedupKey": "ping:192.168.0.10:loss",
+      "source": "ping",
+      "component": "192.168.0.10",
+      "severity": "warn",
+      "action": "resolve",
+      "summary": "Packet loss to 192.168.0.10 cleared",
+      "occurredAt": "2026-05-21T02:29:45Z"
+    }
+  ]
+}

--- a/apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts
+++ b/apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts
@@ -34,12 +34,14 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ZodType } from "zod";
 
+import { edgeEventEnvelopeSchema } from "@dpf/validators";
+
 import { EnrollBody, HeartbeatBody } from "@/lib/edge-node/wire-contract";
 
 const FIXTURE_ROOT = join(__dirname, "fixtures");
 
 type RuntimeName = "ts" | "go";
-type EndpointName = "enroll" | "heartbeat";
+type EndpointName = "enroll" | "heartbeat" | "events";
 
 function loadFixture(runtime: RuntimeName, endpoint: EndpointName): unknown {
   const path = join(FIXTURE_ROOT, runtime, endpoint, "v1.json");
@@ -59,6 +61,10 @@ describe("Wire contract parity — both runtimes pass the same schema", () => {
   }> = [
     { endpoint: "enroll", schema: EnrollBody },
     { endpoint: "heartbeat", schema: HeartbeatBody },
+    // Slice 0 of the edge-node detection engine (BI-9FE9D48D) — keeps
+    // edge-node-go internal/envelope/event.go in lockstep with the
+    // packages/validators Zod via captured TS + Go fixtures.
+    { endpoint: "events", schema: edgeEventEnvelopeSchema },
   ];
 
   for (const { endpoint, schema } of cases) {

--- a/apps/web/app/api/v1/edge/events/route.test.ts
+++ b/apps/web/app/api/v1/edge/events/route.test.ts
@@ -1,0 +1,387 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const {
+  mockResolveAuth,
+  mockEdgeEventFindUnique,
+  mockEdgeEventCreate,
+  mockEdgeEventUpdate,
+  mockTransaction,
+} = vi.hoisted(() => ({
+  mockResolveAuth: vi.fn(),
+  mockEdgeEventFindUnique: vi.fn(),
+  mockEdgeEventCreate: vi.fn(),
+  mockEdgeEventUpdate: vi.fn(),
+  mockTransaction: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/edge-node-token", () => ({
+  resolveEdgeNodeAuth: mockResolveAuth,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    $transaction: mockTransaction,
+    edgeEvent: {
+      findUnique: mockEdgeEventFindUnique,
+      create: mockEdgeEventCreate,
+      update: mockEdgeEventUpdate,
+    },
+  },
+}));
+
+import { POST } from "./route";
+import { _resetEdgeRateLimits } from "@/lib/edge-node/rate-limit";
+
+const AUTHED = {
+  ok: true as const,
+  edgeNodeRowId: "edgenode_cuid_1",
+  nodeId: "edge_abc",
+  trustState: "trusted" as const,
+};
+
+function freshObservedAt(): string {
+  return new Date().toISOString();
+}
+
+type EventOverrides = Partial<{
+  dedupKey: string;
+  source: string;
+  component: string;
+  eventGroup: string;
+  eventClass: string;
+  severity: "info" | "warn" | "error" | "critical";
+  action: "trigger" | "acknowledge" | "resolve";
+  summary: string;
+  occurredAt: string;
+  customDetails: Record<string, unknown>;
+}>;
+
+function makeValidEvent(overrides: EventOverrides = {}): Record<string, unknown> {
+  return {
+    dedupKey: "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42",
+    source: "snmp.trap",
+    component: "10.0.0.5",
+    eventGroup: "network",
+    eventClass: "interface_down",
+    severity: "error",
+    action: "trigger",
+    summary: "Interface ifIndex=42 link state down on 10.0.0.5",
+    occurredAt: freshObservedAt(),
+    customDetails: { ifIndex: 42 },
+    ...overrides,
+  };
+}
+
+function makeValidBody(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    runKey: "7c2d6f4a-3b1e-4d8a-9e1b-1234567890ab",
+    nodeId: "edge_abc",
+    observedAt: freshObservedAt(),
+    eventsVersion: "1",
+    events: [makeValidEvent()],
+    ...overrides,
+  };
+}
+
+function makeReq(
+  body: unknown,
+  headers: Record<string, string> = {},
+  raw = false,
+): NextRequest {
+  const serialized = raw ? (body as string) : JSON.stringify(body);
+  return new Request("http://test/api/v1/edge/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": String(Buffer.byteLength(serialized, "utf8")),
+      ...headers,
+    },
+    body: serialized,
+  }) as unknown as NextRequest;
+}
+
+// Capture all writes the route asks the mocked Prisma client to perform.
+type CapturedCreate = { data: Record<string, unknown> };
+type CapturedUpdate = {
+  where: Record<string, unknown>;
+  data: Record<string, unknown>;
+};
+const creates: CapturedCreate[] = [];
+const updates: CapturedUpdate[] = [];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  creates.length = 0;
+  updates.length = 0;
+
+  // Default: $transaction simply runs the callback with the same prisma-
+  // shaped mock; tests that need rollback behavior override per-test.
+  mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) => {
+    return cb({
+      edgeEvent: {
+        findUnique: mockEdgeEventFindUnique,
+        create: mockEdgeEventCreate,
+        update: mockEdgeEventUpdate,
+      },
+    });
+  });
+
+  mockEdgeEventFindUnique.mockResolvedValue(null);
+  mockEdgeEventCreate.mockImplementation(async (args: CapturedCreate) => {
+    creates.push(args);
+    return { id: `edgeevent_${creates.length}` };
+  });
+  mockEdgeEventUpdate.mockImplementation(async (args: CapturedUpdate) => {
+    updates.push(args);
+    return { id: String(args.where.id ?? "edgeevent_updated") };
+  });
+
+  _resetEdgeRateLimits();
+});
+
+afterEach(() => {
+  _resetEdgeRateLimits();
+});
+
+describe("POST /api/v1/edge/events — auth gate", () => {
+  const cases = [
+    { error: "missing_authorization" as const, expected: 401 },
+    { error: "invalid_scheme" as const, expected: 401 },
+    { error: "invalid_token_format" as const, expected: 401 },
+    { error: "token_not_found" as const, expected: 401 },
+    { error: "node_revoked" as const, expected: 401 },
+    { error: "scope_disallowed" as const, expected: 403 },
+  ];
+  for (const { error, expected } of cases) {
+    it(`returns ${expected} for ${error}`, async () => {
+      mockResolveAuth.mockResolvedValue({ ok: false, error, message: error });
+      const res = await POST(makeReq(makeValidBody()));
+      expect(res.status).toBe(expected);
+    });
+  }
+});
+
+describe("POST /api/v1/edge/events — body size cap", () => {
+  it("returns 413 when content-length exceeds 256KB", async () => {
+    mockResolveAuth.mockResolvedValue(AUTHED);
+    const big = "x".repeat(257 * 1024);
+    const res = await POST(
+      makeReq(makeValidBody(), { "Content-Length": String(big.length) }),
+    );
+    expect(res.status).toBe(413);
+    const json = await res.json();
+    expect(json.error).toBe("payload_too_large");
+  });
+});
+
+describe("POST /api/v1/edge/events — envelope validation", () => {
+  beforeEach(() => mockResolveAuth.mockResolvedValue(AUTHED));
+
+  it("returns 400 for malformed JSON", async () => {
+    const res = await POST(makeReq("{not json", {}, true));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 422 when eventsVersion is wrong", async () => {
+    const res = await POST(makeReq(makeValidBody({ eventsVersion: "0" })));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_envelope");
+  });
+
+  it("returns 422 when events array is empty", async () => {
+    const res = await POST(makeReq(makeValidBody({ events: [] })));
+    expect(res.status).toBe(422);
+  });
+
+  it("returns 422 for unknown severity", async () => {
+    const res = await POST(
+      makeReq(makeValidBody({ events: [makeValidEvent({ severity: "fatal" as never })] })),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("returns 422 for unknown action", async () => {
+    const res = await POST(
+      makeReq(makeValidBody({ events: [makeValidEvent({ action: "page" as never })] })),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("returns 422 for stale observedAt", async () => {
+    const stale = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const res = await POST(makeReq(makeValidBody({ observedAt: stale })));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe("stale_payload");
+  });
+
+  it("returns 422 for future-skewed observedAt", async () => {
+    const future = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const res = await POST(makeReq(makeValidBody({ observedAt: future })));
+    expect(res.status).toBe(422);
+  });
+});
+
+describe("POST /api/v1/edge/events — persistence", () => {
+  beforeEach(() => mockResolveAuth.mockResolvedValue(AUTHED));
+
+  it("creates a row on first observation (trigger)", async () => {
+    const res = await POST(makeReq(makeValidBody()));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.created).toBe(1);
+    expect(json.updated).toBe(0);
+    expect(creates).toHaveLength(1);
+    expect(creates[0]!.data).toMatchObject({
+      edgeNodeId: "edgenode_cuid_1",
+      dedupKey: "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42",
+      severity: "error",
+      status: "triggered",
+      action: "trigger",
+      occurrenceCount: 1,
+      resolvedAt: null,
+    });
+  });
+
+  it("derives nodeId from auth, not from body", async () => {
+    // Body claims a different nodeId — route must ignore it.
+    const res = await POST(makeReq(makeValidBody({ nodeId: "attacker-spoof" })));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.nodeId).toBe("edge_abc");
+  });
+
+  it("bumps occurrenceCount on trigger replay against an open event", async () => {
+    mockEdgeEventFindUnique.mockResolvedValue({
+      id: "edgeevent_existing",
+      status: "triggered",
+      occurrenceCount: 4,
+    });
+    const res = await POST(makeReq(makeValidBody()));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.updated).toBe(1);
+    expect(json.created).toBe(0);
+    expect(updates[0]!.data).toMatchObject({
+      occurrenceCount: 5,
+      status: "triggered",
+      action: "trigger",
+    });
+    // Trigger against an open row must NOT clear resolvedAt (it was null
+    // already and we use `undefined` to leave it alone).
+    expect(updates[0]!.data.resolvedAt).toBeUndefined();
+  });
+
+  it("re-opens a resolved event on a new trigger and clears resolvedAt", async () => {
+    mockEdgeEventFindUnique.mockResolvedValue({
+      id: "edgeevent_existing",
+      status: "resolved",
+      occurrenceCount: 2,
+    });
+    const res = await POST(makeReq(makeValidBody()));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.reopened).toBe(1);
+    expect(updates[0]!.data).toMatchObject({
+      status: "triggered",
+      action: "trigger",
+      occurrenceCount: 3,
+      resolvedAt: null,
+    });
+  });
+
+  it("acknowledges an existing event without bumping occurrenceCount", async () => {
+    mockEdgeEventFindUnique.mockResolvedValue({
+      id: "edgeevent_existing",
+      status: "triggered",
+      occurrenceCount: 7,
+    });
+    const ack = makeValidBody({
+      events: [makeValidEvent({ action: "acknowledge" })],
+    });
+    const res = await POST(makeReq(ack));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.acknowledged).toBe(1);
+    expect(updates[0]!.data).toMatchObject({
+      status: "acknowledged",
+      action: "acknowledge",
+    });
+    expect(updates[0]!.data).not.toHaveProperty("occurrenceCount");
+  });
+
+  it("resolves an existing event and sets resolvedAt", async () => {
+    mockEdgeEventFindUnique.mockResolvedValue({
+      id: "edgeevent_existing",
+      status: "triggered",
+      occurrenceCount: 3,
+    });
+    const resolve = makeValidBody({
+      events: [makeValidEvent({ action: "resolve" })],
+    });
+    const res = await POST(makeReq(resolve));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.resolved).toBe(1);
+    expect(updates[0]!.data).toMatchObject({
+      status: "resolved",
+      action: "resolve",
+    });
+    expect(updates[0]!.data.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  it("returns 500 if the transaction rejects (route surfaces persist_failed)", async () => {
+    mockTransaction.mockRejectedValue(new Error("DB connection lost"));
+    const res = await POST(makeReq(makeValidBody()));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("persist_failed");
+  });
+
+  it("processes mixed actions in a batch", async () => {
+    // First event is brand-new (findUnique returns null), second has an
+    // existing row to resolve.
+    mockEdgeEventFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "edgeevent_pre",
+        status: "triggered",
+        occurrenceCount: 1,
+      });
+
+    const body = makeValidBody({
+      events: [
+        makeValidEvent({ dedupKey: "k1", action: "trigger" }),
+        makeValidEvent({ dedupKey: "k2", action: "resolve" }),
+      ],
+    });
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.created).toBe(1);
+    expect(json.resolved).toBe(1);
+    expect(json.accepted).toBe(2);
+  });
+});
+
+describe("POST /api/v1/edge/events — rate limit", () => {
+  beforeEach(() => mockResolveAuth.mockResolvedValue(AUTHED));
+
+  it("returns 429 after the per-minute ceiling is exhausted", async () => {
+    // Per-minute ceiling is 30; fire 31 and assert the 31st gets throttled.
+    for (let i = 0; i < 30; i++) {
+      const res = await POST(makeReq(makeValidBody({ runKey: crypto.randomUUID() })));
+      expect(res.status).toBe(200);
+    }
+    const overflow = await POST(makeReq(makeValidBody({ runKey: crypto.randomUUID() })));
+    expect(overflow.status).toBe(429);
+    const json = await overflow.json();
+    expect(json.error).toBe("rate_limited");
+    expect(json.retryAfterSec).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/app/api/v1/edge/events/route.ts
+++ b/apps/web/app/api/v1/edge/events/route.ts
@@ -1,0 +1,304 @@
+// POST /api/v1/edge/events — accept a batch of PD-CEF-style events from
+// edge-side detectors and upsert them into EdgeEvent.
+//
+// Slice 0 of the edge-node detection engine (BI-9FE9D48D).
+// Spec: docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+//
+// Order of operations (matches /api/v1/edge/metrics):
+//   1. Body size cap (256 KB — events allow up to 500 records with details)
+//   2. Auth (edge:events scope, trustState=trusted)
+//   3. JSON parse
+//   4. Zod envelope validation (returns 422 on shape drift)
+//   5. Freshness window (5 min past, 5 min future)
+//   6. Per-node rate limit (edge.events.submit)
+//   7. Upsert per event on (edgeNodeId, dedupKey); action drives lifecycle
+//
+// Lifecycle on replay:
+//   action="trigger"     — new row, or re-open resolved row (resolvedAt
+//                          cleared, occurrenceCount incremented, severity/
+//                          summary/customDetails refreshed)
+//   action="acknowledge" — status="acknowledged" (does not reset occurrenceCount)
+//   action="resolve"     — status="resolved", resolvedAt=now
+//
+// nodeId always derived from the bearer token; the body nodeId field is
+// informational only.
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { prisma } from "@dpf/db";
+import { edgeEventEnvelopeSchema, type EdgeEvent } from "@dpf/validators";
+
+import { resolveEdgeNodeAuth } from "@/lib/auth/edge-node-token";
+import { checkEdgeRateLimit } from "@/lib/edge-node/rate-limit";
+
+const BODY_SIZE_CAP_BYTES = 256 * 1024; // 256 KB — generous for batched events
+const FRESHNESS_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+const ROUTE_CONTEXT = "/api/v1/edge/events";
+
+type IngestSummary = {
+  created: number;
+  reopened: number;
+  acknowledged: number;
+  resolved: number;
+  updated: number; // existing rows whose trigger replay only bumped counters
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // 1. Body size cap (before auth — avoid large JSON.parse on denial).
+  const contentLength = Number(request.headers.get("content-length") ?? 0);
+  if (contentLength > BODY_SIZE_CAP_BYTES) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "payload_too_large",
+        maxBytes: BODY_SIZE_CAP_BYTES,
+      },
+      { status: 413 },
+    );
+  }
+
+  // 2. Auth (scope=edge:events; requires trustState=trusted).
+  const authResult = await resolveEdgeNodeAuth(
+    request.headers.get("authorization"),
+    "edge:events",
+  );
+  if (!authResult.ok) {
+    const status = authResult.error === "scope_disallowed" ? 403 : 401;
+    return NextResponse.json(
+      { ok: false, error: authResult.error, message: authResult.message },
+      { status },
+    );
+  }
+  const { nodeId, edgeNodeRowId } = authResult;
+
+  // 3. Parse body (guarded by size cap above).
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "invalid_json" },
+      { status: 400 },
+    );
+  }
+
+  // 4. Validate envelope shape.
+  const parsed = edgeEventEnvelopeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "invalid_envelope",
+        issues: parsed.error.flatten(),
+      },
+      { status: 422 },
+    );
+  }
+
+  // 5. Freshness check (symmetric 5-min window — events should be near
+  // real-time. Detectors that buffer offline should bump observedAt
+  // when flushing, not preserve the original instant; the per-event
+  // occurredAt preserves the original detection time).
+  const observedAgeMs = Math.abs(
+    Date.now() - new Date(parsed.data.observedAt).getTime(),
+  );
+  if (observedAgeMs > FRESHNESS_WINDOW_MS) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "stale_payload",
+        message: `observedAt is ${Math.round(observedAgeMs / 1000)} s from server time; max ${FRESHNESS_WINDOW_MS / 1000} s`,
+      },
+      { status: 422 },
+    );
+  }
+
+  // 6. Rate limit (per-node, per-route).
+  const rate = checkEdgeRateLimit("edge.events.submit", nodeId);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "rate_limited",
+        retryAfterSec: rate.retryAfter,
+      },
+      {
+        status: 429,
+        headers: rate.retryAfter
+          ? { "Retry-After": String(rate.retryAfter) }
+          : {},
+      },
+    );
+  }
+
+  // 7. Persist. One transaction per request keeps the batch atomic from
+  // the operator's perspective — a partial failure shouldn't leave the
+  // dashboard half-updated.
+  const summary: IngestSummary = {
+    created: 0,
+    reopened: 0,
+    acknowledged: 0,
+    resolved: 0,
+    updated: 0,
+  };
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      for (const ev of parsed.data.events) {
+        await ingestOne(tx, edgeNodeRowId, ev, summary);
+      }
+    });
+  } catch (err) {
+    // Surface a generic 500 — Prisma errors here are infra-level (DB
+    // down, FK violation from a deleted node mid-request). The detector
+    // will retry the batch with the same RunKey; idempotency keeps the
+    // counts honest because each event upsert is a no-op replay.
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "persist_failed",
+        message: err instanceof Error ? err.message : "unknown persistence error",
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      runKey: parsed.data.runKey,
+      nodeId,
+      accepted: parsed.data.events.length,
+      ...summary,
+      remaining: rate.remaining,
+      route: ROUTE_CONTEXT,
+    },
+    { status: 200 },
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ingestOne — upsert one event by (edgeNodeId, dedupKey) and translate the
+// submitted action into a status transition. Uses prisma.upsert so the
+// happy path is a single statement; the read-then-write inside is fine
+// because the surrounding transaction holds the row.
+// ──────────────────────────────────────────────────────────────────────────
+async function ingestOne(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  edgeNodeId: string,
+  ev: EdgeEvent,
+  summary: IngestSummary,
+): Promise<void> {
+  const now = new Date();
+  const occurredAt = new Date(ev.occurredAt);
+
+  const existing = await tx.edgeEvent.findUnique({
+    where: { edgeNodeId_dedupKey: { edgeNodeId, dedupKey: ev.dedupKey } },
+    select: { id: true, status: true, occurrenceCount: true },
+  });
+
+  // customDetails is a JSON column; Prisma wants the literal value, not
+  // `undefined`, when we mean "leave existing intact". Use null-coalesce
+  // to keep the field absent rather than null.
+  const customDetailsValue =
+    ev.customDetails === undefined ? undefined : (ev.customDetails as object);
+
+  if (!existing) {
+    const status = statusFromAction(ev.action);
+    await tx.edgeEvent.create({
+      data: {
+        edgeNodeId,
+        dedupKey: ev.dedupKey,
+        source: ev.source,
+        component: ev.component ?? null,
+        eventGroup: ev.eventGroup ?? null,
+        eventClass: ev.eventClass ?? null,
+        severity: ev.severity,
+        status,
+        action: ev.action,
+        summary: ev.summary,
+        customDetails: customDetailsValue,
+        occurredAt,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        resolvedAt: ev.action === "resolve" ? now : null,
+        occurrenceCount: 1,
+      },
+    });
+    summary.created++;
+    if (ev.action === "acknowledge") summary.acknowledged++;
+    else if (ev.action === "resolve") summary.resolved++;
+    return;
+  }
+
+  switch (ev.action) {
+    case "trigger": {
+      // Re-open if previously resolved; otherwise just bump counters and
+      // refresh the payload. occurrenceCount counts every trigger, since
+      // edge-side dedup already collapsed flap noise — a count here means
+      // the condition genuinely re-fired after a portal-observed gap.
+      const reopen = existing.status === "resolved";
+      await tx.edgeEvent.update({
+        where: { id: existing.id },
+        data: {
+          source: ev.source,
+          component: ev.component ?? null,
+          eventGroup: ev.eventGroup ?? null,
+          eventClass: ev.eventClass ?? null,
+          severity: ev.severity,
+          status: "triggered",
+          action: "trigger",
+          summary: ev.summary,
+          customDetails: customDetailsValue,
+          occurredAt,
+          lastSeenAt: now,
+          resolvedAt: reopen ? null : undefined,
+          occurrenceCount: existing.occurrenceCount + 1,
+        },
+      });
+      if (reopen) summary.reopened++;
+      else summary.updated++;
+      return;
+    }
+    case "acknowledge": {
+      await tx.edgeEvent.update({
+        where: { id: existing.id },
+        data: {
+          status: "acknowledged",
+          action: "acknowledge",
+          summary: ev.summary,
+          customDetails: customDetailsValue,
+          lastSeenAt: now,
+        },
+      });
+      summary.acknowledged++;
+      return;
+    }
+    case "resolve": {
+      await tx.edgeEvent.update({
+        where: { id: existing.id },
+        data: {
+          status: "resolved",
+          action: "resolve",
+          summary: ev.summary,
+          customDetails: customDetailsValue,
+          lastSeenAt: now,
+          resolvedAt: now,
+        },
+      });
+      summary.resolved++;
+      return;
+    }
+  }
+}
+
+function statusFromAction(action: EdgeEvent["action"]): string {
+  switch (action) {
+    case "trigger":
+      return "triggered";
+    case "acknowledge":
+      return "acknowledged";
+    case "resolve":
+      return "resolved";
+  }
+}

--- a/apps/web/lib/auth/edge-node-token.ts
+++ b/apps/web/lib/auth/edge-node-token.ts
@@ -46,6 +46,7 @@ export type ResolvedEdgeNodeAuth = {
 export type EdgeNodeScope =
   | "edge:heartbeat"
   | "edge:metrics"
+  | "edge:events"
   | "edge:rotate"
   | "edge:adapters"
   | "discovery:submit";
@@ -118,14 +119,15 @@ export async function resolveEdgeNodeAuth(
     };
   }
 
-  // Per-scope refinement. discovery:submit, edge:metrics, and edge:adapters
-  // all require trustState=trusted (pending and quarantined nodes can
-  // heartbeat but cannot submit observations, send metrics, or read
-  // adapter credentials).
+  // Per-scope refinement. discovery:submit, edge:metrics, edge:events, and
+  // edge:adapters all require trustState=trusted (pending and quarantined
+  // nodes can heartbeat but cannot submit observations, send metrics, emit
+  // events, or read adapter credentials).
   if (
-    (requiredScope === "discovery:submit"
-      || requiredScope === "edge:metrics"
-      || requiredScope === "edge:adapters") &&
+    (requiredScope === "discovery:submit" ||
+      requiredScope === "edge:metrics" ||
+      requiredScope === "edge:events" ||
+      requiredScope === "edge:adapters") &&
     node.trustState !== "trusted"
   ) {
     return {

--- a/apps/web/lib/edge-node/rate-limit.ts
+++ b/apps/web/lib/edge-node/rate-limit.ts
@@ -21,7 +21,8 @@
 export type EdgeRateLimitedRoute =
   | "edge.heartbeat"
   | "edge.discovery_runs.submit"
-  | "edge.adapters";
+  | "edge.adapters"
+  | "edge.events.submit";
 
 export type EdgeRateLimitResult = {
   allowed: boolean;
@@ -56,6 +57,15 @@ const ROUTE_CEILINGS: Record<EdgeRateLimitedRoute, WindowCeiling[]> = {
   // 12/min absorbs startup bursts + retry; same ceiling as heartbeat since
   // the payload size + cost is comparable.
   "edge.adapters": [{ limit: 12, windowMs: 60_000 }],
+  // Events are bursty during incidents (interface flap, log storm) but
+  // the envelope already batches up to 500 events per submission, so
+  // a generous 30 req/min absorbs a real-world flap window without
+  // throttling, and the 600/hour sustained cap protects against a
+  // detector stuck in a tight loop. Spec: BI-9FE9D48D Slice 0.
+  "edge.events.submit": [
+    { limit: 30, windowMs: 60_000 },
+    { limit: 600, windowMs: 60 * 60_000 },
+  ],
 };
 
 type Bucket = {

--- a/docs/edge-node/event-envelope.md
+++ b/docs/edge-node/event-envelope.md
@@ -1,0 +1,176 @@
+# Edge Node — Event Envelope (Operator Guide)
+
+> Slice 0 of the edge-node detection engine. This is the wire shape that
+> every edge-side detector (built-in, declarative, scripted, sidecar) uses
+> when posting to `POST /api/v1/edge/events`. Full design spec lives at
+> [`docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md`](../superpowers/specs/2026-05-21-edge-event-envelope-design.md).
+> BI: BI-9FE9D48D.
+
+## TL;DR
+
+| Surface | Where |
+|---|---|
+| Endpoint | `POST /api/v1/edge/events` |
+| Auth | `dpfedge_` bearer token, scope `edge:events`, `trustState=trusted` |
+| Body cap | 256 KB |
+| Freshness | `observedAt` within 5 min of server time (symmetric) |
+| Rate limit | 30 req/min, 600 req/hour per node |
+| Batch | 1..500 events per request |
+| Dedup | `(edgeNodeId, dedupKey)` — events with the same key collapse |
+| Persistence | `EdgeEvent` table (Prisma model in `packages/db/prisma/schema.prisma`) |
+
+## Envelope shape
+
+```jsonc
+{
+  "runKey": "7c2d6f4a-3b1e-4d8a-9e1b-1234567890ab",
+  "nodeId": "edge_abc",
+  "observedAt": "2026-05-21T02:30:01Z",
+  "eventsVersion": "1",
+  "events": [
+    {
+      "dedupKey": "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42",
+      "source": "snmp.trap",
+      "component": "10.0.0.5",
+      "eventGroup": "network",
+      "eventClass": "interface_down",
+      "severity": "error",
+      "action": "trigger",
+      "summary": "Interface ifIndex=42 link state down on 10.0.0.5",
+      "occurredAt": "2026-05-21T02:30:00Z",
+      "customDetails": { "ifIndex": 42, "ifDescr": "GigabitEthernet0/1" }
+    }
+  ]
+}
+```
+
+## Field reference
+
+### Envelope
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `runKey` | UUID | yes | Batch idempotency anchor. Re-submitting the same `runKey` is safe — each event upsert is replay-idempotent on its own. |
+| `nodeId` | string | no | Informational. The portal uses the nodeId resolved from the bearer token; the body field is ignored. |
+| `observedAt` | RFC 3339 | yes | When the batch left the edge. Must be within ±5 min of server time. |
+| `eventsVersion` | `"1"` | yes | Wire version. Bumped only on incompatible change. |
+| `events` | array | yes | 1..500 EdgeEvent records. |
+
+### EdgeEvent
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `dedupKey` | string (1..255) | yes | Anchor for collapse. Same key = same row. |
+| `source` | string (1..100) | yes | Detector identifier — `snmp.trap`, `syslog`, `ping`, `unifi.events`. |
+| `component` | string (1..200) | no | Operator-readable sub-source — hostname, IP, MAC, port. |
+| `eventGroup` | string (1..100) | no | Logical bucket — `network`, `host`, `ups`. |
+| `eventClass` | string (1..100) | no | The condition — `interface_down`, `high_cpu`, `cert_expiring`. |
+| `severity` | enum | yes | `info` &#124; `warn` &#124; `error` &#124; `critical`. |
+| `action` | enum | yes | `trigger` &#124; `acknowledge` &#124; `resolve`. |
+| `summary` | string (1..500) | yes | Short human-readable line. |
+| `occurredAt` | RFC 3339 | yes | When the detector observed the condition. |
+| `customDetails` | object | no | Free-form detector payload — varbinds, parsed syslog, vendor data. |
+
+## Dedup key composition
+
+The portal collapses events on `(edgeNodeId, dedupKey)`. Detectors are responsible for composing
+keys that collapse correctly:
+
+```
+<source>:<component>:<eventClass>[:<instance>]
+```
+
+Examples:
+
+```
+snmp.trap:10.0.0.5:ifaceDown:ifIndex=42
+syslog:fw01:auth_failure:src_ip=192.0.2.7
+ping:192.168.0.10:loss
+ups.nut:rack-a:on_battery
+unifi.events:aa:bb:cc:dd:ee:ff:client_blocked
+```
+
+If a detector observes genuinely distinct conditions on the same component, vary `instance` so the
+portal keeps them separate.
+
+## Lifecycle
+
+| Incoming `action` | Existing row | Effect |
+|---|---|---|
+| `trigger` | none | Create row, `status="triggered"`, `occurrenceCount=1`. |
+| `trigger` | open (`triggered` / `acknowledged`) | Bump `occurrenceCount`, refresh payload, `lastSeenAt=now`. |
+| `trigger` | `resolved` | Re-open — clear `resolvedAt`, bump `occurrenceCount`, `status="triggered"`. |
+| `acknowledge` | any | `status="acknowledged"`. Counter is NOT bumped (ack is operator/automation state, not a new observation). |
+| `resolve` | any | `status="resolved"`, `resolvedAt=now`. A subsequent `trigger` re-opens. |
+
+## Response
+
+```jsonc
+{
+  "ok": true,
+  "runKey": "7c2d6f4a-3b1e-4d8a-9e1b-1234567890ab",
+  "nodeId": "edge_abc",
+  "accepted": 5,          // events in this batch
+  "created": 2,           // new rows
+  "reopened": 1,          // resolved -> triggered
+  "acknowledged": 0,
+  "resolved": 1,
+  "updated": 1,           // trigger replay against an open row
+  "remaining": 29,        // rate-limit budget remaining this minute
+  "route": "/api/v1/edge/events"
+}
+```
+
+## Error responses
+
+| Status | Error | Cause |
+|---|---|---|
+| 400 | `invalid_json` | Body is not valid JSON. |
+| 401 | `missing_authorization` / `invalid_scheme` / `invalid_token_format` / `token_not_found` / `node_revoked` | Bearer-token auth failures. |
+| 403 | `scope_disallowed` | Node is `pending` or `quarantined`, not `trusted`. |
+| 413 | `payload_too_large` | `Content-Length` exceeds 256 KB. |
+| 422 | `invalid_envelope` | Zod rejected the body shape. `issues` contains field-level errors. |
+| 422 | `stale_payload` | `observedAt` outside the ±5 min freshness window. |
+| 429 | `rate_limited` | 30/min or 600/hour ceiling hit. Honor `Retry-After`. |
+| 500 | `persist_failed` | DB transaction failed. Retry with the same `runKey` — upserts are idempotent. |
+
+## Capability declaration
+
+Edge nodes that emit events should advertise `events.emit` in `advertisedCapabilities` during enroll
+and report status in heartbeats. The portal's accepted-capabilities negotiation includes it in
+`RESERVED_CAPABILITIES` (`packages/db/src/edge-node-types.ts`).
+
+## Quick local check (cURL)
+
+```bash
+curl -X POST https://localhost:3000/api/v1/edge/events \
+  -H "Authorization: Bearer dpfedge_<your_token>" \
+  -H "Content-Type: application/json" \
+  -d @- <<'JSON'
+{
+  "runKey": "7c2d6f4a-3b1e-4d8a-9e1b-1234567890ab",
+  "observedAt": "2026-05-21T02:30:01Z",
+  "eventsVersion": "1",
+  "events": [{
+    "dedupKey": "ping:192.168.0.10:loss",
+    "source": "ping",
+    "component": "192.168.0.10",
+    "severity": "warn",
+    "action": "trigger",
+    "summary": "Packet loss to 192.168.0.10 (35% over 60s)",
+    "occurredAt": "2026-05-21T02:30:00Z"
+  }]
+}
+JSON
+```
+
+## What this is NOT (yet)
+
+Slice 0 ships ingest + persistence only. There is **no** event list UI, **no** correlation across
+sources, **no** escalation, **no** on-call. Those land in follow-on slices:
+
+- Slice 1 — edge detector framework
+- Slice 2 — first built-in detector pack
+- Portal slices A / B / C — correlation, lifecycle UX, escalation + on-call
+
+Track the parent BI `BI-9FE9D48D` for the slice plan.

--- a/docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+++ b/docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
@@ -1,0 +1,167 @@
+# Edge Node — Canonical Event Envelope (Detection Engine, Slice 0)
+
+| Field | Value |
+|-------|-------|
+| **BI** | [BI-9FE9D48D](../../../../docs/triage/) — Edge-node detection engine: single-binary detector framework on services/edge-node-go/ (PagerDuty-equivalent network/device event coverage foundation) |
+| **IT4IT Alignment** | §5.7 Operate (Event Management FC) |
+| **Depends On** | Phase 0 edge node (`services/edge-node-go/`), `2026-05-09-dpf-edge-node-design.md` (token + trust model), `2026-05-19-edge-node-network-telemetry-adapters-design.md` (SNMP/LLDP/UniFi adapters become detectors) |
+| **Status** | Slice 0 — Draft (envelope + portal ingest only; detector framework + first detector pack land in follow-on slices) |
+| **Created** | 2026-05-21 |
+| **Author** | Claude (Software Engineer) + Mark Bodman (CEO) |
+
+---
+
+## 1. Problem Statement
+
+PagerDuty's "700 integrations" surface boils down to: receive a normalized event, dedupe it, run an
+incident lifecycle, route + escalate to a human. DPF already runs Prometheus + Grafana + the edge
+node's discovery and telemetry plane, but it has **no canonical event** — every adapter today writes
+its own bespoke shape, so cross-source correlation and noise reduction are impossible without first
+re-flattening the data.
+
+Slice 0 closes that by defining one envelope shared between every edge detector and the portal, plus
+the minimum ingest path to land events with replay-safe dedupe. Slice 0 is the lock-step contract
+that downstream slices (detector framework, detector packs, correlation, escalation, on-call) depend
+on; until it exists, every later slice would have to invent its own.
+
+## 2. Goals (Slice 0)
+
+1. One wire shape — `EdgeEventEnvelope` — used by every edge detector and validated identically by
+   the portal Zod + the Go envelope validator + the cross-runtime parity test.
+2. Lifecycle primitives — `trigger` / `acknowledge` / `resolve` — that map cleanly onto a portal-side
+   incident state machine in later slices.
+3. Replay-safe dedupe on `(edgeNodeId, dedupKey)` so flap/flood noise that survived edge-side
+   collapse still folds into one row at the portal.
+4. Auth + rate-limit parity with the existing edge ingest routes (`heartbeat`, `discovery-runs`,
+   `metrics`) — same `dpfedge_` bearer-token model, same per-node ceiling pattern.
+5. No portal UX yet — the row is for follow-on slices to read.
+
+## 3. Non-Goals (Slice 0)
+
+- Detector framework on the edge (Slice 1).
+- Reachability/SNMP/syslog/ARP/DHCP detector pack (Slice 2).
+- Vendor detector packs — UniFi events, Synology, HA, NUT, Suricata (Slice 3+).
+- Cross-source correlation and ML grouping (separate portal slice).
+- Incident UX, escalation policies, on-call schedules (separate portal slices).
+- Re-platforming `PortfolioQualityIssue`, `ComplianceIncident`, or `RegulatoryAlert` — those keep
+  their domain semantics. `EdgeEvent` is a new row class for edge-detected operational events only.
+
+## 4. Wire Contract
+
+The envelope is intentionally PD-CEF-shaped so adapters from external monitoring tools (a future
+PagerDuty-compatible webhook adapter, for example) translate to the same vocabulary without a second
+mapping pass.
+
+### 4.1 EdgeEventEnvelope
+
+```ts
+{
+  runKey: string;          // UUID — idempotency at batch level
+  nodeId?: string;         // informational; portal trusts the bearer token
+  observedAt: string;      // RFC 3339 — when the batch left the edge
+  eventsVersion: "1";      // literal — bumped only on incompatible change
+  events: EdgeEvent[];     // 1..500
+}
+```
+
+### 4.2 EdgeEvent
+
+```ts
+{
+  dedupKey: string;            // anchor; (edgeNodeId, dedupKey) is unique
+  source: string;              // detector — "snmp.trap", "syslog", "ping"
+  component?: string;          // sub-source — hostname, IP, MAC, port
+  eventGroup?: string;         // logical bucket — "network", "host", "ups"
+  eventClass?: string;         // condition — "interface_down", "cert_expiring"
+  severity: "info" | "warn" | "error" | "critical";
+  action: "trigger" | "acknowledge" | "resolve";
+  summary: string;             // human-readable line for incident lists
+  occurredAt: string;          // RFC 3339 — when the detector observed
+  customDetails?: Record<string, unknown>;
+}
+```
+
+`dedupKey` composition convention (operator-facing, enforced only by detector code):
+
+```
+<source>:<component>:<eventClass>[:<instance>]
+```
+
+Detectors that observe genuinely distinct conditions on the same component MUST vary `instance` so
+the portal doesn't collapse two separate problems into one row.
+
+## 5. Portal Ingest — POST /api/v1/edge/events
+
+Order of operations (mirrors `/metrics`):
+
+1. **Body size cap** — 256 KB. Larger than `/metrics` because events allow up to 500 records each
+   with `customDetails`.
+2. **Auth** — `edge:events` scope, `trustState=trusted` (same gate as `discovery:submit` /
+   `edge:metrics`).
+3. **JSON parse**.
+4. **Envelope validation** — `edgeEventEnvelopeSchema.safeParse`. 422 on shape drift.
+5. **Freshness** — symmetric 5-min window. Detectors buffering offline should bump `observedAt` on
+   flush; per-event `occurredAt` preserves the original instant.
+6. **Per-node rate limit** — `edge.events.submit` (30/min, 600/hour). Generous because the envelope
+   already batches.
+7. **Persist** — one `prisma.$transaction` per request; per-event upsert on `(edgeNodeId, dedupKey)`.
+
+`nodeId` always derives from the bearer token; the body field is informational.
+
+### 5.1 Lifecycle on upsert
+
+| Incoming action | Existing row | Effect |
+|---|---|---|
+| `trigger` | none | Create row, `status="triggered"`, `occurrenceCount=1` |
+| `trigger` | open (`triggered` / `acknowledged`) | Bump `occurrenceCount`, refresh payload, `lastSeenAt=now` |
+| `trigger` | `resolved` | Re-open: clear `resolvedAt`, bump `occurrenceCount`, `status="triggered"` |
+| `acknowledge` | none | Create row, `status="acknowledged"`, `occurrenceCount=1` |
+| `acknowledge` | any | `status="acknowledged"` (counter NOT bumped) |
+| `resolve` | none | Create row, `status="resolved"`, `resolvedAt=now`, `occurrenceCount=1` |
+| `resolve` | any | `status="resolved"`, `resolvedAt=now` |
+
+### 5.2 Response
+
+```json
+{
+  "ok": true,
+  "runKey": "...",
+  "nodeId": "edge_abc",
+  "accepted": 5,
+  "created": 2,
+  "reopened": 1,
+  "acknowledged": 0,
+  "resolved": 1,
+  "updated": 1,
+  "remaining": 29,
+  "route": "/api/v1/edge/events"
+}
+```
+
+## 6. Cross-Runtime Parity
+
+The Go `internal/envelope/event.go` carries struct tags identical to the Zod field names; the
+cross-runtime parity test at `apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts` replays
+captured TS + Go fixtures against the same `edgeEventEnvelopeSchema`. Drift in either runtime fails
+the test.
+
+## 7. Out-of-Scope (Future Slices)
+
+| Slice | Title | Notes |
+|---|---|---|
+| 1 | Edge detector framework | `internal/detector/`: contract, registry, scheduler, in-process bus, enricher, local-dedupe, embedded state store, outbound transport with offline buffer |
+| 2 | First built-in detector pack | reachability (ping/TCP/HTTP/DNS/TLS), SNMP poll + trap receiver, syslog listener, ARP/DHCP delta, host self-metrics |
+| 3+ | Vendor detector packs (per-BI) | UniFi events, Synology, HA, NUT, Suricata — each its own follow-on BI |
+| P-A | Portal correlation | Group related events into incidents |
+| P-B | Incident lifecycle | Full state machine + assignment UX |
+| P-C | Escalation + on-call | Routing rules, schedules, paging |
+
+## 8. Open Questions
+
+- **Customer-facing event names** vs. detector-facing identifiers. Slice 0 uses raw strings; a
+  catalog (mapping `source/eventClass` → human-readable name + remediation runbook) would slot in
+  before Slice 2 ships.
+- **Event TTL / archival** — `EdgeEvent` rows grow unbounded; Slice 0 ships without compaction.
+  Add policy after Slice P-B (incident lifecycle) defines what "closed and aged out" means.
+- **Severity-to-priority mapping** — Slice 0 keeps severity as a string; portal-side incident
+  priority depends on policy not yet defined (see P-A / P-C).

--- a/packages/db/prisma/migrations/20260521000000_add_edge_event_table/migration.sql
+++ b/packages/db/prisma/migrations/20260521000000_add_edge_event_table/migration.sql
@@ -1,0 +1,42 @@
+-- Slice 0 of edge-node detection engine (PagerDuty-equivalent event coverage).
+-- Spec: docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+-- BI:   BI-9FE9D48D
+--
+-- Canonical PD-CEF-style event row persisted from POST /api/v1/edge/events.
+-- Dedup is (edgeNodeId, dedupKey) so the same condition collapses on replay
+-- and the keyspace is isolated per edge node.
+
+CREATE TABLE "EdgeEvent" (
+    "id"              TEXT NOT NULL,
+    "edgeNodeId"      TEXT NOT NULL,
+    "dedupKey"        TEXT NOT NULL,
+    "source"          TEXT NOT NULL,
+    "component"       TEXT,
+    "eventGroup"      TEXT,
+    "eventClass"      TEXT,
+    "severity"        TEXT NOT NULL DEFAULT 'warn',
+    "status"          TEXT NOT NULL DEFAULT 'triggered',
+    "action"          TEXT NOT NULL DEFAULT 'trigger',
+    "summary"         TEXT NOT NULL,
+    "customDetails"   JSONB,
+    "occurredAt"      TIMESTAMP(3) NOT NULL,
+    "firstSeenAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt"      TIMESTAMP(3),
+    "occurrenceCount" INTEGER NOT NULL DEFAULT 1,
+    "createdAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"       TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EdgeEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EdgeEvent_edgeNodeId_dedupKey_key" ON "EdgeEvent"("edgeNodeId", "dedupKey");
+CREATE INDEX "EdgeEvent_edgeNodeId_status_idx" ON "EdgeEvent"("edgeNodeId", "status");
+CREATE INDEX "EdgeEvent_severity_idx" ON "EdgeEvent"("severity");
+CREATE INDEX "EdgeEvent_source_idx" ON "EdgeEvent"("source");
+CREATE INDEX "EdgeEvent_occurredAt_idx" ON "EdgeEvent"("occurredAt");
+
+ALTER TABLE "EdgeEvent"
+    ADD CONSTRAINT "EdgeEvent_edgeNodeId_fkey"
+    FOREIGN KEY ("edgeNodeId") REFERENCES "EdgeNode"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -35,68 +35,68 @@ enum BriefStatus {
 }
 
 model User {
-  id                           String                        @id @default(cuid())
-  email                        String                        @unique
-  passwordHash                 String
-  isActive                     Boolean                       @default(true)
-  isSuperuser                  Boolean                       @default(false)
-  createdAt                    DateTime                      @default(now())
-  approvedProposals            AgentActionProposal[]         @relation("ProposalDecisions")
-  agentThreads                 AgentThread[]
-  apiTokens                    ApiToken[]
-  mcpApiTokens                 McpApiToken[]
-  backlogSubmissions           BacklogItem[]                 @relation("BacklogSubmissions")
-  customEvalDimsApproved       CustomEvalDimension[]         @relation("CustomEvalDimensionApprover")
-  customEvalDimsCreated        CustomEvalDimension[]         @relation("CustomEvalDimensionCreator")
-  grantedDelegations           DelegationGrant[]             @relation("DelegationGrantGrantor")
-  employeeProfile              EmployeeProfile?
-  authoredEmploymentEvents     EmploymentEvent[]
-  epicSubmissions              Epic[]                        @relation("EpicSubmissions")
-  externalEvidenceRecords      ExternalEvidenceRecord[]
-  featureBuilds                FeatureBuild[]
-  improvementReviews           ImprovementProposal[]         @relation("ImprovementReviews")
-  improvementSubmissions       ImprovementProposal[]         @relation("ImprovementSubmissions")
-  notifications                Notification[]
-  requestedPasswordResetTokens PasswordResetToken[]          @relation("PasswordResetRequestedBy")
-  passwordResetTokens          PasswordResetToken[]          @relation("PasswordResetForUser")
-  issueReports                 PlatformIssueReport[]
-  policyRulesCreated           PolicyRule[]                  @relation("PolicyRuleCreator")
-  pushDevices                  PushDeviceRegistration[]
-  taskRequirementsApproved     TaskRequirement[]             @relation("TaskRequirementApprover")
-  taskRequirementsCreated      TaskRequirement[]             @relation("TaskRequirementCreator")
-  teamMemberships              TeamMembership[]
-  groups                       UserGroup[]
-  userSkills                   UserSkill[]                   @relation("UserSkillCreator")
-  invoicesCreated              Invoice[]                     @relation("InvoiceCreations")
-  paymentsCreated              Payment[]                     @relation("PaymentCreations")
-  engagementAssignments        Engagement[]                  @relation("EngagementAssignments")
-  opportunityAssignments       Opportunity[]                 @relation("OpportunityAssignments")
-  activitiesCreated            Activity[]                    @relation("ActivityCreations")
-  quotesCreated                Quote[]                       @relation("QuoteCreations")
-  billsCreated                 Bill[]                        @relation("BillCreations")
-  posCreated                   PurchaseOrder[]               @relation("PurchaseOrderCreations")
-  approvalRules                ApprovalRule[]                @relation("ApprovalRuleApprover")
-  billApprovals                BillApproval[]                @relation("BillApprovalResponses")
-  recurringSchedulesCreated    RecurringSchedule[]           @relation("RecurringScheduleCreations")
-  expenseApprovals             ExpenseClaim[]                @relation("ExpenseApprovals")
-  platformSetupProgress        PlatformSetupProgress?        @relation("UserSetupProgress")
-  taskRuns                     TaskRun[]
-  businessModelRoleAssignments BusinessModelRoleAssignment[]
-  platformDevConfigs           PlatformDevConfig[]           @relation("PlatformDevConfiguredBy")
-  platformDevDcoAcceptances    PlatformDevConfig[]           @relation("PlatformDevDcoAcceptedBy")
-  agentModelConfigs            AgentModelConfig[]            @relation("AgentModelConfiguredBy")
-  knowledgeArticles            KnowledgeArticle[]            @relation("KnowledgeArticleAuthor")
-  knowledgeRevisions           KnowledgeArticleRevision[]    @relation("KnowledgeRevisionCreator")
-  wikiRevisions                WikiPageRevision[]            @relation("WikiRevisionCreator")
-  wikiIngestEvents             WikiIngestEvent[]             @relation("WikiIngestEventUser")
-  workItemAssignments          WorkItem[]                    @relation("WorkItemAssignee")
-  workSchedule                 WorkSchedule?
-  adminActivities              AdminActivity[]
-  userFacts                    UserFact[]
-  decisionEscalationsResolved  EscalationCapture[]           @relation("DecisionEscalationResolverUser")
+  id                            String                        @id @default(cuid())
+  email                         String                        @unique
+  passwordHash                  String
+  isActive                      Boolean                       @default(true)
+  isSuperuser                   Boolean                       @default(false)
+  createdAt                     DateTime                      @default(now())
+  approvedProposals             AgentActionProposal[]         @relation("ProposalDecisions")
+  agentThreads                  AgentThread[]
+  apiTokens                     ApiToken[]
+  mcpApiTokens                  McpApiToken[]
+  backlogSubmissions            BacklogItem[]                 @relation("BacklogSubmissions")
+  customEvalDimsApproved        CustomEvalDimension[]         @relation("CustomEvalDimensionApprover")
+  customEvalDimsCreated         CustomEvalDimension[]         @relation("CustomEvalDimensionCreator")
+  grantedDelegations            DelegationGrant[]             @relation("DelegationGrantGrantor")
+  employeeProfile               EmployeeProfile?
+  authoredEmploymentEvents      EmploymentEvent[]
+  epicSubmissions               Epic[]                        @relation("EpicSubmissions")
+  externalEvidenceRecords       ExternalEvidenceRecord[]
+  featureBuilds                 FeatureBuild[]
+  improvementReviews            ImprovementProposal[]         @relation("ImprovementReviews")
+  improvementSubmissions        ImprovementProposal[]         @relation("ImprovementSubmissions")
+  notifications                 Notification[]
+  requestedPasswordResetTokens  PasswordResetToken[]          @relation("PasswordResetRequestedBy")
+  passwordResetTokens           PasswordResetToken[]          @relation("PasswordResetForUser")
+  issueReports                  PlatformIssueReport[]
+  policyRulesCreated            PolicyRule[]                  @relation("PolicyRuleCreator")
+  pushDevices                   PushDeviceRegistration[]
+  taskRequirementsApproved      TaskRequirement[]             @relation("TaskRequirementApprover")
+  taskRequirementsCreated       TaskRequirement[]             @relation("TaskRequirementCreator")
+  teamMemberships               TeamMembership[]
+  groups                        UserGroup[]
+  userSkills                    UserSkill[]                   @relation("UserSkillCreator")
+  invoicesCreated               Invoice[]                     @relation("InvoiceCreations")
+  paymentsCreated               Payment[]                     @relation("PaymentCreations")
+  engagementAssignments         Engagement[]                  @relation("EngagementAssignments")
+  opportunityAssignments        Opportunity[]                 @relation("OpportunityAssignments")
+  activitiesCreated             Activity[]                    @relation("ActivityCreations")
+  quotesCreated                 Quote[]                       @relation("QuoteCreations")
+  billsCreated                  Bill[]                        @relation("BillCreations")
+  posCreated                    PurchaseOrder[]               @relation("PurchaseOrderCreations")
+  approvalRules                 ApprovalRule[]                @relation("ApprovalRuleApprover")
+  billApprovals                 BillApproval[]                @relation("BillApprovalResponses")
+  recurringSchedulesCreated     RecurringSchedule[]           @relation("RecurringScheduleCreations")
+  expenseApprovals              ExpenseClaim[]                @relation("ExpenseApprovals")
+  platformSetupProgress         PlatformSetupProgress?        @relation("UserSetupProgress")
+  taskRuns                      TaskRun[]
+  businessModelRoleAssignments  BusinessModelRoleAssignment[]
+  platformDevConfigs            PlatformDevConfig[]           @relation("PlatformDevConfiguredBy")
+  platformDevDcoAcceptances     PlatformDevConfig[]           @relation("PlatformDevDcoAcceptedBy")
+  agentModelConfigs             AgentModelConfig[]            @relation("AgentModelConfiguredBy")
+  knowledgeArticles             KnowledgeArticle[]            @relation("KnowledgeArticleAuthor")
+  knowledgeRevisions            KnowledgeArticleRevision[]    @relation("KnowledgeRevisionCreator")
+  wikiRevisions                 WikiPageRevision[]            @relation("WikiRevisionCreator")
+  wikiIngestEvents              WikiIngestEvent[]             @relation("WikiIngestEventUser")
+  workItemAssignments           WorkItem[]                    @relation("WorkItemAssignee")
+  workSchedule                  WorkSchedule?
+  adminActivities               AdminActivity[]
+  userFacts                     UserFact[]
+  decisionEscalationsResolved   EscalationCapture[]           @relation("DecisionEscalationResolverUser")
   triggeredDecisionInteractions DecisionInteraction[]         @relation("DecisionInteractionTriggeredByUser")
-  scheduledAgentTasks          ScheduledAgentTask[]          @relation("ScheduledAgentTaskOwner")
-  addedLocalities              City[]                        @relation("CityAddedByUser")
+  scheduledAgentTasks           ScheduledAgentTask[]          @relation("ScheduledAgentTaskOwner")
+  addedLocalities               City[]                        @relation("CityAddedByUser")
 }
 
 model UserGroup {
@@ -219,32 +219,32 @@ model TeamMembership {
 }
 
 model Principal {
-  id                    String           @id @default(cuid())
-  principalId           String           @unique
-  kind                  String
-  status                String           @default("active")
-  displayName           String
-  aliases               PrincipalAlias[]
-  communicationChannelBindings CommunicationChannelBinding[]
-  communicationChannelSessions CommunicationChannelSession[]
+  id                                  String                              @id @default(cuid())
+  principalId                         String                              @unique
+  kind                                String
+  status                              String                              @default("active")
+  displayName                         String
+  aliases                             PrincipalAlias[]
+  communicationChannelBindings        CommunicationChannelBinding[]
+  communicationChannelSessions        CommunicationChannelSession[]
   // Per AGENTS.md §11 (Principal convergence, 2026-05-09): EdgeNode
   // identity lives on Principal + PrincipalAlias, with EdgeNode as a
   // host-attributes side table keyed by `principalId`. 1:1 cardinality.
-  edgeNode              EdgeNode?        @relation("EdgeNodeIdentity")
-  edgeNodesApproved     EdgeNode[]       @relation("EdgeNodeApprover")
-  bootstrapTokensIssued BootstrapToken[] @relation("BootstrapTokenIssuer")
-  ownedDocuments        Document[]       @relation("DocumentOwner")
-  createdDocuments      Document[]       @relation("DocumentCreator")
-  documentVersions      DocumentVersion[] @relation("DocumentVersionCreator")
-  documentReferences    DocumentReference[] @relation("DocumentReferenceCreator")
-  documentAccessGrants  DocumentAccessGrant[] @relation("DocumentAccessGrantPrincipal")
-  documentAccessGrantsCreated DocumentAccessGrant[] @relation("DocumentAccessGrantCreator")
-  documentLifecycleEvents DocumentLifecycleEvent[] @relation("DocumentLifecycleActor")
-  ownedDecisionPerspectiveProfiles DecisionPerspectiveProfile[] @relation("DecisionPerspectiveProfileOwner")
+  edgeNode                            EdgeNode?                           @relation("EdgeNodeIdentity")
+  edgeNodesApproved                   EdgeNode[]                          @relation("EdgeNodeApprover")
+  bootstrapTokensIssued               BootstrapToken[]                    @relation("BootstrapTokenIssuer")
+  ownedDocuments                      Document[]                          @relation("DocumentOwner")
+  createdDocuments                    Document[]                          @relation("DocumentCreator")
+  documentVersions                    DocumentVersion[]                   @relation("DocumentVersionCreator")
+  documentReferences                  DocumentReference[]                 @relation("DocumentReferenceCreator")
+  documentAccessGrants                DocumentAccessGrant[]               @relation("DocumentAccessGrantPrincipal")
+  documentAccessGrantsCreated         DocumentAccessGrant[]               @relation("DocumentAccessGrantCreator")
+  documentLifecycleEvents             DocumentLifecycleEvent[]            @relation("DocumentLifecycleActor")
+  ownedDecisionPerspectiveProfiles    DecisionPerspectiveProfile[]        @relation("DecisionPerspectiveProfileOwner")
   promotedDecisionPerspectiveVersions DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersionPromoter")
-  decisionEscalationsResolved EscalationCapture[] @relation("DecisionEscalationResolverPrincipal")
-  createdAt             DateTime         @default(now())
-  updatedAt             DateTime         @updatedAt
+  decisionEscalationsResolved         EscalationCapture[]                 @relation("DecisionEscalationResolverPrincipal")
+  createdAt                           DateTime                            @default(now())
+  updatedAt                           DateTime                            @updatedAt
 }
 
 model PrincipalAlias {
@@ -262,85 +262,85 @@ model PrincipalAlias {
 }
 
 model EmployeeProfile {
-  id                        String                  @id @default(cuid())
-  employeeId                String                  @unique
-  userId                    String?                 @unique
-  firstName                 String
-  middleName                String?
-  lastName                  String
-  displayName               String
-  workEmail                 String?
-  personalEmail             String?
-  phoneWork                 String?
-  status                    String                  @default("onboarding")
-  employmentTypeId          String?
-  departmentId              String?
-  positionId                String?
-  managerEmployeeId         String?
-  dottedLineManagerId       String?
-  workLocationId            String?
-  timezone                  String?
-  startDate                 DateTime?
-  confirmationDate          DateTime?
-  endDate                   DateTime?
-  createdAt                 DateTime                @default(now())
-  updatedAt                 DateTime                @updatedAt
-  phoneMobile               String?
-  phoneEmergency            String?
-  accountableItems          BacklogItem[]           @relation("ItemAccountable")
-  calendarEvents            CalendarEvent[]
-  calendarSyncs             CalendarSync[]
+  id                           String                        @id @default(cuid())
+  employeeId                   String                        @unique
+  userId                       String?                       @unique
+  firstName                    String
+  middleName                   String?
+  lastName                     String
+  displayName                  String
+  workEmail                    String?
+  personalEmail                String?
+  phoneWork                    String?
+  status                       String                        @default("onboarding")
+  employmentTypeId             String?
+  departmentId                 String?
+  positionId                   String?
+  managerEmployeeId            String?
+  dottedLineManagerId          String?
+  workLocationId               String?
+  timezone                     String?
+  startDate                    DateTime?
+  confirmationDate             DateTime?
+  endDate                      DateTime?
+  createdAt                    DateTime                      @default(now())
+  updatedAt                    DateTime                      @updatedAt
+  phoneMobile                  String?
+  phoneEmergency               String?
+  accountableItems             BacklogItem[]                 @relation("ItemAccountable")
+  calendarEvents               CalendarEvent[]
+  calendarSyncs                CalendarSync[]
   communicationChannelBindings CommunicationChannelBinding[]
-  auditsPerformed           ComplianceAudit[]       @relation("AuditAuditor")
-  complianceAuditLogs       ComplianceAuditLog[]    @relation("ComplianceAuditLogActor")
-  evidenceCollected         ComplianceEvidence[]    @relation("EvidenceCollector")
-  incidentsReported         ComplianceIncident[]    @relation("IncidentReporter")
-  controlOwnership          Control[]               @relation("ControlOwner")
-  correctiveActionsOwned    CorrectiveAction[]      @relation("CorrectiveActionOwner")
-  correctiveActionsVerified CorrectiveAction[]      @relation("CorrectiveActionVerifier")
-  headedDepartments         Department[]            @relation("DepartmentHead")
-  addresses                 EmployeeAddress[]
-  department                Department?             @relation("DepartmentEmployees", fields: [departmentId], references: [id])
-  dottedLineManager         EmployeeProfile?        @relation("EmployeeDottedManager", fields: [dottedLineManagerId], references: [id])
-  dottedLineReports         EmployeeProfile[]       @relation("EmployeeDottedManager")
-  employmentType            EmploymentType?         @relation(fields: [employmentTypeId], references: [id])
-  manager                   EmployeeProfile?        @relation("EmployeeManager", fields: [managerEmployeeId], references: [id])
-  directReports             EmployeeProfile[]       @relation("EmployeeManager")
-  position                  Position?               @relation(fields: [positionId], references: [id])
-  user                      User?                   @relation(fields: [userId], references: [id])
-  workLocation              WorkLocation?           @relation(fields: [workLocationId], references: [id])
-  employmentEvents          EmploymentEvent[]
-  accountableEpics          Epic[]                  @relation("EpicAccountable")
-  accountableBuilds         FeatureBuild[]          @relation("BuildAccountable")
-  feedbackGiven             FeedbackNote[]          @relation("FeedbackFrom")
-  feedbackReceived          FeedbackNote[]          @relation("FeedbackTo")
-  leaveBalances             LeaveBalance[]
-  leaveApprovals            LeaveRequest[]          @relation("LeaveApprovals")
-  leaveRequests             LeaveRequest[]
-  obligationOwnership       Obligation[]            @relation("ObligationOwner")
-  onboardingTasks           OnboardingTask[]
-  policiesApproved          Policy[]                @relation("PolicyApprover")
-  policiesOwned             Policy[]                @relation("PolicyOwner")
-  policyAcknowledgments     PolicyAcknowledgment[]  @relation("PolicyAcknowledgments")
-  alertsReviewed            RegulatoryAlert[]       @relation("AlertReviewer")
-  scansTriggered            RegulatoryMonitorScan[] @relation("ScanTriggerer")
-  regulatorySubmissions     RegulatorySubmission[]  @relation("SubmissionSubmitter")
-  requirementCompletions    RequirementCompletion[] @relation("RequirementCompletions")
-  reviewInstances           ReviewInstance[]        @relation("ReviewsAsEmployee")
-  reviewsAsReviewer         ReviewInstance[]        @relation("ReviewsAsReviewer")
-  riskAssessments           RiskAssessment[]        @relation("RiskAssessor")
-  terminationRecord         TerminationRecord?
-  timesheetApprovals        TimesheetPeriod[]       @relation("TimesheetApprovals")
-  timesheets                TimesheetPeriod[]
-  expenseClaims             ExpenseClaim[]          @relation("ExpenseClaims")
-  serviceProviders          ServiceProvider[]
-  aiProviderContracts       SupplierContract[]      @relation("AiContractOwner")
-  aiFinanceWorkItems        FinanceWorkItem[]       @relation("AiFinanceWorkItemOwner")
-  changeRequestsRequested   ChangeRequest[]         @relation("ChangeRequestedBy")
-  changeRequestsAssessed    ChangeRequest[]         @relation("ChangeAssessedBy")
-  changeRequestsApproved    ChangeRequest[]         @relation("ChangeApprovedBy")
-  changeRequestsExecuted    ChangeRequest[]         @relation("ChangeExecutedBy")
-  standardChangesApproved   StandardChangeCatalog[] @relation("StandardChangeApprover")
+  auditsPerformed              ComplianceAudit[]             @relation("AuditAuditor")
+  complianceAuditLogs          ComplianceAuditLog[]          @relation("ComplianceAuditLogActor")
+  evidenceCollected            ComplianceEvidence[]          @relation("EvidenceCollector")
+  incidentsReported            ComplianceIncident[]          @relation("IncidentReporter")
+  controlOwnership             Control[]                     @relation("ControlOwner")
+  correctiveActionsOwned       CorrectiveAction[]            @relation("CorrectiveActionOwner")
+  correctiveActionsVerified    CorrectiveAction[]            @relation("CorrectiveActionVerifier")
+  headedDepartments            Department[]                  @relation("DepartmentHead")
+  addresses                    EmployeeAddress[]
+  department                   Department?                   @relation("DepartmentEmployees", fields: [departmentId], references: [id])
+  dottedLineManager            EmployeeProfile?              @relation("EmployeeDottedManager", fields: [dottedLineManagerId], references: [id])
+  dottedLineReports            EmployeeProfile[]             @relation("EmployeeDottedManager")
+  employmentType               EmploymentType?               @relation(fields: [employmentTypeId], references: [id])
+  manager                      EmployeeProfile?              @relation("EmployeeManager", fields: [managerEmployeeId], references: [id])
+  directReports                EmployeeProfile[]             @relation("EmployeeManager")
+  position                     Position?                     @relation(fields: [positionId], references: [id])
+  user                         User?                         @relation(fields: [userId], references: [id])
+  workLocation                 WorkLocation?                 @relation(fields: [workLocationId], references: [id])
+  employmentEvents             EmploymentEvent[]
+  accountableEpics             Epic[]                        @relation("EpicAccountable")
+  accountableBuilds            FeatureBuild[]                @relation("BuildAccountable")
+  feedbackGiven                FeedbackNote[]                @relation("FeedbackFrom")
+  feedbackReceived             FeedbackNote[]                @relation("FeedbackTo")
+  leaveBalances                LeaveBalance[]
+  leaveApprovals               LeaveRequest[]                @relation("LeaveApprovals")
+  leaveRequests                LeaveRequest[]
+  obligationOwnership          Obligation[]                  @relation("ObligationOwner")
+  onboardingTasks              OnboardingTask[]
+  policiesApproved             Policy[]                      @relation("PolicyApprover")
+  policiesOwned                Policy[]                      @relation("PolicyOwner")
+  policyAcknowledgments        PolicyAcknowledgment[]        @relation("PolicyAcknowledgments")
+  alertsReviewed               RegulatoryAlert[]             @relation("AlertReviewer")
+  scansTriggered               RegulatoryMonitorScan[]       @relation("ScanTriggerer")
+  regulatorySubmissions        RegulatorySubmission[]        @relation("SubmissionSubmitter")
+  requirementCompletions       RequirementCompletion[]       @relation("RequirementCompletions")
+  reviewInstances              ReviewInstance[]              @relation("ReviewsAsEmployee")
+  reviewsAsReviewer            ReviewInstance[]              @relation("ReviewsAsReviewer")
+  riskAssessments              RiskAssessment[]              @relation("RiskAssessor")
+  terminationRecord            TerminationRecord?
+  timesheetApprovals           TimesheetPeriod[]             @relation("TimesheetApprovals")
+  timesheets                   TimesheetPeriod[]
+  expenseClaims                ExpenseClaim[]                @relation("ExpenseClaims")
+  serviceProviders             ServiceProvider[]
+  aiProviderContracts          SupplierContract[]            @relation("AiContractOwner")
+  aiFinanceWorkItems           FinanceWorkItem[]             @relation("AiFinanceWorkItemOwner")
+  changeRequestsRequested      ChangeRequest[]               @relation("ChangeRequestedBy")
+  changeRequestsAssessed       ChangeRequest[]               @relation("ChangeAssessedBy")
+  changeRequestsApproved       ChangeRequest[]               @relation("ChangeApprovedBy")
+  changeRequestsExecuted       ChangeRequest[]               @relation("ChangeExecutedBy")
+  standardChangesApproved      StandardChangeCatalog[]       @relation("StandardChangeApprover")
 
   @@index([status])
   @@index([departmentId])
@@ -894,73 +894,73 @@ model ServiceOffering {
 }
 
 model TaxonomyNode {
-  id                       String                     @id @default(cuid())
-  nodeId                   String                     @unique
+  id                       String                        @id @default(cuid())
+  nodeId                   String                        @unique
   name                     String
   portfolioId              String?
   parentId                 String?
-  status                   String                     @default("active")
+  status                   String                        @default("active")
   governance               Json?
   description              String?
   enrichment               Json?
   backlogItems             BacklogItem[]
   products                 DigitalProduct[]
   eaElements               EaElement[]
-  businessCapabilityLinks      BusinessCapabilityTraceLink[] @relation("BusinessCapabilityTaxonomyLinks")
+  businessCapabilityLinks  BusinessCapabilityTraceLink[] @relation("BusinessCapabilityTaxonomyLinks")
   fingerprintRules         DiscoveryFingerprintRule[]
   inventoryEntities        InventoryEntity[]
   portfolioQualityIssues   PortfolioQualityIssue[]
-  triageSelectionDecisions DiscoveryTriageDecision[]  @relation("DiscoveryTriageDecisionSelectedTaxonomy")
-  parent                   TaxonomyNode?              @relation("TaxonomyTree", fields: [parentId], references: [id])
-  children                 TaxonomyNode[]             @relation("TaxonomyTree")
+  triageSelectionDecisions DiscoveryTriageDecision[]     @relation("DiscoveryTriageDecisionSelectedTaxonomy")
+  parent                   TaxonomyNode?                 @relation("TaxonomyTree", fields: [parentId], references: [id])
+  children                 TaxonomyNode[]                @relation("TaxonomyTree")
 }
 
 model BacklogItem {
-  id                    String                   @id @default(cuid())
-  itemId                String                   @unique
-  title                 String
-  status                String
-  type                  String
-  body                  String?
-  createdAt             DateTime                 @default(now())
-  updatedAt             DateTime                 @updatedAt
-  priority              Int?
-  digitalProductId      String?
-  taxonomyNodeId        String?
-  epicId                String?
-  source                String?
-  triageOutcome         String?
-  effortSize            String?
-  proposedOutcome       String?
-  activeBuildId         String?                  @unique
-  duplicateOfId         String?
-  resolution            String?
-  abandonReason         String?
-  stalenessDetectedAt   DateTime?
-  occurrenceCount       Int                      @default(1)
-  lastSeenAt            DateTime?
-  submittedById         String?
-  completedAt           DateTime?
-  agentId               String?
-  accountableEmployeeId String?
-  claimedById           String?
-  claimedByAgentId      String?
-  claimedAt             DateTime?
-  claimStatus           String?
-  upstreamIssueNumber   Int?
-  upstreamIssueUrl      String?
-  upstreamSyncedAt      DateTime?
-  accountableEmployee   EmployeeProfile?         @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
-  activeBuild           FeatureBuild?            @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
-  digitalProduct        DigitalProduct?          @relation(fields: [digitalProductId], references: [id])
-  duplicateOf           BacklogItem?             @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
-  duplicates            BacklogItem[]            @relation("BacklogItemDuplicates")
-  epic                  Epic?                    @relation(fields: [epicId], references: [id])
-  featureBuilds         FeatureBuild[]           @relation("BacklogItemOriginator")
-  submittedBy           User?                    @relation("BacklogSubmissions", fields: [submittedById], references: [id])
-  taxonomyNode          TaxonomyNode?            @relation(fields: [taxonomyNodeId], references: [id])
-  activities            BacklogItemActivity[]
-  coworkerNeeds         CoworkerCapabilityNeed[] @relation("BacklogItemCoworkerCapabilityNeeds")
+  id                      String                        @id @default(cuid())
+  itemId                  String                        @unique
+  title                   String
+  status                  String
+  type                    String
+  body                    String?
+  createdAt               DateTime                      @default(now())
+  updatedAt               DateTime                      @updatedAt
+  priority                Int?
+  digitalProductId        String?
+  taxonomyNodeId          String?
+  epicId                  String?
+  source                  String?
+  triageOutcome           String?
+  effortSize              String?
+  proposedOutcome         String?
+  activeBuildId           String?                       @unique
+  duplicateOfId           String?
+  resolution              String?
+  abandonReason           String?
+  stalenessDetectedAt     DateTime?
+  occurrenceCount         Int                           @default(1)
+  lastSeenAt              DateTime?
+  submittedById           String?
+  completedAt             DateTime?
+  agentId                 String?
+  accountableEmployeeId   String?
+  claimedById             String?
+  claimedByAgentId        String?
+  claimedAt               DateTime?
+  claimStatus             String?
+  upstreamIssueNumber     Int?
+  upstreamIssueUrl        String?
+  upstreamSyncedAt        DateTime?
+  accountableEmployee     EmployeeProfile?              @relation("ItemAccountable", fields: [accountableEmployeeId], references: [id])
+  activeBuild             FeatureBuild?                 @relation("BacklogItemActiveBuild", fields: [activeBuildId], references: [id])
+  digitalProduct          DigitalProduct?               @relation(fields: [digitalProductId], references: [id])
+  duplicateOf             BacklogItem?                  @relation("BacklogItemDuplicates", fields: [duplicateOfId], references: [id])
+  duplicates              BacklogItem[]                 @relation("BacklogItemDuplicates")
+  epic                    Epic?                         @relation(fields: [epicId], references: [id])
+  featureBuilds           FeatureBuild[]                @relation("BacklogItemOriginator")
+  submittedBy             User?                         @relation("BacklogSubmissions", fields: [submittedById], references: [id])
+  taxonomyNode            TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
+  activities              BacklogItemActivity[]
+  coworkerNeeds           CoworkerCapabilityNeed[]      @relation("BacklogItemCoworkerCapabilityNeeds")
   businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityBacklogLinks")
 }
 
@@ -1122,6 +1122,7 @@ model RuntimeVerification {
   @@index([workCapsuleId, kind, status])
   @@index([kind, status])
 }
+
 model Epic {
   id                    String           @id @default(cuid())
   epicId                String           @unique
@@ -2238,32 +2239,32 @@ model RecipePerformance {
 // Captures observed adapter capabilities per (adapterKind, adapterVersion).
 // Replaces hand-maintained capability tables with probe-populated rows.
 model AdapterCapabilityProfile {
-  id                          String   @id @default(cuid())
-  adapterKind                 String   // "http-anthropic" | "claude-code-cli" | "codex-cli" | "codex-mcp" | "local-ollama"
-  adapterVersion              String   // e.g. "claude-code/1.2.3", "codex-cli/0.125.0", "anthropic-http/2024-06-01"
-  probedAt                    DateTime
-  probedBy                    String   // host/process identity, for cache invalidation across replicas
+  id             String   @id @default(cuid())
+  adapterKind    String // "http-anthropic" | "claude-code-cli" | "codex-cli" | "codex-mcp" | "local-ollama"
+  adapterVersion String // e.g. "claude-code/1.2.3", "codex-cli/0.125.0", "anthropic-http/2024-06-01"
+  probedAt       DateTime
+  probedBy       String // host/process identity, for cache invalidation across replicas
 
   // Observed capabilities — booleans, not aspirations
-  supportsStreamingEvents     Boolean
-  supportsMcpAttach           Boolean
-  supportsMcpAttachPerInvoke  Boolean  // Claude Code: yes (--mcp-config); Codex: no (static config only)
-  supportsSubagents           Boolean
-  supportsHooks               Boolean
-  supportsPlanState           Boolean
-  supportsTodoState           Boolean
-  supportsWebFetch            Boolean
-  supportsWebSearch           Boolean
-  supportsSessionResume       Boolean
-  supportsExtendedThinking    Boolean
-  supportsOutputSchema        Boolean
+  supportsStreamingEvents    Boolean
+  supportsMcpAttach          Boolean
+  supportsMcpAttachPerInvoke Boolean // Claude Code: yes (--mcp-config); Codex: no (static config only)
+  supportsSubagents          Boolean
+  supportsHooks              Boolean
+  supportsPlanState          Boolean
+  supportsTodoState          Boolean
+  supportsWebFetch           Boolean
+  supportsWebSearch          Boolean
+  supportsSessionResume      Boolean
+  supportsExtendedThinking   Boolean
+  supportsOutputSchema       Boolean
 
   // Operating envelope
-  maxInteractiveLatencyMs     Int      // wall-clock budget for first event
-  supportedAuthModes          String[] // "api-key" | "oauth" | "local"
+  maxInteractiveLatencyMs Int // wall-clock budget for first event
+  supportedAuthModes      String[] // "api-key" | "oauth" | "local"
 
   // Known landmines (Codex example: --json silently ignored when MCP active)
-  knownDegradations           Json?    // [{ trigger: string, behavior: string, source: string }]
+  knownDegradations Json? // [{ trigger: string, behavior: string, source: string }]
 
   @@unique([adapterKind, adapterVersion])
   @@index([adapterKind, probedAt])
@@ -2274,19 +2275,19 @@ model AdapterCapabilityProfile {
 // usage, and schema-drift detection. Supports single/shadow/race execution
 // modes via raceCohortId grouping. Feeds nightly outcome scoring (§6.4).
 model AdapterRunTelemetry {
-  id                  String    @id @default(cuid())
-  threadId            String?   // null for non-coworker runs (probes, eval)
-  agentMessageId      String?   // joins to AgentMessage when applicable
-  buildId             String?   // for Build Studio dispatch via the substrate
-  agentId             String?   // attribution (PR #607 convention)
-  skillId             String?   // active skill at run time (PR #623 precedent)
-  adapterKind         String
-  adapterVersion      String
-  providerId          String
-  modelId             String
+  id             String  @id @default(cuid())
+  threadId       String? // null for non-coworker runs (probes, eval)
+  agentMessageId String? // joins to AgentMessage when applicable
+  buildId        String? // for Build Studio dispatch via the substrate
+  agentId        String? // attribution (PR #607 convention)
+  skillId        String? // active skill at run time (PR #623 precedent)
+  adapterKind    String
+  adapterVersion String
+  providerId     String
+  modelId        String
 
-  executionMode       String    // "single" | "shadow-primary" | "shadow-alt" | "race-primary" | "race-loser"
-  raceCohortId        String?   // groups concurrent race/shadow runs
+  executionMode String // "single" | "shadow-primary" | "shadow-alt" | "race-primary" | "race-loser"
+  raceCohortId  String? // groups concurrent race/shadow runs
 
   startedAt           DateTime
   finishedAt          DateTime?
@@ -2294,28 +2295,28 @@ model AdapterRunTelemetry {
   firstEventLatencyMs Int?
 
   // Outcome dimensions (spec §5.4)
-  status              String    // "success" | "refusal" | "error" | "timeout" | "cancelled" | "policy-block"
-  httpStatus          Int?      // raw HTTP status code from the provider (null for CLI adapters and successes without errors)
-  refusalReason       String?
-  errorClass          String?
-  inputTokens         Int?
-  cachedInputTokens   Int?
-  cacheCreationInputTokens Int?  // tokens written into the Anthropic prompt cache this call
-  outputTokens        Int?
+  status                   String // "success" | "refusal" | "error" | "timeout" | "cancelled" | "policy-block"
+  httpStatus               Int? // raw HTTP status code from the provider (null for CLI adapters and successes without errors)
+  refusalReason            String?
+  errorClass               String?
+  inputTokens              Int?
+  cachedInputTokens        Int?
+  cacheCreationInputTokens Int? // tokens written into the Anthropic prompt cache this call
+  outputTokens             Int?
 
-  reasoningTokens     Int?
-  estimatedCostUsd    Decimal?  @db.Decimal(10, 6)
-  quotaPoolConsumed   String?   // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
+  reasoningTokens   Int?
+  estimatedCostUsd  Decimal? @db.Decimal(10, 6)
+  quotaPoolConsumed String? // "anthropic-api" | "anthropic-oauth" | "openai-api" | "openai-chatgpt" | "local"
 
-  toolCallsTotal      Int       @default(0)
-  toolCallsInvalid    Int       @default(0) // fabricated tool names, schema mismatches
-  capabilitiesUsed    String[]  // which capability booleans were actually exercised this run
-  schemaDriftDetected Boolean   @default(false) // adapter emitted unexpected event shape
+  toolCallsTotal      Int      @default(0)
+  toolCallsInvalid    Int      @default(0) // fabricated tool names, schema mismatches
+  capabilitiesUsed    String[] // which capability booleans were actually exercised this run
+  schemaDriftDetected Boolean  @default(false) // adapter emitted unexpected event shape
 
-  userAccepted        Boolean?  // null = not yet decided; true = message kept; false = retried/discarded
-  acceptedAt          DateTime?
+  userAccepted Boolean? // null = not yet decided; true = message kept; false = retried/discarded
+  acceptedAt   DateTime?
 
-  rawEventDigest      String?   // sha256 of normalized event log, for cross-adapter equivalence checks
+  rawEventDigest String? // sha256 of normalized event log, for cross-adapter equivalence checks
 
   @@index([adapterKind, startedAt])
   @@index([raceCohortId])
@@ -2329,8 +2330,8 @@ model AdapterRunTelemetry {
 model AgentBudgetEvent {
   id          String   @id @default(cuid())
   agentId     String
-  buildRunId  String?  // FK intentionally soft — build runs may be ephemeral
-  eventKind   String   // "inference" | "tool_call" | "budget_exceeded"
+  buildRunId  String? // FK intentionally soft — build runs may be ephemeral
+  eventKind   String // "inference" | "tool_call" | "budget_exceeded"
   amountUsd   Decimal  @db.Decimal(10, 6)
   tokensTotal Int?
   modelId     String?
@@ -2351,19 +2352,19 @@ model AgentBudgetEvent {
 // Per spec §9, no-op cleanups are NOT logged to avoid bloating the table
 // — quality regression is detected from the rows we do write.
 model TranscriptCleanupAudit {
-  id                   String   @id @default(cuid())
-  threadId             String?
-  agentMessageId       String?
-  userId               String?
-  rawText              String   @db.Text
-  cleanedText          String   @db.Text
-  levenshteinRatio     Float
-  injectionSuspected   Boolean  @default(false)
-  injectionIndicators  String[] // populated when injectionSuspected = true
-  providerId           String?  // cleanup-pass provider; null when short-circuited before LLM
-  modelId              String?
-  durationMs           Int?
-  createdAt            DateTime @default(now())
+  id                  String   @id @default(cuid())
+  threadId            String?
+  agentMessageId      String?
+  userId              String?
+  rawText             String   @db.Text
+  cleanedText         String   @db.Text
+  levenshteinRatio    Float
+  injectionSuspected  Boolean  @default(false)
+  injectionIndicators String[] // populated when injectionSuspected = true
+  providerId          String? // cleanup-pass provider; null when short-circuited before LLM
+  modelId             String?
+  durationMs          Int?
+  createdAt           DateTime @default(now())
 
   @@index([createdAt])
   @@index([injectionSuspected])
@@ -2582,8 +2583,8 @@ model Organization {
   wikiLintFindings              WikiLintFinding[]
   documents                     Document[]
   decisionPerspectiveProfiles   DecisionPerspectiveProfile[]
-  integrationCoverageProviders  IntegrationCoverageProvider[] @relation("OrgToCoverageProviders")
-  integrationRoleCoverages      IntegrationRoleCoverage[]     @relation("OrgToCoverageCells")
+  integrationCoverageProviders  IntegrationCoverageProvider[]  @relation("OrgToCoverageProviders")
+  integrationRoleCoverages      IntegrationRoleCoverage[]      @relation("OrgToCoverageCells")
 }
 
 model BusinessContext {
@@ -3476,7 +3477,7 @@ model AgentThread {
 
   // Specialist subtask thread spawning (feat/agent-thread-spawning)
   parentThreadId String?
-  childCount     Int       @default(0)
+  childCount     Int           @default(0)
   cancelledAt    DateTime?
   idempotencyKey String?
   terminalError  Json?
@@ -3613,31 +3614,31 @@ model AdminActivity {
 }
 
 model ToolExecution {
-  id            String                @id @default(cuid())
-  threadId      String
-  agentId       String
-  userId        String
-  toolName      String
-  parameters    Json
-  result        Json
-  success       Boolean
-  executionMode String
-  routeContext  String?
-  durationMs    Int?
-  createdAt     DateTime              @default(now())
+  id                      String                   @id @default(cuid())
+  threadId                String
+  agentId                 String
+  userId                  String
+  toolName                String
+  parameters              Json
+  result                  Json
+  success                 Boolean
+  executionMode           String
+  routeContext            String?
+  durationMs              Int?
+  createdAt               DateTime                 @default(now())
   // Phase 3: audit enrichment — nullable; backfill via backfill-capability-ids.ts
-  auditClass    String?
-  capabilityId  String?
-  summary       String?
+  auditClass              String?
+  capabilityId            String?
+  summary                 String?
   // External MCP transport (spec §13) — set when the tool call originated from
   // a Bearer-token authenticated request through /api/mcp/v1.
-  apiTokenId    String?
+  apiTokenId              String?
   // Autonomous coworker runtime Slice 1: nullable parent TaskRun link.
   // Persisted by mcp-governed-execute.ts when context.taskRunId is provided.
-  taskRunId     String?
+  taskRunId               String?
   // Governed Hermes learning Slice 1: nullable active skill attribution.
-  skillId       String?
-  receipt       ToolExecutionReceipt?
+  skillId                 String?
+  receipt                 ToolExecutionReceipt?
   documentLifecycleEvents DocumentLifecycleEvent[]
 
   @@index([agentId, createdAt])
@@ -3766,25 +3767,25 @@ model Document {
 }
 
 model DocumentVersion {
-  id                         String              @id @default(cuid())
-  documentId                 String
-  version                    Int
-  title                      String
-  contentFormat              String
-  contentText                String?             @db.Text
-  contentBlobId              String?
-  contentSha256              String?
-  sizeBytes                  Int?
-  summary                    String?             @db.Text
-  createdByPrincipalId       String?
-  createdAt                  DateTime            @default(now())
-  document                   Document            @relation("DocumentVersions", fields: [documentId], references: [id], onDelete: Cascade)
-  currentForDocuments        Document[]          @relation("DocumentCurrentVersion")
-  contentBlob                DocumentBlob?       @relation(fields: [contentBlobId], references: [id], onDelete: SetNull)
-  createdByPrincipal         Principal?          @relation("DocumentVersionCreator", fields: [createdByPrincipalId], references: [id])
-  sourceReferences           DocumentReference[] @relation("DocumentReferenceSourceVersion")
-  targetReferences           DocumentReference[] @relation("DocumentReferenceTargetVersion")
-  renditions                 DocumentRendition[]
+  id                   String              @id @default(cuid())
+  documentId           String
+  version              Int
+  title                String
+  contentFormat        String
+  contentText          String?             @db.Text
+  contentBlobId        String?
+  contentSha256        String?
+  sizeBytes            Int?
+  summary              String?             @db.Text
+  createdByPrincipalId String?
+  createdAt            DateTime            @default(now())
+  document             Document            @relation("DocumentVersions", fields: [documentId], references: [id], onDelete: Cascade)
+  currentForDocuments  Document[]          @relation("DocumentCurrentVersion")
+  contentBlob          DocumentBlob?       @relation(fields: [contentBlobId], references: [id], onDelete: SetNull)
+  createdByPrincipal   Principal?          @relation("DocumentVersionCreator", fields: [createdByPrincipalId], references: [id])
+  sourceReferences     DocumentReference[] @relation("DocumentReferenceSourceVersion")
+  targetReferences     DocumentReference[] @relation("DocumentReferenceTargetVersion")
+  renditions           DocumentRendition[]
 
   @@unique([documentId, version])
   @@index([documentId])
@@ -3795,14 +3796,14 @@ model DocumentVersion {
 }
 
 model DocumentBlob {
-  id          String              @id @default(cuid())
-  sha256      String              @unique
-  storageKey  String              @unique
-  mimeType    String?
-  sizeBytes   Int
-  createdAt   DateTime            @default(now())
-  versions    DocumentVersion[]
-  renditions  DocumentRendition[]
+  id         String              @id @default(cuid())
+  sha256     String              @unique
+  storageKey String              @unique
+  mimeType   String?
+  sizeBytes  Int
+  createdAt  DateTime            @default(now())
+  versions   DocumentVersion[]
+  renditions DocumentRendition[]
 
   @@index([sizeBytes])
 }
@@ -3862,17 +3863,17 @@ model DocumentAccessGrant {
 }
 
 model DocumentLifecycleEvent {
-  id                   String         @id @default(cuid())
-  documentId           String
-  fromState            String?
-  toState              String
-  reason               String?        @db.Text
-  actorPrincipalId     String?
-  toolExecutionId      String?
-  createdAt            DateTime       @default(now())
-  document             Document       @relation(fields: [documentId], references: [id], onDelete: Cascade)
-  actorPrincipal       Principal?     @relation("DocumentLifecycleActor", fields: [actorPrincipalId], references: [id])
-  toolExecution        ToolExecution? @relation(fields: [toolExecutionId], references: [id])
+  id               String         @id @default(cuid())
+  documentId       String
+  fromState        String?
+  toState          String
+  reason           String?        @db.Text
+  actorPrincipalId String?
+  toolExecutionId  String?
+  createdAt        DateTime       @default(now())
+  document         Document       @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  actorPrincipal   Principal?     @relation("DocumentLifecycleActor", fields: [actorPrincipalId], references: [id])
+  toolExecution    ToolExecution? @relation(fields: [toolExecutionId], references: [id])
 
   @@index([documentId, createdAt])
   @@index([toState])
@@ -4272,17 +4273,17 @@ model ArtifactReceiptUsage {
 }
 
 model Sandbox {
-  id                   String       @id @default(cuid())
+  id                   String          @id @default(cuid())
   buildId              String
   providerId           String
   agentId              String?
   portalInstanceId     String
   state                String
-  startedAt            DateTime     @default(now())
+  startedAt            DateTime        @default(now())
   destroyedAt          DateTime?
   previewUrl           String?
   capabilitiesSnapshot Json
-  featureBuild         FeatureBuild @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
+  featureBuild         FeatureBuild    @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
   runtimeTargets       RuntimeTarget[]
 
   @@index([buildId])
@@ -4290,10 +4291,10 @@ model Sandbox {
 }
 
 model GitPromotionCandidate {
-  id                      String    @id @default(cuid())
-  candidateId             String    @unique
-  provider                String    @default("github")
-  deliveryKey             String    @unique
+  id                      String                @id @default(cuid())
+  candidateId             String                @unique
+  provider                String                @default("github")
+  deliveryKey             String                @unique
   eventName               String
   repositoryFullName      String
   repositoryCloneUrl      String?
@@ -4301,7 +4302,7 @@ model GitPromotionCandidate {
   branch                  String?
   beforeSha               String?
   afterSha                String?
-  status                  String    @default("queued")
+  status                  String                @default("queued")
   statusReason            String?
   sandboxProviderId       String?
   sandboxId               String?
@@ -4309,8 +4310,8 @@ model GitPromotionCandidate {
   verificationCompletedAt DateTime?
   verificationResult      Json?
   payload                 Json?
-  createdAt               DateTime  @default(now())
-  updatedAt               DateTime  @updatedAt
+  createdAt               DateTime              @default(now())
+  updatedAt               DateTime              @updatedAt
   runtimeVerifications    RuntimeVerification[]
 
   @@index([status, createdAt])
@@ -4318,18 +4319,18 @@ model GitPromotionCandidate {
 }
 
 model SandboxSlot {
-  id          String    @id @default(cuid())
-  slotIndex   Int       @unique
-  containerId String
-  port        Int
-  status      String    @default("available")
-  buildId     String?   @unique
-  userId      String?
-  acquiredAt  DateTime?
-  releasedAt  DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  runtimeTargets           RuntimeTarget[]
+  id             String          @id @default(cuid())
+  slotIndex      Int             @unique
+  containerId    String
+  port           Int
+  status         String          @default("available")
+  buildId        String?         @unique
+  userId         String?
+  acquiredAt     DateTime?
+  releasedAt     DateTime?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  runtimeTargets RuntimeTarget[]
 
   @@index([status])
 }
@@ -4434,42 +4435,42 @@ model PromotionBackup {
 // ─── Task Governance Runtime ──────────────────────────────────────
 
 model TaskRun {
-  id                 String            @id @default(cuid())
-  taskRunId          String            @unique
-  userId             String
-  threadId           String?
-  contextId          String?
-  buildId            String?
-  initiatingAgentId  String?
-  currentAgentId     String?
-  parentTaskRunId    String?
-  routeContext       String?
-  title              String
-  objective          String            @db.Text
-  source             String            @default("coworker") // coworker | build | skill | proactive
+  id                   String                @id @default(cuid())
+  taskRunId            String                @unique
+  userId               String
+  threadId             String?
+  contextId            String?
+  buildId              String?
+  initiatingAgentId    String?
+  currentAgentId       String?
+  parentTaskRunId      String?
+  routeContext         String?
+  title                String
+  objective            String                @db.Text
+  source               String                @default("coworker") // coworker | build | skill | proactive
   /// A2A-aligned task states: submitted | working | input-required | auth-required | completed | failed | canceled | rejected | archived
-  status             String            @default("submitted")
-  authorityScope     Json?
-  a2aMetadata        Json?
-  progressPayload    Json?
-  repeatedPatternKey String?
-  templateId         String?
-  startedAt          DateTime          @default(now())
-  completedAt        DateTime?
-  archivedAt         DateTime?
+  status               String                @default("submitted")
+  authorityScope       Json?
+  a2aMetadata          Json?
+  progressPayload      Json?
+  repeatedPatternKey   String?
+  templateId           String?
+  startedAt            DateTime              @default(now())
+  completedAt          DateTime?
+  archivedAt           DateTime?
   // Cooperative heartbeat written by long-running loops (agent runtime,
   // deliberation rounds, sandbox pipeline, Codex CLI) so the watchdog can
   // distinguish a live task from a wedged one. See BI-4ab6be39 §6.1.
-  lastHeartbeatAt    DateTime?
-  createdAt          DateTime          @default(now())
-  updatedAt          DateTime          @updatedAt
-  user               User              @relation(fields: [userId], references: [id], onDelete: Cascade)
-  nodes              TaskNode[]
-  messages           TaskMessage[]
-  artifacts          TaskArtifact[]
-  deliberationRuns   DeliberationRun[]
+  lastHeartbeatAt      DateTime?
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  user                 User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  nodes                TaskNode[]
+  messages             TaskMessage[]
+  artifacts            TaskArtifact[]
+  deliberationRuns     DeliberationRun[]
   decisionInteractions DecisionInteraction[]
-  stallEvents        StallEvent[]
+  stallEvents          StallEvent[]
 
   @@index([userId, status])
   @@index([threadId])
@@ -4489,23 +4490,23 @@ model TaskRun {
 // abandon, escalate). Used by the Build Studio phase panel history
 // strip and as candidate WWMD profile material in v2.
 model StallEvent {
-  id                   String    @id @default(cuid())
-  taskRunId            String
-  buildId              String?
-  phase                String?   // FeatureBuild.phase at detection time
-  reason               String    // "heartbeat_timeout" | "total_timeout" | "never_started" | "parent_stalled" | "parent_abandoned"
-  detectedAt           DateTime  @default(now())
-  lastHeartbeatAt      DateTime?
-  startedAt            DateTime
-  thresholdHeartbeatS  Int
-  thresholdTotalS      Int
-  outcome              String?   // null (pending) | "retry" | "abandoned" | "escalated" | "auto-recovered"
-  outcomeAt            DateTime?
-  outcomeBy            String?   // User.id of operator who acted; null if watchdog auto-action
-  notes                String?   @db.Text
-  createdAt            DateTime  @default(now())
+  id                  String    @id @default(cuid())
+  taskRunId           String
+  buildId             String?
+  phase               String? // FeatureBuild.phase at detection time
+  reason              String // "heartbeat_timeout" | "total_timeout" | "never_started" | "parent_stalled" | "parent_abandoned"
+  detectedAt          DateTime  @default(now())
+  lastHeartbeatAt     DateTime?
+  startedAt           DateTime
+  thresholdHeartbeatS Int
+  thresholdTotalS     Int
+  outcome             String? // null (pending) | "retry" | "abandoned" | "escalated" | "auto-recovered"
+  outcomeAt           DateTime?
+  outcomeBy           String? // User.id of operator who acted; null if watchdog auto-action
+  notes               String?   @db.Text
+  createdAt           DateTime  @default(now())
 
-  taskRun              TaskRun   @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
+  taskRun TaskRun @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
 
   @@index([taskRunId])
   @@index([buildId])
@@ -4877,32 +4878,32 @@ model EaDqRule {
 }
 
 model EaElement {
-  id                String               @id @default(cuid())
-  elementTypeId     String
-  name              String
-  description       String?
-  properties        Json                 @default("{}")
-  lifecycleStage    String               @default("plan")
-  lifecycleStatus   String               @default("draft")
-  createdById       String?
-  digitalProductId  String?
-  infraCiKey        String?
-  portfolioId       String?
-  taxonomyNodeId    String?
-  syncedAt          DateTime?
-  refinementLevel   String?
-  itValueStream     String?
-  ontologyRole      String?
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
-  conformanceIssues EaConformanceIssue[]
-  digitalProduct    DigitalProduct?      @relation(fields: [digitalProductId], references: [id])
-  elementType       EaElementType        @relation(fields: [elementTypeId], references: [id])
-  portfolio         Portfolio?           @relation(fields: [portfolioId], references: [id])
-  taxonomyNode      TaxonomyNode?        @relation(fields: [taxonomyNodeId], references: [id])
-  fromRelationships EaRelationship[]     @relation("FromElement")
-  toRelationships   EaRelationship[]     @relation("ToElement")
-  viewElements      EaViewElement[]
+  id                      String                        @id @default(cuid())
+  elementTypeId           String
+  name                    String
+  description             String?
+  properties              Json                          @default("{}")
+  lifecycleStage          String                        @default("plan")
+  lifecycleStatus         String                        @default("draft")
+  createdById             String?
+  digitalProductId        String?
+  infraCiKey              String?
+  portfolioId             String?
+  taxonomyNodeId          String?
+  syncedAt                DateTime?
+  refinementLevel         String?
+  itValueStream           String?
+  ontologyRole            String?
+  createdAt               DateTime                      @default(now())
+  updatedAt               DateTime                      @updatedAt
+  conformanceIssues       EaConformanceIssue[]
+  digitalProduct          DigitalProduct?               @relation(fields: [digitalProductId], references: [id])
+  elementType             EaElementType                 @relation(fields: [elementTypeId], references: [id])
+  portfolio               Portfolio?                    @relation(fields: [portfolioId], references: [id])
+  taxonomyNode            TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
+  fromRelationships       EaRelationship[]              @relation("FromElement")
+  toRelationships         EaRelationship[]              @relation("ToElement")
+  viewElements            EaViewElement[]
   businessCapabilityLinks BusinessCapabilityTraceLink[] @relation("BusinessCapabilityEaElementLinks")
 
   @@index([portfolioId])
@@ -4910,7 +4911,6 @@ model EaElement {
   @@index([digitalProductId])
   @@index([elementTypeId])
 }
-
 
 model BusinessCapability {
   id                String                        @id @default(cuid())
@@ -7259,7 +7259,7 @@ model BuildStudioStallThreshold {
   heartbeatTimeoutSeconds  Int
   totalPhaseTimeoutSeconds Int
   updatedAt                DateTime @updatedAt
-  updatedBy                String?  // User.id of last operator edit; null if seeded
+  updatedBy                String? // User.id of last operator edit; null if seeded
 
   @@index([scope])
 }
@@ -8087,13 +8087,13 @@ model DeliberationRun {
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 
-  taskRun         TaskRun                @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
-  pattern         DeliberationPattern    @relation(fields: [patternId], references: [id])
-  outcome         DeliberationOutcome?
-  issueSets       DeliberationIssueSet[]
-  claims          ClaimRecord[]
-  evidenceBundles EvidenceBundle[]
-  branchNodes     TaskNode[]             @relation("DeliberationRunBranchNodes")
+  taskRun              TaskRun                @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
+  pattern              DeliberationPattern    @relation(fields: [patternId], references: [id])
+  outcome              DeliberationOutcome?
+  issueSets            DeliberationIssueSet[]
+  claims               ClaimRecord[]
+  evidenceBundles      EvidenceBundle[]
+  branchNodes          TaskNode[]             @relation("DeliberationRunBranchNodes")
   decisionInteractions DecisionInteraction[]
 
   @@index([taskRunId])
@@ -8195,32 +8195,32 @@ model EvidenceSource {
 }
 
 model DecisionPerspectiveProfile {
-  id                  String                  @id @default(cuid())
-  profileId           String                  @unique
-  name                String
-  kind                String
-  scope               Json                    @default("{}")
-  ownerOrganizationId String?
-  ownerPrincipalId    String?
-  fallbackProfileId   String?
-  currentVersionId    String?                 @unique
-  defaultResolver     Json?
-  autonomyPolicy      Json                    @default("{}")
-  status              String                  @default("active")
-  personaConfig       Json?
-  voiceEnabled        Boolean                 @default(false)
-  createdAt           DateTime                @default(now())
-  updatedAt           DateTime                @updatedAt
-  ownerOrganization   Organization?           @relation(fields: [ownerOrganizationId], references: [id], onDelete: SetNull)
-  ownerPrincipal      Principal?              @relation("DecisionPerspectiveProfileOwner", fields: [ownerPrincipalId], references: [id], onDelete: SetNull)
-  fallbackProfile     DecisionPerspectiveProfile? @relation("DecisionPerspectiveProfileFallback", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
-  fallbackChildren    DecisionPerspectiveProfile[] @relation("DecisionPerspectiveProfileFallback")
-  currentVersion      DecisionPerspectiveProfileVersion? @relation("DecisionPerspectiveProfileCurrentVersion", fields: [currentVersionId], references: [versionId], onDelete: SetNull)
-  versions            DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersions")
-  materials           PerspectiveMaterial[]
-  interactions        DecisionInteraction[]   @relation("DecisionInteractionProfile")
-  fallbackInteractions DecisionInteraction[]  @relation("DecisionInteractionFallbackProfile")
-  voiceProfile        VoiceProfile?
+  id                   String                              @id @default(cuid())
+  profileId            String                              @unique
+  name                 String
+  kind                 String
+  scope                Json                                @default("{}")
+  ownerOrganizationId  String?
+  ownerPrincipalId     String?
+  fallbackProfileId    String?
+  currentVersionId     String?                             @unique
+  defaultResolver      Json?
+  autonomyPolicy       Json                                @default("{}")
+  status               String                              @default("active")
+  personaConfig        Json?
+  voiceEnabled         Boolean                             @default(false)
+  createdAt            DateTime                            @default(now())
+  updatedAt            DateTime                            @updatedAt
+  ownerOrganization    Organization?                       @relation(fields: [ownerOrganizationId], references: [id], onDelete: SetNull)
+  ownerPrincipal       Principal?                          @relation("DecisionPerspectiveProfileOwner", fields: [ownerPrincipalId], references: [id], onDelete: SetNull)
+  fallbackProfile      DecisionPerspectiveProfile?         @relation("DecisionPerspectiveProfileFallback", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
+  fallbackChildren     DecisionPerspectiveProfile[]        @relation("DecisionPerspectiveProfileFallback")
+  currentVersion       DecisionPerspectiveProfileVersion?  @relation("DecisionPerspectiveProfileCurrentVersion", fields: [currentVersionId], references: [versionId], onDelete: SetNull)
+  versions             DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersions")
+  materials            PerspectiveMaterial[]
+  interactions         DecisionInteraction[]               @relation("DecisionInteractionProfile")
+  fallbackInteractions DecisionInteraction[]               @relation("DecisionInteractionFallbackProfile")
+  voiceProfile         VoiceProfile?
 
   @@index([kind, status])
   @@index([ownerOrganizationId])
@@ -8229,17 +8229,17 @@ model DecisionPerspectiveProfile {
 }
 
 model DecisionPerspectiveProfileVersion {
-  id                    String                     @id @default(cuid())
-  versionId             String                     @unique
+  id                    String                      @id @default(cuid())
+  versionId             String                      @unique
   profileId             String
   versionNumber         Int
   materialFingerprint   String
   changeSummary         String?
   promotedByPrincipalId String?
-  createdAt             DateTime                   @default(now())
-  profile               DecisionPerspectiveProfile @relation("DecisionPerspectiveProfileVersions", fields: [profileId], references: [profileId], onDelete: Cascade)
+  createdAt             DateTime                    @default(now())
+  profile               DecisionPerspectiveProfile  @relation("DecisionPerspectiveProfileVersions", fields: [profileId], references: [profileId], onDelete: Cascade)
   currentForProfile     DecisionPerspectiveProfile? @relation("DecisionPerspectiveProfileCurrentVersion")
-  promotedByPrincipal   Principal?                 @relation("DecisionPerspectiveProfileVersionPromoter", fields: [promotedByPrincipalId], references: [id], onDelete: SetNull)
+  promotedByPrincipal   Principal?                  @relation("DecisionPerspectiveProfileVersionPromoter", fields: [promotedByPrincipalId], references: [id], onDelete: SetNull)
   materials             PerspectiveMaterial[]
   interactions          DecisionInteraction[]
 
@@ -8249,27 +8249,27 @@ model DecisionPerspectiveProfileVersion {
 }
 
 model PerspectiveMaterial {
-  id               String                     @id @default(cuid())
-  materialId       String                     @unique
+  id               String                             @id @default(cuid())
+  materialId       String                             @unique
   profileId        String
   profileVersionId String?
   sourceType       String
-  sourceRef        Json                       @default("{}")
-  scope            Json                       @default("{}")
-  domainClass      String                     @default("plan-readiness")
-  direction        String                     @default("neutral")
-  domains          String[]                   @default([])
-  freshness        String                     @default("current")
-  evidenceGrade    String                     @default("A")
+  sourceRef        Json                               @default("{}")
+  scope            Json                               @default("{}")
+  domainClass      String                             @default("plan-readiness")
+  direction        String                             @default("neutral")
+  domains          String[]                           @default([])
+  freshness        String                             @default("current")
+  evidenceGrade    String                             @default("A")
   stalenessPolicy  Json?
   lastValidatedAt  DateTime?
-  confidenceWeight Float                      @default(0.5)
-  reviewStatus     String                     @default("draft")
-  promotionState   String                     @default("candidate")
-  summary          String?                    @db.Text
-  createdAt        DateTime                   @default(now())
-  updatedAt        DateTime                   @updatedAt
-  profile          DecisionPerspectiveProfile @relation(fields: [profileId], references: [profileId], onDelete: Cascade)
+  confidenceWeight Float                              @default(0.5)
+  reviewStatus     String                             @default("draft")
+  promotionState   String                             @default("candidate")
+  summary          String?                            @db.Text
+  createdAt        DateTime                           @default(now())
+  updatedAt        DateTime                           @updatedAt
+  profile          DecisionPerspectiveProfile         @relation(fields: [profileId], references: [profileId], onDelete: Cascade)
   profileVersion   DecisionPerspectiveProfileVersion? @relation(fields: [profileVersionId], references: [versionId], onDelete: SetNull)
 
   @@index([profileId, freshness])
@@ -8283,8 +8283,8 @@ model PerspectiveMaterial {
 }
 
 model DecisionInteraction {
-  id                String                     @id @default(cuid())
-  interactionId     String                     @unique
+  id                String                            @id @default(cuid())
+  interactionId     String                            @unique
   profileId         String
   profileVersionId  String
   fallbackProfileId String?
@@ -8295,28 +8295,28 @@ model DecisionInteraction {
   routeContext      String?
   phaseFrom         String?
   phaseTo           String?
-  domainClass       String                     @default("plan-readiness")
-  question          String                     @db.Text
-  options           Json                       @default("[]")
-  evidenceBundle    Json                       @default("{}")
-  sources           Json                       @default("[]")
-  rationale         String?                    @db.Text
+  domainClass       String                            @default("plan-readiness")
+  question          String                            @db.Text
+  options           Json                              @default("[]")
+  evidenceBundle    Json                              @default("{}")
+  sources           Json                              @default("[]")
+  rationale         String?                           @db.Text
   riskTier          String
   confidenceBefore  Float?
   confidenceAfter   Float?
   outcomeType       String
-  principleConflict Boolean                    @default(false)
-  outcomePayload    Json                       @default("{}")
+  principleConflict Boolean                           @default(false)
+  outcomePayload    Json                              @default("{}")
   humanOutcome      Json?
-  createdAt         DateTime                   @default(now())
-  updatedAt         DateTime                   @updatedAt
-  profile           DecisionPerspectiveProfile @relation("DecisionInteractionProfile", fields: [profileId], references: [profileId], onDelete: Cascade)
+  createdAt         DateTime                          @default(now())
+  updatedAt         DateTime                          @updatedAt
+  profile           DecisionPerspectiveProfile        @relation("DecisionInteractionProfile", fields: [profileId], references: [profileId], onDelete: Cascade)
   profileVersion    DecisionPerspectiveProfileVersion @relation(fields: [profileVersionId], references: [versionId], onDelete: Restrict)
-  fallbackProfile   DecisionPerspectiveProfile? @relation("DecisionInteractionFallbackProfile", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
-  build             FeatureBuild?              @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
-  taskRun           TaskRun?                   @relation(fields: [taskRunId], references: [taskRunId], onDelete: SetNull)
-  deliberationRun   DeliberationRun?           @relation(fields: [deliberationRunId], references: [id], onDelete: SetNull)
-  triggeredByUser   User?                      @relation("DecisionInteractionTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
+  fallbackProfile   DecisionPerspectiveProfile?       @relation("DecisionInteractionFallbackProfile", fields: [fallbackProfileId], references: [profileId], onDelete: SetNull)
+  build             FeatureBuild?                     @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
+  taskRun           TaskRun?                          @relation(fields: [taskRunId], references: [taskRunId], onDelete: SetNull)
+  deliberationRun   DeliberationRun?                  @relation(fields: [deliberationRunId], references: [id], onDelete: SetNull)
+  triggeredByUser   User?                             @relation("DecisionInteractionTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
   escalationCapture EscalationCapture?
   deferralCapture   DeferralCapture?
   voiceOutput       DecisionInteractionVoiceOutput?
@@ -8382,19 +8382,19 @@ model DeferralCapture {
 //
 
 model VoiceConsentRecord {
-  id                      String         @id @default(cuid())
-  subjectName             String
-  subjectEmail            String?
-  consentMethod           String
-  authorizedUseCases      String[]       @default([])
-  authorizedLanguages     String[]       @default(["en"])
-  authorizedTerritories   String[]       @default(["global"])
-  expiresAt               DateTime
-  capturedByPrincipalId   String
-  evidenceRef             String?
-  revokedAt               DateTime?
-  createdAt               DateTime       @default(now())
-  voiceProfiles           VoiceProfile[]
+  id                    String         @id @default(cuid())
+  subjectName           String
+  subjectEmail          String?
+  consentMethod         String
+  authorizedUseCases    String[]       @default([])
+  authorizedLanguages   String[]       @default(["en"])
+  authorizedTerritories String[]       @default(["global"])
+  expiresAt             DateTime
+  capturedByPrincipalId String
+  evidenceRef           String?
+  revokedAt             DateTime?
+  createdAt             DateTime       @default(now())
+  voiceProfiles         VoiceProfile[]
 
   @@index([capturedByPrincipalId])
 }
@@ -8421,16 +8421,16 @@ model VoiceProfile {
 }
 
 model VoiceTrainingJob {
-  id              String       @id @default(cuid())
-  voiceProfileId  String
-  status          String       @default("pending")
-  providerJobId   String?
-  inputSamples    Json         @default("[]")
-  errorMessage    String?
-  startedAt       DateTime?
-  completedAt     DateTime?
-  createdAt       DateTime     @default(now())
-  voiceProfile    VoiceProfile @relation(fields: [voiceProfileId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  voiceProfileId String
+  status         String       @default("pending")
+  providerJobId  String?
+  inputSamples   Json         @default("[]")
+  errorMessage   String?
+  startedAt      DateTime?
+  completedAt    DateTime?
+  createdAt      DateTime     @default(now())
+  voiceProfile   VoiceProfile @relation(fields: [voiceProfileId], references: [id], onDelete: Cascade)
 
   @@index([voiceProfileId, status])
 }
@@ -8542,6 +8542,7 @@ model EdgeNode {
   capabilityRows EdgeNodeCapability[]
   discoveryRuns  DiscoveryRun[]       @relation("EdgeNodeDiscoveryRuns")
   consumedTokens BootstrapToken[]     @relation("BootstrapTokenConsumer")
+  events         EdgeEvent[]          @relation("EdgeNodeEvents")
 
   @@index([trustState])
   @@index([status])
@@ -8624,6 +8625,77 @@ model EdgeNodeCapability {
 
   @@unique([edgeNodeId, capability])
   @@index([capability])
+}
+
+// ─── Edge-detected events (PagerDuty-equivalent) ─────────────────────────────
+// Canonical PD-CEF-style envelope persisted from POST /api/v1/edge/events.
+// Detectors on the edge (reachability probes, SNMP poll/trap, syslog, ARP/DHCP
+// delta, host self, vendor adapters) emit Events; the route upserts by
+// (edgeNodeId, dedupKey) so flap/flood noise that survived edge-side dedupe
+// collapses here too rather than fanning out into duplicate rows.
+//
+// Lifecycle (action drives status):
+//   action="trigger"     -> status="triggered" on insert; lastSeenAt bumped on replay
+//   action="acknowledge" -> status="acknowledged" (preserves lastSeenAt)
+//   action="resolve"     -> status="resolved", resolvedAt set; later "trigger"
+//                            on the same dedupKey re-opens (resolvedAt=null,
+//                            occurrenceCount++)
+//
+// Slice 0 owns ingest + persistence only. Cross-source correlation, escalation
+// policies, on-call routing, and ML grouping are separate downstream slices
+// — see BI-9FE9D48D.
+model EdgeEvent {
+  id              String    @id @default(cuid())
+  // FK to EdgeNode.id (the cuid surrogate); distinct from EdgeNode.nodeId.
+  // The route fills this from the bearer-token auth, never from the body.
+  edgeNodeId      String
+  // Dedup anchor. Edge-side detectors compose this from
+  // source + component + class (+ instance) so the same condition collapses
+  // on replay. Scoped per-node by the @@unique to keep keyspaces isolated.
+  dedupKey        String
+  // Producing detector — "snmp.trap", "syslog", "ping", "unifi.events", etc.
+  source          String
+  // Sub-source identifier the operator can read — hostname, IP, MAC, port.
+  component       String?
+  // PD-CEF group: logical bucket within the source ("network", "host", "ups").
+  eventGroup      String?
+  // PD-CEF class: the specific condition ("interface_down", "high_cpu",
+  // "cert_expiring", "rogue_ap").
+  eventClass      String?
+  // info | warn | error | critical
+  severity        String    @default("warn")
+  // Lifecycle state. Mirrors PagerDuty incident states.
+  //   triggered | acknowledged | resolved | suppressed
+  status          String    @default("triggered")
+  // Last action submitted by the edge: trigger | acknowledge | resolve.
+  // Kept distinct from `status` because actions can race with operator state.
+  action          String    @default("trigger")
+  // Short human-readable line for incident lists.
+  summary         String
+  // Free-form: probe response details, syslog message, SNMP varbinds,
+  // counter deltas, vendor payload — whatever the detector wants to attach.
+  customDetails   Json?
+  // When the edge detector observed the condition (RFC 3339, set by detector).
+  occurredAt      DateTime
+  // When this dedupKey first appeared at the portal.
+  firstSeenAt     DateTime  @default(now())
+  // Bumped on every replay (including trigger after resolve).
+  lastSeenAt      DateTime  @default(now())
+  // Set when action=resolve; cleared on re-open.
+  resolvedAt      DateTime?
+  // Number of times the same dedupKey has been submitted.
+  occurrenceCount Int       @default(1)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  node EdgeNode @relation("EdgeNodeEvents", fields: [edgeNodeId], references: [id], onDelete: Cascade)
+
+  @@unique([edgeNodeId, dedupKey])
+  @@index([edgeNodeId, status])
+  @@index([severity])
+  @@index([source])
+  @@index([occurredAt])
 }
 
 // ─── Integration Coverage Matrix ─────────────────────────────────────────────

--- a/packages/db/src/edge-node-types.ts
+++ b/packages/db/src/edge-node-types.ts
@@ -75,6 +75,9 @@ export const RESERVED_CAPABILITIES = [
   // Network telemetry adapters — spec: 2026-05-19-edge-node-network-telemetry-adapters-design.md
   "metrics.network",
   "discovery.lldp",
+  // Detection engine — spec: 2026-05-21-edge-event-envelope-design.md (BI-9FE9D48D).
+  // Slice 0: edge emits PD-CEF-style events to POST /api/v1/edge/events.
+  "events.emit",
   "identity.broker",
   "mcp.gateway",
   "a2a.gateway",

--- a/packages/validators/src/edge.ts
+++ b/packages/validators/src/edge.ts
@@ -114,3 +114,78 @@ export const edgeHeartbeatSchema = z.object({
 });
 
 export type EdgeHeartbeat = z.infer<typeof edgeHeartbeatSchema>;
+
+// ---------------------------------------------------------------------------
+// EdgeEvent — canonical PD-CEF-style envelope for POST /api/v1/edge/events
+//
+// Slice 0 of the edge-node detection engine (BI-9FE9D48D).
+// Spec: docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+//
+// The wire shape mirrors PagerDuty's PD-CEF (source / component / group /
+// class / severity / custom_details) with an explicit dedupKey + action so
+// the portal can collapse replays and run a triggered → acknowledged →
+// resolved lifecycle without inventing a new contract per detector.
+// ---------------------------------------------------------------------------
+
+export const EDGE_EVENT_SEVERITIES = [
+  "info",
+  "warn",
+  "error",
+  "critical",
+] as const;
+export type EdgeEventSeverity = (typeof EDGE_EVENT_SEVERITIES)[number];
+
+export const EDGE_EVENT_ACTIONS = [
+  "trigger",
+  "acknowledge",
+  "resolve",
+] as const;
+export type EdgeEventAction = (typeof EDGE_EVENT_ACTIONS)[number];
+
+export const edgeEventSchema = z.object({
+  /**
+   * Dedup anchor — detectors compose from source + component + class
+   * (+ instance) so the same condition collapses on replay. Scoped per
+   * edge node by the portal's @@unique([edgeNodeId, dedupKey]).
+   */
+  dedupKey: z.string().min(1).max(255),
+  /** Producing detector — "snmp.trap", "syslog", "ping", "unifi.events". */
+  source: z.string().min(1).max(100),
+  /** Operator-readable sub-source — hostname, IP, MAC, port. */
+  component: z.string().max(200).optional(),
+  /** PD-CEF group — logical bucket ("network", "host", "ups"). */
+  eventGroup: z.string().max(100).optional(),
+  /** PD-CEF class — specific condition ("interface_down", "cert_expiring"). */
+  eventClass: z.string().max(100).optional(),
+  severity: z.enum(EDGE_EVENT_SEVERITIES),
+  /**
+   * trigger raises or re-raises an event; acknowledge marks under-investigation;
+   * resolve closes it. A later trigger on the same dedupKey re-opens
+   * (resolvedAt cleared, occurrenceCount++).
+   */
+  action: z.enum(EDGE_EVENT_ACTIONS),
+  /** Short human-readable line for incident lists. */
+  summary: z.string().min(1).max(500),
+  /** RFC 3339 timestamp the edge detector observed the condition. */
+  occurredAt: z.string().datetime(),
+  /** Free-form detector payload — varbinds, deltas, parsed syslog, etc. */
+  customDetails: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type EdgeEvent = z.infer<typeof edgeEventSchema>;
+
+export const edgeEventEnvelopeSchema = z.object({
+  /** UUID idempotency key — same pattern as discovery-runs + metrics. */
+  runKey: z.string().uuid(),
+  /**
+   * nodeId from the client. The portal IGNORES this field and uses the
+   * nodeId resolved from the bearer token instead (mirrors metrics).
+   */
+  nodeId: z.string().min(1).max(100).optional(),
+  /** ISO 8601 timestamp when the batch left the edge node. */
+  observedAt: z.string().datetime(),
+  eventsVersion: z.literal("1"),
+  events: z.array(edgeEventSchema).min(1).max(500),
+});
+
+export type EdgeEventEnvelope = z.infer<typeof edgeEventEnvelopeSchema>;

--- a/services/edge-node-go/internal/envelope/event.go
+++ b/services/edge-node-go/internal/envelope/event.go
@@ -1,0 +1,151 @@
+// Package envelope defines the canonical wire shape for events emitted by
+// edge-side detectors and posted to POST /api/v1/edge/events.
+//
+// The Go struct here mirrors the Zod schema in
+// packages/validators/src/edge.ts (edgeEventEnvelopeSchema). Drift between
+// the two is caught by the cross-runtime parity test at
+// apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts — keep the
+// json tags and field order identical when changing either side.
+//
+// Slice 0 of the edge-node detection engine (BI-9FE9D48D).
+// Spec: docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+package envelope
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// EnvelopeVersion is the wire-format version literal. Bumped only when the
+// shape changes in a backwards-incompatible way; the portal Zod uses a
+// literal type so any drift here surfaces as a 422 invalid_envelope.
+const EnvelopeVersion = "1"
+
+// Severity is the PD-CEF severity ordering: info < warn < error < critical.
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarn     Severity = "warn"
+	SeverityError    Severity = "error"
+	SeverityCritical Severity = "critical"
+)
+
+// Action drives the portal-side lifecycle. trigger opens or re-opens an
+// event; acknowledge marks it under investigation; resolve closes it.
+// A later trigger on the same dedupKey re-opens the row (resolvedAt
+// cleared, occurrenceCount++).
+type Action string
+
+const (
+	ActionTrigger     Action = "trigger"
+	ActionAcknowledge Action = "acknowledge"
+	ActionResolve     Action = "resolve"
+)
+
+// Event is one detector observation. DedupKey is the only field detectors
+// MUST compose carefully — the portal collapses replays on
+// (edgeNodeId, dedupKey), so the same condition observed twice must produce
+// byte-identical dedupKey strings. Recommended composition:
+//
+//	source + ":" + component + ":" + eventClass [+ ":" + instance]
+//
+// e.g. "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42".
+type Event struct {
+	DedupKey      string         `json:"dedupKey"`
+	Source        string         `json:"source"`
+	Component     string         `json:"component,omitempty"`
+	EventGroup    string         `json:"eventGroup,omitempty"`
+	EventClass    string         `json:"eventClass,omitempty"`
+	Severity      Severity       `json:"severity"`
+	Action        Action         `json:"action"`
+	Summary       string         `json:"summary"`
+	OccurredAt    string         `json:"occurredAt"` // RFC 3339
+	CustomDetails map[string]any `json:"customDetails,omitempty"`
+}
+
+// Envelope is the POST /api/v1/edge/events body. RunKey provides
+// idempotency at the batch level the same way it does for discovery-runs
+// and metrics; NodeID is informational only (the portal trusts the bearer
+// token, not the body).
+type Envelope struct {
+	RunKey        string  `json:"runKey"`
+	NodeID        string  `json:"nodeId,omitempty"`
+	ObservedAt    string  `json:"observedAt"` // RFC 3339
+	EventsVersion string  `json:"eventsVersion"`
+	Events        []Event `json:"events"`
+}
+
+// MaxEventsPerBatch caps a single submission at 500 events — matches the
+// portal's z.array(...).max(500). Detectors that need to flush more should
+// split into multiple Envelopes with distinct RunKeys.
+const MaxEventsPerBatch = 500
+
+// Validate runs the same shape + enum checks the portal Zod will apply, so
+// detectors and the transport layer can fail fast without a round trip.
+//
+// Validate does NOT check freshness (observedAt within 5 min of "now")
+// because that's a portal-side ingestion control and the edge may
+// legitimately queue events offline; the portal returns 422 stale_payload
+// in that case and the transport retries with a fresh observedAt.
+func (e Event) Validate() error {
+	if e.DedupKey == "" {
+		return errors.New("dedupKey is required")
+	}
+	if len(e.DedupKey) > 255 {
+		return fmt.Errorf("dedupKey exceeds 255 chars: %d", len(e.DedupKey))
+	}
+	if e.Source == "" {
+		return errors.New("source is required")
+	}
+	if len(e.Source) > 100 {
+		return fmt.Errorf("source exceeds 100 chars: %d", len(e.Source))
+	}
+	if e.Summary == "" {
+		return errors.New("summary is required")
+	}
+	if len(e.Summary) > 500 {
+		return fmt.Errorf("summary exceeds 500 chars: %d", len(e.Summary))
+	}
+	switch e.Severity {
+	case SeverityInfo, SeverityWarn, SeverityError, SeverityCritical:
+	default:
+		return fmt.Errorf("invalid severity %q (want info|warn|error|critical)", e.Severity)
+	}
+	switch e.Action {
+	case ActionTrigger, ActionAcknowledge, ActionResolve:
+	default:
+		return fmt.Errorf("invalid action %q (want trigger|acknowledge|resolve)", e.Action)
+	}
+	if _, err := time.Parse(time.RFC3339, e.OccurredAt); err != nil {
+		return fmt.Errorf("occurredAt is not RFC 3339: %w", err)
+	}
+	return nil
+}
+
+// Validate the full batch. Returns the first failing event's index for
+// debuggability; callers may choose to filter-and-resubmit instead.
+func (env Envelope) Validate() error {
+	if env.RunKey == "" {
+		return errors.New("runKey is required")
+	}
+	if env.EventsVersion != EnvelopeVersion {
+		return fmt.Errorf("eventsVersion must be %q (got %q)", EnvelopeVersion, env.EventsVersion)
+	}
+	if _, err := time.Parse(time.RFC3339, env.ObservedAt); err != nil {
+		return fmt.Errorf("observedAt is not RFC 3339: %w", err)
+	}
+	if len(env.Events) == 0 {
+		return errors.New("events must contain at least one event")
+	}
+	if len(env.Events) > MaxEventsPerBatch {
+		return fmt.Errorf("events exceeds max batch size %d: %d", MaxEventsPerBatch, len(env.Events))
+	}
+	for i, ev := range env.Events {
+		if err := ev.Validate(); err != nil {
+			return fmt.Errorf("events[%d]: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/services/edge-node-go/internal/envelope/event_test.go
+++ b/services/edge-node-go/internal/envelope/event_test.go
@@ -1,0 +1,164 @@
+package envelope
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validEvent() Event {
+	return Event{
+		DedupKey:   "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42",
+		Source:     "snmp.trap",
+		Component:  "10.0.0.5",
+		EventGroup: "network",
+		EventClass: "interface_down",
+		Severity:   SeverityError,
+		Action:     ActionTrigger,
+		Summary:    "Interface ifIndex=42 link state down on 10.0.0.5",
+		OccurredAt: "2026-05-21T02:30:00Z",
+		CustomDetails: map[string]any{
+			"ifIndex":    42,
+			"ifDescr":    "GigabitEthernet0/1",
+			"trapSource": "10.0.0.5",
+		},
+	}
+}
+
+func validEnvelope() Envelope {
+	return Envelope{
+		RunKey:        "1a2b3c4d-5e6f-4a7b-8c9d-eeff00112233",
+		NodeID:        "edge-node-test",
+		ObservedAt:    "2026-05-21T02:30:01Z",
+		EventsVersion: EnvelopeVersion,
+		Events:        []Event{validEvent()},
+	}
+}
+
+func TestEvent_Validate_HappyPath(t *testing.T) {
+	if err := validEvent().Validate(); err != nil {
+		t.Fatalf("valid event rejected: %v", err)
+	}
+}
+
+func TestEvent_Validate_MissingRequired(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*Event)
+		want string
+	}{
+		{"no dedupKey", func(e *Event) { e.DedupKey = "" }, "dedupKey"},
+		{"no source", func(e *Event) { e.Source = "" }, "source"},
+		{"no summary", func(e *Event) { e.Summary = "" }, "summary"},
+		{"bad severity", func(e *Event) { e.Severity = "panic" }, "severity"},
+		{"bad action", func(e *Event) { e.Action = "page" }, "action"},
+		{"bad occurredAt", func(e *Event) { e.OccurredAt = "yesterday" }, "occurredAt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validEvent()
+			tc.mut(&e)
+			err := e.Validate()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvent_Validate_TooLong(t *testing.T) {
+	e := validEvent()
+	e.DedupKey = strings.Repeat("x", 256)
+	if err := e.Validate(); err == nil || !strings.Contains(err.Error(), "dedupKey") {
+		t.Fatalf("expected dedupKey length error, got %v", err)
+	}
+	e = validEvent()
+	e.Summary = strings.Repeat("y", 501)
+	if err := e.Validate(); err == nil || !strings.Contains(err.Error(), "summary") {
+		t.Fatalf("expected summary length error, got %v", err)
+	}
+}
+
+func TestEnvelope_Validate_HappyPath(t *testing.T) {
+	if err := validEnvelope().Validate(); err != nil {
+		t.Fatalf("valid envelope rejected: %v", err)
+	}
+}
+
+func TestEnvelope_Validate_BadVersion(t *testing.T) {
+	env := validEnvelope()
+	env.EventsVersion = "0"
+	if err := env.Validate(); err == nil || !strings.Contains(err.Error(), "eventsVersion") {
+		t.Fatalf("expected eventsVersion error, got %v", err)
+	}
+}
+
+func TestEnvelope_Validate_EmptyEvents(t *testing.T) {
+	env := validEnvelope()
+	env.Events = nil
+	if err := env.Validate(); err == nil || !strings.Contains(err.Error(), "events") {
+		t.Fatalf("expected empty events error, got %v", err)
+	}
+}
+
+func TestEnvelope_Validate_BatchTooLarge(t *testing.T) {
+	env := validEnvelope()
+	env.Events = make([]Event, MaxEventsPerBatch+1)
+	for i := range env.Events {
+		env.Events[i] = validEvent()
+	}
+	if err := env.Validate(); err == nil || !strings.Contains(err.Error(), "max batch size") {
+		t.Fatalf("expected batch size error, got %v", err)
+	}
+}
+
+func TestEnvelope_Validate_PropagatesEventIndex(t *testing.T) {
+	env := validEnvelope()
+	bad := validEvent()
+	bad.Severity = "fatal"
+	env.Events = []Event{validEvent(), bad}
+	err := env.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid event[1]")
+	}
+	if !strings.Contains(err.Error(), "events[1]") {
+		t.Fatalf("error should include event index, got %q", err)
+	}
+}
+
+// TestEnvelope_JSON_RoundTrip is the canonical sanity check that the
+// json tags match the Zod schema's field names — drift here will also
+// surface in the cross-runtime wire-contract parity test, but failing
+// fast in the Go test loop is cheaper.
+func TestEnvelope_JSON_RoundTrip(t *testing.T) {
+	env := validEnvelope()
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	keys := []string{
+		`"runKey"`,
+		`"nodeId"`,
+		`"observedAt"`,
+		`"eventsVersion"`,
+		`"events"`,
+		`"dedupKey"`,
+		`"source"`,
+		`"component"`,
+		`"eventGroup"`,
+		`"eventClass"`,
+		`"severity"`,
+		`"action"`,
+		`"summary"`,
+		`"occurredAt"`,
+		`"customDetails"`,
+	}
+	for _, k := range keys {
+		if !strings.Contains(string(raw), k) {
+			t.Fatalf("serialized envelope missing key %s: %s", k, raw)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Slice 0 of the edge-node detection engine (PagerDuty-equivalent event coverage). Defines one canonical wire shape used by every edge-side detector and adds the minimum portal ingest path with replay-safe dedupe. Downstream slices (edge detector framework, first built-in detector pack, portal correlation/escalation/on-call) all depend on this contract.

- **Wire contract:** `EdgeEventEnvelope` (PD-CEF-style: source/component/group/class/severity, with explicit `dedupKey` + `action`). Defined in `packages/validators/src/edge.ts` and mirrored in `services/edge-node-go/internal/envelope/event.go` with byte-identical JSON field names. Cross-runtime parity is enforced by the existing wire-contract test, extended with `events` fixtures for both TS and Go.
- **Ingest:** `POST /api/v1/edge/events` — 256 KB body cap, new `edge:events` bearer scope (trustState=trusted), Zod envelope validation, 5-min freshness, per-node rate limit (30/min, 600/hour), per-event upsert on `(edgeNodeId, dedupKey)` in one transaction. Lifecycle: `trigger` creates or re-opens (clearing `resolvedAt`, bumping `occurrenceCount`); `acknowledge` transitions status without bumping the counter; `resolve` closes.
- **Data:** new `EdgeEvent` Prisma model + migration; `events.emit` added to `RESERVED_CAPABILITIES`; `edge:events` added to the `EdgeNodeScope` union.

**Out of scope** (separate slices): edge detector framework, detector packs, portal correlation, incident lifecycle, escalation policies, on-call routing. Spec at `docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md` calls these out explicitly.

**Tracking:** BI-9FE9D48D · WC-BAF793F7 · IT4IT §5.7 Operate (Event Mgmt FC).

## Test plan

- [x] `go test ./internal/envelope/...` — all envelope unit tests pass (validation, RFC 3339, batch cap, JSON round-trip)
- [x] `pnpm vitest run` — 225/225 across full edge surface (events route, adapters route, heartbeat, discovery-runs, wire-contract parity, auth, rate-limit)
- [x] `pnpm typecheck` clean across `packages/db`, `packages/validators`, `apps/web`
- [x] `pnpm prisma format` + `pnpm prisma generate` clean
- [x] Migration SQL replayed against the live portal schema inside a rollback transaction — table + 4 indexes + FK to `EdgeNode` confirmed
- [x] Cross-runtime parity test exercises both TS and Go fixtures against the same Zod schema
- [ ] Manual end-to-end smoke once an edge node is enrolled with `edge:events` scope (not yet — out of slice; the first detector pack lands in Slice 2 and will exercise this path)

## Notes for review

- **Schema diff churn:** the large `packages/db/prisma/schema.prisma` diff is mostly `prisma format` re-alignment from running `npx prisma format`; the substantive change is the new `EdgeEvent` model + an `events` relation on `EdgeNode`. The diff also includes a clean merge of the `personaConfig`/`voiceEnabled` additions from #889 (no semantic change to that model from this PR — only formatter touch).
- **Conflict resolution:** `apps/web/lib/auth/edge-node-token.ts` and `apps/web/lib/edge-node/rate-limit.ts` both gained new entries in #893 (`edge:adapters` / `edge.adapters`) and in this PR (`edge:events` / `edge.events.submit`). Combined both unions into one block in each file — no semantic conflict, just textual.
- **Body cap:** 256 KB on `/api/v1/edge/events` (vs. 64 KB on `/metrics`) because the envelope batches up to 500 events each with optional `customDetails`. Generous but bounded.
- **Local dedupe before WAN:** detectors are expected to collapse flap/flood noise at the edge before submitting; the portal-side `(edgeNodeId, dedupKey)` unique still catches any that slip through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)