### PR TITLE
fix(ops-map): lift stalled TaskRuns into projection set independent of top-40 cap

### DIFF
--- a/apps/web/lib/ai-operations-map/load-map-data.test.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.test.ts
@@ -51,7 +51,7 @@ vi.mock("@dpf/db", () => ({
 }));
 
 import { prisma } from "@dpf/db";
-import { loadOperationsMapData } from "./load-map-data";
+import { loadOperationsMapData, mergeTaskRunsDedupeById } from "./load-map-data";
 
 describe("loadOperationsMapData", () => {
   beforeEach(() => {
@@ -623,3 +623,54 @@ function makeScheduledJobRow() {
     lastStatus: "ok",
   };
 }
+
+describe("mergeTaskRunsDedupeById", () => {
+  // BI-OPS-MAP-STALLED-WINDOW (2026-05-21): loadOperationsMapData fetches
+  // two task-run windows — recent-40 and stalled-200. They overlap when a
+  // row is stalled AND in the recent-40 (typical case). The merge helper
+  // dedupes by cuid id so a row appears exactly once in the projection set.
+
+  it("returns recent rows when stalled list is empty", () => {
+    const recent = [{ id: "a" }, { id: "b" }];
+    expect(mergeTaskRunsDedupeById(recent, [])).toEqual(recent);
+  });
+
+  it("returns stalled rows when recent list is empty", () => {
+    const stalled = [{ id: "x" }, { id: "y" }];
+    expect(mergeTaskRunsDedupeById([], stalled)).toEqual(stalled);
+  });
+
+  it("appends stalled rows that aren't already in recent", () => {
+    const recent = [{ id: "a" }, { id: "b" }];
+    const stalled = [{ id: "c" }, { id: "d" }];
+    expect(mergeTaskRunsDedupeById(recent, stalled).map((r) => r.id)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  it("dedupes rows that appear in both lists (a row stalled AND in recent-40)", () => {
+    const recent = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const stalled = [{ id: "b" }, { id: "d" }];
+    const merged = mergeTaskRunsDedupeById(recent, stalled);
+    expect(merged.map((r) => r.id)).toEqual(["a", "b", "c", "d"]);
+    expect(merged.filter((r) => r.id === "b")).toHaveLength(1);
+  });
+
+  it("preserves the recent-list version when the same id is in both", () => {
+    // The recent-list copy wins — it's inserted first. This matters because
+    // both queries select identical fields today, but if they diverge in
+    // future (e.g. recent adds a field), the recent shape is canonical.
+    const recent = [{ id: "a", source: "recent" }];
+    const stalled = [{ id: "a", source: "stalled" }];
+    const merged = mergeTaskRunsDedupeById(recent, stalled);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.source).toBe("recent");
+  });
+
+  it("handles both empty", () => {
+    expect(mergeTaskRunsDedupeById([], [])).toEqual([]);
+  });
+});

--- a/apps/web/lib/ai-operations-map/load-map-data.ts
+++ b/apps/web/lib/ai-operations-map/load-map-data.ts
@@ -24,6 +24,21 @@ import type {
 
 export const RECENT_TOOL_LIMIT = 40;
 
+/**
+ * Cap on how many stalled TaskRuns are lifted into the projection set
+ * regardless of the recent-40 cutoff. The operator-recovery UI (Retry /
+ * Abandon / Escalate) needs every stalled row to be clickable; without
+ * this independent fetch, rows that age out of the recent-40 window
+ * become orphaned — the server actions still work but no tile renders
+ * in any station inspector. See BI-OPS-MAP-STALLED-WINDOW (2026-05-21,
+ * surfaced during the F2 cleanup-pass dogfooding).
+ *
+ * 200 is intentionally generous: stalled is operator-actionable and
+ * shouldn't silently drop off; in practice we'd expect well under that
+ * once the spawn-loop concurrency issue is fixed.
+ */
+export const STALLED_TASK_RUN_LIMIT = 200;
+
 export type OperationsMapData = {
   template: OperationsMapTemplate;
   agents: StationedOperationsMapAgent[];
@@ -36,7 +51,8 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
   const [
     storefrontConfig,
     agents,
-    taskRuns,
+    recentTaskRuns,
+    stalledTaskRuns,
     toolExecutions,
     toolReceipts,
     backlogEvidence,
@@ -90,6 +106,32 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
       },
       orderBy: { startedAt: "desc" },
       take: RECENT_TOOL_LIMIT,
+      select: {
+        id: true,
+        taskRunId: true,
+        status: true,
+        source: true,
+        currentAgentId: true,
+        routeContext: true,
+        title: true,
+        startedAt: true,
+        completedAt: true,
+      },
+    }),
+    // BI-OPS-MAP-STALLED-WINDOW (2026-05-21): lift stalled rows into the
+    // projection set independently of the recent-40 cap. The operator
+    // needs every stalled TaskRun to render as a clickable tile so Retry/
+    // Abandon/Escalate stay reachable through the UI. Without this query,
+    // stalled rows older than the 40th-most-recent proactive task were
+    // silently dropped from the inspector list. We dedupe in app code
+    // after merging — a row stalled AND in the recent-40 appears once.
+    prisma.taskRun.findMany({
+      where: {
+        archivedAt: null,
+        status: "stalled",
+      },
+      orderBy: { startedAt: "desc" },
+      take: STALLED_TASK_RUN_LIMIT,
       select: {
         id: true,
         taskRunId: true,
@@ -338,6 +380,12 @@ export async function loadOperationsMapData(): Promise<OperationsMapData> {
     },
   }));
 
+  // Merge recent + stalled task-runs, deduping by cuid id. A row that is
+  // both stalled AND in the recent-40 (typical case) appears once. Order
+  // doesn't matter for the projection set — the final sort by occurredAt
+  // below handles display order.
+  const taskRuns = mergeTaskRunsDedupeById(recentTaskRuns, stalledTaskRuns);
+
   const projections = [
     ...taskRuns.map((row) => projectTaskRun(row as OperationsMapTaskRun, template)),
     ...toolExecutions.map((row) => projectToolExecution(row as OperationsMapToolExecution, template)),
@@ -384,4 +432,34 @@ function getActivationProfileType(value: unknown): string | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const profileType = (value as { profileType?: unknown }).profileType;
   return typeof profileType === "string" ? profileType : null;
+}
+
+/**
+ * Merge the recent-40 task-run window with the stalled-200 window,
+ * keeping each cuid id once. Exported so the unit test can lock in the
+ * dedup behavior — the AI Operations Map's correctness depends on a row
+ * appearing exactly once in the projection set.
+ *
+ * Both inputs share the same row shape (the Prisma select clauses match).
+ * Recent rows are inserted first, then stalled rows that haven't already
+ * appeared — this keeps existing test snapshots stable and matches the
+ * mental model "stalled is added on top of recent."
+ */
+export function mergeTaskRunsDedupeById<T extends { id: string }>(
+  recent: T[],
+  stalled: T[],
+): T[] {
+  const seen = new Set<string>();
+  const merged: T[] = [];
+  for (const row of recent) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    merged.push(row);
+  }
+  for (const row of stalled) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    merged.push(row);
+  }
+  return merged;
 }


### PR DESCRIPTION
## Summary

**BI:** BI-OPS-MAP-STALLED-WINDOW (filed today)

Caught during the F2 operator-recovery cleanup pass on 30 stalled TaskRuns: 29/30 were abandoned through the AI Operations Map UX path, but the 30th (no `buildId` / no `routeContext`, started 36h prior) had no clickable tile in any station inspector. Root cause: `loadOperationsMapData` fetches proactive task-runs with `take=RECENT_TOOL_LIMIT=40` — anything older silently drops from the projection set, even when `status='stalled'`.

Customer impact: any stalled TaskRun more than ~40 newer-tasks-old is orphaned in the UI. As proactive volume grows the recovery window collapses; the `taskrunRetry/Abandon/Escalate` server actions still work, but the operator has no UX path to reach them.

## Change

- Parallel fetch for `status='stalled'` rows, capped at `STALLED_TASK_RUN_LIMIT = 200`.
- New `mergeTaskRunsDedupeById` helper. A row in both windows (stalled AND in recent-40) appears once; the recent-list copy wins on tie so the shape stays canonical if the two queries diverge later.
- No change to non-stalled recent display.

## Test plan

- [x] `pnpm vitest run lib/ai-operations-map/load-map-data.test.ts` — 12/12 green (6 new tests on dedup helper: empty lists, full overlap, partial overlap, append behavior, recent-wins on tie, both empty).
- [x] Pre-commit scoped typecheck passes.
- [ ] After merge + deploy: re-spawn a stalled TaskRun outside the recent-40 window and confirm it appears as a clickable tile in the appropriate station inspector.

## Related

- BI-4ab6be39 (parent spec — Build Studio stall detection & recovery)
- PR #896 (audit completeness for synthesized StallEvent on operator recovery)
- PR #911 (Stall history strip folds repeat entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)