### PR TITLE
feat(security): CodeQL inflow gate — block new critical/high in PRs

### DIFF
--- a/.github/workflows/security-inflow-gate.yml
+++ b/.github/workflows/security-inflow-gate.yml
@@ -1,0 +1,80 @@
+name: Security Inflow Gate
+
+# Why this exists
+# ---------------
+# Blocks merging a PR that introduces NEW critical or high CodeQL findings.
+# Pre-existing baseline findings (tracked at docs/security/codeql-baseline.json)
+# are catalogued as backlog items (see BI-04701325 and child cluster BIs) and
+# burned down separately — they don't block unrelated PRs.
+#
+# Trigger: workflow_run after the default-setup "CodeQL" workflow completes.
+# Reason: we need CodeQL to have analyzed the PR's head SHA before we can
+# diff its alerts. Running directly on `pull_request` would race against
+# CodeQL and see stale alerts (effectively giving every PR a pass).
+#
+# Trust-boundary note (per BI-5940955C)
+# -------------------------------------
+# This workflow runs in the base-repo context with access to GITHUB_TOKEN.
+# It MUST NOT check out the PR's head SHA and execute code from it. The
+# checkout step below pins to the default branch — the script lives in the
+# trusted base repo and only the PR's alert numbers are used as data.
+#
+# When fixing baseline findings
+# -----------------------------
+# After a PR fixes one or more baseline findings (and the corresponding
+# CodeQL alerts close), regenerate the baseline so it reflects reality:
+#
+#   GH_TOKEN=$(gh auth token) GH_REPOSITORY=OpenDigitalProductFactory/opendigitalproductfactory \
+#     node scripts/security/regenerate-baseline.mjs
+#
+# Commit the updated baseline alongside the fix.
+
+on:
+  workflow_run:
+    workflows: ["CodeQL"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  security-events: read
+  contents: read
+  actions: read
+
+concurrency:
+  group: security-inflow-${{ github.event.workflow_run.head_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Security Inflow Gate
+    # Only run for PR-triggered CodeQL completions that succeeded, or manual
+    # dispatch (for testing / on-demand checks). Pushes to main don't need
+    # gating — they ARE the new baseline once merged.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout default branch (trusted base — do not check out PR head)
+        uses: actions/checkout@v6
+        # Intentionally NO `ref:` parameter. Defaults to the workflow file's
+        # ref (default branch on workflow_run), which is what we want — the
+        # baseline file and gate script must come from the trusted base, not
+        # the PR being evaluated.
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Compare alerts against committed baseline
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass head SHA via env (BI-5940955C lesson — never interpolate
+          # github.event.* into shell). Used only for logging, not exec.
+          PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+        run: node scripts/security/check-inflow-gate.mjs

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,98 @@
+# Security findings — workflow and baseline
+
+This directory holds the operational substrate for the security inflow gate
+introduced by **BI-04701325** (Security & quality findings → Build Studio
+intake with full phase rigor).
+
+## The two-loop model
+
+We run two complementary loops over GitHub code-scanning findings:
+
+1. **Inflow gate** (this directory). Per-PR, machine-enforced. Blocks new
+   critical/high findings from landing on `main`. Implemented by
+   `.github/workflows/security-inflow-gate.yml` and the helper scripts in
+   `scripts/security/`.
+
+2. **Backlog sweep** (separate work, BI-04701325). Nightly portal job that
+   triages existing findings into cluster BIs, runs them through Build
+   Studio with regression-test-first rigor, and contributes the fix
+   patterns (plus CodeQL rules) back to the hive.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `codeql-baseline.json` | Snapshot of CodeQL alerts that pre-existed when the gate landed. PRs are allowed to leave these alone; they're burned down through the BS pipeline. |
+| `../../scripts/security/check-inflow-gate.mjs` | The gate script. Fetches current open alerts, diffs against baseline, fails if a new critical/high appears. |
+| `../../scripts/security/regenerate-baseline.mjs` | Re-snapshot the baseline. Run after fixing or dismissing alerts. |
+| `../../.github/workflows/security-inflow-gate.yml` | Wires the gate to run after every CodeQL completion. |
+
+## What the baseline contains
+
+At inception, the baseline carries every open CodeQL alert. Each entry is
+keyed by GitHub's stable per-finding `number`. The diff is alert-number
+based (not count-based) so a PR that closes one finding and opens a
+different one is still caught.
+
+The 8 criticals in the baseline are tracked by these cluster BIs and will
+be removed as fixes ship:
+
+- **BI-5E53A265** — SSRF cluster (alerts #33-38, `js/request-forgery`)
+- **BI-7DB95878** — Command injection (alert #55, `js/command-line-injection`)
+- **BI-5940955C** — GitHub Actions code injection (alert #1, `actions/code-injection/critical`)
+
+The 43 high and 20 medium findings will be clustered as the nightly sweep
+(BI-04701325) automates that triage.
+
+## When you need to regenerate the baseline
+
+After **any** of the following lands on `main`:
+
+1. A PR fixes one or more findings (so they close in CodeQL).
+2. A maintainer dismisses a false positive in the GitHub UI with a written
+   justification.
+3. CodeQL re-numbers alerts (rare, but happens on configuration changes).
+
+Run:
+
+```bash
+GH_REPOSITORY=OpenDigitalProductFactory/opendigitalproductfactory \
+  GH_TOKEN=$(gh auth token) \
+  node scripts/security/regenerate-baseline.mjs
+```
+
+Commit the updated `codeql-baseline.json` in the same PR as the fix.
+
+## What this gate is NOT
+
+- **Not a substitute for review.** It catches CodeQL-detectable regressions
+  in a known severity floor. It does not see logic bugs, design flaws,
+  privilege escalation in business logic, etc. Human + bot review still
+  matter.
+- **Not a substitute for fixing the backlog.** The whole point is to stop
+  the bleeding while the backlog is burned down through Build Studio. If
+  the baseline grows over time, the gate has failed its job.
+- **Not authorized to dismiss alerts.** It only reads. Dismissals are
+  explicit human decisions with audit trails — see the kernel principle
+  proposed for "Every security finding gets a regression test before a fix"
+  and the dismissal-justification requirement in BI-04701325.
+
+## Why workflow_run trigger (not pull_request)
+
+The gate must run AFTER CodeQL has analyzed the PR's merge commit. If we
+triggered directly on `pull_request`, we'd race CodeQL and see stale alerts
+(making every PR pass trivially). `workflow_run` fires once CodeQL
+completes, ensuring we diff against fresh data.
+
+## Trust-boundary note
+
+The gate workflow runs in the base-repo context with access to
+`GITHUB_TOKEN`. It MUST NOT check out the PR's head SHA and execute code
+from it — that would let a malicious fork PR tamper with the gate's own
+logic. The workflow explicitly omits a `ref:` parameter so checkout pins
+to the default branch (which contains the trusted gate script).
+
+This pattern was reinforced by **BI-5940955C** (GitHub Actions code
+injection finding in `dco-signoff-dependabot.yml`). Workflows touching
+`pull_request_target` or `workflow_run` triggers are trust-boundary code
+and are subject to the two-maintainer carve-out described in **BI-860603DA**.

--- a/docs/security/codeql-baseline.json
+++ b/docs/security/codeql-baseline.json
@@ -1,0 +1,576 @@
+{
+  "$schema": "./codeql-baseline.schema.json",
+  "description": "CodeQL findings accepted as pre-existing at the time of snapshot. The security-inflow-gate workflow blocks PRs that introduce alert NUMBERS not in this list. Burn-down is tracked via the cluster BIs referenced in docs/security/README.md.",
+  "generatedAt": "2026-05-21T23:03:07.358Z",
+  "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
+  "alerts": [
+    {
+      "number": 1,
+      "ruleId": "actions/code-injection/critical",
+      "severity": "critical",
+      "path": ".github/workflows/dco-signoff-dependabot.yml",
+      "startLine": 68,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 2,
+      "ruleId": "actions/untrusted-checkout/high",
+      "severity": "high",
+      "path": ".github/workflows/dco-signoff-dependabot.yml",
+      "startLine": 33,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 3,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/audit-routing-invariants.yml",
+      "startLine": 36,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 4,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/audit-coworker-personas.yml",
+      "startLine": 46,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 5,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/audit-prompt-state-leakage.yml",
+      "startLine": 35,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 6,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/audit-coworker-tool-grants.yml",
+      "startLine": 39,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 7,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 15,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 8,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 54,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 9,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 84,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 10,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/release-gates.yml",
+      "startLine": 59,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 11,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 130,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 12,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/release-gates.yml",
+      "startLine": 101,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 13,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/release-gates.yml",
+      "startLine": 137,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 14,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 153,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 15,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/schema-regression-guard.yml",
+      "startLine": 18,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 16,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 185,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 17,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/release-gates.yml",
+      "startLine": 183,
+      "createdAt": "2026-05-19T04:47:43Z"
+    },
+    {
+      "number": 18,
+      "ruleId": "py/stack-trace-exposure",
+      "severity": "medium",
+      "path": "services/browser-use/server.py",
+      "startLine": 645,
+      "createdAt": "2026-05-19T04:47:54Z"
+    },
+    {
+      "number": 21,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "apps/web/lib/authority/bootstrap-bindings.ts",
+      "startLine": 59,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 22,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "apps/web/lib/tak/agent-form-assist.ts",
+      "startLine": 93,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 23,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "apps/web/lib/mcp-tools.ts",
+      "startLine": 12386,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 24,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "apps/web/lib/tak/prompt-loader.ts",
+      "startLine": 150,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 25,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "packages/db/src/discovery-collectors/unifi.ts",
+      "startLine": 166,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 26,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "packages/db/src/discovery-inference.ts",
+      "startLine": 273,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 27,
+      "ruleId": "js/polynomial-redos",
+      "severity": "high",
+      "path": "packages/db/src/software-normalization.ts",
+      "startLine": 70,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 28,
+      "ruleId": "js/redos",
+      "severity": "high",
+      "path": "apps/web/lib/voice/vocabulary-bias.ts",
+      "startLine": 112,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 29,
+      "ruleId": "js/redos",
+      "severity": "high",
+      "path": "packages/db/src/discovery-fingerprint-redaction.ts",
+      "startLine": 7,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 30,
+      "ruleId": "js/reflected-xss",
+      "severity": "high",
+      "path": "apps/web/app/api/sandbox/preview/route.ts",
+      "startLine": 109,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 31,
+      "ruleId": "js/reflected-xss",
+      "severity": "high",
+      "path": "apps/web/app/api/sandbox/preview/route.ts",
+      "startLine": 137,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 32,
+      "ruleId": "js/weak-cryptographic-algorithm",
+      "severity": "high",
+      "path": "apps/web/lib/actions/calendar-sync.ts",
+      "startLine": 90,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 33,
+      "ruleId": "js/request-forgery",
+      "severity": "critical",
+      "path": "apps/web/lib/actions/calendar-sync.ts",
+      "startLine": 48,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 34,
+      "ruleId": "js/request-forgery",
+      "severity": "critical",
+      "path": "apps/web/lib/actions/platform-dev-config.ts",
+      "startLine": 461,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 35,
+      "ruleId": "js/request-forgery",
+      "severity": "critical",
+      "path": "apps/web/lib/integrate/github-fork.ts",
+      "startLine": 39,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 36,
+      "ruleId": "js/request-forgery",
+      "severity": "critical",
+      "path": "apps/web/lib/public-web-tools.ts",
+      "startLine": 357,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 37,
+      "ruleId": "js/request-forgery",
+      "severity": "critical",
+      "path": "apps/web/lib/public-web-tools.ts",
+      "startLine": 366,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 38,
+      "ruleId": "js/request-forgery",
+      "severity": "critical",
+      "path": "apps/web/lib/tak/mcp-server-health.ts",
+      "startLine": 31,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 39,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/actions/agent-task-scheduler.ts",
+      "startLine": 404,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 42,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/actions/build.ts",
+      "startLine": 1033,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 43,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/govern/activate-provider.ts",
+      "startLine": 132,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 44,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/govern/activate-provider.ts",
+      "startLine": 140,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 45,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/govern/activate-provider.ts",
+      "startLine": 163,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 46,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/govern/activate-provider.ts",
+      "startLine": 185,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 47,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/inference/ai-provider-internals.ts",
+      "startLine": 55,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 48,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/inference/ai-provider-internals.ts",
+      "startLine": 1018,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 49,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/mcp-governed-execute.ts",
+      "startLine": 225,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 50,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/mcp-governed-execute.ts",
+      "startLine": 292,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 51,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/mcp-governed-execute.ts",
+      "startLine": 332,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 52,
+      "ruleId": "js/tainted-format-string",
+      "severity": "high",
+      "path": "apps/web/lib/mcp-tools.ts",
+      "startLine": 12648,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 53,
+      "ruleId": "js/shell-command-injection-from-environment",
+      "severity": "medium",
+      "path": "packages/db/scripts/check-all-providers.js",
+      "startLine": 12,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 55,
+      "ruleId": "js/command-line-injection",
+      "severity": "critical",
+      "path": "apps/web/lib/tak/mcp-server-health.ts",
+      "startLine": 66,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 56,
+      "ruleId": "js/bad-tag-filter",
+      "severity": "high",
+      "path": "apps/web/lib/public-web-tools.ts",
+      "startLine": 59,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 57,
+      "ruleId": "js/bad-tag-filter",
+      "severity": "high",
+      "path": "apps/web/lib/public-web-tools.ts",
+      "startLine": 293,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 58,
+      "ruleId": "js/bad-tag-filter",
+      "severity": "high",
+      "path": "apps/web/lib/public-web-tools.ts",
+      "startLine": 330,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 59,
+      "ruleId": "js/incomplete-multi-character-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/shared/file-parsers.ts",
+      "startLine": 78,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 60,
+      "ruleId": "js/incomplete-sanitization",
+      "severity": "high",
+      "path": "packages/db/src/sanitized-clone.ts",
+      "startLine": 245,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 61,
+      "ruleId": "js/disabling-certificate-validation",
+      "severity": "high",
+      "path": "packages/db/src/discovery-collectors/unifi.ts",
+      "startLine": 122,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 62,
+      "ruleId": "js/path-injection",
+      "severity": "high",
+      "path": "apps/web/lib/wiki/ingest.ts",
+      "startLine": 129,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 63,
+      "ruleId": "js/insufficient-password-hash",
+      "severity": "high",
+      "path": "apps/web/lib/mcp-governed-execute.ts",
+      "startLine": 247,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 64,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/govern/provider-oauth.ts",
+      "startLine": 130,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 65,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/govern/provider-oauth.ts",
+      "startLine": 130,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 66,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/govern/provider-oauth.ts",
+      "startLine": 244,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 67,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/govern/provider-oauth.ts",
+      "startLine": 244,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 68,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/integrate/contribution-review.ts",
+      "startLine": 198,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 69,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/integrate/contribution-review.ts",
+      "startLine": 198,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 70,
+      "ruleId": "js/incomplete-url-substring-sanitization",
+      "severity": "high",
+      "path": "apps/web/lib/tak/mcp-catalog-sync.test.ts",
+      "startLine": 53,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 71,
+      "ruleId": "js/overly-large-range",
+      "severity": "medium",
+      "path": "apps/web/lib/brand/extraction/codebase-adapter.ts",
+      "startLine": 19,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 72,
+      "ruleId": "js/insecure-randomness",
+      "severity": "high",
+      "path": "apps/web/components/employee/EmployeeFormPanel.tsx",
+      "startLine": 40,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 73,
+      "ruleId": "js/regex-injection",
+      "severity": "high",
+      "path": "apps/web/lib/integrate/codebase-tools.ts",
+      "startLine": 192,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 74,
+      "ruleId": "js/regex-injection",
+      "severity": "high",
+      "path": "apps/web/lib/integrate/schema-validator.ts",
+      "startLine": 302,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 75,
+      "ruleId": "js/identity-replacement",
+      "severity": "medium",
+      "path": "scripts/detect-hardware-host.ts",
+      "startLine": 72,
+      "createdAt": "2026-05-19T04:52:08Z"
+    },
+    {
+      "number": 77,
+      "ruleId": "actions/missing-workflow-permissions",
+      "severity": "medium",
+      "path": ".github/workflows/ci.yml",
+      "startLine": 38,
+      "createdAt": "2026-05-20T05:09:48Z"
+    }
+  ]
+}

--- a/scripts/security/check-inflow-gate.mjs
+++ b/scripts/security/check-inflow-gate.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * BI-04701325 Phase 1 — Security inflow gate.
+ *
+ * Compares current open CodeQL alerts against the committed baseline at
+ * docs/security/codeql-baseline.json. Fails CI if any NEW critical or high
+ * alert appears (by alert number — CodeQL assigns a stable number per
+ * finding instance, so "in current AND not in baseline" = "introduced by
+ * this PR").
+ *
+ * Pre-existing baseline alerts are tracked as cluster BIs (see BI-5E53A265,
+ * BI-7DB95878, BI-5940955C for the criticals) and burned down separately.
+ * They do NOT block unrelated PRs.
+ *
+ * Why alert-number diffing (not severity-count diffing):
+ *   A simple count comparison would let a PR that closes one critical and
+ *   opens a different one through (net change = 0). Number-diffing catches
+ *   that.
+ *
+ * Run locally:
+ *   GH_REPOSITORY=OpenDigitalProductFactory/opendigitalproductfactory \
+ *     GH_TOKEN=$(gh auth token) \
+ *     node scripts/security/check-inflow-gate.mjs
+ *
+ * Environment:
+ *   GH_REPOSITORY    Required. owner/repo.
+ *   GH_TOKEN         Required. Token with security-events:read.
+ *   BASELINE_PATH    Optional. Default: docs/security/codeql-baseline.json.
+ *   FAIL_SEVERITIES  Optional. Comma-separated severity floor.
+ *                    Default: "critical,high".
+ *   PR_HEAD_SHA      Optional. Used only for diagnostic output.
+ *   PR_DISPLAY_TITLE Optional. Used only for diagnostic output.
+ *
+ * Exit codes:
+ *   0  No new findings vs baseline.
+ *   1  New findings introduced (PR should be blocked).
+ *   2  Configuration error (missing env, can't reach API, etc).
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const FAIL_SEVERITIES = (process.env.FAIL_SEVERITIES ?? "critical,high")
+  .split(",")
+  .map((s) => s.trim().toLowerCase());
+const BASELINE_PATH = process.env.BASELINE_PATH ?? "docs/security/codeql-baseline.json";
+const repo = process.env.GH_REPOSITORY;
+const token = process.env.GH_TOKEN;
+
+if (!repo) {
+  console.error("ERROR: GH_REPOSITORY env var is required (e.g. owner/repo).");
+  process.exit(2);
+}
+if (!token) {
+  console.error("ERROR: GH_TOKEN env var is required (security-events:read scope).");
+  process.exit(2);
+}
+
+async function fetchOpenAlerts() {
+  const out = [];
+  let page = 1;
+  // GitHub caps page_size at 100. Loop until a short page or empty.
+  while (true) {
+    const url = `https://api.github.com/repos/${repo}/code-scanning/alerts?state=open&per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`GH API ${res.status} on page ${page}: ${body.slice(0, 400)}`);
+    }
+    const items = await res.json();
+    if (!Array.isArray(items)) {
+      throw new Error(`Unexpected response shape on page ${page}: ${JSON.stringify(items).slice(0, 200)}`);
+    }
+    out.push(...items);
+    if (items.length < 100) break;
+    page++;
+    if (page > 50) throw new Error("Pagination runaway (>5000 alerts)");
+  }
+  return out;
+}
+
+let baseline;
+try {
+  const raw = await readFile(resolve(BASELINE_PATH), "utf8");
+  baseline = JSON.parse(raw);
+} catch (err) {
+  console.error(`ERROR: Could not read baseline at ${BASELINE_PATH}: ${err.message}`);
+  console.error("Generate one with: node scripts/security/regenerate-baseline.mjs");
+  process.exit(2);
+}
+
+if (!Array.isArray(baseline.alerts)) {
+  console.error(`ERROR: Baseline file missing required field 'alerts' (array). Got: ${typeof baseline.alerts}`);
+  process.exit(2);
+}
+
+const baselineNumbers = new Set(baseline.alerts.map((a) => a.number));
+
+let current;
+try {
+  current = await fetchOpenAlerts();
+} catch (err) {
+  console.error(`ERROR: Could not fetch alerts: ${err.message}`);
+  process.exit(2);
+}
+
+const introduced = current.filter((alert) => {
+  if (baselineNumbers.has(alert.number)) return false;
+  const sev = (alert.rule?.security_severity_level ?? "").toLowerCase();
+  return FAIL_SEVERITIES.includes(sev);
+});
+
+// Surface what's CLOSED too — informational. Helps maintainers know the
+// baseline needs regenerating when a PR fixes findings.
+const currentNumbers = new Set(current.map((a) => a.number));
+const closedSinceBaseline = baseline.alerts.filter((a) => !currentNumbers.has(a.number));
+
+console.log(`Baseline: ${baseline.alerts.length} accepted findings (snapshot: ${baseline.generatedAt ?? "unknown"})`);
+console.log(`Current:  ${current.length} open findings`);
+if (process.env.PR_HEAD_SHA) {
+  console.log(`PR head:  ${process.env.PR_HEAD_SHA}${process.env.PR_DISPLAY_TITLE ? ` — ${process.env.PR_DISPLAY_TITLE}` : ""}`);
+}
+console.log("");
+
+if (closedSinceBaseline.length > 0) {
+  console.log(`ℹ ${closedSinceBaseline.length} baseline finding(s) closed since baseline snapshot:`);
+  for (const a of closedSinceBaseline) {
+    console.log(`   #${a.number} ${(a.severity ?? "").toUpperCase()} ${a.ruleId} — ${a.path}:${a.startLine}`);
+  }
+  console.log("   Consider regenerating the baseline: node scripts/security/regenerate-baseline.mjs");
+  console.log("");
+}
+
+if (introduced.length === 0) {
+  console.log(`✓ Inflow gate PASSED — no new ${FAIL_SEVERITIES.join("/")} CodeQL findings introduced.`);
+  process.exit(0);
+}
+
+console.error(`✗ Inflow gate FAILED — ${introduced.length} new ${FAIL_SEVERITIES.join("/")} CodeQL finding(s) introduced by this PR:`);
+console.error("");
+for (const a of introduced) {
+  const sev = (a.rule?.security_severity_level ?? "?").toUpperCase();
+  const loc = `${a.most_recent_instance?.location?.path ?? "?"}:${a.most_recent_instance?.location?.start_line ?? "?"}`;
+  console.error(`  #${a.number} ${sev} ${a.rule?.id ?? "?"}`);
+  console.error(`     ${loc}`);
+  console.error(`     ${a.html_url}`);
+  if (a.most_recent_instance?.message?.text) {
+    console.error(`     ${a.most_recent_instance.message.text.split("\n")[0]}`);
+  }
+  console.error("");
+}
+
+console.error("How to resolve");
+console.error("--------------");
+console.error("  1. Fix the finding (preferred). See BI-04701325 and AGENTS.md for the");
+console.error("     security intake process — every fix carries a regression test first.");
+console.error("");
+console.error("  2. If a false positive: dismiss it in the GitHub UI WITH a written");
+console.error("     justification citing a kernel principle or BI. CodeQL suppressions");
+console.error("     should also be encoded in .github/codeql/config.yml so they persist.");
+console.error("");
+console.error("  3. After resolving (fix OR dismiss), regenerate the baseline:");
+console.error("       GH_REPOSITORY=… GH_TOKEN=… node scripts/security/regenerate-baseline.mjs");
+console.error("     Commit the updated baseline alongside the fix.");
+
+process.exit(1);

--- a/scripts/security/regenerate-baseline.mjs
+++ b/scripts/security/regenerate-baseline.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * BI-04701325 Phase 1 — Regenerate the CodeQL baseline snapshot.
+ *
+ * Captures the current open CodeQL alerts into docs/security/codeql-baseline.json
+ * so future PRs only need to clear NEW findings, not historical ones.
+ *
+ * Run this:
+ *   - After fixing one or more baseline findings (so the baseline shrinks).
+ *   - After dismissing a false positive in the GitHub UI (with justification).
+ *   - Never to "silence" an unfixed new finding — that defeats the gate.
+ *
+ * Usage:
+ *   GH_REPOSITORY=OpenDigitalProductFactory/opendigitalproductfactory \
+ *     GH_TOKEN=$(gh auth token) \
+ *     node scripts/security/regenerate-baseline.mjs
+ *
+ * Optional env:
+ *   BASELINE_PATH  Default: docs/security/codeql-baseline.json
+ */
+
+import { writeFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { mkdir } from "node:fs/promises";
+
+const BASELINE_PATH = process.env.BASELINE_PATH ?? "docs/security/codeql-baseline.json";
+const repo = process.env.GH_REPOSITORY;
+const token = process.env.GH_TOKEN;
+
+if (!repo || !token) {
+  console.error("ERROR: GH_REPOSITORY and GH_TOKEN env vars are required.");
+  process.exit(2);
+}
+
+async function fetchOpenAlerts() {
+  const out = [];
+  let page = 1;
+  while (true) {
+    const url = `https://api.github.com/repos/${repo}/code-scanning/alerts?state=open&per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`GH API ${res.status}: ${(await res.text()).slice(0, 400)}`);
+    }
+    const items = await res.json();
+    out.push(...items);
+    if (items.length < 100) break;
+    page++;
+    if (page > 50) throw new Error("Pagination runaway");
+  }
+  return out;
+}
+
+const current = await fetchOpenAlerts();
+
+const baseline = {
+  $schema: "./codeql-baseline.schema.json",
+  description:
+    "CodeQL findings accepted as pre-existing at the time of snapshot. The security-inflow-gate workflow blocks PRs that introduce alert NUMBERS not in this list. Burn-down is tracked via the cluster BIs referenced in docs/security/README.md.",
+  generatedAt: new Date().toISOString(),
+  repository: repo,
+  alerts: current
+    .map((a) => ({
+      number: a.number,
+      ruleId: a.rule?.id ?? null,
+      severity: a.rule?.security_severity_level ?? null,
+      path: a.most_recent_instance?.location?.path ?? null,
+      startLine: a.most_recent_instance?.location?.start_line ?? null,
+      createdAt: a.created_at,
+    }))
+    .sort((a, b) => a.number - b.number),
+};
+
+const fullPath = resolve(BASELINE_PATH);
+await mkdir(dirname(fullPath), { recursive: true });
+await writeFile(fullPath, JSON.stringify(baseline, null, 2) + "\n", "utf8");
+
+// Summary
+const bySeverity = {};
+for (const a of baseline.alerts) {
+  const s = a.severity ?? "unknown";
+  bySeverity[s] = (bySeverity[s] ?? 0) + 1;
+}
+
+console.log(`✓ Wrote ${baseline.alerts.length} alerts to ${BASELINE_PATH}`);
+console.log("  By severity:");
+for (const [sev, n] of Object.entries(bySeverity).sort()) {
+  console.log(`    ${sev.padEnd(8)} ${n}`);
+}


### PR DESCRIPTION
## Summary

Wires a `workflow_run`-triggered gate that fires after CodeQL completes on every pull request. Diffs current open alerts against a committed baseline (`docs/security/codeql-baseline.json`) and **fails CI if any new critical or high alert is introduced by the PR**.

Pre-existing baseline findings (8 critical + 43 high + 20 medium at snapshot, captured 2026-05-21) are tracked through Build Studio via the cluster BIs filed under BI-04701325. The gate stops the bleeding while burn-down happens through the BS pipeline.

## Why this matters

These are late findings — every critical sitting in the queue would have been a real customer breach if shipped to a production install. We have 8 critical, 43 high open right now. Without an inflow gate, more can land at any time. This PR adds the floor.

## What's in this PR

| File | Purpose |
|---|---|
| `.github/workflows/security-inflow-gate.yml` | `workflow_run` trigger after CodeQL, runs the gate script |
| `scripts/security/check-inflow-gate.mjs` | Fetches open alerts, diffs vs baseline by alert number, fails on new critical/high |
| `scripts/security/regenerate-baseline.mjs` | Maintainer command to re-snapshot after fixes land |
| `docs/security/codeql-baseline.json` | The 71 accepted findings at snapshot time |
| `docs/security/README.md` | Operator docs — what the gate is, isn't, how to use |

## Trust-boundary discipline

Per the lesson from BI-5940955C (CodeQL alert #1 — `actions/code-injection/critical` in `dco-signoff-dependabot.yml`):

- Workflow runs in base-repo context, **does not check out the PR head SHA**. Checkout pins to the default branch so the gate script can't be tampered with by a fork PR.
- `github.event.*` values passed via **env vars**, never interpolated inline into `run:` blocks.

This same discipline will be enforced by the new `audit-actions-injection.yml` auditor proposed in BI-5940955C.

## Why alert-number diffing (not count diffing)

A simple severity-count comparison would let a PR through that closes one critical and opens a different one (net change = 0). Number-diffing catches that.

## Smoke test (local)

```
# PASS — current matches baseline
$ node scripts/security/check-inflow-gate.mjs
Baseline: 71 accepted findings (snapshot: 2026-05-21T23:03:07.358Z)
Current:  71 open findings
✓ Inflow gate PASSED — no new critical/high CodeQL findings introduced.

# FAIL — tampered baseline (alert #55 removed)
$ BASELINE_PATH=fake-baseline.json node scripts/security/check-inflow-gate.mjs
Baseline: 70 accepted findings (snapshot: 2026-05-21T23:03:07.358Z)
Current:  71 open findings

✗ Inflow gate FAILED — 1 new critical/high CodeQL finding(s) introduced by this PR:

  #55 CRITICAL js/command-line-injection
     apps/web/lib/tak/mcp-server-health.ts:66
     https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/security/code-scanning/55
     ...
```

Both exit codes verified.

## Maintainer workflow after this lands

1. PR introduces new critical/high → gate fails → fix or dismiss with justification → re-run.
2. PR fixes baseline findings → gate passes (closed alerts don't fail), but baseline now stale → regenerate:
   ```
   GH_REPOSITORY=… GH_TOKEN=$(gh auth token) node scripts/security/regenerate-baseline.mjs
   ```
   Commit the updated baseline alongside the fix.

## Related backlog

- **BI-04701325** — Security & quality findings → Build Studio intake (this PR's parent)
- **BI-860603DA** — External contribution governance (sibling, broader scope)
- **BI-5E53A265** — SSRF cluster (6 alerts)
- **BI-7DB95878** — Command injection (1 alert)
- **BI-5940955C** — Actions code injection (1 alert, this PR exemplifies its lesson)

## Test plan

- [ ] CI green on this PR (typecheck + existing audits, plus the new gate runs on itself after CodeQL completes — should PASS since this PR introduces no new findings).
- [ ] After merge, future PRs see the gate as a required check.
- [ ] Confirm a deliberate fail by opening a follow-up PR with a synthetic `js/insecure-randomness` violation; gate blocks it.
- [ ] Confirm pass-through when a baseline alert is fixed: open a PR fixing BI-7DB95878's #55; baseline regeneration in the same PR keeps the gate green.

## Not in this PR (tracked separately)

- Burn-down of the existing 71 findings → BS via the 3 cluster BIs.
- Nightly portal sweep that auto-files BIs for new findings → next slice of BI-04701325.
- Conversion of CodeQL from default-setup to advanced setup → optional optimization, not blocking.
- External-PR governance + bot reviewer → BI-860603DA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)