### PR TITLE
fix(build-studio): detect stalled-at-pending pipeline state and surface Reset Build

### DIFF
--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -781,6 +781,39 @@ describe("deriveWorkflowStageGuidance", () => {
     expect(action.message).toMatch(/contradictory|checkpoint/i);
   });
 
+  // Pipeline stalled before setting first step (e.g. portal restart killed
+  // autoExecuteBuild before stepCreateSandbox could write step="sandbox_created").
+  // FB-7A21E1F6 shape: buildExecState has sourceCurrency and metadata but no step.
+  it("surfaces Reset Build when buildExecState exists but has no step (stalled at pending)", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        phase: "build",
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        taskResults: null,
+        verificationOut: null,
+        buildExecState: {
+          // No `step` field — pipeline was killed before writing its first checkpoint.
+          // Casting to satisfy the type; the runtime JSONB can be missing this key.
+          sourceCurrency: {
+            dirty: false,
+            branch: "build/FB-7A21E1F6",
+            status: "current",
+            aheadBy: 0,
+            headSha: "41c46682a3f9df4b4963cb749842765f8371f27f",
+            behindBy: 0,
+            checkedAt: "2026-05-20T02:20:08.893Z",
+          } as unknown as never,
+        } as unknown as FeatureBuildRow["buildExecState"],
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    expect(action.kind).toBe("reset-build");
+    expect(action.primaryLabel).toBe("Reset Build");
+    expect(action.disabledReason).toBeNull();
+    expect(action.message).toMatch(/stalled|interrupted/i);
+  });
+
   it("does NOT surface Reset Build for a legitimate step=failed state — that path uses Retry Sandbox Launch", () => {
     const action = deriveBuildStudioWorkflowAction({
       build: makeBuild({

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -346,6 +346,17 @@ function hasContradictoryExecState(
   verificationOut?: FeatureBuildRow["verificationOut"] | null,
 ): boolean {
   if (!state) return false;
+  // Pipeline died before setting the first step (e.g. portal restart killed
+  // the fire-and-forget autoExecuteBuild call during stepCreateSandbox).
+  // The state object has content (sourceCurrency, ideateResearchRequested, etc.)
+  // but no `step` key — so no standard recovery path applies:
+  //   • retryBuildExecution requires step==="failed"
+  //   • resumeBuildImplementation requires a releasable diff
+  //   • advance-phase (review) is blocked without verificationOut
+  // Reset Build is the only viable restart path.
+  if (state.step == null) {
+    return true;
+  }
   // `failed` is a legitimate terminal step that retryBuildExecution handles;
   // every other step with an error/failedAt breadcrumb is contradictory.
   if (state.step !== "failed" && (state.error != null || state.failedAt != null)) {
@@ -445,6 +456,8 @@ export function deriveBuildStudioWorkflowAction({
     // with an error breadcrumb), Resume Implementation will fail regardless
     // of task state. Reset Build is the only viable recovery path.
     if (hasContradictoryExecState(build.buildExecState, build.verificationOut)) {
+      const isStalledAtPending =
+        build.buildExecState != null && build.buildExecState.step == null;
       const isSilentComplete =
         build.buildExecState?.step === "complete" &&
         (build.buildExecState?.error == null && build.buildExecState?.failedAt == null) &&
@@ -452,16 +465,20 @@ export function deriveBuildStudioWorkflowAction({
       return {
         kind: "reset-build",
         title: "Build Pipeline Needs Reset",
-        message: isSilentComplete
-          ? "The pipeline reported completion but verification results are missing — the sandbox likely ran but tests were never captured. Reset will restart the full build from the beginning."
-          : "The build pipeline checkpoint is in a contradictory shape (a prior run left an error breadcrumb on a non-failed step). Clear the checkpoint and re-run the pipeline from the start.",
+        message: isStalledAtPending
+          ? "The build pipeline stalled before it could start — the process was likely interrupted (e.g. portal restart) before the first step completed. Reset will restart the pipeline from scratch."
+          : isSilentComplete
+            ? "The pipeline reported completion but verification results are missing — the sandbox likely ran but tests were never captured. Reset will restart the full build from the beginning."
+            : "The build pipeline checkpoint is in a contradictory shape (a prior run left an error breadcrumb on a non-failed step). Clear the checkpoint and re-run the pipeline from the start.",
         primaryLabel: "Reset Build",
         targetPhase: null,
         disabledReason: null,
         coworkerLabel: "Diagnose with coworker",
-        coworkerPrompt: isSilentComplete
-          ? "The build shows step=complete but verificationOut is null, meaning tests never ran or the result was not captured. Explain what likely happened and confirm whether a full Reset Build is the right recovery."
-          : "The build's execution checkpoint is contradictory (step says complete but an error breadcrumb is set). Read buildExecState and tell me whether a Reset Build is safe or if the original error needs investigation first.",
+        coworkerPrompt: isStalledAtPending
+          ? "The build pipeline has no recorded step — it was likely interrupted before the first step completed. Confirm whether a Reset Build is safe to restart the pipeline from scratch."
+          : isSilentComplete
+            ? "The build shows step=complete but verificationOut is null, meaning tests never ran or the result was not captured. Explain what likely happened and confirm whether a full Reset Build is the right recovery."
+            : "The build's execution checkpoint is contradictory (step says complete but an error breadcrumb is set). Read buildExecState and tell me whether a Reset Build is safe or if the original error needs investigation first.",
       };
     }
 

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -709,8 +709,14 @@ export async function resetBuildExecution(buildId: string): Promise<void> {
     throw new Error("Build has no execution state to reset.");
   }
 
+  // "Stalled at pending": the pipeline started accumulating state (sourceCurrency,
+  // ideateResearchRequested, etc.) but was killed before setting the first step
+  // (e.g. portal restart during the fire-and-forget autoExecuteBuild call).
+  // No step means no standard recovery path applies, so reset is valid.
+  const isStalledAtPending = state.step == null;
   const isContradictory =
-    state.step !== "failed" && (state.error != null || state.failedAt != null);
+    isStalledAtPending ||
+    (state.step !== "failed" && (state.error != null || state.failedAt != null));
   if (!isContradictory) {
     throw new Error(
       "Build execution state is not contradictory. Use Retry Build for failed states or Resume Implementation for partial task failures.",
@@ -727,13 +733,14 @@ export async function resetBuildExecution(buildId: string): Promise<void> {
 
   revalidatePortalContextForBuild(buildId);
 
+  const summaryStepLabel = isStalledAtPending ? "none (stalled before first step)" : String(state.step);
   prisma.buildActivity
     .create({
       data: {
         buildId,
         tool: "resetBuildExecution",
         summary:
-          `Reset contradictory pipeline checkpoint (prior step=${state.step}` +
+          `Reset contradictory pipeline checkpoint (prior step=${summaryStepLabel}` +
           `${state.failedAt ? `, failedAt=${state.failedAt}` : ""}` +
           `${state.error ? `, error=${state.error.slice(0, 200)}` : ""}` +
           `)`,

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -122,6 +122,23 @@ export async function runBuildPipeline(params: {
     startedAt: new Date().toISOString(),
   };
 
+  // Persist the initial "pending" checkpoint before entering the step loop.
+  // This closes a race window where the DB has buildExecState content
+  // (e.g. sourceCurrency from recordBuildSourceCurrency) but no `step` field
+  // — which is indistinguishable from a portal-restart-killed stall.
+  // Without this write, the UI correctly shows "Reset Build" for a stalled run
+  // but also incorrectly shows it during a legitimately in-flight first step.
+  // Guarded to new/stalled-at-pending runs only; resumes already have a valid step.
+  if (state.step == null) {
+    state = {
+      ...state,
+      step: "pending",
+      retryCount: state.retryCount ?? 0,
+      startedAt: state.startedAt ?? new Date().toISOString(),
+    };
+    await updateState(state);
+  }
+
   try {
     for (const step of stepsToRun) {
       // Skip terminal steps — these are not executable.


### PR DESCRIPTION
## Summary

- `hasContradictoryExecState` now returns `true` when `buildExecState` exists but has no `step` field — the pipeline was killed (e.g. portal restart) before writing its first checkpoint
- `resetBuildExecution` server action now accepts this state as valid for reset, clearing the stalled state and restarting `autoExecuteBuild`
- UI shows a targeted "stalled before first step" message distinguishing this from the silent-complete and error-breadcrumb cases
- New test covers the FB-7A21E1F6 runtime shape: state with `sourceCurrency` but no `step`

**Root cause observed on:** FB-7A21E1F6 (Portal self-upgrade). Portal was rebuilt to pick up PRs #881/#884/#917 while `autoExecuteBuild` was in-flight. The fire-and-forget process died before `stepCreateSandbox` could write `step: "sandbox_created"`. After restart, no UI action was available to recover the build.

## Test plan

- [x] `build-studio-workflow-actions.test.ts` — 25 tests pass (was 24), new test covers stalled-at-pending shape
- [ ] CI typecheck + full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)