### PR TITLE
fix(sandbox): add bash to dpf-sandbox image (unblocks BS verification)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,6 +1,13 @@
 FROM node:24-alpine
 RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN apk add --no-cache git postgresql16-client curl bubblewrap
+# bash is required by Claude Code CLI ("Claude CLI requires a POSIX shell
+# environment"). The Alpine base image only ships /bin/sh (BusyBox), so
+# every QA-phase agent dispatch (vitest, tsc) was failing at "No suitable
+# shell found" and silently degrading to static-analysis-only verification.
+# That broke the BS verification gate for every build dispatched into this
+# sandbox. SHELL is also exported so child processes inherit a known shell.
+RUN apk add --no-cache git postgresql16-client curl bubblewrap bash
+ENV SHELL=/bin/bash
 # Codex CLI: OpenAI's coding agent (like Claude Code but for OpenAI models).
 # Used by the Build Studio orchestrator to execute build tasks autonomously.
 RUN npm install -g @openai/codex


### PR DESCRIPTION
## Summary

Adds `bash` and `ENV SHELL=/bin/bash` to `Dockerfile.sandbox`. The Alpine base image only ships BusyBox `/bin/sh`, but Claude Code CLI errors with "No suitable shell found. Claude CLI requires a POSIX shell environment." when bash is absent.

## Why this matters

This was the upstream cause behind the "no PR has gone in cleanly" symptom Mark called out. Diagnosis from this session:

- Every BS QA-phase agent dispatch (`pnpm exec vitest`, `pnpm exec tsc`, etc.) ran via Claude CLI inside `dpf-sandbox-1`.
- Without bash, the CLI immediately died and the QA agent silently degraded to static-analysis-only verification — visible in task summaries as: *"The Bash tool is non-functional in this sandbox. Every shell invocation fails with: No suitable shell found."*
- Tasks were then marked DONE on chat self-report rather than passing verification, contaminated/incomplete diffs slipped through, and promotion attempts produced the contamination pattern that closed PRs #957, #961, #969 today.

PR #973 (already merged) added a server-side guard that catches the *output* of this pattern. This PR fixes the *upstream cause* so the guard isn't tripped in the first place.

## Forensics

```
$ docker exec dpf-sandbox-1 sh -c 'echo SHELL=$SHELL ; ls /bin/bash 2>&1 ; cat /etc/os-release | head -3'
SHELL=
ls: /bin/bash: No such file or directory
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.23.4
```

## Test plan

- [x] One-line `apk add` addition + ENV SHELL. No other changes.
- [ ] After merge, rebuild `dpf-sandbox` image and verify `docker exec dpf-sandbox-1 bash -c 'echo $SHELL'` returns `/bin/bash`.
- [ ] Dispatch a fresh BS build and verify the QA agent reports actual vitest/tsc execution rather than the "shell unavailable" fallback.

## Companion docs

- Triage from earlier in the session: `docs/triage/2026-05-22-overnight-session-summary.md` (PR #987).
- Related substrate items in queue: FB-3CA106CC, FB-78E967D4, FB-7F8C7368, FB-9709981A, FB-5D6F7000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)