### PR TITLE
feat(assurance): add SBOM ledger and export

### DIFF
--- a/apps/web/app/(shell)/portfolio/product/[id]/supply-chain/page.tsx
+++ b/apps/web/app/(shell)/portfolio/product/[id]/supply-chain/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { ProductSupplyChainPanel } from "@/components/product/ProductSupplyChainPanel";
+import { getLatestBomComponentsForProduct } from "@/lib/assurance/bom-read";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function ProductSupplyChainPage({ params }: Props) {
+  const { id } = await params;
+  const product = await prisma.digitalProduct.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+
+  if (!product) notFound();
+
+  const { latestBom, components } = await getLatestBomComponentsForProduct(prisma, id);
+
+  return (
+    <ProductSupplyChainPanel
+      productId={id}
+      latestBom={latestBom}
+      components={components}
+    />
+  );
+}

--- a/apps/web/app/api/portfolio/product/[id]/supply-chain/bom/route.ts
+++ b/apps/web/app/api/portfolio/product/[id]/supply-chain/bom/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { getLatestCycloneDxForProduct } from "@/lib/assurance/bom-export";
+
+type Context = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(_request: Request, { params }: Context) {
+  const { id } = await params;
+  const bom = await getLatestCycloneDxForProduct(prisma, id);
+
+  if (!bom) {
+    return NextResponse.json({ error: "No BOM found" }, { status: 404 });
+  }
+
+  return new NextResponse(JSON.stringify(bom.raw, null, 2), {
+    headers: {
+      "content-type": "application/vnd.cyclonedx+json; charset=utf-8",
+      "content-disposition": `attachment; filename="${bom.documentId}.shareable.cdx.json"`,
+    },
+  });
+}

--- a/apps/web/components/build/BuildAssuranceGateCard.test.tsx
+++ b/apps/web/components/build/BuildAssuranceGateCard.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
+
+vi.mock("@/lib/actions/assurance", () => ({
+  requestBuildBomGeneration: vi.fn(async () => ({ queued: true })),
+}));
+
+import { requestBuildBomGeneration } from "@/lib/actions/assurance";
+
+afterEach(cleanup);
+
+describe("BuildAssuranceGateCard", () => {
+  it("shows an honest missing-BOM state", () => {
+    render(
+      <BuildAssuranceGateCard
+        buildId="BUILD-1"
+        summary={{ state: "missing", document: null, counts: { components: 0, models: 0 } }}
+      />,
+    );
+
+    expect(screen.getByText("Assurance Gate")).toBeInTheDocument();
+    expect(screen.getByText("No BOM generated")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Generate BOM/i })).toBeInTheDocument();
+  });
+
+  it("shows component and model counts when a BOM exists", () => {
+    render(
+      <BuildAssuranceGateCard
+        buildId="BUILD-1"
+        summary={{
+          state: "current",
+          document: {
+            documentId: "bom_abc",
+            digest: "abc123",
+            generatedAt: new Date("2026-05-22T00:00:00.000Z"),
+            componentCount: 12,
+            sourceKind: "pnpm-lock",
+          },
+          counts: { components: 12, models: 2 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("BOM current")).toBeInTheDocument();
+    expect(screen.getByText("12 components")).toBeInTheDocument();
+    expect(screen.getByText("2 AI models")).toBeInTheDocument();
+  });
+
+  it("queues a background BOM run without blocking the card", async () => {
+    render(
+      <BuildAssuranceGateCard
+        buildId="BUILD-1"
+        summary={{ state: "missing", document: null, counts: { components: 0, models: 0 } }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate BOM/i }));
+
+    await waitFor(() => {
+      expect(requestBuildBomGeneration).toHaveBeenCalledWith("BUILD-1");
+    });
+  });
+});

--- a/apps/web/components/build/BuildAssuranceGateCard.tsx
+++ b/apps/web/components/build/BuildAssuranceGateCard.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Clock3, RefreshCw, ShieldCheck, TriangleAlert } from "lucide-react";
+import { useState, useTransition } from "react";
+import { requestBuildBomGeneration } from "@/lib/actions/assurance";
+import type { BomSummary } from "@/lib/assurance/bom-read";
+
+type RequestState = "idle" | "queued" | "failed";
+
+function formatGeneratedAt(value: Date | string | null | undefined): string {
+  if (!value) return "not generated";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "not generated";
+  return date.toLocaleString();
+}
+
+function statusLabel(summary: BomSummary): string {
+  if (summary.state === "current") return "BOM current";
+  if (summary.state === "stale") return "BOM stale";
+  return "No BOM generated";
+}
+
+export function BuildAssuranceGateCard({
+  buildId,
+  summary,
+}: {
+  buildId: string;
+  summary: BomSummary;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [requestState, setRequestState] = useState<RequestState>("idle");
+  const hasBom = summary.state !== "missing" && summary.document;
+  const StatusIcon = hasBom ? ShieldCheck : TriangleAlert;
+  const statusColor = summary.state === "current"
+    ? "text-[var(--dpf-success)]"
+    : summary.state === "stale"
+      ? "text-[var(--dpf-warning)]"
+      : "text-[var(--dpf-muted)]";
+  const modelLabel = `${summary.counts.models} AI model${summary.counts.models === 1 ? "" : "s"}`;
+  const buttonLabel = pending ? "Queueing" : requestState === "queued" ? "Queued" : "Generate BOM";
+
+  return (
+    <section
+      data-testid="build-assurance-gate-card"
+      className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 shadow-dpf-xs"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+            <StatusIcon className={`h-4 w-4 ${statusColor}`} aria-hidden="true" />
+            <h2>Assurance Gate</h2>
+          </div>
+          <p className={`mt-1 text-xs font-medium ${statusColor}`}>{statusLabel(summary)}</p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-8 items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-xs font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={pending}
+          onClick={() => {
+            setRequestState("idle");
+            startTransition(() => {
+              void requestBuildBomGeneration(buildId)
+                .then(() => setRequestState("queued"))
+                .catch(() => setRequestState("failed"));
+            });
+          }}
+        >
+          <RefreshCw className={pending ? "h-3.5 w-3.5 animate-spin" : "h-3.5 w-3.5"} aria-hidden="true" />
+          {buttonLabel}
+        </button>
+      </div>
+
+      <dl className="mt-3 grid min-h-14 grid-cols-3 divide-x divide-[var(--dpf-border)] border-t border-[var(--dpf-border)] pt-3 text-xs">
+        <div className="min-w-0 pr-3">
+          <dt className="text-[var(--dpf-muted)]">Components</dt>
+          <dd className="mt-1 truncate font-semibold text-[var(--dpf-text)]">
+            {summary.counts.components} components
+          </dd>
+        </div>
+        <div className="min-w-0 px-3">
+          <dt className="text-[var(--dpf-muted)]">Models</dt>
+          <dd className="mt-1 truncate font-semibold text-[var(--dpf-text)]">{modelLabel}</dd>
+        </div>
+        <div className="min-w-0 pl-3">
+          <dt className="flex items-center gap-1 text-[var(--dpf-muted)]">
+            <Clock3 className="h-3 w-3" aria-hidden="true" />
+            Generated
+          </dt>
+          <dd className="mt-1 truncate font-semibold text-[var(--dpf-text)]">
+            {formatGeneratedAt(summary.document?.generatedAt)}
+          </dd>
+        </div>
+      </dl>
+
+      {requestState === "failed" && (
+        <p className="mt-2 text-xs text-[var(--dpf-error)]" role="status">
+          Queue failed. Try again after the worker is available.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -18,6 +18,7 @@ import { BuildProgressOperationalPanel } from "./BuildProgressOperationalPanel";
 import { ReleaseDecisionPanel } from "./ReleaseDecisionPanel";
 import { BuildStudioWorkflowActionCard } from "./BuildStudioWorkflowActionCard";
 import { CodeIntelligenceStatusCard } from "./CodeIntelligenceStatusCard";
+import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
 import { deriveFleetCounts, deriveNeedsAttention, deriveQueueState } from "./fleet-derivation";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
@@ -28,9 +29,11 @@ import { getFeatureBuild } from "@/lib/actions/build-read";
 import { getBuildFlowStateAction } from "@/lib/actions/build-flow";
 import { getBuildProgressVisibilityAction } from "@/lib/actions/build-progress-visibility";
 import { getCodeGraphFreshnessAction } from "@/lib/actions/code-intelligence";
+import { getBuildBomSummary } from "@/lib/actions/assurance";
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import type { BuildFlowState } from "@/lib/build-flow-state";
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
+import type { BomSummary } from "@/lib/assurance/bom-read";
 import type { CodeGraphFreshness } from "@/lib/integrate/code-graph-access";
 import type { BuildExecutionState } from "@/lib/integrate/build-exec-types";
 import { STEP_LABELS } from "@/lib/integrate/build-exec-types";
@@ -54,6 +57,12 @@ type Props = {
   submissionBranchShortId?: string | null;
   initialBuildId?: string | null;
   portalContext?: PortalContextEnvelope | null;
+};
+
+const MISSING_BOM_SUMMARY: BomSummary = {
+  state: "missing",
+  document: null,
+  counts: { components: 0, models: 0 },
 };
 
 export function BuildStudio({
@@ -121,6 +130,7 @@ export function BuildStudio({
   const [flowState, setFlowState] = useState<BuildFlowState | null>(null);
   const [progressVisibility, setProgressVisibility] = useState<BuildProgressVisibility | null>(null);
   const [codeGraphFreshness, setCodeGraphFreshness] = useState<CodeGraphFreshness | null>(null);
+  const [bomSummary, setBomSummary] = useState<BomSummary>(MISSING_BOM_SUMMARY);
   const workflowAction = activeBuild
     ? deriveBuildStudioWorkflowAction({
       build: activeBuild,
@@ -136,18 +146,21 @@ export function BuildStudio({
   }, [activeBuild?.buildId, initialBuildId, router]);
 
   const refreshActiveBuildState = useCallback(async (buildId: string) => {
-    const [freshResult, flowResult, progressResult] = await Promise.allSettled([
+    const [freshResult, flowResult, progressResult, bomResult] = await Promise.allSettled([
       getFeatureBuild(buildId),
       getBuildFlowStateAction(buildId),
       getBuildProgressVisibilityAction(buildId),
+      getBuildBomSummary(buildId),
     ]);
     const fresh = freshResult.status === "fulfilled" ? freshResult.value : null;
     const nextFlow = flowResult.status === "fulfilled" ? flowResult.value : null;
     const nextProgress = progressResult.status === "fulfilled" ? progressResult.value : null;
+    const nextBomSummary = bomResult.status === "fulfilled" ? bomResult.value : MISSING_BOM_SUMMARY;
 
     if (fresh) setActiveBuild(fresh);
     setFlowState(nextFlow);
     setProgressVisibility(nextProgress);
+    setBomSummary(nextBomSummary);
   }, []);
   const debouncedRefetch = useCallback(async () => {
     if (!activeBuild) return;
@@ -172,21 +185,25 @@ export function BuildStudio({
     if (!activeBuild) {
       setFlowState(null);
       setProgressVisibility(null);
+      setBomSummary(MISSING_BOM_SUMMARY);
       return;
     }
     let cancelled = false;
     Promise.allSettled([
       getBuildFlowStateAction(activeBuild.buildId),
       getBuildProgressVisibilityAction(activeBuild.buildId),
-    ]).then(([flowResult, progressResult]) => {
+      getBuildBomSummary(activeBuild.buildId),
+    ]).then(([flowResult, progressResult, bomResult]) => {
       if (!cancelled) {
         setFlowState(flowResult.status === "fulfilled" ? flowResult.value : null);
         setProgressVisibility(progressResult.status === "fulfilled" ? progressResult.value : null);
+        setBomSummary(bomResult.status === "fulfilled" ? bomResult.value : MISSING_BOM_SUMMARY);
       }
     }).catch(() => {
       if (!cancelled) {
         setFlowState(null);
         setProgressVisibility(null);
+        setBomSummary(MISSING_BOM_SUMMARY);
       }
     });
     return () => { cancelled = true; };
@@ -572,7 +589,10 @@ export function BuildStudio({
                   data-testid={BUILD_STUDIO_TEST_IDS.graphPanel}
                 >
                   <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
-                    <CodeIntelligenceStatusCard freshness={codeGraphFreshness} />
+                    <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(280px,380px)]">
+                      <CodeIntelligenceStatusCard freshness={codeGraphFreshness} />
+                      <BuildAssuranceGateCard buildId={activeBuild.buildId} summary={bomSummary} />
+                    </div>
                   </div>
                   <div className="border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
                     Select any stage or task to inspect — or open Details on the right for progress, brief, review, sandbox, and BS Queue evidence.

--- a/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+++ b/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
@@ -50,6 +50,15 @@ vi.mock("@/lib/actions/code-intelligence", () => ({
   getCodeGraphFreshnessAction: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("@/lib/actions/assurance", () => ({
+  getBuildBomSummary: vi.fn().mockResolvedValue({
+    state: "missing",
+    document: null,
+    counts: { components: 0, models: 0 },
+  }),
+  requestBuildBomGeneration: vi.fn(async () => ({ queued: true })),
+}));
+
 vi.mock("@/components/build/PhaseIndicator", () => ({
   PhaseIndicator: () => <div data-testid="phase-indicator" />,
 }));

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -43,6 +43,15 @@ vi.mock("@/lib/actions/build-progress-visibility", () => ({
   getBuildProgressVisibilityAction: vi.fn(),
 }));
 
+vi.mock("@/lib/actions/assurance", () => ({
+  getBuildBomSummary: vi.fn().mockResolvedValue({
+    state: "missing",
+    document: null,
+    counts: { components: 0, models: 0 },
+  }),
+  requestBuildBomGeneration: vi.fn(async () => ({ queued: true })),
+}));
+
 vi.mock("@/components/build/PhaseIndicator", () => ({
   PhaseIndicator: () => <div data-testid="phase-indicator" />,
 }));
@@ -258,6 +267,22 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).toContain('data-testid="build-studio-details-drawer-pill"');
     expect(html).toContain('data-testid="build-studio-details-drawer"');
     expect(html).toMatch(/data-testid="build-studio-details-drawer"[^>]*data-open="false"/);
+  });
+
+  it("renders the build assurance gate next to code intelligence", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild()]}
+        portfolios={[]}
+        governedBacklogEnabled
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+      />,
+    );
+
+    expect(html).toContain('data-testid="build-assurance-gate-card"');
+    expect(html).toContain("Assurance Gate");
+    expect(html).toContain("No BOM generated");
   });
 
   it("renders the portal context strip when a server envelope is provided", () => {

--- a/apps/web/components/build/BuildStudioNodeInspector.test.tsx
+++ b/apps/web/components/build/BuildStudioNodeInspector.test.tsx
@@ -59,6 +59,15 @@ vi.mock("@/lib/actions/code-intelligence", () => ({
   getCodeGraphFreshnessAction: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("@/lib/actions/assurance", () => ({
+  getBuildBomSummary: vi.fn().mockResolvedValue({
+    state: "missing",
+    document: null,
+    counts: { components: 0, models: 0 },
+  }),
+  requestBuildBomGeneration: vi.fn(async () => ({ queued: true })),
+}));
+
 vi.mock("@/components/build/PhaseIndicator", () => ({
   PhaseIndicator: () => <div data-testid="phase-indicator" />,
 }));

--- a/apps/web/components/product/ProductSupplyChainPanel.test.tsx
+++ b/apps/web/components/product/ProductSupplyChainPanel.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProductSupplyChainPanel } from "./ProductSupplyChainPanel";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(cleanup);
+
+describe("ProductSupplyChainPanel", () => {
+  it("shows an empty state when there is no BOM", () => {
+    render(<ProductSupplyChainPanel productId="prod-1" latestBom={null} components={[]} />);
+
+    expect(screen.getByText("Supply Chain")).toBeInTheDocument();
+    expect(screen.getByText("No BOM has been generated for this product yet.")).toBeInTheDocument();
+  });
+
+  it("renders component rows and export link", () => {
+    render(
+      <ProductSupplyChainPanel
+        productId="prod-1"
+        latestBom={{
+          documentId: "bom_abc",
+          generatedAt: new Date("2026-05-22T00:00:00.000Z"),
+          digest: "abcdef1234567890",
+          componentCount: 2,
+        }}
+        components={[
+          {
+            name: "next",
+            version: "16.2.6",
+            componentType: "framework",
+            ecosystem: "npm",
+            packageUrl: "pkg:npm/next@16.2.6",
+          },
+          {
+            name: "gpt-5.4",
+            version: "2026-05",
+            componentType: "model",
+            ecosystem: "ai-model",
+            packageUrl: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("next")).toBeInTheDocument();
+    expect(screen.getByText("gpt-5.4")).toBeInTheDocument();
+    expect(screen.getByText("2 components")).toBeInTheDocument();
+    expect(screen.getByText("1 AI model")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Export shareable SBOM/i })).toHaveAttribute(
+      "href",
+      "/api/portfolio/product/prod-1/supply-chain/bom",
+    );
+  });
+});

--- a/apps/web/components/product/ProductSupplyChainPanel.tsx
+++ b/apps/web/components/product/ProductSupplyChainPanel.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { BrainCircuit, Download, Fingerprint, PackageCheck } from "lucide-react";
+import type { ReactNode } from "react";
+import type {
+  ProductSupplyChainBomRows,
+  ProductSupplyChainComponentRow,
+} from "@/lib/assurance/bom-read";
+
+export type ProductSupplyChainComponent = ProductSupplyChainComponentRow;
+export type ProductSupplyChainLatestBom = NonNullable<ProductSupplyChainBomRows["latestBom"]>;
+
+function formatGeneratedAt(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  return date.toLocaleString();
+}
+
+function shortDigest(value: string): string {
+  return value.length > 16 ? value.slice(0, 16) : value;
+}
+
+export function ProductSupplyChainPanel({
+  productId,
+  latestBom,
+  components,
+}: {
+  productId: string;
+  latestBom: ProductSupplyChainLatestBom | null;
+  components: ProductSupplyChainComponent[];
+}) {
+  const modelCount = components.filter((component) => component.componentType === "model").length;
+  const packageCountLabel = `${latestBom?.componentCount ?? 0} component${latestBom?.componentCount === 1 ? "" : "s"}`;
+  const modelCountLabel = `${modelCount} AI model${modelCount === 1 ? "" : "s"}`;
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold text-[var(--dpf-text)]">Supply Chain</h1>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+            BOM components, AI model dependencies, and shareable customer evidence.
+          </p>
+        </div>
+        {latestBom ? (
+          <Link
+            className="inline-flex h-9 items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 text-sm font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+            href={`/api/portfolio/product/${productId}/supply-chain/bom`}
+          >
+            <Download className="h-4 w-4" aria-hidden="true" />
+            Export shareable SBOM
+          </Link>
+        ) : null}
+      </div>
+
+      {!latestBom ? (
+        <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+          <div className="flex items-start gap-3">
+            <PackageCheck className="mt-0.5 h-5 w-5 text-[var(--dpf-muted)]" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-medium text-[var(--dpf-text)]">No BOM has been generated for this product yet.</p>
+              <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+                Generate a Build Studio BOM for a build linked to this product to populate the ledger.
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : (
+        <>
+          <section className="grid gap-3 md:grid-cols-3" aria-label="Supply chain summary">
+            <Metric
+              icon={<PackageCheck className="h-4 w-4" aria-hidden="true" />}
+              label="Components"
+              value={packageCountLabel}
+              detail={`Generated ${formatGeneratedAt(latestBom.generatedAt)}`}
+            />
+            <Metric
+              icon={<BrainCircuit className="h-4 w-4" aria-hidden="true" />}
+              label="Models"
+              value={modelCountLabel}
+              detail="First-class runtime dependencies"
+            />
+            <Metric
+              icon={<Fingerprint className="h-4 w-4" aria-hidden="true" />}
+              label="Digest"
+              value={shortDigest(latestBom.digest)}
+              detail={latestBom.documentId}
+            />
+          </section>
+
+          <div className="overflow-x-auto rounded-md border border-[var(--dpf-border)]">
+            <table className="min-w-full text-left text-sm">
+              <thead className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-xs text-[var(--dpf-muted)]">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Component</th>
+                  <th className="px-3 py-2 font-medium">Version</th>
+                  <th className="px-3 py-2 font-medium">Type</th>
+                  <th className="px-3 py-2 font-medium">Ecosystem</th>
+                  <th className="px-3 py-2 font-medium">Package URL</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)]">
+                {components.map((component) => (
+                  <tr key={`${component.name}:${component.version ?? ""}:${component.componentType}`}>
+                    <td className="px-3 py-2 font-medium">{component.name}</td>
+                    <td className="px-3 py-2 text-[var(--dpf-muted)]">{component.version ?? "unknown"}</td>
+                    <td className="px-3 py-2 text-[var(--dpf-muted)]">{component.componentType}</td>
+                    <td className="px-3 py-2 text-[var(--dpf-muted)]">{component.ecosystem ?? "unknown"}</td>
+                    <td className="max-w-xs break-all px-3 py-2 text-xs text-[var(--dpf-muted)]">
+                      {component.packageUrl ?? "not applicable"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-center gap-2 text-xs font-medium text-[var(--dpf-muted)]">
+        {icon}
+        {label}
+      </div>
+      <p className="mt-2 text-base font-semibold text-[var(--dpf-text)]">{value}</p>
+      <p className="mt-1 truncate text-xs text-[var(--dpf-muted)]" title={detail}>{detail}</p>
+    </div>
+  );
+}

--- a/apps/web/components/product/ProductTabNav.test.tsx
+++ b/apps/web/components/product/ProductTabNav.test.tsx
@@ -50,4 +50,13 @@ describe("ProductTabNav", () => {
     expect(html).toContain(">Dependencies &amp; Estate<");
     expect(html).not.toContain(">Inventory<");
   });
+
+  it("includes supply chain under the operate family", () => {
+    pathname = "/portfolio/product/prod-1/supply-chain";
+    const html = renderToStaticMarkup(<ProductTabNav productId="prod-1" />);
+
+    expect(html).toContain('href="/portfolio/product/prod-1/supply-chain"');
+    expect(html).toContain(">Supply Chain<");
+    expect(html).toContain(">Dependencies &amp; Estate<");
+  });
 });

--- a/apps/web/components/product/ProductTabNav.tsx
+++ b/apps/web/components/product/ProductTabNav.tsx
@@ -37,6 +37,7 @@ export function ProductTabNav({ productId }: { productId: string }) {
       subItems: [
         { label: "Health", href: `${base}/health` },
         { label: "Dependencies & Estate", href: `${base}/inventory` },
+        { label: "Supply Chain", href: `${base}/supply-chain` },
       ],
     },
     {

--- a/apps/web/lib/actions/assurance.test.ts
+++ b/apps/web/lib/actions/assurance.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    bomDocument: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/assurance/bom-trigger", () => ({
+  queueBuildBomGeneration: vi.fn(),
+}));
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { queueBuildBomGeneration } from "@/lib/assurance/bom-trigger";
+import { getBuildBomSummary, requestBuildBomGeneration } from "./assurance";
+
+describe("assurance actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queues BOM generation for an authorized platform user", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1", platformRole: "HR-000", isSuperuser: false },
+    } as never);
+    vi.mocked(queueBuildBomGeneration).mockResolvedValue({ ids: ["evt-1"] } as never);
+
+    await expect(requestBuildBomGeneration("BUILD-1")).resolves.toEqual({ queued: true });
+
+    expect(queueBuildBomGeneration).toHaveBeenCalledWith({
+      buildId: "BUILD-1",
+      requestedByUserId: "user-1",
+    });
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    await expect(requestBuildBomGeneration("BUILD-1")).rejects.toThrow("Unauthorized");
+    expect(queueBuildBomGeneration).not.toHaveBeenCalled();
+  });
+
+  it("normalizes build summary read failures to a missing state", async () => {
+    vi.mocked(prisma.bomDocument.findFirst).mockRejectedValue(new Error("db down"));
+
+    await expect(getBuildBomSummary("BUILD-1")).resolves.toEqual({
+      state: "missing",
+      document: null,
+      counts: { components: 0, models: 0 },
+    });
+  });
+});

--- a/apps/web/lib/actions/assurance.ts
+++ b/apps/web/lib/actions/assurance.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { getLatestBomSummaryForBuild, missingBomSummary } from "@/lib/assurance/bom-read";
+import type { BomSummary } from "@/lib/assurance/bom-read";
+import { queueBuildBomGeneration } from "@/lib/assurance/bom-trigger";
+
+async function requirePlatformUser(): Promise<string> {
+  const session = await auth();
+  const user = session?.user;
+
+  if (!user?.id || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")) {
+    throw new Error("Unauthorized");
+  }
+
+  return user.id;
+}
+
+export async function requestBuildBomGeneration(buildId: string): Promise<{ queued: true }> {
+  const requestedByUserId = await requirePlatformUser();
+  await queueBuildBomGeneration({ buildId, requestedByUserId });
+  return { queued: true };
+}
+
+export async function getBuildBomSummary(buildId: string): Promise<BomSummary> {
+  try {
+    return await getLatestBomSummaryForBuild(prisma, buildId);
+  } catch (err) {
+    console.error(
+      `[tool-trace] failed to load build BOM summary buildId=${buildId} error=${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return missingBomSummary();
+  }
+}

--- a/apps/web/lib/assurance/bom-export.test.ts
+++ b/apps/web/lib/assurance/bom-export.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { getLatestCycloneDxForProduct } from "./bom-export";
+
+describe("getLatestCycloneDxForProduct", () => {
+  it("returns null when the product has no BOM", async () => {
+    const db = { bomDocument: { findFirst: vi.fn(async () => null) } };
+
+    await expect(getLatestCycloneDxForProduct(db, "product-1")).resolves.toBeNull();
+  });
+
+  it("returns a shareable CycloneDX document for the newest product BOM", async () => {
+    const db = {
+      bomDocument: {
+        findFirst: vi.fn(async () => ({
+          documentId: "bom_1",
+          raw: {
+            bomFormat: "CycloneDX",
+            specVersion: "1.7",
+            serialNumber: "urn:uuid:test",
+            version: 1,
+            metadata: { properties: [{ name: "dpf:workspacePath", value: "D:/DPF/apps/web" }] },
+            components: [{ name: "next", version: "16.2.6" }],
+            dependencies: [],
+          },
+        })),
+      },
+    };
+
+    const result = await getLatestCycloneDxForProduct(db, "product-1");
+
+    expect(result?.documentId).toBe("bom_1");
+    expect(JSON.stringify(result?.raw)).not.toContain("workspacePath");
+    expect(db.bomDocument.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { digitalProductId: "product-1" },
+      orderBy: { generatedAt: "desc" },
+    }));
+  });
+});

--- a/apps/web/lib/assurance/bom-export.ts
+++ b/apps/web/lib/assurance/bom-export.ts
@@ -1,0 +1,24 @@
+import type { CycloneDxDocument } from "./bom-types";
+import { createShareableCycloneDxBom } from "./bom-redaction";
+
+export async function getLatestCycloneDxForProduct(
+  db: {
+    bomDocument: {
+      findFirst(args: unknown): Promise<null | { raw: unknown; documentId: string }>;
+    };
+  },
+  digitalProductId: string,
+): Promise<null | { documentId: string; raw: CycloneDxDocument }> {
+  const document = await db.bomDocument.findFirst({
+    where: { digitalProductId },
+    orderBy: { generatedAt: "desc" },
+    select: { documentId: true, raw: true },
+  });
+
+  if (!document) return null;
+
+  return {
+    documentId: document.documentId,
+    raw: createShareableCycloneDxBom(document.raw as CycloneDxDocument),
+  };
+}

--- a/apps/web/lib/assurance/bom-job.test.ts
+++ b/apps/web/lib/assurance/bom-job.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateAndPersistBuildBom } from "./bom-job";
+
+const packageJson = JSON.stringify({ name: "web", version: "0.1.0" });
+const lockText = `
+lockfileVersion: '9.0'
+importers:
+  apps/web:
+    dependencies:
+      next:
+        specifier: ^16.2.6
+        version: 16.2.6(react@19.2.6)
+`;
+
+describe("generateAndPersistBuildBom", () => {
+  it("returns skipped when the build does not exist", async () => {
+    const db = {
+      featureBuild: { findUnique: vi.fn(async () => null) },
+    };
+
+    await expect(generateAndPersistBuildBom({
+      db,
+      buildId: "missing",
+      requestedByUserId: "user-1",
+      projectRoot: "D:/DPF",
+      now: new Date("2026-05-22T00:00:00.000Z"),
+    })).resolves.toEqual({ skipped: true, reason: "build not found" });
+  });
+
+  it("creates run, receipt, persisted BOM, and build activity for an existing build", async () => {
+    const db = {
+      featureBuild: {
+        findUnique: vi.fn(async () => ({
+          buildId: "BUILD-1",
+          title: "Assurance build",
+          threadId: null,
+          createdById: "creator-1",
+          digitalProductId: "product-1",
+        })),
+      },
+      modelProfile: {
+        findMany: vi.fn(async () => [{ providerId: "openai", modelId: "gpt-5.4", modelStatus: "active" }]),
+      },
+      toolExecution: {
+        create: vi.fn(async () => ({ id: "tool-1" })),
+      },
+      toolExecutionReceipt: {
+        create: vi.fn(async () => ({ id: "receipt-1" })),
+      },
+      assuranceRun: {
+        create: vi.fn(async () => ({ id: "run-db-1", runId: "run-1" })),
+      },
+      bomComponent: {
+        upsert: vi.fn(async ({ where }: { where: { componentKey: string } }) => ({
+          id: `db-${where.componentKey}`,
+          componentKey: where.componentKey,
+        })),
+      },
+      bomDocument: {
+        upsert: vi.fn(async ({ create }: { create: { documentId: string } }) => ({
+          id: "document-db-1",
+          documentId: create.documentId,
+        })),
+      },
+      bomComponentOccurrence: {
+        createMany: vi.fn(async ({ data }: { data: unknown[] }) => ({ count: data.length })),
+      },
+      buildActivity: {
+        create: vi.fn(async () => ({})),
+      },
+    };
+
+    const result = await generateAndPersistBuildBom({
+      db,
+      buildId: "BUILD-1",
+      requestedByUserId: "user-1",
+      projectRoot: "D:/DPF",
+      now: new Date("2026-05-22T00:00:00.000Z"),
+      gitRef: "abc123",
+      readTextFile: vi.fn(async (path: string) => path.endsWith("package.json") ? packageJson : lockText),
+    });
+
+    expect(result).toMatchObject({ skipped: false, componentCount: 2, occurrenceCount: 2 });
+    expect(db.toolExecution.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        toolName: "generate_cyclonedx_bom",
+        success: true,
+        userId: "user-1",
+      }),
+    }));
+    expect(db.toolExecutionReceipt.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        toolExecutionId: "tool-1",
+        receiptKind: "assurance-bom",
+      }),
+    }));
+    expect(db.assuranceRun.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        runId: "assurance_bom_BUILD-1_tool-1",
+        status: "passed",
+        toolExecutionId: "tool-1",
+        toolExecutionReceiptId: "receipt-1",
+      }),
+    }));
+    expect(db.bomDocument.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        buildId: "BUILD-1",
+        digitalProductId: "product-1",
+        assuranceRunId: "run-db-1",
+      }),
+    }));
+    expect(db.buildActivity.create).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/assurance/bom-job.ts
+++ b/apps/web/lib/assurance/bom-job.ts
@@ -1,0 +1,201 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Prisma } from "@dpf/db";
+import { generateCycloneDxBom } from "./cyclonedx-generator";
+import { persistGeneratedBom } from "./bom-persistence";
+
+type BomJobDb = {
+  featureBuild: {
+    findUnique(args: unknown): Promise<null | {
+      buildId: string;
+      title: string;
+      threadId: string | null;
+      createdById: string;
+      digitalProductId: string | null;
+    }>;
+  };
+  modelProfile?: {
+    findMany(args: unknown): Promise<Array<{ providerId: string; modelId: string; modelStatus: string | null }>>;
+  };
+  toolExecution?: {
+    create(args: unknown): Promise<{ id: string }>;
+  };
+  toolExecutionReceipt?: {
+    create(args: unknown): Promise<{ id: string }>;
+  };
+  assuranceRun?: {
+    create(args: unknown): Promise<{ id: string; runId: string }>;
+  };
+  buildActivity?: {
+    create(args: unknown): Promise<unknown>;
+  };
+  bomComponent?: {
+    upsert(args: unknown): Promise<{ id: string; componentKey: string }>;
+  };
+  bomDocument?: {
+    upsert(args: unknown): Promise<{ id: string; documentId: string }>;
+  };
+  bomComponentOccurrence?: {
+    createMany(args: unknown): Promise<{ count: number }>;
+  };
+};
+
+export type GenerateAndPersistBuildBomResult =
+  | { skipped: true; reason: string }
+  | { skipped: false; documentId: string; componentCount: number; occurrenceCount: number; runId: string };
+
+export interface GenerateAndPersistBuildBomInput {
+  db: BomJobDb;
+  buildId: string;
+  requestedByUserId: string;
+  projectRoot: string;
+  now: Date;
+  gitRef?: string;
+  readTextFile?: (path: string) => Promise<string>;
+}
+
+async function defaultReadTextFile(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+function requirePersistenceDb(db: BomJobDb) {
+  if (!db.toolExecution || !db.toolExecutionReceipt || !db.assuranceRun || !db.bomComponent || !db.bomDocument || !db.bomComponentOccurrence) {
+    throw new Error("BOM persistence requires tool execution, receipt, run, document, component, and occurrence delegates");
+  }
+  return db as BomJobDb & Required<Pick<BomJobDb, "toolExecution" | "toolExecutionReceipt" | "assuranceRun" | "bomComponent" | "bomDocument" | "bomComponentOccurrence">>;
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function createRunId(buildId: string, toolExecutionId: string): string {
+  const buildPart = buildId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  const executionPart = toolExecutionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  return `assurance_bom_${buildPart}_${executionPart}`;
+}
+
+export async function generateAndPersistBuildBom(input: GenerateAndPersistBuildBomInput): Promise<GenerateAndPersistBuildBomResult> {
+  const build = await input.db.featureBuild.findUnique({
+    where: { buildId: input.buildId },
+    select: {
+      buildId: true,
+      title: true,
+      threadId: true,
+      createdById: true,
+      digitalProductId: true,
+    },
+  });
+
+  if (!build) return { skipped: true, reason: "build not found" };
+
+  const db = requirePersistenceDb(input.db);
+  const readTextFile = input.readTextFile ?? defaultReadTextFile;
+  const [packageJson, lockText, modelProfiles] = await Promise.all([
+    readTextFile(join(input.projectRoot, "apps/web/package.json")),
+    readTextFile(join(input.projectRoot, "pnpm-lock.yaml")),
+    input.db.modelProfile?.findMany({
+      where: { modelStatus: "active" },
+      select: { providerId: true, modelId: true, modelStatus: true },
+    }) ?? Promise.resolve([]),
+  ]);
+
+  const generatedBom = generateCycloneDxBom({
+    workspacePath: "apps/web",
+    packageJson,
+    lockText,
+    generatedAt: input.now,
+    gitRef: input.gitRef ?? process.env.GIT_COMMIT ?? "unknown",
+    modelProfiles,
+  });
+
+  const toolExecution = await db.toolExecution.create({
+    data: {
+      threadId: build.threadId ?? build.buildId,
+      agentId: "system:assurance-ledger",
+      userId: input.requestedByUserId,
+      toolName: "generate_cyclonedx_bom",
+      parameters: {
+        buildId: build.buildId,
+        digitalProductId: build.digitalProductId,
+        workspacePath: "apps/web",
+      } satisfies Prisma.InputJsonValue,
+      result: {
+        documentDigest: generatedBom.documentDigest,
+        componentCount: generatedBom.components.length,
+      } satisfies Prisma.InputJsonValue,
+      success: true,
+      executionMode: "background",
+      routeContext: "/build",
+      durationMs: null,
+      summary: `Generated CycloneDX BOM for ${build.title}.`,
+    },
+  });
+
+  const receipt = await db.toolExecutionReceipt.create({
+    data: {
+      toolExecutionId: toolExecution.id,
+      buildId: build.buildId,
+      receiptKind: "assurance-bom",
+      inputFingerprint: generatedBom.sourceDigest,
+      outputDigest: { sha256: generatedBom.documentDigest } satisfies Prisma.InputJsonValue,
+      executionStatus: "passed",
+      expiresAt: addDays(input.now, 365),
+    },
+  });
+
+  const assuranceRun = await db.assuranceRun.create({
+    data: {
+      runId: createRunId(build.buildId, toolExecution.id),
+      scopeType: "build",
+      scopeId: build.buildId,
+      adapterKey: "cyclonedx-pnpm-lock",
+      adapterVersion: "1.0.0",
+      status: "passed",
+      summary: {
+        documentDigest: generatedBom.documentDigest,
+        componentCount: generatedBom.components.length,
+      } satisfies Prisma.InputJsonValue,
+      startedAt: input.now,
+      completedAt: input.now,
+      buildId: build.buildId,
+      digitalProductId: build.digitalProductId,
+      toolExecutionId: toolExecution.id,
+      toolExecutionReceiptId: receipt.id,
+    },
+  });
+
+  const persisted = await persistGeneratedBom(db, {
+    buildId: build.buildId,
+    digitalProductId: build.digitalProductId,
+    assuranceRunId: assuranceRun.id,
+    generatedBom,
+  });
+
+  await input.db.buildActivity?.create({
+    data: {
+      buildId: build.buildId,
+      tool: "assurance-bom",
+      summary: `Generated shareable CycloneDX SBOM ${persisted.documentId} with ${persisted.componentCount} components.`,
+    },
+  });
+
+  if (build.threadId) {
+    const { agentEventBus } = await import("@/lib/agent-event-bus");
+    agentEventBus.emit(build.threadId, {
+      type: "evidence:update",
+      buildId: build.buildId,
+      field: "assuranceBom",
+    });
+  }
+
+  return {
+    skipped: false,
+    documentId: persisted.documentId,
+    componentCount: persisted.componentCount,
+    occurrenceCount: persisted.occurrenceCount,
+    runId: assuranceRun.runId,
+  };
+}

--- a/apps/web/lib/assurance/bom-persistence.test.ts
+++ b/apps/web/lib/assurance/bom-persistence.test.ts
@@ -48,7 +48,7 @@ describe("persistGeneratedBom", () => {
         upsert: vi.fn(async () => ({ id: "db-component-1", componentKey: "component-1" })),
       },
       bomDocument: {
-        create: vi.fn(async () => ({ id: "db-document-1", documentId: "bom_document-digest" })),
+        upsert: vi.fn(async () => ({ id: "db-document-1", documentId: "bom_document-digest" })),
       },
       bomComponentOccurrence: {
         createMany: vi.fn(async () => ({ count: 1 })),
@@ -66,8 +66,13 @@ describe("persistGeneratedBom", () => {
     expect(db.bomComponent.upsert).toHaveBeenCalledWith(expect.objectContaining({
       where: { componentKey: "component-1" },
     }));
-    expect(db.bomDocument.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
+    expect(db.bomDocument.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { documentId: "bom_document-digest" },
+      create: expect.objectContaining({
+        digest: "document-digest",
+        raw: generatedBom.cyclonedx,
+      }),
+      update: expect.objectContaining({
         digest: "document-digest",
         raw: generatedBom.cyclonedx,
       }),

--- a/apps/web/lib/assurance/bom-persistence.test.ts
+++ b/apps/web/lib/assurance/bom-persistence.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { persistGeneratedBom } from "./bom-persistence";
+import type { GeneratedBom } from "./bom-types";
+
+const generatedBom: GeneratedBom = {
+  cyclonedx: {
+    bomFormat: "CycloneDX",
+    specVersion: "1.7",
+    serialNumber: "urn:uuid:test",
+    version: 1,
+    metadata: {},
+    components: [],
+    dependencies: [],
+  },
+  components: [
+    {
+      componentKey: "component-1",
+      componentType: "library",
+      name: "next",
+      version: "16.2.6",
+      packageUrl: "pkg:npm/next@16.2.6",
+      supplierName: null,
+      licenseExpression: null,
+      ecosystem: "npm",
+      scope: "required",
+      metadata: {},
+    },
+  ],
+  occurrences: [
+    {
+      occurrenceKey: "occurrence-1",
+      componentKey: "component-1",
+      workspaceName: "web",
+      workspacePath: "apps/web",
+      dependencyKind: "dependencies",
+      direct: true,
+      evidence: {},
+    },
+  ],
+  sourceDigest: "source-digest",
+  documentDigest: "document-digest",
+};
+
+describe("persistGeneratedBom", () => {
+  it("persists document, components, and occurrences through stable keys", async () => {
+    const db = {
+      bomComponent: {
+        upsert: vi.fn(async () => ({ id: "db-component-1", componentKey: "component-1" })),
+      },
+      bomDocument: {
+        create: vi.fn(async () => ({ id: "db-document-1", documentId: "bom_document-digest" })),
+      },
+      bomComponentOccurrence: {
+        createMany: vi.fn(async () => ({ count: 1 })),
+      },
+    };
+
+    const result = await persistGeneratedBom(db, {
+      buildId: "BUILD-1",
+      digitalProductId: "product-1",
+      assuranceRunId: "run-1",
+      generatedBom,
+    });
+
+    expect(result.documentId).toBe("bom_document-digest");
+    expect(db.bomComponent.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { componentKey: "component-1" },
+    }));
+    expect(db.bomDocument.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        digest: "document-digest",
+        raw: generatedBom.cyclonedx,
+      }),
+    }));
+    expect(db.bomComponentOccurrence.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: [expect.objectContaining({ occurrenceKey: "occurrence-1" })],
+      skipDuplicates: true,
+    }));
+  });
+});

--- a/apps/web/lib/assurance/bom-persistence.ts
+++ b/apps/web/lib/assurance/bom-persistence.ts
@@ -1,0 +1,102 @@
+import type { Prisma } from "@dpf/db";
+import type { GeneratedBom, NormalizedBomComponent } from "./bom-types";
+
+type BomPersistenceDb = {
+  bomComponent: {
+    upsert(args: unknown): Promise<{ id: string; componentKey: string }>;
+  };
+  bomDocument: {
+    create(args: unknown): Promise<{ id: string; documentId: string }>;
+  };
+  bomComponentOccurrence: {
+    createMany(args: unknown): Promise<{ count: number }>;
+  };
+};
+
+function componentCreateData(component: NormalizedBomComponent) {
+  return {
+    componentKey: component.componentKey,
+    componentType: component.componentType,
+    name: component.name,
+    version: component.version,
+    packageUrl: component.packageUrl,
+    supplierName: component.supplierName,
+    licenseExpression: component.licenseExpression,
+    ecosystem: component.ecosystem,
+    scope: component.scope,
+    metadata: component.metadata as Prisma.InputJsonValue,
+  };
+}
+
+export async function persistGeneratedBom(
+  db: BomPersistenceDb,
+  input: {
+    buildId: string | null;
+    digitalProductId: string | null;
+    assuranceRunId: string | null;
+    artifactRevisionId?: string | null;
+    generatedBom: GeneratedBom;
+  },
+): Promise<{ documentDbId: string; documentId: string; componentCount: number; occurrenceCount: number }> {
+  const componentRows = new Map<string, { id: string; componentKey: string }>();
+
+  for (const component of input.generatedBom.components) {
+    const data = componentCreateData(component);
+    const row = await db.bomComponent.upsert({
+      where: { componentKey: component.componentKey },
+      create: data,
+      update: {
+        ...data,
+        lastSeenAt: new Date(),
+      },
+    });
+    componentRows.set(component.componentKey, row);
+  }
+
+  const documentId = `bom_${input.generatedBom.documentDigest.slice(0, 24)}`;
+  const document = await db.bomDocument.create({
+    data: {
+      documentId,
+      format: "cyclonedx-json",
+      formatVersion: input.generatedBom.cyclonedx.specVersion,
+      serialNumber: input.generatedBom.cyclonedx.serialNumber,
+      version: input.generatedBom.cyclonedx.version,
+      digest: input.generatedBom.documentDigest,
+      sourceKind: "pnpm-lock",
+      sourceDigest: input.generatedBom.sourceDigest,
+      componentCount: input.generatedBom.components.length,
+      raw: input.generatedBom.cyclonedx as unknown as Prisma.InputJsonValue,
+      buildId: input.buildId,
+      digitalProductId: input.digitalProductId,
+      assuranceRunId: input.assuranceRunId,
+      artifactRevisionId: input.artifactRevisionId ?? null,
+    },
+  });
+
+  const occurrenceRows = input.generatedBom.occurrences.flatMap((occurrence) => {
+    const component = componentRows.get(occurrence.componentKey);
+    if (!component) return [];
+    return [{
+      occurrenceKey: occurrence.occurrenceKey,
+      bomDocumentId: document.id,
+      componentId: component.id,
+      workspaceName: occurrence.workspaceName,
+      workspacePath: occurrence.workspacePath,
+      dependencyKind: occurrence.dependencyKind,
+      direct: occurrence.direct,
+      evidence: occurrence.evidence as Prisma.InputJsonValue,
+    }];
+  });
+
+  const createdOccurrences = await db.bomComponentOccurrence.createMany({
+    data: occurrenceRows,
+    skipDuplicates: true,
+  });
+
+  return {
+    documentDbId: document.id,
+    documentId: document.documentId,
+    componentCount: input.generatedBom.components.length,
+    occurrenceCount: createdOccurrences.count,
+  };
+}

--- a/apps/web/lib/assurance/bom-persistence.ts
+++ b/apps/web/lib/assurance/bom-persistence.ts
@@ -6,7 +6,7 @@ type BomPersistenceDb = {
     upsert(args: unknown): Promise<{ id: string; componentKey: string }>;
   };
   bomDocument: {
-    create(args: unknown): Promise<{ id: string; documentId: string }>;
+    upsert(args: unknown): Promise<{ id: string; documentId: string }>;
   };
   bomComponentOccurrence: {
     createMany(args: unknown): Promise<{ count: number }>;
@@ -54,23 +54,28 @@ export async function persistGeneratedBom(
   }
 
   const documentId = `bom_${input.generatedBom.documentDigest.slice(0, 24)}`;
-  const document = await db.bomDocument.create({
-    data: {
+  const documentData = {
+    format: "cyclonedx-json",
+    formatVersion: input.generatedBom.cyclonedx.specVersion,
+    serialNumber: input.generatedBom.cyclonedx.serialNumber,
+    version: input.generatedBom.cyclonedx.version,
+    digest: input.generatedBom.documentDigest,
+    sourceKind: "pnpm-lock",
+    sourceDigest: input.generatedBom.sourceDigest,
+    componentCount: input.generatedBom.components.length,
+    raw: input.generatedBom.cyclonedx as unknown as Prisma.InputJsonValue,
+    buildId: input.buildId,
+    digitalProductId: input.digitalProductId,
+    assuranceRunId: input.assuranceRunId,
+    artifactRevisionId: input.artifactRevisionId ?? null,
+  };
+  const document = await db.bomDocument.upsert({
+    where: { documentId },
+    create: {
       documentId,
-      format: "cyclonedx-json",
-      formatVersion: input.generatedBom.cyclonedx.specVersion,
-      serialNumber: input.generatedBom.cyclonedx.serialNumber,
-      version: input.generatedBom.cyclonedx.version,
-      digest: input.generatedBom.documentDigest,
-      sourceKind: "pnpm-lock",
-      sourceDigest: input.generatedBom.sourceDigest,
-      componentCount: input.generatedBom.components.length,
-      raw: input.generatedBom.cyclonedx as unknown as Prisma.InputJsonValue,
-      buildId: input.buildId,
-      digitalProductId: input.digitalProductId,
-      assuranceRunId: input.assuranceRunId,
-      artifactRevisionId: input.artifactRevisionId ?? null,
+      ...documentData,
     },
+    update: documentData,
   });
 
   const occurrenceRows = input.generatedBom.occurrences.flatMap((occurrence) => {

--- a/apps/web/lib/assurance/bom-read.test.ts
+++ b/apps/web/lib/assurance/bom-read.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getLatestBomComponentsForProduct,
+  getLatestBomSummaryForBuild,
+  getLatestBomSummaryForProduct,
+} from "./bom-read";
+
+describe("getLatestBomSummaryForBuild", () => {
+  it("returns a missing state when no BOM exists", async () => {
+    const db = { bomDocument: { findFirst: vi.fn(async () => null) } };
+
+    await expect(getLatestBomSummaryForBuild(db, "BUILD-1")).resolves.toEqual({
+      state: "missing",
+      document: null,
+      counts: { components: 0, models: 0 },
+    });
+  });
+
+  it("summarizes the newest build BOM and model count", async () => {
+    const generatedAt = new Date("2026-05-22T00:00:00.000Z");
+    const db = {
+      bomDocument: {
+        findFirst: vi.fn(async () => ({
+          documentId: "bom_1",
+          digest: "abc",
+          generatedAt,
+          componentCount: 3,
+          sourceKind: "pnpm-lock",
+          status: "current",
+          occurrences: [
+            { component: { componentType: "library" } },
+            { component: { componentType: "model" } },
+          ],
+        })),
+      },
+    };
+
+    await expect(getLatestBomSummaryForBuild(db, "BUILD-1")).resolves.toEqual({
+      state: "current",
+      document: {
+        documentId: "bom_1",
+        digest: "abc",
+        generatedAt,
+        componentCount: 3,
+        sourceKind: "pnpm-lock",
+      },
+      counts: { components: 3, models: 1 },
+    });
+    expect(db.bomDocument.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { buildId: "BUILD-1" },
+      orderBy: { generatedAt: "desc" },
+    }));
+  });
+});
+
+describe("getLatestBomSummaryForProduct", () => {
+  it("marks non-current product BOMs stale", async () => {
+    const db = {
+      bomDocument: {
+        findFirst: vi.fn(async () => ({
+          documentId: "bom_stale",
+          digest: "def",
+          generatedAt: new Date("2026-05-20T00:00:00.000Z"),
+          componentCount: 1,
+          sourceKind: "pnpm-lock",
+          status: "superseded",
+          occurrences: [],
+        })),
+      },
+    };
+
+    const summary = await getLatestBomSummaryForProduct(db, "product-1");
+
+    expect(summary.state).toBe("stale");
+    expect(db.bomDocument.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { digitalProductId: "product-1" },
+    }));
+  });
+});
+
+describe("getLatestBomComponentsForProduct", () => {
+  it("returns the latest product BOM rows for the supply chain table", async () => {
+    const generatedAt = new Date("2026-05-22T00:00:00.000Z");
+    const db = {
+      bomDocument: {
+        findFirst: vi.fn(async () => ({
+          documentId: "bom_2",
+          generatedAt,
+          digest: "ghi",
+          componentCount: 1,
+          occurrences: [
+            {
+              component: {
+                name: "next",
+                version: "16.2.6",
+                componentType: "framework",
+                ecosystem: "npm",
+                packageUrl: "pkg:npm/next@16.2.6",
+              },
+            },
+          ],
+        })),
+      },
+    };
+
+    await expect(getLatestBomComponentsForProduct(db, "product-1")).resolves.toEqual({
+      latestBom: {
+        documentId: "bom_2",
+        generatedAt,
+        digest: "ghi",
+        componentCount: 1,
+      },
+      components: [
+        {
+          name: "next",
+          version: "16.2.6",
+          componentType: "framework",
+          ecosystem: "npm",
+          packageUrl: "pkg:npm/next@16.2.6",
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/lib/assurance/bom-read.ts
+++ b/apps/web/lib/assurance/bom-read.ts
@@ -1,0 +1,186 @@
+export interface BomSummary {
+  state: "missing" | "current" | "stale";
+  document: null | {
+    documentId: string;
+    digest: string;
+    generatedAt: Date;
+    componentCount: number;
+    sourceKind: string;
+  };
+  counts: {
+    components: number;
+    models: number;
+  };
+}
+
+export interface ProductSupplyChainComponentRow {
+  name: string;
+  version: string | null;
+  componentType: string;
+  ecosystem: string | null;
+  packageUrl: string | null;
+}
+
+export interface ProductSupplyChainBomRows {
+  latestBom: null | {
+    documentId: string;
+    generatedAt: Date;
+    digest: string;
+    componentCount: number;
+  };
+  components: ProductSupplyChainComponentRow[];
+}
+
+type BomSummaryRow = {
+  documentId: string;
+  digest: string;
+  generatedAt: Date;
+  componentCount: number;
+  sourceKind: string;
+  status?: string | null;
+  occurrences?: Array<{ component?: { componentType?: string | null } | null }>;
+};
+
+type ProductBomRows = {
+  documentId: string;
+  generatedAt: Date;
+  digest: string;
+  componentCount: number;
+  occurrences?: Array<{
+    component: ProductSupplyChainComponentRow;
+  }>;
+};
+
+type BomReadDb = {
+  bomDocument: {
+    findFirst(args: unknown): Promise<null | BomSummaryRow>;
+  };
+};
+
+type ProductBomReadDb = {
+  bomDocument: {
+    findFirst(args: unknown): Promise<null | ProductBomRows>;
+  };
+};
+
+export function missingBomSummary(): BomSummary {
+  return {
+    state: "missing",
+    document: null,
+    counts: { components: 0, models: 0 },
+  };
+}
+
+function summarizeBomDocument(document: BomSummaryRow | null): BomSummary {
+  if (!document) return missingBomSummary();
+
+  const modelCount = (document.occurrences ?? []).filter((entry) => (
+    entry.component?.componentType === "model"
+  )).length;
+
+  return {
+    state: document.status && document.status !== "current" ? "stale" : "current",
+    document: {
+      documentId: document.documentId,
+      digest: document.digest,
+      generatedAt: document.generatedAt,
+      componentCount: document.componentCount,
+      sourceKind: document.sourceKind,
+    },
+    counts: {
+      components: document.componentCount,
+      models: modelCount,
+    },
+  };
+}
+
+function latestBomSummarySelect() {
+  return {
+    documentId: true,
+    digest: true,
+    generatedAt: true,
+    componentCount: true,
+    sourceKind: true,
+    status: true,
+    occurrences: {
+      select: {
+        component: {
+          select: {
+            componentType: true,
+          },
+        },
+      },
+    },
+  };
+}
+
+export async function getLatestBomSummaryForBuild(
+  db: BomReadDb,
+  buildId: string,
+): Promise<BomSummary> {
+  const document = await db.bomDocument.findFirst({
+    where: { buildId },
+    orderBy: { generatedAt: "desc" },
+    select: latestBomSummarySelect(),
+  });
+
+  return summarizeBomDocument(document);
+}
+
+export async function getLatestBomSummaryForProduct(
+  db: BomReadDb,
+  digitalProductId: string,
+): Promise<BomSummary> {
+  const document = await db.bomDocument.findFirst({
+    where: { digitalProductId },
+    orderBy: { generatedAt: "desc" },
+    select: latestBomSummarySelect(),
+  });
+
+  return summarizeBomDocument(document);
+}
+
+export async function getLatestBomComponentsForProduct(
+  db: ProductBomReadDb,
+  digitalProductId: string,
+  limit = 200,
+): Promise<ProductSupplyChainBomRows> {
+  const document = await db.bomDocument.findFirst({
+    where: { digitalProductId },
+    orderBy: { generatedAt: "desc" },
+    select: {
+      documentId: true,
+      generatedAt: true,
+      digest: true,
+      componentCount: true,
+      occurrences: {
+        select: {
+          component: {
+            select: {
+              name: true,
+              version: true,
+              componentType: true,
+              ecosystem: true,
+              packageUrl: true,
+            },
+          },
+        },
+        take: limit,
+      },
+    },
+  });
+
+  if (!document) {
+    return { latestBom: null, components: [] };
+  }
+
+  return {
+    latestBom: {
+      documentId: document.documentId,
+      generatedAt: document.generatedAt,
+      digest: document.digest,
+      componentCount: document.componentCount,
+    },
+    components: (document.occurrences ?? []).map((occurrence) => occurrence.component),
+  };
+}

--- a/apps/web/lib/assurance/bom-redaction.test.ts
+++ b/apps/web/lib/assurance/bom-redaction.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { CycloneDxDocument } from "./bom-types";
+import { createShareableCycloneDxBom } from "./bom-redaction";
+
+const internalBom: CycloneDxDocument = {
+  bomFormat: "CycloneDX",
+  specVersion: "1.7",
+  serialNumber: "urn:uuid:11111111-1111-1111-1111-111111111111",
+  version: 1,
+  metadata: {
+    timestamp: "2026-05-22T00:00:00.000Z",
+    component: { type: "application", name: "dpf-web", version: "0.1.0" },
+    properties: [
+      { name: "dpf:sourceDigest", value: "internal-source-digest" },
+      { name: "dpf:workspacePath", value: "D:/DPF/apps/web" },
+      { name: "supplier", value: "Open Digital Product Factory" },
+    ],
+  },
+  components: [
+    {
+      type: "framework",
+      name: "next",
+      version: "16.2.6",
+      purl: "pkg:npm/next@16.2.6",
+      evidence: { workspacePath: "D:/DPF/apps/web", requestedByUserId: "user_123" },
+    },
+    {
+      type: "machine-learning-model",
+      name: "gpt-5.4",
+      version: "2026-05",
+      properties: [{ name: "dpf:routeContext", value: "/build" }],
+    },
+  ],
+  dependencies: [{ ref: "pkg:npm/next@16.2.6" }],
+};
+
+describe("createShareableCycloneDxBom", () => {
+  it("preserves machine-readable component inventory", () => {
+    const shareable = createShareableCycloneDxBom(internalBom);
+
+    expect(shareable.bomFormat).toBe("CycloneDX");
+    expect(shareable.specVersion).toBe("1.7");
+    expect(shareable.components).toHaveLength(2);
+    expect(shareable.components[0]).toMatchObject({
+      name: "next",
+      version: "16.2.6",
+      purl: "pkg:npm/next@16.2.6",
+    });
+    expect(shareable.components[1]).toMatchObject({
+      name: "gpt-5.4",
+      version: "2026-05",
+    });
+  });
+
+  it("removes internal execution metadata from shareable exports", () => {
+    const serialized = JSON.stringify(createShareableCycloneDxBom(internalBom));
+
+    expect(serialized).not.toContain("D:/DPF");
+    expect(serialized).not.toContain("workspacePath");
+    expect(serialized).not.toContain("requestedByUserId");
+    expect(serialized).not.toContain("routeContext");
+    expect(serialized).not.toContain("internal-source-digest");
+  });
+
+  it("marks the export profile without removing non-internal properties", () => {
+    const shareable = createShareableCycloneDxBom(internalBom);
+    const properties = shareable.metadata.properties as Array<{ name: string; value: string }>;
+
+    expect(properties).toContainEqual({ name: "supplier", value: "Open Digital Product Factory" });
+    expect(properties).toContainEqual({ name: "dpf:exportProfile", value: "shareable" });
+  });
+});

--- a/apps/web/lib/assurance/bom-redaction.ts
+++ b/apps/web/lib/assurance/bom-redaction.ts
@@ -1,0 +1,85 @@
+import type { CycloneDxDocument } from "./bom-types";
+
+const INTERNAL_KEYS = new Set([
+  "absolutePath",
+  "apiKey",
+  "internalUrl",
+  "localPath",
+  "requestedByUserId",
+  "routeContext",
+  "secret",
+  "sourceDigest",
+  "sourcePath",
+  "toolExecutionId",
+  "userId",
+  "workspacePath",
+]);
+
+const INTERNAL_PROPERTY_NAMES = new Set([
+  "dpf:routeContext",
+  "dpf:sourceDigest",
+  "dpf:workspacePath",
+]);
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isInternalKey(key: string): boolean {
+  return INTERNAL_KEYS.has(key);
+}
+
+function isInternalProperty(property: unknown): boolean {
+  if (!isPlainRecord(property)) return false;
+  const name = typeof property.name === "string" ? property.name : "";
+  return INTERNAL_PROPERTY_NAMES.has(name);
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => redactValue(entry))
+      .filter((entry) => entry !== undefined);
+  }
+
+  if (!isPlainRecord(value)) return value;
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (isInternalKey(key)) continue;
+
+    if (key === "properties" && Array.isArray(entry)) {
+      redacted[key] = redactValue(entry.filter((property) => !isInternalProperty(property)));
+      continue;
+    }
+
+    const child = redactValue(entry);
+    if (child !== undefined) {
+      redacted[key] = child;
+    }
+  }
+
+  return redacted;
+}
+
+function metadataProperties(metadata: Record<string, unknown>): Array<Record<string, unknown>> {
+  return Array.isArray(metadata.properties)
+    ? metadata.properties.filter(isPlainRecord)
+    : [];
+}
+
+export function createShareableCycloneDxBom(input: CycloneDxDocument): CycloneDxDocument {
+  const redacted = redactValue(input) as CycloneDxDocument;
+  const metadata = redacted.metadata ?? {};
+
+  return {
+    ...redacted,
+    metadata: {
+      ...metadata,
+      properties: [
+        ...metadataProperties(metadata),
+        { name: "dpf:exportProfile", value: "shareable" },
+      ],
+    },
+  };
+}

--- a/apps/web/lib/assurance/bom-trigger.test.ts
+++ b/apps/web/lib/assurance/bom-trigger.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/queue/inngest-client", () => ({
+  inngest: { send: vi.fn() },
+}));
+
+import { inngest } from "@/lib/queue/inngest-client";
+import { queueBuildBomGeneration } from "./bom-trigger";
+
+describe("queueBuildBomGeneration", () => {
+  it("queues the assurance BOM generation event", async () => {
+    vi.mocked(inngest.send).mockResolvedValue({ ids: ["evt-1"] } as never);
+
+    await queueBuildBomGeneration({ buildId: "BUILD-1", requestedByUserId: "user-1" });
+
+    expect(inngest.send).toHaveBeenCalledWith({
+      name: "assurance/bom.generate",
+      data: { buildId: "BUILD-1", requestedByUserId: "user-1" },
+    });
+  });
+});

--- a/apps/web/lib/assurance/bom-trigger.ts
+++ b/apps/web/lib/assurance/bom-trigger.ts
@@ -1,0 +1,10 @@
+import { inngest, type AssuranceBomGenerateEvent } from "@/lib/queue/inngest-client";
+
+export async function queueBuildBomGeneration(input: { buildId: string; requestedByUserId: string }) {
+  const event: AssuranceBomGenerateEvent = {
+    name: "assurance/bom.generate",
+    data: input,
+  };
+
+  return inngest.send(event);
+}

--- a/apps/web/lib/assurance/bom-types.ts
+++ b/apps/web/lib/assurance/bom-types.ts
@@ -1,0 +1,43 @@
+export const BOM_COMPONENT_TYPES = ["library", "framework", "application", "container", "model"] as const;
+export type BomComponentType = (typeof BOM_COMPONENT_TYPES)[number];
+
+export interface NormalizedBomComponent {
+  componentKey: string;
+  componentType: BomComponentType;
+  name: string;
+  version: string | null;
+  packageUrl: string | null;
+  supplierName: string | null;
+  licenseExpression: string | null;
+  ecosystem: string | null;
+  scope: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface NormalizedBomOccurrence {
+  occurrenceKey: string;
+  componentKey: string;
+  workspaceName: string | null;
+  workspacePath: string | null;
+  dependencyKind: string | null;
+  direct: boolean;
+  evidence: Record<string, unknown>;
+}
+
+export interface CycloneDxDocument {
+  bomFormat: "CycloneDX";
+  specVersion: "1.7";
+  serialNumber: string;
+  version: number;
+  metadata: Record<string, unknown>;
+  components: Array<Record<string, unknown>>;
+  dependencies: Array<Record<string, unknown>>;
+}
+
+export interface GeneratedBom {
+  cyclonedx: CycloneDxDocument;
+  components: NormalizedBomComponent[];
+  occurrences: NormalizedBomOccurrence[];
+  sourceDigest: string;
+  documentDigest: string;
+}

--- a/apps/web/lib/assurance/component-key.test.ts
+++ b/apps/web/lib/assurance/component-key.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { createComponentKey, createNpmPackageUrl } from "./component-key";
+
+describe("createComponentKey", () => {
+  it("creates stable keys for package components", () => {
+    const input = {
+      componentType: "library",
+      ecosystem: "npm",
+      name: "@dpf/db",
+      version: "0.1.0",
+      packageUrl: "pkg:npm/%40dpf/db@0.1.0",
+    } as const;
+
+    expect(createComponentKey(input)).toBe(createComponentKey(input));
+    expect(createComponentKey(input)).toMatch(/^[a-f0-9]{24}$/);
+  });
+
+  it("creates different keys for model components", () => {
+    const left = createComponentKey({
+      componentType: "model",
+      ecosystem: "ai-model",
+      name: "gpt-5.4",
+      version: "2026-05",
+      packageUrl: null,
+    });
+    const right = createComponentKey({
+      componentType: "library",
+      ecosystem: "npm",
+      name: "gpt-5.4",
+      version: "2026-05",
+      packageUrl: null,
+    });
+
+    expect(left).not.toBe(right);
+  });
+});
+
+describe("createNpmPackageUrl", () => {
+  it("encodes scoped npm package names", () => {
+    expect(createNpmPackageUrl("@dpf/db", "0.1.0")).toBe("pkg:npm/%40dpf/db@0.1.0");
+  });
+
+  it("encodes unscoped npm package names", () => {
+    expect(createNpmPackageUrl("next", "16.2.6")).toBe("pkg:npm/next@16.2.6");
+  });
+});

--- a/apps/web/lib/assurance/component-key.ts
+++ b/apps/web/lib/assurance/component-key.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+import type { BomComponentType } from "./bom-types";
+
+export interface ComponentKeyInput {
+  componentType: BomComponentType;
+  ecosystem: string | null;
+  name: string;
+  version: string | null;
+  packageUrl: string | null;
+}
+
+export function createComponentKey(input: ComponentKeyInput): string {
+  return createHash("sha256")
+    .update([
+      input.componentType,
+      input.ecosystem ?? "",
+      input.name.trim().toLowerCase(),
+      input.version ?? "",
+      input.packageUrl ?? "",
+    ].join("::"))
+    .digest("hex")
+    .slice(0, 24);
+}
+
+export function createNpmPackageUrl(name: string, version: string): string {
+  const encodedName = name.startsWith("@") ? `%40${name.slice(1)}` : name;
+  return `pkg:npm/${encodedName}@${version}`;
+}

--- a/apps/web/lib/assurance/cyclonedx-generator.test.ts
+++ b/apps/web/lib/assurance/cyclonedx-generator.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { generateCycloneDxBom } from "./cyclonedx-generator";
+
+const packageJson = JSON.stringify({
+  name: "web",
+  version: "0.1.0",
+});
+
+const lockText = `
+lockfileVersion: '9.0'
+importers:
+  apps/web:
+    dependencies:
+      next:
+        specifier: ^16.2.6
+        version: 16.2.6(react@19.2.6)
+      '@dpf/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+`;
+
+describe("generateCycloneDxBom", () => {
+  it("creates CycloneDX JSON plus normalized package and model components", () => {
+    const result = generateCycloneDxBom({
+      workspacePath: "apps/web",
+      packageJson,
+      lockText,
+      generatedAt: new Date("2026-05-22T00:00:00.000Z"),
+      gitRef: "abc123",
+      modelProfiles: [
+        { providerId: "openai", modelId: "gpt-5.4", modelStatus: "active" },
+      ],
+    });
+
+    expect(result.cyclonedx.bomFormat).toBe("CycloneDX");
+    expect(result.cyclonedx.specVersion).toBe("1.7");
+    expect(result.components.map((component) => component.name)).toEqual([
+      "next",
+      "@dpf/db",
+      "gpt-5.4",
+    ]);
+    expect(result.components.find((component) => component.name === "gpt-5.4")).toMatchObject({
+      componentType: "model",
+      ecosystem: "ai-model",
+      supplierName: "openai",
+    });
+    expect(result.documentDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/apps/web/lib/assurance/cyclonedx-generator.ts
+++ b/apps/web/lib/assurance/cyclonedx-generator.ts
@@ -1,0 +1,126 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { CycloneDxDocument, GeneratedBom, NormalizedBomComponent, NormalizedBomOccurrence } from "./bom-types";
+import { createComponentKey, createNpmPackageUrl } from "./component-key";
+import { parseImporterDependencies } from "./pnpm-lock-parser";
+
+export interface BomModelProfileInput {
+  providerId: string;
+  modelId: string;
+  modelStatus?: string | null;
+}
+
+export interface GenerateCycloneDxBomInput {
+  workspacePath: string;
+  packageJson: string;
+  lockText: string;
+  generatedAt: Date;
+  gitRef: string;
+  modelProfiles: BomModelProfileInput[];
+}
+
+function sha256(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function packageComponent(name: string, version: string): NormalizedBomComponent {
+  const packageUrl = version.startsWith("workspace:") ? null : createNpmPackageUrl(name, version);
+  const componentType = name === "next" || name.startsWith("@dpf/") ? "framework" : "library";
+  return {
+    componentKey: createComponentKey({ componentType, ecosystem: "npm", name, version, packageUrl }),
+    componentType,
+    name,
+    version,
+    packageUrl,
+    supplierName: null,
+    licenseExpression: null,
+    ecosystem: "npm",
+    scope: "required",
+    metadata: {},
+  };
+}
+
+function modelComponent(profile: BomModelProfileInput): NormalizedBomComponent {
+  return {
+    componentKey: createComponentKey({
+      componentType: "model",
+      ecosystem: "ai-model",
+      name: profile.modelId,
+      version: profile.modelStatus ?? null,
+      packageUrl: null,
+    }),
+    componentType: "model",
+    name: profile.modelId,
+    version: profile.modelStatus ?? null,
+    packageUrl: null,
+    supplierName: profile.providerId,
+    licenseExpression: null,
+    ecosystem: "ai-model",
+    scope: "runtime",
+    metadata: { providerId: profile.providerId },
+  };
+}
+
+function cycloneDxType(component: NormalizedBomComponent): string {
+  return component.componentType === "model" ? "machine-learning-model" : component.componentType;
+}
+
+function componentRef(component: NormalizedBomComponent): string {
+  return component.packageUrl ?? component.componentKey;
+}
+
+export function generateCycloneDxBom(input: GenerateCycloneDxBomInput): GeneratedBom {
+  const pkg = JSON.parse(input.packageJson) as { name?: string; version?: string };
+  const deps = parseImporterDependencies(input.lockText, input.workspacePath);
+  const components = [
+    ...deps.map((dep) => packageComponent(dep.name, dep.resolvedVersion)),
+    ...input.modelProfiles.map(modelComponent),
+  ];
+  const occurrences: NormalizedBomOccurrence[] = components.map((component) => ({
+    occurrenceKey: createHash("sha256")
+      .update([component.componentKey, input.workspacePath, component.scope ?? ""].join("::"))
+      .digest("hex")
+      .slice(0, 24),
+    componentKey: component.componentKey,
+    workspaceName: pkg.name ?? "web",
+    workspacePath: input.workspacePath,
+    dependencyKind: component.ecosystem === "npm" ? "dependencies" : "runtime-model",
+    direct: true,
+    evidence: { gitRef: input.gitRef },
+  }));
+  const cyclonedx: CycloneDxDocument = {
+    bomFormat: "CycloneDX",
+    specVersion: "1.7",
+    serialNumber: `urn:uuid:${randomUUID()}`,
+    version: 1,
+    metadata: {
+      timestamp: input.generatedAt.toISOString(),
+      component: {
+        type: "application",
+        name: pkg.name ?? "web",
+        version: pkg.version ?? "0.0.0",
+        "bom-ref": pkg.name ?? "web",
+      },
+      properties: [
+        { name: "dpf:gitRef", value: input.gitRef },
+        { name: "dpf:workspacePath", value: input.workspacePath },
+      ],
+    },
+    components: components.map((component) => ({
+      "bom-ref": componentRef(component),
+      type: cycloneDxType(component),
+      name: component.name,
+      version: component.version ?? undefined,
+      purl: component.packageUrl ?? undefined,
+      supplier: component.supplierName ? { name: component.supplierName } : undefined,
+    })),
+    dependencies: components.map((component) => ({ ref: componentRef(component) })),
+  };
+
+  return {
+    cyclonedx,
+    components,
+    occurrences,
+    sourceDigest: sha256({ lockText: input.lockText, packageJson: input.packageJson, modelProfiles: input.modelProfiles }),
+    documentDigest: sha256(cyclonedx),
+  };
+}

--- a/apps/web/lib/assurance/pnpm-lock-parser.test.ts
+++ b/apps/web/lib/assurance/pnpm-lock-parser.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseImporterDependencies } from "./pnpm-lock-parser";
+
+const lockText = `
+lockfileVersion: '9.0'
+importers:
+  apps/web:
+    dependencies:
+      next:
+        specifier: ^16.2.6
+        version: 16.2.6(react@19.2.6)
+      '@dpf/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+    devDependencies:
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5
+`;
+
+describe("parseImporterDependencies", () => {
+  it("extracts production dependencies for a workspace importer", () => {
+    expect(parseImporterDependencies(lockText, "apps/web")).toEqual([
+      {
+        name: "next",
+        specifier: "^16.2.6",
+        resolvedVersion: "16.2.6",
+        dependencyKind: "dependencies",
+      },
+      {
+        name: "@dpf/db",
+        specifier: "workspace:*",
+        resolvedVersion: "workspace:*",
+        dependencyKind: "dependencies",
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/assurance/pnpm-lock-parser.ts
+++ b/apps/web/lib/assurance/pnpm-lock-parser.ts
@@ -1,0 +1,63 @@
+export interface PnpmImporterDependency {
+  name: string;
+  specifier: string;
+  resolvedVersion: string;
+  dependencyKind: "dependencies" | "devDependencies" | "optionalDependencies";
+}
+
+function normalizeVersion(raw: string, specifier: string): string {
+  const trimmed = raw.trim().replace(/^['"]|['"]$/g, "");
+  if (trimmed.startsWith("link:") || trimmed.startsWith("workspace:")) return specifier;
+  return trimmed.split("(")[0] ?? trimmed;
+}
+
+export function parseImporterDependencies(lockText: string, importerPath: string): PnpmImporterDependency[] {
+  const lines = lockText.replace(/\r\n/g, "\n").split("\n");
+  const importerHeader = `  ${importerPath}:`;
+  const start = lines.findIndex((line) => line === importerHeader);
+  if (start < 0) return [];
+
+  const result: PnpmImporterDependency[] = [];
+  let currentKind: PnpmImporterDependency["dependencyKind"] | null = null;
+  let currentName: string | null = null;
+  let currentSpecifier: string | null = null;
+
+  for (let index = start + 1; index < lines.length; index++) {
+    const line = lines[index] ?? "";
+    if (/^  \S/.test(line)) break;
+
+    const kindMatch = line.match(/^    (dependencies|devDependencies|optionalDependencies):$/);
+    if (kindMatch) {
+      currentKind = kindMatch[1] as PnpmImporterDependency["dependencyKind"];
+      currentName = null;
+      currentSpecifier = null;
+      continue;
+    }
+    if (!currentKind) continue;
+
+    const nameMatch = line.match(/^      (.+):$/);
+    if (nameMatch) {
+      currentName = nameMatch[1]!.replace(/^['"]|['"]$/g, "");
+      currentSpecifier = null;
+      continue;
+    }
+
+    const specifierMatch = line.match(/^        specifier: (.+)$/);
+    if (specifierMatch) {
+      currentSpecifier = specifierMatch[1]!.trim().replace(/^['"]|['"]$/g, "");
+      continue;
+    }
+
+    const versionMatch = line.match(/^        version: (.+)$/);
+    if (versionMatch && currentName && currentSpecifier && currentKind === "dependencies") {
+      result.push({
+        name: currentName,
+        specifier: currentSpecifier,
+        resolvedVersion: normalizeVersion(versionMatch[1]!, currentSpecifier),
+        dependencyKind: currentKind,
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/web/lib/queue/functions/assurance-bom.ts
+++ b/apps/web/lib/queue/functions/assurance-bom.ts
@@ -1,0 +1,25 @@
+import { inngest } from "../inngest-client";
+
+export const assuranceBomGenerate = inngest.createFunction(
+  {
+    id: "assurance/bom-generate",
+    retries: 1,
+    concurrency: [{ limit: 2 }],
+    triggers: [{ event: "assurance/bom.generate" }],
+  },
+  async ({ event, step }) => {
+    const { buildId, requestedByUserId } = event.data as { buildId: string; requestedByUserId: string };
+
+    return step.run("generate-and-persist-bom", async () => {
+      const { prisma } = await import("@dpf/db");
+      const { generateAndPersistBuildBom } = await import("@/lib/assurance/bom-job");
+      return generateAndPersistBuildBom({
+        db: prisma,
+        buildId,
+        requestedByUserId,
+        projectRoot: process.env.PROJECT_ROOT ?? process.cwd(),
+        now: new Date(),
+      });
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -11,6 +11,7 @@ import { taskrunWatchdog } from "./taskrun-watchdog";
 import { evalBackground, probeBackground } from "./eval-background";
 import { brandExtract } from "./brand-extract";
 import { buildReviewVerification } from "./build-review-verification";
+import { assuranceBomGenerate } from "./assurance-bom";
 import { deliberationRun } from "./deliberation-run";
 import {
   governedBacklogTeeUpRequested,
@@ -52,6 +53,7 @@ export const allFunctions = [
   probeBackground,
   brandExtract,
   buildReviewVerification,
+  assuranceBomGenerate,
   deliberationRun,
   governedBacklogTeeUpScheduled,
   governedBacklogTeeUpRequested,

--- a/apps/web/lib/queue/inngest-client.ts
+++ b/apps/web/lib/queue/inngest-client.ts
@@ -109,6 +109,14 @@ export interface BuildGitUpdateReceivedEvent {
   };
 }
 
+export interface AssuranceBomGenerateEvent {
+  name: "assurance/bom.generate";
+  data: {
+    buildId: string;
+    requestedByUserId: string;
+  };
+}
+
 export interface PortalSelfUpgradeRequestedEvent {
   name: "portal/self-upgrade.requested";
   data: {

--- a/packages/db/prisma/migrations/20260521220215_assurance_bom_persistence/migration.sql
+++ b/packages/db/prisma/migrations/20260521220215_assurance_bom_persistence/migration.sql
@@ -1,0 +1,179 @@
+-- CreateTable
+CREATE TABLE "AssuranceRun" (
+    "id" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "scopeType" TEXT NOT NULL,
+    "scopeId" TEXT NOT NULL,
+    "policyKey" TEXT,
+    "adapterKey" TEXT NOT NULL,
+    "adapterVersion" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'running',
+    "summary" JSONB NOT NULL DEFAULT '{}',
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "buildId" TEXT,
+    "digitalProductId" TEXT,
+    "releaseBundleId" TEXT,
+    "toolExecutionId" TEXT,
+    "toolExecutionReceiptId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AssuranceRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BomDocument" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "format" TEXT NOT NULL,
+    "formatVersion" TEXT NOT NULL,
+    "serialNumber" TEXT,
+    "version" INTEGER NOT NULL,
+    "digest" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL,
+    "sourceDigest" TEXT NOT NULL,
+    "componentCount" INTEGER NOT NULL,
+    "raw" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'current',
+    "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "buildId" TEXT,
+    "digitalProductId" TEXT,
+    "assuranceRunId" TEXT,
+    "artifactRevisionId" TEXT,
+
+    CONSTRAINT "BomDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BomComponent" (
+    "id" TEXT NOT NULL,
+    "componentKey" TEXT NOT NULL,
+    "componentType" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "version" TEXT,
+    "packageUrl" TEXT,
+    "supplierName" TEXT,
+    "licenseExpression" TEXT,
+    "ecosystem" TEXT,
+    "scope" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BomComponent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BomComponentOccurrence" (
+    "id" TEXT NOT NULL,
+    "occurrenceKey" TEXT NOT NULL,
+    "bomDocumentId" TEXT NOT NULL,
+    "componentId" TEXT NOT NULL,
+    "workspaceName" TEXT,
+    "workspacePath" TEXT,
+    "dependencyKind" TEXT,
+    "direct" BOOLEAN NOT NULL DEFAULT false,
+    "evidence" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BomComponentOccurrence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AssuranceRun_runId_key" ON "AssuranceRun"("runId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AssuranceRun_toolExecutionId_key" ON "AssuranceRun"("toolExecutionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AssuranceRun_toolExecutionReceiptId_key" ON "AssuranceRun"("toolExecutionReceiptId");
+
+-- CreateIndex
+CREATE INDEX "AssuranceRun_scopeType_scopeId_startedAt_idx" ON "AssuranceRun"("scopeType", "scopeId", "startedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "AssuranceRun_buildId_startedAt_idx" ON "AssuranceRun"("buildId", "startedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "AssuranceRun_digitalProductId_startedAt_idx" ON "AssuranceRun"("digitalProductId", "startedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "AssuranceRun_adapterKey_status_idx" ON "AssuranceRun"("adapterKey", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BomDocument_documentId_key" ON "BomDocument"("documentId");
+
+-- CreateIndex
+CREATE INDEX "BomDocument_buildId_generatedAt_idx" ON "BomDocument"("buildId", "generatedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "BomDocument_digitalProductId_generatedAt_idx" ON "BomDocument"("digitalProductId", "generatedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "BomDocument_digest_idx" ON "BomDocument"("digest");
+
+-- CreateIndex
+CREATE INDEX "BomDocument_status_idx" ON "BomDocument"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BomComponent_componentKey_key" ON "BomComponent"("componentKey");
+
+-- CreateIndex
+CREATE INDEX "BomComponent_componentType_name_idx" ON "BomComponent"("componentType", "name");
+
+-- CreateIndex
+CREATE INDEX "BomComponent_packageUrl_idx" ON "BomComponent"("packageUrl");
+
+-- CreateIndex
+CREATE INDEX "BomComponent_ecosystem_idx" ON "BomComponent"("ecosystem");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BomComponentOccurrence_occurrenceKey_key" ON "BomComponentOccurrence"("occurrenceKey");
+
+-- CreateIndex
+CREATE INDEX "BomComponentOccurrence_bomDocumentId_idx" ON "BomComponentOccurrence"("bomDocumentId");
+
+-- CreateIndex
+CREATE INDEX "BomComponentOccurrence_componentId_idx" ON "BomComponentOccurrence"("componentId");
+
+-- CreateIndex
+CREATE INDEX "BomComponentOccurrence_workspacePath_idx" ON "BomComponentOccurrence"("workspacePath");
+
+-- CreateIndex
+CREATE INDEX "BomComponentOccurrence_dependencyKind_idx" ON "BomComponentOccurrence"("dependencyKind");
+
+-- AddForeignKey
+ALTER TABLE "AssuranceRun" ADD CONSTRAINT "AssuranceRun_buildId_fkey" FOREIGN KEY ("buildId") REFERENCES "FeatureBuild"("buildId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AssuranceRun" ADD CONSTRAINT "AssuranceRun_digitalProductId_fkey" FOREIGN KEY ("digitalProductId") REFERENCES "DigitalProduct"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AssuranceRun" ADD CONSTRAINT "AssuranceRun_releaseBundleId_fkey" FOREIGN KEY ("releaseBundleId") REFERENCES "ReleaseBundle"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AssuranceRun" ADD CONSTRAINT "AssuranceRun_toolExecutionId_fkey" FOREIGN KEY ("toolExecutionId") REFERENCES "ToolExecution"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AssuranceRun" ADD CONSTRAINT "AssuranceRun_toolExecutionReceiptId_fkey" FOREIGN KEY ("toolExecutionReceiptId") REFERENCES "ToolExecutionReceipt"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BomDocument" ADD CONSTRAINT "BomDocument_buildId_fkey" FOREIGN KEY ("buildId") REFERENCES "FeatureBuild"("buildId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BomDocument" ADD CONSTRAINT "BomDocument_digitalProductId_fkey" FOREIGN KEY ("digitalProductId") REFERENCES "DigitalProduct"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BomDocument" ADD CONSTRAINT "BomDocument_assuranceRunId_fkey" FOREIGN KEY ("assuranceRunId") REFERENCES "AssuranceRun"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BomDocument" ADD CONSTRAINT "BomDocument_artifactRevisionId_fkey" FOREIGN KEY ("artifactRevisionId") REFERENCES "BuildArtifactRevision"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BomComponentOccurrence" ADD CONSTRAINT "BomComponentOccurrence_bomDocumentId_fkey" FOREIGN KEY ("bomDocumentId") REFERENCES "BomDocument"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BomComponentOccurrence" ADD CONSTRAINT "BomComponentOccurrence_componentId_fkey" FOREIGN KEY ("componentId") REFERENCES "BomComponent"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -579,6 +579,8 @@ model DigitalProduct {
   observationConfig            Json?
   backlogItems                 BacklogItem[]
   manifests                    CodebaseManifest[]
+  assuranceRuns                AssuranceRun[]
+  bomDocuments                 BomDocument[]
   portfolio                    Portfolio?                    @relation(fields: [portfolioId], references: [id])
   taxonomyNode                 TaxonomyNode?                 @relation(fields: [taxonomyNodeId], references: [id])
   eaElements                   EaElement[]
@@ -3671,6 +3673,7 @@ model ToolExecution {
   outputTokens  Int?
   costUsd       Float?
   receipt       ToolExecutionReceipt?
+  assuranceRun  AssuranceRun?
   documentLifecycleEvents DocumentLifecycleEvent[]
 
   @@index([agentId, createdAt])
@@ -3698,6 +3701,7 @@ model ToolExecutionReceipt {
   build            FeatureBuild?          @relation(fields: [buildId], references: [buildId])
   toolExecution    ToolExecution          @relation(fields: [toolExecutionId], references: [id], onDelete: Cascade)
   usages           ArtifactReceiptUsage[]
+  assuranceRun     AssuranceRun?
 
   @@index([buildId, createdAt(sort: Desc)])
   @@index([receiptKind, createdAt(sort: Desc)])
@@ -4213,6 +4217,8 @@ model FeatureBuild {
   activities               BuildActivity[]
   dispatchAttempts         BuildDispatchAttempt[]
   artifactRevisions        BuildArtifactRevision[]
+  assuranceRuns            AssuranceRun[]
+  bomDocuments             BomDocument[]
   phaseHandoffs            PhaseHandoff[]
   phaseRuns                BuildPhaseRun[]
   toolExecutionReceipts    ToolExecutionReceipt[]
@@ -4288,6 +4294,7 @@ model BuildArtifactRevision {
   createdAt      DateTime               @default(now())
   build          FeatureBuild           @relation(fields: [buildId], references: [buildId], onDelete: Cascade)
   receiptUsages  ArtifactReceiptUsage[]
+  bomDocuments   BomDocument[]
 
   @@unique([buildId, field, revisionNumber])
   @@index([buildId, field, createdAt(sort: Desc)])
@@ -4304,6 +4311,111 @@ model ArtifactReceiptUsage {
 
   @@unique([artifactRevisionId, receiptId])
   @@index([receiptId])
+}
+
+model AssuranceRun {
+  id                     String                @id @default(cuid())
+  runId                  String                @unique
+  scopeType              String
+  scopeId                String
+  policyKey              String?
+  adapterKey             String
+  adapterVersion         String
+  status                 String                @default("running")
+  summary                Json                  @default("{}")
+  startedAt              DateTime              @default(now())
+  completedAt            DateTime?
+  buildId                String?
+  digitalProductId       String?
+  releaseBundleId        String?
+  toolExecutionId        String?               @unique
+  toolExecutionReceiptId String?               @unique
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+  build                  FeatureBuild?         @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
+  digitalProduct         DigitalProduct?       @relation(fields: [digitalProductId], references: [id], onDelete: SetNull)
+  releaseBundle          ReleaseBundle?        @relation(fields: [releaseBundleId], references: [id], onDelete: SetNull)
+  toolExecution          ToolExecution?        @relation(fields: [toolExecutionId], references: [id], onDelete: SetNull)
+  toolExecutionReceipt   ToolExecutionReceipt? @relation(fields: [toolExecutionReceiptId], references: [id], onDelete: SetNull)
+  bomDocuments           BomDocument[]
+
+  @@index([scopeType, scopeId, startedAt(sort: Desc)])
+  @@index([buildId, startedAt(sort: Desc)])
+  @@index([digitalProductId, startedAt(sort: Desc)])
+  @@index([adapterKey, status])
+}
+
+model BomDocument {
+  id                 String                   @id @default(cuid())
+  documentId         String                   @unique
+  format             String
+  formatVersion      String
+  serialNumber       String?
+  version            Int
+  digest             String
+  sourceKind         String
+  sourceDigest       String
+  componentCount     Int
+  raw                Json
+  status             String                   @default("current")
+  generatedAt        DateTime                 @default(now())
+  createdAt          DateTime                 @default(now())
+  updatedAt          DateTime                 @updatedAt
+  buildId            String?
+  digitalProductId   String?
+  assuranceRunId     String?
+  artifactRevisionId String?
+  build              FeatureBuild?            @relation(fields: [buildId], references: [buildId], onDelete: SetNull)
+  digitalProduct     DigitalProduct?          @relation(fields: [digitalProductId], references: [id], onDelete: SetNull)
+  assuranceRun       AssuranceRun?            @relation(fields: [assuranceRunId], references: [id], onDelete: SetNull)
+  artifactRevision   BuildArtifactRevision?   @relation(fields: [artifactRevisionId], references: [id], onDelete: SetNull)
+  occurrences        BomComponentOccurrence[]
+
+  @@index([buildId, generatedAt(sort: Desc)])
+  @@index([digitalProductId, generatedAt(sort: Desc)])
+  @@index([digest])
+  @@index([status])
+}
+
+model BomComponent {
+  id                String                   @id @default(cuid())
+  componentKey      String                   @unique
+  componentType     String
+  name              String
+  version           String?
+  packageUrl        String?
+  supplierName      String?
+  licenseExpression String?
+  ecosystem         String?
+  scope             String?
+  metadata          Json                     @default("{}")
+  firstSeenAt       DateTime                 @default(now())
+  lastSeenAt        DateTime                 @default(now())
+  occurrences       BomComponentOccurrence[]
+
+  @@index([componentType, name])
+  @@index([packageUrl])
+  @@index([ecosystem])
+}
+
+model BomComponentOccurrence {
+  id             String       @id @default(cuid())
+  occurrenceKey  String       @unique
+  bomDocumentId  String
+  componentId    String
+  workspaceName  String?
+  workspacePath  String?
+  dependencyKind String?
+  direct         Boolean      @default(false)
+  evidence       Json         @default("{}")
+  createdAt      DateTime     @default(now())
+  bomDocument    BomDocument  @relation(fields: [bomDocumentId], references: [id], onDelete: Cascade)
+  component      BomComponent @relation(fields: [componentId], references: [id], onDelete: Cascade)
+
+  @@index([bomDocumentId])
+  @@index([componentId])
+  @@index([workspacePath])
+  @@index([dependencyKind])
 }
 
 model Sandbox {
@@ -4386,6 +4498,7 @@ model ReleaseBundle {
   createdAt          DateTime       @default(now())
   updatedAt          DateTime       @updatedAt
   builds             FeatureBuild[]
+  assuranceRuns      AssuranceRun[]
 
   @@index([status])
 }

--- a/packages/db/test/assurance-schema-contract.test.ts
+++ b/packages/db/test/assurance-schema-contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(resolve(__dirname, "../prisma/schema.prisma"), "utf8");
+
+function modelBlock(modelName: string): string {
+  const match = schema.match(new RegExp(`model ${modelName} \\{[\\s\\S]*?\\n\\}`, "m"));
+  return match?.[0] ?? "";
+}
+
+describe("Assurance BOM schema", () => {
+  it("adds assurance run and BOM persistence models", () => {
+    expect(modelBlock("AssuranceRun")).toContain("toolExecutionId");
+    expect(modelBlock("BomDocument")).toContain("raw");
+    expect(modelBlock("BomComponent")).toContain("componentKey");
+    expect(modelBlock("BomComponentOccurrence")).toContain("occurrenceKey");
+  });
+
+  it("does not add AssuranceFinding in Phase 1A", () => {
+    expect(modelBlock("AssuranceFinding")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Add Assurance Ledger Phase 1A persistence for CycloneDX BOM documents, components, occurrences, runs, and execution receipts.
- Generate CycloneDX 1.7 BOMs from `apps/web/package.json`, `pnpm-lock.yaml`, workspace dependencies, and active AI model profiles.
- Add the Build Studio Assurance Gate card, product Supply Chain tab, and shareable SBOM export endpoint.

## Verification

- `pnpm --filter @dpf/db exec vitest run test/assurance-schema-contract.test.ts`
- `pnpm --filter web exec vitest run lib/assurance/component-key.test.ts lib/assurance/pnpm-lock-parser.test.ts lib/assurance/cyclonedx-generator.test.ts lib/assurance/bom-persistence.test.ts lib/assurance/bom-job.test.ts lib/assurance/bom-read.test.ts lib/assurance/bom-redaction.test.ts lib/assurance/bom-export.test.ts lib/assurance/bom-trigger.test.ts lib/actions/assurance.test.ts components/build/BuildAssuranceGateCard.test.tsx components/build/BuildStudioHeaderLayout.test.tsx components/product/ProductTabNav.test.tsx components/product/ProductSupplyChainPanel.test.tsx`
- `pnpm --filter @dpf/db typecheck`
- `pnpm --filter @dpf/db exec prisma validate --schema prisma/schema.prisma`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- Isolated Docker portal smoke on `http://localhost:3102`: setup completed, Build Studio Assurance Gate rendered and queued BOM generation, BOM job persisted `bom_dc4cb32d56f460669e0e6a37` with 76 components / 75 occurrences, product Supply Chain tab rendered the BOM, and `/api/portfolio/product/[id]/supply-chain/bom` returned CycloneDX 1.7 with 76 components and no internal-only properties.

Note: the worktree-scoped `browser-use` image build failed before app startup due a Python dependency resolver error unrelated to this branch. For the UX smoke, the already-built portal image was started with only the services needed for the web path; the queue button was verified to reach the queued state, and the same BOM job function was invoked directly inside the portal container to verify persisted SBOM/export behavior.