### PR TITLE
fix(build-studio): block contaminated promotion PRs

### DIFF
--- a/apps/web/lib/build/sandbox-state.test.ts
+++ b/apps/web/lib/build/sandbox-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertSandboxReadyForPromotion,
   buildSandboxStateFromRecord,
   extractExpectedPlanFiles,
   parseDiffstat,
@@ -117,6 +118,142 @@ describe("buildSandboxStateFromRecord", () => {
       status: "behind",
       targetRef: "origin/main",
       recommendedAction: "auto-refresh",
+    });
+  });
+});
+
+describe("assertSandboxReadyForPromotion", () => {
+  it("blocks promotion when the captured diff is missing files promised by the plan", () => {
+    const state = buildSandboxStateFromRecord({
+      buildBranch: "build/FB-STALE",
+      gitCommitHashes: ["abc1234"],
+      diffPatch: `diff --git a/packages/db/prisma/schema.prisma b/packages/db/prisma/schema.prisma
+@@ -1 +1,2 @@
++new
+`,
+      updatedAt: new Date("2026-05-18T12:00:00.000Z"),
+      planDocument: `## File Structure
+- Create \`apps/web/lib/inference/ollama-url.ts\`: URL resolver
+- Create \`apps/web/components/platform/OllamaManagement.tsx\`: model manager
+`,
+      description: null,
+      buildExecState: {
+        sourceCurrency: {
+          source: "sandbox-git",
+          status: "ahead",
+          recommendedAction: "allow",
+          workspace: "/workspace",
+          branch: "build/FB-STALE",
+          headSha: "head",
+          headTreeSha: "tree-head",
+          targetRef: "origin/main",
+          targetSha: "target",
+          targetTreeSha: "tree-target",
+          mergeBaseSha: "target",
+          aheadBy: 2,
+          behindBy: 0,
+          dirty: false,
+          localSourceChangeCount: 2,
+          checkedAt: "2026-05-18T12:00:00.000Z",
+          reason: "Sandbox has local source commits.",
+        },
+      },
+    });
+
+    const gate = assertSandboxReadyForPromotion(state);
+
+    expect(gate.ok).toBe(false);
+    if (gate.ok) throw new Error("Expected sandbox promotion gate to block missing plan files.");
+    expect(gate.message).toContain("missing files promised by the build plan");
+    expect(gate.failures).toEqual(expect.arrayContaining([
+      expect.stringContaining("apps/web/lib/inference/ollama-url.ts"),
+      expect.stringContaining("apps/web/components/platform/OllamaManagement.tsx"),
+    ]));
+  });
+
+  it("blocks promotion when persisted source-currency asks the operator to pause", () => {
+    const state = buildSandboxStateFromRecord({
+      buildBranch: "build/FB-DIVERGED",
+      gitCommitHashes: ["abc1234"],
+      diffPatch: `diff --git a/apps/web/lib/inference/ollama-url.ts b/apps/web/lib/inference/ollama-url.ts
+@@ -1 +1,2 @@
++new
+`,
+      updatedAt: new Date("2026-05-18T12:00:00.000Z"),
+      planDocument: `## File Structure
+- Create \`apps/web/lib/inference/ollama-url.ts\`: URL resolver
+`,
+      description: null,
+      buildExecState: {
+        sourceCurrency: {
+          source: "sandbox-git",
+          status: "diverged",
+          recommendedAction: "pause",
+          workspace: "/workspace",
+          branch: "build/FB-DIVERGED",
+          headSha: "head",
+          headTreeSha: "tree-head",
+          targetRef: "origin/main",
+          targetSha: "target",
+          targetTreeSha: "tree-target",
+          mergeBaseSha: "base",
+          aheadBy: 6,
+          behindBy: 1,
+          dirty: false,
+          localSourceChangeCount: 6,
+          checkedAt: "2026-05-18T12:00:00.000Z",
+          reason: "Sandbox has local commits and is missing origin/main commits.",
+        },
+      },
+    });
+
+    const gate = assertSandboxReadyForPromotion(state);
+
+    expect(gate.ok).toBe(false);
+    if (gate.ok) throw new Error("Expected sandbox promotion gate to block paused source currency.");
+    expect(gate.message).toContain("source is not promotable");
+    expect(gate.failures).toContain("Sandbox source is diverged and requires pause: Sandbox has local commits and is missing origin/main commits.");
+  });
+
+  it("allows promotion when expected plan files are present and source currency allows release", () => {
+    const state = buildSandboxStateFromRecord({
+      buildBranch: "build/FB-CURRENT",
+      gitCommitHashes: ["abc1234"],
+      diffPatch: `diff --git a/apps/web/lib/inference/ollama-url.ts b/apps/web/lib/inference/ollama-url.ts
+@@ -1 +1,2 @@
++new
+`,
+      updatedAt: new Date("2026-05-18T12:00:00.000Z"),
+      planDocument: `## File Structure
+- Create \`apps/web/lib/inference/ollama-url.ts\`: URL resolver
+`,
+      description: null,
+      buildExecState: {
+        sourceCurrency: {
+          source: "sandbox-git",
+          status: "current",
+          recommendedAction: "allow",
+          workspace: "/workspace",
+          branch: "build/FB-CURRENT",
+          headSha: "head",
+          headTreeSha: "tree-head",
+          targetRef: "origin/main",
+          targetSha: "target",
+          targetTreeSha: "tree-head",
+          mergeBaseSha: "head",
+          aheadBy: 0,
+          behindBy: 0,
+          dirty: false,
+          localSourceChangeCount: 0,
+          checkedAt: "2026-05-18T12:00:00.000Z",
+          reason: "Sandbox source tree matches origin/main.",
+        },
+      },
+    });
+
+    expect(assertSandboxReadyForPromotion(state)).toEqual({
+      ok: true,
+      message: "Sandbox promotion integrity checks passed.",
     });
   });
 });

--- a/apps/web/lib/build/sandbox-state.ts
+++ b/apps/web/lib/build/sandbox-state.ts
@@ -26,6 +26,10 @@ export type BuildSandboxState = {
   unavailableReason: string | null;
 };
 
+export type SandboxPromotionGateResult =
+  | { ok: true; message: string }
+  | { ok: false; message: string; failures: string[]; state: BuildSandboxState };
+
 export type SandboxRecordInput = {
   buildBranch: string | null;
   gitCommitHashes: string[];
@@ -92,6 +96,50 @@ export function buildSandboxStateFromRecord(input: SandboxRecordInput): BuildSan
     sourceCurrency: extractSourceCurrency(input.buildExecState),
     observedAt,
     unavailableReason: input.diffPatch ? null : "Live sandbox git diff is not available from the projection yet.",
+  };
+}
+
+export function assertSandboxReadyForPromotion(state: BuildSandboxState): SandboxPromotionGateResult {
+  const failures: string[] = [];
+
+  if (state.sourceCurrency && state.sourceCurrency.recommendedAction !== "allow") {
+    const reason = trimTrailingPeriod(state.sourceCurrency.reason ?? "no source-currency reason recorded");
+    failures.push(
+      `Sandbox source is ${state.sourceCurrency.status} and requires ${state.sourceCurrency.recommendedAction}: ${reason}.`,
+    );
+  }
+
+  const missingPlanFiles = state.expectedPlanFiles.filter((file) => file.status === "missing");
+  if (missingPlanFiles.length > 0) {
+    failures.push(
+      `Captured diff is missing files promised by the build plan: ${missingPlanFiles.map((file) => file.path).join(", ")}.`,
+    );
+  }
+
+  const unknownPlanFiles = state.expectedPlanFiles.filter((file) => file.status === "unknown");
+  if (unknownPlanFiles.length > 0) {
+    failures.push(
+      `Captured diff could not prove planned files are present: ${unknownPlanFiles.map((file) => file.path).join(", ")}.`,
+    );
+  }
+
+  if (failures.length === 0) {
+    return { ok: true, message: "Sandbox promotion integrity checks passed." };
+  }
+
+  const hasSourceCurrencyFailure = Boolean(state.sourceCurrency && state.sourceCurrency.recommendedAction !== "allow");
+  const hasPlanFailure = missingPlanFiles.length > 0 || unknownPlanFiles.length > 0;
+  const message = hasSourceCurrencyFailure && hasPlanFailure
+    ? "Sandbox promotion blocked: source is not promotable and the captured diff is missing files promised by the build plan."
+    : hasSourceCurrencyFailure
+      ? "Sandbox promotion blocked: source is not promotable."
+      : "Sandbox promotion blocked: captured diff is missing files promised by the build plan.";
+
+  return {
+    ok: false,
+    message,
+    failures,
+    state,
   };
 }
 
@@ -173,6 +221,10 @@ function extractFilePaths(value: string): string[] {
     .map((match) => match[0].replace(/[),.;:]$/, ""));
 }
 
+function trimTrailingPeriod(value: string): string {
+  return value.replace(/\.+$/, "");
+}
+
 function getIgnoredReason(path: string): IgnoredSandboxDiffEntry["reason"] | null {
   if (path.includes("/.next/") || path.startsWith(".next/") || path.includes("/coverage/")) {
     return "generated";
@@ -186,7 +238,7 @@ function getIgnoredReason(path: string): IgnoredSandboxDiffEntry["reason"] | nul
   return null;
 }
 
-function serializePlanDocument(plan: unknown): string | null {
+export function serializePlanDocument(plan: unknown): string | null {
   if (!plan || typeof plan !== "object") {
     return null;
   }

--- a/apps/web/lib/integrate/github-api-commit.test.ts
+++ b/apps/web/lib/integrate/github-api-commit.test.ts
@@ -234,6 +234,36 @@ describe("createBranchAndPR head/base split", () => {
     expect(calls.find((c) => c.method === "POST" && c.url === `${headRepoBase}/git/refs`), "ref POST to HEAD").toBeDefined();
   });
 
+  it("uses the DCO sign-off identity as the GitHub commit author and committer", async () => {
+    const { calls } = setupFetchMock();
+
+    await createBranchAndPR({
+      headOwner: "upstream-org",
+      headRepo: "upstream-repo",
+      baseOwner: "upstream-org",
+      baseRepo: "upstream-repo",
+      baseBranch: "main",
+      branchName: "feat/tiny",
+      commitMessage: SIGNED_COMMIT_MESSAGE,
+      diff: TINY_DIFF,
+      prTitle: "feat: tiny",
+      prBody: "body",
+      labels: [],
+      token: "ghp_test",
+    });
+
+    const commitPost = calls.find((c) => c.method === "POST" && c.url.endsWith("/git/commits"));
+    expect(commitPost, "commit POST must happen").toBeDefined();
+    expect(commitPost!.body!.author).toEqual({
+      name: "dpf-agent-a1b2c3d4",
+      email: "agent-a1b2c3d4@hive.dpf",
+    });
+    expect(commitPost!.body!.committer).toEqual({
+      name: "dpf-agent-a1b2c3d4",
+      email: "agent-a1b2c3d4@hive.dpf",
+    });
+  });
+
   it("POSTs labels to the BASE repo's issue (not the HEAD repo's)", async () => {
     const { calls } = setupFetchMock();
 

--- a/apps/web/lib/integrate/github-api-commit.ts
+++ b/apps/web/lib/integrate/github-api-commit.ts
@@ -55,10 +55,24 @@ export interface GitHubCommitResult {
   prNumber: number | null;
 }
 
-const DCO_SIGNOFF_PATTERN = /^Signed-off-by:\s+.+\s+<[^<>\s@]+@[^<>\s@]+>$/im;
+const DCO_SIGNOFF_PATTERN = /^Signed-off-by:\s+(.+?)\s+<([^<>\s@]+@[^<>\s@]+)>$/im;
+
+type GitCommitIdentity = {
+  name: string;
+  email: string;
+};
+
+function parseDcoSignedCommitIdentity(commitMessage: string): GitCommitIdentity | null {
+  const match = commitMessage.match(DCO_SIGNOFF_PATTERN);
+  if (!match) return null;
+  return {
+    name: match[1].trim(),
+    email: match[2].trim(),
+  };
+}
 
 function assertDcoSignedCommitMessage(commitMessage: string): void {
-  if (DCO_SIGNOFF_PATTERN.test(commitMessage)) return;
+  if (parseDcoSignedCommitIdentity(commitMessage)) return;
   throw new Error(
     "DCO sign-off is required for Build Studio pull requests. Include a `Signed-off-by: Name <email>` trailer in the commit message.",
   );
@@ -266,6 +280,10 @@ export async function createBranchAndPR(input: {
   token: string;
 }): Promise<GitHubCommitResult> {
   assertDcoSignedCommitMessage(input.commitMessage);
+  const dcoIdentity = parseDcoSignedCommitIdentity(input.commitMessage);
+  if (!dcoIdentity) {
+    throw new Error("DCO sign-off identity could not be parsed from the commit message.");
+  }
 
   const {
     headOwner,
@@ -366,6 +384,8 @@ export async function createBranchAndPR(input: {
       message: commitMessage,
       tree: tree.sha,
       parents: [baseSha],
+      author: dcoIdentity,
+      committer: dcoIdentity,
     },
     token,
   );

--- a/apps/web/lib/mcp-tools-sandbox-admin.test.ts
+++ b/apps/web/lib/mcp-tools-sandbox-admin.test.ts
@@ -5,6 +5,14 @@ const mockPrisma = {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
   },
+  featurePack: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  improvementProposal: {
+    updateMany: vi.fn(),
+  },
   buildActivity: {
     create: vi.fn().mockResolvedValue({ id: "activity-1" }),
   },
@@ -16,6 +24,7 @@ const mockPrisma = {
 const mockDiagnoseSandboxReadiness = vi.hoisted(() => vi.fn());
 const mockRecoverSandbox = vi.hoisted(() => vi.fn());
 const mockResolveHiveToken = vi.hoisted(() => vi.fn());
+const mockCreateBranchAndPR = vi.hoisted(() => vi.fn());
 
 vi.mock("@dpf/db", () => ({
   DISCOVERY_TRIAGE_AGENT_ID: "AGT-DISCOVERY",
@@ -36,6 +45,19 @@ vi.mock("@/lib/integrate/sandbox/sandbox-recovery", () => ({
 
 vi.mock("@/lib/integrate/identity-privacy", () => ({
   resolveHiveToken: mockResolveHiveToken,
+  getPlatformIdentity: vi.fn(async () => ({
+    authorName: "dpf-agent-a1b2c3d4",
+    authorEmail: "agent-a1b2c3d4@hive.dpf",
+    clientId: "a1b2c3d4-0000-0000-0000-000000000000",
+    shortId: "a1b2c3d4",
+    dcoSignoff: "Signed-off-by: dpf-agent-a1b2c3d4 <agent-a1b2c3d4@hive.dpf>",
+  })),
+  generatePrivateBranchName: vi.fn(() => "dpf/a1b2c3d4/sandbox-fix"),
+  generateAnonymousCommitMessage: vi.fn(() => "feat: Sandbox fix\n\nSigned-off-by: dpf-agent-a1b2c3d4 <agent-a1b2c3d4@hive.dpf>"),
+}));
+
+vi.mock("@/lib/integrate/github-api-commit", () => ({
+  createBranchAndPR: mockCreateBranchAndPR,
 }));
 
 vi.mock("@/lib/platform-dev-policy", () => ({
@@ -52,6 +74,17 @@ const FORBIDDEN_SANDBOX_HANDOFF_PATTERNS = [
 describe("sandbox admin MCP and coworker messaging", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrisma.buildActivity.create.mockResolvedValue({ id: "activity-1" });
+    mockPrisma.featurePack.findFirst.mockResolvedValue(null);
+    mockPrisma.featurePack.create.mockResolvedValue({ packId: "FP-TEST" });
+    mockPrisma.featurePack.update.mockResolvedValue({ packId: "FP-TEST" });
+    mockPrisma.improvementProposal.updateMany.mockResolvedValue({ count: 0 });
+    mockCreateBranchAndPR.mockResolvedValue({
+      branchName: "dpf/a1b2c3d4/sandbox-fix",
+      commitSha: "commit-sha",
+      prUrl: null,
+      prNumber: null,
+    });
   });
 
   it("exposes diagnose_sandbox as a read-only build/review/ship tool", async () => {
@@ -281,5 +314,132 @@ describe("sandbox admin MCP and coworker messaging", () => {
         summary: expect.stringContaining("upstream contribution"),
       }),
     }));
+  });
+
+  it("blocks create_portal_pr when the captured diff misses files promised by the build plan", async () => {
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        buildId: "FB-PROMOTE-1",
+        createdById: "user-1",
+      })
+      .mockResolvedValueOnce({
+        id: "feature-build-row-1",
+        title: "Ollama model management",
+        diffPatch: "diff --git a/packages/db/prisma/schema.prisma b/packages/db/prisma/schema.prisma\n@@ -1 +1,2 @@\n+new\n",
+        buildBranch: "build/FB-PROMOTE-1",
+        gitCommitHashes: ["abc1234"],
+        updatedAt: new Date("2026-05-22T12:00:00.000Z"),
+        buildExecState: {
+          sourceCurrency: {
+            source: "sandbox-git",
+            status: "ahead",
+            recommendedAction: "allow",
+            workspace: "/workspace",
+            branch: "build/FB-PROMOTE-1",
+            headSha: "head",
+            headTreeSha: "tree-head",
+            targetRef: "origin/main",
+            targetSha: "target",
+            targetTreeSha: "tree-target",
+            mergeBaseSha: "target",
+            aheadBy: 1,
+            behindBy: 0,
+            dirty: false,
+            localSourceChangeCount: 1,
+            checkedAt: "2026-05-22T12:00:00.000Z",
+            reason: "Sandbox has local source commits.",
+          },
+        },
+        verificationOut: { typecheckPassed: true, testsPassed: 1, testsFailed: 0 },
+        acceptanceMet: [{ met: true }],
+        phase: "ship",
+        designDoc: null,
+        buildPlan: "## File Structure\n- Create `apps/web/lib/inference/ollama-url.ts`: URL resolver\n",
+        description: null,
+        productVersions: [],
+      });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("create_portal_pr", {
+      buildId: "FB-PROMOTE-1",
+    }, "user-1", { agentId: "AGT-ORCH-600" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Sandbox promotion integrity blocked PR creation.");
+    expect(result.message).toContain("missing files promised by the build plan");
+    expect(mockCreateBranchAndPR).not.toHaveBeenCalled();
+  });
+
+  it("blocks contribute_to_hive before FeaturePack creation when persisted source-currency says pause", async () => {
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({
+        buildId: "FB-PROMOTE-2",
+        createdById: "user-1",
+      })
+      .mockResolvedValueOnce({
+        id: "feature-build-row-2",
+        title: "Ollama model management",
+        brief: {},
+        diffPatch: "diff --git a/apps/web/lib/inference/ollama-url.ts b/apps/web/lib/inference/ollama-url.ts\n@@ -1 +1,2 @@\n+new\n",
+        diffSummary: "summary",
+        sandboxId: "dpf-sandbox-2",
+        portfolioId: null,
+        createdById: "user-1",
+        createdBy: { email: "admin@dpf.local" },
+        buildBranch: "build/FB-PROMOTE-2",
+        gitCommitHashes: ["abc1234"],
+        updatedAt: new Date("2026-05-22T12:00:00.000Z"),
+        buildPlan: "## File Structure\n- Create `apps/web/lib/inference/ollama-url.ts`: URL resolver\n",
+        description: null,
+        buildExecState: {
+          sourceCurrency: {
+            source: "sandbox-git",
+            status: "diverged",
+            recommendedAction: "pause",
+            workspace: "/workspace",
+            branch: "build/FB-PROMOTE-2",
+            headSha: "head",
+            headTreeSha: "tree-head",
+            targetRef: "origin/main",
+            targetSha: "target",
+            targetTreeSha: "tree-target",
+            mergeBaseSha: "base",
+            aheadBy: 6,
+            behindBy: 1,
+            dirty: false,
+            localSourceChangeCount: 6,
+            checkedAt: "2026-05-22T12:00:00.000Z",
+            reason: "Sandbox has local commits and is missing origin/main commits.",
+          },
+        },
+      });
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValueOnce({
+      contributionMode: "contribute_all",
+      upstreamRemoteUrl: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git",
+      dcoAcceptedAt: new Date("2026-05-22T12:00:00.000Z"),
+      gitRemoteUrl: null,
+    });
+    mockResolveHiveToken.mockResolvedValueOnce("ghp_test");
+    mockDiagnoseSandboxReadiness.mockResolvedValueOnce({
+      buildId: "FB-PROMOTE-2",
+      state: "healthy",
+      canDeploy: true,
+      canContribute: true,
+      summary: "Sandbox is running, bound to the expected worktree, current, clean, and verified.",
+      checks: [],
+      recommendedActions: [],
+      inspectedAt: "2026-05-22T12:00:00.000Z",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("contribute_to_hive", {
+      buildId: "FB-PROMOTE-2",
+    }, "user-1", { agentId: "AGT-ORCH-700" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Sandbox promotion integrity blocked contribution.");
+    expect(result.message).toContain("source is not promotable");
+    expect(mockPrisma.featurePack.findFirst).not.toHaveBeenCalled();
+    expect(mockCreateBranchAndPR).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -8006,6 +8006,7 @@ export async function executeTool(
         where: { buildId },
         select: {
           id: true, title: true, diffPatch: true, buildBranch: true,
+          description: true, gitCommitHashes: true, updatedAt: true, buildExecState: true,
           verificationOut: true, acceptanceMet: true, phase: true,
           designDoc: true, buildPlan: true,
           productVersions: {
@@ -8022,6 +8023,33 @@ export async function executeTool(
 
       const diff = (build.diffPatch ?? "") as string;
       if (!diff.trim()) return { success: false, error: "No diff available.", message: "Run deploy_feature first to extract the diff." };
+
+      const { buildSandboxStateFromRecord, assertSandboxReadyForPromotion, serializePlanDocument } = await import("@/lib/build/sandbox-state");
+      const sandboxState = buildSandboxStateFromRecord({
+        buildBranch: build.buildBranch,
+        gitCommitHashes: build.gitCommitHashes,
+        diffPatch: diff,
+        updatedAt: build.updatedAt,
+        planDocument: typeof build.buildPlan === "string" ? build.buildPlan : serializePlanDocument(build.buildPlan),
+        description: build.description,
+        buildExecState: build.buildExecState,
+      });
+      const promotionGate = assertSandboxReadyForPromotion(sandboxState);
+      if (!promotionGate.ok) {
+        logBuildActivity(buildId, "create_portal_pr", promotionGate.message);
+        return {
+          success: false,
+          error: "Sandbox promotion integrity blocked PR creation.",
+          message: `${promotionGate.message}\n\n${promotionGate.failures.join("\n")}`,
+          data: {
+            gate: {
+              ok: false,
+              failures: promotionGate.failures,
+            },
+            sandbox: promotionGate.state,
+          },
+        };
+      }
 
       // Resolve the portal's own repo from git remote
       let repoOwner: string | null = null;
@@ -8961,6 +8989,8 @@ export async function executeTool(
         select: {
           id: true, title: true, brief: true, diffPatch: true, diffSummary: true,
           sandboxId: true, portfolioId: true, createdById: true,
+          buildBranch: true, gitCommitHashes: true, updatedAt: true, buildPlan: true,
+          description: true, buildExecState: true,
           createdBy: { select: { email: true } },
         },
       });
@@ -8984,6 +9014,33 @@ export async function executeTool(
 
       const diff = (build.diffPatch ?? "") as string;
       if (!diff.trim()) return { success: false, error: "No diff available.", message: "Run deploy_feature first to extract the diff." };
+
+      const { buildSandboxStateFromRecord, assertSandboxReadyForPromotion, serializePlanDocument } = await import("@/lib/build/sandbox-state");
+      const sandboxState = buildSandboxStateFromRecord({
+        buildBranch: build.buildBranch,
+        gitCommitHashes: build.gitCommitHashes,
+        diffPatch: diff,
+        updatedAt: build.updatedAt,
+        planDocument: typeof build.buildPlan === "string" ? build.buildPlan : serializePlanDocument(build.buildPlan),
+        description: build.description,
+        buildExecState: build.buildExecState,
+      });
+      const promotionGate = assertSandboxReadyForPromotion(sandboxState);
+      if (!promotionGate.ok) {
+        logBuildActivity(buildId, "contribute_to_hive", promotionGate.message);
+        return {
+          success: false,
+          error: "Sandbox promotion integrity blocked contribution.",
+          message: `${promotionGate.message}\n\n${promotionGate.failures.join("\n")}`,
+          data: {
+            gate: {
+              ok: false,
+              failures: promotionGate.failures,
+            },
+            sandbox: promotionGate.state,
+          },
+        };
+      }
 
       const includeMigrations = params.include_migrations !== false;
       const brief = build.brief as Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
- block `create_portal_pr` and `contribute_to_hive` when the stored sandbox source-currency says pause/inspect/refresh instead of allow
- block promotion when the captured diff is missing files promised by the build plan
- set GitHub commit `author` and `committer` from the DCO Signed-off-by identity so generated commits satisfy DCO

## Root Cause
The promoted PRs were able to use a stale/polluted Build Studio diff even when sandbox state showed missing planned files or non-promotable source currency. The GitHub commit API path also put the DCO sign-off in the message but did not set commit author/committer to the same pseudonymous identity, which leaves DCO checks vulnerable to token-owner metadata.

## Verification
- `pnpm --filter web exec vitest run lib/mcp-tools-sandbox-admin.test.ts lib/integrate/github-api-commit.test.ts lib/build/sandbox-state.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web exec next build`