### PR TITLE
fix(security): hotfix audit-actions-injection workflow startup failure

### DIFF
--- a/.github/workflows/audit-actions-injection.yml
+++ b/.github/workflows/audit-actions-injection.yml
@@ -55,5 +55,11 @@ jobs:
         with:
           node-version: 24
 
-      - name: Scan workflows for `${{ github.event.* }}` in run: blocks
+      - name: Scan workflows for dangerous expressions in run blocks
+        # The expression syntax that's flagged by this audit is too dangerous
+        # to put in a step `name:` field — GitHub Actions tries to evaluate
+        # the substring as a template expression at workflow-startup time
+        # and the workflow fails before any job runs. Description lives in
+        # the YAML header instead. See the hotfix PR that introduced this
+        # rewording.
         run: node scripts/security/check-actions-injection.mjs


### PR DESCRIPTION
## Summary

Hotfix for the Actions Injection Audit workflow (added in #941) which has been **failing on every push to main since merge** with zero jobs executed.

## Root cause

The step name in `.github/workflows/audit-actions-injection.yml` contained a literal expression substring intended as documentation:

```yaml
- name: Scan workflows for `${{ github.event.* }}` in run: blocks
```

GitHub Actions evaluates step `name:` fields as templates at workflow-startup time. The `.*` is not valid expression syntax, so the workflow fails to parse and runs report `conclusion: failure` with `jobs: []`.

Ironic: the auditor itself is designed to catch `${{ github.event.* }}` in `run:` blocks. Step `name:` fields go through expression evaluation too — the auditor doesn't currently scan them, so it didn't catch its own workflow.

## Fix

Rewording the step name to remove the embedded expression. The detailed description of what's being scanned remains in the YAML header.

```diff
-      - name: Scan workflows for `${{ github.event.* }}` in run: blocks
+      - name: Scan workflows for dangerous expressions in run blocks
```

## Verified

```
$ node scripts/security/check-actions-injection.mjs
Workflows scanned: 12
Baseline accepts:  5 occurrence(s)
Currently found:   5 occurrence(s)
✓ Actions injection audit PASSED — no new occurrences.
```

## Follow-up

The audit script should be extended to scan step `name:` (and other expression-containing fields) too, not just `run:` blocks. Tracked as part of the BI-5940955C / BI-D094AF1D burn-down.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, push events to main should see Actions Injection Audit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)