### PR TITLE
fix(security): close 3 HIGH ReDoS alerts (prompt-loader + agent-form-assist + hostname)

### DIFF
--- a/apps/web/lib/tak/agent-form-assist.ts
+++ b/apps/web/lib/tak/agent-form-assist.ts
@@ -90,7 +90,10 @@ export function extractFormAssistResult(
   content: string,
   context: AgentFormAssistContext,
 ): ExtractedAssist {
-  const blockMatch = content.match(/```agent-form\s*([\s\S]*?)```/i);
+  // CodeQL #22 (js/polynomial-redos): cap the block content at 50k chars
+  // so adversarial input with many `\`\`\`agent-form` markers can't trigger
+  // exponential backtracking.
+  const blockMatch = content.match(/```agent-form\s*([\s\S]{0,50000}?)```/i);
   if (!blockMatch) {
     return {
       displayContent: content.trim(),

--- a/apps/web/lib/tak/prompt-loader.ts
+++ b/apps/web/lib/tak/prompt-loader.ts
@@ -147,7 +147,10 @@ export function invalidatePromptCache(category?: string, slug?: string): void {
 function resolveIncludes(content: string, composesFrom: string[], depth = 0): string {
   if (depth > 3 || !content.includes("{{include:")) return content;
 
-  return content.replace(/\{\{include:([^}]+)\}\}/g, (_match, ref: string) => {
+  // CodeQL #24 (js/polynomial-redos): cap the include-ref length at 200
+  // so backtracking is bounded for malformed user input like `{{include:`
+  // followed by many `{{include:|` repetitions.
+  return content.replace(/\{\{include:([^}]{1,200})\}\}/g, (_match, ref: string) => {
     const [cat, sl] = ref.split("/");
     if (!cat || !sl) return _match;
 

--- a/packages/db/src/discovery-fingerprint-redaction.ts
+++ b/packages/db/src/discovery-fingerprint-redaction.ts
@@ -3,8 +3,12 @@ import type { FingerprintRedactionResult, RedactionStatus } from "./discovery-fi
 const IPV4_PATTERN =
   /\b(?:(?:10)|(?:127)|(?:172\.(?:1[6-9]|2\d|3[0-1]))|(?:192\.168))\.(?:\d{1,3}\.){1,2}\d{1,3}\b/g;
 const MAC_PATTERN = /\b[0-9a-f]{2}(?::[0-9a-f]{2}){5}\b/gi;
+// CodeQL #29 (js/redos): previous `[a-z0-9][a-z0-9-]*(?:-[a-z0-9][a-z0-9-]*)*`
+// had overlapping quantifiers; strings of many `-0` could backtrack
+// exponentially. RFC 1035 caps a hostname segment at 63 chars, so a single
+// bounded `[a-z0-9-]{0,62}` segment is both spec-correct and ReDoS-safe.
 const INTERNAL_HOSTNAME_PATTERN =
-  /\b[a-z0-9][a-z0-9-]*(?:-[a-z0-9][a-z0-9-]*)*\.(?:internal|corp|local|lan|home|intranet)(?:\.[a-z0-9.-]+)?\b/gi;
+  /\b[a-z0-9][a-z0-9-]{0,62}\.(?:internal|corp|local|lan|home|intranet)(?:\.[a-z0-9-]{1,63}){0,4}\b/gi;
 const SERIAL_PATTERN = /\b(?:serial|sn|service tag)\s*[:#-]?\s*[a-z0-9-]+\b/gi;
 const SECRET_PATTERN = /\b(?:authorization:\s*bearer|api[_-]?key|access[_-]?token|secret|password)\b/i;
 


### PR DESCRIPTION
## Summary

3 HIGH ReDoS alerts closed by bounding regex backtracking.

| Alert | File | Fix |
|---|---|---|
| #24 `js/polynomial-redos` | `prompt-loader.ts:150` | Cap include-ref at 200 chars (`[^}]{1,200}`) |
| #22 `js/polynomial-redos` | `agent-form-assist.ts:93` | Cap inner content at 50k chars (`[\s\S]{0,50000}?`) |
| #29 `js/redos` | `discovery-fingerprint-redaction.ts:7` | Rewrote hostname pattern to single bounded RFC 1035-compliant segment — no overlapping quantifiers |

Each preserves match semantics for legitimate input; only bounds worst-case backtracking on adversarial input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)