### PR TITLE
fix(security): close 2 HIGH reflected-XSS alerts in sandbox/preview route

### DIFF
--- a/apps/web/app/api/sandbox/preview/route.ts
+++ b/apps/web/app/api/sandbox/preview/route.ts
@@ -14,6 +14,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!buildId) {
     return NextResponse.json({ error: "buildId required" }, { status: 400 });
   }
+  // CodeQL #30, #31 (js/reflected-xss): buildId is interpolated into
+  // both an inline <script> block and an HTML status page. Validate
+  // the format up front so only the documented FB-XXXXXXXX shape (or
+  // legacy alphanumeric IDs) is accepted. Anything else returns 400
+  // before ever reaching the HTML response.
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(buildId)) {
+    return NextResponse.json({ error: "buildId malformed" }, { status: 400 });
+  }
 
   const build = await prisma.featureBuild.findUnique({
     where: { buildId },
@@ -55,9 +63,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
       // Script intercepts clicks on <a> tags and client-side navigation,
       // rewriting them to go through the proxy endpoint.
+      // Defense-in-depth: even with the regex validation above, escape
+      // `</` to `<\/` so a JSON-encoded buildId containing `</script>`
+      // can't break out of the script tag. Recognised CodeQL sanitizer
+      // pattern for js/reflected-xss in inline scripts.
+      const safeBidJson = JSON.stringify(buildId).replace(/</g, "\\u003c");
       const navScript = `<script data-sandbox-nav>
 (function(){
-  var bid = ${JSON.stringify(buildId)};
+  var bid = ${safeBidJson};
   var proxyBase = "/api/sandbox/preview?buildId=" + encodeURIComponent(bid) + "&path=";
   var blocked = ["/build", "/platform"];
 
@@ -131,7 +144,7 @@ h2{color:#7c8cf8;margin:0 0 8px}p{font-size:13px;color:#888;line-height:1.5}
 <body><div class="card">
 <div class="spinner"></div>
 <h2>Sandbox Active</h2>
-<p>Build: ${buildId}</p>
+<p>Build: ${buildId.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!)}</p>
 <p>The sandbox environment is running. Code is being generated — the preview will update automatically when the dev server starts.</p>
 </div></body></html>`;
     return new NextResponse(statusHtml, {


### PR DESCRIPTION
## Summary

Closes 2 HIGH `js/reflected-xss` alerts in `apps/web/app/api/sandbox/preview/route.ts`. Both traced to `buildId` from `request.nextUrl.searchParams` flowing unescaped into HTML responses.

| Alert | Line | Vector |
|---|---|---|
| #30 | 60 | `\${JSON.stringify(buildId)}` inside `<script>` — literal `</script>` in the JSON value breaks out of the tag |
| #31 | 134 | `<p>Build: \${buildId}</p>` — raw HTML interpolation |

## Three defenses (defense in depth)

1. **Format validation at function entry** — `buildId` must match `/^[A-Za-z0-9_-]{1,64}$/` (the actual shape of every buildId, e.g. `FB-F8528BF6`). Malformed values return 400 before the HTML response is built.
2. **Script-context escape** — `</` → `<\u003c` so JSON-stringified buildId can't break out of the script tag (CodeQL-recognised js/reflected-xss sanitizer).
3. **HTML escape on the status page** — inline 5-char escape for `&<>\"'`.

#1 alone is sufficient defense; #2 and #3 are defense-in-depth so future relaxation of the validation doesn't silently re-open the XSS.

## Test plan

- [ ] CI green
- [ ] CodeQL re-scan closes #30 and #31
- [ ] Manual smoke: legitimate buildId (`FB-F8528BF6`) still renders sandbox preview
- [ ] Malicious buildId (`</script><script>alert(1)</script>`) returns 400 with the new regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)