### PR TITLE
docs(install): note portal self-upgrade + Edge Node deployment modes

### DIFF
--- a/docs/install/cloud-single-vm.md
+++ b/docs/install/cloud-single-vm.md
@@ -319,6 +319,15 @@ on the customer's network using
 Point it at `https://dpf.example.com` via `DPF_AUTHORITY_URL`. It
 phones home over outbound HTTPS — no VPC peering or VPN required.
 
+> **Picking the right Edge Node runtime for the on-prem host:** the
+> Edge Node ships in two runtimes (Linux container vs. native binary
+> on Windows / macOS / embedded). On Docker Desktop hosts the container
+> path is a dead end — WSL2 mirrored networking does not cross the
+> Docker Engine boundary, so the container only sees Docker's internal
+> services network. The user-guide page
+> [Edge Nodes — Deployment Modes](../user-guide/platform/edge-nodes#deployment-modes)
+> has the full matrix and the verified-2026-05-20 finding behind it.
+
 See [edge-node-multi-host.md](edge-node-multi-host.md) for the
 standalone Edge Node runbook.
 
@@ -342,10 +351,35 @@ Same lifecycle commands as bare-metal Linux:
 |------|---------|
 | Stop the stack | `bash dpf-stop.sh` |
 | Start the stack | `bash dpf-start.sh` |
-| Update images | `git pull && bash dpf-stop.sh && bash dpf-start.sh` |
+| Update images (manual) | `git pull && bash dpf-stop.sh && bash dpf-start.sh` |
 | Diagnostic bundle | `bash install-dpf.sh doctor` |
 | Uninstall (keep data) | `bash uninstall-dpf.sh` |
 | Uninstall (wipe data) | `bash uninstall-dpf.sh --purge --yes` |
+
+### Portal self-upgrade (cloud VM operators)
+
+The platform ships a governed **portal self-upgrade** runtime that
+detects when the running portal is behind `origin/main` and runs an
+in-place upgrade through the same promoter, backup, swap, health, and
+rollback path used for Build Studio ship-phase promotions. For a
+single cloud VM this removes the SSH-and-`git pull` cycle from your
+weekly maintenance.
+
+| Surface | What it does |
+|---------|--------------|
+| `/ops/self-upgrade` | Operations dashboard panel — current SHA, target SHA, recent run history, manual trigger. Read access is gated by the `view_operations` capability; manual triggers require `manage_provider_connections`. |
+| **Daily cron** | `portal/self-upgrade-scheduled` runs at `0 8 * * *` (`SelfUpgradeRun` row written for each cycle; runs that find no new commits exit with `status: "skipped"`). |
+| **Manual trigger** | The dashboard's manual-trigger button fires the `portal/self-upgrade.requested` event, which runs the same cycle on demand. |
+| **Completion sweep** | A separate `*/15 * * * *` cron reconciles runs in the `completing` state — important when the swap succeeded but the post-build verification needs to confirm the running SHA before the run flips to `succeeded`. |
+
+Canonical status enum: `queued | running | succeeded | failed | rolled_back | completing | skipped`. On health-check failure during the swap the promoter rolls back to the previous image and the run lands in `rolled_back`; the operator can investigate from the dashboard without losing the running portal.
+
+To **disable** scheduled self-upgrade on a particular install, set the
+relevant `PlatformConfig.selfUpgrade.*` flag from the admin surface —
+the manual trigger remains available for operators who want to run
+the cycle on their own schedule.
+
+Implementation reference: [`docs/superpowers/plans/2026-05-20-portal-self-upgrade-local.md`](../superpowers/plans/2026-05-20-portal-self-upgrade-local.md).
 
 ## What Phase 0 does NOT cover
 


### PR DESCRIPTION
## Summary

Two enrichments to the Cloud Single-VM runbook, both following from documentation that landed earlier this session.

- **Portal self-upgrade — Day-to-day section.** Single cloud VMs benefit most from auto-upgrade vs the manual SSH + \`git pull\` + restart cycle. New subsection documents \`/ops/self-upgrade\`, the \`0 8 * * *\` daily cron (\`portal/self-upgrade-scheduled\`), the \`*/15 * * * *\` completion-sweep cron, the canonical status enum (\`queued | running | succeeded | failed | rolled_back | completing | skipped\`), and the operator-facing capability gates (\`view_operations\` for read, \`manage_provider_connections\` for manual trigger). Existing manual-update row renamed \"Update images (manual)\" so the table distinguishes the two paths.
- **Edge Node deployment-mode cross-link.** Cross-link from the cloud runbook's Edge Node section to the user-guide page's new Deployment Modes table ([PR #932](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/932) just landed). With Docker Desktop on Windows now confirmed a dead end (verified 2026-05-20), an operator deploying an on-prem Edge Node needs to know to pick the native binary before they start. The matrix lives in one canonical place.

## Diff shape

| File | Change |
|---|---|
| \`docs/install/cloud-single-vm.md\` | +35 / −1 |

## Conservative-by-design

- Every claim anchored to a shipped PR (#822, #830, #852, #927) or the self-upgrade implementation plan
- The disable-via-\`PlatformConfig\` path is described in operator language without overcommitting to a specific admin UI surface name
- No structural / Terraform / provisioning changes — pure operational reference

## Test plan

- [ ] Spot-check the cross-link \`../user-guide/platform/edge-nodes#deployment-modes\` resolves against the page that landed in PR #932
- [ ] Confirm consistency with the homepage's Portal self-upgrade row (PR #928) and the Edge Node maturity row
- [ ] Verify the \`PlatformConfig.selfUpgrade.*\` reference matches the actual config key shape (operator-facing language is intentionally permissive so the runbook doesn't pin a specific path)