### PR TITLE
fix(topology): suppress container hex hostnames + Docker bridge IPs from default view

### DIFF
--- a/apps/web/lib/graph/docker-filter.test.ts
+++ b/apps/web/lib/graph/docker-filter.test.ts
@@ -1,0 +1,126 @@
+// Tests for isDockerOriginNode + isDockerOriginEntityKey.
+//
+// Both helpers feed the topology-view Show-Docker toggle + the
+// server-side quality-issue suppression. A regression here re-floods
+// the operator view with container hex hostnames + docker bridge IPs,
+// so the matrix below is the canonical contract.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isDockerOriginEntityKey,
+  isDockerOriginNode,
+  stripDockerOrigin,
+} from "./docker-filter";
+
+// Test fixture is intentionally minimal — only the fields the helper
+// reads are populated. The broader GraphData Node shape isn't relevant
+// for these unit tests, so we cast through to the parameter type.
+type Node = { id: string; name: string; label?: string; color?: string; size?: number; ciType?: string };
+const isDocker = (n: Node) =>
+  isDockerOriginNode(n as unknown as Parameters<typeof isDockerOriginNode>[0]);
+
+describe("isDockerOriginNode", () => {
+  it("matches by ciType", () => {
+    expect(isDocker({ id: "1", name: "x", ciType: "container" })).toBe(true);
+    expect(isDocker({ id: "1", name: "x", ciType: "docker_runtime" })).toBe(true);
+    expect(isDocker({ id: "1", name: "x", ciType: "docker_host" })).toBe(true);
+    expect(isDocker({ id: "1", name: "x", ciType: "host" })).toBe(false);
+  });
+
+  it("matches by docker-discovery name prefixes", () => {
+    expect(isDocker({ id: "1", name: "Docker: dpf_default (172.18.0.0/16)" })).toBe(true);
+    expect(isDocker({ id: "2", name: "Docker GW dpf_default (172.18.0.1)" })).toBe(true);
+    expect(isDocker({ id: "3", name: "Real Router" })).toBe(false);
+  });
+
+  it("matches 12-hex-char container hostnames", () => {
+    expect(isDocker({ id: "1", name: "5ce3e0f1cfd6" })).toBe(true);
+    expect(isDocker({ id: "2", name: "a9d8ef4fb717" })).toBe(true);
+    // Real hostnames must not match
+    expect(isDocker({ id: "3", name: "DESKTOP-A290QNG" })).toBe(false);
+    expect(isDocker({ id: "4", name: "iphone-mark" })).toBe(false);
+    // Not exactly 12 hex chars (boundary): 11 / 13 / mixed
+    expect(isDocker({ id: "5", name: "5ce3e0f1cfd" })).toBe(false);
+    expect(isDocker({ id: "6", name: "5ce3e0f1cfd60" })).toBe(false);
+    expect(isDocker({ id: "7", name: "g5ce3e0f1cfd" })).toBe(false);
+  });
+
+  it("matches LAN Host 172.x bridge IPs (ARP-discovered Docker containers)", () => {
+    expect(isDocker({ id: "1", name: "LAN Host 172.18.0.5" })).toBe(true);
+    expect(isDocker({ id: "2", name: "LAN Host 172.17.0.1" })).toBe(true);
+    expect(isDocker({ id: "3", name: "LAN Host 172.31.255.254" })).toBe(true);
+    // Boundaries
+    expect(isDocker({ id: "4", name: "LAN Host 172.15.0.1" })).toBe(false); // below /12
+    expect(isDocker({ id: "5", name: "LAN Host 172.32.0.1" })).toBe(false); // above /12
+    expect(isDocker({ id: "6", name: "LAN Host 192.168.0.10" })).toBe(false); // real LAN
+  });
+
+  it("matches Docker Desktop vpnkit gateway IPs", () => {
+    expect(isDocker({ id: "1", name: "LAN Host 192.168.65.1" })).toBe(true);
+    expect(isDocker({ id: "2", name: "LAN Host 192.168.65.2" })).toBe(true);
+    expect(isDocker({ id: "3", name: "LAN Host 192.168.65.3" })).toBe(true);
+    // Adjacent IPs in the same /24 must NOT match — could be a real
+    // user LAN.
+    expect(isDocker({ id: "4", name: "LAN Host 192.168.65.4" })).toBe(false);
+  });
+
+  it("stripDockerOrigin removes matching nodes + dangling edges", () => {
+    const graph = {
+      nodes: [
+        { id: "real", name: "Cloud Gateway Ultra" },
+        { id: "ctr1", name: "5ce3e0f1cfd6" },
+        { id: "br1", name: "LAN Host 172.18.0.5" },
+        { id: "dock", name: "Docker: dpf_default (172.18.0.0/16)" },
+      ],
+      links: [
+        { source: "real", target: "ctr1", type: "HOSTS" },
+        { source: "real", target: "real", type: "SELF" },
+      ],
+    };
+    const stripped = stripDockerOrigin(graph as never);
+    expect(stripped.nodes.map((n) => n.id)).toEqual(["real"]);
+    // Edge to ctr1 dropped, self-edge preserved.
+    expect(stripped.links).toEqual([
+      { source: "real", target: "real", type: "SELF" },
+    ]);
+  });
+});
+
+describe("isDockerOriginEntityKey", () => {
+  it("matches docker discovery collector key shapes", () => {
+    expect(isDockerOriginEntityKey("subnet:docker-bridge")).toBe(true);
+    expect(isDockerOriginEntityKey("gateway:docker-gw:bridge:172.17.0.1")).toBe(true);
+    expect(isDockerOriginEntityKey("container:dpf-portal-1")).toBe(true);
+    expect(isDockerOriginEntityKey("runtime:docker:engine")).toBe(true);
+    expect(isDockerOriginEntityKey("docker_host:linux:abc123")).toBe(true);
+  });
+
+  it("matches 12-hex container hostnames seen by the ARP collector", () => {
+    expect(isDockerOriginEntityKey("host:hostname:5ce3e0f1cfd6")).toBe(true);
+    expect(isDockerOriginEntityKey("host:hostname:a9d8ef4fb717")).toBe(true);
+    // Real hostnames are preserved
+    expect(isDockerOriginEntityKey("host:hostname:DESKTOP-A290QNG")).toBe(false);
+    expect(isDockerOriginEntityKey("host:hostname:iphone-mark")).toBe(false);
+  });
+
+  it("matches 172.16/12 bridge IPs and vpnkit gateways via host:arp:", () => {
+    expect(isDockerOriginEntityKey("host:arp:172.18.0.5")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:172.17.0.10")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:192.168.65.1")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:192.168.0.49")).toBe(false); // real LAN
+    expect(isDockerOriginEntityKey("host:arp:10.0.0.1")).toBe(false); // real LAN
+  });
+
+  it("falls back to name when entityKey is unrecognized", () => {
+    expect(isDockerOriginEntityKey("unknown:key:1", "5ce3e0f1cfd6")).toBe(true);
+    expect(isDockerOriginEntityKey("unknown:key:1", "Real Router")).toBe(false);
+  });
+
+  it("returns false for genuine InventoryEntity keys", () => {
+    expect(isDockerOriginEntityKey("access_point:unifi:ac:8b:a9:58:3e:8d")).toBe(false);
+    expect(isDockerOriginEntityKey("switch:unifi:d0:21:f9:df:56:92")).toBe(false);
+    expect(isDockerOriginEntityKey("network_client:arp:192.168.0.49")).toBe(false);
+    expect(isDockerOriginEntityKey("host:arp:192.168.0.5")).toBe(false);
+  });
+});

--- a/apps/web/lib/graph/docker-filter.ts
+++ b/apps/web/lib/graph/docker-filter.ts
@@ -6,15 +6,22 @@
 // perspective almost never want to see it; users debugging the platform
 // itself can opt in via the toggle in TopologyGraph.
 //
-// Detection is purely client-side and pattern-based — Docker-origin
-// metadata isn't projected to Neo4j InfraCI properties yet, so we rely
-// on the naming and ciType conventions established in
-// `packages/db/src/discovery-collectors/docker.ts`:
+// Detection is purely pattern-based — Docker-origin metadata isn't
+// projected to Neo4j InfraCI properties yet, so we rely on the naming +
+// ciType + entityKey conventions established by
+// `packages/db/src/discovery-collectors/docker.ts` and the edge-node
+// ARP collector:
 //
-//   - Subnets:   itemType "subnet"  + name "Docker: <network> (<cidr>)"
-//   - Gateways:  itemType "gateway" + name "Docker GW <network> (<ip>)"
+//   - Subnets:    itemType "subnet"  + name "Docker: <network> (<cidr>)"
+//   - Gateways:   itemType "gateway" + name "Docker GW <network> (<ip>)"
 //   - Containers: itemType "container" → ciType "container"
 //   - Docker host/runtime CIs from the same collector
+//   - 12-hex-char hostnames the kernel sees from container ARP (Docker
+//     auto-assigns containers a /etc/hostname of the truncated container
+//     ID — never a real OS hostname).
+//   - 172.16.0.0/12 IPs the edge node's ARP cache picks up from
+//     Docker bridge networks.
+//   - Docker Desktop's vpnkit gateway at 192.168.65.1 / .2 / .3.
 //
 // If Docker discovery adds new shapes in the future, extend this helper
 // and the corresponding test — every other call site reads through here.
@@ -26,6 +33,53 @@ type RawNode = GraphData["nodes"][number];
 const DOCKER_NAME_PREFIXES = ["Docker:", "Docker GW "];
 const DOCKER_CI_TYPES = new Set(["container", "docker_runtime", "docker_host"]);
 
+/** Matches a 12-hex-char string with nothing else — Docker's default container hostname. */
+const DOCKER_CONTAINER_HOSTNAME_RE = /^[0-9a-f]{12}$/;
+
+/**
+ * Returns true for IPv4 strings inside 172.16.0.0/12 — Docker's default
+ * bridge-network range. We deliberately don't try to catch user-defined
+ * Docker networks outside this range; those need explicit subnet markers.
+ */
+function isDocker172BridgeIp(value: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/.exec(value);
+  if (!m) return false;
+  const o1 = Number(m[1]);
+  const o2 = Number(m[2]);
+  return o1 === 172 && o2 >= 16 && o2 <= 31;
+}
+
+/**
+ * Docker Desktop's vpnkit on macOS/Windows assigns its host gateway in
+ * 192.168.65.0/24. Tiny fixed range — safe to enumerate the 3 IPs we've
+ * actually seen rather than treating the whole /24 as Docker (so user
+ * LANs that happen to use 192.168.65.x are unaffected if anyone ever
+ * does that).
+ */
+const DOCKER_DESKTOP_VPNKIT_IPS = new Set([
+  "192.168.65.1",
+  "192.168.65.2",
+  "192.168.65.3",
+]);
+
+/**
+ * Patterns matched against the literal name on a graph node OR an
+ * inventory entity. Kept narrow on purpose: a true positive here hides
+ * the node from the default topology view, so false positives would
+ * actively damage operator visibility.
+ */
+function nameLooksDockerOrigin(name: string): boolean {
+  for (const prefix of DOCKER_NAME_PREFIXES) {
+    if (name.startsWith(prefix)) return true;
+  }
+  if (DOCKER_CONTAINER_HOSTNAME_RE.test(name)) return true;
+  if (name.startsWith("LAN Host ")) {
+    const ip = name.slice("LAN Host ".length);
+    if (isDocker172BridgeIp(ip) || DOCKER_DESKTOP_VPNKIT_IPS.has(ip)) return true;
+  }
+  return false;
+}
+
 export function isDockerOriginNode(node: RawNode): boolean {
   const ciType = (node as Record<string, unknown>).ciType;
   if (typeof ciType === "string" && DOCKER_CI_TYPES.has(ciType)) {
@@ -33,11 +87,43 @@ export function isDockerOriginNode(node: RawNode): boolean {
   }
 
   const name = node.name;
-  if (typeof name === "string") {
-    for (const prefix of DOCKER_NAME_PREFIXES) {
-      if (name.startsWith(prefix)) return true;
-    }
+  if (typeof name === "string" && nameLooksDockerOrigin(name)) {
+    return true;
   }
+
+  return false;
+}
+
+/**
+ * Server-side variant for InventoryEntity rows where we have an
+ * `entityKey` instead of a graph node. Used to suppress quality-issue
+ * generation (lifecycle_unverified, stale_entity, etc.) on Docker-origin
+ * entities — they're not real estate to manage.
+ *
+ * Keep the entity-key heuristics aligned with the edge-node ARP
+ * collector + docker discovery collector — both produce the keys this
+ * function returns true for.
+ */
+export function isDockerOriginEntityKey(entityKey: string, name?: string | null): boolean {
+  // Docker discovery collector key shapes.
+  if (entityKey.startsWith("subnet:docker-")) return true;
+  if (entityKey.startsWith("gateway:docker-gw:")) return true;
+  if (entityKey.startsWith("container:")) return true;
+  if (entityKey.startsWith("runtime:docker")) return true;
+  if (entityKey.startsWith("docker_host:")) return true;
+
+  // ARP-discovered container hostnames + bridge IPs land under the host
+  // entityType with these key shapes.
+  const m = /^host:hostname:([^:]+)$/.exec(entityKey);
+  if (m && m[1] && DOCKER_CONTAINER_HOSTNAME_RE.test(m[1])) return true;
+
+  const arpMatch = /^host:arp:([^:]+)$/.exec(entityKey);
+  if (arpMatch && arpMatch[1]) {
+    if (isDocker172BridgeIp(arpMatch[1])) return true;
+    if (DOCKER_DESKTOP_VPNKIT_IPS.has(arpMatch[1])) return true;
+  }
+
+  if (name && nameLooksDockerOrigin(name)) return true;
 
   return false;
 }

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -1,3 +1,5 @@
+import { isDockerOriginEntityKey } from "./docker-origin";
+
 const LOW_CONFIDENCE_THRESHOLD = 0.55;
 const STOP_WORDS = new Set([
   "and",
@@ -329,6 +331,15 @@ export function evaluateInventoryQuality(
   const issues: InventoryQualityIssue[] = [];
 
   for (const entity of entities) {
+    // Docker-origin entities (containers, bridge-IP hosts, vpnkit
+    // gateways) aren't real estate to manage — they spawn one quality
+    // issue per row otherwise, drowning the actual signal. Skip the
+    // entire issue-generation loop for them. Entity-key heuristics
+    // catch every Docker shape without needing a name pass-through.
+    if (isDockerOriginEntityKey(entity.entityKey)) {
+      continue;
+    }
+
     if (entity.attributionStatus === "needs_review" || entity.attributionStatus === "unmapped") {
       issues.push({
         issueKey: `inventory_entity:${entity.entityKey}:attribution_missing`,

--- a/packages/db/src/docker-origin.test.ts
+++ b/packages/db/src/docker-origin.test.ts
@@ -1,0 +1,48 @@
+// Server-side parity test for isDockerOriginEntityKey. Mirrors the
+// client-side helper test at apps/web/lib/graph/docker-filter.test.ts.
+
+import { describe, expect, it } from "vitest";
+
+import { isDockerOriginEntityKey } from "./docker-origin";
+
+describe("isDockerOriginEntityKey (server-side)", () => {
+  it("matches docker discovery collector key shapes", () => {
+    expect(isDockerOriginEntityKey("subnet:docker-bridge")).toBe(true);
+    expect(isDockerOriginEntityKey("gateway:docker-gw:bridge:172.17.0.1")).toBe(true);
+    expect(isDockerOriginEntityKey("container:dpf-portal-1")).toBe(true);
+    expect(isDockerOriginEntityKey("runtime:docker:engine")).toBe(true);
+    expect(isDockerOriginEntityKey("docker_host:linux:abc123")).toBe(true);
+  });
+
+  it("matches 12-hex container hostnames via host:hostname:", () => {
+    expect(isDockerOriginEntityKey("host:hostname:5ce3e0f1cfd6")).toBe(true);
+    expect(isDockerOriginEntityKey("host:hostname:a9d8ef4fb717")).toBe(true);
+    expect(isDockerOriginEntityKey("host:hostname:DESKTOP-A290QNG")).toBe(false);
+    expect(isDockerOriginEntityKey("host:hostname:iphone-mark")).toBe(false);
+  });
+
+  it("matches 172.16/12 bridge IPs and vpnkit gateway via host:arp:", () => {
+    expect(isDockerOriginEntityKey("host:arp:172.18.0.5")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:172.17.0.10")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:172.31.255.254")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:172.15.0.1")).toBe(false); // outside /12
+    expect(isDockerOriginEntityKey("host:arp:172.32.0.1")).toBe(false); // outside /12
+    expect(isDockerOriginEntityKey("host:arp:192.168.65.1")).toBe(true);
+    expect(isDockerOriginEntityKey("host:arp:192.168.65.4")).toBe(false); // outside the known vpnkit triplet
+    expect(isDockerOriginEntityKey("host:arp:192.168.0.49")).toBe(false); // real LAN
+  });
+
+  it("uses optional name fallback when entityKey doesn't match a known shape", () => {
+    expect(isDockerOriginEntityKey("unknown:key:1", "5ce3e0f1cfd6")).toBe(true);
+    expect(isDockerOriginEntityKey("unknown:key:1", "Docker: my_app (172.20.0.0/16)")).toBe(true);
+    expect(isDockerOriginEntityKey("unknown:key:1", "Real Router")).toBe(false);
+    expect(isDockerOriginEntityKey("unknown:key:1", null)).toBe(false);
+  });
+
+  it("returns false for genuine InventoryEntity keys", () => {
+    expect(isDockerOriginEntityKey("access_point:unifi:ac:8b:a9:58:3e:8d")).toBe(false);
+    expect(isDockerOriginEntityKey("switch:unifi:d0:21:f9:df:56:92")).toBe(false);
+    expect(isDockerOriginEntityKey("network_client:arp:192.168.0.49")).toBe(false);
+    expect(isDockerOriginEntityKey("host:arp:192.168.0.5")).toBe(false);
+  });
+});

--- a/packages/db/src/docker-origin.ts
+++ b/packages/db/src/docker-origin.ts
@@ -1,0 +1,72 @@
+// docker-origin.ts
+//
+// Server-side detector for InventoryEntity rows that originate from
+// Docker discovery. Mirrors the client-side helper at
+// `apps/web/lib/graph/docker-filter.ts` — keep the heuristics aligned
+// so the topology view and quality-issue layer suppress the same set.
+//
+// Why this exists: Docker auto-assigns each container a 12-hex-char
+// hostname and a 172.16.0.0/12 bridge IP. The discovery pipeline picks
+// these up via ARP and surfaces them as `host` entities, but they are
+// not real estate to manage — the operator can't update their support
+// lifecycle, attribute them to a portfolio, or do anything useful with
+// them. Generating quality issues for them just buries the real signal.
+
+/** Matches Docker's default container hostname pattern. */
+const DOCKER_CONTAINER_HOSTNAME_RE = /^[0-9a-f]{12}$/;
+
+const DOCKER_DESKTOP_VPNKIT_IPS = new Set([
+  "192.168.65.1",
+  "192.168.65.2",
+  "192.168.65.3",
+]);
+
+function isDocker172BridgeIp(value: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/.exec(value);
+  if (!m) return false;
+  const o1 = Number(m[1]);
+  const o2 = Number(m[2]);
+  return o1 === 172 && o2 >= 16 && o2 <= 31;
+}
+
+function nameLooksDockerOrigin(name: string): boolean {
+  if (name.startsWith("Docker:") || name.startsWith("Docker GW ")) return true;
+  if (DOCKER_CONTAINER_HOSTNAME_RE.test(name)) return true;
+  if (name.startsWith("LAN Host ")) {
+    const ip = name.slice("LAN Host ".length);
+    if (isDocker172BridgeIp(ip) || DOCKER_DESKTOP_VPNKIT_IPS.has(ip)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true when the given InventoryEntity entityKey (and optional
+ * `name`) clearly originates from Docker discovery. Conservative on
+ * purpose — a true positive here suppresses quality issues, so false
+ * positives would hide real operator workload.
+ */
+export function isDockerOriginEntityKey(
+  entityKey: string,
+  name?: string | null,
+): boolean {
+  if (entityKey.startsWith("subnet:docker-")) return true;
+  if (entityKey.startsWith("gateway:docker-gw:")) return true;
+  if (entityKey.startsWith("container:")) return true;
+  if (entityKey.startsWith("runtime:docker")) return true;
+  if (entityKey.startsWith("docker_host:")) return true;
+
+  const hostnameMatch = /^host:hostname:([^:]+)$/.exec(entityKey);
+  if (hostnameMatch && hostnameMatch[1] && DOCKER_CONTAINER_HOSTNAME_RE.test(hostnameMatch[1])) {
+    return true;
+  }
+
+  const arpMatch = /^host:arp:([^:]+)$/.exec(entityKey);
+  if (arpMatch && arpMatch[1]) {
+    if (isDocker172BridgeIp(arpMatch[1])) return true;
+    if (DOCKER_DESKTOP_VPNKIT_IPS.has(arpMatch[1])) return true;
+  }
+
+  if (name && nameLooksDockerOrigin(name)) return true;
+
+  return false;
+}


### PR DESCRIPTION
## Summary

The Infrastructure Topology view was rendering hundreds of Docker-origin nodes per sweep that the operator never wants to see — drowning the 4 APs / 1 switch / 1 gateway / 63 real clients in noise. The existing `isDockerOriginNode` helper only matched `ciType === container` + `Docker:` / `Docker GW ` name prefixes. Three real shapes fell through:

- **12-hex-char container hostnames** (Docker auto-fills `/etc/hostname` with the truncated container ID — never a real OS hostname; e.g. `5ce3e0f1cfd6`).
- **"LAN Host 172.x.x.x"** entries — the edge-node ARP collector picking up Docker bridge networks.
- **Docker Desktop vpnkit gateway** at `192.168.65.1` / `.2` / `.3`.

Plus a related issue: the discovery-attribution pipeline was generating one quality issue *per Docker entity* (`lifecycle_unverified`, `stale_entity`, `attribution_missing`). On a typical install that's **384 LIFECYCLE_UNVERIFIED chips** the operator can't action — there's no support lifecycle to verify for a container that exists for 30 seconds.

## Changes

- **`apps/web/lib/graph/docker-filter.ts`** — extend `isDockerOriginNode` to catch the three shapes above. Export a parallel **`isDockerOriginEntityKey(entityKey, name?)`** for server-side use. Detection stays narrow: 172.16/12 boundary checks reject 172.15.x and 172.32.x (real LANs that happen to live just outside Docker's range); the vpnkit triplet is fixed (`192.168.65.1`/`.2`/`.3`) so adjacent IPs in the same /24 are NOT auto-suppressed.

- **`packages/db/src/docker-origin.ts`** — server-side mirror of the entity-key detector. Lives in `@dpf/db` so the attribution pipeline can use it without a cross-package dependency. Heuristics intentionally kept in lockstep with the client-side filter; both files cross-reference each other for future drift.

- **`packages/db/src/discovery-attribution.ts`** — `evaluateInventoryQuality` now skips the entire issue-generation loop for Docker-origin entities. One-line entity-key gate; no name pass-through needed because the key shapes are unambiguous.

## Test plan

- [x] **`apps/web/lib/graph/docker-filter.test.ts` — 11 cases**: every ciType, every name prefix, every 12-hex-hostname (negatives at 11 / 13 chars + non-hex), 172.16/12 boundary (15.x and 32.x rejected), the vpnkit triplet + adjacent-IP rejection, plus a `stripDockerOrigin` integration that verifies dangling-edge cleanup. **All pass.**
- [x] **`packages/db/src/docker-origin.test.ts` — 5 cases**: server-side parity for entity-key matching, with the same boundary coverage. **All pass.**
- [x] Existing **`discovery-attribution-model` + `discovery-promotion`** suites still green (23 passing in packages/db).
- [x] Existing **`promotion-audit.test.ts`** in apps/web still green (7 passing).
- [ ] CI: typecheck + vitest + production build.

## Live impact (preview)

On a Windows Docker Desktop install before this PR:
- Topology page had **1,210 hex hostnames** rendered as graph nodes
- **98 "LAN Host 172.x.x.x"** noise nodes
- **384 LIFECYCLE_UNVERIFIED** quality-issue chips on the discovery page

With this PR (all behind the existing **Show Docker** toggle, off by default):
- Hex hostnames + bridge IPs + vpnkit gateway hidden from the default view
- Quality-issue panel returns to surfacing only entities the operator can actually action

🤖 Generated with [Claude Code](https://claude.com/claude-code)