### PR TITLE
fix(voice): keep suggested script visible during mic recording

### DIFF
--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -317,7 +317,7 @@ function MicRecorder({ profileId }: { profileId: string }) {
   return (
     <div className="space-y-3">
       {/* Suggested script */}
-      {showScript && recState === "idle" && (
+      {showScript && recState !== "preview" && recState !== "uploading" && (
         <div className="rounded-md bg-muted/50 border border-border p-3 space-y-2">
           <div className="flex items-center justify-between">
             <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Suggested script</p>


### PR DESCRIPTION
## Problem

When the user clicks "Start recording", `recState` transitions from `idle` → `permission` → `recording`. The suggested script was conditionally rendered as `showScript && recState === "idle"`, so it disappeared the moment recording began — exactly when the user needs to read it.

## Fix

Changed condition to `recState !== "preview" && recState !== "uploading"`.

The script now stays visible during `idle`, `permission_check`, `recording`, and `error` states. It only hides during `preview` (the user has finished speaking and is reviewing the clip) and `uploading` (submitting). The "dismiss" button still works to permanently hide it.

## Change

```diff
- {showScript && recState === "idle" && (
+ {showScript && recState !== "preview" && recState !== "uploading" && (
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)