### PR TITLE
feat(wiki): voice profile admin page for WWMD/WWTD persona voices

### DIFF
--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -2,6 +2,7 @@
 // Shows kernel pages + the platform organization's overlay rows.
 // Server component; queries Prisma directly.
 
+import Link from "next/link";
 import { prisma } from "@dpf/db";
 
 import { WikiPageList, type WikiPageListItem } from "@/components/wiki/WikiPageList";
@@ -80,6 +81,22 @@ export default async function WikiBrowsePage({
       </header>
 
       <WikiPageList pages={pages} />
+
+      {/* Decision Perspectives — voice admin entry point */}
+      <div className="mt-8 rounded-lg border border-border p-4 flex items-center justify-between">
+        <div>
+          <p className="font-medium text-sm">Decision Perspectives</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Configure voice narration for WWMD / WWTD persona profiles
+          </p>
+        </div>
+        <Link
+          href="/wiki/perspectives"
+          className="text-sm text-primary hover:underline shrink-0 ml-4"
+        >
+          Manage →
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(shell)/wiki/perspectives/[profileId]/voice/page.tsx
+++ b/apps/web/app/(shell)/wiki/perspectives/[profileId]/voice/page.tsx
@@ -1,0 +1,122 @@
+// Voice profile admin page — wiki context.
+// Route: /wiki/perspectives/[profileId]/voice
+//
+// Surfaces consent capture, sample upload, training status, and
+// enable/disable toggle for WWMD/WWTD decision perspective personas.
+// Components: VoiceProfileSetup (client), VoiceConsentForm, VoiceTrainingStatus.
+// Spec: docs/superpowers/specs/2026-05-19-persona-voice-layer-wwtd-design.md
+
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { prisma } from "@dpf/db"
+import { auth } from "@/lib/auth"
+import { VoiceProfileSetup } from "@/components/wiki/VoiceProfileSetup"
+
+export const dynamic = "force-dynamic"
+
+type Params = Promise<{ profileId: string }>
+
+export default async function VoiceProfileAdminPage({ params }: { params: Params }) {
+  const { profileId } = await params
+  const session = await auth()
+  if (!session?.user?.id) notFound()
+
+  const profile = await prisma.decisionPerspectiveProfile.findUnique({
+    where: { profileId },
+    select: {
+      profileId: true,
+      name: true,
+      kind: true,
+      voiceEnabled: true,
+      personaConfig: true,
+      voiceProfile: {
+        include: {
+          consentRecord: {
+            select: {
+              id: true,
+              subjectName: true,
+              expiresAt: true,
+              revokedAt: true,
+            },
+          },
+          trainingJobs: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            select: {
+              id: true,
+              status: true,
+              errorMessage: true,
+              createdAt: true,
+              completedAt: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!profile) notFound()
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      {/* Breadcrumb */}
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/wiki" className="hover:text-foreground">Wiki</Link>
+        <span>/</span>
+        <Link href="/wiki/perspectives" className="hover:text-foreground">Perspectives</Link>
+        <span>/</span>
+        <span className="text-foreground font-medium">{profile.name}</span>
+        <span>/</span>
+        <span className="text-foreground">Voice</span>
+      </nav>
+
+      {/* Profile header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground bg-muted px-2 py-0.5 rounded">
+            {profile.kind}
+          </span>
+        </div>
+        <h1 className="text-2xl font-bold">{profile.name}</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Decision perspective profile · Voice configuration
+        </p>
+      </div>
+
+      <VoiceProfileSetup
+        profileId={profile.profileId}
+        profileName={profile.name}
+        voiceEnabled={profile.voiceEnabled}
+        currentUserId={session.user.id}
+        voiceProfile={
+          profile.voiceProfile
+            ? {
+                id: profile.voiceProfile.id,
+                provider: profile.voiceProfile.provider,
+                providerVoiceId: profile.voiceProfile.providerVoiceId,
+                status: profile.voiceProfile.status,
+                consentType: profile.voiceProfile.consentType,
+                qualityScore: profile.voiceProfile.qualityScore,
+                language: profile.voiceProfile.language,
+                consentRecord: profile.voiceProfile.consentRecord
+                  ? {
+                      id: profile.voiceProfile.consentRecord.id,
+                      subjectName: profile.voiceProfile.consentRecord.subjectName,
+                      expiresAt: profile.voiceProfile.consentRecord.expiresAt,
+                      revokedAt: profile.voiceProfile.consentRecord.revokedAt,
+                    }
+                  : null,
+                trainingJobs: profile.voiceProfile.trainingJobs.map(j => ({
+                  id: j.id,
+                  status: j.status,
+                  errorMessage: j.errorMessage,
+                  createdAt: j.createdAt,
+                  completedAt: j.completedAt,
+                })),
+              }
+            : null
+        }
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(shell)/wiki/perspectives/page.tsx
+++ b/apps/web/app/(shell)/wiki/perspectives/page.tsx
@@ -1,0 +1,109 @@
+// EP-WIKI-001 Phase 6a: Decision Perspective Profiles index.
+// Route: /wiki/perspectives
+//
+// Lists all active decision perspective profiles with links to each
+// profile's voice configuration page. Entry point for voice admin.
+
+import Link from "next/link"
+import { prisma } from "@dpf/db"
+import { notFound } from "next/navigation"
+import { auth } from "@/lib/auth"
+
+export const dynamic = "force-dynamic"
+
+export const metadata = {
+  title: "Decision Perspectives · Wiki",
+}
+
+const KIND_LABELS: Record<string, string> = {
+  organization: "Organization",
+  platform: "Platform",
+  "persona-real": "Real persona",
+  "persona-fictional": "Fictional persona",
+  "persona-synthetic": "Synthetic persona",
+}
+
+const VOICE_STATUS_LABELS: Record<string, { label: string; className: string }> = {
+  ready:      { label: "Voice ready",    className: "bg-green-500/10 text-green-600 border border-green-500/20" },
+  training:   { label: "Training…",      className: "bg-yellow-500/10 text-yellow-600 border border-yellow-500/20" },
+  failed:     { label: "Training failed", className: "bg-red-500/10 text-red-600 border border-red-500/20" },
+  pending:    { label: "Pending",         className: "bg-muted text-muted-foreground" },
+}
+
+export default async function PerspectivesIndexPage() {
+  const session = await auth()
+  if (!session?.user?.id) notFound()
+
+  const profiles = await prisma.decisionPerspectiveProfile.findMany({
+    where: { status: "active" },
+    orderBy: [{ kind: "asc" }, { name: "asc" }],
+    select: {
+      profileId: true,
+      name: true,
+      kind: true,
+      voiceEnabled: true,
+      voiceProfile: {
+        select: { status: true },
+      },
+    },
+  })
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4">
+      <nav className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/wiki" className="hover:text-foreground">Wiki</Link>
+        <span>/</span>
+        <span className="text-foreground font-medium">Decision Perspectives</span>
+      </nav>
+
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold text-[var(--dpf-text)] mb-1">
+          Decision Perspectives
+        </h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Active perspective profiles for WWMD/WWTD decision narration. Configure
+          a cloned voice for any profile to enable spoken decision rationale.
+        </p>
+      </header>
+
+      {profiles.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No active perspective profiles found.</p>
+      ) : (
+        <div className="divide-y divide-border rounded-lg border border-border">
+          {profiles.map((profile) => {
+            const voiceStatus = profile.voiceProfile?.status ?? null
+            const badge = voiceStatus ? VOICE_STATUS_LABELS[voiceStatus] : null
+
+            return (
+              <div key={profile.profileId} className="flex items-center justify-between px-4 py-3 hover:bg-muted/40 transition-colors">
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground bg-muted px-2 py-0.5 rounded shrink-0">
+                    {KIND_LABELS[profile.kind] ?? profile.kind}
+                  </span>
+                  <span className="font-medium text-sm truncate">{profile.name}</span>
+                  {profile.voiceEnabled && voiceStatus === "ready" && (
+                    <span className="text-xs text-green-600 shrink-0">● active</span>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3 shrink-0 ml-4">
+                  {badge && (
+                    <span className={`text-xs px-2 py-0.5 rounded ${badge.className}`}>
+                      {badge.label}
+                    </span>
+                  )}
+                  <Link
+                    href={`/wiki/perspectives/${profile.profileId}/voice`}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Voice config →
+                  </Link>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -1,0 +1,250 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { VoiceConsentForm } from "@/components/admin/VoiceConsentForm"
+import { VoiceTrainingStatus } from "@/components/admin/VoiceTrainingStatus"
+import { setVoiceEnabled } from "@/lib/actions/voice-profile"
+
+interface ConsentRecord {
+  id: string
+  subjectName: string
+  expiresAt: Date | string
+  revokedAt: Date | string | null
+}
+
+interface TrainingJob {
+  id: string
+  status: string
+  errorMessage: string | null
+  createdAt: Date | string
+  completedAt: Date | string | null
+}
+
+interface VoiceProfileData {
+  id: string
+  provider: string
+  providerVoiceId: string | null
+  status: string
+  consentType: string
+  qualityScore: number | null
+  language: string
+  consentRecord: ConsentRecord | null
+  trainingJobs: TrainingJob[]
+}
+
+interface Props {
+  profileId: string
+  profileName: string
+  voiceEnabled: boolean
+  currentUserId: string
+  voiceProfile: VoiceProfileData | null
+}
+
+export function VoiceProfileSetup({
+  profileId,
+  profileName,
+  voiceEnabled,
+  currentUserId,
+  voiceProfile,
+}: Props) {
+  const [enabled, setEnabled] = useState(voiceEnabled)
+  const [isPending, startTransition] = useTransition()
+
+  const latestJob = voiceProfile?.trainingJobs[0]
+  const hasValidConsent =
+    voiceProfile?.consentRecord &&
+    !voiceProfile.consentRecord.revokedAt &&
+    new Date(voiceProfile.consentRecord.expiresAt) > new Date()
+
+  const handleToggle = () => {
+    const next = !enabled
+    setEnabled(next)
+    startTransition(async () => {
+      await setVoiceEnabled(profileId, next)
+    })
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="border-b border-border pb-4">
+        <h2 className="text-lg font-semibold">Voice Profile</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure a cloned voice for <strong>{profileName}</strong>. Once trained,
+          WWMD gate decisions will be narrated in this voice.
+        </p>
+      </div>
+
+      {/* Enable toggle — only show when voice is ready */}
+      {voiceProfile?.status === "ready" && (
+        <div className="flex items-center justify-between rounded-lg border border-border p-4">
+          <div>
+            <p className="font-medium text-sm">Voice narration</p>
+            <p className="text-xs text-muted-foreground">
+              Narrate WWMD decision rationale using this voice profile
+            </p>
+          </div>
+          <button
+            onClick={handleToggle}
+            disabled={isPending}
+            aria-label={enabled ? "Disable voice" : "Enable voice"}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              enabled ? "bg-primary" : "bg-muted"
+            } ${isPending ? "opacity-50" : ""}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                enabled ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </div>
+      )}
+
+      {/* Step 1: Consent */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold ${hasValidConsent ? "bg-green-500 text-white" : "bg-muted text-muted-foreground"}`}>
+            {hasValidConsent ? "✓" : "1"}
+          </span>
+          <h3 className="font-medium">Consent record</h3>
+        </div>
+
+        {hasValidConsent ? (
+          <div className="rounded-md border border-green-500/20 bg-green-500/5 px-4 py-3 text-sm">
+            Consent on file for <strong>{voiceProfile!.consentRecord!.subjectName}</strong>.
+            Expires {new Date(voiceProfile!.consentRecord!.expiresAt).toLocaleDateString()}.
+          </div>
+        ) : (
+          <div className="rounded-md border border-border p-4">
+            <p className="text-sm text-muted-foreground mb-4">
+              A consent record is required before uploading voice samples.
+            </p>
+            <VoiceConsentForm
+              capturedByPrincipalId={currentUserId}
+              onSuccess={() => window.location.reload()}
+            />
+          </div>
+        )}
+      </section>
+
+      {/* Step 2: Upload & Train */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold ${voiceProfile?.status === "ready" ? "bg-green-500 text-white" : "bg-muted text-muted-foreground"}`}>
+            {voiceProfile?.status === "ready" ? "✓" : "2"}
+          </span>
+          <h3 className="font-medium">Voice samples</h3>
+        </div>
+
+        {!hasValidConsent ? (
+          <p className="text-sm text-muted-foreground pl-8">Complete step 1 first.</p>
+        ) : voiceProfile?.status === "ready" ? (
+          <div className="rounded-md border border-green-500/20 bg-green-500/5 px-4 py-3 text-sm">
+            Voice profile ready.
+            {voiceProfile.qualityScore && (
+              <span className="ml-2 text-muted-foreground">
+                Quality: {Math.round(voiceProfile.qualityScore * 100)}%
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-md border border-border p-4 space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Upload 10–30 seconds of clean audio or video. Cartesia Sonic 3 will clone
+              the voice. Minimum: 3 seconds of clear speech with low background noise.
+            </p>
+
+            {latestJob && (
+              <VoiceTrainingStatus
+                status={latestJob.status as any}
+                errorMessage={latestJob.errorMessage ?? undefined}
+              />
+            )}
+
+            {(!latestJob || latestJob.status === "failed") && (
+              <TrainingUploadForm profileId={profileId} consentRecordId={voiceProfile?.consentRecord?.id} />
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* Step 3: Activate */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold ${enabled && voiceProfile?.status === "ready" ? "bg-green-500 text-white" : "bg-muted text-muted-foreground"}`}>
+            {enabled && voiceProfile?.status === "ready" ? "✓" : "3"}
+          </span>
+          <h3 className="font-medium">Activate</h3>
+        </div>
+        <p className="text-sm text-muted-foreground pl-8">
+          {voiceProfile?.status === "ready"
+            ? enabled
+              ? "Voice narration is active. The next WWMD gate decision will play audio."
+              : "Toggle voice narration on above to activate."
+            : "Complete steps 1 and 2 first."}
+        </p>
+      </section>
+    </div>
+  )
+}
+
+// Minimal upload form — posts to /api/voice/train
+function TrainingUploadForm({
+  profileId,
+  consentRecordId,
+}: {
+  profileId: string
+  consentRecordId?: string
+}) {
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setUploading(true)
+    setError(null)
+    const form = e.currentTarget
+    const fileInput = form.querySelector<HTMLInputElement>('input[type="file"]')
+    const file = fileInput?.files?.[0]
+    if (!file) { setError("Select an audio or video file."); setUploading(false); return }
+
+    const body = new FormData()
+    body.append("voiceProfileId", profileId)
+    if (consentRecordId) body.append("consentRecordId", consentRecordId)
+    body.append("audio", file)
+
+    try {
+      const res = await fetch("/api/voice/train", { method: "POST", body })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error ?? `Upload failed (${res.status})`)
+      } else {
+        window.location.reload()
+      }
+    } catch {
+      setError("Network error — try again.")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <input
+        type="file"
+        accept="audio/*,video/*,.mp3,.wav,.m4a,.mp4,.mov,.webm"
+        className="block w-full text-sm text-muted-foreground file:mr-3 file:rounded file:border-0 file:bg-muted file:px-3 file:py-1.5 file:text-sm file:font-medium"
+        required
+      />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <button
+        type="submit"
+        disabled={uploading}
+        className="rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        {uploading ? "Uploading…" : "Start training"}
+      </button>
+    </form>
+  )
+}

--- a/apps/web/lib/actions/voice-profile.ts
+++ b/apps/web/lib/actions/voice-profile.ts
@@ -1,0 +1,65 @@
+"use server"
+
+import { prisma } from "@dpf/db"
+import { revalidatePath } from "next/cache"
+
+export async function setVoiceEnabled(profileId: string, enabled: boolean) {
+  await prisma.decisionPerspectiveProfile.update({
+    where: { profileId },
+    data: { voiceEnabled: enabled },
+  })
+  revalidatePath(`/wiki/perspectives/${profileId}/voice`)
+}
+
+export async function getVoiceProfileData(profileId: string) {
+  const profile = await prisma.decisionPerspectiveProfile.findUnique({
+    where: { profileId },
+    select: {
+      profileId: true,
+      name: true,
+      kind: true,
+      voiceEnabled: true,
+      personaConfig: true,
+      voiceProfile: {
+        include: {
+          consentRecord: {
+            select: {
+              id: true,
+              subjectName: true,
+              expiresAt: true,
+              revokedAt: true,
+            },
+          },
+          trainingJobs: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            select: {
+              id: true,
+              status: true,
+              errorMessage: true,
+              createdAt: true,
+              completedAt: true,
+            },
+          },
+        },
+      },
+    },
+  })
+  return profile
+}
+
+export async function listVoiceProfiles() {
+  return prisma.decisionPerspectiveProfile.findMany({
+    where: { status: "active" },
+    orderBy: { name: "asc" },
+    select: {
+      profileId: true,
+      name: true,
+      kind: true,
+      voiceEnabled: true,
+      voiceProfile: {
+        select: { status: true },
+      },
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Adds `/wiki/perspectives` — index of all active decision perspective profiles with voice status badges (ready / training / failed) and a direct link to each profile's voice config page
- Adds `/wiki/perspectives/[profileId]/voice` — 3-step voice setup flow: capture consent record → upload audio + start Cartesia Sonic 3 training → toggle `voiceEnabled` once the profile is ready
- New `VoiceProfileSetup` client component wires `VoiceConsentForm` + `VoiceTrainingStatus` (both already existed in `components/admin/`) into the wiki context
- New `voice-profile` server actions (`setVoiceEnabled`, `getVoiceProfileData`, `listVoiceProfiles`) back the toggle and profile data fetches
- Wiki index page (`/wiki`) gains a "Decision Perspectives → Manage" card as the entry point

Entry point for live install: `/wiki` → **Decision Perspectives → Manage** → **Voice config →** on any profile (e.g. `mark-dpf-platform`)

## Test plan

- [ ] Navigate to `/wiki` — "Decision Perspectives" card appears below the page list
- [ ] Click "Manage" — `/wiki/perspectives` loads; `mark-dpf-platform` (and other active profiles) are listed
- [ ] Click "Voice config →" for `mark-dpf-platform` — lands on `/wiki/perspectives/mark-dpf-platform/voice`
- [ ] Step 1 (no consent yet): VoiceConsentForm renders; fill in subject name + expiry + method + save — step 1 badge turns green
- [ ] Step 2 unlocks: upload an audio file → POST `/api/voice/train` kicks off training job; VoiceTrainingStatus shows "Training in progress"
- [ ] Once voice profile `status = ready`: step 2 badge green, toggle appears
- [ ] Toggle on → `setVoiceEnabled` persists `voiceEnabled = true`; step 3 badge turns green with "Voice narration is active" message
- [ ] Unauthenticated visit to either perspective route → `notFound()`

Spec: `docs/superpowers/specs/2026-05-19-persona-voice-layer-wwtd-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)