### PR TITLE
fix(orchestrator): remove overly-broad concern pattern that false-positives on failure-handling tasks

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.test.ts
+++ b/apps/web/lib/integrate/build-orchestrator.test.ts
@@ -108,7 +108,7 @@ describe("classifyOutcome", () => {
     expect(classifyOutcome(result, "frontend-engineer")).toBe("BLOCKED");
   });
 
-  it("returns DONE for QA even with errors (test results are informational)", () => {
+  it("returns DONE_WITH_CONCERNS when CLI content contains numeric test failure count ('2 failed')", () => {
     const result = mockResult({
       content: "Typecheck passed. 8 tests pass, 2 failed.",
       executedTools: [
@@ -116,6 +116,32 @@ describe("classifyOutcome", () => {
       ],
     });
     expect(classifyOutcome(result, "qa-engineer")).toBe("DONE_WITH_CONCERNS");
+  });
+
+  // Regression: tasks whose subject matter is failure handling (e.g. "Queue failure path",
+  // "UI history and failure details") should not be classified as DONE_WITH_CONCERNS
+  // just because the QA summary naturally uses the word "failure" or "failed" in a
+  // narrative description of correct behavior.  The plain /\bfailed\b/ pattern caused
+  // false positives; we now require a numeric count ("2 failed") instead.
+  it("returns DONE when CLI dispatch result describes failure-handling code correctly (no numeric failure count)", () => {
+    // ClaudeResult (has durationMs, no providerId) → CLI dispatch path
+    const result = {
+      content: "The failure path correctly catches errors and marks the run as failed. All failure-handling tests verify the expected behavior.",
+      success: true,
+      executedTools: [],
+      durationMs: 1000,
+    };
+    expect(classifyOutcome(result, "qa-engineer")).toBe("DONE");
+  });
+
+  it("returns DONE_WITH_CONCERNS when CLI dispatch result has 'error:' prefix diagnostic", () => {
+    const result = {
+      content: "error: Cannot find module '@/lib/foo'",
+      success: true,
+      executedTools: [],
+      durationMs: 500,
+    };
+    expect(classifyOutcome(result, "software-engineer")).toBe("DONE_WITH_CONCERNS");
   });
 });
 

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -563,15 +563,23 @@ export function classifyOutcome(result: AgenticResult | CodexResult | ClaudeResu
       return "BLOCKED";
     }
     // CLI succeeded — check content for concern indicators using contextual patterns.
-    // Avoids false positives from phrases like "Fixed the error handling".
+    // Avoids false positives from phrases like "Fixed the error handling",
+    // "failure path", "failure handling", or task names that include "failure".
+    // Patterns must match *output diagnostics*, not narrative descriptions.
     const CLI_CONCERN_PATTERNS = [
       /\berrors?[:]\s/i,           // "error: something" or "errors: 3"
-      /\bfailed\b/i,              // "failed" as standalone word (not "fixed the failed")
+      // NOTE: plain /\bfailed\b/i is intentionally absent — it causes false positives
+      // on tasks whose subject matter is about failure scenarios (e.g. "Queue failure path",
+      // "UI history and failure details") where the QA summary naturally mentions "failed"
+      // cases as part of a correct implementation description.
       /\bwarnings?[:]\s/i,        // "warning: something"
       /\d+\s+errors?\b/i,         // "3 errors"
       /\d+\s+warnings?\b/i,       // "5 warnings"
       /typecheck.*fail/i,         // "typecheck failed"
       /build.*fail/i,             // "build failed"
+      /\d+\s+tests?\s+failed\b/i, // "3 tests failed" (numeric test failure count)
+      /\b\d+\s+failed\b/i,        // "2 failed" (standalone numeric count, e.g. jest/vitest output)
+      /test\s+suite.*fail/i,      // "test suite failed"
     ];
     if (CLI_CONCERN_PATTERNS.some(pat => pat.test(content))) {
       return "DONE_WITH_CONCERNS";


### PR DESCRIPTION
## Summary

- Removes `/\bfailed\b/i` from `CLI_CONCERN_PATTERNS` in `classifyOutcome()` — this pattern caused `DONE_WITH_CONCERNS` for any task whose QA summary naturally used the word "failed" when describing correct failure-handling code
- Replaces with more specific patterns: `/\d+\s+tests?\s+failed\b/i` (vitest/jest test count output), `/\b\d+\s+failed\b/i` (numeric failure count), and `/test\s+suite.*fail/i`
- Adds regression test for the false-positive case

**Observed on:** FB-7A21E1F6 (Portal self-upgrade). Tasks "Queue failure path", "UI status sections", and "UI history and failure details" received `DONE_WITH_CONCERNS` in every orchestrator pass because their descriptions naturally used "failure"/"failed" when documenting correct behavior. This permanently blocked the build → review advance gate.

## Test plan

- [x] 51 orchestrator tests pass (added 2 new cases covering the false-positive and the numeric failure count patterns)
- [ ] CI typecheck + full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)