### PR TITLE
fix(build): harden taxonomy placement

### DIFF
--- a/apps/web/components/build/FeatureBriefPanel.test.tsx
+++ b/apps/web/components/build/FeatureBriefPanel.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FeatureBriefPanel } from "./FeatureBriefPanel";
+import type { FeatureBuildRow, FeatureBrief } from "@/lib/feature-build-types";
+
+const brief: FeatureBrief = {
+  title: "Agent budget controls",
+  description: "Track agent cost events and enforce budget policy.",
+  portfolioContext: "foundational",
+  targetRoles: ["Platform operator"],
+  inputs: [],
+  dataNeeds: "AgentBudgetEvent",
+  acceptanceCriteria: ["Shows spend by feature build"],
+};
+
+function makeBuild(): FeatureBuildRow {
+  return {
+    buildId: "FB-1",
+    happyPathState: {
+      intake: {
+        status: "pending",
+        taxonomyNodeId: null,
+        backlogItemId: null,
+        epicId: null,
+        constrainedGoal: null,
+        failureReason: null,
+      },
+      execution: { engine: null, source: null, status: "pending", failureStage: null },
+      verification: { status: "pending", checks: [] },
+    },
+    deliberationSummary: null,
+    designDoc: null,
+    designReview: null,
+    taxonomyAttribution: {
+      method: "heuristic",
+      confidence: 0.394,
+      confirmedNodeId: null,
+      topCandidate: {
+        nodeId: "manufacturing_and_delivery/requirement_to_deploy/test_validate",
+        nodeName: "Test & Validate",
+        score: 0.394,
+        evidence: "matched: test, validate",
+      },
+      candidates: [
+        {
+          nodeId: "manufacturing_and_delivery/requirement_to_deploy/test_validate",
+          nodeName: "Test & Validate",
+          score: 0.394,
+          evidence: "matched: test, validate",
+        },
+      ],
+      proposedNewNode: null,
+      attributedAt: "2026-05-21T00:00:00.000Z",
+    },
+  } as unknown as FeatureBuildRow;
+}
+
+describe("FeatureBriefPanel taxonomy placement", () => {
+  it("surfaces low-confidence placement evidence beside the brief", () => {
+    render(<FeatureBriefPanel brief={brief} phase="ideate" diffSummary={null} build={makeBuild()} />);
+
+    expect(screen.getByText("Taxonomy Placement")).toBeInTheDocument();
+    expect(screen.getByText("Low confidence")).toBeInTheDocument();
+    expect(screen.getByText("39%")).toBeInTheDocument();
+    expect(screen.getAllByText("Test & Validate").length).toBeGreaterThan(0);
+    expect(screen.getByText("matched: test, validate")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/build/FeatureBriefPanel.tsx
+++ b/apps/web/components/build/FeatureBriefPanel.tsx
@@ -95,6 +95,7 @@ export function FeatureBriefPanel({ brief, phase, diffSummary, attachments, buil
         {phaseSummary && deliberationPhase && (
           <DeliberationSummaryCard phase={deliberationPhase} summary={phaseSummary} />
         )}
+        {build?.taxonomyAttribution && <TaxonomyPlacementCard attribution={build.taxonomyAttribution} />}
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-bold text-[var(--dpf-text)]">Design Research</h3>
           {designReview && (
@@ -180,6 +181,7 @@ export function FeatureBriefPanel({ brief, phase, diffSummary, attachments, buil
           <DeliberationSummaryCard phase={deliberationPhase} summary={phaseSummary} />
         )}
         {build && <HappyPathStatusCard build={build} />}
+        {build?.taxonomyAttribution && <TaxonomyPlacementCard attribution={build.taxonomyAttribution} />}
         {progressMsg && (
           <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)] animate-pulse">
             <span className="w-2 h-2 rounded-full bg-[var(--dpf-accent)] shrink-0" />
@@ -199,6 +201,7 @@ export function FeatureBriefPanel({ brief, phase, diffSummary, attachments, buil
         <DeliberationSummaryCard phase={deliberationPhase} summary={phaseSummary} />
       )}
       {build && <HappyPathStatusCard build={build} />}
+      {build?.taxonomyAttribution && <TaxonomyPlacementCard attribution={build.taxonomyAttribution} />}
       {progressMsg && (
         <div className="flex items-center gap-2 text-xs text-[var(--dpf-muted)] animate-pulse">
           <span className="w-2 h-2 rounded-full bg-[var(--dpf-accent)] shrink-0" />
@@ -272,6 +275,91 @@ function HappyPathStatusCard({ build }: { build: FeatureBuildRow }) {
         {execution.failureStage ? ` · failed at ${execution.failureStage}` : ""}
         {intake.failureReason ? ` · ${intake.failureReason}` : ""}
       </div>
+    </div>
+  );
+}
+
+function TaxonomyPlacementCard({ attribution }: { attribution: NonNullable<FeatureBuildRow["taxonomyAttribution"]> }) {
+  const confidence = Math.max(0, Math.min(100, Math.round((attribution.confidence ?? 0) * 100)));
+  const status =
+    attribution.method === "invalid_portfolio"
+      ? { label: "Needs portfolio", tone: "warning" as const }
+      : attribution.proposedNewNode
+        ? { label: "Proposed", tone: "accent" as const }
+        : attribution.confirmedNodeId
+          ? { label: "Confirmed", tone: "success" as const }
+          : confidence < 55
+            ? { label: "Low confidence", tone: "warning" as const }
+            : { label: "Suggested", tone: "accent" as const };
+  const toneVar =
+    status.tone === "success"
+      ? "var(--dpf-success)"
+      : status.tone === "warning"
+        ? "var(--dpf-warning)"
+        : "var(--dpf-accent)";
+  const primaryPlacement =
+    attribution.confirmedNodeId
+      ?? attribution.topCandidate?.nodeName
+      ?? attribution.invalidPortfolioContext
+      ?? "Unplaced";
+  const candidates = attribution.candidates?.slice(0, 3) ?? [];
+
+  return (
+    <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <span className="text-xs font-semibold text-[var(--dpf-text)]">Taxonomy Placement</span>
+          <p className="mt-0.5 text-[11px] text-[var(--dpf-muted)] truncate">{safeRenderValue(primaryPlacement)}</p>
+        </div>
+        <span
+          className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold"
+          style={{
+            color: toneVar,
+            background: `color-mix(in srgb, ${toneVar} 12%, var(--dpf-surface-2))`,
+            border: `1px solid color-mix(in srgb, ${toneVar} 50%, var(--dpf-border))`,
+          }}
+        >
+          {status.label}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="h-1.5 flex-1 rounded-full bg-[var(--dpf-surface-1)] overflow-hidden">
+          <div
+            className="h-full rounded-full"
+            style={{ width: `${confidence}%`, background: toneVar }}
+          />
+        </div>
+        <span className="w-9 text-right text-[11px] font-semibold text-[var(--dpf-text)]">{confidence}%</span>
+      </div>
+
+      {attribution.invalidPortfolioContext && (
+        <div className="text-[11px] leading-snug text-[var(--dpf-warning)]">
+          Invalid portfolio context: {safeRenderValue(attribution.invalidPortfolioContext)}
+        </div>
+      )}
+
+      {attribution.proposedNewNode && (
+        <div className="text-[11px] leading-snug text-[var(--dpf-muted)]">
+          Proposed node: <span className="text-[var(--dpf-text)]">{safeRenderValue(attribution.proposedNewNode.name)}</span>
+        </div>
+      )}
+
+      {candidates.length > 0 && (
+        <div className="flex flex-col gap-1 border-t border-[var(--dpf-border)] pt-2">
+          {candidates.map((candidate) => (
+            <div key={candidate.nodeId} className="grid grid-cols-[1fr_auto] gap-2 text-[11px] leading-snug">
+              <div className="min-w-0">
+                <div className="truncate font-medium text-[var(--dpf-text)]">{safeRenderValue(candidate.nodeName)}</div>
+                {candidate.evidence && (
+                  <div className="truncate text-[var(--dpf-muted)]">{safeRenderValue(candidate.evidence)}</div>
+                )}
+              </div>
+              <span className="text-[var(--dpf-muted)]">{Math.round(candidate.score * 100)}% match</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/lib/explore/feature-build-data.test.ts
+++ b/apps/web/lib/explore/feature-build-data.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    featureBuild: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    platformDevConfig: {
+      findUnique: vi.fn(),
+    },
+    taxonomyNode: {
+      findUnique: vi.fn(),
+    },
+    digitalProduct: {
+      findMany: vi.fn(),
+    },
+    portfolio: {
+      findUnique: vi.fn(),
+    },
+    businessContext: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock("@/lib/decision-perspective/types", () => ({
+  PLAN_READINESS_DOMAIN_CLASS: "plan-readiness",
+}));
+
+vi.mock("@/lib/decision-perspective/view-model", () => ({
+  DECISION_INTERACTION_GATE_SELECT: { id: true },
+  decisionInteractionRowToGateView: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/brand/read", () => ({
+  readBrandContext: vi.fn(async () => ({ structured: null, legacyMarkdown: null })),
+}));
+
+vi.mock("@/lib/design-intelligence", () => ({
+  generateDesignSystem: vi.fn(() => "Generated design system"),
+}));
+
+import { prisma } from "@dpf/db";
+import { getFeatureBuildForContext } from "./feature-build-data";
+
+describe("getFeatureBuildForContext taxonomy context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.platformDevConfig.findUnique).mockResolvedValue({ contributionMode: "private" } as never);
+    vi.mocked(prisma.businessContext.findFirst).mockResolvedValue(null as never);
+    vi.mocked(prisma.digitalProduct.findMany).mockResolvedValue([
+      { name: "Agent Runtime" },
+      { name: "Agent Authority" },
+    ] as never);
+  });
+
+  it("resolves confirmed taxonomy nodeId slugs to internal taxonomy rows before walking context", async () => {
+    const confirmedNodeId = "foundational/platform_services/ai_and_agent_platform";
+    vi.mocked(prisma.featureBuild.findUnique)
+      .mockResolvedValueOnce({
+        buildId: "FB-1",
+        title: "Agent cost controls",
+        phase: "ideate",
+        brief: { title: "Agent cost controls" },
+        designDoc: null,
+        designReview: null,
+        buildPlan: null,
+        planReview: null,
+        verificationOut: null,
+        acceptanceMet: null,
+        uxVerificationStatus: null,
+        uxTestResults: null,
+        plan: null,
+        portfolioId: null,
+        createdById: "user-1",
+        scoutFindings: null,
+        phaseHandoffs: [],
+        taxonomyAttribution: {
+          confirmedNodeId,
+        },
+      } as never);
+
+    vi.mocked(prisma.taxonomyNode.findUnique).mockImplementation((async (input: unknown) => {
+      const where = (input as { where: Record<string, string> }).where;
+      if (where.nodeId === confirmedNodeId || where.id === "node-ai") {
+        return { id: "node-ai", name: "AI and Agent Platform", parentId: "node-platform" } as never;
+      }
+      if (where.id === "node-platform") {
+        return { id: "node-platform", name: "Platform Services", parentId: "node-foundational" } as never;
+      }
+      if (where.id === "node-foundational") {
+        return { id: "node-foundational", name: "Foundational", parentId: null } as never;
+      }
+      return null as never;
+    }) as never);
+
+    const context = await getFeatureBuildForContext("FB-1", "user-1");
+
+    expect(context?.taxonomyContext).toEqual({
+      path: "Foundational > Platform Services > AI and Agent Platform",
+      siblingProducts: ["Agent Runtime", "Agent Authority"],
+    });
+    expect(prisma.digitalProduct.findMany).toHaveBeenCalledWith({
+      where: { taxonomyNodeId: "node-ai" },
+      select: { name: true },
+      take: 10,
+    });
+  });
+});

--- a/apps/web/lib/explore/feature-build-data.ts
+++ b/apps/web/lib/explore/feature-build-data.ts
@@ -62,6 +62,7 @@ export const getFeatureBuilds = cache(async (userId: string): Promise<FeatureBui
       uxTestResults: true,
       uxVerificationStatus: true,
       buildExecState: true,
+      taxonomyAttribution: true,
       scoutFindings: true,
       deliberationSummary: true,
       digitalProduct: {
@@ -114,6 +115,7 @@ export const getFeatureBuilds = cache(async (userId: string): Promise<FeatureBui
     uxTestResults: r.uxTestResults as FeatureBuildRow["uxTestResults"],
     uxVerificationStatus: r.uxVerificationStatus as FeatureBuildRow["uxVerificationStatus"],
     buildExecState: r.buildExecState as FeatureBuildRow["buildExecState"],
+    taxonomyAttribution: r.taxonomyAttribution as FeatureBuildRow["taxonomyAttribution"],
     scoutFindings: r.scoutFindings as FeatureBuildRow["scoutFindings"],
     deliberationSummary: r.deliberationSummary as BuildDeliberationSummary | null,
     happyPathState: normalizeHappyPathState((r.plan as Record<string, unknown> | null)?.happyPathState ?? null),
@@ -164,6 +166,7 @@ export const getFeatureBuildById = cache(async (buildId: string): Promise<Featur
       uxTestResults: true,
       uxVerificationStatus: true,
       buildExecState: true,
+      taxonomyAttribution: true,
       scoutFindings: true,
       deliberationSummary: true,
       digitalProduct: {
@@ -218,6 +221,7 @@ export const getFeatureBuildById = cache(async (buildId: string): Promise<Featur
     uxTestResults: r.uxTestResults as FeatureBuildRow["uxTestResults"],
     uxVerificationStatus: r.uxVerificationStatus as FeatureBuildRow["uxVerificationStatus"],
     buildExecState: r.buildExecState as FeatureBuildRow["buildExecState"],
+    taxonomyAttribution: r.taxonomyAttribution as FeatureBuildRow["taxonomyAttribution"],
     scoutFindings: r.scoutFindings as FeatureBuildRow["scoutFindings"],
     deliberationSummary: r.deliberationSummary as BuildDeliberationSummary | null,
     happyPathState: normalizeHappyPathState((r.plan as Record<string, unknown> | null)?.happyPathState ?? null),
@@ -284,6 +288,7 @@ export async function getFeatureBuildForContext(
       plan: true,
       portfolioId: true,
       createdById: true,
+      taxonomyAttribution: true,
       scoutFindings: true,
       phaseHandoffs: {
         orderBy: { createdAt: "asc" },
@@ -312,34 +317,45 @@ export async function getFeatureBuildForContext(
 
   // Resolve taxonomy path and sibling products for richer context
   let taxonomyContext: { path: string; siblingProducts: string[] } | undefined;
-  const taxonomyAttr = (await prisma.featureBuild.findUnique({
-    where: { buildId },
-    select: { taxonomyAttribution: true },
-  }))?.taxonomyAttribution as { confirmedNodeId?: string } | null;
+  const taxonomyAttr = r.taxonomyAttribution as { confirmedNodeId?: string } | null;
 
   if (taxonomyAttr?.confirmedNodeId) {
-    // Walk the taxonomy tree upward to build the full path
-    const pathParts: string[] = [];
-    let currentNodeId: string | null = taxonomyAttr.confirmedNodeId;
-    while (currentNodeId) {
-      const node: { name: string; parentId: string | null } | null = await prisma.taxonomyNode.findUnique({
-        where: { id: currentNodeId },
-        select: { name: true, parentId: true },
-      });
-      if (!node) break;
-      pathParts.unshift(node.name);
-      currentNodeId = node.parentId;
-    }
-    // Find sibling products in the same taxonomy node
-    const siblings = await prisma.digitalProduct.findMany({
-      where: { taxonomyNodeId: taxonomyAttr.confirmedNodeId },
-      select: { name: true },
-      take: 10,
+    const startingNode = await prisma.taxonomyNode.findUnique({
+      where: { nodeId: taxonomyAttr.confirmedNodeId },
+      select: { id: true, name: true, parentId: true },
+    }) ?? await prisma.taxonomyNode.findUnique({
+      where: { id: taxonomyAttr.confirmedNodeId },
+      select: { id: true, name: true, parentId: true },
     });
-    taxonomyContext = {
-      path: pathParts.join(" > "),
-      siblingProducts: siblings.map((s) => s.name),
-    };
+
+    if (startingNode) {
+      // Walk the taxonomy tree upward to build the full path. confirmedNodeId is
+      // a human-readable nodeId slug; relationships and product links use row ids.
+      const pathParts: string[] = [];
+      const seen = new Set<string>();
+      let node: { id: string; name: string; parentId: string | null } | null = startingNode;
+      while (node && !seen.has(node.id)) {
+        seen.add(node.id);
+        pathParts.unshift(node.name);
+        node = node.parentId
+          ? await prisma.taxonomyNode.findUnique({
+              where: { id: node.parentId },
+              select: { id: true, name: true, parentId: true },
+            })
+          : null;
+      }
+
+      // Find sibling products in the same taxonomy node
+      const siblings = await prisma.digitalProduct.findMany({
+        where: { taxonomyNodeId: startingNode.id },
+        select: { name: true },
+        take: 10,
+      });
+      taxonomyContext = {
+        path: pathParts.join(" > "),
+        siblingProducts: siblings.map((s) => s.name),
+      };
+    }
   } else if (r.portfolioId) {
     const portfolio = await prisma.portfolio.findUnique({
       where: { slug: r.portfolioId },

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -26,6 +26,35 @@ export type FeatureBrief = {
   acceptanceCriteria: string[];
 };
 
+export type TaxonomyAttributionView = {
+  method: "rule" | "heuristic" | "ai_proposed" | "manual" | "invalid_portfolio";
+  confidence: number;
+  portfolioSlug?: string | null;
+  invalidPortfolioContext?: string | null;
+  validPortfolioOptions?: Array<{ slug: string; name: string }>;
+  confirmedNodeId: string | null;
+  topCandidate: {
+    nodeId: string;
+    nodeName: string;
+    score: number;
+    evidence: string;
+  } | null;
+  candidates: Array<{
+    nodeId: string;
+    nodeName: string;
+    score: number;
+    evidence: string;
+  }>;
+  proposedNewNode: {
+    parentNodeId: string;
+    name: string;
+    description: string;
+    rationale: string;
+    proposalId?: string | null;
+  } | null;
+  attributedAt: string;
+};
+
 // ─── Build Disciplines Evidence Types ────────────────────────────────────────
 
 export type ReviewResult = {
@@ -249,6 +278,7 @@ export type FeatureBuildRow = {
   claimedAt: Date | null;
   claimStatus: string | null;
   buildExecState: BuildExecutionState | null;
+  taxonomyAttribution?: TaxonomyAttributionView | null;
   deliberationSummary: BuildDeliberationSummary | null;
   originator: {
     id: string;

--- a/apps/web/lib/integrate/feature-attribution.test.ts
+++ b/apps/web/lib/integrate/feature-attribution.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    featureBuild: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    portfolio: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    taxonomyNode: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    taxonomyProposal: {
+      create: vi.fn(),
+    },
+  },
+  scoreTaxonomyCandidates: vi.fn(),
+  flattenEnrichmentForScoring: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock("@dpf/db/discovery-attribution", () => ({
+  scoreTaxonomyCandidates: mocks.scoreTaxonomyCandidates,
+  flattenEnrichmentForScoring: mocks.flattenEnrichmentForScoring,
+}));
+
+import { prisma } from "@dpf/db";
+import {
+  attributeFeatureBuild,
+  confirmFeatureTaxonomy,
+  formatAttributionRecommendation,
+} from "./feature-attribution";
+
+describe("Build Studio taxonomy attribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.flattenEnrichmentForScoring.mockReturnValue("");
+    mocks.scoreTaxonomyCandidates.mockReturnValue([]);
+    vi.mocked(prisma.featureBuild.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.portfolio.findMany).mockResolvedValue([
+      { slug: "foundational", name: "Foundational" },
+      { slug: "manufacturing_and_delivery", name: "Manufacturing & Delivery" },
+    ] as never);
+  });
+
+  it("does not widen placement search when the brief has an invalid portfolio slug", async () => {
+    vi.mocked(prisma.featureBuild.findUnique).mockResolvedValue({
+      digitalProductId: null,
+      digitalProduct: null,
+    } as never);
+    vi.mocked(prisma.portfolio.findUnique).mockResolvedValue(null as never);
+
+    const attribution = await attributeFeatureBuild("FB-invalid-portfolio", {
+      title: "Cost governance ledger",
+      description: "Track AgentBudgetEvent records and enforce budget policy.",
+      portfolioContext: "platform",
+      acceptanceCriteria: [],
+      targetRoles: ["Platform operator"],
+      dataNeeds: "AgentBudgetEvent",
+    });
+
+    expect(attribution.method).toBe("invalid_portfolio");
+    expect(attribution.confidence).toBe(0);
+    expect((attribution as { invalidPortfolioContext?: string }).invalidPortfolioContext).toBe("platform");
+    expect(attribution.candidates).toEqual([]);
+    expect(prisma.taxonomyNode.findMany).not.toHaveBeenCalled();
+    expect(formatAttributionRecommendation(attribution)).toContain("platform is not a valid portfolio");
+  });
+
+  it("canonicalizes a unique taxonomy node suffix when confirming placement", async () => {
+    const canonicalNodeId = "foundational/platform_services/ai_and_agent_platform";
+    vi.mocked(prisma.featureBuild.findUnique).mockResolvedValue({
+      id: "fb-row-1",
+      taxonomyAttribution: {
+        method: "heuristic",
+        confidence: 0.4,
+        confirmedNodeId: null,
+        topCandidate: null,
+        candidates: [],
+        proposedNewNode: null,
+        attributedAt: "2026-05-21T00:00:00.000Z",
+      },
+    } as never);
+    vi.mocked(prisma.taxonomyNode.findUnique).mockResolvedValue(null as never);
+    vi.mocked(prisma.taxonomyNode.findMany).mockResolvedValue([
+      { id: "tax-row-1", nodeId: canonicalNodeId, name: "AI and Agent Platform" },
+    ] as never);
+
+    const result = await confirmFeatureTaxonomy("FB-1", "ai_and_agent_platform");
+
+    expect(result.success).toBe(true);
+    expect((result as { confirmedNodeId?: string }).confirmedNodeId).toBe(canonicalNodeId);
+    expect(prisma.featureBuild.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { buildId: "FB-1" },
+      data: {
+        taxonomyAttribution: expect.objectContaining({
+          method: "manual",
+          confidence: 1,
+          confirmedNodeId: canonicalNodeId,
+        }),
+      },
+    }));
+  });
+
+  it("persists proposed taxonomy nodes into a review queue", async () => {
+    const parentNodeId = "manufacturing_and_delivery/requirement_to_deploy/test_validate";
+    vi.mocked(prisma.featureBuild.findUnique).mockResolvedValue({
+      id: "fb-row-2",
+      taxonomyAttribution: null,
+    } as never);
+    vi.mocked(prisma.taxonomyNode.findUnique).mockResolvedValue({
+      id: "parent-row-1",
+      nodeId: parentNodeId,
+      name: "Test & Validate",
+    } as never);
+    vi.mocked(prisma.taxonomyProposal.create).mockResolvedValue({ id: "tp-1" } as never);
+
+    const result = await confirmFeatureTaxonomy("FB-2", null, {
+      parentNodeId,
+      name: "Agent Cost Governance",
+      description: "Budget policy and event-ledger controls for agent work.",
+      rationale: "Existing test and deploy nodes are too execution-focused.",
+    });
+
+    expect(result.success).toBe(true);
+    expect((result as { proposalId?: string }).proposalId).toBe("tp-1");
+    expect((result as { confirmedNodeId?: string }).confirmedNodeId).toBe(parentNodeId);
+    expect(prisma.taxonomyProposal.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        parentNodeId: "parent-row-1",
+        featureBuildId: "fb-row-2",
+        proposedName: "Agent Cost Governance",
+        description: "Budget policy and event-ledger controls for agent work.",
+        rationale: "Existing test and deploy nodes are too execution-focused.",
+        status: "proposed",
+      }),
+      select: { id: true },
+    });
+    expect(prisma.featureBuild.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { buildId: "FB-2" },
+      data: {
+        taxonomyAttribution: expect.objectContaining({
+          method: "ai_proposed",
+          confirmedNodeId: parentNodeId,
+          proposedNewNode: expect.objectContaining({ proposalId: "tp-1" }),
+        }),
+      },
+    }));
+  });
+});

--- a/apps/web/lib/integrate/feature-attribution.ts
+++ b/apps/web/lib/integrate/feature-attribution.ts
@@ -4,19 +4,21 @@
 // Reuses the token-scoring pipeline from discovery-attribution,
 // adapted for feature briefs instead of infrastructure entities.
 
-import { prisma } from "@dpf/db";
+import { prisma, type Prisma } from "@dpf/db";
 import {
   scoreTaxonomyCandidates,
   flattenEnrichmentForScoring,
   type TaxonomyNodeCandidate,
-  type RankedTaxonomyCandidate,
 } from "@dpf/db/discovery-attribution";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type TaxonomyAttribution = {
-  method: "rule" | "heuristic" | "ai_proposed" | "manual";
+  method: "rule" | "heuristic" | "ai_proposed" | "manual" | "invalid_portfolio";
   confidence: number;
+  portfolioSlug?: string | null;
+  invalidPortfolioContext?: string | null;
+  validPortfolioOptions?: Array<{ slug: string; name: string }>;
   confirmedNodeId: string | null;
   topCandidate: {
     nodeId: string;
@@ -35,6 +37,7 @@ export type TaxonomyAttribution = {
     name: string;
     description: string;
     rationale: string;
+    proposalId?: string | null;
   } | null;
   attributedAt: string;
 };
@@ -47,6 +50,89 @@ type FeatureBriefInput = {
   targetRoles?: string[];
   dataNeeds?: string;
 };
+
+type TaxonomyNodeReference = {
+  id: string;
+  nodeId: string;
+  name: string;
+  parentId: string | null;
+};
+
+type TaxonomyNodeResolution =
+  | { status: "found"; node: TaxonomyNodeReference }
+  | { status: "not_found"; message: string }
+  | { status: "ambiguous"; message: string };
+
+const TAXONOMY_NODE_REFERENCE_SELECT = {
+  id: true,
+  nodeId: true,
+  name: true,
+  parentId: true,
+} as const;
+
+function defaultAttribution(): TaxonomyAttribution {
+  return {
+    method: "manual",
+    confidence: 1.0,
+    confirmedNodeId: null,
+    topCandidate: null,
+    candidates: [],
+    proposedNewNode: null,
+    attributedAt: new Date().toISOString(),
+  };
+}
+
+function normalizeExistingAttribution(raw: unknown): TaxonomyAttribution {
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? { ...defaultAttribution(), ...(raw as Partial<TaxonomyAttribution>) }
+    : defaultAttribution();
+}
+
+function attributionJson(attribution: TaxonomyAttribution): Prisma.InputJsonValue {
+  return attribution as unknown as Prisma.InputJsonValue;
+}
+
+async function resolveTaxonomyNodeReference(reference: string): Promise<TaxonomyNodeResolution> {
+  const trimmed = reference.trim();
+  if (!trimmed) {
+    return { status: "not_found", message: "Taxonomy node reference is empty" };
+  }
+
+  const exactNodeId = await prisma.taxonomyNode.findUnique({
+    where: { nodeId: trimmed },
+    select: TAXONOMY_NODE_REFERENCE_SELECT,
+  });
+  if (exactNodeId) return { status: "found", node: exactNodeId };
+
+  const exactRowId = await prisma.taxonomyNode.findUnique({
+    where: { id: trimmed },
+    select: TAXONOMY_NODE_REFERENCE_SELECT,
+  });
+  if (exactRowId) return { status: "found", node: exactRowId };
+
+  const suffixMatches = await prisma.taxonomyNode.findMany({
+    where: {
+      status: "active",
+      nodeId: { endsWith: `/${trimmed}` },
+    },
+    select: TAXONOMY_NODE_REFERENCE_SELECT,
+    orderBy: { nodeId: "asc" },
+    take: 5,
+  });
+
+  if (suffixMatches.length === 1) {
+    return { status: "found", node: suffixMatches[0]! };
+  }
+
+  if (suffixMatches.length > 1) {
+    return {
+      status: "ambiguous",
+      message: `Taxonomy node reference ${trimmed} is ambiguous. Use the full nodeId: ${suffixMatches.map((n) => n.nodeId).join(", ")}`,
+    };
+  }
+
+  return { status: "not_found", message: `Taxonomy node ${trimmed} not found` };
+}
 
 // ─── Attribution Pipeline ───────────────────────────────────────────────────
 
@@ -87,6 +173,7 @@ export async function attributeFeatureBuild(
     return {
       method: "rule",
       confidence: 0.98,
+      portfolioSlug: null,
       confirmedNodeId: build.digitalProduct.taxonomyNode.nodeId,
       topCandidate: {
         nodeId: build.digitalProduct.taxonomyNode.nodeId,
@@ -101,13 +188,35 @@ export async function attributeFeatureBuild(
   }
 
   // 2. Load taxonomy nodes, scoped to portfolio if provided.
+  const portfolioContext = brief.portfolioContext?.trim() ?? "";
   let portfolioId: string | null = null;
-  if (brief.portfolioContext) {
+  let portfolioSlug: string | null = null;
+  if (portfolioContext) {
     const portfolio = await prisma.portfolio.findUnique({
-      where: { slug: brief.portfolioContext },
-      select: { id: true },
+      where: { slug: portfolioContext },
+      select: { id: true, slug: true, name: true },
     });
+    if (!portfolio) {
+      const options = await prisma.portfolio.findMany({
+        select: { slug: true, name: true },
+        orderBy: { name: "asc" },
+        take: 8,
+      });
+      return {
+        method: "invalid_portfolio",
+        confidence: 0,
+        portfolioSlug: null,
+        invalidPortfolioContext: portfolioContext,
+        validPortfolioOptions: options,
+        confirmedNodeId: null,
+        topCandidate: null,
+        candidates: [],
+        proposedNewNode: null,
+        attributedAt: new Date().toISOString(),
+      };
+    }
     portfolioId = portfolio?.id ?? null;
+    portfolioSlug = portfolio?.slug ?? null;
   }
 
   const nodes = await prisma.taxonomyNode.findMany({
@@ -146,6 +255,7 @@ export async function attributeFeatureBuild(
   return {
     method: "heuristic",
     confidence,
+    portfolioSlug,
     confirmedNodeId: null,  // not confirmed until user approves
     topCandidate: best,
     candidates: mappedCandidates.slice(0, 5),
@@ -162,7 +272,7 @@ export async function confirmFeatureTaxonomy(
   buildId: string,
   nodeId: string | null,
   proposeNew?: { parentNodeId: string; name: string; description: string; rationale: string },
-): Promise<{ success: boolean; message: string }> {
+): Promise<{ success: boolean; message: string; confirmedNodeId?: string; proposalId?: string }> {
   const build = await prisma.featureBuild.findUnique({
     where: { buildId },
     select: { id: true, taxonomyAttribution: true },
@@ -172,76 +282,97 @@ export async function confirmFeatureTaxonomy(
   // Safely parse existing attribution — guard against corrupted JSON
   let existing: TaxonomyAttribution;
   try {
-    const raw = build.taxonomyAttribution;
-    existing = (raw && typeof raw === "object" ? raw : null) as TaxonomyAttribution | null ?? {
-      method: "manual" as const,
-      confidence: 1.0,
-      confirmedNodeId: null,
-      topCandidate: null,
-      candidates: [],
-      proposedNewNode: null,
-      attributedAt: new Date().toISOString(),
-    };
+    existing = normalizeExistingAttribution(build.taxonomyAttribution);
   } catch {
-    existing = {
-      method: "manual" as const,
-      confidence: 1.0,
-      confirmedNodeId: null,
-      topCandidate: null,
-      candidates: [],
-      proposedNewNode: null,
-      attributedAt: new Date().toISOString(),
-    };
+    existing = defaultAttribution();
   }
 
   if (proposeNew && !nodeId) {
-    // Validate that parentNodeId exists
-    const parentNode = await prisma.taxonomyNode.findUnique({
-      where: { nodeId: proposeNew.parentNodeId },
-      select: { nodeId: true, name: true },
+    const proposedName = proposeNew.name.trim();
+    const description = proposeNew.description.trim();
+    const rationale = proposeNew.rationale.trim();
+    if (!proposedName) {
+      return { success: false, message: "Proposed taxonomy node name is required" };
+    }
+
+    const parentResolution = await resolveTaxonomyNodeReference(proposeNew.parentNodeId);
+    if (parentResolution.status !== "found") {
+      return { success: false, message: parentResolution.message };
+    }
+    const parentNode = parentResolution.node;
+
+    const proposal = await prisma.taxonomyProposal.create({
+      data: {
+        parentNodeId: parentNode.id,
+        featureBuildId: build.id,
+        proposedName,
+        description: description || null,
+        rationale,
+        status: "proposed",
+      },
+      select: { id: true },
     });
-    if (!parentNode) return { success: false, message: `Parent taxonomy node ${proposeNew.parentNodeId} not found` };
 
     // Proposing a new taxonomy node
+    const nextAttribution: TaxonomyAttribution = {
+      ...existing,
+      method: "ai_proposed",
+      confirmedNodeId: parentNode.nodeId,  // place under parent for now
+      proposedNewNode: {
+        parentNodeId: parentNode.nodeId,
+        name: proposedName,
+        description,
+        rationale,
+        proposalId: proposal.id,
+      },
+      attributedAt: new Date().toISOString(),
+    };
     await prisma.featureBuild.update({
       where: { buildId },
       data: {
-        taxonomyAttribution: {
-          ...existing,
-          method: "ai_proposed",
-          confirmedNodeId: proposeNew.parentNodeId,  // place under parent for now
-          proposedNewNode: proposeNew,
-          attributedAt: new Date().toISOString(),
-        },
+        taxonomyAttribution: attributionJson(nextAttribution),
       },
     });
     return {
       success: true,
-      message: `Proposed new taxonomy node "${proposeNew.name}" under ${parentNode.name} (${proposeNew.parentNodeId}). The architecture team will review this proposal.`,
+      confirmedNodeId: parentNode.nodeId,
+      proposalId: proposal.id,
+      message: `Proposed new taxonomy node "${proposedName}" under ${parentNode.name} (${parentNode.nodeId}). Proposal ${proposal.id} is queued for architecture review.`,
     };
   }
 
   if (nodeId) {
     // Confirming an existing node
-    const node = await prisma.taxonomyNode.findUnique({
-      where: { nodeId },
-      select: { nodeId: true, name: true },
-    });
-    if (!node) return { success: false, message: `Taxonomy node ${nodeId} not found` };
+    const nodeResolution = await resolveTaxonomyNodeReference(nodeId);
+    if (nodeResolution.status !== "found") {
+      return { success: false, message: nodeResolution.message };
+    }
+    const node = nodeResolution.node;
 
+    const nextAttribution: TaxonomyAttribution = {
+      ...existing,
+      confirmedNodeId: node.nodeId,
+      method: existing.method === "rule" ? "rule" : "manual",
+      confidence: 1.0,
+      topCandidate: {
+        nodeId: node.nodeId,
+        nodeName: node.name,
+        score: 1,
+        evidence: "Manually confirmed taxonomy placement",
+      },
+      attributedAt: new Date().toISOString(),
+    };
     await prisma.featureBuild.update({
       where: { buildId },
       data: {
-        taxonomyAttribution: {
-          ...existing,
-          confirmedNodeId: nodeId,
-          method: existing.method === "rule" ? "rule" : "manual",
-          confidence: 1.0,
-          attributedAt: new Date().toISOString(),
-        },
+        taxonomyAttribution: attributionJson(nextAttribution),
       },
     });
-    return { success: true, message: `Taxonomy placement confirmed: ${node.name} (${nodeId})` };
+    return {
+      success: true,
+      confirmedNodeId: node.nodeId,
+      message: `Taxonomy placement confirmed: ${node.name} (${node.nodeId})`,
+    };
   }
 
   return { success: false, message: "Either nodeId or proposeNew must be provided" };
@@ -252,6 +383,13 @@ export async function confirmFeatureTaxonomy(
  */
 export function formatAttributionRecommendation(attribution: TaxonomyAttribution): string {
   const { confidence, topCandidate, candidates } = attribution;
+
+  if (attribution.method === "invalid_portfolio" && attribution.invalidPortfolioContext) {
+    const options = attribution.validPortfolioOptions?.length
+      ? ` Valid portfolio contexts: ${attribution.validPortfolioOptions.map((p) => `${p.slug} (${p.name})`).join(", ")}.`
+      : "";
+    return `${attribution.invalidPortfolioContext} is not a valid portfolio context, so I did not search the full taxonomy.${options} Update the feature brief portfolio and run placement again.`;
+  }
 
   if (attribution.method === "rule" && topCandidate) {
     return `This feature belongs under **${topCandidate.nodeName}** (inherited from the existing product). No action needed.`;

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -5686,6 +5686,8 @@ export async function executeTool(
         data: {
           method: attribution.method,
           confidence: attribution.confidence,
+          invalidPortfolioContext: attribution.invalidPortfolioContext ?? null,
+          validPortfolioOptions: attribution.validPortfolioOptions ?? [],
           topCandidate: attribution.topCandidate,
           candidates: attribution.candidates,
         },
@@ -5715,14 +5717,22 @@ export async function executeTool(
           // When parentNodeId/name are empty, silently ignore proposeNew — fall through to nodeId path
         }
         const result = await confirmFeatureTaxonomy(buildId, nodeId, proposeNew);
-        if (result.success && nodeId) {
+        if (result.success && result.confirmedNodeId) {
           await updateBuildHappyPathState(userId, {
             intake: {
-              taxonomyNodeId: nodeId,
+              taxonomyNodeId: result.confirmedNodeId,
             },
           }, buildId);
         }
-        return { success: result.success, entityId: buildId, message: result.message };
+        return {
+          success: result.success,
+          entityId: buildId,
+          message: result.message,
+          data: {
+            confirmedNodeId: result.confirmedNodeId ?? null,
+            proposalId: result.proposalId ?? null,
+          },
+        };
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Unknown error";
         console.error(`[confirm_taxonomy_placement] Error:`, msg);

--- a/packages/db/prisma/migrations/20260521140000_build_studio_taxonomy_proposals/migration.sql
+++ b/packages/db/prisma/migrations/20260521140000_build_studio_taxonomy_proposals/migration.sql
@@ -1,0 +1,35 @@
+-- Persist Build Studio taxonomy expansion proposals for architecture review.
+CREATE TABLE "TaxonomyProposal" (
+  "id" TEXT NOT NULL,
+  "parentNodeId" TEXT NOT NULL,
+  "proposedName" TEXT NOT NULL,
+  "description" TEXT,
+  "rationale" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'proposed',
+  "featureBuildId" TEXT,
+  "reviewedById" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  "reviewNotes" TEXT,
+  "createdNodeId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "TaxonomyProposal_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "TaxonomyProposal_status_idx" ON "TaxonomyProposal"("status");
+CREATE INDEX "TaxonomyProposal_parentNodeId_idx" ON "TaxonomyProposal"("parentNodeId");
+CREATE INDEX "TaxonomyProposal_featureBuildId_idx" ON "TaxonomyProposal"("featureBuildId");
+CREATE INDEX "TaxonomyProposal_createdNodeId_idx" ON "TaxonomyProposal"("createdNodeId");
+
+ALTER TABLE "TaxonomyProposal"
+  ADD CONSTRAINT "TaxonomyProposal_parentNodeId_fkey"
+  FOREIGN KEY ("parentNodeId") REFERENCES "TaxonomyNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "TaxonomyProposal"
+  ADD CONSTRAINT "TaxonomyProposal_createdNodeId_fkey"
+  FOREIGN KEY ("createdNodeId") REFERENCES "TaxonomyNode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "TaxonomyProposal"
+  ADD CONSTRAINT "TaxonomyProposal_featureBuildId_fkey"
+  FOREIGN KEY ("featureBuildId") REFERENCES "FeatureBuild"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -911,8 +911,34 @@ model TaxonomyNode {
   inventoryEntities        InventoryEntity[]
   portfolioQualityIssues   PortfolioQualityIssue[]
   triageSelectionDecisions DiscoveryTriageDecision[]  @relation("DiscoveryTriageDecisionSelectedTaxonomy")
+  taxonomyProposalParents  TaxonomyProposal[]         @relation("TaxonomyProposalParent")
+  createdTaxonomyProposals TaxonomyProposal[]         @relation("TaxonomyProposalCreatedNode")
   parent                   TaxonomyNode?              @relation("TaxonomyTree", fields: [parentId], references: [id])
   children                 TaxonomyNode[]             @relation("TaxonomyTree")
+}
+
+model TaxonomyProposal {
+  id             String        @id @default(cuid())
+  parentNodeId   String
+  proposedName   String
+  description    String?
+  rationale      String
+  status         String        @default("proposed")
+  featureBuildId String?
+  reviewedById   String?
+  reviewedAt     DateTime?
+  reviewNotes    String?
+  createdNodeId  String?
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+  parentNode     TaxonomyNode  @relation("TaxonomyProposalParent", fields: [parentNodeId], references: [id], onDelete: Cascade)
+  createdNode    TaxonomyNode? @relation("TaxonomyProposalCreatedNode", fields: [createdNodeId], references: [id], onDelete: SetNull)
+  featureBuild   FeatureBuild? @relation(fields: [featureBuildId], references: [id], onDelete: SetNull)
+
+  @@index([status])
+  @@index([parentNodeId])
+  @@index([featureBuildId])
+  @@index([createdNodeId])
 }
 
 model BacklogItem {
@@ -4190,6 +4216,7 @@ model FeatureBuild {
   phaseHandoffs            PhaseHandoff[]
   phaseRuns                BuildPhaseRun[]
   toolExecutionReceipts    ToolExecutionReceipt[]
+  taxonomyProposals        TaxonomyProposal[]
   activeForBacklogItem     BacklogItem?            @relation("BacklogItemActiveBuild")
   accountableEmployee      EmployeeProfile?        @relation("BuildAccountable", fields: [accountableEmployeeId], references: [id])
   createdBy                User                    @relation(fields: [createdById], references: [id])


### PR DESCRIPTION
## Summary
- Harden Build Studio taxonomy attribution so invalid portfolio slugs stop placement instead of widening to the full taxonomy.
- Canonicalize confirmed taxonomy node references, including unique suffixes such as `ai_and_agent_platform`, before storing happy-path anchors.
- Add a durable `TaxonomyProposal` review queue and surface low-confidence placement evidence in the Build Studio Details panel.

## Verification
- `pnpm --filter web exec vitest run lib/integrate/feature-attribution.test.ts lib/explore/feature-build-data.test.ts components/build/FeatureBriefPanel.test.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter web build` (passes with existing Turbopack warnings for `@dpf/db/data/agent_registry.json` tracing)
- `pnpm --filter @dpf/db exec prisma migrate deploy` against a disposable Postgres database
- Browser smoke: `/build?buildId=FB-QATAXON261F4A` on branch server, Details tab showed low-confidence Taxonomy Placement card; temporary QA row and server were cleaned up