### PR TITLE
docs(security): expand CODEOWNERS with trust-boundary paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,49 @@
-# Default owner for all paths.
-# Extend this file as domain owners step forward for specific areas.
+# Code ownership — supports trust-boundary review under BI-860603DA.
+#
+# Branch protection setting "Require review from Code Owners" makes the
+# patterns below enforceable. Without that setting, this file is documentation
+# of intent. Both modes are useful: even as documentation, a contributor or
+# bot reviewer can see which paths need owner approval.
+#
+# Trust-boundary paths (BI-860603DA, BI-5940955C)
+# -----------------------------------------------
+# Files where a malicious or careless change can compromise the whole repo
+# or every install of the platform. PRs that touch these get extra scrutiny,
+# regardless of size, regardless of provenance (internal or fork).
+#
+# Reference: docs/security/README.md "What this gate is NOT" — gates catch
+# patterns; trust-boundary review catches design + intent.
+
+# Default — every path falls through to here unless overridden below.
 * @markdbodman
+
+# ─── CI infrastructure ────────────────────────────────────────────────
+# Every workflow file runs with at least GITHUB_TOKEN. Several use
+# `pull_request_target` (DCO sign-off for Dependabot) which executes
+# with `contents: write`. A tampered workflow can leak secrets, push
+# code, or change protection settings — see BI-5940955C.
+/.github/workflows/  @markdbodman
+/.github/CODEOWNERS  @markdbodman
+/.github/dependabot.yml  @markdbodman
+
+# ─── Security substrate ───────────────────────────────────────────────
+# Auditors, baselines, and the scripts that enforce the inflow gate.
+# Modifying these = modifying the platform's security policy. The
+# baselines in particular: lowering an entry without a fix is the
+# textbook way to silently regress security.
+/scripts/security/     @markdbodman
+/docs/security/        @markdbodman
+
+# ─── Kernel and decision substrate ────────────────────────────────────
+# Principles ship with every install. A change here propagates to every
+# DPF deployment via the hive update. The WWMD Decision Perspective
+# Kernel adjudicates every phase gate — tampering routes feature work
+# around governance.
+/docs/founder-kernel/wiki/principles/  @markdbodman
+/apps/web/lib/decision-perspective/     @markdbodman
+
+# ─── Existing audit invariants ────────────────────────────────────────
+# These auditors lock specific architectural patterns into CI. They
+# are referenced by the audit-*.yml workflows above; changes here
+# need owner review even when the workflow file isn't touched.
+/apps/web/scripts/audit-*.ts           @markdbodman

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -95,4 +95,25 @@ to the default branch (which contains the trusted gate script).
 This pattern was reinforced by **BI-5940955C** (GitHub Actions code
 injection finding in `dco-signoff-dependabot.yml`). Workflows touching
 `pull_request_target` or `workflow_run` triggers are trust-boundary code
-and are subject to the two-maintainer carve-out described in **BI-860603DA**.
+and are subject to the carve-out described in **BI-860603DA**.
+
+### Trust-boundary paths
+
+The full list of paths that require extra owner review lives in
+[`.github/CODEOWNERS`](../../.github/CODEOWNERS). Categories include:
+
+- CI infrastructure (`.github/workflows/`, `.github/CODEOWNERS` itself,
+  Dependabot config).
+- Security substrate (`scripts/security/`, `docs/security/`) — modifying
+  the baselines is exactly how silent security regressions happen.
+- Kernel principles (`docs/founder-kernel/wiki/principles/`) and the
+  WWMD Decision Perspective Kernel
+  (`apps/web/lib/decision-perspective/`) — these propagate to every
+  install via the hive update.
+- Audit invariants (`apps/web/scripts/audit-*.ts`).
+
+Enforcement requires branch protection's "Require review from Code Owners"
+to be enabled. With one maintainer, CODEOWNERS today is documentation
+plus a hard signal for the bot reviewer (BI-860603DA) to look up which
+files need that signal. Branch-protection enforcement adds the second
+maintainer requirement when the team grows.


### PR DESCRIPTION
## Summary

Expands `.github/CODEOWNERS` with explicit ownership for the categories of files where a tampered change can compromise the whole repo or propagate to every install of the platform. Operationalizes the trust-boundary concept from **BI-860603DA**.

## What gets owner review

| Category | Paths | Why |
|---|---|---|
| **CI infrastructure** | `.github/workflows/`, `.github/CODEOWNERS`, `.github/dependabot.yml` | Workflows have `GITHUB_TOKEN`; some run `pull_request_target` with `contents: write`. See BI-5940955C. |
| **Security substrate** | `scripts/security/`, `docs/security/` | Modifying the baselines is exactly how silent security regressions happen. |
| **Kernel principles** | `docs/founder-kernel/wiki/principles/` | Ships with every install via the hive update. |
| **Decision substrate** | `apps/web/lib/decision-perspective/` | The WWMD kernel adjudicates every phase gate. |
| **Audit invariants** | `apps/web/scripts/audit-*.ts` | Locked-in patterns; changing the auditor changes the contract. |

## Enforcement modes

**Today** (one maintainer, no branch protection toggle): CODEOWNERS is documentation. A bot reviewer or contributor can read the file and know which paths need owner approval. PRs still merge on owner approval alone (since the owner is the only reviewer).

**After branch protection is enabled** with \"Require review from Code Owners\": GitHub enforces owner approval automatically on these paths. When the team grows beyond one maintainer, the second-maintainer requirement from BI-860603DA becomes effective without further changes.

Both modes are useful. This PR makes the path list explicit either way.

## Why this PR, why now

The last two PRs (#936 inflow gate, #941 actions auditor) demonstrated that workflow files and security scripts are exactly the kind of code where a single careless change can break the gates. Listing them as owner-only is the cheapest defense.

## Not in this PR

- Toggling branch protection \"Require review from Code Owners\" — repo admin action, you decide when.
- Bot reviewer that reads CODEOWNERS to route reviews — BI-860603DA, Build Studio scope.
- Expanding the maintainer list beyond \@markdbodman — happens when contributors step up.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, future PRs touching any of the listed paths show @markdbodman as a required reviewer in the PR sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)