### PR TITLE
feat(build-studio): fleet-density sidebar — compact rows + queue header

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -15,6 +15,7 @@ import { ReleaseDecisionPanel } from "./ReleaseDecisionPanel";
 import { BuildStudioWorkflowActionCard } from "./BuildStudioWorkflowActionCard";
 import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
 import { BuildListItem } from "./BuildListItem";
+import { deriveFleetCounts, deriveNeedsAttention, deriveQueueState } from "./fleet-derivation";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { deriveBuildStudioWorkflowAction } from "./build-studio-workflow-actions";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
@@ -423,54 +424,29 @@ export function BuildStudio({
             </div>
           )}
 
-          <div className="flex-1 overflow-auto p-2">
-            {buildRows.length === 0 ? (
-              <div className="p-6 text-center">
-                <div className="text-3xl mb-3 opacity-20">&#128161;</div>
-                <p className="text-sm text-[var(--dpf-muted)] mb-2">No builds yet</p>
-                <p className="text-xs text-[var(--dpf-muted)] opacity-70">
-                  Type a feature name above and press <strong className="text-[var(--dpf-text)]">New</strong> to start.
-                </p>
-              </div>
-            ) : (
-              buildRows.map((build, idx) => {
-                const lifecycleLabel = deriveLifecycleLabel({
-                  backlogItem: build.originator
-                    ? {
-                      status: build.originator.status,
-                      triageOutcome: build.originator.triageOutcome,
-                      activeBuildId: build.originator.activeBuildId,
-                    }
-                    : null,
-                  featureBuild: build,
-                  governedBacklogEnabled,
-                });
-
-                return (
-                  <BuildListItem
-                    key={build.buildId}
-                    build={build}
-                    active={activeBuild?.buildId === build.buildId}
-                    index={idx}
-                    lifecycleLabel={lifecycleLabel}
-                    isDevEnvironment={isDevEnvironment}
-                    onSelect={() => {
-                      setActiveBuild(build);
-                      setSidebarOpen(true);
-                    }}
-                    onDelete={() => {
-                      if (isDevEnvironment) return;
-                      if (!confirm(`Delete "${build.title}"?`)) return;
-                      deleteFeatureBuild(build.buildId).then(() => {
-                        if (activeBuild?.buildId === build.buildId) setActiveBuild(null);
-                        router.refresh();
-                      });
-                    }}
-                  />
-                );
-              })
-            )}
-          </div>
+          {/* Fleet rail (compact density) — replaces the legacy comfortable
+              build cards. Per spec §1: one row per in-flight build, ≤32px
+              tall, phase mini-rail + queue badge + needs-attention dot.
+              Order: running → blocked → queued → idle. Falls back to FB
+              ascending for same-kind tie-break. */}
+          <FleetRailZone
+            buildRows={buildRows}
+            activeBuildId={activeBuild?.buildId ?? null}
+            governedBacklogEnabled={governedBacklogEnabled}
+            isDevEnvironment={isDevEnvironment}
+            onSelectBuild={(build) => {
+              setActiveBuild(build);
+              setSidebarOpen(true);
+            }}
+            onDeleteBuild={(build) => {
+              if (isDevEnvironment) return;
+              if (!confirm(`Delete "${build.title}"?`)) return;
+              deleteFeatureBuild(build.buildId).then(() => {
+                if (activeBuild?.buildId === build.buildId) setActiveBuild(null);
+                router.refresh();
+              });
+            }}
+          />
         </div>
 
         {/* Right: Preview or Brief */}
@@ -752,6 +728,114 @@ function BuildFailedBanner({ execState }: { execState: BuildExecutionState | nul
           <p className="text-xs text-[var(--dpf-muted)] mt-2">{hint}</p>
         </div>
       </div>
+    </div>
+  );
+}
+
+function FleetRailZone({
+  buildRows,
+  activeBuildId,
+  governedBacklogEnabled,
+  isDevEnvironment,
+  onSelectBuild,
+  onDeleteBuild,
+}: {
+  buildRows: FeatureBuildRow[];
+  activeBuildId: string | null;
+  governedBacklogEnabled: boolean;
+  isDevEnvironment: boolean;
+  onSelectBuild: (build: FeatureBuildRow) => void;
+  onDeleteBuild: (build: FeatureBuildRow) => void;
+}) {
+  // Derive per-row fleet entries: queueState + needsAttention + lifecycle.
+  // queueState falls back to phase-based heuristics until the concurrency
+  // dispatcher exposes real values (its thread owns that surface).
+  const entries = buildRows.map((build) => ({
+    build,
+    queueState: deriveQueueState(build),
+    needsAttention: deriveNeedsAttention(build),
+    lifecycleLabel: deriveLifecycleLabel({
+      backlogItem: build.originator
+        ? {
+          status: build.originator.status,
+          triageOutcome: build.originator.triageOutcome,
+          activeBuildId: build.originator.activeBuildId,
+        }
+        : null,
+      featureBuild: build,
+      governedBacklogEnabled,
+    }),
+  }));
+
+  // Sort: running → blocked → queued (by position) → idle. Stable tie-break
+  // by buildId so render order doesn't flicker across re-renders.
+  const kindRank = { running: 0, blocked: 1, queued: 2, idle: 3 } as const;
+  const sorted = [...entries].sort((a, b) => {
+    const ra = kindRank[a.queueState.kind];
+    const rb = kindRank[b.queueState.kind];
+    if (ra !== rb) return ra - rb;
+    if (a.queueState.kind === "queued" && b.queueState.kind === "queued") {
+      return a.queueState.position - b.queueState.position;
+    }
+    return a.build.buildId.localeCompare(b.build.buildId);
+  });
+
+  const counts = deriveFleetCounts(entries.map((e) => e.queueState));
+
+  if (buildRows.length === 0) {
+    return (
+      <div className="flex-1 overflow-auto p-2">
+        <div className="p-6 text-center">
+          <div className="text-3xl mb-3 opacity-20">&#128161;</div>
+          <p className="text-sm text-[var(--dpf-muted)] mb-2">No builds yet</p>
+          <p className="text-xs text-[var(--dpf-muted)] opacity-70">
+            Type a feature name above and press <strong className="text-[var(--dpf-text)]">New</strong> to start.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Compact fleet header — surfaces in-flight aggregate so the
+          operator can see queue pressure without opening every build.
+          Click target is currently inert; the DetailsDrawer queue
+          subsection lands in a follow-up slice. */}
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="build-studio-fleet-header"
+        className="flex shrink-0 items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-[11px] font-semibold text-[var(--dpf-text)]"
+      >
+        <span data-testid="fleet-header-label">
+          Builds: {counts.runningCount} running
+          {counts.blockedCount > 0 && (
+            <> · <span className="text-[var(--dpf-warning)]">{counts.blockedCount} blocked</span></>
+          )}
+          {counts.queuedCount > 0 && (
+            <> · {counts.queuedCount} queued</>
+          )}
+        </span>
+      </div>
+      <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1" data-testid="fleet-rail-body">
+        {sorted.map((entry, idx) => (
+          <li key={entry.build.buildId}>
+            <BuildListItem
+              build={entry.build}
+              active={activeBuildId === entry.build.buildId}
+              index={idx}
+              lifecycleLabel={entry.lifecycleLabel}
+              isDevEnvironment={isDevEnvironment}
+              density="fleet"
+              queueState={entry.queueState}
+              needsAttention={entry.needsAttention}
+              onSelect={() => onSelectBuild(entry.build)}
+              onDelete={() => onDeleteBuild(entry.build)}
+            />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/web/components/build/fleet-derivation.test.ts
+++ b/apps/web/components/build/fleet-derivation.test.ts
@@ -1,0 +1,219 @@
+// apps/web/components/build/fleet-derivation.test.ts
+//
+// Pin the conservative defaults for fleet-state derivation. Concurrency-
+// thread dispatcher will eventually supply real queue positions; until
+// then these tests lock in the phase-based fallback contract so the
+// fleet rail's UX doesn't silently drift.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveFleetCounts,
+  deriveNeedsAttention,
+  deriveQueueState,
+} from "./fleet-derivation";
+import {
+  normalizeHappyPathState,
+  type FeatureBuildRow,
+} from "@/lib/feature-build-types";
+
+function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    id: "row-1",
+    buildId: "FB-AAAAAAAA",
+    title: "Sample",
+    description: null,
+    portfolioId: null,
+    originatingBacklogItemId: null,
+    brief: null,
+    plan: null,
+    phase: "ideate",
+    sandboxId: null,
+    sandboxPort: null,
+    diffSummary: null,
+    diffPatch: null,
+    codingProvider: null,
+    threadId: null,
+    digitalProductId: null,
+    product: null,
+    createdById: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    draftApprovedAt: null,
+    designDoc: null,
+    designReview: null,
+    buildPlan: null,
+    planReview: null,
+    taskResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    scoutFindings: null,
+    uxTestResults: null,
+    uxVerificationStatus: null,
+    accountableEmployeeId: null,
+    claimedByAgentId: null,
+    claimedAt: null,
+    claimStatus: null,
+    buildExecState: null,
+    deliberationSummary: null,
+    happyPathState: normalizeHappyPathState(null),
+    originator: null,
+    phaseHandoffs: [],
+    ...overrides,
+  };
+}
+
+describe("deriveQueueState", () => {
+  it("returns idle for ideate / plan / ship / complete phases", () => {
+    expect(deriveQueueState(makeBuild({ phase: "ideate" }))).toEqual({ kind: "idle" });
+    expect(deriveQueueState(makeBuild({ phase: "plan" }))).toEqual({ kind: "idle" });
+    expect(deriveQueueState(makeBuild({ phase: "ship" }))).toEqual({ kind: "idle" });
+    expect(deriveQueueState(makeBuild({ phase: "complete" }))).toEqual({ kind: "idle" });
+  });
+
+  it("returns blocked for terminal failure", () => {
+    const state = deriveQueueState(makeBuild({ phase: "failed" }));
+    expect(state.kind).toBe("blocked");
+    expect(state.kind === "blocked" && state.reason).toMatch(/failed/i);
+  });
+
+  it("returns running with humanized step label when phase=build + step set", () => {
+    const state = deriveQueueState(
+      makeBuild({
+        phase: "build",
+        buildExecState: { step: "code_generated" } as unknown as FeatureBuildRow["buildExecState"],
+      }),
+    );
+    expect(state).toEqual({ kind: "running", stepLabel: "Generating code" });
+  });
+
+  it("returns blocked when phase=build but exec carries an error", () => {
+    const state = deriveQueueState(
+      makeBuild({
+        phase: "build",
+        buildExecState: { step: "code_generated", error: "sandbox died unexpectedly" } as unknown as FeatureBuildRow["buildExecState"],
+      }),
+    );
+    expect(state.kind).toBe("blocked");
+    expect(state.kind === "blocked" && state.reason).toBe("sandbox died unexpectedly");
+  });
+
+  it("returns running with null stepLabel when phase=build + no exec yet", () => {
+    const state = deriveQueueState(makeBuild({ phase: "build", buildExecState: null }));
+    expect(state).toEqual({ kind: "running", stepLabel: null });
+  });
+
+  it("returns running when phase=review (verification & review in flight)", () => {
+    const state = deriveQueueState(makeBuild({ phase: "review" }));
+    expect(state).toEqual({ kind: "running", stepLabel: "Verification & review" });
+  });
+
+  it("truncates very long error messages to keep tooltips bounded", () => {
+    const longErr = "x".repeat(500);
+    const state = deriveQueueState(
+      makeBuild({
+        phase: "build",
+        buildExecState: { error: longErr } as unknown as FeatureBuildRow["buildExecState"],
+      }),
+    );
+    expect(state.kind === "blocked" && state.reason.length).toBe(140);
+  });
+
+  it("falls back to raw step name for unknown step ids", () => {
+    const state = deriveQueueState(
+      makeBuild({
+        phase: "build",
+        buildExecState: { step: "unknown_phase_xyz" } as unknown as FeatureBuildRow["buildExecState"],
+      }),
+    );
+    expect(state).toEqual({ kind: "running", stepLabel: "unknown phase xyz" });
+  });
+});
+
+describe("deriveNeedsAttention", () => {
+  it("is true when phase=failed", () => {
+    expect(deriveNeedsAttention(makeBuild({ phase: "failed" }))).toBe(true);
+  });
+
+  it("is true when build phase carries an exec error", () => {
+    expect(
+      deriveNeedsAttention(
+        makeBuild({
+          phase: "build",
+          buildExecState: { error: "deps install failed" } as unknown as FeatureBuildRow["buildExecState"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true when designReview decision=fail", () => {
+    expect(
+      deriveNeedsAttention(
+        makeBuild({
+          phase: "plan",
+          designReview: { decision: "fail" } as unknown as FeatureBuildRow["designReview"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true when planReview decision=fail", () => {
+    expect(
+      deriveNeedsAttention(
+        makeBuild({
+          phase: "plan",
+          planReview: { decision: "fail" } as unknown as FeatureBuildRow["planReview"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true when phase=ship + acceptanceMet is null (operator decision pending)", () => {
+    expect(
+      deriveNeedsAttention(makeBuild({ phase: "ship", acceptanceMet: null })),
+    ).toBe(true);
+  });
+
+  it("is true when claim is abandoned", () => {
+    expect(
+      deriveNeedsAttention(makeBuild({ phase: "build", claimStatus: "abandoned" as FeatureBuildRow["claimStatus"] })),
+    ).toBe(true);
+  });
+
+  it("is false for a healthy in-flight build (phase=build, no error, no failed reviews)", () => {
+    expect(
+      deriveNeedsAttention(
+        makeBuild({
+          phase: "build",
+          buildExecState: { step: "code_generated" } as unknown as FeatureBuildRow["buildExecState"],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for an idle ideate build", () => {
+    expect(deriveNeedsAttention(makeBuild({ phase: "ideate" }))).toBe(false);
+  });
+});
+
+describe("deriveFleetCounts", () => {
+  it("counts running, queued, and blocked states; ignores idle", () => {
+    const counts = deriveFleetCounts([
+      { kind: "running", stepLabel: null },
+      { kind: "running", stepLabel: "x" },
+      { kind: "queued", position: 1, reason: "capacity", ahead: 0 },
+      { kind: "blocked", reason: "x" },
+      { kind: "idle" },
+      { kind: "idle" },
+    ]);
+    expect(counts).toEqual({ runningCount: 2, queuedCount: 1, blockedCount: 1 });
+  });
+
+  it("returns zeros for an empty list", () => {
+    expect(deriveFleetCounts([])).toEqual({
+      runningCount: 0,
+      queuedCount: 0,
+      blockedCount: 0,
+    });
+  });
+});

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -1,0 +1,128 @@
+// apps/web/components/build/fleet-derivation.ts
+//
+// Pure helpers that derive per-build fleet-rail state from a FeatureBuildRow.
+// The real queue runtime (concurrency cap, FIFO position, dependency blocks)
+// is owned by a separate thread — these helpers produce conservative
+// phase-based defaults until that thread surfaces real values. They're
+// split out so the BuildStudio shell wiring stays thin and so the
+// derivation rule is unit-testable in isolation.
+
+import type { FeatureBuildRow } from "@/lib/feature-build-types";
+import type { BuildQueueState } from "./QueueStateBadge";
+
+/**
+ * Derive a BuildQueueState from the FeatureBuildRow's phase + execution state.
+ *
+ * Until the concurrency-thread dispatcher lands, the fleet rail surfaces
+ * runtime state by inference:
+ *   - phase = "build" + executing → "running" with the current step label
+ *   - phase = "build" + failed/concerning state → "blocked"
+ *   - phase = "failed" → "blocked" (terminal failure)
+ *   - anything else (ideate / plan / review / ship / complete) → "idle"
+ *
+ * When the dispatcher exposes real queue positions, this helper switches to
+ * a passthrough from that source — the discriminated-union shape doesn't
+ * change, so callers won't need to update.
+ */
+export function deriveQueueState(build: FeatureBuildRow): BuildQueueState {
+  // Terminal failure — operator needs to look.
+  if (build.phase === "failed") {
+    return { kind: "blocked", reason: "Build failed; reset or retry from the action card." };
+  }
+
+  // Build phase: examine buildExecState for richer signal.
+  if (build.phase === "build") {
+    const exec = build.buildExecState as
+      | { step?: string; error?: string | null }
+      | null
+      | undefined;
+    if (exec?.error) {
+      return { kind: "blocked", reason: exec.error.slice(0, 140) };
+    }
+    if (exec?.step) {
+      // Step name doubles as the stepLabel for the running glyph tooltip.
+      return { kind: "running", stepLabel: humanizeStep(exec.step) };
+    }
+    // Phase says "build" but no exec yet — treat as running with unknown step.
+    return { kind: "running", stepLabel: null };
+  }
+
+  // Review phase with verification results pending → running.
+  if (build.phase === "review") {
+    return { kind: "running", stepLabel: "Verification & review" };
+  }
+
+  // All other phases (ideate, plan, ship, complete) are idle from a runtime
+  // queue perspective. The mini-rail conveys progress; the badge stays off.
+  return { kind: "idle" };
+}
+
+/**
+ * Map an internal step id to a human label for the running glyph tooltip.
+ * Falls back to the raw step name if no friendly form is known.
+ */
+function humanizeStep(step: string): string {
+  const friendly: Record<string, string> = {
+    sandbox_created: "Creating sandbox",
+    workspace_initialized: "Initializing workspace",
+    db_ready: "Preparing database",
+    deps_installed: "Installing dependencies",
+    code_generated: "Generating code",
+    tests_run: "Running tests",
+    complete: "Wrapping up",
+  };
+  return friendly[step] ?? step.replace(/_/g, " ");
+}
+
+/**
+ * Does this build need the operator's attention right now?
+ *
+ * Heuristic — kept conservative so the attention dot stays meaningful:
+ *   - phase=failed → yes (terminal)
+ *   - phase=build + buildExecState.error set → yes
+ *   - planReview / designReview with decision="fail" → yes (waiting on revision)
+ *   - phase=ship with no acceptanceMet → yes (operator decision needed)
+ *   - claim status indicates a stalled / abandoned claim → yes
+ *
+ * The dot is shape+color (red dot + ring) so color-blind users still see it.
+ */
+export function deriveNeedsAttention(build: FeatureBuildRow): boolean {
+  if (build.phase === "failed") return true;
+
+  if (build.phase === "build") {
+    const exec = build.buildExecState as { error?: string | null } | null | undefined;
+    if (exec?.error) return true;
+  }
+
+  const designReview = build.designReview as { decision?: string } | null | undefined;
+  if (designReview?.decision === "fail") return true;
+
+  const planReview = build.planReview as { decision?: string } | null | undefined;
+  if (planReview?.decision === "fail") return true;
+
+  if (build.phase === "ship" && build.acceptanceMet === null) return true;
+
+  if (build.claimStatus === "abandoned") return true;
+
+  return false;
+}
+
+/**
+ * Counters for the FleetRail header label. Pure — operates over the
+ * derived queueStates so the count matches what the rail renders.
+ */
+export function deriveFleetCounts(states: readonly BuildQueueState[]): {
+  runningCount: number;
+  queuedCount: number;
+  blockedCount: number;
+} {
+  let running = 0;
+  let queued = 0;
+  let blocked = 0;
+  for (const s of states) {
+    if (s.kind === "running") running++;
+    else if (s.kind === "queued") queued++;
+    else if (s.kind === "blocked") blocked++;
+  }
+  return { runningCount: running, queuedCount: queued, blockedCount: blocked };
+}


### PR DESCRIPTION
## Summary

Next slice of the Build Studio layout redesign. The left sidebar's legacy comfortable-density build cards become **fleet-density rows** with **derived queue state**, sorted so the operator's eye lands on work that needs attention.

Spec: \`docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md\` §1 + queue-surface amendment (PR #898 / #903).

## What you'll see

- Build list rows are now compact ≤32px with the phase mini-rail, queue-state badge, and red attention dot when something needs you.
- A new header above the list reads "Builds: N running · M blocked · K queued" (omits zero counts). \`role="status" + aria-live="polite"\` so assistive tech announces queue-pressure changes.
- Sort order: running → blocked → queued (by position) → idle. Same-rank ties break by buildId so render is stable across re-renders.
- Empty-state placeholder unchanged.

## What's deliberately NOT in this PR

- **Sidebar width tightening** to 150–180px. The new-feature input + Work Control button still live in the wider 280–320px container; they need a different home (modal, header bar, or the bottom of the rail) before the width tightens. Next slice.
- **FleetRail component proper.** I composed inline here because nesting \`<aside>\` inside the legacy sidebar wrapper conflicted on width + border. \`FleetRail.tsx\` (PR #903) stays ready for the future shell-zone refactor where the legacy wrapper is dropped entirely.
- **Queue header click target.** Currently inert. Wires to the DetailsDrawer BS-Queue subsection in the next slice.

## New helpers — \`apps/web/components/build/fleet-derivation.ts\`

Pure functions; testable in isolation; conservative fallbacks until the concurrency-thread dispatcher publishes real values:

- \`deriveQueueState(build)\` — discriminated-union queue state from FB phase + buildExecState. Maps \`failed → blocked\`, \`build + exec.error → blocked\`, \`build + exec.step → running\` (humanized step label), \`review → running\`, all others \`idle\`.
- \`deriveNeedsAttention(build)\` — heuristic for the attention dot.
- \`deriveFleetCounts(states)\` — \`{ running, queued, blocked }\` for the header.

When the dispatcher lands, \`deriveQueueState\` becomes a passthrough — the union shape doesn't change.

## Test plan

- [ ] CI Typecheck pass
- [ ] CI Production Build pass
- [ ] CI Unit Tests: 18 new fleet-derivation cases + existing BuildStudio + BuildStudioHeaderLayout + ActionCard cases all green (36 locally)
- [ ] Manual on \`/build\`: build list rows are now ≤32px; phase mini-rails render; failed builds show the attention dot; running build with active exec step shows the play glyph and tooltip names the step
- [ ] Manual: header reads correctly when 1+ builds are blocked / queued / idle
- [ ] No regression in build select/delete/refresh flow (existing handlers unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)