### PR TITLE
feat(ep-cost): budget events UI + compactPhase wiring at phase transitions

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -13,6 +13,8 @@ import { ServiceSection } from "@/components/platform/ServiceSection";
 import { ServiceRow } from "@/components/platform/ServiceRow";
 import { getAllCliPoolStatuses } from "@/lib/routing/cli-pool-status";
 import { CliPoolStatusPanel } from "@/components/platform/CliPoolStatusPanel";
+import { getRecentBudgetEvents, countRecentRejections } from "@/lib/inference/budget-events-data";
+import { AgentBudgetEventsPanel } from "@/components/platform/AgentBudgetEventsPanel";
 import Link from "next/link";
 
 
@@ -45,7 +47,7 @@ export default async function ProvidersPage() {
   const currentMonth = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
 
   // Bypass React cache for jobs — syncProviderRegistry() may have mutated the DB above.
-  const [providers, byProvider, byAgent, freshJobs, detected, modelSummaries, cliPoolStatuses] = await Promise.all([
+  const [providers, byProvider, byAgent, freshJobs, detected, modelSummaries, cliPoolStatuses, budgetEvents, recentRejections] = await Promise.all([
     getProviders(),
     getTokenSpendByProvider(currentMonth),
     getTokenSpendByAgent(currentMonth),
@@ -53,6 +55,8 @@ export default async function ProvidersPage() {
     detectMcpServers(),
     getProviderModelSummaries(),
     getAllCliPoolStatuses(),
+    getRecentBudgetEvents(),
+    countRecentRejections(),
   ]);
   const aiProviders = providers.filter((pw) => pw.provider.endpointType !== "service");
 
@@ -72,6 +76,9 @@ export default async function ProvidersPage() {
 
       {/* EP-COST Phase 4: CLI Pool Status — surface rate-limit state for claude-cli and codex-cli */}
       <CliPoolStatusPanel statuses={cliPoolStatuses} />
+
+      {/* EP-COST Phase 2: Agent Budget Events — surface warning_95 and rejected threshold crossings */}
+      <AgentBudgetEventsPanel events={budgetEvents} recentRejections={recentRejections} />
 
       <div
         style={{

--- a/apps/web/components/platform/AgentBudgetEventsPanel.tsx
+++ b/apps/web/components/platform/AgentBudgetEventsPanel.tsx
@@ -1,0 +1,143 @@
+// apps/web/components/platform/AgentBudgetEventsPanel.tsx
+//
+// EP-COST-001 Phase 2: surfaces AgentBudgetEvent threshold crossings on
+// Admin > AI Providers so operators can see which agents are near or over
+// their daily token budgets.
+//
+// Only warning_95 and rejected events are shown (routine inference events
+// are filtered out in the data layer). The panel is hidden when there are
+// no qualifying events in the last 7 days.
+
+import type { BudgetEventRow } from "@/lib/inference/budget-events-data";
+
+interface Props {
+  events: BudgetEventRow[];
+  recentRejections: number;
+}
+
+const KIND_LABELS: Record<string, string> = {
+  warning_95: "95% of limit",
+  rejected: "Budget exceeded",
+};
+
+const KIND_COLOR: Record<string, string> = {
+  warning_95: "var(--dpf-warning, #f59e0b)",
+  rejected: "var(--dpf-error, #ef4444)",
+};
+
+function formatTokens(n: number | null): string {
+  if (n == null) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
+}
+
+function formatUsd(s: string): string {
+  const n = parseFloat(s);
+  if (isNaN(n)) return "—";
+  return `$${n.toFixed(4)}`;
+}
+
+function relativeTime(date: Date): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHrs = Math.floor(diffMins / 60);
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  return `${Math.floor(diffHrs / 24)}d ago`;
+}
+
+export function AgentBudgetEventsPanel({ events, recentRejections }: Props) {
+  if (events.length === 0) return null;
+
+  const hasRejections = recentRejections > 0;
+
+  return (
+    <div
+      style={{
+        marginBottom: 16,
+        border: `1px solid ${hasRejections ? "var(--dpf-error, #ef4444)" : "var(--dpf-warning, #f59e0b)"}`,
+        borderRadius: 8,
+        padding: "12px 14px",
+        background: hasRejections
+          ? "var(--dpf-error-surface, #fef2f2)"
+          : "var(--dpf-warning-surface, #fffbeb)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 12,
+            fontWeight: 600,
+            color: hasRejections ? "var(--dpf-error-text, #991b1b)" : "var(--dpf-warning-text, #92400e)",
+          }}
+        >
+          Agent Budget Events
+          {hasRejections && (
+            <span style={{ marginLeft: 8, fontWeight: 400 }}>
+              — {recentRejections} rejection{recentRejections !== 1 ? "s" : ""} in the last 24h
+            </span>
+          )}
+        </p>
+        <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>Last 7 days</span>
+      </div>
+
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 11 }}>
+        <thead>
+          <tr style={{ color: "var(--dpf-muted)" }}>
+            <th style={{ textAlign: "left", padding: "2px 6px 4px 0", fontWeight: 500 }}>Agent</th>
+            <th style={{ textAlign: "left", padding: "2px 6px 4px", fontWeight: 500 }}>Event</th>
+            <th style={{ textAlign: "right", padding: "2px 0 4px 6px", fontWeight: 500 }}>Tokens</th>
+            <th style={{ textAlign: "right", padding: "2px 0 4px 6px", fontWeight: 500 }}>Est. cost</th>
+            <th style={{ textAlign: "right", padding: "2px 0 4px 6px", fontWeight: 500 }}>When</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((evt) => (
+            <tr
+              key={evt.id}
+              style={{ borderTop: "1px solid var(--dpf-border-subtle, rgba(0,0,0,0.05))" }}
+            >
+              <td style={{ padding: "3px 6px 3px 0", color: "var(--dpf-text)", fontFamily: "monospace", fontSize: 10 }}>
+                {evt.agentId.length > 30 ? `${evt.agentId.slice(0, 28)}…` : evt.agentId}
+              </td>
+              <td style={{ padding: "3px 6px" }}>
+                <span
+                  style={{
+                    display: "inline-block",
+                    padding: "1px 6px",
+                    borderRadius: 4,
+                    fontSize: 10,
+                    fontWeight: 600,
+                    background: KIND_COLOR[evt.eventKind] ?? "var(--dpf-muted)",
+                    color: "#fff",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {KIND_LABELS[evt.eventKind] ?? evt.eventKind}
+                </span>
+              </td>
+              <td style={{ textAlign: "right", padding: "3px 0 3px 6px", color: "var(--dpf-text)", fontVariantNumeric: "tabular-nums" }}>
+                {formatTokens(evt.tokensTotal)}
+              </td>
+              <td style={{ textAlign: "right", padding: "3px 0 3px 6px", color: "var(--dpf-muted)", fontVariantNumeric: "tabular-nums" }}>
+                {formatUsd(evt.amountUsd)}
+              </td>
+              <td style={{ textAlign: "right", padding: "3px 0 3px 6px", color: "var(--dpf-muted)", whiteSpace: "nowrap" }}>
+                {relativeTime(evt.createdAt)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p style={{ margin: "6px 0 0", fontSize: 10, color: "var(--dpf-muted)" }}>
+        Budget limits are configured per-agent in{" "}
+        <code style={{ fontFamily: "monospace" }}>agent_registry.json</code> → <code style={{ fontFamily: "monospace" }}>token_budget.daily_limit</code>.
+        Rejected events halt inference for that agent for the remainder of the UTC day.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/lib/inference/budget-events-data.ts
+++ b/apps/web/lib/inference/budget-events-data.ts
@@ -1,0 +1,81 @@
+// apps/web/lib/inference/budget-events-data.ts
+//
+// EP-COST-001 Phase 2: data helpers for surfacing AgentBudgetEvent rows
+// in the Admin > AI Providers UI.
+//
+// Fetches the most recent budget pressure events (warning_95 + rejected)
+// for display so operators can see which agents are near or over their
+// daily token budgets without needing to query the DB directly.
+
+import { prisma } from "@dpf/db";
+
+export type BudgetEventRow = {
+  id: string;
+  agentId: string;
+  eventKind: string;
+  tokensTotal: number | null;
+  amountUsd: string; // Decimal serialized as string
+  modelId: string | null;
+  providerId: string | null;
+  buildRunId: string | null;
+  createdAt: Date;
+};
+
+/**
+ * Fetch the most recent budget pressure events (warning_95 + rejected).
+ * Excludes routine "inference" events — only returns threshold crossings.
+ * Defaults to events from the past 7 days, capped at 50 rows.
+ */
+export async function getRecentBudgetEvents(opts?: {
+  sinceHours?: number;
+  limit?: number;
+}): Promise<BudgetEventRow[]> {
+  const sinceHours = opts?.sinceHours ?? 168; // 7 days
+  const limit = opts?.limit ?? 50;
+  const since = new Date(Date.now() - sinceHours * 3_600_000);
+
+  try {
+    const rows = await prisma.agentBudgetEvent.findMany({
+      where: {
+        eventKind: { in: ["warning_95", "rejected"] },
+        createdAt: { gte: since },
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      select: {
+        id: true,
+        agentId: true,
+        eventKind: true,
+        tokensTotal: true,
+        amountUsd: true,
+        modelId: true,
+        providerId: true,
+        buildRunId: true,
+        createdAt: true,
+      },
+    });
+
+    return rows.map((r) => ({
+      ...r,
+      amountUsd: r.amountUsd.toString(),
+    }));
+  } catch (err) {
+    console.warn("[budget-events-data] Failed to fetch budget events:", err);
+    return [];
+  }
+}
+
+/**
+ * Count active rejections (events in the last 24 hours where kind=rejected).
+ * Used to decide whether to show the warning banner prominently.
+ */
+export async function countRecentRejections(): Promise<number> {
+  const since = new Date(Date.now() - 24 * 3_600_000);
+  try {
+    return await prisma.agentBudgetEvent.count({
+      where: { eventKind: "rejected", createdAt: { gte: since } },
+    });
+  } catch {
+    return 0;
+  }
+}

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -1374,10 +1374,12 @@ export async function runBuildOrchestrator(params: {
         verificationOut: updatedBuild.verificationOut,
       });
       if (gate.allowed) {
-        // EP-COST Phase 3: record build-phase cost rollup before transitioning.
+        // EP-COST Phase 3: record build-phase cost rollup and compact thread before review starts.
         const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
         void completeBuildPhaseRun(buildId, "build");
         void startBuildPhaseRun(buildId, "review");
+        const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
+        void persistPhaseHandoffSummary(parentThreadId, "build");
         await prisma.featureBuild.update({ where: { buildId }, data: { phase: "review" } });
         await queueBuildReviewVerification(buildId);
         agentEventBus.emit(parentThreadId, { type: "phase:change", buildId, phase: "review" });

--- a/apps/web/lib/integrate/phase-compaction-wire.ts
+++ b/apps/web/lib/integrate/phase-compaction-wire.ts
@@ -1,0 +1,68 @@
+// apps/web/lib/integrate/phase-compaction-wire.ts
+//
+// EP-COST Phase 3: wiring helper for phase-boundary compaction.
+//
+// Called at phase transition points (ideate→plan, plan→build) to:
+//   1. Fetch the last N messages from the coworker thread
+//   2. Call compactPhase() to summarize them
+//   3. Persist the summary as a "system" AgentMessage so the next
+//      specialist sees it at the top of the new phase context
+//
+// Fire-and-forget from all callsites — errors are swallowed so a DB
+// hiccup never blocks the phase transition.
+
+import { prisma } from "@dpf/db";
+import type { ChatMessage } from "@/lib/ai-inference";
+
+/** Maximum number of thread messages to include in the phase summary. */
+const PHASE_WINDOW_SIZE = 40;
+
+/**
+ * Summarize the coworker thread for the completed phase and persist the
+ * result as a system message so the next specialist's first turn carries
+ * a concise handoff rather than the raw full history.
+ *
+ * @param threadId  - Active coworker thread ID
+ * @param phase     - Phase that just COMPLETED (e.g. "ideate" when going ideate→plan)
+ */
+export async function persistPhaseHandoffSummary(
+  threadId: string,
+  phase: string,
+): Promise<void> {
+  try {
+    const { compactPhase } = await import("@/lib/integrate/phase-compaction");
+
+    // Fetch the most recent messages from this thread for the summary window
+    const rows = await prisma.agentMessage.findMany({
+      where: { threadId },
+      orderBy: { createdAt: "desc" },
+      take: PHASE_WINDOW_SIZE,
+      select: { role: true, content: true },
+    });
+
+    if (rows.length === 0) return;
+
+    // Reverse to chronological order and map to ChatMessage[]
+    const messages: ChatMessage[] = rows.reverse().map((r) => ({
+      role: r.role as ChatMessage["role"],
+      content: r.content,
+    }));
+
+    const handoff = await compactPhase(phase, messages);
+
+    // Persist the handoff summary as a system message in the thread.
+    // Role "system" is used so it appears as a context injection rather
+    // than a user turn — the coworker's history loader includes it.
+    await prisma.agentMessage.create({
+      data: {
+        threadId,
+        role: "system",
+        content: typeof handoff.content === "string"
+          ? handoff.content
+          : JSON.stringify(handoff.content),
+      },
+    });
+  } catch (err) {
+    console.warn("[phase-compaction-wire] Failed to persist phase handoff:", { threadId, phase }, err);
+  }
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -6681,10 +6681,14 @@ export async function executeTool(
             happyPathState,
           });
           if (gate.allowed) {
-            // EP-COST Phase 3: record ideate-phase cost rollup and start plan-phase tracking
+            // EP-COST Phase 3: record ideate-phase cost rollup, start plan tracking, and compact thread
             const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
             void completeBuildPhaseRun(buildId, "ideate");
             void startBuildPhaseRun(buildId, "plan");
+            if (context?.threadId) {
+              const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
+              void persistPhaseHandoffSummary(context.threadId, "ideate");
+            }
             await prisma.featureBuild.update({ where: { buildId }, data: { phase: "plan" } });
             if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "plan" });
             logBuildActivity(buildId, "phase:advance", "Phase advanced: ideate → plan");
@@ -6842,10 +6846,14 @@ export async function executeTool(
                 logBuildActivity(buildId, "phase:gate-blocked", "Auto-advance to build blocked: sandbox not running. Start the sandbox, then call start_build.");
               } else {
                 await startBuildBranch(buildId);
-                // EP-COST Phase 3: record plan-phase cost rollup and start build-phase tracking
+                // EP-COST Phase 3: record plan-phase cost rollup, start build tracking, and compact thread
                 const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
                 void completeBuildPhaseRun(buildId, "plan");
                 void startBuildPhaseRun(buildId, "build");
+                if (context?.threadId) {
+                  const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
+                  void persistPhaseHandoffSummary(context.threadId, "plan");
+                }
                 await prisma.featureBuild.update({ where: { buildId }, data: { phase: "build" } });
                 if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "build" });
                 logBuildActivity(buildId, "phase:advance", "Phase advanced: plan → build (buildBranch initialized)");


### PR DESCRIPTION
## Summary

**Phase 2 UI completion:**
- `budget-events-data.ts`: `getRecentBudgetEvents()` (warning_95 + rejected from last 7 days, capped 50) + `countRecentRejections()` (24h window for banner severity)
- `AgentBudgetEventsPanel`: table of threshold crossings on Admin > AI Providers — agent ID, event kind pill (amber/red), token count, estimated cost, relative time. Hidden when no events exist. Links to `agent_registry.json` config for limit management
- Wired into providers page alongside `CliPoolStatusPanel`

**Phase 3 production wiring:**
- `phase-compaction-wire.ts`: `persistPhaseHandoffSummary(threadId, phase)` — fetches last 40 messages from coworker thread, calls `compactPhase()`, persists result as `role: "system"` AgentMessage so next specialist's first turn gets a concise handoff
- Wired at three transitions (fire-and-forget, non-fatal):
  - `mcp-tools.ts` reviewDesignDoc gate → ideate handoff before plan starts
  - `mcp-tools.ts` reviewBuildPlan gate → plan handoff before build starts
  - `build-orchestrator.ts` build→review → build handoff before review starts

This closes the loop between Phase 3 (the `compactPhase` utility) and the live Build Studio phase transitions — the summaries now actually fire in production.

## Part of EP-COST-001 (AI Cost Governance)
- Phase 1 (observability): PR #875 ✅
- Phase 2 (budget gate + costTier): PR #894 ✅; **Phase 2 UI: this PR**
- Phase 3 (context compaction): PR #897 ✅; **Phase 3 production wiring: this PR**
- Phase 4 (CLI pool visibility): PR #899 ✅
- Phase 5 (schema completion + BuildPhaseRun): PR #900 (CI running)

## Test plan
- [x] TypeScript pre-commit check passes clean
- [x] All new code is fire-and-forget / non-fatal — budget DB error or compaction failure never blocks a phase transition
- [x] `AgentBudgetEventsPanel` renders nothing when `events.length === 0` (no noise on clean installs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)