### PR TITLE
feat(edge): add customer site scope controls

### DIFF
--- a/apps/web/app/(shell)/platform/edge-nodes/page.tsx
+++ b/apps/web/app/(shell)/platform/edge-nodes/page.tsx
@@ -49,6 +49,10 @@ type EdgeNodeRow = {
    */
   hostHostname: string | null;
   hostIpAddresses: string[] | null;
+  customerAccountId: string | null;
+  customerAccountName: string | null;
+  customerSiteId: string | null;
+  customerSiteName: string | null;
 };
 
 /**
@@ -88,6 +92,23 @@ type BootstrapTokenRow = {
   consumedAt: string | null;
   consumedByNodeId: string | null;
   revokedAt: string | null;
+  targetCustomerAccountId: string | null;
+  targetCustomerAccountName: string | null;
+  targetCustomerSiteId: string | null;
+  targetCustomerSiteName: string | null;
+};
+
+type CustomerAccountOption = {
+  id: string;
+  accountId: string;
+  name: string;
+  status: string;
+  sites: {
+    id: string;
+    siteId: string;
+    name: string;
+    status: string;
+  }[];
 };
 
 export default async function EdgeNodesAdminPage() {
@@ -111,7 +132,11 @@ export default async function EdgeNodesAdminPage() {
   // Principal, not on EdgeNode.
   const nodes = await prisma.edgeNode.findMany({
     orderBy: [{ trustState: "asc" }, { lastSeenAt: "desc" }],
-    include: { principal: { select: { displayName: true } } },
+    include: {
+      principal: { select: { displayName: true } },
+      customerAccount: { select: { name: true } },
+      customerSite: { select: { name: true } },
+    },
   });
 
   // Recent (non-expired, non-consumed) bootstrap tokens so the
@@ -125,6 +150,27 @@ export default async function EdgeNodesAdminPage() {
     take: 20,
     include: {
       consumedByEdgeNode: { select: { nodeId: true } },
+      targetCustomerAccount: { select: { name: true } },
+      targetCustomerSite: { select: { name: true } },
+    },
+  });
+
+  const customerAccounts = await prisma.customerAccount.findMany({
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      accountId: true,
+      name: true,
+      status: true,
+      customerSites: {
+        orderBy: { name: "asc" },
+        select: {
+          id: true,
+          siteId: true,
+          name: true,
+          status: true,
+        },
+      },
     },
   });
 
@@ -151,6 +197,10 @@ export default async function EdgeNodesAdminPage() {
         : [],
       hostHostname: hostMetadata.hostname,
       hostIpAddresses: hostMetadata.ipAddresses,
+      customerAccountId: n.customerAccountId,
+      customerAccountName: n.customerAccount?.name ?? null,
+      customerSiteId: n.customerSiteId,
+      customerSiteName: n.customerSite?.name ?? null,
     };
   });
 
@@ -163,7 +213,26 @@ export default async function EdgeNodesAdminPage() {
     consumedAt: t.consumedAt?.toISOString() ?? null,
     consumedByNodeId: t.consumedByEdgeNode?.nodeId ?? null,
     revokedAt: t.revokedAt?.toISOString() ?? null,
+    targetCustomerAccountId: t.targetCustomerAccountId,
+    targetCustomerAccountName: t.targetCustomerAccount?.name ?? null,
+    targetCustomerSiteId: t.targetCustomerSiteId,
+    targetCustomerSiteName: t.targetCustomerSite?.name ?? null,
   }));
+
+  const customerAccountOptions: CustomerAccountOption[] = customerAccounts.map(
+    (account) => ({
+      id: account.id,
+      accountId: account.accountId,
+      name: account.name,
+      status: account.status,
+      sites: account.customerSites.map((site) => ({
+        id: site.id,
+        siteId: site.siteId,
+        name: site.name,
+        status: site.status,
+      })),
+    }),
+  );
 
   return (
     <div className="space-y-6">
@@ -176,7 +245,11 @@ export default async function EdgeNodesAdminPage() {
         </p>
       </div>
 
-      <EdgeNodesAdminClient nodes={nodeRows} tokens={tokenRows} />
+      <EdgeNodesAdminClient
+        nodes={nodeRows}
+        tokens={tokenRows}
+        customerAccounts={customerAccountOptions}
+      />
     </div>
   );
 }

--- a/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx
@@ -4,12 +4,106 @@
 // T2.4 IP / hostname surface in the Edge Nodes admin table.
 
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { __test_HostAddressCell as HostAddressCell } from "./EdgeNodesAdminClient";
+const { mockIssueBootstrapTokenAction } = vi.hoisted(() => ({
+  mockIssueBootstrapTokenAction: vi.fn(),
+}));
 
-afterEach(() => cleanup());
+vi.mock("@/lib/actions/edge-nodes", () => ({
+  approveEdgeNodeAction: vi.fn(),
+  issueEdgeBootstrapTokenAction: mockIssueBootstrapTokenAction,
+  quarantineEdgeNodeAction: vi.fn(),
+  revokeEdgeNodeAction: vi.fn(),
+}));
+
+import {
+  EdgeNodesAdminClient,
+  __test_HostAddressCell as HostAddressCell,
+} from "./EdgeNodesAdminClient";
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+const BASE_NODE = {
+  id: "edge_1",
+  nodeId: "dpf-edge-1",
+  platform: "linux",
+  installMode: "container-host",
+  version: "0.1.0",
+  status: "active",
+  trustState: "trusted",
+  lastSeenAt: null,
+  enrolledAt: null,
+  approvedAt: null,
+  quarantinedAt: null,
+  quarantineReason: null,
+  revokedAt: null,
+  revocationReason: null,
+  displayName: "Acme HQ Edge",
+  capabilities: [],
+  hostHostname: "edge-acme-hq",
+  hostIpAddresses: ["10.0.0.5"],
+  customerAccountId: "cust_acme",
+  customerAccountName: "Acme Dental",
+  customerSiteId: "site_hq",
+  customerSiteName: "Headquarters",
+};
+
+const BASE_TOKEN = {
+  id: "boot_1",
+  prefix: "dpfboot_ACME",
+  scope: "edge:enroll",
+  issuedAt: "2026-05-22T12:00:00.000Z",
+  expiresAt: "2026-05-22T12:15:00.000Z",
+  consumedAt: null,
+  consumedByNodeId: null,
+  revokedAt: null,
+  targetCustomerAccountId: "cust_acme",
+  targetCustomerAccountName: "Acme Dental",
+  targetCustomerSiteId: "site_hq",
+  targetCustomerSiteName: "Headquarters",
+};
+
+const CUSTOMER_ACCOUNTS = [
+  {
+    id: "cust_acme",
+    accountId: "CUST-001",
+    name: "Acme Dental",
+    status: "active",
+    sites: [
+      {
+        id: "site_hq",
+        siteId: "SITE-HQ",
+        name: "Headquarters",
+        status: "active",
+      },
+      {
+        id: "site_branch",
+        siteId: "SITE-BR",
+        name: "Branch Office",
+        status: "active",
+      },
+    ],
+  },
+  {
+    id: "cust_contoso",
+    accountId: "CUST-002",
+    name: "Contoso Clinic",
+    status: "active",
+    sites: [
+      {
+        id: "site_contoso_hq",
+        siteId: "SITE-CT-HQ",
+        name: "Main Office",
+        status: "active",
+      },
+    ],
+  },
+];
 
 describe("HostAddressCell", () => {
   it('renders "—" placeholder when both hostname and IPs are absent', () => {
@@ -73,5 +167,61 @@ describe("HostAddressCell", () => {
     render(<HostAddressCell hostname={null} ipAddresses={["192.168.1.42"]} />);
     expect(screen.queryByText("—")).not.toBeInTheDocument();
     expect(screen.getByText("192.168.1.42")).toBeInTheDocument();
+  });
+});
+
+describe("EdgeNodesAdminClient customer/site scope", () => {
+  it("renders customer/site scope badges for nodes and bootstrap tokens", () => {
+    render(
+      <EdgeNodesAdminClient
+        nodes={[BASE_NODE]}
+        tokens={[BASE_TOKEN]}
+        customerAccounts={CUSTOMER_ACCOUNTS}
+      />,
+    );
+
+    expect(screen.getByText("Scope")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.getAllByText("Acme Dental / Headquarters")).toHaveLength(2);
+  });
+
+  it("filters sites by selected customer and forwards the scope when issuing a token", async () => {
+    mockIssueBootstrapTokenAction.mockResolvedValue({
+      ok: true,
+      tokenId: "boot_scoped",
+      plaintext: "dpfboot_SCOPED",
+      prefix: "dpfboot_SCO",
+      expiresAt: "2026-05-22T12:15:00.000Z",
+    });
+
+    render(
+      <EdgeNodesAdminClient
+        nodes={[]}
+        tokens={[]}
+        customerAccounts={CUSTOMER_ACCOUNTS}
+      />,
+    );
+
+    const customerSelect = screen.getByLabelText("Customer account");
+    const siteSelect = screen.getByLabelText("Customer site");
+
+    expect(siteSelect).toBeDisabled();
+
+    fireEvent.change(customerSelect, { target: { value: "cust_acme" } });
+    expect(siteSelect).not.toBeDisabled();
+    expect(screen.getByRole("option", { name: "Headquarters" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Main Office" })).not.toBeInTheDocument();
+
+    fireEvent.change(siteSelect, { target: { value: "site_hq" } });
+    fireEvent.click(screen.getByRole("button", { name: "Issue token" }));
+
+    await waitFor(() => {
+      expect(mockIssueBootstrapTokenAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetCustomerAccountId: "cust_acme",
+          targetCustomerSiteId: "site_hq",
+        }),
+      );
+    });
   });
 });

--- a/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx
@@ -28,6 +28,10 @@ type EdgeNodeRow = {
   capabilities: string[];
   hostHostname: string | null;
   hostIpAddresses: string[] | null;
+  customerAccountId: string | null;
+  customerAccountName: string | null;
+  customerSiteId: string | null;
+  customerSiteName: string | null;
 };
 
 type BootstrapTokenRow = {
@@ -39,11 +43,31 @@ type BootstrapTokenRow = {
   consumedAt: string | null;
   consumedByNodeId: string | null;
   revokedAt: string | null;
+  targetCustomerAccountId: string | null;
+  targetCustomerAccountName: string | null;
+  targetCustomerSiteId: string | null;
+  targetCustomerSiteName: string | null;
+};
+
+type CustomerSiteOption = {
+  id: string;
+  siteId: string;
+  name: string;
+  status: string;
+};
+
+type CustomerAccountOption = {
+  id: string;
+  accountId: string;
+  name: string;
+  status: string;
+  sites: CustomerSiteOption[];
 };
 
 type Props = {
   nodes: EdgeNodeRow[];
   tokens: BootstrapTokenRow[];
+  customerAccounts: CustomerAccountOption[];
 };
 
 type FlashMessage = {
@@ -81,6 +105,39 @@ function formatTimestamp(iso: string | null): string {
   } catch {
     return iso;
   }
+}
+
+type ScopeBadgeInput = {
+  customerAccountId: string | null;
+  customerAccountName: string | null;
+  customerSiteId: string | null;
+  customerSiteName: string | null;
+};
+
+function formatScopeLabel(scope: ScopeBadgeInput): string {
+  const accountLabel = scope.customerAccountName ?? scope.customerAccountId;
+  const siteLabel = scope.customerSiteName ?? scope.customerSiteId;
+  if (accountLabel && siteLabel) return `${accountLabel} / ${siteLabel}`;
+  if (accountLabel) return accountLabel;
+  if (siteLabel) return siteLabel;
+  return "Organization";
+}
+
+function ScopeBadge({ scope }: { scope: ScopeBadgeInput }) {
+  const isScoped = Boolean(scope.customerAccountId || scope.customerSiteId);
+  return (
+    <span
+      className="inline-flex max-w-56 items-center rounded border px-2 py-0.5 text-xs font-medium"
+      style={{
+        borderColor: isScoped ? "var(--dpf-accent)" : "var(--dpf-border)",
+        backgroundColor: "var(--dpf-surface-2)",
+        color: isScoped ? "var(--dpf-accent)" : "var(--dpf-muted)",
+      }}
+      title={formatScopeLabel(scope)}
+    >
+      <span className="truncate">{formatScopeLabel(scope)}</span>
+    </span>
+  );
 }
 
 /**
@@ -132,14 +189,23 @@ function HostAddressCell({
 // above; this is not part of the public component API.
 export { HostAddressCell as __test_HostAddressCell };
 
-export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
+export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props) {
   const [flash, setFlash] = useState<FlashMessage | null>(null);
   const [issuedToken, setIssuedToken] = useState<IssuedTokenView | null>(null);
   const [ttlMinutes, setTtlMinutes] = useState<number>(15);
+  const [selectedCustomerAccountId, setSelectedCustomerAccountId] = useState<string>("");
+  const [selectedCustomerSiteId, setSelectedCustomerSiteId] = useState<string>("");
   const [isPending, startTransition] = useTransition();
+  const selectedCustomerAccount =
+    customerAccounts.find((account) => account.id === selectedCustomerAccountId) ?? null;
 
   function clearFlash() {
     setFlash(null);
+  }
+
+  function onCustomerAccountChange(value: string) {
+    setSelectedCustomerAccountId(value);
+    setSelectedCustomerSiteId("");
   }
 
   function onIssueBootstrap() {
@@ -148,6 +214,8 @@ export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
     startTransition(async () => {
       const result = await issueEdgeBootstrapTokenAction({
         ttlMs: Math.max(60_000, ttlMinutes * 60_000),
+        targetCustomerAccountId: selectedCustomerAccountId || null,
+        targetCustomerSiteId: selectedCustomerSiteId || null,
       });
       if (result.ok) {
         setIssuedToken({
@@ -303,23 +371,94 @@ export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
           One-time enrollment credential for a new Edge Node. Single-use, hashed at rest. TTL
           15 min default; cap 24h.
         </p>
-        <div className="flex items-center gap-3">
-          <label className="text-sm text-[var(--dpf-text)]">
-            TTL (minutes)
+        <div className="grid gap-3 md:grid-cols-[minmax(7rem,0.6fr)_minmax(12rem,1fr)_minmax(12rem,1fr)_auto] md:items-end">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="edge-bootstrap-ttl"
+              className="text-xs font-medium text-[var(--dpf-muted)]"
+            >
+              TTL (minutes)
+            </label>
             <input
+              id="edge-bootstrap-ttl"
               type="number"
               min={1}
               max={24 * 60}
               value={ttlMinutes}
               onChange={(e) => setTtlMinutes(parseInt(e.target.value, 10) || 15)}
-              className="ml-2 w-20 rounded border px-2 py-1 text-sm"
+              className="w-full rounded border px-2 py-1.5 text-sm"
               style={{
                 borderColor: "var(--dpf-border)",
                 backgroundColor: "var(--dpf-surface-2)",
                 color: "var(--dpf-text)",
               }}
             />
-          </label>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="edge-bootstrap-customer-account"
+              className="text-xs font-medium text-[var(--dpf-muted)]"
+            >
+              Customer account
+            </label>
+            <select
+              id="edge-bootstrap-customer-account"
+              value={selectedCustomerAccountId}
+              onChange={(e) => onCustomerAccountChange(e.target.value)}
+              className="w-full rounded border px-2 py-1.5 text-sm"
+              style={{
+                borderColor: "var(--dpf-border)",
+                backgroundColor: "var(--dpf-surface-2)",
+                color: "var(--dpf-text)",
+              }}
+            >
+              <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                Organization scope
+              </option>
+              {customerAccounts.map((account) => (
+                <option
+                  key={account.id}
+                  value={account.id}
+                  className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+                >
+                  {account.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="edge-bootstrap-customer-site"
+              className="text-xs font-medium text-[var(--dpf-muted)]"
+            >
+              Customer site
+            </label>
+            <select
+              id="edge-bootstrap-customer-site"
+              value={selectedCustomerSiteId}
+              disabled={!selectedCustomerAccount}
+              onChange={(e) => setSelectedCustomerSiteId(e.target.value)}
+              className="w-full rounded border px-2 py-1.5 text-sm disabled:opacity-60"
+              style={{
+                borderColor: "var(--dpf-border)",
+                backgroundColor: "var(--dpf-surface-2)",
+                color: "var(--dpf-text)",
+              }}
+            >
+              <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+                Account-wide
+              </option>
+              {selectedCustomerAccount?.sites.map((site) => (
+                <option
+                  key={site.id}
+                  value={site.id}
+                  className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+                >
+                  {site.name}
+                </option>
+              ))}
+            </select>
+          </div>
           <button
             type="button"
             onClick={onIssueBootstrap}
@@ -358,6 +497,7 @@ export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Node ID</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Platform / mode</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Host / LAN address</th>
+                  <th className="p-2 text-left text-[var(--dpf-muted)]">Scope</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Trust state</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Last seen</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Actions</th>
@@ -380,6 +520,16 @@ export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
                       <HostAddressCell
                         hostname={n.hostHostname}
                         ipAddresses={n.hostIpAddresses}
+                      />
+                    </td>
+                    <td className="p-2">
+                      <ScopeBadge
+                        scope={{
+                          customerAccountId: n.customerAccountId,
+                          customerAccountName: n.customerAccountName,
+                          customerSiteId: n.customerSiteId,
+                          customerSiteName: n.customerSiteName,
+                        }}
                       />
                     </td>
                     <td className="p-2">
@@ -482,6 +632,7 @@ export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
               <thead>
                 <tr style={{ borderBottom: "1px solid var(--dpf-border)" }}>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Prefix</th>
+                  <th className="p-2 text-left text-[var(--dpf-muted)]">Target</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Issued</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Expires</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Status</th>
@@ -499,6 +650,16 @@ export function EdgeNodesAdminClient({ nodes, tokens }: Props) {
                     <tr key={t.id} style={{ borderBottom: "1px solid var(--dpf-border)" }}>
                       <td className="p-2 font-mono text-xs text-[var(--dpf-muted)]">
                         {t.prefix}
+                      </td>
+                      <td className="p-2">
+                        <ScopeBadge
+                          scope={{
+                            customerAccountId: t.targetCustomerAccountId,
+                            customerAccountName: t.targetCustomerAccountName,
+                            customerSiteId: t.targetCustomerSiteId,
+                            customerSiteName: t.targetCustomerSiteName,
+                          }}
+                        />
                       </td>
                       <td className="p-2 text-xs text-[var(--dpf-muted)]">
                         {formatTimestamp(t.issuedAt)}

--- a/apps/web/lib/actions/edge-nodes.test.ts
+++ b/apps/web/lib/actions/edge-nodes.test.ts
@@ -4,6 +4,8 @@ const { mockAuth, mockPrisma, mockIssueBootstrapToken, mockRevalidatePath } = vi
   mockAuth: vi.fn(),
   mockPrisma: {
     principalAlias: { findFirst: vi.fn() },
+    customerAccount: { findUnique: vi.fn() },
+    customerSite: { findFirst: vi.fn() },
     edgeNode: { findUnique: vi.fn(), update: vi.fn() },
   },
   mockIssueBootstrapToken: vi.fn(),
@@ -156,6 +158,12 @@ describe("issueEdgeBootstrapTokenAction", () => {
   });
 
   it("forwards customer/site targets to the bootstrap issuer", async () => {
+    mockPrisma.customerAccount.findUnique.mockResolvedValue({
+      id: "cust_acme",
+    });
+    mockPrisma.customerSite.findFirst.mockResolvedValue({
+      id: "site_hq",
+    });
     mockIssueBootstrapToken.mockResolvedValue({
       tokenId: "boot_scoped",
       plaintext: "dpfboot_scoped",
@@ -175,6 +183,40 @@ describe("issueEdgeBootstrapTokenAction", () => {
         targetCustomerSiteId: "site_hq",
       }),
     );
+  });
+
+  it("rejects an unknown customer account target before issuing a token", async () => {
+    mockPrisma.customerAccount.findUnique.mockResolvedValue(null);
+
+    const result = await issueEdgeBootstrapTokenAction({
+      targetCustomerAccountId: "cust_missing",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("invalid_input");
+      expect(result.message).toContain("Customer account");
+    }
+    expect(mockIssueBootstrapToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects a customer site target that does not belong to the selected account", async () => {
+    mockPrisma.customerAccount.findUnique.mockResolvedValue({
+      id: "cust_acme",
+    });
+    mockPrisma.customerSite.findFirst.mockResolvedValue(null);
+
+    const result = await issueEdgeBootstrapTokenAction({
+      targetCustomerAccountId: "cust_acme",
+      targetCustomerSiteId: "site_other",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("invalid_input");
+      expect(result.message).toContain("Customer site");
+    }
+    expect(mockIssueBootstrapToken).not.toHaveBeenCalled();
   });
 
   it("revalidates the admin path on success so the table re-renders", async () => {

--- a/apps/web/lib/actions/edge-nodes.ts
+++ b/apps/web/lib/actions/edge-nodes.ts
@@ -111,7 +111,9 @@ export async function issueEdgeBootstrapTokenAction(input: {
       message: "ttlMs must be a positive number",
     };
   }
-  if (input.targetCustomerSiteId && !input.targetCustomerAccountId) {
+  const targetCustomerAccountId = input.targetCustomerAccountId?.trim() || null;
+  const targetCustomerSiteId = input.targetCustomerSiteId?.trim() || null;
+  if (targetCustomerSiteId && !targetCustomerAccountId) {
     return {
       ok: false,
       error: "invalid_input",
@@ -121,15 +123,38 @@ export async function issueEdgeBootstrapTokenAction(input: {
   // Spec caps bootstrap TTL at 24h; the lib enforces it server-side.
 
   try {
+    if (targetCustomerAccountId) {
+      const account = await prisma.customerAccount.findUnique({
+        where: { id: targetCustomerAccountId },
+        select: { id: true },
+      });
+      if (!account) {
+        return {
+          ok: false,
+          error: "invalid_input",
+          message: "Customer account target not found",
+        };
+      }
+    }
+    if (targetCustomerAccountId && targetCustomerSiteId) {
+      const site = await prisma.customerSite.findFirst({
+        where: { id: targetCustomerSiteId, accountId: targetCustomerAccountId },
+        select: { id: true },
+      });
+      if (!site) {
+        return {
+          ok: false,
+          error: "invalid_input",
+          message: "Customer site target must belong to the selected customer account",
+        };
+      }
+    }
+
     const result = await issueBootstrapToken({
       issuedByPrincipalId: gate.principalId,
       ...(ttlMs !== undefined ? { ttlMs } : {}),
-      ...(input.targetCustomerAccountId
-        ? { targetCustomerAccountId: input.targetCustomerAccountId }
-        : {}),
-      ...(input.targetCustomerSiteId
-        ? { targetCustomerSiteId: input.targetCustomerSiteId }
-        : {}),
+      ...(targetCustomerAccountId ? { targetCustomerAccountId } : {}),
+      ...(targetCustomerSiteId ? { targetCustomerSiteId } : {}),
     });
     revalidatePath(ADMIN_PATH);
     return {

--- a/docs/superpowers/plans/2026-05-22-edge-node-customer-site-binding-plan.md
+++ b/docs/superpowers/plans/2026-05-22-edge-node-customer-site-binding-plan.md
@@ -80,14 +80,15 @@ Bind scope at the authority boundary first. The Edge Node should never self-assi
 - [x] Write this implementation plan.
 - [x] Link the prior MSP applicability handoff to this focused spec/plan.
 
-## Chunk 6: UI Follow-Up
+## Chunk 6: Bootstrap Scope UI
 
-**Not in this PR.** This branch creates the platform contract. The next UI slice should:
+**Follow-up PR after the platform contract.** This slice makes the install-time customer/site boundary usable from `/platform/edge-nodes` without expanding into adapter management.
 
-- add customer/site selectors to bootstrap-token issuance;
-- show token and node scope badges in `/platform/edge-nodes`;
-- add adapter target selectors for organization, customer account, customer site, and specific node;
-- verify the production Docker portal route only, not a separate portal instance.
+- [x] Add customer/site selectors to bootstrap-token issuance.
+- [x] Show token and node scope badges in `/platform/edge-nodes`.
+- [x] Validate server-side that a selected customer site belongs to the selected customer account.
+- [ ] Add adapter target selectors for organization, customer account, customer site, and specific node.
+- [x] Verify the production Docker portal route on the existing `dpf-portal-1` only, not a separate portal instance.
 
 ## Verification Gate
 


### PR DESCRIPTION
## Summary
- Adds customer account and customer site selectors to Edge Node bootstrap token issuance.
- Shows customer/site scope badges on enrolled Edge Nodes and recent bootstrap tokens.
- Adds server-side validation so a token cannot target a missing account or a site outside the selected account.
- Updates the Edge Node customer/site binding plan to mark this UI slice complete while leaving adapter target selectors as a separate follow-on.

## Validation
- `pnpm --filter web exec vitest run components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx lib/actions/edge-nodes.test.ts lib/edge-node/scope.test.ts lib/edge-node/enrollment.test.ts lib/auth/edge-node-token.test.ts app/api/v1/edge/adapters/route.test.ts app/api/v1/edge/discovery-runs/route.test.ts` — 7 files, 142 tests passed.
- `pnpm --filter web typecheck` — passed.
- `cd apps/web && pnpm exec next build` — passed; emitted the existing Turbopack/NFT warning around `app/api/voice/synthesize/route.ts`.
- `docker compose --env-file D:\DPF\.env -p dpf build portal portal-init` — passed on retry after one transient Next build worker `SIGSEGV`; the local production build and retry both succeeded.
- `docker compose --env-file D:\DPF\.env -p dpf up -d portal-init portal` — reused the existing `dpf` Compose project and `dpf-portal-1` on `http://localhost:3000`.
- Live UI smoke at `http://localhost:3000/platform/edge-nodes` — logged in as local admin, issued a token scoped to a QA customer/site, reloaded, and verified the `QA Edge Scope Co / Headquarters` badge rendered. Screenshot captured at `output/playwright/edge-node-scope-ui-rebased.png`.

## Follow-up
- Logged backlog item `BI-REFACTOR-5FADD568` for the stale `CustomerAccount` search trigger that still references a missing `searchVector` column.