### PR TITLE
fix(coworker): keep question context composer usable on mobile

### DIFF
--- a/apps/web/components/agent/AgentMessageInput.test.tsx
+++ b/apps/web/components/agent/AgentMessageInput.test.tsx
@@ -256,4 +256,21 @@ describe("AgentMessageInput — optional question packet context", () => {
       },
     });
   });
+
+  it("keeps the context composer scrollable and wrappable for narrow panels", () => {
+    render(<AgentMessageInput {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+
+    const messageBox = screen.getByPlaceholderText(/ask your co-worker/i);
+    const contextButton = screen.getByRole("button", { name: /hide context/i });
+    const composerRow = contextButton.closest("div");
+    const composerRoot = composerRow?.parentElement;
+
+    expect(composerRoot?.style.minHeight).toBe("0px");
+    expect(composerRoot?.style.overflowY).toBe("auto");
+    expect(composerRow?.style.flexWrap).toBe("wrap");
+    expect(messageBox.style.flex).toBe("1 1 180px");
+    expect(messageBox.style.minWidth).toBe("0px");
+  });
 });

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -158,7 +158,13 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
   const overLimit = value.trim().length > MAX_MESSAGE_LENGTH;
 
   return (
-    <div style={{ borderTop: "1px solid var(--dpf-border)" }}>
+    <div
+      style={{
+        borderTop: "1px solid var(--dpf-border)",
+        minHeight: 0,
+        overflowY: showQuestionContext ? "auto" : "visible",
+      }}
+    >
       {/*
         Voice Slice 2 follow-up: surface voice errors INLINE, not just in the
         button tooltip. Operators were clicking the mic, getting silent
@@ -342,6 +348,7 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
       )}
       <div style={{
         display: "flex",
+        flexWrap: "wrap",
         gap: 6,
         padding: "10px 12px",
         alignItems: "flex-end",
@@ -355,7 +362,8 @@ export function AgentMessageInput({ onSend, disabled, busy, threadId, pendingFil
           placeholder={disabled ? "Sending..." : busy ? "Agent is working... type your next message" : "Ask your co-worker..."}
           rows={1}
           style={{
-            flex: 1,
+            flex: "1 1 180px",
+            minWidth: 0,
             background: "color-mix(in srgb, var(--dpf-bg) 80%, transparent)",
             border: `1px solid ${overLimit ? "var(--dpf-error)" : "var(--dpf-border)"}`,
             borderRadius: 6,


### PR DESCRIPTION
## Summary
- keep the optional question-context composer scrollable inside fixed coworker panels
- allow the message composer row to wrap so narrow/mobile panels keep controls reachable
- add a regression test for the narrow-panel composer styles

## Verification
- pnpm --filter web exec vitest run components/agent/AgentMessageInput.test.tsx
- pnpm --filter web typecheck
- pnpm --filter web exec next build