### PR TITLE
feat(ep-cost): Phase 4 — CLI pool visibility + pre-dispatch rate-limit check

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -11,6 +11,8 @@ import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
 import { SyncProvidersButton } from "@/components/platform/SyncProvidersButton";
 import { ServiceSection } from "@/components/platform/ServiceSection";
 import { ServiceRow } from "@/components/platform/ServiceRow";
+import { getAllCliPoolStatuses } from "@/lib/routing/cli-pool-status";
+import { CliPoolStatusPanel } from "@/components/platform/CliPoolStatusPanel";
 import Link from "next/link";
 
 
@@ -43,13 +45,14 @@ export default async function ProvidersPage() {
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
 
   // Bypass React cache for jobs — syncProviderRegistry() may have mutated the DB above.
-  const [providers, byProvider, byAgent, freshJobs, detected, modelSummaries] = await Promise.all([
+  const [providers, byProvider, byAgent, freshJobs, detected, modelSummaries, cliPoolStatuses] = await Promise.all([
     getProviders(),
     getTokenSpendByProvider(currentMonth),
     getTokenSpendByAgent(currentMonth),
     prisma.scheduledJob.findMany({ orderBy: { jobId: "asc" } }),
     detectMcpServers(),
     getProviderModelSummaries(),
+    getAllCliPoolStatuses(),
   ]);
   const aiProviders = providers.filter((pw) => pw.provider.endpointType !== "service");
 
@@ -66,6 +69,9 @@ export default async function ProvidersPage() {
       </div>
 
       <DetectedServicesBanner detected={detected} />
+
+      {/* EP-COST Phase 4: CLI Pool Status — surface rate-limit state for claude-cli and codex-cli */}
+      <CliPoolStatusPanel statuses={cliPoolStatuses} />
 
       <div
         style={{

--- a/apps/web/components/platform/CliPoolStatusPanel.tsx
+++ b/apps/web/components/platform/CliPoolStatusPanel.tsx
@@ -1,0 +1,133 @@
+// apps/web/components/platform/CliPoolStatusPanel.tsx
+//
+// EP-COST Phase 4: Surfaces CLI pool rate-limit state on Admin > AI Providers.
+// Shows a banner only when at least one pool is exhausted; hidden when all
+// pools are healthy. No persistent exhaustion rows means no banner.
+
+import type { CliPoolState } from "@/lib/routing/cli-pool-status";
+
+interface Props {
+  statuses: CliPoolState[];
+}
+
+const ADAPTER_LABELS: Record<string, string> = {
+  "claude-cli": "Claude Code CLI (subscription)",
+  "codex-cli": "Codex CLI (OpenAI subscription)",
+};
+
+function formatResetTime(resetAt: Date | null, secondsUntilReset: number | null): string {
+  if (!resetAt) return "unknown";
+  if (secondsUntilReset != null && secondsUntilReset <= 0) return "any moment";
+  if (secondsUntilReset != null && secondsUntilReset < 60) return `~${secondsUntilReset}s`;
+  if (secondsUntilReset != null) return `~${Math.ceil(secondsUntilReset / 60)}min`;
+  return new Date(resetAt).toLocaleTimeString();
+}
+
+export function CliPoolStatusPanel({ statuses }: Props) {
+  const exhausted = statuses.filter((s) => s.isExhausted);
+  const recentlyLimited = statuses.filter((s) => !s.isExhausted && s.rateLimitedAt);
+
+  if (statuses.length === 0) {
+    // No 429 events recorded — healthy state, nothing to show.
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        marginBottom: 16,
+        border: `1px solid ${exhausted.length > 0 ? "var(--dpf-warning, #f59e0b)" : "var(--dpf-border)"}`,
+        borderRadius: 8,
+        padding: "12px 14px",
+        background: exhausted.length > 0
+          ? "var(--dpf-warning-surface, #fffbeb)"
+          : "var(--dpf-surface-1)",
+      }}
+    >
+      <p
+        style={{
+          margin: "0 0 8px",
+          fontSize: 12,
+          fontWeight: 600,
+          color: exhausted.length > 0 ? "var(--dpf-warning-text, #92400e)" : "var(--dpf-text)",
+        }}
+      >
+        CLI Pool Status
+        {exhausted.length > 0 && (
+          <span style={{ marginLeft: 8, fontWeight: 400, color: "var(--dpf-warning-text, #92400e)" }}>
+            — {exhausted.length} pool{exhausted.length !== 1 ? "s" : ""} rate-limited
+          </span>
+        )}
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {statuses.map((s) => (
+          <div
+            key={s.adapterType}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 11,
+              color: "var(--dpf-text)",
+            }}
+          >
+            {/* Status dot */}
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                flexShrink: 0,
+                background: s.isExhausted
+                  ? "var(--dpf-warning, #f59e0b)"
+                  : "var(--dpf-success, #10b981)",
+              }}
+            />
+
+            {/* Adapter name */}
+            <span style={{ minWidth: 200, fontWeight: 500 }}>
+              {ADAPTER_LABELS[s.adapterType] ?? s.adapterType}
+            </span>
+
+            {/* State */}
+            {s.isExhausted ? (
+              <span style={{ color: "var(--dpf-warning-text, #92400e)" }}>
+                Rate-limited · resets {formatResetTime(s.resetAt, s.secondsUntilReset)}
+              </span>
+            ) : (
+              <span style={{ color: "var(--dpf-muted)" }}>
+                Previously limited {new Date(s.rateLimitedAt).toLocaleTimeString()} · pool recovered
+              </span>
+            )}
+
+            {/* Error snippet */}
+            {s.errorSnippet && (
+              <span
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: "monospace",
+                  fontSize: 10,
+                  color: "var(--dpf-muted)",
+                  maxWidth: 260,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+                title={s.errorSnippet}
+              >
+                {s.errorSnippet.slice(0, 80)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {recentlyLimited.length > 0 && exhausted.length === 0 && (
+        <p style={{ margin: "8px 0 0", fontSize: 10, color: "var(--dpf-muted)" }}>
+          All pools healthy. Historical events shown; rows clear automatically on the next successful call.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -27,6 +27,7 @@ import {
   type ExecutionAdapterSelector,
 } from "../routing/execution-adapter-types";
 import { writeAdapterTelemetry } from "../routing/adapter-telemetry-writer";
+import { getCliPoolStatus } from "../routing/cli-pool-status";
 import "../routing/chat-adapter"; // side-effect: registers "chat" adapter
 import "../routing/responses-adapter"; // side-effect: registers "responses" adapter
 import "../routing/image-gen-adapter"; // EP-INF-009c: registers "image_gen" adapter
@@ -455,6 +456,24 @@ export async function callProvider(
   const isCliAdapter =
     selector !== null &&
     (selector.kind === "claude-code-cli" || selector.kind === "codex-cli");
+
+  // EP-COST Phase 4: consult CliPoolStatus before dispatching a CLI-backed call.
+  // If the pool is known-exhausted (resetAt is in the future), throw rate_limit
+  // so routed-inference.ts falls back to the next provider in the priority list
+  // rather than firing into an already-saturated CLI pool.
+  if (isCliAdapter && selector !== null) {
+    const cliAdapterType = selector.kind === "claude-code-cli" ? "claude-cli" : "codex-cli";
+    const poolState = await getCliPoolStatus(cliAdapterType);
+    if (poolState?.isExhausted) {
+      const waitSecs = poolState.secondsUntilReset ?? "unknown";
+      throw new InferenceError(
+        `${cliAdapterType} pool exhausted — resets in ~${waitSecs}s (EP-COST pool check)`,
+        "rate_limit",
+        providerId,
+      );
+    }
+  }
+
   const baseUrl = isCliAdapter ? "cli://local" : await resolveExecutionBaseUrl(providerId, provider);
   if (!baseUrl) throw new InferenceError("No base URL configured", "provider_error", providerId);
   const headers = isCliAdapter ? {} : await buildAuthHeaders(providerId, provider.authMethod, provider.authHeader);

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -24,6 +24,7 @@ import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { extractToolCalls as extractToolCallsFromText } from "./extract-tool-calls";
 import { createMcpSessionToken } from "@/lib/mcp/session-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
+import { recordCliRateLimit, clearCliRateLimit } from "./cli-pool-status";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
@@ -548,6 +549,8 @@ export const cliAdapter: ExecutionAdapterHandler = {
                 providerId,
               ));
             } else if (stderr.includes("rate") || stderr.includes("429")) {
+              // EP-COST Phase 4: record pool exhaustion so orchestrator can back off
+              void recordCliRateLimit("claude-cli", providerId, stderr);
               reject(new InferenceError(
                 `Claude CLI rate limited: ${stderr.slice(0, 300)}`,
                 "rate_limit",
@@ -631,6 +634,9 @@ export const cliAdapter: ExecutionAdapterHandler = {
           `[tool-trace] adapter=claude-cli CALLS-PARSED head=${JSON.stringify(parsed.text.slice(0, 600))}`,
         );
       }
+
+      // EP-COST Phase 4: successful call proves the pool is available — clear any stale exhaustion record.
+      void clearCliRateLimit("claude-cli");
 
       return {
         text: parsed.text,

--- a/apps/web/lib/routing/cli-pool-status.test.ts
+++ b/apps/web/lib/routing/cli-pool-status.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock Prisma ──────────────────────────────────────────────────────────────
+vi.mock("@dpf/db", () => {
+  const rows = new Map<string, Record<string, unknown>>();
+  return {
+    prisma: {
+      cliPoolStatus: {
+        upsert: vi.fn(async ({ where, create, update }: { where: { adapterType: string }; create: Record<string, unknown>; update: Record<string, unknown> }) => {
+          const existing = rows.get(where.adapterType);
+          const row = existing ? { ...existing, ...update } : { ...create };
+          rows.set(where.adapterType, row);
+          return row;
+        }),
+        findUnique: vi.fn(async ({ where }: { where: { adapterType: string } }) => {
+          return rows.get(where.adapterType) ?? null;
+        }),
+        findMany: vi.fn(async () => [...rows.values()]),
+        deleteMany: vi.fn(async ({ where }: { where: { adapterType: string } }) => {
+          rows.delete(where.adapterType);
+          return { count: 1 };
+        }),
+        _rows: rows,
+      },
+    },
+  };
+});
+
+import {
+  parseRetryAfterSeconds,
+  recordCliRateLimit,
+  getCliPoolStatus,
+  getAllCliPoolStatuses,
+  clearCliRateLimit,
+} from "./cli-pool-status";
+import { prisma } from "@dpf/db";
+
+// Helper to reset the in-memory rows map between tests
+function clearMockRows() {
+  // @ts-expect-error accessing test-only _rows
+  (prisma.cliPoolStatus._rows as Map<string, unknown>).clear();
+}
+
+describe("parseRetryAfterSeconds", () => {
+  it("parses Retry-After: <seconds> header", () => {
+    expect(parseRetryAfterSeconds("Retry-After: 30")).toBe(30);
+    expect(parseRetryAfterSeconds("retry-after: 120")).toBe(120);
+  });
+
+  it("parses X-RateLimit-Reset epoch header", () => {
+    const futureEpoch = Math.floor(Date.now() / 1000) + 60;
+    const result = parseRetryAfterSeconds(`X-RateLimit-Reset: ${futureEpoch}`);
+    // Should be within ±2s of 60
+    expect(result).toBeGreaterThan(55);
+    expect(result).toBeLessThanOrEqual(62);
+  });
+
+  it("parses 'N seconds' from error message body", () => {
+    expect(parseRetryAfterSeconds("Rate limit exceeded. Please wait 45 seconds.")).toBe(45);
+    expect(parseRetryAfterSeconds("try again in 10 seconds")).toBe(10);
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(parseRetryAfterSeconds("rate limited")).toBeNull();
+    expect(parseRetryAfterSeconds("429 Too Many Requests")).toBeNull();
+    expect(parseRetryAfterSeconds("")).toBeNull();
+  });
+});
+
+describe("recordCliRateLimit", () => {
+  beforeEach(() => {
+    clearMockRows();
+    vi.clearAllMocks();
+  });
+
+  it("writes a CliPoolStatus row on first call", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limited: Retry-After: 60");
+    expect(prisma.cliPoolStatus.upsert).toHaveBeenCalledOnce();
+
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status).not.toBeNull();
+    expect(status!.adapterType).toBe("claude-cli");
+    expect(status!.retryAfterSeconds).toBe(60);
+    expect(status!.isExhausted).toBe(true);
+  });
+
+  it("upserts — overwrites existing row on second 429", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limited: Retry-After: 30");
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limited: Retry-After: 120");
+    expect(prisma.cliPoolStatus.upsert).toHaveBeenCalledTimes(2);
+
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status!.retryAfterSeconds).toBe(120);
+  });
+
+  it("truncates errorSnippet to 300 characters", async () => {
+    const longError = "x".repeat(400);
+    await recordCliRateLimit("codex-cli", "chatgpt", longError);
+    const status = await getCliPoolStatus("codex-cli");
+    expect(status!.errorSnippet).toHaveLength(300);
+  });
+
+  it("handles missing Retry-After gracefully (resetAt is null)", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limit hit");
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status!.resetAt).toBeNull();
+    expect(status!.isExhausted).toBe(false); // no reset time means we don't know — not blocking
+  });
+
+  it("swallows db errors without throwing", async () => {
+    vi.mocked(prisma.cliPoolStatus.upsert).mockRejectedValueOnce(new Error("db down"));
+    await expect(
+      recordCliRateLimit("claude-cli", "anthropic-sub", "rate limited"),
+    ).resolves.not.toThrow();
+  });
+});
+
+describe("getCliPoolStatus", () => {
+  beforeEach(() => {
+    clearMockRows();
+    vi.clearAllMocks();
+  });
+
+  it("returns null when no rate-limit recorded for that adapter", async () => {
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status).toBeNull();
+  });
+
+  it("computes isExhausted=true when resetAt is in the future", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "Retry-After: 300");
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status!.isExhausted).toBe(true);
+    expect(status!.secondsUntilReset).toBeGreaterThan(290);
+  });
+
+  it("computes isExhausted=false when resetAt is null", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "rate limited");
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status!.isExhausted).toBe(false);
+    expect(status!.secondsUntilReset).toBeNull();
+  });
+
+  it("swallows db errors and returns null", async () => {
+    vi.mocked(prisma.cliPoolStatus.findUnique).mockRejectedValueOnce(new Error("db down"));
+    await expect(getCliPoolStatus("claude-cli")).resolves.toBeNull();
+  });
+});
+
+describe("getAllCliPoolStatuses", () => {
+  beforeEach(() => {
+    clearMockRows();
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array when no entries exist", async () => {
+    const statuses = await getAllCliPoolStatuses();
+    expect(statuses).toEqual([]);
+  });
+
+  it("returns all recorded adapters", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "Retry-After: 60");
+    await recordCliRateLimit("codex-cli", "chatgpt", "rate limited");
+    const statuses = await getAllCliPoolStatuses();
+    expect(statuses).toHaveLength(2);
+    expect(statuses.map((s) => s.adapterType).sort()).toEqual(["claude-cli", "codex-cli"]);
+  });
+});
+
+describe("clearCliRateLimit", () => {
+  beforeEach(() => {
+    clearMockRows();
+    vi.clearAllMocks();
+  });
+
+  it("removes the row so subsequent getCliPoolStatus returns null", async () => {
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "Retry-After: 60");
+    await clearCliRateLimit("claude-cli");
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status).toBeNull();
+  });
+
+  it("swallows db errors without throwing", async () => {
+    vi.mocked(prisma.cliPoolStatus.deleteMany).mockRejectedValueOnce(new Error("db down"));
+    await expect(clearCliRateLimit("claude-cli")).resolves.not.toThrow();
+  });
+});

--- a/apps/web/lib/routing/cli-pool-status.ts
+++ b/apps/web/lib/routing/cli-pool-status.ts
@@ -1,0 +1,182 @@
+// apps/web/lib/routing/cli-pool-status.ts
+//
+// CLI pool rate-limit state tracker — EP-COST-001 Phase 4.
+//
+// When a CLI adapter (claude-cli or codex-cli) receives a 429 / rate-limit
+// error it calls `recordCliRateLimit`. The orchestrator calls
+// `getCliPoolStatus` before dispatching CLI-backed tasks; if the pool is
+// exhausted (resetAt is in the future) the caller can wait or fall back to
+// the API adapter instead of firing into a known-exhausted pool.
+//
+// Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §4d
+
+import { prisma } from "@dpf/db";
+
+export type CliAdapterType = "claude-cli" | "codex-cli";
+
+export interface CliPoolState {
+  adapterType: CliAdapterType;
+  providerId: string;
+  rateLimitedAt: Date;
+  /** Null when the CLI didn't emit a parseable reset time. */
+  resetAt: Date | null;
+  retryAfterSeconds: number | null;
+  errorSnippet: string | null;
+  /** True when resetAt is in the future (pool is currently exhausted). */
+  isExhausted: boolean;
+  /** Seconds until the pool is expected to be available again. Null if unknown. */
+  secondsUntilReset: number | null;
+}
+
+/**
+ * Parse a Retry-After value (seconds or HTTP-date) from CLI stderr output.
+ * Returns seconds as a number, or null if nothing parseable is found.
+ */
+export function parseRetryAfterSeconds(stderr: string): number | null {
+  // "Retry-After: 30" or "retry-after: 30"
+  const secondsMatch = /retry-after:\s*(\d+)/i.exec(stderr);
+  if (secondsMatch) {
+    const s = parseInt(secondsMatch[1]!, 10);
+    return isNaN(s) ? null : s;
+  }
+
+  // "X-RateLimit-Reset: 1716300000" (epoch seconds)
+  const epochMatch = /x-ratelimit-reset:\s*(\d{10,})/i.exec(stderr);
+  if (epochMatch) {
+    const epoch = parseInt(epochMatch[1]!, 10);
+    if (!isNaN(epoch)) {
+      return Math.max(0, epoch - Math.floor(Date.now() / 1000));
+    }
+  }
+
+  // "rate limit.*(\d+) seconds?" — common in OpenAI / Anthropic CLI output
+  const msgMatch = /(\d+)\s*second/i.exec(stderr);
+  if (msgMatch) {
+    const s = parseInt(msgMatch[1]!, 10);
+    return isNaN(s) ? null : s;
+  }
+
+  return null;
+}
+
+/**
+ * Record a 429 / rate-limit event for the given CLI adapter.
+ * Upserts the CliPoolStatus row (one row per adapterType).
+ * Fire-and-forget from the adapter — errors are swallowed so they never
+ * block the InferenceError from propagating to the caller.
+ */
+export async function recordCliRateLimit(
+  adapterType: CliAdapterType,
+  providerId: string,
+  errorText: string,
+): Promise<void> {
+  try {
+    const retryAfterSeconds = parseRetryAfterSeconds(errorText);
+    const now = new Date();
+    const resetAt =
+      retryAfterSeconds != null
+        ? new Date(now.getTime() + retryAfterSeconds * 1_000)
+        : null;
+
+    await prisma.cliPoolStatus.upsert({
+      where: { adapterType },
+      create: {
+        adapterType,
+        providerId,
+        rateLimitedAt: now,
+        resetAt,
+        retryAfterSeconds,
+        errorSnippet: errorText.slice(0, 300),
+        updatedAt: now,
+      },
+      update: {
+        providerId,
+        rateLimitedAt: now,
+        resetAt,
+        retryAfterSeconds,
+        errorSnippet: errorText.slice(0, 300),
+        updatedAt: now,
+      },
+    });
+  } catch (err) {
+    // Non-fatal: pool tracking should never interrupt the inference error path.
+    console.warn("[cli-pool-status] Failed to record rate limit:", { adapterType }, err);
+  }
+}
+
+/**
+ * Fetch the current pool state for a given CLI adapter.
+ * Returns null when there is no recorded rate-limit event for this adapter.
+ */
+export async function getCliPoolStatus(
+  adapterType: CliAdapterType,
+): Promise<CliPoolState | null> {
+  try {
+    const row = await prisma.cliPoolStatus.findUnique({
+      where: { adapterType },
+    });
+    if (!row) return null;
+
+    const now = Date.now();
+    const resetMs = row.resetAt ? row.resetAt.getTime() : null;
+    const isExhausted = resetMs != null && resetMs > now;
+    const secondsUntilReset =
+      isExhausted && resetMs != null ? Math.ceil((resetMs - now) / 1_000) : null;
+
+    return {
+      adapterType: row.adapterType as CliAdapterType,
+      providerId: row.providerId,
+      rateLimitedAt: row.rateLimitedAt,
+      resetAt: row.resetAt,
+      retryAfterSeconds: row.retryAfterSeconds,
+      errorSnippet: row.errorSnippet,
+      isExhausted,
+      secondsUntilReset,
+    };
+  } catch (err) {
+    console.warn("[cli-pool-status] Failed to read pool status:", { adapterType }, err);
+    return null;
+  }
+}
+
+/**
+ * Fetch pool status for all CLI adapters.
+ * Used by the Admin UI to surface current pool state.
+ */
+export async function getAllCliPoolStatuses(): Promise<CliPoolState[]> {
+  try {
+    const rows = await prisma.cliPoolStatus.findMany({
+      orderBy: { adapterType: "asc" },
+    });
+    const now = Date.now();
+    return rows.map((row) => {
+      const resetMs = row.resetAt ? row.resetAt.getTime() : null;
+      const isExhausted = resetMs != null && resetMs > now;
+      return {
+        adapterType: row.adapterType as CliAdapterType,
+        providerId: row.providerId,
+        rateLimitedAt: row.rateLimitedAt,
+        resetAt: row.resetAt,
+        retryAfterSeconds: row.retryAfterSeconds,
+        errorSnippet: row.errorSnippet,
+        isExhausted,
+        secondsUntilReset: isExhausted && resetMs != null ? Math.ceil((resetMs - now) / 1_000) : null,
+      };
+    });
+  } catch (err) {
+    console.warn("[cli-pool-status] Failed to read all pool statuses:", err);
+    return [];
+  }
+}
+
+/**
+ * Clear the rate-limit record for a given adapter (e.g. after a successful call
+ * proves the pool is available again).
+ */
+export async function clearCliRateLimit(adapterType: CliAdapterType): Promise<void> {
+  try {
+    await prisma.cliPoolStatus.deleteMany({ where: { adapterType } });
+  } catch (err) {
+    console.warn("[cli-pool-status] Failed to clear rate limit:", { adapterType }, err);
+  }
+}

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -21,6 +21,7 @@ import { getDecryptedCredential, getProviderBearerToken } from "@/lib/inference/
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { extractToolCalls as sharedExtractToolCalls } from "./extract-tool-calls";
+import { recordCliRateLimit, clearCliRateLimit } from "./cli-pool-status";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
@@ -299,6 +300,8 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
                 providerId,
               ));
             } else if (stderr.includes("rate") || stderr.includes("429")) {
+              // EP-COST Phase 4: record pool exhaustion so orchestrator can back off
+              void recordCliRateLimit("codex-cli", providerId, stderr);
               reject(new InferenceError(
                 `Codex CLI rate limited: ${stderr.slice(0, 300)}`,
                 "rate_limit",
@@ -398,6 +401,9 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
           `[tool-trace] CALLS-PARSED head=${JSON.stringify(text.slice(0, 600))}`,
         );
       }
+
+      // EP-COST Phase 4: successful call proves the pool is available — clear any stale exhaustion record.
+      void clearCliRateLimit("codex-cli");
 
       return {
         text: toolCalls.length > 0 ? text.replace(/```json\n?\{[\s\S]*?```/g, "").trim() : text,

--- a/packages/db/prisma/migrations/20260521100000_ep_cost_p4_cli_pool_status/migration.sql
+++ b/packages/db/prisma/migrations/20260521100000_ep_cost_p4_cli_pool_status/migration.sql
@@ -1,0 +1,24 @@
+-- EP-COST-001 Phase 4: CLI Pool Status
+-- Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §4d
+--
+-- Tracks the last-known rate-limit state for each CLI adapter pool.
+-- One row per adapter type (claude-cli, codex-cli); upserted on 429 events.
+
+CREATE TABLE IF NOT EXISTS "CliPoolStatus" (
+  "id"                TEXT NOT NULL,
+  "adapterType"       TEXT NOT NULL,
+  "providerId"        TEXT NOT NULL,
+  "rateLimitedAt"     TIMESTAMP(3) NOT NULL,
+  "resetAt"           TIMESTAMP(3),
+  "retryAfterSeconds" INTEGER,
+  "errorSnippet"      TEXT,
+  "updatedAt"         TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "CliPoolStatus_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "CliPoolStatus_adapterType_key"
+  ON "CliPoolStatus"("adapterType");
+
+CREATE INDEX IF NOT EXISTS "CliPoolStatus_adapterType_resetAt_idx"
+  ON "CliPoolStatus"("adapterType", "resetAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -8736,3 +8736,33 @@ model IntegrationRoleCoverage {
   @@unique([organizationId, providerKey, role, surface])
   @@index([organizationId])
 }
+
+// ─── EP-COST-001 Phase 4: CLI Pool Status ──────────────────────────────────
+//
+// Tracks the last-known rate-limit state for each CLI adapter pool.
+// Written by cli-adapter.ts and codex-cli-adapter.ts when they receive a
+// 429 / rate-limit error from the underlying subprocess. The orchestrator
+// consults this table before dispatching CLI-backed tasks so it can
+// wait or fall back to the API adapter rather than firing into a known-
+// exhausted pool.
+//
+// One row per adapter type; upserted on each 429 event.
+// The row is cleared (resetAt set to null) once the wall clock passes resetAt.
+//
+// Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §4d
+model CliPoolStatus {
+  id                String    @id @default(cuid())
+  /// "claude-cli" | "codex-cli"
+  adapterType       String    @unique
+  providerId        String
+  rateLimitedAt     DateTime
+  /// Best-effort reset time parsed from Retry-After/X-RateLimit-Reset in stderr.
+  /// Null when the CLI didn't emit a parseable header.
+  resetAt           DateTime?
+  retryAfterSeconds Int?
+  /// First 300 chars of the stderr / error message for debugging.
+  errorSnippet      String?
+  updatedAt         DateTime  @updatedAt
+
+  @@index([adapterType, resetAt])
+}


### PR DESCRIPTION
## Summary

- **`CliPoolStatus` table** (`schema.prisma` + migration `20260521100000`): one row per CLI adapter type, upserted when a 429 is received. Stores `rateLimitedAt`, `resetAt` (parsed from `Retry-After`/`X-RateLimit-Reset` or stderr body), `retryAfterSeconds`, and an error snippet.
- **`cli-pool-status.ts`**: `recordCliRateLimit` (fire-and-forget upsert), `getCliPoolStatus`, `getAllCliPoolStatuses`, `clearCliRateLimit` — 17 unit tests, all non-fatal.
- **`cli-adapter.ts` + `codex-cli-adapter.ts`**: `recordCliRateLimit("claude-cli"|"codex-cli", ...)` wired at every `rate_limit` InferenceError; `clearCliRateLimit` on successful return (so the record auto-clears the moment the pool recovers).
- **`ai-inference.ts`** pre-dispatch check: when `isCliAdapter` and the pool's `resetAt` is in the future, throws a `rate_limit` InferenceError *before* spawning the subprocess — routed-inference falls back to the next provider in the priority list rather than wasting a CLI invocation into a known-exhausted pool.
- **`CliPoolStatusPanel.tsx`**: surfaced on Admin > AI Providers. Amber banner when pools are exhausted; status-dot rows for all adapters showing reset countdown or recovery time. Hidden when no 429 events have been recorded.

## Part of EP-COST-001 (AI Cost Governance)
- Phase 1 (observability + cache telemetry): PR #875 ✅
- Phase 2 (budget gate + costTier fix): PR #894 ✅
- Phase 3 (context compaction): PR #897 (CI in progress)
- **Phase 4 (CLI pool visibility): this PR**

## Test plan
- [x] `cli-pool-status.test.ts`: 17 unit tests — `parseRetryAfterSeconds`, `recordCliRateLimit`, `getCliPoolStatus`, `getAllCliPoolStatuses`, `clearCliRateLimit` (fallback on DB errors, upsert, truncation, isExhausted computation)
- [x] TypeScript pre-commit check passes clean
- [x] LF line endings normalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)