### PR TITLE
ci(schema-regression-guard): ignore whitespace-only diffs (-w)

### DIFF
--- a/.github/workflows/schema-regression-guard.yml
+++ b/.github/workflows/schema-regression-guard.yml
@@ -30,8 +30,14 @@ jobs:
           #   - Prisma field definitions (2-space indent + identifier)
           #   - model / enum declarations
           # "+" lines and diff headers are excluded.
+          #
+          # `-w` suppresses pairs where the line content is unchanged modulo
+          # whitespace — those are formatter / column-alignment edits, not
+          # real field removals. A genuine drop (or a type / attribute change)
+          # still produces non-whitespace-equivalent +/- pairs, which awk
+          # still reports.
           REMOVED=$(
-            git diff origin/main...HEAD -- packages/db/prisma/schema.prisma \
+            git diff -w origin/main...HEAD -- packages/db/prisma/schema.prisma \
               | awk '/^-/ && !/^---/ && (/^-  [a-zA-Z@]/ || /^-(model|enum) /) { print }'
           )
 


### PR DESCRIPTION
## Summary

The Schema Regression Guard was firing on PR #901 even though that PR was a pure whitespace revert with zero semantic schema change (token-level diff confirmed 0 lines of difference). Root cause: the guard does a plain `git diff origin/main...HEAD` and treats any `-` line matching a Prisma field pattern as a field removal — without checking whether a corresponding `+` line exists with different padding.

This PR adds `-w` to the `git diff` invocation so whitespace-only reformats no longer fire the guard. Real regressions (field drops, type changes, attribute changes) still produce non-whitespace-equivalent diff lines and are still caught.

## Why this is safe

The guard's stated intent (per its own header comment) is to catch stale-sandbox field drops where a Build Studio sandbox image regenerates the schema from an older snapshot and accidentally loses fields. That scenario produces real content drops, not whitespace nudges — `-w` doesn't affect detection of it.

The only thing `-w` suppresses is the case where the same field appears with different whitespace on both sides of the diff. That's a formatter / column-alignment change, not a regression.

## Verification

Ran the guard's awk pipeline locally against PR #901's diff (the canonical false-positive):

```bash
git diff -w origin/main...HEAD -- packages/db/prisma/schema.prisma \
  | awk '/^-/ && !/^---/ && (/^-  [a-zA-Z@]/ || /^-(model|enum) /) { print }'
```

Output: empty. Without `-w`, this produced 534 false-positive lines.

## Test plan

- [x] Local re-run of the guard awk pipeline on PR #901's pre-merge diff: 0 hits (was 534)
- [ ] CI re-runs and passes on this PR (single-file change in `.github/workflows/`)

## Followup

Convention to document elsewhere (per the conversation that produced #895 → #901): **don't run `npx prisma format` on schema.prisma changes that don't intentionally restyle the whole file.** The schema's existing column alignment is hand-curated and the format tool's choices diverge from it. The guard's `-w` flag is a safety net, not a license to reformat freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)