### PR TITLE
fix(security): apply safe-fetch to MCP health-check HTTP transport (Task 15)

### DIFF
--- a/apps/web/lib/tak/mcp-server-health.ts
+++ b/apps/web/lib/tak/mcp-server-health.ts
@@ -4,6 +4,7 @@
 import type { McpConnectionConfig, HealthCheckResult } from "./mcp-server-types";
 import { lazyChildProcess } from "@/lib/shared/lazy-node";
 import { safeSpawn, type SpawnFn } from "@/lib/security/safe-spawn";
+import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
 
 const HTTP_TIMEOUT_MS = 5_000;
 const STDIO_TIMEOUT_MS = 10_000;
@@ -26,10 +27,34 @@ function isServerless(): boolean {
 async function checkHttp(url: string, headers?: Record<string, string>): Promise<HealthCheckResult> {
   const start = Date.now();
   try {
+    // BI-5E53A265 follow-up (CodeQL alert #38): the MCP transport URL is
+    // admin-configured but still user-controlled in the SSRF sense — a
+    // misconfigured (or compromised-admin) entry could point at internal
+    // services or cloud-metadata IPs. assertSafeOutboundUrl gates scheme +
+    // private-network. The explicit hostname-format regex below gives
+    // CodeQL's js/request-forgery query a recognised sanitiser signal.
+    let validated: URL;
+    try {
+      validated = assertSafeOutboundUrl(url);
+    } catch (e) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        error: e instanceof Error ? e.message : "Invalid URL",
+      };
+    }
+    if (!/^[a-z0-9][a-z0-9.-]*$/i.test(validated.hostname)) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        error: `Invalid hostname: ${validated.hostname}`,
+      };
+    }
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
 
-    const res = await fetch(url, {
+    const res = await fetch(validated.href, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(MCP_INITIALIZE_REQUEST),


### PR DESCRIPTION
## Summary

Task 15 follow-up to **BI-5E53A265 / PR #965**. The HTTP/SSE transport in `checkMcpServerHealth` was deferred from PR #965 to avoid merge conflict with PR #963 (which was editing the same file). Both prior PRs landed; applying the same safe-fetch defense here closes CodeQL alert #38.

## What changed

`apps/web/lib/tak/mcp-server-health.ts` `checkHttp()` now:
1. Calls `assertSafeOutboundUrl(url)` — same private-network / metadata-IP / scheme defense the other 3 SSRF sites now use.
2. Adds an inline hostname-format regex check (CodeQL's recognised SSRF sanitiser pattern).
3. Fetches `validated.href` instead of the raw input.

Same pattern as calendar-sync.ts in PR #965.

## CodeQL outcome — honest expectation

If CodeQL's `js/request-forgery` query is consistent with PR #965, it may still flag this site as a false positive (the helper does the real work but CodeQL doesn't recognise private-IP blocks as SSRF sanitisers). Calendar-sync currently sits on main with the same shape — alert #83. If this PR's scan flags similarly, the alert needs UI dismissal following the precedent of #40 / #41.

The actual security defense is in place either way.

## Test plan

- [ ] Typecheck ✓ (pre-commit hook passed)
- [ ] Existing 8 tests pass ✓
- [ ] CI green
- [ ] CodeQL alert #38 either closes (best case) or transitions to a new FP alert needing UI dismissal

## Related

- BI-5E53A265 (parent — partial resolution)
- PR #965 (helper + 3 sites)
- PR #963 (sibling — safe-spawn for same file)
- Sibling FP precedent: calendar-sync.ts (PR #965, alert #83 — same shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)