### PR TITLE
feat(build-studio): T10 DetailsDrawer + Pill (atom; preview of shell-wiring stack)

### DIFF
--- a/apps/web/components/build/ActionBanner.test.tsx
+++ b/apps/web/components/build/ActionBanner.test.tsx
@@ -1,0 +1,197 @@
+// apps/web/components/build/ActionBanner.test.tsx
+//
+// Pins the ActionBanner contract:
+//   - 40px fixed height (ACTION_BANNER_HEIGHT_CLASS = h-10 via build-studio-layout).
+//   - One sentence is the heading — no separate "Build Status" / "Operational status" label.
+//   - detail only rendered for "blocked" / "review_failed".
+//   - Primary action right-aligned with min-width 120px.
+//   - role="region" with aria-label.
+//   - Distinct fg/bg tokens per state (no yellow-on-yellow class of bug).
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ActionBanner } from "./ActionBanner";
+import { ACTION_BANNER_HEIGHT_CLASS, BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+describe("ActionBanner", () => {
+  it("uses the 40px height class from the layout helper", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="ready" sentence="Ready to advance." />,
+    );
+    expect(html).toContain(ACTION_BANNER_HEIGHT_CLASS);
+    expect(ACTION_BANNER_HEIGHT_CLASS).toBe("h-10");
+  });
+
+  it("renders role=region with an aria-label", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="ready" sentence="Ready to advance." />,
+    );
+    expect(html).toMatch(/role="region"/);
+    expect(html).toContain('aria-label="Current build action"');
+  });
+
+  it("renders the sentence exactly once — no duplicate heading", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="ready" sentence="Plan review passed." />,
+    );
+    // The sentence appears once
+    const matches = html.match(/Plan review passed\./g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("does NOT render a 'Build Status' or 'Operational status' label", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="ready" sentence="Plan review passed." />,
+    );
+    expect(html).not.toContain("Build Status");
+    expect(html).not.toContain("Operational status");
+  });
+
+  it("does NOT render detail when state is 'ready'", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="ready"
+        sentence="Ready to advance."
+        detail="This should not appear."
+      />,
+    );
+    expect(html).not.toContain("This should not appear.");
+    expect(html).not.toContain('data-testid="action-banner-detail"');
+  });
+
+  it("does NOT render detail when state is 'running'", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="running"
+        sentence="Build running."
+        detail="Should not appear."
+      />,
+    );
+    expect(html).not.toContain("Should not appear.");
+  });
+
+  it("does NOT render detail when state is 'complete'", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="complete"
+        sentence="Build complete."
+        detail="Should not appear."
+      />,
+    );
+    expect(html).not.toContain("Should not appear.");
+  });
+
+  it("renders detail when state is 'blocked'", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="blocked"
+        sentence="Blocked on dependency."
+        detail="Waiting for cache module."
+      />,
+    );
+    expect(html).toContain("Waiting for cache module.");
+    expect(html).toContain('data-testid="action-banner-detail"');
+  });
+
+  it("renders detail when state is 'review_failed'", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="review_failed"
+        sentence="Plan review failed."
+        detail="Fix the dependency ordering."
+      />,
+    );
+    expect(html).toContain("Fix the dependency ordering.");
+  });
+
+  it("renders primary action right-aligned with min-width", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="ready"
+        sentence="Advance available."
+        primaryAction={{ label: "Advance to Plan", onClick: () => {} }}
+      />,
+    );
+    expect(html).toContain("Advance to Plan");
+    expect(html).toContain("min-w-[120px]");
+    expect(html).toContain('data-testid="action-banner-primary"');
+    expect(html).toContain("action-banner__primary");
+  });
+
+  it("respects disabled prop on the primary action", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner
+        state="blocked"
+        sentence="Blocked."
+        primaryAction={{ label: "Retry", onClick: () => {}, disabled: true }}
+      />,
+    );
+    expect(html).toMatch(/aria-disabled="true"/);
+    expect(html).toContain("disabled");
+  });
+
+  it("omits the primary action button when no primaryAction prop is provided", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="running" sentence="Build running." />,
+    );
+    expect(html).not.toContain('data-testid="action-banner-primary"');
+  });
+
+  it("uses distinct fg/bg tokens for 'blocked' state — no chip-collapse bug", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="blocked" sentence="Blocked." detail="Reason." />,
+    );
+    expect(html).toContain("bg-[var(--dpf-state-warning)]");
+    expect(html).toContain("border-[var(--dpf-warning)]");
+    // Foreground is var(--dpf-text), not the same warning token.
+    expect(html).toContain("text-[var(--dpf-text)]");
+    // The bg/border var name and the fg var name must not be identical sources.
+    expect(html).not.toMatch(/bg-\[var\(--dpf-warning\)\][^"]*text-\[var\(--dpf-warning\)\]/);
+  });
+
+  it("uses distinct tokens for each non-default state", () => {
+    const states = ["running", "blocked", "review_failed", "complete"] as const;
+    for (const state of states) {
+      const html = renderToStaticMarkup(
+        <ActionBanner state={state} sentence={`State: ${state}`} />,
+      );
+      // None of the states should use the same bg+text var pair (the chip bug).
+      const bgMatch = html.match(/bg-\[var\(--dpf-state-[a-z]+\)\]/);
+      const txtMatch = html.match(/text-\[var\(--dpf-[a-z]+\)\]/);
+      expect(bgMatch).toBeTruthy();
+      expect(txtMatch).toBeTruthy();
+      // The fg should be --dpf-text (neutral) for readability against the tinted bg.
+      expect(txtMatch?.[0]).toContain("--dpf-text");
+    }
+  });
+
+  it("emits data-state for snapshot diffing", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="review_failed" sentence="x" />,
+    );
+    expect(html).toContain('data-state="review_failed"');
+  });
+
+  it("emits the canonical test ID on the wrapper", () => {
+    const html = renderToStaticMarkup(
+      <ActionBanner state="ready" sentence="x" />,
+    );
+    expect(html).toContain(`data-testid="${BUILD_STUDIO_TEST_IDS.actionBanner}"`);
+  });
+
+  it("uses no hex literals (DPF variable invariant)", () => {
+    const allStates = ["ready", "running", "blocked", "review_failed", "complete"] as const;
+    for (const state of allStates) {
+      const html = renderToStaticMarkup(
+        <ActionBanner
+          state={state}
+          sentence="x"
+          detail="y"
+          primaryAction={{ label: "z", onClick: () => {} }}
+        />,
+      );
+      expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+    }
+  });
+});

--- a/apps/web/components/build/ActionBanner.tsx
+++ b/apps/web/components/build/ActionBanner.tsx
@@ -1,0 +1,129 @@
+// apps/web/components/build/ActionBanner.tsx
+//
+// Compact 40px presentation of the build's current state + primary action.
+// Replaces the current ~200px stacked "Build Status / heading / repeated
+// sentence / button / repeated detail" card in the new layout. Used by
+// BuildStudio (and, via delegation, by BuildStudioWorkflowActionCard) in
+// later waves — this PR introduces the component standalone with tests.
+//
+// Per the design spec §1 + §6:
+//   - One sentence describes the state. The sentence IS the heading — no
+//     duplicate "Build Status" label or repeated warning.
+//   - Detail line is rendered ONLY when the state is "blocked" or "review_failed".
+//   - Height is exactly 40px (Tailwind h-10).
+//   - role="region" with an aria-label so screen readers can land here.
+//   - Uses ACTION_BANNER_HEIGHT_CLASS so the size lives in one place.
+//   - Status color comes from --dpf-state-* variables (now subtle tints
+//     after PR #905) — fg uses the matching --dpf-{tone} variable so the
+//     two are distinct.
+
+"use client";
+
+import { ACTION_BANNER_HEIGHT_CLASS, BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+export type ActionBannerState = "ready" | "running" | "blocked" | "review_failed" | "complete";
+
+export type ActionBannerPrimaryAction = {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+};
+
+export type ActionBannerProps = {
+  state: ActionBannerState;
+  /** One sentence describing the current state. This IS the heading — no separate title. */
+  sentence: string;
+  /** Optional primary action. Right-aligned, min-width 120px. */
+  primaryAction?: ActionBannerPrimaryAction;
+  /** Extra detail line. Rendered ONLY when state is "blocked" or "review_failed". */
+  detail?: string;
+};
+
+/** Distinct fg + bg tokens per state. Tints come from --dpf-state-* (PR #905). */
+function stateClassName(state: ActionBannerState): string {
+  if (state === "blocked" || state === "review_failed") {
+    return [
+      "bg-[var(--dpf-state-warning)]",
+      "text-[var(--dpf-text)]",
+      "border-[var(--dpf-warning)]",
+    ].join(" ");
+  }
+  if (state === "running") {
+    return [
+      "bg-[var(--dpf-state-info)]",
+      "text-[var(--dpf-text)]",
+      "border-[var(--dpf-info)]",
+    ].join(" ");
+  }
+  if (state === "complete") {
+    return [
+      "bg-[var(--dpf-state-success)]",
+      "text-[var(--dpf-text)]",
+      "border-[var(--dpf-success)]",
+    ].join(" ");
+  }
+  // "ready" — default surface, no state color.
+  return [
+    "bg-[var(--dpf-surface-2)]",
+    "text-[var(--dpf-text)]",
+    "border-[var(--dpf-border)]",
+  ].join(" ");
+}
+
+/** Detail is intentionally rendered only for blocked / review_failed. */
+function shouldShowDetail(state: ActionBannerState, detail: string | undefined): detail is string {
+  if (!detail) return false;
+  return state === "blocked" || state === "review_failed";
+}
+
+export function ActionBanner({ state, sentence, primaryAction, detail }: ActionBannerProps) {
+  const showDetail = shouldShowDetail(state, detail);
+  return (
+    <div
+      role="region"
+      aria-label="Current build action"
+      data-testid={BUILD_STUDIO_TEST_IDS.actionBanner}
+      data-state={state}
+      className={[
+        ACTION_BANNER_HEIGHT_CLASS,
+        "flex",
+        "shrink-0",
+        "items-center",
+        "justify-between",
+        "gap-3",
+        "border-b",
+        "px-4",
+        "text-xs",
+        "leading-tight",
+        stateClassName(state),
+      ].join(" ")}
+    >
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* The sentence IS the heading — render as a single line that describes the state. */}
+        <span className="min-w-0 truncate font-medium" data-testid="action-banner-sentence">
+          {sentence}
+        </span>
+        {showDetail && (
+          <span
+            className="min-w-0 truncate text-[10px] text-[var(--dpf-muted)]"
+            data-testid="action-banner-detail"
+          >
+            {detail}
+          </span>
+        )}
+      </div>
+      {primaryAction && (
+        <button
+          type="button"
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled}
+          aria-disabled={primaryAction.disabled}
+          data-testid="action-banner-primary"
+          className="action-banner__primary inline-flex min-w-[120px] shrink-0 items-center justify-center rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+        >
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/build/BuildListItem.test.tsx
+++ b/apps/web/components/build/BuildListItem.test.tsx
@@ -111,3 +111,237 @@ describe("BuildListItem", () => {
     expect(html.slice(openControlStart, deleteControlStart)).toContain("</button>");
   });
 });
+
+describe("BuildListItem fleet density", () => {
+  it("renders the compact fleet row instead of the comfortable card", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain('data-density="fleet"');
+    expect(html).toContain("fleet-row");
+    // Fleet density must NOT use the comfortable min/max-h tokens.
+    expect(html).not.toContain("min-h-[88px]");
+    expect(html).not.toContain("max-h-[128px]");
+  });
+
+  it("uses the ≤32px row height class from the layout helper (no pixel assertion)", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    // Class assertion only — jsdom can't measure layout reliably.
+    expect(html).toContain("max-h-8");
+    expect(html).toContain("min-h-8");
+  });
+
+  it("does NOT render the 'Updated MMM DD' chrome at fleet density", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).not.toContain("Updated Apr");
+  });
+
+  it("renders the phase mini-rail wrapper", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    // PhaseMiniRail emits role=img + Active: <phase> in its aria-label.
+    expect(html).toMatch(/role="img"/);
+    expect(html).toContain("Active: build");
+  });
+
+  it("renders QueueStateBadge when queueState !== 'idle'", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        queueState={{ kind: "queued", position: 3, reason: "capacity", ahead: 2 }}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain('aria-label="Queued, position 3"');
+    expect(html).toContain('data-kind="queued"');
+  });
+
+  it("omits the QueueStateBadge when queueState is 'idle' (or missing)", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    // No badge rendered for idle / undefined queueState.
+    expect(html).not.toContain('data-kind="running"');
+    expect(html).not.toContain('data-kind="queued"');
+    expect(html).not.toContain('data-kind="blocked"');
+  });
+
+  it("renders the attention dot when needsAttention is true", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        needsAttention
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain('data-testid="fleet-row-attention"');
+    expect(html).toContain('aria-label="Needs attention"');
+  });
+
+  it("omits the attention dot when needsAttention is false (default)", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).not.toContain('data-testid="fleet-row-attention"');
+  });
+
+  it("uses 4px left-border accent + aria-current for the active row (not just color)", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain("border-l-4");
+    expect(html).toContain("border-[var(--dpf-accent)]");
+    expect(html).toContain('aria-current="true"');
+    expect(html).toContain('data-active="true"');
+  });
+
+  it("inactive row uses transparent border (not aria-current)", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain("border-transparent");
+    expect(html).not.toContain('aria-current="true"');
+  });
+
+  it("shows the BI-* originator code as a hover tooltip on the FB code", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    // The originator itemId becomes the title attribute on the FB code span.
+    expect(html).toMatch(/title="BI-5B839D74"/);
+  });
+
+  it("delete button is icon-only and hidden by default at fleet density", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active={false}
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).toContain('data-testid="fleet-row-delete"');
+    expect(html).toContain("hidden"); // hidden until hover/focus
+    expect(html).toContain("group-hover:flex");
+  });
+
+  it("renders no hex literals at fleet density (DPF variable invariant)", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        queueState={{ kind: "running", stepLabel: "Generate" }}
+        needsAttention
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+  });
+});

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
-import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+import {
+  BUILD_STUDIO_TEST_IDS,
+  FLEET_ROW_HEIGHT_CLASS,
+} from "./build-studio-layout";
+import { PhaseMiniRail, type PhaseRailPhase } from "./PhaseMiniRail";
+import { QueueStateBadge, type BuildQueueState } from "./QueueStateBadge";
+
+export type BuildListItemDensity = "comfortable" | "fleet";
 
 type BuildListItemProps = {
   build: FeatureBuildRow;
@@ -11,6 +18,14 @@ type BuildListItemProps = {
   isDevEnvironment: boolean;
   onSelect: () => void;
   onDelete: () => void;
+  /** Optional density variant. Defaults to "comfortable" so existing callers
+   *  render the legacy card. The fleet rail uses "fleet" for ≤32px rows. */
+  density?: BuildListItemDensity;
+  /** Runtime queue state surfaced as a badge between the claim and the
+   *  attention dot. Used only by the fleet density variant. */
+  queueState?: BuildQueueState;
+  /** Render the attention dot when true. Fleet density only. */
+  needsAttention?: boolean;
 };
 
 function formatUpdatedAt(value: Date | string) {
@@ -18,6 +33,28 @@ function formatUpdatedAt(value: Date | string) {
     month: "short",
     day: "numeric",
   }).format(new Date(value));
+}
+
+/** Resolve which canonical PhaseMiniRail phase to render for an FB phase.
+ *  The mini-rail only knows about the 5 canonical phases — failed/complete
+ *  fall back to the closest sensible representation. */
+function toPhaseRailPhase(phase: FeatureBuildRow["phase"]): PhaseRailPhase {
+  switch (phase) {
+    case "ideate":
+    case "plan":
+    case "build":
+    case "review":
+    case "ship":
+      return phase;
+    case "complete":
+      return "ship";
+    case "failed":
+    case "abandoned":
+      // Treat terminal-failure states as still-in-review for the mini-rail.
+      return "review";
+    default:
+      return "ideate";
+  }
 }
 
 export function BuildListItem({
@@ -28,7 +65,26 @@ export function BuildListItem({
   isDevEnvironment,
   onSelect,
   onDelete,
+  density = "comfortable",
+  queueState,
+  needsAttention = false,
 }: BuildListItemProps) {
+  if (density === "fleet") {
+    return (
+      <FleetDensityRow
+        build={build}
+        active={active}
+        index={index}
+        isDevEnvironment={isDevEnvironment}
+        onSelect={onSelect}
+        onDelete={onDelete}
+        queueState={queueState ?? { kind: "idle" }}
+        needsAttention={needsAttention}
+      />
+    );
+  }
+
+  // ── Comfortable density (legacy) — unchanged so existing callers + tests pass ──
   return (
     <div
       data-testid={BUILD_STUDIO_TEST_IDS.buildListItem}
@@ -82,6 +138,111 @@ export function BuildListItem({
         disabled={isDevEnvironment}
         onClick={onDelete}
         className="grid w-8 shrink-0 cursor-pointer place-items-start rounded-r-md px-2 py-2 text-xs text-[var(--dpf-muted)] transition-colors hover:text-[var(--dpf-error)] focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* Fleet density — compact 32px row with phase mini-rail + queue badge.       */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+type FleetRowProps = {
+  build: FeatureBuildRow;
+  active: boolean;
+  index: number;
+  isDevEnvironment: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  queueState: BuildQueueState;
+  needsAttention: boolean;
+};
+
+function FleetDensityRow({
+  build,
+  active,
+  index,
+  isDevEnvironment,
+  onSelect,
+  onDelete,
+  queueState,
+  needsAttention,
+}: FleetRowProps) {
+  const railPhase = toPhaseRailPhase(build.phase);
+  const biCostTooltip = build.originator?.itemId ?? "";
+  return (
+    <div
+      data-testid={BUILD_STUDIO_TEST_IDS.buildListItem}
+      data-density="fleet"
+      data-active={active ? "true" : "false"}
+      aria-current={active ? "true" : undefined}
+      className={[
+        "fleet-row",
+        "group",
+        "relative",
+        "flex",
+        "items-center",
+        "gap-2",
+        "rounded-md",
+        "border-l-4",
+        active ? "border-[var(--dpf-accent)] bg-[var(--dpf-surface-2)]" : "border-transparent bg-transparent",
+        "px-2",
+        "py-0.5",
+        "hover:bg-[var(--dpf-surface-2)]",
+        FLEET_ROW_HEIGHT_CLASS,
+        "animate-slide-up",
+      ].join(" ")}
+      style={{
+        animationDelay: `${index * 30}ms`,
+        animationFillMode: "backwards",
+      }}
+    >
+      <button
+        type="button"
+        aria-label={`Open build ${build.title}`}
+        aria-pressed={active}
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
+      >
+        <span
+          className="shrink-0 font-mono text-[11px] text-[var(--dpf-text)]"
+          title={biCostTooltip || undefined}
+        >
+          {build.buildId}
+        </span>
+        <PhaseMiniRail currentPhase={railPhase} />
+        {build.claimStatus === "claimed" && build.claimedByAgentId && (
+          <span
+            className="inline-flex h-3.5 items-center justify-center rounded-full bg-[var(--dpf-accent-soft)] px-1.5 text-[9px] font-semibold uppercase text-[var(--dpf-accent)]"
+            title={`Claimed by ${build.claimedByAgentId}`}
+            data-testid="fleet-row-claim"
+          >
+            ●
+          </span>
+        )}
+        <QueueStateBadge state={queueState} />
+        {needsAttention && (
+          <span
+            role="img"
+            aria-label="Needs attention"
+            title="Needs your attention"
+            data-testid="fleet-row-attention"
+            className="inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full bg-[var(--dpf-error)] ring-1 ring-[var(--dpf-error)] ring-offset-1 ring-offset-[var(--dpf-surface-1)]"
+          />
+        )}
+        <span className="ml-auto min-w-0 truncate text-[11px] text-[var(--dpf-muted)]">
+          {build.title}
+        </span>
+      </button>
+      <button
+        type="button"
+        aria-label={`Delete ${build.title}`}
+        disabled={isDevEnvironment}
+        onClick={onDelete}
+        data-testid="fleet-row-delete"
+        className="hidden h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-[10px] text-[var(--dpf-muted)] transition-colors hover:text-[var(--dpf-error)] focus-visible:flex focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2 group-hover:flex disabled:cursor-not-allowed disabled:opacity-40"
       >
         &times;
       </button>

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -49,8 +49,7 @@ function toPhaseRailPhase(phase: FeatureBuildRow["phase"]): PhaseRailPhase {
     case "complete":
       return "ship";
     case "failed":
-    case "abandoned":
-      // Treat terminal-failure states as still-in-review for the mini-rail.
+      // Treat terminal-failure as still-in-review for the mini-rail.
       return "review";
     default:
       return "ideate";

--- a/apps/web/components/build/DetailsDrawer.test.tsx
+++ b/apps/web/components/build/DetailsDrawer.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+//
+// apps/web/components/build/DetailsDrawer.test.tsx
+//
+// Pins the DetailsDrawer contract:
+//   - Slides in/out via translate-x, motion-reduce gating.
+//   - role=region + aria-label + aria-hidden reflects open state.
+//   - Sections render in given order; defaultOpen drives initial expansion.
+//   - Accordion toggle flips aria-expanded.
+//   - Esc closes when open; close button invokes onClose.
+//   - BS-Queue subsection has the canonical test ID for integration.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DetailsDrawer, DetailsDrawerPill, type DetailsDrawerSection } from "./DetailsDrawer";
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+afterEach(cleanup);
+
+function sampleSections(): DetailsDrawerSection[] {
+  return [
+    { id: "progress", title: "Progress", content: <p data-testid="content-progress">progress body</p> },
+    { id: "brief", title: "Brief / Design Doc", defaultOpen: true, content: <p data-testid="content-brief">brief body</p> },
+    { id: "review", title: "Review", content: <p data-testid="content-review">review body</p> },
+    { id: "sandbox", title: "Sandbox", content: <p data-testid="content-sandbox">sandbox body</p> },
+    { id: "bs-queue", title: "BS Queue", content: <p data-testid="content-queue">queue body</p> },
+  ];
+}
+
+describe("DetailsDrawer", () => {
+  it("renders role=region with aria-label='Build details'", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const drawer = screen.getByRole("region", { name: "Build details" });
+    expect(drawer).toHaveAttribute("data-open", "true");
+  });
+
+  it("aria-hidden=true and translate-x-full when closed", () => {
+    render(
+      <DetailsDrawer isOpen={false} onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const drawer = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer);
+    expect(drawer).toHaveAttribute("aria-hidden", "true");
+    expect(drawer.className).toContain("translate-x-full");
+  });
+
+  it("translate-x-0 when open", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const drawer = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer);
+    expect(drawer.className).toContain("translate-x-0");
+  });
+
+  it("motion-reduce class disables transitions for prefers-reduced-motion users", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const drawer = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer);
+    expect(drawer.className).toContain("motion-reduce:transition-none");
+  });
+
+  it("renders sections in given order", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const sections = Array.from(document.querySelectorAll("[data-section-id]"));
+    expect(sections.map((s) => s.getAttribute("data-section-id"))).toEqual([
+      "progress",
+      "brief",
+      "review",
+      "sandbox",
+      "bs-queue",
+    ]);
+  });
+
+  it("defaultOpen drives initial expansion (Brief expanded, others collapsed)", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    expect(screen.getByText("brief body")).toBeInTheDocument();
+    expect(screen.queryByText("progress body")).not.toBeInTheDocument();
+    expect(screen.queryByText("review body")).not.toBeInTheDocument();
+  });
+
+  it("clicking a collapsed section header expands it (aria-expanded flips, body renders)", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const progressHeader = screen.getByRole("button", { name: "Progress" });
+    expect(progressHeader).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(progressHeader);
+    expect(progressHeader).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("progress body")).toBeInTheDocument();
+  });
+
+  it("clicking an expanded section header collapses it", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    const briefHeader = screen.getByRole("button", { name: "Brief / Design Doc" });
+    expect(briefHeader).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(briefHeader);
+    expect(briefHeader).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("brief body")).not.toBeInTheDocument();
+  });
+
+  it("the BS-queue section uses the canonical detailsDrawerQueue test ID for integration", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
+    );
+    expect(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerQueue)).toBeInTheDocument();
+  });
+
+  it("Esc closes the drawer when open", () => {
+    const onClose = vi.fn();
+    render(
+      <DetailsDrawer isOpen onClose={onClose} sections={sampleSections()} />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Esc does NOT trigger onClose when drawer is closed", () => {
+    const onClose = vi.fn();
+    render(
+      <DetailsDrawer isOpen={false} onClose={onClose} sections={sampleSections()} />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("close button invokes onClose", () => {
+    const onClose = vi.fn();
+    render(
+      <DetailsDrawer isOpen onClose={onClose} sections={sampleSections()} />,
+    );
+    fireEvent.click(screen.getByLabelText("Close details drawer"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an empty-state placeholder when sections is empty", () => {
+    render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={[]} />,
+    );
+    expect(screen.getByText(/No details for this build\./i)).toBeInTheDocument();
+  });
+
+  it("re-seeds expansion when sections change (different defaultOpen)", () => {
+    const initial = sampleSections();
+    const { rerender } = render(
+      <DetailsDrawer isOpen onClose={vi.fn()} sections={initial} />,
+    );
+    expect(screen.getByText("brief body")).toBeInTheDocument();
+
+    const updated: DetailsDrawerSection[] = initial.map((s) => ({
+      ...s,
+      defaultOpen: s.id === "review",
+    }));
+    rerender(<DetailsDrawer isOpen onClose={vi.fn()} sections={updated} />);
+    expect(screen.queryByText("brief body")).not.toBeInTheDocument();
+    expect(screen.getByText("review body")).toBeInTheDocument();
+  });
+});
+
+describe("DetailsDrawerPill", () => {
+  it("renders with the canonical test ID + aria-expanded reflecting state", () => {
+    const { rerender } = render(<DetailsDrawerPill isOpen={false} onClick={vi.fn()} />);
+    const pill = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill);
+    expect(pill).toHaveAttribute("aria-expanded", "false");
+    expect(pill).toHaveAttribute("aria-label", "Open build details drawer");
+
+    rerender(<DetailsDrawerPill isOpen onClick={vi.fn()} />);
+    expect(pill).toHaveAttribute("aria-expanded", "true");
+    expect(pill).toHaveAttribute("aria-label", "Close build details drawer");
+  });
+
+  it("click invokes onClick", () => {
+    const onClick = vi.fn();
+    render(<DetailsDrawerPill isOpen={false} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/build/DetailsDrawer.tsx
+++ b/apps/web/components/build/DetailsDrawer.tsx
@@ -1,0 +1,189 @@
+// apps/web/components/build/DetailsDrawer.tsx
+//
+// Right-edge drawer that hosts the evidence surfaces that used to live in
+// the Progress/Details/Docs/Preview tabs. Slides in from the workflow
+// canvas region; never covers the AI Coworker rail (the parent shell
+// guarantees that via layout).
+//
+// Per the design spec §5 + the queue-surface amendment (PR #898):
+//   - Width: min(480px, 40vw) via DETAILS_DRAWER_WIDTH_CLASS.
+//   - 200ms slide via getDetailsDrawerClassName; respects prefers-reduced-motion.
+//   - Sections are accordion items; defaultOpen drives the initial expansion.
+//     Each section supplies its own content slot — DetailsDrawer is purely
+//     presentational; the BuildStudio shell composes (Progress / Brief /
+//     Review / Sandbox / BS Queue) and passes them in.
+//   - 24px vertical pill on the right edge of the canvas — exported as a
+//     sibling component (DetailsDrawerPill) so it can sit on the canvas
+//     while the drawer mounts inside the active zone.
+//   - role="region" + aria-label; close button has aria-label.
+
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+import {
+  BUILD_STUDIO_TEST_IDS,
+  getDetailsDrawerClassName,
+  getDetailsDrawerPillClassName,
+} from "./build-studio-layout";
+
+export type DetailsDrawerSection = {
+  /** Stable id — used for aria-controls + the optional default-open key. */
+  id: string;
+  /** Accordion heading text. */
+  title: string;
+  /** When true, the section is expanded on mount (the BuildStudio shell sets
+   *  this based on the active build's phase). */
+  defaultOpen?: boolean;
+  /** Section body. May render existing surfaces (BuildProgressOperationalPanel,
+   *  ReviewPanel, FeatureBriefPanel, BuildSandboxCard, BS-Queue table). */
+  content: ReactNode;
+};
+
+export type DetailsDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  sections: readonly DetailsDrawerSection[];
+};
+
+export function DetailsDrawer({ isOpen, onClose, sections }: DetailsDrawerProps) {
+  // Track which sections are expanded. Re-seed from defaultOpen when sections
+  // change (e.g. phase change reorders the default-open section).
+  const initialOpen = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of sections) {
+      if (s.defaultOpen) set.add(s.id);
+    }
+    return set;
+  }, [sections]);
+  const [openIds, setOpenIds] = useState<Set<string>>(initialOpen);
+
+  useEffect(() => {
+    setOpenIds(initialOpen);
+  }, [initialOpen]);
+
+  // Esc to close — only when drawer is open, capture-phase so it wins over
+  // nested inputs.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (typeof document === "undefined") return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [isOpen, onClose]);
+
+  const toggle = (id: string) => {
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <aside
+      role="region"
+      aria-label="Build details"
+      aria-hidden={!isOpen}
+      data-testid={BUILD_STUDIO_TEST_IDS.detailsDrawer}
+      data-open={isOpen ? "true" : "false"}
+      className={getDetailsDrawerClassName(isOpen)}
+    >
+      <header className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--dpf-border)] px-3 py-2">
+        <h2 className="m-0 text-xs font-semibold uppercase tracking-wider text-[var(--dpf-muted)]">
+          Build details
+        </h2>
+        <button
+          type="button"
+          aria-label="Close details drawer"
+          onClick={onClose}
+          className="rounded p-1 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {sections.length === 0 && (
+          <p className="px-3 py-3 text-xs text-[var(--dpf-muted)]">No details for this build.</p>
+        )}
+        {sections.map((section) => {
+          const open = openIds.has(section.id);
+          const headerId = `details-drawer-${section.id}-header`;
+          const panelId = `details-drawer-${section.id}-panel`;
+          const sectionTestId =
+            section.id === "bs-queue" ? BUILD_STUDIO_TEST_IDS.detailsDrawerQueue : `details-drawer-section-${section.id}`;
+          return (
+            <section
+              key={section.id}
+              data-testid={sectionTestId}
+              data-section-id={section.id}
+              data-open={open ? "true" : "false"}
+              className="border-b border-[var(--dpf-border)]"
+            >
+              <h3 className="m-0">
+                <button
+                  type="button"
+                  id={headerId}
+                  aria-expanded={open}
+                  aria-controls={panelId}
+                  onClick={() => toggle(section.id)}
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs font-semibold text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+                >
+                  <span>{section.title}</span>
+                  <span aria-hidden="true" className="text-[var(--dpf-muted)]">
+                    {open ? "▾" : "▸"}
+                  </span>
+                </button>
+              </h3>
+              {open && (
+                <div
+                  id={panelId}
+                  role="region"
+                  aria-labelledby={headerId}
+                  className="px-3 py-2 text-xs text-[var(--dpf-text)]"
+                >
+                  {section.content}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+export type DetailsDrawerPillProps = {
+  isOpen: boolean;
+  onClick: () => void;
+};
+
+/**
+ * Thin 24-px vertical pill on the right edge of the workflow canvas. Opens
+ * (or closes) the DetailsDrawer. Lives next to the canvas — NOT inside the
+ * drawer — so it's always reachable when the drawer is closed.
+ */
+export function DetailsDrawerPill({ isOpen, onClick }: DetailsDrawerPillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={isOpen ? "Close build details drawer" : "Open build details drawer"}
+      aria-expanded={isOpen}
+      data-testid={BUILD_STUDIO_TEST_IDS.detailsDrawerPill}
+      className={getDetailsDrawerPillClassName()}
+    >
+      <span className="rotate-180" style={{ writingMode: "vertical-rl" }}>
+        Details
+      </span>
+    </button>
+  );
+}

--- a/apps/web/components/build/FleetRail.test.tsx
+++ b/apps/web/components/build/FleetRail.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+//
+// apps/web/components/build/FleetRail.test.tsx
+//
+// Pins the FleetRail contract:
+//   - Header label format + role=status + aria-live polite (queue surface
+//     amendment PR #898).
+//   - Default sort: running → blocked → queued (by position) → idle.
+//   - Header click invokes onOpenQueueDrawer.
+//   - Row select / delete propagate to the right entry.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FleetRail, formatFleetHeader, sortFleetEntries, type FleetRailEntry } from "./FleetRail";
+import {
+  normalizeHappyPathState,
+  type FeatureBuildRow,
+} from "@/lib/feature-build-types";
+
+afterEach(cleanup);
+
+function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    id: `row-${overrides.buildId ?? "X"}`,
+    buildId: "FB-AAAAAAAA",
+    title: "A build",
+    description: null,
+    portfolioId: null,
+    originatingBacklogItemId: null,
+    brief: null,
+    plan: null,
+    phase: "build",
+    sandboxId: null,
+    sandboxPort: null,
+    diffSummary: null,
+    diffPatch: null,
+    codingProvider: null,
+    threadId: null,
+    digitalProductId: null,
+    product: null,
+    createdById: "user-1",
+    createdAt: new Date("2026-05-21T00:00:00Z"),
+    updatedAt: new Date("2026-05-21T00:00:00Z"),
+    draftApprovedAt: null,
+    designDoc: null,
+    designReview: null,
+    buildPlan: null,
+    planReview: null,
+    taskResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    scoutFindings: null,
+    uxTestResults: null,
+    uxVerificationStatus: null,
+    accountableEmployeeId: null,
+    claimedByAgentId: null,
+    claimedAt: null,
+    claimStatus: null,
+    buildExecState: null,
+    deliberationSummary: null,
+    happyPathState: normalizeHappyPathState(null),
+    originator: null,
+    phaseHandoffs: [],
+    ...overrides,
+  };
+}
+
+function entry(
+  buildId: string,
+  queueState: FleetRailEntry["queueState"],
+  needsAttention = false,
+): FleetRailEntry {
+  return {
+    build: makeBuild({ buildId, title: `Build ${buildId}` }),
+    lifecycleLabel: null,
+    queueState,
+    needsAttention,
+  };
+}
+
+describe("formatFleetHeader", () => {
+  it("formats running/cap and queued count", () => {
+    expect(formatFleetHeader(2, 3, 4)).toBe("Builds: 2/3 · 4 queued");
+    expect(formatFleetHeader(0, 5, 0)).toBe("Builds: 0/5 · 0 queued");
+  });
+});
+
+describe("sortFleetEntries", () => {
+  it("orders by queueState.kind: running → blocked → queued → idle", () => {
+    const idle = entry("FB-1IDLE", { kind: "idle" });
+    const queued2 = entry("FB-2QQQQQQ", { kind: "queued", position: 2, reason: "capacity", ahead: 1 });
+    const blocked = entry("FB-3BLOCK", { kind: "blocked", reason: "x" });
+    const running = entry("FB-4RUN", { kind: "running", stepLabel: null });
+    const sorted = sortFleetEntries([idle, queued2, blocked, running]);
+    expect(sorted.map((e) => e.build.buildId)).toEqual([
+      "FB-4RUN",
+      "FB-3BLOCK",
+      "FB-2QQQQQQ",
+      "FB-1IDLE",
+    ]);
+  });
+
+  it("orders multiple queued entries by position ascending", () => {
+    const q3 = entry("FB-QQQ3", { kind: "queued", position: 3, reason: "capacity", ahead: 2 });
+    const q1 = entry("FB-QQQ1", { kind: "queued", position: 1, reason: "capacity", ahead: 0 });
+    const q2 = entry("FB-QQQ2", { kind: "queued", position: 2, reason: "capacity", ahead: 1 });
+    const sorted = sortFleetEntries([q3, q1, q2]);
+    expect(sorted.map((e) => e.build.buildId)).toEqual([
+      "FB-QQQ1",
+      "FB-QQQ2",
+      "FB-QQQ3",
+    ]);
+  });
+
+  it("breaks same-kind ties (non-queued) by buildId ascending for stable rendering", () => {
+    const a = entry("FB-ARUNA", { kind: "running", stepLabel: null });
+    const b = entry("FB-BRUNB", { kind: "running", stepLabel: null });
+    const sorted = sortFleetEntries([b, a]);
+    expect(sorted.map((e) => e.build.buildId)).toEqual(["FB-ARUNA", "FB-BRUNB"]);
+  });
+
+  it("returns a new array — input is not mutated", () => {
+    const input = [
+      entry("FB-IDLE-X", { kind: "idle" }),
+      entry("FB-RUN-X", { kind: "running", stepLabel: null }),
+    ];
+    const before = input.map((e) => e.build.buildId);
+    sortFleetEntries(input);
+    expect(input.map((e) => e.build.buildId)).toEqual(before);
+  });
+});
+
+describe("FleetRail rendering", () => {
+  it("renders the header label with the right counts", () => {
+    render(
+      <FleetRail
+        entries={[]}
+        activeBuildId={null}
+        cap={3}
+        runningCount={1}
+        queuedCount={2}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={vi.fn()}
+        onSelectBuild={vi.fn()}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("fleet-header-label")).toHaveTextContent("Builds: 1/3 · 2 queued");
+  });
+
+  it("header has role=status + aria-live=polite for queue-change announcement", () => {
+    render(
+      <FleetRail
+        entries={[]}
+        activeBuildId={null}
+        cap={3}
+        runningCount={1}
+        queuedCount={2}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={vi.fn()}
+        onSelectBuild={vi.fn()}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    // role=status comes from the button element.
+    const header = screen.getByRole("status");
+    expect(header).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("clicking the header invokes onOpenQueueDrawer", () => {
+    const onOpenQueueDrawer = vi.fn();
+    render(
+      <FleetRail
+        entries={[]}
+        activeBuildId={null}
+        cap={3}
+        runningCount={1}
+        queuedCount={2}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={onOpenQueueDrawer}
+        onSelectBuild={vi.fn()}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("status"));
+    expect(onOpenQueueDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a placeholder when there are no entries", () => {
+    render(
+      <FleetRail
+        entries={[]}
+        activeBuildId={null}
+        cap={3}
+        runningCount={0}
+        queuedCount={0}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={vi.fn()}
+        onSelectBuild={vi.fn()}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No builds\./i)).toBeInTheDocument();
+  });
+
+  it("propagates onSelectBuild with the right build", () => {
+    const onSelectBuild = vi.fn();
+    const run = entry("FB-RUNRUN", { kind: "running", stepLabel: null });
+    render(
+      <FleetRail
+        entries={[run]}
+        activeBuildId={null}
+        cap={3}
+        runningCount={1}
+        queuedCount={0}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={vi.fn()}
+        onSelectBuild={onSelectBuild}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Open build Build FB-RUNRUN"));
+    expect(onSelectBuild).toHaveBeenCalledTimes(1);
+    expect(onSelectBuild).toHaveBeenCalledWith(run.build);
+  });
+
+  it("renders rows in sort order (running first)", () => {
+    const idle = entry("FB-IDLEIDL", { kind: "idle" });
+    const running = entry("FB-RUNRUN", { kind: "running", stepLabel: null });
+    const queued = entry("FB-QQQQ1Q", { kind: "queued", position: 1, reason: "capacity", ahead: 0 });
+    render(
+      <FleetRail
+        entries={[idle, queued, running]}
+        activeBuildId={null}
+        cap={3}
+        runningCount={1}
+        queuedCount={1}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={vi.fn()}
+        onSelectBuild={vi.fn()}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    const rows = Array.from(document.querySelectorAll('[data-density="fleet"]'));
+    const ids = rows.map((row) => row.parentElement?.querySelector('button[aria-label^="Open build"]')?.getAttribute("aria-label"));
+    expect(ids[0]).toContain("FB-RUNRUN");
+    expect(ids[1]).toContain("FB-QQQQ1Q");
+    expect(ids[2]).toContain("FB-IDLEIDL");
+  });
+
+  it("marks the active row with aria-current=true", () => {
+    const a = entry("FB-AAAAAA1", { kind: "idle" });
+    const b = entry("FB-BBBBBB2", { kind: "idle" });
+    render(
+      <FleetRail
+        entries={[a, b]}
+        activeBuildId="FB-BBBBBB2"
+        cap={3}
+        runningCount={0}
+        queuedCount={0}
+        isDevEnvironment={false}
+        onOpenQueueDrawer={vi.fn()}
+        onSelectBuild={vi.fn()}
+        onDeleteBuild={vi.fn()}
+      />,
+    );
+    const activeRows = document.querySelectorAll('[data-density="fleet"][data-active="true"]');
+    expect(activeRows.length).toBe(1);
+    expect(activeRows[0]).toHaveAttribute("aria-current", "true");
+  });
+});

--- a/apps/web/components/build/FleetRail.tsx
+++ b/apps/web/components/build/FleetRail.tsx
@@ -1,0 +1,151 @@
+// apps/web/components/build/FleetRail.tsx
+//
+// The compact left rail of the redesigned Build Studio shell. Shows every
+// in-flight build as a ≤32px row plus a header that surfaces the BS queue
+// runtime state (concurrency cap + running + queued counts).
+//
+// Per the spec §1 (Fleet Rail) and the queue surface amendment (PR #898):
+//   - Header: "Builds: {running}/{cap} · {queuedCount} queued", role=status,
+//     aria-live="polite" so cap/queue-position changes are announced.
+//   - Default sort: running → blocked → queued (by position) → idle.
+//   - Each row uses BuildListItem density="fleet".
+//   - Clicking the header invokes onOpenQueueDrawer (the BuildStudio shell
+//     opens the DetailsDrawer scrolled to the BS-Queue subsection).
+
+"use client";
+
+import type { FeatureBuildRow } from "@/lib/feature-build-types";
+
+import {
+  BUILD_STUDIO_TEST_IDS,
+  getFleetRailBodyClassName,
+  getFleetRailClassName,
+  getFleetRailHeaderClassName,
+} from "./build-studio-layout";
+import { BuildListItem } from "./BuildListItem";
+import type { BuildQueueState } from "./QueueStateBadge";
+
+/** Each visible entry: the FeatureBuildRow plus per-row queue/attention state. */
+export type FleetRailEntry = {
+  build: FeatureBuildRow;
+  lifecycleLabel: string | null;
+  queueState: BuildQueueState;
+  needsAttention: boolean;
+};
+
+export type FleetRailProps = {
+  /** All visible builds. Sort order is determined HERE by queueState.kind,
+   *  not by the caller — the caller passes raw entries. */
+  entries: readonly FleetRailEntry[];
+  /** buildId of the currently-selected build (for active-row styling). */
+  activeBuildId: string | null;
+  /** Concurrency cap from the BS runtime. */
+  cap: number;
+  /** Count of running builds (derived from entries — passed in so the runtime
+   *  thread owns the source of truth, not this component). */
+  runningCount: number;
+  /** Count of queued builds (same provenance as runningCount). */
+  queuedCount: number;
+  /** Build Studio is hidden/disabled in dev environments — passed through to
+   *  BuildListItem so the delete button respects that state. */
+  isDevEnvironment: boolean;
+  /** Click handler for the FleetRail header — opens the BS-Queue drawer subsection. */
+  onOpenQueueDrawer: () => void;
+  /** Per-build click handler — the BuildStudio shell uses this to set the active build. */
+  onSelectBuild: (build: FeatureBuildRow) => void;
+  /** Per-build delete handler. */
+  onDeleteBuild: (build: FeatureBuildRow) => void;
+};
+
+/** Sort priority — running first, then blocked, then queued (by position ascending), then idle.
+ *  Pure: callers can rely on the same input producing the same render order. */
+export function sortFleetEntries(entries: readonly FleetRailEntry[]): FleetRailEntry[] {
+  const kindRank: Record<BuildQueueState["kind"], number> = {
+    running: 0,
+    blocked: 1,
+    queued: 2,
+    idle: 3,
+  };
+  return [...entries].sort((a, b) => {
+    const ra = kindRank[a.queueState.kind];
+    const rb = kindRank[b.queueState.kind];
+    if (ra !== rb) return ra - rb;
+    if (a.queueState.kind === "queued" && b.queueState.kind === "queued") {
+      return a.queueState.position - b.queueState.position;
+    }
+    // Same rank, non-queued: stable by buildId for determinism.
+    return a.build.buildId.localeCompare(b.build.buildId);
+  });
+}
+
+/** Formats the header label. Pinned as a helper so tests can assert it. */
+export function formatFleetHeader(runningCount: number, cap: number, queuedCount: number): string {
+  return `Builds: ${runningCount}/${cap} · ${queuedCount} queued`;
+}
+
+export function FleetRail({
+  entries,
+  activeBuildId,
+  cap,
+  runningCount,
+  queuedCount,
+  isDevEnvironment,
+  onOpenQueueDrawer,
+  onSelectBuild,
+  onDeleteBuild,
+}: FleetRailProps) {
+  const sorted = sortFleetEntries(entries);
+  return (
+    <aside
+      data-testid={BUILD_STUDIO_TEST_IDS.fleet}
+      aria-label="Build fleet"
+      className={getFleetRailClassName()}
+    >
+      <button
+        type="button"
+        onClick={onOpenQueueDrawer}
+        data-testid={BUILD_STUDIO_TEST_IDS.fleetHeader}
+        role="status"
+        aria-live="polite"
+        aria-label={`Open queue details — ${formatFleetHeader(runningCount, cap, queuedCount)}`}
+        className={[
+          getFleetRailHeaderClassName(),
+          "cursor-pointer",
+          "hover:text-[var(--dpf-accent)]",
+          "focus-visible:outline-2",
+          "focus-visible:outline-offset-2",
+          "focus-visible:outline-[var(--dpf-accent)]",
+        ].join(" ")}
+      >
+        <span data-testid="fleet-header-label">
+          {formatFleetHeader(runningCount, cap, queuedCount)}
+        </span>
+        <span aria-hidden="true" className="text-[var(--dpf-muted)]">
+          ›
+        </span>
+      </button>
+
+      <ul className={getFleetRailBodyClassName()} data-testid="fleet-rail-body">
+        {sorted.length === 0 && (
+          <li className="px-3 py-2 text-[11px] text-[var(--dpf-muted)]">No builds.</li>
+        )}
+        {sorted.map((entry, index) => (
+          <li key={entry.build.buildId}>
+            <BuildListItem
+              build={entry.build}
+              active={activeBuildId === entry.build.buildId}
+              index={index}
+              lifecycleLabel={entry.lifecycleLabel}
+              isDevEnvironment={isDevEnvironment}
+              density="fleet"
+              queueState={entry.queueState}
+              needsAttention={entry.needsAttention}
+              onSelect={() => onSelectBuild(entry.build)}
+              onDelete={() => onDeleteBuild(entry.build)}
+            />
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/apps/web/components/build/NodeInspector.a11y.test.tsx
+++ b/apps/web/components/build/NodeInspector.a11y.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+//
+// apps/web/components/build/NodeInspector.a11y.test.tsx
+//
+// Pins the accessibility + close-lifecycle contract: Esc closes,
+// click-outside closes, click-inside keeps open, focus is trapped
+// to the sentinel pair, focus returns to the trigger on close.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NodeInspector } from "./NodeInspector";
+
+afterEach(cleanup);
+
+function rect(left: number, top: number, w: number, h: number) {
+  return {
+    left,
+    top,
+    width: w,
+    height: h,
+    right: left + w,
+    bottom: top + h,
+  };
+}
+
+function renderInspector(extra: Partial<Parameters<typeof NodeInspector>[0]> = {}) {
+  const onClose = vi.fn();
+  const onAskCoworker = vi.fn();
+  const result = render(
+    <div>
+      <button type="button" data-testid="trigger">trigger</button>
+      <div data-graph-node data-testid="graph-node">graph node</div>
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1 inspector"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={onClose}
+        onAskCoworker={onAskCoworker}
+        {...extra}
+      />
+    </div>,
+  );
+  return { ...result, onClose, onAskCoworker };
+}
+
+describe("NodeInspector a11y + close lifecycle", () => {
+  it("Esc closes the inspector (capture phase wins over text inputs)", () => {
+    const { onClose } = renderInspector();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("mousedown outside the dialog AND outside graph nodes closes", () => {
+    const { onClose } = renderInspector();
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("mousedown INSIDE the dialog does NOT close", () => {
+    const { onClose } = renderInspector();
+    const dialog = screen.getByRole("dialog");
+    fireEvent.mouseDown(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("mousedown on a graph node does NOT close (parent handles toggle)", () => {
+    const { onClose } = renderInspector();
+    const graphNode = screen.getByTestId("graph-node");
+    fireEvent.mouseDown(graphNode);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("close button click invokes onClose", () => {
+    const { onClose } = renderInspector();
+    const closeBtn = screen.getByLabelText("Close inspector");
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders sentinel pair for focus trapping", () => {
+    renderInspector();
+    expect(screen.getByTestId("node-inspector-sentinel-start")).toBeInTheDocument();
+    expect(screen.getByTestId("node-inspector-sentinel-end")).toBeInTheDocument();
+  });
+
+  it("focus on the start sentinel wraps to the last focusable", () => {
+    const { onAskCoworker } = renderInspector();
+    expect(onAskCoworker).toBeDefined(); // sanity — ensures the ask-coworker button renders
+    const startSentinel = screen.getByTestId("node-inspector-sentinel-start");
+    fireEvent.focus(startSentinel);
+    // Last focusable is the "Ask coworker" button (when provided).
+    expect(screen.getByTestId("node-inspector-ask-coworker")).toHaveFocus();
+  });
+
+  it("focus on the end sentinel wraps to the first focusable", () => {
+    renderInspector();
+    const endSentinel = screen.getByTestId("node-inspector-sentinel-end");
+    fireEvent.focus(endSentinel);
+    // First focusable is the expand button.
+    expect(screen.getByLabelText("Expand inspector")).toHaveFocus();
+  });
+
+  it("restores focus to the previously-focused element on unmount", () => {
+    // jsdom doesn't auto-focus; emulate the prior focus state.
+    const trigger = document.createElement("button");
+    trigger.textContent = "trigger-outside";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1 inspector"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+
+  it("dialog has role + aria-modal=false + aria-labelledby pointing at the title element", () => {
+    renderInspector();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "false");
+    const labelledBy = dialog.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    const labelEl = document.getElementById(labelledBy!);
+    expect(labelEl).not.toBeNull();
+    expect(labelEl).toHaveTextContent("T1 inspector");
+  });
+});

--- a/apps/web/components/build/NodeInspector.expand.test.tsx
+++ b/apps/web/components/build/NodeInspector.expand.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+//
+// apps/web/components/build/NodeInspector.expand.test.tsx
+//
+// Pins the expand-handle contract:
+//   - Toggle button flips data-expanded.
+//   - Expanded mode grows to ~80% of container, never escapes container bounds.
+//   - Re-anchor on size change keeps the dialog inside the container.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { NodeInspector } from "./NodeInspector";
+
+afterEach(cleanup);
+
+function rect(left: number, top: number, w: number, h: number) {
+  return {
+    left,
+    top,
+    width: w,
+    height: h,
+    right: left + w,
+    bottom: top + h,
+  };
+}
+
+describe("NodeInspector expand", () => {
+  it("starts collapsed (data-expanded='false')", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-expanded", "false");
+  });
+
+  it("expand handle toggles data-expanded", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const expandBtn = screen.getByLabelText("Expand inspector");
+    fireEvent.click(expandBtn);
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-expanded", "true");
+    // Label flips to "Collapse" once expanded.
+    const collapseBtn = screen.getByLabelText("Collapse inspector");
+    fireEvent.click(collapseBtn);
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-expanded", "false");
+  });
+
+  it("expanded inspector grows but stays within container bounds", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog") as HTMLElement;
+    const compactWidth = parseInt(dialog.style.width, 10);
+
+    fireEvent.click(screen.getByLabelText("Expand inspector"));
+    const expandedWidth = parseInt(dialog.style.width, 10);
+    const expandedHeight = parseInt(dialog.style.height, 10);
+
+    expect(expandedWidth).toBeGreaterThan(compactWidth);
+    // Capped at ~80% of container width/height.
+    expect(expandedWidth).toBeLessThanOrEqual(1200);
+    expect(expandedHeight).toBeLessThanOrEqual(1000);
+  });
+
+  it("expand handle has aria-pressed reflecting state", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const btn = screen.getByLabelText("Expand inspector");
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(btn);
+    expect(screen.getByLabelText("Collapse inspector")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("expanded position respects container bounds (clamped, never escapes)", () => {
+    // Tight container where expand would overflow viewport in an unclamped
+    // implementation. Verify the clamped position is still inside.
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(20, 20, 60, 40)}
+        containerRect={rect(0, 0, 600, 500)}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Expand inspector"));
+    const dialog = screen.getByRole("dialog") as HTMLElement;
+    const top = parseInt(dialog.style.top, 10);
+    const left = parseInt(dialog.style.left, 10);
+    const w = parseInt(dialog.style.width, 10);
+    const h = parseInt(dialog.style.height, 10);
+    expect(top + h).toBeLessThanOrEqual(500);
+    expect(left + w).toBeLessThanOrEqual(600);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(left).toBeGreaterThanOrEqual(0);
+  });
+
+  it("respects prefers-reduced-motion (no transition class duplication)", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    // The component opts every transition out via motion-reduce:transition-none.
+    expect(dialog.className).toContain("motion-reduce:transition-none");
+  });
+});

--- a/apps/web/components/build/NodeInspector.placement.test.tsx
+++ b/apps/web/components/build/NodeInspector.placement.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+//
+// apps/web/components/build/NodeInspector.placement.test.tsx
+//
+// Verifies that NodeInspector's inline position style derives from
+// getInspectorPlacement() and uses CONTAINER bounds (not viewport).
+// Re-render with a different rect must re-position.
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { NodeInspector } from "./NodeInspector";
+
+afterEach(cleanup);
+
+function rect(left: number, top: number, w: number, h: number) {
+  return {
+    left,
+    top,
+    width: w,
+    height: h,
+    right: left + w,
+    bottom: top + h,
+  };
+}
+
+describe("NodeInspector placement", () => {
+  it("renders role='dialog' with aria-modal='false' and an accessible name", () => {
+    render(
+      <NodeInspector
+        nodeId="phase:plan"
+        title="Plan phase"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog", { name: "Plan phase" });
+    expect(dialog).toHaveAttribute("aria-modal", "false");
+  });
+
+  it("anchors below a centered node with room everywhere (first-fit by priority)", () => {
+    render(
+      <NodeInspector
+        nodeId="phase:plan"
+        title="Plan phase"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("data-side", "below");
+    // top = nodeBottom + gap = 260 + 8 = 268
+    expect((dialog as HTMLElement).style.top).toBe("268px");
+  });
+
+  it("anchors above when the node is in the bottom-right corner", () => {
+    render(
+      <NodeInspector
+        nodeId="phase:ship"
+        title="Ship"
+        anchorRect={rect(1050, 720, 120, 60)}
+        containerRect={rect(0, 0, 1200, 800)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("data-side", "above");
+  });
+
+  it("uses container bounds — placement values are container-relative, not viewport", () => {
+    // Node + container both offset off-screen. The inspector's top/left must
+    // still be inside the container (not the viewport).
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(2000, 1500, 120, 60)}
+        containerRect={rect(1800, 1200, 1200, 800)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog") as HTMLElement;
+    const topPx = parseInt(dialog.style.top, 10);
+    const leftPx = parseInt(dialog.style.left, 10);
+    expect(topPx).toBeGreaterThanOrEqual(0);
+    expect(leftPx).toBeGreaterThanOrEqual(0);
+    expect(leftPx).toBeLessThanOrEqual(1200);
+    expect(topPx).toBeLessThanOrEqual(800);
+  });
+
+  it("re-positions when the anchor rect changes (re-anchor on prop update)", () => {
+    const { rerender } = render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog1 = screen.getByRole("dialog") as HTMLElement;
+    const initialTop = dialog1.style.top;
+
+    rerender(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 400, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    const dialog2 = screen.getByRole("dialog") as HTMLElement;
+    expect(dialog2.style.top).not.toBe(initialTop);
+  });
+
+  it("respects containerScrollTop in top calculation", () => {
+    const { rerender } = render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        containerScrollTop={0}
+        onClose={() => {}}
+      />,
+    );
+    const noScrollTop = parseInt((screen.getByRole("dialog") as HTMLElement).style.top, 10);
+
+    rerender(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        containerScrollTop={120}
+        onClose={() => {}}
+      />,
+    );
+    const scrolledTop = parseInt((screen.getByRole("dialog") as HTMLElement).style.top, 10);
+    expect(scrolledTop - noScrollTop).toBe(120);
+  });
+
+  it("emits data-side reflecting the chosen placement", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-side", "below");
+  });
+
+  it("renders the children body content", () => {
+    render(
+      <NodeInspector
+        nodeId="task:T1"
+        title="T1"
+        anchorRect={rect(540, 200, 120, 60)}
+        containerRect={rect(0, 0, 1200, 1000)}
+        onClose={() => {}}
+      >
+        <p data-testid="body">Step details</p>
+      </NodeInspector>,
+    );
+    expect(screen.getByTestId("body")).toHaveTextContent("Step details");
+  });
+});

--- a/apps/web/components/build/NodeInspector.tsx
+++ b/apps/web/components/build/NodeInspector.tsx
@@ -1,0 +1,265 @@
+// apps/web/components/build/NodeInspector.tsx
+//
+// Anchored inspector overlay that opens inside the workflow region when a
+// graph node is clicked. NEVER displaces the AI Coworker rail.
+//
+// Per the design spec §2 and the chief-architect review:
+//   - role="dialog" + aria-modal="false" so the coworker rail stays reachable.
+//   - Position computed by getInspectorPlacement (lib/build/node-inspector-placement.ts).
+//   - Authoritative bounds are the GRAPH CONTAINER, NOT the viewport.
+//   - Focus trap is inspector-only (sentinel pair) — not a page-level trap.
+//   - Esc / click-outside / re-click-anchor close. Focus returns to the trigger.
+//   - Expand handle toggles a larger overlay capped to the container — never
+//     escapes into the coworker rail.
+//   - All transitions gated on prefers-reduced-motion.
+
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+
+import { BUILD_STUDIO_TEST_IDS, getNodeInspectorClassName } from "./build-studio-layout";
+import {
+  getInspectorPlacement,
+  type InspectorSide,
+  type PlacementInput,
+} from "@/lib/build/node-inspector-placement";
+
+const DEFAULT_INSPECTOR_WIDTH = 340;
+const DEFAULT_INSPECTOR_HEIGHT = 380;
+const DEFAULT_GAP = 8;
+
+/** A minimal "rect-like" shape — accepts both real DOMRect and plain objects from tests. */
+type RectLike = Pick<DOMRect, "left" | "top" | "right" | "bottom" | "width" | "height">;
+
+export type NodeInspectorProps = {
+  /** Stable identifier for the inspector instance — used for aria-labelledby + close detection. */
+  nodeId: string;
+  /** Human-readable title used as the dialog's accessible name. */
+  title: string;
+  /** Bounding rect of the clicked node, viewport-relative. */
+  anchorRect: RectLike;
+  /** Bounding rect of the graph container, viewport-relative. Authoritative bounds. */
+  containerRect: RectLike;
+  /** containerRef.scrollTop so the inspector tracks scroll. */
+  containerScrollTop?: number;
+  /** Optional dimension overrides — defaults are 340x380 (compact). */
+  inspectorWidth?: number;
+  inspectorHeight?: number;
+  /** Body content rendered between the header and the action row. */
+  children?: ReactNode;
+  /** Optional primary + secondary actions rendered in the footer of the inspector. */
+  actions?: ReactNode;
+  /** Optional "Ask coworker about this step" handler. When provided, renders an
+   *  Ask-coworker button in the footer. */
+  onAskCoworker?: () => void;
+  /** Called when the inspector should close: Esc, click-outside, programmatic close. */
+  onClose: () => void;
+};
+
+export function NodeInspector({
+  nodeId,
+  title,
+  anchorRect,
+  containerRect,
+  containerScrollTop = 0,
+  inspectorWidth = DEFAULT_INSPECTOR_WIDTH,
+  inspectorHeight = DEFAULT_INSPECTOR_HEIGHT,
+  children,
+  actions,
+  onAskCoworker,
+  onClose,
+}: NodeInspectorProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const firstFocusableRef = useRef<HTMLButtonElement | null>(null);
+  const lastFocusableRef = useRef<HTMLButtonElement | null>(null);
+  const previouslyFocusedRef = useRef<Element | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  // ── Placement ─────────────────────────────────────────────────────────
+  // Recompute on every prop change (anchor / container / scroll / size). For
+  // expanded mode, the size grows — we size to a generous fraction of the
+  // container and let the placement helper clamp inside.
+  const effectiveSize = useMemo(() => {
+    if (!expanded) return { w: inspectorWidth, h: inspectorHeight };
+    // Expanded: cap at 80% of container, never overflow.
+    const w = Math.max(inspectorWidth, Math.floor(containerRect.width * 0.8) - DEFAULT_GAP * 2);
+    const h = Math.max(inspectorHeight, Math.floor(containerRect.height * 0.8) - DEFAULT_GAP * 2);
+    return { w, h };
+  }, [expanded, inspectorWidth, inspectorHeight, containerRect.width, containerRect.height]);
+
+  const placement = useMemo(() => {
+    const input: PlacementInput = {
+      nodeRect: anchorRect,
+      containerRect,
+      containerScrollTop,
+      inspectorW: effectiveSize.w,
+      inspectorH: effectiveSize.h,
+      gap: DEFAULT_GAP,
+    };
+    return getInspectorPlacement(input);
+  }, [anchorRect, containerRect, containerScrollTop, effectiveSize.w, effectiveSize.h]);
+
+  // ── Focus management ─────────────────────────────────────────────────
+  // Save the previously-focused element on mount and restore on unmount.
+  // Focus the inspector's first focusable element after mount so keyboard
+  // users land inside the dialog.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    previouslyFocusedRef.current = document.activeElement;
+    // Defer focus to after the dialog is in the DOM.
+    const handle = window.requestAnimationFrame(() => {
+      firstFocusableRef.current?.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(handle);
+      const prev = previouslyFocusedRef.current;
+      if (prev && prev instanceof HTMLElement) {
+        // Restore focus to the trigger on close. Fall through to body if the
+        // trigger is no longer attached (e.g. graph re-rendered).
+        if (document.contains(prev)) prev.focus();
+      }
+    };
+  }, []);
+
+  // ── Esc to close ──────────────────────────────────────────────────────
+  // Mount on open, unmount on close. Capture phase so it wins over text
+  // inputs inside the inspector.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [onClose]);
+
+  // ── Click outside to close ────────────────────────────────────────────
+  // Listens on document mousedown. If the click is outside the dialog AND
+  // outside any element marked as a graph node (data-graph-node attribute),
+  // close. Re-clicking the same node is detected by the parent BuildStudio,
+  // not here — this hook only handles "click off the graph entirely".
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const handler = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (dialogRef.current?.contains(target)) return; // click inside dialog — keep open
+      // Don't close on clicks that land on graph nodes — the parent toggles
+      // the inspector for those (re-click closes via onClose).
+      if (target.closest("[data-graph-node]")) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  // ── Focus trap (sentinel pair) ───────────────────────────────────────
+  // Tab from the last focusable wraps to the first; Shift+Tab from the
+  // first wraps to the last. Inspector-only — the rest of the page is
+  // still reachable via standard browser focus order.
+  const handleFirstSentinelFocus = useCallback(() => {
+    lastFocusableRef.current?.focus();
+  }, []);
+  const handleLastSentinelFocus = useCallback(() => {
+    firstFocusableRef.current?.focus();
+  }, []);
+
+  // ── Render style ──────────────────────────────────────────────────────
+  const style: CSSProperties = {
+    top: placement.top,
+    left: placement.left,
+    width: effectiveSize.w,
+    height: effectiveSize.h,
+  };
+
+  const labelledById = `node-inspector-title-${nodeId}`;
+
+  return (
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={labelledById}
+      data-testid={BUILD_STUDIO_TEST_IDS.nodeInspector}
+      data-node-id={nodeId}
+      data-side={placement.side as InspectorSide}
+      data-expanded={expanded ? "true" : "false"}
+      style={style}
+      className={[
+        getNodeInspectorClassName(),
+        "motion-reduce:transition-none",
+      ].join(" ")}
+    >
+      {/* Sentinel: wrap focus back to the last interactive element on shift+tab from the start. */}
+      <span
+        tabIndex={0}
+        aria-hidden="true"
+        data-testid="node-inspector-sentinel-start"
+        onFocus={handleFirstSentinelFocus}
+      />
+
+      <header className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--dpf-border)] px-3 py-2">
+        <h3
+          id={labelledById}
+          className="m-0 min-w-0 truncate text-xs font-semibold text-[var(--dpf-text)]"
+        >
+          {title}
+        </h3>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            ref={firstFocusableRef}
+            type="button"
+            data-testid={BUILD_STUDIO_TEST_IDS.nodeInspectorExpand}
+            aria-label={expanded ? "Collapse inspector" : "Expand inspector"}
+            aria-pressed={expanded}
+            onClick={() => setExpanded((p) => !p)}
+            className="rounded p-1 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            {expanded ? "↙" : "↗"}
+          </button>
+          <button
+            type="button"
+            aria-label="Close inspector"
+            onClick={onClose}
+            className="rounded p-1 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            ×
+          </button>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto px-3 py-2 text-xs text-[var(--dpf-text)]">
+        {children}
+      </div>
+
+      {(actions || onAskCoworker) && (
+        <footer className="flex shrink-0 items-center justify-end gap-2 border-t border-[var(--dpf-border)] px-3 py-2">
+          {actions}
+          {onAskCoworker && (
+            <button
+              ref={lastFocusableRef}
+              type="button"
+              onClick={onAskCoworker}
+              data-testid="node-inspector-ask-coworker"
+              className="inline-flex items-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+            >
+              Ask coworker about this step
+            </button>
+          )}
+        </footer>
+      )}
+
+      {/* Sentinel: wrap focus back to the first interactive element on tab from the end. */}
+      <span
+        tabIndex={0}
+        aria-hidden="true"
+        data-testid="node-inspector-sentinel-end"
+        onFocus={handleLastSentinelFocus}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/build/OpenSandboxButton.test.tsx
+++ b/apps/web/components/build/OpenSandboxButton.test.tsx
@@ -1,0 +1,106 @@
+// apps/web/components/build/OpenSandboxButton.test.tsx
+//
+// Pins the security + label contract the peer reviewer demanded:
+//   R3: single shared link → never emit multiple anchors.
+//   Mandatory rel="noopener noreferrer" when target="_blank".
+//   Disabled visual + aria-disabled when sandboxUrl is empty.
+//   Label format matches formatSandboxLabel(driver).
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { OpenSandboxButton } from "./OpenSandboxButton";
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+describe("OpenSandboxButton", () => {
+  it("renders <a target=\"_blank\" rel=\"noopener noreferrer\"> — mandatory rel", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-B33E84B5" sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toMatch(/target="_blank"/);
+    expect(html).toMatch(/rel="noopener noreferrer"/);
+    expect(html).toMatch(/href="http:\/\/localhost:5555"/);
+  });
+
+  it('renders the canonical label format "Open sandbox · driving: {code}"', () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-B33E84B5" sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toContain("Open sandbox");
+    expect(html).toContain("driving: FB-B33E84B5");
+  });
+
+  it('renders "driving: idle" when no build is driving', () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode={null} sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toContain("driving: idle");
+  });
+
+  it("emits data-driving for snapshot diffing", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-CCC" sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toContain('data-driving="FB-CCC"');
+  });
+
+  it("emits data-driving=\"idle\" when drivingBuildCode is null", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode={null} sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toContain('data-driving="idle"');
+  });
+
+  it("emits the canonical test ID on the wrapper", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-X" sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toContain(`data-testid="${BUILD_STUDIO_TEST_IDS.openSandbox}"`);
+  });
+
+  it("renders ONLY one anchor element (single-shared-link rule R3)", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-X" sandboxUrl="http://localhost:5555" />,
+    );
+    const anchors = html.match(/<a[\s>]/g) ?? [];
+    expect(anchors).toHaveLength(1);
+  });
+
+  it("renders a non-link <span role=\"link\" aria-disabled> when sandboxUrl is empty", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-X" sandboxUrl="" />,
+    );
+    // Must not emit an <a> tag (no dangling href).
+    expect(html).not.toMatch(/<a[\s>]/);
+    // Must indicate disabled state to assistive tech.
+    expect(html).toContain('role="link"');
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain("cursor-not-allowed");
+  });
+
+  it("treats whitespace-only sandboxUrl as empty", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-X" sandboxUrl="   " />,
+    );
+    expect(html).not.toMatch(/<a[\s>]/);
+    expect(html).toContain('aria-disabled="true"');
+  });
+
+  it("uses DPF CSS variables only — no hex literals", () => {
+    for (const url of ["http://localhost:5555", ""]) {
+      const html = renderToStaticMarkup(
+        <OpenSandboxButton drivingBuildCode="FB-X" sandboxUrl={url} />,
+      );
+      expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+      expect(html).toContain("var(--dpf-");
+    }
+  });
+
+  it("includes focus-visible styling for keyboard users", () => {
+    const html = renderToStaticMarkup(
+      <OpenSandboxButton drivingBuildCode="FB-X" sandboxUrl="http://localhost:5555" />,
+    );
+    expect(html).toContain("focus-visible:outline-2");
+    expect(html).toContain("focus-visible:outline-[var(--dpf-accent)]");
+  });
+});

--- a/apps/web/components/build/OpenSandboxButton.tsx
+++ b/apps/web/components/build/OpenSandboxButton.tsx
@@ -1,0 +1,62 @@
+// apps/web/components/build/OpenSandboxButton.tsx
+//
+// Single shared "Open sandbox" button. Lives in the BuildStudio footer; the
+// per-build Preview tab is removed in this redesign because the sandbox is
+// shared across all in-flight builds (project_self_upgrade_kills_in_session_ux).
+//
+// Per the design spec §1 (Footer) and §6 (component contract):
+//   - Renders <a target="_blank" rel="noopener noreferrer"> — rel is non-optional.
+//   - Label: "Open sandbox · driving: {code | 'idle'}".
+//   - Disabled visual + aria-disabled when sandboxUrl is empty.
+//   - Deterministic driver via sandbox-driver helper (R1 from peer review).
+//
+// This component is intentionally dumb: it consumes a pre-computed driver
+// code + URL. The shell that mounts it (T8c) is responsible for calling
+// computeDrivingBuild() and passing the resulting code in.
+
+"use client";
+
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+import { formatSandboxLabel } from "@/lib/build/sandbox-driver";
+
+export type OpenSandboxButtonProps = {
+  /** Semantic FB-* code of the build that owns the sandbox right now, or null
+   *  when nothing is running. */
+  drivingBuildCode: string | null;
+  /** Sandbox preview URL. Empty/null disables the button. */
+  sandboxUrl: string;
+};
+
+export function OpenSandboxButton({ drivingBuildCode, sandboxUrl }: OpenSandboxButtonProps) {
+  const label = formatSandboxLabel(drivingBuildCode);
+  const isDisabled = !sandboxUrl || sandboxUrl.trim().length === 0;
+
+  if (isDisabled) {
+    // Render a non-link span so we don't emit a dangling anchor with no href.
+    // aria-disabled communicates the disabled state to screen readers.
+    return (
+      <span
+        role="link"
+        aria-disabled="true"
+        data-testid={BUILD_STUDIO_TEST_IDS.openSandbox}
+        data-driving={drivingBuildCode ?? "idle"}
+        className="inline-flex cursor-not-allowed select-none items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-muted)] opacity-60"
+      >
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={sandboxUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid={BUILD_STUDIO_TEST_IDS.openSandbox}
+      data-driving={drivingBuildCode ?? "idle"}
+      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+    >
+      {label}
+    </a>
+  );
+}

--- a/apps/web/components/build/PhaseMiniRail.test.tsx
+++ b/apps/web/components/build/PhaseMiniRail.test.tsx
@@ -1,0 +1,101 @@
+// apps/web/components/build/PhaseMiniRail.test.tsx
+//
+// Pins the accessibility + shape-not-just-color contract for the phase rail.
+// The peer reviewer flagged "color-only conveyor" as a critical risk; these
+// tests assert role=img on the wrapper, aria-label on each dot, and that
+// reached/pending states render distinct CSS class hooks (filled vs outline).
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PhaseMiniRail, PHASE_RAIL_ORDER, derivePhaseDotStates } from "./PhaseMiniRail";
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+describe("PhaseMiniRail", () => {
+  it("wrapper has role='img' and a descriptive aria-label", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="build" />);
+    expect(html).toMatch(/role="img"/);
+    expect(html).toContain('aria-label="Phases reached: ideate, plan. Active: build."');
+  });
+
+  it("falls back to 'No phases reached' for ideate (first phase)", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="ideate" />);
+    expect(html).toContain('aria-label="No phases reached. Active: ideate."');
+  });
+
+  it("renders one dot per canonical phase", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="build" />);
+    for (const phase of PHASE_RAIL_ORDER) {
+      // each dot has data-phase=phase
+      expect(html).toContain(`data-phase="${phase}"`);
+    }
+  });
+
+  it("each dot has a discrete aria-label naming its phase and state", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="build" />);
+    // ideate + plan are reached; build is active; review + ship are pending
+    expect(html).toContain('aria-label="ideate: reached"');
+    expect(html).toContain('aria-label="plan: reached"');
+    expect(html).toContain('aria-label="build: active"');
+    expect(html).toContain('aria-label="review: pending"');
+    expect(html).toContain('aria-label="ship: pending"');
+  });
+
+  it("uses shape (filled vs outlined) in addition to color — passes WCAG 1.4.1", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="build" />);
+    // Reached + active use a filled-shape class hook.
+    expect(html).toContain("phase-dot--reached");
+    expect(html).toContain("phase-dot--active");
+    // Pending uses an outlined-shape class hook (border + transparent bg).
+    expect(html).toContain("phase-dot--pending");
+    expect(html).toContain("border-[var(--dpf-muted)]");
+    expect(html).toContain("bg-transparent");
+  });
+
+  it("active dot has a ring AND a fill — distinguishable from plain 'reached' by shape too", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="plan" />);
+    // The active dot should include a ring utility class.
+    expect(html).toMatch(/data-phase="plan"[^>]+ring-2/);
+    // The reached dot (ideate) should NOT include the ring.
+    expect(html).not.toMatch(/data-phase="ideate"[^>]+ring-2/);
+  });
+
+  it("uses DPF CSS variables for color tokens — no hex literals", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="build" />);
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+    expect(html).toContain("var(--dpf-accent)");
+    expect(html).toContain("var(--dpf-muted)");
+  });
+
+  it("emits the canonical test ID on the wrapper", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="ideate" />);
+    expect(html).toContain(`data-testid="${BUILD_STUDIO_TEST_IDS.phaseMiniRail}"`);
+  });
+
+  it("emits data-current-phase on the wrapper for snapshot diffing", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="review" />);
+    expect(html).toContain('data-current-phase="review"');
+  });
+
+  it("merges a caller-provided className without losing default classes", () => {
+    const html = renderToStaticMarkup(<PhaseMiniRail currentPhase="ship" className="custom-spacing" />);
+    expect(html).toContain("custom-spacing");
+    expect(html).toContain("inline-flex");
+    expect(html).toContain("items-center");
+    expect(html).toContain("gap-1");
+  });
+});
+
+describe("derivePhaseDotStates", () => {
+  it("returns the correct state per phase for each position in the canonical order", () => {
+    expect(derivePhaseDotStates("ideate")).toEqual(["active", "pending", "pending", "pending", "pending"]);
+    expect(derivePhaseDotStates("plan")).toEqual(["reached", "active", "pending", "pending", "pending"]);
+    expect(derivePhaseDotStates("build")).toEqual(["reached", "reached", "active", "pending", "pending"]);
+    expect(derivePhaseDotStates("review")).toEqual(["reached", "reached", "reached", "active", "pending"]);
+    expect(derivePhaseDotStates("ship")).toEqual(["reached", "reached", "reached", "reached", "active"]);
+  });
+
+  it("output length matches PHASE_RAIL_ORDER length", () => {
+    expect(derivePhaseDotStates("build")).toHaveLength(PHASE_RAIL_ORDER.length);
+  });
+});

--- a/apps/web/components/build/PhaseMiniRail.tsx
+++ b/apps/web/components/build/PhaseMiniRail.tsx
@@ -1,0 +1,124 @@
+// apps/web/components/build/PhaseMiniRail.tsx
+//
+// Compact 5-dot phase indicator for the fleet rail. Shows where a build is
+// across the canonical ideate → plan → build → review → ship sequence.
+//
+// Per the design spec §1 + §3:
+//   - Shape AND color carry "reached vs pending" (filled vs outlined) so the
+//     mini-rail passes WCAG 1.4.1 (color is not the sole conveyor).
+//   - Wrapper is role="img" with an aria-label summarizing the reached phases.
+//   - Each dot has its own aria-label.
+//   - Renders at fleet-row density (≤32px); the dots fit in ~14px each.
+
+"use client";
+
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+/** The canonical phase progression visible in the fleet rail. */
+export const PHASE_RAIL_ORDER = ["ideate", "plan", "build", "review", "ship"] as const;
+export type PhaseRailPhase = (typeof PHASE_RAIL_ORDER)[number];
+
+/** State for a single dot in the rail. */
+export type PhaseDotState = "reached" | "active" | "pending";
+
+export type PhaseMiniRailProps = {
+  /** Current phase the build is on. */
+  currentPhase: PhaseRailPhase;
+  /** Optional class to merge into the wrapper (e.g. spacing tweaks from callers). */
+  className?: string;
+};
+
+/**
+ * Derive the {reached|active|pending} state of each dot from the current phase.
+ *
+ * "reached" = phases before currentPhase. "active" = the current phase itself.
+ * "pending" = phases after currentPhase.
+ */
+export function derivePhaseDotStates(currentPhase: PhaseRailPhase): readonly PhaseDotState[] {
+  const idx = PHASE_RAIL_ORDER.indexOf(currentPhase);
+  return PHASE_RAIL_ORDER.map((_, i) => {
+    if (i < idx) return "reached";
+    if (i === idx) return "active";
+    return "pending";
+  });
+}
+
+function dotClassName(state: PhaseDotState): string {
+  // Shape distinction: reached/active use a filled circle, pending uses an outlined ring.
+  // Color distinction: reached uses accent, active uses accent (stronger), pending uses muted border.
+  if (state === "reached") {
+    return [
+      "phase-dot",
+      "phase-dot--reached",
+      "h-2.5",
+      "w-2.5",
+      "rounded-full",
+      "bg-[var(--dpf-accent)]",
+    ].join(" ");
+  }
+  if (state === "active") {
+    return [
+      "phase-dot",
+      "phase-dot--active",
+      "h-2.5",
+      "w-2.5",
+      "rounded-full",
+      "bg-[var(--dpf-accent)]",
+      "ring-2",
+      "ring-[var(--dpf-accent)]",
+      "ring-offset-1",
+      "ring-offset-[var(--dpf-surface-1)]",
+    ].join(" ");
+  }
+  return [
+    "phase-dot",
+    "phase-dot--pending",
+    "h-2.5",
+    "w-2.5",
+    "rounded-full",
+    "border",
+    "border-[var(--dpf-muted)]",
+    "bg-transparent",
+  ].join(" ");
+}
+
+function dotAriaLabel(phase: PhaseRailPhase, state: PhaseDotState): string {
+  return `${phase}: ${state}`;
+}
+
+/**
+ * Wrapper aria-label summarizes which phases are reached + which is active.
+ * Example: "Phases reached: ideate, plan. Active: build."
+ */
+function wrapperAriaLabel(currentPhase: PhaseRailPhase): string {
+  const idx = PHASE_RAIL_ORDER.indexOf(currentPhase);
+  const reached = PHASE_RAIL_ORDER.slice(0, idx);
+  if (reached.length === 0) {
+    return `No phases reached. Active: ${currentPhase}.`;
+  }
+  return `Phases reached: ${reached.join(", ")}. Active: ${currentPhase}.`;
+}
+
+export function PhaseMiniRail({ currentPhase, className }: PhaseMiniRailProps) {
+  const states = derivePhaseDotStates(currentPhase);
+
+  return (
+    <span
+      role="img"
+      aria-label={wrapperAriaLabel(currentPhase)}
+      data-testid={BUILD_STUDIO_TEST_IDS.phaseMiniRail}
+      data-current-phase={currentPhase}
+      className={["inline-flex", "items-center", "gap-1", className].filter(Boolean).join(" ")}
+    >
+      {PHASE_RAIL_ORDER.map((phase, i) => (
+        <span
+          key={phase}
+          aria-label={dotAriaLabel(phase, states[i])}
+          data-phase={phase}
+          data-state={states[i]}
+          className={dotClassName(states[i])}
+        />
+      ))}
+    </span>
+  );
+}

--- a/apps/web/components/build/ProcessGraph.tsx
+++ b/apps/web/components/build/ProcessGraph.tsx
@@ -18,6 +18,8 @@ import type { BuildPhase, FeatureBuildRow } from "@/lib/feature-build-types";
 import type { AssignedTask } from "@/lib/integrate/task-dependency-graph";
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import { buildDependencyGraph } from "@/lib/integrate/task-dependency-graph";
+import { lookupAssignedTaskByTitle, type ProcessGraphNodeClickInfo } from "./ProcessGraphClickInfo";
+export type { ProcessGraphNodeKind, ProcessGraphNodeClickInfo } from "./ProcessGraphClickInfo";
 import {
   buildPhaseGraph,
   buildTaskGraph,
@@ -60,14 +62,25 @@ type Props = {
   workflowLabel: string | null;
   governedBacklogEnabled: boolean;
   progressVisibility?: BuildProgressVisibility | null;
+  /**
+   * Optional click delegate. When provided, ProcessGraph SKIPS its internal
+   * TaskInspector / WorkflowStageInspector and surfaces click context to the
+   * parent instead. Used by the new BuildStudio shell to open the anchored
+   * WorkflowNodeInspector inside the workflow region (see spec §2 + §6).
+   *
+   * When NOT provided, the legacy internal-inspector behavior is preserved
+   * so existing callers (and `/build?v=1`) continue to work unchanged.
+   */
+  onNodeClick?: (info: ProcessGraphNodeClickInfo) => void;
 };
 
 type AnimatedProcessEdge = ProcessEdge & { type: "animatedFlow" };
 
 // ─── Component ─────────────────────────────────────────────────────────────
 
-export function ProcessGraph({ build, workflowLabel, governedBacklogEnabled, progressVisibility }: Props) {
+export function ProcessGraph({ build, workflowLabel, governedBacklogEnabled, progressVisibility, onNodeClick }: Props) {
   const reactFlowRef = useRef<ReactFlowInstance<Node, AnimatedProcessEdge> | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // ─── Live running-task state via DOM CustomEvents ──────────────────────
   const [activeTaskTitles, setActiveTaskTitles] = useState<Set<string>>(
@@ -177,7 +190,48 @@ export function ProcessGraph({ build, workflowLabel, governedBacklogEnabled, pro
   const [inspectedPhase, setInspectedPhase] = useState<BuildPhase | null>(null);
 
   const handleNodeClick = useCallback(
-    (_event: React.MouseEvent, node: Node) => {
+    (event: React.MouseEvent, node: Node) => {
+      // ── Delegate path ────────────────────────────────────────────────
+      // When the parent provided onNodeClick, gather the geometry the new
+      // anchored inspector needs and hand off. Do NOT touch the internal
+      // inspector state — the parent owns the inspector lifecycle.
+      if (onNodeClick) {
+        const containerEl = containerRef.current;
+        if (!containerEl) return;
+        const nodeEl = event.currentTarget as HTMLElement;
+        const anchorRect = nodeEl.getBoundingClientRect();
+        const containerRect = containerEl.getBoundingClientRect();
+        const containerScrollTop = containerEl.scrollTop;
+
+        if (node.type === "processPhase" || node.type === "processForkJoin") {
+          const data = node.data as PhaseNodeData;
+          onNodeClick({
+            nodeId: String(node.id),
+            kind: node.type === "processPhase" ? "phase" : "forkJoin",
+            phase: data.phase,
+            anchorRect,
+            containerRect,
+            containerScrollTop,
+          });
+          return;
+        }
+        if (node.type === "processTask") {
+          const data = node.data as TaskNodeData;
+          const task = lookupAssignedTaskByTitle(build, data.label) ?? undefined;
+          onNodeClick({
+            nodeId: String(node.id),
+            kind: "task",
+            task,
+            anchorRect,
+            containerRect,
+            containerScrollTop,
+          });
+          return;
+        }
+        return;
+      }
+
+      // ── Legacy internal-inspector path ───────────────────────────────
       if (node.type === "processPhase" || node.type === "processForkJoin") {
         const nodeData = node.data as PhaseNodeData;
         setInspectedTask(null);
@@ -206,7 +260,7 @@ export function ProcessGraph({ build, workflowLabel, governedBacklogEnabled, pro
         }
       }
     },
-    [build.buildPlan],
+    [build, onNodeClick],
   );
 
   const handleInspectorClose = useCallback(() => {
@@ -223,7 +277,7 @@ export function ProcessGraph({ build, workflowLabel, governedBacklogEnabled, pro
     : undefined;
 
   return (
-    <div style={{ width: "100%", height: "100%", position: "relative" }}>
+    <div ref={containerRef} style={{ width: "100%", height: "100%", position: "relative" }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/apps/web/components/build/ProcessGraphClickInfo.test.ts
+++ b/apps/web/components/build/ProcessGraphClickInfo.test.ts
@@ -1,0 +1,89 @@
+// apps/web/components/build/ProcessGraphClickInfo.test.ts
+//
+// Unit tests for the pure helper that resolves a task-node label to its
+// AssignedTask. ProcessGraph.tsx delegates to this when a parent opts
+// into the onNodeClick callback; pinning the contract here keeps the
+// click-info shape stable as the dependency-graph layer evolves.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { lookupAssignedTaskByTitle } from "./ProcessGraphClickInfo";
+
+vi.mock("@/lib/integrate/task-dependency-graph", () => ({
+  buildDependencyGraph: (_fs: unknown, tasks: { title: string }[]) => {
+    // Stub: pack all tasks into a single "phase" so the lookup walks them.
+    return [
+      { tasks: tasks.map((t) => ({ ...t, deps: [] })) },
+    ];
+  },
+}));
+
+function makeBuild(buildPlan: unknown): { buildPlan: unknown } {
+  // FeatureBuildRow has lots of fields; the helper only reads .buildPlan.
+  // Use a structural mock.
+  return { buildPlan } as unknown as { buildPlan: unknown };
+}
+
+describe("lookupAssignedTaskByTitle", () => {
+  it("returns null when build.buildPlan is null", () => {
+    // Cast through unknown to satisfy the FeatureBuildRow contract for the helper.
+    const result = lookupAssignedTaskByTitle(makeBuild(null) as never, "T1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tasks is missing/empty", () => {
+    expect(
+      lookupAssignedTaskByTitle(
+        makeBuild({ fileStructure: [], tasks: [] }) as never,
+        "T1",
+      ),
+    ).toBeNull();
+    expect(
+      lookupAssignedTaskByTitle(
+        makeBuild({ fileStructure: [] }) as never,
+        "T1",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns the matching task when the title matches", () => {
+    const result = lookupAssignedTaskByTitle(
+      makeBuild({
+        fileStructure: [],
+        tasks: [
+          { title: "T1: placement helper", implement: "..." },
+          { title: "T2: PhaseMiniRail", implement: "..." },
+        ],
+      }) as never,
+      "T2: PhaseMiniRail",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.title).toBe("T2: PhaseMiniRail");
+  });
+
+  it("returns null when no task title matches", () => {
+    const result = lookupAssignedTaskByTitle(
+      makeBuild({
+        fileStructure: [],
+        tasks: [
+          { title: "T1: placement helper", implement: "..." },
+        ],
+      }) as never,
+      "T999: nonexistent",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("matches by exact title — does not match by substring", () => {
+    const result = lookupAssignedTaskByTitle(
+      makeBuild({
+        fileStructure: [],
+        tasks: [
+          { title: "T1: placement helper", implement: "..." },
+        ],
+      }) as never,
+      "placement helper", // partial
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/components/build/ProcessGraphClickInfo.ts
+++ b/apps/web/components/build/ProcessGraphClickInfo.ts
@@ -1,0 +1,59 @@
+// apps/web/components/build/ProcessGraphClickInfo.ts
+//
+// Pure helpers that resolve ProcessGraph node-click context for the new
+// BuildStudio shell. Split out from ProcessGraph.tsx so the lookup logic
+// can be unit-tested without rendering React Flow.
+//
+// Used by ProcessGraph when an onNodeClick callback is provided by the
+// parent (the new layout's BuildStudio shell). When no callback is
+// provided, ProcessGraph keeps its legacy internal-inspector behavior.
+
+import type { BuildPhase, FeatureBuildRow } from "@/lib/feature-build-types";
+import type { AssignedTask } from "@/lib/integrate/task-dependency-graph";
+import { buildDependencyGraph } from "@/lib/integrate/task-dependency-graph";
+
+/** Discriminator for what kind of graph node was clicked. */
+export type ProcessGraphNodeKind = "phase" | "task" | "forkJoin";
+
+/** Click context surfaced to parents that opt-in via onNodeClick. */
+export type ProcessGraphNodeClickInfo = {
+  /** Stable React Flow node id. */
+  nodeId: string;
+  /** What kind of node was clicked (drives the inspector payload shape). */
+  kind: ProcessGraphNodeKind;
+  /** Set when kind === "phase" or "forkJoin". */
+  phase?: BuildPhase;
+  /** Set when kind === "task" AND the title matches an entry in the build plan. */
+  task?: AssignedTask;
+  /** Viewport rect of the clicked node element. */
+  anchorRect: DOMRect;
+  /** Viewport rect of the graph container that wraps the inspector. */
+  containerRect: DOMRect;
+  /** Container scrollTop, needed by getInspectorPlacement to position correctly. */
+  containerScrollTop: number;
+};
+
+/**
+ * Resolve the AssignedTask matching a task-node label by walking the
+ * build's dependency graph. Returns null if no match (build has no plan,
+ * or no task title matches).
+ *
+ * Pulled out of ProcessGraph.handleNodeClick so it can be exercised
+ * directly in unit tests — no React Flow required.
+ */
+export function lookupAssignedTaskByTitle(
+  build: FeatureBuildRow,
+  taskTitle: string,
+): AssignedTask | null {
+  if (build.buildPlan == null) return null;
+  const { fileStructure, tasks } = build.buildPlan;
+  if (!tasks || tasks.length === 0) return null;
+
+  const execPhases = buildDependencyGraph(fileStructure, tasks);
+  for (const phase of execPhases) {
+    for (const assignedTask of phase.tasks) {
+      if (assignedTask.title === taskTitle) return assignedTask;
+    }
+  }
+  return null;
+}

--- a/apps/web/components/build/QueueStateBadge.test.tsx
+++ b/apps/web/components/build/QueueStateBadge.test.tsx
@@ -1,0 +1,106 @@
+// apps/web/components/build/QueueStateBadge.test.tsx
+//
+// Pins the WCAG-1.4.1 shape+color contract for the BS-queue badge and the
+// per-kind tooltip + aria-label shape.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { QueueStateBadge, type BuildQueueState } from "./QueueStateBadge";
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+function htmlFor(state: BuildQueueState): string {
+  return renderToStaticMarkup(<QueueStateBadge state={state} />);
+}
+
+describe("QueueStateBadge", () => {
+  it("renders NOTHING for kind='idle' (no DOM output)", () => {
+    expect(htmlFor({ kind: "idle" })).toBe("");
+  });
+
+  it("renders running glyph + correct aria-label + tooltip", () => {
+    const html = htmlFor({ kind: "running", stepLabel: "Generate code" });
+    expect(html).toContain('aria-label="Running"');
+    expect(html).toContain('title="Running: Generate code"');
+    expect(html).toContain('data-kind="running"');
+    // Running glyph uses a <polygon> (filled triangle play).
+    expect(html).toContain("<polygon");
+  });
+
+  it("renders running tooltip without step label gracefully", () => {
+    const html = htmlFor({ kind: "running", stepLabel: null });
+    expect(html).toContain('title="Running"');
+  });
+
+  it("renders queued glyph with the position number inside the SVG (shape-not-just-color)", () => {
+    const html = htmlFor({ kind: "queued", position: 3, reason: "capacity", ahead: 2 });
+    expect(html).toContain('aria-label="Queued, position 3"');
+    expect(html).toContain('title="Queued at position 3 (capacity — 2 builds ahead)"');
+    expect(html).toContain('data-kind="queued"');
+    expect(html).toContain('data-position="3"');
+    // Number appears inside the SVG text element.
+    expect(html).toMatch(/<text[^>]*>3<\/text>/);
+  });
+
+  it("renders queued tooltip with singular '1 build ahead' when ahead=1", () => {
+    const html = htmlFor({ kind: "queued", position: 2, reason: "dependency", ahead: 1 });
+    expect(html).toContain("1 build ahead");
+    expect(html).toContain("dependency");
+  });
+
+  it("caps queued position display at 99+ so the badge stays bounded", () => {
+    const html = htmlFor({ kind: "queued", position: 142, reason: "capacity", ahead: 141 });
+    expect(html).toMatch(/<text[^>]*>99\+<\/text>/);
+  });
+
+  it("renders blocked glyph (two pause bars) + reason in tooltip", () => {
+    const html = htmlFor({ kind: "blocked", reason: "review failed" });
+    expect(html).toContain('aria-label="Blocked"');
+    expect(html).toContain('title="Blocked: review failed"');
+    expect(html).toContain('data-kind="blocked"');
+    // Pause glyph uses two <rect> bars.
+    const rects = html.match(/<rect[\s>]/g) ?? [];
+    expect(rects.length).toBe(2);
+  });
+
+  it("uses distinct shape glyphs per kind (running=polygon, blocked=rects, queued=text)", () => {
+    const running = htmlFor({ kind: "running", stepLabel: null });
+    const blocked = htmlFor({ kind: "blocked", reason: "x" });
+    const queued = htmlFor({ kind: "queued", position: 1, reason: "capacity", ahead: 0 });
+    // Each glyph has a unique shape signature, so color alone isn't conveying state.
+    expect(running).toContain("<polygon");
+    expect(blocked).not.toContain("<polygon");
+    expect(queued).toMatch(/<path[\s>]/);
+  });
+
+  it("uses DPF CSS variables for color tokens (state + foreground)", () => {
+    const html = htmlFor({ kind: "running", stepLabel: null });
+    expect(html).toContain("var(--dpf-state-success)");
+    expect(html).toContain("var(--dpf-success)");
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+  });
+
+  it("uses distinct fg/bg variable sources per state (no chip-collapse bug)", () => {
+    // Distinct state-X bg + foreground X for each non-idle kind.
+    expect(htmlFor({ kind: "running", stepLabel: null })).toMatch(
+      /bg-\[var\(--dpf-state-success\)\][^"]*text-\[var\(--dpf-success\)\]/,
+    );
+    expect(htmlFor({ kind: "queued", position: 1, reason: "capacity", ahead: 0 })).toMatch(
+      /bg-\[var\(--dpf-state-info\)\][^"]*text-\[var\(--dpf-info\)\]/,
+    );
+    expect(htmlFor({ kind: "blocked", reason: "x" })).toMatch(
+      /bg-\[var\(--dpf-state-warning\)\][^"]*text-\[var\(--dpf-warning\)\]/,
+    );
+  });
+
+  it("emits the canonical test ID on the wrapper for non-idle states", () => {
+    const html = htmlFor({ kind: "running", stepLabel: null });
+    expect(html).toContain(`data-testid="${BUILD_STUDIO_TEST_IDS.queueStateBadge}"`);
+  });
+
+  it("bounded size: 14x14 — won't expand the 32px fleet row", () => {
+    const html = htmlFor({ kind: "running", stepLabel: null });
+    expect(html).toContain("h-[14px]");
+    expect(html).toContain("w-[14px]");
+  });
+});

--- a/apps/web/components/build/QueueStateBadge.tsx
+++ b/apps/web/components/build/QueueStateBadge.tsx
@@ -1,0 +1,152 @@
+// apps/web/components/build/QueueStateBadge.tsx
+//
+// Discriminated-union badge that conveys a build's queue runtime state in the
+// fleet rail. The Build Studio runtime caps concurrent coworker-driven builds;
+// without this badge the operator can't tell if a quiet build is running,
+// blocked, or waiting in queue.
+//
+// Per the layout spec amendment (PR #898):
+//   - Renders shape + color so it passes WCAG 1.4.1 (color is not sole conveyor).
+//   - 14×14 inline SVG, bounded so it never expands the 32px fleet row.
+//   - Tooltip (title attribute) surfaces the reason from the discriminated union.
+//   - "idle" renders no badge so idle rows stay visually quiet.
+
+"use client";
+
+import type { ReactElement } from "react";
+
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+
+/** The runtime states the fleet rail surfaces. Source of truth for the shape. */
+export type BuildQueueState =
+  | { kind: "running"; stepLabel: string | null }
+  | { kind: "queued"; position: number; reason: "capacity" | "dependency"; ahead: number }
+  | { kind: "blocked"; reason: string }
+  | { kind: "idle" };
+
+export type QueueStateBadgeProps = {
+  state: BuildQueueState;
+};
+
+function tooltipFor(state: BuildQueueState): string {
+  switch (state.kind) {
+    case "running":
+      return state.stepLabel ? `Running: ${state.stepLabel}` : "Running";
+    case "queued": {
+      const reason = state.reason === "capacity" ? "capacity" : "dependency";
+      const ahead = state.ahead === 1 ? "1 build ahead" : `${state.ahead} builds ahead`;
+      return `Queued at position ${state.position} (${reason} — ${ahead})`;
+    }
+    case "blocked":
+      return `Blocked: ${state.reason}`;
+    case "idle":
+      return "Idle";
+  }
+}
+
+function ariaLabelFor(state: BuildQueueState): string {
+  switch (state.kind) {
+    case "running":
+      return "Running";
+    case "queued":
+      return `Queued, position ${state.position}`;
+    case "blocked":
+      return "Blocked";
+    case "idle":
+      return "Idle";
+  }
+}
+
+/** Filled triangle play glyph — running. */
+function RunningGlyph(): ReactElement {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <polygon points="2,1 9,5 2,9" fill="currentColor" />
+    </svg>
+  );
+}
+
+/** Numbered hourglass — queued. The number sits inside the glyph for at-a-glance position. */
+function QueuedGlyph({ position }: { position: number }): ReactElement {
+  // 1-indexed positions; cap visual width at 2 chars so the badge stays 14px.
+  const text = position > 99 ? "99+" : String(position);
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <path
+        d="M3,2 L11,2 M3,12 L11,12 M3,2 L11,12 M11,2 L3,12"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        fill="none"
+      />
+      <text
+        x="7"
+        y="9.5"
+        textAnchor="middle"
+        fontSize="6"
+        fill="currentColor"
+        fontWeight="700"
+      >
+        {text}
+      </text>
+    </svg>
+  );
+}
+
+/** Two pause bars — blocked. */
+function BlockedGlyph(): ReactElement {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect x="2" y="1" width="2.5" height="8" fill="currentColor" />
+      <rect x="5.5" y="1" width="2.5" height="8" fill="currentColor" />
+    </svg>
+  );
+}
+
+/** Color class per state (uses DPF state tokens from globals.css). */
+function stateClassName(state: BuildQueueState): string {
+  switch (state.kind) {
+    case "running":
+      return "bg-[var(--dpf-state-success)] text-[var(--dpf-success)] border-[var(--dpf-success)]";
+    case "queued":
+      return "bg-[var(--dpf-state-info)] text-[var(--dpf-info)] border-[var(--dpf-info)]";
+    case "blocked":
+      return "bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)] border-[var(--dpf-warning)]";
+    case "idle":
+      return "";
+  }
+}
+
+export function QueueStateBadge({ state }: QueueStateBadgeProps) {
+  if (state.kind === "idle") {
+    // Idle renders nothing — keeps the fleet row visually quiet.
+    return null;
+  }
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabelFor(state)}
+      title={tooltipFor(state)}
+      data-testid={BUILD_STUDIO_TEST_IDS.queueStateBadge}
+      data-kind={state.kind}
+      data-position={state.kind === "queued" ? state.position : undefined}
+      className={[
+        "queue-state-badge",
+        `queue-state-badge--${state.kind}`,
+        "inline-flex",
+        "h-[14px]",
+        "w-[14px]",
+        "shrink-0",
+        "items-center",
+        "justify-center",
+        "rounded-sm",
+        "border",
+        stateClassName(state),
+      ].join(" ")}
+    >
+      {state.kind === "running" && <RunningGlyph />}
+      {state.kind === "queued" && <QueuedGlyph position={state.position} />}
+      {state.kind === "blocked" && <BlockedGlyph />}
+    </span>
+  );
+}

--- a/apps/web/components/portal-context/PortalContextStrip.test.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.test.tsx
@@ -37,7 +37,8 @@ describe("PortalContextStrip", () => {
     // Must not collapse to a single var-source (the bug).
     expect(html).not.toMatch(/bg-\[var\(--dpf-warning\)\][^"]*text-\[var\(--dpf-warning\)\]/);
     // And the signal label must be in the DOM so the chip isn't visually empty.
-    // Note: signalLabel() returns "Lease expired" (capital L) for the lease_expired kind.
+    // signalLabel() in PortalContextStrip.tsx returns "Lease expired" (Capital L)
+    // for kind="lease_expired"; the assertion matches that canonical label.
     expect(html).toContain("Lease expired");
   });
 

--- a/apps/web/lib/build/sandbox-driver.test.ts
+++ b/apps/web/lib/build/sandbox-driver.test.ts
@@ -1,0 +1,110 @@
+// apps/web/lib/build/sandbox-driver.test.ts
+//
+// Pins the deterministic-driver contract called out by the peer reviewer:
+//   R1 deterministic driver, R2 port validation, R3 single shared link.
+// These tests live with the helper, not the button, because the helper is
+// what makes the contract testable in isolation.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDrivingBuild,
+  formatSandboxLabel,
+  isValidSandboxPort,
+  type SandboxDriverCandidate,
+} from "./sandbox-driver";
+
+function candidate(
+  buildCode: string,
+  sandboxPort: number | null,
+  lastActivityAt: Date | null,
+): SandboxDriverCandidate {
+  return { buildCode, sandboxPort, lastActivityAt };
+}
+
+describe("isValidSandboxPort", () => {
+  it("accepts integers in the TCP range (1-65535)", () => {
+    expect(isValidSandboxPort(1)).toBe(true);
+    expect(isValidSandboxPort(3000)).toBe(true);
+    expect(isValidSandboxPort(65535)).toBe(true);
+  });
+
+  it.each([null, undefined, 0, -1, 65536, NaN, Infinity, -Infinity, 3.14])(
+    "rejects %s",
+    (input) => {
+      expect(isValidSandboxPort(input as number | null | undefined)).toBe(false);
+    },
+  );
+});
+
+describe("computeDrivingBuild", () => {
+  it("returns null when the candidate list is empty", () => {
+    expect(computeDrivingBuild([])).toBeNull();
+  });
+
+  it("returns null when no candidate has a live port", () => {
+    expect(
+      computeDrivingBuild([
+        candidate("FB-AAA", null, new Date()),
+        candidate("FB-BBB", 0, new Date()),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns the only live candidate", () => {
+    const result = computeDrivingBuild([
+      candidate("FB-AAA", null, new Date()),
+      candidate("FB-BBB", 3000, new Date()),
+      candidate("FB-CCC", 0, new Date()),
+    ]);
+    expect(result?.buildCode).toBe("FB-BBB");
+  });
+
+  it("picks the most recently active when multiple are live", () => {
+    const older = new Date("2026-05-20T00:00:00Z");
+    const newer = new Date("2026-05-21T05:00:00Z");
+    const result = computeDrivingBuild([
+      candidate("FB-OLD", 3000, older),
+      candidate("FB-NEW", 3001, newer),
+      candidate("FB-MID", 3002, new Date("2026-05-20T12:00:00Z")),
+    ]);
+    expect(result?.buildCode).toBe("FB-NEW");
+  });
+
+  it("sorts candidates with null lastActivityAt LAST", () => {
+    const result = computeDrivingBuild([
+      candidate("FB-NULL", 3000, null),
+      candidate("FB-DATED", 3001, new Date("2026-05-20T00:00:00Z")),
+    ]);
+    expect(result?.buildCode).toBe("FB-DATED");
+  });
+
+  it("breaks deeper ties by buildCode ascending — deterministic across renders", () => {
+    const sameTime = new Date("2026-05-21T05:00:00Z");
+    const result = computeDrivingBuild([
+      candidate("FB-ZZZ", 3000, sameTime),
+      candidate("FB-AAA", 3001, sameTime),
+      candidate("FB-MMM", 3002, sameTime),
+    ]);
+    expect(result?.buildCode).toBe("FB-AAA");
+  });
+
+  it("filters port validation before tie-breaking", () => {
+    // FB-BAD has the most recent timestamp but an invalid port — must NOT win.
+    const result = computeDrivingBuild([
+      candidate("FB-BAD", 0, new Date("2026-05-21T06:00:00Z")),
+      candidate("FB-GOOD", 3000, new Date("2026-05-20T00:00:00Z")),
+    ]);
+    expect(result?.buildCode).toBe("FB-GOOD");
+  });
+});
+
+describe("formatSandboxLabel", () => {
+  it("renders the driving build code when provided", () => {
+    expect(formatSandboxLabel("FB-B33E84B5")).toBe("Open sandbox · driving: FB-B33E84B5");
+  });
+
+  it('renders "idle" when there is no driver', () => {
+    expect(formatSandboxLabel(null)).toBe("Open sandbox · driving: idle");
+  });
+});

--- a/apps/web/lib/build/sandbox-driver.ts
+++ b/apps/web/lib/build/sandbox-driver.ts
@@ -1,0 +1,75 @@
+// apps/web/lib/build/sandbox-driver.ts
+//
+// Pure helper that decides which in-flight build is currently "driving"
+// the shared sandbox.
+//
+// Per the design spec §1 (footer) and §6 (OpenSandboxButton):
+//   - All builds share one sandbox (project_self_upgrade_kills_in_session_ux).
+//   - The footer button always shows ONE label: "Open sandbox · driving: {code}".
+//   - "Driving" = the build whose preview port is live; on ties, the most
+//     recently active. When nothing is running, label says "idle".
+//
+// Splitting this into a pure helper makes the contract testable without
+// rendering the component or wiring React Flow.
+
+/** Minimal build shape the driver helper reads. Keep this loose so callers
+ *  can pass either FeatureBuildRow or a projection from getBuildSandboxState
+ *  without coupling this module to either type. */
+export type SandboxDriverCandidate = {
+  /** Semantic FB-* identifier. Used as the displayed label. */
+  buildCode: string;
+  /** Sandbox port reported by the runtime. null/0 means no live preview. */
+  sandboxPort: number | null;
+  /** Most recent activity timestamp (e.g. updatedAt). Used for tie-break. */
+  lastActivityAt: Date | null;
+};
+
+/**
+ * Pick the build that owns the sandbox right now.
+ *
+ * Rules:
+ *   1. Filter out candidates without a live port (port is null, 0, or NaN).
+ *   2. If none qualify, return null (footer shows "idle").
+ *   3. If exactly one qualifies, return it.
+ *   4. On a tie, pick the one with the most recent lastActivityAt. Builds
+ *      with null lastActivityAt sort last.
+ *   5. On a deeper tie (same timestamp), sort by buildCode ascending so the
+ *      result is deterministic (no flicker between identical states).
+ */
+export function computeDrivingBuild(
+  candidates: readonly SandboxDriverCandidate[],
+): SandboxDriverCandidate | null {
+  if (!candidates || candidates.length === 0) return null;
+
+  const live = candidates.filter((c) => isValidSandboxPort(c.sandboxPort));
+  if (live.length === 0) return null;
+  if (live.length === 1) return live[0];
+
+  // Sort: most recent activity first; nulls last; tie-break by buildCode asc.
+  const sorted = [...live].sort((a, b) => {
+    const aMs = a.lastActivityAt?.getTime() ?? -Infinity;
+    const bMs = b.lastActivityAt?.getTime() ?? -Infinity;
+    if (aMs !== bMs) return bMs - aMs;
+    return a.buildCode.localeCompare(b.buildCode);
+  });
+  return sorted[0];
+}
+
+/** Sandbox port validation — accepts only positive integers within the TCP
+ *  range. Used both by the driver helper and the button render path so the
+ *  rule lives in one place. */
+export function isValidSandboxPort(port: number | null | undefined): port is number {
+  if (port == null) return false;
+  if (typeof port !== "number") return false;
+  if (!Number.isFinite(port)) return false;
+  if (!Number.isInteger(port)) return false;
+  if (port <= 0) return false;
+  if (port > 65535) return false;
+  return true;
+}
+
+/** Format the label used by OpenSandboxButton. Stays in this module so the
+ *  string contract is centralized. */
+export function formatSandboxLabel(drivingBuildCode: string | null): string {
+  return `Open sandbox · driving: ${drivingBuildCode ?? "idle"}`;
+}


### PR DESCRIPTION
## Summary

T10 of the Build Studio layout redesign — the right-edge drawer that rehouses the content of the removed Progress/Details/Docs/Preview tabs. Stacks on top of PR #903 (Wave 1–3 atoms); the BuildStudio shell refactor (T8a/b/c) that consumes this drawer will follow as additional commits to this branch.

Spec: \`docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md\` §5 + queue-surface amendment (PR #898).

## What's in this PR (so far)

- \`DetailsDrawer.tsx\` — sliding right-edge container, accordion sections, Esc-to-close, aria-controls/aria-labelledby wiring, motion-reduce gating, defaultOpen re-seed on section change.
- \`DetailsDrawerPill.tsx\` (exported from the same file) — 24-px vertical pill that lives on the canvas edge so it's reachable while the drawer is closed.
- 16 vitest cases under \`@vitest-environment jsdom\` + \`@testing-library/react\` — render state, slide classes, motion-reduce, section ordering, defaultOpen, accordion toggle, Esc behavior, empty placeholder, BS-Queue canonical test ID, re-seed on prop change.

## What's next (this same branch)

- T8a: BuildStudio.tsx zone shell wiring — replace existing tab selector with the three-zone shell from \`build-studio-layout.ts\`, remove the desktop \`PhaseIndicator\` strip, mount FleetRail in the left zone.
- T8b: ProcessGraph onNodeClick → NodeInspector lifecycle wiring in the shell.
- T8c: Footer OpenSandboxButton + DetailsDrawer pill + Preview-tab removal.
- T9: BuildStudioWorkflowActionCard delegates compact presentation to \`ActionBanner\`.
- T11: BuildStudio integration test (end-to-end regression net).

## Stack note

This PR depends on PR #903 (Wave 1–3 atoms) for: \`build-studio-layout.ts\` helpers, \`PhaseMiniRail\`, \`ActionBanner\`, \`NodeInspector\`, \`OpenSandboxButton\`, \`FleetRail\`, \`BuildListItem\` fleet density, \`QueueStateBadge\`, \`ProcessGraph\` \`onNodeClick\`. Merging PR #903 first keeps this branch linear; otherwise rebase will be required.

## Test plan

- [ ] CI vitest passes for \`DetailsDrawer.test.tsx\`
- [ ] CI typecheck passes
- [ ] DetailsDrawer renders nothing on the page until T8c wires it in
- [ ] No regression in the existing \`/build\` view (this PR doesn't touch BuildStudio.tsx yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)