### PR TITLE
fix(build-studio): auto-dispatch Ideate research on approve_start (urgent hotfix)

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -165,6 +165,26 @@ export async function approveBuildStart(buildId: string): Promise<{ approvedAt: 
     },
   }).catch(() => {});
 
+  // Auto-dispatch Ideate-phase design-doc research for backlog-promoted drafts.
+  // Without this, approve_start was a structural success that produced no
+  // functional truth — the build sat at "Ready for Planning / A design document
+  // is required before planning" until the operator manually engaged the
+  // coworker chat. The helper is fire-and-forget, idempotent (skips if designDoc
+  // already exists), and only fires for backlog-promoted drafts. Maps to kernel
+  // principle `structural-verification-is-not-functional`.
+  if (build.originatingBacklogItemId) {
+    void (async () => {
+      try {
+        const { dispatchIdeateForApprovedBuild } = await import("@/lib/integrate/ideate-on-approval");
+        await dispatchIdeateForApprovedBuild({ buildId, userId });
+      } catch (err) {
+        // dispatchIdeateForApprovedBuild already catches internally and writes
+        // a BuildActivity row; this is belt-and-braces for the dynamic import.
+        console.error("[approveBuildStart] Ideate auto-dispatch import/invoke failed:", { buildId }, err);
+      }
+    })();
+  }
+
   return { approvedAt };
 }
 

--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    featureBuild: { findUnique: vi.fn() },
+    backlogItem: { findUnique: vi.fn() },
+    buildActivity: { create: vi.fn() },
+  },
+}));
+
+const { mockDispatchIdeateResearch, mockGetBuildStudioConfig, mockExecuteTool } = vi.hoisted(() => ({
+  mockDispatchIdeateResearch: vi.fn(),
+  mockGetBuildStudioConfig: vi.fn(),
+  mockExecuteTool: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+
+vi.mock("./ideate-dispatch", () => ({
+  dispatchIdeateResearch: mockDispatchIdeateResearch,
+}));
+
+vi.mock("@/lib/integrate/build-studio-config", () => ({
+  getBuildStudioConfig: mockGetBuildStudioConfig,
+}));
+
+vi.mock("@/lib/mcp-tools", () => ({
+  executeTool: mockExecuteTool,
+}));
+
+import { dispatchIdeateForApprovedBuild } from "./ideate-on-approval";
+
+describe("dispatchIdeateForApprovedBuild", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.buildActivity.create.mockResolvedValue({});
+    mockGetBuildStudioConfig.mockResolvedValue({
+      provider: "claude",
+      claudeProviderId: "anthropic-sub",
+      codexProviderId: "",
+      claudeModel: "sonnet",
+      codexModel: "",
+    });
+  });
+
+  it("skips with no-bi outcome when the build is not backlog-promoted", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      originatingBacklogItemId: null,
+      designDoc: null,
+      title: "Untitled",
+      description: "",
+      businessContext: null,
+    });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("skipped-no-bi");
+    expect(mockDispatchIdeateResearch).not.toHaveBeenCalled();
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          buildId: "FB-X",
+          tool: "ideate_dispatch",
+          summary: expect.stringContaining("Skipped"),
+        }),
+      }),
+    );
+  });
+
+  it("skips with already-has-design outcome when designDoc has a non-empty problemStatement", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      originatingBacklogItemId: "BI-1",
+      designDoc: { problemStatement: "Already drafted." },
+      title: "T",
+      description: "D",
+      businessContext: null,
+    });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("skipped-already-has-design");
+    expect(mockDispatchIdeateResearch).not.toHaveBeenCalled();
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+  });
+
+  it("skips with no-provider outcome when the dispatch config has no external CLI provider", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      originatingBacklogItemId: "BI-1",
+      designDoc: null,
+      title: "T",
+      description: "D",
+      businessContext: null,
+    });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "BI body content." });
+    mockGetBuildStudioConfig.mockResolvedValue({
+      provider: "agentic",
+      claudeProviderId: "",
+      codexProviderId: "",
+      claudeModel: "sonnet",
+      codexModel: "",
+    });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("skipped-no-provider");
+    expect(mockDispatchIdeateResearch).not.toHaveBeenCalled();
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+  });
+
+  it("dispatches research and saves designDoc evidence on the happy path", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      originatingBacklogItemId: "BI-1",
+      designDoc: null,
+      title: "Fallback Title",
+      description: "Fallback description.",
+      businessContext: "biz",
+    });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({
+      title: "BI Title",
+      body: "Problem statement and acceptance criteria.",
+    });
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: true,
+      designDoc: {
+        problemStatement: "P",
+        existingFunctionalityAudit: "A",
+        proposedApproach: "x".repeat(60),
+        acceptanceCriteria: ["one"],
+      },
+      rawOutput: "",
+      durationMs: 1234,
+    });
+    mockExecuteTool.mockResolvedValue({ success: true });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("dispatched-success");
+    expect(mockDispatchIdeateResearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        featureTitle: "BI Title",
+        featureDescription: "Problem statement and acceptance criteria.",
+        providerId: "anthropic-sub",
+        dispatchEngine: "claude",
+      }),
+    );
+    expect(mockExecuteTool).toHaveBeenCalledWith(
+      "saveBuildEvidence",
+      { field: "designDoc", value: expect.objectContaining({ problemStatement: "P" }) },
+      "u-1",
+      expect.any(Object),
+    );
+    // Should write at least two activity rows: the "Dispatching..." log and the "Auto-dispatched..." success log.
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns dispatched-failure when dispatchIdeateResearch reports failure", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      originatingBacklogItemId: "BI-1",
+      designDoc: null,
+      title: "T",
+      description: "D",
+      businessContext: null,
+    });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body." });
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: false,
+      designDoc: null,
+      rawOutput: "",
+      durationMs: 500,
+      error: "auth failed",
+    });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("dispatched-failure");
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+  });
+
+  it("returns dispatched-failure when saveBuildEvidence rejects", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      originatingBacklogItemId: "BI-1",
+      designDoc: null,
+      title: "T",
+      description: "D",
+      businessContext: null,
+    });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body." });
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: true,
+      designDoc: { problemStatement: "P", proposedApproach: "y".repeat(60) },
+      rawOutput: "",
+      durationMs: 100,
+    });
+    mockExecuteTool.mockResolvedValue({ success: false, message: "validation failed" });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("dispatched-failure");
+    if (outcome.kind === "dispatched-failure") {
+      expect(outcome.error).toContain("saveBuildEvidence");
+    }
+  });
+
+  it("never throws when an unexpected error occurs — logs and returns dispatched-failure", async () => {
+    mockPrisma.featureBuild.findUnique.mockRejectedValue(new Error("DB connection lost"));
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("dispatched-failure");
+    if (outcome.kind === "dispatched-failure") {
+      expect(outcome.error).toContain("DB connection lost");
+    }
+  });
+});

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -1,0 +1,207 @@
+// apps/web/lib/integrate/ideate-on-approval.ts
+//
+// Auto-dispatch the Ideate-phase design-doc research when an operator approves
+// the start of a backlog-promoted Build Studio draft.
+//
+// Why this exists:
+//   approveBuildStart() (apps/web/lib/actions/build.ts) only sets draftApprovedAt
+//   and writes a BuildActivity row. It does NOT trigger the design-doc agent.
+//   The dispatchIdeateResearch helper in ./ideate-dispatch.ts is wired to a flag
+//   (buildExecState.ideateResearchRequested) that is only set from inside the
+//   agentic coworker loop — which means the operator must open the build's chat
+//   panel and have a conversation before any agent work begins.
+//
+//   For backlog-promoted drafts, the BacklogItem.title + body already contain
+//   the problem statement and acceptance criteria. The conversation step is
+//   unnecessary friction. Without this auto-dispatch, every backlog-promoted
+//   build sits forever at "Ready for Planning / A design document is required
+//   before planning" until the operator manually engages the coworker chat.
+//
+// Behavior:
+//   - Fire-and-forget invocation from approveBuildStart so the operator's
+//     approval click returns immediately.
+//   - Idempotent: skip if the build already has a non-empty designDoc.
+//   - Only runs for backlog-promoted drafts (originatingBacklogItemId set).
+//   - Logs an "ideate_dispatch" BuildActivity row on each exit path so the
+//     dispatch is observable in the build UI alongside approve_start.
+//   - Catches all errors — never throws into the calling startTransition.
+//
+// Maps to commandment-tier kernel principle:
+//   `structural-verification-is-not-functional` — the approve_start activity
+//   was a structural success that produced no functional truth. This wires
+//   the structural success to the functional dispatch.
+
+import { prisma } from "@dpf/db";
+
+type DispatchOutcome =
+  | { kind: "skipped-no-bi"; reason: string }
+  | { kind: "skipped-already-has-design"; reason: string }
+  | { kind: "skipped-no-provider"; reason: string }
+  | { kind: "dispatched-success"; designDocKeys: string[]; durationMs: number }
+  | { kind: "dispatched-failure"; error: string; durationMs: number };
+
+/**
+ * Auto-dispatch Ideate-phase design-doc research for an approved backlog-promoted
+ * draft. Designed to be called fire-and-forget from approveBuildStart; never
+ * throws. All exit paths log a BuildActivity row tagged "ideate_dispatch".
+ *
+ * @param buildId  FB-* semantic build id
+ * @param userId   the approving user — used as the actor for the saveBuildEvidence call
+ */
+export async function dispatchIdeateForApprovedBuild(params: {
+  buildId: string;
+  userId: string;
+}): Promise<DispatchOutcome> {
+  const { buildId, userId } = params;
+
+  const logActivity = async (summary: string): Promise<void> => {
+    await prisma.buildActivity.create({
+      data: { buildId, tool: "ideate_dispatch", summary },
+    }).catch((err) => {
+      console.warn("[ideate-on-approval] Failed to log BuildActivity:", { buildId, summary }, err);
+    });
+  };
+
+  try {
+    // Fetch the build with the linked BI and current designDoc evidence.
+    const build = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: {
+        originatingBacklogItemId: true,
+        designDoc: true,
+        title: true,
+        description: true,
+        businessContext: true,
+      },
+    });
+
+    if (!build || !build.originatingBacklogItemId) {
+      const outcome: DispatchOutcome = {
+        kind: "skipped-no-bi",
+        reason: "Build is not backlog-promoted (originatingBacklogItemId is null) — auto-dispatch only fires for backlog-promoted drafts.",
+      };
+      await logActivity(`Skipped auto-dispatch: ${outcome.reason}`);
+      return outcome;
+    }
+
+    // Idempotency guard: skip if a non-empty designDoc already exists.
+    // designDoc shape is BuildDesignDoc | null; we treat presence of a
+    // non-empty problemStatement as "real evidence already saved".
+    const existingDesignDoc = build.designDoc as { problemStatement?: string } | null;
+    if (existingDesignDoc && typeof existingDesignDoc.problemStatement === "string" && existingDesignDoc.problemStatement.trim().length > 0) {
+      const outcome: DispatchOutcome = {
+        kind: "skipped-already-has-design",
+        reason: "Build already has a designDoc with a non-empty problemStatement — skipping re-dispatch to preserve existing evidence.",
+      };
+      await logActivity(`Skipped auto-dispatch: ${outcome.reason}`);
+      return outcome;
+    }
+
+    // Fetch the BI title + body for the research context.
+    const bi = await prisma.backlogItem.findUnique({
+      where: { itemId: build.originatingBacklogItemId },
+      select: { title: true, body: true },
+    });
+
+    if (!bi) {
+      const outcome: DispatchOutcome = {
+        kind: "skipped-no-bi",
+        reason: `originatingBacklogItemId ${build.originatingBacklogItemId} did not resolve to a BacklogItem row — data inconsistency.`,
+      };
+      await logActivity(`Skipped auto-dispatch: ${outcome.reason}`);
+      return outcome;
+    }
+
+    // Resolve dispatch provider config. The "agentic" default has no external
+    // provider — dispatchIdeateResearch would return an "auth error" anyway.
+    // Short-circuit to a clean skip with a meaningful BuildActivity row.
+    const { getBuildStudioConfig } = await import("@/lib/integrate/build-studio-config");
+    const config = await getBuildStudioConfig();
+    const providerId = config.provider === "claude"
+      ? config.claudeProviderId
+      : config.codexProviderId;
+
+    if (config.provider === "agentic" || !providerId) {
+      const outcome: DispatchOutcome = {
+        kind: "skipped-no-provider",
+        reason: `No external CLI provider configured (provider=${config.provider}, providerId=${providerId || "(empty)"}). Configure Claude or Codex in Admin > AI Providers to enable auto-dispatch.`,
+      };
+      await logActivity(`Skipped auto-dispatch: ${outcome.reason}`);
+      return outcome;
+    }
+
+    const model = config.provider === "claude" ? config.claudeModel : config.codexModel;
+
+    // The BI body is the canonical context for backlog-promoted drafts.
+    // It typically contains problem statement, acceptance criteria, and
+    // architectural notes — exactly what the research prompt needs.
+    const featureTitle = bi.title || build.title || "Untitled Feature";
+    const featureDescription = bi.body || build.description || "";
+    const userContext = bi.body || ""; // Same source — BI body is operator-authored context.
+
+    const startedAt = Date.now();
+    await logActivity(`Dispatching ideate research via ${config.provider} (provider=${providerId}, model=${model || "default"})`);
+
+    const { dispatchIdeateResearch } = await import("./ideate-dispatch");
+    const ideateResult = await dispatchIdeateResearch({
+      featureTitle,
+      featureDescription,
+      reusabilityScope: "parameterizable",
+      userContext,
+      businessContext: build.businessContext ?? undefined,
+      providerId,
+      model,
+      dispatchEngine: config.provider,
+    });
+
+    const durationMs = Date.now() - startedAt;
+
+    if (!ideateResult.success || !ideateResult.designDoc) {
+      const outcome: DispatchOutcome = {
+        kind: "dispatched-failure",
+        error: ideateResult.error ?? "Ideate research returned no designDoc",
+        durationMs,
+      };
+      await logActivity(`Auto-dispatch failed after ${(durationMs / 1000).toFixed(1)}s: ${outcome.error.slice(0, 200)}`);
+      return outcome;
+    }
+
+    // Persist via the same code path the agentic coworker uses, so the
+    // saveBuildEvidence audit trail is consistent regardless of which
+    // dispatch path produced the designDoc.
+    const { executeTool } = await import("@/lib/mcp-tools");
+    const saveResult = await executeTool(
+      "saveBuildEvidence",
+      { field: "designDoc", value: ideateResult.designDoc },
+      userId,
+      {},
+    );
+
+    if (!saveResult.success) {
+      const outcome: DispatchOutcome = {
+        kind: "dispatched-failure",
+        error: `saveBuildEvidence rejected the designDoc: ${saveResult.message || saveResult.error || "(no message)"}`,
+        durationMs,
+      };
+      await logActivity(`Auto-dispatch saved-evidence step failed after ${(durationMs / 1000).toFixed(1)}s: ${outcome.error.slice(0, 200)}`);
+      return outcome;
+    }
+
+    const designDocKeys = Object.keys(ideateResult.designDoc as Record<string, unknown>);
+    const outcome: DispatchOutcome = {
+      kind: "dispatched-success",
+      designDocKeys,
+      durationMs,
+    };
+    await logActivity(`Auto-dispatched and saved designDoc in ${(durationMs / 1000).toFixed(1)}s (fields: ${designDocKeys.slice(0, 8).join(", ")})`);
+    return outcome;
+
+  } catch (err) {
+    // Belt-and-braces: never let an unexpected throw bubble out of a
+    // fire-and-forget helper. Log and return a structured failure.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[ideate-on-approval] Unhandled error in auto-dispatch:", { buildId }, err);
+    await logActivity(`Auto-dispatch threw unexpectedly: ${message.slice(0, 200)}`);
+    return { kind: "dispatched-failure", error: message, durationMs: 0 };
+  }
+}


### PR DESCRIPTION
## Summary

`approveBuildStart()` set `draftApprovedAt` and wrote an `approve_start` BuildActivity row but **never triggered the design-doc agent**. For backlog-promoted drafts this meant builds sat forever at "Ready for Planning / A design document is required before planning" — the only path to dispatch was for the operator to open the build's coworker chat and have the agentic loop call its `start_ideate_research` tool. The UX gave no signal that the chat was the required next move, so freshly-promoted FBs accumulated approval-then-silence forever.

Six FBs filed during a FB-AD454C98 postmortem session this week exhibited this exact pattern: `approve_start` logged, then 0 activity rows for hours. Investigation traced the chain:

- `approveBuildStart` (lib/actions/build.ts) — writes the activity row, returns
- `dispatchIdeateResearch` (lib/integrate/ideate-dispatch.ts) — the helper that actually shells out to Codex/Claude CLI
- Only caller: `lib/actions/agent-coworker.ts:1547`, gated on `buildExecState.ideateResearchRequested === true`
- That flag is only ever set inside the agentic coworker loop, when the operator engages the chat

Nothing else listens for `draftApprovedAt`. No Inngest function, no cron, no queue dispatch. The dispatch graph is structurally disconnected from the operator approval action.

This is the same `structural-verification-is-not-functional` failure-shape we have been documenting at other layers (prUrl=null, coworker hallucination, modal silent submit). It is the highest-leverage instance because it blocks every backlog-promoted build in the system.

## Fix

New module `apps/web/lib/integrate/ideate-on-approval.ts` exporting `dispatchIdeateForApprovedBuild({ buildId, userId })`:

- Reads the linked `BacklogItem.title` + `body` as the research context — for backlog-promoted drafts the BI body already contains problem statement + acceptance criteria, so no operator conversation is needed
- Calls `dispatchIdeateResearch` with `getBuildStudioConfig` provider settings
- Persists the result via the same `executeTool("saveBuildEvidence", { field: "designDoc", ... })` path the agentic coworker uses, so the audit trail is consistent regardless of which dispatch path produced the designDoc
- Logs an `ideate_dispatch` BuildActivity row on every exit path (skip / dispatched / failure) so dispatch outcomes show up next to `approve_start` in the build UI's Dispatch Attempts pane
- Catches all errors — fire-and-forget; the operator's approval click returns immediately

Idempotency:
- Skips if the build already has a designDoc with a non-empty problemStatement (re-approval / partial recovery does not overwrite)
- Skips with a clean activity row when `provider === "agentic"` or no CLI providerId is configured (would otherwise produce a buried auth error)
- Only fires for backlog-promoted drafts (`originatingBacklogItemId != null`) — non-backlog drafts are unaffected

`approveBuildStart` wires it in via an IIFE so the synchronous approval response is unchanged:

```ts
if (build.originatingBacklogItemId) {
  void (async () => {
    try {
      const { dispatchIdeateForApprovedBuild } = await import("@/lib/integrate/ideate-on-approval");
      await dispatchIdeateForApprovedBuild({ buildId, userId });
    } catch (err) {
      console.error("[approveBuildStart] Ideate auto-dispatch import/invoke failed:", { buildId }, err);
    }
  })();
}
```

## Why this qualifies as urgent hotfix

Per AGENTS.md, Claude opens PRs directly only for deps/cleanup/governance/urgent hotfixes — features go through Build Studio. This is a platform-critical regression that prevents Build Studio itself from functioning on backlog-promoted drafts. Filing it through BS would be circular (the BIs filed during the postmortem are themselves stuck on this exact bug).

## Test plan

- [x] `pnpm --filter web exec vitest run lib/integrate/ideate-on-approval.test.ts` — 7 cases covering every `DispatchOutcome` variant pass locally (skipped-no-bi / skipped-already-has-design / skipped-no-provider / dispatched-success / dispatched-failure on research / dispatched-failure on saveBuildEvidence / unexpected-throw recovery)
- [x] `pnpm --filter web exec vitest run lib/actions/build-governed.test.ts lib/integrate/` — 745 tests pass, existing `approveBuildStart stamps draftApprovedAt` test unaffected (the fire-and-forget IIFE is transparent to the synchronous response)
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web test` — 7222 / 7222 (excluding 15 skipped + 18 todo), one flaky time-sensitive test failed on first run and passed on re-run, unrelated to this change
- [ ] **Manual verification after merge + self-upgrade**: approve start on a backlog-promoted FB that currently shows "Ready for Planning / A design document is required before planning"; observe `ideate_dispatch` activity rows in the build's Dispatch Attempts pane; designDoc appears in evidence within ~30s–2min; status flips to "Design review is required before planning"
- [ ] **Backfill the 6 stuck FBs**: FB-8D694FA6, FB-6BDCB12B, FB-3CA106CC, FB-9709981A, FB-4261943C, FB-72747E68 — re-approve start (idempotent on `draftApprovedAt`) to trigger the new auto-dispatch

## Files

- `apps/web/lib/integrate/ideate-on-approval.ts` (new, 199 lines)
- `apps/web/lib/integrate/ideate-on-approval.test.ts` (new, 215 lines)
- `apps/web/lib/actions/build.ts` (+20 lines in `approveBuildStart`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)