### PR TITLE
feat(edge): bind edge nodes to customer sites

### DIFF
--- a/apps/web/app/api/v1/edge/adapters/route.test.ts
+++ b/apps/web/app/api/v1/edge/adapters/route.test.ts
@@ -35,6 +35,9 @@ const AUTHED = {
   edgeNodeRowId: "edgenode_cuid_1",
   nodeId: "edge_abc",
   trustState: "trusted" as const,
+  customerAccountId: null,
+  customerSiteId: null,
+  scopePolicy: null,
 };
 
 function makeReq(headers: Record<string, string> = {}): NextRequest {
@@ -131,7 +134,52 @@ describe("GET /api/v1/edge/adapters — happy path", () => {
     mockFindMany.mockResolvedValue([]);
     await GET(makeReq({ Authorization: "Bearer dpfedge_xyz" }));
     const call = mockFindMany.mock.calls[0][0];
-    expect(call.where).toEqual({ collectorType: "unifi", status: "active" });
+    expect(call.where).toEqual({
+      collectorType: "unifi",
+      status: "active",
+      OR: [
+        { targetEdgeNodeId: "edgenode_cuid_1" },
+        {
+          targetEdgeNodeId: null,
+          customerAccountId: null,
+          customerSiteId: null,
+        },
+      ],
+    });
+  });
+
+  it("scopes adapter rows to the authenticated customer account and site", async () => {
+    mockResolveAuth.mockResolvedValue({
+      ...AUTHED,
+      customerAccountId: "cust_acme",
+      customerSiteId: "site_hq",
+      scopePolicy: {
+        ownershipScope: "customer-site",
+        enforcement: "strict-customer-scope",
+      },
+    });
+    mockFindMany.mockResolvedValue([]);
+
+    await GET(makeReq({ Authorization: "Bearer dpfedge_xyz" }));
+
+    const call = mockFindMany.mock.calls[0][0];
+    expect(call.where).toEqual({
+      collectorType: "unifi",
+      status: "active",
+      OR: [
+        { targetEdgeNodeId: "edgenode_cuid_1" },
+        {
+          targetEdgeNodeId: null,
+          customerAccountId: "cust_acme",
+          customerSiteId: "site_hq",
+        },
+        {
+          targetEdgeNodeId: null,
+          customerAccountId: "cust_acme",
+          customerSiteId: null,
+        },
+      ],
+    });
   });
 
   it("skips rows with missing or undecryptable keys (doesn't fail the whole request)", async () => {

--- a/apps/web/app/api/v1/edge/adapters/route.ts
+++ b/apps/web/app/api/v1/edge/adapters/route.ts
@@ -22,6 +22,49 @@ import { decryptSecret } from "@/lib/govern/credential-crypto";
 
 const ROUTE_CONTEXT = "/api/v1/edge/adapters";
 
+type AdapterScopeWhere = {
+  collectorType: "unifi";
+  status: "active";
+  OR: Array<Record<string, string | null>>;
+};
+
+function buildAdapterScopeWhere(authResult: {
+  edgeNodeRowId: string;
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+}): AdapterScopeWhere {
+  const scopedRows: AdapterScopeWhere["OR"] = [
+    { targetEdgeNodeId: authResult.edgeNodeRowId },
+  ];
+
+  if (authResult.customerAccountId) {
+    scopedRows.push({
+      targetEdgeNodeId: null,
+      customerAccountId: authResult.customerAccountId,
+      customerSiteId: authResult.customerSiteId,
+    });
+    if (authResult.customerSiteId) {
+      scopedRows.push({
+        targetEdgeNodeId: null,
+        customerAccountId: authResult.customerAccountId,
+        customerSiteId: null,
+      });
+    }
+  } else {
+    scopedRows.push({
+      targetEdgeNodeId: null,
+      customerAccountId: null,
+      customerSiteId: null,
+    });
+  }
+
+  return {
+    collectorType: "unifi",
+    status: "active",
+    OR: scopedRows,
+  };
+}
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
   const authResult = await resolveEdgeNodeAuth(
@@ -71,12 +114,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // For Phase 0 every trusted node sees every active unifi connection.
-  // BI-35de9ce8 follow-up adds targetEdgeNodeId routing; until then
-  // operators with multiple edge nodes will see duplicate work, which
-  // is observable + harmless (idempotent upserts on InventoryEntity).
+  // Scope is derived from the authenticated EdgeNode, not the request.
+  // Organization-scoped nodes keep the legacy all-null adapter path.
+  // Customer-scoped nodes receive rows targeted to that exact node plus
+  // account/site-matching rows only.
   const rows = await prisma.discoveryConnection.findMany({
-    where: { collectorType: "unifi", status: "active" },
+    where: buildAdapterScopeWhere(authResult),
     select: {
       id: true,
       connectionKey: true,

--- a/apps/web/app/api/v1/edge/discovery-runs/route.test.ts
+++ b/apps/web/app/api/v1/edge/discovery-runs/route.test.ts
@@ -42,6 +42,15 @@ const AUTHED = {
   edgeNodeRowId: "edgenode_cuid_1",
   nodeId: "edge_abc",
   trustState: "trusted" as const,
+  customerAccountId: "cust_acme",
+  customerSiteId: "site_hq",
+  scopePolicy: {
+    ownershipScope: "customer-site",
+    enforcement: "strict-customer-scope",
+    source: "bootstrap-token",
+    customerAccountId: "cust_acme",
+    customerSiteId: "site_hq",
+  },
 };
 
 // observedAt must be within the route's freshness window (+/- 24h
@@ -269,6 +278,8 @@ describe("POST /api/v1/edge/discovery-runs — happy path (persists)", () => {
     expect(input.edgeNodeId).toBe("edgenode_cuid_1");
     expect(input.nodeId).toBe("edge_abc");
     expect(input.runKey).toBe("run_a1b2c3");
+    expect(input.customerAccountId).toBe("cust_acme");
+    expect(input.customerSiteId).toBe("site_hq");
     expect(input.submittedOutput.items).toEqual([
       {
         sourceKind: "edge_node",

--- a/apps/web/app/api/v1/edge/discovery-runs/route.ts
+++ b/apps/web/app/api/v1/edge/discovery-runs/route.ts
@@ -502,6 +502,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     summary = await persistSubmittedDiscoveryRun(prisma as never, {
       edgeNodeId: authResult.edgeNodeRowId,
       nodeId: authResult.nodeId,
+      customerAccountId: authResult.customerAccountId,
+      customerSiteId: authResult.customerSiteId,
       runKey: parsed.data.runKey,
       submittedOutput,
     });

--- a/apps/web/lib/actions/edge-nodes.test.ts
+++ b/apps/web/lib/actions/edge-nodes.test.ts
@@ -146,6 +146,37 @@ describe("issueEdgeBootstrapTokenAction", () => {
     if (!result.ok) expect(result.error).toBe("invalid_input");
   });
 
+  it("rejects targetCustomerSiteId without targetCustomerAccountId", async () => {
+    const result = await issueEdgeBootstrapTokenAction({
+      targetCustomerSiteId: "site_hq",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("invalid_input");
+    expect(mockIssueBootstrapToken).not.toHaveBeenCalled();
+  });
+
+  it("forwards customer/site targets to the bootstrap issuer", async () => {
+    mockIssueBootstrapToken.mockResolvedValue({
+      tokenId: "boot_scoped",
+      plaintext: "dpfboot_scoped",
+      prefix: "dpfboot_sco",
+      expiresAt: new Date(),
+    });
+
+    await issueEdgeBootstrapTokenAction({
+      targetCustomerAccountId: "cust_acme",
+      targetCustomerSiteId: "site_hq",
+    });
+
+    expect(mockIssueBootstrapToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issuedByPrincipalId: "principal_admin_1",
+        targetCustomerAccountId: "cust_acme",
+        targetCustomerSiteId: "site_hq",
+      }),
+    );
+  });
+
   it("revalidates the admin path on success so the table re-renders", async () => {
     mockIssueBootstrapToken.mockResolvedValue({
       tokenId: "boot_1",

--- a/apps/web/lib/actions/edge-nodes.ts
+++ b/apps/web/lib/actions/edge-nodes.ts
@@ -95,6 +95,10 @@ export async function issueEdgeBootstrapTokenAction(input: {
   ttlMs?: number;
   /** Optional note for operator memory; persisted in BootstrapToken.metadata. */
   note?: string;
+  /** Optional MSP customer-account install target. */
+  targetCustomerAccountId?: string | null;
+  /** Optional MSP customer-site install target; requires account target. */
+  targetCustomerSiteId?: string | null;
 }): Promise<IssueBootstrapTokenAction> {
   const gate = await assertManagePlatform();
   if (!gate.ok) return gate;
@@ -107,12 +111,25 @@ export async function issueEdgeBootstrapTokenAction(input: {
       message: "ttlMs must be a positive number",
     };
   }
+  if (input.targetCustomerSiteId && !input.targetCustomerAccountId) {
+    return {
+      ok: false,
+      error: "invalid_input",
+      message: "targetCustomerSiteId requires targetCustomerAccountId",
+    };
+  }
   // Spec caps bootstrap TTL at 24h; the lib enforces it server-side.
 
   try {
     const result = await issueBootstrapToken({
       issuedByPrincipalId: gate.principalId,
       ...(ttlMs !== undefined ? { ttlMs } : {}),
+      ...(input.targetCustomerAccountId
+        ? { targetCustomerAccountId: input.targetCustomerAccountId }
+        : {}),
+      ...(input.targetCustomerSiteId
+        ? { targetCustomerSiteId: input.targetCustomerSiteId }
+        : {}),
     });
     revalidatePath(ADMIN_PATH);
     return {

--- a/apps/web/lib/api/__tests__/edge-metrics-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/edge-metrics-endpoints.test.ts
@@ -29,6 +29,9 @@ const VALID_AUTH = {
   edgeNodeRowId: "row-001",
   nodeId: "edge-node-001",
   trustState: "trusted" as const,
+  customerAccountId: null,
+  customerSiteId: null,
+  scopePolicy: null,
 };
 
 function validEnvelope(overrides?: Partial<{ observedAt: string; runKey: string }>) {

--- a/apps/web/lib/auth/edge-node-token.test.ts
+++ b/apps/web/lib/auth/edge-node-token.test.ts
@@ -28,6 +28,15 @@ const ACTIVE_TRUSTED_NODE = {
   lastSeenAt: new Date(),
   capabilities: ["discovery.network"],
   metadata: null,
+  customerAccountId: "cust_acme",
+  customerSiteId: "site_hq",
+  scopePolicy: {
+    ownershipScope: "customer-site",
+    enforcement: "strict-customer-scope",
+    source: "bootstrap-token",
+    customerAccountId: "cust_acme",
+    customerSiteId: "site_hq",
+  },
   tokenHash: "hashed",
   tokenPrefix: "dpfedge_xyz",
   tokenRotatedAt: new Date(),
@@ -104,6 +113,12 @@ describe("resolveEdgeNodeAuth — token resolution", () => {
       expect(r.edgeNodeRowId).toBe("edgenode_cuid_1");
       expect(r.nodeId).toBe("edge_a1b2c3");
       expect(r.trustState).toBe("trusted");
+      expect(r.customerAccountId).toBe("cust_acme");
+      expect(r.customerSiteId).toBe("site_hq");
+      expect(r.scopePolicy).toMatchObject({
+        ownershipScope: "customer-site",
+        enforcement: "strict-customer-scope",
+      });
     }
   });
 

--- a/apps/web/lib/auth/edge-node-token.ts
+++ b/apps/web/lib/auth/edge-node-token.ts
@@ -41,6 +41,12 @@ export type ResolvedEdgeNodeAuth = {
   /** EdgeNode.nodeId (the stable external identifier). */
   nodeId: string;
   trustState: "pending" | "trusted" | "quarantined" | "revoked";
+  /** Optional MSP customer-account scope approved at enrollment. */
+  customerAccountId: string | null;
+  /** Optional MSP customer-site scope approved at enrollment. */
+  customerSiteId: string | null;
+  /** Policy metadata approved at enrollment. */
+  scopePolicy: Record<string, unknown> | null;
 };
 
 export type EdgeNodeScope =
@@ -142,5 +148,8 @@ export async function resolveEdgeNodeAuth(
     edgeNodeRowId: node.id,
     nodeId: node.nodeId,
     trustState: node.trustState as ResolvedEdgeNodeAuth["trustState"],
+    customerAccountId: node.customerAccountId,
+    customerSiteId: node.customerSiteId,
+    scopePolicy: node.scopePolicy as Record<string, unknown> | null,
   };
 }

--- a/apps/web/lib/edge-node/enrollment.test.ts
+++ b/apps/web/lib/edge-node/enrollment.test.ts
@@ -106,6 +106,35 @@ describe("issueBootstrapToken", () => {
     const persistedData = tokCreate.mock.calls[0]?.[0]?.data;
     expect(persistedData?.autoApprove).toBe(true);
   });
+
+  it("persists customer/site scope onto the bootstrap token", async () => {
+    tokCreate.mockImplementation(async ({ data }: { data: { tokenHash: string; expiresAt: Date } }) => ({
+      id: "btok_cuid_scoped",
+      ...data,
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+    }));
+
+    await issueBootstrapToken({
+      issuedByPrincipalId: "principal_user_admin",
+      targetCustomerAccountId: "cust_acme",
+      targetCustomerSiteId: "site_hq",
+    });
+
+    const persistedData = tokCreate.mock.calls[0]?.[0]?.data;
+    expect(persistedData).toMatchObject({
+      targetCustomerAccountId: "cust_acme",
+      targetCustomerSiteId: "site_hq",
+      scopePolicy: {
+        ownershipScope: "customer-site",
+        enforcement: "strict-customer-scope",
+        source: "bootstrap-token",
+        customerAccountId: "cust_acme",
+        customerSiteId: "site_hq",
+      },
+    });
+  });
 });
 
 // ── enrollEdgeNode — validation paths (no transaction needed) ────────────────
@@ -594,6 +623,77 @@ describe("enrollEdgeNode — happy path", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.trustState).toBe("pending");
+  });
+
+  it("copies bootstrap customer/site scope onto the enrolled edge node", async () => {
+    tokFindUnique.mockResolvedValueOnce({
+      id: "btok_scoped",
+      tokenHash: "hash",
+      prefix: "dpfboot_scoped",
+      scope: "edge:enroll",
+      issuedAt: new Date(),
+      issuedByPrincipalId: "principal_installer",
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: null,
+      consumedByEdgeNodeId: null,
+      revokedAt: null,
+      autoApprove: true,
+      targetCustomerAccountId: "cust_acme",
+      targetCustomerSiteId: "site_hq",
+      scopePolicy: {
+        ownershipScope: "customer-site",
+        enforcement: "strict-customer-scope",
+        source: "bootstrap-token",
+        customerAccountId: "cust_acme",
+        customerSiteId: "site_hq",
+      },
+    });
+
+    let edgeNodeCreateData: Record<string, unknown> | undefined;
+    $transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        bootstrapToken: { update: vi.fn(async () => ({})) },
+        principal: { create: vi.fn(async () => ({ id: "principal_edge_scoped" })) },
+        principalAlias: { create: vi.fn(async () => ({})) },
+        edgeNode: {
+          create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+            edgeNodeCreateData = args.data;
+            return { id: "edgenode_scoped" };
+          }),
+        },
+        edgeNodeCapability: { create: vi.fn(async () => ({})) },
+      };
+      return fn(tx);
+    });
+
+    const result = await enrollEdgeNode({
+      bootstrapToken: "dpfboot_SCOPED",
+      displayName: "Scoped node",
+      platform: "linux",
+      installMode: "container-host",
+      version: "0.1.0",
+      advertisedCapabilities: ["discovery.network"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(edgeNodeCreateData).toMatchObject({
+      customerAccountId: "cust_acme",
+      customerSiteId: "site_hq",
+      scopePolicy: {
+        ownershipScope: "customer-site",
+        enforcement: "strict-customer-scope",
+        source: "bootstrap-token",
+        customerAccountId: "cust_acme",
+        customerSiteId: "site_hq",
+      },
+    });
+    expect(result.customerAccountId).toBe("cust_acme");
+    expect(result.customerSiteId).toBe("site_hq");
+    expect(result.scopePolicy).toMatchObject({
+      ownershipScope: "customer-site",
+      enforcement: "strict-customer-scope",
+    });
   });
 });
 

--- a/apps/web/lib/edge-node/enrollment.ts
+++ b/apps/web/lib/edge-node/enrollment.ts
@@ -47,6 +47,7 @@ import {
   generateNodeToken,
   hashToken,
 } from "./tokens";
+import { normalizeEdgeNodeScopeBinding } from "./scope";
 
 // ── Issuance (operator-side) ─────────────────────────────────────────────────
 
@@ -80,6 +81,12 @@ export type IssueBootstrapInput = {
    * makes remote enrollment opt-in).
    */
   autoApprove?: boolean;
+  /** Optional MSP customer-account install target. */
+  targetCustomerAccountId?: string | null;
+  /** Optional MSP customer-site install target; requires account target. */
+  targetCustomerSiteId?: string | null;
+  /** Optional policy metadata. Defaults from the customer/site target. */
+  scopePolicy?: Record<string, unknown> | null;
 };
 
 export type IssueBootstrapResult = {
@@ -103,6 +110,11 @@ export async function issueBootstrapToken(
 ): Promise<IssueBootstrapResult> {
   const { plaintext, hash, prefix } = generateBootstrapToken();
   const expiresAt = computeBootstrapExpiry(input.ttlMs);
+  const scopeBinding = normalizeEdgeNodeScopeBinding({
+    customerAccountId: input.targetCustomerAccountId,
+    customerSiteId: input.targetCustomerSiteId,
+    scopePolicy: input.scopePolicy,
+  });
 
   const row = await prisma.bootstrapToken.create({
     data: {
@@ -112,6 +124,9 @@ export async function issueBootstrapToken(
       issuedByPrincipalId: input.issuedByPrincipalId,
       expiresAt,
       autoApprove: input.autoApprove === true,
+      targetCustomerAccountId: scopeBinding.customerAccountId,
+      targetCustomerSiteId: scopeBinding.customerSiteId,
+      scopePolicy: scopeBinding.scopePolicy as never,
     },
   });
 
@@ -173,6 +188,12 @@ export type EnrollResult =
       acceptedCapabilities: Phase0Capability[];
       /** trustState at enrollment ("trusted" if auto-approved else "pending"). */
       trustState: "trusted" | "pending";
+      /** Customer-account scope copied from the consumed bootstrap token. */
+      customerAccountId: string | null;
+      /** Customer-site scope copied from the consumed bootstrap token. */
+      customerSiteId: string | null;
+      /** Policy metadata copied from the consumed bootstrap token. */
+      scopePolicy: Record<string, unknown> | null;
     }
   | {
       ok: false;
@@ -281,6 +302,11 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
   const trustState = effectiveAutoApprove ? "trusted" : "pending";
   const status = effectiveAutoApprove ? "active" : "pending";
   const now = new Date();
+  const scopeBinding = normalizeEdgeNodeScopeBinding({
+    customerAccountId: tokenRow.targetCustomerAccountId,
+    customerSiteId: tokenRow.targetCustomerSiteId,
+    scopePolicy: tokenRow.scopePolicy as Record<string, unknown> | null,
+  });
 
   // Atomic transaction: consume the bootstrap token + create the
   // Principal + alias + EdgeNode + initial capability rows. If any
@@ -347,6 +373,9 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
         tokenPrefix: nodeToken.prefix,
         tokenRotatedAt: now,
         enrolledAt: now,
+        customerAccountId: scopeBinding.customerAccountId,
+        customerSiteId: scopeBinding.customerSiteId,
+        scopePolicy: scopeBinding.scopePolicy as never,
         ...(effectiveAutoApprove
           ? { approvedAt: now, approvedByPrincipalId: tokenRow.issuedByPrincipalId }
           : {}),
@@ -385,6 +414,9 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
     sweepIntervalSec: DEFAULT_SWEEP_INTERVAL_SEC,
     acceptedCapabilities,
     trustState,
+    customerAccountId: scopeBinding.customerAccountId,
+    customerSiteId: scopeBinding.customerSiteId,
+    scopePolicy: scopeBinding.scopePolicy,
   };
 }
 

--- a/apps/web/lib/edge-node/scope.test.ts
+++ b/apps/web/lib/edge-node/scope.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEdgeNodeScopeBinding } from "./scope";
+
+describe("normalizeEdgeNodeScopeBinding", () => {
+  it("keeps organization-scoped nodes unbound", () => {
+    expect(normalizeEdgeNodeScopeBinding({})).toEqual({
+      customerAccountId: null,
+      customerSiteId: null,
+      scopePolicy: null,
+    });
+  });
+
+  it("builds strict account policy for a customer account target", () => {
+    expect(
+      normalizeEdgeNodeScopeBinding({
+        customerAccountId: "cust_acme",
+      }),
+    ).toEqual({
+      customerAccountId: "cust_acme",
+      customerSiteId: null,
+      scopePolicy: {
+        ownershipScope: "customer-account",
+        enforcement: "strict-customer-scope",
+        source: "bootstrap-token",
+        customerAccountId: "cust_acme",
+        customerSiteId: null,
+      },
+    });
+  });
+
+  it("builds strict site policy when both customer and site targets exist", () => {
+    expect(
+      normalizeEdgeNodeScopeBinding({
+        customerAccountId: "cust_acme",
+        customerSiteId: "site_hq",
+      }),
+    ).toEqual({
+      customerAccountId: "cust_acme",
+      customerSiteId: "site_hq",
+      scopePolicy: {
+        ownershipScope: "customer-site",
+        enforcement: "strict-customer-scope",
+        source: "bootstrap-token",
+        customerAccountId: "cust_acme",
+        customerSiteId: "site_hq",
+      },
+    });
+  });
+
+  it("rejects a site target without its customer account", () => {
+    expect(() =>
+      normalizeEdgeNodeScopeBinding({ customerSiteId: "site_orphan" }),
+    ).toThrow("customer-site scope requires customerAccountId");
+  });
+});

--- a/apps/web/lib/edge-node/scope.ts
+++ b/apps/web/lib/edge-node/scope.ts
@@ -1,0 +1,60 @@
+export type EdgeNodeOwnershipScope =
+  | "organization"
+  | "customer-account"
+  | "customer-site";
+
+export type EdgeNodeScopePolicy = {
+  ownershipScope: EdgeNodeOwnershipScope;
+  enforcement: "organization-scope" | "strict-customer-scope";
+  source: "bootstrap-token";
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
+};
+
+export type EdgeNodeScopeBindingInput = {
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
+  scopePolicy?: Record<string, unknown> | null;
+};
+
+export type EdgeNodeScopeBinding = {
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+  scopePolicy: Record<string, unknown> | null;
+};
+
+function defaultScopePolicy(input: {
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+}): EdgeNodeScopePolicy | null {
+  if (!input.customerAccountId && !input.customerSiteId) return null;
+
+  return {
+    ownershipScope: input.customerSiteId
+      ? "customer-site"
+      : "customer-account",
+    enforcement: "strict-customer-scope",
+    source: "bootstrap-token",
+    customerAccountId: input.customerAccountId,
+    customerSiteId: input.customerSiteId,
+  };
+}
+
+export function normalizeEdgeNodeScopeBinding(
+  input: EdgeNodeScopeBindingInput,
+): EdgeNodeScopeBinding {
+  const customerAccountId = input.customerAccountId ?? null;
+  const customerSiteId = input.customerSiteId ?? null;
+
+  if (customerSiteId && !customerAccountId) {
+    throw new Error("customer-site scope requires customerAccountId");
+  }
+
+  return {
+    customerAccountId,
+    customerSiteId,
+    scopePolicy:
+      input.scopePolicy ??
+      defaultScopePolicy({ customerAccountId, customerSiteId }),
+  };
+}

--- a/docs/superpowers/plans/2026-05-22-archetype-capability-applicability-and-msp-segmentation-plan.md
+++ b/docs/superpowers/plans/2026-05-22-archetype-capability-applicability-and-msp-segmentation-plan.md
@@ -262,6 +262,11 @@
 
 `docs/superpowers/specs/YYYY-MM-DD-edge-node-customer-site-binding-design.md`
 
+Focused follow-on created:
+
+- `docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md`
+- `docs/superpowers/plans/2026-05-22-edge-node-customer-site-binding-plan.md`
+
 Inputs for that spec (recorded here so they aren't lost):
 
 - Reference `EP-EDGE-NODE`, `EP-SITE-7C4D2B`, and `EP-CTRL-5E21A4`.

--- a/docs/superpowers/plans/2026-05-22-edge-node-customer-site-binding-plan.md
+++ b/docs/superpowers/plans/2026-05-22-edge-node-customer-site-binding-plan.md
@@ -1,0 +1,100 @@
+# Edge Node Customer Site Binding Plan
+
+**Date:** 2026-05-22
+**Status:** In progress
+**Author:** OpenAI Codex with user direction
+**Spec:** `docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md`
+
+## Implementation Principle
+
+Bind scope at the authority boundary first. The Edge Node should never self-assign a customer or site through request JSON. Every route derives customer/site context from the authenticated `EdgeNode` row.
+
+## Chunk 1: Additive Schema Foundation
+
+**Files:**
+- `packages/db/prisma/schema.prisma`
+- `packages/db/prisma/migrations/20260522160000_edge_node_customer_site_scope/migration.sql`
+- `packages/db/src/edge-node-types.test.ts`
+
+- [x] Add nullable scope fields to `BootstrapToken`, `EdgeNode`, `DiscoveryRun`, and `DiscoveryConnection`.
+- [x] Add relations back to `CustomerAccount`, `CustomerSite`, and targeted `EdgeNode`.
+- [x] Add indexes for customer account, customer site, and target Edge Node lookups.
+- [x] Keep migration additive and avoid guessing existing row scope.
+- [x] Update test fixtures for the generated Prisma shape.
+- [x] Verify migration applies cleanly against an isolated database.
+
+## Chunk 2: Scope Normalization Helper
+
+**Files:**
+- `apps/web/lib/edge-node/scope.ts`
+- `apps/web/lib/edge-node/scope.test.ts`
+
+- [x] Implement a shared normalizer for organization, customer-account, and customer-site scope.
+- [x] Require `customerAccountId` when `customerSiteId` is set.
+- [x] Generate default strict customer-scope policy metadata.
+- [x] Test organization, account, site, and invalid orphan-site cases.
+
+## Chunk 3: Bootstrap And Enrollment
+
+**Files:**
+- `apps/web/lib/edge-node/enrollment.ts`
+- `apps/web/lib/edge-node/enrollment.test.ts`
+- `apps/web/lib/actions/edge-nodes.ts`
+- `apps/web/lib/actions/edge-nodes.test.ts`
+
+- [x] Extend bootstrap issuance input with target customer account and optional site.
+- [x] Persist target scope and default policy on `BootstrapToken`.
+- [x] Copy scope from bootstrap token to `EdgeNode` during enrollment.
+- [x] Include copied scope in the enrollment response.
+- [x] Validate action input so site target requires customer account target.
+- [x] Add tests for issuance, enrollment copy, and action forwarding.
+
+## Chunk 4: Auth, Discovery, And Adapter Enforcement
+
+**Files:**
+- `apps/web/lib/auth/edge-node-token.ts`
+- `apps/web/lib/auth/edge-node-token.test.ts`
+- `apps/web/app/api/v1/edge/discovery-runs/route.ts`
+- `apps/web/app/api/v1/edge/discovery-runs/route.test.ts`
+- `packages/db/src/discovery-sync.ts`
+- `packages/db/src/persist-submitted-discovery-run.ts`
+- `packages/db/src/persist-submitted-discovery-run.test.ts`
+- `apps/web/app/api/v1/edge/adapters/route.ts`
+- `apps/web/app/api/v1/edge/adapters/route.test.ts`
+
+- [x] Expose authenticated customer/site scope from `resolveEdgeNodeAuth`.
+- [x] Persist discovery runs with customer/site scope from auth.
+- [x] Filter adapter rows by target node, customer account, and customer site before decrypting credentials.
+- [x] Preserve legacy organization-scoped adapter behavior for unscoped nodes.
+- [x] Add route and helper tests for scoped and unscoped behavior.
+
+## Chunk 5: Documentation And Handoff
+
+**Files:**
+- `docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md`
+- `docs/superpowers/plans/2026-05-22-edge-node-customer-site-binding-plan.md`
+- `docs/superpowers/plans/2026-05-22-archetype-capability-applicability-and-msp-segmentation-plan.md`
+
+- [x] Write the focused binding spec.
+- [x] Include research and benchmarking for tenant/customer/site/device patterns.
+- [x] Write this implementation plan.
+- [x] Link the prior MSP applicability handoff to this focused spec/plan.
+
+## Chunk 6: UI Follow-Up
+
+**Not in this PR.** This branch creates the platform contract. The next UI slice should:
+
+- add customer/site selectors to bootstrap-token issuance;
+- show token and node scope badges in `/platform/edge-nodes`;
+- add adapter target selectors for organization, customer account, customer site, and specific node;
+- verify the production Docker portal route only, not a separate portal instance.
+
+## Verification Gate
+
+- [x] `pnpm --filter web exec vitest run lib/edge-node/scope.test.ts lib/edge-node/enrollment.test.ts lib/auth/edge-node-token.test.ts lib/actions/edge-nodes.test.ts lib/api/__tests__/edge-metrics-endpoints.test.ts app/api/v1/edge/adapters/route.test.ts app/api/v1/edge/discovery-runs/route.test.ts`
+- [x] `pnpm exec vitest run packages/db/src/persist-submitted-discovery-run.test.ts packages/db/src/edge-node-types.test.ts`
+- [x] `pnpm --filter web typecheck`
+- [x] `pnpm --filter @dpf/db typecheck`
+- [x] `pnpm --filter @dpf/db exec prisma migrate deploy` against an isolated database
+- [x] `cd apps/web && pnpm exec next build`
+- [ ] Production Docker portal smoke on the existing `dpf-portal-1` only if UI or runtime route exercise is needed.

--- a/docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md
+++ b/docs/superpowers/specs/2026-05-22-edge-node-customer-site-binding-design.md
@@ -1,0 +1,194 @@
+# Edge Node Customer Site Binding Design
+
+**Date:** 2026-05-22
+**Status:** Draft
+**Author:** OpenAI Codex with user direction
+**Related archetype:** `it-managed-services`
+**Related docs:**
+- `docs/superpowers/specs/2026-05-22-archetype-capability-applicability-and-msp-segmentation-design.md`
+- `docs/superpowers/plans/2026-05-22-archetype-capability-applicability-and-msp-segmentation-plan.md`
+- `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`
+- `docs/superpowers/specs/2026-05-19-edge-node-network-telemetry-adapters-design.md`
+- `docs/superpowers/specs/2026-04-23-it-service-provider-msp-archetype-design.md`
+
+## 1. Problem Statement
+
+The MSP archetype needs Edge Nodes that can be installed inside a managed customer's environment without mixing that customer's inventory, adapter credentials, discovery runs, or operational evidence with another customer.
+
+The platform already has `CustomerAccount`, `CustomerSite`, `CustomerConfigurationItem`, `EdgeNode`, `DiscoveryRun`, and `DiscoveryConnection`. The missing boundary is the install-time authority binding: an Edge Node should learn its customer/site scope from an authority-issued bootstrap token, then every runtime path should derive customer scope from the authenticated node record.
+
+This is not a TeamLogic-only customization. TeamLogic IT is the first target customer informing the work, but the pattern belongs to the MSP archetype and to any future archetype that manages multiple customer estates.
+
+## 2. Goals
+
+- Bind bootstrap tokens to a target `CustomerAccount` and optional `CustomerSite`.
+- Copy that binding onto `EdgeNode` during enrollment.
+- Expose the authenticated node scope through `resolveEdgeNodeAuth`.
+- Persist discovery submissions with the authenticated customer/site scope.
+- Filter edge adapter credentials by authenticated node, customer account, and customer site.
+- Preserve organization-scoped Edge Nodes for non-MSP and platform-local installs.
+- Keep customer and site IDs out of untrusted Edge Node request bodies.
+
+## 3. Non-Goals
+
+- No customer-site selector UI in this first slice.
+- No remote support consent workflow in this first slice.
+- No migration of existing unscoped adapter rows into customer/site rows.
+- No attempt to model the whole customer estate lifecycle here; the existing customer-estate and site specs remain authoritative for that layer.
+
+## 4. Current State
+
+`EdgeNode` currently authenticates by bearer token and exposes `edgeNodeRowId`, `nodeId`, and `trustState` to edge routes. Discovery submissions already thread `edgeNodeId` into `DiscoveryRun`, and adapter polling reads active `DiscoveryConnection` rows.
+
+However, the current schema has no `EdgeNode.customerAccountId`, no customer/site target on `BootstrapToken`, no customer/site fields on `DiscoveryRun`, and no customer/site or target-node filter on `DiscoveryConnection`. That means a future MSP install could authenticate the node but still lack a durable customer estate boundary.
+
+## 5. Research & Benchmarking
+
+### 5.1 NetBox
+
+NetBox uses tenancy to associate core infrastructure objects with owners or dependencies. Its docs explicitly call out MSPs representing each customer as a tenant, and list tenant-assignable objects such as sites, devices, prefixes, IP addresses, VLANs, circuits, clusters, and virtual machines.
+
+Source: https://netbox.readthedocs.io/en/stable/features/tenancy/
+
+Adopted pattern: customer ownership should be a first-class relation on infrastructure records, not a label in raw metadata.
+
+Rejected pattern: assigning every shared object to a customer. NetBox notes that shared infrastructure may not belong to one tenant; DPF keeps organization-scoped Edge Nodes and global adapter rows for that reason.
+
+### 5.2 NinjaOne
+
+NinjaOne models organizations as the customer or department shell, locations as subdivisions under an organization, and devices as assigned into an organization/location. Its installer flow can deploy devices directly into the selected organization and location, and policies may apply at organization, location, or device levels.
+
+Sources:
+- https://www.ninjaone.com/docs/endpoint-management/hardware-inventory/organizations-and-locations/
+- https://www.ninjaone.com/docs/policies-and-conditions/ninjaone-policies/
+
+Adopted pattern: installation intent should carry the customer/location target so the agent lands in the correct scope at enrollment.
+
+Rejected pattern: letting the endpoint self-assert its organization. DPF binds scope through the bootstrap token issued by the authority.
+
+### 5.3 GLPI
+
+GLPI entities isolate assets, users, profiles, assistance records, and permissions inside one installation. Its documentation describes entity segmentation for isolating client assets and limiting asset visibility.
+
+Source: https://help.glpi-project.org/documentation/modules/administration/entities
+
+Adopted pattern: customer isolation has to affect visibility and operational records, not only inventory rows.
+
+Rejected pattern: using a single hierarchy for every type of grouping. DPF keeps `CustomerAccount`, `CustomerSite`, and Edge Node scope separate from generic tags and groups.
+
+### 5.4 Snipe-IT
+
+Snipe-IT supports company-scoped visibility and company-restricted locations for asset management. Its asset overview also distinguishes assets checked out to people, locations, or other assets.
+
+Sources:
+- https://snipe-it.readme.io/docs/general-settings
+- https://snipe-it.readme.io/docs/overview
+
+Adopted pattern: location matters, but location should not replace the accountable customer.
+
+Rejected pattern: treating a location as the responsible owner. DPF requires `customerAccountId` when `customerSiteId` is set.
+
+### 5.5 ConnectWise PSA
+
+ConnectWise PSA configurations are company-associated records for hardware, managed services, renewals, rentals, spam statistics, and other tracked operational items. Some configurations may also carry a location/business unit filter.
+
+Source: https://docs.connectwise.com/ConnectWise_Documentation/015/010/015/150
+
+Adopted pattern: customer-associated configuration items should be the downstream destination for discovery and adapter evidence.
+
+Rejected pattern: storing everything directly as PSA-style configurations. DPF keeps discovery evidence and normalized customer CIs separate so automation can improve confidence before publishing customer-facing estate records.
+
+## 6. Target Model
+
+### 6.1 Scope fields
+
+Add nullable customer/site fields where scope is needed:
+
+- `BootstrapToken.targetCustomerAccountId`
+- `BootstrapToken.targetCustomerSiteId`
+- `BootstrapToken.scopePolicy`
+- `EdgeNode.customerAccountId`
+- `EdgeNode.customerSiteId`
+- `EdgeNode.scopePolicy`
+- `DiscoveryRun.customerAccountId`
+- `DiscoveryRun.customerSiteId`
+- `DiscoveryConnection.customerAccountId`
+- `DiscoveryConnection.customerSiteId`
+- `DiscoveryConnection.targetEdgeNodeId`
+
+Null customer/site scope means organization-scoped, not "unknown customer." If `customerSiteId` is present, `customerAccountId` must be present.
+
+### 6.2 Enrollment contract
+
+Bootstrap token issuance accepts customer/site target fields from the trusted operator/admin surface. Enrollment never accepts customer/site IDs from the Edge Node request body.
+
+During enrollment:
+
+1. The node presents a `dpfboot_*` bootstrap token.
+2. The authority loads the bootstrap token row.
+3. The authority derives normalized scope from the token's target customer/site fields.
+4. The transaction creates the Edge Node with that scope.
+5. The enrollment response includes the copied scope for local agent state, but server enforcement remains tied to the stored Edge Node row.
+
+### 6.3 Runtime contract
+
+`resolveEdgeNodeAuth` returns:
+
+- `edgeNodeRowId`
+- `nodeId`
+- `trustState`
+- `customerAccountId`
+- `customerSiteId`
+- `scopePolicy`
+
+Routes derive tenant context from that object. Customer/site IDs in edge-submitted JSON are ignored or rejected in later slices.
+
+### 6.4 Adapter selection
+
+`GET /api/v1/edge/adapters` should return:
+
+- rows targeted directly to the authenticated `targetEdgeNodeId`;
+- for customer-scoped nodes, rows matching the node's customer account and exact site;
+- for site-scoped nodes, account-wide rows with `customerSiteId = null`;
+- for organization-scoped nodes, legacy global rows with all scope columns null.
+
+This lets an MSP issue one adapter credential to a specific customer site, an account-wide credential to all customer sites, or a node-specific credential for exceptional cases.
+
+## 7. Security And Governance
+
+- The trusted boundary is bootstrap issuance, not Edge Node request data.
+- Scope must be copied inside the enrollment transaction so token consumption and node creation cannot disagree.
+- Adapter credential access is filtered before decryption.
+- Discovery submissions persist customer/site scope from auth, not from submitted payload.
+- Future remote-control work must add customer consent and operator authority checks before any remote support action can run against a scoped node.
+
+## 8. Migration Approach
+
+The first migration is additive:
+
+- add nullable fields;
+- add indexes;
+- add foreign keys with `ON DELETE SET NULL`;
+- add check constraints so site scope cannot exist without account scope;
+- avoid backfilling existing rows into guessed customer/site scopes.
+
+Existing Edge Nodes, bootstrap tokens, discovery runs, and adapter connections stay organization-scoped until an operator or migration workflow explicitly assigns scope.
+
+## 9. UX Direction
+
+The first UI slice should be in `/platform/edge-nodes` and customer-estate context pages:
+
+- issue bootstrap token with optional customer and site selectors;
+- show a compact scope badge for each token and node;
+- show organization-scoped, customer-scoped, and site-scoped states without explanatory clutter;
+- keep all colors theme-token based;
+- make customer/site scope read-only after enrollment unless a governed rebind workflow exists.
+
+## 10. Open Follow-Ups
+
+- Customer/site selector UI for token issuance.
+- Adapter management UI for customer/site/node targeting.
+- Customer-estate projection from scoped discovery into `CustomerConfigurationItem`.
+- Remote support consent and authority for scoped nodes.
+- Policy inheritance for organization, customer account, customer site, and node.
+- Operational reports by customer/site, including backup, security, endpoint, and network posture.

--- a/packages/db/prisma/migrations/20260522160000_edge_node_customer_site_scope/migration.sql
+++ b/packages/db/prisma/migrations/20260522160000_edge_node_customer_site_scope/migration.sql
@@ -1,0 +1,86 @@
+-- Bind Edge Nodes, bootstrap tokens, adapter connections, and submitted
+-- discovery runs to customer-estate scope. All fields are nullable so
+-- existing organization-scoped installs continue to operate unchanged.
+
+ALTER TABLE "EdgeNode"
+  ADD COLUMN "customerAccountId" TEXT,
+  ADD COLUMN "customerSiteId" TEXT,
+  ADD COLUMN "scopePolicy" JSONB;
+
+ALTER TABLE "BootstrapToken"
+  ADD COLUMN "targetCustomerAccountId" TEXT,
+  ADD COLUMN "targetCustomerSiteId" TEXT,
+  ADD COLUMN "scopePolicy" JSONB;
+
+ALTER TABLE "DiscoveryRun"
+  ADD COLUMN "customerAccountId" TEXT,
+  ADD COLUMN "customerSiteId" TEXT;
+
+ALTER TABLE "DiscoveryConnection"
+  ADD COLUMN "customerAccountId" TEXT,
+  ADD COLUMN "customerSiteId" TEXT,
+  ADD COLUMN "targetEdgeNodeId" TEXT;
+
+ALTER TABLE "EdgeNode"
+  ADD CONSTRAINT "EdgeNode_customerAccountId_fkey"
+    FOREIGN KEY ("customerAccountId") REFERENCES "CustomerAccount"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "EdgeNode_customerSiteId_fkey"
+    FOREIGN KEY ("customerSiteId") REFERENCES "CustomerSite"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "BootstrapToken"
+  ADD CONSTRAINT "BootstrapToken_targetCustomerAccountId_fkey"
+    FOREIGN KEY ("targetCustomerAccountId") REFERENCES "CustomerAccount"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "BootstrapToken_targetCustomerSiteId_fkey"
+    FOREIGN KEY ("targetCustomerSiteId") REFERENCES "CustomerSite"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DiscoveryRun"
+  ADD CONSTRAINT "DiscoveryRun_customerAccountId_fkey"
+    FOREIGN KEY ("customerAccountId") REFERENCES "CustomerAccount"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DiscoveryRun_customerSiteId_fkey"
+    FOREIGN KEY ("customerSiteId") REFERENCES "CustomerSite"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DiscoveryConnection"
+  ADD CONSTRAINT "DiscoveryConnection_customerAccountId_fkey"
+    FOREIGN KEY ("customerAccountId") REFERENCES "CustomerAccount"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DiscoveryConnection_customerSiteId_fkey"
+    FOREIGN KEY ("customerSiteId") REFERENCES "CustomerSite"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DiscoveryConnection_targetEdgeNodeId_fkey"
+    FOREIGN KEY ("targetEdgeNodeId") REFERENCES "EdgeNode"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EdgeNode"
+  ADD CONSTRAINT "EdgeNode_customer_site_requires_account"
+    CHECK ("customerSiteId" IS NULL OR "customerAccountId" IS NOT NULL);
+
+ALTER TABLE "BootstrapToken"
+  ADD CONSTRAINT "BootstrapToken_target_site_requires_account"
+    CHECK ("targetCustomerSiteId" IS NULL OR "targetCustomerAccountId" IS NOT NULL);
+
+ALTER TABLE "DiscoveryRun"
+  ADD CONSTRAINT "DiscoveryRun_customer_site_requires_account"
+    CHECK ("customerSiteId" IS NULL OR "customerAccountId" IS NOT NULL);
+
+ALTER TABLE "DiscoveryConnection"
+  ADD CONSTRAINT "DiscoveryConnection_customer_site_requires_account"
+    CHECK ("customerSiteId" IS NULL OR "customerAccountId" IS NOT NULL);
+
+CREATE INDEX "EdgeNode_customerAccountId_idx" ON "EdgeNode"("customerAccountId");
+CREATE INDEX "EdgeNode_customerSiteId_idx" ON "EdgeNode"("customerSiteId");
+
+CREATE INDEX "BootstrapToken_targetCustomerAccountId_idx" ON "BootstrapToken"("targetCustomerAccountId");
+CREATE INDEX "BootstrapToken_targetCustomerSiteId_idx" ON "BootstrapToken"("targetCustomerSiteId");
+
+CREATE INDEX "DiscoveryRun_customerAccountId_idx" ON "DiscoveryRun"("customerAccountId");
+CREATE INDEX "DiscoveryRun_customerSiteId_idx" ON "DiscoveryRun"("customerSiteId");
+
+CREATE INDEX "DiscoveryConnection_customerAccountId_idx" ON "DiscoveryConnection"("customerAccountId");
+CREATE INDEX "DiscoveryConnection_customerSiteId_idx" ON "DiscoveryConnection"("customerSiteId");
+CREATE INDEX "DiscoveryConnection_targetEdgeNodeId_idx" ON "DiscoveryConnection"("targetEdgeNodeId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2085,6 +2085,10 @@ model CustomerAccount {
   contactRoles       ContactAccountRole[]
   customerSites      CustomerSite[]
   configurationItems CustomerConfigurationItem[]
+  edgeNodes          EdgeNode[]
+  edgeBootstrapTokens BootstrapToken[]
+  discoveryRuns      DiscoveryRun[]
+  discoveryConnections DiscoveryConnection[]
   parentAccount      CustomerAccount?            @relation("AccountHierarchy", fields: [parentAccountId], references: [id])
   childAccounts      CustomerAccount[]           @relation("AccountHierarchy")
   invoices           Invoice[]
@@ -2117,6 +2121,10 @@ model CustomerSite {
   primaryAddress     Address?                    @relation(fields: [primaryAddressId], references: [id])
   configurationItems CustomerConfigurationItem[]
   nodes              CustomerSiteNode[]
+  edgeNodes          EdgeNode[]
+  edgeBootstrapTokens BootstrapToken[]
+  discoveryRuns      DiscoveryRun[]
+  discoveryConnections DiscoveryConnection[]
 
   @@index([accountId])
   @@index([primaryAddressId])
@@ -3166,15 +3174,21 @@ model DiscoveryRun {
   // /api/v1/edge/discovery-runs and routed through
   // persistSubmittedDiscoveryRun.
   edgeNodeId              String?
+  customerAccountId       String?
+  customerSiteId          String?
   discoveredItems         DiscoveredItem[]
   discoveredRelations     DiscoveredRelationship[]
   fingerprintObservations DiscoveryFingerprintObservation[]
   confirmedEntities       InventoryEntity[]                 @relation("InventoryEntityConfirmedRun")
   confirmedRelations      InventoryRelationship[]           @relation("InventoryRelationshipConfirmedRun")
   edgeNode                EdgeNode?                         @relation("EdgeNodeDiscoveryRuns", fields: [edgeNodeId], references: [id])
+  customerAccount         CustomerAccount?                   @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
+  customerSite            CustomerSite?                      @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
 
   @@unique([edgeNodeId, runKey])
   @@index([edgeNodeId])
+  @@index([customerAccountId])
+  @@index([customerSiteId])
 }
 
 model DiscoveredItem {
@@ -8030,13 +8044,22 @@ model DiscoveryConnection {
   lastTestStatus    String? // ok | auth_failed | unreachable | tls_error
   lastTestMessage   String?
   gatewayEntityId   String? // FK to the InventoryEntity that triggered this connection
+  customerAccountId String?
+  customerSiteId    String?
+  targetEdgeNodeId  String?
   gatewayEntity     InventoryEntity?  @relation("DiscoveryConnectionGateway", fields: [gatewayEntityId], references: [id])
+  customerAccount   CustomerAccount?  @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
+  customerSite      CustomerSite?     @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
+  targetEdgeNode    EdgeNode?         @relation("EdgeNodeTargetedDiscoveryConnections", fields: [targetEdgeNodeId], references: [id], onDelete: SetNull)
   inventoryEntities InventoryEntity[] @relation("DiscoveredViaConnection")
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 
   @@index([collectorType])
   @@index([status])
+  @@index([customerAccountId])
+  @@index([customerSiteId])
+  @@index([targetEdgeNodeId])
 }
 
 // ---- Collaborative Work Queue (EP-CWQ-001) ----
@@ -8688,6 +8711,9 @@ model EdgeNode {
   // Hostname / IP intentionally not first-class fields per Wazuh-IP-as-key
   // anti-pattern (R&B section).
   metadata     Json?
+  customerAccountId String?
+  customerSiteId    String?
+  scopePolicy       Json?
 
   // ── Auth (per spec § Token namespaces and lifecycle) ─────────────
   // dpfedge_* node token, hashed at rest (mirrors McpApiToken pattern).
@@ -8721,8 +8747,11 @@ model EdgeNode {
   // Relations
   principal      Principal            @relation("EdgeNodeIdentity", fields: [principalId], references: [id], onDelete: Cascade)
   approvedBy     Principal?           @relation("EdgeNodeApprover", fields: [approvedByPrincipalId], references: [id])
+  customerAccount CustomerAccount?     @relation(fields: [customerAccountId], references: [id], onDelete: SetNull)
+  customerSite    CustomerSite?        @relation(fields: [customerSiteId], references: [id], onDelete: SetNull)
   capabilityRows EdgeNodeCapability[]
   discoveryRuns  DiscoveryRun[]       @relation("EdgeNodeDiscoveryRuns")
+  targetedDiscoveryConnections DiscoveryConnection[] @relation("EdgeNodeTargetedDiscoveryConnections")
   consumedTokens BootstrapToken[]     @relation("BootstrapTokenConsumer")
   events         EdgeEvent[]          @relation("EdgeNodeEvents")
   changes        ChangeEvent[]        @relation("EdgeNodeChanges")
@@ -8731,6 +8760,8 @@ model EdgeNode {
   @@index([status])
   @@index([tokenHash])
   @@index([lastSeenAt])
+  @@index([customerAccountId])
+  @@index([customerSiteId])
 }
 
 model BootstrapToken {
@@ -8775,14 +8806,21 @@ model BootstrapToken {
   // with host access already, so a flag carrying that intent is no
   // weaker than the install path itself).
   autoApprove Boolean @default(false)
+  targetCustomerAccountId String?
+  targetCustomerSiteId    String?
+  scopePolicy             Json?
 
   // Relations
-  issuedBy           Principal @relation("BootstrapTokenIssuer", fields: [issuedByPrincipalId], references: [id])
-  consumedByEdgeNode EdgeNode? @relation("BootstrapTokenConsumer", fields: [consumedByEdgeNodeId], references: [id])
+  issuedBy              Principal        @relation("BootstrapTokenIssuer", fields: [issuedByPrincipalId], references: [id])
+  consumedByEdgeNode    EdgeNode?        @relation("BootstrapTokenConsumer", fields: [consumedByEdgeNodeId], references: [id])
+  targetCustomerAccount CustomerAccount? @relation(fields: [targetCustomerAccountId], references: [id], onDelete: SetNull)
+  targetCustomerSite    CustomerSite?    @relation(fields: [targetCustomerSiteId], references: [id], onDelete: SetNull)
 
   @@index([tokenHash])
   @@index([expiresAt])
   @@index([consumedAt])
+  @@index([targetCustomerAccountId])
+  @@index([targetCustomerSiteId])
 }
 
 model EdgeNodeCapability {

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -27,6 +27,10 @@ type DiscoveryRunMeta = {
   // DiscoveryRun row carries this through so consumers can attribute
   // observations back to a specific agent.
   edgeNodeId?: string | null;
+  // Customer-estate scope derived server-side from the authenticated
+  // EdgeNode, never from an edge request body.
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
 };
 
 export type DiscoveryProjectionOptions = {
@@ -46,6 +50,8 @@ type DiscoverySyncTx = {
         itemCount: number;
         relationshipCount: number;
         edgeNodeId?: string | null;
+        customerAccountId?: string | null;
+        customerSiteId?: string | null;
       };
       select: { id: true };
     }): Promise<{ id: string }>;
@@ -205,6 +211,12 @@ export async function persistBootstrapDiscoveryRun(
         // column default (null) takes effect.
         ...(runMeta.edgeNodeId !== undefined
           ? { edgeNodeId: runMeta.edgeNodeId }
+          : {}),
+        ...(runMeta.customerAccountId !== undefined
+          ? { customerAccountId: runMeta.customerAccountId }
+          : {}),
+        ...(runMeta.customerSiteId !== undefined
+          ? { customerSiteId: runMeta.customerSiteId }
           : {}),
       },
       select: { id: true },

--- a/packages/db/src/edge-node-types.test.ts
+++ b/packages/db/src/edge-node-types.test.ts
@@ -42,6 +42,9 @@ function makeNode(overrides: Partial<EdgeNode> = {}): EdgeNode {
     lastSeenAt: null,
     capabilities: ["discovery.network"],
     metadata: null,
+    customerAccountId: null,
+    customerSiteId: null,
+    scopePolicy: null,
     tokenHash: null,
     tokenPrefix: null,
     tokenRotatedAt: null,
@@ -71,6 +74,9 @@ function makeToken(overrides: Partial<BootstrapToken> = {}): BootstrapToken {
     consumedAt: null,
     consumedByEdgeNodeId: null,
     revokedAt: null,
+    targetCustomerAccountId: null,
+    targetCustomerSiteId: null,
+    scopePolicy: null,
     // Paste-provisioned default per spec § Approval policy. Tests that
     // care about the auto-approve path override via `overrides`.
     autoApprove: false,

--- a/packages/db/src/load-env.ts
+++ b/packages/db/src/load-env.ts
@@ -43,7 +43,6 @@ export function loadDbEnv(options?: {
     const result = loadDotenv({
       path: envPath,
       override: false,
-      quiet: true,
     });
 
     if (!result.error) {

--- a/packages/db/src/persist-submitted-discovery-run.test.ts
+++ b/packages/db/src/persist-submitted-discovery-run.test.ts
@@ -62,13 +62,15 @@ beforeEach(() => {
 });
 
 describe("persistSubmittedDiscoveryRun", () => {
-  it("threads edgeNodeId through to persistBootstrapDiscoveryRun's runMeta", async () => {
+  it("threads edgeNodeId and customer scope through to persistBootstrapDiscoveryRun's runMeta", async () => {
     persistMock.mockResolvedValueOnce(summary);
 
     const result = await persistSubmittedDiscoveryRun(fakeDb, {
       edgeNodeId: "edgenode_cuid_42",
       nodeId: "edge_a1b2c3",
       runKey: "run_idempotent_42",
+      customerAccountId: "cust_acme",
+      customerSiteId: "site_hq",
       submittedOutput: sampleOutput,
     });
 
@@ -92,6 +94,8 @@ describe("persistSubmittedDiscoveryRun", () => {
       trigger: "edge_node",
       status: "completed",
       edgeNodeId: "edgenode_cuid_42",
+      customerAccountId: "cust_acme",
+      customerSiteId: "site_hq",
     });
   });
 

--- a/packages/db/src/persist-submitted-discovery-run.ts
+++ b/packages/db/src/persist-submitted-discovery-run.ts
@@ -32,6 +32,10 @@ export type SubmittedDiscoveryRunInput = {
   edgeNodeId: string;
   /** Stable nodeId (used in sourceSlug for human-readable provenance). */
   nodeId: string;
+  /** Customer account scope derived from the authenticated EdgeNode. */
+  customerAccountId?: string | null;
+  /** Customer site scope derived from the authenticated EdgeNode. */
+  customerSiteId?: string | null;
   /** Agent-supplied idempotency key. Becomes DiscoveryRun.runKey. */
   runKey: string;
   /** Agent-supplied envelope (CollectorOutput shape). */
@@ -73,6 +77,8 @@ export async function persistSubmittedDiscoveryRun(
       trigger: SUBMITTED_TRIGGER,
       status: "completed",
       edgeNodeId: input.edgeNodeId,
+      customerAccountId: input.customerAccountId ?? null,
+      customerSiteId: input.customerSiteId ?? null,
     },
     options,
   );


### PR DESCRIPTION
## Summary
- Adds customer-account and customer-site scope to Edge Node bootstrap tokens, enrolled Edge Nodes, submitted discovery runs, and discovery adapter connections.
- Derives runtime scope from the authority-issued bootstrap token and authenticated Edge Node row, not from Edge Node request bodies.
- Filters adapter credentials by target node/customer/site before decryption and persists discovery submissions with authenticated customer scope.
- Adds the focused Edge Node customer/site binding spec and plan, linked from the MSP applicability handoff.

## Why
MSP customers each have their own IT estate. An Edge Node installed inside one customer or site needs a durable authority-bound scope so inventory, monitoring, adapter credentials, and later support workflows do not bleed across customer boundaries.

## Validation
- `pnpm --filter web exec vitest run lib/edge-node/scope.test.ts lib/edge-node/enrollment.test.ts lib/auth/edge-node-token.test.ts lib/actions/edge-nodes.test.ts lib/api/__tests__/edge-metrics-endpoints.test.ts app/api/v1/edge/adapters/route.test.ts app/api/v1/edge/discovery-runs/route.test.ts` -> 7 files, 141 tests passed.
- `pnpm exec vitest run packages/db/src/persist-submitted-discovery-run.test.ts packages/db/src/edge-node-types.test.ts` -> 2 files, 31 tests passed.
- `pnpm --filter web typecheck` -> passed.
- `pnpm --filter @dpf/db typecheck` -> passed.
- `cd apps/web && pnpm exec next build` -> passed; existing Turbopack NFT tracing warning remains in `apps/web/next.config.mjs` via `app/api/voice/synthesize/route.ts`.
- `pnpm --filter @dpf/db exec prisma migrate deploy` against isolated `dpf-dev-postgres-1` temp DB -> all migrations applied, temp DB dropped.