### PR TITLE
fix(security): close 12 HIGH js/tainted-format-string alerts (cluster)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -401,7 +401,8 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
 
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : "unknown error";
-    console.error(`[agent-task-scheduler] Task ${taskId} failed:`, errMsg);
+    // CodeQL #39 (js/tainted-format-string): taskId via format-arg.
+    console.error("[agent-task-scheduler] Task %s failed:", taskId, errMsg);
 
     const ref = taskRunRef;
     if (ref) {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -1050,7 +1050,8 @@ export async function resumeBuildImplementation(buildId: string): Promise<Resume
   }).catch(() => {});
 
   autoExecuteBuild(buildId).catch((err) =>
-    console.error(`[build] resumeBuildImplementation failed for ${buildId}:`, err),
+    // CodeQL #42 (js/tainted-format-string): buildId via format-arg.
+    console.error("[build] resumeBuildImplementation failed for %s:", buildId, err),
   );
 
   return {

--- a/apps/web/lib/govern/activate-provider.ts
+++ b/apps/web/lib/govern/activate-provider.ts
@@ -129,7 +129,11 @@ export async function activateProvider(
       }
     }
   } catch (err) {
-    console.warn(`[activateProvider] MCP link activation failed for ${providerId}:`, err);
+    // CodeQL #43 (js/tainted-format-string): providerId came from a user-
+    // facing source; passing it inside the format-string template lets it
+    // act as a format directive (%s, %j etc). Use the format-arg form so
+    // console treats it as a value.
+    console.warn("[activateProvider] MCP link activation failed for %s:", providerId, err);
   }
 
   // 4. Activate sibling provider (codex↔chatgpt bidirectional sync)
@@ -137,7 +141,8 @@ export async function activateProvider(
     try {
       await activateLinkedSibling(providerId, opts);
     } catch (err) {
-      console.warn(`[activateProvider] Sibling activation failed for ${providerId}:`, err);
+      // CodeQL #44 — see #43 comment above.
+      console.warn("[activateProvider] Sibling activation failed for %s:", providerId, err);
     }
   }
 
@@ -153,14 +158,21 @@ export async function activateProvider(
       profiled = result.profiled;
       if (result.error) {
         warning = result.error;
+        // CodeQL #45 — format-arg form per #43 comment.
         console.warn(
-          `[activateProvider] Discovery warning for ${providerId} (trigger=${opts.trigger}): ${result.error}`,
+          "[activateProvider] Discovery warning for %s (trigger=%s): %s",
+          providerId,
+          opts.trigger,
+          result.error,
         );
       }
     } catch (err) {
       warning = err instanceof Error ? err.message : String(err);
+      // CodeQL #46 — format-arg form per #43 comment.
       console.warn(
-        `[activateProvider] Discovery failed for ${providerId} (trigger=${opts.trigger}):`,
+        "[activateProvider] Discovery failed for %s (trigger=%s):",
+        providerId,
+        opts.trigger,
         err,
       );
     }
@@ -182,7 +194,8 @@ export async function activateProvider(
       },
     });
   } catch (err) {
-    console.warn(`[activateProvider] Model restoration failed for ${providerId}:`, err);
+    // CodeQL — last activate-provider alert; format-arg form per #43 comment.
+    console.warn("[activateProvider] Model restoration failed for %s:", providerId, err);
   }
 
   return { providerId, status: "active", clearance, discovered, profiled, warning };

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -52,7 +52,8 @@ export async function getDecryptedCredential(providerId: string) {
     if (cred.status !== "key_rotated") {
       prisma.credentialEntry
         .update({ where: { providerId }, data: { status: "key_rotated" } })
-        .catch((err) => console.warn(`[credentials] Failed to mark ${providerId} as key_rotated:`, err));
+        // CodeQL #47 (js/tainted-format-string): providerId is user-influenced.
+        .catch((err) => console.warn("[credentials] Failed to mark %s as key_rotated:", providerId, err));
     }
     return null;
   }
@@ -1014,8 +1015,9 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
       }
       console.log(`[auto-discover] Queued background evals for ${models.length} model(s) on ${providerId}`);
     } catch (err) {
-      // Non-fatal — catalog scores are usable even without live eval
-      console.warn(`[auto-discover] Failed to queue background evals for ${providerId}:`, err);
+      // Non-fatal — catalog scores are usable even without live eval.
+      // CodeQL #48 (js/tainted-format-string): providerId via format-arg.
+      console.warn("[auto-discover] Failed to queue background evals for %s:", providerId, err);
     }
   }
 

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -221,8 +221,11 @@ async function writeAudit(data: {
     // Audit MUST NOT silently fail. Log with enough context to investigate
     // without throwing back to the caller (which would mask successful tool
     // execution).
+    // CodeQL #49 (js/tainted-format-string): tool/source names are user-influenced.
     console.error(
-      `[governed-execute] audit write failed tool=${data.toolName} source=${data.source}:`,
+      "[governed-execute] audit write failed tool=%s source=%s:",
+      data.toolName,
+      data.source,
       err,
     );
     return null;
@@ -288,8 +291,11 @@ async function writeReceipt(data: {
       await prisma.toolExecutionReceipt.create({ data: row });
     }
   } catch (err) {
+    // CodeQL #50 (js/tainted-format-string): tool/build names via format-args.
     console.error(
-      `[governed-execute] receipt write failed tool=${data.toolName} build=${data.buildId}:`,
+      "[governed-execute] receipt write failed tool=%s build=%s:",
+      data.toolName,
+      data.buildId,
       err,
     );
   }
@@ -328,8 +334,11 @@ async function runPostToolHooks(event: ToolLifecyclePostEvent): Promise<void> {
     try {
       await hook.onPostToolUse?.(event);
     } catch (err) {
+      // CodeQL #51 (js/tainted-format-string): hook/tool names via format-args.
       console.error(
-        `[governed-execute] post-tool hook failed hook=${hook.id} tool=${event.toolName}:`,
+        "[governed-execute] post-tool hook failed hook=%s tool=%s:",
+        hook.id,
+        event.toolName,
         err,
       );
     }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -12785,7 +12785,11 @@ export async function executeTool(
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        return { success: false, error: msg, message: `start_deliberation failed: ${msg}` };
+        // CodeQL #52 (js/tainted-format-string): the error message ended up
+        // being used as a format string downstream. Keep the diagnostic in
+        // `error:` (raw value) and use a constant `message:` so downstream
+        // log/format consumers see no user-controlled format specifiers.
+        return { success: false, error: msg, message: "start_deliberation failed" };
       }
     }
 


### PR DESCRIPTION
## Summary

Cluster fix per zero-tolerance burn-down. Closes 12 HIGH-severity CodeQL alerts (all `js/tainted-format-string`) in one PR. All had the same shape: `console.log/warn/error` with a template literal where a user-influenced value (providerId, toolName, buildId, taskId, err.message) was interpolated into the format string itself.

## The defect class

Node's console methods treat the first string argument as a printf-style format. When user values contain `%s` or `%j`, they get interpreted as format directives. Real impact: log injection / log corruption. Not RCE in Node, but enough for CodeQL to classify as HIGH severity.

## Fix pattern (applied uniformly)

```diff
- console.warn(`[X] failed for ${id}:`, err)
+ console.warn("[X] failed for %s:", id, err)
```

The format string is now a constant; user-influenced values move to format-arg positions where console quotes them safely.

## 12 alerts closed across 6 files

| File | Alerts |
|---|---|
| `apps/web/lib/govern/activate-provider.ts` | #43, #44, #45, #46 |
| `apps/web/lib/inference/ai-provider-internals.ts` | #47, #48 |
| `apps/web/lib/mcp-governed-execute.ts` | #49, #50, #51 |
| `apps/web/lib/actions/build.ts` | #42 |
| `apps/web/lib/actions/agent-task-scheduler.ts` | #39 |
| `apps/web/lib/mcp-tools.ts` | #52 (return-shape fix — see below) |

## mcp-tools.ts:12788 was slightly different

The site wasn't a `console.*` call — it was a return shape where `message: \`failed: \${msg}\`` got passed downstream and became a format string in a log consumer. Replaced with constant message + raw value in `error:` field.

## Behavioral impact

None. Log lines render the same way — `%s` substitution produces identical output to template literal interpolation. The only difference is that user-supplied `%` characters in values now render as literal `%` instead of being mis-parsed as format directives.

## Backlog after this PR

Combined with PR #972 (9 alerts) and earlier PRs, this knocks ~21 alerts off the HIGH backlog (was 43). Remaining HIGH clusters:

- 9× ReDoS family (`js/polynomial-redos` + `js/redos`) — each regex needs careful refactor
- 3× `js/bad-tag-filter` in public-web-tools (HTML scraper regexes)
- 2× `js/reflected-xss` in sandbox/preview route (needs proper context-aware escaping)
- 2× `js/regex-injection` (user input compiled as regex)
- 1× each: certificate-validation, sanitization (multi-char + sanitization), insecure-randomness equivalent, insufficient-password-hash, path-injection, actions/untrusted-checkout

## Test plan

- [ ] CI green (typecheck pre-commit passed)
- [ ] CodeQL re-scan closes all 12 alerts (#39, #42-#52)
- [ ] Log output for the affected paths renders unchanged (visual smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)