### PR TITLE
fix(voice): restore providerVoiceId in fallback path; fixes chatterbox unit test

### DIFF
--- a/apps/web/lib/voice-synthesis/adapters/chatterbox.ts
+++ b/apps/web/lib/voice-synthesis/adapters/chatterbox.ts
@@ -56,7 +56,7 @@ export async function synthesizeWithChatterbox(
   const body = {
     model: "tts-1",
     input: text,
-    voice: "default",
+    voice: config.providerVoiceId ?? "default",
     response_format: "wav",
     speed: config.speed ?? 1.0,
   }


### PR DESCRIPTION
## Summary

- PR #959 merged with `voice: "default"` hardcoded in the Chatterbox fallback path (no reference audio)
- The existing unit test `sends correct OpenAI-compatible payload` asserts `body.voice === config.providerVoiceId` — this was failing with `expected 'default' to be 'voice_mark_dpf'`
- Fix: use `config.providerVoiceId ?? "default"` so the fallback path honours the configured voice ID

## Change

`apps/web/lib/voice-synthesis/adapters/chatterbox.ts` — one-line change in the JSON fallback body.

## Note

The zero-shot cloning path (`/v1/audio/speech/upload` with `referenceAudioBuffer`) is unaffected — this only changes the rarely-used fallback that runs when no reference audio buffer is provided (e.g. in unit tests that don't supply one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)