### PR TITLE
feat(build-studio): footer OpenSandboxButton + drop per-build Preview tab

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -7,7 +7,8 @@ import { useRouter } from "next/navigation";
 import { GitBranch } from "lucide-react";
 import { FeatureBriefPanel } from "./FeatureBriefPanel";
 import { ReviewPanel } from "./ReviewPanel";
-import { PreviewUrlCard } from "./PreviewUrlCard";
+import { OpenSandboxButton } from "./OpenSandboxButton";
+import { computeDrivingBuild, isValidSandboxPort, type SandboxDriverCandidate } from "@/lib/build/sandbox-driver";
 import { ClaimBadge } from "./ClaimBadge";
 import { ProcessGraph } from "./ProcessGraph";
 import { BuildProgressOperationalPanel } from "./BuildProgressOperationalPanel";
@@ -70,7 +71,11 @@ export function BuildStudio({
   );
   const [creating, setCreating] = useState(false);
   const [newTitle, setNewTitle] = useState("");
-  const [buildView, setBuildView] = useState<"progress" | "topology" | "preview" | "docs">("progress");
+  // "preview" removed per spec — sandbox is shared across builds, so the
+  // per-build Preview tab is dishonest. A single Open Sandbox button now
+  // lives in the footer and links to whichever build is currently driving
+  // the sandbox runtime.
+  const [buildView, setBuildView] = useState<"progress" | "topology" | "docs">("progress");
   const [sidebarOpen, setSidebarOpen] = useState(() =>
     shouldOpenBuildStudioSidebarByDefault(
       typeof window === "undefined" ? undefined : window.innerWidth,
@@ -582,18 +587,10 @@ export function BuildStudio({
                         ? "Review"
                         : "Details"}
                   </button>
-                  {activeBuild.sandboxPort && (activeBuild.phase === "build" || activeBuild.phase === "review" || activeBuild.phase === "ship") && (
-                    <button
-                      role="tab"
-                      aria-selected={buildView === "preview"}
-                      aria-controls="panel-preview"
-                      onClick={() => setBuildView("preview")}
-                      className="px-3 py-1 rounded-t text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
-                      style={getTabStyle(buildView === "preview")}
-                    >
-                      Preview
-                    </button>
-                  )}
+                  {/* Per-build "Preview" tab removed — sandbox is shared, so
+                      the per-build preview surface was misleading. The footer
+                      OpenSandboxButton handles the shared link labeled with
+                      whichever build is currently driving the sandbox. */}
                 </div>
                 {buildView === "topology" && (
                   <div
@@ -622,12 +619,6 @@ export function BuildStudio({
                   >
                     {buildView === "progress" ? (
                       <BuildProgressOperationalPanel projection={progressVisibility} />
-                    ) : buildView === "preview" && activeBuild.sandboxPort && (activeBuild.phase === "build" || activeBuild.phase === "review" || activeBuild.phase === "ship") ? (
-                      <PreviewUrlCard
-                        buildId={activeBuild.buildId}
-                        phase={activeBuild.phase}
-                        sandboxPort={activeBuild.sandboxPort}
-                      />
                     ) : (
                       <div className="flex-1 overflow-auto">
                         {activeBuild.phase === "review" || activeBuild.phase === "ship" || activeBuild.phase === "complete" ? (
@@ -680,6 +671,40 @@ export function BuildStudio({
           carry it for the active build, and the (still-pending) compact
           fleet mini-rail carries it for the aggregate.
           See docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md §1, §9 #2 */}
+
+      {/* Footer — single shared OpenSandboxButton (sandbox is shared across
+          all in-flight builds; surfacing one link labeled with the current
+          driver replaces the dishonest per-build Preview tab). */}
+      <BuildStudioFooter builds={buildRows} />
+    </div>
+  );
+}
+
+function BuildStudioFooter({ builds }: { builds: FeatureBuildRow[] }) {
+  const candidates: SandboxDriverCandidate[] = builds.map((b) => ({
+    buildCode: b.buildId,
+    sandboxPort: b.sandboxPort,
+    lastActivityAt: b.updatedAt,
+  }));
+  const driving = computeDrivingBuild(candidates);
+  const sandboxUrl =
+    driving && isValidSandboxPort(driving.sandboxPort)
+      ? `http://localhost:${driving.sandboxPort}`
+      : "";
+  return (
+    <div
+      data-testid={BUILD_STUDIO_TEST_IDS.footer}
+      className="flex h-12 shrink-0 items-center justify-between border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-2"
+    >
+      <span className="text-[11px] text-[var(--dpf-muted)]">
+        {driving
+          ? "Sandbox is shared across all in-flight builds."
+          : "No build is currently driving the sandbox."}
+      </span>
+      <OpenSandboxButton
+        drivingBuildCode={driving?.buildCode ?? null}
+        sandboxUrl={sandboxUrl}
+      />
     </div>
   );
 }

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -321,6 +321,68 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).toContain('data-testid="action-banner-detail"');
   });
 
+  it("mounts the footer OpenSandboxButton — single shared sandbox link", () => {
+    // Footer surfaces the shared sandbox without resorting to a per-build
+    // Preview tab. When a build has a live sandboxPort, the footer button
+    // labels itself with the driving build code.
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild({
+          phase: "build",
+          sandboxPort: 5555,
+          draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+    expect(html).toContain('data-testid="build-studio-footer"');
+    expect(html).toContain('data-testid="build-studio-open-sandbox"');
+    expect(html).toContain('data-driving="FB-9B19098C"');
+    expect(html).toContain('href="http://localhost:5555"');
+    expect(html).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  it("footer OpenSandboxButton shows 'idle' when no build has a live sandboxPort", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild({ phase: "ideate", sandboxPort: null })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+    expect(html).toContain('data-testid="build-studio-open-sandbox"');
+    expect(html).toContain('data-driving="idle"');
+    // Disabled span renders (no anchor when sandboxUrl is empty).
+    expect(html).toContain('aria-disabled="true"');
+  });
+
+  it("removes the per-build Preview tab from the tab selector", () => {
+    // Per spec §1: per-build Preview is dishonest (sandbox is shared).
+    // The footer OpenSandboxButton handles the shared link instead.
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild({
+          phase: "build",
+          sandboxPort: 5555,
+          draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+    // No tab with the Preview label.
+    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Preview<\/button>/);
+    // The aria-controls pointing at "panel-preview" must not exist.
+    expect(html).not.toContain('aria-controls="panel-preview"');
+  });
+
   it("renders the dedicated release decision surface when a build reaches ship", () => {
     const html = renderToStaticMarkup(
       <BuildStudio


### PR DESCRIPTION
## Summary

Next slice of the Build Studio layout redesign. Removes the per-build "Preview" tab and adds a **single shared OpenSandboxButton** in the footer, labeled with whichever build is currently driving the sandbox runtime.

Spec: \`docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md\` §1 (Footer + shared sandbox).

## Why this matters

The Build Studio sandbox is shared across all in-flight builds (\`project_self_upgrade_kills_in_session_ux\`). A per-build Preview tab pretended each build had its own runtime — when two builds were active, clicking Preview on either showed the same iframe. The new footer surfaces the truth: one shared link, labeled with the current driver.

## What changes

- **Removed:** Preview tab button (\`<button role="tab">Preview</button>\`), Preview panel render branch, and \`"preview"\` from the \`buildView\` union. Unused \`PreviewUrlCard\` import dropped.
- **Added:** New \`BuildStudioFooter\` component below the main shell — 48px row with a helpful left-side caption and an \`OpenSandboxButton\` on the right.
- The button derives its label + URL via \`computeDrivingBuild()\` (\`lib/build/sandbox-driver.ts\`, PR #903): most-recently-active build with a live \`sandboxPort\` wins; ties break by buildCode ascending. When no build has a live port, the button renders as a disabled span with \`aria-disabled="true"\` and a \`driving: idle\` label.

## Test plan

- [ ] CI Typecheck pass
- [ ] CI Production Build pass
- [ ] CI Unit Tests: 3 new integration cases in \`BuildStudioHeaderLayout.test.tsx\` + existing cases all pass
- [ ] Manual: open \`/build\` with at least one in-flight build that has \`sandboxPort\` set — footer shows \`Open sandbox · driving: FB-…\` button linking to \`http://localhost:<port>\` with \`target="_blank" rel="noopener noreferrer"\`
- [ ] Manual: with all builds in ideate/plan (no port), footer shows \`driving: idle\` disabled state
- [ ] Manual: no Preview tab in the tab selector for any build phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)