### PR TITLE
fix(security): BI-5E53A265 — safe-fetch helper closes 3 of 4 SSRF sites

### DIFF
--- a/apps/web/lib/actions/calendar-sync.ts
+++ b/apps/web/lib/actions/calendar-sync.ts
@@ -5,6 +5,7 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import { parseICal } from "@/lib/ical-parser";
+import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
 import * as crypto from "crypto";
 
 // ─── Add iCal subscription ──────────────────────────────────────────────────
@@ -22,12 +23,20 @@ export async function addICalSubscription(input: {
   });
   if (!profile) return { success: false, error: "Employee profile not found" };
 
-  // Validate URL
+  // Validate URL. BI-5E53A265 fix: assertSafeOutboundUrl gates scheme
+  // (https only by default) and blocks private-network / metadata IPs.
+  // Without this guard, a user could submit feedUrl=
+  // http://169.254.169.254/latest/meta-data/iam/security-credentials/
+  // on a cloud-hosted install and exfiltrate IAM creds through the
+  // fetch error path (CWE-918, CodeQL alert #33).
   let url: URL;
   try {
-    url = new URL(input.feedUrl);
-  } catch {
-    return { success: false, error: "Invalid URL" };
+    url = assertSafeOutboundUrl(input.feedUrl);
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "Invalid URL",
+    };
   }
 
   // Check for duplicate
@@ -45,7 +54,7 @@ export async function addICalSubscription(input: {
   // Fetch and parse the feed
   let icsContent: string;
   try {
-    const res = await fetch(url.toString(), {
+    const res = await fetch(url.href, {
       signal: AbortSignal.timeout(15000),
       headers: { "User-Agent": "DPF-Calendar/1.0" },
     });

--- a/apps/web/lib/actions/calendar-sync.ts
+++ b/apps/web/lib/actions/calendar-sync.ts
@@ -29,6 +29,11 @@ export async function addICalSubscription(input: {
   // http://169.254.169.254/latest/meta-data/iam/security-credentials/
   // on a cloud-hosted install and exfiltrate IAM creds through the
   // fetch error path (CWE-918, CodeQL alert #33).
+  //
+  // The explicit hostname-format regex below is the pattern CodeQL's
+  // SSRF sanitizer recognizes. The helper already enforced everything
+  // we care about; this is defense-in-depth + CodeQL dataflow signal
+  // so js/request-forgery's static analysis sees the validation chain.
   let url: URL;
   try {
     url = assertSafeOutboundUrl(input.feedUrl);
@@ -37,6 +42,9 @@ export async function addICalSubscription(input: {
       success: false,
       error: e instanceof Error ? e.message : "Invalid URL",
     };
+  }
+  if (!/^[a-z0-9][a-z0-9.-]*$/i.test(url.hostname)) {
+    return { success: false, error: `Invalid hostname: ${url.hostname}` };
   }
 
   // Check for duplicate

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -457,22 +457,15 @@ export async function validateGitHubToken(
     if (resolvedAuthMethod === "fine-grained-pat") {
       const probeOwner = input.expectedOwner ?? UPSTREAM_OWNER_REPO_FALLBACK.split("/")[0];
       const probeRepo = UPSTREAM_OWNER_REPO_FALLBACK.split("/")[1];
-      // BI-5E53A265 fix (CodeQL alert #34): assertSafeOutboundUrl pins
-      // the host so the user-supplied probeOwner can't redirect the
-      // probe anywhere else. The explicit `probeUrl.hostname` check
-      // below is the pattern CodeQL's HostnameSanitizer recognizes for
-      // js/request-forgery; the helper's internal check is invisible
-      // to that query. Same defense pattern as github-fork.ts.
-      const probeUrl = assertSafeOutboundUrl(
-        `https://api.github.com/repos/${probeOwner}/${probeRepo}`,
-        { allowedHosts: ["api.github.com"] },
-      );
-      if (probeUrl.hostname !== "api.github.com") {
-        // Defense-in-depth — helper already enforced this.
-        throw new Error(`Unexpected host after sanitization: ${probeUrl.hostname}`);
-      }
+      // BI-5E53A265 fix (CodeQL alert #34). Same construction pattern
+      // as github-fork.ts: hardcoded host + encodeURIComponent on the
+      // user-supplied path parts. CodeQL recognises encodeURIComponent
+      // as a path-component sanitiser.
+      const probeUrl = `https://api.github.com/repos/${encodeURIComponent(String(probeOwner))}/${encodeURIComponent(String(probeRepo))}`;
+      // Defense-in-depth — safe-fetch's full validation runs too.
+      assertSafeOutboundUrl(probeUrl, { allowedHosts: ["api.github.com"] });
 
-      const repoResponse = await fetch(probeUrl.href, {
+      const repoResponse = await fetch(probeUrl, {
         headers: {
           Accept: "application/vnd.github+json",
           Authorization: `Bearer ${token}`,

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -459,11 +459,18 @@ export async function validateGitHubToken(
       const probeRepo = UPSTREAM_OWNER_REPO_FALLBACK.split("/")[1];
       // BI-5E53A265 fix (CodeQL alert #34): assertSafeOutboundUrl pins
       // the host so the user-supplied probeOwner can't redirect the
-      // probe anywhere else. Same defense pattern as github-fork.ts.
+      // probe anywhere else. The explicit `probeUrl.hostname` check
+      // below is the pattern CodeQL's HostnameSanitizer recognizes for
+      // js/request-forgery; the helper's internal check is invisible
+      // to that query. Same defense pattern as github-fork.ts.
       const probeUrl = assertSafeOutboundUrl(
         `https://api.github.com/repos/${probeOwner}/${probeRepo}`,
         { allowedHosts: ["api.github.com"] },
       );
+      if (probeUrl.hostname !== "api.github.com") {
+        // Defense-in-depth — helper already enforced this.
+        throw new Error(`Unexpected host after sanitization: ${probeUrl.hostname}`);
+      }
 
       const repoResponse = await fetch(probeUrl.href, {
         headers: {

--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -4,6 +4,7 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { getPlatformDevPolicyState, type PlatformDevPolicyState } from "@/lib/platform-dev-policy";
+import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
 import { revalidatePath } from "next/cache";
 
 // ─── Auth helper ─────────────────────────────────────────────────────────────
@@ -456,9 +457,15 @@ export async function validateGitHubToken(
     if (resolvedAuthMethod === "fine-grained-pat") {
       const probeOwner = input.expectedOwner ?? UPSTREAM_OWNER_REPO_FALLBACK.split("/")[0];
       const probeRepo = UPSTREAM_OWNER_REPO_FALLBACK.split("/")[1];
-      const probeUrl = `https://api.github.com/repos/${probeOwner}/${probeRepo}`;
+      // BI-5E53A265 fix (CodeQL alert #34): assertSafeOutboundUrl pins
+      // the host so the user-supplied probeOwner can't redirect the
+      // probe anywhere else. Same defense pattern as github-fork.ts.
+      const probeUrl = assertSafeOutboundUrl(
+        `https://api.github.com/repos/${probeOwner}/${probeRepo}`,
+        { allowedHosts: ["api.github.com"] },
+      );
 
-      const repoResponse = await fetch(probeUrl, {
+      const repoResponse = await fetch(probeUrl.href, {
         headers: {
           Accept: "application/vnd.github+json",
           Authorization: `Bearer ${token}`,
@@ -473,7 +480,7 @@ export async function validateGitHubToken(
           authMethod: resolvedAuthMethod,
           scope: scopesHeader ?? undefined,
           expiresAt,
-          error: `Token can't access the fork repo ${probeOwner}/${probeRepo} (status ${repoResponse.status}). Check that the fine-grained PAT grants Contents: read/write on that repository.`,
+          error: `Token can't access the fork repo ${String(probeOwner)}/${String(probeRepo)} (status ${repoResponse.status}). Check that the fine-grained PAT grants Contents: read/write on that repository.`,
         };
       }
     }

--- a/apps/web/lib/integrate/github-fork.ts
+++ b/apps/web/lib/integrate/github-fork.ts
@@ -11,6 +11,8 @@
 // window — callers should surface this as "fork is being created, retry soon"
 // rather than treating it as a failure.
 
+import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
+
 function getHeaders(token: string): Record<string, string> {
   return {
     Accept: "application/vnd.github+json",
@@ -35,13 +37,22 @@ export async function forkExistsAndIsFork(params: {
   token: string;
 }): Promise<ForkCheckResult> {
   const { owner, repo, upstreamOwner, upstreamRepo, token } = params;
-  const url = `https://api.github.com/repos/${owner}/${repo}`;
-  const res = await fetch(url, { headers: getHeaders(token) });
+  // BI-5E53A265 fix (CodeQL alert #35). owner/repo flow from caller
+  // into a fetch URL. Host is hardcoded to api.github.com, but the
+  // dataflow is still user→fetch. assertSafeOutboundUrl pins the
+  // host so a future refactor can't accidentally let the URL go
+  // anywhere else, and the validated `URL` return type makes the
+  // sanitizer pattern legible to CodeQL.
+  const url = assertSafeOutboundUrl(
+    `https://api.github.com/repos/${owner}/${repo}`,
+    { allowedHosts: ["api.github.com"] },
+  );
+  const res = await fetch(url.href, { headers: getHeaders(token) });
 
   if (res.status === 404) return { exists: false, isFork: false };
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`GitHub API GET ${url}: ${res.status} ${body.slice(0, 200)}`);
+    throw new Error(`GitHub API GET ${url.href}: ${res.status} ${body.slice(0, 200)}`);
   }
 
   const body = (await res.json()) as { fork?: boolean; parent?: { full_name?: string } };

--- a/apps/web/lib/integrate/github-fork.ts
+++ b/apps/web/lib/integrate/github-fork.ts
@@ -37,16 +37,22 @@ export async function forkExistsAndIsFork(params: {
   token: string;
 }): Promise<ForkCheckResult> {
   const { owner, repo, upstreamOwner, upstreamRepo, token } = params;
-  // BI-5E53A265 fix (CodeQL alert #35). owner/repo flow from caller
-  // into a fetch URL. Host is hardcoded to api.github.com, but the
-  // dataflow is still user→fetch. assertSafeOutboundUrl pins the
-  // host so a future refactor can't accidentally let the URL go
-  // anywhere else, and the validated `URL` return type makes the
-  // sanitizer pattern legible to CodeQL.
+  // BI-5E53A265 fix (CodeQL alert #35). owner/repo flow into a fetch URL.
+  // Host is hardcoded to api.github.com, but the dataflow is still
+  // user→fetch. assertSafeOutboundUrl pins the host; the explicit
+  // `url.hostname !== "api.github.com"` check below is the pattern
+  // CodeQL's HostnameSanitizer recognizes for js/request-forgery (the
+  // helper's internal check is invisible to that query).
   const url = assertSafeOutboundUrl(
     `https://api.github.com/repos/${owner}/${repo}`,
     { allowedHosts: ["api.github.com"] },
   );
+  if (url.hostname !== "api.github.com") {
+    // Defense-in-depth + CodeQL sanitizer signal. Helper already
+    // enforced this; throwing here would only fire if the helper
+    // regressed silently.
+    throw new Error(`Unexpected host after sanitization: ${url.hostname}`);
+  }
   const res = await fetch(url.href, { headers: getHeaders(token) });
 
   if (res.status === 404) return { exists: false, isFork: false };

--- a/apps/web/lib/integrate/github-fork.ts
+++ b/apps/web/lib/integrate/github-fork.ts
@@ -37,28 +37,26 @@ export async function forkExistsAndIsFork(params: {
   token: string;
 }): Promise<ForkCheckResult> {
   const { owner, repo, upstreamOwner, upstreamRepo, token } = params;
-  // BI-5E53A265 fix (CodeQL alert #35). owner/repo flow into a fetch URL.
-  // Host is hardcoded to api.github.com, but the dataflow is still
-  // user→fetch. assertSafeOutboundUrl pins the host; the explicit
-  // `url.hostname !== "api.github.com"` check below is the pattern
-  // CodeQL's HostnameSanitizer recognizes for js/request-forgery (the
-  // helper's internal check is invisible to that query).
-  const url = assertSafeOutboundUrl(
-    `https://api.github.com/repos/${owner}/${repo}`,
-    { allowedHosts: ["api.github.com"] },
-  );
-  if (url.hostname !== "api.github.com") {
-    // Defense-in-depth + CodeQL sanitizer signal. Helper already
-    // enforced this; throwing here would only fire if the helper
-    // regressed silently.
-    throw new Error(`Unexpected host after sanitization: ${url.hostname}`);
-  }
-  const res = await fetch(url.href, { headers: getHeaders(token) });
+  // BI-5E53A265 fix (CodeQL alert #35). owner/repo flow into the URL.
+  // Host is hardcoded to api.github.com; encodeURIComponent escapes
+  // the owner/repo path components so a malicious value like
+  // "../../private-repo" becomes "..%2F..%2Fprivate-repo" — still
+  // delivered to api.github.com, where it 404s harmlessly.
+  //
+  // CodeQL recognises encodeURIComponent as a sanitiser for URL path
+  // components in its js/request-forgery dataflow, so this construction
+  // pattern silences the false positive while keeping the helper as
+  // defense-in-depth.
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  // Run safe-fetch's defense as well so private-network / scheme drift
+  // gets caught (the helper does much more than CodeQL recognises).
+  assertSafeOutboundUrl(url, { allowedHosts: ["api.github.com"] });
+  const res = await fetch(url, { headers: getHeaders(token) });
 
   if (res.status === 404) return { exists: false, isFork: false };
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`GitHub API GET ${url.href}: ${res.status} ${body.slice(0, 200)}`);
+    throw new Error(`GitHub API GET ${url}: ${res.status} ${body.slice(0, 200)}`);
   }
 
   const body = (await res.json()) as { fork?: boolean; parent?: { full_name?: string } };

--- a/apps/web/lib/security/safe-fetch.test.ts
+++ b/apps/web/lib/security/safe-fetch.test.ts
@@ -1,0 +1,174 @@
+// apps/web/lib/security/safe-fetch.test.ts
+//
+// BI-5E53A265 regression tests. Written BEFORE the implementation per
+// the kernel principle `security-fix-needs-regression-test-first`
+// (PR #953). These tests pin the contract of assertSafeOutboundUrl()
+// so the same SSRF class CAN'T regress: user-controlled URLs that
+// reach an outbound fetch() must clear scheme + host + private-network
+// checks. The catalogue of "bad" cases is the lived experience of every
+// SSRF advisory class for the last decade — cloud metadata, link-local,
+// loopback, RFC1918, file://, hostname containing newline, etc.
+
+import { describe, expect, it } from "vitest";
+import { assertSafeOutboundUrl } from "./safe-fetch";
+
+describe("assertSafeOutboundUrl — scheme gating", () => {
+  it("accepts https by default", () => {
+    const url = assertSafeOutboundUrl("https://example.com/feed.ics");
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("example.com");
+  });
+
+  it("rejects http by default", () => {
+    expect(() => assertSafeOutboundUrl("http://example.com/")).toThrow(/scheme/i);
+  });
+
+  it("rejects file://", () => {
+    expect(() => assertSafeOutboundUrl("file:///etc/passwd")).toThrow();
+  });
+
+  it("rejects gopher://, ftp://, and other unusual schemes", () => {
+    expect(() => assertSafeOutboundUrl("gopher://example.com/")).toThrow();
+    expect(() => assertSafeOutboundUrl("ftp://example.com/")).toThrow();
+    expect(() => assertSafeOutboundUrl("javascript:alert(1)")).toThrow();
+  });
+
+  it("accepts http when explicitly allowed", () => {
+    const url = assertSafeOutboundUrl("http://example.com/", {
+      allowedSchemes: ["http:", "https:"],
+    });
+    expect(url.protocol).toBe("http:");
+  });
+});
+
+describe("assertSafeOutboundUrl — private-network blocks", () => {
+  it("blocks IPv4 loopback (127.0.0.1)", () => {
+    expect(() => assertSafeOutboundUrl("https://127.0.0.1/")).toThrow(/private|loopback/i);
+  });
+
+  it("blocks IPv4 loopback range (127.x.x.x)", () => {
+    expect(() => assertSafeOutboundUrl("https://127.0.0.5/")).toThrow();
+  });
+
+  it("blocks 0.0.0.0", () => {
+    expect(() => assertSafeOutboundUrl("https://0.0.0.0/")).toThrow();
+  });
+
+  it("blocks RFC1918 10.0.0.0/8", () => {
+    expect(() => assertSafeOutboundUrl("https://10.0.0.25/")).toThrow();
+    expect(() => assertSafeOutboundUrl("https://10.255.255.255/")).toThrow();
+  });
+
+  it("blocks RFC1918 172.16.0.0/12", () => {
+    expect(() => assertSafeOutboundUrl("https://172.16.0.1/")).toThrow();
+    expect(() => assertSafeOutboundUrl("https://172.31.255.255/")).toThrow();
+  });
+
+  it("blocks RFC1918 192.168.0.0/16", () => {
+    expect(() => assertSafeOutboundUrl("https://192.168.1.10/")).toThrow();
+  });
+
+  it("blocks the AWS / GCP / Azure metadata IP (169.254.169.254)", () => {
+    // This is the textbook SSRF target — the one calendar-sync was vulnerable to.
+    expect(() => assertSafeOutboundUrl("https://169.254.169.254/latest/meta-data/")).toThrow(
+      /private|metadata|link-local/i,
+    );
+  });
+
+  it("blocks link-local 169.254.0.0/16 broadly", () => {
+    expect(() => assertSafeOutboundUrl("https://169.254.0.1/")).toThrow();
+    expect(() => assertSafeOutboundUrl("https://169.254.255.255/")).toThrow();
+  });
+
+  it("blocks 'localhost' (string literal)", () => {
+    expect(() => assertSafeOutboundUrl("https://localhost/")).toThrow(/private|loopback/i);
+  });
+
+  it("blocks .local mDNS suffixes", () => {
+    expect(() => assertSafeOutboundUrl("https://myprinter.local/")).toThrow();
+  });
+
+  it("blocks IPv6 loopback (::1)", () => {
+    expect(() => assertSafeOutboundUrl("https://[::1]/")).toThrow();
+  });
+
+  it("blocks IPv6 link-local (fe80::/10)", () => {
+    expect(() => assertSafeOutboundUrl("https://[fe80::1]/")).toThrow();
+  });
+
+  it("blocks IPv6 unique-local (fc00::/7)", () => {
+    expect(() => assertSafeOutboundUrl("https://[fc00::1]/")).toThrow();
+    expect(() => assertSafeOutboundUrl("https://[fd00::1]/")).toThrow();
+  });
+
+  it("accepts a public-looking IP (8.8.8.8)", () => {
+    expect(() => assertSafeOutboundUrl("https://8.8.8.8/")).not.toThrow();
+  });
+
+  it("accepts a public hostname", () => {
+    expect(() => assertSafeOutboundUrl("https://example.com/")).not.toThrow();
+  });
+
+  it("blocks private networks even when blockPrivateNetworks is set explicitly true", () => {
+    expect(() =>
+      assertSafeOutboundUrl("https://192.168.1.1/", { blockPrivateNetworks: true }),
+    ).toThrow();
+  });
+
+  it("allows private networks ONLY when blockPrivateNetworks is set to false (escape hatch for internal tooling)", () => {
+    expect(() =>
+      assertSafeOutboundUrl("https://192.168.1.1/", { blockPrivateNetworks: false }),
+    ).not.toThrow();
+  });
+});
+
+describe("assertSafeOutboundUrl — host allowlist", () => {
+  it("accepts the allowed host", () => {
+    const url = assertSafeOutboundUrl("https://api.github.com/repos/foo/bar", {
+      allowedHosts: ["api.github.com"],
+    });
+    expect(url.hostname).toBe("api.github.com");
+  });
+
+  it("rejects any other host even if it looks similar", () => {
+    expect(() =>
+      assertSafeOutboundUrl("https://api.github.com.evil.com/", {
+        allowedHosts: ["api.github.com"],
+      }),
+    ).toThrow(/host/i);
+  });
+
+  it("matches host case-insensitively", () => {
+    expect(() =>
+      assertSafeOutboundUrl("https://API.GitHub.com/", {
+        allowedHosts: ["api.github.com"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects when allowedHosts is empty array (no hosts permitted)", () => {
+    expect(() => assertSafeOutboundUrl("https://example.com/", { allowedHosts: [] })).toThrow();
+  });
+});
+
+describe("assertSafeOutboundUrl — input parsing", () => {
+  it("rejects malformed URLs", () => {
+    expect(() => assertSafeOutboundUrl("not-a-url")).toThrow();
+    expect(() => assertSafeOutboundUrl("")).toThrow();
+    expect(() => assertSafeOutboundUrl("   ")).toThrow();
+  });
+
+  it("rejects URLs with embedded newlines (header-injection vector)", () => {
+    expect(() => assertSafeOutboundUrl("https://example.com/\r\nHost: evil.com")).toThrow();
+  });
+
+  it("returns a URL object (not a string) so the caller passes a sanitized value", () => {
+    // The pattern is `fetch(assertSafeOutboundUrl(input).href)`. Returning
+    // URL (not string) makes CodeQL's sanitizer modeling cleaner: the
+    // input flows through a function whose return type carries the
+    // "validated" signal.
+    const url = assertSafeOutboundUrl("https://example.com/path?q=1");
+    expect(url).toBeInstanceOf(URL);
+    expect(url.pathname).toBe("/path");
+  });
+});

--- a/apps/web/lib/security/safe-fetch.ts
+++ b/apps/web/lib/security/safe-fetch.ts
@@ -1,0 +1,231 @@
+// apps/web/lib/security/safe-fetch.ts
+//
+// BI-5E53A265 — SSRF defense for user-controlled URLs that flow to
+// outbound fetch(). CodeQL flagged 4 true-positive sites
+// (js/request-forgery / CWE-918) where `new URL(userInput)` was used
+// as the ONLY validation before `fetch()`:
+//
+//   - calendar-sync.ts (feed URL — the worst, cloud-metadata exposure)
+//   - github-fork.ts   (api.github.com path injection)
+//   - platform-dev-config.ts (same shape as github-fork)
+//   - mcp-server-health.ts (admin-configured URL, lower risk)
+//
+// The unified fix is a single sanitizer:
+//
+//   const url = assertSafeOutboundUrl(input, opts);
+//   const res = await fetch(url.href, ...);
+//
+// The function throws on any failure (scheme not allowed, host not on
+// allowlist, host resolves to a private network). Returning a `URL`
+// instead of a string makes CodeQL's sanitizer modeling cleaner: the
+// validated value carries a distinct type from the raw input.
+//
+// Anti-goals:
+//   - Not a DNS-rebinding defense. A hostname that resolves to a public
+//     IP at validation time could resolve to a private IP at fetch
+//     time. Closing that gap requires re-resolving at fetch time and
+//     pinning the IP — left as a follow-up. For the audited CWE-918
+//     cases, the simpler check is already a large step up from "no
+//     check at all."
+//   - Not a content-type filter. Operators who want to reject specific
+//     response shapes (e.g., HTML where iCal is expected) should layer
+//     that on top.
+//
+// Tests: apps/web/lib/security/safe-fetch.test.ts — authored before
+// this implementation per the kernel principle
+// `security-fix-needs-regression-test-first`.
+
+/**
+ * Schemes permitted by default. http is intentionally excluded because
+ * a feed URL or webhook target that ships over plain http is almost
+ * always a misconfiguration; callers who genuinely need http (e.g.,
+ * for a local-network-only flow) opt in explicitly.
+ */
+const DEFAULT_ALLOWED_SCHEMES: ReadonlyArray<string> = ["https:"];
+
+/**
+ * Hostnames that resolve (literally or by convention) to the loopback
+ * or local network. Checked as exact string match before IP-range checks
+ * so an attacker can't bypass via `localhost` instead of `127.0.0.1`.
+ */
+const LITERAL_PRIVATE_HOSTS: ReadonlySet<string> = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "ip6-localhost",
+  "ip6-loopback",
+]);
+
+/**
+ * Test if a hostname looks like an IPv4 literal (4 dot-separated octets).
+ * Returns the parsed octets or null.
+ */
+function parseIpv4(host: string): [number, number, number, number] | null {
+  const match = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return null;
+  const octets = match.slice(1, 5).map(Number);
+  if (octets.some((o) => o < 0 || o > 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+/**
+ * Classify an IPv4 address. Returns a reason string if blocked, null
+ * if public. The classes covered:
+ *   - 0.0.0.0/8        unspecified / current network
+ *   - 10.0.0.0/8       RFC1918 private
+ *   - 127.0.0.0/8      loopback
+ *   - 169.254.0.0/16   link-local (includes the 169.254.169.254 cloud
+ *                      metadata address — the textbook SSRF target)
+ *   - 172.16.0.0/12    RFC1918 private
+ *   - 192.168.0.0/16   RFC1918 private
+ *   - 100.64.0.0/10    RFC6598 carrier-grade NAT (treat as private)
+ */
+function classifyIpv4(octets: [number, number, number, number]): string | null {
+  const [a, b] = octets;
+  if (a === 0) return "0.0.0.0/8 (unspecified / current network)";
+  if (a === 10) return "RFC1918 private (10.0.0.0/8)";
+  if (a === 127) return "loopback (127.0.0.0/8)";
+  if (a === 169 && b === 254) return "link-local (169.254.0.0/16) — includes cloud-metadata 169.254.169.254";
+  if (a === 172 && b >= 16 && b <= 31) return "RFC1918 private (172.16.0.0/12)";
+  if (a === 192 && b === 168) return "RFC1918 private (192.168.0.0/16)";
+  if (a === 100 && b >= 64 && b <= 127) return "RFC6598 carrier-grade NAT (100.64.0.0/10)";
+  return null;
+}
+
+/**
+ * Classify an IPv6 hostname (host portion inside brackets, e.g. "::1").
+ * Returns a reason string if blocked, null if not blocked. We are
+ * intentionally permissive for unrecognised shapes — IPv6 has many
+ * formats; the safe direction is to block the known-bad ones.
+ */
+function classifyIpv6(host: string): string | null {
+  const normalized = host.toLowerCase();
+  if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") {
+    return "IPv6 loopback (::1)";
+  }
+  if (normalized === "::" || normalized === "0:0:0:0:0:0:0:0") {
+    return "IPv6 unspecified (::)";
+  }
+  // fe80::/10 link-local
+  if (/^fe[89ab]/i.test(normalized)) return "IPv6 link-local (fe80::/10)";
+  // fc00::/7 unique-local (fc00–fdff)
+  if (/^f[cd]/i.test(normalized)) return "IPv6 unique-local (fc00::/7)";
+  return null;
+}
+
+/**
+ * Test the hostname for known-private forms. Returns a reason if
+ * blocked, null if it appears to be a public address.
+ */
+function classifyHostname(rawHost: string): string | null {
+  // Node's URL.hostname preserves brackets around IPv6 (e.g. `[::1]`).
+  // Strip them before classification so the IPv6 matchers see the bare
+  // address. Single pass — host is lowercased after.
+  const stripped = rawHost.startsWith("[") && rawHost.endsWith("]")
+    ? rawHost.slice(1, -1)
+    : rawHost;
+  const host = stripped.toLowerCase();
+
+  // String-literal private hosts (catches `localhost` directly).
+  if (LITERAL_PRIVATE_HOSTS.has(host)) {
+    return `private hostname literal (${host})`;
+  }
+
+  // mDNS / link-local resolution suffix.
+  if (host.endsWith(".local")) {
+    return "mDNS .local suffix (link-local discovery)";
+  }
+
+  // IPv4 literal.
+  const ipv4 = parseIpv4(host);
+  if (ipv4) {
+    return classifyIpv4(ipv4);
+  }
+
+  // IPv6 literal — host has been de-bracketed above.
+  if (host.includes(":")) {
+    return classifyIpv6(host);
+  }
+
+  return null;
+}
+
+export type AssertSafeOutboundUrlOptions = {
+  /** Schemes permitted. Default: ["https:"]. */
+  allowedSchemes?: ReadonlyArray<"http:" | "https:">;
+  /**
+   * If set, the URL's hostname must match one of these (case-insensitive,
+   * exact match — no subdomain wildcards). Default: no host restriction
+   * (only the private-network and scheme checks apply).
+   */
+  allowedHosts?: ReadonlyArray<string>;
+  /**
+   * Block loopback, RFC1918, link-local, and metadata IPs. Default: true.
+   * Operators who genuinely need to reach a private host (internal tooling,
+   * dev mode) set this to false explicitly — never by accident.
+   */
+  blockPrivateNetworks?: boolean;
+};
+
+/**
+ * Parse `input` as a URL and validate against the configured policy.
+ * Throws on any failure with a message that names the specific rule
+ * violated — operator-facing copy that explains the *why*, not just the
+ * what.
+ *
+ * The return type is `URL` (not `string`) so the caller passes
+ * `result.href` to `fetch`. This makes CodeQL's dataflow easier to
+ * model as a sanitizer: the validated value has a distinct shape from
+ * the raw input.
+ */
+export function assertSafeOutboundUrl(
+  input: string,
+  options: AssertSafeOutboundUrlOptions = {},
+): URL {
+  if (typeof input !== "string" || input.trim() === "") {
+    throw new Error("safe-fetch: URL must be a non-empty string");
+  }
+  if (/[\r\n]/.test(input)) {
+    throw new Error("safe-fetch: URL must not contain newlines (header-injection vector)");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error(`safe-fetch: not a parseable URL: ${input.slice(0, 200)}`);
+  }
+
+  const allowedSchemes = options.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
+  if (!allowedSchemes.includes(url.protocol as "http:" | "https:")) {
+    throw new Error(
+      `safe-fetch: scheme "${url.protocol}" is not allowed. Allowed: ${allowedSchemes.join(", ")}`,
+    );
+  }
+
+  if (options.allowedHosts !== undefined) {
+    const lowerHost = url.hostname.toLowerCase();
+    const allowed = options.allowedHosts.some((h) => h.toLowerCase() === lowerHost);
+    if (!allowed) {
+      throw new Error(
+        `safe-fetch: host "${url.hostname}" is not on the allowlist. Allowed: ${
+          options.allowedHosts.length ? options.allowedHosts.join(", ") : "(none)"
+        }`,
+      );
+    }
+  }
+
+  // Default true — opt out is explicit.
+  const blockPrivate = options.blockPrivateNetworks !== false;
+  if (blockPrivate) {
+    const reason = classifyHostname(url.hostname);
+    if (reason !== null) {
+      throw new Error(
+        `safe-fetch: host "${url.hostname}" is a private network address (${reason}). ` +
+          `Outbound fetch to private/loopback/link-local hosts is blocked by default to prevent SSRF. ` +
+          `If you genuinely need to reach this host, set blockPrivateNetworks: false in the call.`,
+      );
+    }
+  }
+
+  return url;
+}


### PR DESCRIPTION
## Summary

Closes **BI-5E53A265** / FB-B6A812EE (partial — see Deferred). Fixes CodeQL alerts:

| Alert | File | CWE |
|---|---|---|
| #33 | `apps/web/lib/actions/calendar-sync.ts:48` | js/request-forgery |
| #34 | `apps/web/lib/actions/platform-dev-config.ts:461` | js/request-forgery |
| #35 | `apps/web/lib/integrate/github-fork.ts:39` | js/request-forgery |

All three are CWE-918. They share the same shape: user-controlled value → `new URL(input)` → `fetch(url)`. URL parsing catches malformed strings but does **nothing** about scheme, host, or private-network targets.

## Worst case (calendar-sync) — concrete exploit

With no fix in place:

```
feedUrl: "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
```

On any cloud-hosted install, the server fetches AWS instance metadata and surfaces the response body through the error path. Equivalent attacks exist for GCP, Azure, internal services on RFC1918 ranges, `file://`, etc.

## The fix — `apps/web/lib/security/safe-fetch.ts`

`assertSafeOutboundUrl(input, opts)` with three layers:

1. **Scheme allowlist** (default: `https:` only). Rejects `http://` (opt-in), `file://`, `gopher://`, `ftp://`, `javascript:`.
2. **Host allowlist** (optional). Used by the two GitHub sites to pin the dataflow to `api.github.com`.
3. **Private-network block** (default true). Loopback, RFC1918, link-local (169.254/16 — the cloud-metadata range), IPv6 loopback / link-local / unique-local, `.local` mDNS, `localhost` literal, RFC6598 CGN.

Returns `URL` (not string). Caller uses `result.href`. The distinct type makes CodeQL's sanitizer modeling cleaner.

## Test-first (per PR #953 kernel principle)

**RED**: 29 contract tests authored first. `vitest run` failed at import (module didn't exist).

**GREEN**: helper implemented; 29/29 pass.

Test coverage: scheme gating (4 cases), private-network blocks (15 IPv4/IPv6/mDNS cases), host allowlist (4 cases), input parsing (3 edge cases including header-injection via newline).

## Site refactors

| File | Configuration |
|---|---|
| `calendar-sync.ts` | Default mode — private-network block, https only |
| `github-fork.ts` | `allowedHosts: [\"api.github.com\"]` |
| `platform-dev-config.ts` | Same as github-fork |

Each call site comments the alert ID being closed and the rationale, so future maintainers see the *why*.

## Anti-goals (called out in `safe-fetch.ts` header)

- **NOT a DNS-rebinding defense.** A hostname that resolves to public at validation time could resolve to private at fetch time. Re-resolve-and-pin is a follow-up.
- **NOT a content-type filter.** Layer separately if needed.

## Deferred from this PR

- **`mcp-server-health.ts:31` (alert #38).** Same fix pattern, but the file is currently being edited by **PR #963** (BI-7DB95878 safe-spawn refactor). Folding into a small follow-up after #963 merges to avoid conflict.
- **`public-web-tools.ts:357, 366` (alerts #36, #37).** CodeQL false positives — `assertAllowedPublicUrl` already gates these URLs with the same defenses safe-fetch implements. Closing them needs CodeQL sanitizer modeling (a `.github/codeql/config.yml` entry), not a code change.

Both will be tracked as follow-up tasks.

## Trust-boundary discipline

This PR touches `apps/web/lib/security/` (CODEOWNERS-listed). Reviewer note: the IP-classification logic in `safe-fetch.ts` is the central SSRF policy — extending allowed ranges (or weakening any class) expands the attack surface. Default to refusing such changes unless there's a documented operational need.

## Why this is in Claude's lane

Build Studio is temporarily down. Per the operator's direction, finishing the security backlog directly with test-first rigor.

## Test plan

- [ ] CI green: typecheck, unit tests (29 in safe-fetch + existing suites).
- [ ] CodeQL re-scan closes alerts #33, #34, #35.
- [ ] After merge: mark BI-5E53A265 done with partial-resolution note, retire FB-B6A812EE.
- [ ] Follow-up PR for alert #38 (mcp-server-health) after #963 lands.
- [ ] Follow-up: CodeQL sanitizer model for alerts #36/#37.

## Related

- PR #962 (BI-5940955C + BI-D094AF1D), PR #963 (BI-7DB95878), PR #953 (kernel principle), prior #936/#941/#944/#946/#956

🤖 Generated with [Claude Code](https://claude.com/claude-code)