### PR TITLE
feat(edge-node): Slice 1 — change events on the envelope (BI-8405FDA5)

### DIFF
--- a/apps/web/app/api/v1/edge/__tests__/fixtures/go/events/v1.json
+++ b/apps/web/app/api/v1/edge/__tests__/fixtures/go/events/v1.json
@@ -28,6 +28,23 @@
       "action": "resolve",
       "summary": "Packet loss to 192.168.0.10 cleared",
       "occurredAt": "2026-05-21T02:29:45Z"
+    },
+    {
+      "eventType": "change",
+      "dedupKey": "git.deploy:web@abcdef1",
+      "source": "git.deploy",
+      "component": "web",
+      "eventGroup": "deploy",
+      "eventClass": "deploy",
+      "severity": "info",
+      "action": "trigger",
+      "summary": "Deploy abcdef1 to web (production)",
+      "occurredAt": "2026-05-21T02:28:30Z",
+      "customDetails": {
+        "gitSha": "abcdef1",
+        "deployedBy": "ci-bot",
+        "targetEnv": "production"
+      }
     }
   ]
 }

--- a/apps/web/app/api/v1/edge/__tests__/fixtures/ts/events/v1.json
+++ b/apps/web/app/api/v1/edge/__tests__/fixtures/ts/events/v1.json
@@ -28,6 +28,23 @@
       "action": "resolve",
       "summary": "Packet loss to 192.168.0.10 cleared",
       "occurredAt": "2026-05-21T02:29:45Z"
+    },
+    {
+      "eventType": "change",
+      "dedupKey": "git.deploy:web@abcdef1",
+      "source": "git.deploy",
+      "component": "web",
+      "eventGroup": "deploy",
+      "eventClass": "deploy",
+      "severity": "info",
+      "action": "trigger",
+      "summary": "Deploy abcdef1 to web (production)",
+      "occurredAt": "2026-05-21T02:28:30Z",
+      "customDetails": {
+        "gitSha": "abcdef1",
+        "deployedBy": "ci-bot",
+        "targetEnv": "production"
+      }
     }
   ]
 }

--- a/apps/web/app/api/v1/edge/events/route.test.ts
+++ b/apps/web/app/api/v1/edge/events/route.test.ts
@@ -6,12 +6,14 @@ const {
   mockEdgeEventFindUnique,
   mockEdgeEventCreate,
   mockEdgeEventUpdate,
+  mockChangeEventUpsert,
   mockTransaction,
 } = vi.hoisted(() => ({
   mockResolveAuth: vi.fn(),
   mockEdgeEventFindUnique: vi.fn(),
   mockEdgeEventCreate: vi.fn(),
   mockEdgeEventUpdate: vi.fn(),
+  mockChangeEventUpsert: vi.fn(),
   mockTransaction: vi.fn(),
 }));
 
@@ -26,6 +28,9 @@ vi.mock("@dpf/db", () => ({
       findUnique: mockEdgeEventFindUnique,
       create: mockEdgeEventCreate,
       update: mockEdgeEventUpdate,
+    },
+    changeEvent: {
+      upsert: mockChangeEventUpsert,
     },
   },
 }));
@@ -45,6 +50,7 @@ function freshObservedAt(): string {
 }
 
 type EventOverrides = Partial<{
+  eventType: "alert" | "change";
   dedupKey: string;
   source: string;
   component: string;
@@ -109,13 +115,20 @@ type CapturedUpdate = {
   where: Record<string, unknown>;
   data: Record<string, unknown>;
 };
+type CapturedUpsert = {
+  where: Record<string, unknown>;
+  create: Record<string, unknown>;
+  update: Record<string, unknown>;
+};
 const creates: CapturedCreate[] = [];
 const updates: CapturedUpdate[] = [];
+const changeUpserts: CapturedUpsert[] = [];
 
 beforeEach(() => {
   vi.resetAllMocks();
   creates.length = 0;
   updates.length = 0;
+  changeUpserts.length = 0;
 
   // Default: $transaction simply runs the callback with the same prisma-
   // shaped mock; tests that need rollback behavior override per-test.
@@ -125,6 +138,9 @@ beforeEach(() => {
         findUnique: mockEdgeEventFindUnique,
         create: mockEdgeEventCreate,
         update: mockEdgeEventUpdate,
+      },
+      changeEvent: {
+        upsert: mockChangeEventUpsert,
       },
     });
   });
@@ -137,6 +153,10 @@ beforeEach(() => {
   mockEdgeEventUpdate.mockImplementation(async (args: CapturedUpdate) => {
     updates.push(args);
     return { id: String(args.where.id ?? "edgeevent_updated") };
+  });
+  mockChangeEventUpsert.mockImplementation(async (args: CapturedUpsert) => {
+    changeUpserts.push(args);
+    return { id: `changeevent_${changeUpserts.length}` };
   });
 
   _resetEdgeRateLimits();
@@ -366,6 +386,134 @@ describe("POST /api/v1/edge/events — persistence", () => {
     expect(json.created).toBe(1);
     expect(json.resolved).toBe(1);
     expect(json.accepted).toBe(2);
+  });
+});
+
+// Slice 1 (BI-8405FDA5): change-event discriminator path. The route should
+// dispatch eventType="change" to ChangeEvent.upsert and leave EdgeEvent
+// untouched; omitting eventType must continue to route to EdgeEvent (alert).
+describe("POST /api/v1/edge/events — change events (Slice 1)", () => {
+  beforeEach(() => mockResolveAuth.mockResolvedValue(AUTHED));
+
+  function makeChangeEvent(overrides: EventOverrides = {}): Record<string, unknown> {
+    return makeValidEvent({
+      eventType: "change",
+      dedupKey: "git.deploy:web@abcdef1",
+      source: "git.deploy",
+      component: "web",
+      eventGroup: "deploy",
+      eventClass: "deploy",
+      severity: "info",
+      action: "trigger",
+      summary: "Deploy abcdef1 to web (production)",
+      customDetails: {
+        gitSha: "abcdef1",
+        deployedBy: "ci-bot",
+        targetEnv: "production",
+      },
+      ...overrides,
+    });
+  }
+
+  it("routes eventType=change to ChangeEvent.upsert and not EdgeEvent", async () => {
+    const res = await POST(makeReq(makeValidBody({ events: [makeChangeEvent()] })));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.changes).toBe(1);
+    expect(json.created).toBe(0);
+    expect(creates).toHaveLength(0);
+    expect(updates).toHaveLength(0);
+    expect(changeUpserts).toHaveLength(1);
+    expect(changeUpserts[0]!.where).toEqual({
+      edgeNodeId_changeKey: {
+        edgeNodeId: "edgenode_cuid_1",
+        changeKey: "git.deploy:web@abcdef1",
+      },
+    });
+    expect(changeUpserts[0]!.create).toMatchObject({
+      edgeNodeId: "edgenode_cuid_1",
+      changeKey: "git.deploy:web@abcdef1",
+      source: "git.deploy",
+      severity: "info",
+      summary: "Deploy abcdef1 to web (production)",
+    });
+  });
+
+  it("defaults eventType to alert when omitted (Slice 0 wire compatibility)", async () => {
+    // makeValidEvent does NOT include eventType; route should treat as alert
+    // and go down the EdgeEvent create path, leaving ChangeEvent untouched.
+    const res = await POST(makeReq(makeValidBody()));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.created).toBe(1);
+    expect(json.changes).toBe(0);
+    expect(creates).toHaveLength(1);
+    expect(changeUpserts).toHaveLength(0);
+  });
+
+  it("dispatches a mixed batch — alerts and changes both land in one transaction", async () => {
+    const body = makeValidBody({
+      events: [
+        makeValidEvent({ dedupKey: "alert-1" }),
+        makeChangeEvent({ dedupKey: "deploy-1" }),
+        makeValidEvent({ dedupKey: "alert-2" }),
+        makeChangeEvent({ dedupKey: "deploy-2" }),
+      ],
+    });
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.accepted).toBe(4);
+    expect(json.created).toBe(2);
+    expect(json.changes).toBe(2);
+    expect(creates).toHaveLength(2);
+    expect(changeUpserts).toHaveLength(2);
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("change-event update path refreshes summary + customDetails without resetting firstSeenAt", async () => {
+    // Two submissions of the same changeKey should produce two upserts;
+    // the second's `update` payload must include lastSeenAt + refreshed
+    // summary/customDetails but NOT firstSeenAt or occurredAt.
+    await POST(makeReq(makeValidBody({ events: [makeChangeEvent()] })));
+    await POST(
+      makeReq(
+        makeValidBody({
+          runKey: crypto.randomUUID(),
+          events: [
+            makeChangeEvent({
+              summary: "Deploy abcdef1 verified post-rollout",
+              customDetails: {
+                gitSha: "abcdef1",
+                deployedBy: "ci-bot",
+                targetEnv: "production",
+                verifiedAt: new Date().toISOString(),
+              },
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(changeUpserts).toHaveLength(2);
+    const updateData = changeUpserts[1]!.update;
+    expect(updateData).toMatchObject({
+      summary: "Deploy abcdef1 verified post-rollout",
+    });
+    expect(updateData).not.toHaveProperty("firstSeenAt");
+    expect(updateData).not.toHaveProperty("occurredAt");
+    expect(updateData.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects an unknown eventType at the envelope layer (422)", async () => {
+    const body = makeValidBody({
+      events: [makeValidEvent({ eventType: "incident" as never })],
+    });
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_envelope");
+    expect(changeUpserts).toHaveLength(0);
+    expect(creates).toHaveLength(0);
   });
 });
 

--- a/apps/web/app/api/v1/edge/events/route.ts
+++ b/apps/web/app/api/v1/edge/events/route.ts
@@ -1,8 +1,13 @@
 // POST /api/v1/edge/events — accept a batch of PD-CEF-style events from
-// edge-side detectors and upsert them into EdgeEvent.
+// edge-side detectors and route each to its persistence path by eventType.
 //
-// Slice 0 of the edge-node detection engine (BI-9FE9D48D).
-// Spec: docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+// Slice 0 of the edge-node detection engine (BI-9FE9D48D) defined the
+// alert path. Slice 1 (BI-8405FDA5) adds the change path: eventType
+// discriminator on the wire selects EdgeEvent (default, full lifecycle)
+// vs. ChangeEvent (point-in-time, no lifecycle).
+// Specs:
+//   docs/superpowers/specs/2026-05-21-edge-event-envelope-design.md
+//   docs/superpowers/specs/2026-05-21-edge-change-events-design.md
 //
 // Order of operations (matches /api/v1/edge/metrics):
 //   1. Body size cap (256 KB — events allow up to 500 records with details)
@@ -11,14 +16,24 @@
 //   4. Zod envelope validation (returns 422 on shape drift)
 //   5. Freshness window (5 min past, 5 min future)
 //   6. Per-node rate limit (edge.events.submit)
-//   7. Upsert per event on (edgeNodeId, dedupKey); action drives lifecycle
+//   7. Per-event dispatch on eventType:
+//        "alert"  (default) — upsert EdgeEvent on (edgeNodeId, dedupKey);
+//                             action drives the triggered/ack/resolved
+//                             lifecycle
+//        "change"           — upsert ChangeEvent on (edgeNodeId, dedupKey);
+//                             point-in-time fact, no lifecycle, action
+//                             accepted but ignored
 //
-// Lifecycle on replay:
+// Alert lifecycle on replay:
 //   action="trigger"     — new row, or re-open resolved row (resolvedAt
 //                          cleared, occurrenceCount incremented, severity/
 //                          summary/customDetails refreshed)
 //   action="acknowledge" — status="acknowledged" (does not reset occurrenceCount)
 //   action="resolve"     — status="resolved", resolvedAt=now
+//
+// Change replay: same (edgeNodeId, changeKey) — update summary +
+// customDetails + lastSeenAt; firstSeenAt preserved. No occurrenceCount,
+// no resolved/reopened distinction.
 //
 // nodeId always derived from the bearer token; the body nodeId field is
 // informational only.
@@ -41,6 +56,10 @@ type IngestSummary = {
   acknowledged: number;
   resolved: number;
   updated: number; // existing rows whose trigger replay only bumped counters
+  // Slice 1: ChangeEvent rows inserted or updated. Not split by created vs
+  // updated because changes have no meaningful "re-opened" semantics and the
+  // operator-facing distinction is low value at this layer.
+  changes: number;
 };
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -140,12 +159,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     acknowledged: 0,
     resolved: 0,
     updated: 0,
+    changes: 0,
   };
 
   try {
     await prisma.$transaction(async (tx) => {
       for (const ev of parsed.data.events) {
-        await ingestOne(tx, edgeNodeRowId, ev, summary);
+        // Slice 1 (BI-8405FDA5): dispatch by eventType. The Zod default of
+        // "alert" guarantees ev.eventType is always set after parsing, so
+        // a bare equality check is safe; existing Slice 0 producers omit
+        // the field and land on the alert branch unchanged.
+        if (ev.eventType === "change") {
+          await ingestChange(tx, edgeNodeRowId, ev, summary);
+        } else {
+          await ingestOne(tx, edgeNodeRowId, ev, summary);
+        }
       }
     });
   } catch (err) {
@@ -301,4 +329,62 @@ function statusFromAction(action: EdgeEvent["action"]): string {
     case "resolve":
       return "resolved";
   }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ingestChange — Slice 1: upsert a point-in-time change record by
+// (edgeNodeId, changeKey). Changes have no lifecycle — `action` is required
+// by the wire schema for envelope uniformity but ignored here. Re-submission
+// of the same changeKey updates summary + customDetails + lastSeenAt while
+// preserving firstSeenAt; the upstream emitter is expected to use a stable
+// identifier (git SHA, deploy ID, change-ticket ref) so retries collapse
+// rather than duplicating rows.
+// ──────────────────────────────────────────────────────────────────────────
+async function ingestChange(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  edgeNodeId: string,
+  ev: EdgeEvent,
+  summary: IngestSummary,
+): Promise<void> {
+  const now = new Date();
+  const occurredAt = new Date(ev.occurredAt);
+  const customDetailsValue =
+    ev.customDetails === undefined ? undefined : (ev.customDetails as object);
+
+  await tx.changeEvent.upsert({
+    where: {
+      edgeNodeId_changeKey: { edgeNodeId, changeKey: ev.dedupKey },
+    },
+    create: {
+      edgeNodeId,
+      changeKey: ev.dedupKey,
+      source: ev.source,
+      component: ev.component ?? null,
+      eventGroup: ev.eventGroup ?? null,
+      eventClass: ev.eventClass ?? null,
+      severity: ev.severity,
+      summary: ev.summary,
+      customDetails: customDetailsValue,
+      occurredAt,
+      firstSeenAt: now,
+      lastSeenAt: now,
+    },
+    update: {
+      // Refresh the operator-visible fields on replay so an emitter can
+      // amend a change (e.g. post-deploy verification status) without
+      // needing a separate route.
+      source: ev.source,
+      component: ev.component ?? null,
+      eventGroup: ev.eventGroup ?? null,
+      eventClass: ev.eventClass ?? null,
+      severity: ev.severity,
+      summary: ev.summary,
+      customDetails: customDetailsValue,
+      lastSeenAt: now,
+      // firstSeenAt + occurredAt intentionally NOT refreshed — they pin
+      // the original observation in time, which is what the correlation
+      // engine cares about.
+    },
+  });
+  summary.changes++;
 }

--- a/docs/edge-node/event-envelope.md
+++ b/docs/edge-node/event-envelope.md
@@ -60,7 +60,8 @@
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `dedupKey` | string (1..255) | yes | Anchor for collapse. Same key = same row. |
+| `eventType` | enum | no | `alert` (default) &#124; `change`. Discriminator selecting the persistence path. Omitting it keeps Slice 0 wire compatibility. See [Change events](#change-events-slice-1) below. |
+| `dedupKey` | string (1..255) | yes | Anchor for collapse. Same key = same row. For changes, this is the change's stable identifier (git SHA, deploy ID). |
 | `source` | string (1..100) | yes | Detector identifier — `snmp.trap`, `syslog`, `ping`, `unifi.events`. |
 | `component` | string (1..200) | no | Operator-readable sub-source — hostname, IP, MAC, port. |
 | `eventGroup` | string (1..100) | no | Logical bucket — `network`, `host`, `ups`. |
@@ -164,13 +165,71 @@ curl -X POST https://localhost:3000/api/v1/edge/events \
 JSON
 ```
 
+## Change events (Slice 1)
+
+> Slice 1 of the detection engine. BI: `BI-8405FDA5`. Spec:
+> [`2026-05-21-edge-change-events-design.md`](../superpowers/specs/2026-05-21-edge-change-events-design.md).
+
+Set `eventType: "change"` on an event to record a **point-in-time fact** — a deploy, config push,
+feature-flag flip, infra apply — that the correlation engine (separate slice) joins to alerts that
+fire shortly after. This is the highest-leverage pattern borrowed from PagerDuty's PD-CEF model:
+most production incidents trace back to a recent change, and surfacing the join shaves the
+biggest single chunk off MTTR.
+
+**Wire shape:** identical to an alert event. The discriminator is `eventType`. Omit it (or set
+`"alert"`) and the event lands in `EdgeEvent` with the Slice 0 lifecycle. Set it to `"change"`
+and the event lands in `ChangeEvent` instead.
+
+**Semantic differences from alerts:**
+
+| | Alerts | Changes |
+|---|---|---|
+| Lifecycle | triggered → acknowledged → resolved (re-opens on later trigger) | Point-in-time only — no lifecycle, no `resolvedAt`, no `occurrenceCount` |
+| `action` | Drives the state machine | Required by the wire schema for envelope uniformity, but **ignored**. Use `"trigger"`. |
+| `dedupKey` | Detector-composed (`source:component:eventClass[:instance]`) so flap noise collapses | The change's stable identifier — git SHA, deploy ID, change-ticket ref. Re-submitting with the same key **updates** summary + customDetails instead of duplicating. |
+| Replay update | Bumps `occurrenceCount`; may reopen from resolved | Refreshes `summary` / `customDetails` / `lastSeenAt`; `firstSeenAt` + `occurredAt` preserved so the original observation is pinned in time |
+| Persistence | `EdgeEvent` table | `ChangeEvent` table |
+| Useful `severity` | `info` → `critical` based on detector confidence | `info` for routine deploys, `warn` for canaries, `error`/`critical` for emergency hotfixes / rollbacks |
+| Useful `customDetails` | Probe response, syslog body, varbinds | `gitSha`, `deployedBy`, `targetEnv`, `runId`, `ticketRef`, diff URL |
+
+**Example — a deploy:**
+
+```jsonc
+{
+  "eventType": "change",
+  "dedupKey": "git.deploy:web@abcdef1",
+  "source": "git.deploy",
+  "component": "web",
+  "eventGroup": "deploy",
+  "eventClass": "deploy",
+  "severity": "info",
+  "action": "trigger",
+  "summary": "Deploy abcdef1 to web (production)",
+  "occurredAt": "2026-05-21T02:28:30Z",
+  "customDetails": {
+    "gitSha": "abcdef1",
+    "deployedBy": "ci-bot",
+    "targetEnv": "production"
+  }
+}
+```
+
+A mixed batch (alerts + changes) is fine — they share one envelope and land in one transaction.
+The route response splits the counts:
+
+```jsonc
+{ "ok": true, "accepted": 4, "created": 2, "changes": 2, ... }
+```
+
 ## What this is NOT (yet)
 
-Slice 0 ships ingest + persistence only. There is **no** event list UI, **no** correlation across
-sources, **no** escalation, **no** on-call. Those land in follow-on slices:
+Slice 0 + Slice 1 ship the envelope + ingest + per-event persistence only. There is **no** event
+list UI, **no** correlation engine joining alerts to changes, **no** escalation, **no** on-call.
+Those land in follow-on slices:
 
-- Slice 1 — edge detector framework
-- Slice 2 — first built-in detector pack
-- Portal slices A / B / C — correlation, lifecycle UX, escalation + on-call
+- Slice 2 — edge detector framework (registry/scheduler/bus/dedupe/transport in `edge-node-go`)
+- Slice 3 — first built-in detector pack (reachability, SNMP poll+trap, syslog, ARP/DHCP, host self)
+- Portal slice — alert ⇄ change correlation engine (N-minute window join)
+- Portal slices A / B / C — incident lifecycle UX, escalation, on-call
 
-Track the parent BI `BI-9FE9D48D` for the slice plan.
+Track the parent BI `BI-9FE9D48D` (foundation) and follow-on `BI-8405FDA5` (Slice 1 change events).

--- a/docs/superpowers/specs/2026-05-21-edge-change-events-design.md
+++ b/docs/superpowers/specs/2026-05-21-edge-change-events-design.md
@@ -1,0 +1,214 @@
+# Edge Node — Change Events (Detection Engine, Slice 1)
+
+| Field | Value |
+|-------|-------|
+| **BI** | BI-8405FDA5 — Change Events on the edge-event envelope (additive eventType:alert\|change + new ChangeEvent model) |
+| **Parent BI** | BI-9FE9D48D — Edge-node detection engine (Slice 0 foundation) |
+| **IT4IT Alignment** | §5.7 Operate — Event Management FC + Change & Configuration Management FC |
+| **Depends On** | Slice 0 (`2026-05-21-edge-event-envelope-design.md`, merged via PR #895) |
+| **Status** | Slice 1 — Draft (envelope discriminator + ChangeEvent table + route dispatch; correlation engine ships in a separate slice) |
+| **Created** | 2026-05-21 |
+| **Author** | Claude (Software Engineer) + Mark Bodman (CEO) |
+
+---
+
+## 1. Problem Statement
+
+Most production incidents trace back to a recent change — a deploy, a config push, a feature-flag
+flip, an infra apply. PagerDuty's PD-CEF model separates `change_event` records from `alert`/
+`incident` records and joins them in the timeline so responders see "we shipped X at 02:28; this
+fired at 02:31" without manual cross-referencing. Per the PagerDuty research brief
+(post-merge of PR #895), this join is the **highest-leverage single MTTR win** that maps cleanly
+onto our Slice 0 envelope.
+
+DPF has no change record class today. Without one, the future correlation engine has nothing to
+join alerts against. Slice 1 closes that — additively, with no breaking change to Slice 0.
+
+## 2. Goals (Slice 1)
+
+1. One wire shape for both event classes — extend `EdgeEventEnvelope` with an optional `eventType`
+   discriminator (`alert` default, `change` opt-in). Slice 0 producers don't change.
+2. A `ChangeEvent` Prisma model distinct from `EdgeEvent` — point-in-time facts, no lifecycle, no
+   `occurrenceCount` / `resolvedAt` columns, indexed for the future correlation join.
+3. The portal route at `POST /api/v1/edge/events` dispatches per event by `eventType` — alerts go
+   to the existing upsert path; changes go to a new `ChangeEvent.upsert` path. Same auth, same
+   freshness window, same rate limit, same transaction boundary.
+4. Cross-runtime parity: Go envelope mirrors the discriminator; wire-contract fixtures (TS + Go)
+   include a change event so drift surfaces.
+
+## 3. Non-Goals (Slice 1)
+
+- **Correlation engine.** Joining alerts to changes within an N-minute window is its own follow-on
+  slice. Slice 1 ships the substrate the join queries; the join itself ships separately.
+- **Change-emitting detectors.** Git-deploy hooks, kubectl-apply watchers, Terraform-plan parsers
+  each get their own BI.
+- **Change feed UI.** Operator-facing list / timeline ships in a UI slice.
+- **Schema changes to EdgeEvent.** Slice 1 is purely additive. Slice 0 producers continue to work
+  byte-identically.
+
+## 4. Wire Contract
+
+### 4.1 Envelope (unchanged from Slice 0)
+
+```ts
+{
+  runKey: string;          // UUID — idempotency at batch level
+  nodeId?: string;         // informational; portal trusts the bearer token
+  observedAt: string;      // RFC 3339
+  eventsVersion: "1";      // literal
+  events: EdgeEvent[];     // 1..500
+}
+```
+
+### 4.2 Event (extended with `eventType`)
+
+```ts
+{
+  eventType?: "alert" | "change";  // default "alert" — Slice 0 producers omit
+  dedupKey: string;
+  source: string;
+  component?: string;
+  eventGroup?: string;
+  eventClass?: string;
+  severity: "info" | "warn" | "error" | "critical";
+  action: "trigger" | "acknowledge" | "resolve";  // required; ignored for changes
+  summary: string;
+  occurredAt: string;
+  customDetails?: Record<string, unknown>;
+}
+```
+
+### 4.3 Semantic differences
+
+| Aspect | `eventType: "alert"` (default) | `eventType: "change"` |
+|---|---|---|
+| Persistence | `EdgeEvent` table (Slice 0) | `ChangeEvent` table (new) |
+| Lifecycle | triggered → acknowledged → resolved; re-open on later trigger | Point-in-time only |
+| `dedupKey` semantics | Collapse anchor (`source:component:eventClass[:instance]`) | Stable identifier (git SHA, deploy ID, ticket ref) |
+| `action` | Drives state machine | Required by schema, ignored at the route |
+| Replay update | Bumps `occurrenceCount`; may clear `resolvedAt` | Refreshes `summary` / `customDetails` / `lastSeenAt`; `firstSeenAt` + `occurredAt` preserved |
+| Useful `severity` | `info`–`critical` per detector confidence | `info` for routine, `warn` for canary, `error`/`critical` for hotfix / rollback |
+| Useful `customDetails` | Probe / syslog / varbinds | `gitSha`, `deployedBy`, `targetEnv`, `runId`, `ticketRef` |
+
+## 5. Data Model
+
+### 5.1 `ChangeEvent`
+
+```prisma
+model ChangeEvent {
+  id            String   @id @default(cuid())
+  edgeNodeId    String                // FK to EdgeNode.id (cascade)
+  changeKey     String                // envelope dedupKey, scoped per node
+  source        String
+  component     String?
+  eventGroup    String?
+  eventClass    String?
+  severity      String   @default("info")
+  summary       String
+  customDetails Json?
+  occurredAt    DateTime
+  firstSeenAt   DateTime @default(now())
+  lastSeenAt    DateTime @default(now())
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  node EdgeNode @relation("EdgeNodeChanges", fields: [edgeNodeId], references: [id], onDelete: Cascade)
+
+  @@unique([edgeNodeId, changeKey])
+  @@index([edgeNodeId, occurredAt])   // ← powers the correlation join
+  @@index([source])
+  @@index([occurredAt])
+}
+```
+
+The `@@index([edgeNodeId, occurredAt])` composite mirrors `EdgeEvent.@@index([occurredAt])` so both
+sides of the future correlation join (`alerts.occurredAt BETWEEN change.occurredAt AND change.occurredAt + window`)
+are O(log n).
+
+### 5.2 Migration
+
+`packages/db/prisma/migrations/20260521130000_add_change_event_table/migration.sql` —
+`CREATE TABLE`, four indexes, FK to `EdgeNode` with cascade. Schema-only; no data backfill.
+
+## 6. Portal Ingest
+
+Same `POST /api/v1/edge/events` route. Order of operations is unchanged from Slice 0 (size cap →
+auth → JSON → Zod → freshness → rate limit → persist). The persistence loop gains one branch:
+
+```ts
+for (const ev of parsed.data.events) {
+  if (ev.eventType === "change") {
+    await ingestChange(tx, edgeNodeRowId, ev, summary);
+  } else {
+    await ingestOne(tx, edgeNodeRowId, ev, summary);   // Slice 0 path
+  }
+}
+```
+
+`ingestChange` does a single `prisma.changeEvent.upsert` on `(edgeNodeId, changeKey)`:
+
+- **create** path populates every column and stamps `firstSeenAt` = `lastSeenAt` = now.
+- **update** path refreshes `summary`, `customDetails`, the four classification fields, and bumps
+  `lastSeenAt`. `firstSeenAt` and `occurredAt` are intentionally **not** refreshed — the
+  correlation engine cares about when the change *actually happened*, not the last time the
+  emitter re-asserted it.
+
+Response summary gains a `changes` count:
+
+```jsonc
+{
+  "ok": true,
+  "runKey": "...",
+  "nodeId": "edge_abc",
+  "accepted": 5,
+  "created": 2,        // EdgeEvent inserts
+  "reopened": 1,
+  "acknowledged": 0,
+  "resolved": 1,
+  "updated": 1,
+  "changes": 2,        // ChangeEvent inserts + updates
+  "remaining": 29,
+  "route": "/api/v1/edge/events"
+}
+```
+
+## 7. Cross-Runtime Parity
+
+`services/edge-node-go/internal/envelope/event.go` adds an `EventType` Go enum + struct field with
+`json:"eventType,omitempty"` — omitting the field on the wire matches the Zod default of `"alert"`.
+`Validate()` accepts empty, `EventTypeAlert`, or `EventTypeChange`.
+
+`apps/web/app/api/v1/edge/__tests__/wire-contract.test.ts` already covers the events fixture;
+Slice 1 extends both `fixtures/ts/events/v1.json` and `fixtures/go/events/v1.json` with a
+change-event record so drift on either runtime fails the same Zod check.
+
+## 8. Out-of-Scope (Follow-on Slices)
+
+| Slice | Title | Notes |
+|---|---|---|
+| Correlation | Alert ⇄ change join engine | Reads `ChangeEvent.occurredAt` window around each `EdgeEvent.occurredAt`; surfaces matches in incident timeline. |
+| 2 (edge framework) | Detector framework on `edge-node-go` | Registry, scheduler, bus, local-dedupe, transport — same as parent BI-9FE9D48D Slice 2. |
+| 3+ (detectors) | First built-in detector pack | reachability, SNMP poll+trap, syslog, ARP/DHCP, host self. |
+| Portal A | Incident lifecycle UX | Reads both EdgeEvent + correlated ChangeEvent. |
+| Portal B | Escalation policies | Per-service routing. |
+| Portal C | On-call schedules | Calendar + paging. |
+
+## 9. Open Questions
+
+- **Change → service mapping.** Slice 1 has no `Service` first-class object yet; `component`
+  carries the service name as a string. When Service Graph (per PagerDuty research brief item #2)
+  ships, ChangeEvent gains an optional `serviceId` FK.
+- **Change TTL.** Like `EdgeEvent`, `ChangeEvent` rows grow unbounded. Compaction / archival
+  policy depends on the correlation engine's lookback window — defer until correlation lands and
+  the operationally useful window is empirically known.
+- **Cross-node changes.** Some changes (an org-wide kubectl apply) logically belong to many edge
+  nodes but are submitted by one. The `(edgeNodeId, changeKey)` unique scopes that out for now;
+  a future slice may add a `globalChangeKey` field for cross-node dedup.
+
+## 10. Trademark / Licensing Watchouts
+
+Per PagerDuty research brief — schema field names (`source`, `component`, `eventGroup`,
+`eventClass`, `severity`, `customDetails`) are PD-CEF public reference, not protectable. Do not
+copy PagerDuty's marketing strings (e.g. "Change Events" landing-page copy, prompt-library
+phrasings). The term "change event" as a generic operations concept is fine — it's used
+industry-wide.

--- a/packages/db/prisma/migrations/20260521130000_add_change_event_table/migration.sql
+++ b/packages/db/prisma/migrations/20260521130000_add_change_event_table/migration.sql
@@ -1,0 +1,42 @@
+-- Slice 1 of the edge-node detection engine (BI-8405FDA5).
+-- Spec: docs/superpowers/specs/2026-05-21-edge-change-events-design.md
+--
+-- Point-in-time change records (deploys, config pushes, feature flips)
+-- persisted from POST /api/v1/edge/events when eventType="change". The
+-- correlation engine (separate slice) joins alerts to changes within an
+-- N-minute window. Distinct from EdgeEvent because changes have no
+-- lifecycle: action / status / resolvedAt / occurrenceCount don't apply.
+
+CREATE TABLE "ChangeEvent" (
+    "id"            TEXT NOT NULL,
+    "edgeNodeId"    TEXT NOT NULL,
+    "changeKey"     TEXT NOT NULL,
+    "source"        TEXT NOT NULL,
+    "component"     TEXT,
+    "eventGroup"    TEXT,
+    "eventClass"    TEXT,
+    "severity"      TEXT NOT NULL DEFAULT 'info',
+    "summary"       TEXT NOT NULL,
+    "customDetails" JSONB,
+    "occurredAt"    TIMESTAMP(3) NOT NULL,
+    "firstSeenAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"     TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChangeEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ChangeEvent_edgeNodeId_changeKey_key" ON "ChangeEvent"("edgeNodeId", "changeKey");
+
+-- Composite index powers the correlation engine's "changes for this node
+-- in the last N minutes" join against alert events. Mirrors the
+-- EdgeEvent.occurredAt index so both sides of the join are O(log n).
+CREATE INDEX "ChangeEvent_edgeNodeId_occurredAt_idx" ON "ChangeEvent"("edgeNodeId", "occurredAt");
+CREATE INDEX "ChangeEvent_source_idx" ON "ChangeEvent"("source");
+CREATE INDEX "ChangeEvent_occurredAt_idx" ON "ChangeEvent"("occurredAt");
+
+ALTER TABLE "ChangeEvent"
+    ADD CONSTRAINT "ChangeEvent_edgeNodeId_fkey"
+    FOREIGN KEY ("edgeNodeId") REFERENCES "EdgeNode"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -8579,6 +8579,7 @@ model EdgeNode {
   discoveryRuns  DiscoveryRun[]       @relation("EdgeNodeDiscoveryRuns")
   consumedTokens BootstrapToken[]     @relation("BootstrapTokenConsumer")
   events         EdgeEvent[]          @relation("EdgeNodeEvents")
+  changes        ChangeEvent[]        @relation("EdgeNodeChanges")
 
   @@index([trustState])
   @@index([status])
@@ -8730,6 +8731,70 @@ model EdgeEvent {
   @@unique([edgeNodeId, dedupKey])
   @@index([edgeNodeId, status])
   @@index([severity])
+  @@index([source])
+  @@index([occurredAt])
+}
+
+// ─── Edge-detected change events (deploys, config pushes, feature flips) ─────
+// Slice 1 of the edge-node detection engine (BI-8405FDA5). Persisted from
+// POST /api/v1/edge/events when eventType="change". The correlation engine
+// (separate slice) joins alerts to changes within an N-minute window to
+// surface deploy-driven incidents — the highest-leverage borrowed PagerDuty
+// pattern per the research brief.
+//
+// Distinct from EdgeEvent because changes are point-in-time facts, not
+// fire-and-collapse conditions:
+//   - No status lifecycle (a deploy doesn't get "acknowledged" or "resolved")
+//   - No occurrenceCount (each change is a discrete event)
+//   - Idempotency on (edgeNodeId, changeKey) so re-submitting the same
+//     change (e.g. retry after transient failure) updates summary +
+//     customDetails without duplicating the row
+//
+// The portal route accepts the same EdgeEventEnvelope wire shape and
+// discriminates on `eventType`; `action` is required by the schema for
+// envelope uniformity but ignored for changes.
+model ChangeEvent {
+  id            String   @id @default(cuid())
+  // FK to EdgeNode.id (the cuid surrogate). Route fills this from the
+  // bearer-token auth, never from the body.
+  edgeNodeId    String
+  // Stable identifier — git SHA, deploy ID, change-ticket reference.
+  // Carried as `dedupKey` in the envelope. Re-submission with the same
+  // (edgeNodeId, changeKey) updates summary + customDetails.
+  changeKey     String
+  // Producing detector — "git.deploy", "kubectl.apply", "terraform.plan", etc.
+  source        String
+  // Operator-readable sub-source — service name, environment, target host.
+  component     String?
+  // Logical bucket — "deploy", "config", "feature-flag", "rollback".
+  eventGroup    String?
+  // Specific class — "deploy", "rollback", "scale", "flag_enable".
+  eventClass    String?
+  // info | warn | error | critical — routine deploy=info, canary=warn,
+  // emergency hotfix=error.
+  severity      String   @default("info")
+  // Short human-readable line for change feeds + correlation tooltips.
+  summary       String
+  // Free-form: gitSha, deployedBy, targetEnv, runId, ticketRef, diff URL.
+  customDetails Json?
+  // When the change actually happened (RFC 3339, set by detector).
+  occurredAt    DateTime
+  // When the portal first received this changeKey for this edge node.
+  firstSeenAt   DateTime @default(now())
+  // Bumped on every replay. Cheap signal that "this change keeps being
+  // re-asserted by the detector" — useful for debouncing noisy emitters.
+  lastSeenAt    DateTime @default(now())
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  node EdgeNode @relation("EdgeNodeChanges", fields: [edgeNodeId], references: [id], onDelete: Cascade)
+
+  @@unique([edgeNodeId, changeKey])
+  // Composite index powers the correlation engine's "changes for this node
+  // in the last N minutes" join against alert events. Keep this in lockstep
+  // with the EdgeEvent.occurredAt index so both sides of the join are O(log n).
+  @@index([edgeNodeId, occurredAt])
   @@index([source])
   @@index([occurredAt])
 }

--- a/packages/validators/src/edge.ts
+++ b/packages/validators/src/edge.ts
@@ -142,33 +142,56 @@ export const EDGE_EVENT_ACTIONS = [
 ] as const;
 export type EdgeEventAction = (typeof EDGE_EVENT_ACTIONS)[number];
 
+// Slice 1 (BI-8405FDA5): discriminator separating fire-and-collapse alert
+// events from point-in-time change events (deploys, config pushes, feature
+// flips). Defaulted to "alert" so every Slice 0 producer remains untouched
+// on the wire. The portal route discriminates: "alert" upserts EdgeEvent
+// (full lifecycle, replay-collapsed); "change" upserts ChangeEvent (no
+// lifecycle, kept as point-in-time facts the correlation engine joins to
+// alerts within an N-minute window).
+//
+// For eventType="change", `action` should be "trigger" (lifecycle doesn't
+// apply to changes; the route accepts but ignores other values). `dedupKey`
+// is reused as the change's stable identifier — a git SHA, deploy ID, etc.
+// — so re-submissions update rather than duplicate.
+export const EDGE_EVENT_TYPES = ["alert", "change"] as const;
+export type EdgeEventType = (typeof EDGE_EVENT_TYPES)[number];
+
 export const edgeEventSchema = z.object({
   /**
-   * Dedup anchor — detectors compose from source + component + class
-   * (+ instance) so the same condition collapses on replay. Scoped per
-   * edge node by the portal's @@unique([edgeNodeId, dedupKey]).
+   * Discriminator: "alert" (default) follows the Slice 0 lifecycle and
+   * collapses on (edgeNodeId, dedupKey); "change" is a point-in-time fact
+   * persisted to ChangeEvent for downstream correlation to alerts. Optional
+   * with default "alert" so Slice 0 producers don't need to change.
+   */
+  eventType: z.enum(EDGE_EVENT_TYPES).optional().default("alert"),
+  /**
+   * Dedup anchor — for alerts, detectors compose from source + component +
+   * class (+ instance) so the same condition collapses on replay; for
+   * changes, this is the change's stable identifier (git SHA, deploy ID).
+   * Scoped per edge node by the @@unique on each table.
    */
   dedupKey: z.string().min(1).max(255),
   /** Producing detector — "snmp.trap", "syslog", "ping", "unifi.events". */
   source: z.string().min(1).max(100),
   /** Operator-readable sub-source — hostname, IP, MAC, port. */
   component: z.string().max(200).optional(),
-  /** PD-CEF group — logical bucket ("network", "host", "ups"). */
+  /** PD-CEF group — logical bucket ("network", "host", "ups", "deploy"). */
   eventGroup: z.string().max(100).optional(),
-  /** PD-CEF class — specific condition ("interface_down", "cert_expiring"). */
+  /** PD-CEF class — specific condition ("interface_down", "deploy", "rollback"). */
   eventClass: z.string().max(100).optional(),
   severity: z.enum(EDGE_EVENT_SEVERITIES),
   /**
-   * trigger raises or re-raises an event; acknowledge marks under-investigation;
-   * resolve closes it. A later trigger on the same dedupKey re-opens
-   * (resolvedAt cleared, occurrenceCount++).
+   * For alerts: trigger raises or re-raises; acknowledge marks
+   * under-investigation; resolve closes it. For changes: should be
+   * "trigger" — lifecycle does not apply and the route ignores the value.
    */
   action: z.enum(EDGE_EVENT_ACTIONS),
   /** Short human-readable line for incident lists. */
   summary: z.string().min(1).max(500),
   /** RFC 3339 timestamp the edge detector observed the condition. */
   occurredAt: z.string().datetime(),
-  /** Free-form detector payload — varbinds, deltas, parsed syslog, etc. */
+  /** Free-form detector payload — varbinds, deltas, parsed syslog, deploy metadata. */
   customDetails: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/services/edge-node-go/internal/envelope/event.go
+++ b/services/edge-node-go/internal/envelope/event.go
@@ -32,10 +32,11 @@ const (
 	SeverityCritical Severity = "critical"
 )
 
-// Action drives the portal-side lifecycle. trigger opens or re-opens an
-// event; acknowledge marks it under investigation; resolve closes it.
-// A later trigger on the same dedupKey re-opens the row (resolvedAt
-// cleared, occurrenceCount++).
+// Action drives the portal-side lifecycle for alert events. trigger opens
+// or re-opens an event; acknowledge marks it under investigation; resolve
+// closes it. A later trigger on the same dedupKey re-opens the row
+// (resolvedAt cleared, occurrenceCount++). For change events the lifecycle
+// does not apply — set Action=ActionTrigger; the portal ignores the value.
 type Action string
 
 const (
@@ -44,15 +45,38 @@ const (
 	ActionResolve     Action = "resolve"
 )
 
+// EventType discriminates between fire-and-collapse alerts (the Slice 0
+// default — full lifecycle, replay-collapsed on dedupKey) and point-in-time
+// change events (deploys, config pushes, feature flips — persisted to
+// ChangeEvent for downstream correlation to alerts).
+//
+// Slice 1 (BI-8405FDA5). The portal route discriminates and dispatches to
+// the correct persistence path. Defaulted to EventTypeAlert in Validate()
+// so existing Slice 0 detectors remain wire-compatible without changes.
+type EventType string
+
+const (
+	EventTypeAlert  EventType = "alert"
+	EventTypeChange EventType = "change"
+)
+
 // Event is one detector observation. DedupKey is the only field detectors
-// MUST compose carefully — the portal collapses replays on
-// (edgeNodeId, dedupKey), so the same condition observed twice must produce
-// byte-identical dedupKey strings. Recommended composition:
+// MUST compose carefully — for alerts the portal collapses replays on
+// (edgeNodeId, dedupKey), so the same condition observed twice must
+// produce byte-identical dedupKey strings. For changes, DedupKey is the
+// change's stable identifier (git SHA, deploy ID) so re-submissions update
+// the existing row instead of duplicating.
+//
+// Recommended composition for alerts:
 //
 //	source + ":" + component + ":" + eventClass [+ ":" + instance]
 //
 // e.g. "snmp.trap:10.0.0.5:ifaceDown:ifIndex=42".
 type Event struct {
+	// EventType discriminator. Empty / omitted defaults to EventTypeAlert
+	// for Slice 0 wire compatibility; the portal Zod applies the same
+	// default. Detectors that emit changes MUST set this explicitly.
+	EventType     EventType      `json:"eventType,omitempty"`
 	DedupKey      string         `json:"dedupKey"`
 	Source        string         `json:"source"`
 	Component     string         `json:"component,omitempty"`
@@ -107,6 +131,13 @@ func (e Event) Validate() error {
 	}
 	if len(e.Summary) > 500 {
 		return fmt.Errorf("summary exceeds 500 chars: %d", len(e.Summary))
+	}
+	// EventType: empty defaults to alert (Slice 0 compatibility); otherwise
+	// must be a known type. Matches the portal Zod default behavior.
+	switch e.EventType {
+	case "", EventTypeAlert, EventTypeChange:
+	default:
+		return fmt.Errorf("invalid eventType %q (want alert|change)", e.EventType)
 	}
 	switch e.Severity {
 	case SeverityInfo, SeverityWarn, SeverityError, SeverityCritical:

--- a/services/edge-node-go/internal/envelope/event_test.go
+++ b/services/edge-node-go/internal/envelope/event_test.go
@@ -53,6 +53,8 @@ func TestEvent_Validate_MissingRequired(t *testing.T) {
 		{"bad severity", func(e *Event) { e.Severity = "panic" }, "severity"},
 		{"bad action", func(e *Event) { e.Action = "page" }, "action"},
 		{"bad occurredAt", func(e *Event) { e.OccurredAt = "yesterday" }, "occurredAt"},
+		// Slice 1 (BI-8405FDA5): eventType enum validation.
+		{"bad eventType", func(e *Event) { e.EventType = "incident" }, "eventType"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -66,6 +68,39 @@ func TestEvent_Validate_MissingRequired(t *testing.T) {
 				t.Fatalf("error %q does not mention %q", err, tc.want)
 			}
 		})
+	}
+}
+
+// Slice 1 (BI-8405FDA5): EventType acceptance matrix. Empty must accept
+// (Slice 0 wire compatibility); explicit alert + change must accept.
+func TestEvent_Validate_EventTypeAccepted(t *testing.T) {
+	cases := []EventType{"", EventTypeAlert, EventTypeChange}
+	for _, et := range cases {
+		t.Run(string(et), func(t *testing.T) {
+			e := validEvent()
+			e.EventType = et
+			if err := e.Validate(); err != nil {
+				t.Fatalf("eventType %q rejected: %v", et, err)
+			}
+		})
+	}
+}
+
+// JSON tag for EventType uses omitempty so Slice 0 producers omitting the
+// field don't add a noisy "eventType":"" pair on the wire. Verify both
+// directions: explicit type round-trips; omitted type produces no key.
+func TestEvent_EventType_JSONOmitempty(t *testing.T) {
+	withType := validEvent()
+	withType.EventType = EventTypeChange
+	raw, _ := json.Marshal(withType)
+	if !strings.Contains(string(raw), `"eventType":"change"`) {
+		t.Fatalf("explicit eventType missing from JSON: %s", raw)
+	}
+
+	withoutType := validEvent()
+	raw2, _ := json.Marshal(withoutType)
+	if strings.Contains(string(raw2), `"eventType"`) {
+		t.Fatalf("omitted eventType leaked into JSON: %s", raw2)
 	}
 }
 


### PR DESCRIPTION
## Summary

Slice 1 of the edge-node detection engine. Adds **change events** — point-in-time records for deploys, config pushes, and feature flips — alongside the Slice 0 alert path. Per the [PagerDuty research brief](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/895) that informed the post-#895 prioritization, this is the highest-leverage borrowed pattern: most production incidents trace back to a recent change, and surfacing the join is the biggest single MTTR win.

**Additive to Slice 0** — existing producers stay byte-identical on the wire.

- **Wire contract:** new optional `eventType: "alert" | "change"` (default `"alert"`) on `edgeEventSchema`. Mirrored in Go via `EventType` enum + struct field with `json:\"eventType,omitempty\"` so omitting the field round-trips through both runtimes.
- **Data model:** new `ChangeEvent` Prisma model — distinct from `EdgeEvent` because changes are point-in-time facts (no lifecycle, no `occurrenceCount`, no `resolvedAt`). Composite `(edgeNodeId, occurredAt)` index mirrors `EdgeEvent.occurredAt` so both sides of the future correlation join are O(log n). Migration `20260521130000_add_change_event_table`.
- **Route:** `POST /api/v1/edge/events` now dispatches per event by `eventType`. Alerts hit the Slice 0 `EdgeEvent` upsert + lifecycle path; changes hit a new `ingestChange` that does a single `ChangeEvent.upsert` on `(edgeNodeId, changeKey)`. Same transaction, same auth, same freshness window, same rate limit. Response summary gains a `changes` count.
- **Change replay semantics:** re-submitting the same `changeKey` refreshes `summary` + `customDetails` + `lastSeenAt` only. `firstSeenAt` + `occurredAt` are intentionally preserved so the correlation engine sees the original observation time.

## Tracking

- **BI:** BI-8405FDA5 — filed via DPF MCP
- **Work Capsule:** WC-F3B1DCB5 — `adopt_worktree` + `claim_capsule_scope` (8 paths claimed)
- **Parent BI:** BI-9FE9D48D (Slice 0 foundation, merged via #895)
- **IT4IT:** §5.7 Operate — Event Mgmt FC + Change & Configuration Mgmt FC

## Out of scope (separate slices)

- Correlation engine joining alerts to changes within an N-minute window
- Change-emitting detectors (git-deploy hook, kubectl-apply watcher, Terraform-plan parser) — each its own BI
- Operator-facing change feed / timeline UI

## Test plan

- [x] `pnpm prisma generate` clean (no `format` per the post-#901 convention)
- [x] Migration SQL applied to live `dpf-postgres-1` schema in a rollback transaction — table, 5 indexes (PK + unique + 3 secondary), FK to `EdgeNode` confirmed
- [x] `pnpm vitest run` apps/web edge surface: **230/230 pass** (5 new change-event tests added: route dispatch, default eventType=alert, mixed batch, change replay update path, unknown eventType 422)
- [x] `pnpm test` packages/db: **26/26 pass**
- [x] `pnpm typecheck` clean across `packages/db`, `packages/validators`, `apps/web`
- [x] `go test ./internal/envelope/...` OK including new EventType acceptance matrix + JSON omitempty round-trip
- [x] Cross-runtime wire-contract parity: both TS and Go fixtures now include a deploy change event

## Notes for review

- Schema diff is **~83 lines** (the new ChangeEvent model + the `changes` relation field on EdgeNode) — no formatter churn, per the convention #906 + the post-#901 lesson.
- `action` field on change events is intentionally required by the wire schema (envelope uniformity) but ignored by the route handler. Documented in the operator guide + spec.
- The `update` path on `ChangeEvent.upsert` deliberately omits `firstSeenAt` and `occurredAt` — these pin the original change in time so the correlation join is honest. Tested explicitly in route.test.ts.
- Per the PagerDuty research brief, term "change event" is a generic operations term used industry-wide — no trademark concern. Schema field names are PD-CEF public reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)