### PR TITLE
feat(voice): 🔊/🔇 speaker toggle to mute/unmute auto-playback in coworker panel

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { usePathname } from "next/navigation";
 import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
@@ -136,6 +136,29 @@ export function AgentCoworkerPanel({
   // without needing to re-subscribe the EventSource on every render.
   const voiceSynthRef = useRef(voiceSynth);
   voiceSynthRef.current = voiceSynth;
+
+  // Per-session voice playback toggle — persisted in localStorage so it
+  // survives panel close/open within the same browser session.
+  const VOICE_PLAYBACK_KEY = "dpf:voice_playback_enabled";
+  const [voicePlaybackEnabled, setVoicePlaybackEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    const stored = localStorage.getItem(VOICE_PLAYBACK_KEY);
+    return stored === null ? true : stored === "true";
+  });
+
+  const toggleVoicePlayback = useCallback(() => {
+    setVoicePlaybackEnabled((prev) => {
+      const next = !prev;
+      localStorage.setItem(VOICE_PLAYBACK_KEY, String(next));
+      // Stop any in-flight audio immediately when the user disables playback
+      if (!next) voiceSynthRef.current.stop();
+      return next;
+    });
+  }, []);
+
+  // Keep a ref so the SSE done handler always reads the latest value.
+  const voicePlaybackEnabledRef = useRef(voicePlaybackEnabled);
+  voicePlaybackEnabledRef.current = voicePlaybackEnabled;
 
   const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
   const agent = routeAgent;
@@ -294,8 +317,9 @@ export function AgentCoworkerPanel({
                 const filtered = filterMessages(snapshot.messages);
                 setMessages(filtered);
                 // Auto-synthesize the last assistant message if voice is available
+                // and the user has not muted playback via the speaker toggle.
                 const lastMsg = filtered[filtered.length - 1];
-                if (lastMsg?.role === "assistant" && voiceSynthRef.current.available) {
+                if (lastMsg?.role === "assistant" && voiceSynthRef.current.available && voicePlaybackEnabledRef.current) {
                   voiceSynthRef.current.synthesize(lastMsg.content).catch(() => {});
                 }
               }
@@ -924,6 +948,9 @@ export function AgentCoworkerPanel({
         pendingFile={pendingAttachment}
         onFileUploaded={setPendingAttachment}
         onFileClear={() => setPendingAttachment(null)}
+        voiceSynthAvailable={voiceSynth.available}
+        voicePlaybackEnabled={voicePlaybackEnabled}
+        onVoicePlaybackToggle={toggleVoicePlayback}
       />
     </>
   );

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -20,9 +20,15 @@ type Props = {
   pendingFile: PendingFile | null;
   onFileUploaded: (result: PendingFile) => void;
   onFileClear: () => void;
+  /** Whether a ready voice profile is available for synthesis. */
+  voiceSynthAvailable?: boolean;
+  /** Current playback preference set by the user. */
+  voicePlaybackEnabled?: boolean;
+  /** Toggle handler — flips voicePlaybackEnabled and persists to localStorage. */
+  onVoicePlaybackToggle?: () => void;
 };
 
-export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFile, onFileUploaded, onFileClear }: Props) {
+export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voicePlaybackEnabled, onVoicePlaybackToggle }: Props) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -229,6 +235,32 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           onReset={voice.reset}
           disabled={disabled || !!busy}
         />
+        {voiceSynthAvailable && onVoicePlaybackToggle && (
+          <button
+            type="button"
+            onClick={onVoicePlaybackToggle}
+            title={voicePlaybackEnabled ? "Mute voice playback" : "Unmute voice playback"}
+            aria-label={voicePlaybackEnabled ? "Mute voice playback" : "Unmute voice playback"}
+            aria-pressed={voicePlaybackEnabled}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: voicePlaybackEnabled ? "var(--dpf-accent)" : "var(--dpf-muted)",
+              fontSize: 16,
+              lineHeight: 1,
+              padding: "0 2px",
+              flexShrink: 0,
+              height: 32,
+              display: "flex",
+              alignItems: "center",
+              opacity: voicePlaybackEnabled ? 1 : 0.5,
+              transition: "color 0.15s, opacity 0.15s",
+            }}
+          >
+            {voicePlaybackEnabled ? "🔊" : "🔇"}
+          </button>
+        )}
         <AgentFileUpload
           threadId={threadId}
           disabled={disabled || !!busy}


### PR DESCRIPTION
## Summary

- Voice was playing after every assistant response with no way to silence it
- Adds a **🔊 / 🔇 speaker button** immediately to the right of the mic button in the message input bar
- Clicking toggles auto-playback on/off and persists the preference to `localStorage` (`dpf:voice_playback_enabled`) so it survives panel close/reopen
- Disabling immediately stops any in-flight audio
- The button only renders when a ready voice profile is available (no visual noise when TTS isn't set up)
- Defaults to **enabled** (preserves current behaviour for new installs)

## Changes

| File | Change |
|------|--------|
| `AgentCoworkerPanel.tsx` | `voicePlaybackEnabled` state + `toggleVoicePlayback` callback; `voicePlaybackEnabledRef` read in SSE done handler; new props passed to `AgentMessageInput` |
| `AgentMessageInput.tsx` | Three new optional props; speaker button rendered between MicButton and AgentFileUpload |

## Test plan

- [ ] Open coworker panel with a ready voice profile — 🔊 button appears to the right of the mic
- [ ] Send a message — voice plays automatically (enabled state)
- [ ] Click 🔊 — icon changes to 🔇, button dims
- [ ] Send another message — voice does **not** play
- [ ] If audio was playing when you clicked 🔇, it stops immediately
- [ ] Refresh / close + reopen panel — 🔇 state is remembered
- [ ] Click 🔇 — returns to 🔊, auto-play resumes on next response
- [ ] No button appears when voice profile is not set up

🤖 Generated with [Claude Code](https://claude.com/claude-code)