### PR TITLE
fix(voice): store reference audio to disk and clone inline; add re-record button

### DIFF
--- a/apps/web/app/api/voice/reference/route.ts
+++ b/apps/web/app/api/voice/reference/route.ts
@@ -1,19 +1,21 @@
 // POST /api/voice/reference
-// Zero-shot voice registration for Chatterbox self-hosted TTS.
-// Accepts a single reference audio file, registers it with dpf-tts,
-// and immediately marks the VoiceProfile as ready — no async training job.
+// Stores a reference audio clip for Chatterbox zero-shot voice cloning.
+// The clip is saved to disk; providerVoiceId stores the relative path.
+// On every synthesis call the stored clip is passed inline to dpf-tts
+// via POST /v1/audio/speech/upload (multipart with voice_file field).
 //
-// Replaces /api/voice/train (Cartesia async training pipeline).
 // Spec: docs/superpowers/specs/2026-05-21-chatterbox-tts-self-hosted.md §4.2
 
 import { NextResponse } from "next/server"
 import { auth } from "@/lib/auth"
 import { prisma } from "@dpf/db"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
 
-const MAX_BYTES = 50 * 1024 * 1024 // 50 MB
+const MAX_BYTES = 50 * 1024 * 1024
 
-function getTtsUrl(): string {
-  return process.env.DPF_TTS_URL ?? "http://dpf-tts:8000"
+function getStorageRoot(): string {
+  return process.env.UPLOAD_STORAGE_PATH ?? "./data/uploads"
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
@@ -46,9 +48,7 @@ export async function POST(req: Request): Promise<NextResponse> {
   // Verify profile exists and has valid consent
   const voiceProfile = await prisma.voiceProfile.findUnique({
     where: { profileId: voiceProfileId },
-    include: {
-      consentRecord: { select: { expiresAt: true, revokedAt: true } },
-    },
+    include: { consentRecord: { select: { expiresAt: true, revokedAt: true } } },
   })
 
   if (!voiceProfile) {
@@ -60,52 +60,42 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: "Valid consent record required" }, { status: 422 })
   }
 
-  // Register reference audio with dpf-tts (Chatterbox)
-  let providerVoiceId: string
+  // Determine extension from mime type
+  const mimeType = audioEntry.type || "audio/wav"
+  const ext = mimeType.includes("webm") ? "webm"
+    : mimeType.includes("mp4") || mimeType.includes("m4a") ? "m4a"
+    : mimeType.includes("ogg") ? "ogg"
+    : mimeType.includes("mp3") ? "mp3"
+    : "wav"
+
+  // Store reference audio to disk — this file is passed inline on every synthesis call.
+  // Path: {storageRoot}/voices/{profileId}/reference.{ext}
+  const relDir = `voices/${voiceProfileId}`
+  const filename = `reference.${ext}`
+  const storageKey = `${relDir}/${filename}`
+  const absDir = path.join(getStorageRoot(), relDir)
+  const absPath = path.join(getStorageRoot(), storageKey)
+
   try {
-    const ttsForm = new FormData()
-    ttsForm.append("voice_id", voiceProfileId)
-    ttsForm.append(
-      "audio",
-      audioEntry,
-      audioEntry instanceof File ? audioEntry.name : "reference.wav",
-    )
-
-    const ttsRes = await fetch(`${getTtsUrl()}/v1/voices`, {
-      method: "POST",
-      body: ttsForm,
-    })
-
-    if (!ttsRes.ok) {
-      // dpf-tts not running — store voice_id as profileId, mark ready locally.
-      // When dpf-tts starts, the reference audio will be re-registered.
-      console.warn("[tool-trace] voice.reference.dpf-tts.unavailable", {
-        voiceProfileId,
-        status: ttsRes.status,
-      })
-      providerVoiceId = voiceProfileId
-    } else {
-      const json = await ttsRes.json().catch(() => ({}))
-      providerVoiceId = (json as { voice_id?: string }).voice_id ?? voiceProfileId
-    }
-  } catch {
-    // dpf-tts container not reachable (e.g. --profile tts not started yet).
-    // Store voice_id derived from profileId; voice won't synthesize until
-    // dpf-tts is running, but profile is marked ready for configuration.
-    console.warn("[tool-trace] voice.reference.dpf-tts.unreachable", { voiceProfileId })
-    providerVoiceId = voiceProfileId
+    await fs.mkdir(absDir, { recursive: true })
+    const buf = await audioEntry.arrayBuffer()
+    await fs.writeFile(absPath, Buffer.from(buf))
+  } catch (err) {
+    console.error("[tool-trace] voice.reference.storage.failed", { voiceProfileId, err: String(err) })
+    return NextResponse.json({ error: "Failed to store reference audio" }, { status: 500 })
   }
 
-  // Immediately mark VoiceProfile ready — zero-shot, no training wait
+  // Mark VoiceProfile ready; providerVoiceId is the relative path to the stored audio.
   await prisma.voiceProfile.update({
     where: { profileId: voiceProfileId },
     data: {
       provider: "chatterbox",
-      providerVoiceId,
+      providerVoiceId: storageKey,   // e.g. "voices/mark-dpf-platform/reference.webm"
       status: "ready",
       sampleCount: 1,
     },
   })
 
-  return NextResponse.json({ voiceId: providerVoiceId, status: "ready" }, { status: 200 })
+  console.info("[tool-trace] voice.reference.stored", { voiceProfileId, storageKey })
+  return NextResponse.json({ storageKey, status: "ready" }, { status: 200 })
 }

--- a/apps/web/app/api/voice/synthesize/route.ts
+++ b/apps/web/app/api/voice/synthesize/route.ts
@@ -1,5 +1,7 @@
 // POST /api/voice/synthesize
 // Real-time TTS synthesis endpoint used by all three voice surfaces.
+// Loads the stored reference audio for the voice profile and passes it
+// inline to Chatterbox via /v1/audio/speech/upload (zero-shot cloning).
 // Returns raw audio/wav binary — NOT stored, streamed directly.
 //
 // Spec: docs/superpowers/specs/2026-05-21-chatterbox-tts-self-hosted.md §4.3
@@ -8,10 +10,16 @@ import { auth } from "@/lib/auth"
 import { prisma } from "@dpf/db"
 import { synthesizeSpeech, VoiceSynthesisError } from "@/lib/voice-synthesis/voice-service"
 import type { TTSProvider } from "@/lib/voice-synthesis/types"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
 
 interface SynthesizeBody {
   text: string
   voiceProfileId?: string
+}
+
+function getStorageRoot(): string {
+  return process.env.UPLOAD_STORAGE_PATH ?? "./data/uploads"
 }
 
 export async function POST(req: Request): Promise<Response> {
@@ -33,7 +41,7 @@ export async function POST(req: Request): Promise<Response> {
     return Response.json({ error: "text is required" }, { status: 400 })
   }
 
-  // Resolve voice profile: either from explicit ID or first ready + voice-enabled profile
+  // Resolve voice profile
   let voiceProfile: {
     id: string
     provider: string
@@ -49,12 +57,8 @@ export async function POST(req: Request): Promise<Response> {
         select: { id: true, provider: true, providerVoiceId: true, status: true, language: true },
       })
     } else {
-      // Find the first ready VoiceProfile whose linked DecisionPerspectiveProfile has voiceEnabled = true
       voiceProfile = await prisma.voiceProfile.findFirst({
-        where: {
-          status: "ready",
-          profile: { voiceEnabled: true },
-        },
+        where: { status: "ready", profile: { voiceEnabled: true } },
         select: { id: true, provider: true, providerVoiceId: true, status: true, language: true },
         orderBy: { updatedAt: "desc" },
       })
@@ -65,32 +69,43 @@ export async function POST(req: Request): Promise<Response> {
 
   if (!voiceProfile) {
     return Response.json(
-      { error: "No ready voice profile found. Configure one in Admin > Voice.", code: "no_voice_profile" },
+      { error: "No ready voice profile found. Configure one in Wiki > Decision Perspectives.", code: "no_voice_profile" },
       { status: 422 },
     )
   }
 
-  if (voiceProfile.status !== "ready") {
+  if (voiceProfile.status !== "ready" || !voiceProfile.providerVoiceId) {
     return Response.json(
       { error: "Voice profile is not ready", code: "voice_profile_not_ready" },
       { status: 422 },
     )
   }
 
-  if (!voiceProfile.providerVoiceId) {
+  // Load the stored reference audio from disk.
+  // providerVoiceId is a relative path like "voices/mark-dpf-platform/reference.webm"
+  let referenceAudioBuffer: Buffer | undefined
+  try {
+    const absPath = path.join(getStorageRoot(), voiceProfile.providerVoiceId)
+    referenceAudioBuffer = await fs.readFile(absPath)
+  } catch (err) {
+    console.error("[tool-trace] voice.synthesize.reference.read-failed", {
+      providerVoiceId: voiceProfile.providerVoiceId,
+      err: String(err),
+    })
     return Response.json(
-      { error: "Voice profile has no provider voice ID", code: "voice_profile_not_ready" },
+      { error: "Reference audio not found — please re-register your voice sample.", code: "reference_missing" },
       { status: 422 },
     )
   }
 
-  // Synthesize
+  // Synthesize — reference audio passed inline for zero-shot cloning
   try {
     const result = await synthesizeSpeech(text.trim(), {
       provider: voiceProfile.provider as TTSProvider,
       providerVoiceId: voiceProfile.providerVoiceId,
       language: voiceProfile.language,
-    })
+      referenceAudioBuffer,
+    } as Parameters<typeof synthesizeSpeech>[1])
 
     return new Response(result.audioBuffer, {
       status: 200,
@@ -103,7 +118,6 @@ export async function POST(req: Request): Promise<Response> {
   } catch (err) {
     if (err instanceof VoiceSynthesisError) {
       const status = err.statusCode ?? 502
-      // dpf-tts not running or unreachable
       if (status >= 500 || err.message.toLowerCase().includes("econnrefused") || err.message.toLowerCase().includes("fetch failed")) {
         console.warn("[tool-trace] voice.synthesize.tts_unavailable", { message: err.message })
         return Response.json(
@@ -113,9 +127,7 @@ export async function POST(req: Request): Promise<Response> {
       }
       return Response.json({ error: err.message, code: "synthesis_error" }, { status })
     }
-    // Network errors from fetch (ECONNREFUSED, etc.) surface as TypeError
     if (err instanceof TypeError || (err instanceof Error && err.message.includes("fetch"))) {
-      console.warn("[tool-trace] voice.synthesize.tts_unreachable", { message: (err as Error).message })
       return Response.json(
         { error: "Voice synthesis unavailable — dpf-tts not running", code: "tts_unavailable" },
         { status: 503 },

--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useRef, useCallback } from "react"
 import { VoiceConsentForm } from "@/components/admin/VoiceConsentForm"
-import { setVoiceEnabled } from "@/lib/actions/voice-profile"
+import { setVoiceEnabled, resetVoiceProfile } from "@/lib/actions/voice-profile"
 import { selectSupportedMimeType } from "@/components/agent/hooks/mime-probe"
 import { useVoiceSynth } from "@/components/agent/hooks/useVoiceSynth"
 
@@ -44,6 +44,7 @@ export function VoiceProfileSetup({
 }: Props) {
   const [enabled, setEnabled] = useState(voiceEnabled)
   const [isPending, startTransition] = useTransition()
+  const [resetting, setResetting] = useState(false)
   const voiceSynth = useVoiceSynth()
 
   const hasValidConsent =
@@ -165,6 +166,18 @@ export function VoiceProfileSetup({
                     : "▶ Preview voice"}
               </button>
             )}
+            <button
+              type="button"
+              disabled={resetting}
+              onClick={async () => {
+                setResetting(true)
+                await resetVoiceProfile(profileId)
+                window.location.reload()
+              }}
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-white/50 px-3 py-1 text-xs font-medium text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+            >
+              {resetting ? "Resetting…" : "↺ Replace voice sample"}
+            </button>
           </div>
         ) : (
           <VoiceSampleCapture profileId={profileId} />

--- a/apps/web/lib/actions/voice-profile.ts
+++ b/apps/web/lib/actions/voice-profile.ts
@@ -37,6 +37,15 @@ export async function getVoiceProfileData(profileId: string) {
   return profile
 }
 
+/** Reset a voice profile to pending so the user can re-record their reference audio. */
+export async function resetVoiceProfile(profileId: string) {
+  await prisma.voiceProfile.update({
+    where: { profileId },
+    data: { status: "pending", providerVoiceId: null, sampleCount: 0 },
+  })
+  revalidatePath(`/wiki/perspectives/${profileId}/voice`)
+}
+
 export async function listVoiceProfiles() {
   return prisma.decisionPerspectiveProfile.findMany({
     where: { status: "active" },

--- a/apps/web/lib/voice-synthesis/adapters/chatterbox.ts
+++ b/apps/web/lib/voice-synthesis/adapters/chatterbox.ts
@@ -34,7 +34,7 @@ export async function synthesizeWithChatterbox(
     form.append("response_format", "wav")
     form.append(
       "voice_file",
-      new Blob([config.referenceAudioBuffer], { type: "audio/wav" }),
+      new Blob([new Uint8Array(config.referenceAudioBuffer)], { type: "audio/wav" }),
       "reference.wav",
     )
 

--- a/apps/web/lib/voice-synthesis/adapters/chatterbox.ts
+++ b/apps/web/lib/voice-synthesis/adapters/chatterbox.ts
@@ -1,5 +1,6 @@
 // Chatterbox TTS adapter — self-hosted, zero-shot voice cloning.
-// Calls devnen/Chatterbox-TTS-Server via OpenAI-compatible /v1/audio/speech.
+// Uses /v1/audio/speech/upload (multipart) to pass the stored reference
+// audio inline on every synthesis call — no pre-registration needed.
 // No API key required. Docker service: dpf-tts:8000 (--profile tts).
 // Spec: docs/superpowers/specs/2026-05-21-chatterbox-tts-self-hosted.md
 
@@ -10,21 +11,57 @@ function getTtsUrl(): string {
   return process.env.DPF_TTS_URL ?? "http://dpf-tts:8000"
 }
 
+export interface ChatterboxSynthesisConfig extends VoiceSynthesisConfig {
+  /**
+   * Raw bytes of the reference audio clip. When provided, the adapter
+   * POSTs to /v1/audio/speech/upload (multipart) so Chatterbox clones
+   * the voice from this sample. Without it, dpf-tts uses its built-in
+   * default voice.
+   */
+  referenceAudioBuffer?: Buffer
+}
+
 export async function synthesizeWithChatterbox(
   text: string,
-  config: VoiceSynthesisConfig,
+  config: ChatterboxSynthesisConfig,
 ): Promise<RawSynthesisResult> {
-  const url = `${getTtsUrl()}/v1/audio/speech`
+  const baseUrl = getTtsUrl()
 
+  if (config.referenceAudioBuffer && config.referenceAudioBuffer.length > 0) {
+    // Zero-shot cloning: pass reference audio inline via multipart upload
+    const form = new FormData()
+    form.append("input", text)
+    form.append("response_format", "wav")
+    form.append(
+      "voice_file",
+      new Blob([config.referenceAudioBuffer], { type: "audio/wav" }),
+      "reference.wav",
+    )
+
+    const res = await fetch(`${baseUrl}/v1/audio/speech/upload`, {
+      method: "POST",
+      body: form,
+    })
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "unknown")
+      throw new VoiceSynthesisError(detail, "chatterbox", res.status)
+    }
+
+    const audioBuffer = await res.arrayBuffer()
+    return { audioBuffer, provider: "chatterbox", ttsCostUnits: text.length }
+  }
+
+  // Fallback: no reference audio — uses dpf-tts default voice (for testing only)
   const body = {
     model: "tts-1",
     input: text,
-    voice: config.providerVoiceId,
+    voice: "default",
     response_format: "wav",
     speed: config.speed ?? 1.0,
   }
 
-  const res = await fetch(url, {
+  const res = await fetch(`${baseUrl}/v1/audio/speech`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/apps/web/lib/voice-synthesis/voice-service.ts
+++ b/apps/web/lib/voice-synthesis/voice-service.ts
@@ -1,7 +1,7 @@
 import type { VoiceSynthesisConfig, TTSProvider } from "./types"
 import { synthesizeWithCartesia, VoiceSynthesisError } from "./adapters/cartesia"
 import { synthesizeWithFishAudio } from "./adapters/fish-audio"
-import { synthesizeWithChatterbox } from "./adapters/chatterbox"
+import { synthesizeWithChatterbox, type ChatterboxSynthesisConfig } from "./adapters/chatterbox"
 
 export interface SynthesisOutput {
   audioBuffer: ArrayBuffer
@@ -22,11 +22,11 @@ export function defaultProvider(): TTSProvider {
 
 export async function synthesizeSpeech(
   text: string,
-  config: VoiceSynthesisConfig,
+  config: VoiceSynthesisConfig | ChatterboxSynthesisConfig,
 ): Promise<SynthesisOutput> {
   switch (config.provider) {
     case "chatterbox":
-      return synthesizeWithChatterbox(text, config) as Promise<SynthesisOutput>
+      return synthesizeWithChatterbox(text, config as ChatterboxSynthesisConfig) as Promise<SynthesisOutput>
     case "cartesia":
       return synthesizeWithCartesia(text, config) as Promise<SynthesisOutput>
     case "fish-audio":


### PR DESCRIPTION
## Summary

- **Root cause of female voice**: `/api/voice/reference` was POSTing to a non-existent `/v1/voices` registration endpoint on the travisvn Chatterbox image. It silently fell back to storing the profile ID string as `providerVoiceId`, so synthesis called the dpf-tts default voice.
- **Fix — audio stored to disk**: Reference audio is now written to `{UPLOAD_STORAGE_PATH}/voices/{profileId}/reference.{ext}` via `fs.writeFile`. The relative path (e.g. `voices/mark-dpf-platform/reference.webm`) is stored as `providerVoiceId`.
- **Fix — inline zero-shot cloning**: `/api/voice/synthesize` reads the stored file back from disk and passes it as `referenceAudioBuffer`. The Chatterbox adapter POSTs to `/v1/audio/speech/upload` (multipart) with a `voice_file` field on every synthesis call — true zero-shot cloning, no pre-registration needed.
- **Re-record button**: Added `resetVoiceProfile()` server action and a "↺ Replace voice sample" button in the step 2 ready state so users aren't stuck if the sample is bad.

## Files changed

| File | Change |
|------|--------|
| `app/api/voice/reference/route.ts` | Write audio to disk; store relative path as `providerVoiceId` |
| `app/api/voice/synthesize/route.ts` | Read reference file from disk; pass as `referenceAudioBuffer` |
| `lib/voice-synthesis/adapters/chatterbox.ts` | Use `/v1/audio/speech/upload` multipart for zero-shot cloning |
| `lib/voice-synthesis/voice-service.ts` | Accept `ChatterboxSynthesisConfig` union type |
| `lib/actions/voice-profile.ts` | Add `resetVoiceProfile()` server action |
| `components/wiki/VoiceProfileSetup.tsx` | Add "↺ Replace voice sample" button |

## Test plan

- [ ] Navigate to Wiki → Decision Perspectives → [persona] → Voice
- [ ] Complete consent form and record a 10s voice sample
- [ ] Confirm upload succeeds and page shows "Voice profile ready"
- [ ] Click "▶ Preview voice" — audio should sound like your voice (zero-shot clone), not a female default
- [ ] Click "↺ Replace voice sample" — page resets to the recording interface
- [ ] Re-record and re-register — confirm new sample replaces old one
- [ ] Trigger a WWMD gate in Build Studio — confirm audio plays in cloned voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)