### PR TITLE
fix(wiki): strip backslash slugs that duplicate principles on Windows

### DIFF
--- a/packages/db/prisma/migrations/20260521120000_fix_wiki_backslash_slug_duplicates/migration.sql
+++ b/packages/db/prisma/migrations/20260521120000_fix_wiki_backslash_slug_duplicates/migration.sql
@@ -1,0 +1,13 @@
+-- Fix: Wiki principles duplicated on Windows due to backslash slugs
+--
+-- Root cause: seed-wiki-kernel.ts deriveSlug() stripped leading '/' but not '\'
+-- so on Windows every principle was seeded twice:
+--   once with slug '\principles\all-changes-land-via-pr'  (backslash, Windows)
+--   once with slug  'principles/all-changes-land-via-pr'  (forward slash, correct)
+--
+-- This migration deletes the backslash-slug rows. The correct forward-slash rows
+-- remain. The seed fix (deriveSlug now normalises \ → /) prevents recurrence.
+
+DELETE FROM "WikiPage"
+WHERE slug LIKE '\%'        -- slug starts with a backslash
+   OR slug LIKE '%\%';     -- or contains a backslash anywhere

--- a/packages/db/src/seed-wiki-kernel.ts
+++ b/packages/db/src/seed-wiki-kernel.ts
@@ -284,9 +284,11 @@ function walkMarkdownFiles(dir: string): string[] {
  */
 export function deriveSlug(absolutePath: string, baseDir: string): string {
   const rel = absolutePath.startsWith(baseDir)
-    ? absolutePath.slice(baseDir.length).replace(/^\/+/, "")
+    ? absolutePath.slice(baseDir.length).replace(/^[/\\]+/, "")
     : absolutePath;
-  return rel.replace(/\.md$/, "");
+  // Normalise Windows backslashes to forward slashes so slugs are
+  // consistent across platforms and the upsert key never duplicates.
+  return rel.replace(/\\/g, "/").replace(/\.md$/, "");
 }
 
 // ─── Seed: Raw Sources ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Every principle in the Wiki was appearing twice — 98 entries instead of ~49
- **Root cause:** `deriveSlug()` in `seed-wiki-kernel.ts` used `/^\/+/` to strip the leading path separator, which only matches forward slashes. On Windows, `path.join()` produces backslashes, so slugs were created as `\principles\all-changes-land-via-pr`. When the portal restarted and re-seeded, it produced the correct forward-slash slug — the unique key `(organizationId, slug)` treated them as two distinct rows, doubling every entry.
- **Seed fix:** strip both `\` and `/` from the leading edge; normalise all remaining backslashes to `/`
- **DB fix:** migration deletes all `WikiPage` rows whose slug contains a backslash; the correct forward-slash rows are retained

## Test plan

- [ ] Wiki page shows ~49 principles (not 98)
- [ ] Re-running the seed does not re-create duplicates
- [ ] Principles with forward-slash slugs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)