### PR TITLE
docs(kernel): draft two principles from the security-flow session

### DIFF
--- a/docs/founder-kernel/wiki/principles/external-and-internal-work-share-gates.md
+++ b/docs/founder-kernel/wiki/principles/external-and-internal-work-share-gates.md
@@ -1,0 +1,74 @@
+---
+title: External and internal work share gates; only entry doors differ
+pageKind: principle
+status: draft
+abstract: A PR clears the same phase gates regardless of who wrote it — maintainer, autonomous coworker, external contributor, or bot. Provenance is recorded for credit and learning, never for shortcutting approval.
+principleTier: core
+principleDirection: Prefer one gate set with multiple entry doors over per-provenance approval paths.
+principleDimensionVector: {"governance_compliance": 0.9, "long_term_maintainability": 0.6, "blast_radius": -0.7, "speed_to_value": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: universal
+principlePublic: true
+principlePublicRationale: This is a contributor guarantee. External contributors should know that their work will be judged by the same criteria the maintainers hold themselves to — no special path, no extra friction. Operators should know that no path bypasses governance.
+sources: []
+---
+
+## Rule
+
+The phase gates that approve a change (typecheck, tests, security audits, CodeQL diff, design review, kernel-principle alignment, etc.) are the same gates regardless of who authored the change. Internal Build Studio work, autonomous coworker output, external fork PRs, and maintainer hotfixes enter through different doors but pass the same gates. Provenance is metadata; approval is evidence.
+
+## Why
+
+If a "trusted contributor" path exists that skips gates, the trusted contributor becomes the single point of compromise. A maintainer account takeover, a leaked SSH key, a careless autonomous agent — any of these can ship code that the gate set would have caught.
+
+The DPF substrate already operationalizes this in spirit through the operator-ratified stance that "governance approves evidence, not provenance" — Build Studio phase gates judge evidence quality regardless of who produced it. This principle is the operational corollary: what that stance requires of the entry doors.
+
+A second-order benefit: external contributors get a predictable, fair experience. There's no "we'll be more careful with your PR because you're new" friction tax; the gate set is the contract. The bot reviewer for external PRs (under BI-860603DA) applies the same checklist a maintainer would apply to their own work.
+
+A third-order benefit: maintainers earn the same scrutiny they impose. A maintainer cannot bypass a check that an external contributor must clear. This is what keeps the gates honest over time — they have to be actually useful, not ceremonial.
+
+## Applies To
+
+Every change-approval flow:
+
+- **Code changes** — typecheck, lint, unit tests, integration tests, production build, security inflow gate, audit-* invariants, CodeQL.
+- **Architectural changes** — design review, kernel-principle alignment, spec compliance.
+- **Governance changes** — CODEOWNERS, branch protection rules, kernel principles themselves, security baselines.
+
+The principle does NOT mean every PR runs every gate — paths can be filtered (`release-gates.yml` only runs on installer changes), and conditional checks can skip when irrelevant. But the *gate set per file class* is uniform across provenance.
+
+The principle ALSO does NOT mean the bar is identical regardless of risk. Trust-boundary paths (CODEOWNERS-listed files: workflows, security substrate, kernel principles, decision substrate) require *more* review than ordinary application code. Everyone — maintainer, coworker, external contributor — clears that higher bar on those paths.
+
+## How To Apply
+
+1. **Define gates at the file-class level**, not the contributor level. A workflow change runs the actions-injection audit no matter who wrote it.
+2. **Never offer "skip CI on owner approval"** as a shortcut. If a check is slow or flaky, fix the check. If a check is bypassable, it's not a gate.
+3. **Apply trust-boundary carve-outs uniformly.** Files listed in [`.github/CODEOWNERS`](../../../../.github/CODEOWNERS) require owner review regardless of provenance — including when the maintainer themselves opens the PR.
+4. **Bot review counts.** The bot reviewer described in BI-860603DA runs the same pr-review-toolkit agents on external PRs that BS uses on internal work. The bot's pass is evidence; the human review is the second signal, not a replacement.
+5. **Record provenance for learning, not for routing.** Track who authored what so the hive can attribute contributions and so kernel updates can credit sources. Never route approval decisions through that metadata.
+
+## Decision Dimensions
+
+- `governance_compliance: 0.9` — the audit trail is uniform. SOC 2, ISO 27001, and similar frameworks ask "show me the controls that gate every change." A single answer is defensible; multiple answers per contributor class are not.
+- `long_term_maintainability: 0.6` — one gate set is easier to evolve than N parallel sets. When the gate set tightens (e.g. adding the security inflow gate), it tightens everywhere at once.
+- `blast_radius: -0.7` — strongly reduces blast radius from any single point of trust compromise. No maintainer account, no autonomous agent, no contractor relationship is a single point of failure if every PR clears the gates.
+- `speed_to_value: -0.3` — slower than a trusted-fast-path for the maintainer who knows the codebase. The cost is paid in marginal seconds per PR; the protection covers every contributor for the life of the project.
+
+## Examples
+
+- **Positive:** PR [#936](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/936) (security inflow gate) was opened by an autonomous agent. It cleared the same DCO check, typecheck, CodeQL analysis on four languages, audit invariants, and production build that an external contributor PR would clear. The agent's provenance was logged; it did not exempt the PR from any gate.
+- **Counterexample:** Allowing the autonomous agent to mark a security finding "dismissed - false positive" without the dismissal-justification field that an external contributor would have to fill in. The agent's trust earns it speed of action; it does not earn it a skipped justification.
+
+## Related principles
+
+- [`structural-verification-is-not-functional`](structural-verification-is-not-functional.md) — gates check structure (compile, lint, test); the operator-level functional check is still required after gates pass.
+- [`destructive-actions-require-explicit-go`](destructive-actions-require-explicit-go.md) — gates don't replace explicit-go for the small class of actions that require it. The two layers compose.
+
+Candidate for kernel promotion: "governance approves evidence, not provenance" — the operator-ratified stance this principle operationalizes is not yet a published kernel page. When it ships, link it here.
+
+## Sources
+
+Rendered from the `sources:` frontmatter array via `WikiSourceCitations`.

--- a/docs/founder-kernel/wiki/principles/security-fix-needs-regression-test-first.md
+++ b/docs/founder-kernel/wiki/principles/security-fix-needs-regression-test-first.md
@@ -1,0 +1,65 @@
+---
+title: Security findings get a regression test before a fix
+pageKind: principle
+status: draft
+abstract: Every security finding ships with a test that fails without the fix and passes with it — the test is written and demonstrated red before the fix lands.
+principleTier: core
+principleDirection: Prefer test-first remediation over fix-then-test, for any defect that escaped review.
+principleDimensionVector: {"long_term_maintainability": 0.9, "governance_compliance": 0.7, "blast_radius": -0.7, "speed_to_value": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: universal
+principlePublic: true
+principlePublicRationale: Operators adopting DPF should know how the platform handles its own defects. Test-first remediation is a public commitment that every shipped security fix carries proof it cannot regress silently — that promise is part of what the platform sells.
+sources: []
+---
+
+## Rule
+
+When fixing a security finding — CodeQL alert, Dependabot advisory, manually-discovered vulnerability — write the regression test **before** the fix. The test must fail against the unfixed code (demonstrably red) and pass after the fix. The fix and the test land in the same PR.
+
+## Why
+
+A security finding represents a defect that escaped review. Fixing it without a test means the same defect can re-enter through any of: a refactor, a copy-paste, a dependency upgrade that rolls back a sanitizer, a maintainer who doesn't know the historical context. The test is the durable record of the constraint.
+
+The "fix is mechanical, no test needed" framing is the canonical anti-pattern. Most security findings ARE mechanical at the line level (add a sanitizer, replace a regex, escape an env var). The mechanical-ness is exactly what makes them easy to undo. The test prevents the undo.
+
+Test-first matters more than test-eventually because the order proves the test is real. A test written after the fix can pass trivially if it tests the wrong path — and the author doesn't notice because the fix is already in place. Writing the test first means the author sees it fail, sees their understanding of the defect confirmed, and then drives the fix to green. The red-to-green transition is the evidence.
+
+## Applies To
+
+Every PR that addresses a security finding, regardless of provenance: internal Build Studio work, external contributor PR, autonomous coworker fix, maintainer hotfix. The principle does NOT apply to security-adjacent governance work that does not address a specific defect (e.g., adding a new auditor, updating CODEOWNERS, drafting a kernel principle). It applies to the *defect class*, not to all security work.
+
+The principle is also OPT-IN-able for false-positive dismissals: if a finding is marked as a false positive with written justification, no regression test is needed — the dismissal itself is the audit trail.
+
+## How To Apply
+
+1. **Reproduce the finding as a test.** Construct the minimal input that triggers the vulnerability. Run the test; confirm it fails for the exact reason the finding describes (not for some incidental reason).
+2. **Land the test first** in a draft PR or as the first commit of the working branch. The red CI run is the evidence.
+3. **Implement the fix.** Drive the test green.
+4. **Sweep for siblings.** Most CWEs cluster — if you fixed SSRF in one file, search the codebase for the same pattern in others. Each sibling gets the same test-first treatment.
+5. **Document the suppression** if you'd like CodeQL to learn the sanitizer pattern: add a `.github/codeql/config.yml` entry or an inline `// codeql[rule-id]: justification` comment. The suppression is part of the regression evidence — without it, CodeQL re-flags the fixed code on next scan.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.9` — the test is the durable artifact. Years later, when a refactor would have undone the fix, CI fails and points at the test. The lesson outlives the maintainer who wrote it.
+- `governance_compliance: 0.7` — regulated industries (SOC 2, ISO 27001, HIPAA) require evidence of remediation, not just the patch. A red-to-green test commit is exactly that evidence.
+- `blast_radius: -0.7` — strongly reduces blast radius of regression. A future PR cannot reintroduce the same defect without breaking the test; the cost of regression is paid in CI, not in a customer breach.
+- `speed_to_value: -0.4` — slower than fix-only on the first pass. Writing the test takes time. The cost is paid once; the protection is permanent.
+
+## Examples
+
+- **Positive:** BI-5E53A265 (SSRF cluster fix). Plan requires `safe-fetch.test.ts` to land first with cases covering 169.254.169.254 (cloud metadata), localhost, file://, and DNS rebinding. Each case fails against the current code, passes after the helper lands. Six CodeQL alerts close as the helper is adopted across the four true-positive sites.
+- **Counterexample:** BI-D094AF1D auto-promoted as "small mechanical fix — env-var passthrough on two workflow_dispatch lines." If shipped without a CI assertion that those lines no longer interpolate `${{ github.event.* }}` into shell, the next maintainer who edits those workflows can reintroduce the pattern. The auditor catches it, but only because that auditor exists — the audit IS the regression test for this class. Without the auditor, the fix is undoable in one careless edit.
+
+## Related principles
+
+- [`structural-verification-is-not-functional`](structural-verification-is-not-functional.md) — the test must demonstrate the actual exploit, not just that the patched line compiles.
+- [`evidence-before-diagnosis`](evidence-before-diagnosis.md) — the test reproduces the diagnosis. If you can't write the test, you don't fully understand the finding.
+- [`research-before-implementing`](research-before-implementing.md) — understand the CWE class before writing the test; the test should be representative of the pattern, not just the one observed instance.
+
+## Sources
+
+Rendered from the `sources:` frontmatter array via `WikiSourceCitations`.


### PR DESCRIPTION
## Summary

Two new principle drafts captured from the work shipped under **BI-04701325** (Security findings → BS intake) and **BI-860603DA** (External contribution governance). Both filed as `status: draft` pending maintainer ratification.

## The principles

### 1. `security-fix-needs-regression-test-first`

**Rule:** When fixing a security finding, write the regression test before the fix. The test must fail against the unfixed code (demonstrably red) and pass after. The fix and the test land in the same PR.

**Why now:** BI-04701325 names this as an acceptance criterion (every security BI requires regression test first). Drafting the principle locks the requirement into the kernel so it propagates via the hive update to every install.

**Dimension vector:**
- `long_term_maintainability: 0.9` — the test outlives the maintainer
- `governance_compliance: 0.7` — SOC 2 / ISO 27001 ask for evidence of remediation
- `blast_radius: -0.7` — prevents class regression at CI cost, not customer cost
- `speed_to_value: -0.4` — slower than fix-only on the first pass

### 2. `external-and-internal-work-share-gates`

**Rule:** A PR clears the same phase gates regardless of who authored it — maintainer, autonomous coworker, external contributor, bot. Provenance is metadata; approval is evidence.

**Why now:** This is the operational corollary to the operator-ratified \"governance approves evidence, not provenance\" stance. The session's three governance PRs (#936, #941, #946) all demonstrated this in practice — autonomous-agent-authored PRs cleared the same DCO, typecheck, CodeQL, audit-* checks an external contributor would clear.

**Dimension vector:**
- `governance_compliance: 0.9` — uniform audit trail
- `long_term_maintainability: 0.6` — one gate set evolves
- `blast_radius: -0.7` — no single-point-of-trust compromise
- `speed_to_value: -0.3` — marginal seconds per PR

## Tier

Both `core`. Neither bumps to `commandment` in this draft — that promotion is reserved for after live operation surfaces the rule in real decisions. Existing commandment-tier principles (`structural-verification-is-not-functional`, `never-ask-user-to-run-commands`) earned their tier through repeated violation cost.

## Audience

Both `principlePublic: true`:

- `security-fix-needs-regression-test-first` — operators adopting DPF should know how the platform handles its own defects. Test-first remediation is a sellable commitment.
- `external-and-internal-work-share-gates` — contributor guarantee. External contributors should know their work is judged by the same criteria maintainers hold themselves to.

Both apply to all three populations: `in_platform_coworker + external_coding_agent + human`.

## Open dependency

`external-and-internal-work-share-gates` references the \"governance approves evidence, not provenance\" stance, which is operator-ratified but not yet a published kernel page. The draft notes this in its \"Related principles\" footer with a \"Candidate for kernel promotion\" hint. When that stance lands as a kernel page, the link should be updated.

## Test plan

- [ ] CI green on this PR (no code touched — pure docs).
- [ ] Wiki lint clean (no orphans or dangling refs introduced).
- [ ] Maintainer reviews tier/public/dimensions for each.
- [ ] If approved, promote `status: draft → published` in a follow-up.

## Related

- BI-04701325, BI-860603DA, BI-5E53A265, BI-7DB95878, BI-5940955C, BI-D094AF1D
- PR [#936](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/936) — Security inflow gate
- PR [#941](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/941) — Actions code-injection auditor
- PR [#944](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/944) — Auditor startup hotfix
- PR [#946](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/946) — CODEOWNERS trust-boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)