### PR TITLE
feat(coworker): provider badge on each assistant turn

### DIFF
--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -1,6 +1,52 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { AgentMessageBubble } from "./AgentMessageBubble";
+import { AgentMessageBubble, formatProviderBadge } from "./AgentMessageBubble";
+
+describe("formatProviderBadge", () => {
+  it("returns null when no provider is attached", () => {
+    expect(formatProviderBadge(undefined)).toBeNull();
+  });
+
+  it("renders provider name plus model for API adapters", () => {
+    expect(
+      formatProviderBadge({
+        name: "Anthropic",
+        modelId: "claude-opus-4-7",
+        adapterKind: "anthropic-api",
+      }),
+    ).toBe("Anthropic · claude-opus-4-7");
+  });
+
+  it("appends ' CLI' for CLI adapters", () => {
+    expect(
+      formatProviderBadge({
+        name: "ChatGPT",
+        modelId: "gpt-5-codex",
+        adapterKind: "codex-cli",
+      }),
+    ).toBe("ChatGPT CLI · gpt-5-codex");
+  });
+
+  it("does not double-stamp CLI when the provider name already says CLI", () => {
+    expect(
+      formatProviderBadge({
+        name: "Codex CLI",
+        modelId: "gpt-5-codex",
+        adapterKind: "codex-cli",
+      }),
+    ).toBe("Codex CLI · gpt-5-codex");
+  });
+
+  it("renders provider name alone when model is missing (fallback path)", () => {
+    expect(
+      formatProviderBadge({
+        name: "Anthropic",
+        modelId: null,
+        adapterKind: null,
+      }),
+    ).toBe("Anthropic");
+  });
+});
 
 describe("AgentMessageBubble", () => {
   it("renders assistant markdown as structured HTML", () => {
@@ -86,6 +132,73 @@ describe("AgentMessageBubble", () => {
 
     expect(html).toContain("Not sent");
     expect(html).toContain("Retry");
+  });
+
+  it("renders the provider badge inline with the agent name on assistant turns", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-prov-1",
+          role: "assistant",
+          content: "Routed answer.",
+          agentId: "software-engineer",
+          routeContext: "/build",
+          createdAt: "2026-05-22T12:00:00.000Z",
+          provider: {
+            name: "ChatGPT",
+            modelId: "gpt-5-codex",
+            adapterKind: "codex-cli",
+          },
+        }}
+        showAgentLabel={true}
+        agentName="Software Engineer"
+      />,
+    );
+
+    expect(html).toContain("Software Engineer");
+    expect(html).toContain("ChatGPT CLI · gpt-5-codex");
+    expect(html).toContain('data-testid="agent-message-provider"');
+  });
+
+  it("omits the provider badge when no provider info is attached", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-prov-2",
+          role: "assistant",
+          content: "Legacy answer with no telemetry.",
+          agentId: "ops-coordinator",
+          routeContext: "/ops",
+          createdAt: "2026-05-22T12:00:00.000Z",
+        }}
+        showAgentLabel={true}
+        agentName="Ops Coordinator"
+      />,
+    );
+
+    expect(html).toContain("Ops Coordinator");
+    expect(html).not.toContain('data-testid="agent-message-provider"');
+  });
+
+  it("omits the provider badge on user messages even if provider were set", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-prov-3",
+          role: "user",
+          content: "user text",
+          agentId: null,
+          routeContext: "/ops",
+          createdAt: "2026-05-22T12:00:00.000Z",
+          // user messages shouldn't carry provider, but defensive check
+          provider: { name: "Anthropic", modelId: "claude-opus-4-7", adapterKind: "anthropic-api" },
+        }}
+        showAgentLabel={false}
+        agentName={null}
+      />,
+    );
+
+    expect(html).not.toContain('data-testid="agent-message-provider"');
   });
 
   it("renders managed document chips for assistant messages with stable document ids", () => {

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -3,9 +3,28 @@
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import { FileText } from "lucide-react";
-import type { AgentMessageRow } from "@/lib/agent-coworker-types";
+import type { AgentMessageProvider, AgentMessageRow } from "@/lib/agent-coworker-types";
 import type { ReactNode } from "react";
 import { AgentAttachmentCard } from "./AgentAttachmentCard";
+
+/**
+ * Format the provider badge label shown next to the coworker name.
+ * Examples:
+ *   { name: "Anthropic", modelId: "claude-opus-4-7", adapterKind: "anthropic-api" }
+ *     → "Anthropic · claude-opus-4-7"
+ *   { name: "ChatGPT", modelId: "gpt-5-codex", adapterKind: "codex-cli" }
+ *     → "ChatGPT CLI · gpt-5-codex"
+ *   { name: "Anthropic", modelId: null, adapterKind: null }
+ *     → "Anthropic"
+ * Returns null when there is nothing meaningful to show.
+ */
+export function formatProviderBadge(provider: AgentMessageProvider | undefined): string | null {
+  if (!provider) return null;
+  const isCli = !!provider.adapterKind && /cli/i.test(provider.adapterKind);
+  const cliAlreadyInName = /\bcli\b/i.test(provider.name);
+  const base = isCli && !cliAlreadyInName ? `${provider.name} CLI` : provider.name;
+  return provider.modelId ? `${base} · ${provider.modelId}` : base;
+}
 
 type Props = {
   message: AgentMessageRow;
@@ -143,6 +162,30 @@ function looksLikeAgentError(content: string): boolean {
   );
 }
 
+function ProviderBadge({ label, title }: { label: string; title: string }) {
+  return (
+    <span
+      data-testid="agent-message-provider"
+      title={title}
+      style={{
+        fontSize: 9,
+        lineHeight: 1,
+        color: "var(--dpf-muted)",
+        background: "color-mix(in srgb, var(--dpf-muted) 12%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--dpf-muted) 22%, transparent)",
+        borderRadius: 999,
+        padding: "2px 6px",
+        maxWidth: 220,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
 function formatRelativeTime(isoString: string): string {
   const diff = Date.now() - new Date(isoString).getTime();
   const mins = Math.floor(diff / 60_000);
@@ -184,6 +227,8 @@ export function AgentMessageBubble({
   const isUser = message.role === "user";
 
   // Proposal card rendering for assistant messages with a proposal
+  const providerBadge = !isUser ? formatProviderBadge(message.provider) : null;
+
   if (!isUser && message.proposal) {
     const p = message.proposal;
     const isPending = p.status === "proposed";
@@ -280,9 +325,12 @@ export function AgentMessageBubble({
         }}
       >
         {showAgentLabel && agentName && (
-          <span style={{ fontSize: 10, color: "var(--dpf-accent)", marginLeft: 4 }}>
-            {agentName}
-          </span>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginLeft: 4, flexWrap: "wrap" }}>
+            <span style={{ fontSize: 10, color: "var(--dpf-accent)" }}>
+              {agentName}
+            </span>
+            {providerBadge && <ProviderBadge label={providerBadge} title={providerBadge} />}
+          </div>
         )}
         <div style={{ maxWidth: "85%" }}>
           {/* Show the text content first if any */}
@@ -392,9 +440,12 @@ export function AgentMessageBubble({
       }}
     >
       {showAgentLabel && agentName && !isUser && (
-        <span style={{ fontSize: 10, color: "var(--dpf-accent)", marginLeft: 4 }}>
-          {agentName}
-        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginLeft: 4, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 10, color: "var(--dpf-accent)" }}>
+            {agentName}
+          </span>
+          {providerBadge && <ProviderBadge label={providerBadge} title={providerBadge} />}
+        </div>
       )}
       <div
         data-testid="agent-message-content"

--- a/apps/web/lib/tak/agent-coworker-data.test.ts
+++ b/apps/web/lib/tak/agent-coworker-data.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { selectVisibleTelemetry } from "./agent-coworker-data";
+
+const baseRow = {
+  providerId: "anthropic",
+  modelId: "claude-opus-4-7",
+  adapterKind: "anthropic-api",
+};
+
+describe("selectVisibleTelemetry", () => {
+  it("returns an empty map when no rows are provided", () => {
+    expect(selectVisibleTelemetry([])).toEqual(new Map());
+  });
+
+  it("skips telemetry rows without an agentMessageId", () => {
+    const out = selectVisibleTelemetry([
+      {
+        ...baseRow,
+        agentMessageId: null,
+        executionMode: "single",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+      },
+    ]);
+    expect(out.size).toBe(0);
+  });
+
+  it("keeps single-mode rows and drops shadow-alt / race-loser", () => {
+    const out = selectVisibleTelemetry([
+      {
+        ...baseRow,
+        agentMessageId: "msg-a",
+        executionMode: "single",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+      },
+      {
+        ...baseRow,
+        agentMessageId: "msg-b",
+        executionMode: "shadow-alt",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+      },
+      {
+        ...baseRow,
+        agentMessageId: "msg-c",
+        executionMode: "race-loser",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+      },
+    ]);
+    expect([...out.keys()].sort()).toEqual(["msg-a"]);
+  });
+
+  it("when multiple visible rows exist for one message, picks the most recent", () => {
+    const out = selectVisibleTelemetry([
+      {
+        ...baseRow,
+        agentMessageId: "msg-x",
+        executionMode: "single",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+        modelId: "old-model",
+      },
+      {
+        ...baseRow,
+        agentMessageId: "msg-x",
+        executionMode: "single",
+        startedAt: new Date("2026-05-22T12:05:00Z"),
+        modelId: "new-model",
+      },
+    ]);
+    expect(out.get("msg-x")?.modelId).toBe("new-model");
+  });
+
+  it("treats race-primary and shadow-primary as user-visible", () => {
+    const out = selectVisibleTelemetry([
+      {
+        ...baseRow,
+        agentMessageId: "msg-race",
+        executionMode: "race-primary",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+      },
+      {
+        ...baseRow,
+        agentMessageId: "msg-shadow",
+        executionMode: "shadow-primary",
+        startedAt: new Date("2026-05-22T12:00:00Z"),
+      },
+    ]);
+    expect([...out.keys()].sort()).toEqual(["msg-race", "msg-shadow"]);
+  });
+});

--- a/apps/web/lib/tak/agent-coworker-data.ts
+++ b/apps/web/lib/tak/agent-coworker-data.ts
@@ -1,6 +1,10 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
-import type { AgentMessageRow, AttachmentInfo } from "@/lib/agent-coworker-types";
+import type {
+  AgentMessageProvider,
+  AgentMessageRow,
+  AttachmentInfo,
+} from "@/lib/agent-coworker-types";
 
 type AttachmentRow = {
   id: string;
@@ -10,6 +14,18 @@ type AttachmentRow = {
   parsedContent: unknown;
 };
 
+type TelemetryRow = {
+  agentMessageId: string | null;
+  providerId: string;
+  modelId: string;
+  adapterKind: string;
+  executionMode: string;
+  startedAt: Date;
+};
+
+/** Adapter kinds whose telemetry was the user-visible response (not a shadow/loser). */
+const VISIBLE_EXEC_MODES = new Set(["single", "shadow-primary", "race-primary"]);
+
 function serializeMessage(
   m: {
     id: string;
@@ -18,6 +34,7 @@ function serializeMessage(
     agentId: string | null;
     routeContext: string | null;
     createdAt: Date;
+    providerId?: string | null;
     attachments?: AttachmentRow[];
   },
   proposal?: {
@@ -28,6 +45,7 @@ function serializeMessage(
     resultEntityId: string | null;
     resultError: string | null;
   } | null,
+  provider?: AgentMessageProvider,
 ): AgentMessageRow {
   const row: AgentMessageRow = {
     id: m.id,
@@ -58,7 +76,93 @@ function serializeMessage(
       ...(proposal.resultError ? { resultError: proposal.resultError } : {}),
     };
   }
+  if (provider) {
+    row.provider = provider;
+  }
   return row;
+}
+
+/**
+ * Pick the user-visible telemetry row for each agentMessageId.
+ *
+ * Multiple rows can exist per message in race/shadow modes; only the
+ * primary/single rows are what the user actually saw. Most-recent wins for
+ * the rare case of replays.
+ */
+function selectVisibleTelemetry(rows: TelemetryRow[]): Map<string, TelemetryRow> {
+  const sorted = [...rows].sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime());
+  const out = new Map<string, TelemetryRow>();
+  for (const r of sorted) {
+    if (!r.agentMessageId) continue;
+    if (!VISIBLE_EXEC_MODES.has(r.executionMode)) continue;
+    if (!out.has(r.agentMessageId)) out.set(r.agentMessageId, r);
+  }
+  return out;
+}
+
+/**
+ * Build the provider info attached to each assistant turn for display.
+ *
+ * Returns a map keyed by AgentMessage.id. Telemetry is the source of truth
+ * for adapter/model; AgentMessage.providerId is a name-only fallback for
+ * pre-telemetry rows.
+ */
+async function loadProviderInfo(
+  messages: Array<{ id: string; role: string; providerId?: string | null }>,
+): Promise<Map<string, AgentMessageProvider>> {
+  const assistantIds = messages
+    .filter((m) => m.role === "assistant")
+    .map((m) => m.id);
+  if (assistantIds.length === 0) return new Map();
+
+  const telemetry = (await prisma.adapterRunTelemetry.findMany({
+    where: { agentMessageId: { in: assistantIds } },
+    select: {
+      agentMessageId: true,
+      providerId: true,
+      modelId: true,
+      adapterKind: true,
+      executionMode: true,
+      startedAt: true,
+    },
+  })) as TelemetryRow[];
+
+  const visible = selectVisibleTelemetry(telemetry);
+
+  // Gather provider ids to resolve display names — from telemetry first, then
+  // from AgentMessage.providerId for messages without telemetry.
+  const providerIds = new Set<string>();
+  for (const r of visible.values()) providerIds.add(r.providerId);
+  for (const m of messages) {
+    if (m.role === "assistant" && m.providerId && !visible.has(m.id)) {
+      providerIds.add(m.providerId);
+    }
+  }
+  if (providerIds.size === 0) return new Map();
+
+  const providers = await prisma.modelProvider.findMany({
+    where: { providerId: { in: [...providerIds] } },
+    select: { providerId: true, name: true },
+  });
+  const nameByProviderId = new Map(providers.map((p) => [p.providerId, p.name]));
+
+  const out = new Map<string, AgentMessageProvider>();
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    const t = visible.get(m.id);
+    if (t) {
+      const name = nameByProviderId.get(t.providerId);
+      if (!name) continue;
+      out.set(m.id, { name, modelId: t.modelId, adapterKind: t.adapterKind });
+      continue;
+    }
+    if (m.providerId) {
+      const name = nameByProviderId.get(m.providerId);
+      if (!name) continue;
+      out.set(m.id, { name, modelId: null, adapterKind: null });
+    }
+  }
+  return out;
 }
 
 /**
@@ -78,14 +182,18 @@ export const getRecentMessages = cache(
         content: true,
         agentId: true,
         routeContext: true,
+        providerId: true,
         createdAt: true,
         attachments: {
           select: { id: true, fileName: true, mimeType: true, sizeBytes: true, parsedContent: true },
         },
       },
     });
-    return messages.reverse().map((m) => serializeMessage(m));
+    const providerInfo = await loadProviderInfo(messages);
+    return messages
+      .reverse()
+      .map((m) => serializeMessage(m, undefined, providerInfo.get(m.id)));
   },
 );
 
-export { serializeMessage };
+export { serializeMessage, loadProviderInfo, selectVisibleTelemetry };

--- a/apps/web/lib/tak/agent-coworker-types.ts
+++ b/apps/web/lib/tak/agent-coworker-types.ts
@@ -8,6 +8,23 @@ export type AttachmentInfo = {
   parsedSummary: string | null;
 };
 
+/**
+ * Provider/adapter that produced an assistant turn — surfaced in the UI so
+ * users can tell which leg of dynamic routing answered (e.g. Codex CLI vs
+ * Anthropic API). Sourced from AdapterRunTelemetry joined on agentMessageId,
+ * falling back to AgentMessage.providerId for pre-telemetry rows. Omitted
+ * when no provider data is available (user messages, system messages,
+ * legacy rows).
+ */
+export type AgentMessageProvider = {
+  /** Display name (from ModelProvider.name), e.g. "Anthropic", "ChatGPT". */
+  name: string;
+  /** Model id used for the call, e.g. "claude-opus-4-7", "gpt-5-codex". May be null when only AgentMessage.providerId is known. */
+  modelId: string | null;
+  /** Adapter kind from telemetry (e.g. "claude-cli", "anthropic-api", "openai-api"). Null when falling back to AgentMessage.providerId. */
+  adapterKind: string | null;
+};
+
 /** Serialized message for client/server boundary. */
 export type AgentMessageRow = {
   id: string;
@@ -17,6 +34,7 @@ export type AgentMessageRow = {
   routeContext: string | null;
   createdAt: string; // ISO string via .toISOString()
   attachments?: AttachmentInfo[];
+  provider?: AgentMessageProvider;
   proposal?: {
     proposalId: string;
     actionType: string;


### PR DESCRIPTION
## Summary
- Adds a small pill next to the coworker name on each assistant turn showing the **provider + adapter + model** that actually answered (e.g. *ChatGPT CLI · gpt-5-codex*, *Anthropic · claude-opus-4-7*).
- Source of truth: `AdapterRunTelemetry` joined on `agentMessageId`. Falls back to `AgentMessage.providerId` when no telemetry exists. Skips `shadow-alt` / `race-loser` rows so only the user-visible call surfaces.
- Scoped to historical messages via `getRecentMessages`. Freshly-sent messages will pop the badge in on next refresh — the existing panel-level `providerInfo` already gives live feedback in the header. Intentional scope choice; trivial follow-up if you want the badge on the just-sent turn too.

Refs: BI-460BF2E4

## Files
- `apps/web/lib/tak/agent-coworker-types.ts` — new `AgentMessageProvider` type on `AgentMessageRow`
- `apps/web/lib/tak/agent-coworker-data.ts` — adds `providerId` to the select, batched `AdapterRunTelemetry` + `ModelProvider` lookups, `selectVisibleTelemetry` helper
- `apps/web/components/agent/AgentMessageBubble.tsx` — `ProviderBadge` component + `formatProviderBadge` formatter, rendered next to `agentName` in both the proposal and standard assistant-bubble code paths
- Tests for both new surfaces

## Test plan
- [x] `pnpm --filter web test` — 7288 pass, 1 unrelated flake (`mcp-tools-backlog > create_epic` times out under full-suite load; passes 15/15 in isolation)
- [x] `pnpm --filter web typecheck` — clean
- [x] `npx next build` — clean (only the pre-existing Turbopack NFT cascade warning from `next.config.mjs` — same warning as on `main`)
- [x] Loader exercised against the live local DB. Fallback path returns `Claude / Anthropic (OAuth Subscription)` for 6/11 assistant turns in the most recent thread; remaining have null `providerId` (orchestrator messages and legacy rows), correctly omitted.
- [ ] **UX functional verification** in the rendered portal: deferred. Build Studio is currently down, the running portal container at :3000 ships merged main (not these changes), and full-login on a worktree dev server adds significant scope. The risk surface is contained: pure read query against existing schema fields + a sibling DOM element gated on `!isUser && message.provider`. Unit tests render the badge variants directly (`renderToStaticMarkup`).

## Follow-ups spotted while verifying
- Zero `AdapterRunTelemetry` rows in this install have `agentMessageId` populated. The Anthropic/Codex adapters call `void writeAdapterTelemetry({..., agentMessageId})` but the field never lands in the DB. Worth a dedicated investigation — fixing it lights up the model/adapterKind side of this badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)