### PR TITLE
fix(security): close 16 MEDIUM actions/missing-workflow-permissions alerts

### DIFF
--- a/.github/workflows/audit-coworker-personas.yml
+++ b/.github/workflows/audit-coworker-personas.yml
@@ -13,6 +13,11 @@ on:
   push:
     branches: [main]
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+# Read-only audit; needs no write surface.
+permissions:
+  contents: read
+
 concurrency:
   group: audit-coworker-personas-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/audit-coworker-tool-grants.yml
+++ b/.github/workflows/audit-coworker-tool-grants.yml
@@ -1,5 +1,10 @@
 name: Coworker Tool-Grant Audit
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+# Read-only audit; needs no write surface.
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/audit-prompt-state-leakage.yml
+++ b/.github/workflows/audit-prompt-state-leakage.yml
@@ -1,5 +1,9 @@
 name: Prompt State-Leakage Audit
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/audit-routing-invariants.yml
+++ b/.github/workflows/audit-routing-invariants.yml
@@ -1,5 +1,9 @@
 name: Routing Invariants Audit
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default
+# applied at workflow level. All CI jobs only need to read the source.
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -1,5 +1,9 @@
 name: Installer Release Gates
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+permissions:
+  contents: read
+
 # Per the installer-parity roadmap Phase 9b (CI release gates). Three
 # fast gates plus one paid macos-14 gate, all path-filtered so they
 # only run when installer-touching files change. Image-manifests

--- a/.github/workflows/schema-regression-guard.yml
+++ b/.github/workflows/schema-regression-guard.yml
@@ -8,6 +8,10 @@ name: Schema Regression Guard
 # hand-edited branches, manual cherry-picks, or any path that bypasses
 # deploy_feature.
 
+# CodeQL actions/missing-workflow-permissions: least-privilege default.
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## Summary

Adds explicit top-level `permissions: contents: read` to 7 workflow files. Closes **16 MEDIUM** CodeQL `actions/missing-workflow-permissions` alerts in one shot.

Each workflow is read-only by design (audit checks, typecheck, build, shell lint) — least-privilege is the obvious posture.

| File | Alerts |
|---|---|
| `ci.yml` | 7 (one per job) |
| `release-gates.yml` | 4 (one per job) |
| `audit-coworker-personas.yml` | 1 |
| `audit-coworker-tool-grants.yml` | 1 |
| `audit-prompt-state-leakage.yml` | 1 |
| `audit-routing-invariants.yml` | 1 |
| `schema-regression-guard.yml` | 1 |

## Intentionally NOT in this batch

- `dco-signoff-dependabot.yml` — already has `contents: write` (needs to push re-signed commits)
- `publish-image.yml` — has per-job blocks for `packages: write`, `id-token: write`, `attestations: write`
- `audit-actions-injection.yml`, `security-inflow-gate.yml` — shipped earlier with explicit permissions

No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)