### PR TITLE
feat(build-studio): add sandbox admin recovery foundation

### DIFF
--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -237,15 +237,16 @@ BEFORE PHASE TRANSITION: When the plan passes review, immediately call save_phas
 
 Call start_build FIRST. It verifies the sandbox is running and creates your git branch.
 If start_build returns "not running":
-  1. Call check_sandbox to see the status ("running", "stopped", or "not_found").
-  2. If "stopped" — call start_sandbox to start it, then retry start_build.
-  3. If "not_found" — the container has never been created. Tell the user: "The sandbox container needs to be created once. Please run: docker compose up -d sandbox" — this is the only time the user needs to touch the terminal for sandbox setup.
+  1. Call diagnose_sandbox to classify the sandbox state and read the recommended recovery actions.
+  2. If the state is "stopped", call start_sandbox and retry start_build.
+  3. If the state is "not_found", "detached", or "mixed_compose_project", stop and report the recovery action returned by diagnose_sandbox. Do not hand Docker commands back to the user.
 
 ${PROJECT_CONTEXT}
 
 YOU HAVE THESE TOOLS — use the right one for the job:
-- check_sandbox(): Check if sandbox is running, stopped, or not found. Use when start_build fails.
-- start_sandbox(): Start the sandbox container if it is stopped. Call after check_sandbox confirms "stopped".
+- diagnose_sandbox(): Diagnose the active build sandbox and return platform-owned recovery actions. Use when start_build fails.
+- check_sandbox(): Quick running/stopped/not-found check. For anything other than stopped, use diagnose_sandbox.
+- start_sandbox(): Start the sandbox container if it is stopped. Call after diagnose_sandbox confirms "stopped".
 - start_build(): FIRST CALL. Creates the build branch and verifies sandbox is running. Call once.
 - write_sandbox_file(path, content): CREATE a new file with full content. Both parameters required.
 - read_sandbox_file(path, offset?, limit?): READ a file before changing it. ALWAYS read first. Use offset/limit for large files.

--- a/apps/web/lib/integrate/sandbox/docker-compose-inspector.test.ts
+++ b/apps/web/lib/integrate/sandbox/docker-compose-inspector.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDockerInspectJson } from "./docker-compose-inspector";
+
+describe("parseDockerInspectJson", () => {
+  it("extracts compose ownership labels", () => {
+    const parsed = parseDockerInspectJson(JSON.stringify([{
+      Id: "abc123",
+      Name: "/dpf-sandbox-1",
+      State: { Status: "running", Running: true },
+      Config: {
+        Labels: {
+          "com.docker.compose.project": "dpf",
+          "com.docker.compose.service": "sandbox",
+          "com.docker.compose.project.working_dir": "D:\\DPF-clean-main-linux",
+          "com.docker.compose.project.config_files": "D:\\DPF-clean-main-linux\\docker-compose.yml",
+        },
+      },
+      NetworkSettings: { Ports: { "3035/tcp": [{ HostPort: "3035" }] } },
+    }]));
+
+    expect(parsed?.containerName).toBe("dpf-sandbox-1");
+    expect(parsed?.status).toBe("running");
+    expect(parsed?.composeProjectName).toBe("dpf");
+    expect(parsed?.composeServiceName).toBe("sandbox");
+    expect(parsed?.composeWorkingDir).toBe("D:\\DPF-clean-main-linux");
+    expect(parsed?.composeConfigFiles).toEqual(["D:\\DPF-clean-main-linux\\docker-compose.yml"]);
+    expect(parsed?.hostPorts).toEqual([3035]);
+  });
+
+  it("returns null for empty inspect output", () => {
+    expect(parseDockerInspectJson("[]")).toBeNull();
+  });
+});

--- a/apps/web/lib/integrate/sandbox/docker-compose-inspector.ts
+++ b/apps/web/lib/integrate/sandbox/docker-compose-inspector.ts
@@ -1,0 +1,54 @@
+export type DockerComposeContainerInfo = {
+  containerId: string;
+  containerName: string;
+  status: string;
+  running: boolean;
+  composeProjectName: string | null;
+  composeServiceName: string | null;
+  composeWorkingDir: string | null;
+  composeConfigFiles: string[];
+  hostPorts: number[];
+};
+
+type RawInspect = {
+  Id?: string;
+  Name?: string;
+  State?: { Status?: string; Running?: boolean };
+  Config?: { Labels?: Record<string, string> };
+  NetworkSettings?: { Ports?: RawPortBindings };
+};
+
+type RawPortBindings = Record<string, Array<{ HostPort?: string }> | null>;
+
+function splitConfigFiles(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split(",").map((part) => part.trim()).filter(Boolean);
+}
+
+function extractHostPorts(ports: RawPortBindings | undefined): number[] {
+  if (!ports) return [];
+  return Object.values(ports)
+    .flatMap((bindings) => bindings ?? [])
+    .map((binding) => Number(binding.HostPort))
+    .filter((port) => Number.isInteger(port) && port > 0);
+}
+
+export function parseDockerInspectJson(stdout: string): DockerComposeContainerInfo | null {
+  const parsed = JSON.parse(stdout) as RawInspect[];
+  const first = parsed[0];
+  if (!first) return null;
+
+  const labels = first.Config?.Labels ?? {};
+
+  return {
+    containerId: first.Id ?? "",
+    containerName: (first.Name ?? "").replace(/^\//, ""),
+    status: first.State?.Status ?? "unknown",
+    running: first.State?.Running === true,
+    composeProjectName: labels["com.docker.compose.project"] ?? null,
+    composeServiceName: labels["com.docker.compose.service"] ?? null,
+    composeWorkingDir: labels["com.docker.compose.project.working_dir"] ?? null,
+    composeConfigFiles: splitConfigFiles(labels["com.docker.compose.project.config_files"]),
+    hostPorts: extractHostPorts(first.NetworkSettings?.Ports),
+  };
+}

--- a/apps/web/lib/integrate/sandbox/sandbox-admin-types.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-admin-types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SANDBOX_READINESS_STATES,
+  SANDBOX_RECOVERY_ACTIONS,
+  isSandboxReadinessState,
+  isSandboxRecoveryAction,
+} from "./sandbox-admin-types";
+
+describe("sandbox admin types", () => {
+  it("accepts every supported readiness state", () => {
+    expect(SANDBOX_READINESS_STATES).toEqual([
+      "healthy",
+      "stopped",
+      "not_found",
+      "detached",
+      "mixed_compose_project",
+      "branch_mismatch",
+      "stale_source",
+      "dirty_or_leaking",
+      "verification_red",
+      "stuck_mid_phase",
+      "unrecoverable",
+    ]);
+
+    for (const state of SANDBOX_READINESS_STATES) {
+      expect(isSandboxReadinessState(state)).toBe(true);
+    }
+  });
+
+  it("rejects unknown readiness state strings", () => {
+    expect(isSandboxReadinessState("running")).toBe(false);
+    expect(isSandboxReadinessState("ready")).toBe(false);
+  });
+
+  it("accepts every supported recovery action", () => {
+    expect(SANDBOX_RECOVERY_ACTIONS).toEqual([
+      "start",
+      "restart",
+      "rebind_runtime_target",
+      "release_stale_slot",
+      "checkout_registered_branch",
+      "reset_from_main",
+      "quarantine_runtime_target",
+      "reset_build_phase",
+    ]);
+
+    for (const action of SANDBOX_RECOVERY_ACTIONS) {
+      expect(isSandboxRecoveryAction(action)).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/integrate/sandbox/sandbox-admin-types.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-admin-types.ts
@@ -1,0 +1,80 @@
+export const SANDBOX_READINESS_STATES = [
+  "healthy",
+  "stopped",
+  "not_found",
+  "detached",
+  "mixed_compose_project",
+  "branch_mismatch",
+  "stale_source",
+  "dirty_or_leaking",
+  "verification_red",
+  "stuck_mid_phase",
+  "unrecoverable",
+] as const;
+
+export type SandboxReadinessState = (typeof SANDBOX_READINESS_STATES)[number];
+
+const READINESS_STATE_SET = new Set<string>(SANDBOX_READINESS_STATES);
+
+export function isSandboxReadinessState(value: unknown): value is SandboxReadinessState {
+  return typeof value === "string" && READINESS_STATE_SET.has(value);
+}
+
+export type SandboxCheckStatus = "pass" | "warn" | "fail" | "unknown";
+
+export type SandboxCheckResult = {
+  id: string;
+  label: string;
+  status: SandboxCheckStatus;
+  expected?: string | number | boolean | null;
+  actual?: string | number | boolean | null;
+  detail?: string;
+};
+
+export type SandboxRecoveryAction =
+  | "start"
+  | "restart"
+  | "rebind_runtime_target"
+  | "release_stale_slot"
+  | "checkout_registered_branch"
+  | "reset_from_main"
+  | "quarantine_runtime_target"
+  | "reset_build_phase";
+
+export const SANDBOX_RECOVERY_ACTIONS = [
+  "start",
+  "restart",
+  "rebind_runtime_target",
+  "release_stale_slot",
+  "checkout_registered_branch",
+  "reset_from_main",
+  "quarantine_runtime_target",
+  "reset_build_phase",
+] as const satisfies readonly SandboxRecoveryAction[];
+
+const RECOVERY_ACTION_SET = new Set<string>(SANDBOX_RECOVERY_ACTIONS);
+
+export function isSandboxRecoveryAction(value: unknown): value is SandboxRecoveryAction {
+  return typeof value === "string" && RECOVERY_ACTION_SET.has(value);
+}
+
+export type RecommendedSandboxAction = {
+  action: SandboxRecoveryAction;
+  label: string;
+  requiresApproval: boolean;
+  disabledReason?: string | null;
+};
+
+export type SandboxReadinessSnapshot = {
+  buildId: string;
+  state: SandboxReadinessState;
+  canDeploy: boolean;
+  canContribute: boolean;
+  summary: string;
+  checks: SandboxCheckResult[];
+  recommendedActions: RecommendedSandboxAction[];
+  inspectedAt: string;
+  runtimeTargetId?: string | null;
+  containerId?: string | null;
+  branchName?: string | null;
+};

--- a/apps/web/lib/integrate/sandbox/sandbox-admin.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-admin.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  diagnoseSandboxReadiness,
+  type SandboxAdminDb,
+  type SandboxGitProbe,
+} from "./sandbox-admin";
+import type { DockerComposeContainerInfo } from "./docker-compose-inspector";
+
+const healthyContainer: DockerComposeContainerInfo = {
+  containerId: "sandbox-container-1",
+  containerName: "dpf-sandbox-BI-123",
+  status: "running",
+  running: true,
+  composeProjectName: "dpf-build-BI-123",
+  composeServiceName: "sandbox",
+  composeWorkingDir: "D:\\DPF\\.worktrees\\BI-123",
+  composeConfigFiles: ["D:\\DPF\\.worktrees\\BI-123\\docker-compose.yml"],
+  hostPorts: [3310],
+};
+
+const healthyGit: SandboxGitProbe = {
+  branchName: "build/BI-123",
+  dirty: false,
+  sourceCurrencyStatus: "current",
+  sourceCurrencySummary: "Sandbox source current.",
+};
+
+function makeBuild(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "feature-build-row-1",
+    buildId: "BI-123",
+    sandboxId: "sandbox-container-1",
+    sandboxPort: 3310,
+    buildBranch: "build/BI-123",
+    diffPatch: "diff --git a/file.ts b/file.ts",
+    buildExecState: { phase: "build" },
+    taskResults: { completedTasks: 1, totalTasks: 1, tasks: [{ outcome: "DONE" }] },
+    verificationOut: { typecheckPassed: true, buildPassed: true, testsFailed: 0 },
+    phase: "build",
+    ...overrides,
+  };
+}
+
+function makeRuntimeTarget(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "runtime-target-row-1",
+    targetId: "RT-BI-123",
+    status: "assigned",
+    composeProjectName: "dpf-build-BI-123",
+    serviceName: "sandbox",
+    containerName: "dpf-sandbox-BI-123",
+    port: 3310,
+    featureBuildId: "feature-build-row-1",
+    sandboxId: "sandbox-row-1",
+    slotId: "slot-row-1",
+    ...overrides,
+  };
+}
+
+function makeDb(args: {
+  build?: Record<string, unknown> | null;
+  runtimeTarget?: Record<string, unknown> | null;
+  phaseRun?: Record<string, unknown> | null;
+} = {}): SandboxAdminDb {
+  return {
+    featureBuild: {
+      findUnique: vi.fn().mockResolvedValue(args.build === undefined ? makeBuild() : args.build),
+    },
+    runtimeTarget: {
+      findFirst: vi.fn().mockResolvedValue(
+        args.runtimeTarget === undefined ? makeRuntimeTarget() : args.runtimeTarget,
+      ),
+    },
+    buildPhaseRun: {
+      findFirst: vi.fn().mockResolvedValue(args.phaseRun ?? null),
+    },
+  };
+}
+
+describe("diagnoseSandboxReadiness", () => {
+  it("marks a build without sandbox metadata as not found and non-deployable", async () => {
+    const snapshot = await diagnoseSandboxReadiness({
+      buildId: "BI-123",
+      db: makeDb({ build: makeBuild({ sandboxId: null, sandboxPort: null }) }),
+      inspectContainer: vi.fn(),
+      inspectGit: vi.fn(),
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    });
+
+    expect(snapshot.state).toBe("not_found");
+    expect(snapshot.canDeploy).toBe(false);
+    expect(snapshot.canContribute).toBe(false);
+    expect(snapshot.recommendedActions.map((item) => item.action)).toContain("restart");
+    expect(snapshot.checks).toContainEqual(expect.objectContaining({
+      id: "sandbox_metadata",
+      status: "fail",
+    }));
+  });
+
+  it("detects a detached compose project when the container belongs to a different worktree", async () => {
+    const snapshot = await diagnoseSandboxReadiness({
+      buildId: "BI-123",
+      db: makeDb(),
+      expectedWorkspaceRoot: "D:\\DPF\\.worktrees\\BI-123",
+      inspectContainer: vi.fn().mockResolvedValue({
+        ...healthyContainer,
+        composeWorkingDir: "D:\\DPF-other-build",
+      }),
+      inspectGit: vi.fn().mockResolvedValue(healthyGit),
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    });
+
+    expect(snapshot.state).toBe("mixed_compose_project");
+    expect(snapshot.canDeploy).toBe(false);
+    expect(snapshot.canContribute).toBe(false);
+    expect(snapshot.recommendedActions.map((item) => item.action)).toEqual([
+      "rebind_runtime_target",
+      "restart",
+    ]);
+    expect(snapshot.checks).toContainEqual(expect.objectContaining({
+      id: "compose_working_dir",
+      status: "fail",
+      actual: "D:\\DPF-other-build",
+    }));
+  });
+
+  it("marks a matching running sandbox as healthy and deployable", async () => {
+    const snapshot = await diagnoseSandboxReadiness({
+      buildId: "BI-123",
+      db: makeDb(),
+      expectedWorkspaceRoot: "D:\\DPF\\.worktrees\\BI-123",
+      inspectContainer: vi.fn().mockResolvedValue(healthyContainer),
+      inspectGit: vi.fn().mockResolvedValue(healthyGit),
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    });
+
+    expect(snapshot.state).toBe("healthy");
+    expect(snapshot.canDeploy).toBe(true);
+    expect(snapshot.canContribute).toBe(true);
+    expect(snapshot.recommendedActions).toEqual([]);
+    expect(snapshot.checks).toContainEqual(expect.objectContaining({
+      id: "verification",
+      status: "pass",
+    }));
+  });
+
+  it("flags complete/no-diff builds as stuck mid phase instead of asking for a PR diff override", async () => {
+    const snapshot = await diagnoseSandboxReadiness({
+      buildId: "BI-123",
+      db: makeDb({
+        build: makeBuild({
+          diffPatch: "",
+          buildExecState: { phase: "ship", step: "complete" },
+          taskResults: { completedTasks: 1, totalTasks: 1, tasks: [], filesChanged: 0 },
+        }),
+      }),
+      expectedWorkspaceRoot: "D:\\DPF\\.worktrees\\BI-123",
+      inspectContainer: vi.fn().mockResolvedValue(healthyContainer),
+      inspectGit: vi.fn().mockResolvedValue(healthyGit),
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    });
+
+    expect(snapshot.state).toBe("stuck_mid_phase");
+    expect(snapshot.canDeploy).toBe(false);
+    expect(snapshot.recommendedActions.map((item) => item.action)).toContain("reset_build_phase");
+    expect(snapshot.summary).toMatch(/finished without a releasable diff/i);
+  });
+});

--- a/apps/web/lib/integrate/sandbox/sandbox-admin.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-admin.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   diagnoseSandboxReadiness,
+  normalizeSandboxPathForComparison,
   type SandboxAdminDb,
   type SandboxGitProbe,
 } from "./sandbox-admin";
@@ -79,6 +80,13 @@ function makeDb(args: {
 }
 
 describe("diagnoseSandboxReadiness", () => {
+  it("normalizes workspace paths with repeated trailing separators for safe comparison", () => {
+    expect(normalizeSandboxPathForComparison(" D:\\DPF\\.worktrees\\BI-123////\\\\ ")).toBe(
+      "d:/dpf/.worktrees/bi-123",
+    );
+    expect(normalizeSandboxPathForComparison("   ")).toBeNull();
+  });
+
   it("marks a build without sandbox metadata as not found and non-deployable", async () => {
     const snapshot = await diagnoseSandboxReadiness({
       buildId: "BI-123",

--- a/apps/web/lib/integrate/sandbox/sandbox-admin.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-admin.ts
@@ -420,8 +420,8 @@ function checkComposeOwnership(args: {
   const expectedProject = args.runtimeTarget?.composeProjectName ?? null;
   const actualProject = args.container.composeProjectName;
   const projectMismatch = expectedProject && actualProject && expectedProject !== actualProject;
-  const expectedRoot = normalizePath(args.expectedWorkspaceRoot);
-  const actualRoot = normalizePath(args.container.composeWorkingDir);
+  const expectedRoot = normalizeSandboxPathForComparison(args.expectedWorkspaceRoot);
+  const actualRoot = normalizeSandboxPathForComparison(args.container.composeWorkingDir);
   const rootMismatch = expectedRoot && actualRoot && expectedRoot !== actualRoot;
 
   if (projectMismatch || rootMismatch) {
@@ -584,9 +584,18 @@ function booleanField(record: JsonRecord, key: string): boolean | null {
   return typeof value === "boolean" ? value : null;
 }
 
-function normalizePath(value: string | null | undefined): string | null {
+export function normalizeSandboxPathForComparison(value: string | null | undefined): string | null {
   if (!value?.trim()) return null;
-  return value.trim().replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  const trimmed = value.trim();
+  let end = trimmed.length;
+
+  while (end > 0) {
+    const code = trimmed.charCodeAt(end - 1);
+    if (code !== 47 && code !== 92) break;
+    end -= 1;
+  }
+
+  return trimmed.slice(0, end).split("\\").join("/").toLowerCase();
 }
 
 function shellQuote(value: string): string {

--- a/apps/web/lib/integrate/sandbox/sandbox-admin.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-admin.ts
@@ -1,0 +1,594 @@
+import { prisma } from "@dpf/db";
+
+import { lazyExec } from "@/lib/shared/lazy-node";
+
+import {
+  buildSandboxSourceCurrencyProbeCommand,
+  formatSandboxSourceCurrencySummary,
+  parseSandboxSourceCurrencyProbeOutput,
+  type SandboxSourceCurrencyStatus,
+} from "./sandbox-source-currency";
+import { execInSandbox } from "./sandbox";
+import {
+  parseDockerInspectJson,
+  type DockerComposeContainerInfo,
+} from "./docker-compose-inspector";
+import type {
+  RecommendedSandboxAction,
+  SandboxCheckResult,
+  SandboxReadinessSnapshot,
+  SandboxReadinessState,
+} from "./sandbox-admin-types";
+
+type JsonRecord = Record<string, unknown>;
+
+type FeatureBuildRow = {
+  id: string;
+  buildId: string;
+  phase?: string | null;
+  sandboxId?: string | null;
+  sandboxPort?: number | null;
+  buildBranch?: string | null;
+  diffPatch?: string | null;
+  taskResults?: unknown;
+  verificationOut?: unknown;
+  uxVerificationStatus?: string | null;
+  buildExecState?: unknown;
+};
+
+type RuntimeTargetRow = {
+  id: string;
+  targetId?: string | null;
+  status?: string | null;
+  composeProjectName?: string | null;
+  serviceName?: string | null;
+  containerName?: string | null;
+  port?: number | null;
+  lastHeartbeatAt?: Date | string | null;
+};
+
+type BuildPhaseRunRow = {
+  phase: string;
+  startedAt: Date | string;
+  completedAt?: Date | string | null;
+};
+
+export type SandboxAdminDb = {
+  featureBuild: {
+    findUnique(args: unknown): Promise<FeatureBuildRow | null>;
+  };
+  runtimeTarget: {
+    findFirst(args: unknown): Promise<RuntimeTargetRow | null>;
+  };
+  buildPhaseRun?: {
+    findFirst(args: unknown): Promise<BuildPhaseRunRow | null>;
+  };
+};
+
+export type SandboxGitProbe = {
+  branchName: string | null;
+  dirty: boolean;
+  sourceCurrencyStatus: SandboxSourceCurrencyStatus | "unverified";
+  sourceCurrencySummary?: string | null;
+};
+
+export type DiagnoseSandboxReadinessArgs = {
+  buildId: string;
+  db?: SandboxAdminDb;
+  expectedWorkspaceRoot?: string | null;
+  inspectContainer?: (containerId: string) => Promise<DockerComposeContainerInfo | null>;
+  inspectGit?: (containerId: string, build: FeatureBuildRow) => Promise<SandboxGitProbe>;
+  now?: Date;
+};
+
+const PHASE_STUCK_AFTER_MS = 45 * 60 * 1000;
+
+const exec = lazyExec();
+
+export async function diagnoseSandboxReadiness(
+  args: DiagnoseSandboxReadinessArgs,
+): Promise<SandboxReadinessSnapshot> {
+  const db = args.db ?? (prisma as unknown as SandboxAdminDb);
+  const now = args.now ?? new Date();
+  const inspectedAt = now.toISOString();
+  const checks: SandboxCheckResult[] = [];
+  const build = await findBuild(db, args.buildId);
+
+  if (!build) {
+    checks.push(check("build_row", "Build record", "fail", {
+      expected: args.buildId,
+      actual: null,
+      detail: "Build Studio has no FeatureBuild row for this build id.",
+    }));
+    return snapshot({
+      buildId: args.buildId,
+      inspectedAt,
+      state: "not_found",
+      summary: "Build Studio cannot find the submitted build record.",
+      checks,
+      recommendedActions: [action("reset_build_phase")],
+    });
+  }
+
+  checks.push(check("build_row", "Build record", "pass", {
+    expected: args.buildId,
+    actual: build.buildId,
+  }));
+
+  const runtimeTarget = await findRuntimeTarget(db, build);
+  const phaseRun = await findCurrentPhaseRun(db, build);
+  const containerId = build.sandboxId?.trim() || null;
+
+  if (!containerId) {
+    checks.push(check("sandbox_metadata", "Sandbox metadata", "fail", {
+      expected: "container id",
+      actual: null,
+      detail: "FeatureBuild.sandboxId is empty, so Build Studio has no sandbox to inspect.",
+    }));
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      branchName: build.buildBranch ?? null,
+      state: "not_found",
+      summary: "Build Studio has no registered sandbox container for this build.",
+      checks,
+      recommendedActions: [action("restart")],
+    });
+  }
+
+  checks.push(check("sandbox_metadata", "Sandbox metadata", "pass", {
+    expected: "container id",
+    actual: containerId,
+  }));
+  checks.push(check(
+    "runtime_target",
+    "Runtime target",
+    runtimeTarget ? "pass" : "warn",
+    {
+      expected: "runtime target row",
+      actual: runtimeTarget?.targetId ?? runtimeTarget?.id ?? null,
+      detail: runtimeTarget
+        ? "Runtime target is registered for this build."
+        : "No RuntimeTarget row is linked to this build; admin actions may need to rebind it.",
+    },
+  ));
+
+  const inspectContainer = args.inspectContainer ?? inspectDockerContainer;
+  const container = await inspectContainer(containerId);
+
+  if (!container) {
+    checks.push(check("docker_container", "Docker container", "fail", {
+      expected: containerId,
+      actual: null,
+      detail: "Docker inspect did not return a container for the build sandbox id.",
+    }));
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId,
+      branchName: build.buildBranch ?? null,
+      state: "not_found",
+      summary: "The registered sandbox container no longer exists.",
+      checks,
+      recommendedActions: [action("restart"), action("quarantine_runtime_target")],
+    });
+  }
+
+  checks.push(check("docker_container", "Docker container", container.running ? "pass" : "fail", {
+    expected: "running",
+    actual: container.status,
+    detail: container.running
+      ? "Docker reports the registered sandbox container is running."
+      : "Docker reports the registered sandbox container is not running.",
+  }));
+
+  if (!container.running) {
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: build.buildBranch ?? null,
+      state: "stopped",
+      summary: "The registered sandbox container exists but is stopped.",
+      checks,
+      recommendedActions: [action("start"), action("restart")],
+    });
+  }
+
+  const composeState = checkComposeOwnership({
+    expectedWorkspaceRoot: args.expectedWorkspaceRoot,
+    runtimeTarget,
+    container,
+  });
+  checks.push(composeState.check);
+  if (composeState.state) {
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: build.buildBranch ?? null,
+      state: composeState.state,
+      summary: "The registered sandbox container belongs to a different Compose project or worktree.",
+      checks,
+      recommendedActions: [action("rebind_runtime_target"), action("restart")],
+    });
+  }
+
+  const inspectGit = args.inspectGit ?? inspectSandboxGit;
+  const git = await inspectGit(containerId, build);
+  checks.push(check("sandbox_branch", "Sandbox branch", git.branchName === build.buildBranch ? "pass" : "fail", {
+    expected: build.buildBranch ?? null,
+    actual: git.branchName,
+    detail: git.branchName === build.buildBranch
+      ? "Sandbox git branch matches the FeatureBuild branch."
+      : "Sandbox git branch does not match the FeatureBuild branch.",
+  }));
+  checks.push(check("workspace_dirty", "Workspace dirty state", git.dirty ? "fail" : "pass", {
+    expected: false,
+    actual: git.dirty,
+    detail: git.dirty
+      ? "Sandbox has uncommitted source changes that must be reconciled before deployment."
+      : "Sandbox working tree is clean.",
+  }));
+  checks.push(check("source_currency", "Source currency", git.sourceCurrencyStatus === "current" ? "pass" : "warn", {
+    expected: "current",
+    actual: git.sourceCurrencyStatus,
+    detail: git.sourceCurrencySummary ?? undefined,
+  }));
+
+  if (git.branchName !== build.buildBranch) {
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: git.branchName,
+      state: "branch_mismatch",
+      summary: "The sandbox is checked out to a different branch than the submitted build.",
+      checks,
+      recommendedActions: [action("checkout_registered_branch"), action("restart")],
+    });
+  }
+
+  if (git.dirty) {
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: git.branchName,
+      state: "dirty_or_leaking",
+      summary: "The sandbox working tree is dirty and cannot be deployed safely.",
+      checks,
+      recommendedActions: [action("quarantine_runtime_target"), action("restart")],
+    });
+  }
+
+  if (git.sourceCurrencyStatus !== "current" && git.sourceCurrencyStatus !== "ahead") {
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: git.branchName,
+      state: "stale_source",
+      summary: "The sandbox source is not current with the registered target ref.",
+      checks,
+      recommendedActions: [action("reset_from_main"), action("restart")],
+    });
+  }
+
+  const stuckReason = classifyStuckMidPhase(build, phaseRun, now);
+  if (stuckReason) {
+    checks.push(check("phase_progress", "Build phase progress", "fail", {
+      expected: "active phase with releasable diff",
+      actual: stuckReason,
+    }));
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: git.branchName,
+      state: "stuck_mid_phase",
+      summary: stuckReason,
+      checks,
+      recommendedActions: [action("reset_build_phase"), action("restart")],
+    });
+  }
+
+  const verificationCheck = classifyVerification(build);
+  checks.push(verificationCheck);
+  if (verificationCheck.status === "fail") {
+    return snapshot({
+      buildId: build.buildId,
+      inspectedAt,
+      runtimeTargetId: runtimeTarget?.id ?? null,
+      containerId: container.containerId || containerId,
+      branchName: git.branchName,
+      state: "verification_red",
+      summary: "The sandbox is reachable, but the recorded verification gate is red.",
+      checks,
+      recommendedActions: [action("reset_build_phase")],
+    });
+  }
+
+  return snapshot({
+    buildId: build.buildId,
+    inspectedAt,
+    runtimeTargetId: runtimeTarget?.id ?? null,
+    containerId: container.containerId || containerId,
+    branchName: git.branchName,
+    state: "healthy",
+    summary: "Sandbox is running, bound to the expected worktree, current, clean, and verified.",
+    checks,
+    recommendedActions: [],
+    canDeploy: true,
+    canContribute: true,
+  });
+}
+
+export async function inspectDockerContainer(containerId: string): Promise<DockerComposeContainerInfo | null> {
+  try {
+    const { stdout } = await exec(`docker inspect ${shellQuote(containerId)}`);
+    return parseDockerInspectJson(stdout);
+  } catch {
+    return null;
+  }
+}
+
+export async function inspectSandboxGit(
+  containerId: string,
+  build: FeatureBuildRow,
+): Promise<SandboxGitProbe> {
+  try {
+    const targetRef = "origin/main";
+    const workspace = "/workspace";
+    const output = await execInSandbox(
+      containerId,
+      buildSandboxSourceCurrencyProbeCommand({ workspace, targetRef }),
+    );
+    const sourceSnapshot = parseSandboxSourceCurrencyProbeOutput(output, {
+      targetRef,
+      workspace,
+    });
+    return {
+      branchName: sourceSnapshot.branch,
+      dirty: sourceSnapshot.dirty,
+      sourceCurrencyStatus: sourceSnapshot.status,
+      sourceCurrencySummary: formatSandboxSourceCurrencySummary(sourceSnapshot),
+    };
+  } catch {
+    return {
+      branchName: build.buildBranch ?? null,
+      dirty: false,
+      sourceCurrencyStatus: "unverified",
+      sourceCurrencySummary: "Sandbox git source could not be inspected.",
+    };
+  }
+}
+
+async function findBuild(db: SandboxAdminDb, buildId: string) {
+  return db.featureBuild.findUnique({
+    where: { buildId },
+    select: {
+      id: true,
+      buildId: true,
+      phase: true,
+      sandboxId: true,
+      sandboxPort: true,
+      buildBranch: true,
+      diffPatch: true,
+      taskResults: true,
+      verificationOut: true,
+      uxVerificationStatus: true,
+      buildExecState: true,
+    },
+  });
+}
+
+async function findRuntimeTarget(db: SandboxAdminDb, build: FeatureBuildRow) {
+  return db.runtimeTarget.findFirst({
+    where: {
+      OR: [
+        { featureBuildId: build.id },
+        { containerName: build.sandboxId },
+        { sandboxId: build.sandboxId },
+      ],
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+}
+
+async function findCurrentPhaseRun(db: SandboxAdminDb, build: FeatureBuildRow) {
+  if (!db.buildPhaseRun || !build.phase) return null;
+  return db.buildPhaseRun.findFirst({
+    where: { buildId: build.buildId, phase: build.phase },
+    orderBy: { startedAt: "desc" },
+  });
+}
+
+function checkComposeOwnership(args: {
+  expectedWorkspaceRoot?: string | null;
+  runtimeTarget: RuntimeTargetRow | null;
+  container: DockerComposeContainerInfo;
+}): { state: SandboxReadinessState | null; check: SandboxCheckResult } {
+  const expectedProject = args.runtimeTarget?.composeProjectName ?? null;
+  const actualProject = args.container.composeProjectName;
+  const projectMismatch = expectedProject && actualProject && expectedProject !== actualProject;
+  const expectedRoot = normalizePath(args.expectedWorkspaceRoot);
+  const actualRoot = normalizePath(args.container.composeWorkingDir);
+  const rootMismatch = expectedRoot && actualRoot && expectedRoot !== actualRoot;
+
+  if (projectMismatch || rootMismatch) {
+    return {
+      state: "mixed_compose_project",
+      check: check("compose_working_dir", "Compose working directory", "fail", {
+        expected: args.expectedWorkspaceRoot ?? expectedProject,
+        actual: args.container.composeWorkingDir ?? actualProject,
+        detail: "Docker labels point at a different Compose owner than the registered build context.",
+      }),
+    };
+  }
+
+  return {
+    state: null,
+    check: check("compose_working_dir", "Compose working directory", "pass", {
+      expected: args.expectedWorkspaceRoot ?? expectedProject,
+      actual: args.container.composeWorkingDir ?? actualProject,
+    }),
+  };
+}
+
+function classifyStuckMidPhase(
+  build: FeatureBuildRow,
+  phaseRun: BuildPhaseRunRow | null,
+  now: Date,
+): string | null {
+  const execState = asRecord(build.buildExecState);
+  const taskResults = asRecord(build.taskResults);
+  const step = stringField(execState, "step") ?? stringField(execState, "status");
+  const filesChanged = numberField(taskResults, "filesChanged");
+  const hasDiff = Boolean(build.diffPatch?.trim());
+
+  if (step === "complete" && filesChanged === 0 && !hasDiff) {
+    return "Build phase finished without a releasable diff.";
+  }
+
+  if (!phaseRun || phaseRun.completedAt) {
+    return null;
+  }
+
+  const startedAt = new Date(phaseRun.startedAt).getTime();
+  if (Number.isFinite(startedAt) && now.getTime() - startedAt > PHASE_STUCK_AFTER_MS) {
+    return `Build phase ${phaseRun.phase} has been running without completion for more than 45 minutes.`;
+  }
+
+  return null;
+}
+
+function classifyVerification(build: FeatureBuildRow): SandboxCheckResult {
+  const verification = asRecord(build.verificationOut);
+  const typecheckPassed = booleanField(verification, "typecheckPassed");
+  const buildPassed = booleanField(verification, "buildPassed");
+  const testsFailed = numberField(verification, "testsFailed");
+  const testsPassed = booleanField(verification, "testsPassed");
+  const uxFailed = build.uxVerificationStatus === "failed";
+  const failed = typecheckPassed === false ||
+    buildPassed === false ||
+    uxFailed ||
+    (testsFailed != null && testsFailed > 0) ||
+    testsPassed === false;
+
+  if (failed) {
+    return check("verification", "Verification gate", "fail", {
+      expected: "passing",
+      actual: "red",
+      detail: "Recorded Build Studio verification has at least one failing check.",
+    });
+  }
+
+  if (typecheckPassed === true || buildPassed === true || testsPassed === true || testsFailed === 0) {
+    return check("verification", "Verification gate", "pass", {
+      expected: "passing",
+      actual: "passing",
+    });
+  }
+
+  return check("verification", "Verification gate", "warn", {
+    expected: "verification evidence",
+    actual: "missing",
+    detail: "Build Studio has not recorded verification evidence yet.",
+  });
+}
+
+function snapshot(args: {
+  buildId: string;
+  inspectedAt: string;
+  state: SandboxReadinessState;
+  summary: string;
+  checks: SandboxCheckResult[];
+  recommendedActions: RecommendedSandboxAction[];
+  runtimeTargetId?: string | null;
+  containerId?: string | null;
+  branchName?: string | null;
+  canDeploy?: boolean;
+  canContribute?: boolean;
+}): SandboxReadinessSnapshot {
+  const canDeploy = args.canDeploy ?? false;
+  return {
+    buildId: args.buildId,
+    state: args.state,
+    canDeploy,
+    canContribute: args.canContribute ?? canDeploy,
+    summary: args.summary,
+    checks: args.checks,
+    recommendedActions: args.recommendedActions,
+    inspectedAt: args.inspectedAt,
+    runtimeTargetId: args.runtimeTargetId ?? null,
+    containerId: args.containerId ?? null,
+    branchName: args.branchName ?? null,
+  };
+}
+
+function check(
+  id: string,
+  label: string,
+  status: SandboxCheckResult["status"],
+  data: Omit<SandboxCheckResult, "id" | "label" | "status"> = {},
+): SandboxCheckResult {
+  return { id, label, status, ...data };
+}
+
+function action(actionName: RecommendedSandboxAction["action"]): RecommendedSandboxAction {
+  const labels: Record<RecommendedSandboxAction["action"], string> = {
+    start: "Start sandbox",
+    restart: "Restart sandbox",
+    rebind_runtime_target: "Rebind runtime target",
+    release_stale_slot: "Release stale slot",
+    checkout_registered_branch: "Checkout registered branch",
+    reset_from_main: "Reset sandbox from main",
+    quarantine_runtime_target: "Quarantine runtime target",
+    reset_build_phase: "Reset build phase",
+  };
+
+  return {
+    action: actionName,
+    label: labels[actionName],
+    requiresApproval: actionName !== "start" && actionName !== "checkout_registered_branch",
+  };
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonRecord
+    : {};
+}
+
+function stringField(record: JsonRecord, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function numberField(record: JsonRecord, key: string): number | null {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function booleanField(record: JsonRecord, key: string): boolean | null {
+  const value = record[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+function normalizePath(value: string | null | undefined): string | null {
+  if (!value?.trim()) return null;
+  return value.trim().replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}

--- a/apps/web/lib/integrate/sandbox/sandbox-readiness-gate.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-readiness-gate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertSandboxReadyForContribution,
+  assertSandboxReadyForDeploy,
+} from "./sandbox-readiness-gate";
+import type { SandboxReadinessSnapshot } from "./sandbox-admin-types";
+
+const healthy: SandboxReadinessSnapshot = {
+  buildId: "FB-TEST",
+  state: "healthy",
+  canDeploy: true,
+  canContribute: true,
+  summary: "healthy",
+  checks: [],
+  recommendedActions: [],
+  inspectedAt: "2026-05-22T00:00:00.000Z",
+};
+
+describe("sandbox readiness gates", () => {
+  it("allows deploy for healthy sandbox", () => {
+    expect(assertSandboxReadyForDeploy(healthy)).toEqual({ ok: true });
+  });
+
+  it("blocks deploy for detached sandbox", () => {
+    const result = assertSandboxReadyForDeploy({
+      ...healthy,
+      state: "detached",
+      canDeploy: false,
+      summary: "sandbox is detached",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      state: "detached",
+      message: expect.stringContaining("deploy_feature"),
+    });
+  });
+
+  it("blocks contribution when source is stale", () => {
+    const result = assertSandboxReadyForContribution({
+      ...healthy,
+      state: "stale_source",
+      canContribute: false,
+      summary: "source is stale",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      state: "stale_source",
+      message: expect.stringContaining("upstream contribution"),
+    });
+  });
+});

--- a/apps/web/lib/integrate/sandbox/sandbox-readiness-gate.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-readiness-gate.ts
@@ -1,0 +1,23 @@
+import type { SandboxReadinessSnapshot } from "./sandbox-admin-types";
+
+export type SandboxGateResult =
+  | { ok: true }
+  | { ok: false; message: string; state: SandboxReadinessSnapshot["state"] };
+
+export function assertSandboxReadyForDeploy(snapshot: SandboxReadinessSnapshot): SandboxGateResult {
+  if (snapshot.canDeploy && snapshot.state === "healthy") return { ok: true };
+  return {
+    ok: false,
+    state: snapshot.state,
+    message: `Sandbox is not ready for deploy_feature: ${snapshot.summary}`,
+  };
+}
+
+export function assertSandboxReadyForContribution(snapshot: SandboxReadinessSnapshot): SandboxGateResult {
+  if (snapshot.canContribute && snapshot.state === "healthy") return { ok: true };
+  return {
+    ok: false,
+    state: snapshot.state,
+    message: `Sandbox is not ready for upstream contribution: ${snapshot.summary}`,
+  };
+}

--- a/apps/web/lib/integrate/sandbox/sandbox-recovery.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-recovery.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recoverSandbox, type SandboxRecoveryDb } from "./sandbox-recovery";
+import type { SandboxReadinessSnapshot } from "./sandbox-admin-types";
+
+function snapshot(overrides: Partial<SandboxReadinessSnapshot> = {}): SandboxReadinessSnapshot {
+  return {
+    buildId: "FB-TEST",
+    state: "stopped",
+    canDeploy: false,
+    canContribute: false,
+    summary: "stopped",
+    checks: [],
+    recommendedActions: [],
+    inspectedAt: "2026-05-22T12:00:00.000Z",
+    runtimeTargetId: "runtime-target-row-1",
+    containerId: "dpf-sandbox-1",
+    branchName: "build/FB-TEST",
+    ...overrides,
+  };
+}
+
+function makeDb(overrides: Partial<SandboxRecoveryDb> = {}): SandboxRecoveryDb {
+  return {
+    buildActivity: {
+      create: vi.fn(),
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    buildPhaseRun: {
+      updateMany: vi.fn(),
+    },
+    runtimeTarget: {
+      updateMany: vi.fn(),
+    },
+    sandboxSlot: {
+      updateMany: vi.fn(),
+    },
+    featureBuild: {
+      update: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+describe("recoverSandbox", () => {
+  it("blocks reset_from_main without confirmation", async () => {
+    const result = await recoverSandbox({
+      buildId: "FB-TEST",
+      action: "reset_from_main",
+      confirmation: null,
+      diagnose: vi.fn().mockResolvedValue(snapshot({ state: "stale_source" })),
+      runCommand: vi.fn(),
+      recordActivity: vi.fn(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("confirmation");
+  });
+
+  it("starts a stopped owned sandbox", async () => {
+    const runCommand = vi.fn().mockResolvedValue("");
+    const result = await recoverSandbox({
+      buildId: "FB-TEST",
+      action: "start",
+      confirmation: null,
+      diagnose: vi.fn()
+        .mockResolvedValueOnce(snapshot({ state: "stopped", containerId: "dpf-sandbox-1" }))
+        .mockResolvedValueOnce(snapshot({ state: "healthy", canDeploy: true, canContribute: true, summary: "healthy" })),
+      runCommand,
+      recordActivity: vi.fn(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith("docker", ["start", "dpf-sandbox-1"]);
+    expect(result.snapshot?.state).toBe("healthy");
+  });
+
+  it("blocks stale slot release when the build is not abandoned for seven days", async () => {
+    const latestActivity = { createdAt: new Date("2026-05-18T12:00:00.000Z") };
+    const db = makeDb({
+      buildActivity: {
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(latestActivity),
+      },
+    });
+
+    const result = await recoverSandbox({
+      buildId: "FB-TEST",
+      action: "release_stale_slot",
+      confirmation: { discardSandboxChanges: true, reason: "operator confirmed slot release" },
+      diagnose: vi.fn().mockResolvedValue(snapshot({ state: "detached" })),
+      runCommand: vi.fn(),
+      db,
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("slot is held by paused-but-not-abandoned build");
+    expect(db.sandboxSlot?.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("resets a stuck build phase only with structured acknowledgement", async () => {
+    const db = makeDb();
+
+    const result = await recoverSandbox({
+      buildId: "FB-TEST",
+      action: "reset_build_phase",
+      confirmation: { acknowledgeReset: true, reason: "complete step had filesChanged:0" },
+      diagnose: vi.fn()
+        .mockResolvedValueOnce(snapshot({ state: "stuck_mid_phase" }))
+        .mockResolvedValueOnce(snapshot({ state: "not_found", summary: "phase reset" })),
+      runCommand: vi.fn(),
+      db,
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    });
+
+    expect(result.success).toBe(true);
+    expect(db.buildPhaseRun?.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ buildId: "FB-TEST", completedAt: null }),
+      data: expect.objectContaining({ completedAt: new Date("2026-05-22T12:00:00.000Z") }),
+    }));
+    expect(db.buildActivity?.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        buildId: "FB-TEST",
+        tool: "sandbox_recovery:reset_build_phase",
+        summary: expect.stringContaining("operator_reset_after_stall"),
+      }),
+    }));
+    expect(db.sandboxSlot?.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { buildId: "FB-TEST" },
+      data: expect.objectContaining({ status: "available", buildId: null }),
+    }));
+  });
+});

--- a/apps/web/lib/integrate/sandbox/sandbox-recovery.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-recovery.ts
@@ -1,0 +1,306 @@
+import { prisma } from "@dpf/db";
+
+import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+
+import { diagnoseSandboxReadiness } from "./sandbox-admin";
+import type {
+  SandboxReadinessSnapshot,
+  SandboxRecoveryAction,
+} from "./sandbox-admin-types";
+
+export type SandboxRecoveryConfirmation = {
+  discardSandboxChanges?: boolean;
+  acknowledgeReset?: boolean;
+  reason?: string;
+} | null;
+
+export type SandboxRecoveryDb = {
+  buildActivity?: {
+    create(args: unknown): Promise<unknown>;
+    findFirst?(args: unknown): Promise<{ createdAt: Date | string } | null>;
+  };
+  buildPhaseRun?: {
+    updateMany(args: unknown): Promise<unknown>;
+  };
+  runtimeTarget?: {
+    updateMany(args: unknown): Promise<unknown>;
+  };
+  sandboxSlot?: {
+    updateMany(args: unknown): Promise<unknown>;
+  };
+  featureBuild?: {
+    update(args: unknown): Promise<unknown>;
+  };
+};
+
+export type SandboxRecoveryResult = {
+  success: boolean;
+  message: string;
+  error?: string;
+  snapshot?: SandboxReadinessSnapshot;
+};
+
+export type RecoverSandboxArgs = {
+  buildId: string;
+  action: SandboxRecoveryAction;
+  confirmation?: SandboxRecoveryConfirmation;
+  diagnose?: (buildId: string) => Promise<SandboxReadinessSnapshot>;
+  runCommand?: (command: string, args: string[]) => Promise<string>;
+  recordActivity?: (buildId: string, summary: string) => Promise<void>;
+  db?: SandboxRecoveryDb;
+  now?: Date;
+};
+
+const STALE_SLOT_IDLE_FLOOR_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function recoverSandbox(args: RecoverSandboxArgs): Promise<SandboxRecoveryResult> {
+  const db = args.db ?? (prisma as unknown as SandboxRecoveryDb);
+  const diagnose = args.diagnose ?? ((buildId: string) => diagnoseSandboxReadiness({ buildId }));
+  const runCommand = args.runCommand ?? runCommandDefault;
+  const now = args.now ?? new Date();
+  const before = await diagnose(args.buildId);
+
+  switch (args.action) {
+    case "start":
+      return runContainerAction({
+        buildId: args.buildId,
+        before,
+        diagnose,
+        runCommand,
+        commandArgs: ["start", requireContainerId(before)],
+        message: "Sandbox start completed.",
+        record: (summary) => recordRecoveryActivity(args, db, summary),
+      });
+
+    case "restart":
+      return runContainerAction({
+        buildId: args.buildId,
+        before,
+        diagnose,
+        runCommand,
+        commandArgs: ["restart", requireContainerId(before)],
+        message: "Sandbox restart completed.",
+        record: (summary) => recordRecoveryActivity(args, db, summary),
+      });
+
+    case "quarantine_runtime_target":
+      await quarantineRuntimeTarget(db, before, now);
+      await recordRecoveryActivity(args, db, "sandbox_recovery: quarantine_runtime_target");
+      return successWithSnapshot(args.buildId, "Runtime target quarantined.", diagnose);
+
+    case "release_stale_slot":
+      return releaseStaleSlot({
+        ...args,
+        db,
+        diagnose,
+        now,
+        before,
+      });
+
+    case "reset_build_phase":
+      return resetBuildPhase({
+        ...args,
+        db,
+        diagnose,
+        now,
+        before,
+      });
+
+    case "reset_from_main":
+      await recordRecoveryActivity(args, db, "sandbox_recovery: reset_from_main blocked pending destructive reset workflow");
+      if (!args.confirmation?.discardSandboxChanges || !hasReason(args.confirmation)) {
+        return {
+          success: false,
+          error: "confirmation required",
+          message: "reset_from_main requires confirmation with discardSandboxChanges=true and a reason.",
+          snapshot: before,
+        };
+      }
+      return {
+        success: false,
+        error: "reset_from_main not implemented",
+        message: "reset_from_main is blocked until the destructive reset workflow records a full incident.",
+        snapshot: before,
+      };
+
+    case "rebind_runtime_target":
+    case "checkout_registered_branch":
+      return {
+        success: false,
+        error: "recovery action not implemented",
+        message: `${args.action} is not implemented in the V1 recovery service.`,
+        snapshot: before,
+      };
+  }
+}
+
+async function runContainerAction(args: {
+  buildId: string;
+  before: SandboxReadinessSnapshot;
+  diagnose: (buildId: string) => Promise<SandboxReadinessSnapshot>;
+  runCommand: (command: string, args: string[]) => Promise<string>;
+  commandArgs: string[];
+  message: string;
+  record: (summary: string) => Promise<void>;
+}): Promise<SandboxRecoveryResult> {
+  const containerId = args.commandArgs[1];
+  if (!containerId) {
+    return {
+      success: false,
+      error: "container id missing",
+      message: "Sandbox recovery cannot run because the diagnosis did not return a container id.",
+      snapshot: args.before,
+    };
+  }
+
+  await args.runCommand("docker", args.commandArgs);
+  await args.record(`sandbox_recovery: docker ${args.commandArgs[0]} ${containerId}`);
+  return successWithSnapshot(args.buildId, args.message, args.diagnose);
+}
+
+async function releaseStaleSlot(args: RecoverSandboxArgs & {
+  db: SandboxRecoveryDb;
+  diagnose: (buildId: string) => Promise<SandboxReadinessSnapshot>;
+  now: Date;
+  before: SandboxReadinessSnapshot;
+}): Promise<SandboxRecoveryResult> {
+  if (!args.confirmation?.discardSandboxChanges || !hasReason(args.confirmation)) {
+    return {
+      success: false,
+      error: "confirmation required",
+      message: "release_stale_slot requires confirmation with discardSandboxChanges=true and a reason.",
+      snapshot: args.before,
+    };
+  }
+
+  const latestActivity = await args.db.buildActivity?.findFirst?.({
+    where: { buildId: args.buildId },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+  });
+  if (latestActivity && args.now.getTime() - new Date(latestActivity.createdAt).getTime() < STALE_SLOT_IDLE_FLOOR_MS) {
+    return {
+      success: false,
+      error: "slot is held by paused-but-not-abandoned build",
+      message: "Sandbox slot release is blocked because this build has activity within the last 7 days.",
+      snapshot: args.before,
+    };
+  }
+
+  await releaseSlotForBuild(args.db, args.buildId, args.now);
+  await args.db.featureBuild?.update({
+    where: { buildId: args.buildId },
+    data: { sandboxId: null, sandboxPort: null },
+  });
+  await recordRecoveryActivity(args, args.db, `sandbox_recovery: release_stale_slot - ${args.confirmation.reason}`);
+  return successWithSnapshot(args.buildId, "Stale sandbox slot released.", args.diagnose);
+}
+
+async function resetBuildPhase(args: RecoverSandboxArgs & {
+  db: SandboxRecoveryDb;
+  diagnose: (buildId: string) => Promise<SandboxReadinessSnapshot>;
+  now: Date;
+  before: SandboxReadinessSnapshot;
+}): Promise<SandboxRecoveryResult> {
+  if (!args.confirmation?.acknowledgeReset || !hasReason(args.confirmation)) {
+    return {
+      success: false,
+      error: "confirmation required",
+      message: "reset_build_phase requires acknowledgement and a reason.",
+      snapshot: args.before,
+    };
+  }
+
+  await args.db.buildPhaseRun?.updateMany({
+    where: { buildId: args.buildId, completedAt: null },
+    data: { completedAt: args.now },
+  });
+  await releaseSlotForBuild(args.db, args.buildId, args.now);
+  await quarantineRuntimeTarget(args.db, args.before, args.now);
+  await recordRecoveryActivity(
+    args,
+    args.db,
+    `sandbox_recovery:reset_build_phase operator_reset_after_stall - ${args.confirmation.reason}`,
+  );
+
+  return successWithSnapshot(args.buildId, "Build phase reset recorded; no phase was auto-dispatched.", args.diagnose);
+}
+
+async function releaseSlotForBuild(db: SandboxRecoveryDb, buildId: string, now: Date): Promise<void> {
+  await db.sandboxSlot?.updateMany({
+    where: { buildId },
+    data: {
+      status: "available",
+      buildId: null,
+      userId: null,
+      releasedAt: now,
+    },
+  });
+}
+
+async function quarantineRuntimeTarget(
+  db: SandboxRecoveryDb,
+  snapshot: SandboxReadinessSnapshot,
+  now: Date,
+): Promise<void> {
+  if (!snapshot.runtimeTargetId) return;
+  await db.runtimeTarget?.updateMany({
+    where: { id: snapshot.runtimeTargetId },
+    data: {
+      status: "quarantined",
+      debugReason: `sandbox_readiness:${snapshot.state}`,
+      lastHeartbeatAt: now,
+    },
+  });
+}
+
+async function successWithSnapshot(
+  buildId: string,
+  message: string,
+  diagnose: (buildId: string) => Promise<SandboxReadinessSnapshot>,
+): Promise<SandboxRecoveryResult> {
+  const snapshot = await diagnose(buildId);
+  return {
+    success: true,
+    message,
+    snapshot,
+  };
+}
+
+async function recordRecoveryActivity(
+  args: RecoverSandboxArgs,
+  db: SandboxRecoveryDb,
+  summary: string,
+): Promise<void> {
+  if (args.recordActivity) {
+    await args.recordActivity(args.buildId, summary);
+    return;
+  }
+
+  await db.buildActivity?.create({
+    data: {
+      buildId: args.buildId,
+      tool: `sandbox_recovery:${args.action}`,
+      summary,
+    },
+  });
+}
+
+function requireContainerId(snapshot: SandboxReadinessSnapshot): string {
+  return snapshot.containerId ?? "";
+}
+
+function hasReason(confirmation: NonNullable<SandboxRecoveryConfirmation>): boolean {
+  return typeof confirmation.reason === "string" && confirmation.reason.trim().length > 0;
+}
+
+async function runCommandDefault(command: string, args: string[]): Promise<string> {
+  const { execFile } = lazyChildProcess();
+  const { promisify } = lazyUtil();
+  const execFileAsync = promisify(execFile);
+  const result = await execFileAsync(command, args, {
+    encoding: "utf-8",
+    timeout: 30_000,
+  }) as { stdout: string };
+  return result.stdout;
+}

--- a/apps/web/lib/mcp-tools-sandbox-admin.test.ts
+++ b/apps/web/lib/mcp-tools-sandbox-admin.test.ts
@@ -5,10 +5,17 @@ const mockPrisma = {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
   },
+  buildActivity: {
+    create: vi.fn().mockResolvedValue({ id: "activity-1" }),
+  },
+  platformDevConfig: {
+    findUnique: vi.fn(),
+  },
 };
 
 const mockDiagnoseSandboxReadiness = vi.hoisted(() => vi.fn());
 const mockRecoverSandbox = vi.hoisted(() => vi.fn());
+const mockResolveHiveToken = vi.hoisted(() => vi.fn());
 
 vi.mock("@dpf/db", () => ({
   DISCOVERY_TRIAGE_AGENT_ID: "AGT-DISCOVERY",
@@ -25,6 +32,14 @@ vi.mock("@/lib/integrate/sandbox/sandbox-admin", () => ({
 
 vi.mock("@/lib/integrate/sandbox/sandbox-recovery", () => ({
   recoverSandbox: mockRecoverSandbox,
+}));
+
+vi.mock("@/lib/integrate/identity-privacy", () => ({
+  resolveHiveToken: mockResolveHiveToken,
+}));
+
+vi.mock("@/lib/platform-dev-policy", () => ({
+  getPlatformDevPolicyState: vi.fn(() => "contribution_ready"),
 }));
 
 const FORBIDDEN_SANDBOX_HANDOFF_PATTERNS = [
@@ -174,5 +189,97 @@ describe("sandbox admin MCP and coworker messaging", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("invalid_action");
     expect(mockRecoverSandbox).not.toHaveBeenCalled();
+  });
+
+  it("blocks deploy_feature before diff extraction when sandbox readiness is red", async () => {
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        buildId: "FB-SANDBOX-1",
+        createdById: "user-1",
+      })
+      .mockResolvedValueOnce({
+        sandboxId: "dpf-sandbox-1",
+        buildBranch: "build/FB-SANDBOX-1",
+        phase: "ship",
+        createdById: "user-1",
+      });
+    mockDiagnoseSandboxReadiness.mockResolvedValueOnce({
+      buildId: "FB-SANDBOX-1",
+      state: "detached",
+      canDeploy: false,
+      canContribute: false,
+      summary: "The sandbox is detached from this build.",
+      checks: [],
+      recommendedActions: [],
+      inspectedAt: "2026-05-22T12:00:00.000Z",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("deploy_feature", {
+      buildId: "FB-SANDBOX-1",
+    }, "user-1", { agentId: "AGT-ORCH-400" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Sandbox readiness blocked deploy_feature.");
+    expect(result.data).toMatchObject({ state: "detached" });
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        buildId: "FB-SANDBOX-1",
+        tool: "deploy_feature",
+        summary: expect.stringContaining("not ready"),
+      }),
+    }));
+  });
+
+  it("blocks contribute_to_hive before FeaturePack creation when sandbox readiness is red", async () => {
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        buildId: "FB-SANDBOX-1",
+        createdById: "user-1",
+      })
+      .mockResolvedValueOnce({
+        id: "feature-build-row-1",
+        title: "Sandbox fix",
+        brief: {},
+        diffPatch: "diff --git a/a.ts b/a.ts\n",
+        diffSummary: "summary",
+        sandboxId: "dpf-sandbox-1",
+        portfolioId: null,
+        createdById: "user-1",
+        createdBy: { email: "admin@dpf.local" },
+      });
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValueOnce({
+      contributionMode: "contribute_all",
+      upstreamRemoteUrl: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git",
+      dcoAcceptedAt: new Date("2026-05-22T12:00:00.000Z"),
+      gitRemoteUrl: null,
+    });
+    mockResolveHiveToken.mockResolvedValueOnce("ghp_test");
+    mockDiagnoseSandboxReadiness.mockResolvedValueOnce({
+      buildId: "FB-SANDBOX-1",
+      state: "stale_source",
+      canDeploy: false,
+      canContribute: false,
+      summary: "The sandbox source is stale.",
+      checks: [],
+      recommendedActions: [],
+      inspectedAt: "2026-05-22T12:00:00.000Z",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("contribute_to_hive", {
+      buildId: "FB-SANDBOX-1",
+    }, "user-1", { agentId: "AGT-ORCH-500" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Sandbox readiness blocked contribution.");
+    expect(result.data).toMatchObject({ state: "stale_source" });
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        buildId: "FB-SANDBOX-1",
+        tool: "contribute_to_hive",
+        summary: expect.stringContaining("upstream contribution"),
+      }),
+    }));
   });
 });

--- a/apps/web/lib/mcp-tools-sandbox-admin.test.ts
+++ b/apps/web/lib/mcp-tools-sandbox-admin.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrisma = {
+  featureBuild: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+  },
+};
+
+const mockDiagnoseSandboxReadiness = vi.hoisted(() => vi.fn());
+const mockRecoverSandbox = vi.hoisted(() => vi.fn());
+
+vi.mock("@dpf/db", () => ({
+  DISCOVERY_TRIAGE_AGENT_ID: "AGT-DISCOVERY",
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/tak/prompt-loader", () => ({
+  loadPrompt: vi.fn(async (_category: string, _slug: string, fallback: string) => fallback),
+}));
+
+vi.mock("@/lib/integrate/sandbox/sandbox-admin", () => ({
+  diagnoseSandboxReadiness: mockDiagnoseSandboxReadiness,
+}));
+
+vi.mock("@/lib/integrate/sandbox/sandbox-recovery", () => ({
+  recoverSandbox: mockRecoverSandbox,
+}));
+
+const FORBIDDEN_SANDBOX_HANDOFF_PATTERNS = [
+  "user must run",
+  "user needs to run",
+  "tell the user to run",
+  "docker compose up -d sandbox",
+] as const;
+
+describe("sandbox admin MCP and coworker messaging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes diagnose_sandbox as a read-only build/review/ship tool", async () => {
+    const { PLATFORM_TOOLS } = await import("./mcp-tools");
+
+    const tool = PLATFORM_TOOLS.find((candidate) => candidate.name === "diagnose_sandbox");
+
+    expect(tool).toBeDefined();
+    expect(tool?.requiredCapability).toBe("view_platform");
+    expect(tool?.sideEffect).toBe(false);
+    expect(tool?.buildPhases).toEqual(["build", "review", "ship"]);
+    expect(tool?.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+  });
+
+  it("exposes recover_sandbox as a governed side-effect tool", async () => {
+    const { PLATFORM_TOOLS } = await import("./mcp-tools");
+
+    const tool = PLATFORM_TOOLS.find((candidate) => candidate.name === "recover_sandbox");
+    const schema = tool?.inputSchema as { properties?: Record<string, { enum?: string[] }> } | undefined;
+
+    expect(tool).toBeDefined();
+    expect(tool?.requiredCapability).toBe("view_platform");
+    expect(tool?.sideEffect).toBe(true);
+    expect(tool?.buildPhases).toEqual(["build", "review", "ship"]);
+    expect(schema?.properties?.action.enum).toContain("reset_build_phase");
+    expect(schema?.properties?.action.enum).toContain("release_stale_slot");
+  });
+
+  it("does not tell the coworker to hand Docker commands back to the user", async () => {
+    const [{ PLATFORM_TOOLS }, { getBuildPhasePrompt }] = await Promise.all([
+      import("./mcp-tools"),
+      import("./integrate/build-agent-prompts"),
+    ]);
+    const sandboxToolText = PLATFORM_TOOLS
+      .filter((tool) => tool.name.includes("sandbox") || tool.description.toLowerCase().includes("sandbox"))
+      .map((tool) => `${tool.name}: ${tool.description}`)
+      .join("\n");
+    const buildPrompt = await getBuildPhasePrompt("build");
+    const text = `${sandboxToolText}\n${buildPrompt}`.toLowerCase();
+
+    for (const forbidden of FORBIDDEN_SANDBOX_HANDOFF_PATTERNS) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  it("executeTool routes diagnose_sandbox to the readiness diagnosis service", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValueOnce({
+      buildId: "FB-SANDBOX-1",
+      createdById: "user-1",
+    });
+    mockDiagnoseSandboxReadiness.mockResolvedValueOnce({
+      buildId: "FB-SANDBOX-1",
+      state: "not_found",
+      canDeploy: false,
+      canContribute: false,
+      summary: "The registered sandbox container no longer exists.",
+      checks: [],
+      recommendedActions: [{ action: "restart", label: "Restart sandbox", requiresApproval: true }],
+      inspectedAt: "2026-05-22T12:00:00.000Z",
+      runtimeTargetId: null,
+      containerId: null,
+      branchName: "build/FB-SANDBOX-1",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("diagnose_sandbox", {
+      buildId: "FB-SANDBOX-1",
+      expectedWorkspaceRoot: "D:\\DPF\\.worktrees\\FB-SANDBOX-1",
+    }, "user-1", { agentId: "AGT-ORCH-300" });
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Sandbox readiness: not_found");
+    expect(result.data).toMatchObject({
+      buildId: "FB-SANDBOX-1",
+      state: "not_found",
+    });
+    expect(mockDiagnoseSandboxReadiness).toHaveBeenCalledWith(expect.objectContaining({
+      buildId: "FB-SANDBOX-1",
+      expectedWorkspaceRoot: "D:\\DPF\\.worktrees\\FB-SANDBOX-1",
+    }));
+  });
+
+  it("executeTool validates and routes recover_sandbox to the recovery service", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValueOnce({
+      buildId: "FB-SANDBOX-1",
+      createdById: "user-1",
+    });
+    mockRecoverSandbox.mockResolvedValueOnce({
+      success: true,
+      message: "Build phase reset recorded; no phase was auto-dispatched.",
+      snapshot: {
+        buildId: "FB-SANDBOX-1",
+        state: "not_found",
+        canDeploy: false,
+        canContribute: false,
+        summary: "phase reset",
+        checks: [],
+        recommendedActions: [],
+        inspectedAt: "2026-05-22T12:00:00.000Z",
+      },
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("recover_sandbox", {
+      buildId: "FB-SANDBOX-1",
+      action: "reset_build_phase",
+      confirmation: { acknowledgeReset: true, reason: "stuck mid phase" },
+    }, "user-1", { agentId: "AGT-ORCH-300" });
+
+    expect(result.success).toBe(true);
+    expect(result.entityId).toBe("FB-SANDBOX-1");
+    expect(mockRecoverSandbox).toHaveBeenCalledWith(expect.objectContaining({
+      buildId: "FB-SANDBOX-1",
+      action: "reset_build_phase",
+      confirmation: { acknowledgeReset: true, reason: "stuck mid phase" },
+    }));
+  });
+
+  it("rejects invalid recover_sandbox actions before the recovery service runs", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValueOnce({
+      buildId: "FB-SANDBOX-1",
+      createdById: "user-1",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("recover_sandbox", {
+      buildId: "FB-SANDBOX-1",
+      action: "docker_shell",
+    }, "user-1", { agentId: "AGT-ORCH-300" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("invalid_action");
+    expect(mockRecoverSandbox).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -45,6 +45,10 @@ import {
   type IntegrationTreatment,
 } from "@/lib/integrate/integration-benchmarking";
 import { normalizeBuildPlanPaths } from "@/lib/integrate/build-plan-paths";
+import {
+  SANDBOX_RECOVERY_ACTIONS,
+  isSandboxRecoveryAction,
+} from "@/lib/integrate/sandbox/sandbox-admin-types";
 import { getToolMarketplaceReadiness } from "@/lib/actions/tool-marketplace-readiness";
 import {
   listCoworkerCapabilityNeeds,
@@ -1731,8 +1735,62 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     buildPhases: ["plan"],
   },
   {
+    name: "diagnose_sandbox",
+    description: "Diagnose Build Studio sandbox readiness for the active build. Returns the authoritative state, failed checks, and governed recovery actions; use this instead of asking the operator to run Docker commands.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "Optional FB-* build ID. Omit to target the current active build." },
+        expectedWorkspaceRoot: { type: "string", description: "Optional host worktree path expected to own the sandbox Compose project." },
+      },
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    buildPhases: ["build", "review", "ship"],
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+  },
+  {
+    name: "recover_sandbox",
+    description: "Run a governed Build Studio sandbox recovery action for the active build. Requires structured confirmation for destructive actions and records recovery activity instead of sending Docker instructions to the operator.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "Optional FB-* build ID. Omit to target the current active build." },
+        action: {
+          type: "string",
+          enum: [...SANDBOX_RECOVERY_ACTIONS],
+          description: "Governed sandbox recovery action to run.",
+        },
+        confirmation: {
+          type: "object",
+          description: "Structured confirmation for destructive actions, e.g. { discardSandboxChanges: true, acknowledgeReset: true, reason: '...' }.",
+          properties: {
+            discardSandboxChanges: { type: "boolean" },
+            acknowledgeReset: { type: "boolean" },
+            reason: { type: "string" },
+          },
+        },
+      },
+      required: ["action"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    buildPhases: ["build", "review", "ship"],
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+    },
+  },
+  {
     name: "check_sandbox",
-    description: "Check whether the sandbox container (dpf-sandbox-1) is running. Returns status: 'running', 'stopped', or 'not_found'. Call this before start_build to diagnose sandbox issues.",
+    description: "Check whether the sandbox container (dpf-sandbox-1) is running. Returns status: 'running', 'stopped', or 'not_found'. If the result is not_found or detached, call diagnose_sandbox for governed recovery guidance.",
     inputSchema: { type: "object", properties: {} },
     requiredCapability: "view_platform",
     executionMode: "immediate",
@@ -1741,7 +1799,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "start_sandbox",
-    description: "Start the sandbox container if it is stopped. If status is 'stopped', this will start it and wait up to 20 seconds for it to become ready. If status is 'not_found', the container has never been created — the user must run 'docker compose up -d sandbox' once to create it. Call check_sandbox first to confirm the status before calling this.",
+    description: "Start the sandbox container if it is stopped. If status is 'stopped', this will start it and wait up to 20 seconds for it to become ready. If status is 'not_found', call diagnose_sandbox because sandbox creation or rebinding is a platform-owned recovery action.",
     inputSchema: { type: "object", properties: {} },
     requiredCapability: "view_platform",
     executionMode: "immediate",
@@ -1750,7 +1808,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "start_build",
-    description: "Initialize the build workspace. Call this ONCE at the start of the build phase. Verifies the sandbox container is running and creates a git branch for this build. If it returns 'not running', call start_sandbox first, then retry start_build.",
+    description: "Initialize the build workspace. Call this ONCE at the start of the build phase. Verifies the sandbox container is running and creates a git branch for this build. If it returns 'not running', call diagnose_sandbox and use the returned recovery actions.",
     inputSchema: { type: "object", properties: {} },
     requiredCapability: "view_platform",
     executionMode: "immediate",
@@ -6962,6 +7020,57 @@ export async function executeTool(
       });
     }
 
+    case "diagnose_sandbox": {
+      const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
+      if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
+
+      const { diagnoseSandboxReadiness } = await import("@/lib/integrate/sandbox/sandbox-admin");
+      const snapshot = await diagnoseSandboxReadiness({
+        buildId,
+        expectedWorkspaceRoot: optionalString(params["expectedWorkspaceRoot"]),
+      });
+
+      return {
+        success: true,
+        message: `Sandbox readiness: ${snapshot.state}. ${snapshot.summary}`,
+        data: {
+          ...snapshot,
+        },
+      };
+    }
+
+    case "recover_sandbox": {
+      const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
+      if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
+
+      const action = params["action"];
+      if (!isSandboxRecoveryAction(action)) {
+        return {
+          success: false,
+          error: "invalid_action",
+          message: "Invalid sandbox recovery action.",
+        };
+      }
+
+      const confirmation = params["confirmation"] && typeof params["confirmation"] === "object"
+        ? params["confirmation"] as { discardSandboxChanges?: boolean; acknowledgeReset?: boolean; reason?: string }
+        : null;
+      const { recoverSandbox } = await import("@/lib/integrate/sandbox/sandbox-recovery");
+      const result = await recoverSandbox({
+        buildId,
+        action,
+        confirmation,
+      });
+
+      return {
+        success: result.success,
+        error: result.error,
+        message: result.message,
+        entityId: buildId,
+        data: result.snapshot ? { ...result.snapshot } : undefined,
+      };
+    }
+
     case "check_sandbox": {
       const sandboxId = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
       try {
@@ -6981,7 +7090,7 @@ export async function executeTool(
       } catch {
         return {
           success: true,
-          message: `Sandbox container (${sandboxId}) does not exist. The user must run 'docker compose up -d sandbox' once from the DPF directory to create it.`,
+          message: `Sandbox container (${sandboxId}) does not exist. Call diagnose_sandbox for the authoritative Build Studio recovery actions.`,
           data: { status: "not_found", containerId: sandboxId },
         };
       }
@@ -7003,7 +7112,7 @@ export async function executeTool(
           return {
             success: false,
             error: "Sandbox container not found.",
-            message: `The sandbox container (${sandboxId}) has never been created. The user needs to run 'docker compose up -d sandbox' from the DPF directory once to create it. After that, this tool can start and stop it.`,
+            message: `The sandbox container (${sandboxId}) has never been created or is not registered. Call diagnose_sandbox so Build Studio can classify the sandbox and surface governed recovery actions.`,
           };
         }
 
@@ -7309,7 +7418,7 @@ export async function executeTool(
         return {
           success: false,
           error: "Sandbox container is not running.",
-          message: "The sandbox (dpf-sandbox-1) is not running. Call start_build first, or if that also fails, tell the user to run: docker compose up -d sandbox",
+          message: "The sandbox (dpf-sandbox-1) is not running. Call diagnose_sandbox and use the returned recovery action before retrying this file tool.",
         };
       }
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -7781,6 +7781,20 @@ export async function executeTool(
         };
       }
 
+      const { diagnoseSandboxReadiness } = await import("@/lib/integrate/sandbox/sandbox-admin");
+      const { assertSandboxReadyForDeploy } = await import("@/lib/integrate/sandbox/sandbox-readiness-gate");
+      const readiness = await diagnoseSandboxReadiness({ buildId });
+      const readinessGate = assertSandboxReadyForDeploy(readiness);
+      if (!readinessGate.ok) {
+        logBuildActivity(buildId, "deploy_feature", readinessGate.message);
+        return {
+          success: false,
+          error: "Sandbox readiness blocked deploy_feature.",
+          message: readinessGate.message,
+          data: { ...readiness },
+        };
+      }
+
       const devConfig = await prisma.platformDevConfig.findUnique({
         where: { id: "singleton" },
         select: { contributionMode: true, gitRemoteUrl: true },
@@ -8952,6 +8966,20 @@ export async function executeTool(
       });
       if (!build || build.createdById !== userId) {
         return { success: false, error: "Build not found.", message: `No active build ${buildId} was found for this user.` };
+      }
+
+      const { diagnoseSandboxReadiness } = await import("@/lib/integrate/sandbox/sandbox-admin");
+      const { assertSandboxReadyForContribution } = await import("@/lib/integrate/sandbox/sandbox-readiness-gate");
+      const readiness = await diagnoseSandboxReadiness({ buildId });
+      const readinessGate = assertSandboxReadyForContribution(readiness);
+      if (!readinessGate.ok) {
+        logBuildActivity(buildId, "contribute_to_hive", readinessGate.message);
+        return {
+          success: false,
+          error: "Sandbox readiness blocked contribution.",
+          message: readinessGate.message,
+          data: { ...readiness },
+        };
       }
 
       const diff = (build.diffPatch ?? "") as string;

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -40,6 +40,18 @@ describe("TOOL_TO_GRANTS — Build / Sandbox entries", () => {
     expect(isToolAllowedByGrants("create_portal_pr", ["backlog_write"])).toBe(false);
   });
 
+  it("diagnose_sandbox is available to sandbox executors and read-only build observers", () => {
+    expect(isToolAllowedByGrants("diagnose_sandbox", ["sandbox_execute"])).toBe(true);
+    expect(isToolAllowedByGrants("diagnose_sandbox", ["work_capsule_read"])).toBe(true);
+    expect(isToolAllowedByGrants("diagnose_sandbox", ["backlog_read"])).toBe(false);
+  });
+
+  it("recover_sandbox requires sandbox execution authority", () => {
+    expect(isToolAllowedByGrants("recover_sandbox", ["sandbox_execute"])).toBe(true);
+    expect(isToolAllowedByGrants("recover_sandbox", ["work_capsule_read"])).toBe(false);
+    expect(isToolAllowedByGrants("recover_sandbox", [])).toBe(false);
+  });
+
   it("Build Studio observer tools require read-only work capsule access", () => {
     const tools = [
       "get_build_progress_visibility",

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -140,6 +140,8 @@ const TOOL_TO_GRANTS: Record<string, string[]> = {
   saveBuildEvidence: ["backlog_write"],
   reviewDesignDoc: ["architecture_read"],
   reviewBuildPlan: ["build_plan_write"],
+  diagnose_sandbox: ["sandbox_execute", "work_capsule_read"],
+  recover_sandbox: ["sandbox_execute"],
   // Build-progress observation tools are read-only work capsule inspection.
   get_build_progress_visibility: ["work_capsule_read"],
   get_build_sandbox_state: ["work_capsule_read"],

--- a/docs/superpowers/plans/2026-05-22-build-studio-sandbox-admin-recovery.md
+++ b/docs/superpowers/plans/2026-05-22-build-studio-sandbox-admin-recovery.md
@@ -65,6 +65,7 @@ describe("sandbox admin types", () => {
       "stale_source",
       "dirty_or_leaking",
       "verification_red",
+      "stuck_mid_phase",
       "unrecoverable",
     ]);
 
@@ -105,6 +106,7 @@ export const SANDBOX_READINESS_STATES = [
   "stale_source",
   "dirty_or_leaking",
   "verification_red",
+  "stuck_mid_phase",
   "unrecoverable",
 ] as const;
 
@@ -134,7 +136,8 @@ export type SandboxRecoveryAction =
   | "release_stale_slot"
   | "checkout_registered_branch"
   | "reset_from_main"
-  | "quarantine_runtime_target";
+  | "quarantine_runtime_target"
+  | "reset_build_phase";
 
 export type RecommendedSandboxAction = {
   action: SandboxRecoveryAction;
@@ -677,15 +680,30 @@ case "diagnose_sandbox": {
 }
 ```
 
-- [ ] **Step 5: Replace unsafe legacy tool messages**
+- [ ] **Step 5: Replace unsafe legacy tool messages across ALL surfaces**
 
-In `check_sandbox` and `start_sandbox`, replace user-run command messages with:
+The legacy "tell the user to run docker compose" pattern is duplicated. Fix every occurrence in one pass:
+
+| File | Site | Replacement requirement |
+| --- | --- | --- |
+| `apps/web/lib/mcp-tools.ts` | `check_sandbox` `not_found` message (~L6984) | Direct to `diagnose_sandbox` + Sandbox Control panel. |
+| `apps/web/lib/mcp-tools.ts` | `start_sandbox` description string (~L1744) and `not_found` return (~L7006) | Remove the `docker compose up -d sandbox` instruction; describe the governed recovery path. |
+| `apps/web/lib/mcp-tools.ts` | `start_build` fallback message (~L7312) `"tell the user to run: docker compose up -d sandbox"` | Replace with: call `diagnose_sandbox`; if blocked, surface platform incident — never instruct the user. |
+| `apps/web/lib/mcp-tools.ts` | `run_ux_test` browser-use unreachable message (~L9171, L9260) `"Run 'docker compose up -d browser-use'"` | Replace with: record platform-issue, fall back to code-only analysis; never instruct the user to run docker. |
+| `apps/web/lib/integrate/build-agent-prompts.ts` | STEP 0 `not_found` branch (~L242) `"Please run: docker compose up -d sandbox"` | Replace with the diagnose/recover flow specified in spec §11.1 (`not_found` template). |
+
+Add a string-level regression test in `mcp-tools-sandbox-admin.test.ts` that scans the source of `mcp-tools.ts` and `build-agent-prompts.ts` and asserts NONE of these substrings appear in user-facing strings:
 
 ```typescript
-message: "Sandbox container is missing. Use diagnose_sandbox for build-specific details, then use the Admin > Build Studio > Sandbox Control recovery action to recreate the sandbox."
+const FORBIDDEN_DIALOG = [
+  "docker compose up -d sandbox",
+  "docker compose up -d browser-use",
+  "tell the user to run",
+  "Please run: docker",
+];
 ```
 
-Do not include `docker compose up -d sandbox` in user-facing tool descriptions or prompts.
+Allowed only in code comments referencing this audit by its issue ID. This test guards against regressions where a future PR re-introduces the pattern.
 
 - [ ] **Step 6: Update Build Studio prompts**
 
@@ -798,7 +816,11 @@ export async function recoverSandbox(args: {
 }
 ```
 
-V1 must implement `start`, `restart`, `quarantine_runtime_target`, and `release_stale_slot`. `reset_from_main` may return blocked until confirmation handling is fully implemented, but it must do so deliberately and with a recorded incident.
+V1 must implement `start`, `restart`, `quarantine_runtime_target`, `release_stale_slot`, and `reset_build_phase`. `reset_from_main` may return blocked until confirmation handling is fully implemented, but it must do so deliberately and with a recorded incident.
+
+`release_stale_slot` MUST enforce the spec §13.5 idle floor: if the build's most recent `BuildActivity` is younger than 7 days, return `{ success: false, error: "slot is held by paused-but-not-abandoned build" }` even when the operator confirms. Add a test that proves it.
+
+`reset_build_phase` MUST require structured confirmation (`{ acknowledgeReset: true, reason: string }`), mark the active `BuildPhaseRun` failed with `operator_reset_after_stall`, write a `BuildActivity` row, and release a slot held only by this build. It MUST NOT auto-redispatch the next phase — that is a separate operator action. Add a test that exercises the 4-stuck-builds class (`deps_installed` past heartbeat budget; `complete` with `filesChanged:0`).
 
 - [ ] **Step 4: Add `recover_sandbox` MCP handler**
 
@@ -1242,6 +1264,79 @@ git commit -s -m "feat(admin): add Build Studio sandbox control panel"
 
 ---
 
+## Task 10b: Add Coworker Dialog Templates and Forbidden-Pattern Guard
+
+**Files:**
+- Create: `apps/web/lib/integrate/sandbox/coworker-dialog-templates.ts`
+- Create: `apps/web/lib/integrate/sandbox/coworker-dialog-templates.test.ts`
+- Modify: handler sites that surface sandbox/deploy/contribution failure messages back to the AI Coworker panel.
+
+This task implements spec §11.1. The coworker dialog is the user-visible failure path; it must be tested independently of the underlying tool.
+
+- [ ] **Step 1: Write template tests**
+
+Create `coworker-dialog-templates.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { renderCoworkerDialog, FORBIDDEN_DIALOG_PATTERNS } from "./coworker-dialog-templates";
+
+describe("coworker dialog templates", () => {
+  it("renders detached state with quarantine incident and three options", () => {
+    const text = renderCoworkerDialog({
+      state: "mixed_compose_project",
+      summary: "Owned by D:\\DPF-clean-main-linux",
+      incidentId: "PIR-123",
+    });
+    expect(text).toContain("D:\\DPF-clean-main-linux");
+    expect(text).toContain("PIR-123");
+    expect(text).toMatch(/Options:.*Rebuild.*Switch.*Open Sandbox Control/s);
+  });
+
+  it("never returns text matching forbidden dialog patterns", () => {
+    for (const state of ["stopped", "not_found", "detached", "mixed_compose_project", "stale_source", "dirty_or_leaking", "verification_red", "stuck_mid_phase", "unrecoverable"] as const) {
+      const text = renderCoworkerDialog({ state, summary: "x", incidentId: null });
+      for (const forbidden of FORBIDDEN_DIALOG_PATTERNS) {
+        expect(text.toLowerCase()).not.toContain(forbidden.toLowerCase());
+      }
+      expect(text).toMatch(/\*\*Options:\*\*/);
+    }
+  });
+
+  it("ends every template with concrete options, not internal status", () => {
+    for (const state of ["healthy", "stopped", "unrecoverable"] as const) {
+      const text = renderCoworkerDialog({ state, summary: "x", incidentId: null });
+      expect(text).not.toMatch(/\b(Done|Continuing|Investigating)\.\s*$/);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Implement template module**
+
+Create `coworker-dialog-templates.ts` exporting `FORBIDDEN_DIALOG_PATTERNS` (matching spec §11.1) and `renderCoworkerDialog({ state, summary, incidentId, branchName?, ago? })`. Each state returns one of the verbatim templates from spec §11.1 with the supplied substitutions. Helper rule: every returned string must contain the literal `**Options:**` marker.
+
+- [ ] **Step 3: Wire into failure paths**
+
+In every `deploy_feature` / `contribute_to_hive` / `recover_sandbox` failure return, populate the user-facing `message` field by calling `renderCoworkerDialog(...)` with the diagnostic snapshot's `state`, `summary`, and any incident id. Do NOT hand-write per-call strings — go through the template module so the forbidden-pattern test catches drift.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter web exec vitest run apps/web/lib/integrate/sandbox/coworker-dialog-templates.test.ts apps/web/lib/mcp-tools-sandbox-admin.test.ts
+```
+
+Expected: PASS, including the forbidden-pattern source scan from Task 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/integrate/sandbox/coworker-dialog-templates.ts apps/web/lib/integrate/sandbox/coworker-dialog-templates.test.ts apps/web/lib/mcp-tools.ts
+git commit -s -m "feat(build-studio): coworker dialog templates for sandbox readiness states"
+```
+
+---
+
 ## Task 11: Add Build Studio Readiness Strip
 
 **Files:**
@@ -1323,10 +1418,21 @@ git commit -s -m "feat(build-studio): show sandbox readiness in build detail"
 Run:
 
 ```bash
-pnpm --filter web exec vitest run apps/web/lib/integrate/sandbox apps/web/lib/runtime-coordination/build-studio-runtime.test.ts apps/web/lib/integrate/build-pipeline.test.ts apps/web/lib/integrate/github-api-commit.test.ts apps/web/lib/integrate/contribution-review.test.ts apps/web/lib/actions/build-sandbox-admin.test.ts apps/web/components/build/SandboxReadinessStrip.test.tsx
+pnpm --filter web exec vitest run apps/web/lib/integrate/sandbox apps/web/lib/runtime-coordination/build-studio-runtime.test.ts apps/web/lib/integrate/build-pipeline.test.ts apps/web/lib/integrate/github-api-commit.test.ts apps/web/lib/integrate/contribution-review.test.ts apps/web/lib/actions/build-sandbox-admin.test.ts apps/web/components/build/SandboxReadinessStrip.test.tsx apps/web/lib/integrate/sandbox/coworker-dialog-templates.test.ts apps/web/lib/mcp-tools-sandbox-admin.test.ts
 ```
 
 Expected: all listed tests pass.
+
+- [ ] **Step 1b: Run FULL vitest suite (mandatory before push)**
+
+Run:
+
+```bash
+pnpm --filter web exec vitest run
+pnpm --filter @dpf/db exec vitest run
+```
+
+Expected: all suites pass. Per standing rule, pre-commit only runs typecheck — vitest must be run locally or CI will break for everyone.
 
 - [ ] **Step 2: Run typecheck**
 
@@ -1377,6 +1483,17 @@ Use a test build or fixture that points to a deliberately mismatched sandbox tar
 
 Use the `createBranchAndPR` test harness or a mocked GitHub token environment. Verify the create-commit payload includes matching `author`, `committer`, and `Signed-off-by` identities.
 
+- [ ] **Step 6b: PR overlap sweep before push**
+
+Before opening or pushing to the PR, run an overlap sweep — concurrent sessions may be touching the same surfaces:
+
+```bash
+gh pr list --state open --limit 30 --json number,title,headRefName,updatedAt
+git log origin/main --since="7 days ago" --oneline -- apps/web/lib/mcp-tools.ts apps/web/lib/integrate/sandbox apps/web/lib/integrate/build-agent-prompts.ts apps/web/lib/integrate/build-pipeline.ts apps/web/lib/integrate/github-api-commit.ts apps/web/lib/integrate/contribution-review.ts apps/web/lib/runtime-coordination/build-studio-runtime.ts
+```
+
+If another open PR or recent main commit overlaps the same files, reconcile before pushing. Re-run this sweep before *every* push in long autonomous runs, not just the first one.
+
 - [ ] **Step 7: Final commit**
 
 Run:
@@ -1395,10 +1512,14 @@ If the implementation tasks were committed along the way, this final commit shou
 
 - Diagnostic service: Tasks 1-3.
 - Runtime target ownership: Task 4.
-- MCP diagnosis/recovery tools: Tasks 5-6.
+- MCP diagnosis/recovery tools (incl. `reset_build_phase` for stuck-build class): Tasks 5-6.
+- Legacy "user-run docker" audit + forbidden-pattern source scan: Task 5.
 - Deploy and contribution gate integration: Tasks 7-9.
 - Codegen/verification hard failures: Task 8.
 - Admin UI and Build Studio UI: Tasks 10-11.
+- Coworker dialog templates + forbidden-pattern guard (spec §11.1): Task 10b.
+- Stuck mid-phase recovery + 7-day idle floor (spec §13.5): Tasks 6, 12.
+- Full vitest + PR overlap sweep before push: Task 12.
 - Verification and QA evidence: Task 12.
 
 No placeholder tasks remain. Every task has exact file paths, commands, and expected outcomes.

--- a/docs/superpowers/specs/2026-05-22-build-studio-sandbox-admin-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-22-build-studio-sandbox-admin-recovery-design.md
@@ -40,6 +40,7 @@ The diagnosis that produced this spec was grounded in current code, live databas
 
 - `check_sandbox` in `apps/web/lib/mcp-tools.ts` only checks `docker inspect ... .State.Status`; it does not validate build ownership, Compose project, source path, branch, slot, runtime target, source currency, or active diff base.
 - `start_sandbox` tells the user to run `docker compose up -d sandbox` when the container is missing. That violates AGENTS.md's "never ask the user to run commands" rule.
+- The same violation appears in at least four more places that this spec must address as one cohort, not piecemeal: `start_build` legacy fallback message in `mcp-tools.ts` (`"tell the user to run: docker compose up -d sandbox"`), `run_ux_test` browser-use unreachable path (`"Run 'docker compose up -d browser-use'"`), `evaluate_page` browser-use fallback (same string), and the `start_build` instructions in `build-agent-prompts.ts` STEP 0 ("Please run: docker compose up -d sandbox"). The legacy text is duplicated; the fix must be too.
 - `deploy_feature` blocks missing `sandboxId` or missing `buildBranch`, and it has a schema-regression guard, but it trusts the registered sandbox identity too much once those fields exist.
 - `contribute_to_hive` requires a non-empty stored diff, but it does not rerun sandbox readiness, schema regression, CI prediction, DCO identity validation, or the Build Studio verification gate before opening a PR.
 - `createBranchAndPR` validates only that a `Signed-off-by` trailer exists; it does not ensure the GitHub commit author/committer matches that trailer.
@@ -154,7 +155,10 @@ The diagnostic service returns one of these states:
 | `stale_source` | Sandbox cannot prove current `origin/main` or configured base ref. | Block PR contribution; allow `reset_from_main` only when diff preservation policy passes. |
 | `dirty_or_leaking` | Workspace has source changes not attributable to this build, generated artifacts in the releasable diff, or a dirty tree before a new build starts. | Block deploy; record issue; require reset or manual review. |
 | `verification_red` | Sandbox is structurally healthy but build evidence is red, contradictory, or absent. | Block contribution; return next verification action. |
+| `stuck_mid_phase` | Build is registered to a sandbox and a `BuildPhaseRun` is `running` past its heartbeat budget, or last phase finished with `filesChanged:0` and no further activity. | Block deploy; offer governed `reset_build_phase`/`release_stale_slot`; never silently mark complete. |
 | `unrecoverable` | Recovery would be destructive or the platform lacks authority. | Stop; record incident; surface admin status. |
+
+The `stuck_mid_phase` state is the umbrella for the current "stuck COST-P1 builds awaiting Reset Build" class: builds wedged at `deps_installed` or builds at `complete` with `filesChanged:0`. This spec's governed `reset_build_phase` action replaces the missing Reset Build UI for sandbox-side stuck states; the broader phase-reset feature can land separately, but sandbox-attributable stuck states must be clearable here.
 
 ### 7.2 Readiness checks
 
@@ -258,8 +262,9 @@ Supported v1 actions:
 | `checkout_registered_branch` | Branch mismatch but no dirty source changes. | Checkout the registered `build/<buildId>` branch and rerun diagnostics. |
 | `reset_from_main` | No unpreserved build diff exists, or operator approved discard. | Fetch/reset from `origin/main`, recreate client/build branch, record source currency. |
 | `quarantine_runtime_target` | Container belongs to wrong worktree/project or unknown owner. | Mark target `misconfigured`, block deploy/contribution, record issue. |
+| `reset_build_phase` | Build is `stuck_mid_phase` past heartbeat budget OR phase finished with `filesChanged:0` and no diff. | Mark phase failed with reason, release sandbox slot if held, surface for re-dispatch. |
 
-`reset_from_main` and any action that could discard source changes require an explicit recovery confirmation captured as structured input, not an implied chat "yes."
+`reset_from_main`, `reset_build_phase`, and any action that could discard source changes or in-flight build state require an explicit recovery confirmation captured as structured input, not an implied chat "yes." A build that is merely paused (no heartbeat activity but inside the idle window) must NOT be eligible for slot release — see §13.5 for the staleness threshold.
 
 ### 9.3 `record_sandbox_incident`
 
@@ -327,6 +332,43 @@ The Build Studio coworker must follow these rules:
 6. Do not treat an already-submitted PR as authoritative when GitHub checks are red.
 7. Do not call `contribute_to_hive` unless `deploy_feature` succeeded in the current readiness window and contribution gates pass.
 8. If the issue is platform capability rather than user input, say so directly: "Build Studio is blocked because the sandbox recovery tool is missing or denied."
+
+### 11.1 Coworker dialog contract
+
+The rules above describe *what* the coworker may not do. This section specifies *what it must say* — the text the user actually sees in the AI Coworker panel. Every dialog ends with concrete next-step choices (never internal status, never "your call"). The coworker drives the portal UI itself where possible (Claude-in-Chrome → server action → MCP tool → SQL, in that order of preference); chat is the explanation surface, not the operator console.
+
+Required dialog templates per readiness state:
+
+| State | Required coworker dialog (paraphrasable, but must end with choices) |
+| --- | --- |
+| `stopped` | "Your sandbox container is stopped. I'm starting it now via the platform — no action needed from you. **Options:** (1) Wait for restart and continue (default), (2) Open Sandbox Control to watch progress." |
+| `not_found` | "The sandbox container does not exist for this install. I'll request the platform to provision it. **Options:** (1) Provision now (default), (2) Open Sandbox Control to review prerequisites." |
+| `detached` / `mixed_compose_project` | "Build Studio's sandbox is owned by a different worktree (`<wrong path>`). I cannot safely deploy from this state, and I will not ask you to run Docker. The platform has quarantined the target and recorded incident `<PIR-id>`. **Options:** (1) Rebuild the sandbox from this worktree (default), (2) Switch the active build to the owning worktree, (3) Open Sandbox Control." |
+| `stale_source` | "The sandbox cannot prove it is current against `origin/main` — `PlatformDevConfig.upstreamRemoteUrl` is unset or the fetch probe failed. I will not open a PR from unverified base. **Options:** (1) Configure upstream remote and reprobe (default), (2) Hold this build in review until source currency is verified, (3) Open Platform Development settings." |
+| `dirty_or_leaking` | "The sandbox workspace contains changes not attributable to this build (generated artifacts / cross-build leakage). I'm blocking deploy to prevent a contaminated PR. **Options:** (1) Show me the leaking paths (default), (2) Reset workspace from `build/<id>` with structured confirmation, (3) Open Sandbox Control." |
+| `verification_red` | "Verification is red: <one-line failure summary from raw output>. The earlier green summary booleans were wrong; I'm trusting the raw test/typecheck output. **Options:** (1) Show me the failing output (default), (2) Re-run verification, (3) Send build back to code generation." |
+| `stuck_mid_phase` | "The build is wedged at `<phase>` — last heartbeat `<ago>`, `filesChanged: <n>`, `ranTests: <bool>`. I will not advance it on contradictory evidence. **Options:** (1) Reset this phase and re-dispatch (default), (2) Show me the last task output, (3) Mark the build paused for later." |
+| `unrecoverable` | "Build Studio is blocked because the sandbox recovery tool is missing or denied — this is a platform issue, not something you can fix from chat. I've recorded `<PIR-id>`. **Options:** (1) Open the incident, (2) Open Sandbox Control to review state, (3) Switch to a different build." |
+
+Forbidden coworker dialog patterns (all currently observed in the FB-9706671B trace and in surrounding `mcp-tools.ts` strings):
+
+- "Please run `docker compose up -d sandbox`."
+- "Tell the user to run …"
+- "Run `docker compose up -d browser-use` …"
+- "Want me to skip the sandbox check and submit anyway?" / "Should I override deploy_feature?"
+- "I've submitted the PR — let me know if CI is red." (treating a red PR as authoritative.)
+- "Try restarting Docker Desktop."
+- Replies that end with internal status ("Done.", "Continuing.", "Investigating.") rather than user choices.
+
+The dialog test in §10 of the plan must assert at least one negative example per forbidden pattern and one positive example per required template.
+
+### 11.2 Self-upgrade interaction
+
+Per the live `project_self_upgrade_kills_in_session_ux` note: the portal recycles whenever the main bundle hash changes (every merged sibling PR). Sandbox recovery actions must therefore be:
+
+1. **Idempotent** — calling `recover_sandbox` twice with the same `(buildId, action)` after a portal restart must not double-execute. Use `BuildActivity` for the de-dupe lookup.
+2. **Resumable from snapshot** — the UI re-derives state from `RuntimeTarget` + `BuildActivity` + `PlatformIssueReport` on cold load; chat-only state does not survive restart.
+3. **Non-blocking on portal restart** — if a recovery server action is interrupted mid-flight, the next `diagnose_sandbox` call must distinguish "action was rolled back" from "action partially applied" via the persisted activity row.
 
 ## 12. Gate Integration
 
@@ -414,6 +456,27 @@ The GitHub commit API call must set explicit `author` and `committer` metadata t
 3. Coworker tells the operator the PR should be closed or superseded.
 4. Repair happens from a clean branch/worktree; the bad PR is not used as authoritative source.
 
+### 13.5 Stuck mid-phase recovery
+
+Heartbeat budget per phase (initial values; tunable via `PlatformDevConfig`):
+
+| Phase | In-flight heartbeat budget | Idle (no activity) staleness | Notes |
+| --- | --- | --- | --- |
+| `deps_installed` → next phase dispatch | 30 min | 7 days | Current stuck-build class. |
+| `code_generation` (active) | 90 min | 7 days | Long-running agentic runs allowed. |
+| `code_generation` (returned `filesChanged:0`) | n/a | immediate-fail (no idle window) | Hard-fail per §12.2. |
+| `verification` | 60 min | 7 days | |
+| `review` / `ship` (awaiting operator) | n/a | 14 days | Paused work; never auto-released. |
+
+The 7-day idle floor is intentional and derives from the `idle_is_not_abandoned` operating rule: paused work must survive a full week to absorb the operator's travel and weekly rate-limit resets. `release_stale_slot` against a build whose last activity is younger than the idle threshold returns `blocked` even if the operator clicks the button — the UI must disable it with that reason.
+
+Recovery flow:
+
+1. Diagnostic detects `stuck_mid_phase`.
+2. Coworker emits the §11.1 dialog and offers `reset_build_phase` (default) plus "show last task output" and "pause for later."
+3. On operator confirmation, `recover_sandbox({ action:"reset_build_phase" })` marks the active `BuildPhaseRun` failed with reason `operator_reset_after_stall`, records `BuildActivity`, releases the slot if it was held by this build only, and reruns diagnosis.
+4. Re-dispatch is governed by the existing phase dispatcher; this recovery does NOT auto-restart the phase — that is a separate operator choice.
+
 ## 14. Acceptance Criteria
 
 ### 14.1 Diagnostic correctness
@@ -441,6 +504,15 @@ The GitHub commit API call must set explicit `author` and `committer` metadata t
 - Admin sandbox console exposes governed recovery actions with disabled reasons.
 - Coworker never asks the user to run Docker or skip sandbox diff extraction.
 - In the `FB-9706671B` failure class, the platform blocks PR creation and records an incident before any GitHub PR is opened.
+- Coworker dialog templates from §11.1 are used verbatim (or paraphrased while preserving structure); every reply ends with concrete options, never internal status.
+- An automated test asserts that none of the forbidden dialog patterns from §11.1 appear in any sandbox/build prompt source file or in any sandbox/start_build/run_ux_test/evaluate_page tool return message — caught at the string level, not behaviorally.
+- Recovery is idempotent across a portal self-upgrade restart (§11.2): replaying the same recovery action does not double-apply.
+
+### 14.5 Stuck build class
+
+- `stuck_mid_phase` correctly classifies the four builds currently wedged (3 at `deps_installed`, 1 at `complete/no-diff`) without requiring DB inspection by the operator.
+- `reset_build_phase` clears them through the governed path; no SQL is required.
+- The 7-day idle floor for `release_stale_slot` is enforced and surfaced as a disabled-button reason.
 
 ## 15. Implementation Slices
 
@@ -458,4 +530,6 @@ These decisions should be resolved at implementation start:
 1. Should `reset_from_main` be v1, or should v1 stop at `quarantine_runtime_target` and require a later rebuild workflow?
 2. Should contribution PR creation create the `FeaturePack` before or after PR creation? This spec recommends after all pre-PR gates pass, but existing code creates it first.
 3. Should generated snapshot churn have a generic denylist or be per-task allowlisted through build-plan metadata?
-4. Should Build Studio mark the existing PR #961 lineage as superseded through GitHub comments automatically, or should that stay manual for v1?
+4. Heartbeat budgets in §13.5 are initial values — should they live in `PlatformDevConfig` (operator-tunable) or in code constants for v1?
+
+(The earlier "should we comment on PR #961 from Build Studio?" decision is *not* architectural and belongs to the followup PR that closes the FB-9706671B incident, not this spec.)


### PR DESCRIPTION
## Summary
- Add typed Build Studio sandbox readiness states, Docker Compose inspection, and read-only sandbox diagnosis.
- Add `diagnose_sandbox` and governed `recover_sandbox` MCP tools, replacing impossible user-run Docker handoffs in sandbox prompts/tool messages.
- Add sandbox readiness gates so `deploy_feature` and `contribute_to_hive` fail closed before diff extraction, FeaturePack creation, or PR creation when the sandbox is detached/stale/red.

## Verification
- `pnpm --filter web exec vitest run lib/integrate/sandbox/sandbox-admin.test.ts lib/integrate/sandbox/docker-compose-inspector.test.ts lib/integrate/sandbox/sandbox-admin-types.test.ts lib/integrate/sandbox/sandbox-recovery.test.ts lib/integrate/sandbox/sandbox-readiness-gate.test.ts lib/mcp-tools-sandbox-admin.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` (passes; existing Turbopack/NFT warning remains for `apps/web/app/api/voice/synthesize/route.ts`)