### PR TITLE
feat(build-studio): T9 + T8 — ActionBanner delegation + drop redundant chrome

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { GitBranch } from "lucide-react";
-import { PhaseIndicator } from "./PhaseIndicator";
 import { FeatureBriefPanel } from "./FeatureBriefPanel";
 import { ReviewPanel } from "./ReviewPanel";
 import { PreviewUrlCard } from "./PreviewUrlCard";
@@ -500,14 +499,10 @@ export function BuildStudio({
                         </span>
                       </>
                     )}
-                    {activeLifecycleLabel && (
-                      <>
-                        <span>&middot;</span>
-                        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 font-medium text-[var(--dpf-text)]">
-                          Workflow: {activeLifecycleLabel}
-                        </span>
-                      </>
-                    )}
+                    {/* "Workflow: <label>" header pill removed per spec — the
+                        workflow rail / mini-rail already conveys the same
+                        information without duplicating it in the header.
+                        See docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md */}
                     {branchBadge && (
                       <>
                         <span>&middot;</span>
@@ -561,10 +556,15 @@ export function BuildStudio({
                   </div>
                 )}
                 {activeBuild && workflowAction && activeBuild.phase !== "ship" && (
-                  <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+                  <div className="border-b border-[var(--dpf-border)]">
+                    {/* compact=true renders the 40px ActionBanner via the
+                        delegation in BuildStudioWorkflowActionCard (T9). The
+                        ~200px card is the legacy presentation; the compact
+                        path is now the default per spec §1 (center zone). */}
                     <BuildStudioWorkflowActionCard
                       build={activeBuild}
                       action={workflowAction}
+                      compact
                       onCompleted={() => refreshActiveBuildState(activeBuild.buildId)}
                     />
                   </div>
@@ -699,9 +699,11 @@ export function BuildStudio({
         </div>
       </div>
 
-      {activeBuild && buildView !== "topology" && (
-        <PhaseIndicator currentPhase={activeBuild.phase} flowState={flowState} />
-      )}
+      {/* PhaseIndicator bottom strip removed per spec — phase progression
+          is now visible exactly once per surface: the ProcessGraph nodes
+          carry it for the active build, and the (still-pending) compact
+          fleet mini-rail carries it for the aggregate.
+          See docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md §1, §9 #2 */}
     </div>
   );
 }

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -274,9 +274,17 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Build Status");
+    // The legacy "Build Status" heading + "Review with coworker" secondary
+    // button are gone — BuildStudio now renders the compact ActionBanner
+    // for the active workflow action (T8 + T9). The primary action label
+    // ("Record Approve Start") still appears as the banner's primary button.
+    expect(html).toContain('data-testid="build-studio-action-banner"');
     expect(html).toContain("Record Approve Start");
-    expect(html).toContain("Review with coworker");
+    // Banner exposes its current state via data-state — approve-start is "ready".
+    expect(html).toMatch(/data-state="ready"/);
+    // Legacy chrome explicitly absent.
+    expect(html).not.toContain(">Build Status<");
+    expect(html).not.toContain(">Review with coworker<");
   });
 
   it("renders an implementation control once the plan is approved and start approval is recorded", () => {
@@ -302,9 +310,15 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Ready for Implementation");
+    // Legacy card's "Ready for Implementation" heading and "Refine the plan"
+    // secondary button are gone — compact ActionBanner shows the action's
+    // sentence + primary button only. "Start Implementation" remains as the
+    // banner's primary action label.
+    expect(html).toContain('data-testid="build-studio-action-banner"');
     expect(html).toContain("Start Implementation");
-    expect(html).toContain("Refine the plan");
+    // Detail line surfaces the intake-incomplete reason (banner shows detail
+    // only when state ∈ {blocked, review_failed}, which intake-missing maps to).
+    expect(html).toContain('data-testid="action-banner-detail"');
   });
 
   it("renders the dedicated release decision surface when a build reaches ship", () => {

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -4,7 +4,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { BuildStudioWorkflowActionCard } from "./BuildStudioWorkflowActionCard";
+import {
+  BuildStudioWorkflowActionCard,
+  deriveActionBannerState,
+} from "./BuildStudioWorkflowActionCard";
 import type { BuildStudioWorkflowAction } from "./build-studio-workflow-actions";
 import {
   normalizeHappyPathState,
@@ -259,5 +262,139 @@ describe("BuildStudioWorkflowActionCard resume visibility", () => {
     });
     expect(mockResumeBuildImplementation).toHaveBeenCalledWith("FB-9B19098C");
     expect(onCompleted).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deriveActionBannerState", () => {
+  // The card delegates compact rendering to ActionBanner; this helper is the
+  // contract between dispatch + presentation. Pinning the mapping ensures the
+  // banner color/detail behavior stays consistent across phase changes.
+
+  it("returns 'blocked' when action.disabledReason is set, regardless of phase", () => {
+    expect(deriveActionBannerState({ phase: "ideate" }, { disabledReason: "Awaiting design review" })).toBe("blocked");
+    expect(deriveActionBannerState({ phase: "complete" }, { disabledReason: "Decision pending" })).toBe("blocked");
+  });
+
+  it("returns 'review_failed' when phase is failed and no disabledReason", () => {
+    expect(deriveActionBannerState({ phase: "failed" }, { disabledReason: null })).toBe("review_failed");
+  });
+
+  it("returns 'complete' when phase is complete", () => {
+    expect(deriveActionBannerState({ phase: "complete" }, { disabledReason: null })).toBe("complete");
+  });
+
+  it("returns 'running' when phase is build or review", () => {
+    expect(deriveActionBannerState({ phase: "build" }, { disabledReason: null })).toBe("running");
+    expect(deriveActionBannerState({ phase: "review" }, { disabledReason: null })).toBe("running");
+  });
+
+  it("returns 'ready' for ideate / plan / ship phases", () => {
+    expect(deriveActionBannerState({ phase: "ideate" }, { disabledReason: null })).toBe("ready");
+    expect(deriveActionBannerState({ phase: "plan" }, { disabledReason: null })).toBe("ready");
+    expect(deriveActionBannerState({ phase: "ship" }, { disabledReason: null })).toBe("ready");
+  });
+
+  it("disabledReason has higher precedence than phase=failed", () => {
+    // If a failed build also reports a disabledReason, the operator should
+    // see 'blocked' (action needs them) before 'review_failed' (status info).
+    expect(deriveActionBannerState({ phase: "failed" }, { disabledReason: "Resolve upstream first" })).toBe("blocked");
+  });
+});
+
+describe("BuildStudioWorkflowActionCard compact rendering", () => {
+  function actionFor(phase: FeatureBuildRow["phase"]): BuildStudioWorkflowAction {
+    return {
+      kind: "advance-phase",
+      title: "Ready to advance",
+      message: "Move this reviewed plan into sandbox execution so the coworker can start work.",
+      primaryLabel: "Start Implementation",
+      targetPhase: "build",
+      disabledReason: null,
+      coworkerLabel: "Ask coworker",
+      coworkerPrompt: "Tell me what's needed before I can start build.",
+    };
+  }
+
+  it("compact=true delegates the visible heading + sentence to ActionBanner (one sentence, no duplicate Build Status label)", () => {
+    const action = actionFor("plan");
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan", decisionInteraction: null })}
+        action={action}
+        compact
+      />,
+    );
+
+    // ActionBanner emits a region with the canonical aria-label.
+    const banner = screen.getByRole("region", { name: "Current build action" });
+    expect(banner).toBeInTheDocument();
+    // The sentence is from action.message — no separate "Build Status" or
+    // "Operational status" label duplicates the heading.
+    expect(banner).toHaveTextContent(action.message);
+    expect(screen.queryByText("Build Status")).not.toBeInTheDocument();
+    expect(screen.queryByText("Operational status")).not.toBeInTheDocument();
+  });
+
+  it("compact=true exposes a primary action wired to handlePrimaryAction (delegation, not new dispatch)", async () => {
+    mockAdvanceBuildPhase.mockResolvedValue({ buildId: "FB-9B19098C" });
+    const onCompleted = vi.fn();
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan", decisionInteraction: null })}
+        action={actionFor("plan")}
+        compact
+        onCompleted={onCompleted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Implementation" }));
+    await waitFor(() => {
+      expect(mockAdvanceBuildPhase).toHaveBeenCalledWith("FB-9B19098C", "build");
+    });
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("compact=true with disabledReason renders the banner in 'blocked' state with detail visible", () => {
+    const blocked: BuildStudioWorkflowAction = {
+      ...actionFor("plan"),
+      disabledReason: "Plan review failed. Refine the plan first.",
+    };
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan", decisionInteraction: null })}
+        action={blocked}
+        compact
+      />,
+    );
+    const banner = screen.getByRole("region", { name: "Current build action" });
+    expect(banner).toHaveAttribute("data-state", "blocked");
+    expect(banner).toHaveTextContent("Plan review failed. Refine the plan first.");
+  });
+
+  it("compact=true falls back to the full card when a decision interaction needs capture", () => {
+    // makeBuild() default already includes a decisionInteraction that
+    // requires capture — perfect setup for the fallback path.
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan" })}
+        action={actionFor("plan")}
+        compact
+      />,
+    );
+    // Decision panel needs the larger card; the banner does not render here.
+    expect(screen.queryByRole("region", { name: "Current build action" })).not.toBeInTheDocument();
+    // The full card heading should be present instead.
+    expect(screen.getByText("Build Status")).toBeInTheDocument();
+  });
+
+  it("compact=false renders the full card unchanged (back-compat with existing callers)", () => {
+    render(
+      <BuildStudioWorkflowActionCard
+        build={makeBuild({ phase: "plan" })}
+        action={actionFor("plan")}
+      />,
+    );
+    expect(screen.getByText("Build Status")).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Current build action" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -15,6 +15,7 @@ import { captureDecisionInteraction } from "@/lib/actions/decision-perspective";
 import type { ResumeBuildImplementationOutcome } from "@/lib/build/progress-visibility-types";
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { DecisionGateCaptureDraft } from "@/lib/decision-perspective/capture-types";
+import { ActionBanner, type ActionBannerState } from "./ActionBanner";
 import { DecisionPerspectiveGatePanel } from "./DecisionPerspectiveGatePanel";
 import { TruthSourceBadge } from "./TruthSourceBadge";
 import type { BuildStudioWorkflowAction } from "./build-studio-workflow-actions";
@@ -25,6 +26,32 @@ type Props = {
   compact?: boolean;
   onCompleted?: () => Promise<void> | void;
 };
+
+/**
+ * Map (build phase + action.disabledReason) onto an ActionBannerState.
+ *
+ * The card carries dispatch + derivation logic; the banner is just a
+ * compact presentation. This helper is the contract between the two —
+ * extracted so T9's delegation can be tested without instantiating the
+ * full card and so the derivation rule lives in one place.
+ *
+ * Precedence:
+ *   1. disabledReason set → "blocked" (operator needs to clear an upstream gap)
+ *   2. phase=failed → "review_failed"
+ *   3. phase=complete → "complete"
+ *   4. phase ∈ {build, review} → "running" (sandbox flow in motion)
+ *   5. fallback → "ready"
+ */
+export function deriveActionBannerState(
+  build: Pick<FeatureBuildRow, "phase">,
+  action: Pick<BuildStudioWorkflowAction, "disabledReason">,
+): ActionBannerState {
+  if (action.disabledReason) return "blocked";
+  if (build.phase === "failed") return "review_failed";
+  if (build.phase === "complete") return "complete";
+  if (build.phase === "build" || build.phase === "review") return "running";
+  return "ready";
+}
 
 export function BuildStudioWorkflowActionCard({
   build,
@@ -144,6 +171,45 @@ export function BuildStudioWorkflowActionCard({
     );
     router.refresh();
     await onCompleted?.();
+  }
+
+  // ── Compact rendering — delegate to ActionBanner ───────────────────────
+  // Per spec §6, the BuildStudio shell mounts a 40px pinned ActionBanner
+  // at the top of the active-build zone instead of the legacy ~200px card.
+  // The derivation logic (action computation, dispatch flow, decision
+  // interaction) stays in this file — the banner only changes presentation.
+  //
+  // If there's an open decision interaction that needs capture, fall back to
+  // the full card so the DecisionPerspectiveGatePanel still renders — the
+  // 40px banner has no room for the capture UI.
+  const compactBannerEligible = compact && !decisionInteraction;
+  if (compactBannerEligible) {
+    const bannerState = deriveActionBannerState(build, action);
+    const bannerPrimaryAction = primaryLabel
+      ? {
+        label: primaryLabel,
+        onClick: handlePrimaryAction,
+        disabled: !primaryEnabled || pending,
+      }
+      : undefined;
+    return (
+      <div data-testid="build-studio-workflow-action-card">
+        <ActionBanner
+          state={bannerState}
+          sentence={action.message}
+          primaryAction={bannerPrimaryAction}
+          detail={action.disabledReason ?? undefined}
+        />
+        {error && (
+          <div
+            role="alert"
+            className="mt-1 rounded-md border border-[var(--dpf-error)] bg-[color-mix(in_srgb,var(--dpf-error)_8%,var(--dpf-surface-1))] px-3 py-1.5 text-[11px] leading-snug text-[var(--dpf-error)]"
+          >
+            {error}
+          </div>
+        )}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Next slice of the Build Studio layout redesign (FB-B33E84B5). Lands the **visible UX shift** by wiring the existing atoms (PR #903) into the live BuildStudio shell:

- **T9** — `BuildStudioWorkflowActionCard` delegates compact rendering to the 40px `ActionBanner` (PR #903). Dispatch + derivation + decision-interaction logic unchanged.
- **T8 (minimal)** — three surgical edits in `BuildStudio.tsx`:
  1. Pass `compact={true}` to the workflow action card so the live `/build` view shows the new banner instead of the ~200px stacked card.
  2. Remove the redundant `"Workflow: <label>"` header pill (phase progression now in one place per surface).
  3. Remove the desktop `PhaseIndicator` bottom strip (same invariant).

Spec: `docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md` §1 + §9 #2 + §6 (ActionBanner contract).

## What's NOT here (follow-up slices)

The full T8 shell refactor is split across PRs to keep diffs reviewable. Still to come, each as its own focused PR:

- **FleetRail swap** on the left — legacy `BuildListItem` sidebar still renders. The fleet primitives, `QueueStateBadge`, and `FleetRail` itself are already on main; wiring them in needs careful per-build state derivation (queueState, needsAttention) plus integration with the existing `setActiveBuild`/`onDelete` channels.
- **NodeInspector lifecycle wiring** via the `onNodeClick` delegate (`ProcessGraphClickInfo`). The shell still uses the internal `TaskInspector`/`WorkflowStageInspector` path until that wiring lands.
- **DetailsDrawer + Pill** mount.
- **Footer `OpenSandboxButton`** + Preview-tab removal.
- **BuildStudio end-to-end integration test (T11)**.

## Test plan

- [ ] CI Typecheck passes (`pnpm --filter web typecheck`)
- [ ] CI Production Build passes
- [ ] CI Unit Tests: `BuildStudio.test.ts` (legacy layout helpers) + `BuildStudioWorkflowActionCard.test.tsx` (5 existing + 11 new T9 cases) = 23 cases all green
- [ ] Manual: visit `/build` against a feature build — confirm the compact 40px banner renders, no "Workflow:" pill, no bottom phase strip
- [ ] Manual: compact banner with `disabledReason` set shows "blocked" state + detail line
- [ ] Manual: when phase=plan + decisionInteraction needs capture, the full card still renders (fallback preserves the gate-capture UX)

## Atom inventory used here

From PR #903 (already on main): `ActionBanner.tsx` + tests, `BUILD_STUDIO_TEST_IDS.actionBanner`, `ACTION_BANNER_HEIGHT_CLASS`. From PR #912 (already on main): `DetailsDrawer.tsx` (not yet wired). From this PR: `deriveActionBannerState()` helper exported from `BuildStudioWorkflowActionCard.tsx` so future T8 slices and integration tests can share the mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)