### PR TITLE
fix(build-studio): guard undefined fileStructure on /build page

### DIFF
--- a/apps/web/lib/build/process-graph-builder.ts
+++ b/apps/web/lib/build/process-graph-builder.ts
@@ -411,7 +411,10 @@ export function buildTaskGraph(
     return { nodes: [], edges: [] };
   }
 
-  const execPhases = buildDependencyGraph(fileStructure, tasks);
+  // `fileStructure` is typed required on BuildPlanDoc but lives in a Prisma
+  // JSON column with no runtime shape enforcement; guard so a partial plan
+  // does not throw inside buildDependencyGraph.
+  const execPhases = buildDependencyGraph(fileStructure ?? [], tasks);
   const nodes: ProcessNode[] = [];
   const edges: ProcessEdge[] = [];
 

--- a/apps/web/lib/integrate/task-dependency-graph.test.ts
+++ b/apps/web/lib/integrate/task-dependency-graph.test.ts
@@ -105,4 +105,22 @@ describe("buildDependencyGraph", () => {
     expect(phases).toHaveLength(1); // QA only
     expect(phases[0]!.tasks[0]!.specialist).toBe("qa-engineer");
   });
+
+  it("does not throw when fileStructure is undefined and tasks exist", () => {
+    // Regression: a stored buildPlan with `{ tasks: [...] }` but no
+    // `fileStructure` used to crash the /build page when the build was
+    // selected. The static type declares fileStructure required, but the
+    // Prisma JSON column does not enforce that at runtime.
+    const tasks: PlanTask[] = [
+      { title: "Add AgentBudgetEvent Prisma model and run migration", testFirst: "", implement: "", verify: "" },
+    ];
+
+    expect(() => buildDependencyGraph(undefined, tasks)).not.toThrow();
+    expect(() => buildDependencyGraph(null, tasks)).not.toThrow();
+
+    const phases = buildDependencyGraph(undefined, tasks);
+    expect(phases.length).toBeGreaterThan(0);
+    // QA phase is always appended last.
+    expect(phases[phases.length - 1]?.tasks[0]?.specialist).toBe("qa-engineer");
+  });
 });

--- a/apps/web/lib/integrate/task-dependency-graph.ts
+++ b/apps/web/lib/integrate/task-dependency-graph.ts
@@ -113,11 +113,18 @@ const ROLE_PRIORITY: Record<SpecialistRole, number> = {
  * 4. A QA phase is always appended at the end
  */
 export function buildDependencyGraph(
-  files: PlanFileEntry[],
+  files: PlanFileEntry[] | null | undefined,
   tasks: PlanTask[],
 ): ExecutionPhase[] {
+  // Tolerate missing fileStructure — the BuildPlanDoc type says required,
+  // but the Prisma JSON column does not enforce shape and some legacy /
+  // partially-written plans store only `tasks`. Without this guard the
+  // client-side process graph crashes the entire /build page when a user
+  // selects a build whose stored buildPlan lacks `fileStructure`.
+  const safeFiles = Array.isArray(files) ? files : [];
+
   // Assign specialists to tasks
-  const assigned = tasks.map((task, i) => assignSpecialist(task, i, files));
+  const assigned = tasks.map((task, i) => assignSpecialist(task, i, safeFiles));
 
   // Group by priority level
   const byPriority = new Map<number, AssignedTask[]>();


### PR DESCRIPTION
## Summary

- Defensive `?? []` for `BuildPlanDoc.fileStructure` at both the React-side graph builder and the dependency-graph function. Selecting any FB whose stored buildPlan was written without a `fileStructure` field (the type says it's required, but it's a Prisma JSON column with no runtime shape enforcement) currently crashes the entire `/build` page with `Cannot read properties of undefined (reading 'filter')`.
- Reproduced live on FB-5222FED1 (BI-COST-P1-04 — AgentBudgetEvent schema task).
- Regression test added in `task-dependency-graph.test.ts` covering both `undefined` and `null` `files`.

## Crash path

```
process-graph-builder.ts:414  buildDependencyGraph(fileStructure /* undefined */, tasks)
  ↓
task-dependency-graph.ts:120  tasks.map((t,i) => assignSpecialist(t, i, files /* undefined */))
  ↓
task-dependency-graph.ts:53    files.filter(...)   ← TypeError
```

This is the React rendering path; PR #917 already hardened the *orchestrator* path with a similar guard, but not the client-side graph builder used by `ProcessGraph`.

## Test plan

- [x] `pnpm exec vitest run lib/integrate/task-dependency-graph.test.ts lib/build/process-graph-builder.test.ts` → 30/30 pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] Pre-commit scoped typecheck passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)