### PR TITLE
fix(security): close 4 final MEDIUM alerts (identity-replacement + overly-large-range + shell-cmd-injection + stack-trace-exposure)

### DIFF
--- a/apps/web/lib/brand/extraction/codebase-adapter.ts
+++ b/apps/web/lib/brand/extraction/codebase-adapter.ts
@@ -16,7 +16,10 @@ function parseTailwindColors(source: string): Record<string, string> {
   const colorsMatch = source.match(/colors\s*:\s*\{([^}]*)\}/s);
   if (!colorsMatch) return result;
   const inner = colorsMatch[1];
-  const pairs = inner.matchAll(/(\w+)\s*:\s*["']([#a-fA-F0-9\d,().\s]+)["']/g);
+  // CodeQL #71 (js/overly-large-range): `0-9` and `\d` overlap in the
+  // same character class. Removed the redundant `\d`; `0-9` already
+  // matches the same digits.
+  const pairs = inner.matchAll(/(\w+)\s*:\s*["']([#a-fA-F0-9,().\s]+)["']/g);
   for (const m of pairs) {
     result[m[1]] = m[2].trim();
   }

--- a/packages/db/scripts/check-all-providers.js
+++ b/packages/db/scripts/check-all-providers.js
@@ -8,9 +8,16 @@ const sqlFile = path.join(__dirname, "_temp_query.sql");
 require("fs").writeFileSync(sqlFile, sql);
 
 try {
-  const result = execSync(
-    `npx prisma db execute --file ${sqlFile}`,
-    { cwd: path.join(__dirname, ".."), encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+  // CodeQL #53 (js/shell-command-injection-from-environment): use the
+  // argv form of execFileSync instead of a shell string so $PATH /
+  // environment-supplied npx binary can't be hijacked, and so the
+  // sqlFile path is passed as a single argv element (not parsed by
+  // the shell).
+  const { execFileSync } = require("child_process");
+  const result = execFileSync(
+    "npx",
+    ["prisma", "db", "execute", "--file", sqlFile],
+    { cwd: path.join(__dirname, ".."), encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], shell: false }
   );
   console.log(result);
 } catch (e) {

--- a/scripts/detect-hardware-host.ts
+++ b/scripts/detect-hardware-host.ts
@@ -69,7 +69,11 @@ function detectDarwin(): HostProfile {
     // Unified memory: GPU effectively shares RAM. Report the GPU name
     // for diagnostic value but `vramGB: null` because the concept
     // doesn't apply.
-    gpu = { name: `${cpuName.replace(/^Apple /, "Apple ")} GPU (unified)`, vramGB: null };
+    // CodeQL #75 (js/identity-replacement): the previous replace mapped
+    // "Apple " → "Apple " (no-op). The intent was to keep the "Apple"
+    // prefix while annotating it as a GPU. Direct interpolation is
+    // simpler and correct.
+    gpu = { name: `${cpuName} GPU (unified)`, vramGB: null };
   } else {
     // Intel Mac (out of scope per the installer-parity roadmap, but
     // the script still produces a sensible profile in case someone

--- a/services/browser-use/server.py
+++ b/services/browser-use/server.py
@@ -641,11 +641,16 @@ async def mcp_endpoint(request: Request):
                 "result": {"content": [{"type": "text", "text": json.dumps(result)}]},
             })
         except Exception as e:
+            # CodeQL #18 (py/stack-trace-exposure): str(e) can leak stack
+            # trace context to clients. logger.exception() captures the
+            # full trace server-side for diagnostics; the client gets a
+            # generic message instead.
             logger.exception("Tool %s failed", tool_name)
+            _ = e  # consumed by logger.exception
             return JSONResponse(content={
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "error": {"code": -32000, "message": str(e)},
+                "error": {"code": -32000, "message": "Tool invocation failed (see server logs)"},
             })
 
     # ── initialize ──


### PR DESCRIPTION
## Summary

4 remaining MEDIUM alerts closed across 4 files.

| Alert | File | Fix |
|---|---|---|
| #75 `js/identity-replacement` | `scripts/detect-hardware-host.ts:72` | Removed no-op `replace(/^Apple /, "Apple ")` |
| #71 `js/overly-large-range` | `codebase-adapter.ts:19` | Removed redundant `\d` from `[#a-fA-F0-9\d,().\s]` |
| #53 `js/shell-command-injection-from-environment` | `check-all-providers.js:12` | `execSync(shell-string)` → `execFileSync(argv, shell:false)` |
| #18 `py/stack-trace-exposure` | `services/browser-use/server.py:644` | `str(e)` to client → logger.exception() server-side + generic message to client |

Combined with **PR #995** (16 workflow-permissions alerts), this closes the entire MEDIUM backlog (20 → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)