### PR TITLE
fix(test): PortalContextStrip — case-insensitive 'lease expired' assertion (unblocks CI)

### DIFF
--- a/apps/web/components/portal-context/PortalContextStrip.test.tsx
+++ b/apps/web/components/portal-context/PortalContextStrip.test.tsx
@@ -36,8 +36,11 @@ describe("PortalContextStrip", () => {
     expect(html).toContain("text-[var(--dpf-warning)]");
     // Must not collapse to a single var-source (the bug).
     expect(html).not.toMatch(/bg-\[var\(--dpf-warning\)\][^"]*text-\[var\(--dpf-warning\)\]/);
-    // And the signal label must be in the DOM so the chip isn't visually empty.
-    expect(html).toContain("lease expired");
+    // And the signal label must be in the DOM so the chip isn't visually
+    // empty. The label is sentence-cased ("Lease expired"); use a
+    // case-insensitive containment so the test doesn't break if anyone
+    // tightens or relaxes the casing rule later.
+    expect(html.toLowerCase()).toContain("lease expired");
   });
 
   it("error AttentionChip uses distinct fg/bg tokens (same class of bug)", () => {


### PR DESCRIPTION
## Summary

PR #905 landed sentence-case **"Lease expired"** in the AttentionChip label, but the regression test on the same PR asserts the lowercase form **"lease expired"**. The test renders the right DOM and the casing isn't itself a bug — only the assertion is wrong.

Net effect: **every open PR is failing CI** with:

```
AssertionError: expected '...Lease expired...' to contain 'lease expired'
 ❯ components/portal-context/PortalContextStrip.test.tsx:40:18
```

Confirmed on PR #909 (my topology-view-fixes), which has nothing to do with portal-context.

## Fix

Lowercase both sides of the containment check. One-line change, plus a comment so future label-casing tweaks don't reintroduce the gap.

```diff
-    expect(html).toContain("lease expired");
+    expect(html.toLowerCase()).toContain("lease expired");
```

## Test plan

- [x] `pnpm exec vitest run components/portal-context/PortalContextStrip.test.tsx` — 3 passing locally.
- [ ] CI: typecheck + vitest + production build.

Once this merges, every open PR's CI should pass without rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)