### PR TITLE
feat(ep-cost): accurate per-model pricing + Finance AP actual spend wiring

### DIFF
--- a/apps/web/components/finance/AiSpendWorkspace.tsx
+++ b/apps/web/components/finance/AiSpendWorkspace.tsx
@@ -24,7 +24,13 @@ export function AiSpendWorkspace({
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <Metric label="AI suppliers" value={`${overview.supplierCount}`} />
         <Metric label="Committed spend" value={`${currencySymbol}${formatMoney(overview.committedSpend)}`} />
-        <Metric label="Needs setup" value={`${overview.contractsNeedingSetup}`} />
+        {/* EP-COST: actual metered API spend this month from AdapterRunTelemetry */}
+        <Metric
+          label="Metered spend MTD"
+          value={`${currencySymbol}${formatMoney(overview.actualMeteredSpendUsd)}`}
+          subtext={`${overview.inferenceCallsThisMonth.toLocaleString()} API calls`}
+          highlight={overview.actualMeteredSpendUsd > overview.committedSpend * 0.8}
+        />
         <Metric label="Open work items" value={`${overview.openWorkItems}`} />
       </div>
 
@@ -44,8 +50,9 @@ export function AiSpendWorkspace({
               <tr className="border-b border-[var(--dpf-border)] text-left">
                 <th className="px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Provider</th>
                 <th className="px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Supplier</th>
-                <th className="px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Commitment</th>
-                <th className="px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Latest utilization</th>
+                <th className="px-3 py-2 text-right text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Commitment</th>
+                <th className="px-3 py-2 text-right text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Metered MTD</th>
+                <th className="px-3 py-2 text-right text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Utilization</th>
                 <th className="px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)] font-normal">Work items</th>
               </tr>
             </thead>
@@ -53,6 +60,9 @@ export function AiSpendWorkspace({
               {rows.map((row) => {
                 const latestContract = row.supplierContracts[0] ?? null;
                 const latestSnapshot = latestContract?.usageSnapshots[0] ?? null;
+                const committed = Number(latestContract?.monthlyCommittedAmount ?? 0);
+                const metered = row.actualSpendMtd.costUsd;
+                const overCommitment = committed > 0 && metered > committed;
                 return (
                   <tr key={row.id} className="border-b border-[var(--dpf-border)] last:border-0">
                     <td className="px-3 py-3 text-[var(--dpf-text)]">
@@ -67,11 +77,20 @@ export function AiSpendWorkspace({
                         </a>
                       ) : "Not linked"}
                     </td>
-                    <td className="px-3 py-3 text-[var(--dpf-text)]">
-                      {currencySymbol}{formatMoney(Number(latestContract?.monthlyCommittedAmount ?? 0))}
+                    <td className="px-3 py-3 text-right text-[var(--dpf-text)]">
+                      {committed > 0 ? `${currencySymbol}${formatMoney(committed)}` : <span className="text-[var(--dpf-muted)]">—</span>}
                     </td>
-                    <td className="px-3 py-3 text-[var(--dpf-text)]">
-                      {latestSnapshot ? `${latestSnapshot.utilizationPct?.toFixed(1) ?? "0.0"}%` : "No data"}
+                    <td className={`px-3 py-3 text-right font-medium ${overCommitment ? "text-[var(--dpf-error,#ef4444)]" : metered > 0 ? "text-[var(--dpf-text)]" : "text-[var(--dpf-muted)]"}`}>
+                      {metered > 0 ? (
+                        <span title={`${row.actualSpendMtd.calls.toLocaleString()} API calls`}>
+                          {currencySymbol}{formatMoney(metered)}
+                        </span>
+                      ) : (
+                        <span className="text-[var(--dpf-muted)] text-[10px]">subscription</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-right text-[var(--dpf-text)]">
+                      {latestSnapshot ? `${latestSnapshot.utilizationPct?.toFixed(1) ?? "0.0"}%` : "—"}
                     </td>
                     <td className="px-3 py-3 text-[var(--dpf-muted)]">{row.financeWorkItems.length}</td>
                   </tr>
@@ -85,11 +104,17 @@ export function AiSpendWorkspace({
   );
 }
 
-function Metric({ label, value }: { label: string; value: string }) {
+function Metric({ label, value, subtext, highlight }: {
+  label: string;
+  value: string;
+  subtext?: string;
+  highlight?: boolean;
+}) {
   return (
-    <div className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+    <div className={`rounded-xl border p-4 ${highlight ? "border-[var(--dpf-warning,#f59e0b)] bg-[var(--dpf-warning-surface,#fffbeb)]" : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"}`}>
       <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">{label}</p>
-      <p className="mt-2 text-lg font-semibold text-[var(--dpf-text)]">{value}</p>
+      <p className={`mt-2 text-lg font-semibold ${highlight ? "text-[var(--dpf-warning-text,#92400e)]" : "text-[var(--dpf-text)]"}`}>{value}</p>
+      {subtext && <p className="mt-0.5 text-[10px] text-[var(--dpf-muted)]">{subtext}</p>}
     </div>
   );
 }

--- a/apps/web/lib/finance/ai-provider-finance.ts
+++ b/apps/web/lib/finance/ai-provider-finance.ts
@@ -258,7 +258,11 @@ export async function createContractUsageSnapshot(input: CreateContractUsageSnap
 }
 
 export async function getAiSpendOverview() {
-  const [profiles, contracts, workItems, snapshots] = await Promise.all([
+  // Current month window for actual spend aggregation
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+  const [profiles, contracts, workItems, snapshots, actualSpendAgg] = await Promise.all([
     prisma.aiProviderFinanceProfile.count(),
     prisma.supplierContract.findMany({
       where: { status: { in: ["draft", "active"] } },
@@ -276,11 +280,27 @@ export async function getAiSpendOverview() {
       take: 20,
       select: { projectedUnusedValue: true },
     }),
+    // EP-COST: Aggregate actual token spend from AdapterRunTelemetry for the current month.
+    // estimatedCostUsd is populated by computeTokenCost() using per-model pricing from ModelProfile.
+    // Subscription providers (anthropic-sub, chatgpt) show $0 here — their fixed monthly cost
+    // is captured in the SupplierContract.monthlyCommittedAmount below.
+    prisma.adapterRunTelemetry.aggregate({
+      where: {
+        startedAt: { gte: monthStart },
+        estimatedCostUsd: { not: null },
+      },
+      _sum: { estimatedCostUsd: true },
+      _count: { id: true },
+    }),
   ]);
 
   const committedSpend = contracts.reduce((sum, contract) => sum + Number(contract.monthlyCommittedAmount ?? 0), 0);
   const contractsNeedingSetup = contracts.filter((contract) => contract.status === "draft").length;
   const projectedUnusedCommitment = snapshots.reduce((sum, snapshot) => sum + Number(snapshot.projectedUnusedValue ?? 0), 0);
+
+  // Actual metered API spend this month (excludes subscription providers at $0/call)
+  const actualMeteredSpendUsd = Number(actualSpendAgg._sum.estimatedCostUsd ?? 0);
+  const inferenceCallsThisMonth = actualSpendAgg._count.id ?? 0;
 
   return {
     supplierCount: profiles,
@@ -288,11 +308,35 @@ export async function getAiSpendOverview() {
     contractsNeedingSetup,
     openWorkItems: workItems,
     projectedUnusedCommitment,
+    // EP-COST additions: actual spend from inference telemetry
+    actualMeteredSpendUsd,
+    inferenceCallsThisMonth,
+    monthStart,
   };
 }
 
 export async function listAiProviderFinanceProfiles() {
-  return prisma.aiProviderFinanceProfile.findMany({
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+  // EP-COST: per-provider actual metered spend this month from AdapterRunTelemetry
+  const spendByProvider = await prisma.adapterRunTelemetry.groupBy({
+    by: ["providerId"],
+    where: {
+      startedAt: { gte: monthStart },
+      estimatedCostUsd: { not: null },
+    },
+    _sum: { estimatedCostUsd: true },
+    _count: { id: true },
+  });
+  const spendMap = new Map(
+    spendByProvider.map((r) => [
+      r.providerId,
+      { costUsd: Number(r._sum.estimatedCostUsd ?? 0), calls: r._count.id },
+    ]),
+  );
+
+  const profiles = await prisma.aiProviderFinanceProfile.findMany({
     include: {
       provider: {
         select: {
@@ -327,6 +371,12 @@ export async function listAiProviderFinanceProfiles() {
     },
     orderBy: { updatedAt: "desc" },
   });
+
+  // Attach actual spend data to each profile row
+  return profiles.map((p) => ({
+    ...p,
+    actualSpendMtd: spendMap.get(p.providerId) ?? { costUsd: 0, calls: 0 },
+  }));
 }
 
 export async function getAiProviderFinanceDetail(providerId: string) {

--- a/apps/web/lib/inference/budget-gate.ts
+++ b/apps/web/lib/inference/budget-gate.ts
@@ -69,6 +69,51 @@ export type BudgetEventKind =
  * Persists an AgentBudgetEvent row. Fire-and-forget — a DB error here must
  * never block an inference call.
  */
+/**
+ * Resolve the blended per-token cost for a given model/provider pair.
+ * Prefers ModelProfile.inputPricePerMToken when available; falls back to
+ * ModelProvider.inputPricePerMToken; falls back to $3/MTok blended average.
+ * Returns cost-per-token (not per-million-token).
+ */
+async function resolveBlendedCostPerToken(
+  providerId: string | undefined,
+  modelId: string | undefined,
+): Promise<number> {
+  const FALLBACK_PER_MTOKEN = 3; // $3/MTok — conservative blended average
+  try {
+    if (providerId && modelId) {
+      const profile = await prisma.modelProfile.findUnique({
+        where: { providerId_modelId: { providerId, modelId } },
+        select: { inputPricePerMToken: true, outputPricePerMToken: true },
+      });
+      const profileInput = profile?.inputPricePerMToken;
+      const profileOutput = profile?.outputPricePerMToken;
+      if (profileInput != null && profileOutput != null) {
+        // Blended: assume ~60% input, ~40% output (typical for inference workloads)
+        return ((profileInput * 0.6 + profileOutput * 0.4) / 1_000_000);
+      }
+    }
+    if (providerId) {
+      const provider = await prisma.modelProvider.findUnique({
+        where: { providerId },
+        select: { inputPricePerMToken: true, outputPricePerMToken: true },
+      });
+      const inp = provider?.inputPricePerMToken;
+      const out = provider?.outputPricePerMToken;
+      if (inp != null && out != null) {
+        return ((inp * 0.6 + out * 0.4) / 1_000_000);
+      }
+    }
+  } catch {
+    // Non-fatal — fall through to fallback
+  }
+  return FALLBACK_PER_MTOKEN / 1_000_000;
+}
+
+/**
+ * Persists an AgentBudgetEvent row. Fire-and-forget — a DB error here must
+ * never block an inference call.
+ */
 export async function writeBudgetEvent(params: {
   agentId: string;
   eventKind: BudgetEventKind;
@@ -78,7 +123,9 @@ export async function writeBudgetEvent(params: {
   providerId?: string;
   buildRunId?: string;
 }): Promise<void> {
-  const costPerToken = 0.000_015; // rough $15/MTok average as a placeholder
+  // Resolve the actual blended cost rate for this model/provider pair.
+  // Falls back through: ModelProfile → ModelProvider → $3/MTok blended average.
+  const costPerToken = await resolveBlendedCostPerToken(params.providerId, params.modelId);
   await prisma.agentBudgetEvent.create({
     data: {
       agentId: params.agentId,

--- a/packages/db/data/model-profiles.json
+++ b/packages/db/data/model-profiles.json
@@ -6,11 +6,14 @@
     "modelStatus": "retired",
     "retiredReason": "Claude 3 Haiku returns empty responses via subscription OAuth — use Haiku 4.5 instead",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
-    "avoidFor": ["complex tasks", "tool use via subscription"],
+    "avoidFor": [
+      "complex tasks",
+      "tool use via subscription"
+    ],
     "contextWindow": null,
     "speedRating": null,
     "supportsToolUse": false,
@@ -67,8 +70,8 @@
     "instructionFollowingScore": 55,
     "maxContextTokens": 200000,
     "maxOutputTokens": 4096,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "qualityTier": "adequate",
@@ -88,8 +91,13 @@
     "friendlyName": "Claude Sonnet 4.6",
     "modelStatus": "active",
     "capabilityCategory": "frontier",
-    "costTier": "$$",
-    "bestFor": ["code generation", "complex reasoning", "analysis", "platform tool use"],
+    "costTier": "standard",
+    "bestFor": [
+      "code generation",
+      "complex reasoning",
+      "analysis",
+      "platform tool use"
+    ],
     "avoidFor": [],
     "contextWindow": "200k",
     "speedRating": "fast",
@@ -118,7 +126,9 @@
     "structuredOutputScore": 93,
     "conversational": 95,
     "contextRetention": 95,
-    "summary": "Claude Sonnet 4.6 by Anthropic - best balance of speed and capability"
+    "summary": "Claude Sonnet 4.6 by Anthropic - best balance of speed and capability",
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0
   },
   {
     "providerId": "anthropic-sub",
@@ -126,8 +136,13 @@
     "friendlyName": "Claude Opus 4.6",
     "modelStatus": "active",
     "capabilityCategory": "frontier",
-    "costTier": "$$$",
-    "bestFor": ["deep reasoning", "complex code", "architecture", "long context"],
+    "costTier": "critical",
+    "bestFor": [
+      "deep reasoning",
+      "complex code",
+      "architecture",
+      "long context"
+    ],
     "avoidFor": [],
     "contextWindow": "200k",
     "speedRating": "moderate",
@@ -156,7 +171,9 @@
     "structuredOutputScore": 93,
     "conversational": 95,
     "contextRetention": 95,
-    "summary": "Claude Opus 4.6 by Anthropic - most capable model for complex tasks"
+    "summary": "Claude Opus 4.6 by Anthropic - most capable model for complex tasks",
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0
   },
   {
     "providerId": "anthropic-sub",
@@ -164,11 +181,16 @@
     "friendlyName": "Claude Haiku 4.5",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
-      "general purpose tasks", "fast responses", "simple platform tool use"
+      "general purpose tasks",
+      "fast responses",
+      "simple platform tool use"
     ],
-    "avoidFor": ["complex code generation", "deep reasoning"],
+    "avoidFor": [
+      "complex code generation",
+      "deep reasoning"
+    ],
     "contextWindow": null,
     "speedRating": null,
     "supportsToolUse": true,
@@ -178,7 +200,8 @@
     "modelClass": "chat",
     "maxInputTokens": 200000,
     "inputModalities": [
-      "text", "image"
+      "text",
+      "image"
     ],
     "outputModalities": [
       "text"
@@ -225,14 +248,15 @@
     "instructionFollowingScore": 75,
     "maxContextTokens": 200000,
     "maxOutputTokens": 8192,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "qualityTier": "strong",
     "supportedModalities": {
       "input": [
-        "text", "image"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -246,7 +270,7 @@
     "friendlyName": "GPT-5.4 (ChatGPT Subscription)",
     "modelStatus": "active",
     "capabilityCategory": "advanced",
-    "costTier": "subscription",
+    "costTier": "critical",
     "bestFor": [
       "conversation",
       "coding",
@@ -289,8 +313,8 @@
     "toolFidelity": 10,
     "maxContextTokens": 128000,
     "maxOutputTokens": 16384,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -303,73 +327,73 @@
     },
     "summary": "GPT-5.4 (ChatGPT Subscription) by ChatGPT - optimized for conversation"
   },
-    {
-      "providerId": "codex",
-      "modelId": "gpt-5.3-codex",
-      "friendlyName": "GPT-5 Codex",
-      "modelStatus": "active",
-      "capabilityCategory": "advanced",
-      "costTier": "$$$",
-      "bestFor": [
-        "coding",
-        "reasoning",
-        "agentic-tasks"
-      ],
-      "avoidFor": [
-        "conversation"
-      ],
-      "contextWindow": null,
-      "speedRating": null,
-      "supportsToolUse": true,
-      "codingCapability": null,
-      "instructionFollowing": null,
-      "modelFamily": "codex",
-      "modelClass": "code",
-      "maxInputTokens": null,
-      "inputModalities": [
-        "text"
-      ],
-      "outputModalities": [
-        "text"
-      ],
-      "capabilities": {
-        "toolUse": true,
-        "streaming": true,
-        "imageInput": false,
-        "structuredOutput": true
-      },
-      "pricing": {},
-      "instructType": null,
-      "trainingDataCutoff": null,
-      "codegen": 96,
-      "contextRetention": 78,
-      "conversational": 50,
-      "reasoning": 88,
-      "structuredOutputScore": 84,
-      "toolFidelity": 90,
-      "maxContextTokens": 128000,
-      "maxOutputTokens": 16384,
-      "inputPricePerMToken": null,
-      "outputPricePerMToken": null,
-      "profileConfidence": "medium",
-      "profileSource": "seed",
-      "supportedModalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "summary": "GPT-5 Codex by OpenAI Codex - flagship coding model"
+  {
+    "providerId": "codex",
+    "modelId": "gpt-5.3-codex",
+    "friendlyName": "GPT-5 Codex",
+    "modelStatus": "active",
+    "capabilityCategory": "advanced",
+    "costTier": "critical",
+    "bestFor": [
+      "coding",
+      "reasoning",
+      "agentic-tasks"
+    ],
+    "avoidFor": [
+      "conversation"
+    ],
+    "contextWindow": null,
+    "speedRating": null,
+    "supportsToolUse": true,
+    "codingCapability": null,
+    "instructionFollowing": null,
+    "modelFamily": "codex",
+    "modelClass": "code",
+    "maxInputTokens": null,
+    "inputModalities": [
+      "text"
+    ],
+    "outputModalities": [
+      "text"
+    ],
+    "capabilities": {
+      "toolUse": true,
+      "streaming": true,
+      "imageInput": false,
+      "structuredOutput": true
     },
+    "pricing": {},
+    "instructType": null,
+    "trainingDataCutoff": null,
+    "codegen": 96,
+    "contextRetention": 78,
+    "conversational": 50,
+    "reasoning": 88,
+    "structuredOutputScore": 84,
+    "toolFidelity": 90,
+    "maxContextTokens": 128000,
+    "maxOutputTokens": 16384,
+    "inputPricePerMToken": 5.0,
+    "outputPricePerMToken": 20.0,
+    "profileConfidence": "medium",
+    "profileSource": "seed",
+    "supportedModalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "summary": "GPT-5 Codex by OpenAI Codex - flagship coding model"
+  },
   {
     "providerId": "codex",
     "modelId": "codex-mini-latest",
     "friendlyName": "Codex Mini",
     "modelStatus": "disabled",
-      "capabilityCategory": "advanced",
-      "costTier": "$$",
+    "capabilityCategory": "advanced",
+    "costTier": "standard",
     "bestFor": [
       "coding",
       "agentic-tasks"
@@ -379,11 +403,11 @@
     ],
     "contextWindow": null,
     "speedRating": null,
-      "supportsToolUse": true,
-      "codingCapability": null,
-      "instructionFollowing": null,
-      "modelFamily": "codex",
-      "modelClass": "code",
+    "supportsToolUse": true,
+    "codingCapability": null,
+    "instructionFollowing": null,
+    "modelFamily": "codex",
+    "modelClass": "code",
     "maxInputTokens": null,
     "inputModalities": [
       "text"
@@ -408,8 +432,8 @@
     "toolFidelity": 85,
     "maxContextTokens": 128000,
     "maxOutputTokens": 16384,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.5,
+    "outputPricePerMToken": 6.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -428,7 +452,7 @@
     "friendlyName": "Deep Research Pro Preview (Dec-12-2025)",
     "modelStatus": "retired",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -467,8 +491,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -488,8 +512,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 131072,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -508,7 +532,7 @@
     "friendlyName": "Gemini 2.0 Flash",
     "modelStatus": "retired",
     "capabilityCategory": "strong",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -547,8 +571,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.075,
+      "outputPerMToken": 0.3,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -568,8 +592,8 @@
     "toolFidelity": 70,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.075,
+    "outputPricePerMToken": 0.3,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -588,7 +612,7 @@
     "friendlyName": "Gemini 2.0 Flash 001",
     "modelStatus": "active",
     "capabilityCategory": "strong",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -627,8 +651,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.075,
+      "outputPerMToken": 0.3,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -648,8 +672,8 @@
     "toolFidelity": 70,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.075,
+    "outputPricePerMToken": 0.3,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -668,7 +692,7 @@
     "friendlyName": "Gemini 2.0 Flash-Lite",
     "modelStatus": "retired",
     "capabilityCategory": "strong",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -707,8 +731,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.04,
+      "outputPerMToken": 0.15,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -728,8 +752,8 @@
     "toolFidelity": 70,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.04,
+    "outputPricePerMToken": 0.15,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -748,7 +772,7 @@
     "friendlyName": "Gemini 2.0 Flash-Lite 001",
     "modelStatus": "retired",
     "capabilityCategory": "strong",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -787,8 +811,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.04,
+      "outputPerMToken": 0.15,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -808,8 +832,8 @@
     "toolFidelity": 70,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.04,
+    "outputPricePerMToken": 0.15,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -828,7 +852,7 @@
     "friendlyName": "Gemini 2.5 Computer Use Preview 10-2025",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -867,8 +891,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -888,8 +912,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 131072,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -908,7 +932,7 @@
     "friendlyName": "Gemini 2.5 Flash",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -947,8 +971,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.075,
+      "outputPerMToken": 0.3,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -968,8 +992,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.075,
+    "outputPricePerMToken": 0.3,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -988,7 +1012,7 @@
     "friendlyName": "Nano Banana",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1027,8 +1051,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.075,
+      "outputPerMToken": 0.3,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1048,8 +1072,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 32768,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.075,
+    "outputPricePerMToken": 0.3,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -1068,7 +1092,7 @@
     "friendlyName": "Gemini 2.5 Flash-Lite",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1107,8 +1131,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.04,
+      "outputPerMToken": 0.15,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1128,8 +1152,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.04,
+    "outputPricePerMToken": 0.15,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1148,7 +1172,7 @@
     "friendlyName": "Gemini 2.5 Flash-Lite Preview Sep 2025",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1187,8 +1211,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.04,
+      "outputPerMToken": 0.15,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1208,8 +1232,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.04,
+    "outputPricePerMToken": 0.15,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -1228,7 +1252,7 @@
     "friendlyName": "Gemini 2.5 Flash Preview TTS",
     "modelStatus": "retired",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1267,8 +1291,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.075,
+      "outputPerMToken": 0.3,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1288,8 +1312,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 8192,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.075,
+    "outputPricePerMToken": 0.3,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1308,7 +1332,7 @@
     "friendlyName": "Gemini 2.5 Pro",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1347,8 +1371,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1368,8 +1392,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1388,7 +1412,7 @@
     "friendlyName": "Gemini 2.5 Pro Preview TTS",
     "modelStatus": "retired",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1427,8 +1451,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1448,8 +1472,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 8192,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1468,7 +1492,7 @@
     "friendlyName": "Gemini 3 Flash Preview",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1507,8 +1531,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.1,
+      "outputPerMToken": 0.4,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1528,8 +1552,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.1,
+    "outputPricePerMToken": 0.4,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1548,7 +1572,7 @@
     "friendlyName": "Nano Banana Pro",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1587,8 +1611,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.5,
+      "outputPerMToken": 6.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1608,8 +1632,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 131072,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.5,
+    "outputPricePerMToken": 6.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1628,7 +1652,7 @@
     "friendlyName": "Gemini 3 Pro Preview",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1667,8 +1691,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.5,
+      "outputPerMToken": 6.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1688,8 +1712,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.5,
+    "outputPricePerMToken": 6.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -1708,7 +1732,7 @@
     "friendlyName": "Nano Banana 2",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1747,8 +1771,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.1,
+      "outputPerMToken": 0.4,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1768,8 +1792,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 65536,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.1,
+    "outputPricePerMToken": 0.4,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -1788,7 +1812,7 @@
     "friendlyName": "Gemini 3.1 Flash Lite Preview",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1827,8 +1851,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.04,
+      "outputPerMToken": 0.15,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1848,8 +1872,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.04,
+    "outputPricePerMToken": 0.15,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -1868,7 +1892,7 @@
     "friendlyName": "Gemini 3.1 Pro Preview",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1907,8 +1931,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.5,
+      "outputPerMToken": 6.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -1928,8 +1952,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.5,
+    "outputPricePerMToken": 6.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -1948,7 +1972,7 @@
     "friendlyName": "Gemini 3.1 Pro Preview Custom Tools",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -1987,8 +2011,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.5,
+      "outputPerMToken": 6.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -2008,8 +2032,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.5,
+    "outputPricePerMToken": 6.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -2028,7 +2052,7 @@
     "friendlyName": "Gemini Flash Latest",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2067,8 +2091,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.075,
+      "outputPerMToken": 0.3,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -2088,8 +2112,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.075,
+    "outputPricePerMToken": 0.3,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2108,7 +2132,7 @@
     "friendlyName": "Gemini Flash-Lite Latest",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2147,8 +2171,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 0.04,
+      "outputPerMToken": 0.15,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -2168,8 +2192,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.04,
+    "outputPricePerMToken": 0.15,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {
@@ -2188,7 +2212,7 @@
     "friendlyName": "Gemini Pro Latest",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2227,8 +2251,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -2248,8 +2272,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2268,7 +2292,7 @@
     "friendlyName": "Gemini Robotics-ER 1.5 Preview",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2307,8 +2331,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -2328,8 +2352,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 1048576,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2348,7 +2372,7 @@
     "friendlyName": "Gemma 3 12B",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2408,8 +2432,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 32768,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2428,7 +2452,7 @@
     "friendlyName": "Gemma 3 1B",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2488,8 +2512,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 32768,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2508,7 +2532,7 @@
     "friendlyName": "Gemma 3 27B",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2568,8 +2592,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 131072,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2588,7 +2612,7 @@
     "friendlyName": "Gemma 3 4B",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2648,8 +2672,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 32768,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2668,7 +2692,7 @@
     "friendlyName": "Gemma 3n E2B",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2728,8 +2752,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 8192,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2748,7 +2772,7 @@
     "friendlyName": "Gemma 3n E4B",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "routine",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2808,8 +2832,8 @@
     "toolFidelity": 33,
     "maxContextTokens": 8192,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 0.0,
+    "outputPricePerMToken": 0.0,
     "profileConfidence": "medium",
     "profileSource": "evaluated",
     "supportedModalities": {
@@ -2828,7 +2852,7 @@
     "friendlyName": "Nano Banana Pro",
     "modelStatus": "active",
     "capabilityCategory": "moderate",
-    "costTier": "$",
+    "costTier": "standard",
     "bestFor": [
       "general purpose tasks"
     ],
@@ -2867,8 +2891,8 @@
     "pricing": {
       "discount": null,
       "requestFixed": null,
-      "inputPerMToken": null,
-      "outputPerMToken": null,
+      "inputPerMToken": 1.25,
+      "outputPerMToken": 5.0,
       "cacheReadPerMToken": null,
       "imageOutputPerUnit": null,
       "reasoningPerMToken": null,
@@ -2888,8 +2912,8 @@
     "toolFidelity": 50,
     "maxContextTokens": 131072,
     "maxOutputTokens": null,
-    "inputPricePerMToken": null,
-    "outputPricePerMToken": null,
+    "inputPricePerMToken": 1.25,
+    "outputPricePerMToken": 5.0,
     "profileConfidence": "medium",
     "profileSource": "seed",
     "supportedModalities": {

--- a/packages/db/prisma/migrations/20260521120000_ep_cost_model_pricing/migration.sql
+++ b/packages/db/prisma/migrations/20260521120000_ep_cost_model_pricing/migration.sql
@@ -1,0 +1,128 @@
+-- EP-COST-001: Accurate per-model pricing backfill
+-- Source: Anthropic, Google, OpenAI published pricing as of 2026-05-21
+--
+-- These prices are used by computeTokenCost() in ai-inference.ts to populate
+-- AdapterRunTelemetry.estimatedCostUsd and drive the Finance AP spend pipeline.
+--
+-- anthropic-sub models: per-call price is $0 (flat Max/Pro subscription).
+--   Actual subscription cost is tracked separately in AiProviderFinanceProfile.
+--   Setting $0/$0 here is CORRECT — it prevents double-counting.
+--
+-- Gemma / local models: $0/$0 (compute cost tracked separately via electricityRateKwh).
+--
+-- Gemini 3.x, nano-banana, robotics, veo, lyria: Google has not published stable
+--   per-model pricing for these preview/specialised models. We assign them to the
+--   nearest published tier as a conservative estimate until Google publishes rates.
+--   All estimates are tagged so they can be updated when official rates land.
+
+-- ── Anthropic (API key — anthropic provider) ─────────────────────────────────
+-- Source: https://www.anthropic.com/pricing
+
+-- Claude 3 Haiku (retired but may still route)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.25,  "outputPricePerMToken" = 1.25,  "costTier" = 'routine'
+  WHERE "providerId" = 'anthropic' AND "modelId" LIKE 'claude-3-haiku%';
+
+-- Claude 4 Haiku family ($0.80 input / $4.00 output)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.80,  "outputPricePerMToken" = 4.00,  "costTier" = 'routine'
+  WHERE "providerId" IN ('anthropic', 'anthropic-sub') AND (
+    "modelId" LIKE 'claude-haiku-4%' OR "modelId" LIKE 'claude-3-5-haiku%'
+  );
+
+-- Claude Sonnet 4.x ($3 input / $15 output)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 3.00,  "outputPricePerMToken" = 15.00, "costTier" = 'standard'
+  WHERE "providerId" IN ('anthropic', 'anthropic-sub') AND "modelId" LIKE 'claude-sonnet-4%';
+
+-- Claude Sonnet 3.x legacy
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 3.00,  "outputPricePerMToken" = 15.00, "costTier" = 'standard'
+  WHERE "providerId" IN ('anthropic', 'anthropic-sub') AND "modelId" LIKE 'claude-3-%sonnet%';
+
+-- Claude Opus 4.x ($15 input / $75 output)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 15.00, "outputPricePerMToken" = 75.00, "costTier" = 'critical'
+  WHERE "providerId" IN ('anthropic', 'anthropic-sub') AND "modelId" LIKE 'claude-opus-4%';
+
+-- anthropic-sub subscription models: $0 per-call (flat subscription billing)
+-- These are already correct if set to 0/0; this UPDATE is a no-op guard.
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.00,  "outputPricePerMToken" = 0.00
+  WHERE "providerId" = 'anthropic-sub'
+    AND ("inputPricePerMToken" IS NULL OR "inputPricePerMToken" != 0);
+
+-- ── Gemini (Google AI Studio / Cloud — gemini provider) ───────────────────────
+-- Source: https://ai.google.dev/pricing (prices per million tokens)
+
+-- Gemini 2.0 Flash family ($0.075 / $0.30)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.075, "outputPricePerMToken" = 0.30,  "costTier" = 'routine'
+  WHERE "providerId" = 'gemini' AND (
+    "modelId" LIKE 'gemini-2.0-flash%'
+  );
+
+-- Gemini 2.5 Flash family ($0.075 / $0.30)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.075, "outputPricePerMToken" = 0.30,  "costTier" = 'routine'
+  WHERE "providerId" = 'gemini' AND "modelId" LIKE 'gemini-2.5-flash%';
+
+-- Gemini 2.5 Flash Lite (~50% cheaper; estimate pending Google publish)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.04,  "outputPricePerMToken" = 0.15,  "costTier" = 'routine'
+  WHERE "providerId" = 'gemini' AND "modelId" IN (
+    'gemini-2.5-flash-lite', 'gemini-2.5-flash-lite-preview-09-2025', 'gemini-flash-lite-latest'
+  );
+
+-- Gemini 2.5 Pro ($1.25 / $5.00)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 1.25,  "outputPricePerMToken" = 5.00,  "costTier" = 'standard'
+  WHERE "providerId" = 'gemini' AND "modelId" LIKE 'gemini-2.5-pro%';
+
+-- Gemini 3.x Flash family (estimate: similar to 2.5 Flash until Google publishes)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.10,  "outputPricePerMToken" = 0.40,  "costTier" = 'routine'
+  WHERE "providerId" = 'gemini' AND (
+    "modelId" LIKE 'gemini-3-%flash%'
+    OR "modelId" = 'gemini-flash-latest'
+    OR "modelId" LIKE 'gemini-3.1-flash%'
+    OR "modelId" LIKE 'gemini-3.5-flash%'
+  );
+
+-- Gemini 3.x Pro family (estimate: similar to 2.5 Pro)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 1.50,  "outputPricePerMToken" = 6.00,  "costTier" = 'standard'
+  WHERE "providerId" = 'gemini' AND (
+    "modelId" LIKE 'gemini-3-%pro%'
+    OR "modelId" = 'gemini-pro-latest'
+    OR "modelId" LIKE 'gemini-3.1-pro%'
+  );
+
+-- Gemini Deep Research (estimate: Pro pricing)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 1.25,  "outputPricePerMToken" = 5.00,  "costTier" = 'standard'
+  WHERE "providerId" = 'gemini' AND "modelId" LIKE 'deep-research%';
+
+-- Specialised Gemini preview models (robotics, veo, lyria, imagen, nano-banana):
+-- No published per-token rate. Assign Pro-tier pricing as conservative estimate.
+-- Tag with costTier=standard pending official rates.
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 1.25,  "outputPricePerMToken" = 5.00,  "costTier" = 'standard'
+  WHERE "providerId" = 'gemini'
+    AND "inputPricePerMToken" IS NULL
+    AND "modelId" NOT LIKE 'gemma%';
+
+-- Gemma (open-source): $0 per token — compute cost only
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.00,  "outputPricePerMToken" = 0.00,  "costTier" = 'routine'
+  WHERE "providerId" = 'gemini' AND "modelId" LIKE 'gemma%';
+
+-- ── OpenAI / Codex ────────────────────────────────────────────────────────────
+-- Source: https://openai.com/api/pricing
+
+-- GPT-5.3 Codex (Responses API) — $5 input / $20 output
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 5.00,  "outputPricePerMToken" = 20.00, "costTier" = 'critical'
+  WHERE "providerId" IN ('codex', 'openai') AND "modelId" LIKE 'gpt-5.3-codex%';
+
+-- Codex mini — $1.50 / $6.00
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 1.50,  "outputPricePerMToken" = 6.00,  "costTier" = 'standard'
+  WHERE "modelId" LIKE 'codex-mini%';
+
+-- GPT-5.4 — $10 input / $40 output (ChatGPT subscription: $0 per-call)
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 10.00, "outputPricePerMToken" = 40.00, "costTier" = 'critical'
+  WHERE "providerId" = 'openai' AND "modelId" LIKE 'gpt-5.4%';
+
+UPDATE "ModelProfile" SET "inputPricePerMToken" = 0.00,  "outputPricePerMToken" = 0.00,  "costTier" = 'critical'
+  WHERE "providerId" = 'chatgpt' AND "modelId" LIKE 'gpt-5.4%';
+
+-- ── Fix stale '$' costTier placeholder left from earlier migrations ────────────
+-- The migration 20260521090000 only fixed rows WHERE costTier = '' (empty string).
+-- Some rows may still have '$' / '$$' / '$$$' from the JSON seed.
+UPDATE "ModelProfile" SET "costTier" = 'routine'  WHERE "costTier" = '$';
+UPDATE "ModelProfile" SET "costTier" = 'standard' WHERE "costTier" = '$$';
+UPDATE "ModelProfile" SET "costTier" = 'critical'  WHERE "costTier" = '$$$';


### PR DESCRIPTION
## The problems this fixes

1. **69/75 ModelProfile rows had null pricing** — `estimatedCostUsd` was $0 for most inference calls, making Finance > AI Spend useless
2. **budget-gate.ts used a hardcoded $15/MTok placeholder** — wrong by 400× for Gemini Flash Lite ($0.04), wrong by 5× for Opus ($75 output)
3. **Finance > AI Spend showed committed contract amounts only** — no connection to actual token consumption data

## Changes

### Migration `20260521120000_ep_cost_model_pricing`
Backfills `inputPricePerMToken`/`outputPricePerMToken` on all ModelProfile rows from published provider rates (Anthropic, Google, OpenAI). Subscription providers (anthropic-sub, chatgpt) correctly set to $0/$0 per-call — their cost is tracked as fixed monthly commitment in AP.

### `model-profiles.json`
All 38 seed profiles updated with same prices so fresh installs are accurate from boot.

### `budget-gate.ts`
Replaces `const costPerToken = 0.000_015` with `resolveBlendedCostPerToken()` — looks up ModelProfile → ModelProvider → $3/MTok fallback. Budget event `amountUsd` now reflects actual model pricing.

### `ai-provider-finance.ts`
- `getAiSpendOverview()`: adds `actualMeteredSpendUsd` + `inferenceCallsThisMonth` from `AdapterRunTelemetry.estimatedCostUsd` for current calendar month
- `listAiProviderFinanceProfiles()`: adds `actualSpendMtd { costUsd, calls }` per provider from same source

### `AiSpendWorkspace.tsx`
- New "Metered spend MTD" tile (amber when > 80% of commitment)
- Per-provider "Metered MTD" column — red when over commitment, "subscription" label for $0 providers
- API call count as subtext

## What's still not done (known gaps)
- Month-end auto-bill generation from `generateDraftBillForAiContract()` is not wired — AP bills are still created manually
- Anthropic subscription allocation model (fixed monthly cost → per-agent cost attribution) needs a separate spec
- Prices marked as "estimate" in the migration (Gemini 3.x, specialised preview models) need updating when Google publishes official rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)