### PR TITLE
feat(ep-cost): BuildPhaseCostCard — per-phase cost breakdown in Build Studio

### DIFF
--- a/apps/web/components/build/BuildPhaseCostCard.tsx
+++ b/apps/web/components/build/BuildPhaseCostCard.tsx
@@ -1,0 +1,131 @@
+"use client";
+// apps/web/components/build/BuildPhaseCostCard.tsx
+//
+// EP-COST Phase 3: per-phase cost breakdown for Build Studio operational panel.
+// Shows token counts, duration, and estimated cost for each completed phase.
+// Hidden when no BuildPhaseRun rows exist for this build (new builds or
+// installs before EP-COST Phase 5 shipped).
+
+import type { PhaseRunSummary } from "@/lib/build/progress-visibility";
+
+const PHASE_ORDER = ["ideate", "plan", "build", "review", "ship"];
+const PHASE_LABELS: Record<string, string> = {
+  ideate: "Ideate",
+  plan: "Plan",
+  build: "Build",
+  review: "Review",
+  ship: "Ship",
+};
+
+function formatDuration(ms: number | null): string {
+  if (ms == null) return "—";
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.floor((ms % 60_000) / 1_000);
+  if (mins === 0) return `${secs}s`;
+  return `${mins}m ${secs}s`;
+}
+
+function formatTokens(n: number): string {
+  if (n === 0) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
+}
+
+function formatCost(s: string | null): string {
+  if (!s) return "—";
+  const n = parseFloat(s);
+  if (isNaN(n) || n === 0) return "—";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(3)}`;
+}
+
+type Props = {
+  phaseRuns: PhaseRunSummary[];
+};
+
+export function BuildPhaseCostCard({ phaseRuns }: Props) {
+  if (phaseRuns.length === 0) return null;
+
+  // Sort by canonical phase order
+  const sorted = [...phaseRuns].sort((a, b) => {
+    const ia = PHASE_ORDER.indexOf(a.phase);
+    const ib = PHASE_ORDER.indexOf(b.phase);
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  });
+
+  const totalTokens = sorted.reduce((s, r) => s + r.inputTokens + r.outputTokens, 0);
+  const totalCost = sorted.reduce((s, r) => s + (r.costUsd ? parseFloat(r.costUsd) : 0), 0);
+  const totalCalls = sorted.reduce((s, r) => s + r.inferenceCount, 0);
+
+  return (
+    <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase text-[var(--dpf-muted)]">Phase cost breakdown</p>
+          <h3 className="mt-1 text-base font-semibold text-[var(--dpf-text)]">
+            {totalCost > 0 ? `$${totalCost.toFixed(3)} estimated` : `${formatTokens(totalTokens)} tokens`}
+          </h3>
+        </div>
+        <div className="text-right text-[11px] text-[var(--dpf-muted)]">
+          <div>{totalCalls} inference calls</div>
+          <div>{formatTokens(totalTokens)} total tokens</div>
+        </div>
+      </div>
+
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-[var(--dpf-border)] text-left">
+              <th className="pb-2 pr-3 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Phase</th>
+              <th className="pb-2 pr-3 text-right text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Duration</th>
+              <th className="pb-2 pr-3 text-right text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Tokens in</th>
+              <th className="pb-2 pr-3 text-right text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Tokens out</th>
+              <th className="pb-2 pr-3 text-right text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Calls</th>
+              <th className="pb-2 text-right text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Est. cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((r) => (
+              <tr key={r.phase} className="border-b border-[var(--dpf-border)] last:border-0">
+                <td className="py-2 pr-3 font-medium text-[var(--dpf-text)]">
+                  {PHASE_LABELS[r.phase] ?? r.phase}
+                  {!r.completedAt && (
+                    <span className="ml-1 text-[9px] text-[var(--dpf-accent)]">active</span>
+                  )}
+                </td>
+                <td className="py-2 pr-3 text-right tabular-nums text-[var(--dpf-muted)]">{formatDuration(r.durationMs)}</td>
+                <td className="py-2 pr-3 text-right tabular-nums text-[var(--dpf-text)]">{formatTokens(r.inputTokens)}</td>
+                <td className="py-2 pr-3 text-right tabular-nums text-[var(--dpf-text)]">{formatTokens(r.outputTokens)}</td>
+                <td className="py-2 pr-3 text-right tabular-nums text-[var(--dpf-muted)]">{r.inferenceCount || "—"}</td>
+                <td className="py-2 text-right tabular-nums text-[var(--dpf-text)]">{formatCost(r.costUsd)}</td>
+              </tr>
+            ))}
+          </tbody>
+          {sorted.length > 1 && (
+            <tfoot>
+              <tr className="border-t-2 border-[var(--dpf-border)]">
+                <td className="pt-2 pr-3 text-[10px] font-semibold uppercase text-[var(--dpf-muted)]">Total</td>
+                <td className="pt-2 pr-3" />
+                <td className="pt-2 pr-3 text-right tabular-nums font-medium text-[var(--dpf-text)]">
+                  {formatTokens(sorted.reduce((s, r) => s + r.inputTokens, 0))}
+                </td>
+                <td className="pt-2 pr-3 text-right tabular-nums font-medium text-[var(--dpf-text)]">
+                  {formatTokens(sorted.reduce((s, r) => s + r.outputTokens, 0))}
+                </td>
+                <td className="pt-2 pr-3 text-right tabular-nums font-medium text-[var(--dpf-text)]">{totalCalls}</td>
+                <td className="pt-2 text-right tabular-nums font-semibold text-[var(--dpf-text)]">
+                  {totalCost > 0 ? `$${totalCost.toFixed(3)}` : "—"}
+                </td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </div>
+
+      <p className="mt-3 text-[10px] text-[var(--dpf-muted)]">
+        Cost estimated from per-model pricing in ModelProfile. Subscription providers (Claude, ChatGPT) show $0 — their fixed monthly cost is tracked in Finance → AI Spend.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/components/build/BuildProgressOperationalPanel.test.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.test.tsx
@@ -132,6 +132,7 @@ function makeProjection(): BuildProgressVisibility {
       minutesQuiet: 7,
       lastObservableSignalAt: "2026-05-18T11:53:00.000Z",
     },
+    phaseRuns: [],
   };
 }
 

--- a/apps/web/components/build/BuildProgressOperationalPanel.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.tsx
@@ -7,6 +7,7 @@ import { BuildSandboxCard } from "./BuildSandboxCard";
 import { BuildVerificationScopedCard } from "./BuildVerificationScopedCard";
 import { TruthSourceBadge } from "./TruthSourceBadge";
 import { StallEventHistoryStrip } from "./StallEventHistoryStrip";
+import { BuildPhaseCostCard } from "./BuildPhaseCostCard";
 
 type Props = {
   projection: BuildProgressVisibility | null;
@@ -99,6 +100,7 @@ export function BuildProgressOperationalPanel({ projection }: Props) {
         </section>
 
         <div className="grid gap-3 xl:grid-cols-3">
+          <BuildPhaseCostCard phaseRuns={projection.phaseRuns} />
           <BuildSandboxCard sandbox={projection.sandbox} />
           <BuildDispatchHistoryCard attempts={projection.dispatchHistory} />
           <BuildVerificationScopedCard verification={projection.verification} />

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -344,6 +344,7 @@ describe("deriveBuildStudioWorkflowAction", () => {
         minutesQuiet: 135,
         lastObservableSignalAt: "2026-05-19T17:23:40.189Z",
       },
+      phaseRuns: [],
     } satisfies BuildProgressVisibility;
 
     const action = deriveBuildStudioWorkflowAction({
@@ -726,6 +727,7 @@ describe("deriveWorkflowStageGuidance", () => {
         minutesQuiet: 135,
         lastObservableSignalAt: "2026-05-19T17:23:40.189Z",
       },
+      phaseRuns: [],
     } satisfies BuildProgressVisibility;
 
     const topCardAction = deriveBuildStudioWorkflowAction({

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -23,6 +23,18 @@ export type ChatProgressMessageInput = {
   createdAt: Date | string | null;
 };
 
+/** EP-COST Phase 3: per-phase cost rollup from BuildPhaseRun table */
+export type PhaseRunSummary = {
+  phase: string;
+  startedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: string | null; // Decimal serialized as string
+  inferenceCount: number;
+};
+
 export type BuildProgressVisibility = {
   buildId: string;
   generatedAt: string;
@@ -44,6 +56,8 @@ export type BuildProgressVisibility = {
     minutesQuiet: number;
     lastObservableSignalAt: string | null;
   };
+  /** Phase-level cost rollup; empty array when BuildPhaseRun rows don't exist yet */
+  phaseRuns: PhaseRunSummary[];
 };
 
 export function buildProgressProjectionFromParts(args: {
@@ -55,6 +69,7 @@ export function buildProgressProjectionFromParts(args: {
   dispatchHistory: BuildDispatchAttemptView[];
   verification: ScopedVerificationView | null;
   lastActivityAt: string | null;
+  phaseRuns?: PhaseRunSummary[];
 }): BuildProgressVisibility {
   const now = args.now ?? new Date();
   const conflicts = getProgressConflicts(args.dbTasks.source, args.chatSnapshots);
@@ -103,6 +118,7 @@ export function buildProgressProjectionFromParts(args: {
       minutesQuiet,
       lastObservableSignalAt,
     },
+    phaseRuns: args.phaseRuns ?? [],
   };
 }
 
@@ -141,6 +157,32 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     })
     : [];
 
+  // EP-COST Phase 3: fetch BuildPhaseRun rows for cost breakdown panel
+  const phaseRunRows = await prisma.buildPhaseRun.findMany({
+    where: { buildId },
+    orderBy: { startedAt: "asc" },
+    select: {
+      phase: true,
+      startedAt: true,
+      completedAt: true,
+      durationMs: true,
+      inputTokens: true,
+      outputTokens: true,
+      costUsd: true,
+      inferenceCount: true,
+    },
+  });
+  const phaseRuns: PhaseRunSummary[] = phaseRunRows.map((r) => ({
+    phase: r.phase,
+    startedAt: r.startedAt.toISOString(),
+    completedAt: r.completedAt?.toISOString() ?? null,
+    durationMs: r.durationMs,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    costUsd: r.costUsd?.toString() ?? null,
+    inferenceCount: r.inferenceCount,
+  }));
+
   return buildProgressProjectionFromParts({
     buildId,
     dbTasks: normalizeTaskResults(build.taskResults),
@@ -149,6 +191,7 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     dispatchHistory: await getDispatchHistoryForBuild(buildId),
     verification: await getScopedVerificationForBuild(buildId),
     lastActivityAt: build.activities[0]?.createdAt.toISOString() ?? build.updatedAt.toISOString(),
+    phaseRuns,
   });
 }
 


### PR DESCRIPTION
## Summary

Closes the last open EP-COST Phase 3 spec deliverable: *"Add BuildPhaseRun table with cost rollup; expose in Build Studio detail view."*

**`progress-visibility.ts`**: adds `PhaseRunSummary` type to `BuildProgressVisibility`; `getBuildProgressVisibility()` now queries `BuildPhaseRun` rows and includes them in the projection that drives the operational panel.

**`BuildPhaseCostCard`**: a new card rendered at the top of `BuildProgressOperationalPanel` (before sandbox / dispatch history) showing a table of:
- Phase name (with "active" badge for the current in-flight phase)
- Wall-clock duration
- Input tokens, output tokens
- Inference call count
- Estimated USD cost

Totals row when multiple phases are present. Hidden entirely when no `BuildPhaseRun` rows exist (pre-EP-COST builds, or before any phase transition has fired). Footnote notes that subscription providers (Claude, ChatGPT) show $0 and links to Finance > AI Spend for fixed monthly cost view.

## Dependency
Requires `BuildPhaseRun` table (PR #900 ✅) and phase transition wiring (PRs #900, #902 ✅). Pricing accuracy depends on PR #908 (in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)