### PR TITLE
fix(sandbox): raise maxBuffer to 100 MB for seedSandboxDb pg_dump

### DIFF
--- a/apps/web/lib/integrate/sandbox/sandbox-db.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-db.ts
@@ -205,6 +205,7 @@ export async function seedSandboxDb(
 ): Promise<void> {
   await exec(
     `docker exec ${productionDbContainerName} pg_dump --data-only -U dpf dpf | docker exec -i ${sandboxDbContainerId} psql -U dpf dpf`,
+    { maxBuffer: 100 * 1024 * 1024 },
   );
 }
 


### PR DESCRIPTION
## Summary

- `seedSandboxDb` ran `pg_dump --data-only | psql` via Node.js `exec` with **no `maxBuffer`**, defaulting to 1 MB
- Production DB (455 backlog items, 54 epics, builds, etc.) now dumps >1 MB, throwing `stderr maxBuffer length exceeded` at the `workspace_initialized` pipeline step
- Every sandbox build retry stalls at `stepInitDb` with this error — including FB-5222FED1 and any future builds once the DB grows

Same class of bug as #884 (source-copy tar maxBuffer), different call site.

## Change

One-line fix: pass `{ maxBuffer: 100 * 1024 * 1024 }` to the `exec` call in `seedSandboxDb`, matching the cap already set on `execInSandbox` and the tar copy.

## Test plan

- [ ] Trigger a build retry on FB-5222FED1 after portal picks up this fix — expect `workspace_initialized` step to complete and pipeline to advance to `deps_installed`
- [ ] Confirm no `stderr maxBuffer` errors in portal logs during `seedSandboxDb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)