### PR TITLE
feat(build-studio): mount DetailsDrawer + Pill, drop global tab selector

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -10,6 +10,7 @@ import { ReviewPanel } from "./ReviewPanel";
 import { NodeInspector } from "./NodeInspector";
 import type { ProcessGraphNodeClickInfo } from "./ProcessGraphClickInfo";
 import { OpenSandboxButton } from "./OpenSandboxButton";
+import { DetailsDrawer, DetailsDrawerPill, type DetailsDrawerSection } from "./DetailsDrawer";
 import { computeDrivingBuild, isValidSandboxPort, type SandboxDriverCandidate } from "@/lib/build/sandbox-driver";
 import { ClaimBadge } from "./ClaimBadge";
 import { ProcessGraph } from "./ProcessGraph";
@@ -73,11 +74,12 @@ export function BuildStudio({
   );
   const [creating, setCreating] = useState(false);
   const [newTitle, setNewTitle] = useState("");
-  // "preview" removed per spec — sandbox is shared across builds, so the
-  // per-build Preview tab is dishonest. A single Open Sandbox button now
-  // lives in the footer and links to whichever build is currently driving
-  // the sandbox runtime.
-  const [buildView, setBuildView] = useState<"progress" | "topology" | "docs">("progress");
+  // Tab selector removed per spec §1 + §9 #11 — the workflow graph is the
+  // always-visible primary surface of the active-build pane. Progress /
+  // Brief / Review / Sandbox / BS-Queue evidence migrates into the
+  // DetailsDrawer accordion (PR #912's DetailsDrawer + this slice).
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerInitialSectionId, setDrawerInitialSectionId] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(() =>
     shouldOpenBuildStudioSidebarByDefault(
       typeof window === "undefined" ? undefined : window.innerWidth,
@@ -383,12 +385,6 @@ export function BuildStudio({
     }
   }
 
-  const getTabStyle = (selected: boolean) => ({
-    background: selected ? "var(--dpf-surface-2)" : "transparent",
-    color: selected ? "var(--dpf-text)" : "var(--dpf-muted)",
-    borderBottom: selected ? "2px solid var(--dpf-accent)" : "2px solid transparent",
-  });
-
   return (
     <div className={getBuildStudioShellClassName()} data-testid={BUILD_STUDIO_TEST_IDS.shell}>
       <div className="relative flex flex-1 overflow-hidden">
@@ -463,6 +459,10 @@ export function BuildStudio({
                 if (activeBuild?.buildId === build.buildId) setActiveBuild(null);
                 router.refresh();
               });
+            }}
+            onOpenQueueDrawer={() => {
+              setDrawerInitialSectionId("bs-queue");
+              setDrawerOpen(true);
             }}
           />
         </div>
@@ -563,117 +563,69 @@ export function BuildStudio({
                     />
                   </div>
                 )}
-                {/* Tab selector */}
-                <div role="tablist" aria-label="Workflow view tabs" className="flex gap-1 px-4 pt-3 pb-0">
-                  <button
-                    role="tab"
-                    aria-selected={buildView === "progress"}
-                    aria-controls="panel-progress"
-                    onClick={() => setBuildView("progress")}
-                    className="px-3 py-1 rounded-t text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
-                    style={getTabStyle(buildView === "progress")}
-                  >
-                    Progress
-                  </button>
-                  <button
-                    role="tab"
-                    aria-selected={buildView === "topology"}
-                    aria-controls="panel-topology"
-                    onClick={() => setBuildView("topology")}
-                    className="px-3 py-1 rounded-t text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
-                    style={getTabStyle(buildView === "topology")}
-                  >
-                    Workflow
-                  </button>
-                  {/* Details tab — always available so design doc / brief is visible during ideate/plan */}
-                  <button
-                    role="tab"
-                    aria-selected={buildView === "docs"}
-                    aria-controls="panel-docs"
-                    onClick={() => setBuildView("docs")}
-                    className="px-3 py-1 rounded-t text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-[var(--dpf-accent)] focus-visible:outline-offset-2"
-                    style={getTabStyle(buildView === "docs")}
-                  >
-                    {activeBuild.phase === "ship"
-                      ? "Release"
-                      : (activeBuild.phase === "review" || activeBuild.phase === "complete")
-                        ? "Review"
-                        : "Details"}
-                  </button>
-                  {/* Per-build "Preview" tab removed — sandbox is shared, so
-                      the per-build preview surface was misleading. The footer
-                      OpenSandboxButton handles the shared link labeled with
-                      whichever build is currently driving the sandbox. */}
-                </div>
-                {buildView === "topology" && (
-                  <div
-                    id="panel-topology"
-                    className={`${getBuildStudioGraphPanelClassName()} relative`}
-                    data-testid={BUILD_STUDIO_TEST_IDS.graphPanel}
-                  >
-                    <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
-                      <CodeIntelligenceStatusCard freshness={codeGraphFreshness} />
-                    </div>
-                    <div className="border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
-                      Select any stage or task to inspect what happened, related artifacts, and the next approval gate.
-                    </div>
-                    <ProcessGraph
-                      build={activeBuild}
-                      workflowLabel={activeLifecycleLabel}
-                      governedBacklogEnabled={governedBacklogEnabled}
-                      progressVisibility={progressVisibility}
-                      onNodeClick={(info) => {
-                        // Re-clicking the same node toggles the inspector closed.
-                        setSelectedNodeClick((prev) =>
-                          prev?.nodeId === info.nodeId ? null : info,
+                {/* Workflow graph — always-visible primary surface of the
+                    active-build pane. The tab selector (Progress/Workflow/
+                    Details/Preview) is gone; evidence migrates into the
+                    DetailsDrawer below. See spec §1 + §9 #11. */}
+                <div
+                  className={`${getBuildStudioGraphPanelClassName()} relative`}
+                  data-testid={BUILD_STUDIO_TEST_IDS.graphPanel}
+                >
+                  <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+                    <CodeIntelligenceStatusCard freshness={codeGraphFreshness} />
+                  </div>
+                  <div className="border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
+                    Select any stage or task to inspect — or open Details on the right for progress, brief, review, sandbox, and BS Queue evidence.
+                  </div>
+                  <ProcessGraph
+                    build={activeBuild}
+                    workflowLabel={activeLifecycleLabel}
+                    governedBacklogEnabled={governedBacklogEnabled}
+                    progressVisibility={progressVisibility}
+                    onNodeClick={(info) => {
+                      setSelectedNodeClick((prev) =>
+                        prev?.nodeId === info.nodeId ? null : info,
+                      );
+                    }}
+                  />
+                  {selectedNodeClick && (
+                    <NodeInspector
+                      nodeId={selectedNodeClick.nodeId}
+                      title={resolveInspectorTitle(selectedNodeClick)}
+                      anchorRect={selectedNodeClick.anchorRect}
+                      containerRect={selectedNodeClick.containerRect}
+                      containerScrollTop={selectedNodeClick.containerScrollTop}
+                      onClose={() => setSelectedNodeClick(null)}
+                      onAskCoworker={() => {
+                        const prefill = buildCoworkerPrefill(selectedNodeClick, activeBuild.buildId);
+                        document.dispatchEvent(
+                          new CustomEvent("open-agent-panel", {
+                            detail: { autoMessage: prefill, targetBuildId: activeBuild.buildId },
+                          }),
                         );
                       }}
-                    />
-                    {selectedNodeClick && (
-                      <NodeInspector
-                        nodeId={selectedNodeClick.nodeId}
-                        title={resolveInspectorTitle(selectedNodeClick)}
-                        anchorRect={selectedNodeClick.anchorRect}
-                        containerRect={selectedNodeClick.containerRect}
-                        containerScrollTop={selectedNodeClick.containerScrollTop}
-                        onClose={() => setSelectedNodeClick(null)}
-                        onAskCoworker={() => {
-                          const prefill = buildCoworkerPrefill(selectedNodeClick, activeBuild.buildId);
-                          document.dispatchEvent(
-                            new CustomEvent("open-agent-panel", {
-                              detail: { autoMessage: prefill, targetBuildId: activeBuild.buildId },
-                            }),
-                          );
-                        }}
-                      >
-                        <NodeInspectorBody info={selectedNodeClick} />
-                      </NodeInspector>
+                    >
+                      <NodeInspectorBody info={selectedNodeClick} />
+                    </NodeInspector>
+                  )}
+                  <DetailsDrawerPill
+                    isOpen={drawerOpen}
+                    onClick={() => {
+                      setDrawerOpen((p) => !p);
+                      setDrawerInitialSectionId(null);
+                    }}
+                  />
+                  <DetailsDrawer
+                    isOpen={drawerOpen}
+                    onClose={() => setDrawerOpen(false)}
+                    sections={buildDetailsDrawerSections(
+                      activeBuild,
+                      progressVisibility,
+                      drawerInitialSectionId,
+                      buildRows,
                     )}
-                  </div>
-                )}
-                {buildView !== "topology" && (
-                  <div
-                    id={`panel-${buildView}`}
-                    className={buildView === "progress" ? "flex min-h-0 flex-1 overflow-hidden" : "flex min-h-0 flex-1 gap-4 p-4"}
-                  >
-                    {buildView === "progress" ? (
-                      <BuildProgressOperationalPanel projection={progressVisibility} />
-                    ) : (
-                      <div className="flex-1 overflow-auto">
-                        {activeBuild.phase === "review" || activeBuild.phase === "ship" || activeBuild.phase === "complete" ? (
-                          <ReviewPanel build={activeBuild} />
-                        ) : (
-                          <FeatureBriefPanel
-                            brief={activeBuild.brief}
-                            phase={activeBuild.phase}
-                            diffSummary={activeBuild.diffSummary}
-                            build={activeBuild}
-                          />
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
+                  />
+                </div>
               </div>
             </>
           ) : (
@@ -715,6 +667,115 @@ export function BuildStudio({
           all in-flight builds; surfacing one link labeled with the current
           driver replaces the dishonest per-build Preview tab). */}
       <BuildStudioFooter builds={buildRows} />
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* DetailsDrawer — derive accordion sections from active build + drawer state.*/
+/* ────────────────────────────────────────────────────────────────────────── */
+
+function buildDetailsDrawerSections(
+  activeBuild: FeatureBuildRow,
+  progressVisibility: BuildProgressVisibility | null,
+  initialSectionId: string | null,
+  allBuilds: readonly FeatureBuildRow[],
+): DetailsDrawerSection[] {
+  // Default-open section depends on phase + explicit operator intent.
+  // - When the queue header opened the drawer, BS-Queue is the explicit pick.
+  // - Otherwise: ideate/plan → Brief; build → Progress; review/ship/complete → Review.
+  const defaultId =
+    initialSectionId ??
+    (activeBuild.phase === "ideate" || activeBuild.phase === "plan"
+      ? "brief"
+      : activeBuild.phase === "build"
+        ? "progress"
+        : "review");
+
+  return [
+    {
+      id: "progress",
+      title: "Progress",
+      defaultOpen: defaultId === "progress",
+      content: <BuildProgressOperationalPanel projection={progressVisibility} />,
+    },
+    {
+      id: "brief",
+      title: activeBuild.phase === "complete" ? "Shipped — original brief" : "Brief / Design Doc",
+      defaultOpen: defaultId === "brief",
+      content: (
+        <FeatureBriefPanel
+          brief={activeBuild.brief}
+          phase={activeBuild.phase}
+          diffSummary={activeBuild.diffSummary}
+          build={activeBuild}
+        />
+      ),
+    },
+    {
+      id: "review",
+      title: activeBuild.phase === "ship" ? "Release" : "Review",
+      defaultOpen: defaultId === "review",
+      content: <ReviewPanel build={activeBuild} />,
+    },
+    {
+      id: "bs-queue",
+      title: "BS Queue",
+      defaultOpen: defaultId === "bs-queue",
+      content: <BsQueueSection builds={allBuilds} />,
+    },
+  ];
+}
+
+function BsQueueSection({ builds }: { builds: readonly FeatureBuildRow[] }) {
+  const entries = builds.map((b) => ({
+    build: b,
+    queueState: deriveQueueState(b),
+    needsAttention: deriveNeedsAttention(b),
+  }));
+  const kindRank = { running: 0, blocked: 1, queued: 2, idle: 3 } as const;
+  const sorted = [...entries].sort((a, b) => {
+    const ra = kindRank[a.queueState.kind];
+    const rb = kindRank[b.queueState.kind];
+    if (ra !== rb) return ra - rb;
+    if (a.queueState.kind === "queued" && b.queueState.kind === "queued") {
+      return a.queueState.position - b.queueState.position;
+    }
+    return a.build.buildId.localeCompare(b.build.buildId);
+  });
+  const counts = deriveFleetCounts(entries.map((e) => e.queueState));
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-[var(--dpf-muted)]">
+        Shared sandbox runtime — read-only view. Per spec §10, queue mutation
+        (start/cancel/reorder) belongs to the concurrency thread, not this layout.
+      </p>
+      <div className="flex flex-wrap gap-3 text-[11px] text-[var(--dpf-text)]">
+        <span>Running: <span className="font-semibold">{counts.runningCount}</span></span>
+        <span>Blocked: <span className="font-semibold text-[var(--dpf-warning)]">{counts.blockedCount}</span></span>
+        <span>Queued: <span className="font-semibold">{counts.queuedCount}</span></span>
+      </div>
+      <ul className="flex flex-col gap-1">
+        {sorted.map((entry) => (
+          <li
+            key={entry.build.buildId}
+            className="flex items-center gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[11px]"
+            data-build-id={entry.build.buildId}
+            data-queue-kind={entry.queueState.kind}
+          >
+            <span className="font-mono text-[var(--dpf-text)]">{entry.build.buildId}</span>
+            <span className="truncate text-[var(--dpf-muted)]">{entry.build.title}</span>
+            <span className="ml-auto text-[10px] uppercase tracking-wider text-[var(--dpf-muted)]">
+              {entry.queueState.kind}
+              {entry.queueState.kind === "queued" && ` @${entry.queueState.position}`}
+            </span>
+          </li>
+        ))}
+        {sorted.length === 0 && (
+          <li className="text-[var(--dpf-muted)]">No builds.</li>
+        )}
+      </ul>
     </div>
   );
 }
@@ -895,6 +956,7 @@ function FleetRailZone({
   isDevEnvironment,
   onSelectBuild,
   onDeleteBuild,
+  onOpenQueueDrawer,
 }: {
   buildRows: FeatureBuildRow[];
   activeBuildId: string | null;
@@ -902,6 +964,7 @@ function FleetRailZone({
   isDevEnvironment: boolean;
   onSelectBuild: (build: FeatureBuildRow) => void;
   onDeleteBuild: (build: FeatureBuildRow) => void;
+  onOpenQueueDrawer: () => void;
 }) {
   // Derive per-row fleet entries: queueState + needsAttention + lifecycle.
   // queueState falls back to phase-based heuristics until the concurrency
@@ -956,13 +1019,15 @@ function FleetRailZone({
     <div className="flex min-h-0 flex-1 flex-col">
       {/* Compact fleet header — surfaces in-flight aggregate so the
           operator can see queue pressure without opening every build.
-          Click target is currently inert; the DetailsDrawer queue
-          subsection lands in a follow-up slice. */}
-      <div
+          Click opens the DetailsDrawer's BS-Queue section. */}
+      <button
+        type="button"
+        onClick={onOpenQueueDrawer}
         role="status"
         aria-live="polite"
+        aria-label="Open build details drawer — BS queue section"
         data-testid="build-studio-fleet-header"
-        className="flex shrink-0 items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-[11px] font-semibold text-[var(--dpf-text)]"
+        className="flex w-full shrink-0 cursor-pointer items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-text)] transition-colors hover:bg-[var(--dpf-surface-3)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
       >
         <span data-testid="fleet-header-label">
           Builds: {counts.runningCount} running
@@ -973,7 +1038,8 @@ function FleetRailZone({
             <> · {counts.queuedCount} queued</>
           )}
         </span>
-      </div>
+        <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>
+      </button>
       <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1" data-testid="fleet-rail-body">
         {sorted.map((entry, idx) => (
           <li key={entry.build.buildId}>

--- a/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+++ b/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
@@ -1,0 +1,300 @@
+// @vitest-environment jsdom
+//
+// apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+//
+// Pins the DetailsDrawer integration on BuildStudio:
+//   - Pill click toggles the drawer open/closed.
+//   - Drawer mounts the canonical sections (Progress, Brief, Review, BS Queue).
+//   - Default-open section follows phase:
+//       ideate / plan → Brief
+//       build         → Progress
+//       review/ship/complete → Review
+//   - Fleet queue header click opens drawer scrolled to BS-Queue.
+
+import "../build-studio/test-setup";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BuildStudio } from "./BuildStudio";
+import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
+import {
+  normalizeHappyPathState,
+  type FeatureBuildRow,
+} from "@/lib/feature-build-types";
+
+afterEach(cleanup);
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/build", () => ({
+  createFeatureBuild: vi.fn(),
+  deleteFeatureBuild: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/build-read", () => ({
+  getFeatureBuild: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/build-flow", () => ({
+  getBuildFlowStateAction: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/actions/build-progress-visibility", () => ({
+  getBuildProgressVisibilityAction: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/actions/code-intelligence", () => ({
+  getCodeGraphFreshnessAction: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/components/build/PhaseIndicator", () => ({
+  PhaseIndicator: () => <div data-testid="phase-indicator" />,
+}));
+
+vi.mock("@/components/build/FeatureBriefPanel", () => ({
+  FeatureBriefPanel: () => <div data-testid="feature-brief-panel" />,
+}));
+
+vi.mock("@/components/build/ReviewPanel", () => ({
+  ReviewPanel: () => <div data-testid="review-panel" />,
+}));
+
+vi.mock("@/components/build/PreviewUrlCard", () => ({
+  PreviewUrlCard: () => <div data-testid="preview-url-card" />,
+}));
+
+vi.mock("@/components/build/ClaimBadge", () => ({
+  ClaimBadge: () => <div data-testid="claim-badge" />,
+}));
+
+vi.mock("@/components/build/ProcessGraph", () => ({
+  ProcessGraph: () => <div data-testid="process-graph-mock" />,
+}));
+
+vi.mock("@/components/build/ReleaseDecisionPanel", () => ({
+  ReleaseDecisionPanel: () => <div data-testid="release-decision-panel" />,
+}));
+
+vi.mock("@/components/build/BuildProgressOperationalPanel", () => ({
+  BuildProgressOperationalPanel: () => <div data-testid="build-progress-operational-panel" />,
+}));
+
+function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
+  return {
+    id: "row-1",
+    buildId: "FB-9B19098C",
+    title: "Layout redesign",
+    description: null,
+    portfolioId: null,
+    originatingBacklogItemId: null,
+    brief: null,
+    plan: null,
+    phase: "ideate",
+    sandboxId: null,
+    sandboxPort: null,
+    diffSummary: null,
+    diffPatch: null,
+    codingProvider: null,
+    threadId: null,
+    digitalProductId: null,
+    product: null,
+    createdById: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    draftApprovedAt: null,
+    designDoc: null,
+    designReview: null,
+    buildPlan: null,
+    planReview: null,
+    taskResults: null,
+    verificationOut: null,
+    acceptanceMet: null,
+    scoutFindings: null,
+    uxTestResults: null,
+    uxVerificationStatus: null,
+    accountableEmployeeId: null,
+    claimedByAgentId: null,
+    claimedAt: null,
+    claimStatus: null,
+    buildExecState: null,
+    deliberationSummary: null,
+    happyPathState: normalizeHappyPathState(null),
+    originator: null,
+    phaseHandoffs: [],
+    ...overrides,
+  };
+}
+
+describe("BuildStudio DetailsDrawer integration", () => {
+  it("drawer starts closed (translate-x-full + data-open=false)", () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    const drawer = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer);
+    expect(drawer).toHaveAttribute("data-open", "false");
+    expect(drawer.className).toContain("translate-x-full");
+  });
+
+  it("pill click opens the drawer", async () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    const pill = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill);
+    fireEvent.click(pill);
+    await waitFor(() => {
+      const drawer = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer);
+      expect(drawer).toHaveAttribute("data-open", "true");
+      expect(drawer.className).toContain("translate-x-0");
+    });
+  });
+
+  it("renders the canonical 4 drawer sections in order", () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    // Open the drawer so section content materializes.
+    fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
+    const sectionHeaders = document.querySelectorAll("[data-section-id]");
+    const ids = Array.from(sectionHeaders).map((s) => s.getAttribute("data-section-id"));
+    expect(ids).toEqual(["progress", "brief", "review", "bs-queue"]);
+  });
+
+  it("phase=ideate → Brief is default-open", () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild({ phase: "ideate" })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
+    const briefSection = document.querySelector('[data-section-id="brief"]');
+    expect(briefSection).toHaveAttribute("data-open", "true");
+    // FeatureBriefPanel mock renders inside the open section.
+    expect(screen.getByTestId("feature-brief-panel")).toBeInTheDocument();
+  });
+
+  it("phase=build → Progress is default-open", () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild({ phase: "build" })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
+    const progressSection = document.querySelector('[data-section-id="progress"]');
+    expect(progressSection).toHaveAttribute("data-open", "true");
+    expect(screen.getByTestId("build-progress-operational-panel")).toBeInTheDocument();
+  });
+
+  it("phase=review → Review is default-open", () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild({ phase: "review" })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
+    const reviewSection = document.querySelector('[data-section-id="review"]');
+    expect(reviewSection).toHaveAttribute("data-open", "true");
+    expect(screen.getByTestId("review-panel")).toBeInTheDocument();
+  });
+
+  it("fleet queue header click opens drawer with BS-Queue section default-open", async () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild({ phase: "ideate" })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    // Before click: drawer closed, Brief default (phase=ideate)
+    const drawer = screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer);
+    expect(drawer).toHaveAttribute("data-open", "false");
+
+    const fleetHeader = screen.getByTestId("build-studio-fleet-header");
+    fireEvent.click(fleetHeader);
+
+    await waitFor(() => {
+      expect(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer)).toHaveAttribute("data-open", "true");
+      const queueSection = document.querySelector(`[data-testid="${BUILD_STUDIO_TEST_IDS.detailsDrawerQueue}"]`);
+      expect(queueSection).toHaveAttribute("data-open", "true");
+    });
+  });
+
+  it("BS-Queue section lists builds with kind + buildId", () => {
+    render(
+      <BuildStudio
+        builds={[
+          makeBuild({ buildId: "FB-RUNRUNRUN", phase: "build" }),
+          makeBuild({ buildId: "FB-IDLEEEEEE", phase: "ideate" }),
+        ]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("build-studio-fleet-header"));
+    const queueSection = document.querySelector(`[data-testid="${BUILD_STUDIO_TEST_IDS.detailsDrawerQueue}"]`);
+    expect(queueSection).toBeInTheDocument();
+    // Both rows rendered, sorted running → idle.
+    const rows = queueSection!.querySelectorAll("[data-build-id]");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAttribute("data-build-id", "FB-RUNRUNRUN");
+    expect(rows[0]).toHaveAttribute("data-queue-kind", "running");
+    expect(rows[1]).toHaveAttribute("data-build-id", "FB-IDLEEEEEE");
+    expect(rows[1]).toHaveAttribute("data-queue-kind", "idle");
+  });
+
+  it("close button on the drawer closes it back to translate-x-full", async () => {
+    render(
+      <BuildStudio
+        builds={[makeBuild()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="abc12345"
+      />,
+    );
+    fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
+    await waitFor(() => {
+      expect(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer)).toHaveAttribute("data-open", "true");
+    });
+    fireEvent.click(screen.getByLabelText("Close details drawer"));
+    await waitFor(() => {
+      expect(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer)).toHaveAttribute("data-open", "false");
+    });
+  });
+});

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -228,7 +228,11 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).toMatch(/class=\"truncate\">dpf\/fb8783b9\/fix-build-studio-header-content-overlap-in-workflo/);
   });
 
-  it("defaults to the operational progress view and keeps topology available", () => {
+  it("makes the workflow graph the always-visible primary surface; tabs are gone", () => {
+    // Spec §1 + §9 #11: the global tab selector (Progress/Workflow/Details/
+    // Preview) is removed. The workflow canvas is the active-build pane's
+    // primary surface. Evidence (Progress, Brief, Review, Sandbox, BS Queue)
+    // moves into the DetailsDrawer accordion behind a pill on the canvas edge.
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[makeBuild()]}
@@ -239,11 +243,21 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain(">Progress<");
-    expect(html).toContain(">Workflow<");
-    expect(html).toContain("Loading build progress...");
-    expect(html).not.toContain("code-intelligence-status-card");
-    expect(html).not.toContain("process-graph");
+    // No global tab list / tab buttons.
+    expect(html).not.toMatch(/role="tablist"[^>]*aria-label="Workflow view tabs"/);
+    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Progress<\/button>/);
+    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Workflow<\/button>/);
+    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Details<\/button>/);
+
+    // Workflow canvas surfaces are rendered eagerly (not gated by tab state).
+    expect(html).toContain('data-testid="build-studio-graph-panel"');
+    expect(html).toContain('data-testid="code-intelligence-status-card"');
+    expect(html).toContain('data-testid="process-graph"');
+
+    // DetailsDrawer + Pill are mounted; drawer starts closed.
+    expect(html).toContain('data-testid="build-studio-details-drawer-pill"');
+    expect(html).toContain('data-testid="build-studio-details-drawer"');
+    expect(html).toMatch(/data-testid="build-studio-details-drawer"[^>]*data-open="false"/);
   });
 
   it("renders the portal context strip when a server envelope is provided", () => {

--- a/apps/web/components/build/BuildStudioNodeInspector.test.tsx
+++ b/apps/web/components/build/BuildStudioNodeInspector.test.tsx
@@ -168,6 +168,10 @@ function mockClickInfo(overrides: Partial<ProcessGraphNodeClickInfo> = {}): Proc
 }
 
 async function renderInTopologyView(buildOverrides: Partial<FeatureBuildRow> = {}) {
+  // Post-DetailsDrawer-mount: the workflow graph is the always-visible primary
+  // surface of the active-build pane. No tab click needed; ProcessGraph mounts
+  // immediately on render. Waits for the mock's onNodeClick prop capture so
+  // tests can fire it before asserting against state.
   const result = render(
     <BuildStudio
       builds={[makeBuild(buildOverrides)]}
@@ -177,9 +181,7 @@ async function renderInTopologyView(buildOverrides: Partial<FeatureBuildRow> = {
       submissionBranchShortId="abc12345"
     />,
   );
-  // Switch to the Workflow tab so ProcessGraph mounts.
-  const workflowTab = await screen.findByRole("tab", { name: "Workflow" });
-  fireEvent.click(workflowTab);
+  await screen.findByTestId("process-graph-mock");
   return result;
 }
 


### PR DESCRIPTION
## Summary

The biggest remaining shape change. The active-build pane's **Workflow / Progress / Details tab selector is gone**. The workflow graph is now the always-visible primary surface (spec §1: workflow-as-canvas). Evidence (Progress, Brief / Design Doc, Review, BS Queue) migrates into a **DetailsDrawer accordion** behind a 24px pill on the canvas's right edge.

Spec: \`docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md\` §1 + §5 + §9 #11.

## What you'll see on \`/build\`

- No tab strip at the top of the active-build pane.
- Workflow graph (CodeIntelligenceStatusCard header + ProcessGraph + anchored NodeInspector) is always rendered.
- A thin "Details" pill sits on the right edge of the canvas. Click it (or the fleet header) → drawer slides in from the right.
- Drawer accordion default-opens the section that matches the active phase:
  - ideate / plan → **Brief / Design Doc**
  - build → **Progress**
  - review / ship / complete → **Review**
- Fleet header click opens drawer with **BS Queue** default-open instead. The header is now a real button with a chevron and a focus-visible outline.

## New surface: \`BsQueueSection\`

Read-only listing inside the drawer:
- Cap-aware counts (running / blocked / queued).
- Per-build row: code · title · kind tag (\`running\` / \`queued@N\` / \`blocked\` / \`idle\`).
- Sorted running → blocked → queued (by position) → idle.
- Caption explicitly defers queue mutation to the concurrency thread per spec §10.

## What's NOT in this PR (follow-up)

- TaskInspector / WorkflowStageInspector content migration into the NodeInspector expanded view. The inspector still shows the minimal task-plan body (specialist / implement / testFirst / verify) introduced in PR #943.
- Sidebar width tightening (still on the legacy 280-320px container; tightening waits until the new-feature input has a new home).
- T11 BuildStudio end-to-end integration test.

## Test plan

- [ ] CI Typecheck pass
- [ ] CI Production Build pass
- [ ] CI Unit Tests: 30 cases across BuildStudio + BuildStudioHeaderLayout + BuildStudioNodeInspector + BuildStudioDetailsDrawer (9 new for drawer integration) all green
- [ ] Manual on \`/build\`: workflow graph renders without clicking any tab; pill toggles the drawer; phase-appropriate section is default-open
- [ ] Manual: click the fleet header (the "Builds: N running" row above the build list) — drawer opens at BS Queue
- [ ] Manual: drawer never crosses into the coworker rail (no visual overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)