### PR TITLE
fix(security): close 2 HIGH js/regex-injection alerts (schema-validator + codebase-tools)

### DIFF
--- a/apps/web/lib/integrate/codebase-tools.ts
+++ b/apps/web/lib/integrate/codebase-tools.ts
@@ -187,7 +187,27 @@ function globMatches(filePath: string, glob?: string): boolean {
   return filePath === normalized || filePath.endsWith(`/${normalized}`);
 }
 
+// CodeQL #73 (js/regex-injection): query is user-supplied and gets used
+// as a regex by design (this is the search feature). The risk isn't
+// pattern injection (that IS the feature) but ReDoS — a malicious
+// pattern can stall the matcher.
+//
+// Defenses:
+//   1. Length cap (200 chars) — bounds catastrophic-backtracking growth.
+//   2. Fall back to substring match if the regex compile fails OR if the
+//      pattern looks too aggressive (>4 `*`/`+` quantifiers).
 function makeLineMatcher(query: string): (line: string) => boolean {
+  const MAX_QUERY_LEN = 200;
+  const MAX_QUANTIFIERS = 4;
+  if (query.length > MAX_QUERY_LEN) {
+    return (line) => line.includes(query.slice(0, MAX_QUERY_LEN));
+  }
+  const quantifierCount = (query.match(/[*+?]/g) ?? []).length;
+  if (quantifierCount > MAX_QUANTIFIERS) {
+    // Quantifier-heavy patterns are the classic ReDoS shape. Fall back
+    // to substring search to keep the matcher bounded.
+    return (line) => line.includes(query);
+  }
   try {
     const pattern = new RegExp(query);
     return (line) => pattern.test(line);

--- a/apps/web/lib/integrate/schema-validator.ts
+++ b/apps/web/lib/integrate/schema-validator.ts
@@ -11,6 +11,13 @@
  * BEFORE prisma migrate is attempted.
  */
 
+// Escape regex metacharacters in user-supplied strings before embedding
+// them in a `new RegExp(...)` pattern. Used by the model-extractor below.
+// Plain TS implementation — no dependency needed for 11 characters.
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export interface SchemaIssue {
   severity: "error" | "warning";
   line: number;
@@ -299,7 +306,11 @@ export function describeModel(schemaContent: string, modelName: string): ModelDe
     const trimmed = lines[i].trim();
 
     if (!inModel) {
-      const match = trimmed.match(new RegExp(`^model\\s+${modelName}\\s*\\{`));
+      // CodeQL #74 (js/regex-injection): modelName could contain regex
+      // metacharacters (e.g. ".*"), which would make the pattern match
+      // unrelated lines or run slow. escapeRegex turns every char into
+      // a literal match.
+      const match = trimmed.match(new RegExp(`^model\\s+${escapeRegex(modelName)}\\s*\\{`));
       if (match) {
         inModel = true;
         startLine = i + 1;


### PR DESCRIPTION
## Summary

2 HIGH-severity `js/regex-injection` alerts closed.

| Alert | File | Issue | Fix |
|---|---|---|---|
| #74 | `schema-validator.ts:302` | `new RegExp(\`^model\s+\${modelName}\s*\{\`)` — modelName could contain regex metacharacters | Added `escapeRegex()` helper; modelName escaped before embedding |
| #73 | `codebase-tools.ts:192` | `makeLineMatcher` intentionally compiles user query as regex (search feature) — ReDoS risk | Length cap (200 chars) + quantifier-count gate (>4 `*`/`+`/`?` → substring fallback) |

## Why two different fix patterns

- **Schema-validator**: the regex metacharacters in modelName are a bug — not a feature. Escaping returns to literal-match semantics, which is what the code intended.
- **Codebase-tools**: the user gives a regex on purpose (project search). Escaping would remove the feature. Instead, we cap input length and reject quantifier-heavy patterns that are the classic ReDoS shape. The search still works for normal regexes; pathological patterns fall back to substring.

## Test plan

- [ ] CI green
- [ ] CodeQL re-scan closes alerts #73 and #74
- [ ] Manual smoke: search with normal regex (`function\s+foo`) still works; pathological pattern (`(.+)+x` x 200 chars) falls back without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)