### PR TITLE
fix(portal-context): AttentionChip yellow-on-yellow — tint state backgrounds

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -16,8 +16,14 @@
   --dpf-success: #16a34a;
   --dpf-warning: #d97706;
   --dpf-error: #dc2626;
-  --dpf-state-warning: var(--dpf-warning);
-  --dpf-state-error: var(--dpf-error);
+  /* State backgrounds are TINTED versions of the foreground color so chips can
+     pair fg + bg without becoming a solid color block (e.g. AttentionChip in
+     PortalContextStrip). Use color-mix to derive a subtle background while
+     preserving the surface beneath. */
+  --dpf-state-warning: color-mix(in srgb, var(--dpf-warning) 13%, var(--dpf-surface-1));
+  --dpf-state-error: color-mix(in srgb, var(--dpf-error) 13%, var(--dpf-surface-1));
+  --dpf-state-info: color-mix(in srgb, var(--dpf-info) 13%, var(--dpf-surface-1));
+  --dpf-state-success: color-mix(in srgb, var(--dpf-success) 13%, var(--dpf-surface-1));
   --dpf-info: #0284c7;
   --dpf-font-body: Inter, system-ui, sans-serif;
   --dpf-font-heading: Inter, system-ui, sans-serif;
@@ -40,8 +46,11 @@
     --dpf-success: #4ade80;
     --dpf-warning: #fbbf24;
     --dpf-error: #f87171;
-    --dpf-state-warning: var(--dpf-warning);
-    --dpf-state-error: var(--dpf-error);
+    /* See light-mode comment above — tinted backgrounds preserve fg/bg contrast. */
+    --dpf-state-warning: color-mix(in srgb, var(--dpf-warning) 18%, var(--dpf-surface-1));
+    --dpf-state-error: color-mix(in srgb, var(--dpf-error) 18%, var(--dpf-surface-1));
+    --dpf-state-info: color-mix(in srgb, var(--dpf-info) 18%, var(--dpf-surface-1));
+    --dpf-state-success: color-mix(in srgb, var(--dpf-success) 18%, var(--dpf-surface-1));
     --dpf-info: #38bdf8;
   }
 }

--- a/apps/web/components/portal-context/PortalContextStrip.test.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.test.tsx
@@ -16,9 +16,47 @@ describe("PortalContextStrip", () => {
     expect(html).toContain("border-[var(--dpf-border)]");
     expect(html).not.toMatch(/text-gray|bg-white|#[0-9a-fA-F]{3,6}/);
   });
+
+  it("warning AttentionChip does NOT use the same token for background and foreground (regression: yellow-on-yellow chip)", () => {
+    // Repro: AttentionChip rendered a solid yellow rectangle because
+    // bg-[var(--dpf-state-warning)] resolved to the same CSS variable as
+    // text-[var(--dpf-warning)] (--dpf-state-warning was aliased to --dpf-warning).
+    // The token separation lives in globals.css; this assertion pins the
+    // component contract so a future refactor can't reintroduce the alias.
+    const html = renderToStaticMarkup(<PortalContextStrip envelope={makeEnvelope({
+      attention: [{
+        kind: "lease_expired",
+        severity: "warning",
+        message: "Work capsule lease expired.",
+      }],
+    })} />);
+
+    // The chip must render and use distinct fg/bg tokens.
+    expect(html).toContain("bg-[var(--dpf-state-warning)]");
+    expect(html).toContain("text-[var(--dpf-warning)]");
+    // Must not collapse to a single var-source (the bug).
+    expect(html).not.toMatch(/bg-\[var\(--dpf-warning\)\][^"]*text-\[var\(--dpf-warning\)\]/);
+    // And the signal label must be in the DOM so the chip isn't visually empty.
+    expect(html).toContain("lease expired");
+  });
+
+  it("error AttentionChip uses distinct fg/bg tokens (same class of bug)", () => {
+    const html = renderToStaticMarkup(<PortalContextStrip envelope={makeEnvelope({
+      attention: [{
+        kind: "missing_evidence",
+        severity: "error",
+        message: "Required design doc is missing.",
+      }],
+    })} />);
+
+    expect(html).toContain("bg-[var(--dpf-state-error)]");
+    expect(html).toContain("text-[var(--dpf-error)]");
+    expect(html).not.toMatch(/bg-\[var\(--dpf-error\)\][^"]*text-\[var\(--dpf-error\)\]/);
+    expect(html).toContain("Missing evidence");
+  });
 });
 
-function makeEnvelope(): PortalContextEnvelope {
+function makeEnvelope(overrides: Partial<PortalContextEnvelope> = {}): PortalContextEnvelope {
   return {
     envelopeId: "env-1",
     resolvedAt: "2026-05-17T18:23:30.000Z",
@@ -68,5 +106,6 @@ function makeEnvelope(): PortalContextEnvelope {
       },
     ],
     promptDigest: "Route: /build\nAttention: no_active_build(info)",
+    ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

The \`AttentionChip\` in \`PortalContextStrip\` was rendering as a **solid yellow rectangle** in the Build Studio header (noticed against \`FB-5222FED1\`). Root cause: theme tokens for warning/error states were aliased to their foreground colors:

\`\`\`css
--dpf-state-warning: var(--dpf-warning);
--dpf-state-error:   var(--dpf-error);
\`\`\`

So when the chip applied \`bg-[var(--dpf-state-warning)] + text-[var(--dpf-warning)]\` plus an \`AlertTriangle\` icon using \`currentColor\`, the background, text, and icon all resolved to the same yellow → empty yellow block.

## Fix

State backgrounds are now subtle tinted versions of the foreground via \`color-mix\`:

\`\`\`css
--dpf-state-warning: color-mix(in srgb, var(--dpf-warning) 13%, var(--dpf-surface-1));
--dpf-state-error:   color-mix(in srgb, var(--dpf-error)   13%, var(--dpf-surface-1));
--dpf-state-info:    color-mix(in srgb, var(--dpf-info)    13%, var(--dpf-surface-1));
--dpf-state-success: color-mix(in srgb, var(--dpf-success) 13%, var(--dpf-surface-1));
\`\`\`

Light mode uses 13%, dark mode 18% — matches the pattern \`StalenessIndicator\` already uses for its warning chip. Same dormant bug existed for \`--dpf-state-error\`; fixed at the same time. Adds \`--dpf-state-info\` and \`--dpf-state-success\` while the door is open so future status surfaces don't trip the same wire.

## Regression test

Two new assertions in \`PortalContextStrip.test.tsx\` pin the chip contract:

- Warning chip references \`bg-[var(--dpf-state-warning)]\` and \`text-[var(--dpf-warning)]\` as **distinct** tokens (regex rules out the bg→fg alias collapsing).
- Signal label is in the DOM (chip is visually non-empty).
- Same pair of assertions for the error severity.

Local vitest can't run from this worktree (path/JSX transform), so CI will run the real test.

## Why this is its own PR

Independent of the layout redesign work (PR #903). The fix touches CSS tokens + a portal-context component, lands cleanly on its own, and the new layout surfaces will inherit the fix once merged.

## Test plan

- [ ] CI vitest passes for \`PortalContextStrip.test.tsx\` (2 new assertions on warning + error chip)
- [ ] CI typecheck passes
- [ ] Manual check on the build view: the yellow rectangle next to WC-* in the portal context strip now shows the AlertTriangle icon + signal label clearly on a subtle tinted background
- [ ] No regression on existing \`StalenessIndicator\` or other components using \`var(--dpf-warning)\` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)