### PR TITLE
fix(wiki): corrective migration — position() to delete backslash slugs on fresh installs

### DIFF
--- a/packages/db/prisma/migrations/20260521130000_fix_wiki_backslash_slug_cleanup/migration.sql
+++ b/packages/db/prisma/migrations/20260521130000_fix_wiki_backslash_slug_cleanup/migration.sql
@@ -1,0 +1,9 @@
+-- Corrective migration: the prior migration (20260521120000) used
+-- LIKE '\%' which is a no-op in PostgreSQL (backslash is the LIKE
+-- escape character, so '\%' matches a literal %, not a backslash).
+-- This migration uses position() which unambiguously matches any slug
+-- containing a literal backslash character.
+-- Idempotent: already-clean installs will match 0 rows.
+
+DELETE FROM "WikiPage"
+WHERE position('\' in slug) > 0;


### PR DESCRIPTION
## Summary

The migration in PR #904 used `LIKE '\%'` which is a no-op in PostgreSQL — backslash is the LIKE escape character so `'\%'` matches a literal `%` not a backslash. That migration ran on all existing installs but deleted nothing.

This adds a corrective migration (`20260521130000`) using `position('\' in slug) > 0` which reliably deletes all WikiPage rows containing a backslash in their slug.

- **Live install**: already cleaned via direct SQL (138 → 75 rows). This migration will be a no-op there.
- **Fresh installs**: will pick up both migrations; this one correctly cleans the backslash rows the first one missed.

## Test plan
- [ ] Fresh install: wiki shows ~49 principles, no duplicates, all links work
- [ ] Existing install: migration runs, 0 rows deleted (already clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)