### PR TITLE
fix(stall-recovery): synthesize StallEvent on operator recovery when no open event exists

### DIFF
--- a/apps/web/lib/actions/taskrun-recovery.test.ts
+++ b/apps/web/lib/actions/taskrun-recovery.test.ts
@@ -32,7 +32,11 @@ const {
   const deliberationRunFindFirst = anyFn();
   const transactionImpl = vi.fn(async (fn: (tx: unknown) => unknown) =>
     fn({
-      taskRun: { update: taskRunUpdate, create: taskRunCreate, findMany: taskRunFindMany },
+      // tx.taskRun.findUnique is reached by upsertRecoveryOutcome when no
+      // open StallEvent exists and it has to look up startedAt to synthesize
+      // one. Tests that exercise the synthesize path use mockResolvedValueOnce
+      // chains to differentiate the loadStalled call from this lookup.
+      taskRun: { update: taskRunUpdate, create: taskRunCreate, findMany: taskRunFindMany, findUnique: taskRunFindUnique },
       stallEvent: { findFirst: stallEventFindFirst, update: stallEventUpdate, create: stallEventCreate },
       notification: { create: notificationCreate },
     }),
@@ -253,6 +257,10 @@ describe("taskrunAbandon", () => {
 
   it("cascades one level to live children with reason=parent_abandoned", async () => {
     taskRunFindUnique.mockResolvedValue(stalledRow());
+    // Have an open StallEvent on the parent so upsertRecoveryOutcome takes
+    // the update path; the cascade-create assertions below stay focused on
+    // child synthesis without conflating with parent synthesis.
+    stallEventFindFirst.mockResolvedValue({ id: "se-parent-open" });
     taskRunFindMany.mockResolvedValue([
       { id: "cuid-child-1", taskRunId: "TR-CHILD-1", startedAt: new Date(), buildId: null, lastHeartbeatAt: null },
       { id: "cuid-child-2", taskRunId: "TR-CHILD-2", startedAt: new Date(), buildId: null, lastHeartbeatAt: null },
@@ -320,5 +328,92 @@ describe("taskrunEscalate", () => {
     await taskrunEscalate("TR-STALL-1", "op-1");
     const notifyArg = notificationCreate.mock.calls[0]![0] as { data: { userId: string } };
     expect(notifyArg.data.userId).toBe("user-1");
+  });
+});
+
+describe("audit completeness — synthesize StallEvent when no open event exists", () => {
+  // Caught during F2 UX dogfooding (2026-05-20): the Escalate path fired a
+  // Notification but no StallEvent.outcome='escalated' row appeared in the
+  // ledger because the watchdog hadn't inserted a fresh open event for that
+  // taskRun. Same gap existed for Retry and Abandon. upsertRecoveryOutcome
+  // now synthesizes a StallEvent with reason='operator_recovery_synthesized'
+  // whenever there's no open event to close.
+
+  function setupNoOpenEvent() {
+    // First findUnique call = loadStalled → returns the stalled row.
+    // Second findUnique call = upsertRecoveryOutcome lookup for startedAt.
+    const startedAt = new Date("2026-05-20T10:00:00Z");
+    const lastHeartbeatAt = new Date("2026-05-20T10:00:30Z");
+    taskRunFindUnique
+      .mockResolvedValueOnce(stalledRow())
+      .mockResolvedValueOnce({ startedAt, lastHeartbeatAt });
+    stallEventFindFirst.mockResolvedValue(null);
+    return { startedAt, lastHeartbeatAt };
+  }
+
+  it("Retry synthesizes a StallEvent with outcome='retry' when no open event exists", async () => {
+    setupNoOpenEvent();
+    taskRunCreate.mockResolvedValue({ taskRunId: "TR-RETRY-SYN" });
+    await taskrunRetry("TR-STALL-1", "op-syn");
+    expect(stallEventUpdate).not.toHaveBeenCalled();
+    expect(stallEventCreate).toHaveBeenCalledTimes(1);
+    const createArg = stallEventCreate.mock.calls[0]![0] as {
+      data: { outcome: string; reason: string; outcomeBy: string; thresholdHeartbeatS: number; thresholdTotalS: number };
+    };
+    expect(createArg.data.outcome).toBe("retry");
+    expect(createArg.data.reason).toBe("operator_recovery_synthesized");
+    expect(createArg.data.outcomeBy).toBe("op-syn");
+    expect(createArg.data.thresholdHeartbeatS).toBe(0);
+    expect(createArg.data.thresholdTotalS).toBe(0);
+  });
+
+  it("Abandon synthesizes a StallEvent with outcome='abandoned' when no open event exists", async () => {
+    setupNoOpenEvent();
+    await taskrunAbandon("TR-STALL-1", "op-syn");
+    // Only the parent abandon synthesize — there are no live children in this setup.
+    expect(stallEventCreate).toHaveBeenCalledTimes(1);
+    const createArg = stallEventCreate.mock.calls[0]![0] as {
+      data: { outcome: string; reason: string; outcomeBy: string };
+    };
+    expect(createArg.data.outcome).toBe("abandoned");
+    expect(createArg.data.reason).toBe("operator_recovery_synthesized");
+    expect(createArg.data.outcomeBy).toBe("op-syn");
+  });
+
+  it("Escalate synthesizes a StallEvent with outcome='escalated' when no open event exists", async () => {
+    setupNoOpenEvent();
+    await taskrunEscalate("TR-STALL-1", "op-syn", "operator note");
+    expect(stallEventUpdate).not.toHaveBeenCalled();
+    expect(stallEventCreate).toHaveBeenCalledTimes(1);
+    const createArg = stallEventCreate.mock.calls[0]![0] as {
+      data: { outcome: string; reason: string; outcomeBy: string; notes: string };
+    };
+    expect(createArg.data.outcome).toBe("escalated");
+    expect(createArg.data.reason).toBe("operator_recovery_synthesized");
+    expect(createArg.data.outcomeBy).toBe("op-syn");
+    expect(createArg.data.notes).toBe("operator note");
+  });
+
+  it("synthesized StallEvent carries the startedAt and lastHeartbeatAt of the underlying TaskRun", async () => {
+    const { startedAt, lastHeartbeatAt } = setupNoOpenEvent();
+    await taskrunEscalate("TR-STALL-1", "op-syn");
+    const createArg = stallEventCreate.mock.calls[0]![0] as {
+      data: { startedAt: Date; lastHeartbeatAt: Date | null };
+    };
+    expect(createArg.data.startedAt).toEqual(startedAt);
+    expect(createArg.data.lastHeartbeatAt).toEqual(lastHeartbeatAt);
+  });
+
+  it("synthesized StallEvent tolerates lastHeartbeatAt=null (row never reported a heartbeat)", async () => {
+    const startedAt = new Date("2026-05-20T10:00:00Z");
+    taskRunFindUnique
+      .mockResolvedValueOnce(stalledRow())
+      .mockResolvedValueOnce({ startedAt, lastHeartbeatAt: null });
+    stallEventFindFirst.mockResolvedValue(null);
+    await taskrunEscalate("TR-STALL-1", "op-syn");
+    const createArg = stallEventCreate.mock.calls[0]![0] as {
+      data: { lastHeartbeatAt: Date | null };
+    };
+    expect(createArg.data.lastHeartbeatAt).toBeNull();
   });
 });

--- a/apps/web/lib/actions/taskrun-recovery.ts
+++ b/apps/web/lib/actions/taskrun-recovery.ts
@@ -251,22 +251,18 @@ export async function taskrunRetry(
       },
     });
 
-    // Close the most recent open StallEvent on the stalled row as "retry".
-    const openEvent = await tx.stallEvent.findFirst({
-      where: { taskRunId: stalled.id, outcome: null },
-      orderBy: { detectedAt: "desc" },
+    // Close the most recent open StallEvent on the stalled row as "retry",
+    // or synthesize one if no open event exists (audit completeness — see
+    // upsertRecoveryOutcome).
+    await upsertRecoveryOutcome(tx, {
+      stalledCuid: stalled.id,
+      buildId: stalled.buildId,
+      phase: stalled.phase,
+      outcome: "retry",
+      operatorUserId,
+      now,
+      notes: decision.notes,
     });
-    if (openEvent) {
-      await tx.stallEvent.update({
-        where: { id: openEvent.id },
-        data: {
-          outcome: "retry",
-          outcomeAt: now,
-          outcomeBy: operatorUserId,
-          notes: decision.notes,
-        },
-      });
-    }
 
     return { newTaskRunId: newRun.taskRunId };
   });
@@ -296,21 +292,17 @@ export async function taskrunAbandon(
       data: { status: "canceled", completedAt: now },
     });
 
-    // 2. Close the most recent open StallEvent as "abandoned".
-    const openEvent = await tx.stallEvent.findFirst({
-      where: { taskRunId: stalled.id, outcome: null },
-      orderBy: { detectedAt: "desc" },
+    // 2. Close the most recent open StallEvent as "abandoned", or
+    //    synthesize one if no open event exists (audit completeness — see
+    //    upsertRecoveryOutcome).
+    await upsertRecoveryOutcome(tx, {
+      stalledCuid: stalled.id,
+      buildId: stalled.buildId,
+      phase: stalled.phase,
+      outcome: "abandoned",
+      operatorUserId,
+      now,
     });
-    if (openEvent) {
-      await tx.stallEvent.update({
-        where: { id: openEvent.id },
-        data: {
-          outcome: "abandoned",
-          outcomeAt: now,
-          outcomeBy: operatorUserId,
-        },
-      });
-    }
 
     // 3. Cascade one level: find live children, cancel them, write
     //    parent_abandoned StallEvent for each.
@@ -356,6 +348,15 @@ export async function taskrunAbandon(
  * outcome). Writes StallEvent.outcome=escalated and notifies the accountable
  * human — build owner if buildId resolves to a FeatureBuild.createdById,
  * else the task's userId.
+ *
+ * Audit completeness (BI-4ab6be39 follow-up, 2026-05-20): if no open
+ * StallEvent exists for this row when the operator escalates, we synthesize
+ * one with the outcome already set. The earlier behavior silently skipped
+ * the audit row when the watchdog hadn't yet inserted a fresh open event,
+ * leaving the StallEvent ledger one record short of the Notification row —
+ * caught during F2 UX dogfooding when the notification fired but no
+ * outcome='escalated' row appeared in StallEvent. Retry and Abandon have
+ * the same pattern; see taskrunRetry / taskrunAbandon for parity.
  */
 export async function taskrunEscalate(
   taskRunId: string,
@@ -376,21 +377,15 @@ export async function taskrunEscalate(
   }
 
   await prisma.$transaction(async (tx) => {
-    const openEvent = await tx.stallEvent.findFirst({
-      where: { taskRunId: stalled.id, outcome: null },
-      orderBy: { detectedAt: "desc" },
+    await upsertRecoveryOutcome(tx, {
+      stalledCuid: stalled.id,
+      buildId: stalled.buildId,
+      phase: stalled.phase,
+      outcome: "escalated",
+      operatorUserId,
+      now,
+      notes,
     });
-    if (openEvent) {
-      await tx.stallEvent.update({
-        where: { id: openEvent.id },
-        data: {
-          outcome: "escalated",
-          outcomeAt: now,
-          outcomeBy: operatorUserId,
-          notes,
-        },
-      });
-    }
 
     if (notifyUserId) {
       await tx.notification.create({
@@ -403,5 +398,79 @@ export async function taskrunEscalate(
         },
       });
     }
+  });
+}
+
+/**
+ * Close the most recent open StallEvent for a recovery operation, or
+ * synthesize one with the outcome pre-set if no open event exists.
+ *
+ * The watchdog only INSERTs a StallEvent when it transitions a row from
+ * working/active → stalled. If an operator recovers a row whose open event
+ * has already been resolved (e.g. earlier action, or the row was force-
+ * stalled by an admin tool that didn't write an event), the prior behavior
+ * silently dropped the outcome row, leaving the StallEvent ledger missing
+ * a record of the operator action. This helper guarantees one outcome row
+ * lands per recovery call.
+ *
+ * thresholdHeartbeatS / thresholdTotalS are 0 sentinels on synthesized
+ * rows (matching the parent_abandoned cascade rows in taskrunAbandon),
+ * since the original watchdog thresholds aren't recoverable after the fact.
+ *
+ * The `startedAt` field is required by the schema. We look it up rather
+ * than threading it through every call site, so the helper stays tight.
+ */
+async function upsertRecoveryOutcome(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  args: {
+    stalledCuid: string;
+    buildId: string | null;
+    phase: string | null;
+    outcome: "retry" | "abandoned" | "escalated";
+    operatorUserId: string;
+    now: Date;
+    notes?: string;
+  },
+): Promise<void> {
+  const openEvent = await tx.stallEvent.findFirst({
+    where: { taskRunId: args.stalledCuid, outcome: null },
+    orderBy: { detectedAt: "desc" },
+  });
+  if (openEvent) {
+    await tx.stallEvent.update({
+      where: { id: openEvent.id },
+      data: {
+        outcome: args.outcome,
+        outcomeAt: args.now,
+        outcomeBy: args.operatorUserId,
+        notes: args.notes,
+      },
+    });
+    return;
+  }
+
+  // No open event — synthesize one so the audit row lands. Pull startedAt
+  // from the TaskRun itself; lastHeartbeatAt may legitimately be null on
+  // rows that never reported a heartbeat before transitioning to stalled.
+  const row = await tx.taskRun.findUnique({
+    where: { id: args.stalledCuid },
+    select: { startedAt: true, lastHeartbeatAt: true },
+  });
+  if (!row) return; // Shouldn't happen — loadStalled already validated.
+  await tx.stallEvent.create({
+    data: {
+      taskRunId: args.stalledCuid,
+      buildId: args.buildId,
+      phase: args.phase,
+      reason: "operator_recovery_synthesized",
+      lastHeartbeatAt: row.lastHeartbeatAt,
+      startedAt: row.startedAt,
+      thresholdHeartbeatS: 0,
+      thresholdTotalS: 0,
+      outcome: args.outcome,
+      outcomeAt: args.now,
+      outcomeBy: args.operatorUserId,
+      notes: args.notes ?? "Synthesized on operator recovery — no open StallEvent at recovery time.",
+    },
   });
 }


### PR DESCRIPTION
## Summary

BI-4ab6be39 follow-up caught during F2 UX dogfooding on the AI Operations Map:

- Clicked Escalate on a stalled deliberation → `Notification` row created, but no `StallEvent.outcome='escalated'` row appeared in the audit ledger.
- Root cause: `taskrunEscalate` only updated the most recent open StallEvent, silently no-op'ing when none existed. `taskrunRetry` and `taskrunAbandon` had the same pattern.

Now: all three recovery paths route through `upsertRecoveryOutcome`. If an open StallEvent exists, it's closed as before. If not, a new row is synthesized with `reason='operator_recovery_synthesized'` so the ledger always carries one outcome row per operator click.

## Test plan

- [x] Unit tests pass (`pnpm vitest run lib/actions/taskrun-recovery.test.ts`) — 28/28 green, includes 5 new tests covering synthesize path for each action and a null-`lastHeartbeatAt` edge case.
- [x] Pre-commit scoped typecheck passes.
- [ ] After merge: trigger a manual Escalate on a stalled row in the live install and verify a fresh `StallEvent` row with `outcome='escalated'` lands in the DB.

## Context

Discovered while verifying F1 + F2 end-to-end through the AI Operations Map UX:
- F1 (Build station inspector shows stalled projections) ✅ verified
- F2a Retry ✅ verified (sibling TaskRun spawned, StallEvent closed)
- F2b Abandon ✅ verified (status→canceled, StallEvent closed)
- F2c Escalate ✅ Notification fired, but StallEvent gap surfaced — this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)