### PR TITLE
fix(coworker): persist agentMessageId on AdapterRunTelemetry so PR #964 badge resolves model + CLI/API

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { randomUUID } from "node:crypto";
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { validateMessageInput } from "@/lib/agent-coworker-types";
@@ -1280,6 +1281,13 @@ export async function sendMessage(input: {
   let responseModelId: string | null = null;
   let formAssistUpdate: Record<string, unknown> | undefined;
   let systemMessage: AgentMessageRow | undefined;
+  // Pre-allocate the assistant AgentMessage id so adapter telemetry rows
+  // written inside the agentic loop carry the join key back to the row this
+  // sendMessage will eventually create (either the proposal path or the
+  // standard path below). Without this, AdapterRunTelemetry.agentMessageId is
+  // always null and the per-turn provider/model badge degrades to provider
+  // name only.
+  const pendingAgentMessageId = randomUUID();
   const currentTaskRun = await findCurrentAutonomousWorkRun({
     userId: user.id!,
     threadId: input.threadId,
@@ -1422,6 +1430,7 @@ export async function sendMessage(input: {
       buildPhase: activeBuild?.phase ?? null,
       featureBuildId: activeBuild?.id ?? null,
       activeSkillId,
+      agentMessageId: pendingAgentMessageId,
       ...(Object.keys(modelReqs).length > 0 ? { modelRequirements: modelReqs } : {}),
       onProgress: (event) => agentEventBus.emit(input.threadId, event),
     });
@@ -1435,6 +1444,7 @@ export async function sendMessage(input: {
       const proposalId = "AP-" + Math.random().toString(36).substring(2, 7).toUpperCase();
       const agentMsg = await prisma.agentMessage.create({
         data: {
+          id: pendingAgentMessageId,
           threadId: input.threadId, role: "assistant",
           taskRunId: currentTaskRun?.taskRunId ?? null,
           content: tc.content || `I'd like to ${tc.name.replace(/_/g, " ")} with the following details.`,
@@ -1810,6 +1820,7 @@ export async function sendMessage(input: {
   // Persist agent response
   const agentMsg = await prisma.agentMessage.create({
     data: {
+      id: pendingAgentMessageId,
       threadId: input.threadId,
       role: "assistant",
       taskRunId: currentTaskRun?.taskRunId ?? null,

--- a/apps/web/lib/inference/ai-inference.call-provider.test.ts
+++ b/apps/web/lib/inference/ai-inference.call-provider.test.ts
@@ -52,6 +52,7 @@ vi.mock("../routing/transcription-adapter", () => ({}));
 vi.mock("../routing/async-adapter", () => ({}));
 
 import { callProvider } from "./ai-inference";
+import { _setAdapterTelemetryWriteOverrideForTests } from "../routing/adapter-telemetry-writer";
 
 describe("callProvider", () => {
   beforeEach(() => {
@@ -117,6 +118,49 @@ describe("callProvider", () => {
             "Content-Type": "application/json",
           }),
         }),
+      }),
+    );
+  });
+
+  it("forwards attribution.agentMessageId into AdapterRunTelemetry on the success path", async () => {
+    // Regression for PR #964 follow-up: the assistant-turn badge query joins
+    // AdapterRunTelemetry → AgentMessage on agentMessageId. callProvider is
+    // the only site that writes telemetry rows for the coworker turn, so the
+    // pre-allocated id has to make it through `attribution` into both writer
+    // call sites (success + error).
+    mockPrisma.modelProvider.findUnique.mockResolvedValue({
+      providerId: "anthropic",
+      authMethod: "oauth2_authorization_code",
+      authHeader: "Authorization",
+      baseUrl: "https://api.anthropic.com",
+      endpoint: null,
+    });
+    mockGetProviderBearerToken.mockResolvedValue({ token: "tok-1" });
+
+    const writeSpy = vi.fn().mockResolvedValue(undefined);
+    _setAdapterTelemetryWriteOverrideForTests(writeSpy);
+    try {
+      await callProvider(
+        "anthropic",
+        "claude-sonnet-4-6",
+        [{ role: "user", content: "hi" }],
+        "You are helpful.",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { agentId: "agt_1", threadId: "thr_1", agentMessageId: "msg_pending_42" },
+      );
+    } finally {
+      // wait a microtask so the void-write resolves before assertions
+      await new Promise((r) => setImmediate(r));
+      _setAdapterTelemetryWriteOverrideForTests(null);
+    }
+
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "success",
+        agentMessageId: "msg_pending_42",
       }),
     );
   });

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -363,7 +363,7 @@ export async function callProvider(
   plan?: RoutedExecutionPlan,
   previousResponseId?: string,
   mcpSession?: import("@/lib/routing/adapter-types").AdapterMcpSession,
-  attribution?: { agentId?: string | null; threadId?: string | null; skillId?: string | null },
+  attribution?: { agentId?: string | null; threadId?: string | null; skillId?: string | null; agentMessageId?: string | null },
 ): Promise<InferenceResult> {
   // 0. EP-COST-001 Phase 2 — pre-call budget gate.
   // Check the agent's daily token budget before dispatching. If the agent has
@@ -531,6 +531,7 @@ export async function callProvider(
       agentId: attribution?.agentId ?? undefined,
       threadId: attribution?.threadId ?? undefined,
       skillId: attribution?.skillId ?? undefined,
+      agentMessageId: attribution?.agentMessageId ?? undefined,
     });
     throw err;
   }
@@ -565,6 +566,7 @@ export async function callProvider(
     agentId: attribution?.agentId ?? undefined,
     threadId: attribution?.threadId ?? undefined,
     skillId: attribution?.skillId ?? undefined,
+    agentMessageId: attribution?.agentMessageId ?? undefined,
   });
 
   // 5. Map AdapterResult → InferenceResult

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -122,6 +122,15 @@ export interface RouteAndCallOptions {
    */
   agentId?: string;
   /**
+   * Pre-allocated AgentMessage id for the assistant turn this call belongs to.
+   * Threaded down to AdapterRunTelemetry rows so the badge/cost-rollup join
+   * (telemetry.agentMessageId → AgentMessage.id) can succeed even though the
+   * AgentMessage row is persisted only after the agentic loop returns. The
+   * caller (agent-coworker.sendMessage) allocates the id with `randomUUID()`
+   * before starting the loop and uses the same id when creating the row.
+   */
+  agentMessageId?: string;
+  /**
    * Actor responsible for this routing decision. Agent calls normally set
    * agentId; system utilities and schedulers should set this explicitly so
    * RouteDecisionLog never lands as an unattributed audit event.
@@ -435,7 +444,7 @@ export async function routeAndCall(
       decision.executionPlan,
       options?.previousResponseId,
       options?.mcpSession,
-      { agentId: options?.agentId ?? null },
+      { agentId: options?.agentId ?? null, agentMessageId: options?.agentMessageId ?? null },
     );
 
     // If the adapter returned an operation ID (async adapter), create tracking record

--- a/apps/web/lib/routing/adapter-telemetry-writer.test.ts
+++ b/apps/web/lib/routing/adapter-telemetry-writer.test.ts
@@ -75,6 +75,25 @@ describe("writeAdapterTelemetry", () => {
     );
   });
 
+  it("persists agentMessageId so the badge/cost-rollup join key reaches the row", async () => {
+    // Regression for PR #964 follow-up: the assistant-turn badge joins
+    // AdapterRunTelemetry → AgentMessage on agentMessageId. If the writer
+    // drops the field, every turn degrades to provider-name-only.
+    await writeAdapterTelemetry({
+      adapterKind: "claude-code-cli",
+      adapterVersion: "claude-code/1.2.3",
+      providerId: "anthropic-sub",
+      modelId: "claude-opus-4-7",
+      executionMode: "single",
+      startedAt: new Date(),
+      status: "success",
+      agentMessageId: "msg_abc123",
+    });
+    expect(writeOverride).toHaveBeenCalledWith(
+      expect.objectContaining({ agentMessageId: "msg_abc123" }),
+    );
+  });
+
   it("omits optional fields when undefined (no nulls forced)", async () => {
     await writeAdapterTelemetry({
       adapterKind: "codex-cli",

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -18,6 +18,14 @@ import {
 
 type RouteOutcomeAttribution = {
   agentId?: string | null;
+  /**
+   * Pre-allocated AgentMessage id for the assistant turn this call is part of.
+   * Threaded into AdapterRunTelemetry rows so a thread's badge/cost rollups
+   * can join telemetry → message without depending on row-creation ordering
+   * (the AgentMessage row is persisted after the agentic loop returns, but
+   * adapter rows are written inside each iteration).
+   */
+  agentMessageId?: string | null;
 };
 
 export interface FallbackResult {
@@ -102,6 +110,7 @@ export async function callWithFallbackChain(
   let overloadRetried = false;
   let transientRetried = false;
   const agentId = outcomeAttribution?.agentId?.trim() || mcpSession?.agentId?.trim() || null;
+  const agentMessageId = outcomeAttribution?.agentMessageId?.trim() || null;
 
   for (let i = 0; i < chain.length; i++) {
     const entry = chain[i]!;
@@ -136,7 +145,7 @@ export async function callWithFallbackChain(
         i === 0 ? plan : undefined,
         i === 0 ? previousResponseId : undefined,
         mcpSession,
-        { agentId },
+        { agentId, agentMessageId },
       );
 
       // EP-INF-004: Record successful request for rate tracking

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -745,6 +745,15 @@ export async function runAgenticLoop(params: {
    * by a specific skill invocation.
    */
   activeSkillId?: string | null;
+  /**
+   * Pre-allocated AgentMessage id for the assistant turn this loop is
+   * producing. Threaded down to AdapterRunTelemetry so the badge/cost-rollup
+   * join (telemetry.agentMessageId → AgentMessage.id) succeeds even though
+   * the AgentMessage row is persisted by the caller (agent-coworker) only
+   * after the loop returns. When omitted, telemetry rows are written without
+   * the join key and the UI badge degrades to provider-name-only.
+   */
+  agentMessageId?: string | null;
 }): Promise<AgenticResult> {
   const {
     chatHistory,
@@ -764,6 +773,7 @@ export async function runAgenticLoop(params: {
     taskRunId,
     apiTokenId,
     activeSkillId,
+    agentMessageId,
   } = params;
 
   const userContext = await resolveUserContext(userId);
@@ -798,6 +808,7 @@ export async function runAgenticLoop(params: {
     minimumCapabilities,
     agentMinimumContextTokens,
     agentId,
+    ...(agentMessageId ? { agentMessageId } : {}),
     // mcpSession is forwarded through callWithFallbackChain → callProvider →
     // AdapterRequest. The Claude CLI execution adapter consumes it to mint a
     // short-lived JWT for `--mcp-config`, exposing platform tools as native

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -192,6 +192,13 @@ export async function executeAutonomousAgenticLoop(input: {
    * can be attributed to the active skill.
    */
   activeSkillId?: string | null;
+  /**
+   * Pre-allocated AgentMessage id for the assistant turn this loop is
+   * producing. Threaded through to AdapterRunTelemetry so badge / cost-rollup
+   * queries can join telemetry rows to the resulting AgentMessage row even
+   * though the row itself is persisted by the caller after the loop returns.
+   */
+  agentMessageId?: string | null;
   onProgress?: (event: AgentEvent) => void;
 }) {
   const { runAgenticLoop } = await import("@/lib/tak/agentic-loop");
@@ -217,6 +224,7 @@ export async function executeAutonomousAgenticLoop(input: {
     buildPhase: input.buildPhase,
     featureBuildId: input.featureBuildId,
     activeSkillId: input.activeSkillId ?? null,
+    agentMessageId: input.agentMessageId ?? null,
     ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
     onProgress: input.onProgress,
   });


### PR DESCRIPTION
## Summary

Follow-up to [#964](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/964) (per-turn provider/adapter badge). The badge query joins `AdapterRunTelemetry` → `AgentMessage` on `agentMessageId`, but a live-DB check of the most recent telemetry rows showed every row had `agentMessageId = NULL`. The badge was silently degrading to provider-name-only (e.g. \"Claude / Anthropic (OAuth Subscription)\") for every turn — model id and CLI vs API never surfaced.

**Root cause (timing).** `callProvider` writes the telemetry row inside the agentic loop, but the caller (`sendMessage` in `agent-coworker.ts`) only persists the AgentMessage row *after* the loop returns. The join key did not exist at write time, so the writer received `agentMessageId: undefined` and the field stayed null.

**Fix (one direction, pre-allocate).** `sendMessage` allocates the assistant AgentMessage id (`randomUUID()`) up front and threads it through:

> `sendMessage` → `executeAutonomousAgenticLoop` → `runAgenticLoop` (routeOptions) → `routeAndCall` → `callWithFallbackChain` (outcome attribution) → `callProvider` (attribution) → `writeAdapterTelemetry`

Both `AgentMessage.create` sites in `sendMessage` (the proposal path and the standard path) then create the row with that same pre-allocated id. The column is a soft join (no FK), so writing the id ahead of the row is safe — the join becomes valid the moment the AgentMessage row lands.

## Tests

- `adapter-telemetry-writer.test.ts` — regression: `agentMessageId` reaches the writer's row payload.
- `ai-inference.call-provider.test.ts` — regression: `attribution.agentMessageId` forwards from `callProvider` into the success-path telemetry row.

Full `lib/tak` + `lib/routing` + `lib/inference` suite: **1275 / 1275 passing.**

## Test plan

Functional verification requires this PR to merge and self-upgrade to recycle the portal (the worktree changes aren't running in localhost:3000 today). After merge:

- [ ] Send a coworker message in the portal at http://localhost:3000.
- [ ] Query:
  ```sql
  select id, "agentMessageId", "providerId", "modelId", "adapterKind", "executionMode", "startedAt"
  from \"AdapterRunTelemetry\"
  order by \"startedAt\" desc
  limit 5;
  ```
  At least one of the new rows should have a non-null `agentMessageId` joining to the AgentMessage row created by that turn.
- [ ] Re-load any thread in the coworker panel — the badge should now show the full label (e.g. `Claude [CLI] · claude-opus-4-7`) rather than provider name only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)